### PR TITLE
test(models): cover the checksum guard + enable/disable persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "zeroize",
 ]

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -38,17 +38,11 @@ fn enabled_name() -> Option<String> {
 }
 
 fn file_state(m: &ThirdPartyModel) -> &'static str {
-    let path = thirdparty::model_path(m);
-    match std::fs::read(&path) {
-        Ok(bytes) => {
-            use sha2::Digest;
-            if format!("{:x}", sha2::Sha256::digest(&bytes)) == m.sha256 {
-                "weights present, checksum ok"
-            } else {
-                "weights present but CHECKSUM MISMATCH (daemon will refuse them)"
-            }
-        }
-        Err(_) => "weights not fetched",
+    use thirdparty::WeightState::*;
+    match thirdparty::weight_state(m) {
+        ChecksumOk => "weights present, checksum ok",
+        ChecksumMismatch => "weights present but CHECKSUM MISMATCH (daemon will refuse them)",
+        Absent => "weights not fetched",
     }
 }
 
@@ -164,8 +158,7 @@ fn enable(name: Option<&str>) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    use sha2::Digest;
-    let digest = format!("{:x}", sha2::Sha256::digest(&bytes));
+    let digest = thirdparty::sha256_hex(&bytes);
     if digest != m.sha256 {
         let _ = std::fs::remove_file(&tmp);
         eprintln!("[models] CHECKSUM MISMATCH: got sha256 {digest}");

--- a/crates/irlume-common/Cargo.toml
+++ b/crates/irlume-common/Cargo.toml
@@ -10,3 +10,4 @@ serde_json.workspace = true
 thiserror.workspace = true
 zeroize.workspace = true
 libc.workspace = true
+sha2.workspace = true

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -156,4 +156,29 @@ mod tests {
         std::env::remove_var("IRLUME_CONFIG_DIR");
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[test]
+    fn third_party_pad_enable_then_disable_round_trips() {
+        // The models feature persists its enabled state as this key: a model
+        // name means enabled, an empty value means disabled. Locks in that
+        // `write_kv(key, "")` reads back as None (not Some("")), which is what
+        // `irlume models disable` and the daemon's enabled_name() rely on.
+        let _g = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("irlume-tp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+
+        let key = crate::thirdparty::SETTINGS_KEY;
+        assert_eq!(read_kv("settings.conf", key), None); // absent = disabled
+
+        write_kv("settings.conf", key, "flir").unwrap(); // enable
+        assert_eq!(read_kv("settings.conf", key).as_deref(), Some("flir"));
+
+        write_kv("settings.conf", key, "").unwrap(); // disable
+        assert_eq!(read_kv("settings.conf", key), None);
+
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -15,7 +15,7 @@
 //! wires any entry here as a DENY-ONLY cue: it may reject a presentation, it
 //! can never approve one the built-in gate rejected.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// `settings.conf` key naming the enabled model (absent/empty = disabled).
 pub const SETTINGS_KEY: &str = "third_party_pad";
@@ -76,6 +76,41 @@ pub fn model_path(m: &ThirdPartyModel) -> PathBuf {
     dir().join(m.file)
 }
 
+/// Lowercase hex SHA-256 of `bytes`. The one place the checksum is computed, so
+/// the CLI's enable/verify path and the daemon's load guard agree byte for byte.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::Digest;
+    format!("{:x}", sha2::Sha256::digest(bytes))
+}
+
+/// Whether a fetched weight file is present and matches its pinned checksum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WeightState {
+    /// No file at the expected path (not fetched, or disabled and deleted).
+    Absent,
+    /// File present and its SHA-256 matches the catalog pin.
+    ChecksumOk,
+    /// File present but its SHA-256 does not match; the daemon refuses to load
+    /// it and the CLI reports tampering.
+    ChecksumMismatch,
+}
+
+/// [`WeightState`] for a catalog entry at its on-disk path.
+pub fn weight_state(m: &ThirdPartyModel) -> WeightState {
+    weight_state_at(&model_path(m), m.sha256)
+}
+
+/// [`WeightState`] for an explicit path against an expected hex SHA-256. Split
+/// out from [`weight_state`] so the check is testable without touching the
+/// state dir.
+pub fn weight_state_at(path: &Path, expected_sha256: &str) -> WeightState {
+    match std::fs::read(path) {
+        Ok(bytes) if sha256_hex(&bytes) == expected_sha256 => WeightState::ChecksumOk,
+        Ok(_) => WeightState::ChecksumMismatch,
+        Err(_) => WeightState::Absent,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,5 +145,44 @@ mod tests {
     fn lookup_by_name() {
         assert!(by_name("flir").is_some());
         assert!(by_name("nope").is_none());
+    }
+
+    #[test]
+    fn sha256_hex_matches_known_vectors() {
+        // NIST FIPS 180-4 examples.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn weight_state_reports_present_matching_and_tampered() {
+        let tmp = std::env::temp_dir().join(format!("irlume-ws-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        let file = tmp.join("w.onnx");
+        let good = b"pretend these are model weights";
+        let good_sha = sha256_hex(good);
+
+        // Absent: nothing on disk yet.
+        assert_eq!(weight_state_at(&file, &good_sha), WeightState::Absent);
+
+        // Present and matching the pin.
+        std::fs::write(&file, good).unwrap();
+        assert_eq!(weight_state_at(&file, &good_sha), WeightState::ChecksumOk);
+
+        // Present but the pin no longer matches (a swapped / tampered file):
+        // the daemon must refuse it, so this stays distinct from ChecksumOk.
+        std::fs::write(&file, b"different bytes entirely").unwrap();
+        assert_eq!(
+            weight_state_at(&file, &good_sha),
+            WeightState::ChecksumMismatch
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -132,8 +132,7 @@ fn main() {
                     return None;
                 }
             };
-            use sha2::Digest;
-            let digest = format!("{:x}", sha2::Sha256::digest(&bytes));
+            let digest = irlume_common::thirdparty::sha256_hex(&bytes);
             if digest != entry.sha256 {
                 eprintln!(
                     "irlumed: WARNING: third-party PAD '{name}' checksum mismatch (sha256 {digest}); cue DISABLED, refusing to load unpinned weights"


### PR DESCRIPTION
Follow-up to the coverage audit: the `irlume models` third-party-PAD feature had no automated tests for its two security-relevant behaviors, and the checksum logic was duplicated. This closes both.

## What was untested
- The **anti-tamper checksum** (a swapped/tampered weight file must be refused) had zero coverage in the CLI or the daemon.
- The **enable/disable persistence** (clearing the setting must read back as disabled) was implicit.

## Changes
- Centralize the SHA-256 in `irlume_common::thirdparty`: `sha256_hex`, a `WeightState` enum (`Absent` / `ChecksumOk` / `ChecksumMismatch`), and a path-based `weight_state_at`. The CLI's `file_state` and the daemon's load guard each had their own `format!("{:x}", Sha256::digest(..)) == pin`; now there is one implementation they share, so they can't drift.
- **Tests** (all in `irlume-common`, CI-runnable, no hardware):
  - `sha256_hex` against FIPS 180-4 vectors.
  - `weight_state_at` across absent / matching / tampered — the exact boundary the daemon enforces. Path-based, so no env var, no parallel-test race.
  - `third_party_pad` enable → disable round trip, locking in that clearing the key reads back as `None`.

The deny-only gate logic and catalog shape were already tested; this fills the remaining gaps on the plumbing side.
