### PR TITLE
test: coverage round 3 (core + CLI pure-logic)

### DIFF
--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -210,3 +210,43 @@ fn run_cmd(cmd: &str, args: &[&str]) -> bool {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_uid_matches_the_real_euid() {
+        // The /proc/self/status parse must yield the kernel's effective uid.
+        assert_eq!(effective_uid(), unsafe { libc::geteuid() });
+    }
+
+    #[test]
+    fn require_root_gates_on_the_effective_uid() {
+        // Consistent with effective_uid: only uid 0 clears the gate.
+        if effective_uid() == 0 {
+            assert!(require_root("enable"));
+        } else {
+            assert!(!require_root("enable"));
+        }
+    }
+
+    #[test]
+    fn run_cmd_maps_spawn_and_exit_outcomes_to_a_bool() {
+        // Zero exit → true, non-zero → false, un-spawnable → false. Uses the
+        // harmless true/false shells, never a real authselect/pam-auth-update.
+        assert!(run_cmd("true", &[]));
+        assert!(!run_cmd("false", &[]));
+        assert!(!run_cmd("irlume-no-such-command-xyz", &["arg"]));
+    }
+
+    #[test]
+    fn enroll_one_refuses_without_fprintd_or_a_reader() {
+        // When the tooling or the sensor is missing, enrollment bails early with
+        // false and never drives hardware. On a box that has both, this branch
+        // isn't reachable without a live sensor, so it is skipped.
+        if !fp::fprintd_present() || !fp::reader_present() {
+            assert!(!enroll_one("irlume-nonexistent-test-user"));
+        }
+    }
+}

--- a/crates/irlume-cli/src/logs.rs
+++ b/crates/irlume-cli/src/logs.rs
@@ -28,9 +28,17 @@ pub fn run(sub: Option<&str>, args: &[String]) -> ExitCode {
     }
 }
 
-fn view(opts: &[String]) -> ExitCode {
-    let mut cmd = Command::new("journalctl");
-    cmd.args(["--no-pager", "-g", PATTERN]);
+/// Build the full journalctl argv (program + args) from the view options, or an
+/// error message for a bad option. Extracted verbatim from `view` so the argv
+/// assembly (the whole point of the option parse) is unit-testable without
+/// execing journalctl; `view` just runs what this returns. Zero behavior change.
+fn build_view_argv(opts: &[String]) -> Result<Vec<String>, String> {
+    let mut argv = vec![
+        "journalctl".to_string(),
+        "--no-pager".to_string(),
+        "-g".to_string(),
+        PATTERN.to_string(),
+    ];
     let mut follow = false;
     let mut since = false;
     let mut it = opts.iter().map(String::as_str);
@@ -40,24 +48,40 @@ fn view(opts: &[String]) -> ExitCode {
             "--since" => match it.next() {
                 Some(v) => {
                     since = true;
-                    cmd.args(["--since", v]);
+                    argv.push("--since".to_string());
+                    argv.push(v.to_string());
                 }
                 None => {
-                    eprintln!("[logs] --since needs a value, e.g. --since \"10 min ago\"");
-                    return ExitCode::FAILURE;
+                    return Err(
+                        "[logs] --since needs a value, e.g. --since \"10 min ago\"".to_string()
+                    );
                 }
             },
             other => {
-                eprintln!("[logs] unknown option '{other}' (usage: irlume logs [-f] [--since T] [debug on|off])");
-                return ExitCode::FAILURE;
+                return Err(format!(
+                    "[logs] unknown option '{other}' (usage: irlume logs [-f] [--since T] [debug on|off])"
+                ));
             }
         }
     }
     if follow {
-        cmd.arg("-f");
+        argv.push("-f".to_string());
     } else if !since {
-        cmd.arg("-b");
+        argv.push("-b".to_string());
     } // default: this boot
+    Ok(argv)
+}
+
+fn view(opts: &[String]) -> ExitCode {
+    let argv = match build_view_argv(opts) {
+        Ok(a) => a,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let mut cmd = Command::new(&argv[0]);
+    cmd.args(&argv[1..]);
     if !is_root() {
         eprintln!("[logs] note: without root (or the systemd-journal group) the system journal may be hidden; re-run with sudo if this looks empty");
     }
@@ -139,4 +163,63 @@ fn restart_daemon() {
 
 fn is_root() -> bool {
     unsafe { libc::geteuid() == 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn default_view_greps_the_pattern_this_boot() {
+        // No options → the fixed grep argv plus `-b` (this boot).
+        assert_eq!(
+            build_view_argv(&[]).unwrap(),
+            vec!["journalctl", "--no-pager", "-g", PATTERN, "-b"]
+        );
+    }
+
+    #[test]
+    fn follow_replaces_the_boot_filter_with_f() {
+        // -f / --follow both set follow, which suppresses -b and appends -f.
+        for flag in ["-f", "--follow"] {
+            let argv = build_view_argv(&opts(&[flag])).unwrap();
+            assert_eq!(argv.last().unwrap(), "-f");
+            assert!(!argv.contains(&"-b".to_string()));
+        }
+    }
+
+    #[test]
+    fn since_passes_its_value_through_and_drops_the_boot_filter() {
+        let argv = build_view_argv(&opts(&["--since", "10 min ago"])).unwrap();
+        // --since <value> present, in order, and no default -b when a window is given.
+        let pos = argv.iter().position(|a| a == "--since").unwrap();
+        assert_eq!(argv[pos + 1], "10 min ago");
+        assert!(!argv.contains(&"-b".to_string()));
+        assert!(!argv.contains(&"-f".to_string()));
+    }
+
+    #[test]
+    fn since_without_a_value_is_an_error() {
+        let err = build_view_argv(&opts(&["--since"])).unwrap_err();
+        assert!(err.contains("--since needs a value"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_option_names_itself_in_the_error() {
+        let err = build_view_argv(&opts(&["--bogus"])).unwrap_err();
+        assert!(err.contains("unknown option '--bogus'"), "{err}");
+    }
+
+    #[test]
+    fn follow_and_since_compose() {
+        // Both given: --since value present AND -f appended, still no -b.
+        let argv = build_view_argv(&opts(&["--since", "1h", "-f"])).unwrap();
+        assert!(argv.windows(2).any(|w| w == ["--since", "1h"]));
+        assert_eq!(argv.last().unwrap(), "-f");
+        assert!(!argv.contains(&"-b".to_string()));
+    }
 }

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -343,4 +343,55 @@ mod tests {
         }
         let _ = std::fs::remove_dir_all(&root);
     }
+
+    /// `enabled_name` reads the third-party key from settings.conf: absent file
+    /// → None, a set key → its value. `file_state` classifies the weights file
+    /// as absent vs checksum-mismatch (the on-disk states we can produce without
+    /// the real pinned bytes).
+    #[test]
+    fn enabled_name_and_file_state_read_config_and_weights() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("irlume-models-cfg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let (cfg, state) = (root.join("cfg"), root.join("state"));
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::fs::create_dir_all(&state).unwrap();
+        let old_cfg = std::env::var_os("IRLUME_CONFIG_DIR");
+        let old_state = std::env::var_os("IRLUME_STATE_DIR");
+        std::env::set_var("IRLUME_CONFIG_DIR", &cfg);
+        std::env::set_var("IRLUME_STATE_DIR", &state);
+
+        // No settings.conf → nothing enabled.
+        assert_eq!(enabled_name(), None);
+        let m = &thirdparty::CATALOG[0];
+
+        // The weights file is absent until fetched.
+        assert_eq!(file_state(m), "weights not fetched");
+
+        // Bytes that do not match the pinned sha256 classify as a mismatch.
+        std::fs::create_dir_all(thirdparty::dir()).unwrap();
+        std::fs::write(thirdparty::model_path(m), b"not the real weights").unwrap();
+        assert!(file_state(m).contains("CHECKSUM MISMATCH"));
+        std::fs::remove_file(thirdparty::model_path(m)).unwrap();
+
+        // A set key is read back verbatim.
+        std::fs::write(
+            cfg.join("settings.conf"),
+            format!("{}={}\n", thirdparty::SETTINGS_KEY, m.name),
+        )
+        .unwrap();
+        assert_eq!(enabled_name().as_deref(), Some(m.name));
+
+        match old_cfg {
+            Some(v) => std::env::set_var("IRLUME_CONFIG_DIR", v),
+            None => std::env::remove_var("IRLUME_CONFIG_DIR"),
+        }
+        match old_state {
+            Some(v) => std::env::set_var("IRLUME_STATE_DIR", v),
+            None => std::env::remove_var("IRLUME_STATE_DIR"),
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1415,4 +1415,329 @@ mod tests {
         assert!(!is_passwd_substack("auth required pam_unix.so", "auth"));
         assert!(!is_passwd_substack("# auth substack password-auth", "auth"));
     }
+
+    #[test]
+    fn dm_pam_services_maps_each_login_manager_to_its_services() {
+        // GDM (and the Debian gdm3 alias) drive a separate fingerprint service.
+        assert_eq!(
+            dm_pam_services("gdm"),
+            ("gdm-password", Some("gdm-fingerprint"))
+        );
+        assert_eq!(
+            dm_pam_services("gdm3"),
+            ("gdm-password", Some("gdm-fingerprint"))
+        );
+        // Single-greeter DMs: KDE/others put fingerprint on the lock screen, so
+        // no separate fingerprint service here.
+        assert_eq!(dm_pam_services("sddm"), ("sddm", None));
+        assert_eq!(dm_pam_services("plasmalogin"), ("plasmalogin", None));
+        assert_eq!(dm_pam_services("lightdm"), ("lightdm", None));
+        assert_eq!(dm_pam_services("greetd"), ("greetd", None));
+        assert_eq!(dm_pam_services("ly"), ("ly", None));
+        assert_eq!(dm_pam_services("cosmic-greeter"), ("cosmic-greeter", None));
+        // Anything unrecognised is named "(unknown)" with no fingerprint service.
+        assert_eq!(dm_pam_services("mystery-dm"), ("(unknown)", None));
+    }
+
+    #[test]
+    fn label_of_takes_the_basename() {
+        assert_eq!(label_of("/etc/pam.d/gdm-password"), "gdm-password");
+        assert_eq!(label_of("/etc/pam.d/kde"), "kde");
+        assert_eq!(label_of("sudo"), "sudo"); // no slash → whole string
+    }
+
+    #[test]
+    fn is_include_auth_layout_matches_only_the_inline_includes() {
+        // Debian @include forms.
+        assert!(is_include_auth_layout("@include common-auth"));
+        assert!(is_include_auth_layout("@include login"));
+        // Arch inline includes a success=N jump cannot skip.
+        assert!(is_include_auth_layout(
+            "auth       include     system-login"
+        ));
+        assert!(is_include_auth_layout("auth include system-local-login"));
+        assert!(is_include_auth_layout("auth include system-auth"));
+        // NOT an include-auth layout: a Fedora substack (atomic for jumps), a
+        // different @include, or an include of a non-login file.
+        assert!(!is_include_auth_layout(
+            "auth     substack     password-auth"
+        ));
+        assert!(!is_include_auth_layout("@include common-account"));
+        assert!(!is_include_auth_layout("auth include password-auth"));
+        assert!(!is_include_auth_layout("account include system-login"));
+    }
+
+    #[test]
+    fn is_auth_directive_recognises_auth_lines_only() {
+        assert!(is_auth_directive("auth required pam_unix.so"));
+        assert!(is_auth_directive("-auth optional pam_gnome_keyring.so")); // leading '-'
+        assert!(is_auth_directive("   auth   substack password-auth")); // leading ws
+        assert!(!is_auth_directive("# auth required pam_unix.so")); // comment
+        assert!(!is_auth_directive("account required pam_unix.so"));
+        assert!(!is_auth_directive("session optional pam_unix.so"));
+    }
+
+    // gdm-fingerprint: the keyring unseal must land right AFTER pam_fprintd's
+    // auth line and BEFORE pam_gnome_keyring's auth line, so the sealed password
+    // is set before the keyring module reads it.
+    const GDM_FP: &str = "#%PAM-1.0\nauth       required      pam_env.so\nauth       required      pam_fprintd.so\nauth       optional      pam_gnome_keyring.so\nsession    optional      pam_gnome_keyring.so auto_start\n";
+
+    #[test]
+    fn wire_fp_keyring_inserts_between_fprintd_and_the_keyring_auth_line() {
+        let (w, changed) = wire_fp_keyring(GDM_FP);
+        assert!(changed);
+        let lines: Vec<&str> = w.lines().collect();
+        let fp = lines
+            .iter()
+            .position(|l| l.contains("pam_fprintd.so"))
+            .unwrap();
+        let kr = lines
+            .iter()
+            .position(|l| l.contains("pam_irlume.so keyring"))
+            .unwrap();
+        let gk = lines
+            .iter()
+            .position(|l| l.trim_start().starts_with("auth") && l.contains("pam_gnome_keyring.so"))
+            .unwrap();
+        assert!(
+            fp < kr && kr < gk,
+            "keyring unseal must sit fprintd→keyring"
+        );
+        // Idempotent: a second pass is a no-op.
+        let (w2, c2) = wire_fp_keyring(&w);
+        assert!(!c2 && w2 == w);
+    }
+
+    #[test]
+    fn wire_fp_keyring_needs_an_fprintd_anchor() {
+        // No pam_fprintd line → nothing to anchor to → unchanged.
+        let (w, changed) = wire_fp_keyring("#%PAM-1.0\nauth required pam_unix.so\n");
+        assert!(!changed);
+        assert_eq!(w, "#%PAM-1.0\nauth required pam_unix.so\n");
+        // A commented fprintd line is not an anchor either.
+        let (_, c) = wire_fp_keyring("#%PAM-1.0\n# auth required pam_fprintd.so\n");
+        assert!(!c);
+    }
+
+    #[test]
+    fn wire_greeter_keyring_only_in_include_layout_adds_no_face_line() {
+        // face=false, keyring=true on a @include greeter: keyring + reseal ride
+        // in, but no face `unseal` line and no permit landing.
+        let (w, changed) = wire_greeter_impl(COSMIC, false, true, true);
+        assert!(changed);
+        assert!(w.contains("pam_irlume.so keyring"));
+        assert!(w.contains("pam_irlume.so reseal"));
+        assert!(!w.contains("unseal")); // no face line at all
+    }
+
+    #[test]
+    fn wire_greeter_without_any_auth_anchor_is_a_noop() {
+        // No include layout, no password substack, no auth directive → unchanged.
+        let src = "#%PAM-1.0\naccount required pam_unix.so\nsession required pam_unix.so\n";
+        let (w, changed) = wire_greeter_impl(src, true, false, false);
+        assert!(!changed);
+        assert_eq!(w, src);
+    }
+
+    #[test]
+    fn wire_single_appends_when_there_is_no_auth_directive() {
+        // A stack with no auth line: the stanza is appended at the end.
+        let (w, c) = wire_single("#%PAM-1.0\n# comment only\n", SUDO_STANZA);
+        assert!(c && content_has_module(&w));
+        assert!(w.trim_end().ends_with(SUDO_STANZA));
+    }
+
+    #[test]
+    fn wire_lock_without_an_auth_anchor_is_a_noop() {
+        let (w, c) = wire_lock("#%PAM-1.0\naccount required pam_unix.so\n");
+        assert!(!c);
+        assert_eq!(w, "#%PAM-1.0\naccount required pam_unix.so\n");
+    }
+
+    #[test]
+    fn status_report_labels_and_login_wired_agree() {
+        // The report's rows are the greeters, the fingerprint service, the lock
+        // screen, then sudo, in that order; labels come from the constant paths.
+        let rows = status_report();
+        let labels: Vec<&str> = rows.iter().map(|(l, _, _)| l.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec![
+                "gdm-password",
+                "sddm",
+                "lightdm",
+                "plasmalogin",
+                "cosmic-greeter",
+                "greetd",
+                "gdm-fingerprint",
+                "kde",
+                "sudo",
+            ]
+        );
+        // login_wired is exactly "any non-sudo row is wired" (sudo excluded).
+        let any_login = rows[..rows.len() - 1].iter().any(|(_, _, w)| *w);
+        assert_eq!(login_wired(), any_login);
+    }
+
+    #[test]
+    fn effective_uid_matches_the_real_euid() {
+        assert_eq!(effective_uid(), unsafe { libc::geteuid() });
+    }
+
+    #[test]
+    fn selinux_pp_honours_the_env_override_only_when_it_exists() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = TestDir::new("selinux-pp");
+        let pp = dir.0.join("irlume.pp");
+        std::fs::write(&pp, b"module").unwrap();
+        let old = std::env::var_os("IRLUME_SELINUX_PP");
+        // An existing override path is returned verbatim.
+        std::env::set_var("IRLUME_SELINUX_PP", &pp);
+        assert_eq!(selinux_pp(), Some(pp.to_string_lossy().into_owned()));
+        // A nonexistent override is ignored (never returned) and the search
+        // falls through to the packaged/in-repo locations instead.
+        let missing = dir.0.join("missing.pp");
+        std::env::set_var("IRLUME_SELINUX_PP", &missing);
+        assert_ne!(selinux_pp().as_deref(), missing.to_str());
+        match old {
+            Some(v) => std::env::set_var("IRLUME_SELINUX_PP", v),
+            None => std::env::remove_var("IRLUME_SELINUX_PP"),
+        }
+    }
+
+    // ---- wire_service strategy matrix (override vs edit-in-place) -------------
+
+    // A vendor-shipped greeter (Fedora substack layout), the kind plasmalogin/kde
+    // materialize an /etc override from.
+    const VENDOR_GREETER: &str = "#%PAM-1.0\nauth       substack      password-auth\nauth       optional      pam_gnome_keyring.so\naccount    include       password-auth\nsession    include       password-auth\n";
+
+    #[test]
+    fn wire_service_override_materialize_idempotent_then_remove() {
+        let dir = TestDir::new("wsvc-override");
+        let vendor = dir.0.join("plasmalogin.vendor");
+        std::fs::write(&vendor, VENDOR_GREETER).unwrap();
+        let etc = dir.0.join("plasmalogin"); // no admin /etc copy yet
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: Some(leak(&vendor)),
+        };
+        let wire = |c: &str| wire_greeter_impl(c, true, false, true);
+
+        // First enable → materialize the override from the vendor copy.
+        let msg = wire_service(&svc, true, true, &wire).unwrap();
+        assert!(msg.contains("materialized override from"), "{msg}");
+        assert!(etc.exists());
+        let body = std::fs::read_to_string(&etc).unwrap();
+        assert!(body.starts_with(CREATED_PREFIX));
+        assert!(file_is_created_override(&etc));
+        assert!(body.contains("pam_irlume.so unseal ondemand"));
+
+        // Re-enable with the same inputs → recognised as already correct.
+        let msg2 = wire_service(&svc, true, true, &wire).unwrap();
+        assert!(msg2.contains("already correctly wired"), "{msg2}");
+
+        // Disable → the created override is removed and the vendor copy restored.
+        let msg3 = wire_service(&svc, false, true, &wire).unwrap();
+        assert!(msg3.contains("removed override"), "{msg3}");
+        assert!(!etc.exists());
+    }
+
+    #[test]
+    fn wire_service_override_skips_when_vendor_absent() {
+        let dir = TestDir::new("wsvc-novendor");
+        let etc = dir.0.join("plasmalogin");
+        let vendor = dir.0.join("plasmalogin.vendor"); // never created
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: Some(leak(&vendor)),
+        };
+        let wire = |c: &str| wire_greeter_impl(c, true, false, true);
+        let msg = wire_service(&svc, true, true, &wire).unwrap();
+        assert!(msg.contains("not installed (skipped)"), "{msg}");
+        assert!(!etc.exists());
+    }
+
+    #[test]
+    fn wire_service_edit_skips_absent_and_anchorless_files() {
+        let wire = |c: &str| wire_greeter_impl(c, true, false, false);
+
+        // No /etc file at all → skipped.
+        let dir = TestDir::new("wsvc-absent");
+        let etc = dir.0.join("gdm-password");
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: None,
+        };
+        let msg = wire_service(&svc, true, true, &wire).unwrap();
+        assert!(msg.contains("not installed (skipped)"), "{msg}");
+
+        // Present but nothing to anchor to → skipped, no backup left behind.
+        let dir2 = TestDir::new("wsvc-noanchor");
+        let etc2 = dir2.0.join("greeter");
+        std::fs::write(&etc2, "#%PAM-1.0\naccount required pam_unix.so\n").unwrap();
+        let svc2 = Svc {
+            etc: leak(&etc2),
+            vendor: None,
+        };
+        let msg2 = wire_service(&svc2, true, true, &wire).unwrap();
+        assert!(msg2.contains("no anchor to wire"), "{msg2}");
+        assert!(!dir2.0.join(format!("greeter{BACKUP}")).exists());
+    }
+
+    #[test]
+    fn wire_service_edit_enable_backs_up_then_recognises_already_wired() {
+        let dir = TestDir::new("wsvc-enable");
+        let etc = dir.0.join("gdm-password");
+        std::fs::write(&etc, GDM).unwrap();
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: None,
+        };
+        let wire = |c: &str| wire_greeter_impl(c, true, true, false);
+
+        let msg = wire_service(&svc, true, true, &wire).unwrap();
+        assert!(msg.contains("wired (backup"), "{msg}");
+        assert!(dir.0.join(format!("gdm-password{BACKUP}")).exists());
+        let after = std::fs::read_to_string(&etc).unwrap();
+        assert!(content_has_module(&after));
+
+        // Second identical enable is a recognised no-op (rebuilt from backup).
+        let msg2 = wire_service(&svc, true, true, &wire).unwrap();
+        assert!(msg2.contains("already correctly wired"), "{msg2}");
+    }
+
+    #[test]
+    fn wire_service_edit_disable_strips_when_no_backup_exists() {
+        // Wired file, no .pre-irlume backup → strip in place (not restore).
+        let dir = TestDir::new("wsvc-strip");
+        let (wired, _) = wire_greeter_impl(GDM, true, true, false);
+        let etc = dir.0.join("gdm-password");
+        std::fs::write(&etc, &wired).unwrap();
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: None,
+        };
+        let wire = |c: &str| wire_greeter_impl(c, true, true, false);
+        let msg = wire_service(&svc, false, true, &wire).unwrap();
+        assert!(msg.contains("stripped irlume lines"), "{msg}");
+        assert!(!msg.contains("backup kept")); // the no-backup phrasing
+        let after = std::fs::read_to_string(&etc).unwrap();
+        assert!(!content_has_module(&after));
+    }
+
+    #[test]
+    fn wire_service_edit_disable_reports_a_clean_file_as_not_wired() {
+        let dir = TestDir::new("wsvc-clean");
+        let etc = dir.0.join("gdm-password");
+        std::fs::write(&etc, GDM).unwrap(); // never wired
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: None,
+        };
+        let wire = |c: &str| wire_greeter_impl(c, true, true, false);
+        let msg = wire_service(&svc, false, true, &wire).unwrap();
+        assert!(msg.contains("not wired"), "{msg}");
+    }
 }

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -380,4 +380,43 @@ mod tests {
     fn remove_repo_files_tolerates_a_missing_directory() {
         remove_repo_files("/nonexistent/irlume-repo-dir");
     }
+
+    // remove_repo_files also backs the PPA teardown, which sweeps several key
+    // dirs; a nested subdir must be ignored (it only deletes files it names).
+    #[test]
+    fn remove_repo_files_ignores_subdirectories() {
+        let dir = std::env::temp_dir().join(format!("irlume-repo-sub-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("irlume-subdir")).unwrap();
+        std::fs::write(dir.join("irlume.list"), b"x").unwrap();
+        remove_repo_files(dir.to_str().unwrap());
+        assert!(!dir.join("irlume.list").exists(), "file should be removed");
+        assert!(
+            dir.join("irlume-subdir").is_dir(),
+            "a same-named subdir must be left in place"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn yn_reports_yes_or_the_maybe_not_running_note() {
+        assert_eq!(yn(true), "yes");
+        assert_eq!(yn(false), "no (may not have been running)");
+    }
+
+    // run_pkg maps a package manager's exit into a readable Result: success →
+    // Ok, non-zero → Err naming the tool, spawn failure → Err. Exercised with
+    // the harmless `true`/`false` shells and a bin that does not exist (never a
+    // real package manager, which would touch the system).
+    #[test]
+    fn run_pkg_maps_exit_status_to_a_result() {
+        assert_eq!(
+            run_pkg("true", &["remove", "irlume"]).unwrap(),
+            "removed the true package"
+        );
+        let nonzero = run_pkg("false", &[]).unwrap_err();
+        assert!(nonzero.contains("false exited with"), "{nonzero}");
+        let missing = run_pkg("irlume-no-such-pkg-manager-xyz", &[]).unwrap_err();
+        assert!(missing.contains("could not run"), "{missing}");
+    }
 }

--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -156,4 +156,135 @@ mod tests {
         assert_eq!(env.policy, PolicyKind::PcrLiteral);
         assert_eq!(env.pcrs, vec![7]);
     }
+
+    #[test]
+    fn describe_names_each_tier() {
+        assert_eq!(
+            PolicyKind::PcrLiteral.describe(),
+            "literal PolicyPCR (Tier 3)"
+        );
+        assert_eq!(
+            PolicyKind::Authorized {
+                pubkey_pem: "PEM".into(),
+                policy_ref: vec![0xde, 0xad],
+            }
+            .describe(),
+            "signed PolicyAuthorize (Tier 1)"
+        );
+        assert_eq!(
+            PolicyKind::PcrlockNv {
+                nv_index: 0x1c00002
+            }
+            .describe(),
+            "pcrlock NV 0x1c00002 (Tier 2)"
+        );
+    }
+
+    #[test]
+    fn authorized_variant_serde_roundtrips_and_skips_empty_policy_ref() {
+        // Non-empty policy_ref is base64-encoded and survives a round-trip.
+        let env = SealedEnvelope {
+            version: CURRENT_VERSION,
+            policy: PolicyKind::Authorized {
+                pubkey_pem: "PEM-BODY".into(),
+                policy_ref: vec![0xde, 0xad, 0xbe, 0xef],
+            },
+            pcrs: vec![11],
+            public: vec![1],
+            private: vec![2],
+            pcr_values: vec![],
+        };
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(s.contains(r#""kind":"Authorized""#), "{s}");
+        let back: SealedEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.policy, env.policy);
+
+        // Empty policy_ref must be omitted from the JSON and default back to empty.
+        let env2 = SealedEnvelope {
+            version: CURRENT_VERSION,
+            policy: PolicyKind::Authorized {
+                pubkey_pem: "P".into(),
+                policy_ref: vec![],
+            },
+            pcrs: vec![11],
+            public: vec![1],
+            private: vec![2],
+            pcr_values: vec![],
+        };
+        let s2 = serde_json::to_string(&env2).unwrap();
+        assert!(!s2.contains("policy_ref"), "{s2}");
+        let back2: SealedEnvelope = serde_json::from_str(&s2).unwrap();
+        match back2.policy {
+            PolicyKind::Authorized { policy_ref, .. } => assert!(policy_ref.is_empty()),
+            other => panic!("expected Authorized, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_invalid_base64_field() {
+        // The b64 field deserializer must surface a decode error rather than
+        // yielding garbage bytes.
+        let bad = r#"{"version":1,"pcrs":[7],"public":"@@@","private":"BAUG"}"#;
+        assert!(serde_json::from_str::<SealedEnvelope>(bad).is_err());
+    }
+
+    #[test]
+    fn save_then_load_roundtrips_on_disk_with_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("irlume-env-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // Nested path forces save() to create the missing parent directory.
+        let p = dir.join("sub/sealed.json");
+        let env = SealedEnvelope {
+            version: CURRENT_VERSION,
+            policy: PolicyKind::PcrlockNv {
+                nv_index: 0x1c00002,
+            },
+            pcrs: vec![7, 11],
+            public: vec![9, 8, 7],
+            private: vec![0],
+            pcr_values: vec![PcrValue {
+                pcr: 7,
+                value: vec![0x11; 32],
+            }],
+        };
+        env.save(&p).unwrap();
+
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "envelope must be root-only");
+
+        let back = SealedEnvelope::load(&p).unwrap();
+        assert_eq!(back.version, CURRENT_VERSION);
+        assert_eq!(back.pcrs, vec![7, 11]);
+        assert_eq!(back.public, vec![9, 8, 7]);
+        assert_eq!(
+            back.policy,
+            PolicyKind::PcrlockNv {
+                nv_index: 0x1c00002
+            }
+        );
+        assert_eq!(back.pcr_values.len(), 1);
+        assert_eq!(back.pcr_values[0].value, vec![0x11; 32]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_errors_on_missing_and_malformed_file() {
+        let dir = std::env::temp_dir().join(format!("irlume-env-err-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let missing = dir.join("nope.json");
+        assert!(matches!(SealedEnvelope::load(&missing), Err(Error::Io(_))));
+
+        let bad = dir.join("bad.json");
+        std::fs::write(&bad, "{ not json").unwrap();
+        assert!(matches!(
+            SealedEnvelope::load(&bad),
+            Err(Error::Protocol(_))
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/irlume-core/src/pcrsig.rs
+++ b/crates/irlume-core/src/pcrsig.rs
@@ -215,4 +215,184 @@ mod tests {
         let bad = "{\"sha256\":[{\"pcrs\":[7],\"pkfp\":\"7682\",\"pol\":\"2\u{01f0}bfca5\",\"sig\":\"\"}]}";
         assert!(parse_signatures(bad, "sha256").is_err());
     }
+
+    #[test]
+    fn rejects_bad_signature_base64() {
+        // `sig` is base64-decoded; a non-base64 body must surface as a Protocol
+        // error tagged so the operator can tell it apart from a bad `pol`.
+        let bad = r#"{"sha256":[{"pcrs":[11],"pkfp":"7682","pol":"01","sig":"@@not-b64@@"}]}"#;
+        match parse_signatures(bad, "sha256") {
+            Err(Error::Protocol(m)) => assert!(m.contains("bad signature base64"), "{m}"),
+            other => panic!("expected Protocol(bad signature base64), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        match parse_signatures("{ this is not json", "sha256") {
+            Err(Error::Protocol(_)) => {}
+            other => panic!("expected Protocol on bad JSON, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_entry_missing_required_field() {
+        // `sig` omitted: serde fails the RawEntry decode -> Protocol.
+        let bad = r#"{"sha256":[{"pcrs":[11],"pkfp":"aa","pol":"01"}]}"#;
+        assert!(matches!(
+            parse_signatures(bad, "sha256"),
+            Err(Error::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_odd_length_hex_pol() {
+        let bad = r#"{"sha256":[{"pcrs":[11],"pkfp":"aa","pol":"abc","sig":"AQ=="}]}"#;
+        match parse_signatures(bad, "sha256") {
+            Err(Error::Protocol(m)) => assert!(m.contains("odd-length"), "{m}"),
+            other => panic!("expected Protocol(odd-length), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_empty_pcrs_and_decodes_sig() {
+        // Empty `pcrs` is structurally valid JSON and must parse; the base64
+        // `sig` "AQ==" decodes to the single byte 0x01.
+        let j = r#"{"sha256":[{"pcrs":[],"pkfp":"aa","pol":"02","sig":"AQ=="}]}"#;
+        let sigs = parse_signatures(j, "sha256").unwrap();
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].pcrs, Vec::<u32>::new());
+        assert_eq!(sigs[0].pol, vec![0x02]);
+        assert_eq!(sigs[0].sig, vec![0x01]);
+    }
+
+    // ---- filesystem/discovery paths (env-driven; serialized on ENV_LOCK) ----
+
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static TMP_SEQ: AtomicU32 = AtomicU32::new(0);
+
+    fn unique_tmp(name: &str) -> PathBuf {
+        let n = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "irlume-pcrsig-test-{}-{}-{}",
+            std::process::id(),
+            n,
+            name
+        ))
+    }
+
+    fn clear_pcr_env() {
+        std::env::remove_var("IRLUME_PCR_SIGNATURE");
+        std::env::remove_var("IRLUME_PCR_PUBKEY");
+    }
+
+    #[test]
+    fn discover_signature_path_env_override() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        clear_pcr_env();
+        let p = unique_tmp("sig.json");
+        std::fs::write(&p, FIXTURE).unwrap();
+        std::env::set_var("IRLUME_PCR_SIGNATURE", &p);
+        assert_eq!(discover_signature_path(), Some(p.clone()));
+
+        // Env pointing at a nonexistent file yields None (not the stale path).
+        std::env::set_var("IRLUME_PCR_SIGNATURE", "/nonexistent/irlume/none.json");
+        assert_eq!(discover_signature_path(), None);
+
+        // With the override gone, discovery walks the system dirs. Whatever it
+        // returns (if anything) must be a real, correctly-named path.
+        std::env::remove_var("IRLUME_PCR_SIGNATURE");
+        if let Some(found) = discover_signature_path() {
+            assert!(found.exists(), "discover must only return existing paths");
+            assert!(found.ends_with(SIGNATURE_FILE));
+        }
+        clear_pcr_env();
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn discover_pubkey_path_env_override() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        clear_pcr_env();
+        let p = unique_tmp("pub.pem");
+        std::fs::write(&p, "PEM").unwrap();
+        std::env::set_var("IRLUME_PCR_PUBKEY", &p);
+        assert_eq!(discover_pubkey_path(), Some(p.clone()));
+
+        std::env::set_var("IRLUME_PCR_PUBKEY", "/nonexistent/irlume/none.pem");
+        assert_eq!(discover_pubkey_path(), None);
+
+        std::env::remove_var("IRLUME_PCR_PUBKEY");
+        if let Some(found) = discover_pubkey_path() {
+            assert!(found.exists());
+            assert!(found.ends_with(PUBKEY_FILE));
+        }
+        clear_pcr_env();
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn signed_policy_available_needs_both_artifacts() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        clear_pcr_env();
+        let sig = unique_tmp("sig2.json");
+        let pk = unique_tmp("pub2.pem");
+        std::fs::write(&sig, FIXTURE).unwrap();
+        std::fs::write(&pk, "PEM").unwrap();
+
+        std::env::set_var("IRLUME_PCR_SIGNATURE", &sig);
+        std::env::set_var("IRLUME_PCR_PUBKEY", &pk);
+        assert!(signed_policy_available());
+
+        // Missing the pubkey -> unavailable.
+        std::env::set_var("IRLUME_PCR_PUBKEY", "/nonexistent/irlume/none.pem");
+        assert!(!signed_policy_available());
+
+        clear_pcr_env();
+        let _ = std::fs::remove_file(&sig);
+        let _ = std::fs::remove_file(&pk);
+    }
+
+    #[test]
+    fn load_pubkey_pem_reads_file_or_errors() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        clear_pcr_env();
+        let pk = unique_tmp("pub3.pem");
+        let body = "-----BEGIN PUBLIC KEY-----\nMFkw\n-----END PUBLIC KEY-----\n";
+        std::fs::write(&pk, body).unwrap();
+        std::env::set_var("IRLUME_PCR_PUBKEY", &pk);
+        assert_eq!(load_pubkey_pem().unwrap(), body);
+
+        // No discoverable key -> Policy error, not a panic.
+        std::env::set_var("IRLUME_PCR_PUBKEY", "/nonexistent/irlume/none.pem");
+        assert!(matches!(load_pubkey_pem(), Err(Error::Policy(_))));
+
+        clear_pcr_env();
+        let _ = std::fs::remove_file(&pk);
+    }
+
+    #[test]
+    fn load_signatures_and_signed_pcrs_via_file() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        clear_pcr_env();
+        let sig = unique_tmp("sig4.json");
+        std::fs::write(&sig, FIXTURE).unwrap();
+        std::env::set_var("IRLUME_PCR_SIGNATURE", &sig);
+
+        let sigs = load_signatures("sha256").unwrap();
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].pkfp, "7682");
+
+        assert_eq!(signed_pcrs("sha256"), Some(vec![11]));
+        // A bank with no entries -> first() is None.
+        assert_eq!(signed_pcrs("sha384"), None);
+
+        // No signature file discoverable -> Policy error from load_signatures.
+        std::env::set_var("IRLUME_PCR_SIGNATURE", "/nonexistent/irlume/none.json");
+        assert!(matches!(load_signatures("sha256"), Err(Error::Policy(_))));
+        assert_eq!(signed_pcrs("sha256"), None);
+
+        clear_pcr_env();
+        let _ = std::fs::remove_file(&sig);
+    }
 }

--- a/crates/irlume-core/src/policy.rs
+++ b/crates/irlume-core/src/policy.rs
@@ -75,4 +75,68 @@ mod tests {
         assert!(Method::Fingerprint.face_disabled());
         assert!(!Method::Auto.face_disabled());
     }
+
+    #[test]
+    fn parse_handles_aliases_and_whitespace_and_case() {
+        // Every accepted fingerprint spelling, plus surrounding whitespace and
+        // mixed case, must resolve to Fingerprint.
+        for s in ["finger", "  Fingerprint\n", "FP", "\tfp "] {
+            assert_eq!(Method::parse(s), Method::Fingerprint, "{s:?}");
+        }
+        assert_eq!(Method::parse("  FACE  "), Method::Face);
+        // Only Fingerprint disables face; Face behaves like Auto for the daemon.
+        assert!(!Method::Face.face_disabled());
+    }
+
+    #[test]
+    fn path_honours_env_override() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        std::env::set_var("IRLUME_METHOD_CONF", "/tmp/irlume-method-override");
+        assert_eq!(path(), PathBuf::from("/tmp/irlume-method-override"));
+        std::env::remove_var("IRLUME_METHOD_CONF");
+        assert_eq!(path(), PathBuf::from("/etc/irlume/method"));
+    }
+
+    #[test]
+    fn method_reads_file_and_defaults_when_absent() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("irlume-policy-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("method");
+        std::env::set_var("IRLUME_METHOD_CONF", &f);
+
+        // Absent/unreadable file -> Auto.
+        assert_eq!(method(), Method::Auto);
+
+        std::fs::write(&f, "fingerprint\n").unwrap();
+        assert_eq!(method(), Method::Fingerprint);
+        std::fs::write(&f, "face").unwrap();
+        assert_eq!(method(), Method::Face);
+
+        std::env::remove_var("IRLUME_METHOD_CONF");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn set_method_persists_creates_parent_and_roundtrips() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("irlume-policy-set-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // Nested path: set_method must create the missing parent directory.
+        let f = dir.join("nested/method");
+        std::env::set_var("IRLUME_METHOD_CONF", &f);
+
+        set_method(Method::Fingerprint).unwrap();
+        assert!(f.exists());
+        assert_eq!(std::fs::read_to_string(&f).unwrap(), "fingerprint");
+        assert_eq!(method(), Method::Fingerprint);
+
+        set_method(Method::Auto).unwrap();
+        assert_eq!(std::fs::read_to_string(&f).unwrap(), "auto");
+        assert_eq!(method(), Method::Auto);
+
+        std::env::remove_var("IRLUME_METHOD_CONF");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
Reachable pure-logic pockets the per-file analysis surfaced: pcrsig 59->96%, policy 52->97%, envelope 58->97%, pamwire 56->76%, logs 65->78%, fingerprint 34->50%, models/uninstall up. 52 new tests, no hardware, no new gated CI. One commented verbatim seam (logs build_view_argv). Ratchet bumps after CI reports.
