### PR TITLE
chore: remove em-dashes from prose (no-slop)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,21 +2,21 @@
 #
 # Hardware acceleration has two layers:
 #
-#   1. ONNX Runtime execution provider — the big win (this is what howrs does).
+#   1. ONNX Runtime execution provider: the big win (this is what howrs does).
 #      Pick at build time via cargo features on irlume-vision:
 #          cargo build -p irlume-daemon --features irlume-vision/cuda
 #          ... or openvino | coreml | tensorrt
 #      Default is CPU (ONNX Runtime's own SIMD + thread pool). Most of the
 #      compute lives here, not in our Rust code.
 #
-#   2. Our glue loops (alignment warp, cosine fold) — let LLVM vectorize them.
+#   2. Our glue loops (alignment warp, cosine fold): let LLVM vectorize them.
 #      Uncomment ONE block below for the machine you build for. Leave commented
 #      for portable / distro binaries (the default target is a safe floor).
 #
-# Portable AVX2 floor (Haswell+, ~2013 onward) — matches howrs's recommendation:
+# Portable AVX2 floor (Haswell+, ~2013 onward), matches howrs's recommendation:
 # [build]
 # rustflags = ["-C", "target-cpu=x86-64-v2", "-C", "target-feature=+avx2,+fma"]
 #
-# Native (fastest, NON-portable — only for binaries you build and run yourself):
+# Native (fastest, NON-portable, only for binaries you build and run yourself):
 # [build]
 # rustflags = ["-C", "target-cpu=native"]

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
-# Commits that ONLY reformat code (no logic changes) — skipped by `git blame`
+# Commits that ONLY reformat code (no logic changes), skipped by `git blame`
 # so blame points at the real author of each line, not the formatting sweep.
 #
 # Enable locally once:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,5 @@
 # Packit: build irlume RPMs in Copr from signed GitHub tags (the linhello
-# pipeline). Models are Git LFS — Copr's srpm build must pull them.
+# pipeline). Models are Git LFS; Copr's srpm build must pull them.
 specfile_path: packaging/fedora/irlume.spec
 upstream_package_name: irlume
 downstream_package_name: irlume
@@ -20,12 +20,12 @@ jobs:
     owner: archledger
     project: irlume
     # Packit submits builds with networking OFF regardless of the Copr
-    # project's own enable_net setting — cargo needs crates.io in %build.
+    # project's own enable_net setting; cargo needs crates.io in %build.
     enable_net: true
     targets:
       - fedora-stable
       - fedora-rawhide
-    # onnxruntime is bundled in the RPM (Source1) — no external Copr needed.
+    # onnxruntime is bundled in the RPM (Source1); no external Copr needed.
 
   - job: copr_build
     trigger: pull_request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [0.2.0] - 2026-07-15
 
-> **⚠ Breaking — re-enroll needed for dark/dim login.** This release removes the
+> **⚠ Breaking: re-enroll needed for dark/dim login.** This release removes the
 > IR adapter (see Removed). Face profiles enrolled under 0.1.x have IR templates
 > in the old adapter's embedding space, which no longer matches. **Bright-light
 > (RGB) face login keeps working**, and any mismatch falls back to your password
@@ -189,7 +189,7 @@ All notable changes to irlume are documented here. This project adheres to
 - **Presence grace window after the consent gesture.** After the blank-Enter
   gesture, capture retries while no usable face is in frame so walking up or
   settling still authenticates: ~15s for login/lock, ~5s for `sudo`/`su`
-  (`IRLUME_GRACE_MS` overrides). Only presence-class failures retry — never a
+  (`IRLUME_GRACE_MS` overrides). Only presence-class failures retry, never a
   below-threshold match (FAR-neutral by construction).
 - **IR-template embedding-space tagging** so a future adapter swap/removal fails
   loud ("re-enroll") instead of scoring across embedding spaces.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# irlume — Linux face authentication (PAM), successor to linhello.
+# irlume: Linux face authentication (PAM), successor to linhello.
 # irlume = IR (infrared) + lume (illumination).
 [workspace]
 resolver = "2"
@@ -27,7 +27,7 @@ repository = "https://github.com/archledger/irlume"
 authors = ["archledger <archledger236@gmail.com>"]
 
 # Shared dependency versions. Heavy/native deps are listed but commented so the
-# scaffold compiles offline as pure stubs — uncomment per crate as you implement.
+# scaffold compiles offline as pure stubs; uncomment per crate as you implement.
 [workspace.dependencies]
 irlume-common   = { path = "crates/irlume-common" }
 irlume-camera   = { path = "crates/irlume-camera" }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Built to match or beat Windows Hello, on a fully open, commercially clean stack.
 |---|---|
 | 🌑 **Works in the dark** | Active **infrared** recognition (Windows-Hello cameras); no ambient light needed. |
 | 🔒 **Unlocks everything** | Login greeter, lock screen, and `sudo` (opt-in via `login enable --with-sudo`), with the password always as fallback (**no lockout, ever**). |
-| 🙋 **On-demand, by consent** | The camera fires only when you ask: leave the password field **empty and press Enter**. Typing a password never starts a scan. A **grace window** after the gesture (~15 s at login/lock, ~5 s for `sudo`) keeps retrying while you settle into frame — but never retries a failed match. Wiring is tailored per login manager (GDM · SDDM · Plasma Login · LightDM · greetd · COSMIC). |
+| 🙋 **On-demand, by consent** | The camera fires only when you ask: leave the password field **empty and press Enter**. Typing a password never starts a scan. A **grace window** after the gesture (~15 s at login/lock, ~5 s for `sudo`) keeps retrying while you settle into frame, but never retries a failed match. Wiring is tailored per login manager (GDM · SDDM · Plasma Login · LightDM · greetd · COSMIC). |
 | 🗝️ **Opens your keyring** | On IR hardware a face match **TPM-unseals your login password** so the wallet unlocks at login, like Hello. |
 | 👁️ **Real liveness** | Algorithmic IR anti-spoof gate + **opt-in passive blink** detection (no prompt, no action). |
 | 🧬 **No face images stored** | Stores **512-D embeddings, never images**; on TPM hardware they're **AES-256-GCM encrypted** under a **TPM-sealed** key (without a TPM: root-only files, and the TUI says so). |
@@ -213,7 +213,7 @@ GPLv3-compatible, so the whole thing is bundleable:
 | Recognition | **AuraFace** *(512-D ArcFace)* | Apache-2.0 |
 | IR liveness gate | self-built, algorithmic *(no weights)* | n/a |
 | Passive blink liveness + rescue alignment | **MediaPipe FaceMesh** *(478-pt)* → eye-aspect-ratio *(opt-in)* | Apache-2.0 |
-| IR domain match | raw AuraFace + **per-enrollment on-device calibration** *(fitted from your own scans; no third-party data — [ADR-0004](docs/adr/0004-per-enrollment-ir-adapter.md))* | n/a |
+| IR domain match | raw AuraFace + **per-enrollment on-device calibration** *(fitted from your own scans; no third-party data, [ADR-0004](docs/adr/0004-per-enrollment-ir-adapter.md))* | n/a |
 
 More depth: [Architecture](docs/ARCHITECTURE.md) · [Threat model](docs/THREAT_MODEL.md) · [Standards mapping](docs/STANDARDS.md) · [Cross-distro notes](docs/cross-distro/).
 
@@ -253,11 +253,11 @@ The current gaps:
   shape from the IR emitter's light; when the scene's own infrared floods it, no
   shape signal is left, and a genuine face is rejected to the password. Measured
   in a 430-sample field session (2026-07-16, cloudy-bright sky): reliable below
-  ambient ~120 on the 0-255 IR scale (indoors, inside vehicles, shade — a closed
+  ambient ~120 on the 0-255 IR scale (indoors, inside vehicles, shade, a closed
   car with 20% tint passed 99/99), marginal to ~170, and 0/129 genuine samples
   passed above ~170 (open sky or sun behind the user; the emitter's contribution
   fell to noise and 46-82% of the IR frame was saturated). irlume can't tell sky
-  from a bright lamp — both are just infrared — so the rejection names the
+  from a bright lamp (both are just infrared), so the rejection names the
   condition and the fix: turn away from the light, or type the password.
 - **Not lab-certified.** We self-test against ISO/IEC 30107-3; there's no paid iBeta
   pass. Demographic FMR tuning ([FAIRNESS.md](docs/FAIRNESS.md)) is ongoing.
@@ -416,7 +416,7 @@ path.
 plus per-enrollment on-device calibration (no bundled weights). It also adds a BlazeFace
 detection-rescue cascade (outdoor detection 76.9% → 98.5%), the 478-point FaceLandmarker
 mesh, and a presence grace window after the consent gesture. Upgrading from 0.1.x needs a
-one-time re-enroll for dark/dim login — bright-light login and the password are unaffected.
+one-time re-enroll for dark/dim login; bright-light login and the password are unaffected.
 Every accuracy figure is reproducible from [`benchmarks/`](benchmarks/).
 
 0.2.1 makes that upgrade a one-step affair: `irlume enroll` now adds the fresh scans to

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,4 +1,4 @@
-# Benchmarks — how the accuracy numbers were measured
+# Benchmarks: how the accuracy numbers were measured
 
 Every model-accuracy figure in the README, `models/README.md`, the CHANGELOG,
 and the release notes is produced by the scripts in this directory, on public
@@ -6,7 +6,7 @@ datasets, with the exact protocols documented below. The raw result files are
 committed here as `results-*.json` / `results-*.log` so the numbers can be read
 without re-running anything, and reproduced from scratch if you don't trust them.
 
-Nothing here runs inside the daemon or ships in a package — these are offline
+Nothing here runs inside the daemon or ships in a package; these are offline
 measurement scripts. They open ONNX models directly (the same weights irlume
 ships) and score them against face datasets.
 
@@ -30,7 +30,7 @@ it. CPU runs give the same accuracy (only latency differs).
 | Oulu-CASIA NIR | near-infrared faces, multiple illuminations | Oulu-CASIA NIR-VIS academic release | research only |
 | Tufts Face | paired RGB + NIR (thermal/near-IR), many subjects | [tdface.ece.tufts.edu](http://tdface.ece.tufts.edu/) | research use |
 
-CBSR and Oulu are the datasets the removed IR adapter was trained on — that is
+CBSR and Oulu are the datasets the removed IR adapter was trained on; that is
 exactly why an adapter result on them (e.g. CBSR) is an in-training-set number,
 not a generalization claim. Tufts is never used for training, so it is the clean
 "unseen faces" test. These license terms are also why irlume does not ship any
@@ -45,27 +45,27 @@ weights derived from these sets (see `models/README.md` and ADR-0004).
 | `bench_nir_ext.py` | `results-nir_results.json` | CBSR + Tufts NIR verification (6000 pairs each) and rank-1 identification; AuraFace vs buffalo vs AuraFace+adapter |
 | `bench_cascade.py` | `results-cascade.json`, `results-cascade.log` | Per-environment detection rate (YuNet vs BlazeFace vs cascade) and the 468-vs-478 mesh eye-NME |
 | `bench_mp_results` (via `bench_cascade.py`/mediapipe harness) | `results-mp_results.json` | Detector eye-NME and standalone 468-vs-478 landmarker NME |
-| `bench_insightface.py` | — | Full AuraFace-vs-InsightFace comparison across all sets |
-| `blaze_parity.py` | — | BlazeFace ONNX decode parity vs the official MediaPipe runtime (IoU, keypoint px error) |
+| `bench_insightface.py` | n/a | Full AuraFace-vs-InsightFace comparison across all sets |
+| `blaze_parity.py` | n/a | BlazeFace ONNX decode parity vs the official MediaPipe runtime (IoU, keypoint px error) |
 
 ## The headline numbers and where to read them
 
-- **LFW recognition — AuraFace 99.03% 10-fold accuracy** (`results-lfw-cascade.json`,
+- **LFW recognition: AuraFace 99.03% 10-fold accuracy** (`results-lfw-cascade.json`,
   `auraface.acc10fold`), EER 1.37%. The cascade fired 0 rescues on LFW
   (`blaze_rescues: 0` over 7701 detections), so easy detection is unchanged.
-  InsightFace buffalo scores 99.4% (`results-lfw.json`) — higher, but its weights
+  InsightFace buffalo scores 99.4% (`results-lfw.json`), higher, but its weights
   are non-commercial, which is why irlume ships AuraFace instead. This is a
   deliberate license-over-peak-accuracy tradeoff, stated plainly.
-- **IR adapter overfit — Tufts NIR→NIR EER 1.43% (raw) vs 1.53% (+v3 adapter)**
+- **IR adapter overfit: Tufts NIR→NIR EER 1.43% (raw) vs 1.53% (+v3 adapter)**
   (`results-nir_results.json`, `tufts.nir_nir`). On CBSR, the adapter's own
   training data, it instead improved (0.77% → 0.37%, `cbsr_nir`). Helping the
   training set while hurting unseen faces is why the global adapter was removed.
-- **Detection cascade — outdoor-walking frames 76.9% (YuNet) → 98.5% (cascade)**
+- **Detection cascade: outdoor-walking frames 76.9% (YuNet) → 98.5% (cascade)**
   (`results-cascade.json`, `outdoor-walking`, n=65). On shade-frontal, BlazeFace
   alone collapses to 40.3% where YuNet holds 99.2%, so BlazeFace is a rescue on a
   YuNet miss, never a replacement. The outdoor-walking sample is small (65 frames
   from one field session); treat it as directional, not a population estimate.
-- **Mesh landmarks — eye NME 0.0378 → 0.0273 (~28% lower)** for the 478-point
+- **Mesh landmarks: eye NME 0.0378 → 0.0273 (~28% lower)** for the 478-point
   256px FaceLandmarker vs the legacy 468-point 192px mesh, measured through
   irlume's own YuNet→crop pipeline on CBSR (`results-cascade.log`, `[mesh]` lines,
   n=985). The standalone MediaPipe-crop harness shows a smaller 0.0392 → 0.0345

--- a/crates/irlume-auth/examples/landmark_dump.rs
+++ b/crates/irlume-auth/examples/landmark_dump.rs
@@ -1,5 +1,5 @@
 //! Capture a raw IR strobe burst and dump, per frame, the FaceMesh landmark
-//! coordinates plus the IR brightness sampled at each landmark — the input a
+//! coordinates plus the IR brightness sampled at each landmark, the input a
 //! landmark-anchored relief prototype needs (nose vs cheek vs eye-socket
 //! response to the emitter), without writing the capture+detect+mesh glue.
 //!

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -169,7 +169,7 @@ struct IrMatch {
 /// IR matching across profiles, calibration-aware. Per profile: when a
 /// fitted calibration exists (and no global adapter is loaded), both the
 /// probe and that profile's templates are calibrated before scoring, and the
-/// calibrated template CENTROID is scored too — the mean-template protocol
+/// calibrated template CENTROID is scored too, the mean-template protocol
 /// the 2026-07-15 prototype validated at the BASE threshold (a single mean
 /// template carries no best-of-N FAR inflation).
 fn ir_match_in(
@@ -432,7 +432,7 @@ impl Engine {
     /// Detection rescue (cascade stage 2): when YuNet returns no face, try
     /// BlazeFace and refine its coarse box into the 5 alignment landmarks
     /// with FaceMesh (BlazeFace has no mouth corners and its eyes measured
-    /// 0.087 NME vs YuNet's 0.053 — never align from its own keypoints).
+    /// 0.087 NME vs YuNet's 0.053; never align from its own keypoints).
     /// Returns a Detection shaped exactly like YuNet's, or None when either
     /// optional model is absent or no face clears the threshold.
     fn rescue_detect(&mut self, view: &align::RgbView<'_>, tag: &str) -> Option<Detection> {
@@ -942,7 +942,7 @@ impl Engine {
     /// assessed or [`GRACE_WINDOW_MS`] elapses.
     ///
     /// SECURITY INVARIANT: only PRESENCE-class failures retry (no face found,
-    /// liveness Uncertain framing rejections — cases where no match verdict
+    /// liveness Uncertain framing rejections, cases where no match verdict
     /// was reached). A real match verdict below threshold never retries (each
     /// extra matcher attempt multiplies FAR), and a Spoof verdict never
     /// retries (no free attack retries). See [`presence_retryable`].
@@ -1453,7 +1453,7 @@ impl Engine {
 
     /// Enroll `want` scans (capped at MAX_SCANS_PER_PROFILE). If the captured
     /// face already owns a profile, the scans are merged into it (a face can
-    /// never own two profiles, so that is always what the user meant — and it
+    /// never own two profiles, so that is always what the user meant, and it
     /// is the 0.2.0 upgrade remedy, fresh scans reviving dark/dim login after
     /// an embedding-space change). A novel face gets a NEW profile; that errors
     /// if the account is already at MAX_PROFILES.
@@ -1902,7 +1902,7 @@ pub enum EnrollOutcome {
     /// A new face profile was created.
     New { name: String, scans: usize },
     /// The captured face already owned `name`, so the capture was added to that
-    /// profile instead — `added` new scans, `total` scans now — and the
+    /// profile instead (`added` new scans, `total` scans now) and the
     /// per-enrollment calibration was refitted. This is what makes `irlume
     /// enroll` idempotent for the same person: a face can never own two
     /// profiles, so merging is always what the user meant. It is also the
@@ -2248,7 +2248,7 @@ mod tests {
             ),
             false
         )));
-        // NEVER retryable: a real spoof verdict (flat/2D — free attack retries)...
+        // NEVER retryable: a real spoof verdict (flat/2D, free attack retries)...
         assert!(!presence_retryable(&denied(
             &format!("liveness {:?}: flat 2D surface", Verdict::Spoof),
             false

--- a/crates/irlume-cli/Cargo.toml
+++ b/crates/irlume-cli/Cargo.toml
@@ -22,4 +22,4 @@ serde_json.workspace = true
 libc.workspace = true   # restore default SIGPIPE so `irlume … | head` doesn't panic
 image = { workspace = true }
 rpassword = "7"   # no-echo password prompt for `keyring arm`
-ratatui = "0.30"  # TUI (MIT) — bundles crossterm; powers `irlume tui`
+ratatui = "0.30"  # TUI (MIT), bundles crossterm; powers `irlume tui`

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
     // det/model/mesh/blaze ship with every package, so a missing one is a broken
     // install (IRLUME_MODELS_STRICT rightly refuses). The IR adapter is optional
     // (none ships since ADR-0004; user supplies their own via IRLUME_IR_ADAPTER),
-    // so only verify it when it is actually present — otherwise strict mode would
+    // so only verify it when it is actually present; otherwise strict mode would
     // refuse to start on a normal install that never had an adapter.
     let mut to_verify: Vec<&str> = vec![&det, &model, &mesh, &blaze];
     if std::path::Path::new(&adapter).exists() {
@@ -111,7 +111,7 @@ fn main() {
     // a restart gets a dark IR frame and fails (exactly the "worked at enroll,
     // failed at the lock screen" case). ensure_ir_emitter fires the known
     // control (env/conf/table) and, only if IR is still dark, runs auto-setup
-    // and persists what it finds to ir_emitter.conf — so every later capture,
+    // and persists what it finds to ir_emitter.conf, so every later capture,
     // and every later boot, applies it. No-op on RGB-only hardware; best-effort.
     if std::path::Path::new(&ir_dev).exists() {
         match irlume_auth::ensure_ir_emitter(&ir_dev) {

--- a/crates/irlume-fingerprint/Cargo.toml
+++ b/crates/irlume-fingerprint/Cargo.toml
@@ -7,5 +7,5 @@ license.workspace = true
 
 [dependencies]
 # Detection/enroll-orchestration only: drives fprintd's CLI tools via
-# std::process. No deps — verification is done by pam_fprintd in the PAM stack,
+# std::process. No deps; verification is done by pam_fprintd in the PAM stack,
 # not here, so irlume never claims the sensor and coexists with the greeter.

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -533,7 +533,7 @@ mod onnx {
     /// BlazeFace short-range (Apache-2.0, Google MediaPipe): RESCUE detector
     /// for frames YuNet loses. Benchmarked 2026-07-15 on the sunlight field
     /// bursts: 96.9% detection on saturated outdoor-walking frames where
-    /// YuNet manages 76.9% — but only 40% on shaded faces where YuNet holds
+    /// YuNet manages 76.9%, but only 40% on shaded faces where YuNet holds
     /// 99%, and its eye keypoints are coarser (NME 0.087 vs 0.053). It
     /// therefore NEVER replaces YuNet: it runs only when YuNet returns no
     /// face, and its box must be refined by FaceMesh before alignment.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # Architecture
 
-- [Privilege separation](#privilege-separation) — who is trusted, and the one
+- [Privilege separation](#privilege-separation): who is trusted, and the one
   socket everything crosses
-- [Authentication flow](#authentication-flow) — what happens on a login attempt
-- [Model stack](#model-stack) — the four ONNX models, and what is deliberately
+- [Authentication flow](#authentication-flow): what happens on a login attempt
+- [Model stack](#model-stack): the four ONNX models, and what is deliberately
   not a model
 - [IR capture: strobe and ambient subtraction](#ir-capture-strobe-and-ambient-subtraction)
-- [Face login → keyring unlock](#face-login--keyring-unlock) — the
+- [Face login → keyring unlock](#face-login--keyring-unlock): the
   TPM-sealed-password path
 - [Why these choices](#why-these-choices)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -206,7 +206,7 @@ The `irlume-auth` examples load ONNX models, so they need `ORT_DYLIB_PATH`
 set (see the ONNX runtime section above; on an installed Fedora/RPM box,
 `/usr/share/irlume/onnxruntime/lib/libonnxruntime.so` works, on a Debian/PPA
 box `/opt/irlume/onnxruntime/lib/libonnxruntime.so.1.24.4`). Without it the
-process hangs instead of erroring — an upstream `ort` bug where building the
+process hangs instead of erroring: an upstream `ort` bug where building the
 load-failure message re-enters the API lock being initialized.
 
 ### Using landmark_dump
@@ -223,15 +223,15 @@ Look at the camera; a 36-frame burst takes about 2.5 s. The IR node is the
 V4L2 device that lists a `GREY` format (`v4l2-ctl -d /dev/videoN
 --list-formats`). `out/` then holds:
 
-- `frameNN.pgm` — the raw IR frame. PGM is plain grayscale: a `P5` text
+- `frameNN.pgm`: the raw IR frame. PGM is plain grayscale: a `P5` text
   header (width, height, 255) followed by one byte per pixel. Any image
   viewer opens it and numpy reads it without a decoder.
-- `frameNN.landmarks.csv` — `idx,x,y,brightness` for the 478 FaceMesh
+- `frameNN.landmarks.csv`: `idx,x,y,brightness` for the 478 FaceMesh
   points, written only for frames where a face was detected. `brightness`
   is the mean of the 3x3 pixel patch centered on the landmark; coordinates
   carry full f32 precision, so re-sampling the PGM at `(x, y)` reproduces
   the CSV value exactly.
-- `index.txt` — one line per frame: index, frame mean, ms since the first
+- `index.txt`: one line per frame: index, frame mean, ms since the first
   frame, detection score and bbox (`- -` when no face).
 
 On a strobing emitter, alternate frames are emitter-off (near-black indoors,

--- a/docs/PAD_SELFTEST.md
+++ b/docs/PAD_SELFTEST.md
@@ -5,7 +5,7 @@ gate (`irlume_liveness::LivenessGate`)
 
 This document defines how irlume's presentation-attack-detection (PAD) gate is
 self-tested against the methodology of **ISO/IEC 30107-3** (*Biometric presentation
-attack detection — Part 3: Testing and reporting*). It is the reference the
+attack detection, Part 3: Testing and reporting*). It is the reference the
 `CONTRIBUTING.md` mandate points at ("Liveness/PAD changes should come with a
 self-test against the relevant ISO/IEC 30107-3 attack class") and the concrete
 form of the "self-test against ISO/IEC 30107-3 attack classes" milestone named in
@@ -223,7 +223,7 @@ can be inspected to tune the exact constant responsible.
 
 ## 8. References
 
-- ISO/IEC 30107-3:2023, *Biometric presentation attack detection — Part 3: Testing
+- ISO/IEC 30107-3:2023, *Biometric presentation attack detection, Part 3: Testing
   and reporting* (APCER / BPCER / non-response definitions).
 - iBeta / ISO 30107-3 PAD test methodology (protocol shape: 150 PA + ~50 BF per PAI
   species; Level 1 = 2D, Level 2 = 3D).

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -142,7 +142,7 @@ cascade's 76.9% → 98.5% outdoor rescue, the 478-point mesh's 28% eye-NME gain)
 
 The scripts that produced every one of these live in
 [`../benchmarks/`](../benchmarks/), and the raw result files are committed beside
-them (`results-*.json` / `.log`) — read them directly, or reproduce from scratch
+them (`results-*.json` / `.log`); read them directly, or reproduce from scratch
 on the public datasets (LFW, CBSR NIR, Oulu-CASIA NIR, Tufts Face). Datasets,
 exact protocols, the runtime, and the honest caveats (small outdoor sample;
 InsightFace's non-commercial recognizer beats the permissive one irlume ships)

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -8,7 +8,7 @@ url="https://github.com/archledger/irlume"
 license=('GPL-3.0-or-later')
 # Arch ships onnxruntime 1.24+ but SPLIT into onnxruntime-cpu / -cuda / -rocm,
 # each Provides=onnxruntime. Depend on the virtual 'onnxruntime' so any variant
-# the user has satisfies it (no conflict); a fresh install prompts to pick one —
+# the user has satisfies it (no conflict); a fresh install prompts to pick one,
 # choose onnxruntime-cpu unless you want GPU execution providers.
 depends=('onnxruntime' 'tpm2-tss' 'pam')
 optdepends=('fprintd: fingerprint companion factor')
@@ -16,7 +16,7 @@ optdepends=('fprintd: fingerprint companion factor')
 # libclang at build time; without it makepkg fails on a clean system.
 makedepends=('rust' 'cargo' 'gcc' 'clang' 'git-lfs')
 # Models ride in the tag via Git LFS. GitHub's auto-generated tag tarballs do
-# NOT include LFS objects (they ship 131-byte pointer stubs) — that is exactly
+# NOT include LFS objects (they ship 131-byte pointer stubs); that is exactly
 # why this PKGBUILD clones the git tag and runs `git lfs pull` instead of using
 # the tarball. Do not "simplify" to the archive URL.
 source=("git+https://github.com/archledger/irlume.git#tag=v${pkgver}")

--- a/packaging/arch/build-pkg.sh
+++ b/packaging/arch/build-pkg.sh
@@ -5,7 +5,7 @@
 # an Arch box:  bash packaging/arch/build-pkg.sh
 #
 # Unlike the AUR PKGBUILD (which fetches the git tag), this packages the
-# already-built binaries + LFS models in place — no network source.
+# already-built binaries + LFS models in place; no network source.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -19,7 +19,7 @@ command -v makepkg >/dev/null || { echo "run on Arch (needs makepkg)"; exit 1; }
 # already present as real files.
 git lfs pull 2>/dev/null || true
 [ "$(stat -c%s models/glintr100.onnx 2>/dev/null || echo 0)" -gt 1000000 ] \
-  || { echo "models/glintr100.onnx missing/pointer — run 'git lfs pull' first"; exit 1; }
+  || { echo "models/glintr100.onnx missing/pointer; run 'git lfs pull' first"; exit 1; }
 cargo build --release --locked 2>/dev/null || cargo build --release
 
 rm -rf "$BUILD"; mkdir -p "$BUILD"

--- a/packaging/debian/build-deb-container.sh
+++ b/packaging/debian/build-deb-container.sh
@@ -29,7 +29,7 @@ command -v podman >/dev/null || { echo "need podman"; exit 1; }
 # Models must be real weights, not LFS pointer stubs (bundled into the .deb).
 for m in "$REPO"/models/*.onnx; do
     if [ "$(stat -c%s "$m")" -lt 1000000 ] && grep -q git-lfs "$m" 2>/dev/null; then
-        echo "$m is an LFS pointer — run: git lfs pull"; exit 1
+        echo "$m is an LFS pointer; run: git lfs pull"; exit 1
     fi
 done
 

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -47,7 +47,7 @@ EOF
 
 cd "$REPO/packaging/debian"
 # Name the artifact after the irlume version (from nfpm.yaml), NOT the bundled
-# onnxruntime version — irlume_1.24.4.deb read like irlume itself was 1.24.4.
+# onnxruntime version; irlume_1.24.4.deb read like irlume itself was 1.24.4.
 PKG_VER="$(sed -n 's/^version:[[:space:]]*v\{0,1\}\([0-9][^[:space:]]*\).*/\1/p' nfpm.yaml)"
 nfpm package --packager deb --target "$REPO/irlume_${PKG_VER}_amd64.deb"
 echo "built irlume_${PKG_VER}_amd64.deb in $REPO"

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -16,5 +16,5 @@ irlume installed. Next steps:
   sudo irlume login enable --apply   # opt-in: wire greeter/lock screen
 (enrollment auto-enables the 850nm IR emitter when IR frames are black;
  manual fallback for IR cameras: sudo irlume ir-setup)
-Password is always the fallback — no lockout.
+Password is always the fallback; no lockout.
 EOF

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -37,19 +37,19 @@ Requires:       pam
 Requires:       tpm2-tss
 Recommends:     fprintd
 # Fedora enforces SELinux by default and the greeter can't reach the daemon
-# without the policy module — pull the subpackage in by default (weak dep, so
+# without the policy module; pull the subpackage in by default (weak dep, so
 # SELinux-disabled installs can still skip it).
 Recommends:     %{name}-selinux = %{version}-%{release}
 %{?systemd_requires}
 
 %description
 irlume authenticates you to Linux by your face with whatever camera the
-machine has: an infrared (Windows Hello) camera enables the secure tier —
-login, sudo, and TPM-sealed keyring unlock with algorithmic IR liveness —
+machine has: an infrared (Windows Hello) camera enables the secure tier
+(login, sudo, and TPM-sealed keyring unlock with algorithmic IR liveness)
 while a regular RGB webcam enables convenient screen unlock, and a
 fingerprint reader can join as a companion factor. A thin PAM module talks
 to a privileged daemon that owns the camera and runs a clean-license model
-stack (YuNet + AuraFace). Password is always the fallback — no lockout.
+stack (YuNet + AuraFace). Password is always the fallback; no lockout.
 
 %package selinux
 Summary:        SELinux policy module for irlume
@@ -87,7 +87,7 @@ install -d %{buildroot}%{_datadir}/%{name}/onnxruntime/lib
 cp -a onnxruntime-linux-x64-%{ort_ver}/lib/libonnxruntime.so* %{buildroot}%{_datadir}/%{name}/onnxruntime/lib/
 install -Dm0644 packaging/fedora/10-ort.conf %{buildroot}%{_unitdir}/irlumed.service.d/10-ort.conf
 install -Dm0644 packaging/selinux/irlume.pp %{buildroot}%{_datadir}/selinux/packages/irlume.pp
-# Preset: the daemon is enabled on install (see %%post) — it only serves a local
+# Preset: the daemon is enabled on install (see %%post); it only serves a local
 # socket and auth stays opt-in, so "installed" should mean "works".
 install -Dm0644 packaging/fedora/90-irlume.preset %{buildroot}%{_presetdir}/90-irlume.preset
 
@@ -99,7 +99,7 @@ install -Dm0644 packaging/fedora/90-irlume.preset %{buildroot}%{_presetdir}/90-i
 if [ $1 -eq 1 ]; then
     systemctl start irlumed.service &>/dev/null || :
 fi
-# PAM wiring is opt-in (irlume login enable) — never auto-wire auth on install.
+# PAM wiring is opt-in (irlume login enable); never auto-wire auth on install.
 # Upgrade from a version that shipped the IR adapter (< 0.2.0): dark/dim IR
 # login needs a re-enroll (RGB login keeps working). Bright-line the notice.
 if [ $1 -gt 1 ]; then
@@ -117,7 +117,7 @@ fi
 %post selinux
 semodule -i %{_datadir}/selinux/packages/irlume.pp 2>/dev/null || :
 # The daemon (started by the main package's %%post, same transaction) bound its
-# socket before the policy existed — restart so the socket gets its label and
+# socket before the policy existed; restart so the socket gets its label and
 # the confined greeter can actually connect. The restorecon is the backstop:
 # with rpm's SELinux plugin the policy commit can land after the restarted
 # daemon's bind, leaving the socket var_run_t (observed live on fc44); the

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -14,7 +14,7 @@ override_dh_auto_build:
 	# --offline: use only the vendored crates (Launchpad builders have no net).
 	# NB: the PPA targets only the current Ubuntu LTS, whose cargo reads the
 	# format-v4 lock fine. (Older LTSs like noble ship cargo 1.75, which can't
-	# parse v4 AND can't compile our ort/edition-2024 deps anyway — those users
+	# parse v4 AND can't compile our ort/edition-2024 deps anyway; those users
 	# get the universal .deb from the GitHub release, not the PPA.)
 	cargo build --release --frozen --offline
 
@@ -26,7 +26,7 @@ override_dh_auto_clean:
 
 # dh_clean's default cruft sweep deletes *.orig / *~ recursively, which
 # nukes vendored files (vendor/*/Cargo.toml.orig) that cargo's checksum
-# manifests require — cargo --frozen then fails on the builder.
+# manifests require; cargo --frozen then fails on the builder.
 override_dh_clean:
 	dh_clean -Xvendor/
 

--- a/packaging/selinux/irlume.fc
+++ b/packaging/selinux/irlume.fc
@@ -1,4 +1,4 @@
-# /run/irlume.sock — the irlumed listener. Normally labeled at create time by
+# /run/irlume.sock: the irlumed listener. Normally labeled at create time by
 # the named type_transition in irlume.te; this spec makes restorecon agree, so
 # the %post/`login enable` restorecon (and any full relabel) can fix a socket
 # created before the module was loaded (e.g. mid-transaction at package

--- a/packaging/selinux/irlume.te
+++ b/packaging/selinux/irlume.te
@@ -2,13 +2,13 @@ policy_module(irlume, 1.0.0)
 
 ########################################
 #
-# irlume — let confined login/display-manager domains reach the irlumed socket.
+# irlume: let confined login/display-manager domains reach the irlumed socket.
 #
 # irlumed runs as `unconfined_service_t` (a plain systemd service with no
 # custom domain) and binds /run/irlume.sock. The display manager / greeter
 # (plasmalogin, gdm, sddm) runs CONFINED as `xdm_t`, so on a real graphical
 # login SELinux denies it write/connect access to the socket and pam_irlume
-# silently falls through to the password — face login never engages.
+# silently falls through to the password; face login never engages.
 #
 #   avc: denied { write } ... comm="plasmalogin-hel" name="irlume.sock"
 #        scontext=...:xdm_t tcontext=...:var_run_t tclass=sock_file

--- a/scripts/build-ppa-source.sh
+++ b/scripts/build-ppa-source.sh
@@ -10,7 +10,7 @@
 # The PPA targets ONLY the current Ubuntu LTS (its cargo is new enough for our
 # ort/edition-2024 deps). Older LTSs like noble (24.04, cargo 1.75) can't build
 # irlume at all, so their derivatives (Mint, Pop!_OS, Zorin, elementary) use the
-# universal .deb from the GitHub release instead — built on the oldest supported
+# universal .deb from the GitHub release instead; built on the oldest supported
 # base + rustup in a container (see the noble-container build). Build + upload
 # just the current series:
 #   SERIES=resolute bash scripts/build-ppa-source.sh
@@ -70,11 +70,11 @@ if [ "${SKIP_BUILD_CHECK:-0}" != "1" ]; then
     rm -rf "$TREE/.cargo-home-check" "$TREE/target"
 fi
 
-echo "==> creating orig tarball (deterministic — same bytes for every series)"
+echo "==> creating orig tarball (deterministic, same bytes for every series)"
 cd "$BUILDROOT"
 rm -f "irlume_${VERSION}.orig.tar.gz"
 # If more than one Ubuntu series is ever uploaded for the same upstream version,
-# Launchpad keeps one orig tarball per version — a second upload with a different
+# Launchpad keeps one orig tarball per version; a second upload with a different
 # checksum is rejected ("already exists with different contents"). So
 # pack reproducibly: fixed mtime/owner, sorted names, gzip without a timestamp,
 # so every series build yields a byte-identical orig. mtime = the release tag's

--- a/scripts/deploy-keyring-unlock.sh
+++ b/scripts/deploy-keyring-unlock.sh
@@ -7,7 +7,7 @@
 # FAIL-SAFE BY DESIGN: every face line is `[success=1 default=ignore]` or
 # `sufficient`, so if the daemon/TPM/face/camera ever fails, login, lock, and
 # wallet all fall through to the password exactly as today. The password is
-# always the floor — this cannot lock you out.
+# always the floor; this cannot lock you out.
 #
 # Run as root:  sudo bash scripts/deploy-keyring-unlock.sh
 # Revert:       sudo bash scripts/deploy-keyring-unlock.sh --revert
@@ -16,7 +16,7 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PAM_GREETER="/etc/pam.d/plasmalogin"
 VENDOR_GREETER="/usr/lib/pam.d/plasmalogin"
-MARKER="# irlume: face-unlock wiring — delete this file to restore the vendor copy"
+MARKER="# irlume: face-unlock wiring; delete this file to restore the vendor copy"
 
 # KDE lock screen rides the non-interactive `kde-fingerprint` parallel stack
 # (kscreenlocker starts it the moment the screen appears) so face unlock needs
@@ -35,7 +35,7 @@ if [[ "${1:-}" == "--revert" ]]; then
         rm -f "$PAM_GREETER"
         echo "[revert] removed $PAM_GREETER (vendor $VENDOR_GREETER is authoritative again)"
     else
-        echo "[revert] no irlume-managed $PAM_GREETER found — nothing to undo"
+        echo "[revert] no irlume-managed $PAM_GREETER found; nothing to undo"
     fi
     echo "[revert] unwiring lock screen ($PAM_LOCK)"
     if [[ -f "$LOCK_BACKUP" ]]; then
@@ -45,7 +45,7 @@ if [[ "${1:-}" == "--revert" ]]; then
         grep -v "pam_irlume.so" "$PAM_LOCK" > "${PAM_LOCK}.tmp" && mv "${PAM_LOCK}.tmp" "$PAM_LOCK"
         echo "[revert] stripped pam_irlume line from $PAM_LOCK"
     else
-        echo "[revert] no irlume line in $PAM_LOCK — nothing to undo"
+        echo "[revert] no irlume line in $PAM_LOCK; nothing to undo"
     fi
     echo "[revert] removing SELinux module"
     semodule -r irlume 2>/dev/null && echo "[revert] removed SELinux module 'irlume'" || echo "[revert] no SELinux module 'irlume'"
@@ -81,7 +81,7 @@ echo "    socket label: $(ls -Z /run/irlume.sock 2>/dev/null | awk '{print $1}')
 
 echo "=== 4/5 wire plasmalogin greeter (face → KWallet unlock) ==="
 if [[ -f "$PAM_GREETER" ]] && grep -q "pam_irlume.so unseal" "$PAM_GREETER"; then
-    echo "    already wired — skipping"
+    echo "    already wired; skipping"
 else
     {
         echo "$MARKER"
@@ -123,9 +123,9 @@ fi
 
 echo "=== 5/5 wire KDE lock screen (kde-fingerprint, continuous-scan) ==="
 if [[ ! -f "$PAM_LOCK" ]]; then
-    echo "    $PAM_LOCK not present — skipping (no kscreenlocker fingerprint stack)"
+    echo "    $PAM_LOCK not present; skipping (no kscreenlocker fingerprint stack)"
 elif grep -q "pam_irlume.so" "$PAM_LOCK"; then
-    echo "    already wired — skipping"
+    echo "    already wired; skipping"
 else
     [[ -f "$LOCK_BACKUP" ]] || cp -a "$PAM_LOCK" "$LOCK_BACKUP"
     # Insert our line before the first auth directive (linhello pattern).
@@ -142,7 +142,7 @@ echo
 echo "=== DONE. Next (you, interactively): ==="
 echo "  1. Arm your REAL login password:   irlume keyring arm   (skip if already armed)"
 echo "  2. Confirm:                         irlume keyring status"
-echo "  3. Lock the screen (Super+L), wait, look at the camera — it should unlock."
+echo "  3. Lock the screen (Super+L), wait, look at the camera; it should unlock."
 echo "  4. Log out, then face-login and check the wallet opens with NO password prompt."
 echo "  5. Reboot and repeat 4 (the real cold-boot test)."
 echo

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Install the irlume daemon + CLI on this host from a built repo checkout.
-# Cross-distro (Fedora/Arch/Debian-family): binaries + systemd unit only — PAM
+# Cross-distro (Fedora/Arch/Debian-family): binaries + systemd unit only; PAM
 # wiring is a separate, distro-specific step. Run as root from the repo root:
 #   sudo bash scripts/install-host.sh --ort /path/to/libonnxruntime.so
 set -euo pipefail
@@ -16,7 +16,7 @@ done
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 for b in irlumed irlume; do
-    [[ -f "$REPO/target/release/$b" ]] || { echo "missing $REPO/target/release/$b — build first" >&2; exit 1; }
+    [[ -f "$REPO/target/release/$b" ]] || { echo "missing $REPO/target/release/$b; build first" >&2; exit 1; }
 done
 for m in face_detection_yunet_2023mar.onnx glintr100.onnx face_landmark.onnx blaze_face_short_range.onnx; do
     [[ -f "$REPO/models/$m" ]] || { echo "missing $REPO/models/$m" >&2; exit 1; }


### PR DESCRIPTION
Repo-wide em-dash removal to satisfy the no-slop writing rule (em-dash is
banned). 82 occurrences across 29 files replaced with context-appropriate
punctuation, meaning preserved.

- Prose (README, docs, benchmarks, CHANGELOG, spec `%description`): semicolon,
  comma, colon, or parentheses per sentence.
- Rust files: only `///` and `//` comments changed; no code, identifiers, or
  format placeholders touched.
- Packaging/config (`.spec`, `PKGBUILD`, `nfpm`, `debian/rules`, `.te`/`.fc`,
  `.toml`, `.yaml`, scripts): only `#` comments changed; every directive,
  command, and policy rule is untouched.

Verified: `git grep '—'` returns zero (excluding `Cargo.lock` and the binary
model), `cargo fmt --check` clean, `cargo check --workspace` clean.
