### PR TITLE
test: coverage round 2 (daemon, PAM FFI, CLI capture, camera)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
         run: |
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo test -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
+          IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo test -p irlume-daemon --locked -- --ignored tpm_ --test-threads=1
 
       # Virtual cameras: v4l2loopback provides the V4L2 nodes, ffmpeg feeds
       # test patterns in the exact formats the capture paths negotiate
@@ -113,26 +114,35 @@ jobs:
           # Ubuntu's packaged v4l2loopback (0.12.x) predates this runner
           # kernel's V4L2 API and fails to load; build upstream at a pinned
           # commit instead. videodev (its dependency) lives in modules-extra.
-          sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg
+          # v4l2loopback (built from a pinned upstream commit because Ubuntu's
+          # 0.12.x won't load on the runner kernel) plus pam_wrapper/pamtester
+          # for the PAM FFI tests. video8/9 are fed by ffmpeg; video10 is a
+          # spare the camera streaming tests feed themselves.
+          sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg libpam-wrapper pamtester
           git clone https://github.com/umlaeute/v4l2loopback /tmp/v4l2loopback
           git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
-          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=8,9 exclusive_caps=0
-          sudo chmod 666 /dev/video8 /dev/video9
+          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=3 video_nr=8,9,10 exclusive_caps=0
+          sudo chmod 666 /dev/video8 /dev/video9 /dev/video10
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
           sleep 3
 
-      - name: test (camera paths, against v4l2loopback)
+      - name: test (camera + capture paths, against v4l2loopback)
         env:
           IRLUME_TEST_RGB_DEVICE: /dev/video8
           IRLUME_TEST_IR_DEVICE: /dev/video9
+          IRLUME_TEST_SPARE_DEVICE: /dev/video10
           # Loopback nodes have no physical bus; the exact-path escape lets
-          # verify_pinned accept just these two (see THREAT_MODEL.md).
+          # verify_pinned accept just these (see THREAT_MODEL.md).
           IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
         run: |
-          cargo test -p irlume-camera -p irlume-auth --locked -- --ignored loopback_ --test-threads=1
+          cargo test -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
+          cargo test -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
+
+      - name: test (PAM FFI, against pam_wrapper)
+        run: cargo test -p irlume-pam --locked -- --include-ignored --test-threads=1
 
   # Build + test on current stable, because that is what the packaging lanes
   # and most from-source users compile with. fmt/clippy stay on the MSRV job
@@ -236,13 +246,17 @@ jobs:
           # Ubuntu's packaged v4l2loopback (0.12.x) predates this runner
           # kernel's V4L2 API and fails to load; build upstream at a pinned
           # commit instead. videodev (its dependency) lives in modules-extra.
-          sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg
+          # v4l2loopback (built from a pinned upstream commit because Ubuntu's
+          # 0.12.x won't load on the runner kernel) plus pam_wrapper/pamtester
+          # for the PAM FFI tests. video8/9 are fed by ffmpeg; video10 is a
+          # spare the camera streaming tests feed themselves.
+          sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg libpam-wrapper pamtester
           git clone https://github.com/umlaeute/v4l2loopback /tmp/v4l2loopback
           git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
-          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=2 video_nr=8,9 exclusive_caps=0
-          sudo chmod 666 /dev/video8 /dev/video9
+          sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=3 video_nr=8,9,10 exclusive_caps=0
+          sudo chmod 666 /dev/video8 /dev/video9 /dev/video10
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
           sleep 3
@@ -251,14 +265,18 @@ jobs:
         env:
           IRLUME_TEST_RGB_DEVICE: /dev/video8
           IRLUME_TEST_IR_DEVICE: /dev/video9
+          IRLUME_TEST_SPARE_DEVICE: /dev/video10
           # Loopback nodes have no physical bus; the exact-path escape lets
-          # verify_pinned accept just these two (see THREAT_MODEL.md).
+          # verify_pinned accept just these (see THREAT_MODEL.md).
           IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
         run: |
           cargo llvm-cov --no-report --workspace --locked
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
-          cargo llvm-cov --no-report -p irlume-camera -p irlume-auth --locked -- --ignored loopback_ --test-threads=1
+          IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-daemon --locked -- --ignored tpm_ --test-threads=1
+          cargo llvm-cov --no-report -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
+          cargo llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
+          cargo llvm-cov --no-report -p irlume-pam --locked -- --include-ignored --test-threads=1
           cargo llvm-cov report --summary-only --fail-under-lines 69
 
   deny:

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1470,14 +1470,13 @@ mod tests {
     fn select_pair_env_override_wins() {
         // The explicit env pair short-circuits discovery entirely (no device
         // scan), so this is deterministic on any machine.
-        std::env::set_var("IRLUME_RGB_DEVICE", "/dev/irlume-test-rgb");
-        std::env::set_var("IRLUME_IR_DEVICE", "/dev/irlume-test-ir");
+        let _lock = env_lock();
+        let _r = EnvGuard::set("IRLUME_RGB_DEVICE", "/dev/irlume-test-rgb");
+        let _i = EnvGuard::set("IRLUME_IR_DEVICE", "/dev/irlume-test-ir");
         assert_eq!(
             select_pair(),
             ("/dev/irlume-test-rgb".into(), "/dev/irlume-test-ir".into())
         );
-        std::env::remove_var("IRLUME_RGB_DEVICE");
-        std::env::remove_var("IRLUME_IR_DEVICE");
     }
 
     #[test]
@@ -1509,12 +1508,120 @@ mod tests {
     // Env-gated: CI loads v4l2loopback, feeds the nodes with ffmpeg test
     // patterns (YUYV 640x480 / GREY 640x400), and exports the two vars.
     // Without them the tests return immediately (and are #[ignore]d anyway).
+    // A THIRD node, IRLUME_TEST_SPARE_DEVICE, has NO CI-side feeder: tests
+    // that need a specific pattern (static for the frozen-stream detector,
+    // alternating for strobe pairing) spawn their own ffmpeg against it and
+    // kill the child on drop. Spare-node tests own that node exclusively;
+    // CI runs the gated suite with --test-threads=1.
 
     fn loopback_pair() -> Option<(String, String)> {
         Some((
             std::env::var("IRLUME_TEST_RGB_DEVICE").ok()?,
             std::env::var("IRLUME_TEST_IR_DEVICE").ok()?,
         ))
+    }
+
+    fn spare_device() -> Option<String> {
+        std::env::var("IRLUME_TEST_SPARE_DEVICE").ok()
+    }
+
+    /// Serializes tests that mutate process-global env vars (cargo runs tests
+    /// on threads, and setters would otherwise race readers in other tests).
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// RAII env-var override: restores the previous value (or absence) on
+    /// drop, so a panicking assertion cannot leak state into later tests.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, val: &str) -> Self {
+            let prev = std::env::var_os(key);
+            std::env::set_var(key, val);
+            Self { key, prev }
+        }
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    /// Extend the exact-path virtual-camera escape with `device` for the
+    /// test's lifetime (`verify_pinned` refuses loopback nodes otherwise),
+    /// preserving whatever allowlist the harness already exported. Caller
+    /// must hold `env_lock`.
+    fn allow_virtual(device: &str) -> EnvGuard {
+        const KEY: &str = "IRLUME_TEST_ALLOW_VIRTUAL_CAMERA";
+        let val = match std::env::var(KEY) {
+            Ok(p) if !p.trim().is_empty() => format!("{p},{device}"),
+            _ => device.to_string(),
+        };
+        EnvGuard::set(KEY, &val)
+    }
+
+    /// A self-managed ffmpeg feed into the spare loopback node. Killed and
+    /// reaped on drop, so even a panicking test never leaks a feeder into the
+    /// next spare-node scenario.
+    struct FfmpegFeeder(std::process::Child);
+
+    impl FfmpegFeeder {
+        /// Feed `device` GREY frames from a lavfi source description (the IR
+        /// node format). ffmpeg exists wherever the loopback env is set (a
+        /// harness guarantee; the CI-fed nodes use the same binary).
+        fn spawn(device: &str, lavfi: &str) -> Self {
+            let child = std::process::Command::new("ffmpeg")
+                .args([
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-re",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    lavfi,
+                    "-pix_fmt",
+                    "gray",
+                    "-f",
+                    "v4l2",
+                    device,
+                ])
+                .stdin(std::process::Stdio::null())
+                .spawn()
+                .expect("spawn ffmpeg feeder");
+            let mut feeder = FfmpegFeeder(child);
+            // Let it attach to the node, and fail loudly if it exited (bad
+            // filter graph / device): a capture against an unfed loopback
+            // node blocks indefinitely, which would present as a test hang.
+            for _ in 0..20 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                if let Some(status) = feeder.0.try_wait().expect("poll feeder") {
+                    panic!("ffmpeg feeder exited early ({status}); lavfi source: {lavfi}");
+                }
+            }
+            feeder
+        }
+    }
+
+    impl Drop for FfmpegFeeder {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
     }
 
     #[test]
@@ -1603,9 +1710,9 @@ mod tests {
 
     #[test]
     fn virtual_camera_escape_is_exact_path_only() {
-        // Distinct env vars from select_pair_env_override_wins, so no race.
         // The escape must match the exact device path, nothing looser.
-        std::env::set_var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA", "/dev/null, /dev/zero");
+        let _lock = env_lock();
+        let _esc = EnvGuard::set("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA", "/dev/null, /dev/zero");
         assert!(
             verify_pinned("/dev/null").is_ok(),
             "an exactly-listed existing node passes the escape"
@@ -1620,6 +1727,295 @@ mod tests {
             verify_pinned("/dev/null").is_err(),
             "a prefix must not satisfy the exact-path escape"
         );
-        std::env::remove_var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA");
+    }
+
+    #[test]
+    fn select_pair_persisted_conf_and_discovery_fallback() {
+        let _lock = env_lock();
+        let _rgb_env = EnvGuard::unset("IRLUME_RGB_DEVICE");
+        let _ir_env = EnvGuard::unset("IRLUME_IR_DEVICE");
+        let dir = std::env::temp_dir().join(format!("irlume-selpair-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _conf = EnvGuard::set("IRLUME_CONFIG_DIR", dir.to_str().unwrap());
+
+        // With no env override, no persisted pair and no discoverable Hello
+        // pair, the compiled defaults come back. Loopback nodes can never form
+        // a pair (no USB descriptors in sysfs), so this holds on CI; a dev box
+        // with a real Hello camera legitimately discovers its own pair
+        // instead, so the fallback asserts are skipped there.
+        if list_pairs().is_empty() {
+            assert_eq!(
+                select_pair(),
+                (
+                    DEFAULT_RGB_DEVICE.to_string(),
+                    DEFAULT_IR_DEVICE.to_string()
+                )
+            );
+        }
+
+        // A persisted pair whose nodes are GONE (stale cameras.conf after a
+        // USB re-shuffle) is ignored rather than trusted.
+        std::fs::write(
+            dir.join("cameras.conf"),
+            "rgb=/dev/irlume-gone0\nir=/dev/irlume-gone1\n",
+        )
+        .unwrap();
+        if list_pairs().is_empty() {
+            assert_eq!(
+                select_pair(),
+                (
+                    DEFAULT_RGB_DEVICE.to_string(),
+                    DEFAULT_IR_DEVICE.to_string()
+                )
+            );
+        }
+
+        // A persisted pair whose nodes EXIST wins over discovery and defaults.
+        // /dev/null and /dev/zero exist everywhere; select_pair checks only
+        // existence here (classification happened when the pair was written).
+        std::fs::write(dir.join("cameras.conf"), "rgb=/dev/null\nir=/dev/zero\n").unwrap();
+        assert_eq!(
+            select_pair(),
+            ("/dev/null".to_string(), "/dev/zero".to_string())
+        );
+
+        // A blank env override must not shadow the persisted pair...
+        {
+            let _r = EnvGuard::set("IRLUME_RGB_DEVICE", "");
+            let _i = EnvGuard::set("IRLUME_IR_DEVICE", "  ");
+            assert_eq!(
+                select_pair(),
+                ("/dev/null".to_string(), "/dev/zero".to_string())
+            );
+        }
+        // ...but a real one beats it, without an existence check (explicit
+        // operator intent).
+        let _r = EnvGuard::set("IRLUME_RGB_DEVICE", "/dev/irlume-env-rgb");
+        let _i = EnvGuard::set("IRLUME_IR_DEVICE", "/dev/irlume-env-ir");
+        assert_eq!(
+            select_pair(),
+            (
+                "/dev/irlume-env-rgb".to_string(),
+                "/dev/irlume-env-ir".to_string()
+            )
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_raw_bursts_report_shape_and_monotonic_timing() {
+        let Some((_, ir)) = loopback_pair() else {
+            return;
+        };
+        let timed = ir_probe::capture_raw_burst_timed(&ir, 5).expect("timed burst");
+        assert_eq!(timed.len(), 5);
+        let mut prev = -1.0f64;
+        for (f, ms) in &timed {
+            assert_eq!((f.width, f.height), (IR_W, IR_H));
+            assert_eq!(f.spectrum, Spectrum::Ir);
+            assert!(f.data.len() >= (IR_W * IR_H) as usize);
+            assert!(ms.is_finite() && *ms >= 0.0, "bad timestamp {ms}");
+            assert!(
+                *ms >= prev,
+                "timestamps must be monotonic: {ms} after {prev}"
+            );
+            prev = *ms;
+        }
+        // Five distinct frames from a paced live feed cannot all be dequeued
+        // at one instant: the window must have real width.
+        assert!(
+            timed.last().unwrap().1 > timed.first().unwrap().1,
+            "a live feed must spread dequeues over time"
+        );
+
+        // The untimed variant is the same capture minus the timing column.
+        let frames = ir_probe::capture_raw_burst(&ir, 3).expect("raw burst");
+        assert_eq!(frames.len(), 3);
+        for f in &frames {
+            assert_eq!((f.width, f.height), (IR_W, IR_H));
+            assert_eq!(f.spectrum, Spectrum::Ir);
+            assert!(f.data.len() >= (IR_W * IR_H) as usize);
+        }
+        // n = 0 is a valid degenerate request: open, arm, deliver nothing.
+        assert!(ir_probe::capture_raw_burst(&ir, 0)
+            .expect("empty burst")
+            .is_empty());
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_ir_stats_flag_off_returns_the_raw_brightest_frame() {
+        let _lock = env_lock();
+        let Some((_, ir)) = loopback_pair() else {
+            return;
+        };
+        let _sub = EnvGuard::unset("IRLUME_IR_AMBIENT_SUBTRACT");
+        let (frame, stats) = capture_ir_with_stats(&ir).expect("ir capture");
+        // Stats contract: per-frame mean extremes over the fixed-size burst,
+        // byte-ranged, min <= max. None of it depends on an emitter: a
+        // loopback node has no UVC extension unit, so ir_emitter::enable finds
+        // no control and returns false, and the burst statistics are computed
+        // regardless.
+        assert_eq!(stats.burst_frames, IR_BURST);
+        assert!(stats.ambient_mean >= 0.0 && stats.lit_mean <= 255.0);
+        assert!(
+            stats.ambient_mean <= stats.lit_mean,
+            "ambient (burst min {}) must not exceed lit (burst max {})",
+            stats.ambient_mean,
+            stats.lit_mean
+        );
+        // With the subtraction flag unset, the ambient-pairing block is dead
+        // code and the returned frame IS the brightest raw burst frame: its
+        // recomputed mean equals lit_mean (only f32 rounding apart). A
+        // refactor that subtracts by default, or picks any frame other than
+        // the max-mean one, breaks this.
+        let mean = ir_probe::mean(&frame.data);
+        assert!(
+            (mean - stats.lit_mean as f64).abs() < 0.01,
+            "returned frame mean {mean:.3} != lit_mean {}",
+            stats.lit_mean
+        );
+    }
+
+    #[test]
+    #[ignore = "needs an unfed v4l2loopback node; set IRLUME_TEST_SPARE_DEVICE (CI does this)"]
+    fn loopback_frozen_static_feed_starves_the_sequence_window() {
+        // A bit-identical feed simulates the stalled-sensor failure the
+        // detector was built for (streams observed locking to a constant
+        // mid-grey). Expected arithmetic, from capture_ir_sequence: the first
+        // frame is accepted (no previous signature), every repeat is frozen,
+        // two frozen frames trigger a stream restart (budget 4), and each
+        // restart clears last_sig so exactly one more frame is accepted. A
+        // 6-sample window on a fully static feed therefore returns Ok with
+        // exactly 1 + 4 = 5 frames: a SHORT window, never an error.
+        let _lock = env_lock();
+        let Some(spare) = spare_device() else {
+            return;
+        };
+        let _sub = EnvGuard::unset("IRLUME_IR_AMBIENT_SUBTRACT");
+        let _esc = allow_virtual(&spare);
+        let _feeder = FfmpegFeeder::spawn(&spare, "color=c=gray:size=640x400:rate=15");
+
+        // The single-shot path has no frozen gate: a static feed still yields
+        // a frame (this also blocks until the feeder's frames actually flow).
+        let (frame, _) = capture_ir_with_stats(&spare).expect("static feed single capture");
+        let mean = ir_probe::mean(&frame.data);
+        assert!(
+            (10.0..245.0).contains(&mean),
+            "harness: the static gray feed must sit inside the frozen \
+             detector's normal-exposure band, got mean {mean:.1}"
+        );
+
+        let seq = capture_ir_sequence(&spare, 6, 1).expect("sequence returns Ok, not Err");
+        assert_eq!(
+            seq.len(),
+            5,
+            "static feed: 1 initial accept + 1 per stream restart (budget 4)"
+        );
+        for f in &seq {
+            assert_eq!((f.width, f.height), (IR_W, IR_H));
+            assert_eq!(f.spectrum, Spectrum::Ir);
+        }
+    }
+
+    #[test]
+    #[ignore = "needs an unfed v4l2loopback node; set IRLUME_TEST_SPARE_DEVICE (CI does this)"]
+    fn loopback_ambient_subtract_pairs_strobe_frames() {
+        // Simulated strobing emitter: frames alternate dark/lit (luma 40/200
+        // before any range conversion), the exact lit/off adjacency the opt-in
+        // ambient subtraction pairs up.
+        let _lock = env_lock();
+        let Some(spare) = spare_device() else {
+            return;
+        };
+        let _esc = allow_virtual(&spare);
+        let _sub = EnvGuard::set("IRLUME_IR_AMBIENT_SUBTRACT", "1");
+        let _feeder = FfmpegFeeder::spawn(
+            &spare,
+            "color=c=black:size=640x400:rate=15,geq=lum='40+160*mod(N,2)'",
+        );
+        let (frame, stats) = capture_ir_with_stats(&spare).expect("strobed capture");
+        // Harness sanity, asserted so a drifting feed fails loudly instead of
+        // silently testing the wrong branch: the alternation must present a
+        // real strobe gap above the low-ambient floor.
+        let (lit, amb) = (stats.lit_mean as f64, stats.ambient_mean as f64);
+        assert!(
+            lit - amb > STROBE_MIN_GAP,
+            "harness: strobe gap {:.1} too small to reach the subtract branch",
+            lit - amb
+        );
+        assert!(
+            amb >= LOW_AMBIENT_SKIP,
+            "harness: ambient {amb:.1} under the skip floor"
+        );
+        // Contract: the returned frame is lit-minus-ambient, not the raw lit
+        // frame. The synthetic frames are uniform, so the subtracted mean
+        // equals lit_mean - ambient_mean (driver padding bytes are constant
+        // and cancel; no pixel clamps because lit > ambient everywhere).
+        let mean = ir_probe::mean(&frame.data);
+        assert!(
+            (mean - (lit - amb)).abs() < 2.0,
+            "subtracted frame mean {mean:.1} != lit-ambient {:.1}",
+            lit - amb
+        );
+        assert!(
+            mean < lit - STROBE_MIN_GAP,
+            "frame mean {mean:.1} still at the raw lit level {lit:.1}; subtraction was not applied"
+        );
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_busy_error_names_a_holding_process() {
+        let Some((_, ir)) = loopback_pair() else {
+            return;
+        };
+        // Hold the node open ourselves so /proc provably contains at least one
+        // holder this uid can see (the CI feeder also holds it; whichever the
+        // scan finds first is fine). Read-only open, no streaming: nothing on
+        // /dev/video0..9 is touched.
+        let _held = std::fs::File::open(&ir).expect("open the fed IR node read-only");
+        let msg = map_io(&ir, std::io::Error::from_raw_os_error(16)).to_string();
+        assert!(msg.contains("camera busy"), "{msg}");
+        assert!(
+            msg.contains("in use by"),
+            "expected the named-holder arm, got: {msg}"
+        );
+        assert!(msg.contains("pid "), "holder must carry a pid: {msg}");
+        assert!(
+            !msg.contains("another app is using it"),
+            "anonymous fallback used despite a live holder: {msg}"
+        );
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_nodes_classify_by_fed_format_with_no_identity_or_privacy() {
+        let Some((rgb, ir)) = loopback_pair() else {
+            return;
+        };
+        // Classification keys purely on the advertised FourCC: the YUYV-fed
+        // node is an RGB camera, the GREY-fed node its IR companion.
+        assert_eq!(classify(&rgb), Role::Rgb);
+        assert_eq!(classify(&ir), Role::Ir);
+        // Loopback nodes expose no V4L2_CID_PRIVACY control; the shutter check
+        // degrades to "not engaged" instead of blocking capture.
+        assert!(!privacy_engaged(&rgb));
+        assert!(!privacy_engaged(&ir));
+        // No USB descriptors anywhere up the sysfs chain: no stable identity
+        // to bind an enrollment to.
+        assert_eq!(device_identity(&rgb), None);
+        assert_eq!(device_identity(&ir), None);
+        // And WITHOUT the exact-path escape, the anti-injection pin refuses a
+        // virtual node outright: the very attack the escape documents.
+        let _lock = env_lock();
+        let _esc = EnvGuard::unset("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA");
+        let err = verify_pinned(&ir).unwrap_err().to_string();
+        assert!(
+            err.contains("refusing"),
+            "virtual node must be refused: {err}"
+        );
     }
 }

--- a/crates/irlume-cli/tests/cli_capture.rs
+++ b/crates/irlume-cli/tests/cli_capture.rs
@@ -1,0 +1,560 @@
+//! Black-box tests of the IRLUME_DEV camera/benchmark subcommands (`capture`,
+//! `liveness`, `meshprobe`, `calcapture`, `padcapture`, `genuine`, `suncal`)
+//! against the v4l2loopback virtual-camera harness CI provides.
+//!
+//! The feeder nodes carry ffmpeg test patterns (YUYV 640x480 RGB, GREY 640x400
+//! IR) with NO face in frame, so every test asserts the tools' documented
+//! no-face behavior: the running path past argument parsing, through the real
+//! capture + detection pipeline, to the exact output strings and exit codes.
+//!
+//! Gating follows the camera crate's convention: `loopback_`-prefixed names,
+//! `#[ignore]`, and an early return when the env is absent. CI runs them with
+//! `-- --ignored loopback_ --test-threads=1` and sets:
+//!   IRLUME_TEST_RGB_DEVICE / IRLUME_TEST_IR_DEVICE  (the feeder nodes)
+//! The spawned binary additionally needs IRLUME_TEST_ALLOW_VIRTUAL_CAMERA
+//! naming those exact paths (loopback nodes have no physical bus, so
+//! `verify_pinned` would refuse them); each test sets it itself.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_irlume");
+
+/// Hard ceiling per spawned process: a hung camera read must fail the test,
+/// never wedge CI.
+const WATCHDOG_SECS: u64 = 60;
+
+fn model(name: &str) -> String {
+    format!("{}/../../models/{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The feeder nodes, or None (skip) when the harness is not up.
+fn loopback_pair() -> Option<(String, String)> {
+    Some((
+        std::env::var("IRLUME_TEST_RGB_DEVICE").ok()?,
+        std::env::var("IRLUME_TEST_IR_DEVICE").ok()?,
+    ))
+}
+
+/// `ORT_DYLIB_PATH` for the child: the parent's value when set (CI exports
+/// one), else the packaged/system locations irlume-auth's ort_init probes.
+fn ort_dylib() -> Option<String> {
+    if let Ok(p) = std::env::var("ORT_DYLIB_PATH") {
+        return Some(p);
+    }
+    [
+        "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+        "/usr/lib64/libonnxruntime.so",
+        "/usr/lib/libonnxruntime.so",
+        "/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
+    ]
+    .into_iter()
+    .find(|p| std::path::Path::new(p).exists())
+    .map(String::from)
+}
+
+/// Per-test temp tree (state/config/keyring/work); deleted on drop.
+struct Sandbox {
+    root: PathBuf,
+}
+
+impl Sandbox {
+    fn new(tag: &str) -> Self {
+        let root =
+            std::env::temp_dir().join(format!("irlume-cli-cap-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        for d in ["cfg", "state", "keyring", "work"] {
+            std::fs::create_dir_all(root.join(d)).unwrap();
+        }
+        Sandbox { root }
+    }
+
+    fn path(&self, rel: &str) -> PathBuf {
+        self.root.join(rel)
+    }
+
+    /// A Command for the irlume binary with IRLUME_DEV=1, the virtual-camera
+    /// escape for exactly the two feeder nodes, and every writable path inside
+    /// the sandbox. cwd is a scratch dir so any stray output file lands there.
+    fn dev_cmd(&self, args: &[&str], rgb: &str, ir: &str) -> Command {
+        let mut c = Command::new(BIN);
+        c.args(args)
+            .env("IRLUME_DEV", "1")
+            .env("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA", format!("{rgb},{ir}"))
+            .env("IRLUME_SOCKET", self.root.join("no-daemon.sock"))
+            .env("IRLUME_CONFIG_DIR", self.root.join("cfg"))
+            .env("IRLUME_STATE_DIR", self.root.join("state"))
+            .env("IRLUME_KEYRING_DIR", self.root.join("keyring"))
+            .env_remove("IRLUME_MODEL")
+            .env_remove("IRLUME_DET_MODEL")
+            .env_remove("IRLUME_CAMERA_PIN")
+            .current_dir(self.root.join("work"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(ort) = ort_dylib() {
+            c.env("ORT_DYLIB_PATH", ort);
+        }
+        c
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+/// Run under the watchdog and collect (exit code, stdout, stderr). A process
+/// still alive at the deadline is SIGKILLed and the test fails with a message
+/// naming the command, so a hung capture can never wedge CI.
+fn run_timeboxed(what: &str, cmd: &mut Command) -> (i32, String, String) {
+    let child = cmd.spawn().unwrap_or_else(|e| panic!("spawn {what}: {e}"));
+    let pid = child.id() as i32;
+    let done = Arc::new(AtomicBool::new(false));
+    let timed_out = Arc::new(AtomicBool::new(false));
+    let watchdog = {
+        let (done, timed_out) = (done.clone(), timed_out.clone());
+        std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(WATCHDOG_SECS);
+            while Instant::now() < deadline {
+                if done.load(Ordering::SeqCst) {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+            if !done.load(Ordering::SeqCst) {
+                timed_out.store(true, Ordering::SeqCst);
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+            }
+        })
+    };
+    let out = child
+        .wait_with_output()
+        .unwrap_or_else(|e| panic!("wait {what}: {e}"));
+    done.store(true, Ordering::SeqCst);
+    watchdog.join().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        !timed_out.load(Ordering::SeqCst),
+        "`irlume {what}` exceeded the {WATCHDOG_SECS}s watchdog and was killed.\n\
+         stdout so far:\n{stdout}\nstderr so far:\n{stderr}"
+    );
+    let code = out.status.code().unwrap_or_else(|| {
+        panic!("`irlume {what}` exited by signal.\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    (code, stdout, stderr)
+}
+
+// -------------------------------------------------------------------- capture
+
+#[test]
+#[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+fn loopback_capture_runs_detection_and_reports_no_face() {
+    let Some((rgb, ir)) = loopback_pair() else {
+        return;
+    };
+    let sb = Sandbox::new("capture");
+    let det = model("face_detection_yunet_2023mar.onnx");
+    let rec = model("glintr100.onnx");
+    let (code, out, err) = run_timeboxed(
+        "capture",
+        &mut sb.dev_cmd(
+            &["capture", "--det", &det, "--model", &rec, "--device", &rgb],
+            &rgb,
+            &ir,
+        ),
+    );
+    assert_eq!(
+        code, 0,
+        "no face is a clean outcome, not an error\n{out}\n{err}"
+    );
+    assert!(
+        out.contains(&format!("640x480 RGB frame from {rgb}")),
+        "must capture a live frame from the loopback node: {out}"
+    );
+    assert!(out.contains("[detect]"), "detection stage must run: {out}");
+    assert!(
+        out.contains("no face in frame; sit in view and re-run."),
+        "the test pattern holds no face: {out}"
+    );
+    assert!(
+        !out.contains("[embed]"),
+        "without a face the embed stage must never run: {out}"
+    );
+    // The exact-path escape is deliberately loud: verify_pinned logs each use.
+    assert!(
+        err.contains("accepted without a physical-device pin"),
+        "the virtual-camera escape must warn on stderr: {err}"
+    );
+}
+
+// ------------------------------------------------------------------- liveness
+
+#[test]
+#[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+fn loopback_liveness_probe_gates_a_faceless_feed_as_not_live() {
+    let Some((rgb, ir)) = loopback_pair() else {
+        return;
+    };
+    let sb = Sandbox::new("liveness");
+    let det = model("face_detection_yunet_2023mar.onnx");
+    let (code, out, err) = run_timeboxed(
+        "liveness",
+        &mut sb.dev_cmd(
+            &["liveness", "--det", &det, "--rgb", &rgb, "--ir", &ir],
+            &rgb,
+            &ir,
+        ),
+    );
+    assert_eq!(code, 0, "a no-face probe completes cleanly\n{out}\n{err}");
+    assert!(
+        out.contains("[RGB] 640x480"),
+        "RGB stage must report the loopback geometry: {out}"
+    );
+    assert!(
+        out.contains("[IR ] 640x400"),
+        "IR stage must report the loopback geometry: {out}"
+    );
+    assert!(
+        out.contains("brightness mean"),
+        "IR stats line must print: {out}"
+    );
+    // The gate's first hard cue is face presence; a faceless feed must fail it
+    // and the verdict line names the missing face.
+    assert!(
+        out.contains("[GATE]") && out.contains("no face in"),
+        "verdict must be the no-face refusal: {out}"
+    );
+    assert!(
+        !out.contains("[GATE] Live"),
+        "a faceless feed must never gate Live: {out}"
+    );
+}
+
+// ------------------------------------------------------------------ meshprobe
+
+#[test]
+#[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+fn loopback_meshprobe_reports_spoof_when_no_eyes_are_found() {
+    let Some((rgb, ir)) = loopback_pair() else {
+        return;
+    };
+    let sb = Sandbox::new("meshprobe");
+    let det = model("face_detection_yunet_2023mar.onnx");
+    let mesh = model("face_landmark.onnx");
+    let (code, out, err) = run_timeboxed(
+        "meshprobe",
+        &mut sb.dev_cmd(
+            &[
+                "meshprobe",
+                "--det",
+                &det,
+                "--mesh",
+                &mesh,
+                "--ir",
+                &ir,
+                "--n",
+                "2",
+                "--burst",
+                "1",
+                "--reps",
+                "1",
+            ],
+            &rgb,
+            &ir,
+        ),
+    );
+    assert_eq!(code, 0, "a faceless run completes cleanly\n{out}\n{err}");
+    // No face in any IR frame means zero EAR samples; detect_blink maps that
+    // to NoEyes, which meshprobe prints as the Spoof verdict.
+    assert!(
+        out.contains("[rep  1/1]"),
+        "the single rep must report: {out}"
+    );
+    assert!(
+        out.contains("(n=0)"),
+        "no EAR samples on a faceless feed: {out}"
+    );
+    assert!(
+        out.contains("-> Spoof"),
+        "NoEyes maps to the Spoof verdict: {out}"
+    );
+    assert!(
+        !out.contains("[meshprobe] appended"),
+        "without --species/--kind/--out nothing is recorded: {out}"
+    );
+}
+
+// ----------------------------------------------------------------- calcapture
+
+#[test]
+#[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+fn loopback_calcapture_writes_header_and_faceless_samples() {
+    let Some((rgb, ir)) = loopback_pair() else {
+        return;
+    };
+    let sb = Sandbox::new("calcapture");
+    let det = model("face_detection_yunet_2023mar.onnx");
+    let rec = model("glintr100.onnx");
+    let out_path = sb.path("work/cal.jsonl");
+    let out_str = out_path.to_str().unwrap().to_string();
+    let (code, out, err) = run_timeboxed(
+        "calcapture",
+        &mut sb.dev_cmd(
+            &[
+                "calcapture",
+                "--user",
+                "u",
+                "--det",
+                &det,
+                "--model",
+                &rec,
+                "--out",
+                &out_str,
+                "--rgb",
+                &rgb,
+                "--ir",
+                &ir,
+                "--n",
+                "2",
+            ],
+            &rgb,
+            &ir,
+        ),
+    );
+    assert_eq!(code, 0, "\n{out}\n{err}");
+    assert!(
+        out.contains("[calcapture] user=u tag=untagged n=2"),
+        "run parameters echo: {out}"
+    );
+    assert!(
+        out.contains("rgb_templates=0 ir_templates=0 adapter=no"),
+        "sandboxed state dir has no enrollment: {out}"
+    );
+    assert!(
+        err.contains("cosines from pairwise only"),
+        "unenrolled user is a note, not a failure: {err}"
+    );
+    assert!(
+        out.contains(&format!("wrote 2 samples to {out_str}")),
+        "every requested sample is written even with no face: {out}"
+    );
+
+    let text = std::fs::read_to_string(&out_path).expect("cal.jsonl written");
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 3, "1 session header + 2 samples, got:\n{text}");
+    let hdr: serde_json::Value = serde_json::from_str(lines[0]).expect("header parses");
+    assert_eq!(hdr["session"], serde_json::json!(true));
+    assert_eq!(hdr["user"], serde_json::json!("u"));
+    assert_eq!(hdr["n"], serde_json::json!(2));
+    for (i, l) in lines[1..].iter().enumerate() {
+        let rec: serde_json::Value = serde_json::from_str(l).expect("sample parses");
+        assert_eq!(rec["idx"], serde_json::json!(i));
+        assert_eq!(
+            rec["rgb_present"],
+            serde_json::json!(false),
+            "test pattern holds no RGB face: {l}"
+        );
+        assert_eq!(
+            rec["ir_present"],
+            serde_json::json!(false),
+            "test pattern holds no IR face: {l}"
+        );
+        assert!(
+            rec.get("rgb_emb").is_none() && rec.get("ir_emb_raw").is_none(),
+            "no face means no embeddings in the record: {l}"
+        );
+    }
+}
+
+// ----------------------------------------------------------------- padcapture
+
+#[test]
+#[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+fn loopback_padcapture_ir_only_records_faceless_attack_presentations() {
+    let Some((rgb, ir)) = loopback_pair() else {
+        return;
+    };
+    let sb = Sandbox::new("padcapture");
+    let det = model("face_detection_yunet_2023mar.onnx");
+    let out_path = sb.path("work/pad.jsonl");
+    let out_str = out_path.to_str().unwrap().to_string();
+    let (code, out, err) = run_timeboxed(
+        "padcapture",
+        &mut sb.dev_cmd(
+            &[
+                "padcapture",
+                "--species",
+                "test",
+                "--kind",
+                "attack",
+                "--det",
+                &det,
+                "--out",
+                &out_str,
+                "--path",
+                "ir-only",
+                "--n",
+                "2",
+                "--rgb",
+                &rgb,
+                "--ir",
+                &ir,
+                "--no-prompt",
+            ],
+            &rgb,
+            &ir,
+        ),
+    );
+    assert_eq!(code, 0, "\n{out}\n{err}");
+    assert!(
+        out.contains("species=test kind=attack path=ir-only n=2"),
+        "run parameters echo: {out}"
+    );
+    assert!(
+        out.contains("--no-prompt: capturing 2 frames back-to-back"),
+        "prompt suppression must be announced: {out}"
+    );
+    assert!(
+        out.contains(&format!("appended 2 presentations to {out_str}")),
+        "both presentations recorded: {out}"
+    );
+    assert!(
+        !out.contains("ACCEPTED"),
+        "a faceless attack presentation must never be accepted as Live: {out}"
+    );
+
+    let text = std::fs::read_to_string(&out_path).expect("pad.jsonl written");
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 2, "one record per presentation:\n{text}");
+    for (i, l) in lines.iter().enumerate() {
+        let rec: serde_json::Value = serde_json::from_str(l).expect("record parses");
+        assert_eq!(rec["species"], serde_json::json!("test"));
+        assert_eq!(rec["kind"], serde_json::json!("attack"));
+        assert_eq!(rec["path"], serde_json::json!("ir-only"));
+        assert_eq!(rec["idx"], serde_json::json!(i));
+        assert_eq!(
+            rec["ir_present"],
+            serde_json::json!(false),
+            "no IR face on the pattern: {l}"
+        );
+        // evaluate_ir_only's first hard cue: no IR face is a non-response.
+        assert_eq!(
+            rec["verdict"],
+            serde_json::json!("Uncertain"),
+            "a faceless ir-only presentation is Uncertain, never Live: {l}"
+        );
+    }
+}
+
+// -------------------------------------------------------------------- genuine
+
+#[test]
+#[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+fn loopback_genuine_declines_stats_without_two_face_frames() {
+    let Some((rgb, ir)) = loopback_pair() else {
+        return;
+    };
+    let sb = Sandbox::new("genuine");
+    let det = model("face_detection_yunet_2023mar.onnx");
+    let rec = model("glintr100.onnx");
+    let (code, out, err) = run_timeboxed(
+        "genuine",
+        &mut sb.dev_cmd(
+            &["genuine", "--det", &det, "--model", &rec, "--device", &rgb],
+            &rgb,
+            &ir,
+        ),
+    );
+    assert_eq!(code, 0, "no face is a clean outcome\n{out}\n{err}");
+    assert!(
+        out.contains("capturing 5 frames"),
+        "the fixed 5-frame loop announces itself: {out}"
+    );
+    for k in 1..=5 {
+        assert!(
+            out.contains(&format!("frame {k}: no face")),
+            "every frame of the pattern is faceless: {out}"
+        );
+    }
+    assert!(
+        out.contains("need >=2 frames with a face"),
+        "with <2 face frames the cosine stats must be declined: {out}"
+    );
+    assert!(
+        !out.contains("pairs:"),
+        "no pairwise stats may print without faces: {out}"
+    );
+}
+
+// --------------------------------------------------------------------- suncal
+
+/// Binary P5 PGM bytes for a flat grey frame.
+fn pgm(w: u32, h: u32, fill: u8) -> Vec<u8> {
+    let mut v = format!("P5\n{w} {h}\n255\n").into_bytes();
+    v.extend(vec![fill; (w * h) as usize]);
+    v
+}
+
+/// `suncal` is the offline half of the sunlight-capture toolchain: it replays
+/// recorded IR bursts through the real detector + depth cue. No camera nodes
+/// are opened, but it needs the YuNet model and the ONNX runtime, which only
+/// the loopback CI lane guarantees, so it gates on the same env.
+#[test]
+#[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+fn loopback_suncal_analyzes_a_faceless_burst_dataset() {
+    let Some((rgb, ir)) = loopback_pair() else {
+        return;
+    };
+    let sb = Sandbox::new("suncal");
+    let det = model("face_detection_yunet_2023mar.onnx");
+    // One burst: dim ambient frames around a bright lit frame, all flat grey.
+    // gap = 200 - 5 = 195 (> 8), ambient 5 (>= 5), subtracted mean 195 (>= 12):
+    // the gate chooses the subtracted frame, and no face is detectable.
+    let burst = sb.path("work/dataset/b0");
+    std::fs::create_dir_all(&burst).unwrap();
+    std::fs::write(burst.join("frame00.pgm"), pgm(640, 400, 5)).unwrap();
+    std::fs::write(burst.join("frame01.pgm"), pgm(640, 400, 200)).unwrap();
+    std::fs::write(burst.join("frame02.pgm"), pgm(640, 400, 5)).unwrap();
+    let dataset = sb.path("work/dataset");
+    let dataset_str = dataset.to_str().unwrap().to_string();
+
+    let (code, out, err) = run_timeboxed(
+        "suncal",
+        &mut sb.dev_cmd(&["suncal", &det, &dataset_str], &rgb, &ir),
+    );
+    assert_eq!(code, 0, "\n{out}\n{err}");
+    assert!(
+        out.starts_with("burst\tamb\tlit\tgap"),
+        "TSV header first: {out}"
+    );
+    let row = out
+        .lines()
+        .find(|l| l.starts_with("b0\t"))
+        .unwrap_or_else(|| panic!("burst b0 must produce a row: {out}"));
+    let cols: Vec<&str> = row.split('\t').collect();
+    assert_eq!(cols[1], "5", "ambient mean column: {row}");
+    assert_eq!(cols[2], "200", "lit mean column: {row}");
+    assert_eq!(cols[3], "195", "strobe gap column: {row}");
+    assert_eq!(cols[5], "0.00", "no face means raw depth 0.00: {row}");
+    assert_eq!(cols[8], "n", "raw depth cannot pass without a face: {row}");
+    assert_eq!(
+        cols[9], "sub",
+        "this burst clears the subtraction gate: {row}"
+    );
+    assert_eq!(
+        cols[10], "fail",
+        "gated verdict fails without a face: {row}"
+    );
+    assert!(
+        err.contains("0 bursts with a detectable IR face"),
+        "summary counts detection failures honestly: {err}"
+    );
+}

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1968,4 +1968,1560 @@ mod tests {
         set_mode("/nonexistent/irlume-test/sock", 0o666);
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    // ---- engine-loaded dispatch arms ------------------------------------
+    //
+    // These drive dispatch() with a REAL irlume_auth::Engine (the same model
+    // files the daemon loads in production) and a constructed Peer. The
+    // engine's camera devices are nonexistent paths, so every ungated test
+    // below either refuses before any capture or fails the capture cleanly;
+    // nothing touches real hardware, /var/lib, or a real TPM. Tests that need
+    // fake hardware are env-gated: `loopback_` (v4l2loopback feeder nodes) and
+    // `tpm_` (swtpm via IRLUME_TCTI).
+
+    use irlume_core::storage::{Enrollment, FaceProfile, FaceScan};
+    use std::sync::{MutexGuard, OnceLock};
+
+    const NO_RGB: &str = "/dev/irlume-daemon-test-none-rgb";
+    const NO_IR: &str = "/dev/irlume-daemon-test-none-ir";
+    /// A uid outside any account database (same sentinel the identify-scope
+    /// test uses): authorized_for() is false for every user.
+    const NOBODY: u32 = 0xfffe_fffe;
+
+    fn peer(uid: u32) -> Peer {
+        Peer {
+            uid,
+            gid: uid,
+            pid: 1,
+        }
+    }
+
+    fn model_path(name: &str) -> String {
+        format!("{}/../../models/{name}", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    /// Point `ort` (load-dynamic) at the packaged onnxruntime when the test
+    /// env doesn't already provide `ORT_DYLIB_PATH`. Same fallbacks as
+    /// irlume-auth's engine tests.
+    fn ort_init() {
+        if std::env::var_os("ORT_DYLIB_PATH").is_some() {
+            return;
+        }
+        for cand in [
+            "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+            "/usr/lib64/libonnxruntime.so",
+            "/usr/lib/libonnxruntime.so",
+            "/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
+        ] {
+            if std::path::Path::new(cand).exists() {
+                std::env::set_var("ORT_DYLIB_PATH", cand);
+                return;
+            }
+        }
+    }
+
+    /// Process-wide shared engine, loaded once (glintr100 is big). LOCK ORDER:
+    /// every test takes env_lock() FIRST, then engine(); the initializer only
+    /// touches env vars no other daemon test reads (IRLUME_FORCE_NO_IR,
+    /// ORT_DYLIB_PATH), both left set for the whole process, so every
+    /// engine-backed test sees the same deterministic convenience (RGB-only)
+    /// hardware probe on any machine.
+    fn engine() -> MutexGuard<'static, irlume_auth::Engine> {
+        static E: OnceLock<std::sync::Mutex<irlume_auth::Engine>> = OnceLock::new();
+        E.get_or_init(|| {
+            ort_init();
+            std::env::set_var("IRLUME_FORCE_NO_IR", "1");
+            std::sync::Mutex::new(
+                irlume_auth::Engine::load(
+                    &model_path("face_detection_yunet_2023mar.onnx"),
+                    &model_path("glintr100.onnx"),
+                )
+                .expect("engine load")
+                .with_devices(NO_RGB, NO_IR),
+            )
+        })
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Isolated state/config/keyring/template-key/recovery dirs plus a method
+    /// conf pointing at a missing file (=> method Auto). Redirects every path
+    /// the dispatch arms touch, so no test can read or write this machine's
+    /// real /etc/irlume or /var/lib state. Caller must hold env_lock(); the
+    /// guard must be declared BEFORE the sandbox so Drop runs under it.
+    struct Sandbox {
+        dir: std::path::PathBuf,
+    }
+
+    fn sandbox(tag: &str) -> Sandbox {
+        let dir = std::env::temp_dir().join(format!("irlume-daemon-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("config")).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+        std::env::set_var("IRLUME_CONFIG_DIR", dir.join("config"));
+        std::env::set_var("IRLUME_KEYRING_DIR", dir.join("keyring"));
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", dir.join("template-keys"));
+        std::env::set_var("IRLUME_RECOVERY_DIR", dir.join("recovery"));
+        std::env::set_var("IRLUME_METHOD_CONF", dir.join("no-method-conf"));
+        Sandbox { dir }
+    }
+
+    impl Drop for Sandbox {
+        fn drop(&mut self) {
+            for var in [
+                "IRLUME_STATE_DIR",
+                "IRLUME_CONFIG_DIR",
+                "IRLUME_KEYRING_DIR",
+                "IRLUME_TEMPLATE_KEY_DIR",
+                "IRLUME_RECOVERY_DIR",
+                "IRLUME_METHOD_CONF",
+            ] {
+                std::env::remove_var(var);
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    /// Write a PLAINTEXT enrollment (what a no-TPM host stores) straight into
+    /// the sandbox state dir; never through storage::save, which would seal a
+    /// template key against this machine's real TPM.
+    fn write_enrollment(dir: &std::path::Path, e: &Enrollment) {
+        std::fs::write(
+            dir.join(format!("{}.json", e.user)),
+            serde_json::to_vec(e).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn unit512(seed: usize) -> Vec<f32> {
+        let mut v: Vec<f32> = (0..512)
+            .map(|j| (j as f32 * 0.7).sin() + 0.05 * (seed as f32 * 1.3 + j as f32).sin())
+            .collect();
+        let n = v.iter().map(|x| x * x).sum::<f32>().sqrt() + 1e-9;
+        v.iter_mut().for_each(|x| *x /= n);
+        v
+    }
+
+    fn rgb_scan(name: &str, seed: usize) -> FaceScan {
+        FaceScan {
+            name: name.into(),
+            rgb: unit512(seed),
+            ir: None,
+            ir_space: None,
+            ir_depth: 0.0,
+            ir_brightness: 0.0,
+            pitch: 0.0,
+        }
+    }
+
+    /// One-profile plaintext enrollment: "Face Profile 1" with the named scans.
+    fn enrollment_with(user: &str, scans: &[&str]) -> Enrollment {
+        Enrollment {
+            user: user.into(),
+            profiles: vec![FaceProfile {
+                name: "Face Profile 1".into(),
+                ir_calib: None,
+                scans: scans
+                    .iter()
+                    .enumerate()
+                    .map(|(i, s)| rgb_scan(s, i + 1))
+                    .collect(),
+            }],
+            require_eyes_open: false,
+            require_challenge: false,
+            camera_binding: None,
+        }
+    }
+
+    /// Plant a bogus sealed-password envelope file. has_sealed_password() is a
+    /// pure existence check, so this drives the armed/unarmed branches without
+    /// a TPM; any arm that actually unseals it must then fail on the parse.
+    fn plant_fake_envelope(user: &str) {
+        let path = irlume_core::keyring::envelope_path(user);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"not a sealed envelope").unwrap();
+    }
+
+    #[test]
+    fn dispatch_rejects_an_invalid_username_before_any_arm() {
+        let _g = env_lock();
+        let mut e = engine();
+        for req in [
+            Request::ListProfiles {
+                user: "../root".into(),
+            },
+            Request::Authenticate {
+                user: "a/b".into(),
+                service: None,
+            },
+            Request::UnsealPassword {
+                user: "-flag".into(),
+                service: None,
+            },
+        ] {
+            match dispatch(req, &peer(0), &mut e) {
+                Response::Error(msg) => assert_eq!(msg, "invalid username"),
+                other => panic!("traversal username must be refused, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn ping_answers_pong_through_dispatch() {
+        let _g = env_lock();
+        let mut e = engine();
+        assert!(matches!(
+            dispatch(Request::Ping, &peer(NOBODY), &mut e),
+            Response::Pong
+        ));
+    }
+
+    #[test]
+    fn health_reports_version_and_never_secure_under_forced_no_ir() {
+        let _g = env_lock();
+        let mut e = engine();
+        match dispatch(Request::Health, &peer(NOBODY), &mut e) {
+            Response::Health {
+                tier,
+                ir_dev,
+                mesh,
+                adapter,
+                version,
+                ..
+            } => {
+                // IRLUME_FORCE_NO_IR=1 (set by the shared engine init) forces
+                // ir_pair=false, so no IR node may be reported and the tier can
+                // never be "secure", whatever cameras this machine has.
+                assert_ne!(tier, "secure");
+                assert_eq!(ir_dev, None);
+                // The bare shared engine loaded no optional models.
+                assert!(!mesh && !adapter);
+                assert_eq!(version, env!("CARGO_PKG_VERSION"));
+            }
+            other => panic!("Health must answer Response::Health, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn authenticate_requires_root_or_the_account_owner() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("auth-authz");
+        let _ = &sb;
+        match dispatch(
+            Request::Authenticate {
+                user: "carol".into(),
+                service: None,
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to authenticate 'carol'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn authenticate_stands_down_when_the_method_is_fingerprint() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("auth-fp");
+        std::fs::write(sb.dir.join("method"), "fingerprint").unwrap();
+        std::env::set_var("IRLUME_METHOD_CONF", sb.dir.join("method"));
+        match dispatch(
+            Request::Authenticate {
+                user: "carol".into(),
+                service: Some("kde".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::AuthResult {
+                granted,
+                score,
+                live,
+                reason,
+            } => {
+                assert!(!granted && !live);
+                assert_eq!(score, 0.0);
+                assert_eq!(
+                    reason,
+                    "face auth disabled: the configured method is fingerprint"
+                );
+            }
+            other => panic!("fingerprint mode must deny via AuthResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn authenticate_on_convenience_tier_is_limited_to_screen_unlock() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("auth-conv");
+        let _ = &sb;
+        // (service, the OperationClass Debug name the deny reason must carry)
+        for (service, class) in [("sshd", "Remote"), ("sudo", "Elevation")] {
+            match dispatch(
+                Request::Authenticate {
+                    user: "carol".into(),
+                    service: Some(service.into()),
+                },
+                &peer(0),
+                &mut e,
+            ) {
+                Response::AuthResult {
+                    granted,
+                    live,
+                    reason,
+                    ..
+                } => {
+                    assert!(!granted && !live, "{service} must not grant");
+                    assert_eq!(
+                        reason,
+                        format!(
+                            "RGB-only convenience: face limited to screen unlock (not {class})"
+                        )
+                    );
+                }
+                other => panic!("convenience gate must deny {service}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn authenticate_refuses_an_unenrolled_user_before_the_camera() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("auth-ghost");
+        let _ = &sb;
+        // "kde" classifies as ScreenUnlock, so the convenience gate passes and
+        // the engine itself answers; an unenrolled user is refused before any
+        // capture (the devices don't exist, so reaching the camera would error).
+        match dispatch(
+            Request::Authenticate {
+                user: "irlume-test-ghost".into(),
+                service: Some("kde".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::AuthResult {
+                granted,
+                live,
+                reason,
+                ..
+            } => {
+                assert!(!granted && !live);
+                assert_eq!(reason, "'irlume-test-ghost' is not enrolled");
+                // The reason must survive journal redaction unchanged (no
+                // numeric payload for a spoofer to tune against).
+                assert_eq!(deny_reason(&reason), reason);
+            }
+            other => panic!("unenrolled user must deny via AuthResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn authenticate_surfaces_a_capture_error_for_an_enrolled_user() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("auth-cam");
+        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
+        match dispatch(
+            Request::Authenticate {
+                user: "carol".into(),
+                service: Some("kde".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+            other => panic!("missing camera must be an Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn identify_answers_a_peer_without_an_account_and_needs_a_camera_for_root() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("identify");
+        let _ = &sb;
+        // A peer with no local account gets an empty identify, no capture at all.
+        match dispatch(Request::Identify, &peer(NOBODY), &mut e) {
+            Response::Identified {
+                user,
+                profile,
+                score,
+                live,
+                reason,
+            } => {
+                assert_eq!(user, None);
+                assert_eq!(profile, None);
+                assert_eq!(score, 0.0);
+                assert!(!live);
+                assert_eq!(reason, "caller has no local account");
+            }
+            other => panic!("no-account peer must get Identified, got {other:?}"),
+        }
+        // Root keeps the full 1:N search, which needs the (absent) camera.
+        match dispatch(Request::Identify, &peer(0), &mut e) {
+            Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+            other => panic!("root identify without a camera must Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_profiles_reports_the_enrollment_and_gates_on_authorization() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("list");
+        let mut enr = enrollment_with("carol", &["Face Scan 1", "Face Scan 2"]);
+        enr.require_eyes_open = true;
+        write_enrollment(&sb.dir, &enr);
+        match dispatch(
+            Request::ListProfiles {
+                user: "carol".into(),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Enrollment {
+                profiles,
+                require_eyes_open,
+                require_challenge,
+            } => {
+                assert_eq!(profiles.len(), 1);
+                assert_eq!(profiles[0].name, "Face Profile 1");
+                assert_eq!(
+                    profiles[0].scans,
+                    vec!["Face Scan 1".to_string(), "Face Scan 2".to_string()]
+                );
+                assert!(require_eyes_open);
+                assert!(!require_challenge);
+            }
+            other => panic!("expected Response::Enrollment, got {other:?}"),
+        }
+        // An unenrolled user lists as empty rather than erroring.
+        match dispatch(
+            Request::ListProfiles {
+                user: "ghost".into(),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Enrollment { profiles, .. } => assert!(profiles.is_empty()),
+            other => panic!("unenrolled user must list empty, got {other:?}"),
+        }
+        // A foreign peer may not even list.
+        match dispatch(
+            Request::ListProfiles {
+                user: "carol".into(),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to list 'carol'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn profile_mutations_error_precisely_without_rewriting_state() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("mut-err");
+        write_enrollment(
+            &sb.dir,
+            &enrollment_with("carol", &["Face Scan 1", "Face Scan 2"]),
+        );
+        let root = peer(0);
+        // Every branch here errors BEFORE storage::save, so this runs on any
+        // host (TPM or not) without sealing anything.
+        let cases: Vec<(Request, &str)> = vec![
+            (
+                Request::DeleteProfile {
+                    user: "carol".into(),
+                    profile: "nope".into(),
+                },
+                "no face profile 'nope'",
+            ),
+            (
+                Request::DeleteScan {
+                    user: "carol".into(),
+                    profile: "nope".into(),
+                    scan: "Face Scan 1".into(),
+                },
+                "no face profile 'nope'",
+            ),
+            (
+                Request::RenameScan {
+                    user: "carol".into(),
+                    profile: "Face Profile 1".into(),
+                    scan: "Face Scan 1".into(),
+                    new_name: "Face Scan 2".into(),
+                },
+                "'Face Scan 2' already exists in 'Face Profile 1'",
+            ),
+            (
+                Request::RenameScan {
+                    user: "carol".into(),
+                    profile: "Face Profile 1".into(),
+                    scan: "missing".into(),
+                    new_name: "Front".into(),
+                },
+                "no scan 'missing' in 'Face Profile 1'",
+            ),
+            (
+                Request::DeleteProfile {
+                    user: "ghost".into(),
+                    profile: "Face Profile 1".into(),
+                },
+                "'ghost' is not enrolled",
+            ),
+        ];
+        for (req, want) in cases {
+            match dispatch(req, &root, &mut e) {
+                Response::Error(msg) => assert_eq!(msg, want),
+                other => panic!("expected Error({want}), got {other:?}"),
+            }
+        }
+        // Unauthorized peers are refused before the enrollment is even loaded.
+        match dispatch(
+            Request::DeleteProfile {
+                user: "carol".into(),
+                profile: "Face Profile 1".into(),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to modify 'carol'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+        // The enrollment file is untouched by all of the above.
+        let enr = irlume_core::storage::load("carol").unwrap().unwrap();
+        assert_eq!(enr.profiles[0].scans.len(), 2);
+    }
+
+    #[test]
+    fn delete_scan_never_orphans_a_profile_and_deleting_the_last_profile_erases_the_file() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("del-last");
+        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
+        let root = peer(0);
+        // A profile must keep at least one scan (the deny path never saves).
+        match dispatch(
+            Request::DeleteScan {
+                user: "carol".into(),
+                profile: "Face Profile 1".into(),
+                scan: "Face Scan 1".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(
+                msg,
+                "a profile must keep at least one scan; delete the profile instead"
+            ),
+            other => panic!("last-scan delete must be refused, got {other:?}"),
+        }
+        // Deleting the only profile removes the whole enrollment file
+        // (storage::delete, not save: safe on a TPM host too).
+        match dispatch(
+            Request::DeleteProfile {
+                user: "carol".into(),
+                profile: "Face Profile 1".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Ok(msg) => assert_eq!(msg, "deleted profile 'Face Profile 1'"),
+            other => panic!("sole-profile delete must succeed, got {other:?}"),
+        }
+        assert!(
+            !sb.dir.join("carol.json").exists(),
+            "an enrollment with zero profiles must not linger on disk"
+        );
+        match dispatch(
+            Request::DeleteProfile {
+                user: "carol".into(),
+                profile: "Face Profile 1".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "'carol' is not enrolled"),
+            other => panic!("second delete must report unenrolled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mutations_that_rewrite_the_enrollment_roundtrip_through_dispatch() {
+        // These arms end in storage::save; on a host with /dev/tpm* that would
+        // seal a real template key, so this test only runs on no-TPM hosts
+        // (CI runners). Same convention as irlume-core's storage tests.
+        if irlume_core::template_key::tpm_available() {
+            eprintln!("skipping: TPM present; storage::save would touch real hardware");
+            return;
+        }
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("mut-save");
+        let _ = &sb;
+        write_enrollment(
+            &sb.dir,
+            &enrollment_with("carol", &["Face Scan 1", "Face Scan 2"]),
+        );
+        let root = peer(0);
+        let expect_ok = |resp: Response, want: &str| match resp {
+            Response::Ok(msg) => assert_eq!(msg, want),
+            other => panic!("expected Ok({want}), got {other:?}"),
+        };
+        expect_ok(
+            dispatch(
+                Request::DeleteScan {
+                    user: "carol".into(),
+                    profile: "Face Profile 1".into(),
+                    scan: "Face Scan 2".into(),
+                },
+                &root,
+                &mut e,
+            ),
+            "deleted scan 'Face Scan 2' from 'Face Profile 1'",
+        );
+        expect_ok(
+            dispatch(
+                Request::RenameScan {
+                    user: "carol".into(),
+                    profile: "Face Profile 1".into(),
+                    scan: "Face Scan 1".into(),
+                    new_name: "Front".into(),
+                },
+                &root,
+                &mut e,
+            ),
+            "renamed scan to 'Front'",
+        );
+        expect_ok(
+            dispatch(
+                Request::RenameProfile {
+                    user: "carol".into(),
+                    profile: "Face Profile 1".into(),
+                    new_name: "Work".into(),
+                },
+                &root,
+                &mut e,
+            ),
+            "renamed profile to 'Work'",
+        );
+        // Renaming onto an existing name collides (checked before the lookup,
+        // so even a self-rename is refused).
+        match dispatch(
+            Request::RenameProfile {
+                user: "carol".into(),
+                profile: "Work".into(),
+                new_name: "Work".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "'Work' already exists"),
+            other => panic!("rename collision must be refused, got {other:?}"),
+        }
+        expect_ok(
+            dispatch(
+                Request::SetRequireEyesOpen {
+                    user: "carol".into(),
+                    on: true,
+                },
+                &root,
+                &mut e,
+            ),
+            "require-eyes-open ENABLED",
+        );
+        expect_ok(
+            dispatch(
+                Request::SetRequireChallenge {
+                    user: "carol".into(),
+                    on: false,
+                },
+                &root,
+                &mut e,
+            ),
+            "require-challenge disabled",
+        );
+        // The saved state reflects every mutation.
+        match dispatch(
+            Request::ListProfiles {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Enrollment {
+                profiles,
+                require_eyes_open,
+                require_challenge,
+            } => {
+                assert_eq!(profiles.len(), 1);
+                assert_eq!(profiles[0].name, "Work");
+                assert_eq!(profiles[0].scans, vec!["Front".to_string()]);
+                assert!(require_eyes_open);
+                assert!(!require_challenge);
+            }
+            other => panic!("expected Response::Enrollment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enroll_validates_authorization_and_duplicate_names_before_capture() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("enroll");
+        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
+        match dispatch(
+            Request::Enroll {
+                user: "carol".into(),
+                profile: None,
+                scans: None,
+                reset: false,
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to enroll 'carol'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+        // An explicit duplicate profile name fails fast, before the camera
+        // would open (the devices don't exist, so getting further would turn
+        // this into a hardware error instead).
+        match dispatch(
+            Request::Enroll {
+                user: "carol".into(),
+                profile: Some("Face Profile 1".into()),
+                scans: None,
+                reset: false,
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert!(
+                    msg.contains("a face profile named 'Face Profile 1' already exists"),
+                    "{msg}"
+                );
+            }
+            other => panic!("duplicate profile name must be refused, got {other:?}"),
+        }
+        // Past validation, the capture itself fails cleanly on this hardware.
+        match dispatch(
+            Request::Enroll {
+                user: "carol".into(),
+                profile: Some("Second".into()),
+                scans: Some(1),
+                reset: false,
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+            other => panic!("missing camera must be an Error, got {other:?}"),
+        }
+        // reset:true wipes the old enrollment even though the capture then
+        // fails: the reset half of the arm ran.
+        match dispatch(
+            Request::Enroll {
+                user: "carol".into(),
+                profile: None,
+                scans: None,
+                reset: true,
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+            other => panic!("missing camera must be an Error, got {other:?}"),
+        }
+        assert!(
+            !sb.dir.join("carol.json").exists(),
+            "Enroll{{reset:true}} must delete the previous enrollment first"
+        );
+    }
+
+    #[test]
+    fn add_scan_refuses_unenrolled_users_and_full_profiles_before_capture() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("addscan");
+        match dispatch(
+            Request::AddScan {
+                user: "ghost".into(),
+                profile: "Face Profile 1".into(),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("'ghost' is not enrolled"), "{msg}"),
+            other => panic!("unenrolled AddScan must Error, got {other:?}"),
+        }
+        // A profile at MAX_SCANS_PER_PROFILE is refused before any capture.
+        let max = irlume_core::storage::MAX_SCANS_PER_PROFILE;
+        let names: Vec<String> = (1..=max).map(|i| format!("Face Scan {i}")).collect();
+        let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        write_enrollment(&sb.dir, &enrollment_with("carol", &name_refs));
+        match dispatch(
+            Request::AddScan {
+                user: "carol".into(),
+                profile: "Face Profile 1".into(),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(
+                msg.contains(&format!("already has the max {max} scans")),
+                "{msg}"
+            ),
+            other => panic!("full profile must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn seal_password_gates_authorization_and_refuses_an_empty_secret() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("seal");
+        let _ = &sb;
+        match dispatch(
+            Request::SealPassword {
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(b"pw".to_vec()),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to seal password for 'carol'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+        // The empty-password refusal fires before any TPM operation, so this
+        // is safe (and deterministic) on every host.
+        match dispatch(
+            Request::SealPassword {
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(Vec::new()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert!(msg.contains("refusing to seal an empty password"), "{msg}")
+            }
+            other => panic!("empty password must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unseal_password_arm_gates_peer_method_and_tier_before_the_face_check() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("unseal-gates");
+        // Only a root peer (the PAM stack) may even ask.
+        match dispatch(
+            Request::UnsealPassword {
+                user: "carol".into(),
+                service: None,
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    format!("unseal_password requires root (peer uid {NOBODY})")
+                )
+            }
+            other => panic!("non-root unseal must be refused, got {other:?}"),
+        }
+        // Fingerprint mode refuses credential release outright.
+        std::fs::write(sb.dir.join("method"), "fingerprint").unwrap();
+        std::env::set_var("IRLUME_METHOD_CONF", sb.dir.join("method"));
+        match dispatch(
+            Request::UnsealPassword {
+                user: "carol".into(),
+                service: Some("plasmalogin".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    "face auth disabled: the configured method is fingerprint"
+                )
+            }
+            other => panic!("fingerprint mode must refuse unseal, got {other:?}"),
+        }
+        std::env::set_var("IRLUME_METHOD_CONF", sb.dir.join("no-method-conf"));
+        // The convenience (RGB-only) tier never releases the credential; this
+        // fires before the sealed-password lookup and the face check.
+        match dispatch(
+            Request::UnsealPassword {
+                user: "carol".into(),
+                service: Some("plasmalogin".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(
+                msg,
+                "RGB-only convenience: face cannot release the login credential"
+            ),
+            other => panic!("convenience tier must refuse unseal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn do_unseal_password_requires_an_armed_seal_then_a_granted_face() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("do-unseal");
+        // Nothing armed: refused before any capture or TPM traffic.
+        match do_unseal_password("carol", None, &mut e) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    "no sealed password for 'carol': run `irlume keyring arm`"
+                )
+            }
+            other => panic!("unarmed unseal must be refused, got {other:?}"),
+        }
+        // Armed (existence check only) but the user is not enrolled: the face
+        // check denies before the camera and the envelope is never opened.
+        plant_fake_envelope("carol");
+        match do_unseal_password("carol", None, &mut e) {
+            Response::Error(msg) => {
+                assert_eq!(msg, "face not granted: 'carol' is not enrolled")
+            }
+            other => panic!("unenrolled unseal must be refused, got {other:?}"),
+        }
+        // Enrolled: the capture itself fails on this hardware and maps to a
+        // clean Error (the non-drift branch: no remedy hint appended).
+        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
+        match do_unseal_password("carol", None, &mut e) {
+            Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+            other => panic!("missing camera must be an Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unseal_keyring_gates_peer_service_class_and_envelope_integrity() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("unseal-keyring");
+        let _ = &sb;
+        match dispatch(
+            Request::UnsealKeyring {
+                user: "carol".into(),
+                service: Some("kde".into()),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    format!("unseal_keyring requires root (peer uid {NOBODY})")
+                )
+            }
+            other => panic!("non-root keyring unseal must be refused, got {other:?}"),
+        }
+        match dispatch(
+            Request::UnsealKeyring {
+                user: "carol".into(),
+                service: Some("kde".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    "no sealed password for 'carol': run `irlume keyring arm`"
+                )
+            }
+            other => panic!("unarmed keyring unseal must be refused, got {other:?}"),
+        }
+        plant_fake_envelope("carol");
+        // Only a login / lock-screen service class may release; sudo may not.
+        match dispatch(
+            Request::UnsealKeyring {
+                user: "carol".into(),
+                service: Some("sudo".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "keyring unseal not allowed for Elevation"),
+            other => panic!("elevation keyring unseal must be refused, got {other:?}"),
+        }
+        // A corrupt envelope must surface as an Error, never a secret.
+        match dispatch(
+            Request::UnsealKeyring {
+                user: "carol".into(),
+                service: Some("kde".into()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(!msg.is_empty()),
+            other => panic!("a corrupt envelope must Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn has_sealed_password_and_forget_roundtrip_through_dispatch() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("haspw");
+        let _ = &sb;
+        let root = peer(0);
+        match dispatch(
+            Request::HasSealedPassword {
+                user: "carol".into(),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to query 'carol'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+        match dispatch(
+            Request::HasSealedPassword {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::HasPassword(armed) => assert!(!armed),
+            other => panic!("expected HasPassword(false), got {other:?}"),
+        }
+        plant_fake_envelope("carol");
+        match dispatch(
+            Request::HasSealedPassword {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::HasPassword(armed) => assert!(armed),
+            other => panic!("expected HasPassword(true), got {other:?}"),
+        }
+        match dispatch(
+            Request::ForgetPassword {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::PasswordForgotten => {}
+            other => panic!("expected PasswordForgotten, got {other:?}"),
+        }
+        assert!(
+            !irlume_core::keyring::envelope_path("carol").exists(),
+            "ForgetPassword must remove the envelope file"
+        );
+    }
+
+    #[test]
+    fn keyring_info_reports_unarmed_and_unreadable_envelopes() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("krinfo");
+        let _ = &sb;
+        let root = peer(0);
+        match dispatch(
+            Request::KeyringInfo {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::KeyringInfo {
+                armed,
+                policy,
+                pcrs,
+                drifted,
+            } => {
+                assert!(!armed);
+                assert_eq!(policy, None);
+                assert!(pcrs.is_empty());
+                assert_eq!(drifted, None);
+            }
+            other => panic!("expected KeyringInfo, got {other:?}"),
+        }
+        // Armed but unreadable: report the armed bit alone, don't fail.
+        plant_fake_envelope("carol");
+        match dispatch(
+            Request::KeyringInfo {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::KeyringInfo { armed, policy, .. } => {
+                assert!(armed);
+                assert_eq!(policy, None);
+            }
+            other => panic!("expected KeyringInfo, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reseal_password_reports_not_armed_and_refuses_an_empty_password() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("reseal");
+        let _ = &sb;
+        // Not armed short-circuits before any TPM traffic: never auto-arm.
+        match dispatch(
+            Request::ResealPassword {
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(b"pw".to_vec()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::PasswordResealed { armed, changed } => {
+                assert!(!armed && !changed, "reseal must never arm a fresh user");
+            }
+            other => panic!("expected PasswordResealed, got {other:?}"),
+        }
+        match dispatch(
+            Request::ResealPassword {
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(Vec::new()),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert!(
+                    msg.contains("refusing to reseal an empty password"),
+                    "{msg}"
+                )
+            }
+            other => panic!("empty reseal must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recovery_arms_report_status_and_error_without_a_template_key() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("recovery");
+        let _ = &sb;
+        let root = peer(0);
+        match dispatch(
+            Request::RecoveryStatus {
+                user: "ghost".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::RecoveryStatus {
+                encrypted,
+                recovery_set,
+                ..
+            } => assert!(!encrypted && !recovery_set),
+            other => panic!("expected RecoveryStatus, got {other:?}"),
+        }
+        // No template key exists (and the user isn't enrolled, so none is
+        // minted): setup has nothing to wrap.
+        match dispatch(
+            Request::RecoverySetup {
+                user: "ghost".into(),
+                passphrase: irlume_common::SecretBytes::new(b"phrase".to_vec()),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert!(msg.contains("no template key sealed for 'ghost'"), "{msg}")
+            }
+            other => panic!("setup without a key must Error, got {other:?}"),
+        }
+        match dispatch(
+            Request::RecoveryRestore {
+                user: "ghost".into(),
+                passphrase: irlume_common::SecretBytes::new(b"phrase".to_vec()),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(
+                msg.contains("no recovery passphrase set for 'ghost'"),
+                "{msg}"
+            ),
+            other => panic!("restore without an envelope must Error, got {other:?}"),
+        }
+        match dispatch(
+            Request::RecoveryForget {
+                user: "ghost".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Ok(msg) => assert_eq!(msg, "recovery passphrase erased for 'ghost'"),
+            other => panic!("forget must be idempotent Ok, got {other:?}"),
+        }
+        match dispatch(
+            Request::RecoveryStatus {
+                user: "ghost".into(),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to query 'ghost'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_cameras_requires_root_then_repoints_and_persists() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("setcam");
+        let _ = &sb;
+        match dispatch(
+            Request::SetCameras {
+                rgb: "/dev/video0".into(),
+                ir: "/dev/video2".into(),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    format!("set_cameras requires root (peer uid {NOBODY})")
+                )
+            }
+            other => panic!("non-root SetCameras must be refused, got {other:?}"),
+        }
+        let (rgb, ir) = ("/dev/irlume-test-alt-rgb", "/dev/irlume-test-alt-ir");
+        match dispatch(
+            Request::SetCameras {
+                rgb: rgb.into(),
+                ir: ir.into(),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            // The exact message proves the persist to cameras.conf succeeded
+            // (a failed persist appends a "live only" suffix).
+            Response::Ok(msg) => assert_eq!(msg, format!("cameras set to rgb={rgb} ir={ir}")),
+            other => panic!("root SetCameras must succeed, got {other:?}"),
+        }
+        assert_eq!(e.rgb_device(), rgb);
+        assert_eq!(e.ir_device(), ir);
+        assert_eq!(
+            irlume_common::config::read_kv("cameras.conf", "rgb").as_deref(),
+            Some(rgb)
+        );
+        assert_eq!(
+            irlume_common::config::read_kv("cameras.conf", "ir").as_deref(),
+            Some(ir)
+        );
+        // Restore the shared engine's baseline devices.
+        e.set_devices(NO_RGB, NO_IR);
+    }
+
+    #[test]
+    fn setup_ir_emitter_gates_root_and_surfaces_a_missing_camera() {
+        let _g = env_lock();
+        let mut e = engine();
+        // Dry-run is open to any peer but needs the (absent) IR node.
+        match dispatch(
+            Request::SetupIrEmitter { dry_run: true },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+            other => panic!("dry-run without a camera must Error, got {other:?}"),
+        }
+        // The write path is root-only.
+        match dispatch(
+            Request::SetupIrEmitter { dry_run: false },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    format!("setup_ir_emitter requires root (peer uid {NOBODY})")
+                )
+            }
+            other => panic!("non-root setup must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn selftest_and_position_sample_surface_the_missing_camera() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("selftest");
+        let _ = &sb;
+        for kind in [
+            irlume_common::SelfTestKind::Liveness,
+            irlume_common::SelfTestKind::AlignmentIdentity,
+        ] {
+            match dispatch(Request::SelfTest { kind }, &peer(0), &mut e) {
+                Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+                other => panic!("selftest without a camera must Error, got {other:?}"),
+            }
+        }
+        // A non-root peer asking to tune for another user is silently scoped
+        // to the anonymous band; either way the capture needs the camera.
+        match dispatch(
+            Request::PositionSample {
+                user: Some("root".into()),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
+            other => panic!("position sample without a camera must Error, got {other:?}"),
+        }
+    }
+
+    // ---- env-gated: v4l2loopback feeder nodes ---------------------------
+
+    /// Fresh engine wired to the CI loopback nodes; None when the env is
+    /// absent. The feeder holds no face, so capture arms end in clean denials.
+    fn loopback_engine() -> Option<irlume_auth::Engine> {
+        let (Ok(rgb), Ok(ir)) = (
+            std::env::var("IRLUME_TEST_RGB_DEVICE"),
+            std::env::var("IRLUME_TEST_IR_DEVICE"),
+        ) else {
+            return None;
+        };
+        ort_init();
+        Some(
+            irlume_auth::Engine::load(
+                &model_path("face_detection_yunet_2023mar.onnx"),
+                &model_path("glintr100.onnx"),
+            )
+            .expect("engine load")
+            .with_devices(&rgb, &ir),
+        )
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_authenticate_dispatches_to_a_no_face_denial() {
+        let _g = env_lock();
+        let Some(mut e) = loopback_engine() else {
+            return;
+        };
+        let sb = sandbox("lb-auth");
+        // One-shot capture instead of a grace window: a no-face run finishes
+        // in one camera round.
+        std::env::set_var("IRLUME_GRACE_MS", "0");
+        write_enrollment(&sb.dir, &enrollment_with("lbuser", &["Face Scan 1"]));
+        // "kde" is a ScreenUnlock in every tier, so the dispatch gates pass
+        // whether or not the runner's loopback nodes register as an IR pair.
+        let resp = dispatch(
+            Request::Authenticate {
+                user: "lbuser".into(),
+                service: Some("kde".into()),
+            },
+            &peer(0),
+            &mut e,
+        );
+        std::env::remove_var("IRLUME_GRACE_MS");
+        match resp {
+            Response::AuthResult {
+                granted,
+                live,
+                reason,
+                ..
+            } => {
+                assert!(!granted, "no face on the feed must never grant");
+                assert!(!live);
+                assert!(
+                    reason.to_lowercase().contains("face"),
+                    "denial should name the missing face, got: {reason}"
+                );
+            }
+            other => panic!("a faceless frame is a denial, not an error: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_identify_dispatches_to_a_no_match() {
+        let _g = env_lock();
+        let Some(mut e) = loopback_engine() else {
+            return;
+        };
+        let sb = sandbox("lb-identify");
+        std::env::set_var("IRLUME_GRACE_MS", "0");
+        write_enrollment(&sb.dir, &enrollment_with("lbuser", &["Face Scan 1"]));
+        // Root keeps the full 1:N search; with no face on the feed it must
+        // come back empty, not error and not name anyone.
+        let resp = dispatch(Request::Identify, &peer(0), &mut e);
+        std::env::remove_var("IRLUME_GRACE_MS");
+        match resp {
+            Response::Identified {
+                user,
+                profile,
+                live,
+                reason,
+                ..
+            } => {
+                assert_eq!(user, None, "no face must identify nobody");
+                assert_eq!(profile, None);
+                assert!(!live);
+                assert!(!reason.is_empty());
+            }
+            other => panic!("a faceless identify is a no-match, not an error: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_enroll_reaches_capture_and_fails_the_no_face_probe_cleanly() {
+        let _g = env_lock();
+        let Some(mut e) = loopback_engine() else {
+            return;
+        };
+        let sb = sandbox("lb-enroll");
+        std::env::set_var("IRLUME_GRACE_MS", "0");
+        let resp = dispatch(
+            Request::Enroll {
+                user: "lbenroll".into(),
+                profile: None,
+                scans: Some(1),
+                reset: false,
+            },
+            &peer(0),
+            &mut e,
+        );
+        std::env::remove_var("IRLUME_GRACE_MS");
+        match resp {
+            Response::Error(msg) => assert!(
+                msg.contains("check lighting and framing"),
+                "a faceless enroll must coach, got: {msg}"
+            ),
+            other => panic!("a faceless enroll must Error, got {other:?}"),
+        }
+        assert!(
+            !sb.dir.join("lbenroll.json").exists(),
+            "a failed enroll must not leave a partial enrollment"
+        );
+    }
+
+    // ---- env-gated: swtpm ------------------------------------------------
+
+    #[test]
+    #[ignore = "needs swtpm via IRLUME_TCTI (CI does this); never runs against a real TPM"]
+    fn tpm_seal_and_unseal_keyring_release_the_secret_to_root_only() {
+        // Only ever a software TPM: without the explicit TCTI this returns
+        // rather than fall back to this machine's /dev/tpmrm0.
+        if std::env::var("IRLUME_TCTI").is_err() {
+            return;
+        }
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("tpm-keyring");
+        let _ = &sb;
+        let root = peer(0);
+        let secret = b"hunter2-swtpm".to_vec();
+        match dispatch(
+            Request::SealPassword {
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(secret.clone()),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::PasswordSealed => {}
+            other => panic!("sealing against swtpm must succeed, got {other:?}"),
+        }
+        match dispatch(
+            Request::HasSealedPassword {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::HasPassword(armed) => assert!(armed),
+            other => panic!("expected HasPassword(true), got {other:?}"),
+        }
+        // A real envelope reports its policy.
+        match dispatch(
+            Request::KeyringInfo {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::KeyringInfo { armed, policy, .. } => {
+                assert!(armed);
+                assert!(
+                    policy.is_some(),
+                    "a sealed envelope must describe its policy"
+                );
+            }
+            other => panic!("expected KeyringInfo, got {other:?}"),
+        }
+        // The sealed login secret is released only to a root peer in a
+        // login / lock-screen service class.
+        match dispatch(
+            Request::UnsealKeyring {
+                user: "carol".into(),
+                service: Some("kde".into()),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(
+                    msg,
+                    format!("unseal_keyring requires root (peer uid {NOBODY})")
+                )
+            }
+            other => panic!("non-root peer must never get the secret, got {other:?}"),
+        }
+        match dispatch(
+            Request::UnsealKeyring {
+                user: "carol".into(),
+                service: Some("kde".into()),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::PasswordUnsealed { secret: got } => assert_eq!(got.expose(), secret),
+            other => panic!("root keyring unseal must release the secret, got {other:?}"),
+        }
+        match dispatch(
+            Request::ForgetPassword {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::PasswordForgotten => {}
+            other => panic!("expected PasswordForgotten, got {other:?}"),
+        }
+        match dispatch(
+            Request::HasSealedPassword {
+                user: "carol".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::HasPassword(armed) => assert!(!armed),
+            other => panic!("expected HasPassword(false), got {other:?}"),
+        }
+    }
 }

--- a/crates/irlume-pam/Cargo.toml
+++ b/crates/irlume-pam/Cargo.toml
@@ -8,7 +8,11 @@ license.workspace = true
 name = "pam_irlume"
 # PAM modules are C-ABI shared objects loaded by libpam into the host
 # (login/sudo/sshd/display-manager). Produces pam_irlume.so.
-crate-type = ["cdylib"]
+# "lib" is additionally listed so `cargo test -p irlume-pam` builds the cdylib
+# too (cargo skips a cdylib-only lib target when compiling tests; with both
+# types the one rustc invocation emits both), which the pam_wrapper
+# integration tests (tests/pamwrap.rs) load through a real PAM stack.
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 irlume-common.workspace = true

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -1,0 +1,729 @@
+//! End-to-end tests of the real `pam_irlume.so` driven through a real PAM
+//! stack, no root and no daemon binary required.
+//!
+//! How: `pamtester` (a small CLI that calls `pam_authenticate` etc.) is spawned
+//! with cwrap's pam_wrapper LD_PRELOADed. pam_wrapper redirects libpam's
+//! service-file lookup to `PAM_WRAPPER_SERVICE_DIR`, where each test writes a
+//! stack whose lines reference the ABSOLUTE path of the freshly built
+//! `libpam_irlume.so`. The module's daemon socket is pointed (via
+//! `IRLUME_SOCKET`) at an in-process fake speaking the real line-JSON
+//! `irlume_common` protocol, the same pattern as the swtpm and v4l2loopback
+//! harnesses elsewhere in this repo. So the full production path runs: libpam
+//! dlopens the cdylib, the stack executes, the module talks JSON over a Unix
+//! socket, and the test asserts pamtester's exit status plus the exact requests
+//! the fake daemon received.
+//!
+//! Tool contract (all userspace, no privileges):
+//!   * Fedora: `dnf install pam_wrapper pamtester`
+//!     wrapper at /usr/lib64/libpam_wrapper.so
+//!   * Ubuntu/Debian: `apt-get install libpam-wrapper pamtester`
+//!     wrapper at /usr/lib/x86_64-linux-gnu/libpam_wrapper.so
+//!   * Anywhere else: set `PAM_WRAPPER_SO=/path/to/libpam_wrapper.so`.
+//!     `pam_set_items.so` (ships in the same package) is found in the
+//!     `pam_wrapper/` directory next to the wrapper library.
+//!
+//! The tests are `#[ignore]`d so a bare `cargo test` stays green on boxes
+//! without the tools; CI (and anyone with them installed) runs
+//! `cargo test -p irlume-pam -- --include-ignored`. Each test also returns
+//! early with a note if the tools are missing, so `--include-ignored` is safe
+//! everywhere.
+//!
+//! What pamtester cannot drive: `pam_sm_setcred` (pamtester has no `setcred`
+//! operation; the module's is a constant `SUCCESS` one-liner) and the
+//! greeter-buffered conversations of a real display manager. Everything else
+//! (authenticate in every module mode, open_session, close_session) is covered.
+
+use irlume_common::{Request, Response};
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+// ---------------------------------------------------------------- harness
+
+/// Everything a test needs: tool paths, a per-test scratch dir with the
+/// pam_wrapper service dir, and the socket path the fake daemon binds.
+struct Harness {
+    /// libpam_wrapper.so, to LD_PRELOAD into pamtester.
+    wrapper: PathBuf,
+    /// pam_wrapper's pam_set_items.so: pre-sets PAM items (e.g. PAM_AUTHTOK)
+    /// from pamtester's environment, standing in for a greeter/earlier module.
+    set_items: PathBuf,
+    /// The freshly built pam_irlume.so under test.
+    module: PathBuf,
+    /// Directory of per-service stack files (PAM_WRAPPER_SERVICE_DIR).
+    service_dir: PathBuf,
+    /// Where this test's fake daemon listens (IRLUME_SOCKET).
+    socket: PathBuf,
+    root: PathBuf,
+}
+
+impl Harness {
+    /// `None` (after an explanatory eprintln) when pam_wrapper or pamtester is
+    /// not installed; tests early-return so `--include-ignored` never breaks a
+    /// box without the tools.
+    fn try_new(name: &str) -> Option<Self> {
+        let Some(wrapper) = wrapper_lib() else {
+            eprintln!(
+                "skipping: libpam_wrapper.so not found \
+                 (Fedora: dnf install pam_wrapper; Ubuntu: apt-get install libpam-wrapper; \
+                 or set PAM_WRAPPER_SO)"
+            );
+            return None;
+        };
+        let set_items = wrapper
+            .parent()
+            .expect("wrapper lib has a parent dir")
+            .join("pam_wrapper/pam_set_items.so");
+        assert!(
+            set_items.exists(),
+            "pam_set_items.so not next to {}; pam_wrapper installs both",
+            wrapper.display()
+        );
+        if !pamtester_available() {
+            eprintln!("skipping: pamtester not on PATH (dnf/apt-get install pamtester)");
+            return None;
+        }
+
+        // Keep the socket under /tmp when TMPDIR is deep: sun_path caps a Unix
+        // socket path at 108 bytes and CI/scratch TMPDIRs can exceed it.
+        let base = std::env::temp_dir();
+        let base = if base.as_os_str().len() > 60 {
+            PathBuf::from("/tmp")
+        } else {
+            base
+        };
+        let root = base.join(format!("irlume-pamwrap-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let service_dir = root.join("services");
+        std::fs::create_dir_all(&service_dir).unwrap();
+        Some(Harness {
+            wrapper,
+            set_items,
+            module: built_module(),
+            socket: root.join("irlumed.sock"),
+            service_dir,
+            root,
+        })
+    }
+
+    /// Write a pam_wrapper service file. `lines` are ordinary pam.d lines;
+    /// system modules may use bare names (libpam resolves them in its default
+    /// module dir), ours must be the absolute path.
+    fn write_service(&self, service: &str, lines: &[String]) {
+        let mut body = lines.join("\n");
+        body.push('\n');
+        std::fs::write(self.service_dir.join(service), body).unwrap();
+    }
+
+    /// Run `pamtester <service> <user> <ops...>` under pam_wrapper, feeding
+    /// `stdin` to the PAM conversation. `authtok_env` sets `PAM_AUTHTOK` in
+    /// pamtester's environment for a leading pam_set_items.so line. Returns
+    /// (succeeded, combined stdout+stderr).
+    fn run(
+        &self,
+        service: &str,
+        ops: &[&str],
+        stdin: &str,
+        authtok_env: Option<&str>,
+    ) -> (bool, String) {
+        let mut cmd = Command::new("pamtester");
+        cmd.arg(service).arg("tester").args(ops);
+        cmd.env("LD_PRELOAD", &self.wrapper)
+            .env("PAM_WRAPPER", "1")
+            .env("PAM_WRAPPER_SERVICE_DIR", &self.service_dir)
+            .env("IRLUME_SOCKET", &self.socket)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        match authtok_env {
+            Some(tok) => cmd.env("PAM_AUTHTOK", tok),
+            None => cmd.env_remove("PAM_AUTHTOK"),
+        };
+        let mut child = cmd.spawn().expect("spawn pamtester");
+        child.stdin.take().unwrap().write_all(stdin.as_bytes()).ok();
+        let out = child.wait_with_output().expect("wait for pamtester");
+        let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+        text.push_str(&String::from_utf8_lossy(&out.stderr));
+        (out.status.success(), text)
+    }
+
+    /// `auth <control> <pam_irlume.so> <args>` line for this build's module.
+    fn auth_line(&self, control: &str, args: &str) -> String {
+        format!("auth {control} {} {args}", self.module.display())
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+/// Find libpam_wrapper.so: `PAM_WRAPPER_SO` override first, then the packaged
+/// locations on Fedora/RHEL, Debian/Ubuntu, and Arch.
+fn wrapper_lib() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("PAM_WRAPPER_SO") {
+        let p = PathBuf::from(p);
+        return p.exists().then_some(p);
+    }
+    [
+        "/usr/lib64/libpam_wrapper.so",
+        "/usr/lib/x86_64-linux-gnu/libpam_wrapper.so",
+        "/usr/lib/aarch64-linux-gnu/libpam_wrapper.so",
+        "/usr/lib/libpam_wrapper.so",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .find(|p| p.exists())
+}
+
+fn pamtester_available() -> bool {
+    // Bare `pamtester` prints usage and exits non-zero; all we need is that it
+    // spawns (i.e. exists on PATH).
+    Command::new("pamtester")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+/// The cdylib cargo built for this test run. `cargo test -p irlume-pam` builds
+/// the lib target (producing libpam_irlume.so) alongside this test binary, so
+/// the authoritative location is THIS executable's own artifact dir: that is
+/// what keeps a `cargo llvm-cov` run loading the instrumented .so from
+/// target/llvm-cov-target instead of a stale plain-target build (the test
+/// process does not see CARGO_TARGET_DIR, so env-based resolution picks the
+/// wrong tree there). Fallbacks cover direct `cargo build` layouts.
+fn built_module() -> PathBuf {
+    let mut candidates = Vec::new();
+    if let Ok(exe) = std::env::current_exe() {
+        // <target>/<profile>/deps/pamwrap-<hash> → the cdylib sits in the same
+        // deps dir (unhashed name), or uplifted one level up by `cargo build`.
+        if let Some(deps) = exe.parent() {
+            candidates.push(deps.to_path_buf());
+            if let Some(profile_dir) = deps.parent() {
+                candidates.push(profile_dir.to_path_buf());
+            }
+        }
+    }
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    if let Some(dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        let dir = PathBuf::from(dir);
+        // A relative CARGO_TARGET_DIR is relative to where cargo was invoked,
+        // which for this workspace is its root.
+        let dir = if dir.is_absolute() {
+            dir
+        } else {
+            workspace.join(dir)
+        };
+        candidates.push(dir.join(profile).join("deps"));
+        candidates.push(dir.join(profile));
+    }
+    candidates.push(workspace.join("target").join(profile).join("deps"));
+    candidates.push(workspace.join("target").join(profile));
+    for dir in &candidates {
+        let so = dir.join("libpam_irlume.so");
+        if so.exists() {
+            return so;
+        }
+    }
+    panic!(
+        "libpam_irlume.so not found under {candidates:?}; \
+         `cargo test -p irlume-pam` builds it, so this points at a target-dir \
+         resolution bug in this harness"
+    );
+}
+
+// ------------------------------------------------------------- fake daemon
+
+/// Serve canned responses on `sock` with the daemon's line-JSON protocol (one
+/// request per connection), logging every parsed request so tests can assert
+/// exactly what the module sent. Same pattern as the irlume-cli test daemon.
+fn serve(
+    sock: &Path,
+    respond: impl Fn(&Request) -> Response + Send + 'static,
+) -> Arc<Mutex<Vec<Request>>> {
+    let _ = std::fs::remove_file(sock);
+    let listener = UnixListener::bind(sock).unwrap();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let thread_log = log.clone();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            let mut line = String::new();
+            if BufReader::new(&stream).read_line(&mut line).is_err() {
+                continue;
+            }
+            let Ok(req) = serde_json::from_str::<Request>(&line) else {
+                continue;
+            };
+            let mut reply = serde_json::to_string(&respond(&req)).unwrap();
+            reply.push('\n');
+            thread_log.lock().unwrap().push(req);
+            let _ = (&stream).write_all(reply.as_bytes());
+        }
+    });
+    log
+}
+
+/// A daemon that answers every request with a non-JSON line.
+fn serve_garbage(sock: &Path) {
+    let _ = std::fs::remove_file(sock);
+    let listener = UnixListener::bind(sock).unwrap();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            let mut line = String::new();
+            let _ = BufReader::new(&stream).read_line(&mut line);
+            let _ = (&stream).write_all(b"segfault in sector 7G\n");
+        }
+    });
+}
+
+fn grant() -> Response {
+    Response::AuthResult {
+        granted: true,
+        score: 0.93,
+        live: true,
+        reason: "match".into(),
+    }
+}
+
+fn unsealed(pw: &str) -> Response {
+    Response::PasswordUnsealed {
+        secret: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
+    }
+}
+
+// ------------------------------------------------------------------ tests
+//
+// All #[ignore] strings are identical: needs pam_wrapper + pamtester
+// (attribute literals cannot reference a const).
+
+/// Fail-closed floor: with irlumed unreachable (no socket at all) the module
+/// returns IGNORE, and a stack containing only it can grant nobody. The second
+/// half proves the failure really was the dead daemon: the identical stack
+/// with a granting daemon succeeds.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_dead_daemon_is_pam_ignore_fail_closed() {
+    let Some(h) = Harness::try_new("dead") else {
+        return;
+    };
+    h.write_service("irlume-dead", &[h.auth_line("required", "")]);
+
+    // No listener bound: connect fails, module IGNOREs, nothing granted.
+    let (ok, out) = h.run("irlume-dead", &["authenticate"], "", None);
+    assert!(!ok, "dead daemon must not authenticate anyone: {out}");
+
+    // Control: same stack, live granting daemon.
+    let log = serve(&h.socket, |req| match req {
+        Request::Authenticate { .. } => grant(),
+        _ => Response::Error("unexpected request".into()),
+    });
+    let (ok, out) = h.run("irlume-dead", &["authenticate"], "", None);
+    assert!(ok, "granting daemon must authenticate: {out}");
+    assert_eq!(log.lock().unwrap().len(), 1, "exactly one capture");
+}
+
+/// The default verify path (sudo / in-session unlock): no typed password, so
+/// the module sends one `Authenticate` carrying the user and the PAM service
+/// name, and a grant becomes PAM success.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_granting_daemon_face_path() {
+    let Some(h) = Harness::try_new("verify") else {
+        return;
+    };
+    h.write_service("irlume-face", &[h.auth_line("required", "")]);
+    let log = serve(&h.socket, |req| match req {
+        Request::Authenticate { .. } => grant(),
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (ok, out) = h.run("irlume-face", &["authenticate"], "", None);
+    assert!(ok, "live match must grant: {out}");
+
+    let reqs = log.lock().unwrap();
+    assert_eq!(reqs.len(), 1, "one capture, no retries: {reqs:?}");
+    match &reqs[0] {
+        Request::Authenticate { user, service } => {
+            assert_eq!(user, "tester");
+            assert_eq!(
+                service.as_deref(),
+                Some("irlume-face"),
+                "the PAM service name must reach the daemon for tier gating"
+            );
+        }
+        other => panic!("expected Authenticate, daemon saw {other:?}"),
+    }
+}
+
+/// The login path (`unseal`): submitting an EMPTY password is the face
+/// gesture. The module asks the daemon to release the TPM-sealed password,
+/// sets it as PAM_AUTHTOK, and returns success.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_unseal_face_login_releases_sealed_password() {
+    let Some(h) = Harness::try_new("unseal") else {
+        return;
+    };
+    h.write_service("irlume-login", &[h.auth_line("required", "unseal")]);
+    let log = serve(&h.socket, |req| match req {
+        Request::UnsealPassword { .. } => unsealed("hunter2"),
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    // The module actively prompts ("Password: "); an empty line = face chosen.
+    let (ok, out) = h.run("irlume-login", &["authenticate"], "\n", None);
+    assert!(ok, "unseal grant must authenticate: {out}");
+
+    let reqs = log.lock().unwrap();
+    assert_eq!(reqs.len(), 1, "{reqs:?}");
+    match &reqs[0] {
+        Request::UnsealPassword { user, service } => {
+            assert_eq!(user, "tester");
+            assert_eq!(service.as_deref(), Some("irlume-login"));
+        }
+        other => panic!("expected UnsealPassword, daemon saw {other:?}"),
+    }
+}
+
+/// The documented privacy property: typing a password NEVER starts a scan.
+/// Both discovery paths are covered: the active greeter probe (`unseal`
+/// prompts, the user types) and the passive peek (an earlier module already
+/// set PAM_AUTHTOK, here pam_set_items standing in for the greeter). In both
+/// cases the recording daemon must see ZERO requests, and since nothing else
+/// in the stack grants, authentication fails.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_typed_password_never_fires_the_camera() {
+    let Some(h) = Harness::try_new("typed") else {
+        return;
+    };
+    let log = serve(&h.socket, |_| grant());
+
+    // Active probe: `unseal` asks, the user answers with a real password.
+    h.write_service("irlume-typed-login", &[h.auth_line("required", "unseal")]);
+    let (ok, out) = h.run("irlume-typed-login", &["authenticate"], "hunter2\n", None);
+    assert!(!ok, "module must IGNORE on a typed password: {out}");
+
+    // Passive peek: PAM_AUTHTOK pre-set before our line (verify mode). The
+    // control neutralizes pam_set_items' own SUCCESS verdict so the stack
+    // outcome is decided solely by our module (IGNORE ⇒ nobody granted).
+    h.write_service(
+        "irlume-typed-sudo",
+        &[
+            format!(
+                "auth [success=ignore default=bad] {}",
+                h.set_items.display()
+            ),
+            h.auth_line("required", ""),
+        ],
+    );
+    let (ok, out) = h.run("irlume-typed-sudo", &["authenticate"], "", Some("hunter2"));
+    assert!(!ok, "module must IGNORE on a cached password: {out}");
+
+    let reqs = log.lock().unwrap();
+    assert!(
+        reqs.is_empty(),
+        "typing a password must never reach the daemon (no camera): {reqs:?}"
+    );
+}
+
+/// A daemon that answers with a line that is not JSON: the reply fails to
+/// parse, the module IGNOREs, and the stack fails closed.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_malformed_daemon_reply_is_ignore_fail_closed() {
+    let Some(h) = Harness::try_new("garbage") else {
+        return;
+    };
+    h.write_service("irlume-garbage", &[h.auth_line("required", "")]);
+    serve_garbage(&h.socket);
+
+    let (ok, out) = h.run("irlume-garbage", &["authenticate"], "", None);
+    assert!(!ok, "a garbage reply must never authenticate: {out}");
+}
+
+/// `wait` mode (lock screen): a declined attempt is retried after the gap
+/// instead of falling through to the password, and the retry's grant wins.
+/// The whole exchange must stay far inside the 20s budget (deny + one 400ms
+/// gap + grant), proving success exits the loop immediately.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_wait_mode_retries_until_a_match() {
+    let Some(h) = Harness::try_new("wait") else {
+        return;
+    };
+    h.write_service("irlume-lock", &[h.auth_line("required", "wait")]);
+    // First capture: not the user. Second: match.
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let calls_in_daemon = calls.clone();
+    let log = serve(&h.socket, move |req| match req {
+        Request::Authenticate { .. } => {
+            if calls_in_daemon.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                Response::AuthResult {
+                    granted: false,
+                    score: 0.10,
+                    live: true,
+                    reason: "below threshold".into(),
+                }
+            } else {
+                grant()
+            }
+        }
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let started = std::time::Instant::now();
+    let (ok, out) = h.run("irlume-lock", &["authenticate"], "", None);
+    assert!(ok, "the retried match must authenticate: {out}");
+    assert_eq!(log.lock().unwrap().len(), 2, "deny, one gap, grant");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "a grant must exit the wait loop immediately, not sit out the budget"
+    );
+}
+
+/// A daemon reply whose unsealed secret contains a NUL byte cannot become a
+/// PAM_AUTHTOK (C string); the module must treat it as a decline, and with
+/// nothing else in the stack the authentication fails closed.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_nul_poisoned_secret_is_ignore_fail_closed() {
+    let Some(h) = Harness::try_new("nul") else {
+        return;
+    };
+    h.write_service("irlume-nul", &[h.auth_line("required", "unseal")]);
+    serve(&h.socket, |req| match req {
+        Request::UnsealPassword { .. } => Response::PasswordUnsealed {
+            secret: irlume_common::SecretBytes::new(b"hun\0ter".to_vec()),
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (ok, out) = h.run("irlume-nul", &["authenticate"], "\n", None);
+    assert!(!ok, "a NUL-poisoned secret must never authenticate: {out}");
+}
+
+/// `ondemand` (GDM/cosmic single-service wiring): when the unseal is refused
+/// (convenience tier / un-armed keyring) the module falls back to a plain
+/// verify before giving up, so a warm screen unlock still works.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_ondemand_unseal_falls_back_to_verify() {
+    let Some(h) = Harness::try_new("ondemand") else {
+        return;
+    };
+    h.write_service(
+        "irlume-cosmic",
+        &[h.auth_line("required", "unseal ondemand")],
+    );
+    let log = serve(&h.socket, |req| match req {
+        Request::UnsealPassword { .. } => Response::Error("keyring not armed".into()),
+        Request::Authenticate { .. } => grant(),
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (ok, out) = h.run("irlume-cosmic", &["authenticate"], "\n", None);
+    assert!(ok, "verify fallback must rescue the warm unlock: {out}");
+
+    let reqs = log.lock().unwrap();
+    assert_eq!(
+        reqs.len(),
+        2,
+        "unseal attempt then verify fallback: {reqs:?}"
+    );
+    assert!(matches!(reqs[0], Request::UnsealPassword { .. }));
+    assert!(matches!(reqs[1], Request::Authenticate { .. }));
+}
+
+/// `keyring` mode (fingerprint path, post-auth landing): with no password in
+/// the transaction the module asks for the sealed password to unlock the
+/// keyring; with one already present it stays silent. Either way it returns
+/// IGNORE (best-effort), so the trailing pam_permit decides the stack.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_keyring_mode_unseals_only_without_a_password() {
+    let Some(h) = Harness::try_new("keyring") else {
+        return;
+    };
+    let log = serve(&h.socket, |req| match req {
+        Request::UnsealKeyring { .. } => unsealed("hunter2"),
+        _ => Response::Error("unexpected request".into()),
+    });
+    h.write_service(
+        "irlume-fp",
+        &[
+            h.auth_line("required", "keyring"),
+            "auth required pam_permit.so".into(),
+        ],
+    );
+    h.write_service(
+        "irlume-fp-pw",
+        &[
+            format!("auth required {}", h.set_items.display()),
+            h.auth_line("required", "keyring"),
+            "auth required pam_permit.so".into(),
+        ],
+    );
+
+    // No password in the transaction: unseal the keyring secret.
+    let (ok, out) = h.run("irlume-fp", &["authenticate"], "", None);
+    assert!(ok, "keyring mode must never block the login: {out}");
+    {
+        let reqs = log.lock().unwrap();
+        assert_eq!(reqs.len(), 1, "{reqs:?}");
+        match &reqs[0] {
+            Request::UnsealKeyring { user, service } => {
+                assert_eq!(user, "tester");
+                assert_eq!(service.as_deref(), Some("irlume-fp"));
+            }
+            other => panic!("expected UnsealKeyring, daemon saw {other:?}"),
+        }
+        // (drop the guard before the next run appends)
+    }
+
+    // Password already present: the keyring self-unlocks from it; no request.
+    let (ok, out) = h.run("irlume-fp-pw", &["authenticate"], "", Some("hunter2"));
+    assert!(ok, "{out}");
+    assert_eq!(
+        log.lock().unwrap().len(),
+        1,
+        "a present password must mean no daemon contact"
+    );
+}
+
+/// `kr` (Debian `@include` keyring-continue): a COLD face login that released
+/// the password returns IGNORE instead of SUCCESS, so a `sufficient` control
+/// CONTINUES down the stack (here into pam_deny, making the outcome
+/// distinguishable) instead of short-circuiting. Without `kr` the identical
+/// stack short-circuits at our line. "tester" has no live session, so the
+/// login counts as cold.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_kr_cold_login_continues_instead_of_short_circuiting() {
+    let Some(h) = Harness::try_new("kr") else {
+        return;
+    };
+    let log = serve(&h.socket, |req| match req {
+        Request::UnsealPassword { .. } => unsealed("hunter2"),
+        _ => Response::Error("unexpected request".into()),
+    });
+    h.write_service(
+        "irlume-kr",
+        &[
+            h.auth_line("sufficient", "unseal kr"),
+            "auth required pam_deny.so".into(),
+        ],
+    );
+    h.write_service(
+        "irlume-nokr",
+        &[
+            h.auth_line("sufficient", "unseal"),
+            "auth required pam_deny.so".into(),
+        ],
+    );
+
+    // kr + cold + password released → IGNORE → sufficient continues → deny.
+    let (ok, out) = h.run("irlume-kr", &["authenticate"], "\n", None);
+    assert!(!ok, "kr cold login must continue past our line: {out}");
+    assert_eq!(
+        log.lock().unwrap().len(),
+        1,
+        "the unseal must still have happened (that is what kr hands on)"
+    );
+
+    // Same stack minus kr: SUCCESS short-circuits before pam_deny.
+    let (ok, out) = h.run("irlume-nokr", &["authenticate"], "\n", None);
+    assert!(ok, "without kr a sufficient grant short-circuits: {out}");
+}
+
+/// The `reseal` self-heal, whole transaction: the AUTH line only STASHES the
+/// (pam_set_items-provided, i.e. verified-by-the-stack) password and must not
+/// contact the daemon; the SESSION line, which PAM only reaches after auth
+/// succeeded, hands exactly that password to the daemon for re-sealing.
+/// close_session is driven too (constant IGNORE; permit carries the stack).
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_reseal_stashes_on_auth_and_reseals_on_session() {
+    let Some(h) = Harness::try_new("reseal") else {
+        return;
+    };
+    let log = serve(&h.socket, |req| match req {
+        Request::ResealPassword { .. } => Response::PasswordResealed {
+            armed: true,
+            changed: true,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+    h.write_service(
+        "irlume-reseal",
+        &[
+            format!("auth required {}", h.set_items.display()),
+            h.auth_line("required", "reseal"),
+            "auth required pam_permit.so".into(),
+            format!("session required {} reseal", h.module.display()),
+            "session required pam_permit.so".into(),
+        ],
+    );
+
+    let (ok, out) = h.run(
+        "irlume-reseal",
+        &["authenticate", "open_session", "close_session"],
+        "",
+        Some("hunter2"),
+    );
+    assert!(ok, "auth + session must both pass: {out}");
+
+    let reqs = log.lock().unwrap();
+    assert_eq!(
+        reqs.len(),
+        1,
+        "exactly one reseal, and none during the auth phase: {reqs:?}"
+    );
+    match &reqs[0] {
+        Request::ResealPassword { user, password } => {
+            assert_eq!(user, "tester");
+            assert_eq!(
+                password.expose(),
+                b"hunter2",
+                "the session phase must reseal the stack-verified password verbatim"
+            );
+        }
+        other => panic!("expected ResealPassword, daemon saw {other:?}"),
+    }
+    drop(reqs);
+
+    // A pure face login stashes nothing (blank submit ⇒ empty PAM_AUTHTOK), so
+    // the session half must have nothing to heal with: no daemon contact.
+    h.write_service(
+        "irlume-reseal-empty",
+        &[
+            h.auth_line("required", "reseal"),
+            "auth required pam_permit.so".into(),
+            format!("session required {} reseal", h.module.display()),
+            "session required pam_permit.so".into(),
+        ],
+    );
+    let (ok, out) = h.run(
+        "irlume-reseal-empty",
+        &["authenticate", "open_session"],
+        "",
+        None,
+    );
+    assert!(ok, "{out}");
+    assert_eq!(
+        log.lock().unwrap().len(),
+        1,
+        "an empty stash must never produce a reseal request"
+    );
+}


### PR DESCRIPTION
Fourth-through-seventh fake-hardware harnesses. daemon main.rs 48->74%, irlume-pam 0->95% (pam_wrapper), CLI capture tools and deep camera streaming branches under test. 268 new assertions; production changes are commented verbatim seams plus one crate-type addition (cdylib+lib) so cargo test can link the PAM module. CI adds a spare loopback node and pam_wrapper/pamtester. Ratchet bumps after CI reports.
