### PR TITLE
chore(deps): bump tss-esapi fork pin + correct fork notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi"
 version = "7.7.0"
-source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#df64e66b0f5dd9fd775ee34a4ed3429ffbbd6316"
+source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi-sys"
 version = "0.6.0"
-source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#df64e66b0f5dd9fd775ee34a4ed3429ffbbd6316"
+source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
 dependencies = [
  "pkg-config",
  "target-lexicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,18 +71,19 @@ strip = true
 # minimal patches irlume needs. Today that is (1) Context::policy_authorize_nv
 # (TPM2_PolicyAuthorizeNV), required by the Tier-2 systemd-pcrlock seal implemented
 # in crates/irlume-core/src/tpm.rs (design notes in tpm_pcrlock.rs), and (2) the upstream PR #530 fix that
-# flushes the session handle when tr_sess_set_attributes fails inside
-# execute_with_nullauth_session (a 7.7.0 failure path would otherwise leave a
-# loaded session on the TPM; irlume calls that helper on every seal/unseal).
+# flushes the session handle when tr_sess_set_attributes fails. That fix covers
+# three call sites: execute_with_nullauth_session (which irlume calls on every
+# seal/unseal) plus the AK helpers load_ak and create_ak_2; a 7.7.0 failure path
+# would otherwise leave a loaded session on the TPM.
 # Cargo.lock pins an exact commit, so this is a frozen dependency: it never
 # moves under a user, only when we bump it.
 #
 # Why the fork exists: upstream wrote this method (parallaxsecond PR #486, merged
 # to main 2024-01-23) but never backported it to a 7.x release, so 7.6.0/7.7.0 both
 # ship `// Missing function: PolicyAuthorizeNV`. It only lands in 8.0, whose stable
-# release has been the open tracking issue #495 since Feb 2024 (2.5+ years, only
-# alphas out, a large breaking change set pending). So "just wait for a release" is
-# not a near-term option; we maintain the fork branch instead.
+# release is the open tracking issue #495 (opened Feb 2024, still only alphas out,
+# latest 8.0.0-alpha.2 in Feb 2026, a large breaking change set pending). So "just
+# wait for a release" is not a near-term option; we maintain the fork branch instead.
 #
 # Branch model: our fork's `main` mirrors upstream `main` for reference only. The
 # `irlume-patches` branch sits on a STABLE release tag (currently v7.7.0) + our
@@ -91,7 +92,10 @@ strip = true
 # signature already matches upstream's (`auth_handle: NvAuth`), so adopting a
 # released crate that carries the method upstream would be a call-site no-op; the
 # only fork-local delta is the 7.7.0-flavoured body (Error::from_tss_rc /
-# optional_session_1 vs 8.0's ReturnCode / required_session_1). Only move to a
-# plain crates.io release after that release exists AND passes the HW round-trip.
+# optional_session_1 vs 8.0's ReturnCode / required_session_1). optional_session_1
+# is deliberate: it matches every 7.7.0 policy command except policy_signed and
+# policy_secret, so it is the consistent choice on this base. Upstream flipped all
+# policy commands to required_session_1 only as an 8.0 break (PR #624). Only move to
+# a plain crates.io release after that release exists AND passes the HW round-trip.
 [patch.crates-io]
 tss-esapi = { git = "https://github.com/archledger/rust-tss-esapi", branch = "irlume-patches" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "zeroize",
 ]
@@ -1170,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi"
 version = "7.7.0"
-source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#1c3f982df6fbf484d30fe9f3e33a9a5ee9bcaa4f"
+source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -1192,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi-sys"
 version = "0.6.0"
-source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#1c3f982df6fbf484d30fe9f3e33a9a5ee9bcaa4f"
+source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
 dependencies = [
  "pkg-config",
  "target-lexicon",


### PR DESCRIPTION
Bumps the `archledger/rust-tss-esapi` `irlume-patches` pin from `df64e66`
to the guarded tip `7567f60` (workspace + fuzz locks). The compiled
library is unchanged between the two commits; the delta is added tests, a
rustfmt import rewrap, a README fork-rationale note, and new CI workflows.
`irlume-core` checks clean against the new pin, so no hardware
re-validation is needed.

Also corrects three stale details in the Cargo.toml fork comment:
- PR #530 flushes the session at three call sites (`execute_with_nullauth_session`, `load_ak`, `create_ak_2`), not one.
- Issue #495 open since Feb 2024, latest alpha `8.0.0-alpha.2` (Feb 2026).
- `optional_session_1` documented as the deliberate 7.7.0-consistent choice.

The fork side (branch `irlume-patches`) now carries a README fork note, a
3-job guard workflow (scope-check, MSRV compile, retirement-watch), and
modernized inherited CI; the guard workflow passed on `7567f60`.
