### PR TITLE
test: v4l2loopback virtual-camera harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
         env:
           IRLUME_TEST_RGB_DEVICE: /dev/video42
           IRLUME_TEST_IR_DEVICE: /dev/video43
+          # Loopback nodes have no physical bus; the exact-path escape lets
+          # verify_pinned accept just these two (see THREAT_MODEL.md).
+          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video42,/dev/video43
         run: |
           cargo test -p irlume-camera -p irlume-auth --locked -- --ignored loopback_ --test-threads=1
 
@@ -248,6 +251,9 @@ jobs:
         env:
           IRLUME_TEST_RGB_DEVICE: /dev/video42
           IRLUME_TEST_IR_DEVICE: /dev/video43
+          # Loopback nodes have no physical bus; the exact-path escape lets
+          # verify_pinned accept just these two (see THREAT_MODEL.md).
+          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video42,/dev/video43
         run: |
           cargo llvm-cov --no-report --workspace --locked
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,26 @@ jobs:
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo test -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
 
+      # Virtual cameras: v4l2loopback provides the V4L2 nodes, ffmpeg feeds
+      # test patterns in the exact formats the capture paths negotiate
+      # (YUYV 640x480 for RGB, GREY 640x400 for IR). Same idea as swtpm:
+      # fake hardware, real code.
+      - name: Start virtual cameras (v4l2loopback + ffmpeg feeders)
+        run: |
+          sudo apt-get install -y --no-install-recommends v4l2loopback-dkms "linux-headers-$(uname -r)" ffmpeg
+          sudo modprobe v4l2loopback devices=2 video_nr=42,43 card_label="irlume-test-rgb,irlume-test-ir" exclusive_caps=0
+          sudo chmod 666 /dev/video42 /dev/video43
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video42 >/dev/null 2>&1 &
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video43 >/dev/null 2>&1 &
+          sleep 3
+
+      - name: test (camera paths, against v4l2loopback)
+        env:
+          IRLUME_TEST_RGB_DEVICE: /dev/video42
+          IRLUME_TEST_IR_DEVICE: /dev/video43
+        run: |
+          cargo test -p irlume-camera -p irlume-auth --locked -- --ignored loopback_ --test-threads=1
+
   # Build + test on current stable, because that is what the packaging lanes
   # and most from-source users compile with. fmt/clippy stay on the MSRV job
   # only, so new-stable lint churn never blocks a PR. Not a required check.
@@ -201,11 +221,24 @@ jobs:
             --server type=tcp,port=2321,disconnect --ctrl type=tcp,port=2322 \
             --flags not-need-init,startup-clear --daemon --pid file=/tmp/swtpm/pid
 
-      - name: Coverage incl. TPM-gated tests (fail under the ratchet floor)
+      - name: Start virtual cameras (v4l2loopback + ffmpeg feeders)
+        run: |
+          sudo apt-get install -y --no-install-recommends v4l2loopback-dkms "linux-headers-$(uname -r)" ffmpeg
+          sudo modprobe v4l2loopback devices=2 video_nr=42,43 card_label="irlume-test-rgb,irlume-test-ir" exclusive_caps=0
+          sudo chmod 666 /dev/video42 /dev/video43
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video42 >/dev/null 2>&1 &
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video43 >/dev/null 2>&1 &
+          sleep 3
+
+      - name: Coverage incl. TPM-gated and camera tests (fail under the ratchet floor)
+        env:
+          IRLUME_TEST_RGB_DEVICE: /dev/video42
+          IRLUME_TEST_IR_DEVICE: /dev/video43
         run: |
           cargo llvm-cov --no-report --workspace --locked
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
+          cargo llvm-cov --no-report -p irlume-camera -p irlume-auth --locked -- --ignored loopback_ --test-threads=1
           cargo llvm-cov report --summary-only --fail-under-lines 68
 
   deny:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,19 +118,19 @@ jobs:
           git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
-          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=42,43 exclusive_caps=0
-          sudo chmod 666 /dev/video42 /dev/video43
-          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video42 >/dev/null 2>&1 &
-          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video43 >/dev/null 2>&1 &
+          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=8,9 exclusive_caps=0
+          sudo chmod 666 /dev/video8 /dev/video9
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
           sleep 3
 
       - name: test (camera paths, against v4l2loopback)
         env:
-          IRLUME_TEST_RGB_DEVICE: /dev/video42
-          IRLUME_TEST_IR_DEVICE: /dev/video43
+          IRLUME_TEST_RGB_DEVICE: /dev/video8
+          IRLUME_TEST_IR_DEVICE: /dev/video9
           # Loopback nodes have no physical bus; the exact-path escape lets
           # verify_pinned accept just these two (see THREAT_MODEL.md).
-          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video42,/dev/video43
+          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
         run: |
           cargo test -p irlume-camera -p irlume-auth --locked -- --ignored loopback_ --test-threads=1
 
@@ -241,19 +241,19 @@ jobs:
           git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
-          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=42,43 exclusive_caps=0
-          sudo chmod 666 /dev/video42 /dev/video43
-          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video42 >/dev/null 2>&1 &
-          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video43 >/dev/null 2>&1 &
+          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=8,9 exclusive_caps=0
+          sudo chmod 666 /dev/video8 /dev/video9
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
+          nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
           sleep 3
 
       - name: Coverage incl. TPM-gated and camera tests (fail under the ratchet floor)
         env:
-          IRLUME_TEST_RGB_DEVICE: /dev/video42
-          IRLUME_TEST_IR_DEVICE: /dev/video43
+          IRLUME_TEST_RGB_DEVICE: /dev/video8
+          IRLUME_TEST_IR_DEVICE: /dev/video9
           # Loopback nodes have no physical bus; the exact-path escape lets
           # verify_pinned accept just these two (see THREAT_MODEL.md).
-          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video42,/dev/video43
+          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
         run: |
           cargo llvm-cov --no-report --workspace --locked
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,15 @@ jobs:
       # fake hardware, real code.
       - name: Start virtual cameras (v4l2loopback + ffmpeg feeders)
         run: |
-          sudo apt-get install -y --no-install-recommends v4l2loopback-dkms "linux-headers-$(uname -r)" ffmpeg
-          sudo modprobe v4l2loopback devices=2 video_nr=42,43 card_label="irlume-test-rgb,irlume-test-ir" exclusive_caps=0
+          # Ubuntu's packaged v4l2loopback (0.12.x) predates this runner
+          # kernel's V4L2 API and fails to load; build upstream at a pinned
+          # commit instead. videodev (its dependency) lives in modules-extra.
+          sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg
+          git clone https://github.com/umlaeute/v4l2loopback /tmp/v4l2loopback
+          git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
+          make -C /tmp/v4l2loopback -j"$(nproc)"
+          sudo modprobe videodev
+          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=42,43 exclusive_caps=0
           sudo chmod 666 /dev/video42 /dev/video43
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video42 >/dev/null 2>&1 &
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video43 >/dev/null 2>&1 &
@@ -223,8 +230,15 @@ jobs:
 
       - name: Start virtual cameras (v4l2loopback + ffmpeg feeders)
         run: |
-          sudo apt-get install -y --no-install-recommends v4l2loopback-dkms "linux-headers-$(uname -r)" ffmpeg
-          sudo modprobe v4l2loopback devices=2 video_nr=42,43 card_label="irlume-test-rgb,irlume-test-ir" exclusive_caps=0
+          # Ubuntu's packaged v4l2loopback (0.12.x) predates this runner
+          # kernel's V4L2 API and fails to load; build upstream at a pinned
+          # commit instead. videodev (its dependency) lives in modules-extra.
+          sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg
+          git clone https://github.com/umlaeute/v4l2loopback /tmp/v4l2loopback
+          git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
+          make -C /tmp/v4l2loopback -j"$(nproc)"
+          sudo modprobe videodev
+          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=42,43 exclusive_caps=0
           sudo chmod 666 /dev/video42 /dev/video43
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video42 >/dev/null 2>&1 &
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video43 >/dev/null 2>&1 &

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -3353,4 +3353,63 @@ mod engine_tests {
         }
         teardown_sandbox(&dir);
     }
+
+    /// Full `authenticate()` through the LIVE capture pipeline, against the
+    /// v4l2loopback feeder nodes CI provides: opens both devices, runs the
+    /// parallel RGB+IR capture, detection, and the deny mapping. The ffmpeg
+    /// test pattern holds no face, so the outcome must be a clean denial,
+    /// not an error, with a face-shaped reason. Env-gated like the camera
+    /// crate's loopback tests.
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_authenticate_denies_without_a_face() {
+        let (Ok(rgb), Ok(ir)) = (
+            std::env::var("IRLUME_TEST_RGB_DEVICE"),
+            std::env::var("IRLUME_TEST_IR_DEVICE"),
+        ) else {
+            return;
+        };
+        let _g = env_guard();
+        ort_init();
+        // Legacy one-shot: a single capture pass instead of a grace window,
+        // so a no-face run finishes in one camera round.
+        std::env::set_var("IRLUME_GRACE_MS", "0");
+        let dir = state_sandbox("loopback-auth");
+        write_enrollment(
+            &dir,
+            &Enrollment {
+                user: "lbuser".into(),
+                require_eyes_open: false,
+                require_challenge: false,
+                camera_binding: None,
+                profiles: vec![FaceProfile {
+                    ir_calib: None,
+                    name: "Face Profile 1".into(),
+                    scans: vec![scan512(1, false, None)],
+                }],
+            },
+        );
+
+        let mut e = Engine::load(
+            &model_path("face_detection_yunet_2023mar.onnx"),
+            &model_path("glintr100.onnx"),
+        )
+        .expect("engine load")
+        .with_devices(&rgb, &ir);
+
+        let out = e
+            .authenticate("lbuser", None)
+            .expect("a faceless frame is a denial, not a hardware error");
+        assert!(!out.granted, "no face on the feed must never grant");
+        assert!(!out.live);
+        let reason = out.reason.to_lowercase();
+        assert!(
+            reason.contains("face"),
+            "denial should name the missing face, got: {}",
+            out.reason
+        );
+
+        std::env::remove_var("IRLUME_GRACE_MS");
+        teardown_sandbox(&dir);
+    }
 }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1560,7 +1560,10 @@ mod tests {
         let (frame, stats) = capture_ir_with_stats(&ir).expect("ir capture");
         assert_eq!((frame.width, frame.height), (IR_W, IR_H));
         assert_eq!(frame.spectrum, Spectrum::Ir);
-        assert_eq!(frame.data.len(), (IR_W * IR_H) as usize);
+        // Drivers may hand back a buffer with trailing slack (v4l2loopback
+        // pads by 2 KiB); the contract is at-least-one-byte-per-pixel, and
+        // the consumers guard exactly that.
+        assert!(frame.data.len() >= (IR_W * IR_H) as usize);
         assert!(stats.burst_frames > 0, "burst must have captured frames");
         assert!(
             (0.0..=255.0).contains(&stats.lit_mean),
@@ -1571,20 +1574,30 @@ mod tests {
         let seq = capture_ir_sequence(&ir, 3, 2).expect("ir sequence");
         assert_eq!(seq.len(), 3);
         for f in &seq {
-            assert_eq!(f.data.len(), (IR_W * IR_H) as usize);
+            assert!(f.data.len() >= (IR_W * IR_H) as usize);
         }
     }
 
     #[test]
     #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
-    fn loopback_capabilities_sees_a_usable_rgb_node() {
-        let Some((_rgb, _ir)) = loopback_pair() else {
+    fn loopback_capabilities_classify_rgb_but_never_pair() {
+        // Only meaningful when the loopback nodes sit inside discover_nodes'
+        // /dev/video0..9 scan range (CI uses 8 and 9).
+        let Some((rgb, _ir)) = loopback_pair() else {
             return;
         };
+        if !(0..10).any(|n| rgb == format!("/dev/video{n}")) {
+            return;
+        }
         let caps = capabilities();
         assert!(
             caps.rgb,
-            "a YUYV-fed loopback node must classify as a usable RGB camera"
+            "a YUYV-fed loopback node classifies as a usable RGB camera"
+        );
+        assert!(
+            !caps.ir_pair,
+            "virtual nodes share no physical sysfs parent, so they must never \
+             form a Hello pair"
         );
     }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1489,4 +1489,87 @@ mod tests {
         assert_eq!(parse_pin_allowlist(""), None);
         assert_eq!(parse_pin_allowlist("  ,  "), None);
     }
+
+    // ---- v4l2loopback harness tests -----------------------------------
+    // Env-gated: CI loads v4l2loopback, feeds the nodes with ffmpeg test
+    // patterns (YUYV 640x480 / GREY 640x400), and exports the two vars.
+    // Without them the tests return immediately (and are #[ignore]d anyway).
+
+    fn loopback_pair() -> Option<(String, String)> {
+        Some((
+            std::env::var("IRLUME_TEST_RGB_DEVICE").ok()?,
+            std::env::var("IRLUME_TEST_IR_DEVICE").ok()?,
+        ))
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_rgb_burst_streams_and_converts() {
+        let Some((rgb, _)) = loopback_pair() else {
+            return;
+        };
+        let frames = capture_rgb_burst(&rgb, 3).expect("rgb burst");
+        assert_eq!(frames.len(), 3);
+        for f in &frames {
+            assert_eq!((f.width, f.height), (RGB_W, RGB_H));
+            assert_eq!(f.spectrum, Spectrum::Rgb);
+            assert_eq!(f.data.len(), (RGB_W * RGB_H * 3) as usize);
+            let (min, max) = f
+                .data
+                .iter()
+                .fold((u8::MAX, u8::MIN), |(lo, hi), &b| (lo.min(b), hi.max(b)));
+            assert!(max > min, "a test pattern must not convert to a flat frame");
+        }
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_rgb_single_and_denoised_agree_on_geometry() {
+        let Some((rgb, _)) = loopback_pair() else {
+            return;
+        };
+        let one = capture_rgb(&rgb).expect("single rgb");
+        let den = capture_rgb_denoised(&rgb).expect("denoised rgb");
+        for f in [&one, &den] {
+            assert_eq!((f.width, f.height), (RGB_W, RGB_H));
+            assert_eq!(f.data.len(), (RGB_W * RGB_H * 3) as usize);
+        }
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_ir_capture_with_stats_and_sequence() {
+        let Some((_, ir)) = loopback_pair() else {
+            return;
+        };
+        let (frame, stats) = capture_ir_with_stats(&ir).expect("ir capture");
+        assert_eq!((frame.width, frame.height), (IR_W, IR_H));
+        assert_eq!(frame.spectrum, Spectrum::Ir);
+        assert_eq!(frame.data.len(), (IR_W * IR_H) as usize);
+        assert!(stats.burst_frames > 0, "burst must have captured frames");
+        assert!(
+            (0.0..=255.0).contains(&stats.lit_mean),
+            "lit mean {} out of byte range",
+            stats.lit_mean
+        );
+
+        let seq = capture_ir_sequence(&ir, 3, 2).expect("ir sequence");
+        assert_eq!(seq.len(), 3);
+        for f in &seq {
+            assert_eq!(f.data.len(), (IR_W * IR_H) as usize);
+        }
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_capabilities_sees_a_usable_rgb_node() {
+        let Some((_rgb, _ir)) = loopback_pair() else {
+            return;
+        };
+        let caps = capabilities();
+        assert!(
+            caps.rgb,
+            "a YUYV-fed loopback node must classify as a usable RGB camera"
+        );
+    }
 }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -237,6 +237,21 @@ pub fn verify_pinned(device: &str) -> irlume_common::Result<()> {
     if !std::path::Path::new(device).exists() {
         return Err(Error::Hardware(format!("{device}: no camera found")));
     }
+    // TEST ESCAPE: a comma-separated allowlist of exact device paths that may
+    // bypass the physical-device pin. Exists only for the virtual-camera test
+    // harness (v4l2loopback nodes have no physical bus by definition). The
+    // daemon's environment is root-controlled via its systemd unit, so an
+    // unprivileged local user cannot set this for the auth path; every use is
+    // logged loudly. See docs/THREAT_MODEL.md (camera injection).
+    if let Ok(allow) = std::env::var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA") {
+        if allow.split(',').any(|d| d.trim() == device) {
+            eprintln!(
+                "irlume: WARNING: {device} accepted without a physical-device pin \
+                 (IRLUME_TEST_ALLOW_VIRTUAL_CAMERA)"
+            );
+            return Ok(());
+        }
+    }
     let node = device.strip_prefix("/dev/").unwrap_or(device);
     let link = format!("/sys/class/video4linux/{node}/device");
     let real = std::fs::canonicalize(&link).map_err(|_| {
@@ -1571,5 +1586,27 @@ mod tests {
             caps.rgb,
             "a YUYV-fed loopback node must classify as a usable RGB camera"
         );
+    }
+
+    #[test]
+    fn virtual_camera_escape_is_exact_path_only() {
+        // Distinct env vars from select_pair_env_override_wins, so no race.
+        // The escape must match the exact device path, nothing looser.
+        std::env::set_var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA", "/dev/null, /dev/zero");
+        assert!(
+            verify_pinned("/dev/null").is_ok(),
+            "an exactly-listed existing node passes the escape"
+        );
+        let err = verify_pinned("/dev/urandom").unwrap_err().to_string();
+        assert!(
+            err.contains("refusing"),
+            "an unlisted node must still hit the physical-device pin, got: {err}"
+        );
+        std::env::set_var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA", "/dev/nul");
+        assert!(
+            verify_pinned("/dev/null").is_err(),
+            "a prefix must not satisfy the exact-path escape"
+        );
+        std::env::remove_var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA");
     }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -179,6 +179,18 @@ IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo test -p irlume-core --lib -- 
   tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
 ```
 
+The camera-path tests (also `#[ignore]`) run against v4l2loopback virtual
+cameras fed by ffmpeg test patterns; CI does this too (Secure Boot hosts
+cannot load the unsigned module, which is why the gate is an env var):
+
+```sh
+sudo modprobe v4l2loopback devices=2 video_nr=42,43 exclusive_caps=0
+ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video42 &
+ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video43 &
+IRLUME_TEST_RGB_DEVICE=/dev/video42 IRLUME_TEST_IR_DEVICE=/dev/video43 \
+  cargo test -p irlume-camera -p irlume-auth -- --ignored loopback_ --test-threads=1
+```
+
 `IRLUME_TCTI` is the production TCTI override; the remaining ignored tests
 (durability, fault-injection, and the host-provisioned pcrlock roundtrip)
 are campaign tools that need a provisioned host and stay manual; the

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -61,7 +61,12 @@ requires cryptographic camera attestation, which is **out of scope for V1.0**.
 **Implemented:** `irlume-camera::verify_pinned`, called at the head of every
 `capture_rgb`/`capture_ir`. The physical-bus check is always on (no config);
 `IRLUME_CAMERA_PIN="vid:pid"` and `IRLUME_CAMERA_REQUIRE_FIXED=1` add descriptor
-and removability pinning per host.
+and removability pinning per host. One deliberate exception exists for the CI
+test harness: `IRLUME_TEST_ALLOW_VIRTUAL_CAMERA` names exact device paths
+(v4l2loopback nodes) that may skip the physical-bus check, and every use is
+logged. It weakens nothing in production: the daemon's environment comes from
+its root-owned systemd unit, so setting it requires the same root the pin does
+not defend against, and a unit test pins the escape to exact-path matches.
 
 ## Liveness: algorithmic single-frame gate (no trained weights)
 


### PR DESCRIPTION
Third fake-hardware harness after swtpm and the provisioned pcrlock NV: v4l2loopback + ffmpeg feeders exercise the real V4L2 capture paths (RGB burst/single/denoised, IR stats + sequence, capability classification) and a full authenticate() through live capture to an honest no-face denial. Env-gated (IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE); CI provides the nodes. Ratchet unchanged this PR until CI reports the new coverage number.
