### PR TITLE
docs(ci): note the four required status checks on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Branch protection on `main` requires these four job names as status checks:
+#   "fmt · clippy · build · test", "cargo-deny (advisories · licenses ·
+#   duplicate versions)", "nix flake check", "fuzz (untrusted-input parsers)".
+# Renaming a job below without updating the protection rule leaves a PR waiting
+# on a check that never reports, so it can never merge. Change both together.
 jobs:
   check:
     name: fmt · clippy · build · test


### PR DESCRIPTION
Adds a comment in `ci.yml` recording that the four job names are the
required status checks configured in branch protection on `main`.

This also serves as a live end-to-end proof that the new branch
protection (required checks, no reviews, squash + linear history) does
not block the squash-merge watcher flow.
