### PR TITLE
test: regression tests for 26 previously-fixed bugs + ratchet to 33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
 
       - name: Coverage (fail under the ratchet floor)
-        run: cargo llvm-cov --workspace --locked --summary-only --fail-under-lines 25
+        run: cargo llvm-cov --workspace --locked --summary-only --fail-under-lines 33
 
   deny:
     name: cargo-deny (advisories · licenses · duplicate versions)

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1268,7 +1268,10 @@ SYSTEM INTEGRATION
 
 #[cfg(test)]
 mod origin_tests {
-    use super::{is_copr_repo, ubuntu_codename};
+    use super::{
+        gz_lists_irlume, installed_version, is_copr_repo, ppa_serves, ubuntu_codename,
+        InstallOrigin,
+    };
 
     #[test]
     fn copr_from_repo_matches_only_our_project() {
@@ -1294,5 +1297,135 @@ mod origin_tests {
         // Debian proper: PPAs don't apply.
         let debian = "ID=debian\nVERSION_CODENAME=trixie\n";
         assert_eq!(ubuntu_codename(debian), None);
+    }
+
+    /// gzip-compress `data` with the system gzip (the same tool the probe
+    /// decompresses with, so the round trip is faithful).
+    fn gzip_bytes(data: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+        let mut child = std::process::Command::new("gzip")
+            .arg("-c")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        child.stdin.take().unwrap().write_all(data).unwrap();
+        child.wait_with_output().unwrap().stdout
+    }
+
+    // Regression: e429106. ppa_serves probed the lingering dists Release file,
+    // which returns 200 long after a series' packages are deleted; the probe
+    // must key on an actual `Package: irlume` entry in the Packages index.
+    #[test]
+    fn gz_lists_irlume_needs_an_actual_package_entry() {
+        assert!(gz_lists_irlume(&gzip_bytes(
+            b"Package: irlume\nVersion: 0.2.1\nArchitecture: amd64\n"
+        )));
+        assert!(
+            !gz_lists_irlume(&gzip_bytes(b"")),
+            "an empty index is not served"
+        );
+        assert!(!gz_lists_irlume(&gzip_bytes(
+            b"Package: linhello\nVersion: 1.0\n"
+        )));
+        // A partial-name line must not count either (exact-line match).
+        assert!(!gz_lists_irlume(&gzip_bytes(b"Package: irlume-selinux\n")));
+        assert!(!gz_lists_irlume(b"definitely not gzip data"));
+    }
+
+    /// Drop a fake executable `name` into `dir` (a `#!/bin/sh` script).
+    fn fake_tool(dir: &std::path::Path, name: &str, body: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        let p = dir.join(name);
+        std::fs::write(&p, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    // Regression: 0a7ab5c + e429106 + ee54b23. One test so the PATH override
+    // is mutated in a single place: (a) installed_version must report the
+    // package manager's version, not this binary's compile-time one, on an
+    // overlaid install; (b) ppa_serves must be true only when the Packages
+    // index lists irlume, false on an empty index or HTTP 404; (c) a network
+    // failure must be None (unknown), never "not served".
+    #[test]
+    fn update_probes_query_the_package_manager_and_the_ppa_index() {
+        let dir = std::env::temp_dir().join(format!("irlume-cli-faketools-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        fake_tool(&dir, "rpm", "printf '9.9.9'");
+        fake_tool(
+            &dir,
+            "curl",
+            r#"case "$FAKE_CURL_MODE" in
+  serves) printf 'Package: irlume\nVersion: 9.9.9\n' | gzip -c; exit 0 ;;
+  empty) printf '' | gzip -c; exit 0 ;;
+  http404) exit 22 ;;
+  *) exit 7 ;;
+esac"#,
+        );
+        let old_path = std::env::var("PATH").unwrap();
+        std::env::set_var("PATH", format!("{}:{old_path}", dir.display()));
+
+        // (a) 0a7ab5c: the rpm-owned origins ask rpm, and its answer wins over
+        // the running binary's own version.
+        assert_eq!(installed_version(&InstallOrigin::Copr), "9.9.9");
+        assert_ne!(env!("CARGO_PKG_VERSION"), "9.9.9");
+        assert_eq!(
+            installed_version(&InstallOrigin::LocalRpm(String::new())),
+            "9.9.9"
+        );
+        // Source installs have no owning package; the binary's version is the
+        // documented fallback.
+        assert_eq!(
+            installed_version(&InstallOrigin::Source),
+            env!("CARGO_PKG_VERSION")
+        );
+
+        // (b) e429106: an index that lists irlume is served; a 200 with an
+        // empty index (the lingering-Release case) is NOT.
+        std::env::set_var("FAKE_CURL_MODE", "serves");
+        assert_eq!(ppa_serves("resolute"), Some(true));
+        std::env::set_var("FAKE_CURL_MODE", "empty");
+        assert_eq!(ppa_serves("noble"), Some(false));
+        // (b) a genuine HTTP 404 (curl -f exit 22) is "not served".
+        std::env::set_var("FAKE_CURL_MODE", "http404");
+        assert_eq!(ppa_serves("trusty"), Some(false));
+        // (c) ee54b23: offline / connect failure is unknown, never false.
+        std::env::set_var("FAKE_CURL_MODE", "offline");
+        assert_eq!(ppa_serves("resolute"), None);
+
+        std::env::remove_var("FAKE_CURL_MODE");
+        std::env::set_var("PATH", old_path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Regression: 40f0a4d. The pacman update arm pointed at the retired
+    // irlume-VERSION-1-arch.pkg.tar.zst release asset, which no release since
+    // 0.1.x attaches; the Arch channel is the AUR. The arm is println-only, so
+    // this pins the source text: the needles are assembled at runtime so the
+    // test's own source never satisfies (or trips) the checks.
+    #[test]
+    fn pacman_update_path_points_at_the_aur_not_the_retired_asset() {
+        let src = include_str!("commands.rs");
+        let aur_clone = format!("{}{}", "aur.archlinux.org/", "irlume.git");
+        assert!(
+            src.contains(&aur_clone),
+            "the AUR clone URL must be offered"
+        );
+        let aur_helper = format!("{} {}", "yay", "-Syu irlume");
+        assert!(
+            src.contains(&aur_helper),
+            "the AUR helper route must be offered"
+        );
+        let retired_asset = format!("irlume-{}-1-{}", "{ver}", "{pkg_arch}");
+        assert!(
+            !src.contains(&retired_asset),
+            "the retired .pkg.tar.zst release asset must not be referenced"
+        );
+        let pacman_u = format!("{} {}", "pacman", "-U");
+        assert!(
+            !src.contains(&pacman_u),
+            "no pacman local-file install of a downloaded asset"
+        );
     }
 }

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -502,10 +502,7 @@ fn act(enable: bool, apply: bool, with_sudo: bool) -> ExitCode {
     // A separate lock service (KDE `kde`) is a WARM screen unlock: the module
     // short-circuits (no `kr`), so the keyring (already open) isn't re-touched.
     do_svc(&LOCKSCREEN, &wire_lock, want_face_lock);
-    // face-sudo is opt-in on enable (--with-sudo), but disable must ALWAYS
-    // unwire it: "disable --apply undoes everything" is a documented promise,
-    // and a stale sudo line would point at a module the user may remove next.
-    if with_sudo || !enable {
+    if sudo_in_scope(enable, with_sudo) {
         match wire_service(
             &Svc {
                 etc: SUDO,
@@ -542,6 +539,15 @@ fn act(enable: bool, apply: bool, with_sudo: bool) -> ExitCode {
     } else {
         ExitCode::FAILURE
     }
+}
+
+/// Whether this invocation touches the sudo stack. face-sudo is opt-in on
+/// enable (--with-sudo), but disable must ALWAYS unwire it: "disable --apply
+/// undoes everything" is a documented promise, and a stale sudo line would
+/// point at a module the user may remove next. Kept as a named seam (not
+/// inline in `act`) so the promise stays unit-testable.
+fn sudo_in_scope(enable: bool, with_sudo: bool) -> bool {
+    with_sudo || !enable
 }
 
 /// Wire (or unwire) one service, choosing override-materialize vs edit-in-place.
@@ -1295,6 +1301,104 @@ mod tests {
         // fully reversible.
         let (back, undone) = unwire_lines(&w);
         assert!(undone && !content_has_module(&back));
+    }
+
+    // Regression: 0956be5. `login disable --apply` without --with-sudo left
+    // /etc/pam.d/sudo wired; disable must put sudo in scope regardless of the
+    // flag, while enable keeps face-sudo opt-in.
+    #[test]
+    fn disable_always_unwires_sudo_even_without_the_flag() {
+        assert!(sudo_in_scope(false, false)); // the bug: this used to be false
+        assert!(sudo_in_scope(false, true));
+        assert!(sudo_in_scope(true, true));
+        assert!(!sudo_in_scope(true, false)); // enable stays opt-in
+    }
+
+    // Regression: 7ec33fa. Arch/Plasma ships the locker service only in
+    // /usr/lib/pam.d, and LOCKSCREEN had vendor: None, so the lock screen was
+    // skipped entirely on the Arch layout. The vendor path is what lets
+    // wire_service materialize an /etc override from the vendor copy.
+    #[test]
+    fn kde_lock_service_carries_the_arch_vendor_path() {
+        assert_eq!(LOCKSCREEN.etc, "/etc/pam.d/kde");
+        assert_eq!(LOCKSCREEN.vendor, Some("/usr/lib/pam.d/kde"));
+    }
+
+    /// Self-cleaning scratch dir for the wire_service file tests.
+    struct TestDir(PathBuf);
+    impl TestDir {
+        fn new(tag: &str) -> Self {
+            let d =
+                std::env::temp_dir().join(format!("irlume-pamwire-{tag}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&d);
+            std::fs::create_dir_all(&d).unwrap();
+            TestDir(d)
+        }
+    }
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// `Svc.etc` is `&'static str`; leak the tempdir path to satisfy it.
+    fn leak(p: &Path) -> &'static str {
+        Box::leak(p.to_string_lossy().into_owned().into_boxed_str())
+    }
+
+    const SUDO_STOCK: &str = "#%PAM-1.0\nauth required pam_unix.so\nsession required pam_unix.so\n";
+
+    // Regression: 0be786b. disable restored the stale .pre-irlume backup,
+    // silently reverting admin PAM edits made after wiring (e.g. a faillock
+    // line added to sudo). When backup != current-minus-our-lines, the
+    // strip-in-place path must run: the foreign line survives, the irlume
+    // lines go, and the backup is kept for inspection.
+    #[test]
+    fn disable_strips_in_place_when_the_file_changed_after_wiring() {
+        let dir = TestDir::new("strip");
+        let (wired, changed) = wire_sudo(SUDO_STOCK);
+        assert!(changed);
+        let admin_line = "auth       required   pam_faillock.so preauth";
+        let current = format!("{wired}{admin_line}\n");
+        let etc = dir.0.join("sudo");
+        std::fs::write(&etc, &current).unwrap();
+        std::fs::write(dir.0.join(format!("sudo{BACKUP}")), SUDO_STOCK).unwrap();
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: None,
+        };
+        let msg = wire_service(&svc, false, true, &wire_sudo).unwrap();
+        assert!(msg.contains("stripped irlume lines"), "{msg}");
+        let after = std::fs::read_to_string(&etc).unwrap();
+        assert!(
+            after.contains(admin_line),
+            "admin's post-wiring line must survive disable, got:\n{after}"
+        );
+        assert!(!content_has_module(&after));
+        assert!(
+            dir.0.join(format!("sudo{BACKUP}")).exists(),
+            "backup must be kept for inspection"
+        );
+    }
+
+    // Companion to the strip-in-place case: when nothing changed since wiring
+    // (current minus our lines equals the backup), the backup-restore path is
+    // still the one taken and the backup is consumed.
+    #[test]
+    fn disable_restores_the_backup_when_nothing_else_changed() {
+        let dir = TestDir::new("restore");
+        let (wired, _) = wire_sudo(SUDO_STOCK);
+        let etc = dir.0.join("sudo");
+        std::fs::write(&etc, &wired).unwrap();
+        std::fs::write(dir.0.join(format!("sudo{BACKUP}")), SUDO_STOCK).unwrap();
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: None,
+        };
+        let msg = wire_service(&svc, false, true, &wire_sudo).unwrap();
+        assert!(msg.contains("restored from backup"), "{msg}");
+        assert_eq!(std::fs::read_to_string(&etc).unwrap(), SUDO_STOCK);
+        assert!(!dir.0.join(format!("sudo{BACKUP}")).exists());
     }
 
     #[test]

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3795,3 +3795,491 @@ fn enroll_worker(
     }
     let _ = send(WMsg::Done);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate process-global environment (IRLUME_SOCKET,
+    /// PATH) so they can't race each other under the parallel test runner.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// A bare App for tests: no hardware probes, no daemon socket, no terminal.
+    /// Mirrors `App::new()` but every probe-derived field is inert.
+    fn test_app() -> App {
+        let caps = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: false,
+        };
+        App {
+            user: "testuser".into(),
+            screen: SC_WELCOME,
+            sel: 0,
+            profiles: Vec::new(),
+            eyes_open: false,
+            challenge: false,
+            keyring_armed: None,
+            keyring_policy: None,
+            keyring_drift: None,
+            nodes: Vec::new(),
+            pairs: Vec::new(),
+            activity: Vec::new(),
+            input: None,
+            confirm: None,
+            op: None,
+            enroll: None,
+            enroll_merge: None,
+            fp: FpInfo::default(),
+            recovery: None,
+            suspend: None,
+            resume_enroll: None,
+            identify_result: None,
+            selftest_result: None,
+            repair: Vec::new(),
+            repair_sel: 0,
+            cam_sel: 0,
+            error: None,
+            daemon_up: false,
+            enroll_error: None,
+            health: None,
+            act_scroll: 0,
+            visible: App::compute_visible(&caps, false, false, false, &[]),
+            advanced: false,
+            caps,
+            fp_present: false,
+            spin: 0,
+            quit: false,
+        }
+    }
+
+    /// A running-op placeholder whose worker never answers (the receiver stays
+    /// empty). The sender is returned so the channel stays open for the test.
+    fn fake_op() -> (mpsc::Sender<(bool, String)>, Op) {
+        let (tx, rx) = mpsc::channel();
+        (
+            tx,
+            Op {
+                label: "Identify".into(),
+                tag: OpTag::Identify,
+                rx,
+            },
+        )
+    }
+
+    fn fake_enroll(base: usize, target: usize) -> (mpsc::Sender<WMsg>, EnrollUi) {
+        let (tx, rx) = mpsc::channel();
+        (
+            tx,
+            EnrollUi {
+                rx,
+                stop: Arc::new(AtomicBool::new(false)),
+                profile: "p".into(),
+                last: None,
+                count: None,
+                captured: 0,
+                target,
+                base,
+            },
+        )
+    }
+
+    /// Flatten a TestBackend buffer into one string (rows joined by newlines)
+    /// for substring assertions on rendered output.
+    fn rendered(term: &Terminal<TestBackend>) -> String {
+        let buf = term.backend().buffer();
+        let mut out = String::new();
+        for (i, cell) in buf.content.iter().enumerate() {
+            if i > 0 && i % buf.area.width as usize == 0 {
+                out.push('\n');
+            }
+            out.push_str(cell.symbol());
+        }
+        out
+    }
+
+    // Regression: f00f316. The daemon acks SetRequireEyesOpen with
+    // Response::Ok (via mutate_enrollment), not Response::Enrollment; before
+    // the fix map_settings routed Ok to the "unexpected" fallback and every
+    // eyes-open toggle raised a false error modal.
+    #[test]
+    fn eyes_open_toggle_accepts_ok_response() {
+        let (ok, msg) = map_settings(Response::Ok("require-eyes-open ENABLED".into()));
+        assert!(ok, "Response::Ok must be a success, not an error modal");
+        assert_eq!(msg, "require-eyes-open ENABLED");
+        // The updated-Enrollment reply and genuine errors keep working.
+        let (ok, _) = map_settings(Response::Enrollment {
+            profiles: Vec::new(),
+            require_eyes_open: true,
+            require_challenge: false,
+        });
+        assert!(ok);
+        let (ok, _) = map_settings(Response::Error("boom".into()));
+        assert!(!ok);
+    }
+
+    // Regression: f00f316. modal() had a fixed height of 5, so any body longer
+    // than three wrapped lines was clipped. The wrap math must match what the
+    // renderer does: explicit newlines count, and words wrap at the width.
+    #[test]
+    fn wrapped_line_count_matches_wrap_math() {
+        assert_eq!(wrapped_line_count("short", 32), 1);
+        assert_eq!(wrapped_line_count("line one\nline two", 32), 2);
+        // Eight 4-char words at width 9: two words fit per line ("aaaa aaaa").
+        let words = ["aaaa"; 8].join(" ");
+        assert_eq!(wrapped_line_count(&words, 9), 4);
+        // Degenerate width never divides by zero.
+        assert_eq!(wrapped_line_count("anything", 0), 1);
+    }
+
+    // Regression: f00f316. A long modal body must be fully visible: the box
+    // grows to the wrapped line count instead of clipping at the old fixed
+    // height of 5 (three body rows).
+    #[test]
+    fn modal_grows_to_fit_long_body() {
+        let app = test_app();
+        let mut term = Terminal::new(TestBackend::new(40, 20)).unwrap();
+        // ~8 wrapped lines at the modal's inner width; the last word is the
+        // sentinel that the fixed-height modal used to clip away.
+        let body = format!("{} ENDBODY", ["lorem"; 40].join(" "));
+        term.draw(|f| app.modal(f, "Confirm", &body)).unwrap();
+        let text = rendered(&term);
+        assert!(
+            text.contains("ENDBODY"),
+            "long modal body was clipped:\n{text}"
+        );
+    }
+
+    // Regression: f00f316. The confirm question used to live in the border
+    // title, a single line clamped to the box width, so a long target name was
+    // cut off. It must render inside the wrapping body, with the deliberate
+    // [y] yes / [n] no hint from 093dc56.
+    #[test]
+    fn confirm_modal_question_wraps_in_body() {
+        let mut app = test_app();
+        let question = format!(
+            "Delete profile '{}ZZTARGETZZ' and all its scans?",
+            ["word"; 20].join(" ")
+        );
+        app.confirm = Some((question, Request::Ping));
+        let mut term = Terminal::new(TestBackend::new(80, 30)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        let text = rendered(&term);
+        assert!(
+            text.contains("ZZTARGETZZ"),
+            "end of a long confirm question was clipped:\n{text}"
+        );
+        assert!(text.contains("[y] yes"), "deliberate-confirm hint missing");
+    }
+
+    // Regression: f00f316. At MAX_PROFILES the guidance said only "delete one
+    // first"; refreshing your own face is what [a] Improve Recognition does,
+    // so the at-cap message must point there.
+    #[test]
+    fn enroll_at_cap_points_to_improve_recognition() {
+        let mut app = test_app();
+        app.daemon_up = true; // skip the daemon gate; the cap check is next
+        app.profiles = (0..MAX_PROFILES)
+            .map(|i| ProfileSummary {
+                name: format!("p{i}"),
+                scans: Vec::new(),
+            })
+            .collect();
+        app.begin_enroll();
+        assert!(app.input.is_none(), "no name prompt at the profile cap");
+        let (_, msg) = app.activity.last().expect("a cap message is logged");
+        assert!(
+            msg.contains("Improve Recognition"),
+            "at-cap guidance must name the add-scan path, got: {msg}"
+        );
+    }
+
+    // Regression: 093dc56. Destructive confirms used to cancel on ANY key
+    // other than [y]; a stray keypress must now be ignored, and only [n] or
+    // Esc may cancel.
+    #[test]
+    fn confirm_ignores_stray_keys_and_cancels_only_on_n_or_esc() {
+        let mut app = test_app();
+        app.confirm = Some(("Delete profile 'x'?".into(), Request::Ping));
+        app.on_key(KeyCode::Char('x'));
+        app.on_key(KeyCode::Char(' '));
+        app.on_key(KeyCode::Enter);
+        assert!(
+            app.confirm.is_some(),
+            "a stray key must not cancel a destructive confirm"
+        );
+        app.on_key(KeyCode::Char('n'));
+        assert!(app.confirm.is_none(), "[n] cancels");
+        app.confirm = Some(("Delete scan 's'?".into(), Request::Ping));
+        app.on_key(KeyCode::Esc);
+        assert!(app.confirm.is_none(), "Esc cancels");
+    }
+
+    // Regression: 093dc56. Uninstall must not run off keypresses alone: [U]
+    // opens a typed challenge, a wrong word cancels, and only the exact word
+    // "uninstall" reaches the sudo teardown.
+    #[test]
+    fn uninstall_requires_typed_word() {
+        let mut app = test_app();
+        app.screen = SC_WELCOME;
+        app.on_key(KeyCode::Char('U'));
+        assert!(
+            matches!(app.input, Some((_, _, Pending::UninstallConfirm))),
+            "[U] must open the typed uninstall challenge"
+        );
+        for c in "yes".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Enter);
+        assert!(app.input.is_none());
+        assert!(
+            app.suspend.is_none(),
+            "a wrong word must not trigger the uninstall"
+        );
+        app.on_key(KeyCode::Char('U'));
+        for c in "uninstall".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Enter);
+        assert!(
+            matches!(app.suspend, Some(Suspend::Uninstall)),
+            "the exact word must proceed to the sudo teardown"
+        );
+    }
+
+    // Regression: cae2eea. The error banner says "press any key to dismiss",
+    // but PgUp/PgDn used to scroll the activity log instead of dismissing.
+    // Dismiss must take the key first; the NEXT PgUp scrolls.
+    #[test]
+    fn error_banner_dismissed_by_pgup_before_scroll() {
+        let mut app = test_app();
+        for i in 0..20 {
+            app.log('·', format!("line {i}"));
+        }
+        app.error = Some("camera busy".into());
+        app.on_key(KeyCode::PageUp);
+        assert!(app.error.is_none(), "PgUp must dismiss the banner");
+        assert_eq!(app.act_scroll, 0, "the dismissing key must not also scroll");
+        app.on_key(KeyCode::PageUp);
+        assert_eq!(app.act_scroll, 3, "with no banner up, PgUp scrolls");
+    }
+
+    // Regression: cae2eea. During a running op every key but q/Esc is
+    // swallowed, so the footer must not advertise the dead nav/action keys.
+    #[test]
+    fn footer_shows_minimal_keys_during_op() {
+        let mut app = test_app();
+        let (_tx, op) = fake_op();
+        app.op = Some(op);
+        let mut term = Terminal::new(TestBackend::new(100, 3)).unwrap();
+        term.draw(|f| app.draw_footer(f, f.area())).unwrap();
+        let text = rendered(&term);
+        assert!(text.contains("working"), "op footer missing, got:\n{text}");
+        assert!(
+            !text.contains("switch tab"),
+            "footer advertises dead nav keys during an op:\n{text}"
+        );
+        // Sanity: the full footer returns once the op is gone.
+        app.op = None;
+        term.draw(|f| app.draw_footer(f, f.area())).unwrap();
+        assert!(rendered(&term).contains("switch tab"));
+    }
+
+    // Regression: cae2eea. caps/fp_present were captured once at startup, so a
+    // camera hot-plugged after launch never revealed its tabs. refresh() must
+    // re-derive them. The seeded value is impossible for capabilities() to
+    // return (rgb is true whenever ir_pair is), so a frozen field keeps it and
+    // a re-derived one cannot.
+    #[test]
+    fn refresh_rederives_hardware_capabilities() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("IRLUME_SOCKET", "/nonexistent/irlume-test.sock");
+        let impossible = irlume_camera::Caps {
+            ir_pair: true,
+            rgb: false,
+        };
+        let mut app = test_app();
+        app.caps = impossible;
+        app.refresh();
+        std::env::remove_var("IRLUME_SOCKET");
+        assert_ne!(
+            app.caps, impossible,
+            "refresh() left the startup capability snapshot in place"
+        );
+        assert!(
+            app.caps.rgb || !app.caps.ir_pair,
+            "re-derived caps must satisfy the capabilities() invariant"
+        );
+    }
+
+    // Regression: cae2eea. The double-entry password stash must be Zeroizing,
+    // not a plain String, so the first entry is wiped on drop. This is a
+    // type-level check: reverting the stash to Option<String> breaks the
+    // return type below at compile time.
+    #[test]
+    fn password_stash_is_zeroizing() {
+        fn stash(p: Pending) -> Option<zeroize::Zeroizing<String>> {
+            match p {
+                Pending::KeyringPw(s) => s,
+                Pending::RecoveryPw(s) => s,
+                _ => None,
+            }
+        }
+        let k = stash(Pending::KeyringPw(Some(zeroize::Zeroizing::new(
+            "pw".to_string(),
+        ))));
+        assert_eq!(k.as_deref().map(String::as_str), Some("pw"));
+        let r = stash(Pending::RecoveryPw(Some(zeroize::Zeroizing::new(
+            "phrase".to_string(),
+        ))));
+        assert_eq!(r.as_deref().map(String::as_str), Some("phrase"));
+    }
+
+    // Regression: 1da8bd3. refresh_light used to fire ~6 sequential daemon
+    // reads with long budgets, so a wedged daemon (accepting but never
+    // answering) froze the UI thread. The fix polls Ping first on a short
+    // budget and skips the remaining reads when it gets no answer. The fake
+    // daemon here accepts connections and never replies; only ONE connection
+    // (the Ping probe) may arrive.
+    #[test]
+    fn wedged_daemon_poll_short_circuits_after_ping() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let sock =
+            std::env::temp_dir().join(format!("irlume-tui-wedge-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+        let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let counter = accepted.clone();
+        std::thread::spawn(move || {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept() {
+                counter.fetch_add(1, Ordering::SeqCst);
+                held.push(stream); // hold the connection open, never answer
+            }
+        });
+        std::env::set_var("IRLUME_SOCKET", &sock);
+        let mut app = test_app();
+        app.daemon_up = true;
+        app.health = Some(HealthInfo {
+            tier: "secure".into(),
+            rgb_dev: None,
+            ir_dev: None,
+            mesh: true,
+            adapter: false,
+            version: "test".into(),
+        });
+        let start = std::time::Instant::now();
+        app.refresh_light();
+        std::env::remove_var("IRLUME_SOCKET");
+        let _ = std::fs::remove_file(&sock);
+        assert!(
+            !app.daemon_up,
+            "an unanswered Ping means the daemon is down"
+        );
+        assert!(app.health.is_none(), "stale health must be cleared");
+        assert_eq!(
+            accepted.load(Ordering::SeqCst),
+            1,
+            "only the Ping probe may touch a wedged daemon; the rest must be skipped"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "the status poll must fail fast, not sit through full read budgets"
+        );
+    }
+
+    // Regression: 1da8bd3. After a merge confirm the continuation worker
+    // restarts its own count at 1, but the profile already holds the merged
+    // scan; the on-screen counter must add the EnrollUi base offset instead of
+    // restarting at 0.
+    #[test]
+    fn merge_continuation_scan_counter_keeps_base_offset() {
+        let mut app = test_app();
+        let (tx, enroll) = fake_enroll(1, 4); // one scan merged in already
+        app.enroll = Some(enroll);
+        tx.send(WMsg::Captured(1, 4)).unwrap();
+        app.poll();
+        let (_, msg) = app.activity.last().expect("a capture line is logged");
+        assert_eq!(
+            msg, "captured scan 2/5",
+            "the counter must continue past the merged scan, not restart"
+        );
+    }
+
+    // Regression: 4780805. PgUp/PgDn used to be swallowed by the op and enroll
+    // key gates; the activity panel must stay scrollable mid-op and mid-enroll,
+    // exactly when lines stream fastest.
+    #[test]
+    fn activity_scroll_reaches_panel_during_op_and_enroll() {
+        let mut app = test_app();
+        for i in 0..30 {
+            app.log('·', format!("line {i}"));
+        }
+        let (_tx, op) = fake_op();
+        app.op = Some(op);
+        app.on_key(KeyCode::PageUp);
+        assert_eq!(app.act_scroll, 3, "PgUp must scroll during a running op");
+        app.on_key(KeyCode::PageDown);
+        assert_eq!(app.act_scroll, 0, "PgDn must scroll during a running op");
+        app.op = None;
+        let (_tx2, enroll) = fake_enroll(0, 4);
+        app.enroll = Some(enroll);
+        app.on_key(KeyCode::PageUp);
+        assert_eq!(app.act_scroll, 3, "PgUp must scroll during enrollment");
+        assert!(app.enroll.is_some(), "PgUp must not cancel the enrollment");
+    }
+
+    // Regression: f709fff. Repair "logs" was bound to [v], which the global
+    // basic/all-tabs toggle swallows in on_key before on_action ever runs, so
+    // the action was dead. The binding is [g]; [v] must keep toggling the view
+    // without opening logs.
+    #[test]
+    fn repair_logs_binding_not_swallowed_by_global_toggle() {
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        app.on_key(KeyCode::Char('v'));
+        assert!(app.advanced, "[v] is the global view toggle");
+        assert!(app.suspend.is_none(), "[v] must not open the logs view");
+        app.screen = SC_REPAIR;
+        app.on_key(KeyCode::Char('g'));
+        assert!(
+            matches!(app.suspend, Some(Suspend::Logs)),
+            "the advertised logs key must actually reach the Repair action"
+        );
+    }
+
+    // Regression: 0be786b. A cancelled or failed sudo during the enroll
+    // daemon-gate must drop the parked enrollment immediately; before the fix
+    // the resume path sat through a ~10s daemon wait for a daemon that was
+    // never started. Uses a fake `sudo` that exits 1 (the cancelled case).
+    #[test]
+    fn sudo_failure_drops_parked_enrollment() {
+        use std::os::unix::fs::PermissionsExt;
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!("irlume-fake-sudo-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let fake = dir.join("sudo");
+        std::fs::write(&fake, "#!/bin/sh\nexit 1\n").unwrap();
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let old_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut new_path = dir.into_os_string();
+        new_path.push(":");
+        new_path.push(&old_path);
+        std::env::set_var("PATH", &new_path);
+        let mut app = test_app();
+        app.resume_enroll = Some(ResumeEnroll::New);
+        app.sudo_step("start the daemon", &["systemctl", "start", "irlumed"]);
+        std::env::set_var("PATH", &old_path);
+        assert!(
+            app.resume_enroll.is_none(),
+            "a failed sudo must drop the parked enrollment immediately"
+        );
+        assert!(
+            app.error.is_some(),
+            "the failure must raise the error banner"
+        );
+    }
+}

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -407,6 +407,72 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod tests {
     use super::*;
 
+    /// The `Locked:` kB of the /proc/self/smaps mapping containing `addr`
+    /// (Linux splits a VMA on mlock, so a locked buffer's mapping reports a
+    /// nonzero value). `None` when the address isn't found.
+    fn locked_kb_of(addr: usize) -> Option<u64> {
+        let smaps = std::fs::read_to_string("/proc/self/smaps").ok()?;
+        let mut in_range = false;
+        for line in smaps.lines() {
+            if let Some((range, _)) = line.split_once(' ') {
+                if let Some((s, e)) = range.split_once('-') {
+                    if let (Ok(s), Ok(e)) =
+                        (usize::from_str_radix(s, 16), usize::from_str_radix(e, 16))
+                    {
+                        in_range = s <= addr && addr < e;
+                        continue;
+                    }
+                }
+            }
+            if in_range {
+                if let Some(rest) = line.strip_prefix("Locked:") {
+                    return rest.trim().trim_end_matches("kB").trim().parse().ok();
+                }
+            }
+        }
+        None
+    }
+
+    // Regression: e8e59c2. SecretBytes derived Deserialize, constructing the
+    // inner Vec directly and skipping new()'s mlock: a secret received over
+    // IPC was swappable/dumpable. Deserialization must route through new(),
+    // observable as the deserialized buffer's pages being memlocked.
+    #[test]
+    fn deserialized_secret_bytes_are_memlocked_like_new() {
+        // Big enough to own whole pages, so the smaps Locked field is
+        // unambiguous; serialized from a plain (unlocked) Vec.
+        let payload: Vec<u8> = (0..16384u32).map(|i| (i % 251) as u8).collect();
+        let wire = serde_json::to_string(&payload).unwrap();
+
+        // Deserialize FIRST, before anything else in this test locks pages the
+        // allocator might hand back.
+        let de: SecretBytes = serde_json::from_str(&wire).unwrap();
+        assert_eq!(de.expose(), payload.as_slice());
+        assert_eq!(de.len(), payload.len());
+        assert!(!de.is_empty());
+        // Debug stays redacted through the custom impl path.
+        assert_eq!(format!("{de:?}"), "SecretBytes([16384 bytes redacted])");
+
+        // Control: can this environment mlock at all? (RLIMIT_MEMLOCK may
+        // forbid it; lock_slice is best-effort by design, so then there is
+        // nothing observable to assert and the test stands down.)
+        let control = SecretBytes::new(vec![0x5a; 16384]);
+        let control_mid = control.expose().as_ptr() as usize + 8192;
+        match locked_kb_of(control_mid) {
+            Some(kb) if kb > 0 => {}
+            _ => {
+                eprintln!("skipping: environment cannot mlock (RLIMIT_MEMLOCK?)");
+                return;
+            }
+        }
+        let de_mid = de.expose().as_ptr() as usize + 8192;
+        let locked = locked_kb_of(de_mid).unwrap_or(0);
+        assert!(
+            locked > 0,
+            "a deserialized SecretBytes must be memlocked like a new()-built one"
+        );
+    }
+
     #[test]
     fn enrolled_response_round_trips() {
         // The daemon serializes Response over the socket and the TUI/CLI

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -763,6 +763,86 @@ mod tests {
         assert_eq!(p.next_scan_name(), "Face Scan 1");
     }
 
+    // Regression: 0be786b. write_0600 is the save-path primitive that closes
+    // the world-readable window: the file must be born 0600, not chmodded
+    // after the bytes are already on disk.
+    #[test]
+    #[cfg(unix)]
+    fn write_0600_creates_owner_only_files() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("irlume-core-w600-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("t.bin");
+        write_0600(&p, b"secret bytes").unwrap();
+        let mode = fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "profile files must never be world-readable");
+        assert_eq!(fs::read(&p).unwrap(), b"secret bytes");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // Regression: 0be786b. save() used fs::write straight onto the profile
+    // path: a crash mid-write left a truncated profile and the umask window
+    // made it briefly world-readable. The fix writes a 0600 temp file and
+    // renames it in, so a failed save leaves the existing profile untouched
+    // and a successful one leaves no temp residue.
+    #[test]
+    #[cfg(unix)]
+    fn save_writes_temp_then_rename_and_survives_a_failed_save() {
+        use std::os::unix::fs::PermissionsExt;
+        // The no-TPM plaintext path is the one exercisable in a unit test; on
+        // a box with /dev/tpm* present, save() would try to seal a real key.
+        if crate::template_key::tpm_available() {
+            eprintln!("skipping: TPM present; save() would touch real hardware");
+            return;
+        }
+        let dir = std::env::temp_dir().join(format!("irlume-core-save-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+
+        let mut e = sample();
+        e.user = "atomic-save-test".into();
+        save(&e).unwrap();
+        let path = profile_path(&e.user);
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert!(
+            !path.with_extension("json.tmp").exists(),
+            "a successful save must leave no temp file behind"
+        );
+        let before = fs::read(&path).unwrap();
+
+        // Simulated failure: the dir refuses new files, so the temp file
+        // cannot be created. The old in-place fs::write would still open the
+        // (writable) profile file and replace it; temp+rename must instead
+        // fail cleanly and leave the previous profile byte-for-byte intact.
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o500)).unwrap();
+        if fs::write(dir.join("probe"), b"x").is_ok() {
+            // Running with CAP_DAC_OVERRIDE (root/container): the simulation
+            // cannot bite; restore and bail rather than assert a non-failure.
+            fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).unwrap();
+            std::env::remove_var("IRLUME_STATE_DIR");
+            let _ = fs::remove_dir_all(&dir);
+            eprintln!("skipping failure phase: dir permissions not enforced here");
+            return;
+        }
+        let mut e2 = e.clone();
+        e2.require_challenge = true;
+        assert!(
+            save(&e2).is_err(),
+            "save must fail when the temp file cannot be created"
+        );
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            before,
+            "a failed save must not disturb the existing profile"
+        );
+        std::env::remove_var("IRLUME_STATE_DIR");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn stale_and_usable_ir_counts_partition_the_scans() {
         let ir_scan = |name: &str, space: Option<&str>| FaceScan {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -66,6 +66,20 @@ fn verify_models(paths: &[&str]) {
     }
 }
 
+/// The model files to checksum-verify at startup. det/model/mesh/blaze ship
+/// with every package, so a missing one is a broken install
+/// (IRLUME_MODELS_STRICT rightly refuses). The IR adapter is optional (none
+/// ships since ADR-0004; user supplies their own via IRLUME_IR_ADAPTER), so it
+/// is included only when the file actually exists; otherwise strict mode would
+/// refuse to start on a normal install that never had an adapter.
+fn models_to_verify<'a>(shipped: [&'a str; 4], adapter: &'a str) -> Vec<&'a str> {
+    let mut v: Vec<&str> = shipped.to_vec();
+    if std::path::Path::new(adapter).exists() {
+        v.push(adapter);
+    }
+    v
+}
+
 fn main() {
     let det = env_or("IRLUME_DET_MODEL", "/etc/irlume/det.onnx");
     let model = env_or("IRLUME_MODEL", "/etc/irlume/face.onnx");
@@ -78,16 +92,7 @@ fn main() {
     let socket = std::env::var("IRLUME_SOCKET").unwrap_or_else(|_| SOCKET_PATH.into());
 
     eprintln!("irlumed: loading models (det={det}, model={model})…");
-    // det/model/mesh/blaze ship with every package, so a missing one is a broken
-    // install (IRLUME_MODELS_STRICT rightly refuses). The IR adapter is optional
-    // (none ships since ADR-0004; user supplies their own via IRLUME_IR_ADAPTER),
-    // so only verify it when it is actually present; otherwise strict mode would
-    // refuse to start on a normal install that never had an adapter.
-    let mut to_verify: Vec<&str> = vec![&det, &model, &mesh, &blaze];
-    if std::path::Path::new(&adapter).exists() {
-        to_verify.push(&adapter);
-    }
-    verify_models(&to_verify);
+    verify_models(&models_to_verify([&det, &model, &mesh, &blaze], &adapter));
     // Auto-select the camera pair: explicit IRLUME_RGB_DEVICE/IR_DEVICE, else a
     // discovered Hello camera (built-in or external Brio/NexiGo), else defaults.
     let (rgb_dev, ir_dev) = irlume_auth::select_pair();
@@ -576,19 +581,16 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             // is enrolled. Root keeps the full cross-user search (admin/test);
             // a non-root peer is scoped to its OWN account; the score then only
             // concerns a face the caller already controls, not other users'.
-            let scoped = if peer.uid == 0 {
-                engine.identify()
-            } else {
-                match users::name_for_uid(peer.uid) {
-                    Some(name) => engine.identify_within(&name),
-                    None => Ok(irlume_auth::IdentifyOutcome {
-                        user: None,
-                        profile: None,
-                        score: 0.0,
-                        live: false,
-                        reason: "caller has no local account".into(),
-                    }),
-                }
+            let scoped = match identify_scope(peer) {
+                IdentifyScope::Full => engine.identify(),
+                IdentifyScope::SelfOnly(name) => engine.identify_within(&name),
+                IdentifyScope::NoAccount => Ok(irlume_auth::IdentifyOutcome {
+                    user: None,
+                    profile: None,
+                    score: 0.0,
+                    live: false,
+                    reason: "caller has no local account".into(),
+                }),
             };
             match scoped {
                 Ok(o) => Response::Identified {
@@ -647,25 +649,7 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 Err(e) => eprintln!("irlumed: IR emitter auto-setup skipped: {e}"),
             }
             match engine.enroll_profile(&user, profile, want) {
-                Ok(irlume_auth::EnrollOutcome::New { name, scans }) => Response::Enrolled {
-                    profile: name,
-                    created: true,
-                    added: scans,
-                    total: scans,
-                    added_scans: Vec::new(),
-                },
-                Ok(irlume_auth::EnrollOutcome::Merged {
-                    name,
-                    added,
-                    total,
-                    added_scans,
-                }) => Response::Enrolled {
-                    profile: name,
-                    created: false,
-                    added,
-                    total,
-                    added_scans,
-                },
+                Ok(outcome) => enroll_response(outcome),
                 Err(e) => Response::Error(e.to_string()),
             }
         }
@@ -1103,6 +1087,58 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
     }
 }
 
+/// How a peer's 1:N Identify is scoped. Root keeps the full cross-user search;
+/// any other peer is confined to its own account (or to nothing at all), so
+/// the returned similarity score never concerns a face the caller does not
+/// already control.
+#[derive(Debug, PartialEq, Eq)]
+enum IdentifyScope {
+    /// Full cross-user search (root only).
+    Full,
+    /// Scoped to the peer's own username.
+    SelfOnly(String),
+    /// The peer resolves to no local account; identify matches no one.
+    NoAccount,
+}
+
+fn identify_scope(peer: &Peer) -> IdentifyScope {
+    if peer.uid == 0 {
+        return IdentifyScope::Full;
+    }
+    match users::name_for_uid(peer.uid) {
+        Some(name) => IdentifyScope::SelfOnly(name),
+        None => IdentifyScope::NoAccount,
+    }
+}
+
+/// Map an engine enroll outcome onto the wire response. A merge into an
+/// existing profile MUST report `created: false`: the TUI's split-capture
+/// worker keys off it to stop and confirm, instead of sending the remaining
+/// AddScans to a profile that was never created.
+fn enroll_response(outcome: irlume_auth::EnrollOutcome) -> Response {
+    match outcome {
+        irlume_auth::EnrollOutcome::New { name, scans } => Response::Enrolled {
+            profile: name,
+            created: true,
+            added: scans,
+            total: scans,
+            added_scans: Vec::new(),
+        },
+        irlume_auth::EnrollOutcome::Merged {
+            name,
+            added,
+            total,
+            added_scans,
+        } => Response::Enrolled {
+            profile: name,
+            created: false,
+            added,
+            total,
+            added_scans,
+        },
+    }
+}
+
 /// Load `user`'s enrollment, apply `f`, and save. `f` returns an Ok message or an
 /// error string. Used by the storage-only management operations.
 fn mutate_enrollment(
@@ -1331,6 +1367,143 @@ mod tests {
         };
         // uid_of relies on /etc/passwd; just exercise the root path deterministically.
         assert!(authorized_for(&root, "nonexistent-user"));
+    }
+
+    // Regression: d793a27. Request::Identify was an unauthenticated 1:N
+    // similarity oracle: any local peer got a cross-user search plus the exact
+    // score. Root keeps the full search; a non-root peer is scoped to its own
+    // account; a peer with no local account gets no search at all.
+    #[test]
+    fn identify_scope_confines_non_root_peers_to_their_own_account() {
+        let peer = |uid| Peer {
+            uid,
+            gid: uid,
+            pid: 1,
+        };
+        assert_eq!(identify_scope(&peer(0)), IdentifyScope::Full);
+        // The uid running this test resolves to a real account; its scope must
+        // be exactly that username, never Full.
+        let me = unsafe { libc::geteuid() };
+        if me != 0 {
+            let name = users::name_for_uid(me).expect("test uid has an account");
+            assert_eq!(identify_scope(&peer(me)), IdentifyScope::SelfOnly(name));
+        }
+        // A uid outside the account database is denied any scope.
+        assert_eq!(identify_scope(&peer(0xfffe_fffe)), IdentifyScope::NoAccount);
+        // Ground the reverse lookup itself (added by the same fix).
+        assert_eq!(users::name_for_uid(0).as_deref(), Some("root"));
+    }
+
+    // Regression: 834c71e. IRLUME_MODELS_STRICT=1 refused to start because the
+    // daemon still verified the OPTIONAL IR adapter at its default path even
+    // though none ships since ADR-0004. A missing adapter must be excluded
+    // from verification; a present one is still verified.
+    #[test]
+    fn missing_optional_adapter_is_not_verified() {
+        let shipped = [
+            "/etc/irlume/det.onnx",
+            "/etc/irlume/face.onnx",
+            "/etc/irlume/face_landmark.onnx",
+            "/etc/irlume/blaze_face_short_range.onnx",
+        ];
+        assert_eq!(
+            models_to_verify(shipped, "/nonexistent/irlume-test/ir_adapter.onnx"),
+            shipped.to_vec(),
+            "a missing optional adapter must not reach verify_models"
+        );
+        // An adapter that actually exists is still checked.
+        let dir =
+            std::env::temp_dir().join(format!("irlume-daemon-adapter-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let adapter = dir.join("ir_adapter.onnx");
+        std::fs::write(&adapter, b"weights").unwrap();
+        let ap = adapter.to_string_lossy().into_owned();
+        let v = models_to_verify(shipped, &ap);
+        assert_eq!(v.len(), 5);
+        assert_eq!(v[4], ap);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Regression: 834c71e (companion guard). Excluding the optional adapter
+    // must not soften strict mode for the SHIPPED models: under
+    // IRLUME_MODELS_STRICT=1 an unreadable/deleted shipped model still refuses
+    // to start. verify_models exits the process, so re-exec this test binary
+    // as the child that makes the call.
+    #[test]
+    fn strict_verify_still_refuses_a_missing_shipped_model() {
+        if std::env::var("IRLUME_TEST_VERIFY_CHILD").is_ok() {
+            // Child: strict verify of an unreadable model must exit(1) here.
+            verify_models(&["/nonexistent/irlume-test/det.onnx"]);
+            return; // reaching this line means strict did NOT refuse
+        }
+        let exe = std::env::current_exe().unwrap();
+        let out = std::process::Command::new(exe)
+            .args([
+                "tests::strict_verify_still_refuses_a_missing_shipped_model",
+                "--exact",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("IRLUME_TEST_VERIFY_CHILD", "1")
+            .env("IRLUME_MODELS_STRICT", "1")
+            .output()
+            .unwrap();
+        assert!(
+            !out.status.success(),
+            "strict verify of a missing shipped model must refuse to start"
+        );
+        let err = String::from_utf8_lossy(&out.stderr);
+        assert!(err.contains("refusing to start"), "stderr was: {err}");
+    }
+
+    // Regression: 965d64e. The daemon collapsed EnrollOutcome::New and
+    // ::Merged into Response::Ok(String), so the TUI could not tell a merge
+    // from a new profile and aborted with "no face profile". The engine itself
+    // needs camera + models, so the response-construction seam is what a unit
+    // test can pin: Merged maps to Enrolled with created:false and the exact
+    // appended scan names (the undo handle), New to created:true.
+    #[test]
+    fn enroll_merge_reports_created_false_with_the_added_scans() {
+        let merged = enroll_response(irlume_auth::EnrollOutcome::Merged {
+            name: "Face Profile 1".into(),
+            added: 1,
+            total: 8,
+            added_scans: vec!["Face Scan 8".into()],
+        });
+        match merged {
+            Response::Enrolled {
+                profile,
+                created,
+                added,
+                total,
+                added_scans,
+            } => {
+                assert_eq!(profile, "Face Profile 1");
+                assert!(!created, "a merge must not claim a new profile was created");
+                assert_eq!((added, total), (1, 8));
+                assert_eq!(added_scans, vec!["Face Scan 8".to_string()]);
+            }
+            other => panic!("merge must answer Enrolled, got {other:?}"),
+        }
+        let new = enroll_response(irlume_auth::EnrollOutcome::New {
+            name: "Face Profile 2".into(),
+            scans: 3,
+        });
+        match new {
+            Response::Enrolled {
+                created,
+                added,
+                total,
+                added_scans,
+                ..
+            } => {
+                assert!(created);
+                assert_eq!((added, total), (3, 3));
+                assert!(added_scans.is_empty());
+            }
+            other => panic!("new enroll must answer Enrolled, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
From the bug-fix inventory (60 shipped defects, 12 previously regression-tested): adds tests tied to 26 more fixed bugs across the TUI state machine, pamwire, storage, the daemon dispatch seams, update/channel probing, and SecretBytes memlock. 38/60 shipped bugs now carry a regression test (63%, OpenSSF silver asks 50%). Four behavior-preserving extractions (sudo_in_scope, identify_scope, models_to_verify, enroll_response) create the seams the daemon tests needed; no behavior changes. Line coverage 25.5% -> 34.4%; the CI ratchet floor moves 25 -> 33.
