### PR TITLE
feat: irlume uninstall (CLI + TUI), adaptive removal

### DIFF
--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1242,6 +1242,8 @@ SYSTEM INTEGRATION
                         checksum-pinned, deny-only; fetched, never shipped
   update [--check]                update via the channel this was installed from
                         (Copr/PPA: runs it; .deb/pkg/source: shows the steps)
+  uninstall [--keep-data]         un-wire PAM, stop the daemon, wipe enrolled
+                        data, then show the package-removal command (sudo)
   version                         print the installed irlume version
 
   (developer/benchmark tools are hidden; set IRLUME_DEV=1 to enable them)

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -25,6 +25,7 @@ mod pamwire;
 mod recovery;
 mod suncal;
 mod tui;
+mod uninstall;
 
 pub(crate) fn flag<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
     args.iter()
@@ -101,6 +102,7 @@ fn main() -> std::process::ExitCode {
         (Some("ir-setup"), _) => ir_setup(&args),
         (Some("set-cameras"), _) => set_cameras(&args),
         (Some("update"), _) => commands::update(&args),
+        (Some("uninstall"), _) => uninstall::run(&args),
         (Some("version"), _) | (Some("--version"), _) | (Some("-V"), _) => {
             println!("irlume {}", env!("CARGO_PKG_VERSION"));
             std::process::ExitCode::SUCCESS

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -108,6 +108,10 @@ enum Suspend {
     /// View the face-auth journal (`sudo irlume logs`); the daemon's lines live
     /// in the system journal, so it runs under sudo to guarantee they show.
     Logs,
+    /// Full teardown: un-wire PAM, stop the daemon, wipe data. Root op, so it
+    /// suspends to `sudo irlume uninstall --yes` (the TUI already double-
+    /// confirmed, so --yes skips the CLI's own prompts).
+    Uninstall,
 }
 
 /// Severity of a Repair-tab diagnostic.
@@ -234,6 +238,10 @@ struct App {
     fp: FpInfo,
     recovery: Option<RecoveryInfo>,
     suspend: Option<Suspend>,
+    /// Uninstall confirmation stage: 0 = not confirming, 1 = first prompt shown,
+    /// 2 = second prompt shown. Two Y presses are required before the teardown
+    /// runs, so a stray key can't remove irlume.
+    uninstall_stage: u8,
     /// Enrollment intent parked while the daemon fix runs; resumed (once) as
     /// soon as the daemon answers after the suspended sudo step.
     resume_enroll: Option<ResumeEnroll>,
@@ -328,6 +336,7 @@ impl App {
             fp: FpInfo::default(),
             recovery: None,
             suspend: None,
+            uninstall_stage: 0,
             resume_enroll: None,
             identify_result: None,
             selftest_result: None,
@@ -1354,6 +1363,13 @@ impl App {
             ),
             Suspend::IrSetup => self.sudo_step("enable the IR emitter", &["irlume", "ir-setup"]),
             Suspend::Logs => self.sudo_step("show the face-auth journal", &["irlume", "logs"]),
+            // The TUI already double-confirmed, so pass --yes; the CLI still
+            // does the teardown (un-wire PAM, stop daemon, wipe data) as root
+            // and prints the package-removal command.
+            Suspend::Uninstall => {
+                self.sudo_step("uninstall irlume", &["irlume", "uninstall", "--yes"]);
+                self.quit = true; // irlume is being removed; leave the TUI after
+            }
             // enable + restart: `enable` makes the unit survive reboots (fresh
             // installs ship disabled under distro preset policy) and `restart`
             // also revives an enabled-but-wedged daemon; either alone misses a case.
@@ -1447,6 +1463,26 @@ impl App {
             }
             return;
         }
+        // Uninstall double-confirm: two Y presses, any other key cancels. Held
+        // ahead of the general match so nothing else swallows the keystrokes.
+        if self.uninstall_stage > 0 {
+            if matches!(code, KeyCode::Char('y') | KeyCode::Char('Y')) {
+                if self.uninstall_stage == 1 {
+                    self.uninstall_stage = 2; // ask a second time
+                } else {
+                    self.uninstall_stage = 0;
+                    self.log(
+                        '→',
+                        "uninstall confirmed; suspending to `sudo irlume uninstall`",
+                    );
+                    self.suspend = Some(Suspend::Uninstall);
+                }
+            } else {
+                self.uninstall_stage = 0;
+                self.log('·', "uninstall cancelled");
+            }
+            return;
+        }
         if let Some((_, req)) = &self.confirm {
             if matches!(code, KeyCode::Char('y') | KeyCode::Char('Y')) {
                 let req = req.clone();
@@ -1533,6 +1569,13 @@ impl App {
             (SC_WELCOME, KeyCode::Char('r')) | (SC_DONE, KeyCode::Char('r')) => {
                 self.log('·', "refreshing status…");
                 self.refresh();
+            }
+            // Welcome: start the uninstall double-confirm (capital U, so a
+            // stray lower-case key can't begin it). The two Y presses run in
+            // on_key's uninstall_stage block above.
+            (SC_WELCOME, KeyCode::Char('U')) => {
+                self.uninstall_stage = 1;
+                self.log('·', "uninstall: press Y to confirm (you'll be asked twice)");
             }
             // Welcome quick-launch: jump to Profiles and start enrollment.
             // Gate on the CAMERA, not tab visibility: Identify is an
@@ -1952,6 +1995,20 @@ impl App {
             self.modal(f, prompt, &format!("{shown}▏"));
         } else if let Some((what, _)) = &self.confirm {
             self.modal(f, what, "[y] confirm    [any other key] cancel");
+        } else if self.uninstall_stage > 0 {
+            let (title, hint) = if self.uninstall_stage == 1 {
+                (
+                    "Uninstall irlume? It un-wires PAM, stops the daemon, and DELETES \
+                     every enrolled face and sealed secret.",
+                    "[y] continue    [any other key] cancel",
+                )
+            } else {
+                (
+                    "Are you sure? This cannot be undone.",
+                    "[y] uninstall now    [any other key] cancel",
+                )
+            };
+            self.modal(f, title, hint);
         }
     }
 
@@ -3163,7 +3220,12 @@ impl App {
             return;
         }
         let actions: &[(&str, &str)] = match self.screen {
-            SC_WELCOME => &[("e", "enroll"), ("i", "identify"), ("r", "refresh")],
+            SC_WELCOME => &[
+                ("e", "enroll"),
+                ("i", "identify"),
+                ("r", "refresh"),
+                ("U", "uninstall"),
+            ],
             SC_REPAIR => &[
                 ("f", "fix"),
                 ("r", "re-check"),

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -1,0 +1,213 @@
+//! `irlume uninstall`: the safe teardown a package `remove` cannot do.
+//!
+//! Removing the distro package deletes the binary and `pam_irlume.so`, but the
+//! package manager does not know about the pam.d edits that reference them. A
+//! `pam_irlume.so` line left behind after the module is gone makes PAM fail to
+//! load it, which can lock you out of login and sudo. So the irlume-specific
+//! teardown has to run FIRST, and in this order:
+//!
+//!   1. un-wire PAM from every stack (greeters, sudo, lock screen)
+//!   2. stop and disable the daemon
+//!   3. disarm every enrolled user's TPM keyring seal
+//!   4. wipe enrolled templates, sealed secrets, third-party models, and config
+//!
+//! Only then is removing the package safe. This command does not run the
+//! package manager itself; it prints the exact command for how irlume was
+//! installed. The same teardown backs the TUI's uninstall entry, which puts its
+//! own double-confirmation in front of it.
+
+use crate::commands::{install_origin, InstallOrigin};
+use crate::pamwire;
+use std::io::Write;
+use std::process::{Command, ExitCode};
+
+/// What the teardown actually did, so the CLI and the TUI can report it the
+/// same way.
+pub struct TeardownReport {
+    pub pam_unwired: bool,
+    pub service_stopped: bool,
+    pub users_cleared: usize,
+    pub data_wiped: bool,
+}
+
+pub fn run(args: &[String]) -> ExitCode {
+    let assume_yes = args.iter().any(|a| a == "--yes" || a == "-y");
+    let keep_data = args.iter().any(|a| a == "--keep-data");
+
+    if !is_root() {
+        eprintln!("[uninstall] needs root: sudo irlume uninstall");
+        return ExitCode::FAILURE;
+    }
+
+    println!("irlume uninstall will:");
+    println!("  1. remove irlume from every PAM stack (greeters, sudo, lock screen)");
+    println!("  2. stop and disable the irlumed service");
+    if keep_data {
+        println!("  3. keep your enrolled faces and sealed secrets (--keep-data)");
+    } else {
+        println!("  3. disarm the keyring seal, then delete every enrolled face,");
+        println!("     sealed password, third-party model, and config file");
+    }
+    println!("It does not remove the package; it prints that command at the end.");
+    println!();
+
+    if !assume_yes {
+        if !stdin_is_tty() {
+            eprintln!(
+                "[uninstall] refusing to run unconfirmed without a terminal; pass --yes to proceed"
+            );
+            return ExitCode::FAILURE;
+        }
+        // Double confirmation: a typed word, then a final y/N. Uninstall deletes
+        // sealed secrets that cannot be recovered, so make it deliberate.
+        print!("Type 'uninstall' to continue: ");
+        let _ = std::io::stdout().flush();
+        let mut typed = String::new();
+        if std::io::stdin().read_line(&mut typed).is_err() || typed.trim() != "uninstall" {
+            println!("[uninstall] cancelled; nothing was changed.");
+            return ExitCode::FAILURE;
+        }
+        print!("Really remove irlume from this machine? [y/N] ");
+        let _ = std::io::stdout().flush();
+        let mut yn = String::new();
+        if std::io::stdin().read_line(&mut yn).is_err() || !matches!(yn.trim(), "y" | "Y" | "yes") {
+            println!("[uninstall] cancelled; nothing was changed.");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    let report = perform_teardown(keep_data);
+
+    println!();
+    println!(
+        "[uninstall] PAM un-wired: {}",
+        if report.pam_unwired {
+            "yes (no stack references irlume)"
+        } else {
+            "WARNING: some stack may still reference irlume; check `irlume login status`"
+        }
+    );
+    println!(
+        "[uninstall] service stopped and disabled: {}",
+        yn(report.service_stopped)
+    );
+    println!(
+        "[uninstall] users disarmed: {}{}",
+        report.users_cleared,
+        if report.data_wiped {
+            " (enrollments, seals, models, and config deleted)"
+        } else {
+            " (data kept)"
+        }
+    );
+
+    println!();
+    println!("Teardown done. To remove the package itself:");
+    println!("  {}", removal_hint(&install_origin()));
+    ExitCode::SUCCESS
+}
+
+/// Run the four teardown steps in the lockout-safe order. Public so the TUI
+/// calls the identical sequence behind its own confirmation.
+pub fn perform_teardown(keep_data: bool) -> TeardownReport {
+    // 1. PAM FIRST. Un-wire every greeter, the lock screen, and sudo so no
+    //    stack references pam_irlume.so once the module is removed.
+    let _ = pamwire::run(
+        Some("disable"),
+        &["--apply".to_string(), "--with-sudo".to_string()],
+    );
+    let pam_unwired = !pamwire::login_wired();
+
+    // 2. Stop and disable the daemon.
+    let stop = systemctl(&["stop", "irlumed.service"]);
+    let disable = systemctl(&["disable", "irlumed.service"]);
+    let service_stopped = stop && disable;
+
+    // 3. Disarm each enrolled user's keyring seal (idempotent), and 4. wipe the
+    //    per-user enrollment + sealed secrets unless data is being kept.
+    let users = irlume_core::storage::list_users();
+    for user in &users {
+        let _ = irlume_core::keyring::forget_password(user);
+        if !keep_data {
+            let _ = irlume_core::storage::delete(user);
+        }
+    }
+
+    // 4 (cont). Remove the state and config trees: third-party models, any
+    //    remaining sealed envelopes, cameras.conf/settings.conf. Guarded so
+    //    --keep-data leaves them for a later reinstall.
+    if !keep_data {
+        let _ = std::fs::remove_dir_all(irlume_common::STATE_DIR);
+        let _ = std::fs::remove_dir_all(irlume_common::config::CONFIG_ROOT);
+    }
+
+    TeardownReport {
+        pam_unwired,
+        service_stopped,
+        users_cleared: users.len(),
+        data_wiped: !keep_data,
+    }
+}
+
+/// The package-removal command for how irlume was installed. Pure so it is unit
+/// tested; the teardown above is what actually touches the system.
+pub fn removal_hint(origin: &InstallOrigin) -> String {
+    match origin {
+        InstallOrigin::Copr | InstallOrigin::LocalRpm(_) => "sudo dnf remove irlume".into(),
+        InstallOrigin::Ppa | InstallOrigin::LocalDeb => "sudo apt remove irlume".into(),
+        InstallOrigin::ArchPkg => "sudo pacman -Rns irlume".into(),
+        InstallOrigin::Source => {
+            "source install: remove the binaries you placed (e.g. /usr/local/bin/irlume, \
+             /usr/local/bin/irlumed) and the systemd unit"
+                .into()
+        }
+    }
+}
+
+fn systemctl(args: &[&str]) -> bool {
+    Command::new("systemctl")
+        .args(args)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn yn(b: bool) -> &'static str {
+    if b {
+        "yes"
+    } else {
+        "no (may not have been running)"
+    }
+}
+
+fn is_root() -> bool {
+    unsafe { libc::geteuid() == 0 }
+}
+
+fn stdin_is_tty() -> bool {
+    unsafe { libc::isatty(0) == 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removal_hint_maps_each_origin_to_its_package_manager() {
+        assert_eq!(removal_hint(&InstallOrigin::Copr), "sudo dnf remove irlume");
+        assert_eq!(
+            removal_hint(&InstallOrigin::LocalRpm(String::new())),
+            "sudo dnf remove irlume"
+        );
+        assert_eq!(removal_hint(&InstallOrigin::Ppa), "sudo apt remove irlume");
+        assert_eq!(
+            removal_hint(&InstallOrigin::LocalDeb),
+            "sudo apt remove irlume"
+        );
+        assert_eq!(
+            removal_hint(&InstallOrigin::ArchPkg),
+            "sudo pacman -Rns irlume"
+        );
+        assert!(removal_hint(&InstallOrigin::Source).contains("source install"));
+    }
+}

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -11,14 +11,17 @@
 //!   3. disarm every enrolled user's TPM keyring seal
 //!   4. wipe enrolled templates, sealed secrets, third-party models, and config
 //!
-//! Only then is removing the package safe. This command does not run the
-//! package manager itself; it prints the exact command for how irlume was
-//! installed. The same teardown backs the TUI's uninstall entry, which puts its
-//! own double-confirmation in front of it.
+//! Only then does it remove irlume itself: the package through its manager (so
+//! the package database stays consistent), or the hand-placed files for a
+//! source install. It deletes the binary running this command last of all,
+//! which is fine on Linux (the inode survives until the process exits). The
+//! same teardown-then-remove backs the TUI's uninstall entry, which puts its
+//! own double-confirmation in front of it and exits once it returns.
 
 use crate::commands::{install_origin, InstallOrigin};
 use crate::pamwire;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::{Command, ExitCode};
 
 /// What the teardown actually did, so the CLI and the TUI can report it the
@@ -48,7 +51,7 @@ pub fn run(args: &[String]) -> ExitCode {
         println!("  3. disarm the keyring seal, then delete every enrolled face,");
         println!("     sealed password, third-party model, and config file");
     }
-    println!("It does not remove the package; it prints that command at the end.");
+    println!("  4. remove irlume itself (the package, or the installed files)");
     println!();
 
     if !assume_yes {
@@ -101,10 +104,92 @@ pub fn run(args: &[String]) -> ExitCode {
         }
     );
 
+    // Now actually remove irlume: the package via its manager, or the
+    // hand-placed files for a source install. Done last, because it deletes the
+    // binary running this very command (fine on Linux: the inode survives until
+    // this process exits).
     println!();
-    println!("Teardown done. To remove the package itself:");
-    println!("  {}", removal_hint(&install_origin()));
+    let origin = install_origin();
+    match remove_irlume(&origin) {
+        Ok(what) => {
+            println!("[uninstall] {what}");
+            println!("[uninstall] irlume is removed. This is the last thing it will do.");
+        }
+        Err(e) => {
+            println!("[uninstall] could not finish removal automatically: {e}");
+            println!("[uninstall] the teardown above is done; remove the package by hand:");
+            println!("  {}", removal_hint(&origin));
+        }
+    }
     ExitCode::SUCCESS
+}
+
+/// Remove irlume itself. Package installs go through the package manager (so the
+/// package database stays consistent); a source install has its hand-placed
+/// files deleted directly. `--yes`/confirmation already happened in `run`.
+fn remove_irlume(origin: &InstallOrigin) -> Result<String, String> {
+    match origin {
+        InstallOrigin::Copr | InstallOrigin::LocalRpm(_) => {
+            run_pkg("dnf", &["remove", "-y", "irlume"])
+        }
+        InstallOrigin::Ppa | InstallOrigin::LocalDeb => {
+            run_pkg("apt-get", &["remove", "-y", "irlume"])
+        }
+        InstallOrigin::ArchPkg => run_pkg("pacman", &["-R", "--noconfirm", "irlume"]),
+        InstallOrigin::Source => remove_source_files(),
+    }
+}
+
+/// Run a package-manager removal; map a non-zero exit to a readable error.
+fn run_pkg(bin: &str, args: &[&str]) -> Result<String, String> {
+    println!("[uninstall] removing the package: {bin} {}", args.join(" "));
+    match Command::new(bin).args(args).status() {
+        Ok(s) if s.success() => Ok(format!("removed the {bin} package")),
+        Ok(s) => Err(format!("{bin} exited with {s}")),
+        Err(e) => Err(format!("could not run {bin} ({e})")),
+    }
+}
+
+/// Delete the files a source install placed: the two binaries (this one and its
+/// sibling irlumed), the PAM module, the systemd unit + drop-ins, and the model
+/// tree. The state/config dirs are already gone from the teardown. Best-effort;
+/// reports the count removed.
+fn remove_source_files() -> Result<String, String> {
+    let mut targets: Vec<PathBuf> = Vec::new();
+
+    // The running binary and irlumed next to it.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            targets.push(dir.join("irlumed"));
+        }
+        targets.push(exe);
+    }
+    // The PAM module, wherever the loader keeps modules on this distro.
+    for d in [
+        "/usr/lib/security",
+        "/usr/lib64/security",
+        "/lib/security",
+        "/lib/x86_64-linux-gnu/security",
+    ] {
+        targets.push(PathBuf::from(d).join("pam_irlume.so"));
+    }
+    // The systemd unit and any drop-ins.
+    targets.push(PathBuf::from("/etc/systemd/system/irlumed.service"));
+    let _ = std::fs::remove_dir_all("/etc/systemd/system/irlumed.service.d");
+    // The model tree (the two common source-install prefixes).
+    for d in ["/usr/share/irlume", "/usr/local/share/irlume"] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+
+    let removed = targets
+        .iter()
+        .filter(|p| p.exists() && std::fs::remove_file(p).is_ok())
+        .count();
+    let _ = systemctl(&["daemon-reload"]);
+    if removed == 0 {
+        return Err("found no source-installed files to remove (already gone?)".into());
+    }
+    Ok(format!("removed {removed} source-installed file(s)"))
 }
 
 /// Run the four teardown steps in the lockout-safe order. Public so the TUI


### PR DESCRIPTION
Adds `irlume uninstall` — the safe, install-aware teardown a package `remove` can't do — plus a TUI entry.

## Why
Removing the package deletes the binary and `pam_irlume.so` but leaves the pam.d edits that reference them; a dangling module line can lock the user out of login/sudo. So irlume must un-wire PAM (and clean up) *before* removal.

## CLI `irlume uninstall [--keep-data] [--yes]` (root)
Lockout-safe order: (1) un-wire PAM from every stack, (2) stop+disable the daemon, (3) disarm each user's TPM keyring seal, (4) wipe enrollments/secrets/models/config. Then it **removes irlume through the channel it was installed from** (same `install_origin()` detection `irlume update` uses): `dnf`/`apt-get`/`pacman` for package installs, direct file deletion for a source install. Double-confirm (type `uninstall`, then y/N); refuses without a tty unless `--yes`.

## TUI
Welcome-screen `U` entry with its own two-step confirm, then suspends to `sudo irlume uninstall --yes` and exits.

## Validated on real hardware (Archlinux)
Full teardown + adaptive removal + TUI exit confirmed: irlume removed, `irlume tui` gone.
