### PR TITLE
test: coverage climb 34.4% -> 68.2%, ratchet to 66

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
 
       - name: Coverage (fail under the ratchet floor)
-        run: cargo llvm-cov --workspace --locked --summary-only --fail-under-lines 33
+        run: cargo llvm-cov --workspace --locked --summary-only --fail-under-lines 66
 
   deny:
     name: cargo-deny (advisories · licenses · duplicate versions)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "irlume-core",
  "irlume-liveness",
  "irlume-vision",
+ "serde_json",
  "sha2 0.11.0",
 ]
 

--- a/crates/irlume-auth/Cargo.toml
+++ b/crates/irlume-auth/Cargo.toml
@@ -15,3 +15,6 @@ irlume-camera.workspace = true
 irlume-vision.workspace = true
 irlume-liveness.workspace = true
 irlume-core.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -75,6 +75,8 @@ pub struct Assessment {
 }
 
 /// The authentication decision for a user.
+// Debug is diagnostic-only (tests, dlog); derives add no behavior.
+#[derive(Debug)]
 pub struct Outcome {
     pub granted: bool,
     pub live: bool,
@@ -84,6 +86,8 @@ pub struct Outcome {
 
 /// The result of a 1:N identification ("who is this?"). `user`/`profile` are set
 /// only on a live, above-threshold match against some enrolled face.
+// Debug is diagnostic-only (tests, dlog); derives add no behavior.
+#[derive(Debug)]
 pub struct IdentifyOutcome {
     pub user: Option<String>,
     pub profile: Option<String>,
@@ -2127,6 +2131,15 @@ mod tests {
     use super::*;
     use irlume_core::storage::{Enrollment, FaceProfile, FaceScan};
 
+    /// Serializes access to process-wide env vars (`IRLUME_GRACE_MS`,
+    /// `IRLUME_STATE_DIR`, `IRLUME_METHOD_CONF`, ...) across this binary's
+    /// parallel test threads. Engine tests share it via `super::tests`.
+    pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     fn unit(mut v: Vec<f32>) -> Vec<f32> {
         let n = v.iter().map(|x| x * x).sum::<f32>().sqrt() + 1e-9;
         v.iter_mut().for_each(|x| *x /= n);
@@ -2212,7 +2225,9 @@ mod tests {
 
     #[test]
     fn grace_window_shorter_for_sudo_than_login() {
-        // Env override off for this check (the test process shouldn't set it).
+        // Env override off for this check (guarded: another test sets it).
+        let _g = env_guard();
+        std::env::remove_var("IRLUME_GRACE_MS");
         assert_eq!(grace_window_ms(Some("sudo")), SUDO_GRACE_WINDOW_MS);
         assert_eq!(grace_window_ms(Some("su")), SUDO_GRACE_WINDOW_MS);
         // Login/lock services and an unknown/absent service get the full window.
@@ -2488,6 +2503,289 @@ mod tests {
         let err = enroll_merge_target(&enr, &[&face1, &face2]).unwrap_err();
         assert!(err.to_string().contains("two different profiles"));
     }
+
+    #[test]
+    fn grace_env_override_beats_the_service_table() {
+        let _g = env_guard();
+        // A parseable value wins for every service class.
+        std::env::set_var("IRLUME_GRACE_MS", "1234");
+        assert_eq!(grace_window_ms(Some("sudo")), 1234);
+        assert_eq!(grace_window_ms(Some("plasmalogin")), 1234);
+        assert_eq!(grace_window_ms(None), 1234);
+        // 0 = legacy one-shot.
+        std::env::set_var("IRLUME_GRACE_MS", "0");
+        assert_eq!(grace_window_ms(None), 0);
+        // Unparseable values fall back to the service table.
+        std::env::set_var("IRLUME_GRACE_MS", "abc");
+        assert_eq!(grace_window_ms(Some("sudo")), SUDO_GRACE_WINDOW_MS);
+        assert_eq!(grace_window_ms(None), GRACE_WINDOW_MS);
+        std::env::set_var("IRLUME_GRACE_MS", "");
+        assert_eq!(grace_window_ms(Some("su-l")), SUDO_GRACE_WINDOW_MS);
+        // Negative numbers don't parse as u64 either.
+        std::env::set_var("IRLUME_GRACE_MS", "-5");
+        assert_eq!(grace_window_ms(Some("runuser")), SUDO_GRACE_WINDOW_MS);
+        std::env::remove_var("IRLUME_GRACE_MS");
+    }
+
+    #[test]
+    fn pitch_band_recentres_on_a_calibrated_neutral() {
+        // Uncalibrated: the wide bootstrap band.
+        assert_eq!(pitch_band(None), (FRAME_PITCH_MIN, FRAME_PITCH_MAX));
+        // Calibrated: neutral ± PITCH_TOL, tighter than the bootstrap band.
+        let (lo, hi) = pitch_band(Some(0.62));
+        assert!((lo - (0.62 - PITCH_TOL)).abs() < 1e-6);
+        assert!((hi - (0.62 + PITCH_TOL)).abs() < 1e-6);
+        assert!(hi - lo < FRAME_PITCH_MAX - FRAME_PITCH_MIN);
+    }
+
+    #[test]
+    fn threshold_ladder_orderings_the_decision_paths_rely_on() {
+        use irlume_core::*;
+        // The adapter space uses a lower bar than raw IR (its scores are
+        // recalibrated), and the mixed-light IR fallback is stricter than the
+        // dark path by exactly the margin.
+        // Constant relations the decision paths assume; checked at compile time.
+        const { assert!(IR_ADAPTED_MATCH_THRESHOLD < IR_MATCH_THRESHOLD) };
+        const { assert!(IR_FALLBACK_MARGIN > 0.0) };
+        for n in [1usize, 5, 30, 90] {
+            let dark = scaled_threshold(IR_MATCH_THRESHOLD, n);
+            assert!(dark >= IR_MATCH_THRESHOLD);
+            assert!((dark + IR_FALLBACK_MARGIN) > dark);
+            // Scaling never exceeds base + cap.
+            assert!(dark <= IR_MATCH_THRESHOLD + TEMPLATE_SCALE_MAX_BUMP + 1e-6);
+        }
+        // More templates never lowers the bar (best-of-N FAR compensation).
+        assert!(
+            scaled_threshold(RGB_MATCH_THRESHOLD, 30) >= scaled_threshold(RGB_MATCH_THRESHOLD, 5)
+        );
+    }
+
+    #[test]
+    fn fusion_decision_table_matches_the_stage2_gate() {
+        use irlume_core::fusion::*;
+        // Both modalities strong at full quality: grant, prob = weighted mean.
+        let f = fuse(0.9, 1.0, 0.8, 1.0);
+        assert!(f.grant);
+        assert!((f.prob - 0.85).abs() < 1e-6);
+        // One modality at pure-noise probability vetoes the grant even when the
+        // other is certain (anti single-modality-spoof floor).
+        let f = fuse(0.99, 1.0, FUSION_MIN_PER_MODALITY_PROB - 0.01, 1.0);
+        assert!(!f.grant);
+        // No IR capture (weight 0) never grants, whatever the probabilities.
+        let f = fuse(0.99, 1.0, 0.99, 0.0);
+        assert!(!f.grant);
+        // Boundary: the fused probability at exactly the threshold grants (>=).
+        let f = fuse(FUSION_PROB_THRESHOLD, 1.0, FUSION_PROB_THRESHOLD, 1.0);
+        assert!(f.grant);
+        // Quality weighting: dim RGB shifts the fused prob toward IR.
+        let dim = fuse(
+            0.2,
+            rgb_quality_weight(0.0),
+            0.9,
+            ir_quality_weight(true, 120.0),
+        );
+        let lit = fuse(
+            0.2,
+            rgb_quality_weight(200.0),
+            0.9,
+            ir_quality_weight(true, 120.0),
+        );
+        assert!(dim.prob > lit.prob, "{} vs {}", dim.prob, lit.prob);
+    }
+
+    #[test]
+    fn ir_match_quarantines_wrong_dimension_templates() {
+        let (prof, probe) = calibrated_profile(16);
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(prof);
+        // A probe of a different width matches nothing (adapter-contract change).
+        let short_probe = vec![0.5f32; 8];
+        let m = ir_match_in("raw", false, &enr, &short_probe);
+        assert_eq!(m.n_templates, 0);
+        assert!(m.centroid.is_none());
+        assert_eq!(m.best, f32::NEG_INFINITY);
+        // The right width still matches.
+        assert_eq!(ir_match_in("raw", false, &enr, &probe).n_templates, 5);
+    }
+
+    #[test]
+    fn ir_match_grandfathers_untagged_templates_into_any_space() {
+        let (mut prof, probe) = calibrated_profile(16);
+        for s in &mut prof.scans {
+            s.ir_space = None; // pre-tagging enrollment
+        }
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(prof);
+        for space in ["raw", "adapter:deadbeef0123"] {
+            let m = ir_match_in(space, false, &enr, &probe);
+            assert_eq!(m.n_templates, 5, "untagged templates must match in {space}");
+        }
+    }
+
+    #[test]
+    fn ir_match_uncalibrated_profile_scores_raw_and_names_the_winner() {
+        // Two profiles without calibration: plain cosine, winner labelled.
+        let a = unit(vec![1.0, 0.0, 0.0, 0.0]);
+        let b = unit(vec![0.0, 1.0, 0.0, 0.0]);
+        let mk_prof = |name: &str, v: &[f32]| FaceProfile {
+            name: name.into(),
+            ir_calib: None,
+            scans: vec![FaceScan {
+                name: "s".into(),
+                rgb: vec![0.0; 4],
+                ir: Some(v.to_vec()),
+                ir_space: Some("raw".into()),
+                ir_depth: 0.0,
+                ir_brightness: 0.0,
+                pitch: 0.0,
+            }],
+        };
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(mk_prof("A", &a));
+        enr.profiles.push(mk_prof("B", &b));
+        let m = ir_match_in("raw", false, &enr, &b);
+        assert_eq!(m.n_templates, 2);
+        assert_eq!(m.best_who, "B");
+        assert!((m.best - 1.0).abs() < 1e-5);
+        // No calibration anywhere -> no centroid protocol.
+        assert!(m.centroid.is_none());
+    }
+
+    #[test]
+    fn luma_in_bbox_means_and_clamps() {
+        // 4x4 frame: left half black, right half (100,100,100).
+        let (w, h) = (4u32, 4u32);
+        let mut rgb = vec![0u8; (w * h * 3) as usize];
+        for y in 0..h {
+            for x in 2..w {
+                let i = ((y * w + x) * 3) as usize;
+                rgb[i] = 100;
+                rgb[i + 1] = 100;
+                rgb[i + 2] = 100;
+            }
+        }
+        // Right half only: BT.601 luma of (100,100,100) is 100.
+        assert!((luma_in_bbox(&rgb, w, h, &[2.0, 0.0, 4.0, 4.0]) - 100.0).abs() < 0.5);
+        // Whole frame: half black, half 100 -> 50.
+        assert!((luma_in_bbox(&rgb, w, h, &[0.0, 0.0, 4.0, 4.0]) - 50.0).abs() < 0.5);
+        // A bbox hanging off the frame clamps instead of reading out of bounds.
+        assert!((luma_in_bbox(&rgb, w, h, &[-10.0, -10.0, 100.0, 100.0]) - 50.0).abs() < 0.5);
+        // Zero-area region -> 0.
+        assert_eq!(luma_in_bbox(&rgb, w, h, &[1.0, 1.0, 1.0, 1.0]), 0.0);
+    }
+
+    #[test]
+    fn rgb_luma_stats_reports_mean_and_hot_fraction() {
+        // 2x2: three black pixels + one blown-out white one.
+        let (w, h) = (2u32, 2u32);
+        let mut rgb = vec![0u8; 12];
+        rgb[0] = 255;
+        rgb[1] = 255;
+        rgb[2] = 255;
+        let (mean, hot) = rgb_luma_stats(&rgb, w, h, &[0.0, 0.0, 2.0, 2.0]);
+        assert!((mean - 63.75).abs() < 1.0, "mean {mean}");
+        assert!((hot - 0.25).abs() < 1e-6, "hot {hot}");
+        // No blown pixels -> hot fraction 0.
+        let grey = vec![128u8; 12];
+        let (_, hot) = rgb_luma_stats(&grey, w, h, &[0.0, 0.0, 2.0, 2.0]);
+        assert_eq!(hot, 0.0);
+        // Degenerate region -> (0, 0).
+        assert_eq!(
+            rgb_luma_stats(&rgb, w, h, &[1.0, 1.0, 1.0, 1.0]),
+            (0.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn mean_in_bbox_averages_and_clamps() {
+        let (w, h) = (4u32, 2u32);
+        let grey = [10u8, 20, 30, 40, 50, 60, 70, 80];
+        assert!((mean_in_bbox(&grey, w, h, &[0.0, 0.0, 4.0, 2.0]) - 45.0).abs() < 1e-4);
+        assert!((mean_in_bbox(&grey, w, h, &[0.0, 0.0, 2.0, 1.0]) - 15.0).abs() < 1e-4);
+        // Out-of-frame bbox clamps to the frame.
+        assert!((mean_in_bbox(&grey, w, h, &[-9.0, -9.0, 99.0, 99.0]) - 45.0).abs() < 1e-4);
+        assert_eq!(mean_in_bbox(&grey, w, h, &[3.0, 1.0, 3.0, 1.0]), 0.0);
+    }
+
+    #[test]
+    fn center_edge_ratio_reads_depth_from_center_emphasis() {
+        let (w, h) = (40u32, 40u32);
+        let bbox = [0.0f32, 0.0, 40.0, 40.0];
+        // Emitter-lit 3D face: the center quarter markedly brighter than the rim.
+        let mut face = vec![40u8; (w * h) as usize];
+        for y in 10..30 {
+            for x in 10..30 {
+                face[(y * w + x) as usize] = 200;
+            }
+        }
+        let deep = center_edge_ratio(&face, w, h, &bbox);
+        assert!(deep > 1.5, "center-lit face must read deep, got {deep}");
+        // Flat 2D surface (screen/photo): uniform -> ratio ~1.
+        let flat = vec![120u8; (w * h) as usize];
+        let flat_r = center_edge_ratio(&flat, w, h, &bbox);
+        assert!((flat_r - 1.0).abs() < 0.05, "flat ratio {flat_r}");
+        assert!(deep > flat_r, "monotonic: 3D > 2D");
+        // Degenerate boxes and black frames return 0 (no signal, never inf).
+        assert_eq!(center_edge_ratio(&face, w, h, &[0.0, 0.0, 3.0, 3.0]), 0.0);
+        let black = vec![0u8; (w * h) as usize];
+        assert_eq!(center_edge_ratio(&black, w, h, &bbox), 0.0);
+    }
+
+    /// 64x48 IR frame with optional specular glints at the two eye landmarks.
+    fn ir_frame_with_glints(left: bool, right: bool) -> (Vec<u8>, Landmarks5) {
+        let (w, h) = (64usize, 48usize);
+        let mut grey = vec![60u8; w * h];
+        let lm: Landmarks5 = [
+            (20.0, 20.0),
+            (44.0, 20.0),
+            (32.0, 28.0),
+            (24.0, 36.0),
+            (40.0, 36.0),
+        ];
+        if left {
+            grey[20 * w + 20] = 250;
+        }
+        if right {
+            grey[20 * w + 44] = 250;
+        }
+        (grey, lm)
+    }
+
+    #[test]
+    fn eye_glint_finds_the_specular_peak() {
+        let (grey, lm) = ir_frame_with_glints(true, true);
+        assert_eq!(eye_glint(&grey, 64, 48, &lm), 250.0);
+        // No glint: the diffuse background level is the peak.
+        let (grey, lm) = ir_frame_with_glints(false, false);
+        assert_eq!(eye_glint(&grey, 64, 48, &lm), 60.0);
+        // Landmarks fully outside the frame: nothing sampled, peak 0.
+        let far: Landmarks5 = [(-500.0, -500.0); 5];
+        assert_eq!(eye_glint(&grey, 64, 48, &far), 0.0);
+    }
+
+    #[test]
+    fn both_eyes_open_requires_a_glint_at_each_eye() {
+        let (grey, lm) = ir_frame_with_glints(true, true);
+        assert!(both_eyes_open(&grey, 64, 48, &lm));
+        // One closed lid (no specular point) fails the gate, conservatively.
+        let (grey, lm) = ir_frame_with_glints(true, false);
+        assert!(!both_eyes_open(&grey, 64, 48, &lm));
+        let (grey, lm) = ir_frame_with_glints(false, false);
+        assert!(!both_eyes_open(&grey, 64, 48, &lm));
+    }
+
+    #[test]
+    fn eye_glint_contrast_collapses_without_a_specular_spike() {
+        // Sharp corneal spike on a diffuse background: high contrast.
+        let (grey, lm) = ir_frame_with_glints(true, true);
+        let sharp = eye_glint_contrast(&grey, 64, 48, &lm);
+        assert!(sharp > 100.0, "specular contrast {sharp}");
+        // Uniform lid/print: peak == mean -> contrast 0.
+        let (flat, lm) = ir_frame_with_glints(false, false);
+        let dull = eye_glint_contrast(&flat, 64, 48, &lm);
+        assert_eq!(dull, 0.0);
+        assert!(sharp > dull, "blink/liveness signal must be monotonic");
+    }
 }
 
 #[cfg(test)]
@@ -2513,5 +2811,546 @@ mod thirdparty_cue_tests {
                 assert!(!thirdparty_downgrades(v, p, 0.5));
             }
         }
+    }
+}
+
+/// Engine tests against the REAL shipped models (Git LFS under `models/`), with
+/// the camera devices pointed at nonexistent nodes so no capture can ever run:
+/// everything from the capture boundary inward errors with "no camera found",
+/// and everything decided BEFORE the camera (enrollment state, bindings,
+/// policy, builder wiring) is asserted for real. The engine is expensive to
+/// build (the 512-D recognizer session), so one instance is shared.
+#[cfg(test)]
+mod engine_tests {
+    use super::tests::env_guard;
+    use super::*;
+    use irlume_core::storage::{CameraBinding, Enrollment, FaceProfile, FaceScan};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    const NO_RGB: &str = "/dev/irlume-test-none-rgb";
+    const NO_IR: &str = "/dev/irlume-test-none-ir";
+
+    fn model_path(name: &str) -> String {
+        format!("{}/../../models/{name}", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    /// Point `ort` (load-dynamic) at the packaged onnxruntime when the test
+    /// env doesn't already provide `ORT_DYLIB_PATH`.
+    fn ort_init() {
+        if std::env::var_os("ORT_DYLIB_PATH").is_some() {
+            return;
+        }
+        for cand in [
+            "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+            "/usr/lib64/libonnxruntime.so",
+            "/usr/lib/libonnxruntime.so",
+            "/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
+        ] {
+            if std::path::Path::new(cand).exists() {
+                std::env::set_var("ORT_DYLIB_PATH", cand);
+                return;
+            }
+        }
+    }
+
+    struct Shared {
+        engine: Engine,
+        /// `ir_space()` observed right after loading a real adapter file, for
+        /// the digest-naming assertion (the shared engine then reverts to raw).
+        adapter_space: String,
+    }
+
+    /// LOCK ORDER: every engine test takes env_guard() FIRST, then shared().
+    /// The initializer itself must NOT lock (the caller already holds the env
+    /// guard, and std Mutex is not reentrant); it only touches env vars no
+    /// other test reads (`IRLUME_FORCE_NO_IR`, `ORT_DYLIB_PATH`).
+    fn shared() -> MutexGuard<'static, Shared> {
+        static S: OnceLock<Mutex<Shared>> = OnceLock::new();
+        S.get_or_init(|| {
+            ort_init();
+            // Deterministic hardware probe on any machine: no IR pair, so the
+            // engine sits in convenience tier. Left set for the whole process.
+            std::env::set_var("IRLUME_FORCE_NO_IR", "1");
+            let e = Engine::load(
+                &model_path("face_detection_yunet_2023mar.onnx"),
+                &model_path("glintr100.onnx"),
+            )
+            .expect("engine load")
+            .with_devices(NO_RGB, NO_IR);
+            // Absent optional model files are a no-op for every builder.
+            let e = e
+                .with_ir_adapter("/nonexistent/adapter.onnx")
+                .unwrap()
+                .with_mesh("/nonexistent/mesh.onnx")
+                .unwrap()
+                .with_blaze_rescue("/nonexistent/blaze.onnx")
+                .unwrap()
+                .with_thirdparty_pad("/nonexistent/pad.onnx", 0.5, "absent")
+                .unwrap();
+            assert!(
+                !e.has_ir_adapter()
+                    && !e.has_mesh()
+                    && !e.has_blaze_rescue()
+                    && !e.has_thirdparty_pad(),
+                "absent model files must leave the engine bare"
+            );
+            assert_eq!(e.ir_space(), "raw");
+            // A present adapter file flips the IR space to its digest name. Any
+            // valid ONNX serves; `apply` is never called (BlazeFace here).
+            let blaze = model_path("blaze_face_short_range.onnx");
+            let e = e.with_ir_adapter(&blaze).unwrap();
+            assert!(e.has_ir_adapter());
+            let adapter_space = e.ir_space().to_string();
+            let mut e = e
+                .with_mesh(&model_path("face_landmark.onnx"))
+                .unwrap()
+                .with_blaze_rescue(&blaze)
+                .unwrap()
+                .with_thirdparty_pad(&blaze, 0.75, "test-pad")
+                .unwrap();
+            // Shared baseline is the raw (no-adapter) space; tests needing an
+            // adapter set one temporarily and restore.
+            e.ir_adapter = None;
+            e.ir_space = "raw".into();
+            Mutex::new(Shared {
+                engine: e,
+                adapter_space,
+            })
+        })
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Fresh state sandbox: temp IRLUME_STATE_DIR + a method conf pointing at a
+    /// missing file (=> Auto). Caller must hold the env guard.
+    fn state_sandbox(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("irlume-auth-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+        std::env::set_var("IRLUME_METHOD_CONF", dir.join("no-method-conf"));
+        dir
+    }
+
+    fn teardown_sandbox(dir: &std::path::Path) {
+        std::env::remove_var("IRLUME_STATE_DIR");
+        std::env::remove_var("IRLUME_METHOD_CONF");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Write a PLAINTEXT enrollment (what a no-TPM host stores); never goes
+    /// through storage::save, which would touch this machine's real TPM.
+    fn write_enrollment(dir: &std::path::Path, e: &Enrollment) {
+        std::fs::write(
+            dir.join(format!("{}.json", e.user)),
+            serde_json::to_vec(e).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn unit512(seed: usize) -> Vec<f32> {
+        let mut v: Vec<f32> = (0..512)
+            .map(|j| (j as f32 * 0.7).sin() + 0.05 * (seed as f32 * 1.3 + j as f32).sin())
+            .collect();
+        let n = v.iter().map(|x| x * x).sum::<f32>().sqrt() + 1e-9;
+        v.iter_mut().for_each(|x| *x /= n);
+        v
+    }
+
+    fn scan512(seed: usize, ir: bool, space: Option<&str>) -> FaceScan {
+        FaceScan {
+            name: format!("Face Scan {seed}"),
+            rgb: unit512(seed),
+            ir: ir.then(|| unit512(seed + 100)),
+            ir_space: space.map(String::from),
+            ir_depth: 1.3,
+            ir_brightness: 90.0,
+            pitch: 0.5,
+        }
+    }
+
+    #[test]
+    fn builder_wiring_tier_and_adapter_digest_naming() {
+        let _g = env_guard();
+        let s = shared();
+        let e = &s.engine;
+        // Forced no-IR hardware: convenience tier, no dark path.
+        assert_eq!(e.tier(), Tier::Convenience);
+        assert!(!e.ir_available());
+        assert_eq!(e.rgb_device(), NO_RGB);
+        assert_eq!(e.ir_device(), NO_IR);
+        assert_eq!(e.ir_dim(), irlume_vision::EMBED_DIM);
+        assert_eq!(e.ir_space(), "raw");
+        // Loaded optional models.
+        assert!(e.has_mesh() && e.has_blaze_rescue() && e.has_thirdparty_pad());
+        assert_eq!(e.thirdparty_pad_name(), Some("test-pad"));
+        // Adapter space naming: "adapter:" + first 12 hex of the file's sha256,
+        // computed independently here from the same bytes.
+        let bytes = std::fs::read(model_path("blaze_face_short_range.onnx")).unwrap();
+        let digest = irlume_common::thirdparty::sha256_hex(&bytes);
+        assert_eq!(s.adapter_space, format!("adapter:{}", &digest[..12]));
+    }
+
+    #[test]
+    fn set_devices_switches_the_pair_at_runtime() {
+        let _g = env_guard();
+        let mut s = shared();
+        s.engine
+            .set_devices("/dev/irlume-test-alt-rgb", "/dev/irlume-test-alt-ir");
+        assert_eq!(s.engine.rgb_device(), "/dev/irlume-test-alt-rgb");
+        assert_eq!(s.engine.ir_device(), "/dev/irlume-test-alt-ir");
+        s.engine.set_devices(NO_RGB, NO_IR); // restore the shared baseline
+    }
+
+    #[test]
+    fn refit_profile_calib_fits_skips_and_defers_to_the_adapter() {
+        let _g = env_guard();
+        let mut s = shared();
+        // Healthy paired 512-D scans in the current space: calibration fits.
+        let mut prof = FaceProfile {
+            name: "p".into(),
+            ir_calib: None,
+            scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
+        };
+        s.engine.refit_profile_calib(&mut prof);
+        let calib = prof.ir_calib.as_ref().expect("calibration fitted");
+        assert_eq!(calib.fitted_pairs, 5);
+        // Wrong-dimension IR templates are quarantined: nothing to fit.
+        let mut bad = FaceProfile {
+            name: "bad".into(),
+            ir_calib: None,
+            scans: (0..5)
+                .map(|i| FaceScan {
+                    ir: Some(vec![0.1; 256]),
+                    ..scan512(i, true, Some("raw"))
+                })
+                .collect(),
+        };
+        s.engine.refit_profile_calib(&mut bad);
+        assert!(bad.ir_calib.is_none());
+        // Foreign-space templates (stranded by an adapter change) are skipped.
+        let mut foreign = FaceProfile {
+            name: "foreign".into(),
+            ir_calib: None,
+            scans: (0..5)
+                .map(|i| scan512(i, true, Some("adapter:deadbeef0123")))
+                .collect(),
+        };
+        s.engine.refit_profile_calib(&mut foreign);
+        assert!(foreign.ir_calib.is_none());
+        // With a global adapter loaded, refit is a no-op: an existing
+        // calibration is left untouched and none is fitted.
+        let adapter = Adapter::load_from_file(&model_path("blaze_face_short_range.onnx")).unwrap();
+        s.engine.ir_adapter = Some(adapter);
+        let before = prof.ir_calib.clone().unwrap();
+        s.engine.refit_profile_calib(&mut prof);
+        assert_eq!(
+            prof.ir_calib.as_ref().map(|c| c.fitted_pairs),
+            Some(before.fitted_pairs),
+            "adapter mode must not refit"
+        );
+        let mut fresh = FaceProfile {
+            name: "fresh".into(),
+            ir_calib: None,
+            scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
+        };
+        s.engine.refit_profile_calib(&mut fresh);
+        assert!(fresh.ir_calib.is_none(), "adapter mode must not fit anew");
+        s.engine.ir_adapter = None; // restore the shared baseline
+    }
+
+    #[test]
+    fn binding_mismatch_refuses_swapped_or_vanished_cameras() {
+        let _g = env_guard();
+        let s = shared();
+        // Nonexistent devices carry no USB identity.
+        let bind = s.engine.current_binding();
+        assert_eq!(
+            bind,
+            CameraBinding {
+                rgb: None,
+                ir: None
+            }
+        );
+        // Unbound sides are not checked (pre-binding enrollments keep working).
+        assert_eq!(s.engine.binding_mismatch(&bind), None);
+        // A bound RGB identity that no longer matches (or is gone) refuses.
+        let bind = CameraBinding {
+            rgb: Some("dead:beef".into()),
+            ir: None,
+        };
+        let msg = s.engine.binding_mismatch(&bind).expect("must refuse");
+        assert!(msg.contains("RGB device identity differs"), "{msg}");
+        // Same for a bound IR camera that is absent now.
+        let bind = CameraBinding {
+            rgb: None,
+            ir: Some("dead:beef".into()),
+        };
+        let msg = s.engine.binding_mismatch(&bind).expect("must refuse");
+        assert!(msg.contains("IR camera changed or absent"), "{msg}");
+    }
+
+    #[test]
+    fn authenticate_refuses_before_the_camera_on_state_and_policy() {
+        let _g = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("auth");
+
+        // Fingerprint mode: face declines instantly (pam_fprintd drives).
+        std::fs::write(dir.join("method"), "fingerprint").unwrap();
+        std::env::set_var("IRLUME_METHOD_CONF", dir.join("method"));
+        let o = s.engine.authenticate("anyone", Some("sudo")).unwrap();
+        assert!(!o.granted && !o.live);
+        assert_eq!(o.reason, "face disabled (fingerprint mode)");
+        std::env::set_var("IRLUME_METHOD_CONF", dir.join("no-method-conf"));
+
+        // Unknown user.
+        let o = s.engine.authenticate("irlume-test-ghost", None).unwrap();
+        assert!(!o.granted);
+        assert_eq!(o.reason, "'irlume-test-ghost' is not enrolled");
+
+        // Enrolled but with zero scans.
+        let mut e = Enrollment::new("irlume-test-empty");
+        e.profiles.push(FaceProfile {
+            name: "P1".into(),
+            scans: vec![],
+            ir_calib: None,
+        });
+        write_enrollment(&dir, &e);
+        let o = s.engine.authenticate("irlume-test-empty", None).unwrap();
+        assert!(!o.granted);
+        assert_eq!(o.reason, "'irlume-test-empty' has no face scans enrolled");
+
+        // Camera binding mismatch: anti-swap refusal before any capture.
+        let mut e = Enrollment::new("irlume-test-bound");
+        e.profiles.push(FaceProfile {
+            name: "P1".into(),
+            scans: vec![scan512(1, false, None)],
+            ir_calib: None,
+        });
+        e.camera_binding = Some(CameraBinding {
+            rgb: Some("dead:beef".into()),
+            ir: None,
+        });
+        write_enrollment(&dir, &e);
+        let o = s.engine.authenticate("irlume-test-bound", None).unwrap();
+        assert!(!o.granted && !o.live);
+        assert!(
+            o.reason.contains("camera changed since enrollment"),
+            "{}",
+            o.reason
+        );
+
+        // A healthy enrollment reaches the capture boundary, which fails hard
+        // on the nonexistent device (never a silent grant/deny).
+        let mut e = Enrollment::new("irlume-test-cam");
+        e.profiles.push(FaceProfile {
+            name: "P1".into(),
+            scans: vec![scan512(1, false, None)],
+            ir_calib: None,
+        });
+        write_enrollment(&dir, &e);
+        let err = s.engine.authenticate("irlume-test-cam", None).unwrap_err();
+        assert!(err.to_string().contains("no camera found"), "{err}");
+
+        teardown_sandbox(&dir);
+    }
+
+    #[test]
+    fn identify_respects_fingerprint_mode_and_needs_a_camera() {
+        let _g = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("identify");
+        std::fs::write(dir.join("method"), "fingerprint").unwrap();
+        std::env::set_var("IRLUME_METHOD_CONF", dir.join("method"));
+        let o = s.engine.identify().unwrap();
+        assert!(o.user.is_none() && !o.live);
+        assert_eq!(o.reason, "face disabled (fingerprint mode)");
+        let o = s.engine.identify_within("someone").unwrap();
+        assert!(o.user.is_none());
+        assert_eq!(o.reason, "face disabled (fingerprint mode)");
+        // Back in Auto, identify needs a real capture.
+        std::env::set_var("IRLUME_METHOD_CONF", dir.join("no-method-conf"));
+        let err = s.engine.identify().unwrap_err();
+        assert!(err.to_string().contains("no camera found"), "{err}");
+        teardown_sandbox(&dir);
+    }
+
+    #[test]
+    fn enroll_profile_pre_camera_guards() {
+        let _g = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("enroll");
+        // Duplicate explicit profile name fails BEFORE the camera opens.
+        let mut e = Enrollment::new("irlume-test-enroll");
+        e.profiles.push(FaceProfile {
+            name: "Work Laptop".into(),
+            scans: vec![scan512(1, false, None)],
+            ir_calib: None,
+        });
+        write_enrollment(&dir, &e);
+        let err = s
+            .engine
+            .enroll_profile("irlume-test-enroll", Some("Work Laptop".into()), 3)
+            .unwrap_err();
+        assert!(err.to_string().contains("already exists"), "{err}");
+        // A novel name proceeds to the probe capture, which needs the camera.
+        let err = s
+            .engine
+            .enroll_profile("irlume-test-enroll", Some("New Face".into()), 3)
+            .unwrap_err();
+        assert!(err.to_string().contains("no camera found"), "{err}");
+        teardown_sandbox(&dir);
+    }
+
+    #[test]
+    fn add_scan_pre_camera_guards() {
+        let _g = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("addscan");
+        // Unknown user.
+        let err = s.engine.add_scan("irlume-test-ghost", "P1").unwrap_err();
+        assert!(err.to_string().contains("is not enrolled"), "{err}");
+        // Known user, unknown profile.
+        let mut e = Enrollment::new("irlume-test-add");
+        e.profiles.push(FaceProfile {
+            name: "P1".into(),
+            scans: vec![scan512(1, false, None)],
+            ir_calib: None,
+        });
+        write_enrollment(&dir, &e);
+        let err = s.engine.add_scan("irlume-test-add", "nope").unwrap_err();
+        assert!(err.to_string().contains("no face profile 'nope'"), "{err}");
+        // Full profile: refused before any capture.
+        let mut e = Enrollment::new("irlume-test-full");
+        e.profiles.push(FaceProfile {
+            name: "P1".into(),
+            scans: (0..irlume_core::storage::MAX_SCANS_PER_PROFILE)
+                .map(|i| scan512(i, false, None))
+                .collect(),
+            ir_calib: None,
+        });
+        write_enrollment(&dir, &e);
+        let err = s.engine.add_scan("irlume-test-full", "P1").unwrap_err();
+        assert!(err.to_string().contains("already has the max"), "{err}");
+        // Room in the profile: proceeds to the capture boundary.
+        let err = s.engine.add_scan("irlume-test-add", "P1").unwrap_err();
+        assert!(err.to_string().contains("no camera found"), "{err}");
+        teardown_sandbox(&dir);
+    }
+
+    #[test]
+    fn challenge_gate_only_arms_when_grant_flag_and_hardware_align() {
+        let _g = env_guard();
+        let mut s = shared();
+        let enr_flag = |flag: bool| {
+            let mut e = Enrollment::new("u");
+            e.require_challenge = flag;
+            e
+        };
+        let grant = || Outcome {
+            granted: true,
+            live: true,
+            score: 0.9,
+            reason: "match: p (rgb)".into(),
+        };
+        // A denial is never escalated into a challenge.
+        let denied = Outcome {
+            granted: false,
+            live: false,
+            score: 0.0,
+            reason: "below threshold (ir)".into(),
+        };
+        let o = s
+            .engine
+            .challenge_if_required(&enr_flag(true), denied)
+            .unwrap();
+        assert!(!o.granted);
+        // Grant without the opt-in flag: passes through untouched.
+        let o = s
+            .engine
+            .challenge_if_required(&enr_flag(false), grant())
+            .unwrap();
+        assert!(o.granted);
+        // Flag on but no IR hardware (convenience tier): the blink challenge
+        // cannot run; the grant stands.
+        assert!(!s.engine.ir_available);
+        let o = s
+            .engine
+            .challenge_if_required(&enr_flag(true), grant())
+            .unwrap();
+        assert!(o.granted);
+        // Flag on + IR + no mesh model deployed: logged skip, grant stands.
+        s.engine.ir_available = true;
+        let mesh = s.engine.mesh.take();
+        let o = s
+            .engine
+            .challenge_if_required(&enr_flag(true), grant())
+            .unwrap();
+        assert!(o.granted);
+        // Flag on + IR + mesh loaded: the passive-liveness capture actually
+        // runs, and fails hard without a camera (a grant is never released on
+        // an unverifiable challenge).
+        s.engine.mesh = mesh;
+        let err = s
+            .engine
+            .challenge_if_required(&enr_flag(true), grant())
+            .unwrap_err();
+        assert!(err.to_string().contains("no camera found"), "{err}");
+        s.engine.ir_available = false; // restore the shared baseline
+    }
+
+    #[test]
+    fn passive_liveness_without_mesh_reports_no_eyes() {
+        let _g = env_guard();
+        let mut s = shared();
+        let mesh = s.engine.mesh.take();
+        let r = s.engine.run_passive_liveness().unwrap();
+        assert_eq!(r, irlume_liveness::BlinkResult::NoEyes);
+        s.engine.mesh = mesh;
+    }
+
+    #[test]
+    fn rescue_detect_declines_faceless_frames_and_missing_models() {
+        let _g = env_guard();
+        let mut s = shared();
+        let (w, h) = (64u32, 64u32);
+        let flat = vec![127u8; (w * h * 3) as usize];
+        let view = align::RgbView {
+            data: &flat,
+            width: w,
+            height: h,
+        };
+        // Both rescue models loaded, but no face in the frame.
+        assert!(s.engine.has_blaze_rescue() && s.engine.has_mesh());
+        assert!(s.engine.rescue_detect(&view, "test").is_none());
+        // With BlazeFace missing the cascade stage is simply absent.
+        let blaze = s.engine.blaze.take();
+        assert!(s.engine.rescue_detect(&view, "test").is_none());
+        s.engine.blaze = blaze;
+        // Same when only the mesh refiner is missing.
+        let mesh = s.engine.mesh.take();
+        assert!(s.engine.rescue_detect(&view, "test").is_none());
+        s.engine.mesh = mesh;
+    }
+
+    #[test]
+    fn selftests_and_position_sample_need_a_camera() {
+        let _g = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("selftest");
+        for msg in [
+            s.engine.liveness_selftest().unwrap_err().to_string(),
+            s.engine.alignment_selftest().unwrap_err().to_string(),
+            s.engine.position_sample(None).unwrap_err().to_string(),
+            // The user-scoped variant first consults that user's pitch neutral.
+            s.engine
+                .position_sample(Some("irlume-test-ghost"))
+                .unwrap_err()
+                .to_string(),
+        ] {
+            assert!(msg.contains("no camera found"), "{msg}");
+        }
+        teardown_sandbox(&dir);
     }
 }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -170,12 +170,18 @@ fn xu_query(fd: c_int, unit: u8, selector: u8, query: u8, data: &mut [u8]) -> bo
     unsafe { libc::ioctl(fd, uvcioc_ctrl_query(), &mut q as *mut UvcXuControlQuery) >= 0 }
 }
 
+/// GET_LEN bounds check: a plausible XU control reports 1..=64 payload bytes;
+/// anything else (0 from a phantom control, or an absurd length) is rejected.
+/// Verbatim extraction from [`get_len`] as a test seam; zero behavior change.
+fn valid_ctrl_len(len: usize) -> Option<usize> {
+    (1..=64).contains(&len).then_some(len)
+}
+
 /// Length of XU control (unit, selector) if it exists, via `GET_LEN`. Read-only.
 fn get_len(fd: c_int, unit: u8, selector: u8) -> Option<usize> {
     let mut buf = [0u8; 2];
     if xu_query(fd, unit, selector, UVC_GET_LEN, &mut buf) {
-        let len = u16::from_le_bytes(buf) as usize;
-        (1..=64).contains(&len).then_some(len)
+        valid_ctrl_len(u16::from_le_bytes(buf) as usize)
     } else {
         None
     }
@@ -404,5 +410,220 @@ mod tests {
         let c = candidate_payloads(9);
         assert!(c.iter().all(|p| p.len() == 9));
         assert!(c.contains(&vec![1, 3, 2, 0, 0, 0, 0, 0, 0]));
+    }
+
+    /// Serializes access to the process env vars these tests flip
+    /// (`IRLUME_IR_EMITTER`, `IRLUME_IR_EMITTER_CONF`); cargo runs tests on
+    /// parallel threads sharing one environment.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// An fd that is open but is not a UVC device, so every XU ioctl fails
+    /// (ENOTTY): exercises the query-failure paths without touching a camera.
+    fn non_uvc_fd() -> std::fs::File {
+        std::fs::File::open("/dev/null").expect("open /dev/null")
+    }
+
+    #[test]
+    fn parse_control_accepts_decimal_and_hex() {
+        assert_eq!(
+            parse_control("14:6:1,3,2"),
+            Some(EmitterControl {
+                unit: 14,
+                selector: 6,
+                payload: vec![1, 3, 2],
+            })
+        );
+        assert_eq!(
+            parse_control(" 0x0E:0X06:0x01,255 "),
+            Some(EmitterControl {
+                unit: 14,
+                selector: 6,
+                payload: vec![1, 255],
+            })
+        );
+    }
+
+    #[test]
+    fn parse_control_rejects_garbage() {
+        // Empty / non-numeric / missing fields.
+        assert_eq!(parse_control(""), None);
+        assert_eq!(parse_control("   "), None);
+        assert_eq!(parse_control("abc"), None);
+        assert_eq!(parse_control("1:2"), None); // no payload section
+        assert_eq!(parse_control("1:2:"), None); // empty payload
+        assert_eq!(parse_control("x:2:1"), None); // bad unit
+        assert_eq!(parse_control("1:y:1"), None); // bad selector
+                                                  // Out-of-range unit/selector (u8 overflow) fail the whole parse.
+        assert_eq!(parse_control("256:1:1"), None);
+        assert_eq!(parse_control("1:300:1"), None);
+        // A payload of only invalid bytes is empty -> rejected...
+        assert_eq!(parse_control("1:2:300"), None);
+        // ...while invalid bytes among valid ones are dropped (filter_map).
+        assert_eq!(
+            parse_control("1:2:1,300,2").map(|c| c.payload),
+            Some(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn known_control_table_matches_verified_cards() {
+        // ASUS built-in Hello module: XU unit 14, selector 6.
+        let asus = known_control("USB Camera: ASUS FHD webcam").expect("ASUS entry");
+        assert_eq!((asus.unit, asus.selector), (14, 6));
+        assert_eq!(asus.payload, vec![1, 3, 2, 0, 0, 0, 0, 0, 0]);
+        // NexiGo HelloCam N930W: unit 4, same selector/payload.
+        let nexigo = known_control("NexiGo HelloCam N930W IR").expect("N930W entry");
+        assert_eq!((nexigo.unit, nexigo.selector), (4, 6));
+        assert_eq!(nexigo.payload, vec![1, 3, 2, 0, 0, 0, 0, 0, 0]);
+        // Unlisted cameras get no hard-coded control (auto-setup territory).
+        assert_eq!(known_control("Logitech Brio"), None);
+        assert_eq!(known_control(""), None);
+    }
+
+    #[test]
+    fn valid_ctrl_len_bounds() {
+        // GET_LEN plausibility: 1..=64 accepted, 0 and oversize rejected.
+        assert_eq!(valid_ctrl_len(0), None);
+        assert_eq!(valid_ctrl_len(1), Some(1));
+        assert_eq!(valid_ctrl_len(9), Some(9));
+        assert_eq!(valid_ctrl_len(64), Some(64));
+        assert_eq!(valid_ctrl_len(65), None);
+        assert_eq!(valid_ctrl_len(usize::MAX), None);
+    }
+
+    #[test]
+    fn conf_roundtrip_with_and_without_boost() {
+        let _g = env_guard();
+        let dir = std::env::temp_dir().join(format!("irlume-emitter-conf-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let conf = dir.join("ir_emitter.conf");
+        std::env::set_var("IRLUME_IR_EMITTER_CONF", &conf);
+
+        let emitter = EmitterControl {
+            unit: 4,
+            selector: 6,
+            payload: vec![1, 3, 2],
+        };
+        let boost = EmitterControl {
+            unit: 4,
+            selector: 9,
+            payload: vec![255, 255],
+        };
+        // Emitter alone: one line, no boost on load.
+        save_conf(&emitter).unwrap();
+        assert_eq!(load_conf(), Some(emitter.clone()));
+        assert_eq!(load_boost(), None);
+        // Emitter + boost: two lines, both load back exactly.
+        save_conf_full(&emitter, Some(&boost)).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&conf).unwrap(),
+            "4:6:1,3,2\n4:9:255,255"
+        );
+        assert_eq!(load_conf(), Some(emitter));
+        assert_eq!(load_boost(), Some(boost));
+        // Missing conf: both loaders return None.
+        std::fs::remove_file(&conf).unwrap();
+        assert_eq!(load_conf(), None);
+        assert_eq!(load_boost(), None);
+
+        std::env::remove_var("IRLUME_IR_EMITTER_CONF");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn enable_honors_off_env_and_config_precedence() {
+        let _g = env_guard();
+        let dir = std::env::temp_dir().join(format!("irlume-emitter-en-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Point the conf away from any real /var/lib/irlume install.
+        std::env::set_var("IRLUME_IR_EMITTER_CONF", dir.join("none.conf"));
+        let f = non_uvc_fd();
+        use std::os::fd::AsRawFd;
+        let fd = f.as_raw_fd();
+
+        // `off`/`none` disable before any control lookup or ioctl.
+        std::env::set_var("IRLUME_IR_EMITTER", "off");
+        assert!(!enable(fd, "ASUS"));
+        std::env::set_var("IRLUME_IR_EMITTER", "none");
+        assert!(!enable(fd, "ASUS"));
+        // A valid env control is parsed, but SET_CUR on a non-UVC fd fails.
+        std::env::set_var("IRLUME_IR_EMITTER", "14:6:1,3,2");
+        assert!(!enable(fd, "whatever"));
+        std::env::remove_var("IRLUME_IR_EMITTER");
+        // No env, no conf, unknown card: no control at all.
+        assert!(!enable(fd, "Some Unknown Cam"));
+        // No env, no conf, known card: the table entry is used (ioctl still fails).
+        assert!(!enable(fd, "ASUS"));
+        // No env, conf present: the persisted control is used (ioctl still fails).
+        save_conf(&EmitterControl {
+            unit: 1,
+            selector: 2,
+            payload: vec![7],
+        })
+        .unwrap();
+        assert!(!enable(fd, "Some Unknown Cam"));
+
+        std::env::remove_var("IRLUME_IR_EMITTER_CONF");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn boost_candidates_sized_and_swept_low_to_high_magnitudes() {
+        let c = boost_candidates(4);
+        assert!(c.iter().all(|p| p.len() == 4));
+        assert!(c.contains(&vec![0xFF; 4]));
+        assert!(c.contains(&vec![0x80; 4]));
+        assert!(c.contains(&vec![0xFF, 0, 0, 0]));
+        assert!(c.contains(&vec![0xFF, 0xFF, 0, 0]));
+        // Degenerate size 1: full(0xFF) and low_bytes collapse; dedup shrinks.
+        let one = boost_candidates(1);
+        assert!(one.iter().all(|p| p.len() == 1));
+        assert!(one.contains(&vec![0xFF]));
+    }
+
+    #[test]
+    fn candidate_payloads_truncate_to_small_controls() {
+        // A 1-byte control still gets the leading bytes of each pattern.
+        let one = candidate_payloads(1);
+        assert!(one.iter().all(|p| p.len() == 1));
+        assert!(one.contains(&vec![1]));
+        assert!(one.contains(&vec![3]));
+        assert!(one.contains(&vec![0]));
+    }
+
+    #[test]
+    fn discovery_on_a_non_uvc_fd_finds_nothing_and_stays_safe() {
+        let f = non_uvc_fd();
+        use std::os::fd::AsRawFd;
+        let fd = f.as_raw_fd();
+        // Every GET_LEN fails -> no controls enumerated.
+        assert!(list_controls(fd).is_empty());
+        // Autoconfigure: baseline measured exactly once, sweep finds nothing.
+        let mut calls = 0u32;
+        let mut measure = || {
+            calls += 1;
+            0.0f32
+        };
+        assert_eq!(autoconfigure(fd, &mut measure), None);
+        assert_eq!(calls, 1, "only the emitter-off baseline is measured");
+        // Boost discovery: emitter-on base measured once, nothing found.
+        let emitter = EmitterControl {
+            unit: 14,
+            selector: 6,
+            payload: vec![1, 3, 2],
+        };
+        let mut calls = 0u32;
+        let mut measure = || {
+            calls += 1;
+            0.0f32
+        };
+        assert_eq!(discover_boost(fd, &emitter, &mut measure), None);
+        assert_eq!(calls, 1, "only the emitter-alone base is measured");
     }
 }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -866,6 +866,23 @@ pub mod ir_probe {
     }
 }
 
+/// Sparse content signature for the frozen-stream detector: up to 64 bytes
+/// sampled at a fixed stride across the frame. Verbatim extraction from
+/// [`capture_ir_sequence`] (the former `sig_of` closure) so the pure logic is
+/// unit-testable without a camera; zero behavior change.
+pub(crate) fn frame_signature(data: &[u8]) -> Vec<u8> {
+    let stride = (data.len() / 64).max(1);
+    data.iter().step_by(stride).take(64).copied().collect()
+}
+
+/// Frozen-stream predicate: BIT-IDENTICAL consecutive signatures on a frame
+/// whose mean sits in the normal exposure band (saturated / near-black frames
+/// are optical states, not a stall). Verbatim extraction of the `frozen`
+/// expression in [`capture_ir_sequence`] as a test seam; zero behavior change.
+pub(crate) fn frame_frozen(best_mean: f64, sig: &[u8], last_sig: Option<&[u8]>) -> bool {
+    (10.0..245.0).contains(&best_mean) && last_sig == Some(sig)
+}
+
 /// Capture a time-ordered SEQUENCE of IR frames in a single stream session, for
 /// temporal liveness (the blink challenge). Unlike [`capture_ir`], the eyes-closed
 /// dip of a blink must survive, so this returns every sample rather than only the
@@ -907,10 +924,7 @@ pub fn capture_ir_sequence(
     // repeats exactly. Saturated and near-black frames are excluded from the
     // check: those are optical states (exposure blow-out / emitter-off phase),
     // not a stall, and restarting mid-settle only prolongs the settle.
-    let sig_of = |data: &[u8]| -> Vec<u8> {
-        let stride = (data.len() / 64).max(1);
-        data.iter().step_by(stride).take(64).copied().collect()
-    };
+    // (Signature + predicate live in `frame_signature` / `frame_frozen`.)
     let mut frames = Vec::with_capacity(samples);
     // Attempt budget: enough spare frames to ride out the ~1 s dark-start
     // exposure settle and a stream restart without starving the window, while
@@ -941,9 +955,8 @@ pub fn capture_ir_sequence(
             }
         }
         let Some(data) = best else { continue };
-        let sig = sig_of(&data);
-        let frozen =
-            (10.0..245.0).contains(&best_mean) && last_sig.as_deref() == Some(sig.as_slice());
+        let sig = frame_signature(&data);
+        let frozen = frame_frozen(best_mean, &sig, last_sig.as_deref());
         last_sig = Some(sig);
         if frozen {
             dead_run += 1;
@@ -1176,6 +1189,288 @@ mod tests {
         assert!(!is_physical_camera_path(
             "/sys/devices/virtual/video4linux/video0"
         ));
+    }
+
+    #[test]
+    fn yuyv_full_and_zero_luma_hit_the_clamps() {
+        // Y=255 neutral chroma -> white (clamped at 255); Y=0 -> black.
+        let white = yuyv_to_rgb(&[255, 128, 255, 128], 2, 1);
+        assert_eq!(white, vec![255; 6]);
+        let black = yuyv_to_rgb(&[0, 128, 0, 128], 2, 1);
+        assert_eq!(black, vec![0; 6]);
+    }
+
+    #[test]
+    fn yuyv_chroma_maps_to_the_right_channels() {
+        // High U (blue-difference) with neutral V: blue saturates, red stays at
+        // luma, green dips below it (BT.601: b=y+1.772u, g=y-0.344u).
+        let rgb = yuyv_to_rgb(&[128, 255, 128, 128], 2, 1);
+        let (r, g, b) = (rgb[0], rgb[1], rgb[2]);
+        assert_eq!(b, 255);
+        assert_eq!(r, 128);
+        assert!(g < 128, "green must dip under +U, got {g}");
+        // High V (red-difference): red saturates, blue stays at luma.
+        let rgb = yuyv_to_rgb(&[128, 128, 128, 255], 2, 1);
+        assert_eq!(rgb[0], 255);
+        assert_eq!(rgb[2], 128);
+    }
+
+    #[test]
+    fn yuyv_short_buffer_converts_what_exists_and_zero_fills() {
+        // 4x2 frame needs 16 YUYV bytes; give only 4 (one pixel pair). The
+        // output is still full-sized, with the missing pixels left black.
+        let rgb = yuyv_to_rgb(&[128, 128, 128, 128], 4, 2);
+        assert_eq!(rgb.len(), 4 * 2 * 3);
+        assert!(rgb[..6].iter().all(|&c| (c as i32 - 128).abs() <= 1));
+        assert!(rgb[6..].iter().all(|&c| c == 0));
+    }
+
+    #[test]
+    fn yuyv_odd_pixel_count_drops_the_unpaired_tail() {
+        // 3x1: pairs = 3/2 = 1, so pixels 0-1 convert and pixel 2 stays black
+        // even though input bytes for it exist.
+        let rgb = yuyv_to_rgb(&[128, 128, 128, 128, 128, 128], 3, 1);
+        assert_eq!(rgb.len(), 9);
+        assert!(rgb[..6].iter().all(|&c| (c as i32 - 128).abs() <= 1));
+        assert_eq!(&rgb[6..], &[0, 0, 0]);
+    }
+
+    #[test]
+    fn grey_to_rgb_replicates_each_sample() {
+        assert_eq!(
+            grey_to_rgb(&[0, 128, 255]),
+            vec![0, 0, 0, 128, 128, 128, 255, 255, 255]
+        );
+        assert!(grey_to_rgb(&[]).is_empty());
+    }
+
+    #[test]
+    fn median_frame_even_burst_takes_upper_middle_and_min_length() {
+        // Even burst: sorted [1,2,3,4] -> index 4/2 = 2 -> 3 (upper middle).
+        let frames = vec![frame(&[1]), frame(&[4]), frame(&[2]), frame(&[3])];
+        assert_eq!(median_frame(frames).data, vec![3]);
+        // Mixed-length burst: output truncates to the shortest frame, and the
+        // dimensions/spectrum come from the first frame.
+        let frames = vec![frame(&[9, 9, 9]), frame(&[5, 5]), frame(&[7, 7, 7])];
+        let m = median_frame(frames);
+        assert_eq!(m.data, vec![7, 7]);
+        assert_eq!((m.width, m.height, m.spectrum), (3, 1, Spectrum::Rgb));
+    }
+
+    #[test]
+    fn ir_mean_handles_empty_and_averages() {
+        assert_eq!(ir_probe::mean(&[]), 0.0);
+        assert_eq!(ir_probe::mean(&[0, 255]), 127.5);
+        assert_eq!(ir_probe::mean(&[10, 10, 10]), 10.0);
+    }
+
+    #[test]
+    fn center_border_ratio_separates_lit_subject_from_flat_scene() {
+        let (w, h) = (8u32, 8u32);
+        // Emitter-lit subject: center 4x4 at 200, border at 50 -> ratio 4.
+        let mut lit = vec![50u8; (w * h) as usize];
+        for y in 2..6 {
+            for x in 2..6 {
+                lit[(y * w + x) as usize] = 200;
+            }
+        }
+        assert!((ir_probe::center_border_ratio(&lit, w, h) - 4.0).abs() < 1e-9);
+        // Uniform scene -> ~1 (no subject emphasis).
+        let flat = vec![100u8; (w * h) as usize];
+        assert!((ir_probe::center_border_ratio(&flat, w, h) - 1.0).abs() < 1e-9);
+        // Degenerate inputs: short buffer, tiny dims, all-black border.
+        assert_eq!(ir_probe::center_border_ratio(&[1, 2, 3], w, h), 0.0);
+        assert_eq!(ir_probe::center_border_ratio(&flat, 2, 2), 0.0);
+        assert_eq!(ir_probe::center_border_ratio(&[0u8; 64], 8, 8), 0.0);
+    }
+
+    #[test]
+    fn frame_signature_is_sparse_and_content_sensitive() {
+        // Short frames: the whole content is the signature.
+        assert_eq!(frame_signature(&[1, 2, 3]), vec![1, 2, 3]);
+        // Long frames: capped at 64 sampled bytes.
+        let long = vec![7u8; 640 * 400];
+        let sig = frame_signature(&long);
+        assert_eq!(sig.len(), 64);
+        assert!(sig.iter().all(|&b| b == 7));
+        // Identical content -> identical signature; a change at a sampled
+        // position (index 0 is always sampled) -> different signature.
+        let mut changed = long.clone();
+        changed[0] = 8;
+        assert_eq!(frame_signature(&long), sig);
+        assert_ne!(frame_signature(&changed), sig);
+    }
+
+    #[test]
+    fn frozen_detector_fires_only_on_repeated_normal_exposure_frames() {
+        let sig = frame_signature(&[99u8; 1024]);
+        // First frame of a window (no previous signature): never frozen.
+        assert!(!frame_frozen(99.0, &sig, None));
+        // Bit-identical consecutive mid-grey frames: frozen.
+        assert!(frame_frozen(99.0, &sig, Some(&sig)));
+        // Same signature but saturated / near-black mean: optical state, not a
+        // stall (exposure blow-out or the emitter-off strobe phase).
+        assert!(!frame_frozen(250.0, &sig, Some(&sig)));
+        assert!(!frame_frozen(245.0, &sig, Some(&sig)));
+        assert!(!frame_frozen(5.0, &sig, Some(&sig)));
+        // Boundary means inside the band still count.
+        assert!(frame_frozen(10.0, &sig, Some(&sig)));
+        // Different content -> live stream.
+        let other = frame_signature(&[98u8; 1024]);
+        assert!(!frame_frozen(99.0, &sig, Some(&other)));
+    }
+
+    #[test]
+    fn map_io_translates_busy_permission_and_generic_errors() {
+        // EBUSY (16) on a device nothing holds: generic busy guidance.
+        let e = map_io(
+            "/dev/irlume-test-missing",
+            std::io::Error::from_raw_os_error(16),
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("camera busy"), "{msg}");
+        assert!(msg.contains("another app is using it"), "{msg}");
+        // Permission denied: the video-group hint.
+        let e = map_io(
+            "/dev/irlume-test-missing",
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        );
+        assert!(e.to_string().contains("'video' group"), "{e}");
+        // Anything else: device-prefixed passthrough.
+        let e = map_io(
+            "/dev/irlume-test-missing",
+            std::io::Error::from_raw_os_error(5),
+        );
+        assert!(
+            e.to_string()
+                .starts_with("hardware: /dev/irlume-test-missing:"),
+            "{e}"
+        );
+    }
+
+    #[test]
+    fn camera_holder_finds_our_own_open_file() {
+        // Hold a file open ourselves; the /proc scan must name this process.
+        let dir = std::env::temp_dir().join(format!("irlume-cam-holder-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("held");
+        std::fs::write(&path, b"x").unwrap();
+        let _held = std::fs::File::open(&path).unwrap();
+        let who = camera_holder(path.to_str().unwrap()).expect("holder found");
+        assert!(
+            who.contains(&format!("pid {}", std::process::id())),
+            "unexpected holder: {who}"
+        );
+        // Nothing holds a nonexistent path.
+        assert_eq!(camera_holder("/dev/irlume-test-missing"), None);
+        drop(_held);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_pinned_rejects_missing_and_non_sysfs_devices() {
+        // No node at all: the plain no-camera error, not the injection one.
+        let e = verify_pinned("/dev/irlume-test-missing").unwrap_err();
+        assert!(e.to_string().contains("no camera found"), "{e}");
+        // An existing node with no video4linux sysfs entry (a non-camera): the
+        // anti-injection refusal.
+        let e = verify_pinned("/dev/null").unwrap_err();
+        assert!(e.to_string().contains("no physical device in sysfs"), "{e}");
+    }
+
+    #[test]
+    fn capture_entrypoints_refuse_a_missing_device_before_any_io() {
+        // Every capture path front-doors through verify_pinned, so a missing
+        // node fails fast with the same actionable error and no V4L2 calls.
+        for r in [
+            capture_rgb("/dev/irlume-test-missing")
+                .err()
+                .map(|e| e.to_string()),
+            capture_ir("/dev/irlume-test-missing")
+                .err()
+                .map(|e| e.to_string()),
+            capture_ir_sequence("/dev/irlume-test-missing", 1, 1)
+                .err()
+                .map(|e| e.to_string()),
+            ir_probe::capture_raw_burst("/dev/irlume-test-missing", 1)
+                .err()
+                .map(|e| e.to_string()),
+            setup_ir_emitter("/dev/irlume-test-missing")
+                .err()
+                .map(|e| e.to_string()),
+            list_ir_controls("/dev/irlume-test-missing")
+                .err()
+                .map(|e| e.to_string()),
+        ] {
+            let msg = r.expect("must fail without a device");
+            assert!(msg.contains("no camera found"), "{msg}");
+        }
+    }
+
+    #[test]
+    fn device_identity_absent_for_non_usb_nodes() {
+        assert_eq!(device_identity("/dev/null"), None);
+        assert_eq!(device_identity("/dev/irlume-test-missing"), None);
+    }
+
+    #[test]
+    fn classify_unreadable_or_non_video_nodes_as_other() {
+        assert_eq!(classify("/dev/irlume-test-missing"), Role::Other);
+        // /dev/null opens but answers no V4L2 format ioctls.
+        assert_eq!(classify("/dev/null"), Role::Other);
+    }
+
+    #[test]
+    fn find_attr_dir_walks_up_only_inside_sysfs() {
+        let dir = std::env::temp_dir().join(format!("irlume-attr-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let leaf = dir.join("iface");
+        std::fs::create_dir_all(&leaf).unwrap();
+        // Attribute in the start dir itself: found immediately.
+        std::fs::write(leaf.join("idVendor"), "3277").unwrap();
+        assert_eq!(find_attr_dir(&leaf, "idVendor"), Some(leaf.clone()));
+        // Attribute only above a non-/sys/devices start: the walk refuses to
+        // escape sysfs and gives up (anti-confusion guard).
+        std::fs::write(dir.join("removable"), "fixed").unwrap();
+        assert_eq!(find_attr_dir(&leaf, "removable"), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_vidpid_formats_descriptor_files() {
+        let dir = std::env::temp_dir().join(format!("irlume-vidpid-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Missing descriptors -> None.
+        assert_eq!(read_vidpid(&dir), None);
+        std::fs::write(dir.join("idVendor"), "3277\n").unwrap();
+        assert_eq!(read_vidpid(&dir), None); // product still missing
+        std::fs::write(dir.join("idProduct"), "0059\n").unwrap();
+        assert_eq!(read_vidpid(&dir), Some("3277:0059".into()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn select_pair_env_override_wins() {
+        // The explicit env pair short-circuits discovery entirely (no device
+        // scan), so this is deterministic on any machine.
+        std::env::set_var("IRLUME_RGB_DEVICE", "/dev/irlume-test-rgb");
+        std::env::set_var("IRLUME_IR_DEVICE", "/dev/irlume-test-ir");
+        assert_eq!(
+            select_pair(),
+            ("/dev/irlume-test-rgb".into(), "/dev/irlume-test-ir".into())
+        );
+        std::env::remove_var("IRLUME_RGB_DEVICE");
+        std::env::remove_var("IRLUME_IR_DEVICE");
+    }
+
+    #[test]
+    fn privacy_engaged_is_false_without_a_camera() {
+        // Missing node or a non-V4L2 node: the check degrades to "not engaged"
+        // (the capture path then surfaces the real error).
+        assert!(!privacy_engaged("/dev/irlume-test-missing"));
+        assert!(!privacy_engaged("/dev/null"));
     }
 
     #[test]

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1269,8 +1269,8 @@ SYSTEM INTEGRATION
 #[cfg(test)]
 mod origin_tests {
     use super::{
-        gz_lists_irlume, installed_version, is_copr_repo, ppa_serves, ubuntu_codename,
-        InstallOrigin,
+        arch_names, gz_lists_irlume, installed_version, is_copr_repo, latest_release_tag,
+        ppa_serves, release_assets, ubuntu_codename, version_gt, InstallOrigin,
     };
 
     #[test]
@@ -1349,6 +1349,9 @@ mod origin_tests {
     // failure must be None (unknown), never "not served".
     #[test]
     fn update_probes_query_the_package_manager_and_the_ppa_index() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = std::env::temp_dir().join(format!("irlume-cli-faketools-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
@@ -1395,6 +1398,76 @@ esac"#,
         assert_eq!(ppa_serves("resolute"), None);
 
         std::env::remove_var("FAKE_CURL_MODE");
+        std::env::set_var("PATH", old_path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn version_gt_compares_numeric_fields_and_ignores_distro_suffixes() {
+        assert!(version_gt("0.3.0", "0.2.9"));
+        assert!(version_gt("0.10.0", "0.9.9"), "numeric, not lexicographic");
+        assert!(version_gt("1.0", "0.9.9.9"));
+        assert!(version_gt("0.2.1", "0.2"), "missing fields count as 0");
+        assert!(!version_gt("0.2", "0.2.0"));
+        assert!(!version_gt("0.2.1", "0.2.1"));
+        // The real call is version_gt(release_tag, installed_version), where the
+        // installed side may carry a distro suffix (dpkg "0.2.1-0ppa1~resolute1",
+        // pacman "0.1.3-1"): a same-upstream tag must not read as newer, and the
+        // next upstream tag must.
+        assert!(!version_gt("0.2.1", "0.2.1-0ppa1~resolute1"));
+        assert!(version_gt("0.2.2", "0.2.1-0ppa1~resolute1"));
+        assert!(!version_gt("0.1.3", "0.1.3-1"));
+        assert!(version_gt("0.1.4", "0.1.3-1"));
+        // Pre-release tags compare as their base version.
+        assert!(!version_gt("1.0.0-rc1", "1.0.0"));
+        assert!(!version_gt("1.0.0", "1.0.0-rc1"));
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn arch_names_map_x86_64_to_the_per_ecosystem_spellings() {
+        assert_eq!(arch_names(), ("amd64", "x86_64", "amd64"));
+    }
+
+    #[test]
+    fn ubuntu_codename_falls_back_to_version_codename() {
+        // Older/derivative os-release files may lack UBUNTU_CODENAME entirely.
+        let os = "ID=ubuntu\nVERSION_CODENAME=resolute\n";
+        assert_eq!(ubuntu_codename(os).as_deref(), Some("resolute"));
+    }
+
+    // The release feed is scraped without a JSON dependency; pin what the
+    // scanner keeps (package files) and what it must skip (the release title,
+    // checksum files) plus the offline degradation to None/empty.
+    #[test]
+    fn release_feed_parsing_keeps_only_package_assets() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!("irlume-cli-fakefeed-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let body = r#"{"tag_name": "v9.9.9", "name": "irlume 9.9.9", "assets": [{"name": "irlume_9.9.9_amd64.deb"}, {"name": "irlume-9.9.9-1.fc44.x86_64.rpm"}, {"name": "irlume-9.9.9-1-x86_64.pkg.tar.zst"}, {"name": "SHA256SUMS"}]}"#;
+        fake_tool(&dir, "curl", &format!("printf '%s' '{body}'"));
+        let old_path = std::env::var("PATH").unwrap();
+        std::env::set_var("PATH", format!("{}:{old_path}", dir.display()));
+
+        assert_eq!(latest_release_tag().as_deref(), Some("v9.9.9"));
+        assert_eq!(
+            release_assets(),
+            vec![
+                "irlume_9.9.9_amd64.deb".to_string(),
+                "irlume-9.9.9-1.fc44.x86_64.rpm".to_string(),
+                "irlume-9.9.9-1-x86_64.pkg.tar.zst".to_string(),
+            ],
+            "the release title and SHA256SUMS are not package assets"
+        );
+
+        // Offline (curl connect failure): unknown, never a false answer.
+        fake_tool(&dir, "curl", "exit 7");
+        assert_eq!(latest_release_tag(), None);
+        assert!(release_assets().is_empty());
+
         std::env::set_var("PATH", old_path);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2308,6 +2308,15 @@ fn capture(args: &[String]) -> std::process::ExitCode {
     }
 }
 
+/// Serializes unit tests that mutate process-global environment variables
+/// (PATH, USER, IRLUME_CONFIG_DIR, IRLUME_STATE_DIR, ...): the same pattern as
+/// `tui::tests::ENV_LOCK` (which guards IRLUME_SOCKET), shared here so the
+/// env-mutating tests in main.rs, commands.rs, and models.rs never race.
+#[cfg(test)]
+pub(crate) mod testenv {
+    pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+}
+
 /// Phase-1 make-or-break: load the recognition model and embed the same chip
 /// twice: cosine MUST be ~1.0. Proves the ONNX path is deterministic and the
 /// preprocessing is wired before any matching is trusted. Needs the AuraFace
@@ -2337,5 +2346,145 @@ fn selftest_align(args: &[String]) -> std::process::ExitCode {
             eprintln!("  (need the .onnx file and libonnxruntime.so on the system)");
             std::process::ExitCode::FAILURE
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn flag_returns_the_value_following_the_name() {
+        let a = argv(&["--user", "alice", "--scans", "5"]);
+        assert_eq!(flag(&a, "--user"), Some("alice"));
+        assert_eq!(flag(&a, "--scans"), Some("5"));
+        assert_eq!(flag(&a, "--name"), None);
+    }
+
+    #[test]
+    fn flag_with_the_name_in_last_position_has_no_value() {
+        let a = argv(&["enroll", "--reset"]);
+        assert_eq!(flag(&a, "--reset"), None);
+    }
+
+    #[test]
+    fn flag_takes_the_first_occurrence() {
+        let a = argv(&["--user", "a", "--user", "b"]);
+        assert_eq!(flag(&a, "--user"), Some("a"));
+    }
+
+    #[test]
+    fn user_arg_prefers_the_explicit_flag() {
+        assert_eq!(user_arg(&argv(&["--user", "carol"])), "carol");
+    }
+
+    #[test]
+    fn user_arg_falls_back_to_env_user_when_flag_is_empty_or_absent() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if unsafe { libc::geteuid() } == 0 {
+            return; // the SUDO_USER preference only applies to root; not this run
+        }
+        let old_user = std::env::var_os("USER");
+        let old_sudo = std::env::var_os("SUDO_USER");
+        std::env::set_var("USER", "envuser");
+        // A non-root process must ignore SUDO_USER (the root-only preference).
+        std::env::set_var("SUDO_USER", "someoneelse");
+        assert_eq!(user_arg(&argv(&["--user", ""])), "envuser");
+        assert_eq!(user_arg(&[]), "envuser");
+        match old_user {
+            Some(v) => std::env::set_var("USER", v),
+            None => std::env::remove_var("USER"),
+        }
+        match old_sudo {
+            Some(v) => std::env::set_var("SUDO_USER", v),
+            None => std::env::remove_var("SUDO_USER"),
+        }
+    }
+
+    #[test]
+    fn json_f32_maps_non_finite_to_null() {
+        assert_eq!(json_f32(1.5), serde_json::json!(1.5));
+        assert_eq!(json_f32(0.0), serde_json::json!(0.0));
+        assert_eq!(json_f32(f32::NAN), serde_json::Value::Null);
+        assert_eq!(json_f32(f32::INFINITY), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn darken_chip_scales_rounds_and_clamps() {
+        assert_eq!(darken_chip(&[0, 100, 200, 255], 0.5), vec![0, 50, 100, 128]);
+        assert_eq!(darken_chip(&[200], 2.0), vec![255], "must clamp at 255");
+    }
+
+    #[test]
+    fn blur_chip_keeps_uniform_images_and_spreads_a_point() {
+        let n = 112usize;
+        let uniform = vec![7u8; n * n * 3];
+        assert_eq!(blur_chip(&uniform), uniform);
+
+        // A single bright pixel becomes the 3x3 box average around it.
+        let mut chip = vec![0u8; n * n * 3];
+        chip[(5 * n + 5) * 3] = 90;
+        let out = blur_chip(&chip);
+        assert_eq!(out[(5 * n + 5) * 3], 10, "interior: 90 / 9 neighbours");
+        assert_eq!(out[(4 * n + 4) * 3], 10, "diagonal neighbour sees it too");
+
+        // At the corner only 4 pixels are in the window.
+        let mut chip = vec![0u8; n * n * 3];
+        chip[0] = 80;
+        assert_eq!(blur_chip(&chip)[0], 20, "corner: 80 / 4 neighbours");
+    }
+
+    #[test]
+    fn collect_images_recurses_and_filters_extensions() {
+        let dir = std::env::temp_dir().join(format!("irlume-collect-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        for f in [
+            "a.jpg",
+            "b.PNG",
+            "c.txt",
+            "noext",
+            "sub/d.bmp",
+            "sub/e.jpeg",
+        ] {
+            std::fs::write(dir.join(f), b"x").unwrap();
+        }
+        let mut out = Vec::new();
+        collect_images(&dir, &mut out);
+        let mut names: Vec<String> = out
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names, ["a.jpg", "b.PNG", "d.bmp", "e.jpeg"]);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // A missing directory yields nothing rather than an error.
+        let mut out = Vec::new();
+        collect_images(std::path::Path::new("/nonexistent/irlume-imgs"), &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn eye_glint_takes_the_peak_near_the_eye_landmarks_only() {
+        let (w, h) = (64u32, 64u32);
+        let mut grey = vec![0u8; (w * h) as usize];
+        let landmarks: irlume_vision::Landmarks5 = [
+            (10.0, 10.0), // left eye
+            (30.0, 10.0), // right eye
+            (20.0, 20.0),
+            (12.0, 28.0),
+            (28.0, 28.0),
+        ];
+        assert_eq!(eye_glint(&grey, w, h, &landmarks), 0.0);
+        grey[(12 * w + 12) as usize] = 200; // within radius 8 of the left eye
+        grey[(60 * w + 60) as usize] = 255; // far from both eyes: must not count
+        assert_eq!(eye_glint(&grey, w, h, &landmarks), 200.0);
     }
 }

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -264,3 +264,83 @@ pub fn doctor_line() -> String {
     }
     "none (default; see `irlume models`)".into()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// doctor_line's classification: enabled name vs catalog membership vs
+    /// weight state, all against sandboxed config/state dirs.
+    #[test]
+    fn doctor_line_reports_catalog_membership_and_weight_state() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if is_root() {
+            return; // the unprivileged branches are what is under test
+        }
+        let root = std::env::temp_dir().join(format!("irlume-models-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let (cfg, state) = (root.join("cfg"), root.join("state"));
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::fs::create_dir_all(&state).unwrap();
+        let old_cfg = std::env::var_os("IRLUME_CONFIG_DIR");
+        let old_state = std::env::var_os("IRLUME_STATE_DIR");
+        std::env::set_var("IRLUME_CONFIG_DIR", &cfg);
+        std::env::set_var("IRLUME_STATE_DIR", &state);
+
+        // Nothing enabled, nothing on disk.
+        assert!(
+            doctor_line().starts_with("none (default"),
+            "got: {}",
+            doctor_line()
+        );
+
+        // Weights on disk but no readable enabled key: report the file without
+        // claiming an enabled state the caller cannot confirm.
+        let m = &thirdparty::CATALOG[0];
+        std::fs::create_dir_all(thirdparty::dir()).unwrap();
+        std::fs::write(thirdparty::model_path(m), b"garbage").unwrap();
+        let line = doctor_line();
+        assert!(line.contains("weights installed"), "got: {line}");
+        assert!(line.contains("root-only"), "got: {line}");
+        std::fs::remove_file(thirdparty::model_path(m)).unwrap();
+
+        // An enabled name that is not in the catalog is called out.
+        std::fs::write(cfg.join("settings.conf"), "third_party_pad=ghost\n").unwrap();
+        assert!(
+            doctor_line().contains("NOT in the catalog"),
+            "got: {}",
+            doctor_line()
+        );
+
+        // Enabled catalog model, weights never fetched.
+        std::fs::write(
+            cfg.join("settings.conf"),
+            format!("third_party_pad={}\n", m.name),
+        )
+        .unwrap();
+        assert_eq!(
+            doctor_line(),
+            format!("{} enabled (weights not fetched; deny-only cue)", m.name)
+        );
+
+        // Enabled with weights whose checksum no longer matches the pin.
+        std::fs::write(thirdparty::model_path(m), b"garbage").unwrap();
+        assert!(
+            doctor_line().contains("CHECKSUM MISMATCH"),
+            "got: {}",
+            doctor_line()
+        );
+
+        match old_cfg {
+            Some(v) => std::env::set_var("IRLUME_CONFIG_DIR", v),
+            None => std::env::remove_var("IRLUME_CONFIG_DIR"),
+        }
+        match old_state {
+            Some(v) => std::env::set_var("IRLUME_STATE_DIR", v),
+            None => std::env::remove_var("IRLUME_STATE_DIR"),
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -553,3 +553,143 @@ fn render_markdown(r: &metrics::PadReport, input: &str, paths: &[String]) -> Str
     o.push_str("> evaluation. See `docs/PAD_SELFTEST.md` for protocol, PAI species, and limits.\n");
     o
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use irlume_liveness::{DEPTH_MIN_RATIO, IR_FACE_MIN_BRIGHTNESS, MIN_FACE_SCORE};
+
+    /// Signals that pass every cue the attribution helper looks at.
+    fn passing_signals() -> Signals {
+        Signals {
+            ir_face: Some(FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: MIN_FACE_SCORE + 0.2,
+            }),
+            ir_face_brightness: IR_FACE_MIN_BRIGHTNESS + 20.0,
+            ir_center_edge_ratio: DEPTH_MIN_RATIO + 0.2,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn verdict_str_names_every_verdict() {
+        assert_eq!(verdict_str(Verdict::Live), "Live");
+        assert_eq!(verdict_str(Verdict::Spoof), "Spoof");
+        assert_eq!(verdict_str(Verdict::Uncertain), "Uncertain");
+    }
+
+    // caught_cue replicates the gate's short-circuit order; if the gate's cue
+    // order changes, this attribution must change with it.
+    #[test]
+    fn caught_cue_full_path_attributes_in_gate_order() {
+        let mut s = passing_signals();
+        assert_eq!(caught_cue(Path::Full, &s), None);
+
+        s.ir_center_edge_ratio = DEPTH_MIN_RATIO - 0.1;
+        assert_eq!(caught_cue(Path::Full, &s), Some("depth"));
+
+        // Reflectance failure outranks the depth failure.
+        s.ir_face_brightness = IR_FACE_MIN_BRIGHTNESS - 1.0;
+        assert_eq!(caught_cue(Path::Full, &s), Some("ir_reflectance"));
+
+        // Presence outranks everything: no IR face, or one below MIN_FACE_SCORE.
+        let mut weak = passing_signals();
+        weak.ir_face.as_mut().unwrap().score = MIN_FACE_SCORE - 0.1;
+        assert_eq!(caught_cue(Path::Full, &weak), Some("face_in_ir"));
+        let mut absent = passing_signals();
+        absent.ir_face = None;
+        assert_eq!(caught_cue(Path::Full, &absent), Some("face_in_ir"));
+    }
+
+    #[test]
+    fn caught_cue_ir_only_path_skips_the_presence_cue() {
+        // The IR-only gate assumes presence (it just matched the face); its
+        // first hard cue is reflectance, even with no ir_face in the signals.
+        let mut s = passing_signals();
+        s.ir_face = None;
+        s.ir_face_brightness = IR_FACE_MIN_BRIGHTNESS - 1.0;
+        assert_eq!(caught_cue(Path::IrOnly, &s), Some("ir_reflectance"));
+
+        let mut s = passing_signals();
+        s.ir_center_edge_ratio = DEPTH_MIN_RATIO - 0.1;
+        assert_eq!(caught_cue(Path::IrOnly, &s), Some("depth"));
+        assert_eq!(caught_cue(Path::IrOnly, &passing_signals()), None);
+    }
+
+    #[test]
+    fn pct_formats_rates_and_maps_nan_to_na() {
+        assert_eq!(pct(f64::NAN), "  n/a");
+        assert_eq!(pct(0.0), "  0.0%");
+        assert_eq!(pct(0.25), " 25.0%");
+        assert_eq!(pct(1.0), "100.0%");
+    }
+
+    fn attack(species: &str, outcome: metrics::Outcome, caught: &[&str]) -> metrics::Trial {
+        metrics::Trial {
+            species: species.into(),
+            label: metrics::Label::Attack,
+            outcome,
+            caught: caught.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn bonafide(outcome: metrics::Outcome) -> metrics::Trial {
+        metrics::Trial {
+            species: "bonafide".into(),
+            label: metrics::Label::BonaFide,
+            outcome,
+            caught: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn renderers_carry_the_iso_numbers_and_cue_attribution() {
+        use metrics::Outcome::{Accepted, Rejected};
+        let trials = vec![
+            attack("print_glossy", Rejected, &["depth"]),
+            attack("print_glossy", Rejected, &["depth"]),
+            attack("print_glossy", Accepted, &[]),
+            bonafide(Accepted),
+            bonafide(Accepted),
+            bonafide(Accepted),
+            bonafide(Rejected),
+        ];
+        let r = metrics::analyze(&trials);
+
+        let h = render_human(&r, "pad.jsonl", &["full".to_string()]);
+        assert!(h.contains("gate path(s): full"), "{h}");
+        assert!(h.contains("attack presentations: 3"), "{h}");
+        assert!(h.contains("bona-fide: 4"), "{h}");
+        assert!(h.contains("print_glossy"), "{h}");
+        assert!(h.contains("33.3%"), "APCER 1 accepted of 3: {h}");
+        assert!(h.contains("depth:2"), "cue attribution: {h}");
+        assert!(h.contains("WORST-CASE APCER: print_glossy"), "{h}");
+        assert!(h.contains("25.0%"), "BPCER 1 of 4: {h}");
+        assert!(h.contains("29.2%"), "ACER = (33.3 + 25.0)/2: {h}");
+        assert!(
+            h.contains("upper CI"),
+            "the report must warn against reading 0% literally: {h}"
+        );
+
+        let m = render_markdown(&r, "pad.jsonl", &["full".to_string()]);
+        assert!(m.contains("| print_glossy | 3 | 33.3% |"), "{m}");
+        assert!(
+            m.contains("**Worst-case APCER:** **print_glossy @ 33.3%**"),
+            "{m}"
+        );
+        assert!(m.contains("**BPCER:** 25.0%"), "{m}");
+        assert!(m.contains("not a lab-accredited"), "{m}");
+    }
+
+    #[test]
+    fn render_human_flags_a_missing_bonafide_baseline() {
+        let trials = vec![attack("cutout", metrics::Outcome::Rejected, &["depth"])];
+        let r = metrics::analyze(&trials);
+        let h = render_human(&r, "pad.jsonl", &[]);
+        assert!(h.contains("gate path(s): unknown"), "{h}");
+        assert!(h.contains("no bona-fide presentations captured"), "{h}");
+        assert!(h.contains("n/a"), "BPCER with n=0 renders n/a: {h}");
+    }
+}

--- a/crates/irlume-cli/src/suncal.rs
+++ b/crates/irlume-cli/src/suncal.rs
@@ -196,3 +196,76 @@ pub(crate) fn run(args: &[String]) -> ExitCode {
     );
     ExitCode::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("irlume-suncal-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn pgm_bytes(w: u32, h: u32, fill: u8) -> Vec<u8> {
+        let mut v = format!("P5\n{w} {h}\n255\n").into_bytes();
+        v.extend(vec![fill; (w * h) as usize]);
+        v
+    }
+
+    #[test]
+    fn read_pgm_parses_a_binary_p5_file() {
+        let d = tmp("pgm-ok");
+        let p = d.join("f.pgm");
+        let mut bytes = pgm_bytes(4, 2, 9);
+        bytes.extend([77, 77]); // trailing junk after the pixel block
+        std::fs::write(&p, &bytes).unwrap();
+        let (w, h, px) = read_pgm(&p).expect("valid P5");
+        assert_eq!((w, h), (4, 2));
+        assert_eq!(
+            px,
+            vec![9u8; 8],
+            "exactly w*h pixels, trailing bytes dropped"
+        );
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn read_pgm_rejects_wrong_magic_and_short_pixel_data() {
+        let d = tmp("pgm-bad");
+        let p6 = d.join("p6.pgm");
+        std::fs::write(&p6, b"P6\n2 2\n255\n0123").unwrap();
+        assert!(read_pgm(&p6).is_none(), "P6 (color PPM) is not P5");
+
+        let short = d.join("short.pgm");
+        std::fs::write(&short, b"P5\n4 4\n255\nab").unwrap(); // 2 of 16 pixels
+        assert!(read_pgm(&short).is_none(), "truncated pixel block");
+
+        assert!(read_pgm(&d.join("absent.pgm")).is_none());
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn load_burst_orders_frames_and_ignores_non_frame_files() {
+        let d = tmp("burst");
+        // Written out of order; the loader must sort by name.
+        std::fs::write(d.join("frame01.pgm"), pgm_bytes(3, 2, 1)).unwrap();
+        std::fs::write(d.join("frame00.pgm"), pgm_bytes(3, 2, 0)).unwrap();
+        std::fs::write(d.join("rgb00.ppm"), b"P6 junk").unwrap();
+        std::fs::write(d.join("notes.txt"), b"not a frame").unwrap();
+        let (w, h, frames) = load_burst(&d).expect("burst loads");
+        assert_eq!((w, h), (3, 2));
+        assert_eq!(frames.len(), 2, "only frameNN.pgm files count");
+        assert_eq!(frames[0], vec![0u8; 6], "frame00 first");
+        assert_eq!(frames[1], vec![1u8; 6], "frame01 second");
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn load_burst_of_an_empty_dir_is_none() {
+        let d = tmp("burst-empty");
+        assert!(load_burst(&d).is_none());
+        let _ = std::fs::remove_dir_all(&d);
+    }
+}

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3799,14 +3799,14 @@ fn enroll_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+    /// Serializes tests that mutate process-global environment (IRLUME_SOCKET,
+    /// PATH) so they can't race each other under the parallel test runner.
+    /// One binary-wide lock: main.rs and commands.rs tests use the same one,
+    /// so env mutations can never race across test modules.
+    use crate::testenv::ENV_LOCK;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
     use std::sync::atomic::AtomicUsize;
-    use std::sync::Mutex;
-
-    /// Serializes tests that mutate process-global environment (IRLUME_SOCKET,
-    /// PATH) so they can't race each other under the parallel test runner.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// A bare App for tests: no hardware probes, no daemon socket, no terminal.
     /// Mirrors `App::new()` but every probe-derived field is inert.

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3901,6 +3901,91 @@ mod tests {
         out
     }
 
+    /// Hold ENV_LOCK and point IRLUME_SOCKET at a nonexistent path for the
+    /// guard's lifetime. Every test that can trigger a daemon request (directly
+    /// or on a worker thread) must hold one: a dev box may be running a REAL
+    /// irlumed, and e.g. Request::Identify would fire its camera.
+    struct DeadSocket {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        old: Option<std::ffi::OsString>,
+    }
+
+    fn dead_socket() -> DeadSocket {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let old = std::env::var_os("IRLUME_SOCKET");
+        std::env::set_var("IRLUME_SOCKET", "/nonexistent/irlume-test.sock");
+        DeadSocket { _lock: lock, old }
+    }
+
+    impl Drop for DeadSocket {
+        fn drop(&mut self) {
+            match self.old.take() {
+                Some(v) => std::env::set_var("IRLUME_SOCKET", v),
+                None => std::env::remove_var("IRLUME_SOCKET"),
+            }
+        }
+    }
+
+    /// Drive poll() until the async op finishes (its worker thread answers with
+    /// the dead-socket connect error). Must be called while a DeadSocket guard
+    /// is held so the worker cannot race onto a real socket.
+    fn wait_op_done(app: &mut App) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while app.op.is_some() && std::time::Instant::now() < deadline {
+            app.poll();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(app.op.is_none(), "async op never finished");
+    }
+
+    /// Drive poll() until the guided-enroll worker ends (dead socket → Err).
+    fn wait_enroll_done(app: &mut App) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while app.enroll.is_some() && std::time::Instant::now() < deadline {
+            app.poll();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(app.enroll.is_none(), "enroll worker never finished");
+    }
+
+    /// Render the full frame at 120x50 and return the flattened text.
+    fn draw_text(app: &App) -> String {
+        let mut term = Terminal::new(TestBackend::new(120, 50)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        rendered(&term)
+    }
+
+    fn profile(name: &str, scans: &[&str]) -> ProfileSummary {
+        ProfileSummary {
+            name: name.into(),
+            scans: scans.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn check_row(label: &str, sev: Sev, fix: Fix) -> Check {
+        Check {
+            label: label.into(),
+            sev,
+            detail: format!("{label} detail"),
+            fix,
+        }
+    }
+
+    fn good_report(guidance: &str) -> PositionReport {
+        PositionReport {
+            face: true,
+            face_frac: 0.3,
+            centered: true,
+            yaw_asym: 0.1,
+            pitch_frac: 0.5,
+            brightness: 120.0,
+            ir_ok: true,
+            quality: 85,
+            well_framed: true,
+            guidance: guidance.into(),
+        }
+    }
+
     // Regression: f00f316. The daemon acks SetRequireEyesOpen with
     // Response::Ok (via mutate_enrollment), not Response::Enrollment; before
     // the fix map_settings routed Ok to the "unexpected" fallback and every
@@ -4281,5 +4366,1774 @@ mod tests {
             app.error.is_some(),
             "the failure must raise the error banner"
         );
+    }
+
+    // ---- pure helpers -----------------------------------------------------
+
+    #[test]
+    fn quality_bar_fills_proportionally() {
+        assert_eq!(quality_bar(0), "[░░░░░░░░░░]   0%");
+        assert_eq!(quality_bar(50), "[█████░░░░░]  50%");
+        assert_eq!(quality_bar(100), "[██████████] 100%");
+    }
+
+    #[test]
+    fn map_ok_routes_ack_error_and_unexpected() {
+        assert_eq!(map_ok(Response::Ok("done".into())), (true, "done".into()));
+        assert_eq!(
+            map_ok(Response::Error("boom".into())),
+            (false, "boom".into())
+        );
+        let (ok, msg) = map_ok(Response::Pong);
+        assert!(!ok);
+        assert!(msg.contains("unexpected"), "got: {msg}");
+    }
+
+    #[test]
+    fn map_identify_formats_match_and_both_miss_reasons() {
+        let (ok, msg) = map_identify(Response::Identified {
+            user: Some("alice".into()),
+            profile: Some("Face Profile 1".into()),
+            score: 0.8125,
+            live: true,
+            reason: String::new(),
+        });
+        assert!(ok);
+        assert_eq!(msg, "alice · Face Profile 1 · score 0.812");
+        let (ok, msg) = map_identify(Response::Identified {
+            user: None,
+            profile: None,
+            score: 0.0,
+            live: true,
+            reason: "below threshold".into(),
+        });
+        assert!(!ok);
+        assert_eq!(msg, "live face, no enrolled match (below threshold)");
+        let (ok, msg) = map_identify(Response::Identified {
+            user: None,
+            profile: None,
+            score: 0.0,
+            live: false,
+            reason: "flat depth".into(),
+        });
+        assert!(!ok);
+        assert_eq!(msg, "no live face (flat depth)");
+        assert!(!map_identify(Response::Error("e".into())).0);
+    }
+
+    #[test]
+    fn map_selftest_passes_through_verdict() {
+        assert_eq!(
+            map_selftest(Response::SelfTest {
+                passed: true,
+                detail: "depth 0.7".into()
+            }),
+            (true, "depth 0.7".into())
+        );
+        assert_eq!(
+            map_selftest(Response::SelfTest {
+                passed: false,
+                detail: "too flat".into()
+            }),
+            (false, "too flat".into())
+        );
+    }
+
+    #[test]
+    fn map_confirm_accepts_ok_and_password_forgotten() {
+        assert!(map_confirm(Response::Ok("deleted".into())).0);
+        let (ok, msg) = map_confirm(Response::PasswordForgotten);
+        assert!(ok);
+        assert!(msg.contains("disarmed"), "got: {msg}");
+        assert!(!map_confirm(Response::Error("e".into())).0);
+    }
+
+    #[test]
+    fn map_sealed_reports_armed_and_prefixes_failures() {
+        let (ok, msg) = map_sealed(Response::PasswordSealed);
+        assert!(ok);
+        assert!(msg.contains("keyring armed"), "got: {msg}");
+        let (ok, msg) = map_sealed(Response::Error("tpm gone".into()));
+        assert!(!ok);
+        assert_eq!(msg, "arm failed: tpm gone");
+    }
+
+    #[test]
+    fn recommended_covers_every_hardware_tier() {
+        let mut app = test_app();
+        let cases = [
+            (true, true, true, "Face (IR)"),
+            (false, true, true, "Fingerprint (secure), or Face (RGB)"),
+            (false, true, false, "Face (RGB) · convenience"),
+            (false, false, true, "Fingerprint"),
+            (false, false, false, "Password only"),
+        ];
+        for (ir_pair, rgb, fp, want) in cases {
+            app.caps = irlume_camera::Caps { ir_pair, rgb };
+            app.fp_present = fp;
+            let got = app.recommended();
+            assert!(
+                got.starts_with(want),
+                "caps ir={ir_pair} rgb={rgb} fp={fp}: got '{got}', want prefix '{want}'"
+            );
+        }
+    }
+
+    #[test]
+    fn next_profile_name_skips_taken_names() {
+        let mut app = test_app();
+        assert_eq!(app.next_profile_name(), "Face Profile 1");
+        app.profiles = vec![profile("Face Profile 1", &[])];
+        assert_eq!(app.next_profile_name(), "Face Profile 2");
+        app.profiles = vec![
+            profile("Face Profile 1", &[]),
+            profile("Face Profile 2", &[]),
+            profile("Face Profile 3", &[]),
+        ];
+        assert_eq!(app.next_profile_name(), "Face Profile 4");
+    }
+
+    #[test]
+    fn rows_interleave_profiles_and_scans_and_sel_profile_resolves_owner() {
+        let mut app = test_app();
+        app.profiles = vec![profile("a", &["s1", "s2"]), profile("b", &["t1"])];
+        let rows = app.rows();
+        assert_eq!(rows.len(), 5, "2 profiles + 3 scans");
+        assert!(matches!(rows[0], Row::Profile(0)));
+        assert!(matches!(rows[1], Row::Scan(0, 0)));
+        assert!(matches!(rows[2], Row::Scan(0, 1)));
+        assert!(matches!(rows[3], Row::Profile(1)));
+        assert!(matches!(rows[4], Row::Scan(1, 0)));
+        app.sel = 2; // scan s2 → owner is profile 'a'
+        assert_eq!(app.sel_profile().as_deref(), Some("a"));
+        app.sel = 3;
+        assert_eq!(app.sel_profile().as_deref(), Some("b"));
+        app.sel = 99;
+        assert_eq!(app.sel_profile(), None);
+    }
+
+    // ---- tab visibility & navigation --------------------------------------
+
+    #[test]
+    fn compute_visible_matches_hardware_tiers() {
+        let none = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: false,
+        };
+        let rgb = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: true,
+        };
+        let ir = irlume_camera::Caps {
+            ir_pair: true,
+            rgb: true,
+        };
+        // No biometric hardware: only the always-on steps.
+        assert_eq!(
+            App::compute_visible(&none, false, false, false, &[]),
+            vec![SC_WELCOME, SC_PAM, SC_DONE]
+        );
+        // RGB-only adds the face path (Profiles + Recovery), not Keyring.
+        assert_eq!(
+            App::compute_visible(&rgb, false, false, false, &[]),
+            vec![SC_WELCOME, SC_PROFILES, SC_RECOVERY, SC_PAM, SC_DONE]
+        );
+        // An IR pair earns the Keyring step.
+        assert_eq!(
+            App::compute_visible(&ir, false, false, false, &[]),
+            vec![
+                SC_WELCOME,
+                SC_PROFILES,
+                SC_KEYRING,
+                SC_RECOVERY,
+                SC_PAM,
+                SC_DONE
+            ]
+        );
+        // A fingerprint-only box gets Keyring + Fingerprint, no face tabs.
+        assert_eq!(
+            App::compute_visible(&none, true, false, false, &[]),
+            vec![SC_WELCOME, SC_KEYRING, SC_FINGERPRINT, SC_PAM, SC_DONE]
+        );
+        // Advanced view on full hardware shows every screen.
+        assert_eq!(
+            App::compute_visible(&ir, true, true, false, &[]),
+            (0..SCREENS.len()).collect::<Vec<_>>()
+        );
+        // Repair earns its tab when the daemon is down…
+        assert_eq!(
+            App::compute_visible(&none, false, false, true, &[]),
+            vec![SC_WELCOME, SC_REPAIR, SC_PAM, SC_DONE]
+        );
+        // …or when any check fails, but not for a mere warning.
+        let fail = [check_row("x", Sev::Fail, Fix::None)];
+        assert!(App::compute_visible(&none, false, false, false, &fail).contains(&SC_REPAIR));
+        let warn = [check_row("x", Sev::Warn, Fix::None)];
+        assert!(!App::compute_visible(&none, false, false, false, &warn).contains(&SC_REPAIR));
+    }
+
+    #[test]
+    fn tab_steps_wrap_and_walk_only_visible_screens() {
+        let mut app = test_app();
+        app.caps = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: true,
+        };
+        app.daemon_up = true; // healthy: Repair earns no tab
+        app.recompute_visible(); // Welcome, Profiles, Recovery, PAM, Done
+        assert_eq!(app.screen, SC_WELCOME);
+        app.sel = 3;
+        app.on_key(KeyCode::Tab);
+        assert_eq!(app.screen, SC_PROFILES, "Tab skips the hidden Repair tab");
+        assert_eq!(app.sel, 0, "changing tab resets the selection");
+        app.on_key(KeyCode::Right);
+        assert_eq!(app.screen, SC_RECOVERY, "Cameras/Identify stay hidden");
+        app.on_key(KeyCode::BackTab);
+        app.on_key(KeyCode::Left);
+        assert_eq!(app.screen, SC_WELCOME);
+        app.on_key(KeyCode::BackTab);
+        assert_eq!(app.screen, SC_DONE, "BackTab from the first step wraps");
+        app.on_key(KeyCode::Tab);
+        assert_eq!(app.screen, SC_WELCOME, "Tab from the last step wraps");
+    }
+
+    #[test]
+    fn recompute_visible_snaps_to_nearest_surviving_screen() {
+        let mut app = test_app();
+        app.advanced = true;
+        app.recompute_visible();
+        app.screen = SC_SETTINGS;
+        app.advanced = false;
+        app.recompute_visible();
+        assert_eq!(
+            app.screen, SC_PAM,
+            "leaving advanced view must land on the nearest visible step"
+        );
+    }
+
+    #[test]
+    fn move_sel_wraps_within_each_screens_list() {
+        let mut app = test_app();
+        app.profiles = vec![profile("a", &["s1", "s2"])]; // 3 rows
+        app.screen = SC_PROFILES;
+        app.on_key(KeyCode::Up);
+        assert_eq!(app.sel, 2, "Up from the top wraps to the last row");
+        app.on_key(KeyCode::Char('j'));
+        assert_eq!(app.sel, 0, "j from the bottom wraps to the top");
+        app.on_key(KeyCode::Char('k'));
+        assert_eq!(app.sel, 2);
+        app.screen = SC_REPAIR;
+        app.repair = vec![
+            check_row("a", Sev::Ok, Fix::None),
+            check_row("b", Sev::Fail, Fix::None),
+        ];
+        app.on_key(KeyCode::Down);
+        assert_eq!(app.repair_sel, 1, "Repair has its own selection");
+        assert_eq!(app.sel, 2, "the profile selection must not move");
+        app.on_key(KeyCode::Down);
+        assert_eq!(app.repair_sel, 0);
+        app.screen = SC_CAMERAS;
+        app.pairs = vec![
+            irlume_camera::CameraPair {
+                rgb: "/dev/video0".into(),
+                ir: "/dev/video2".into(),
+                id: None,
+                fixed: true,
+            },
+            irlume_camera::CameraPair {
+                rgb: "/dev/video4".into(),
+                ir: "/dev/video6".into(),
+                id: None,
+                fixed: false,
+            },
+        ];
+        app.on_key(KeyCode::Up);
+        assert_eq!(app.cam_sel, 1, "Cameras has its own selection");
+    }
+
+    // ---- key routing / actions --------------------------------------------
+
+    #[test]
+    fn quit_keys_work_everywhere_but_stray_keys_do_not() {
+        let mut app = test_app();
+        app.on_key(KeyCode::Char('q'));
+        assert!(app.quit);
+        let mut app = test_app();
+        app.on_key(KeyCode::Esc);
+        assert!(app.quit);
+        // During a running op only q/Esc get through; the rest are swallowed.
+        let mut app = test_app();
+        let (_tx, op) = fake_op();
+        app.op = Some(op);
+        app.on_key(KeyCode::Tab);
+        app.on_key(KeyCode::Char('e'));
+        assert_eq!(app.screen, SC_WELCOME, "nav keys are dead during an op");
+        assert!(!app.quit);
+        app.on_key(KeyCode::Char('q'));
+        assert!(app.quit, "q must stay a live escape hatch during an op");
+    }
+
+    #[test]
+    fn welcome_refresh_key_logs_and_reprobes() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.on_key(KeyCode::Char('r'));
+        assert!(
+            app.activity.iter().any(|(_, m)| m.contains("refreshing")),
+            "[r] must announce the refresh in Activity"
+        );
+        assert!(!app.daemon_up, "the dead socket means daemon down");
+    }
+
+    #[test]
+    fn welcome_enroll_and_identify_without_camera_explain_instead_of_noop() {
+        let mut app = test_app(); // caps: no camera
+        app.on_key(KeyCode::Char('e'));
+        assert!(app.input.is_none(), "no name prompt without a camera");
+        let (_, msg) = app.activity.last().expect("a guidance line is logged");
+        assert!(msg.contains("no camera"), "got: {msg}");
+        let before = app.activity.len();
+        app.on_key(KeyCode::Char('i'));
+        assert!(app.op.is_none(), "identify must not start without a camera");
+        assert_eq!(app.activity.len(), before + 1);
+    }
+
+    #[test]
+    fn welcome_enroll_with_camera_jumps_to_profiles_and_prompts_for_name() {
+        let mut app = test_app();
+        app.caps = irlume_camera::Caps {
+            ir_pair: true,
+            rgb: true,
+        };
+        app.daemon_up = true;
+        app.on_key(KeyCode::Char('e'));
+        assert_eq!(app.screen, SC_PROFILES);
+        match &app.input {
+            Some((prompt, _, Pending::EnrollName)) => {
+                assert!(prompt.contains("New profile name"), "got: {prompt}")
+            }
+            other => panic!("expected the enroll-name prompt, got {:?}", other.is_some()),
+        }
+    }
+
+    #[test]
+    fn welcome_identify_stays_put_in_essential_view_and_jumps_in_advanced() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.caps = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: true,
+        };
+        app.recompute_visible();
+        app.on_key(KeyCode::Char('i'));
+        assert_eq!(
+            app.screen, SC_WELCOME,
+            "essential view has no Identify tab; stay put"
+        );
+        assert!(app.op.is_some(), "the 1:N identify op must still start");
+        wait_op_done(&mut app);
+        let (ok, _) = app
+            .identify_result
+            .as_ref()
+            .expect("the op result must land on the Identify card");
+        assert!(!ok, "a dead socket cannot identify anyone");
+        assert!(
+            app.error.is_none(),
+            "an identify miss shows on the card, not the error modal"
+        );
+        // Advanced view: the tab exists, so [i] jumps there. (The refresh at op
+        // completion re-derived caps from real hardware; pin them back so this
+        // half is deterministic on camera-less machines too.)
+        app.caps = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: true,
+        };
+        app.advanced = true;
+        app.recompute_visible();
+        app.screen = SC_WELCOME;
+        app.on_key(KeyCode::Char('i'));
+        assert_eq!(app.screen, SC_IDENTIFY);
+        wait_op_done(&mut app);
+    }
+
+    #[test]
+    fn daemon_gate_parks_the_enroll_intent_and_routes_to_repair() {
+        let mut app = test_app();
+        app.caps = irlume_camera::Caps {
+            ir_pair: true,
+            rgb: true,
+        };
+        app.daemon_up = false;
+        app.screen = SC_PROFILES;
+        app.on_key(KeyCode::Char('e'));
+        assert_eq!(app.screen, SC_REPAIR, "a down daemon routes to Repair");
+        assert_eq!(app.repair_sel, 0, "the Daemon row is selected");
+        assert!(matches!(app.resume_enroll, Some(ResumeEnroll::New)));
+        assert!(matches!(app.suspend, Some(Suspend::RestartDaemon)));
+        assert!(
+            app.input.is_none(),
+            "no name prompt while the daemon is down"
+        );
+        // The add-scan path parks its own intent.
+        let mut app = test_app();
+        app.daemon_up = false;
+        app.profiles = vec![profile("p1", &[])];
+        app.screen = SC_PROFILES;
+        app.on_key(KeyCode::Char('a'));
+        assert!(matches!(app.resume_enroll, Some(ResumeEnroll::Add(ref p)) if p == "p1"));
+    }
+
+    #[test]
+    fn profiles_add_scan_without_profiles_hints_instead_of_starting() {
+        let mut app = test_app();
+        app.daemon_up = true;
+        app.screen = SC_PROFILES;
+        app.on_key(KeyCode::Char('a'));
+        assert!(app.enroll.is_none());
+        let (_, msg) = app.activity.last().expect("a hint is logged");
+        assert!(msg.contains("select a profile first"), "got: {msg}");
+    }
+
+    #[test]
+    fn profiles_add_scan_starts_improve_round_on_selected_profile() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.daemon_up = true;
+        app.profiles = vec![profile("p1", &["s1"])];
+        app.screen = SC_PROFILES;
+        app.sel = 1; // the scan row still resolves to its owning profile
+        app.on_key(KeyCode::Char('a'));
+        {
+            let e = app.enroll.as_ref().expect("an improve round must start");
+            assert_eq!(e.profile, "p1");
+            assert_eq!(e.target, ADD_SCANS, "improve rounds capture ADD_SCANS");
+        }
+        wait_enroll_done(&mut app);
+        let err = app.error.as_ref().expect("dead socket fails the capture");
+        assert!(err.contains("Enrollment failed"), "got: {err}");
+    }
+
+    #[test]
+    fn profiles_rename_and_delete_target_the_selected_row() {
+        let mut app = test_app();
+        app.profiles = vec![profile("p1", &["s1", "s2"])];
+        app.screen = SC_PROFILES;
+        app.on_key(KeyCode::Char('r'));
+        match &app.input {
+            Some((prompt, _, Pending::RenameProfile(old))) => {
+                assert!(prompt.contains("Rename profile 'p1'"), "got: {prompt}");
+                assert_eq!(old, "p1");
+            }
+            _ => panic!("expected the rename-profile prompt"),
+        }
+        app.input = None;
+        app.sel = 2; // second scan
+        app.on_key(KeyCode::Char('r'));
+        match &app.input {
+            Some((prompt, _, Pending::RenameScan(p, s))) => {
+                assert!(prompt.contains("Rename scan 's2'"), "got: {prompt}");
+                assert_eq!((p.as_str(), s.as_str()), ("p1", "s2"));
+            }
+            _ => panic!("expected the rename-scan prompt"),
+        }
+        app.input = None;
+        app.sel = 0;
+        app.on_key(KeyCode::Char('d'));
+        match &app.confirm {
+            Some((q, Request::DeleteProfile { user, profile })) => {
+                assert!(q.contains("Delete profile 'p1'"), "got: {q}");
+                assert_eq!((user.as_str(), profile.as_str()), ("testuser", "p1"));
+            }
+            _ => panic!("expected the delete-profile confirm"),
+        }
+        app.confirm = None;
+        app.sel = 1;
+        app.on_key(KeyCode::Char('d'));
+        match &app.confirm {
+            Some((q, Request::DeleteScan { profile, scan, .. })) => {
+                assert!(q.contains("Delete scan 's1' from 'p1'"), "got: {q}");
+                assert_eq!((profile.as_str(), scan.as_str()), ("p1", "s1"));
+            }
+            _ => panic!("expected the delete-scan confirm"),
+        }
+    }
+
+    #[test]
+    fn keyring_and_recovery_keys_open_masked_prompts_and_confirms() {
+        let mut app = test_app();
+        app.screen = SC_KEYRING;
+        app.on_key(KeyCode::Char('a'));
+        match &app.input {
+            Some((_, _, p @ Pending::KeyringPw(None))) => {
+                assert!(p.masked(), "a password prompt must render masked")
+            }
+            _ => panic!("expected the keyring password prompt"),
+        }
+        app.input = None;
+        app.on_key(KeyCode::Char('f'));
+        match &app.confirm {
+            Some((q, Request::ForgetPassword { user })) => {
+                assert!(q.contains("Erase the TPM-sealed"), "got: {q}");
+                assert_eq!(user, "testuser");
+            }
+            _ => panic!("expected the keyring-forget confirm"),
+        }
+        app.confirm = None;
+        app.screen = SC_RECOVERY;
+        app.on_key(KeyCode::Char('s'));
+        assert!(matches!(app.input, Some((_, _, Pending::RecoveryPw(None)))));
+        app.input = None;
+        app.on_key(KeyCode::Char('t'));
+        match &app.input {
+            Some((_, _, p @ Pending::RecoveryRestorePw)) => assert!(p.masked()),
+            _ => panic!("expected the recovery-restore prompt"),
+        }
+        app.input = None;
+        app.on_key(KeyCode::Char('f'));
+        assert!(matches!(
+            app.confirm,
+            Some((_, Request::RecoveryForget { .. }))
+        ));
+    }
+
+    #[test]
+    fn fingerprint_add_requires_a_reader() {
+        let mut app = test_app();
+        app.screen = SC_FINGERPRINT;
+        app.on_key(KeyCode::Char('a'));
+        assert!(app.suspend.is_none());
+        let (_, msg) = app.activity.last().expect("the refusal is logged");
+        assert!(msg.contains("no fingerprint reader"), "got: {msg}");
+        app.fp.available = true;
+        app.on_key(KeyCode::Char('a'));
+        assert!(matches!(app.suspend, Some(Suspend::FingerprintAdd)));
+    }
+
+    #[test]
+    fn login_wiring_keys_suspend_to_the_right_flows() {
+        let mut app = test_app();
+        app.screen = SC_PAM;
+        app.on_key(KeyCode::Char('w'));
+        assert!(matches!(app.suspend, Some(Suspend::LoginEnable)));
+        assert!(
+            app.activity
+                .iter()
+                .any(|(_, m)| m.contains("login enable --apply")),
+            "the exact sudo command must be announced"
+        );
+        app.suspend = None;
+        app.on_key(KeyCode::Char('s'));
+        assert!(matches!(app.suspend, Some(Suspend::LoginStatus)));
+        // The Done dashboard offers the same last-mile wire.
+        let mut app = test_app();
+        app.screen = SC_DONE;
+        app.on_key(KeyCode::Char('w'));
+        assert!(matches!(app.suspend, Some(Suspend::LoginEnable)));
+    }
+
+    #[test]
+    fn cameras_enter_switches_only_when_a_pair_exists() {
+        let mut app = test_app();
+        app.screen = SC_CAMERAS;
+        app.on_key(KeyCode::Enter);
+        assert!(app.suspend.is_none());
+        let (_, msg) = app.activity.last().expect("the no-pair case is explained");
+        assert!(msg.contains("no paired Hello camera"), "got: {msg}");
+        app.pairs = vec![irlume_camera::CameraPair {
+            rgb: "/dev/video0".into(),
+            ir: "/dev/video2".into(),
+            id: Some("abcd:1234".into()),
+            fixed: true,
+        }];
+        app.cam_sel = 0;
+        app.on_key(KeyCode::Enter);
+        assert!(matches!(
+            app.suspend,
+            Some(Suspend::SetCameras(ref r, ref i)) if r == "/dev/video0" && i == "/dev/video2"
+        ));
+    }
+
+    #[test]
+    fn cameras_emitter_keys_route_setup_and_probe() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_CAMERAS;
+        app.on_key(KeyCode::Char('s'));
+        assert!(matches!(app.suspend, Some(Suspend::IrSetup)));
+        app.suspend = None;
+        app.on_key(KeyCode::Char('p'));
+        assert!(app.op.is_some(), "[p] starts the read-only emitter probe");
+        wait_op_done(&mut app);
+    }
+
+    #[test]
+    fn settings_enter_toggles_eyes_open_via_the_daemon() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.on_key(KeyCode::Enter);
+        assert_eq!(
+            app.op.as_ref().map(|o| o.label.as_str()),
+            Some("toggle require-eyes-open")
+        );
+        wait_op_done(&mut app);
+        assert!(
+            app.error.is_some(),
+            "a failed toggle must raise the error banner, not vanish"
+        );
+    }
+
+    #[test]
+    fn repair_ir_selftest_lands_on_the_card_without_the_error_modal() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        app.on_key(KeyCode::Char('l'));
+        assert!(app.op.is_some());
+        wait_op_done(&mut app);
+        let (ok, _) = app
+            .selftest_result
+            .as_ref()
+            .expect("the self-test verdict must land on the Repair card");
+        assert!(!ok);
+        assert!(
+            app.error.is_none(),
+            "a self-test miss is a card result, not an error modal"
+        );
+    }
+
+    #[test]
+    fn apply_fix_routes_every_fix_kind() {
+        let mut app = test_app();
+        app.repair = vec![
+            check_row("ok", Sev::Ok, Fix::None),
+            check_row("man", Sev::Warn, Fix::Manual("run `foo --bar`".into())),
+            check_row("emitter", Sev::Warn, Fix::Root("ir-setup")),
+            check_row("daemon", Sev::Fail, Fix::Root("restart-daemon")),
+            check_row("reader", Sev::Fail, Fix::Root("restart-fprintd")),
+            check_row("wiring", Sev::Fail, Fix::Root("login-enable")),
+            check_row("finger", Sev::Fail, Fix::Root("fingerprint-add")),
+            check_row("selinux", Sev::Fail, Fix::Root("selinux-load")),
+            check_row("bogus", Sev::Fail, Fix::Root("no-such-fix")),
+        ];
+        app.apply_fix(0);
+        assert!(app.suspend.is_none());
+        assert!(app.activity.last().unwrap().1.contains("nothing to fix"));
+        app.apply_fix(1);
+        assert!(app.suspend.is_none());
+        assert!(
+            app.activity.last().unwrap().1.contains("run `foo --bar`"),
+            "a manual fix must echo the exact command"
+        );
+        let suspended_by = |app: &mut App, idx: usize| {
+            app.suspend = None;
+            app.apply_fix(idx);
+            app.suspend.take()
+        };
+        assert!(matches!(suspended_by(&mut app, 2), Some(Suspend::IrSetup)));
+        assert!(matches!(
+            suspended_by(&mut app, 3),
+            Some(Suspend::RestartDaemon)
+        ));
+        assert!(matches!(
+            suspended_by(&mut app, 4),
+            Some(Suspend::RestartFprintd)
+        ));
+        assert!(matches!(
+            suspended_by(&mut app, 5),
+            Some(Suspend::LoginEnable)
+        ));
+        assert!(matches!(
+            suspended_by(&mut app, 6),
+            Some(Suspend::FingerprintAdd)
+        ));
+        assert!(matches!(
+            suspended_by(&mut app, 7),
+            Some(Suspend::SelinuxLoad)
+        ));
+        app.suspend = None;
+        app.apply_fix(8);
+        assert!(app.suspend.is_none());
+        let err = app.error.as_ref().expect("an unknown fix id must surface");
+        assert!(err.contains("no-such-fix"), "got: {err}");
+        // Out of range: a no-op, not a panic.
+        app.error = None;
+        let before = app.activity.len();
+        app.apply_fix(99);
+        assert_eq!(app.activity.len(), before);
+    }
+
+    // ---- text entry & submit ----------------------------------------------
+
+    #[test]
+    fn input_editing_appends_backspaces_and_esc_cancels() {
+        let mut app = test_app();
+        app.input = Some((
+            "Rename profile 'x' to:".into(),
+            String::new(),
+            Pending::RenameProfile("x".into()),
+        ));
+        for c in "abc".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Backspace);
+        assert_eq!(app.input.as_ref().unwrap().1, "ab");
+        // Nav keys must type into the buffer path, not switch tabs.
+        assert_eq!(app.screen, SC_WELCOME);
+        app.on_key(KeyCode::Esc);
+        assert!(app.input.is_none(), "Esc cancels text entry");
+        assert!(!app.quit, "Esc in a prompt must not quit the TUI");
+    }
+
+    #[test]
+    fn rename_submit_starts_the_async_rename_op() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.input = Some((
+            "Rename profile 'old' to:".into(),
+            "new name".into(),
+            Pending::RenameProfile("old".into()),
+        ));
+        app.on_key(KeyCode::Enter);
+        assert!(app.input.is_none(), "Enter consumes the prompt");
+        assert_eq!(app.op.as_ref().map(|o| o.label.as_str()), Some("Rename"));
+        wait_op_done(&mut app);
+        assert!(
+            app.error.is_some(),
+            "a rename the daemon never acked must surface"
+        );
+    }
+
+    #[test]
+    fn enroll_name_duplicate_is_rejected_before_capture() {
+        let mut app = test_app();
+        app.daemon_up = true;
+        app.profiles = vec![profile("dup", &[])];
+        app.input = Some((
+            "New profile name (blank = default):".into(),
+            "dup".into(),
+            Pending::EnrollName,
+        ));
+        app.on_key(KeyCode::Enter);
+        assert!(app.enroll.is_none(), "a duplicate name must not enroll");
+        let (_, msg) = app.activity.last().unwrap();
+        assert!(msg.contains("already exists"), "got: {msg}");
+    }
+
+    #[test]
+    fn enroll_name_blank_uses_the_default_and_starts_the_worker() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.daemon_up = true;
+        app.input = Some((
+            "New profile name (blank = default):".into(),
+            String::new(),
+            Pending::EnrollName,
+        ));
+        app.on_key(KeyCode::Enter);
+        {
+            let e = app.enroll.as_ref().expect("a blank name starts the enroll");
+            assert_eq!(e.profile, "Face Profile 1");
+            assert_eq!(e.target, ENROLL_SCANS);
+        }
+        wait_enroll_done(&mut app);
+        let err = app.error.as_ref().expect("the dead socket fails the scan");
+        assert!(err.contains("Enrollment failed"), "got: {err}");
+    }
+
+    #[test]
+    fn enroll_name_submit_while_daemon_down_parks_the_named_intent() {
+        let mut app = test_app();
+        app.daemon_up = false;
+        app.input = Some((
+            "New profile name (blank = default):".into(),
+            "zed".into(),
+            Pending::EnrollName,
+        ));
+        app.on_key(KeyCode::Enter);
+        assert!(app.enroll.is_none());
+        assert!(
+            matches!(app.resume_enroll, Some(ResumeEnroll::Named(ref n)) if n == "zed"),
+            "the typed name must survive the daemon fix"
+        );
+        assert!(matches!(app.suspend, Some(Suspend::RestartDaemon)));
+    }
+
+    #[test]
+    fn keyring_password_double_entry_gates_the_seal() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_KEYRING;
+        // Empty first entry aborts.
+        app.on_key(KeyCode::Char('a'));
+        app.on_key(KeyCode::Enter);
+        assert!(app.input.is_none());
+        let err = app.error.take().expect("empty password must abort loudly");
+        assert!(err.contains("empty password"), "got: {err}");
+        // Mismatched confirmation aborts without sealing.
+        app.on_key(KeyCode::Char('a'));
+        for c in "pw1".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Enter);
+        match &app.input {
+            Some((prompt, buf, Pending::KeyringPw(Some(first)))) => {
+                assert!(prompt.contains("Confirm"), "got: {prompt}");
+                assert!(buf.is_empty(), "the confirm entry starts blank");
+                assert_eq!(&***first, "pw1");
+            }
+            _ => panic!("expected the confirm prompt with the stashed first entry"),
+        }
+        for c in "pw2".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Enter);
+        assert!(app.op.is_none(), "a mismatch must never reach SealPassword");
+        let err = app.error.take().expect("the mismatch must abort loudly");
+        assert!(err.contains("don't match"), "got: {err}");
+        // Matching entries seal (async).
+        app.on_key(KeyCode::Char('a'));
+        for c in "pw".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Enter);
+        for c in "pw".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Enter);
+        assert_eq!(
+            app.op.as_ref().map(|o| o.label.as_str()),
+            Some("SealPassword")
+        );
+        wait_op_done(&mut app);
+        assert!(app.error.is_some(), "a failed seal must surface");
+    }
+
+    #[test]
+    fn recovery_passphrase_flows_mirror_the_keyring_gates() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_RECOVERY;
+        // Set: double entry, mismatch aborts.
+        app.on_key(KeyCode::Char('s'));
+        app.on_key(KeyCode::Char('a'));
+        app.on_key(KeyCode::Enter);
+        assert!(matches!(
+            app.input,
+            Some((_, _, Pending::RecoveryPw(Some(_))))
+        ));
+        app.on_key(KeyCode::Char('b'));
+        app.on_key(KeyCode::Enter);
+        assert!(app.op.is_none());
+        let err = app.error.take().expect("mismatch aborts");
+        assert!(err.contains("don't match"), "got: {err}");
+        // Set: matching entries fire RecoverySetup.
+        app.on_key(KeyCode::Char('s'));
+        app.on_key(KeyCode::Char('a'));
+        app.on_key(KeyCode::Enter);
+        app.on_key(KeyCode::Char('a'));
+        app.on_key(KeyCode::Enter);
+        assert_eq!(
+            app.op.as_ref().map(|o| o.label.as_str()),
+            Some("RecoverySetup")
+        );
+        wait_op_done(&mut app);
+        app.error = None;
+        // Restore: empty aborts, non-empty fires RecoveryRestore.
+        app.on_key(KeyCode::Char('t'));
+        app.on_key(KeyCode::Enter);
+        assert!(app.op.is_none());
+        let err = app.error.take().expect("empty restore passphrase aborts");
+        assert!(err.contains("empty passphrase"), "got: {err}");
+        app.on_key(KeyCode::Char('t'));
+        app.on_key(KeyCode::Char('x'));
+        app.on_key(KeyCode::Enter);
+        assert_eq!(
+            app.op.as_ref().map(|o| o.label.as_str()),
+            Some("RecoveryRestore")
+        );
+        wait_op_done(&mut app);
+    }
+
+    // ---- confirm & merge flows --------------------------------------------
+
+    #[test]
+    fn confirm_yes_fires_the_stored_request_async() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.confirm = Some(("Delete profile 'x'?".into(), Request::Ping));
+        app.on_key(KeyCode::Char('y'));
+        assert!(app.confirm.is_none());
+        assert!(app.op.is_some(), "[y] must run the stored request");
+        assert!(
+            app.activity.iter().any(|(_, m)| m.contains("(confirmed)")),
+            "the confirmed op must be visible in Activity"
+        );
+        wait_op_done(&mut app);
+        assert!(app.error.is_some(), "the dead-socket failure must surface");
+    }
+
+    #[test]
+    fn merge_prompt_raises_the_modal_and_caps_remaining_scans() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        let (tx, enroll) = fake_enroll(0, ENROLL_SCANS);
+        app.enroll = Some(enroll);
+        // 28 of 30 scans already on the profile: only 2 more fit the budget.
+        tx.send(WMsg::MergePrompt {
+            profile: "Alice".into(),
+            total: 28,
+            added_scans: vec!["scan28".into()],
+        })
+        .unwrap();
+        app.poll();
+        assert!(app.enroll.is_none(), "the worker hands off to the modal");
+        let mc = app.enroll_merge.as_ref().expect("the merge modal is up");
+        assert_eq!(mc.profile, "Alice");
+        assert_eq!(
+            mc.remaining, 2,
+            "remaining = min(target-1, 30-scan budget left)"
+        );
+        // Below the budget the requested count minus the merged scan survives.
+        let (tx, enroll) = fake_enroll(0, ENROLL_SCANS);
+        app.enroll = Some(enroll);
+        app.enroll_merge = None;
+        tx.send(WMsg::MergePrompt {
+            profile: "Alice".into(),
+            total: 5,
+            added_scans: vec!["scan5".into()],
+        })
+        .unwrap();
+        app.poll();
+        assert_eq!(
+            app.enroll_merge.as_ref().unwrap().remaining,
+            ENROLL_SCANS - 1
+        );
+    }
+
+    #[test]
+    fn merge_modal_renders_the_resolved_profile() {
+        let mut app = test_app();
+        app.enroll_merge = Some(MergeConfirm {
+            profile: "Alice".into(),
+            added_scans: vec!["s".into()],
+            remaining: 4,
+        });
+        let text = draw_text(&app);
+        assert!(text.contains("Already enrolled"), "modal title missing");
+        assert!(text.contains("'Alice'"), "the owning profile must be named");
+        assert!(text.contains("[y] add"), "the confirm keys must be shown");
+    }
+
+    #[test]
+    fn merge_confirm_continues_with_the_base_offset() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.enroll_merge = Some(MergeConfirm {
+            profile: "Alice".into(),
+            added_scans: vec!["s1".into()],
+            remaining: 3,
+        });
+        app.on_key(KeyCode::Char('y'));
+        assert!(app.enroll_merge.is_none());
+        {
+            let e = app.enroll.as_ref().expect("the continuation must start");
+            assert_eq!(e.profile, "Alice");
+            assert_eq!(e.target, 3);
+            assert_eq!(e.base, 1, "the merged scan keeps the counter continuous");
+        }
+        wait_enroll_done(&mut app);
+    }
+
+    #[test]
+    fn merge_confirm_with_nothing_left_just_acknowledges() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.enroll_merge = Some(MergeConfirm {
+            profile: "Alice".into(),
+            added_scans: vec!["s1".into()],
+            remaining: 0,
+        });
+        app.on_key(KeyCode::Char('y'));
+        assert!(app.enroll.is_none(), "nothing left to capture");
+        assert!(
+            app.activity
+                .iter()
+                .any(|(_, m)| m.contains("scan added to 'Alice'")),
+            "the kept scan must be acknowledged"
+        );
+    }
+
+    #[test]
+    fn merge_decline_undoes_the_added_scan_and_stray_keys_are_ignored() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.enroll_merge = Some(MergeConfirm {
+            profile: "Alice".into(),
+            added_scans: vec!["scanZ".into()],
+            remaining: 3,
+        });
+        app.on_key(KeyCode::Char('x'));
+        app.on_key(KeyCode::Enter);
+        assert!(
+            app.enroll_merge.is_some(),
+            "a stray key must not resolve the merge modal"
+        );
+        app.on_key(KeyCode::Char('n'));
+        assert!(app.enroll_merge.is_none());
+        assert!(
+            app.op.is_some(),
+            "declining must fire the DeleteScan undo async"
+        );
+        assert!(
+            app.activity
+                .iter()
+                .any(|(_, m)| m.contains("removing the scan added to 'Alice'")),
+            "the undo must be explained in Activity"
+        );
+        wait_op_done(&mut app);
+        // With no scan recorded there is nothing to undo: no op is started.
+        let mut app = test_app();
+        app.enroll_merge = Some(MergeConfirm {
+            profile: "Alice".into(),
+            added_scans: Vec::new(),
+            remaining: 3,
+        });
+        app.on_key(KeyCode::Esc);
+        assert!(app.enroll_merge.is_none(), "Esc declines");
+        assert!(app.op.is_none());
+    }
+
+    // ---- enroll worker messages & the enroll key gate ----------------------
+
+    #[test]
+    fn poll_routes_cue_count_and_captured_to_the_enroll_ui() {
+        let mut app = test_app();
+        let (tx, enroll) = fake_enroll(0, 4);
+        app.enroll = Some(enroll);
+        tx.send(WMsg::Count(3)).unwrap();
+        app.poll();
+        assert_eq!(app.enroll.as_ref().unwrap().count, Some(3));
+        // A fresh cue clears the countdown (the user drifted off-frame).
+        tx.send(WMsg::Cue(good_report("Hold still"))).unwrap();
+        app.poll();
+        {
+            let e = app.enroll.as_ref().unwrap();
+            assert_eq!(e.count, None, "a cue aborts the on-screen countdown");
+            assert_eq!(e.last.as_ref().unwrap().guidance, "Hold still");
+        }
+        tx.send(WMsg::Count(2)).unwrap();
+        tx.send(WMsg::Captured(1, 4)).unwrap();
+        app.poll();
+        let e = app.enroll.as_ref().unwrap();
+        assert_eq!(e.captured, 1);
+        assert_eq!(e.count, None, "a capture clears the countdown");
+        assert!(
+            app.activity.iter().any(|(_, m)| m == "captured scan 1/4"),
+            "each capture must be logged"
+        );
+    }
+
+    #[test]
+    fn poll_done_completes_the_enrollment() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        let (tx, enroll) = fake_enroll(0, 4);
+        app.enroll = Some(enroll);
+        tx.send(WMsg::Done).unwrap();
+        app.poll();
+        assert!(app.enroll.is_none());
+        assert!(
+            app.activity
+                .iter()
+                .any(|(_, m)| m.contains("enrollment complete")),
+            "completion must be logged"
+        );
+        assert!(app.error.is_none());
+    }
+
+    #[test]
+    fn poll_err_strips_the_hardware_prefix_and_raises_the_banner() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        let (tx, enroll) = fake_enroll(0, 4);
+        app.enroll = Some(enroll);
+        tx.send(WMsg::Err("hardware: camera busy".into())).unwrap();
+        app.poll();
+        assert!(app.enroll.is_none());
+        let err = app.error.as_ref().expect("a failed scan must surface");
+        assert_eq!(err, "Enrollment failed: camera busy");
+    }
+
+    #[test]
+    fn enroll_esc_cancels_and_signals_the_worker_to_stop() {
+        let mut app = test_app();
+        let (_tx, enroll) = fake_enroll(0, 4);
+        let stop = enroll.stop.clone();
+        app.enroll = Some(enroll);
+        app.on_key(KeyCode::Char('e'));
+        assert!(app.enroll.is_some(), "other keys are dead mid-capture");
+        assert!(app.input.is_none());
+        app.on_key(KeyCode::Esc);
+        assert!(app.enroll.is_none());
+        assert!(
+            stop.load(Ordering::Relaxed),
+            "Esc must signal the worker thread to stop"
+        );
+        assert!(
+            app.activity
+                .iter()
+                .any(|(_, m)| m.contains("enrollment cancelled")),
+            "the cancel must be logged"
+        );
+    }
+
+    // ---- rendering ---------------------------------------------------------
+
+    #[test]
+    fn welcome_renders_glance_hint_and_tier_recommendation() {
+        let mut app = test_app();
+        app.caps = irlume_camera::Caps {
+            ir_pair: true,
+            rgb: true,
+        };
+        app.recompute_visible();
+        app.daemon_up = true;
+        app.profiles = vec![profile("a", &["s1", "s2"])];
+        let text = draw_text(&app);
+        assert!(text.contains("irlume - local face authentication"));
+        assert!(text.contains("At a glance"));
+        assert!(text.contains("1 profile(s), 2 scan(s)"));
+        assert!(
+            text.contains("Face (IR)"),
+            "the IR tier must be recommended on IR hardware"
+        );
+        assert!(
+            text.contains("New here? Press [e]"),
+            "the Welcome hint line is missing"
+        );
+        assert!(text.contains("step 1/"), "the wizard position is missing");
+        // No-camera tier: the recommendation flips to password-only.
+        let app2 = test_app();
+        let text = draw_text(&app2);
+        assert!(text.contains("Password only"), "got no fallback tier");
+    }
+
+    #[test]
+    fn profiles_screen_renders_empty_state_and_scan_tree() {
+        let mut app = test_app();
+        app.screen = SC_PROFILES;
+        let text = draw_text(&app);
+        assert!(text.contains("No face profiles yet"));
+        assert!(text.contains("Press [e] to enroll"));
+        app.profiles = vec![profile("Alice", &["scan-a", "scan-b"])];
+        let text = draw_text(&app);
+        assert!(text.contains("● Alice"));
+        assert!(text.contains("(2 scans)"));
+        assert!(text.contains("↳ scan-a"), "scans render under the profile");
+        assert!(
+            text.contains("Improve Recognition"),
+            "the add-scan guidance is missing"
+        );
+    }
+
+    #[test]
+    fn keyring_screen_states_render_distinctly() {
+        let mut app = test_app();
+        app.screen = SC_KEYRING;
+        // Daemon unreachable: unknown, never a fake "not armed".
+        let text = draw_text(&app);
+        assert!(text.contains("unknown (daemon unreachable)"));
+        // Not armed on a fingerprint box: names the fingerprint trigger.
+        app.keyring_armed = Some(false);
+        app.fp_present = true;
+        let text = draw_text(&app);
+        assert!(text.contains("○ not armed"));
+        assert!(text.contains("fingerprint login won't open your wallet yet"));
+        assert!(text.contains("At a fingerprint login"));
+        // Armed on IR hardware with PCR drift and a Tier-2 policy.
+        app.caps = irlume_camera::Caps {
+            ir_pair: true,
+            rgb: true,
+        };
+        app.fp_present = false;
+        app.keyring_armed = Some(true);
+        app.keyring_drift = Some(true);
+        app.keyring_policy = Some("pcrlock NV 0x1a2b (Tier 2)".into());
+        let text = draw_text(&app);
+        assert!(text.contains("● armed"));
+        assert!(text.contains("drifted since sealing"));
+        assert!(text.contains("pcrlock NV 0x1a2b (Tier 2)"));
+        assert!(
+            text.contains("systemd-pcrlock"),
+            "Tier 2 gets the make-policy guidance, not the re-arm warning"
+        );
+        assert!(text.contains("At a face login"));
+        // Armed on the plain PCR-7 tier: the dbx re-arm warning instead.
+        app.keyring_policy = None;
+        app.keyring_drift = None;
+        let text = draw_text(&app);
+        assert!(text.contains("PCR-7 (Secure Boot state)"));
+        assert!(text.contains("firmware/dbx update"));
+    }
+
+    #[test]
+    fn recovery_screen_states_render_distinctly() {
+        let mut app = test_app();
+        app.screen = SC_RECOVERY;
+        // No TPM: plaintext + the recovery-N/A line.
+        app.recovery = Some(RecoveryInfo {
+            encrypted: false,
+            recovery_set: false,
+            tpm_present: false,
+        });
+        let text = draw_text(&app);
+        assert!(text.contains("○ plaintext at rest"));
+        assert!(text.contains("No TPM on this host"));
+        // Encrypted without a backstop: the warning line.
+        app.recovery = Some(RecoveryInfo {
+            encrypted: true,
+            recovery_set: false,
+            tpm_present: true,
+        });
+        let text = draw_text(&app);
+        assert!(text.contains("● encrypted"));
+        assert!(text.contains("No backstop"));
+        assert!(text.contains("[s] set passphrase"));
+        // Fully set: both badges green, no warning.
+        app.recovery = Some(RecoveryInfo {
+            encrypted: true,
+            recovery_set: true,
+            tpm_present: true,
+        });
+        let text = draw_text(&app);
+        assert!(text.contains("● set"));
+        assert!(!text.contains("No backstop"));
+    }
+
+    #[test]
+    fn fingerprint_screen_renders_reader_and_enrolled_fingers() {
+        let mut app = test_app();
+        app.screen = SC_FINGERPRINT;
+        app.fp = FpInfo {
+            available: false,
+            device: None,
+            enrolled: Vec::new(),
+            method: "face".into(),
+        };
+        let text = draw_text(&app);
+        assert!(text.contains("○ none detected"));
+        assert!(text.contains("No usable reader"));
+        app.fp = FpInfo {
+            available: true,
+            device: Some("Goodix Reader".into()),
+            enrolled: vec!["right-index-finger".into()],
+            method: "typed-method-x".into(),
+        };
+        let text = draw_text(&app);
+        assert!(text.contains("● Goodix Reader"));
+        assert!(text.contains("1 (right-index-finger)"));
+        assert!(text.contains("[a] enroll a finger"));
+        assert!(
+            text.contains("typed-method-x"),
+            "the active method value is shown"
+        );
+    }
+
+    #[test]
+    fn identify_screen_renders_hit_miss_and_idle_states() {
+        let mut app = test_app();
+        app.screen = SC_IDENTIFY;
+        let text = draw_text(&app);
+        assert!(text.contains("press [i] and look at the camera"));
+        app.identify_result = Some((true, "alice · Face Profile 1 · score 0.912".into()));
+        let text = draw_text(&app);
+        assert!(text.contains("alice · Face Profile 1 · score 0.912"));
+        assert!(
+            text.contains("result"),
+            "the hit renders in the result card"
+        );
+        app.identify_result = Some((false, "no live face (flat depth)".into()));
+        let text = draw_text(&app);
+        assert!(text.contains("✗"));
+        assert!(text.contains("no live face (flat depth)"));
+    }
+
+    #[test]
+    fn repair_screen_renders_checks_counts_and_fix_hints() {
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        app.repair = vec![
+            check_row("Daemon (irlumed)", Sev::Ok, Fix::None),
+            check_row(
+                "Models",
+                Sev::Warn,
+                Fix::Manual("install the package".into()),
+            ),
+            check_row("SELinux policy", Sev::Fail, Fix::Root("selinux-load")),
+        ];
+        app.repair_sel = 0;
+        let text = draw_text(&app);
+        assert!(text.contains("1 ok"));
+        assert!(text.contains("1 warn"));
+        assert!(text.contains("1 fail"));
+        assert!(text.contains("Daemon (irlumed)"));
+        assert!(
+            text.contains("· [f] fix (sudo)"),
+            "root fixes advertise [f]"
+        );
+        assert!(text.contains("· manual"), "manual fixes are tagged");
+        assert!(
+            text.contains("this row is fine"),
+            "an Ok row selected while another row fails must redirect"
+        );
+        app.repair_sel = 1;
+        let text = draw_text(&app);
+        assert!(text.contains("manual: install the package"));
+        app.repair_sel = 2;
+        let text = draw_text(&app);
+        assert!(text.contains("press [f]: irlume runs the fix with sudo"));
+        // The IR self-test card: idle prompt, then the verdict.
+        assert!(text.contains("press [l] to run the IR PAD self-test"));
+        app.selftest_result = Some((true, "PAD pass: depth 0.71".into()));
+        let text = draw_text(&app);
+        assert!(text.contains("PAD pass: depth 0.71"));
+    }
+
+    #[test]
+    fn cameras_screen_renders_pairs_and_the_no_pair_fallbacks() {
+        let mut app = test_app();
+        app.screen = SC_CAMERAS;
+        // No camera at all.
+        let text = draw_text(&app);
+        assert!(text.contains("no camera found"));
+        // RGB node only: convenience tier, and why Secure needs IR.
+        app.nodes = vec![("/dev/video9".into(), irlume_camera::Role::Rgb)];
+        let text = draw_text(&app);
+        assert!(text.contains("video9"));
+        assert!(text.contains("RGB-only, convenience tier"));
+        assert!(text.contains("no IR node"));
+        // A real Hello pair renders its nodes, kind, and USB id.
+        app.pairs = vec![irlume_camera::CameraPair {
+            rgb: "/dev/video0".into(),
+            ir: "/dev/video2".into(),
+            id: Some("abcd:1234".into()),
+            fixed: true,
+        }];
+        let text = draw_text(&app);
+        assert!(text.contains("video0+video2"));
+        assert!(text.contains("built-in"));
+        assert!(text.contains("[abcd:1234]"));
+        assert!(text.contains("IR emitter (850nm)"));
+        assert!(text.contains("[s]"), "the emitter setup key is advertised");
+    }
+
+    #[test]
+    fn pam_screen_describes_what_each_tier_actually_does() {
+        let mut app = test_app();
+        app.screen = SC_PAM;
+        let text = draw_text(&app);
+        assert!(text.contains("PAM services"));
+        assert!(
+            text.contains("tier unknown (daemon unreachable)"),
+            "no tier claim without the daemon"
+        );
+        assert!(text.contains("wire the login stack now"));
+        app.health = Some(HealthInfo {
+            tier: "convenience".into(),
+            rgb_dev: Some("/dev/video0".into()),
+            ir_dev: None,
+            mesh: false,
+            adapter: false,
+            version: "1.0".into(),
+        });
+        let text = draw_text(&app);
+        assert!(
+            text.contains("face is NOT accepted for login"),
+            "RGB-only must not promise greeter login"
+        );
+        app.health.as_mut().unwrap().tier = "secure".into();
+        let text = draw_text(&app);
+        assert!(text.contains("TPM-unseal password"));
+        assert!(text.contains("always fail-safe to the password"));
+    }
+
+    #[test]
+    fn settings_screen_renders_sections_and_the_eyes_open_state() {
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        let text = draw_text(&app);
+        assert!(text.contains("Require eyes open"));
+        assert!(text.contains("○ no"), "eyes-open starts off");
+        assert!(text.contains("Biopolicy operation-class gate"));
+        assert!(text.contains("Third-party liveness models"));
+        assert!(text.contains("Match thresholds (read-only)"));
+        app.eyes_open = true;
+        let text = draw_text(&app);
+        assert!(text.contains("● yes"), "the toggled state must show");
+    }
+
+    #[test]
+    fn done_screen_status_line_matches_setup_state() {
+        let mut app = test_app();
+        app.screen = SC_DONE;
+        let text = draw_text(&app);
+        assert!(text.contains("Setup dashboard"));
+        assert!(
+            text.contains("Daemon not running; see the Repair tab"),
+            "a down daemon is the first thing Done must flag"
+        );
+        app.daemon_up = true;
+        app.caps = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: true,
+        };
+        let text = draw_text(&app);
+        assert!(
+            text.contains("enroll a face (Welcome [e])"),
+            "an empty enrollment with a camera points at [e]"
+        );
+        app.caps = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: false,
+        };
+        let text = draw_text(&app);
+        assert!(text.contains("No face hardware"));
+    }
+
+    #[test]
+    fn enroll_screen_renders_progress_checklist_countdown_and_guidance() {
+        let mut app = test_app();
+        let (_tx, mut enroll) = fake_enroll(1, 4);
+        enroll.captured = 1;
+        enroll.count = Some(2);
+        enroll.last = Some(good_report("Hold still"));
+        app.enroll = Some(enroll);
+        let text = draw_text(&app);
+        assert!(
+            text.contains("Enrolling 'p' (scan 2/5)"),
+            "progress must include the merged base offset:\n{text}"
+        );
+        assert!(text.contains("85%"), "the quality bar shows the percent");
+        assert!(text.contains("Face detected"));
+        assert!(text.contains("Well lit"));
+        assert!(
+            text.contains("capturing in 2"),
+            "the countdown overrides the guidance line"
+        );
+        assert!(text.contains("[esc] cancel"));
+        assert!(
+            text.contains("Look at the camera and hold still"),
+            "the hint line switches to capture mode"
+        );
+        // Between countdowns the daemon's guidance cue shows instead.
+        app.enroll.as_mut().unwrap().count = None;
+        let text = draw_text(&app);
+        assert!(text.contains("Hold still"));
+        assert!(!text.contains("capturing in"));
+        // Before the first cue arrives the camera-start placeholder shows.
+        app.enroll.as_mut().unwrap().last = None;
+        let text = draw_text(&app);
+        assert!(text.contains("Starting camera…"));
+    }
+
+    #[test]
+    fn error_banner_renders_over_everything_including_prompts() {
+        let mut app = test_app();
+        app.input = Some((
+            "New profile name (blank = default):".into(),
+            String::new(),
+            Pending::EnrollName,
+        ));
+        app.error = Some("camera busy".into());
+        let text = draw_text(&app);
+        assert!(text.contains("⚠ Problem"));
+        assert!(text.contains("camera busy"));
+        assert!(text.contains("[any key] dismiss"));
+        assert!(
+            !text.contains("New profile name"),
+            "the error modal must take precedence over the input prompt"
+        );
+    }
+
+    #[test]
+    fn masked_input_renders_bullets_never_the_password() {
+        let mut app = test_app();
+        app.input = Some((
+            "Login password to seal (••):".into(),
+            "hunter2".into(),
+            Pending::KeyringPw(None),
+        ));
+        let text = draw_text(&app);
+        assert!(
+            text.contains("•••••••"),
+            "7 typed chars must render as 7 bullets"
+        );
+        assert!(
+            !text.contains("hunter2"),
+            "the password must never reach the screen"
+        );
+        // A non-secret prompt renders the actual text.
+        app.input = Some((
+            "Rename profile 'x' to:".into(),
+            "visible".into(),
+            Pending::RenameProfile("x".into()),
+        ));
+        let text = draw_text(&app);
+        assert!(text.contains("visible"));
+    }
+
+    #[test]
+    fn header_counts_steps_over_visible_screens_only() {
+        let mut app = test_app(); // visible: Welcome, Login wiring, Done
+        app.screen = SC_PAM;
+        let text = draw_text(&app);
+        assert!(
+            text.contains("step 2/3: Login wiring"),
+            "the step counter must track visible tabs, got:\n{text}"
+        );
+        assert!(text.contains("testuser"), "the managed user is shown");
+    }
+
+    #[test]
+    fn footer_lists_each_screens_action_keys() {
+        let app = test_app();
+        let footer = |app: &App| {
+            let mut term = Terminal::new(TestBackend::new(200, 3)).unwrap();
+            term.draw(|f| app.draw_footer(f, f.area())).unwrap();
+            rendered(&term)
+        };
+        let cases: [(usize, &str); 11] = [
+            (SC_WELCOME, "uninstall"),
+            (SC_REPAIR, "IR test"),
+            (SC_CAMERAS, "setup emitter"),
+            (SC_PROFILES, "add scan"),
+            (SC_IDENTIFY, "identify"),
+            (SC_KEYRING, "arm"),
+            (SC_RECOVERY, "restore"),
+            (SC_FINGERPRINT, "enroll finger"),
+            (SC_PAM, "wire login (sudo)"),
+            (SC_SETTINGS, "toggle eyes-open"),
+            (SC_DONE, "wire login"),
+        ];
+        let mut app = app;
+        for (screen, needle) in cases {
+            app.screen = screen;
+            let text = footer(&app);
+            assert!(
+                text.contains(needle),
+                "footer for {} must advertise '{needle}', got:\n{text}",
+                SCREENS[screen]
+            );
+            assert!(text.contains("switch tab"), "global nav keys always show");
+        }
+        // The [v] label flips with the view mode.
+        app.screen = SC_WELCOME;
+        assert!(footer(&app).contains("all tabs"));
+        app.advanced = true;
+        assert!(footer(&app).contains("basic"));
+        // Guided enrollment swallows everything but Esc: only that shows.
+        let (_tx, enroll) = fake_enroll(0, 4);
+        app.enroll = Some(enroll);
+        let text = footer(&app);
+        assert!(text.contains("cancel enrollment"));
+        assert!(!text.contains("switch tab"));
+    }
+
+    #[test]
+    fn activity_panel_windows_scroll_and_titles_reflect_state() {
+        let mut app = test_app();
+        for i in 0..30 {
+            app.log('·', format!("line {i}"));
+        }
+        let panel = |app: &App| {
+            let mut term = Terminal::new(TestBackend::new(80, 7)).unwrap();
+            term.draw(|f| app.draw_activity(f, f.area())).unwrap();
+            rendered(&term)
+        };
+        // Following: the newest lines fill the 5 visible rows.
+        let text = panel(&app);
+        assert!(text.contains("line 29"));
+        assert!(text.contains("line 25"));
+        assert!(!text.contains("line 24"), "older lines are scrolled out");
+        assert!(text.contains("newest last"));
+        // Scrolled to the top: the oldest lines and the history title.
+        app.act_scroll = app.act_max();
+        let text = panel(&app);
+        assert!(text.contains("line 0"));
+        assert!(text.contains("line 4"));
+        assert!(!text.contains("line 5"), "the window is 5 rows");
+        assert!(text.contains("history (25 up"));
+        // A running op puts its label in the title.
+        app.act_scroll = 0;
+        let (_tx, op) = fake_op();
+        app.op = Some(op);
+        let text = panel(&app);
+        assert!(text.contains("Identify"));
+    }
+
+    // ---- log ring, scroll bounds, status poll ------------------------------
+
+    #[test]
+    fn log_ring_buffer_caps_at_200_and_keeps_the_newest() {
+        let mut app = test_app();
+        for i in 0..250 {
+            app.log('·', format!("line {i}"));
+        }
+        assert_eq!(app.activity.len(), 200);
+        assert_eq!(app.activity[0].1, "line 50", "the oldest 50 are dropped");
+        assert_eq!(app.activity[199].1, "line 249");
+    }
+
+    #[test]
+    fn log_holds_a_scrolled_view_in_place_as_lines_arrive() {
+        let mut app = test_app();
+        for i in 0..20 {
+            app.log('·', format!("line {i}"));
+        }
+        app.act_scroll = 5;
+        app.log('·', "new line");
+        assert_eq!(
+            app.act_scroll, 6,
+            "new lines must not yank a reading user to the bottom"
+        );
+        app.act_scroll = 0;
+        app.log('·', "another");
+        assert_eq!(app.act_scroll, 0, "at the bottom the view keeps following");
+    }
+
+    #[test]
+    fn scroll_keys_clamp_at_both_ends() {
+        let mut app = test_app();
+        for i in 0..30 {
+            app.log('·', format!("line {i}"));
+        }
+        app.on_key(KeyCode::Home);
+        assert_eq!(app.act_scroll, app.act_max(), "Home jumps to the oldest");
+        app.on_key(KeyCode::PageUp);
+        assert_eq!(
+            app.act_scroll,
+            app.act_max(),
+            "PgUp cannot scroll past the top"
+        );
+        app.on_key(KeyCode::End);
+        assert_eq!(app.act_scroll, 0, "End jumps back to following");
+        app.on_key(KeyCode::PageDown);
+        assert_eq!(app.act_scroll, 0, "PgDn cannot scroll below the bottom");
+    }
+
+    #[test]
+    fn refresh_light_clamps_selections_to_the_shrunken_lists() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.profiles = vec![profile("a", &["s1"])]; // 2 rows
+        app.sel = 9;
+        app.cam_sel = 9;
+        app.refresh_light();
+        assert_eq!(app.sel, 1, "sel must clamp to the last real row");
+        assert!(
+            app.cam_sel < app.pairs.len().max(1),
+            "cam_sel must clamp to the discovered pairs"
+        );
+        assert!(!app.daemon_up);
+        assert!(app.health.is_none());
+    }
+
+    // ---- run_checks with the daemon's self-report ---------------------------
+
+    #[test]
+    fn run_checks_trusts_daemon_health_over_local_probes() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.health = Some(HealthInfo {
+            tier: "secure".into(),
+            rgb_dev: Some("/dev/video0".into()),
+            ir_dev: Some("/dev/video2".into()),
+            mesh: true,
+            adapter: true,
+            version: env!("CARGO_PKG_VERSION").into(),
+        });
+        app.run_checks();
+        let find = |label: &str| {
+            app.repair
+                .iter()
+                .find(|c| c.label == label)
+                .unwrap_or_else(|| panic!("missing check row '{label}'"))
+        };
+        // The socket is dead, so the Daemon row fails with the root fix…
+        let daemon = find("Daemon (irlumed)");
+        assert!(daemon.sev == Sev::Fail);
+        assert!(matches!(daemon.fix, Fix::Root("restart-daemon")));
+        // …but the daemon-reported model/camera state is still ground truth.
+        let ort = find("ONNX Runtime");
+        assert!(ort.sev == Sev::Ok);
+        assert!(ort.detail.contains("reported by the daemon"));
+        let models = find("Models");
+        assert!(models.detail.contains("+ IR adapter"));
+        assert!(models.detail.contains("+ FaceMesh"));
+        let cams = find("Cameras");
+        assert!(cams.sev == Sev::Ok);
+        assert!(cams.detail.contains("secure tier"));
+        assert!(
+            app.repair.iter().any(|c| c.label == "IR emitter"),
+            "an IR node earns the emitter fix row"
+        );
+        assert!(
+            !app.repair.iter().any(|c| c.label == "Daemon build"),
+            "matching daemon/CLI versions must not warn"
+        );
+        let enroll = find("Enrollment");
+        assert!(enroll.sev == Sev::Warn, "no profiles yet is a warning");
+        assert!(enroll.detail.contains("no face enrolled yet"));
+    }
+
+    #[test]
+    fn run_checks_flags_version_skew_challenge_gap_and_corrupt_enrollment() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.health = Some(HealthInfo {
+            tier: "convenience".into(),
+            rgb_dev: Some("/dev/video0".into()),
+            ir_dev: None,
+            mesh: false,
+            adapter: false,
+            version: "0.0.1-old".into(),
+        });
+        app.challenge = true;
+        app.enroll_error = Some("bad ciphertext".into());
+        app.run_checks();
+        let find = |label: &str| {
+            app.repair
+                .iter()
+                .find(|c| c.label == label)
+                .unwrap_or_else(|| panic!("missing check row '{label}'"))
+        };
+        let build = find("Daemon build");
+        assert!(build.sev == Sev::Warn);
+        assert!(
+            build.detail.contains("0.0.1-old"),
+            "names the stale version"
+        );
+        let blink = find("Blink challenge");
+        assert!(blink.sev == Sev::Fail);
+        assert!(blink.detail.contains("challenge is skipped"));
+        let enroll = find("Enrollment");
+        assert!(enroll.sev == Sev::Fail, "unreadable ≠ not enrolled");
+        assert!(enroll.detail.contains("bad ciphertext"));
+        let cams = find("Cameras");
+        assert!(cams.sev == Sev::Warn);
+        assert!(cams.detail.contains("convenience tier"));
+        assert!(
+            !app.repair.iter().any(|c| c.label == "IR emitter"),
+            "no IR node, no emitter row"
+        );
+        assert!(
+            app.repair.iter().any(|c| c.label == "RGB anti-spoof"),
+            "the convenience tier documents its moiré detector"
+        );
+        // The selection clamps when the list shrinks between runs.
+        app.repair_sel = 999;
+        app.run_checks();
+        assert!(app.repair_sel < app.repair.len());
     }
 }

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -5239,6 +5239,12 @@ mod tests {
         );
         wait_op_done(&mut app);
         app.error = None;
+        // wait_op_done pumps poll(), which re-derives hardware capabilities
+        // from the real /dev nodes; on a camera-less host (CI) the visible
+        // screen set shrinks and the current screen gets clamped away from
+        // Recovery. Pin it back so the restore keys land where a user on a
+        // stable machine would be.
+        app.screen = SC_RECOVERY;
         // Restore: empty aborts, non-empty fires RecoveryRestore.
         app.on_key(KeyCode::Char('t'));
         app.on_key(KeyCode::Enter);

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -348,4 +348,36 @@ mod tests {
         );
         assert!(removal_hint(&InstallOrigin::Source).contains("source install"));
     }
+
+    // The repo-residual cleaner backs both the Copr and the PPA teardown; it
+    // must take everything the installers drop (repo file, sources file,
+    // signing keys, any capitalisation) and nothing else in the directory.
+    #[test]
+    fn remove_repo_files_deletes_only_irlume_named_entries() {
+        let dir = std::env::temp_dir().join(format!("irlume-repo-clean-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let ours = [
+            "_copr:copr.fedorainfracloud.org:archledger:irlume.repo",
+            "archledger-ubuntu-irlume-resolute.sources",
+            "IRLUME-2026.gpg",
+        ];
+        let theirs = ["fedora.repo", "docker.list", "archledger-other.gpg"];
+        for f in ours.iter().chain(theirs.iter()) {
+            std::fs::write(dir.join(f), b"x").unwrap();
+        }
+        remove_repo_files(dir.to_str().unwrap());
+        for f in ours {
+            assert!(!dir.join(f).exists(), "{f} should have been removed");
+        }
+        for f in theirs {
+            assert!(dir.join(f).exists(), "{f} must be left alone");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_repo_files_tolerates_a_missing_directory() {
+        remove_repo_files("/nonexistent/irlume-repo-dir");
+    }
 }

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1,0 +1,1620 @@
+//! Black-box tests of the `irlume` binary: argument dispatch, usage errors,
+//! exit codes, and the offline failure paths of every daemon-backed command.
+//!
+//! Every invocation runs inside a sandbox: `IRLUME_SOCKET` points at a path
+//! nothing listens on (so no request can ever reach a real `irlumed`),
+//! `IRLUME_CONFIG_DIR` / `IRLUME_STATE_DIR` / `IRLUME_KEYRING_DIR` point at a
+//! per-test temp tree, and system tools the CLI shells out to (journalctl,
+//! rpm, curl, semodule, ...) are PATH-shadowed with fake scripts. No test
+//! touches the network, a camera, the TPM, or the machine's package database.
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+const BIN: &str = env!("CARGO_BIN_EXE_irlume");
+
+fn is_root() -> bool {
+    unsafe { libc::geteuid() == 0 }
+}
+
+/// Per-test sandbox tree; dropped (deleted) when the test ends.
+struct Sandbox {
+    root: PathBuf,
+}
+
+impl Sandbox {
+    fn new(tag: &str) -> Self {
+        let root = std::env::temp_dir().join(format!("irlume-cli-it-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        for d in ["cfg", "state", "keyring", "bin", "work"] {
+            std::fs::create_dir_all(root.join(d)).unwrap();
+        }
+        Sandbox { root }
+    }
+
+    fn path(&self, rel: &str) -> PathBuf {
+        self.root.join(rel)
+    }
+
+    /// Drop a fake `#!/bin/sh` executable into the sandbox bin dir.
+    fn fake_tool(&self, name: &str, body: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        let p = self.root.join("bin").join(name);
+        std::fs::write(&p, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    /// A Command for the irlume binary, isolated from the host system.
+    fn cmd(&self, args: &[&str]) -> Command {
+        let mut c = Command::new(BIN);
+        c.args(args)
+            .env("IRLUME_SOCKET", self.root.join("no-daemon.sock"))
+            .env("IRLUME_CONFIG_DIR", self.root.join("cfg"))
+            .env("IRLUME_STATE_DIR", self.root.join("state"))
+            .env("IRLUME_KEYRING_DIR", self.root.join("keyring"))
+            .env("IRLUME_METHOD_CONF", self.root.join("cfg").join("method"))
+            .env_remove("IRLUME_DEV")
+            .env_remove("ORT_DYLIB_PATH")
+            .env_remove("IRLUME_MODEL")
+            .env_remove("IRLUME_DET_MODEL")
+            .current_dir(self.root.join("work"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        c
+    }
+
+    /// Like `cmd`, but with the sandbox bin dir prepended to PATH so fake
+    /// tools shadow the real ones.
+    fn cmd_with_fakes(&self, args: &[&str]) -> Command {
+        let mut c = self.cmd(args);
+        c.env(
+            "PATH",
+            format!(
+                "{}:{}",
+                self.root.join("bin").display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        );
+        c
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+/// Run and collect (exit code, stdout, stderr).
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("spawn irlume");
+    (
+        out.status.code().expect("no exit code (signal?)"),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// Run with `input` piped to stdin.
+fn run_stdin(cmd: &mut Command, input: &str) -> (i32, String, String) {
+    let mut child = cmd.stdin(Stdio::piped()).spawn().expect("spawn irlume");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait irlume");
+    (
+        out.status.code().expect("no exit code (signal?)"),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+// ---------------------------------------------------------------- version/help
+
+#[test]
+fn version_prints_the_crate_version_for_all_spellings() {
+    let sb = Sandbox::new("version");
+    for spelling in ["version", "--version", "-V"] {
+        let (code, out, _) = run(&mut sb.cmd(&[spelling]));
+        assert_eq!(code, 0, "`irlume {spelling}` exit code");
+        assert_eq!(
+            out.trim(),
+            format!("irlume {}", env!("CARGO_PKG_VERSION")),
+            "`irlume {spelling}` output"
+        );
+    }
+}
+
+#[test]
+fn help_lists_every_public_command_and_hides_dev_tools() {
+    let sb = Sandbox::new("help");
+    // `help`, `--help`, `-h`, and no arguments all print the same listing.
+    for args in [&["help"][..], &["--help"], &["-h"], &[]] {
+        let (code, out, _) = run(&mut sb.cmd(args));
+        assert_eq!(code, 0, "help exit code for {args:?}");
+        for cmd in [
+            "tui",
+            "setup",
+            "status",
+            "detect",
+            "doctor",
+            "deps",
+            "enroll",
+            "profiles",
+            "identify",
+            "keyring",
+            "reseal",
+            "recovery",
+            "diag",
+            "login",
+            "logs",
+            "fingerprint",
+            "selinux",
+            "ir-setup",
+            "set-cameras",
+            "models",
+            "update",
+            "uninstall",
+            "version",
+        ] {
+            assert!(out.contains(cmd), "help must list `{cmd}`");
+        }
+        assert!(
+            out.contains("IRLUME_DEV=1"),
+            "help must mention the dev gate"
+        );
+        for hidden in ["calcapture", "irbench", "padcapture", "normprobe"] {
+            assert!(
+                !out.contains(hidden),
+                "help must not leak the dev tool `{hidden}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn unknown_command_errors_with_exit_2() {
+    let sb = Sandbox::new("unknown");
+    let (code, _, err) = run(&mut sb.cmd(&["frobnicate"]));
+    assert_eq!(code, 2);
+    assert!(
+        err.contains("unknown command 'frobnicate'"),
+        "stderr: {err}"
+    );
+    assert!(err.contains("irlume help"), "must point at help: {err}");
+}
+
+// ------------------------------------------------------------------ dev gating
+
+const DEV_CMDS: &[&str] = &[
+    "capture",
+    "eval",
+    "irbench",
+    "genuine",
+    "calcapture",
+    "normprobe",
+    "liveness",
+    "meshprobe",
+    "selftest",
+    "padcapture",
+    "padreport",
+    "verify",
+    "enrolldev",
+    "suncal",
+];
+
+#[test]
+fn dev_commands_are_gated_without_irlume_dev() {
+    let sb = Sandbox::new("devgate");
+    for cmd in DEV_CMDS {
+        let (code, _, err) = run(&mut sb.cmd(&[cmd]));
+        assert_eq!(code, 2, "`{cmd}` must be blocked without IRLUME_DEV");
+        assert!(
+            err.contains(cmd) && err.contains("developer/benchmark tool"),
+            "`{cmd}` gate message: {err}"
+        );
+        assert!(
+            err.contains("IRLUME_DEV=1"),
+            "`{cmd}` gate must name the unlock env: {err}"
+        );
+        assert!(
+            !err.contains("usage:"),
+            "`{cmd}` must not reach its own arg parsing when gated: {err}"
+        );
+    }
+}
+
+#[test]
+fn dev_commands_with_env_reach_their_usage_errors() {
+    let sb = Sandbox::new("devusage");
+    // (argv, expected exit code, fragment the usage line must carry). Every
+    // fragment is a real flag or literal from the command's own usage text.
+    let table: &[(&[&str], i32, &str)] = &[
+        (&["capture"], 2, "usage: irlume capture --det"),
+        (&["eval"], 2, "usage: irlume eval --image"),
+        (&["irbench"], 2, "usage: irlume irbench --dir"),
+        (&["genuine"], 2, "usage: irlume genuine --det"),
+        (&["calcapture"], 2, "--out <cal.jsonl>"),
+        (&["normprobe"], 2, "usage: irlume normprobe --dir"),
+        (&["liveness"], 2, "usage: irlume liveness --det"),
+        (&["meshprobe"], 2, "usage: irlume meshprobe --det"),
+        (&["verify"], 2, "usage: irlume verify --user U --det"),
+        (&["enrolldev"], 2, "usage: irlume enrolldev --user U --det"),
+        (&["padcapture"], 2, "usage: irlume padcapture --species"),
+        (&["padreport"], 2, "usage: irlume padreport --in"),
+        (&["suncal"], 1, "usage: IRLUME_DEV=1 irlume suncal"),
+        (
+            &["selftest", "align"],
+            2,
+            "usage: irlume selftest align --model",
+        ),
+    ];
+    for (argv, want, fragment) in table {
+        let (code, _, err) = run(sb.cmd(argv).env("IRLUME_DEV", "1"));
+        assert_eq!(code, *want, "exit code for {argv:?}: {err}");
+        assert!(err.contains(fragment), "{argv:?} usage text: {err}");
+    }
+}
+
+#[test]
+fn selftest_without_align_is_an_unknown_command() {
+    let sb = Sandbox::new("selftest");
+    let (code, _, err) = run(sb.cmd(&["selftest"]).env("IRLUME_DEV", "1"));
+    assert_eq!(code, 2);
+    assert!(err.contains("unknown command 'selftest'"), "stderr: {err}");
+}
+
+#[test]
+fn padcapture_validates_kind_and_path_values() {
+    let sb = Sandbox::new("padargs");
+    let (code, _, err) = run(sb
+        .cmd(&[
+            "padcapture",
+            "--species",
+            "s",
+            "--kind",
+            "maybe",
+            "--det",
+            "d",
+            "--out",
+            "o",
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 2);
+    assert!(
+        err.contains("--kind must be 'attack' or 'bonafide'"),
+        "{err}"
+    );
+
+    let (code, _, err) = run(sb
+        .cmd(&[
+            "padcapture",
+            "--species",
+            "s",
+            "--kind",
+            "attack",
+            "--det",
+            "d",
+            "--out",
+            "o",
+            "--path",
+            "weird",
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 2);
+    assert!(err.contains("--path must be 'full' or 'ir-only'"), "{err}");
+}
+
+#[test]
+fn irbench_rejects_an_empty_dataset_before_loading_models() {
+    let sb = Sandbox::new("irbench");
+    let empty = sb.path("work");
+    let dir = empty.to_str().unwrap();
+    let (code, _, err) = run(sb
+        .cmd(&["irbench", "--dir", dir, "--det", "x", "--model", "y"])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("no jpg/png/bmp images under"), "{err}");
+
+    // Impostor-only (farbench) mode has its own floor: at least two images.
+    let (code, _, err) = run(sb
+        .cmd(&[
+            "irbench",
+            "--dir",
+            dir,
+            "--det",
+            "x",
+            "--model",
+            "y",
+            "--impostor-only",
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("need >=2 images"), "{err}");
+}
+
+#[test]
+fn eval_and_capture_report_an_unreadable_image() {
+    let sb = Sandbox::new("badimage");
+    let missing = sb.path("work/nope.jpg");
+    let img = missing.to_str().unwrap();
+    for argv in [
+        vec!["eval", "--image", img, "--det", "d", "--model", "m"],
+        vec!["capture", "--image", img, "--det", "d", "--model", "m"],
+    ] {
+        let (code, _, err) = run(sb.cmd(&argv).env("IRLUME_DEV", "1"));
+        assert_eq!(code, 1, "{argv:?}");
+        assert!(err.contains("image load failed"), "{argv:?}: {err}");
+    }
+}
+
+#[test]
+fn suncal_reports_a_missing_detector_model() {
+    let sb = Sandbox::new("suncal");
+    let dataset = sb.path("work");
+    let (code, _, err) = run(sb
+        .cmd(&["suncal", "/nonexistent/det.onnx", dataset.to_str().unwrap()])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("load detector"), "{err}");
+}
+
+// -------------------------------------------------------------------- profiles
+
+#[test]
+fn profiles_usage_errors_exit_2() {
+    let sb = Sandbox::new("profusage");
+    let cases: &[&[&str]] = &[
+        &["profiles", "bogus"],
+        &["profiles", "add-scan"],
+        &["profiles", "delete"],
+        &["profiles", "rename", "--profile", "P"],
+        &["profiles", "eyes-open"],
+        &["profiles", "eyes-open", "on", "off"],
+        &["profiles", "challenge"],
+    ];
+    for argv in cases {
+        let (code, _, err) = run(&mut sb.cmd(argv));
+        assert_eq!(code, 2, "{argv:?} should be a usage error: {err}");
+        assert!(err.contains("usage:"), "{argv:?}: {err}");
+    }
+    // The full usage text names the real subcommands and flags.
+    let (_, _, err) = run(&mut sb.cmd(&["profiles", "bogus"]));
+    for frag in [
+        "add-scan --profile P",
+        "rename --profile P [--scan S] --name N",
+        "delete --profile P [--scan S]",
+        "eyes-open <on|off>",
+        "challenge <on|off>",
+    ] {
+        assert!(
+            err.contains(frag),
+            "profiles usage must name `{frag}`: {err}"
+        );
+    }
+}
+
+#[test]
+fn profiles_valid_subcommands_build_requests_and_fail_without_a_daemon() {
+    let sb = Sandbox::new("profreq");
+    // Each of these parses cleanly, constructs the daemon request, and then
+    // fails at the (dead) socket with exit 1, never a usage error.
+    let cases: &[&[&str]] = &[
+        &["profiles"],
+        &["profiles", "list"],
+        &["profiles", "add-scan", "--profile", "P"],
+        &["profiles", "delete", "--profile", "P"],
+        &["profiles", "delete", "--profile", "P", "--scan", "S"],
+        &["profiles", "rename", "--profile", "P", "--name", "N"],
+        &[
+            "profiles",
+            "rename",
+            "--profile",
+            "P",
+            "--scan",
+            "S",
+            "--name",
+            "N",
+        ],
+        &["profiles", "eyes-open", "on"],
+        &["profiles", "challenge", "off"],
+    ];
+    for argv in cases {
+        let (code, _, err) = run(&mut sb.cmd(argv));
+        assert_eq!(code, 1, "{argv:?}: {err}");
+        assert!(
+            err.contains("irlumed is not running"),
+            "{argv:?} must have reached the socket: {err}"
+        );
+        assert!(!err.contains("usage:"), "{argv:?} parsed fine: {err}");
+    }
+}
+
+// ---------------------------------------------------------- daemon-backed cmds
+
+#[test]
+fn enroll_fails_cleanly_without_a_daemon() {
+    let sb = Sandbox::new("enroll");
+    let (code, _, err) = run(&mut sb.cmd(&[
+        "enroll", "--user", "tester", "--name", "Work", "--scans", "3", "--reset",
+    ]));
+    assert_eq!(code, 1);
+    assert!(err.contains("[enroll] --reset: wiping 'tester'"), "{err}");
+    assert!(err.contains("capturing a new face profile"), "{err}");
+    assert!(err.contains("irlumed is not running"), "{err}");
+}
+
+#[test]
+fn keyring_usage_and_daemon_failures() {
+    let sb = Sandbox::new("keyring");
+    let (code, _, err) = run(&mut sb.cmd(&["keyring"]));
+    assert_eq!(code, 2);
+    assert!(
+        err.contains("usage: irlume keyring <arm|status|forget>"),
+        "{err}"
+    );
+
+    // Piped empty stdin: the arm aborts before any request is built.
+    let (code, _, err) = run_stdin(&mut sb.cmd(&["keyring", "arm", "--user", "tester"]), "");
+    assert_eq!(code, 2);
+    assert!(err.contains("empty password; aborted"), "{err}");
+
+    // A piped password reaches the (dead) socket and reports the failure.
+    let (code, out, err) = run_stdin(
+        &mut sb.cmd(&["keyring", "arm", "--user", "tester"]),
+        "sekrit\n",
+    );
+    assert_eq!(code, 1);
+    assert!(
+        out.contains("Arming face-driven keyring unlock for 'tester'"),
+        "{out}"
+    );
+    assert!(
+        err.contains("arm failed") && err.contains("irlumed is not running"),
+        "{err}"
+    );
+
+    let (code, _, err) = run(&mut sb.cmd(&["keyring", "status", "--user", "tester"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("status failed"), "{err}");
+
+    let (code, _, err) = run(&mut sb.cmd(&["keyring", "forget", "--user", "tester"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("forget failed"), "{err}");
+}
+
+#[test]
+fn recovery_usage_and_daemon_failures() {
+    let sb = Sandbox::new("recovery");
+    let (code, _, err) = run(&mut sb.cmd(&["recovery", "bogus"]));
+    assert_eq!(code, 2);
+    assert!(
+        err.contains("usage: irlume recovery <status|setup|restore|forget>"),
+        "{err}"
+    );
+
+    let (code, _, err) = run(&mut sb.cmd(&["recovery", "status", "--user", "tester"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("status failed"), "{err}");
+
+    let (code, _, err) = run_stdin(
+        &mut sb.cmd(&["recovery", "setup", "--user", "tester"]),
+        "passphrase\n",
+    );
+    assert_eq!(code, 1);
+    assert!(err.contains("setup failed"), "{err}");
+
+    // Restore with an empty piped passphrase aborts before any request.
+    let (code, _, err) = run_stdin(
+        &mut sb.cmd(&["recovery", "restore", "--user", "tester"]),
+        "",
+    );
+    assert_eq!(code, 2);
+    assert!(err.contains("empty passphrase; aborted"), "{err}");
+
+    let (code, _, err) = run_stdin(
+        &mut sb.cmd(&["recovery", "restore", "--user", "tester"]),
+        "passphrase\n",
+    );
+    assert_eq!(code, 1);
+    assert!(err.contains("restore failed"), "{err}");
+
+    let (code, _, err) = run(&mut sb.cmd(&["recovery", "forget", "--user", "tester"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("forget failed"), "{err}");
+}
+
+#[test]
+fn set_cameras_usage_and_daemon_failure() {
+    let sb = Sandbox::new("setcam");
+    let (code, _, err) = run(&mut sb.cmd(&["set-cameras"]));
+    assert_eq!(code, 2);
+    assert!(
+        err.contains("usage: irlume set-cameras <rgb-node> <ir-node>"),
+        "{err}"
+    );
+    // One node is not enough either.
+    let (code, _, _) = run(&mut sb.cmd(&["set-cameras", "/dev/video0"]));
+    assert_eq!(code, 2);
+
+    let (code, _, err) = run(&mut sb.cmd(&["set-cameras", "/dev/video0", "/dev/video2"]));
+    assert_eq!(code, 1);
+    assert!(
+        err.contains("[set-cameras]") && err.contains("irlumed is not running"),
+        "{err}"
+    );
+}
+
+#[test]
+fn ir_setup_daemon_failure_and_dry_run_skip_the_probe_banner() {
+    let sb = Sandbox::new("irsetup");
+    let (code, _, err) = run(&mut sb.cmd(&["ir-setup"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("probing the IR camera"), "{err}");
+    assert!(err.contains("[ir-setup]"), "{err}");
+
+    let (code, _, err) = run(&mut sb.cmd(&["ir-setup", "--dry-run"]));
+    assert_eq!(code, 1);
+    assert!(
+        !err.contains("probing the IR camera"),
+        "--dry-run must not print the probe banner: {err}"
+    );
+}
+
+#[test]
+fn identify_reports_the_daemon_error() {
+    let sb = Sandbox::new("identify");
+    let (code, _, err) = run(&mut sb.cmd(&["identify"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("irlumed is not running"), "{err}");
+}
+
+#[test]
+fn reseal_requires_a_reachable_daemon() {
+    let sb = Sandbox::new("reseal");
+    let (code, _, err) = run(&mut sb.cmd(&["reseal", "--user", "tester"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("[reseal] daemon unreachable"), "{err}");
+}
+
+#[test]
+fn setup_stops_at_the_preflight_without_a_daemon() {
+    let sb = Sandbox::new("setup");
+    let (code, out, err) = run(&mut sb.cmd(&["setup", "--user", "tester"]));
+    assert_eq!(code, 1);
+    assert!(out.contains("=== irlume setup for 'tester' ==="), "{out}");
+    assert!(
+        err.contains("daemon not reachable; start it first"),
+        "{err}"
+    );
+}
+
+#[test]
+fn status_reports_an_unreachable_daemon_and_defaults() {
+    let sb = Sandbox::new("status");
+    let (code, out, _) = run(&mut sb.cmd(&["status", "--user", "tester"]));
+    assert_eq!(
+        code, 0,
+        "status always exits 0 (it reports, it doesn't gate)"
+    );
+    assert!(out.contains("irlume status for 'tester'"), "{out}");
+    assert!(out.contains("NOT reachable"), "{out}");
+    assert!(
+        out.contains("Auto"),
+        "method file absent must read Auto: {out}"
+    );
+    assert!(
+        out.contains("enrollment    : unknown (daemon unreachable)"),
+        "{out}"
+    );
+    assert!(out.contains("keyring unlock: unknown"), "{out}");
+    assert!(out.contains("biopolicy     : off (default)"), "{out}");
+}
+
+#[test]
+fn detect_never_reports_ready_without_a_daemon() {
+    let sb = Sandbox::new("detect");
+    let (code, out, _) = run(&mut sb.cmd(&["detect", "--user", "tester"]));
+    // 20 = irlumed binary absent from this machine, 10 = installed but the
+    // daemon is down; either way a dead socket must never yield 0/"ready".
+    match code {
+        10 => assert!(out.starts_with("partial:"), "{out}"),
+        20 => assert!(out.starts_with("absent:"), "{out}"),
+        other => panic!("detect returned {other} with a dead daemon: {out}"),
+    }
+}
+
+#[test]
+fn diag_falls_back_to_the_daemon_summary_and_reports_unknown() {
+    let sb = Sandbox::new("diag");
+    let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("irlume diag for 'tester'"), "{out}");
+    // No envelope in the sandboxed keyring dir + dead socket:
+    assert!(
+        out.contains("seal envelope : unknown (daemon unreachable)"),
+        "{out}"
+    );
+}
+
+#[test]
+fn doctor_runs_fully_offline_with_a_source_origin() {
+    let sb = Sandbox::new("doctor");
+    // No package manager owns irlume in the sandbox: every probe tool fails.
+    for tool in ["rpm", "dnf", "dpkg-query", "apt-cache", "pacman"] {
+        sb.fake_tool(tool, "exit 1");
+    }
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["doctor"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("[doctor] platform:"), "{out}");
+    assert!(
+        out.contains("install origin: source / dev install"),
+        "fake package managers must yield a source origin: {out}"
+    );
+    assert!(out.contains("TPM 2.0:"), "{out}");
+    assert!(out.contains("camera nodes"), "{out}");
+    assert!(out.contains("[doctor] models:"), "{out}");
+    assert!(out.contains("glintr100.onnx"), "{out}");
+    assert!(out.contains("face_detection_yunet_2023mar.onnx"), "{out}");
+    assert!(out.contains("ORT_DYLIB_PATH: (unset)"), "{out}");
+    assert!(
+        out.contains("third-party PAD model: none (default"),
+        "empty sandbox config/state must report no third-party model: {out}"
+    );
+    assert!(out.contains("unknown (daemon not reachable"), "{out}");
+}
+
+#[test]
+fn deps_reports_every_probe() {
+    let sb = Sandbox::new("deps");
+    let (code, out, _) = run(&mut sb.cmd(&["deps"]));
+    assert!(code == 0 || code == 1, "deps exits 0 or 1, got {code}");
+    for probe in ["onnxruntime", "glintr100.onnx", "TPM", "camera (v4l)"] {
+        assert!(out.contains(probe), "deps must report `{probe}`: {out}");
+    }
+    assert!(out.contains("deps:"), "{out}");
+}
+
+// ------------------------------------------------------------------------ logs
+
+#[test]
+fn logs_assembles_the_journalctl_argv() {
+    let sb = Sandbox::new("logsargv");
+    // The fake journalctl echoes one argument per line.
+    sb.fake_tool("journalctl", r#"printf '%s\n' "$@""#);
+    const PATTERN: &str = "irlume|pam_kwallet|pam_gnome_keyring";
+
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["logs"]));
+    assert_eq!(code, 0);
+    let args: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        args,
+        ["--no-pager", "-g", PATTERN, "-b"],
+        "default view = this boot"
+    );
+
+    for follow in ["-f", "--follow"] {
+        let (code, out, _) = run(&mut sb.cmd_with_fakes(&["logs", follow]));
+        assert_eq!(code, 0);
+        let args: Vec<&str> = out.lines().collect();
+        assert_eq!(args, ["--no-pager", "-g", PATTERN, "-f"], "{follow} view");
+    }
+
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["logs", "--since", "10 min ago"]));
+    assert_eq!(code, 0);
+    let args: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        args,
+        ["--no-pager", "-g", PATTERN, "--since", "10 min ago"],
+        "--since must forward its value and drop the -b default"
+    );
+}
+
+#[test]
+fn logs_option_errors_never_run_journalctl() {
+    let sb = Sandbox::new("logserr");
+    sb.fake_tool("journalctl", r#"printf 'JOURNALCTL RAN\n'"#);
+
+    let (code, out, err) = run(&mut sb.cmd_with_fakes(&["logs", "--since"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("--since needs a value"), "{err}");
+    assert!(
+        !out.contains("JOURNALCTL RAN"),
+        "must not have run journalctl"
+    );
+
+    let (code, out, err) = run(&mut sb.cmd_with_fakes(&["logs", "--bogus"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("unknown option '--bogus'"), "{err}");
+    assert!(
+        !out.contains("JOURNALCTL RAN"),
+        "must not have run journalctl"
+    );
+}
+
+#[test]
+fn logs_propagates_a_journalctl_failure() {
+    let sb = Sandbox::new("logsfail");
+    sb.fake_tool("journalctl", "exit 3");
+    let (code, _, _) = run(&mut sb.cmd_with_fakes(&["logs"]));
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn logs_debug_status_and_root_guards() {
+    let sb = Sandbox::new("logsdebug");
+    let (code, out, _) = run(&mut sb.cmd(&["logs", "debug"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("daemon diagnostic tracing"), "{out}");
+
+    if !is_root() {
+        for action in ["on", "off"] {
+            let (code, _, err) = run(&mut sb.cmd(&["logs", "debug", action]));
+            assert_eq!(code, 1, "debug {action} must need root");
+            assert!(err.contains("needs root"), "{err}");
+        }
+    }
+
+    let (code, _, err) = run(&mut sb.cmd(&["logs", "debug", "bogus"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("unknown: 'debug bogus'"), "{err}");
+}
+
+// ---------------------------------------------------------------------- models
+
+#[test]
+fn models_list_reports_catalog_and_enablement_states() {
+    let sb = Sandbox::new("modelslist");
+    // Default: nothing enabled in the sandbox config.
+    let (code, out, _) = run(&mut sb.cmd(&["models"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("flir"), "catalog entry must be listed: {out}");
+    assert!(out.contains("[disabled]"), "{out}");
+    assert!(out.contains("none enabled"), "{out}");
+
+    // Enabled in settings.conf but weights never fetched.
+    std::fs::write(sb.path("cfg/settings.conf"), "third_party_pad=flir\n").unwrap();
+    let (code, out, _) = run(&mut sb.cmd(&["models", "list"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("ENABLED (weights not fetched)"), "{out}");
+    assert!(out.contains("enabled: flir"), "{out}");
+
+    // Weights present but not matching the pinned checksum.
+    let tp = sb.path("state/models-thirdparty");
+    std::fs::create_dir_all(&tp).unwrap();
+    std::fs::write(tp.join("flir.onnx"), b"not the pinned bytes").unwrap();
+    let (code, out, _) = run(&mut sb.cmd(&["models", "list"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("CHECKSUM MISMATCH"), "{out}");
+}
+
+#[test]
+fn models_usage_and_guards() {
+    let sb = Sandbox::new("modelsguard");
+    let (code, _, err) = run(&mut sb.cmd(&["models", "bogus"]));
+    assert_eq!(code, 2);
+    assert!(err.contains("usage: irlume models"), "{err}");
+
+    let (code, _, _) = run(&mut sb.cmd(&["models", "enable"]));
+    assert_eq!(code, 2, "enable without a name is a usage error");
+
+    let (code, _, err) = run(&mut sb.cmd(&["models", "enable", "nope"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("'nope' is not in the catalog"), "{err}");
+
+    if !is_root() {
+        let (code, _, err) = run(&mut sb.cmd(&["models", "enable", "flir"]));
+        assert_eq!(code, 1);
+        assert!(err.contains("needs root"), "{err}");
+
+        let (code, _, err) = run(&mut sb.cmd(&["models", "disable"]));
+        assert_eq!(code, 1);
+        assert!(err.contains("needs root"), "{err}");
+    }
+}
+
+// ----------------------------------------------------------- uninstall/selinux
+
+#[test]
+fn uninstall_requires_root() {
+    if is_root() {
+        return; // the guard under test only exists for unprivileged callers
+    }
+    let sb = Sandbox::new("uninstall");
+    let (code, _, err) = run(&mut sb.cmd(&["uninstall"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("needs root: sudo irlume uninstall"), "{err}");
+}
+
+#[test]
+fn selinux_status_classifies_module_state_from_probe_output() {
+    let sb = Sandbox::new("selinux");
+    // Loaded: semodule lists the module and the socket carries our label.
+    sb.fake_tool("semodule", r#"printf 'irlume\nother\n'"#);
+    sb.fake_tool(
+        "ls",
+        r#"printf 'system_u:object_r:irlume_runtime_t:s0 /run/irlume.sock\n'"#,
+    );
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["selinux", "status"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("module 'irlume': loaded"), "{out}");
+
+    // Listed modules but ours absent, and no socket label: not loaded.
+    sb.fake_tool("semodule", r#"printf 'somethingelse\n'"#);
+    sb.fake_tool("ls", "exit 2");
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["selinux", "status"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("not loaded"), "{out}");
+
+    // semodule prints nothing (non-root): state is unknown, not "not loaded".
+    sb.fake_tool("semodule", "exit 1");
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["selinux", "status"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("unknown"), "{out}");
+
+    let (code, _, err) = run(&mut sb.cmd(&["selinux", "bogus"]));
+    assert_eq!(code, 1);
+    assert!(err.contains("unknown subcommand 'bogus'"), "{err}");
+}
+
+// ----------------------------------------------------------------- fingerprint
+
+#[test]
+fn fingerprint_status_and_usage() {
+    let sb = Sandbox::new("fingerprint");
+    let (code, _, err) = run(&mut sb.cmd(&["fingerprint", "bogus"]));
+    assert_eq!(code, 2);
+    assert!(
+        err.contains("usage: irlume fingerprint [--user U] <status|add|enable|disable>"),
+        "{err}"
+    );
+
+    let (code, out, _) = run(&mut sb.cmd(&["fingerprint", "status", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("fprintd tooling"), "{out}");
+    assert!(out.contains("active method"), "{out}");
+
+    if !is_root() {
+        let (code, _, err) = run(&mut sb.cmd(&["fingerprint", "disable"]));
+        assert_eq!(code, 1);
+        assert!(
+            err.contains("run with: sudo irlume fingerprint disable"),
+            "{err}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------- update
+
+#[test]
+fn update_uses_fake_probes_and_reports_per_scenario() {
+    let sb = Sandbox::new("update");
+    // No package manager owns irlume: origin resolves to source on any distro.
+    for tool in ["rpm", "dnf", "dpkg-query", "apt-cache", "pacman"] {
+        sb.fake_tool(tool, "exit 1");
+    }
+
+    // Scenario 1: a newer release is out.
+    sb.fake_tool(
+        "curl",
+        r#"printf '%s' '{"tag_name": "v99.99.99", "assets": [{"name": "irlume_99.99.99_amd64.deb"}]}'"#,
+    );
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["update", "--check"]));
+    assert_eq!(code, 0);
+    assert!(
+        out.contains(&format!(
+            "[update] installed: {}",
+            env!("CARGO_PKG_VERSION")
+        )),
+        "source installs fall back to the binary's own version: {out}"
+    );
+    assert!(
+        out.contains("install method: source / dev install"),
+        "{out}"
+    );
+    assert!(out.contains("available: v99.99.99"), "{out}");
+    assert!(
+        out.contains("Source install. Update the checkout at the tag:"),
+        "{out}"
+    );
+    assert!(out.contains("git checkout v99.99.99"), "{out}");
+    assert!(out.contains("Release notes:"), "{out}");
+
+    // Scenario 2: already up to date.
+    sb.fake_tool("curl", r#"printf '%s' '{"tag_name": "v0.0.1"}'"#);
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["update", "--check"]));
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("up to date (latest release is v0.0.1)"),
+        "{out}"
+    );
+
+    // Scenario 3: offline; degrade without updating anything.
+    sb.fake_tool("curl", "exit 7");
+    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["update", "--check"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("couldn't reach the release feed"), "{out}");
+}
+
+// ------------------------------------------------------------------- padreport
+
+const PAD_FIXTURE: &str = r#"{"species":"print_matte","kind":"attack","path":"full","verdict":"Spoof","caught":["ir_reflectance"]}
+{"species":"print_matte","kind":"attack","path":"full","verdict":"Spoof","caught":["ir_reflectance"]}
+{"species":"print_matte","kind":"attack","path":"full","verdict":"Live","caught":[]}
+{"species":"phone_replay","kind":"attack","path":"ir-only","verdict":"Uncertain","caught":[]}
+{"species":"bonafide","kind":"bonafide","path":"full","verdict":"Live","caught":[]}
+{"species":"bonafide","kind":"bonafide","path":"full","verdict":"Live","caught":[]}
+{"species":"bonafide","kind":"bonafide","path":"full","verdict":"Live","caught":[]}
+{"species":"bonafide","kind":"bonafide","path":"full","verdict":"Spoof","caught":[]}
+this line is not json
+{"species":"x","kind":"weird","verdict":"Live"}
+"#;
+
+#[test]
+fn padreport_aggregates_a_fixture_into_iso_metrics() {
+    let sb = Sandbox::new("padreport");
+    let jsonl = sb.path("work/pad.jsonl");
+    std::fs::write(&jsonl, PAD_FIXTURE).unwrap();
+    let md = sb.path("work/pad.md");
+
+    let (code, out, err) = run(sb
+        .cmd(&[
+            "padreport",
+            "--in",
+            jsonl.to_str().unwrap(),
+            "--md",
+            md.to_str().unwrap(),
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 0, "stderr: {err}");
+
+    // Malformed lines are skipped loudly, not silently.
+    assert!(err.contains("skipping malformed line 9"), "{err}");
+    assert!(err.contains("skipping line 10"), "{err}");
+
+    // 4 attacks / 4 bona fide, both gate paths seen.
+    assert!(out.contains("attack presentations: 4"), "{out}");
+    assert!(out.contains("bona-fide: 4"), "{out}");
+    assert!(out.contains("full, ir-only"), "{out}");
+
+    // print_matte: 1 accepted of 3 -> APCER 33.3%, caught twice by reflectance.
+    assert!(out.contains("print_matte"), "{out}");
+    assert!(out.contains("33.3%"), "{out}");
+    assert!(out.contains("ir_reflectance:2"), "{out}");
+    // phone_replay: the Uncertain outcome is non-response, not acceptance.
+    assert!(out.contains("100.0%"), "phone_replay non-response: {out}");
+    // Headlines: worst APCER, BPCER 1/4, ACER (33.3 + 25.0)/2.
+    assert!(out.contains("WORST-CASE APCER: print_matte"), "{out}");
+    assert!(out.contains("25.0%"), "BPCER: {out}");
+    assert!(out.contains("(n=4)"), "{out}");
+    assert!(out.contains("29.2%"), "ACER: {out}");
+
+    // The markdown twin carries the same numbers plus the honesty note.
+    let md_text = std::fs::read_to_string(&md).unwrap();
+    assert!(md_text.contains("| print_matte | 3 | 33.3% |"), "{md_text}");
+    assert!(md_text.contains("**Worst-case APCER:**"), "{md_text}");
+    assert!(md_text.contains("**BPCER:** 25.0%"), "{md_text}");
+    assert!(md_text.contains("not a lab-accredited"), "{md_text}");
+    assert!(out.contains("wrote markdown report"), "{out}");
+}
+
+#[test]
+fn padreport_with_attacks_only_flags_the_missing_bonafide_baseline() {
+    let sb = Sandbox::new("padnobf");
+    let jsonl = sb.path("work/attacks.jsonl");
+    std::fs::write(
+        &jsonl,
+        r#"{"species":"cutout","kind":"attack","path":"full","verdict":"Spoof","caught":["depth"]}
+"#,
+    )
+    .unwrap();
+    let (code, out, _) = run(sb
+        .cmd(&["padreport", "--in", jsonl.to_str().unwrap()])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 0);
+    assert!(out.contains("no bona-fide presentations captured"), "{out}");
+    assert!(out.contains("n/a"), "BPCER with den=0 renders n/a: {out}");
+    assert!(out.contains("WORST-CASE APCER: cutout"), "{out}");
+}
+
+#[test]
+fn padreport_input_errors() {
+    let sb = Sandbox::new("paderr");
+    let (code, _, err) = run(sb
+        .cmd(&["padreport", "--in", "/nonexistent/pad.jsonl"])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("cannot read"), "{err}");
+
+    let empty = sb.path("work/empty.jsonl");
+    std::fs::write(&empty, "").unwrap();
+    let (code, _, err) = run(sb
+        .cmd(&["padreport", "--in", empty.to_str().unwrap()])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("no usable records"), "{err}");
+}
+
+// ------------------------------------------------------------- fake daemon
+
+use irlume_common::{ProfileSummary, Request, Response};
+
+/// Serve canned responses on the sandbox socket (same line-JSON protocol as
+/// `irlumed`: one request per connection). Returns a log of every parsed
+/// request so tests can assert exactly what the CLI sent. The accept thread
+/// is detached; it ends with the test process, and the socket file lives in
+/// the sandbox, which is deleted on drop.
+fn serve(
+    sock: &std::path::Path,
+    respond: impl Fn(&Request) -> Response + Send + 'static,
+) -> std::sync::Arc<std::sync::Mutex<Vec<Request>>> {
+    use std::io::{BufRead, BufReader};
+    let _ = std::fs::remove_file(sock);
+    let listener = std::os::unix::net::UnixListener::bind(sock).unwrap();
+    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let thread_log = log.clone();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            let mut line = String::new();
+            if BufReader::new(&stream).read_line(&mut line).is_err() {
+                continue;
+            }
+            let Ok(req) = serde_json::from_str::<Request>(&line) else {
+                continue;
+            };
+            let mut reply = serde_json::to_string(&respond(&req)).unwrap();
+            reply.push('\n');
+            thread_log.lock().unwrap().push(req);
+            let _ = (&stream).write_all(reply.as_bytes());
+        }
+    });
+    log
+}
+
+/// The socket path a Sandbox's commands connect to.
+fn sock(sb: &Sandbox) -> PathBuf {
+    sb.path("no-daemon.sock")
+}
+
+#[test]
+fn keyring_success_paths_with_a_live_daemon() {
+    let sb = Sandbox::new("keyringok");
+    let log = serve(&sock(&sb), |req| match req {
+        Request::SealPassword { .. } => Response::PasswordSealed,
+        Request::HasSealedPassword { .. } => Response::HasPassword(true),
+        Request::ForgetPassword { .. } => Response::PasswordForgotten,
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (code, out, _) = run_stdin(
+        &mut sb.cmd(&["keyring", "arm", "--user", "tester"]),
+        "hunter2\n",
+    );
+    assert_eq!(code, 0);
+    assert!(out.contains("armed. After a face login"), "{out}");
+    assert!(
+        out.contains("if you change your login password"),
+        "the re-arm note must be shown: {out}"
+    );
+
+    let (code, out, _) = run(&mut sb.cmd(&["keyring", "status", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("ARMED"), "{out}");
+
+    let (code, out, _) = run(&mut sb.cmd(&["keyring", "forget", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("sealed password erased; keyring unlock disarmed"),
+        "{out}"
+    );
+
+    // The wire request carried the piped password for the right user.
+    let log = log.lock().unwrap();
+    let sealed = log
+        .iter()
+        .find_map(|r| match r {
+            Request::SealPassword { user, password } => {
+                Some((user.clone(), password.expose().to_vec()))
+            }
+            _ => None,
+        })
+        .expect("a SealPassword request was sent");
+    assert_eq!(sealed.0, "tester");
+    assert_eq!(sealed.1, b"hunter2");
+}
+
+#[test]
+fn recovery_success_paths_with_a_live_daemon() {
+    let sb = Sandbox::new("recoveryok");
+    serve(&sock(&sb), |req| match req {
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: false,
+            tpm_present: true,
+        },
+        Request::RecoverySetup { .. } => Response::Ok("recovery passphrase set".into()),
+        Request::RecoveryRestore { .. } => Response::Ok("template key restored".into()),
+        Request::RecoveryForget { .. } => Response::Ok("recovery envelope erased".into()),
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (code, out, _) = run(&mut sb.cmd(&["recovery", "status", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("templates encrypted : yes"), "{out}");
+    assert!(out.contains("recovery passphrase : not set"), "{out}");
+    assert!(out.contains("TPM present         : yes"), "{out}");
+    assert!(
+        out.contains("no backstop") && out.contains("irlume recovery setup"),
+        "encrypted-but-no-passphrase must warn and name the fix: {out}"
+    );
+
+    let (code, out, _) = run_stdin(
+        &mut sb.cmd(&["recovery", "setup", "--user", "tester"]),
+        "correct horse\n",
+    );
+    assert_eq!(code, 0);
+    assert!(out.contains("recovery passphrase set"), "{out}");
+
+    let (code, out, _) = run_stdin(
+        &mut sb.cmd(&["recovery", "restore", "--user", "tester"]),
+        "correct horse\n",
+    );
+    assert_eq!(code, 0);
+    assert!(out.contains("face unlock is restored"), "{out}");
+
+    let (code, out, _) = run(&mut sb.cmd(&["recovery", "forget", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("recovery envelope erased"), "{out}");
+}
+
+#[test]
+fn recovery_setup_error_names_the_enroll_first_remedy() {
+    let sb = Sandbox::new("recoveryerr");
+    serve(&sock(&sb), |_| {
+        Response::Error("no template key for tester".into())
+    });
+    let (code, _, err) = run_stdin(
+        &mut sb.cmd(&["recovery", "setup", "--user", "tester"]),
+        "pass\n",
+    );
+    assert_eq!(code, 1);
+    assert!(err.contains("setup failed: no template key"), "{err}");
+    assert!(
+        err.contains("enroll a face first"),
+        "the no-template-key error must add the remedy hint: {err}"
+    );
+}
+
+#[test]
+fn profiles_listing_renders_profiles_and_toggle_state() {
+    let sb = Sandbox::new("proflist");
+    serve(&sock(&sb), |req| match req {
+        Request::ListProfiles { .. } => Response::Enrollment {
+            profiles: vec![ProfileSummary {
+                name: "Face Profile 1".into(),
+                scans: vec!["Scan 1".into(), "Glasses".into()],
+            }],
+            require_eyes_open: true,
+            require_challenge: false,
+        },
+        Request::SetRequireEyesOpen { .. } => Response::Ok("eyes-open now ON".into()),
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (code, out, _) = run(&mut sb.cmd(&["profiles", "list", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("require-eyes-open: ON"), "{out}");
+    assert!(out.contains("require-challenge (blink): off"), "{out}");
+    assert!(out.contains("Face Profile 1 (2 scans)"), "{out}");
+    assert!(out.contains("- Scan 1"), "{out}");
+    assert!(out.contains("- Glasses"), "{out}");
+
+    let (code, out, _) = run(&mut sb.cmd(&["profiles", "eyes-open", "on", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("[profiles] eyes-open now ON"), "{out}");
+}
+
+#[test]
+fn profiles_empty_listing_says_none_enrolled() {
+    let sb = Sandbox::new("profempty");
+    serve(&sock(&sb), |_| Response::Enrollment {
+        profiles: Vec::new(),
+        require_eyes_open: false,
+        require_challenge: false,
+    });
+    // Bare `profiles` (no subcommand) defaults to the listing. Note: a flag
+    // directly after `profiles` is read as the subcommand word, so --user
+    // only combines with an explicit `list`.
+    let (code, out, _) = run(&mut sb.cmd(&["profiles"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("[profiles] none enrolled"), "{out}");
+    let (code, out, _) = run(&mut sb.cmd(&["profiles", "list", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("[profiles] none enrolled"), "{out}");
+}
+
+#[test]
+fn enroll_reports_a_new_profile_and_forwards_the_flags() {
+    let sb = Sandbox::new("enrollnew");
+    let log = serve(&sock(&sb), |_| Response::Enrolled {
+        profile: "Night".into(),
+        created: true,
+        added: 3,
+        total: 3,
+        added_scans: vec!["Scan 1".into(), "Scan 2".into(), "Scan 3".into()],
+    });
+    let (code, out, _) = run(&mut sb.cmd(&[
+        "enroll", "--user", "tester", "--name", "Night", "--scans", "3",
+    ]));
+    assert_eq!(code, 0);
+    assert!(out.contains("enrolled 'Night' with 3 scans"), "{out}");
+
+    let log = log.lock().unwrap();
+    match &log[0] {
+        Request::Enroll {
+            user,
+            profile,
+            scans,
+            reset,
+        } => {
+            assert_eq!(user, "tester");
+            assert_eq!(profile.as_deref(), Some("Night"));
+            assert_eq!(*scans, Some(3));
+            assert!(!reset, "--reset was not passed");
+        }
+        other => panic!("expected an Enroll request, got {other:?}"),
+    }
+}
+
+#[test]
+fn enroll_merge_points_at_add_scan() {
+    let sb = Sandbox::new("enrollmerge");
+    serve(&sock(&sb), |_| Response::Enrolled {
+        profile: "Face Profile 1".into(),
+        created: false,
+        added: 2,
+        total: 8,
+        added_scans: vec!["Scan 7".into(), "Scan 8".into()],
+    });
+    let (code, out, _) = run(&mut sb.cmd(&["enroll", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("already enrolled as 'Face Profile 1'"),
+        "{out}"
+    );
+    assert!(out.contains("added 2 scans"), "{out}");
+    assert!(out.contains("(8 total)"), "{out}");
+    assert!(
+        out.contains("profiles add-scan --profile 'Face Profile 1'"),
+        "the merge message must name the follow-up command: {out}"
+    );
+}
+
+#[test]
+fn identify_reports_match_and_no_match() {
+    let sb = Sandbox::new("identok");
+    serve(&sock(&sb), |_| Response::Identified {
+        user: Some("tester".into()),
+        profile: Some("Face Profile 1".into()),
+        score: 0.87,
+        live: true,
+        reason: "match".into(),
+    });
+    let (code, out, _) = run(&mut sb.cmd(&["identify"]));
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("tester (profile 'Face Profile 1', score 0.870)"),
+        "{out}"
+    );
+
+    let sb2 = Sandbox::new("identmiss");
+    serve(&sock(&sb2), |_| Response::Identified {
+        user: None,
+        profile: None,
+        score: 0.1,
+        live: true,
+        reason: "below threshold".into(),
+    });
+    let (code, out, _) = run(&mut sb2.cmd(&["identify"]));
+    assert_eq!(code, 1, "a live but unenrolled face is exit 1");
+    assert!(
+        out.contains("no match: live face, not enrolled (below threshold)"),
+        "{out}"
+    );
+}
+
+#[test]
+fn status_renders_the_full_dashboard_from_daemon_answers() {
+    let sb = Sandbox::new("statusok");
+    serve(&sock(&sb), |req| match req {
+        Request::Ping => Response::Pong,
+        Request::ListProfiles { .. } => Response::Enrollment {
+            profiles: vec![ProfileSummary {
+                name: "Face Profile 1".into(),
+                scans: vec!["Scan 1".into(), "Scan 2".into()],
+            }],
+            require_eyes_open: false,
+            require_challenge: true,
+        },
+        Request::KeyringInfo { .. } => Response::KeyringInfo {
+            armed: true,
+            policy: Some("Tier 2 (pcrlock)".into()),
+            pcrs: vec![7],
+            drifted: Some(true),
+        },
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: true,
+            tpm_present: true,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+    let (code, out, _) = run(&mut sb.cmd(&["status", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("daemon        : running"), "{out}");
+    assert!(out.contains("1 profile(s), 2 scan(s)"), "{out}");
+    assert!(out.contains("passive blink liveness"), "{out}");
+    assert!(out.contains("Face Profile 1 (2 scan(s))"), "{out}");
+    assert!(out.contains("keyring unlock: armed"), "{out}");
+    assert!(out.contains("Tier 2 (pcrlock)"), "{out}");
+    assert!(
+        out.contains("PCR DRIFT") && out.contains("keyring arm"),
+        "drift must be flagged with its remedy: {out}"
+    );
+    assert!(out.contains("templates     : encrypted at rest"), "{out}");
+    assert!(out.contains("recovery pass : set"), "{out}");
+}
+
+#[test]
+fn reseal_rebinds_when_armed_and_refuses_when_not() {
+    let sb = Sandbox::new("resealok");
+    serve(&sock(&sb), |req| match req {
+        Request::HasSealedPassword { .. } => Response::HasPassword(true),
+        Request::SealPassword { .. } => Response::PasswordSealed,
+        _ => Response::Error("unexpected request".into()),
+    });
+    let (code, out, _) = run_stdin(&mut sb.cmd(&["reseal", "--user", "tester"]), "pw\n");
+    assert_eq!(code, 0);
+    assert!(out.contains("re-bound to current PCRs"), "{out}");
+
+    let sb2 = Sandbox::new("resealnone");
+    serve(&sock(&sb2), |_| Response::HasPassword(false));
+    let (code, _, err) = run(&mut sb2.cmd(&["reseal", "--user", "tester"]));
+    assert_eq!(code, 2, "nothing sealed = usage-class refusal");
+    assert!(err.contains("has no sealed password"), "{err}");
+    assert!(
+        err.contains("keyring arm"),
+        "must name the setup command: {err}"
+    );
+}
+
+#[test]
+fn set_cameras_and_ir_setup_success_paths() {
+    let sb = Sandbox::new("camok");
+    let log = serve(&sock(&sb), |req| match req {
+        Request::SetCameras { .. } => Response::Ok("cameras saved".into()),
+        Request::SetupIrEmitter { .. } => Response::Ok("emitter enabled".into()),
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (code, out, _) = run(&mut sb.cmd(&["set-cameras", "/dev/video0", "/dev/video2"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("[set-cameras] cameras saved"), "{out}");
+
+    let (code, out, _) = run(&mut sb.cmd(&["ir-setup", "--dry-run"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("[ir-setup] emitter enabled"), "{out}");
+
+    let log = log.lock().unwrap();
+    assert!(
+        matches!(&log[0], Request::SetCameras { rgb, ir } if rgb == "/dev/video0" && ir == "/dev/video2"),
+        "cameras request must carry both nodes: {:?}",
+        log[0]
+    );
+    assert!(
+        matches!(&log[1], Request::SetupIrEmitter { dry_run: true }),
+        "--dry-run must be forwarded: {:?}",
+        log[1]
+    );
+}
+
+#[test]
+fn setup_walks_every_step_noninteractively() {
+    let sb = Sandbox::new("setupok");
+    serve(&sock(&sb), |req| match req {
+        Request::Ping => Response::Pong,
+        Request::Health => Response::Health {
+            tier: "secure".into(),
+            rgb_dev: None,
+            ir_dev: None,
+            mesh: true,
+            adapter: false,
+            version: env!("CARGO_PKG_VERSION").into(),
+        },
+        Request::ListProfiles { .. } => Response::Enrollment {
+            profiles: Vec::new(),
+            require_eyes_open: false,
+            require_challenge: false,
+        },
+        Request::Enroll { .. } => Response::Enrolled {
+            profile: "Face Profile 1".into(),
+            created: true,
+            added: 6,
+            total: 6,
+            added_scans: Vec::new(),
+        },
+        Request::SealPassword { .. } => Response::PasswordSealed,
+        _ => Response::Error("unexpected request".into()),
+    });
+    // Piped stdin: yes/no prompts take their defaults (enroll: yes, arm: yes),
+    // and the keyring arm reads this line as the login password.
+    let (code, out, _) = run_stdin(&mut sb.cmd(&["setup", "--user", "tester"]), "pw\n");
+    assert_eq!(code, 0);
+    assert!(out.contains("[1/6] Preflight"), "{out}");
+    assert!(
+        out.contains("enrolled 'Face Profile 1' with 6 scans"),
+        "{out}"
+    );
+    assert!(out.contains("armed"), "{out}");
+    assert!(out.contains("[6/6] PAM login wiring"), "{out}");
+    assert!(out.contains("setup complete"), "{out}");
+}
+
+#[test]
+fn unexpected_daemon_responses_are_reported_not_trusted() {
+    let sb = Sandbox::new("pongdaemon");
+    // A daemon that answers everything with Pong: every command must fail
+    // loudly rather than treat it as success.
+    serve(&sock(&sb), |_| Response::Pong);
+    let cases: &[&[&str]] = &[
+        &["keyring", "status", "--user", "tester"],
+        &["profiles", "list", "--user", "tester"],
+        &["enroll", "--user", "tester"],
+        &["identify"],
+        &["set-cameras", "/dev/video0", "/dev/video2"],
+        &["ir-setup", "--dry-run"],
+        &["recovery", "status", "--user", "tester"],
+    ];
+    for argv in cases {
+        let (code, _, err) = run(&mut sb.cmd(argv));
+        assert_eq!(code, 1, "{argv:?} must fail on a nonsense response");
+        assert!(
+            err.contains("unexpected response"),
+            "{argv:?} stderr: {err}"
+        );
+    }
+}
+
+// --------------------------------------------------- repo-backed update paths
+
+/// Minimal mirror of irlume_common::platform::distro_family (ID + ID_LIKE),
+/// so this test can pick the branch that will actually run on this host.
+fn host_family() -> &'static str {
+    let os = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+    let field = |key: &str| -> String {
+        os.lines()
+            .find_map(|l| l.strip_prefix(key))
+            .map(|v| v.trim().trim_matches('"').to_lowercase())
+            .unwrap_or_default()
+    };
+    let hay = format!("{} {}", field("ID="), field("ID_LIKE="));
+    if ["debian", "ubuntu", "mint", "pop", "raspbian"]
+        .iter()
+        .any(|d| hay.contains(d))
+    {
+        "debian"
+    } else if ["fedora", "rhel", "centos", "rocky", "alma"]
+        .iter()
+        .any(|d| hay.contains(d))
+    {
+        "fedora"
+    } else if ["arch", "manjaro", "endeavouros", "garuda"]
+        .iter()
+        .any(|d| hay.contains(d))
+    {
+        "arch"
+    } else {
+        "other"
+    }
+}
+
+/// Origin detection reads /etc/os-release (no seam), so each host exercises
+/// its own family's branch: Copr on Fedora, PPA on Debian/Ubuntu, AUR on
+/// Arch. Every probe and package-manager step is PATH-shadowed.
+#[test]
+fn update_uses_the_repo_channel_of_the_owning_package_manager() {
+    let sb = Sandbox::new("updatechan");
+    sb.fake_tool("curl", r#"printf '%s' '{"tag_name": "v99.99.99"}'"#);
+    match host_family() {
+        "fedora" => {
+            sb.fake_tool("rpm", "printf '0.0.1'");
+            sb.fake_tool(
+                "dnf",
+                r#"case "$1" in
+  repoquery) printf 'copr:copr.fedorainfracloud.org:archledger:irlume\n' ;;
+  *) exit 4 ;;
+esac"#,
+            );
+            sb.fake_tool("sudo", r#"exec "$@""#);
+
+            let (code, out, _) = run(&mut sb.cmd_with_fakes(&["update", "--check"]));
+            assert_eq!(code, 0);
+            assert!(
+                out.contains("install method: Fedora Copr (archledger/irlume)"),
+                "{out}"
+            );
+            assert!(out.contains("[update] installed: 0.0.1"), "{out}");
+            assert!(out.contains("available: v99.99.99"), "{out}");
+            assert!(
+                out.contains("would run: sudo dnf upgrade --refresh irlume"),
+                "--check must not run the upgrade: {out}"
+            );
+
+            // Without --check the dnf step runs (through sudo when unprivileged)
+            // and its failure stops the update with exit 1.
+            let (code, _, err) = run(&mut sb.cmd_with_fakes(&["update"]));
+            assert_eq!(code, 1);
+            assert!(
+                err.contains("`dnf upgrade --refresh irlume` exited with"),
+                "{err}"
+            );
+
+            // And a succeeding step completes the update.
+            sb.fake_tool(
+                "dnf",
+                r#"case "$1" in
+  repoquery) printf 'copr:copr.fedorainfracloud.org:archledger:irlume\n' ;;
+  *) exit 0 ;;
+esac"#,
+            );
+            let (code, out, _) = run(&mut sb.cmd_with_fakes(&["update"]));
+            assert_eq!(code, 0);
+            assert!(out.contains("[update] done."), "{out}");
+        }
+        "debian" => {
+            sb.fake_tool(
+                "dpkg-query",
+                r#"case "$*" in
+  *Status*) printf 'install ok installed' ;;
+  *) printf '0.0.1-0ppa1' ;;
+esac"#,
+            );
+            sb.fake_tool(
+                "apt-cache",
+                r#"printf '     500 https://ppa.launchpadcontent.net/archledger/irlume/ubuntu resolute/main amd64 Packages\n'"#,
+            );
+            let (code, out, _) = run(&mut sb.cmd_with_fakes(&["update", "--check"]));
+            assert_eq!(code, 0);
+            assert!(
+                out.contains("install method: Launchpad PPA (ppa:archledger/irlume)"),
+                "{out}"
+            );
+            assert!(out.contains("[update] installed: 0.0.1-0ppa1"), "{out}");
+            assert!(
+                out.contains(
+                    "would run: sudo apt update && sudo apt install --only-upgrade irlume"
+                ),
+                "{out}"
+            );
+        }
+        "arch" => {
+            sb.fake_tool("pacman", "printf 'irlume 0.0.1-1\\n'");
+            let (code, out, _) = run(&mut sb.cmd_with_fakes(&["update", "--check"]));
+            assert_eq!(code, 0);
+            assert!(
+                out.contains("install method: pacman package (AUR / makepkg)"),
+                "{out}"
+            );
+            assert!(out.contains("[update] installed: 0.0.1-1"), "{out}");
+            assert!(out.contains("yay -Syu irlume"), "{out}");
+            assert!(out.contains("aur.archlinux.org/irlume.git"), "{out}");
+        }
+        _ => {} // unknown family resolves to Source, covered elsewhere
+    }
+}

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -113,3 +113,223 @@ fn connect_with_timeout(path: &Path, timeout: Duration) -> io::Result<UnixStream
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testenv;
+    use std::io::Read as _;
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+
+    /// A per-test socket path in the temp dir (kept short: sun_path is 108 bytes).
+    fn sock(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!("irlume-cl-{tag}-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    #[test]
+    fn socket_path_honours_the_env_override() {
+        let _g = testenv::lock();
+        std::env::remove_var("IRLUME_SOCKET");
+        assert_eq!(socket_path(), PathBuf::from(SOCKET_PATH));
+        std::env::set_var("IRLUME_SOCKET", "/tmp/x.sock");
+        assert_eq!(socket_path(), PathBuf::from("/tmp/x.sock"));
+        std::env::remove_var("IRLUME_SOCKET");
+    }
+
+    #[test]
+    fn request_round_trips_against_a_real_socket_server() {
+        let _g = testenv::lock();
+        let path = sock("rt");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            BufReader::new(&stream).read_line(&mut line).unwrap();
+            // The wire format is one newline-terminated JSON request.
+            assert!(line.ends_with('\n'), "request must be newline-terminated");
+            let req: Request = serde_json::from_str(line.trim()).unwrap();
+            match req {
+                Request::ListProfiles { user } => assert_eq!(user, "alice"),
+                other => panic!("server expected ListProfiles, got {other:?}"),
+            }
+            let reply = Response::Profiles(vec!["Face Profile 1".into()]);
+            let mut out = serde_json::to_vec(&reply).unwrap();
+            out.push(b'\n');
+            (&stream).write_all(&out).unwrap();
+        });
+
+        let resp = request(&Request::ListProfiles {
+            user: "alice".into(),
+        })
+        .expect("round trip");
+        match resp {
+            Response::Profiles(p) => assert_eq!(p, vec!["Face Profile 1".to_string()]),
+            other => panic!("expected Profiles, got {other:?}"),
+        }
+        server.join().unwrap();
+        std::env::remove_var("IRLUME_SOCKET");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_daemon_error_names_the_service_and_the_fix() {
+        let _g = testenv::lock();
+        // Nothing at the path at all: ENOENT.
+        let path = sock("gone");
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let err = request(&Request::Ping).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(
+            err.to_string().contains(
+                "irlumed is not running; start it with: sudo systemctl enable --now irlumed"
+            ),
+            "got: {err}"
+        );
+        // A stale socket file nobody listens on: ECONNREFUSED, same guidance.
+        let stale = sock("stale");
+        drop(UnixListener::bind(&stale).unwrap()); // bind then close: file remains
+        std::env::set_var("IRLUME_SOCKET", &stale);
+        let err = request(&Request::Ping).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
+        assert!(
+            err.to_string().contains("irlumed is not running"),
+            "got: {err}"
+        );
+        std::env::remove_var("IRLUME_SOCKET");
+        let _ = std::fs::remove_file(&stale);
+    }
+
+    #[test]
+    fn server_closing_without_a_reply_is_unexpected_eof() {
+        let _g = testenv::lock();
+        let path = sock("eof");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            let _ = BufReader::new(&stream).read_line(&mut line);
+            // Drop without answering.
+        });
+        let err = request(&Request::Ping).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string()
+                .contains("daemon closed connection without responding"),
+            "got: {err}"
+        );
+        server.join().unwrap();
+        std::env::remove_var("IRLUME_SOCKET");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn garbage_reply_is_invalid_data_not_a_panic() {
+        let _g = testenv::lock();
+        let path = sock("bad");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            let _ = BufReader::new(&stream).read_line(&mut line);
+            (&stream).write_all(b"i am not json\n").unwrap();
+        });
+        let err = request_with_timeout(&Request::Ping, Duration::from_secs(5)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        server.join().unwrap();
+        std::env::remove_var("IRLUME_SOCKET");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn silent_server_times_out_within_the_poll_budget() {
+        let _g = testenv::lock();
+        let path = sock("silent");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            // Read the request, then answer nothing and hold the connection
+            // open until the client gives up and drops its end (read -> 0).
+            let mut buf = [0u8; 4096];
+            while matches!(stream.read(&mut buf), Ok(n) if n > 0) {}
+        });
+        let t = std::time::Instant::now();
+        let err = request_poll(&Request::Ping).unwrap_err();
+        let waited = t.elapsed();
+        // SO_RCVTIMEO expiry surfaces as WouldBlock (EAGAIN) on Linux.
+        assert!(
+            matches!(
+                err.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+            ),
+            "expected a timeout kind, got {err:?}"
+        );
+        // It must have waited (at least) the 1500ms poll read budget, i.e. the
+        // failure came from the deadline, not an instant error.
+        assert!(
+            waited >= Duration::from_millis(1400),
+            "gave up too early: {waited:?}"
+        );
+        std::env::remove_var("IRLUME_SOCKET");
+        drop(_g); // release the env lock before the blocking join cleanup
+        let _ = std::fs::remove_file(&path);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn stalled_listener_hits_the_bounded_connect_timeout() {
+        let _g = testenv::lock();
+        let path = sock("backlog");
+        // A listener that never accepts, with the smallest backlog Linux
+        // allows, so queued fillers exhaust it and further connects BLOCK
+        // (the exact hang connect_with_timeout exists to bound).
+        let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0);
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+        let bytes = path.as_os_str().as_encoded_bytes();
+        assert!(bytes.len() < addr.sun_path.len());
+        for (i, b) in bytes.iter().enumerate() {
+            addr.sun_path[i] = *b as libc::c_char;
+        }
+        let len = std::mem::size_of::<libc::sa_family_t>() + bytes.len() + 1;
+        // SAFETY: addr is a properly initialized sockaddr_un for `len` bytes.
+        let rc = unsafe {
+            libc::bind(
+                fd,
+                &addr as *const _ as *const libc::sockaddr,
+                len as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "bind: {}", io::Error::last_os_error());
+        assert_eq!(unsafe { libc::listen(fd, 0) }, 0);
+
+        // Saturate the accept queue. The fillers that no longer fit block in
+        // their own threads (detached; they die with the process).
+        for _ in 0..4 {
+            let p = path.clone();
+            std::thread::spawn(move || {
+                let _stream = UnixStream::connect(&p);
+                std::thread::sleep(Duration::from_secs(30));
+            });
+        }
+        std::thread::sleep(Duration::from_millis(200)); // let the fillers queue up
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let err = request_poll(&Request::Ping).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            err.to_string().contains("timed out connecting"),
+            "got: {err}"
+        );
+        std::env::remove_var("IRLUME_SOCKET");
+        unsafe { libc::close(fd) };
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -106,13 +106,11 @@ pub fn write_kv(file: &str, key: &str, val: &str) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::testenv;
 
     #[test]
     fn read_write_round_trip_preserves_comments() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = testenv::lock();
         let dir = std::env::temp_dir().join(format!("irlume-cfg-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
@@ -158,12 +156,112 @@ mod tests {
     }
 
     #[test]
+    fn config_path_defaults_to_etc_irlume_without_the_override() {
+        let _g = testenv::lock();
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        assert_eq!(
+            config_path("cameras.conf"),
+            PathBuf::from("/etc/irlume/cameras.conf")
+        );
+    }
+
+    #[test]
+    fn read_kv_skips_malformed_lines_and_empty_values() {
+        let _g = testenv::lock();
+        let dir = std::env::temp_dir().join(format!("irlume-cfg-lines-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+
+        std::fs::write(
+            config_path("settings.conf"),
+            "# comment with = sign\nnot a kv line\nempty=\nreal=value\n",
+        )
+        .unwrap();
+        // A line without '=' and a commented '=' are both ignored.
+        assert_eq!(read_kv("settings.conf", "not a kv line"), None);
+        assert_eq!(read_kv("settings.conf", "# comment with "), None);
+        // `key=` (empty value) reads as absent, not Some("").
+        assert_eq!(read_kv("settings.conf", "empty"), None);
+        assert_eq!(read_kv("settings.conf", "real").as_deref(), Some("value"));
+
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unreadable_config_reads_as_absent_not_a_crash() {
+        let _g = testenv::lock();
+        let dir = std::env::temp_dir().join(format!("irlume-cfg-eperm-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+
+        // A directory where a file is expected: a non-NotFound, non-EACCES read
+        // error (EISDIR). Takes the loud-warning branch and still yields None.
+        std::fs::create_dir_all(config_path("weird.conf")).unwrap();
+        assert_eq!(read_kv("weird.conf", "k"), None);
+
+        // 0600-root-style file we cannot read: the expected unprivileged EACCES
+        // is the quiet branch. Only meaningful when not running as root.
+        if unsafe { libc::geteuid() } != 0 {
+            use std::os::unix::fs::PermissionsExt;
+            let p = config_path("locked.conf");
+            std::fs::write(&p, "k=v\n").unwrap();
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o000)).unwrap();
+            assert_eq!(read_kv("locked.conf", "k"), None);
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_kv_collapses_preexisting_duplicate_keys() {
+        let _g = testenv::lock();
+        let dir = std::env::temp_dir().join(format!("irlume-cfg-dup-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+
+        // A hand-edited file can carry the same key twice; an update must
+        // leave exactly one line, holding the new value, and keep other keys.
+        std::fs::write(
+            config_path("cameras.conf"),
+            "rgb=/dev/video0\nir=/dev/video2\nrgb=/dev/video4\n",
+        )
+        .unwrap();
+        write_kv("cameras.conf", "rgb", "/dev/video8").unwrap();
+        let text = std::fs::read_to_string(config_path("cameras.conf")).unwrap();
+        assert_eq!(text.matches("rgb=").count(), 1);
+        assert!(text.contains("rgb=/dev/video8"));
+        assert_eq!(
+            read_kv("cameras.conf", "ir").as_deref(),
+            Some("/dev/video2")
+        );
+
+        // The file is (re)written 0600: these can hold device choices only the
+        // operator should edit.
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(config_path("cameras.conf"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn third_party_pad_enable_then_disable_round_trips() {
         // The models feature persists its enabled state as this key: a model
         // name means enabled, an empty value means disabled. Locks in that
         // `write_kv(key, "")` reads back as None (not Some("")), which is what
         // `irlume models disable` and the daemon's enabled_name() rely on.
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = testenv::lock();
         let dir = std::env::temp_dir().join(format!("irlume-tp-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();

--- a/crates/irlume-common/src/dbglog.rs
+++ b/crates/irlume-common/src/dbglog.rs
@@ -25,3 +25,58 @@ macro_rules! dlog {
         if $crate::dbglog::on() { eprintln!("irlume[debug]: {}", format_args!($($t)*)); }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // on() caches its answer in a OnceLock for the process lifetime, so each
+    // IRLUME_LOG value gets its own re-exec'd child process; asserting in-process
+    // would only ever see whatever value froze first.
+    #[test]
+    fn irlume_log_values_toggle_tracing_per_process() {
+        if let Ok(expect) = std::env::var("IRLUME_TEST_DBGLOG_EXPECT") {
+            assert_eq!(
+                on(),
+                expect == "1",
+                "IRLUME_LOG={:?}",
+                std::env::var("IRLUME_LOG")
+            );
+            // The answer is frozen after first use, whatever the env does next.
+            std::env::set_var("IRLUME_LOG", "debug");
+            assert_eq!(on(), expect == "1");
+            // The macro must compile and run in both states without output
+            // side effects we could crash on.
+            crate::dlog!("probe {}", 42);
+            return;
+        }
+        let exe = std::env::current_exe().unwrap();
+        let run = |log: Option<&str>, expect: &str| {
+            let mut cmd = std::process::Command::new(&exe);
+            cmd.args([
+                "dbglog::tests::irlume_log_values_toggle_tracing_per_process",
+                "--exact",
+                "--test-threads=1",
+            ])
+            .env("IRLUME_TEST_DBGLOG_EXPECT", expect)
+            .env_remove("IRLUME_LOG");
+            if let Some(v) = log {
+                cmd.env("IRLUME_LOG", v);
+            }
+            let out = cmd.output().unwrap();
+            assert!(
+                out.status.success(),
+                "IRLUME_LOG={log:?} expect={expect}: {}",
+                String::from_utf8_lossy(&out.stdout)
+            );
+        };
+        // The three documented enabling values.
+        for v in ["debug", "trace", "1"] {
+            run(Some(v), "1");
+        }
+        // Unset, and set to something unrecognized: off.
+        run(None, "0");
+        run(Some("verbose"), "0");
+        run(Some(""), "0");
+    }
+}

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -403,6 +403,23 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Test-only: every test that mutates process environment variables
+/// (IRLUME_SOCKET, IRLUME_CONFIG_DIR, IRLUME_STATE_DIR, ...) serializes on this
+/// one lock; setenv/getenv are process-global, and the test harness runs
+/// modules concurrently.
+#[cfg(test)]
+pub(crate) mod testenv {
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    pub fn lock() -> MutexGuard<'static, ()> {
+        // A panic under the lock (failed assert) must not cascade into every
+        // later env test; the env itself is per-test state, not shared data.
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -471,6 +488,101 @@ mod tests {
             locked > 0,
             "a deserialized SecretBytes must be memlocked like a new()-built one"
         );
+    }
+
+    #[test]
+    fn error_display_prefixes_each_variant() {
+        // The PAM module and CLI print these verbatim; the category prefix is
+        // what tells a user (and the docs) which subsystem failed.
+        let cases: &[(Error, &str)] = &[
+            (Error::Io("socket gone".into()), "io: socket gone"),
+            (Error::Protocol("bad frame".into()), "protocol: bad frame"),
+            (
+                Error::NotAuthorized("peer uid 1000".into()),
+                "not authorized: peer uid 1000",
+            ),
+            (Error::Hardware("no camera".into()), "hardware: no camera"),
+            (Error::Tpm("unseal failed".into()), "tpm: unseal failed"),
+            (
+                Error::Policy("PCR mismatch: [7]".into()),
+                "policy: PCR mismatch: [7]",
+            ),
+        ];
+        for (e, want) in cases {
+            assert_eq!(e.to_string(), *want);
+        }
+    }
+
+    #[test]
+    fn secret_bytes_expose_len_and_redaction_invariants() {
+        let sb = SecretBytes::new(vec![1, 2, 3]);
+        assert_eq!(sb.expose(), &[1, 2, 3]);
+        assert_eq!(sb.len(), sb.expose().len());
+        assert!(!sb.is_empty());
+        // Debug must name only the length, never any content byte.
+        assert_eq!(format!("{sb:?}"), "SecretBytes([3 bytes redacted])");
+
+        // A clone exposes the same bytes but its own copy (drop-zeroize of one
+        // must not scrub the other).
+        let clone = sb.clone();
+        assert_eq!(clone.expose(), sb.expose());
+        assert_ne!(clone.expose().as_ptr(), sb.expose().as_ptr());
+
+        // Explicit zeroize empties the buffer (Vec zeroize scrubs + clears).
+        let mut z = SecretBytes::new(vec![9; 32]);
+        z.zeroize();
+        assert!(z.is_empty());
+        assert_eq!(z.len(), 0);
+
+        // Default is the empty secret.
+        let d = SecretBytes::default();
+        assert!(d.is_empty());
+        assert_eq!(format!("{d:?}"), "SecretBytes([0 bytes redacted])");
+
+        // #[serde(transparent)]: ships as a plain byte array on the wire.
+        assert_eq!(
+            serde_json::to_string(&SecretBytes::new(vec![7, 8])).unwrap(),
+            "[7,8]"
+        );
+    }
+
+    #[test]
+    fn request_wire_compat_defaults_for_older_callers() {
+        // An 0.1.x pam_irlume sends Authenticate without `service`; the field
+        // must default to None, not fail the parse (login would break).
+        let r: Request = serde_json::from_str(r#"{"Authenticate":{"user":"alice"}}"#).unwrap();
+        match r {
+            Request::Authenticate { user, service } => {
+                assert_eq!(user, "alice");
+                assert_eq!(service, None);
+            }
+            other => panic!("expected Authenticate, got {other:?}"),
+        }
+        // Enroll without `reset` (pre-0.5 callers) defaults to false: an old
+        // client must never trigger the wipe-first path.
+        let r: Request =
+            serde_json::from_str(r#"{"Enroll":{"user":"alice","profile":null,"scans":null}}"#)
+                .unwrap();
+        match r {
+            Request::Enroll { user, reset, .. } => {
+                assert_eq!(user, "alice");
+                assert!(!reset);
+            }
+            other => panic!("expected Enroll, got {other:?}"),
+        }
+        // Response::Health from a daemon predating `version` parses with the
+        // empty-string default (the TUI shows "unknown" instead of erroring).
+        let r: Response = serde_json::from_str(
+            r#"{"Health":{"tier":"secure","rgb_dev":null,"ir_dev":null,"mesh":true,"adapter":false}}"#,
+        )
+        .unwrap();
+        match r {
+            Response::Health { version, tier, .. } => {
+                assert_eq!(version, "");
+                assert_eq!(tier, "secure");
+            }
+            other => panic!("expected Health, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/irlume-common/src/memlock.rs
+++ b/crates/irlume-common/src/memlock.rs
@@ -40,3 +40,71 @@ pub fn lock_slice(buf: &[u8]) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_and_unaligned_slices_are_handled() {
+        // Empty input is the documented no-op.
+        lock_slice(&[]);
+        // A deliberately unaligned start (offset 1 into a multi-page buffer):
+        // the alignment math must cover it without touching the contents.
+        let buf = vec![7u8; 3 * 4096];
+        lock_slice(&buf[1..2 * 4096 + 1]);
+        assert!(
+            buf.iter().all(|&b| b == 7),
+            "locking must not alter the secret"
+        );
+    }
+
+    // lock_slice is best-effort by contract: when RLIMIT_MEMLOCK forbids the
+    // lock it must WARN and return (auth still works), never abort. mlock
+    // cannot be made to fail in-process without breaking sibling tests, so
+    // re-exec this test with the limit dropped to zero in the child.
+    #[test]
+    fn mlock_refusal_warns_and_continues() {
+        if std::env::var("IRLUME_TEST_MEMLOCK_CHILD").is_ok() {
+            lock_slice(&vec![0x5a_u8; 4096]);
+            println!("survived-without-mlock");
+            return;
+        }
+        use std::os::unix::process::CommandExt;
+        let exe = std::env::current_exe().unwrap();
+        let mut cmd = std::process::Command::new(exe);
+        cmd.args([
+            "memlock::tests::mlock_refusal_warns_and_continues",
+            "--exact",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("IRLUME_TEST_MEMLOCK_CHILD", "1");
+        // SAFETY: setrlimit is async-signal-safe; nothing else runs between
+        // fork and exec.
+        unsafe {
+            cmd.pre_exec(|| {
+                let zero = libc::rlimit {
+                    rlim_cur: 0,
+                    rlim_max: 0,
+                };
+                if libc::setrlimit(libc::RLIMIT_MEMLOCK, &zero) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let out = cmd.output().unwrap();
+        assert!(
+            out.status.success(),
+            "a refused mlock must not fail the caller; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(String::from_utf8_lossy(&out.stdout).contains("survived-without-mlock"));
+        let err = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            err.contains("mlock failed"),
+            "the refusal must be reported (raise RLIMIT_MEMLOCK hint); stderr: {err}"
+        );
+    }
+}

--- a/crates/irlume-common/src/platform.rs
+++ b/crates/irlume-common/src/platform.rs
@@ -29,6 +29,13 @@ impl DistroFamily {
 /// Detect the distro family from `/etc/os-release` (`ID` + `ID_LIKE`).
 pub fn distro_family() -> DistroFamily {
     let os = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+    distro_family_from(&os)
+}
+
+/// Classify raw `os-release` contents. Split out of [`distro_family`] verbatim
+/// (test seam: the parse is exercised against fixture strings without touching
+/// the host's `/etc/os-release`); behavior unchanged.
+fn distro_family_from(os: &str) -> DistroFamily {
     let field = |key: &str| -> String {
         os.lines()
             .find_map(|l| l.strip_prefix(key))
@@ -146,4 +153,136 @@ fn uid_for_name(name: &str) -> Option<u32> {
         return None;
     }
     Some(pwd.pw_uid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distro_family_classifies_real_os_release_shapes() {
+        // Shapes lifted from real distro os-release files: bare vs quoted
+        // values, ID_LIKE chains, derivative IDs.
+        let cases: &[(&str, DistroFamily)] = &[
+            // Fedora: bare ID, no ID_LIKE.
+            (
+                "NAME=\"Fedora Linux\"\nVERSION=\"44 (KDE Plasma)\"\nID=fedora\nVERSION_ID=44\n",
+                DistroFamily::Fedora,
+            ),
+            // RHEL and clones: quoted ID, ID_LIKE chain back to fedora.
+            (
+                "NAME=\"Red Hat Enterprise Linux\"\nID=\"rhel\"\nID_LIKE=\"fedora\"\n",
+                DistroFamily::Fedora,
+            ),
+            (
+                "ID=\"rocky\"\nID_LIKE=\"rhel centos fedora\"\n",
+                DistroFamily::Fedora,
+            ),
+            (
+                "ID=\"almalinux\"\nID_LIKE=\"rhel centos fedora\"\n",
+                DistroFamily::Fedora,
+            ),
+            // Debian family: Debian itself, Ubuntu (ID_LIKE=debian), Mint
+            // (ID=linuxmint, ID_LIKE chains through ubuntu), Pop, Raspbian.
+            (
+                "PRETTY_NAME=\"Debian GNU/Linux 12\"\nID=debian\n",
+                DistroFamily::Debian,
+            ),
+            (
+                "NAME=\"Ubuntu\"\nID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"26.04\"\n",
+                DistroFamily::Debian,
+            ),
+            (
+                "ID=linuxmint\nID_LIKE=\"ubuntu debian\"\n",
+                DistroFamily::Debian,
+            ),
+            ("ID=pop\nID_LIKE=\"ubuntu debian\"\n", DistroFamily::Debian),
+            ("ID=raspbian\nID_LIKE=debian\n", DistroFamily::Debian),
+            // Arch family.
+            (
+                "NAME=\"Arch Linux\"\nID=arch\nBUILD_ID=rolling\n",
+                DistroFamily::Arch,
+            ),
+            ("ID=manjaro\nID_LIKE=arch\n", DistroFamily::Arch),
+            ("ID=endeavouros\nID_LIKE=arch\n", DistroFamily::Arch),
+            ("ID=garuda\nID_LIKE=arch\n", DistroFamily::Arch),
+            // Unmatched distros and degenerate input fall through to Other.
+            ("NAME=NixOS\nID=nixos\n", DistroFamily::Other),
+            (
+                "ID=opensuse-tumbleweed\nID_LIKE=\"opensuse suse\"\n",
+                DistroFamily::Other,
+            ),
+            ("", DistroFamily::Other),
+            ("NAME=\"Something\"\nVERSION_ID=1\n", DistroFamily::Other),
+        ];
+        for (os, want) in cases {
+            assert_eq!(distro_family_from(os), *want, "input: {os:?}");
+        }
+    }
+
+    #[test]
+    fn distro_family_field_parsing_details() {
+        // Uppercase inside a quoted value is lowercased before matching.
+        assert_eq!(distro_family_from("ID=\"Ubuntu\"\n"), DistroFamily::Debian);
+        // Surrounding whitespace on the value is trimmed.
+        assert_eq!(distro_family_from("ID= fedora \n"), DistroFamily::Fedora);
+        // ID_LIKE alone (no ID line) still classifies.
+        assert_eq!(
+            distro_family_from("NAME=Derived\nID_LIKE=debian\n"),
+            DistroFamily::Debian
+        );
+        // `VERSION_ID=` must not be mistaken for `ID=`: a numeric VERSION_ID
+        // with an unmatched ID stays Other.
+        assert_eq!(
+            distro_family_from("VERSION_ID=12\nID=slackware\n"),
+            DistroFamily::Other
+        );
+        // Debian is checked before Fedora/Arch: a hybrid ID_LIKE mentioning
+        // both classifies as Debian (pam-auth-update wiring wins).
+        assert_eq!(
+            distro_family_from("ID=weird\nID_LIKE=\"debian fedora arch\"\n"),
+            DistroFamily::Debian
+        );
+    }
+
+    #[test]
+    fn distro_family_as_str_names_each_family() {
+        assert_eq!(DistroFamily::Debian.as_str(), "Debian-family");
+        assert_eq!(DistroFamily::Fedora.as_str(), "Fedora-family");
+        assert_eq!(DistroFamily::Arch.as_str(), "Arch-family");
+        assert_eq!(DistroFamily::Other.as_str(), "other/unknown");
+    }
+
+    #[test]
+    fn distro_family_reads_the_host_os_release() {
+        // On any Linux box /etc/os-release (or its absence) must classify
+        // without panicking, and agree with feeding the same bytes through the
+        // parse seam.
+        let host = distro_family();
+        let os = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+        assert_eq!(host, distro_family_from(&os));
+    }
+
+    #[test]
+    fn uid_for_name_resolves_root_and_rejects_garbage() {
+        assert_eq!(uid_for_name("root"), Some(0));
+        assert_eq!(uid_for_name("no-such-user-irlume-test"), None);
+        // Interior NUL cannot become a C string; must be None, not a panic.
+        assert_eq!(uid_for_name("a\0b"), None);
+    }
+
+    #[test]
+    fn nonexistent_user_never_has_a_live_session() {
+        // Deterministic on every box: with logind present the bogus user owns
+        // no session (Some(false)); without logind the uid lookup fails and the
+        // /run/user fallback cannot fire either.
+        assert!(!user_has_live_session("no-such-user-irlume-test"));
+    }
+
+    #[test]
+    fn unknown_session_id_is_not_an_active_user_session() {
+        // `loginctl show-session` on a bogus id prints nothing usable; the
+        // parser must fail closed (false), never treat it as active.
+        assert!(!session_is_active_user("irlume-test-no-such-session"));
+    }
 }

--- a/crates/irlume-common/src/secureboot.rs
+++ b/crates/irlume-common/src/secureboot.rs
@@ -3,6 +3,10 @@
 //! Best-effort and never panics: on a non-EFI system, missing efivars, or
 //! unreadable files we return conservative defaults. Shared so the daemon and
 //! `doctor` agree (and so the daemon can gate on the *real* Secure Boot state).
+//!
+//! The public functions read the fixed system paths; each delegates to an
+//! `_at`/`_in` twin parameterized on the efivars directory (test seam: the
+//! parsing runs against fixture files in a tempdir; behavior unchanged).
 
 use std::fs;
 use std::path::Path;
@@ -42,13 +46,21 @@ const LOADER_INFO_VAR: &str = "LoaderInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f";
 
 /// UEFI? and if so, UKI vs traditional loader.
 pub fn detect_boot_mode() -> BootMode {
-    if !Path::new(EFI_ROOT).exists() {
+    detect_boot_mode_at(
+        Path::new(EFI_ROOT),
+        Path::new(EFIVARS),
+        grub_artifacts_present(),
+    )
+}
+
+fn detect_boot_mode_at(efi_root: &Path, efivars: &Path, grub_present: bool) -> BootMode {
+    if !efi_root.exists() {
         return BootMode::Grub;
     }
-    if efivar_exists(STUB_INFO_VAR) {
+    if efivar_exists_in(efivars, STUB_INFO_VAR) {
         return BootMode::Uki;
     }
-    if efivar_exists(LOADER_INFO_VAR) || grub_artifacts_present() {
+    if efivar_exists_in(efivars, LOADER_INFO_VAR) || grub_present {
         return BootMode::Grub;
     }
     BootMode::Unknown
@@ -57,36 +69,53 @@ pub fn detect_boot_mode() -> BootMode {
 /// True when firmware is in SetupMode (no platform keys enrolled). In this
 /// state SecureBoot==1 does NOT mean Secure Boot is enforcing.
 pub fn is_setup_mode() -> bool {
-    matches!(read_efivar_u8(SETUPMODE_VAR), Some(1))
+    setup_mode_in(Path::new(EFIVARS))
+}
+
+fn setup_mode_in(efivars: &Path) -> bool {
+    matches!(read_efivar_u8_in(efivars, SETUPMODE_VAR), Some(1))
 }
 
 /// True when UEFI Secure Boot is actually enforcing: SecureBoot==1 AND not in
 /// SetupMode. (Reporting only SecureBoot==1 gives a false trust signal when the
 /// platform is in setup mode and any key can be enrolled.)
 pub fn is_secure_boot_enabled() -> bool {
-    let Some(secure) = read_efivar_u8(SECUREBOOT_VAR) else {
+    secure_boot_enabled_in(Path::new(EFIVARS))
+}
+
+fn secure_boot_enabled_in(efivars: &Path) -> bool {
+    let Some(secure) = read_efivar_u8_in(efivars, SECUREBOOT_VAR) else {
         return false;
     };
-    let setup = read_efivar_u8(SETUPMODE_VAR).unwrap_or(0);
+    let setup = read_efivar_u8_in(efivars, SETUPMODE_VAR).unwrap_or(0);
     secure == 1 && setup == 0
 }
 
 /// Whether the SecureBoot efivar is readable at all (UEFI boot).
 pub fn secure_boot_present() -> bool {
-    read_efivar_u8(SECUREBOOT_VAR).is_some()
+    secure_boot_present_in(Path::new(EFIVARS))
+}
+
+fn secure_boot_present_in(efivars: &Path) -> bool {
+    read_efivar_u8_in(efivars, SECUREBOOT_VAR).is_some()
 }
 
 /// Best-effort active boot loader / stub name.
 pub fn loader_identity() -> Option<String> {
-    read_efivar_utf16(STUB_INFO_VAR).or_else(|| read_efivar_utf16(LOADER_INFO_VAR))
+    loader_identity_in(Path::new(EFIVARS))
 }
 
-fn efivar_exists(name: &str) -> bool {
-    Path::new(EFIVARS).join(name).exists()
+fn loader_identity_in(efivars: &Path) -> Option<String> {
+    read_efivar_utf16_in(efivars, STUB_INFO_VAR)
+        .or_else(|| read_efivar_utf16_in(efivars, LOADER_INFO_VAR))
 }
 
-fn read_efivar_bytes(name: &str) -> Option<Vec<u8>> {
-    let bytes = fs::read(Path::new(EFIVARS).join(name)).ok()?;
+fn efivar_exists_in(efivars: &Path, name: &str) -> bool {
+    efivars.join(name).exists()
+}
+
+fn read_efivar_bytes_in(efivars: &Path, name: &str) -> Option<Vec<u8>> {
+    let bytes = fs::read(efivars.join(name)).ok()?;
     // First 4 bytes are UEFI variable attributes; strip them.
     if bytes.len() < 5 {
         return None;
@@ -94,12 +123,12 @@ fn read_efivar_bytes(name: &str) -> Option<Vec<u8>> {
     Some(bytes[4..].to_vec())
 }
 
-fn read_efivar_u8(name: &str) -> Option<u8> {
-    read_efivar_bytes(name).and_then(|b| b.first().copied())
+fn read_efivar_u8_in(efivars: &Path, name: &str) -> Option<u8> {
+    read_efivar_bytes_in(efivars, name).and_then(|b| b.first().copied())
 }
 
-fn read_efivar_utf16(name: &str) -> Option<String> {
-    let data = read_efivar_bytes(name)?;
+fn read_efivar_utf16_in(efivars: &Path, name: &str) -> Option<String> {
+    let data = read_efivar_bytes_in(efivars, name)?;
     if data.len() < 2 {
         return None;
     }
@@ -119,4 +148,187 @@ fn grub_artifacts_present() -> bool {
     ]
     .iter()
     .any(|p| Path::new(p).exists())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// A scratch efivars directory. Fixture layout mirrors the kernel's
+    /// efivarfs: 4 little-endian attribute bytes, then the variable value.
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("irlume-sb-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Write an efivar fixture: attrs prefix 0x07,0,0,0 (NV+BS+RT) + value.
+    fn write_var(dir: &Path, name: &str, value: &[u8]) {
+        let mut bytes = vec![0x07, 0, 0, 0];
+        bytes.extend_from_slice(value);
+        std::fs::write(dir.join(name), bytes).unwrap();
+    }
+
+    #[test]
+    fn secure_boot_enabled_requires_sb1_and_not_setup_mode() {
+        let dir = scratch("enabled");
+        // SecureBoot=1, no SetupMode var at all (missing reads as 0): enforcing.
+        write_var(&dir, SECUREBOOT_VAR, &[1]);
+        assert!(secure_boot_present_in(&dir));
+        assert!(secure_boot_enabled_in(&dir));
+        assert!(!setup_mode_in(&dir));
+        // SetupMode=0 explicit: still enforcing.
+        write_var(&dir, SETUPMODE_VAR, &[0]);
+        assert!(secure_boot_enabled_in(&dir));
+        // SetupMode=1: SecureBoot=1 is a false trust signal; must report OFF.
+        write_var(&dir, SETUPMODE_VAR, &[1]);
+        assert!(setup_mode_in(&dir));
+        assert!(!secure_boot_enabled_in(&dir), "setup mode must veto SB=1");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn secure_boot_disabled_and_absent_cases() {
+        let dir = scratch("disabled");
+        // SecureBoot=0: present but not enforcing.
+        write_var(&dir, SECUREBOOT_VAR, &[0]);
+        assert!(secure_boot_present_in(&dir));
+        assert!(!secure_boot_enabled_in(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // No efivars at all (legacy BIOS boot): absent, off, not setup mode.
+        let empty = scratch("absent");
+        assert!(!secure_boot_present_in(&empty));
+        assert!(!secure_boot_enabled_in(&empty));
+        assert!(!setup_mode_in(&empty));
+        let _ = std::fs::remove_dir_all(&empty);
+    }
+
+    #[test]
+    fn truncated_efivar_yields_none_not_garbage() {
+        let dir = scratch("short");
+        // Attrs-only file (4 bytes): no value byte to read.
+        std::fs::write(dir.join(SECUREBOOT_VAR), [0x07, 0, 0, 0]).unwrap();
+        assert_eq!(read_efivar_u8_in(&dir, SECUREBOOT_VAR), None);
+        assert!(!secure_boot_present_in(&dir));
+        // Empty file.
+        std::fs::write(dir.join(SETUPMODE_VAR), []).unwrap();
+        assert_eq!(read_efivar_u8_in(&dir, SETUPMODE_VAR), None);
+        assert!(!setup_mode_in(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn loader_identity_decodes_utf16le_and_prefers_the_stub() {
+        let dir = scratch("loader");
+        let utf16 = |s: &str, nul_terminated: bool| -> Vec<u8> {
+            let mut v: Vec<u8> = s.encode_utf16().flat_map(u16::to_le_bytes).collect();
+            if nul_terminated {
+                v.extend_from_slice(&[0, 0]);
+                // Trailing garbage after the terminator must be ignored.
+                v.extend_from_slice(&[0x41, 0x00]);
+            }
+            v
+        };
+        // LoaderInfo alone.
+        write_var(&dir, LOADER_INFO_VAR, &utf16("systemd-boot 257.6", true));
+        assert_eq!(
+            loader_identity_in(&dir).as_deref(),
+            Some("systemd-boot 257.6")
+        );
+        // StubInfo present too: the stub name wins (a UKI boot chains through
+        // systemd-boot, but the stub is what measured the kernel).
+        write_var(&dir, STUB_INFO_VAR, &utf16("systemd-stub 257.6", false));
+        assert_eq!(
+            loader_identity_in(&dir).as_deref(),
+            Some("systemd-stub 257.6")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn loader_identity_rejects_undecodable_values() {
+        let dir = scratch("badloader");
+        // One byte of value after attrs: too short for a UTF-16 unit.
+        write_var(&dir, LOADER_INFO_VAR, &[0x41]);
+        assert_eq!(loader_identity_in(&dir), None);
+        // An unpaired UTF-16 surrogate (0xD800) cannot decode.
+        write_var(&dir, LOADER_INFO_VAR, &0xD800u16.to_le_bytes());
+        assert_eq!(loader_identity_in(&dir), None);
+        // Odd trailing byte: chunks_exact drops it; the rest still decodes.
+        let mut odd: Vec<u8> = "ok".encode_utf16().flat_map(u16::to_le_bytes).collect();
+        odd.push(0x00);
+        write_var(&dir, STUB_INFO_VAR, &odd);
+        assert_eq!(loader_identity_in(&dir).as_deref(), Some("ok"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn boot_mode_detection_orders_stub_loader_grub_unknown() {
+        let no_efi = scratch("noefi-root").join("missing");
+        let efivars = scratch("bootmode");
+        let efi_root = std::env::temp_dir(); // any existing dir stands in for /sys/firmware/efi
+
+        // No EFI root: legacy boot, GRUB regardless of grub_present.
+        assert_eq!(
+            detect_boot_mode_at(&no_efi, &efivars, false),
+            BootMode::Grub
+        );
+        // EFI, no loader vars, no grub artifacts: Unknown.
+        assert_eq!(
+            detect_boot_mode_at(&efi_root, &efivars, false),
+            BootMode::Unknown
+        );
+        // EFI + grub artifacts on disk: Grub.
+        assert_eq!(
+            detect_boot_mode_at(&efi_root, &efivars, true),
+            BootMode::Grub
+        );
+        // EFI + LoaderInfo (systemd-boot, non-UKI): Grub-tier.
+        write_var(&efivars, LOADER_INFO_VAR, &[0x41, 0x00]);
+        assert_eq!(
+            detect_boot_mode_at(&efi_root, &efivars, false),
+            BootMode::Grub
+        );
+        // StubInfo present: UKI wins over everything else.
+        write_var(&efivars, STUB_INFO_VAR, &[0x41, 0x00]);
+        assert_eq!(
+            detect_boot_mode_at(&efi_root, &efivars, true),
+            BootMode::Uki
+        );
+        let _ = std::fs::remove_dir_all(&efivars);
+    }
+
+    #[test]
+    fn boot_mode_as_str_names_each_mode() {
+        assert_eq!(BootMode::Uki.as_str(), "UKI (signed PCR-11 eligible)");
+        assert_eq!(BootMode::Grub.as_str(), "GRUB/loader (self-healing PCR-7)");
+        assert_eq!(BootMode::Unknown.as_str(), "unknown bootloader");
+    }
+
+    #[test]
+    fn host_wrappers_are_consistent_with_each_other() {
+        // Read-only probes of the real /sys; the values vary by box, but the
+        // invariants cannot: enforcing implies the var is present, and a
+        // present-and-enforcing state excludes setup mode.
+        let present = secure_boot_present();
+        let enabled = is_secure_boot_enabled();
+        let setup = is_setup_mode();
+        if enabled {
+            assert!(
+                present,
+                "enforcing Secure Boot implies a readable SecureBoot var"
+            );
+            assert!(!setup, "enforcing Secure Boot excludes setup mode");
+        }
+        // detect_boot_mode + loader_identity must never panic; a decoded
+        // loader name is never the empty string (the first UTF-16 unit of a
+        // real StubInfo/LoaderInfo value is printable, not NUL).
+        let _ = detect_boot_mode();
+        if let Some(name) = loader_identity() {
+            assert!(!name.is_empty());
+        }
+    }
 }

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -166,6 +166,35 @@ mod tests {
     }
 
     #[test]
+    fn state_dir_env_override_moves_the_weights_dir() {
+        let _g = crate::testenv::lock();
+        std::env::remove_var("IRLUME_STATE_DIR");
+        assert_eq!(
+            dir(),
+            Path::new("/var/lib/irlume").join("models-thirdparty"),
+            "default weights dir must live under the system state dir"
+        );
+        let tmp = std::env::temp_dir().join(format!("irlume-tpdir-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &tmp);
+        assert_eq!(dir(), tmp.join(SUBDIR));
+
+        let m = by_name("flir").unwrap();
+        assert_eq!(model_path(m), tmp.join(SUBDIR).join("flir.onnx"));
+        // Nothing fetched into the sandbox dir yet: Absent through the
+        // state-dir-resolving wrapper too, not just weight_state_at.
+        assert_eq!(weight_state(m), WeightState::Absent);
+        // A fetched file that does not match the catalog pin is tampering.
+        std::fs::create_dir_all(dir()).unwrap();
+        std::fs::write(model_path(m), b"not the pinned weights").unwrap();
+        assert_eq!(weight_state(m), WeightState::ChecksumMismatch);
+
+        std::env::remove_var("IRLUME_STATE_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn weight_state_reports_present_matching_and_tampered() {
         let tmp = std::env::temp_dir().join(format!("irlume-ws-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&tmp);

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -381,24 +381,47 @@ fn handle(stream: UnixStream, engine: &mut irlume_auth::Engine) -> std::io::Resu
     // threaded daemon (and thus ALL logins) forever.
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(15)));
     let _ = stream.set_write_timeout(Some(std::time::Duration::from_secs(15)));
+    match read_request(&stream)? {
+        ReadOutcome::Closed => Ok(()),
+        ReadOutcome::Bad => respond(stream, &Response::Error("bad request".into())),
+        ReadOutcome::Req(req) => {
+            let resp = dispatch(req, &peer, engine);
+            respond(stream, &resp)
+        }
+    }
+}
+
+/// One parsed request line off the wire (see [`read_request`]).
+#[cfg_attr(test, derive(Debug))] // tests unwrap_err() around it; not needed at runtime
+enum ReadOutcome {
+    /// Peer closed without sending a line.
+    Closed,
+    /// The line did not parse; the caller answers a generic "bad request"
+    /// (never echoing the peer's raw bytes / parser internals back).
+    Bad,
+    Req(Request),
+}
+
+/// Read one request line (bounded by [`MAX_REQUEST_BYTES`]) and parse it.
+/// Extracted verbatim from [`handle`] (test seam: exercised over a socketpair
+/// without an [`irlume_auth::Engine`]); behavior unchanged.
+fn read_request(stream: &UnixStream) -> std::io::Result<ReadOutcome> {
     let mut reader = BufReader::new(stream.try_clone()?).take(MAX_REQUEST_BYTES);
     let mut line = String::new();
     if reader.read_line(&mut line)? == 0 {
-        return Ok(());
+        return Ok(ReadOutcome::Closed);
     }
     let req: Request = match serde_json::from_str(line.trim()) {
         Ok(r) => r,
-        // Don't echo the peer's raw bytes / parser internals back to them.
         Err(_) => {
             line.zeroize();
-            return respond(stream, &Response::Error("bad request".into()));
+            return Ok(ReadOutcome::Bad);
         }
     };
     // The line may hold a plaintext secret (SealPassword/RecoverySetup); wipe it
     // now that it's parsed into the zeroizing SecretBytes.
     line.zeroize();
-    let resp = dispatch(req, &peer, engine);
-    respond(stream, &resp)
+    Ok(ReadOutcome::Req(req))
 }
 
 /// A username is interpolated into `<user>.json` paths (enrollment, sealed key,
@@ -1536,5 +1559,413 @@ mod tests {
             deny_reason("'ghost' is not enrolled"),
             "'ghost' is not enrolled"
         );
+    }
+
+    /// Tests that mutate process env vars serialize here (setenv/getenv are
+    /// process-global and the harness runs tests concurrently).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn deny_score_is_quantized_to_one_decimal_without_tracing() {
+        // IRLUME_LOG is unset in the test env, so the anti-oracle quantization
+        // applies: one decimal, ~-prefixed, never the 4-decimal exact score.
+        assert_eq!(deny_score(0.4321), "~0.4");
+        assert_eq!(deny_score(0.06), "~0.1"); // rounds, still one decimal
+        assert_eq!(deny_score(0.0), "~0.0");
+    }
+
+    #[test]
+    fn valid_username_rejects_traversal_and_junk() {
+        // Accepted: ordinary local, NSS, and samba-machine account shapes.
+        for ok in ["alice", "u", "user_1", "web-svc", "a.b-c", "host$", "x1.y2"] {
+            assert!(valid_username(ok), "{ok:?} must be accepted");
+        }
+        // Rejected: empty, oversized, leading '-'/'.', separators, traversal.
+        let long = "a".repeat(65);
+        for bad in [
+            "",
+            long.as_str(),
+            "-flag",
+            ".hidden",
+            "..",
+            "../root",
+            "a/b",
+            "a b",
+            "tab\tname",
+            "new\nline",
+            "nul\0byte",
+            "café",
+            "semi;colon",
+        ] {
+            assert!(!valid_username(bad), "{bad:?} must be rejected");
+        }
+        // Boundary: exactly 64 bytes is still legal.
+        assert!(valid_username(&"a".repeat(64)));
+    }
+
+    #[test]
+    fn request_user_extracts_the_user_from_every_user_bearing_variant() {
+        use irlume_common::SecretBytes;
+        let u = || "carol".to_string();
+        let secret = || SecretBytes::new(b"pw".to_vec());
+        let carrying: Vec<Request> = vec![
+            Request::Authenticate {
+                user: u(),
+                service: Some("sudo".into()),
+            },
+            Request::Enroll {
+                user: u(),
+                profile: None,
+                scans: None,
+                reset: false,
+            },
+            Request::ListProfiles { user: u() },
+            Request::DeleteProfile {
+                user: u(),
+                profile: "p".into(),
+            },
+            Request::DeleteScan {
+                user: u(),
+                profile: "p".into(),
+                scan: "s".into(),
+            },
+            Request::RenameProfile {
+                user: u(),
+                profile: "p".into(),
+                new_name: "q".into(),
+            },
+            Request::RenameScan {
+                user: u(),
+                profile: "p".into(),
+                scan: "s".into(),
+                new_name: "t".into(),
+            },
+            Request::AddScan {
+                user: u(),
+                profile: "p".into(),
+            },
+            Request::SetRequireEyesOpen {
+                user: u(),
+                on: true,
+            },
+            Request::SetRequireChallenge {
+                user: u(),
+                on: false,
+            },
+            Request::SealPassword {
+                user: u(),
+                password: secret(),
+            },
+            Request::UnsealPassword {
+                user: u(),
+                service: None,
+            },
+            Request::UnsealKeyring {
+                user: u(),
+                service: None,
+            },
+            Request::HasSealedPassword { user: u() },
+            Request::KeyringInfo { user: u() },
+            Request::ForgetPassword { user: u() },
+            Request::ResealPassword {
+                user: u(),
+                password: secret(),
+            },
+            Request::RecoveryStatus { user: u() },
+            Request::RecoverySetup {
+                user: u(),
+                passphrase: secret(),
+            },
+            Request::RecoveryRestore {
+                user: u(),
+                passphrase: secret(),
+            },
+            Request::RecoveryForget { user: u() },
+            Request::PositionSample { user: Some(u()) },
+        ];
+        for req in &carrying {
+            assert_eq!(
+                request_user(req),
+                Some("carol"),
+                "variant must expose its user for the traversal guard: {req:?}"
+            );
+        }
+        // Variants with no user field must not invent one.
+        let userless: Vec<Request> = vec![
+            Request::Ping,
+            Request::Health,
+            Request::Identify,
+            Request::SetCameras {
+                rgb: "/dev/video0".into(),
+                ir: "/dev/video2".into(),
+            },
+            Request::SetupIrEmitter { dry_run: true },
+            Request::SelfTest {
+                kind: irlume_common::SelfTestKind::Liveness,
+            },
+            Request::PositionSample { user: None },
+        ];
+        for req in &userless {
+            assert_eq!(request_user(req), None, "no user in {req:?}");
+        }
+    }
+
+    #[test]
+    fn peer_cred_reports_our_own_identity_on_a_socketpair() {
+        let (a, _b) = UnixStream::pair().unwrap();
+        let peer = peer_cred(&a).unwrap();
+        assert_eq!(peer.uid, unsafe { libc::geteuid() });
+        assert_eq!(peer.gid, unsafe { libc::getegid() });
+        assert_eq!(peer.pid, std::process::id() as i32);
+    }
+
+    #[test]
+    fn read_request_parses_one_line_and_rejects_garbage() {
+        // A valid newline-terminated request.
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        (&theirs).write_all(b"\"Ping\"\n").unwrap();
+        match read_request(&ours).unwrap() {
+            ReadOutcome::Req(Request::Ping) => {}
+            _ => panic!("a Ping line must parse to Request::Ping"),
+        }
+        // Unparsable bytes -> Bad (generic error, never an echo).
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        (&theirs).write_all(b"{not json}\n").unwrap();
+        assert!(matches!(read_request(&ours).unwrap(), ReadOutcome::Bad));
+        // Peer closing without a byte -> Closed.
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        drop(theirs);
+        assert!(matches!(read_request(&ours).unwrap(), ReadOutcome::Closed));
+    }
+
+    #[test]
+    fn read_request_caps_an_oversized_payload_at_max_request_bytes() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        // 128 KiB with no newline: a slow-loris / memory-DoS shape. The writer
+        // runs on its own thread in case the kernel buffers fill up.
+        let writer = std::thread::spawn(move || {
+            let payload = vec![b'a'; 2 * MAX_REQUEST_BYTES as usize];
+            let _ = (&theirs).write_all(&payload);
+            let _ = (&theirs).write_all(b"\n\"Ping\"\n");
+        });
+        // The reader must stop at the 64 KiB cap and answer Bad; it must not
+        // buffer the whole flood or hang waiting for the newline.
+        assert!(matches!(read_request(&ours).unwrap(), ReadOutcome::Bad));
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn read_request_honours_the_read_deadline_against_a_silent_peer() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        // Same mechanism handle() arms (shorter here to keep the test quick).
+        ours.set_read_timeout(Some(std::time::Duration::from_millis(300)))
+            .unwrap();
+        let t = std::time::Instant::now();
+        let err = read_request(&ours).unwrap_err();
+        assert!(
+            matches!(
+                err.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            ),
+            "a silent peer must trip the deadline, got {err:?}"
+        );
+        assert!(t.elapsed() >= std::time::Duration::from_millis(250));
+        drop(theirs);
+    }
+
+    #[test]
+    fn respond_writes_one_newline_terminated_json_line() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        respond(ours, &Response::Pong).unwrap();
+        let mut line = String::new();
+        BufReader::new(&theirs).read_line(&mut line).unwrap();
+        assert!(line.ends_with('\n'));
+        assert!(matches!(
+            serde_json::from_str::<Response>(line.trim()).unwrap(),
+            Response::Pong
+        ));
+        // A secret-carrying response survives the wire intact (the zeroize of
+        // the serialization buffer must not corrupt what was already sent).
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        respond(
+            ours,
+            &Response::PasswordUnsealed {
+                secret: irlume_common::SecretBytes::new(b"hunter2".to_vec()),
+            },
+        )
+        .unwrap();
+        let mut line = String::new();
+        BufReader::new(&theirs).read_line(&mut line).unwrap();
+        match serde_json::from_str::<Response>(line.trim()).unwrap() {
+            Response::PasswordUnsealed { secret } => {
+                assert_eq!(secret.expose(), b"hunter2")
+            }
+            other => panic!("expected PasswordUnsealed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn env_or_prefers_the_env_var_over_the_default() {
+        let _g = env_lock();
+        std::env::remove_var("IRLUME_TEST_ENV_OR");
+        assert_eq!(
+            env_or("IRLUME_TEST_ENV_OR", "/etc/fallback"),
+            "/etc/fallback"
+        );
+        std::env::set_var("IRLUME_TEST_ENV_OR", "/tmp/override");
+        assert_eq!(
+            env_or("IRLUME_TEST_ENV_OR", "/etc/fallback"),
+            "/tmp/override"
+        );
+        std::env::remove_var("IRLUME_TEST_ENV_OR");
+    }
+
+    #[test]
+    fn biopolicy_enforced_reads_env_then_settings_conf() {
+        let _g = env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-biopol-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+        std::env::remove_var("IRLUME_ENFORCE_BIOPOLICY");
+
+        // Default: no env, no settings.conf -> off.
+        assert!(!biopolicy_enforced());
+        // settings.conf truthy value turns it on; a falsy one keeps it off.
+        std::fs::write(dir.join("settings.conf"), "enforce_biopolicy=1\n").unwrap();
+        assert!(biopolicy_enforced());
+        std::fs::write(dir.join("settings.conf"), "enforce_biopolicy=0\n").unwrap();
+        assert!(!biopolicy_enforced());
+        // The env var wins over the file, in both directions.
+        std::fs::write(dir.join("settings.conf"), "enforce_biopolicy=1\n").unwrap();
+        std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", "0");
+        assert!(!biopolicy_enforced());
+        std::fs::write(dir.join("settings.conf"), "enforce_biopolicy=0\n").unwrap();
+        for truthy in ["1", "true", "yes", "on", " on "] {
+            std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", truthy);
+            assert!(biopolicy_enforced(), "{truthy:?} must enable");
+        }
+        std::env::remove_var("IRLUME_ENFORCE_BIOPOLICY");
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_models_without_strict_warns_but_continues() {
+        // No IRLUME_MODELS_STRICT in the test env: an unknown digest and a
+        // missing file must both come back (reaching the next line at all is
+        // the contract; strict mode would have exited the process).
+        let dir = std::env::temp_dir().join(format!("irlume-vm-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let unknown = dir.join("custom_adapter.onnx");
+        std::fs::write(&unknown, b"self-trained weights").unwrap();
+        verify_models(&[
+            unknown.to_str().unwrap(),
+            "/nonexistent/irlume-test/missing.onnx",
+        ]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Companion to the missing-model child test: strict mode must also refuse
+    // a PRESENT model whose digest is not in the release manifest (tampering),
+    // and must ACCEPT a shipped model that matches it. verify_models exits the
+    // process, so both run as re-exec'd children.
+    #[test]
+    fn strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one() {
+        if let Ok(path) = std::env::var("IRLUME_TEST_VERIFY_TAMPER_CHILD") {
+            verify_models(&[&path]); // must exit(1) before the return
+            return;
+        }
+        if let Ok(path) = std::env::var("IRLUME_TEST_VERIFY_KNOWN_CHILD") {
+            verify_models(&[&path]); // digest is in the manifest: must survive
+            println!("known-model-accepted");
+            std::process::exit(0);
+        }
+        let exe = std::env::current_exe().unwrap();
+        let run = |var: &str, path: &str| {
+            std::process::Command::new(&exe)
+                .args([
+                    "tests::strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one",
+                    "--exact",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env(var, path)
+                .env("IRLUME_MODELS_STRICT", "1")
+                .output()
+                .unwrap()
+        };
+        // Tampered: on-disk bytes whose sha256 is not in models/SHA256SUMS.
+        let dir = std::env::temp_dir().join(format!("irlume-vm-strict-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let tampered = dir.join("face.onnx");
+        std::fs::write(&tampered, b"swapped weights").unwrap();
+        let out = run(
+            "IRLUME_TEST_VERIFY_TAMPER_CHILD",
+            tampered.to_str().unwrap(),
+        );
+        assert!(
+            !out.status.success(),
+            "strict mode must refuse an unmanifested model"
+        );
+        let err = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            err.contains("refusing to start with unverified models"),
+            "stderr: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // Shipped: a real release model from the repo matches its manifest
+        // digest and must start even under strict.
+        let shipped = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../models/blaze_face_short_range.onnx");
+        if !shipped.exists() {
+            eprintln!("skipping known-model half: repo models/ not present");
+            return;
+        }
+        let out = run("IRLUME_TEST_VERIFY_KNOWN_CHILD", shipped.to_str().unwrap());
+        assert!(
+            out.status.success(),
+            "strict mode must accept a manifest-matching model; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(String::from_utf8_lossy(&out.stdout).contains("known-model-accepted"));
+    }
+
+    #[test]
+    fn mutate_enrollment_reports_a_missing_enrollment() {
+        let _g = env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-mut-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+        let resp = mutate_enrollment("ghost", |_| Ok("never runs".into()));
+        match resp {
+            Response::Error(msg) => assert_eq!(msg, "'ghost' is not enrolled"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+        std::env::remove_var("IRLUME_STATE_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn set_mode_applies_the_requested_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("irlume-mode-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("sock-standin");
+        std::fs::write(&f, b"").unwrap();
+        set_mode(f.to_str().unwrap(), 0o660);
+        let mode = std::fs::metadata(&f).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o660);
+        // Best-effort on a missing path: must not panic.
+        set_mode("/nonexistent/irlume-test/sock", 0o666);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/irlume-daemon/src/users.rs
+++ b/crates/irlume-daemon/src/users.rs
@@ -85,3 +85,72 @@ pub fn chown(path: &std::path::Path, uid: Option<u32>, gid: Option<u32>) -> std:
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uid_and_name_round_trip_for_root_and_the_current_user() {
+        // root is uid 0 on every Linux, in both directions.
+        assert_eq!(uid_for_name("root"), Some(0));
+        assert_eq!(name_for_uid(0).as_deref(), Some("root"));
+        // The uid running this test resolves to a name that resolves back.
+        let me = unsafe { libc::geteuid() };
+        let name = name_for_uid(me).expect("test uid must have an account");
+        assert!(!name.is_empty());
+        assert_eq!(uid_for_name(&name), Some(me));
+    }
+
+    #[test]
+    fn absent_and_unencodable_users_resolve_to_none() {
+        assert_eq!(uid_for_name("no-such-user-irlume-test"), None);
+        // Interior NUL cannot become a C string: None, not a panic.
+        assert_eq!(uid_for_name("a\0b"), None);
+        // 4294967294 = (uid_t)-2, the "nobody owns this" sentinel (used by
+        // idmapped mounts); it must never resolve to an account name.
+        assert_eq!(name_for_uid(4294967294), None);
+    }
+
+    #[test]
+    fn group_lookup_resolves_root_and_rejects_absent_groups() {
+        // The root group is gid 0 on Linux (the socket-permission fallback
+        // logic relies on a failed "irlume" lookup being None, not an error).
+        assert_eq!(gid_for_group("root"), Some(0));
+        assert_eq!(gid_for_group("no-such-group-irlume-test"), None);
+        assert_eq!(gid_for_group("a\0b"), None);
+    }
+
+    #[test]
+    fn chown_no_change_succeeds_and_bad_paths_error() {
+        let dir = std::env::temp_dir().join(format!("irlume-chown-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("f");
+        std::fs::write(&f, b"x").unwrap();
+
+        // None/None maps to (uid_t)-1/(gid_t)-1 = "no change": always allowed
+        // on a file we own, even unprivileged.
+        chown(&f, None, None).unwrap();
+        // Re-asserting our own uid/gid is also a no-op chown and must succeed.
+        let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
+        chown(&f, Some(uid), Some(gid)).unwrap();
+        use std::os::unix::fs::MetadataExt;
+        let md = std::fs::metadata(&f).unwrap();
+        assert_eq!((md.uid(), md.gid()), (uid, gid));
+
+        // A missing path surfaces the OS error instead of pretending success.
+        assert!(chown(
+            std::path::Path::new("/nonexistent/irlume-test/f"),
+            None,
+            None
+        )
+        .is_err());
+        // A path with an interior NUL is rejected before touching libc.
+        let nul_path = std::path::Path::new("has\0nul");
+        let err = chown(nul_path, None, None).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -811,6 +811,268 @@ pub use onnx::{
     PadIr, BLAZE_SCORE_THRESHOLD, EAR_LEFT, EAR_RIGHT, MESH_INPUT, MESH_N, MESH_N_IRIS,
 };
 
+/// Model-backed pipeline tests: run the REAL shipped ONNX models (Git LFS,
+/// under `models/` at the repo root) on synthetic frames, asserting output
+/// dimensions, value ranges, and determinism. Session creation is expensive, so
+/// each model is built once per test binary and shared behind a `OnceLock`.
+#[cfg(all(test, feature = "onnx"))]
+mod model_tests {
+    use super::*;
+    use crate::align;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn model_path(name: &str) -> String {
+        format!("{}/../../models/{name}", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    /// Point `ort` (load-dynamic) at the packaged onnxruntime when the test env
+    /// doesn't already provide `ORT_DYLIB_PATH`.
+    fn ort_init() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            if std::env::var_os("ORT_DYLIB_PATH").is_some() {
+                return;
+            }
+            for cand in [
+                "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+                "/usr/lib64/libonnxruntime.so",
+                "/usr/lib/libonnxruntime.so",
+                "/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
+            ] {
+                if std::path::Path::new(cand).exists() {
+                    std::env::set_var("ORT_DYLIB_PATH", cand);
+                    return;
+                }
+            }
+        });
+    }
+
+    fn embedder() -> MutexGuard<'static, Embedder> {
+        static S: OnceLock<Mutex<Embedder>> = OnceLock::new();
+        S.get_or_init(|| {
+            ort_init();
+            Mutex::new(Embedder::load_from_file(&model_path("glintr100.onnx")).expect("embedder"))
+        })
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn detector() -> MutexGuard<'static, Detector> {
+        static S: OnceLock<Mutex<Detector>> = OnceLock::new();
+        S.get_or_init(|| {
+            ort_init();
+            Mutex::new(
+                Detector::load_from_file(&model_path("face_detection_yunet_2023mar.onnx"))
+                    .expect("detector"),
+            )
+        })
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn facemesh() -> MutexGuard<'static, FaceMesh> {
+        static S: OnceLock<Mutex<FaceMesh>> = OnceLock::new();
+        S.get_or_init(|| {
+            ort_init();
+            Mutex::new(FaceMesh::load_from_file(&model_path("face_landmark.onnx")).expect("mesh"))
+        })
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn blaze() -> MutexGuard<'static, BlazeRescue> {
+        static S: OnceLock<Mutex<BlazeRescue>> = OnceLock::new();
+        S.get_or_init(|| {
+            ort_init();
+            Mutex::new(
+                BlazeRescue::load_from_file(&model_path("blaze_face_short_range.onnx"))
+                    .expect("blaze"),
+            )
+        })
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Deterministic pseudo-textured 112x112 chip (the embedder's input shape).
+    fn chip(seed: usize) -> Vec<u8> {
+        let n = (align::OUT_SIZE * align::OUT_SIZE) as usize * 3;
+        (0..n)
+            .map(|i| ((i * 37 + seed * 101 + 11) % 256) as u8)
+            .collect()
+    }
+
+    /// Deterministic gradient frame of arbitrary size.
+    fn gradient_frame(w: u32, h: u32) -> Vec<u8> {
+        let mut data = vec![0u8; (w * h * 3) as usize];
+        for y in 0..h {
+            for x in 0..w {
+                let i = ((y * w + x) * 3) as usize;
+                data[i] = (x * 255 / w.max(1)) as u8;
+                data[i + 1] = (y * 255 / h.max(1)) as u8;
+                data[i + 2] = ((x + y) % 256) as u8;
+            }
+        }
+        data
+    }
+
+    fn l2(v: &[f32]) -> f32 {
+        v.iter().map(|x| x * x).sum::<f32>().sqrt()
+    }
+
+    #[test]
+    fn embed_is_512d_unit_norm_and_deterministic() {
+        let mut e = embedder();
+        let c = chip(1);
+        let a = e.embed(&c).expect("embed");
+        let b = e.embed(&c).expect("embed again");
+        // Contract: 512-D (by type), L2-normalized, bitwise-stable inference.
+        assert!((l2(&a) - 1.0).abs() < 1e-4, "norm {}", l2(&a));
+        assert!(
+            align::cosine(&a, &b) > 0.9999,
+            "non-deterministic embedding"
+        );
+        // A different input must land somewhere else on the hypersphere.
+        let other = e.embed(&chip(2)).expect("embed other");
+        assert!(
+            align::cosine(&a, &other) < 0.999,
+            "distinct chips collapsed to one embedding: {}",
+            align::cosine(&a, &other)
+        );
+    }
+
+    #[test]
+    fn embed_with_norm_returns_positive_quality_norm() {
+        let mut e = embedder();
+        let (emb, norm) = e.embed_with_norm(&chip(3)).expect("embed_with_norm");
+        assert!(
+            norm > 0.0,
+            "pre-normalization norm must be positive: {norm}"
+        );
+        assert!((l2(&emb) - 1.0).abs() < 1e-4);
+        // The returned embedding is the plain embed() of the same chip.
+        let plain = e.embed(&chip(3)).expect("embed");
+        assert!(align::cosine(&emb, &plain) > 0.9999);
+    }
+
+    #[test]
+    fn embed_tta_is_normalized_deterministic_and_near_plain() {
+        let mut e = embedder();
+        let c = chip(4);
+        let t1 = e.embed_tta(&c).expect("tta");
+        let t2 = e.embed_tta(&c).expect("tta again");
+        assert!((l2(&t1) - 1.0).abs() < 1e-4);
+        assert!(align::cosine(&t1, &t2) > 0.9999);
+        // The flip-average stays close to the un-augmented embedding (it is an
+        // average containing it), but is not bit-identical.
+        let plain = e.embed(&c).expect("embed");
+        let cos = align::cosine(&t1, &plain);
+        assert!(cos > 0.5, "tta drifted implausibly far: {cos}");
+    }
+
+    #[test]
+    fn alignment_identity_selftest_passes_on_the_real_model() {
+        let mut e = embedder();
+        let (passed, detail) = selftest_alignment_identity(&mut e);
+        assert!(passed, "{detail}");
+    }
+
+    #[test]
+    fn detector_finds_no_face_in_synthetic_frames_and_is_deterministic() {
+        let mut d = detector();
+        let (w, h) = (640u32, 480u32);
+        let grad = gradient_frame(w, h);
+        let view = align::RgbView {
+            data: &grad,
+            width: w,
+            height: h,
+        };
+        let dets = d.detect(&view).expect("detect");
+        assert!(
+            dets.is_empty(),
+            "a faceless gradient must yield no detections, got {}",
+            dets.len()
+        );
+        // Full pipeline determinism (letterbox -> session -> decode -> NMS).
+        assert_eq!(d.detect(&view).expect("detect again").len(), 0);
+        // Flat mid-grey behaves the same.
+        let flat = vec![128u8; (w * h * 3) as usize];
+        let view = align::RgbView {
+            data: &flat,
+            width: w,
+            height: h,
+        };
+        assert!(d.detect(&view).expect("detect flat").is_empty());
+    }
+
+    #[test]
+    fn facemesh_emits_full_point_set_in_crop_space() {
+        let mut m = facemesh();
+        let (w, h) = (256u32, 256u32);
+        let frame = gradient_frame(w, h);
+        let view = align::RgbView {
+            data: &frame,
+            width: w,
+            height: h,
+        };
+        let bbox = [64.0, 64.0, 192.0, 192.0];
+        let lm = m.landmarks(&view, &bbox, 0.25).expect("landmarks");
+        // Either mesh generation is acceptable; the EAR/mouth indices used by
+        // the blink gate exist in both.
+        assert!(
+            lm.len() == MESH_N || lm.len() == MESH_N_IRIS,
+            "unexpected landmark count {}",
+            lm.len()
+        );
+        // Points come back mapped to the frame-space crop: finite, and within
+        // the expanded crop square plus slack (the model may overshoot a bit on
+        // a faceless input, but not by orders of magnitude).
+        for &(x, y) in &lm {
+            assert!(x.is_finite() && y.is_finite());
+            assert!((-256.0..512.0).contains(&x), "x out of range: {x}");
+            assert!((-256.0..512.0).contains(&y), "y out of range: {y}");
+        }
+        // Determinism: same crop, same points.
+        let again = m.landmarks(&view, &bbox, 0.25).expect("landmarks again");
+        assert_eq!(lm, again);
+    }
+
+    #[test]
+    fn blaze_rescue_is_deterministic_and_unconfident_on_synthetic_frames() {
+        let mut b = blaze();
+        let (w, h) = (640u32, 400u32);
+        let frame = gradient_frame(w, h);
+        let view = align::RgbView {
+            data: &frame,
+            width: w,
+            height: h,
+        };
+        let r1 = b.detect_top(&view).expect("blaze");
+        let r2 = b.detect_top(&view).expect("blaze again");
+        // Determinism of the full decode (letterbox, sigmoid, anchor mapping).
+        match (&r1, &r2) {
+            (None, None) => {}
+            (Some((bb1, s1)), Some((bb2, s2))) => {
+                assert_eq!(bb1, bb2);
+                assert_eq!(s1, s2);
+            }
+            _ => panic!("blaze non-deterministic on identical input"),
+        }
+        // A faceless gradient must not produce a confident face.
+        assert!(
+            r1.is_none(),
+            "blaze hallucinated a face on a gradient: {r1:?}"
+        );
+        // Flat grey likewise.
+        let flat = vec![127u8; (w * h * 3) as usize];
+        let view = align::RgbView {
+            data: &flat,
+            width: w,
+            height: h,
+        };
+        assert!(b.detect_top(&view).expect("blaze flat").is_none());
+    }
+}
+
 #[cfg(all(test, feature = "onnx"))]
 mod ear_tests {
     use super::{eye_ear, EAR_LEFT};

--- a/crates/irlume-vision/src/moire.rs
+++ b/crates/irlume-vision/src/moire.rs
@@ -130,4 +130,98 @@ mod tests {
         }
         assert!(moire_score(&g) > 50.0);
     }
+
+    #[test]
+    fn short_buffer_scores_zero() {
+        assert_eq!(moire_score(&[128u8; N * N - 1]), 0.0);
+        assert_eq!(moire_score(&[]), 0.0);
+    }
+
+    #[test]
+    fn all_black_crop_scores_zero() {
+        // Zero-mean, zero-energy input: the sum==0 guard, not a division blowup.
+        assert_eq!(moire_score(&vec![0u8; N * N]), 0.0);
+    }
+
+    #[test]
+    fn periodic_stripes_outscore_broadband_texture() {
+        // Skin-analog per the module contract: BROADBAND, non-periodic texture
+        // (deterministic pseudo-noise) whose spectrum falls off smoothly.
+        let mut noise = vec![0u8; N * N];
+        let mut s = 0x2545_F491u32;
+        for p in noise.iter_mut() {
+            // xorshift32: deterministic, aperiodic over this length.
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            *p = (s >> 24) as u8;
+        }
+        // Display-like periodicity: vertical stripes of period 4 (frequency
+        // 0.25, well inside the analyzed band).
+        let mut stripes = vec![0u8; N * N];
+        for y in 0..N {
+            for x in 0..N {
+                stripes[y * N + x] = if (x / 2) % 2 == 0 { 40 } else { 220 };
+            }
+        }
+        let (s_noise, s_stripes) = (moire_score(&noise), moire_score(&stripes));
+        assert!(
+            s_stripes > 10.0 * s_noise.max(1.0),
+            "stripes {s_stripes} vs broadband {s_noise}: periodicity must dominate"
+        );
+        // A slow one-axis gradient (smooth shading) also stays well under the
+        // stripe score, though windowing leakage keeps it above pure noise.
+        let mut smooth = vec![0u8; N * N];
+        for y in 0..N {
+            for x in 0..N {
+                smooth[y * N + x] = (x * 255 / N) as u8;
+            }
+        }
+        let s_smooth = moire_score(&smooth);
+        assert!(
+            s_stripes > 2.0 * s_smooth,
+            "stripes {s_stripes} vs gradient {s_smooth}"
+        );
+    }
+
+    #[test]
+    fn face_gray_n_converts_luma_and_resamples() {
+        // A 4x4 pure-red frame: BT.601 luma of (255,0,0) is 76.
+        let (w, h) = (4u32, 4u32);
+        let mut rgb = vec![0u8; (w * h * 3) as usize];
+        for px in rgb.chunks_mut(3) {
+            px[0] = 255;
+        }
+        let g = face_gray_n(&rgb, w, h, &[0.0, 0.0, 4.0, 4.0]);
+        assert_eq!(g.len(), N * N);
+        assert!(g.iter().all(|&p| p == 76), "expected uniform luma 76");
+    }
+
+    #[test]
+    fn face_gray_n_nearest_resample_preserves_grid_extremes() {
+        // A 2x2 black/white checker upsampled 64x: nearest sampling must keep
+        // pure 0/255 (bilinear would smear them, killing the FFT peak).
+        let (w, h) = (2u32, 2u32);
+        let rgb = [
+            0u8, 0, 0, 255, 255, 255, //
+            255, 255, 255, 0, 0, 0,
+        ];
+        let g = face_gray_n(&rgb, w, h, &[0.0, 0.0, 2.0, 2.0]);
+        assert!(g.iter().all(|&p| p == 0 || p == 255));
+        assert!(g.contains(&0) && g.contains(&255));
+    }
+
+    #[test]
+    fn face_gray_n_clamps_out_of_frame_bboxes() {
+        // A bbox hanging off every edge is clamped into the frame; the crop
+        // still fills the full analysis grid from real pixels.
+        let (w, h) = (8u32, 8u32);
+        let rgb = vec![200u8; (w * h * 3) as usize];
+        let g = face_gray_n(&rgb, w, h, &[-50.0, -50.0, 500.0, 500.0]);
+        assert_eq!(g.len(), N * N);
+        assert!(g.iter().all(|&p| p == 200));
+        // Degenerate inverted/zero-area bbox: clamped to at least one pixel.
+        let g = face_gray_n(&rgb, w, h, &[7.9, 7.9, 7.9, 7.9]);
+        assert!(g.iter().all(|&p| p == 200));
+    }
 }


### PR DESCRIPTION
268 new tests across four areas (TUI, CLI black-box + units, common/daemon, pipeline crates with real models). Zero behavior changes; the only production-code edits are commented verbatim extraction seams, two Debug derives, and one dev-dependency. Full table in the commit message; deliberately-uncovered remainder is hardware-bound (camera streaming, TPM, engine-loaded daemon arms, PAM FFI, tty event loops).
