### PR TITLE
test: swtpm harness for the TPM-gated tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: test (TPM-gated, against swtpm)
         run: |
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo test -p irlume-core --lib --locked -- --ignored \
-            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle
+            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle --test-threads=1
 
   # Build + test on current stable, because that is what the packaging lanes
   # and most from-source users compile with. fmt/clippy stay on the MSRV job
@@ -205,7 +205,7 @@ jobs:
         run: |
           cargo llvm-cov --no-report --workspace --locked
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
-            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle
+            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle --test-threads=1
           cargo llvm-cov report --summary-only --fail-under-lines 67
 
   deny:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,22 @@ jobs:
       - name: test
         run: cargo test --workspace --locked
 
+      # The TPM-gated tests run against a software TPM: same TSS stack, no
+      # hardware. IRLUME_TCTI is the production env override; swtpm state is
+      # throwaway per run.
+      - name: Start swtpm (software TPM)
+        run: |
+          sudo apt-get install -y --no-install-recommends swtpm libtss2-tcti-swtpm0
+          mkdir -p /tmp/swtpm
+          swtpm socket --tpm2 --tpmstate dir=/tmp/swtpm \
+            --server type=tcp,port=2321,disconnect --ctrl type=tcp,port=2322 \
+            --flags not-need-init,startup-clear --daemon --pid file=/tmp/swtpm/pid
+
+      - name: test (TPM-gated, against swtpm)
+        run: |
+          IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo test -p irlume-core --lib --locked -- --ignored \
+            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle
+
   # Build + test on current stable, because that is what the packaging lanes
   # and most from-source users compile with. fmt/clippy stay on the MSRV job
   # only, so new-stable lint churn never blocks a PR. Not a required check.
@@ -177,8 +193,20 @@ jobs:
           tar xzf "onnxruntime-linux-x64-${ver}.tgz"
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
 
-      - name: Coverage (fail under the ratchet floor)
-        run: cargo llvm-cov --workspace --locked --summary-only --fail-under-lines 66
+      - name: Start swtpm (software TPM)
+        run: |
+          sudo apt-get install -y --no-install-recommends swtpm libtss2-tcti-swtpm0
+          mkdir -p /tmp/swtpm
+          swtpm socket --tpm2 --tpmstate dir=/tmp/swtpm \
+            --server type=tcp,port=2321,disconnect --ctrl type=tcp,port=2322 \
+            --flags not-need-init,startup-clear --daemon --pid file=/tmp/swtpm/pid
+
+      - name: Coverage incl. TPM-gated tests (fail under the ratchet floor)
+        run: |
+          cargo llvm-cov --no-report --workspace --locked
+          IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
+            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle
+          cargo llvm-cov report --summary-only --fail-under-lines 67
 
   deny:
     name: cargo-deny (advisories · licenses · duplicate versions)

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -128,6 +128,7 @@ mod tests {
 
     #[test]
     fn envelope_path_under_keyring_dir() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
         std::env::set_var("IRLUME_KEYRING_DIR", "/tmp/irlume-kr-test");
         assert_eq!(
             envelope_path("alice"),
@@ -139,8 +140,9 @@ mod tests {
     /// Full arm → unseal round-trip through the keyring layer on the real TPM.
     /// Ignored: needs /dev/tpmrm0.
     #[test]
-    #[ignore = "requires real TPM (/dev/tpmrm0)"]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn arm_and_unseal_roundtrip() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
         let dir = "/tmp/irlume-kr-rt";
         std::env::set_var("IRLUME_KEYRING_DIR", dir);
         let _ = std::fs::remove_dir_all(dir);
@@ -160,8 +162,9 @@ mod tests {
     /// hits the same reseal path. (Callers gate this on a verified password via
     /// the PAM session phase; see the SAFETY CONTRACT on `reseal_password`.)
     #[test]
-    #[ignore = "requires real TPM (/dev/tpmrm0)"]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn reseal_only_when_stale() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
         let dir = "/tmp/irlume-kr-reseal";
         std::env::set_var("IRLUME_KEYRING_DIR", dir);
         let _ = std::fs::remove_dir_all(dir);

--- a/crates/irlume-core/src/lib.rs
+++ b/crates/irlume-core/src/lib.rs
@@ -115,3 +115,12 @@ mod tests {
         assert!(scaled_threshold(0.55, 100_000) <= 0.55 + TEMPLATE_SCALE_MAX_BUMP + 1e-6);
     }
 }
+
+/// One crate-wide lock for tests that mutate process-global environment
+/// variables (IRLUME_KEYRING_DIR, IRLUME_TEMPLATE_KEY_DIR, ...): env is shared
+/// across the whole test binary, so per-module locks cannot stop cross-module
+/// races when the parallel runner interleaves them.
+#[cfg(test)]
+pub(crate) mod testenv {
+    pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+}

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -169,11 +169,9 @@ fn set_0600(_path: &Path) {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // The override env vars are process-global; serialize the tests that mutate
-    // them so parallel `cargo test` runs don't clobber each other.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // The override env vars are process-global; the crate-wide lock stops
+    // cross-module races too (keyring tests mutate their own override).
+    use crate::testenv::ENV_LOCK;
 
     #[test]
     fn paths_under_override_dirs() {
@@ -212,7 +210,7 @@ mod tests {
     /// Full TPM-backed lifecycle: seal a key, recovery-wrap it, simulate a PCR
     /// move by forgetting the seal, then restore from the passphrase.
     #[test]
-    #[ignore = "requires real TPM (/dev/tpmrm0)"]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn tpm_key_and_recovery_lifecycle() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", "/tmp/irlume-tk-rt");

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -1182,7 +1182,7 @@ mod tests {
     /// Real seal→unseal round-trip on the host TPM. Ignored by default: needs
     /// /dev/tpmrm0 and write access (run as root or a tss-group member).
     #[test]
-    #[ignore = "requires real TPM (/dev/tpmrm0); run as root"]
+    #[ignore = "requires a TPM: real /dev/tpmrm0 (root), or swtpm via IRLUME_TCTI (CI does this)"]
     fn seal_unseal_roundtrip_real_tpm() {
         let secret = b"irlume-keyring-secret-roundtrip!";
         let env = seal_with_pcrs(secret, &[7]).expect("seal");

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -167,6 +167,21 @@ cargo run -p irlume-cli -- doctor   # platform / TPM / camera / model check
 Developer-only benchmark and capture subcommands are gated behind `IRLUME_DEV=1`
 (e.g. `IRLUME_DEV=1 cargo run -p irlume-cli -- selftest align --model models/glintr100.onnx`).
 
+The TPM-gated tests (marked `#[ignore]`) run against a software TPM, no
+hardware or root needed; CI does exactly this:
+
+```sh
+swtpm socket --tpm2 --tpmstate dir=/tmp/swtpm \
+  --server type=tcp,port=2321,disconnect --ctrl type=tcp,port=2322 \
+  --flags not-need-init,startup-clear --daemon --pid file=/tmp/swtpm/pid
+IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo test -p irlume-core --lib -- --ignored \
+  seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle
+```
+
+`IRLUME_TCTI` is the production TCTI override; the remaining ignored tests
+(pcrlock, durability, fault-injection) are campaign tools that need a
+provisioned host and stay manual.
+
 ## Sandbox environment overrides
 
 Every path a privileged component touches can be redirected, so tests and a


### PR DESCRIPTION
Runs the four hardware-independent TPM tests against swtpm in the MSRV and coverage jobs via the existing IRLUME_TCTI override; fixes a latent env race between the two keyring tests; documents the harness in DEVELOPMENT.md. Coverage 68.2% -> 69.7%, ratchet 66 -> 67.
