### PR TITLE
deps: adopt rand 0.10 and sha2 0.11 (both workspaces)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -264,6 +264,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +321,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -481,7 +498,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -521,9 +538,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -859,7 +887,7 @@ dependencies = [
  "irlume-core",
  "irlume-liveness",
  "irlume-vision",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -888,7 +916,7 @@ dependencies = [
  "ratatui",
  "rpassword",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "zeroize",
 ]
 
@@ -899,7 +927,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.19",
  "zeroize",
 ]
@@ -913,11 +941,11 @@ dependencies = [
  "base64",
  "irlume-common",
  "irlume-vision",
- "rand",
+ "rand 0.10.2",
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.19",
  "tss-esapi",
  "zeroize",
@@ -932,7 +960,7 @@ dependencies = [
  "irlume-core",
  "libc",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "zeroize",
 ]
 
@@ -1249,7 +1277,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -1513,7 +1541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1717,13 +1745,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1913,15 +1951,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -2078,7 +2116,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2124,7 +2173,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2317,7 +2366,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -2637,7 +2686,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ thiserror  = "2"
 zeroize    = { version = "1", features = ["derive"] }
 tss-esapi  = "7.5"      # TPM 2.0 seal/unseal of the keyring secret
 base64     = "0.22"     # envelope blob encoding
-sha2       = "0.10"     # PolicyAuthorize digest math (signed-PCR path)
+sha2       = "0.11"     # PolicyAuthorize digest math (signed-PCR path)
 rsa        = { version = "0.9", features = ["sha2"] }  # parse systemd PCR-signing pubkey
 aes-gcm    = "0.11"     # AES-256-GCM for template-at-rest encryption
 argon2     = "0.5"      # Argon2id KDF for the recovery passphrase
-rand       = "0.8"      # CSPRNG for template keys, nonces, recovery salts
+rand       = "0.10"      # CSPRNG for template keys, nonces, recovery salts
 libc       = "0.2"      # mlock/madvise (memlock), NSS getpwnam_r, SO_PEERCRED
 rustfft    = "6"        # 2D FFT for the RGB-only moiré/screen-replay PAD cue
 

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -318,7 +318,7 @@ impl Engine {
             self.ir_adapter = Some(Adapter::load_from_file(path)?);
             let bytes = std::fs::read(path)
                 .map_err(|e| irlume_common::Error::Io(format!("{path}: {e}")))?;
-            let digest = format!("{:x}", <sha2::Sha256 as sha2::Digest>::digest(&bytes));
+            let digest = irlume_common::thirdparty::sha256_hex(&bytes);
             self.ir_space = format!("adapter:{}", &digest[..12]);
         }
         Ok(self)

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1767,7 +1767,7 @@ fn calcapture(args: &[String]) -> std::process::ExitCode {
         let file_sha12 = |p: &str| -> serde_json::Value {
             match std::fs::read(p) {
                 Ok(b) => {
-                    let d = format!("{:x}", <sha2::Sha256 as sha2::Digest>::digest(&b));
+                    let d = irlume_common::thirdparty::sha256_hex(&b);
                     d[..12].to_string().into()
                 }
                 Err(_) => serde_json::Value::Null,

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -80,7 +80,12 @@ pub fn model_path(m: &ThirdPartyModel) -> PathBuf {
 /// the CLI's enable/verify path and the daemon's load guard agree byte for byte.
 pub fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::Digest;
-    format!("{:x}", sha2::Sha256::digest(bytes))
+    // sha2 0.11's digest output no longer implements LowerHex; hex-encode
+    // the bytes directly.
+    sha2::Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 /// Whether a fetched weight file is present and matches its pinned checksum.

--- a/crates/irlume-core/src/crypto.rs
+++ b/crates/irlume-core/src/crypto.rs
@@ -11,7 +11,7 @@
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Nonce};
 use irlume_common::{Error, Result};
-use rand::RngCore;
+use rand::Rng;
 use zeroize::Zeroizing;
 
 pub const KEY_LEN: usize = 32;
@@ -22,7 +22,7 @@ const TAG_LEN: usize = 16;
 /// A fresh random 256-bit key, zeroized on drop.
 pub fn generate_key() -> Zeroizing<Vec<u8>> {
     let mut key = Zeroizing::new(vec![0u8; KEY_LEN]);
-    rand::thread_rng().fill_bytes(&mut key);
+    rand::rng().fill_bytes(&mut key);
     irlume_common::memlock::lock_slice(&key);
     key
 }
@@ -39,7 +39,7 @@ pub fn encrypt(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
         Aes256Gcm::new_from_slice(key).map_err(|e| Error::Tpm(format!("aes init: {e}")))?;
 
     let mut nonce_bytes = [0u8; NONCE_LEN];
-    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    rand::rng().fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from(nonce_bytes);
 
     let ct = cipher

--- a/crates/irlume-core/src/recovery.rs
+++ b/crates/irlume-core/src/recovery.rs
@@ -27,7 +27,7 @@ use crate::crypto;
 use argon2::{Algorithm, Argon2, Params, Version};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use irlume_common::{Error, Result};
-use rand::RngCore;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
@@ -72,7 +72,7 @@ pub fn wrap(passphrase: &[u8], template_key: &[u8]) -> Result<RecoveryEnvelope> 
         return Err(Error::Policy("empty recovery passphrase".into()));
     }
     let mut salt = [0u8; SALT_LEN];
-    rand::thread_rng().fill_bytes(&mut salt);
+    rand::rng().fill_bytes(&mut salt);
     let dk = derive_key(passphrase, &salt, M_COST, T_COST, P_COST)?;
     let wrapped = crypto::encrypt(&dk, template_key)?;
     Ok(RecoveryEnvelope {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -24,7 +24,6 @@ const MODEL_MANIFEST: &str = include_str!("../../../models/SHA256SUMS");
 /// adapters, and refusing to start would turn a model swap into a lockout.
 /// `IRLUME_MODELS_STRICT=1` upgrades the warning to a startup refusal.
 fn verify_models(paths: &[&str]) {
-    use sha2::Digest;
     let known: std::collections::HashSet<&str> = MODEL_MANIFEST
         .lines()
         .filter_map(|l| l.split_whitespace().next())
@@ -47,7 +46,7 @@ fn verify_models(paths: &[&str]) {
                 continue;
             }
         };
-        let digest = format!("{:x}", sha2::Sha256::digest(&bytes));
+        let digest = irlume_common::thirdparty::sha256_hex(&bytes);
         if !known.contains(digest.as_str()) {
             eprintln!(
                 "irlumed: WARNING: {path} does not match any release model checksum (sha256 {digest})"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -143,7 +143,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -192,6 +192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +235,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpubits"
@@ -294,7 +311,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -306,9 +323,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -451,7 +479,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "zeroize",
 ]
@@ -465,11 +493,11 @@ dependencies = [
  "base64",
  "irlume-common",
  "irlume-vision",
- "rand",
+ "rand 0.10.2",
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "tss-esapi",
  "zeroize",
@@ -649,7 +677,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -915,9 +943,19 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -986,15 +1024,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -1095,7 +1133,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1116,7 +1165,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 


### PR DESCRIPTION
Supersedes #31, #32, #35, #36. Their rebased CI runs showed the real breakage: rand 0.10 drops thread_rng/RngCore (call sites move to rand::rng() + Rng, same OS-seeded CSPRNG) and sha2 0.11's digest output loses LowerHex (the shared sha256_hex helper now hex-encodes bytes itself; the three inline {:x} copies in auth/cli/daemon were deduplicated onto it). Checksum values and encrypted blob formats are unchanged; 184 tests pass.
