### PR TITLE
ci: coverage ratchet floor 69 -> 76

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
           cargo llvm-cov --no-report -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
           cargo llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
           cargo llvm-cov --no-report -p irlume-pam --locked -- --include-ignored --test-threads=1
-          cargo llvm-cov report --summary-only --fail-under-lines 69
+          cargo llvm-cov report --summary-only --fail-under-lines 76
 
   deny:
     name: cargo-deny (advisories · licenses · duplicate versions)


### PR DESCRIPTION
CI measures 77.38% lines after the daemon/PAM/CLI/camera coverage round; the floor follows.
