### PR TITLE
fix(#15): merge-aware TUI enrollment; one face is one profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,14 @@ every one is runnable.
 <details>
 <summary><b>Glasses, beards, outdoors: when should I re-enroll?</b></summary>
 
-One enrollment usually lasts. Add to it when reality changes, the same way
-Windows Hello recommends: **wear glasses sometimes?** Enroll a second profile
-named `glasses` (TUI Profiles → `[e]`) so both looks match. **Major appearance
-change** (shaved beard, new heavy frames)? Add a scan (`[a]`) rather than
-starting over. **Recognition flaky in bright sunlight?** Strong ambient IR can
-wash out the emitter's illumination; add a scan captured in that environment.
+One enrollment usually lasts. A profile is one identity, and a face can only
+own one profile, so different looks of the same person are extra **scans** on
+that profile, not a second profile. **Wear glasses sometimes?** Add a scan with
+Improve Recognition (TUI Profiles → `[a]`, or `irlume profiles add-scan`) while
+wearing them. **Major appearance change** (shaved beard, new heavy frames)? Same
+thing, add a scan rather than starting over. **Recognition flaky in bright
+sunlight?** Strong ambient IR can wash out the emitter's illumination; add a
+scan captured in that environment.
 Profiles are per-user and deletable any time.
 </details>
 

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1540,8 +1540,10 @@ impl Engine {
                 )));
             }
             let added = captured.len().min(room);
+            let mut added_scans = Vec::with_capacity(added);
             for (rgb, ir, d, b, pitch) in captured.into_iter().take(room) {
                 let sname = enr.profiles[idx].next_scan_name();
+                added_scans.push(sname.clone());
                 let ir_space = ir.as_ref().map(|_| self.ir_space.clone());
                 enr.profiles[idx].scans.push(FaceScan {
                     name: sname,
@@ -1560,6 +1562,7 @@ impl Engine {
                 name: target,
                 added,
                 total,
+                added_scans,
             });
         }
         if enr.profiles.len() >= MAX_PROFILES {
@@ -1909,6 +1912,10 @@ pub enum EnrollOutcome {
         name: String,
         added: usize,
         total: usize,
+        /// Names of the scans this capture appended, so a caller can undo the
+        /// merge by deleting exactly them (the TUI does this on a declined
+        /// "add to the existing profile?" confirm).
+        added_scans: Vec<String>,
     },
 }
 

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1175,7 +1175,21 @@ fn run_enroll(user: &str, reset: bool) {
         scans: None,
         reset,
     }) {
-        Ok(Response::Ok(msg)) => println!("  {msg} {OK}"),
+        Ok(Response::Enrolled {
+            profile,
+            created,
+            total,
+            ..
+        }) => {
+            if created {
+                println!("  enrolled '{profile}' with {total} scans {OK}");
+            } else {
+                println!(
+                    "  this face is already enrolled as '{profile}'; added scans to it \
+                     ({total} total) {OK}"
+                );
+            }
+        }
         r => eprintln!("  enroll failed: {r:?}"),
     }
 }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -154,8 +154,22 @@ fn enroll(args: &[String]) -> std::process::ExitCode {
         scans,
         reset,
     }) {
-        Ok(Response::Ok(msg)) => {
-            println!("[enroll] {msg}");
+        Ok(Response::Enrolled {
+            profile,
+            created,
+            added,
+            total,
+            ..
+        }) => {
+            if created {
+                println!("[enroll] enrolled '{profile}' with {total} scans");
+            } else {
+                println!(
+                    "[enroll] this face is already enrolled as '{profile}'; added {added} scans \
+                     to it ({total} total). A face can only own one profile; to strengthen \
+                     recognition use `irlume profiles add-scan --profile '{profile}'`."
+                );
+            }
             std::process::ExitCode::SUCCESS
         }
         Ok(Response::Error(e)) => {
@@ -578,7 +592,9 @@ fn enrolldev(args: &[String]) -> std::process::ExitCode {
             println!("[enrolldev] enrolled '{name}' ({scans} scans)");
             std::process::ExitCode::SUCCESS
         }
-        Ok(irlume_auth::EnrollOutcome::Merged { name, added, total }) => {
+        Ok(irlume_auth::EnrollOutcome::Merged {
+            name, added, total, ..
+        }) => {
             println!("[enrolldev] merged into '{name}' (+{added} scans, {total} total)");
             std::process::ExitCode::SUCCESS
         }
@@ -1537,7 +1553,7 @@ fn genuine(args: &[String]) -> std::process::ExitCode {
                 scores[0], impostor_max, mid
             );
         } else {
-            println!("  ⚠ overlap: genuine min {:.3} ≤ impostor max; needs better alignment/lighting or per-profile (e.g. glasses) enrollment",
+            println!("  ⚠ overlap: genuine min {:.3} ≤ impostor max; needs better alignment/lighting or more varied scans (e.g. glasses, angles) on the profile",
                 scores[0]);
         }
         Ok(())

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1588,13 +1588,20 @@ impl App {
             return;
         }
         // Merge confirm: scan 1 of a "new profile" enroll matched an existing
-        // identity. [y] adds the rest of the scans to that profile; any other
-        // key cancels and removes the one scan already merged in.
-        if let Some(mc) = self.enroll_merge.take() {
-            if matches!(code, KeyCode::Char('y') | KeyCode::Char('Y')) {
-                self.confirm_enroll_merge(mc);
-            } else {
-                self.cancel_enroll_merge(mc);
+        // identity. [y] adds the rest of the scans to that profile, [n]/Esc
+        // cancels (removing the one merged scan). Any other key is ignored so a
+        // stray keypress can't silently cancel the enroll.
+        if self.enroll_merge.is_some() {
+            match code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    let mc = self.enroll_merge.take().unwrap();
+                    self.confirm_enroll_merge(mc);
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    let mc = self.enroll_merge.take().unwrap();
+                    self.cancel_enroll_merge(mc);
+                }
+                _ => {} // ignore stray keys; the modal stays up
             }
             return;
         }
@@ -2112,16 +2119,14 @@ impl App {
             };
             self.modal(f, title, hint);
         } else if let Some(mc) = &self.enroll_merge {
-            let title = format!(
-                "This face is already enrolled as '{}'. A face can only own one \
-                 profile, so glasses/lighting variants are added as scans to it.",
+            // Keep the message in the wrapping body, not the border title (which
+            // is a single line clamped to the box width and would truncate).
+            let body = format!(
+                "This face is already enrolled as '{}' (a face owns one profile). \
+                 Add these scans to it?   [y] add   ·   [n] cancel",
                 mc.profile
             );
-            self.modal(
-                f,
-                &title,
-                "[y] add these scans to it    [any other key] cancel",
-            );
+            self.modal(f, "Already enrolled", &body);
         }
     }
 

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -198,6 +198,24 @@ enum WMsg {
     Captured(usize, usize),
     Done,
     Err(String),
+    /// Scan 1 of a "new profile" enroll matched an existing identity, so the
+    /// daemon merged it into `profile` instead. The worker ends here and hands
+    /// off to the UI, which confirms with the user before adding the rest.
+    /// `added_scans` are the scan(s) already appended (undo target on decline).
+    MergePrompt {
+        profile: String,
+        total: usize,
+        added_scans: Vec<String>,
+    },
+}
+
+/// A pending "this face is already enrolled as X; add these scans to it?"
+/// confirmation, raised when scan 1 of a new-profile enroll merged. `remaining`
+/// is how many more scans to capture on confirm (capped at the 30-scan budget).
+struct MergeConfirm {
+    profile: String,
+    added_scans: Vec<String>,
+    remaining: usize,
 }
 
 struct EnrollUi {
@@ -235,6 +253,8 @@ struct App {
     confirm: Option<(String, Request)>,
     op: Option<Op>,
     enroll: Option<EnrollUi>,
+    /// A pending merge confirmation (scan 1 matched an existing profile).
+    enroll_merge: Option<MergeConfirm>,
     fp: FpInfo,
     recovery: Option<RecoveryInfo>,
     suspend: Option<Suspend>,
@@ -333,6 +353,7 @@ impl App {
             confirm: None,
             op: None,
             enroll: None,
+            enroll_merge: None,
             fp: FpInfo::default(),
             recovery: None,
             suspend: None,
@@ -1154,6 +1175,56 @@ impl App {
         });
     }
 
+    /// User confirmed the merge: keep the scan already added and, if the profile
+    /// still has room and more scans were requested, capture the rest via
+    /// AddScan targeting the resolved profile (never a new merge).
+    fn confirm_enroll_merge(&mut self, mc: MergeConfirm) {
+        self.log(
+            '·',
+            format!("adding these scans to '{}' (already your face)", mc.profile),
+        );
+        if mc.remaining == 0 {
+            self.log('✓', format!("scan added to '{}'", mc.profile));
+            self.refresh();
+            return;
+        }
+        let user = self.user.clone();
+        let stop = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = mpsc::channel();
+        let (st, pn) = (stop.clone(), mc.profile.clone());
+        let add = Some(mc.profile.clone());
+        std::thread::spawn(move || enroll_worker(user, pn, add, mc.remaining, st, tx));
+        self.enroll = Some(EnrollUi {
+            rx,
+            stop,
+            profile: mc.profile,
+            last: None,
+            count: None,
+            captured: 0,
+            target: mc.remaining,
+        });
+    }
+
+    /// User declined the merge: remove the scan(s) scan 1 already added, so the
+    /// cancel leaves the existing profile exactly as it was.
+    fn cancel_enroll_merge(&mut self, mc: MergeConfirm) {
+        for scan in &mc.added_scans {
+            let _ = crate::daemon_request(&Request::DeleteScan {
+                user: self.user.clone(),
+                profile: mc.profile.clone(),
+                scan: scan.clone(),
+            });
+        }
+        self.log(
+            '·',
+            format!(
+                "cancelled; '{}' is unchanged (a face can only own one profile)",
+                mc.profile
+            ),
+        );
+        self.refresh();
+    }
+
     fn poll(&mut self) {
         if let Some(op) = &self.op {
             if let Ok((ok, msg)) = op.rx.try_recv() {
@@ -1179,11 +1250,13 @@ impl App {
             }
         }
         if let Some(e) = &self.enroll {
+            let target = e.target;
             let mut msgs = Vec::new();
             while let Ok(m) = e.rx.try_recv() {
                 msgs.push(m);
             }
             let mut finished = false;
+            let mut merge: Option<MergeConfirm> = None;
             for m in msgs {
                 match m {
                     WMsg::Cue(r) => {
@@ -1213,10 +1286,28 @@ impl App {
                         self.set_error(format!("Enrollment failed: {e}"));
                         finished = true;
                     }
+                    WMsg::MergePrompt {
+                        profile,
+                        total,
+                        added_scans,
+                    } => {
+                        // The rest of the requested scans, capped at the profile's
+                        // remaining 30-scan budget (scan 1 already merged in).
+                        let remaining = target
+                            .saturating_sub(1)
+                            .min(irlume_core::storage::MAX_SCANS_PER_PROFILE.saturating_sub(total));
+                        merge = Some(MergeConfirm {
+                            profile,
+                            added_scans,
+                            remaining,
+                        });
+                        finished = true; // the worker has ended; the modal takes over
+                    }
                 }
             }
             if finished {
                 self.enroll = None;
+                self.enroll_merge = merge;
                 self.refresh();
             }
         }
@@ -1493,6 +1584,17 @@ impl App {
                 self.start_async("(confirmed)", OpTag::Generic, req, map_confirm);
             } else {
                 self.confirm = None;
+            }
+            return;
+        }
+        // Merge confirm: scan 1 of a "new profile" enroll matched an existing
+        // identity. [y] adds the rest of the scans to that profile; any other
+        // key cancels and removes the one scan already merged in.
+        if let Some(mc) = self.enroll_merge.take() {
+            if matches!(code, KeyCode::Char('y') | KeyCode::Char('Y')) {
+                self.confirm_enroll_merge(mc);
+            } else {
+                self.cancel_enroll_merge(mc);
             }
             return;
         }
@@ -2009,6 +2111,17 @@ impl App {
                 )
             };
             self.modal(f, title, hint);
+        } else if let Some(mc) = &self.enroll_merge {
+            let title = format!(
+                "This face is already enrolled as '{}'. A face can only own one \
+                 profile, so glasses/lighting variants are added as scans to it.",
+                mc.profile
+            );
+            self.modal(
+                f,
+                &title,
+                "[y] add these scans to it    [any other key] cancel",
+            );
         }
     }
 
@@ -2252,7 +2365,7 @@ impl App {
         let mut items = items;
         items.push(ListItem::new(Line::raw("")));
         items.push(ListItem::new(Line::from(Span::styled(
-            "  Tips: wear glasses sometimes? Enroll a second profile named 'glasses' ([e]).",
+            "  Tips: look different sometimes (glasses, low light)? Add scans to your profile with Improve Recognition ([a]); same identity, not a second profile.",
             Style::new().dim(),
         ))));
         items.push(ListItem::new(Line::from(Span::styled(
@@ -3537,7 +3650,26 @@ fn enroll_worker(
                 }
             };
             match crate::daemon_request(&req) {
-                Ok(Response::Ok(_)) => {
+                // Scan 1 of a new-profile enroll matched an existing identity:
+                // the daemon merged it. Hand off to the UI to confirm before
+                // adding the rest; the worker ends here (the UI spawns a
+                // continuation on confirm, or undoes the scan on decline).
+                Ok(Response::Enrolled {
+                    created: false,
+                    profile: resolved,
+                    total,
+                    added_scans,
+                    ..
+                }) => {
+                    let _ = send(WMsg::MergePrompt {
+                        profile: resolved,
+                        total,
+                        added_scans,
+                    });
+                    return;
+                }
+                // A brand-new profile (created) or an AddScan success.
+                Ok(Response::Enrolled { .. }) | Ok(Response::Ok(_)) => {
                     if !send(WMsg::Captured(i + 1, target)) {
                         return;
                     }

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -303,6 +303,19 @@ pub enum Response {
     },
     /// Generic success ack for management operations, with a human message.
     Ok(String),
+    /// Result of an Enroll capture, carrying the profile the scans actually
+    /// landed on. `created` distinguishes a brand-new profile from a merge into
+    /// an existing identity (the engine auto-merges a face that already owns a
+    /// profile). `added_scans` names the scans this call appended, so a caller
+    /// that wants to undo a merge (e.g. the TUI on a declined confirm) can
+    /// delete exactly them. See EnrollOutcome.
+    Enrolled {
+        profile: String,
+        created: bool,
+        added: usize,
+        total: usize,
+        added_scans: Vec<String>,
+    },
     SelfTest {
         passed: bool,
         detail: String,
@@ -389,3 +402,55 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enrolled_response_round_trips() {
+        // The daemon serializes Response over the socket and the TUI/CLI
+        // deserialize it; the enroll merge fix depends on this variant carrying
+        // the resolved profile + the merged scan names intact.
+        for r in [
+            Response::Enrolled {
+                profile: "Face Profile 1".into(),
+                created: true,
+                added: 3,
+                total: 3,
+                added_scans: vec![],
+            },
+            Response::Enrolled {
+                profile: "Face Profile 1".into(),
+                created: false,
+                added: 1,
+                total: 8,
+                added_scans: vec!["scan8".into()],
+            },
+        ] {
+            let wire = serde_json::to_string(&r).unwrap();
+            let back: Response = serde_json::from_str(&wire).unwrap();
+            match (r, back) {
+                (
+                    Response::Enrolled {
+                        profile: p1,
+                        created: c1,
+                        added: a1,
+                        total: t1,
+                        added_scans: s1,
+                    },
+                    Response::Enrolled {
+                        profile: p2,
+                        created: c2,
+                        added: a2,
+                        total: t2,
+                        added_scans: s2,
+                    },
+                ) => {
+                    assert_eq!((p1, c1, a1, t1, s1), (p2, c2, a2, t2, s2));
+                }
+                _ => panic!("Enrolled did not round-trip to Enrolled"),
+            }
+        }
+    }
+}

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -11,8 +11,10 @@ use std::fs;
 use std::path::PathBuf;
 use zeroize::Zeroizing;
 
-/// Max face profiles per account (e.g. self / self-with-glasses / a trusted
-/// person). A 4th requires deleting one.
+/// Max face profiles per account, one per person (e.g. self / a partner / a
+/// trusted person). A face can only own one profile, so appearance variants
+/// (glasses, lighting) are extra scans on that person's profile, not new
+/// profiles. A 4th person requires deleting one.
 pub const MAX_PROFILES: usize = 3;
 /// Max scans per profile: one fresh enrollment plus four improve-recognition
 /// rounds ([`DEFAULT_ENROLL_SCANS`] + 4 x [`IMPROVE_SCANS`]). Raised from 5:

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -647,15 +647,25 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 Err(e) => eprintln!("irlumed: IR emitter auto-setup skipped: {e}"),
             }
             match engine.enroll_profile(&user, profile, want) {
-                Ok(irlume_auth::EnrollOutcome::New { name, scans }) => {
-                    Response::Ok(format!("enrolled '{name}' with {scans} scans"))
-                }
-                Ok(irlume_auth::EnrollOutcome::Merged { name, added, total }) => {
-                    Response::Ok(format!(
-                        "this face already matches '{name}'; added the {added} fresh scans to \
-                         it ({total} total) and recognition now uses them"
-                    ))
-                }
+                Ok(irlume_auth::EnrollOutcome::New { name, scans }) => Response::Enrolled {
+                    profile: name,
+                    created: true,
+                    added: scans,
+                    total: scans,
+                    added_scans: Vec::new(),
+                },
+                Ok(irlume_auth::EnrollOutcome::Merged {
+                    name,
+                    added,
+                    total,
+                    added_scans,
+                }) => Response::Enrolled {
+                    profile: name,
+                    created: false,
+                    added,
+                    total,
+                    added_scans,
+                },
                 Err(e) => Response::Error(e.to_string()),
             }
         }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -27,8 +27,9 @@ in the footer.
 
 1. **Welcome**: press `[e]` to enroll right away, or `Tab` to walk the steps.
 2. **Profiles**: `[e]` enrolls a face. Look at the camera; it guides your
-   framing and captures three scans automatically. Wear glasses sometimes?
-   Enroll a second profile for that look.
+   framing and captures three scans automatically. Wear glasses sometimes? Add
+   a scan with Improve Recognition (`[a]`) while wearing them, on the same
+   profile; a face can only own one profile.
 3. **Keyring** *(recommended; IR camera + TPM)*: arm TPM keyring unlock so a
    face login opens your wallet with no prompt. You'll enter your login password
    once; it is sealed in the TPM, never stored in plaintext. Skip it and your
@@ -90,9 +91,11 @@ Look at the camera. It captures three scans and saves a profile:
 [enroll] enrolled 'Face Profile 1' with 3 scans
 ```
 
-Options: `--name "Glasses"` names the profile, `--scans K` sets the scan count,
-`--reset` wipes existing profiles first. Enroll a second named profile for a
-different look (glasses on/off). On a machine with a TPM, the templates are now
+Options: `--name "Alex"` names the profile, `--scans K` sets the scan count,
+`--reset` wipes existing profiles first. Name a separate profile for a
+*different person* you trust (up to three); for your own glasses/lighting
+variants, add scans to your own profile instead. On a machine with a TPM, the
+templates are now
 **encrypted at rest** automatically.
 
 Confirm the match:

--- a/docs/adr/0005-enroll-merge-protocol.md
+++ b/docs/adr/0005-enroll-merge-protocol.md
@@ -1,0 +1,81 @@
+# ADR-0005: One face is one profile; the enroll protocol reports the merge
+
+**Status:** Accepted and DONE. The engine already enforced the identity model;
+this ADR records it and fixes the two things sitting on top of it that
+contradicted it (issue #15): the TUI's non-merge-aware split protocol, which
+crashed, and the copy that told users to make a second profile for glasses.
+Implemented 2026-07-18 (`Response::Enrolled`, the merge-aware `enroll_worker`
+plus a confirm modal, and the copy corrections).
+
+**Date:** 2026-07-18
+
+## Context
+
+A profile is one identity. `MAX_PROFILES = 3` people, each holding up to
+`MAX_SCANS_PER_PROFILE = 30` scans of that one person (glasses, lighting, angle,
+beard). A face can never own two profiles: `Engine::enroll_profile`
+(`crates/irlume-auth/src/lib.rs`) probes the capture, and if it matches an
+existing profile above `RGB_MATCH_THRESHOLD` it merges the scans into that
+profile and returns `EnrollOutcome::Merged`; `add_scan` carries the same
+`colliding_profile` guard. So enrollment auto-routes: a matching face strengthens
+its existing profile, a novel face creates a new one (or is refused at 3).
+
+Two things on top of that model disagreed with it.
+
+The TUI drives enrollment as separate daemon calls for per-scan framing: scan 1
+is `Request::Enroll` (create), scans 2..N are `Request::AddScan` (append). Both
+`New` and `Merged` collapsed to `Response::Ok(String)` in the daemon, so
+`enroll_worker` could not tell them apart. For an already-enrolled face, scan 1
+merged into the existing profile, the worker read it as an ordinary success, and
+scan 2's `AddScan` targeted a profile that was never created, failing with
+`no face profile '<name>'`. Net: one orphaned scan on the old profile and a
+confusing error (issue #15).
+
+The Profiles-tab tip, the README FAQ, and the SETUP guide told users to enroll a
+second profile named `glasses`, which the identity model forbids.
+
+## Decision
+
+Carry the resolved profile in the protocol, and make the TUI honor the merge
+instead of fighting it.
+
+- `Response::Enrolled { profile, created, added, total, added_scans }` replaces
+  the stringly `Ok` for enroll results. `created` distinguishes a new profile
+  from a merge; `added_scans` names the scans this call appended so a caller can
+  undo a merge precisely. `EnrollOutcome::Merged` gained the same
+  `added_scans`.
+- `enroll_worker` reads scan 1's `Enrolled`. On a merge it stops and hands off
+  to the UI, which shows a confirm: "this face is already enrolled as X; add
+  these scans to it?". On yes it captures the rest via `AddScan` against the
+  resolved profile (capped at the 30-scan budget); on no it deletes the one
+  merged scan so the profile is left exactly as it was. The CLI enroll paths
+  print the same friendly result.
+- The copy now matches the model everywhere: variants of one person are extra
+  scans added with Improve Recognition (`[a]`), not a second profile (Profiles
+  tip, merge modal, README, SETUP, the `MAX_PROFILES` comment).
+
+The confirm is explicit rather than silent because the user asked for a new
+profile and gets told they already have one; a modal makes that visible and
+reversible instead of surprising.
+
+## Consequences
+
+| Enroll scenario | Result |
+| --- | --- |
+| New person, a slot free | New profile created |
+| New person, already 3 profiles | Refused: "at the max of 3 profiles" |
+| Already-enrolled face, TUI new-profile | Confirm modal; yes adds scans to the matched profile, no leaves it unchanged. No crash, no orphan |
+| Same person, glasses that still match | Merge, strengthening recognition |
+| Same person, look drifts below threshold | A new profile, the one seam below |
+
+The identity check is threshold-based on the face embedding, so "new person"
+means "matches no existing profile above `RGB_MATCH_THRESHOLD`". The one place
+the model can misfire is the same person whose look drifts so far it drops below
+threshold (heavy disguise, drastic lighting): it reads as a stranger and eats a
+profile slot. This is inherent to any threshold identity check and is not a
+policy change here. Making that auto-created profile visible and offering a
+"merge into" action to fold it back is left as a follow-up (issue to file), not
+part of this fix.
+
+Nothing here touches the identity policy or auth security; it is protocol, UI,
+and copy.


### PR DESCRIPTION
Closes #15.

## The bug
Enrolling a "new profile" in the TUI for an **already-enrolled face** merged one scan into the existing profile, then aborted with `no face profile '<name>'`, leaving an orphan scan and no new profile. Root cause: the daemon collapsed both `EnrollOutcome::New` and `::Merged` to `Response::Ok(String)`, so the TUI's split-capture worker (Enroll for scan 1, AddScan for the rest) couldn't tell a merge from a new profile and sent the remaining AddScans to a profile that was never created.

## The model (unchanged, now made consistent)
A profile is one identity: `MAX_PROFILES=3` people, each up to `MAX_SCANS_PER_PROFILE=30` scans of appearance variation. A face can't own two profiles; the engine already merges a matching face and refuses a stranger at 3. This fix makes the protocol, the TUI, and the copy agree with that.

## Changes
- **Protocol**: `Response::Enrolled { profile, created, added, total, added_scans }` replaces the stringly `Ok` for enroll; `EnrollOutcome::Merged` gains `added_scans` (for a precise undo). Daemon returns it; CLI paths print the resolved result.
- **TUI**: `enroll_worker` reads scan 1's result; on a merge it stops and the UI shows a **confirm modal** ("already enrolled as X; add these scans to it? [y] / cancel"). Yes captures the rest via AddScan against the matched profile (capped at 30); cancel deletes the one merged scan, leaving the profile unchanged.
- **Copy**: variants of one person are extra scans via Improve Recognition `[a]`, not a second profile — fixed the Profiles tip, README FAQ, `docs/SETUP.md`, and the `MAX_PROFILES` comment.
- **Tests + ADR**: `Response::Enrolled` serde round-trip; `docs/adr/0005-enroll-merge-protocol.md`. The "look drifts below threshold spawns a new profile" seam is documented as a follow-up.

## Validation
Unit tests + full workspace build/clippy green. Live camera validation (the actual enroll-and-merge flow, which a headless CI can't exercise) is running on real Hello-camera hardware via an isolated throwaway daemon.
