### PR TITLE
feat: preempt competitor failure classes + research-grounded auth hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
           cargo test -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
           cargo test -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
           cargo test -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
+          cargo test -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1
 
       - name: test (PAM FFI, against pam_wrapper)
         run: cargo test -p irlume-pam --locked -- --include-ignored --test-threads=1
@@ -278,6 +279,7 @@ jobs:
           cargo llvm-cov --no-report -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
           cargo llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
           cargo llvm-cov --no-report -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
+          cargo llvm-cov --no-report -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1
           cargo llvm-cov --no-report -p irlume-pam --locked -- --include-ignored --test-threads=1
           cargo llvm-cov report --summary-only --fail-under-lines 79
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,18 @@ probably met ([Howdy](https://github.com/boltgolt/howdy), [visage](https://githu
 
 | | Windows Hello | Howdy | `visage` | **irlume** |
 |---|:---:|:---:|:---:|:---:|
-| **Liveness / anti-spoof** | IR only *(bypassable: [CVE-2021-34466](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34466))* | ❌ none; its own README warns a *"well-printed photo of you could be enough"* | ⚠️ passive (landmark-stability; blocks photos, not video) | ✅ algorithmic IR gate **+** opt-in passive blink; self-tested vs [ISO/IEC 30107-3](docs/PAD_SELFTEST.md) |
+| **Liveness / anti-spoof** | IR only *(bypassable: [CVE-2021-34466](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34466))* | ❌ none; its own README warns a *"well-printed photo of you could be enough"* | ⚠️ passive (landmark-stability; blocks photos, not video) | ✅ algorithmic IR gate on by default (blocks screens and matte prints); **opt-in** passive blink adds a glossy-print/replay defense.<sup>†</sup> Self-tested vs [ISO/IEC 30107-3](docs/PAD_SELFTEST.md) |
 | **Camera-injection defense** | device-trust *(newer HW)* | ❌ none | ❌ none | ✅ device pinning **+** cross-spectrum RGB↔IR |
 | **Template protection** | TPM-bound enclave | ⚠️ unencrypted encodings on disk | AES-256-GCM, key in a 0600 disk file *(not TPM-sealed)* | ✅ AES-256-GCM, **TPM-sealed key** *(survives disk theft)* |
 | **Opens your keyring/wallet** | ✅ | ❌ *(keyring stays locked)* | ❌ | ✅ **TPM-unseals** it at login |
 | **Stores your face as…** | template | encoding | embedding | **embedding only, never an image** |
 | **Model licensing** | proprietary | MIT code · dlib weights | ⚠️ non-commercial weights | ✅ **permissive, bundleable** |
 | **Runs on** | Windows | Linux | Linux | **Linux: Fedora · Arch · Debian/Ubuntu** |
+
+<sup>†</sup> The default IR gate blocks screens and matte prints (0% APCER in
+self-test), but a determined life-size *glossy* print passed it at 98.6% APCER;
+the opt-in passive-blink challenge closes that at the cost of a slower login.
+Enrollment on IR hardware offers to enable it. See [Honest limitations](#-honest-limitations).
 
 ## 📦 Install
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -522,14 +522,74 @@ pub fn capture_rgb_burst(device: &str, n: usize) -> irlume_common::Result<Vec<Fr
 /// The uncompressed RGB fourccs the capture path can decode, best first.
 const DECODABLE_RGB: [&[u8; 4]; 2] = [b"YUYV", b"NV12"];
 
-/// True when an Intel IPU6 camera stack is present. These MIPI cameras (common
-/// on 2024+ Intel laptops) expose no plain V4L2 GREY/YUYV capture node: they
-/// need the libcamera/software-ISP relay, so `discover_nodes` finds nothing and
-/// a user sees a bare "no camera". `doctor` uses this to give a real diagnosis
-/// instead. Detected by the kernel driver's presence in sysfs.
-pub fn ipu6_camera_present() -> bool {
-    std::path::Path::new("/sys/bus/pci/drivers/intel-ipu6").exists()
-        || std::path::Path::new("/sys/module/intel_ipu6").exists()
+/// Detects an Intel IPU6/IPU7 MIPI camera complex and returns which generation
+/// ("IPU6" or "IPU7"), or None. These are common on 2020+ Intel laptops (Tiger
+/// Lake onward; IPU7 on Lunar Lake / Panther Lake / Arrow Lake). They expose no
+/// directly-openable V4L2 capture node: the in-kernel ISYS nodes emit raw Bayer
+/// plus metadata, not YUYV/GREY, so `discover_nodes` finds nothing usable and a
+/// user just sees "no camera". Worse for irlume specifically, the IR / Windows
+/// Hello sensor on these modules is not exposed on Linux at all (only the RGB
+/// sensor, and only through a libcamera software-ISP bridge). `doctor` uses
+/// this to explain the situation instead of a bare "no camera".
+///
+/// Detection is root-free and identical for the out-of-tree dkms driver and the
+/// mainline in-kernel one (both register the same PCI-driver and module names):
+/// a bound PCI device under the driver, or the module loaded, or (hardware
+/// present but driver/firmware missing) a known IPU PCI device ID.
+pub fn intel_ipu_present() -> Option<&'static str> {
+    for (gen, drv, module) in [
+        (
+            "IPU7",
+            "/sys/bus/pci/drivers/intel-ipu7",
+            "/sys/module/intel_ipu7",
+        ),
+        (
+            "IPU6",
+            "/sys/bus/pci/drivers/intel-ipu6",
+            "/sys/module/intel_ipu6",
+        ),
+    ] {
+        if driver_has_bound_device(drv) || std::path::Path::new(module).exists() {
+            return Some(gen);
+        }
+    }
+    ipu_pci_generation()
+}
+
+/// True if a `/sys/bus/pci/drivers/<name>` directory has at least one bound PCI
+/// device (a `0000:*` symlink), i.e. the driver is actually driving hardware.
+fn driver_has_bound_device(driver_dir: &str) -> bool {
+    std::fs::read_dir(driver_dir)
+        .map(|rd| {
+            rd.flatten()
+                .any(|e| e.file_name().to_string_lossy().starts_with("0000:"))
+        })
+        .unwrap_or(false)
+}
+
+/// Scan PCI devices for a known IPU6/IPU7 device ID (vendor 0x8086), catching
+/// the "hardware present but no driver bound" case, the one where the user has
+/// both no camera and no working stack. IDs from the mainline ipu6/ipu7 drivers.
+fn ipu_pci_generation() -> Option<&'static str> {
+    const IPU6: &[&str] = &["0x9a19", "0x4e19", "0x465d", "0x462e", "0xa75d", "0x7d19"];
+    const IPU7: &[&str] = &["0x645d", "0xb05d"];
+    let rd = std::fs::read_dir("/sys/bus/pci/devices").ok()?;
+    for entry in rd.flatten() {
+        let dir = entry.path();
+        let vendor = std::fs::read_to_string(dir.join("vendor")).unwrap_or_default();
+        if vendor.trim() != "0x8086" {
+            continue;
+        }
+        let device = std::fs::read_to_string(dir.join("device")).unwrap_or_default();
+        let device = device.trim();
+        if IPU7.contains(&device) {
+            return Some("IPU7");
+        }
+        if IPU6.contains(&device) {
+            return Some("IPU6");
+        }
+    }
+    None
 }
 
 /// A node's advertised pixel formats (fourcc), for negotiation and `doctor`.
@@ -1321,7 +1381,10 @@ mod tests {
         let rgb = nv12_to_rgb(&nv12, 2, 2);
         assert_eq!(rgb.len(), 2 * 2 * 3);
         for c in &rgb {
-            assert!((*c as i32 - 200).abs() <= 1, "neutral chroma should stay grey");
+            assert!(
+                (*c as i32 - 200).abs() <= 1,
+                "neutral chroma should stay grey"
+            );
         }
         // Chroma carries into RGB: a red-ish V lifts R above Y and drops B.
         let red = [128u8, 128, 128, 128, 128, 200];

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -522,6 +522,15 @@ pub fn capture_rgb_burst(device: &str, n: usize) -> irlume_common::Result<Vec<Fr
 /// The uncompressed RGB fourccs the capture path can decode, best first.
 const DECODABLE_RGB: [&[u8; 4]; 2] = [b"YUYV", b"NV12"];
 
+/// The first decodable format (`DECODABLE_RGB` order) the camera advertises, or
+/// None if it offers only formats we cannot decode (e.g. MJPEG-only).
+fn choose_rgb_format(offered: &[[u8; 4]]) -> Option<[u8; 4]> {
+    DECODABLE_RGB
+        .iter()
+        .find(|f| offered.contains(**f))
+        .map(|f| **f)
+}
+
 /// Detects an Intel IPU6/IPU7 MIPI camera complex and returns which generation
 /// ("IPU6" or "IPU7"), or None. These are common on 2020+ Intel laptops (Tiger
 /// Lake onward; IPU7 on Lunar Lake / Panther Lake / Arrow Lake). They expose no
@@ -571,8 +580,6 @@ fn driver_has_bound_device(driver_dir: &str) -> bool {
 /// the "hardware present but no driver bound" case, the one where the user has
 /// both no camera and no working stack. IDs from the mainline ipu6/ipu7 drivers.
 fn ipu_pci_generation() -> Option<&'static str> {
-    const IPU6: &[&str] = &["0x9a19", "0x4e19", "0x465d", "0x462e", "0xa75d", "0x7d19"];
-    const IPU7: &[&str] = &["0x645d", "0xb05d"];
     let rd = std::fs::read_dir("/sys/bus/pci/devices").ok()?;
     for entry in rd.flatten() {
         let dir = entry.path();
@@ -581,15 +588,25 @@ fn ipu_pci_generation() -> Option<&'static str> {
             continue;
         }
         let device = std::fs::read_to_string(dir.join("device")).unwrap_or_default();
-        let device = device.trim();
-        if IPU7.contains(&device) {
-            return Some("IPU7");
-        }
-        if IPU6.contains(&device) {
-            return Some("IPU6");
+        if let Some(gen) = ipu_generation_for_id(device.trim()) {
+            return Some(gen);
         }
     }
     None
+}
+
+/// Map an Intel PCI device ID (as sysfs prints it, e.g. `0x7d19`) to the IPU
+/// generation, or None. IDs from the mainline ipu6/ipu7 drivers.
+fn ipu_generation_for_id(device_id: &str) -> Option<&'static str> {
+    const IPU6: &[&str] = &["0x9a19", "0x4e19", "0x465d", "0x462e", "0xa75d", "0x7d19"];
+    const IPU7: &[&str] = &["0x645d", "0xb05d"];
+    if IPU7.contains(&device_id) {
+        Some("IPU7")
+    } else if IPU6.contains(&device_id) {
+        Some("IPU6")
+    } else {
+        None
+    }
 }
 
 /// A node's advertised pixel formats (fourcc), for negotiation and `doctor`.
@@ -613,8 +630,8 @@ fn negotiate_rgb_format(device: &str, dev: &Device) -> irlume_common::Result<[u8
     if offered.is_empty() {
         return Ok(*b"YUYV");
     }
-    if let Some(f) = DECODABLE_RGB.iter().find(|f| offered.contains(*f)) {
-        return Ok(**f);
+    if let Some(f) = choose_rgb_format(&offered) {
+        return Ok(f);
     }
     let offered_str: Vec<String> = offered.iter().map(fourcc_str).collect();
     Err(Error::Hardware(format!(
@@ -1372,6 +1389,33 @@ mod tests {
         for c in rgb {
             assert!((c as i32 - 128).abs() <= 1);
         }
+    }
+
+    #[test]
+    fn rgb_format_choice_prefers_yuyv_then_nv12_else_none() {
+        // YUYV wins even when listed after MJPG (real ASUS camera order).
+        assert_eq!(choose_rgb_format(&[*b"MJPG", *b"YUYV"]), Some(*b"YUYV"));
+        // NV12 rescues a camera that offers no YUYV.
+        assert_eq!(choose_rgb_format(&[*b"MJPG", *b"NV12"]), Some(*b"NV12"));
+        // YUYV still preferred over NV12 when both are present.
+        assert_eq!(choose_rgb_format(&[*b"NV12", *b"YUYV"]), Some(*b"YUYV"));
+        // MJPEG-only: nothing decodable, negotiation must fail (not pick MJPG).
+        assert_eq!(choose_rgb_format(&[*b"MJPG"]), None);
+    }
+
+    #[test]
+    fn ipu_generation_maps_ids_and_rejects_others() {
+        assert_eq!(ipu_generation_for_id("0x7d19"), Some("IPU6")); // Meteor Lake
+        assert_eq!(ipu_generation_for_id("0x645d"), Some("IPU7")); // Lunar Lake
+        assert_eq!(ipu_generation_for_id("0xb05d"), Some("IPU7")); // Panther Lake
+        assert_eq!(ipu_generation_for_id("0x1234"), None);
+        assert_eq!(ipu_generation_for_id(""), None);
+    }
+
+    #[test]
+    fn fourcc_str_trims_padding() {
+        assert_eq!(fourcc_str(b"YUYV"), "YUYV");
+        assert_eq!(fourcc_str(b"Y8  "), "Y8");
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -479,32 +479,97 @@ pub fn capture_rgb_burst(device: &str, n: usize) -> irlume_common::Result<Vec<Fr
         id: V4L2_CID_BACKLIGHT_COMPENSATION,
         value: v4l::control::Value::Integer(2),
     });
-    let fmt = Format::new(RGB_W, RGB_H, FourCC::new(b"YUYV"));
+    // Pick an uncompressed format the camera actually offers. Some webcams
+    // advertise RGB only as MJPEG (or NV12) and reject YUYV; classify() still
+    // labels them usable, so without this negotiation they would detect fine
+    // then fail at capture with a cryptic "expected YUYV". YUYV is preferred;
+    // NV12 is the common uncompressed fallback.
+    let chosen = negotiate_rgb_format(device, &dev)?;
+    let fmt = Format::new(RGB_W, RGB_H, FourCC::new(&chosen));
     let fmt = Capture::set_format(&dev, &fmt).map_err(|e| map_io(device, e))?;
-    if &fmt.fourcc.repr != b"YUYV" {
+    if fmt.fourcc.repr != chosen {
         return Err(Error::Hardware(format!(
-            "{device}: driver gave {:?}, expected YUYV",
-            std::str::from_utf8(&fmt.fourcc.repr).unwrap_or("????")
+            "{device}: driver gave {}, expected {}",
+            fourcc_str(&fmt.fourcc.repr),
+            fourcc_str(&chosen)
         )));
     }
     let (w, h) = (fmt.width, fmt.height);
     let mut stream = v4l::io::mmap::Stream::with_buffers(&dev, Type::VideoCapture, 4)
         .map_err(|e| map_io(device, e))?;
 
+    warm_up_stream(device, &mut stream)?;
     for _ in 0..AE_WARMUP {
         stream.next().map_err(|e| map_io(device, e))?; // discard while AE settles
     }
     let mut frames = Vec::with_capacity(n.max(1));
     for _ in 0..n.max(1) {
         let (buf, _meta) = stream.next().map_err(|e| map_io(device, e))?;
+        let data = match &chosen {
+            b"NV12" => nv12_to_rgb(buf, w, h),
+            _ => yuyv_to_rgb(buf, w, h),
+        };
         frames.push(Frame {
             width: w,
             height: h,
             spectrum: Spectrum::Rgb,
-            data: yuyv_to_rgb(buf, w, h),
+            data,
         });
     }
     Ok(frames)
+}
+
+/// The uncompressed RGB fourccs the capture path can decode, best first.
+const DECODABLE_RGB: [&[u8; 4]; 2] = [b"YUYV", b"NV12"];
+
+/// True when an Intel IPU6 camera stack is present. These MIPI cameras (common
+/// on 2024+ Intel laptops) expose no plain V4L2 GREY/YUYV capture node: they
+/// need the libcamera/software-ISP relay, so `discover_nodes` finds nothing and
+/// a user sees a bare "no camera". `doctor` uses this to give a real diagnosis
+/// instead. Detected by the kernel driver's presence in sysfs.
+pub fn ipu6_camera_present() -> bool {
+    std::path::Path::new("/sys/bus/pci/drivers/intel-ipu6").exists()
+        || std::path::Path::new("/sys/module/intel_ipu6").exists()
+}
+
+/// A node's advertised pixel formats (fourcc), for negotiation and `doctor`.
+pub fn rgb_node_formats(device: &str) -> Vec<[u8; 4]> {
+    let Ok(dev) = Device::with_path(device) else {
+        return Vec::new();
+    };
+    Capture::enum_formats(&dev)
+        .map(|v| v.into_iter().map(|d| d.fourcc.repr).collect())
+        .unwrap_or_default()
+}
+
+/// Choose the format to capture in: the first `DECODABLE_RGB` entry the camera
+/// advertises. If it advertises none we can decode (e.g. MJPEG-only), fail with
+/// a message that names what it offers rather than a bare "expected YUYV".
+fn negotiate_rgb_format(device: &str, dev: &Device) -> irlume_common::Result<[u8; 4]> {
+    let offered: Vec<[u8; 4]> = Capture::enum_formats(dev)
+        .map(|v| v.into_iter().map(|d| d.fourcc.repr).collect())
+        .unwrap_or_default();
+    // If enumeration is unavailable, keep the historical behaviour (try YUYV).
+    if offered.is_empty() {
+        return Ok(*b"YUYV");
+    }
+    if let Some(f) = DECODABLE_RGB.iter().find(|f| offered.contains(*f)) {
+        return Ok(**f);
+    }
+    let offered_str: Vec<String> = offered.iter().map(fourcc_str).collect();
+    Err(Error::Hardware(format!(
+        "{device}: RGB camera offers only [{}]; irlume needs an uncompressed \
+         format (YUYV or NV12). MJPEG-only cameras are not supported yet.",
+        offered_str.join(", ")
+    )))
+}
+
+/// Printable fourcc (trailing spaces trimmed), for diagnostics.
+fn fourcc_str(cc: &[u8; 4]) -> String {
+    std::str::from_utf8(cc)
+        .unwrap_or("????")
+        .trim_end()
+        .to_string()
 }
 
 /// Capture one AE-warmed RGB frame (fast path: framing guide, liveness probe).
@@ -616,6 +681,8 @@ pub fn capture_ir_with_stats(device: &str) -> irlume_common::Result<(Frame, IrCa
     let (w, h) = (fmt.width, fmt.height);
     let mut stream = v4l::io::mmap::Stream::with_buffers(&dev, Type::VideoCapture, 4)
         .map_err(|e| map_io(device, e))?;
+    // Survive the first-capture-after-resume race (uvcvideo still re-initializing).
+    warm_up_stream(device, &mut stream)?;
     // Fire the active-IR emitter on the open fd (Hello modules reset it per-open,
     // so we must do it here, while streaming, not via an external one-shot).
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
@@ -1124,6 +1191,66 @@ pub fn yuyv_to_rgb(yuyv: &[u8], width: u32, height: u32) -> Vec<u8> {
     rgb
 }
 
+/// Convert an NV12 (4:2:0, Y plane then interleaved UV plane) buffer to
+/// interleaved RGB8 (BT.601). Each 2x2 pixel block shares one U/V pair.
+pub fn nv12_to_rgb(nv12: &[u8], width: u32, height: u32) -> Vec<u8> {
+    let (w, h) = (width as usize, height as usize);
+    let mut rgb = vec![0u8; w * h * 3];
+    let y_plane = w * h;
+    // Guard against a short buffer: need the full Y plane plus a UV plane.
+    if nv12.len() < y_plane + (w * h / 2) {
+        return rgb;
+    }
+    for row in 0..h {
+        for col in 0..w {
+            let y = nv12[row * w + col] as f32;
+            // UV plane is half-resolution in both axes; one pair per 2x2 block.
+            let uv = y_plane + (row / 2) * w + (col / 2) * 2;
+            let u = nv12[uv] as f32 - 128.0;
+            let v = nv12[uv + 1] as f32 - 128.0;
+            let o = (row * w + col) * 3;
+            rgb[o] = (y + 1.402 * v).clamp(0.0, 255.0) as u8;
+            rgb[o + 1] = (y - 0.344 * u - 0.714 * v).clamp(0.0, 255.0) as u8;
+            rgb[o + 2] = (y + 1.772 * u).clamp(0.0, 255.0) as u8;
+        }
+    }
+    rgb
+}
+
+/// Pull and discard one frame with a short retry, so the FIRST capture after a
+/// suspend/resume (or USB re-enumeration) does not fail outright while the
+/// uvcvideo device is still coming back. The daemon opens the device per
+/// request, so there is no stale handle to recover; the only gap is that the
+/// very first `stream.next()` can return EIO/ENODEV for a few hundred ms after
+/// resume. Retry that, then let the normal AE warmup run.
+fn warm_up_stream(
+    device: &str,
+    stream: &mut v4l::io::mmap::Stream<'_>,
+) -> irlume_common::Result<()> {
+    use std::io::ErrorKind;
+    const TRIES: u32 = 8;
+    const GAP: std::time::Duration = std::time::Duration::from_millis(120);
+    for attempt in 0..TRIES {
+        match stream.next() {
+            Ok(_) => return Ok(()),
+            Err(e)
+                if attempt + 1 < TRIES
+                    && matches!(
+                        e.kind(),
+                        ErrorKind::BrokenPipe
+                            | ErrorKind::NotConnected
+                            | ErrorKind::Other
+                            | ErrorKind::TimedOut
+                    ) =>
+            {
+                std::thread::sleep(GAP);
+            }
+            Err(e) => return Err(map_io(device, e)),
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1185,6 +1312,24 @@ mod tests {
         for c in rgb {
             assert!((c as i32 - 128).abs() <= 1);
         }
+    }
+
+    #[test]
+    fn nv12_neutral_chroma_is_grey_and_short_buffer_is_safe() {
+        // 2x2 Y plane at 200, one neutral UV pair (128,128) -> near-grey 200.
+        let nv12 = [200u8, 200, 200, 200, 128, 128];
+        let rgb = nv12_to_rgb(&nv12, 2, 2);
+        assert_eq!(rgb.len(), 2 * 2 * 3);
+        for c in &rgb {
+            assert!((*c as i32 - 200).abs() <= 1, "neutral chroma should stay grey");
+        }
+        // Chroma carries into RGB: a red-ish V lifts R above Y and drops B.
+        let red = [128u8, 128, 128, 128, 128, 200];
+        let out = nv12_to_rgb(&red, 2, 2);
+        assert!(out[0] > out[2], "V>128 should make R exceed B");
+        // A short buffer never panics; returns a zeroed frame of the right size.
+        let short = [0u8; 3];
+        assert_eq!(nv12_to_rgb(&short, 2, 2).len(), 2 * 2 * 3);
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -149,7 +149,7 @@ fn enroll(args: &[String]) -> std::process::ExitCode {
         "[enroll] '{user}': capturing a new face profile; stay in frame, look at the camera…"
     );
     match daemon_request(&Request::Enroll {
-        user,
+        user: user.clone(),
         profile: name,
         scans,
         reset,
@@ -163,6 +163,7 @@ fn enroll(args: &[String]) -> std::process::ExitCode {
         }) => {
             if created {
                 println!("[enroll] enrolled '{profile}' with {total} scans");
+                offer_blink_challenge(&user);
             } else {
                 println!(
                     "[enroll] this face is already enrolled as '{profile}'; added {added} scans \
@@ -184,6 +185,52 @@ fn enroll(args: &[String]) -> std::process::ExitCode {
             eprintln!("enroll: {e}");
             std::process::ExitCode::FAILURE
         }
+    }
+}
+
+/// After a fresh enrollment on IR hardware, make the opt-in anti-spoof blink
+/// challenge an informed choice rather than a hidden flag. It stays OFF by
+/// default (every mainstream face authenticator, Windows Hello / Face ID /
+/// Android, ships passive PAD, not an active challenge; the default IR gate is
+/// the passive analogue). This offers the extra print/replay defense to those
+/// who want it, being honest about the latency and glasses cost.
+fn offer_blink_challenge(user: &str) {
+    use std::io::{BufRead, IsTerminal, Write};
+    // Only meaningful on IR-capable (Secure-tier) hardware.
+    if !irlume_camera::capabilities().ir_pair {
+        return;
+    }
+    let tip =
+        "Tip: the opt-in anti-spoof blink challenge blocks printed/screen-replay spoofs.\n      \
+               Enable it any time with: irlume profiles challenge on";
+    if !std::io::stdin().is_terminal() {
+        println!("{tip}");
+        return;
+    }
+    print!(
+        "\nEnable the anti-spoof blink challenge now? It blocks printed-photo and\n\
+         screen-replay spoofs, but adds a few seconds per login and can be finicky\n\
+         with glasses. The default IR gate already blocks screens and matte prints.\n\
+         Enable blink challenge? [y/N] "
+    );
+    let _ = std::io::stdout().flush();
+    let mut line = String::new();
+    if std::io::stdin().lock().read_line(&mut line).is_err() {
+        println!("{tip}");
+        return;
+    }
+    if matches!(line.trim(), "y" | "Y" | "yes" | "Yes") {
+        match daemon_request(&irlume_common::Request::SetRequireChallenge {
+            user: user.to_string(),
+            on: true,
+        }) {
+            Ok(irlume_common::Response::Enrollment { .. }) | Ok(irlume_common::Response::Ok(_)) => {
+                println!("[enroll] anti-spoof blink challenge enabled. Disable with `irlume profiles challenge off`.")
+            }
+            _ => println!("[enroll] could not enable the challenge now; run `irlume profiles challenge on` later."),
+        }
+    } else {
+        println!("[enroll] keeping the default (fast) IR gate. {tip}");
     }
 }
 
@@ -2175,11 +2222,15 @@ fn doctor() -> std::process::ExitCode {
     let nodes = irlume_camera::discover_nodes();
     if nodes.is_empty() {
         println!("  (none found under /dev/video0..9)");
-        if irlume_camera::ipu6_camera_present() {
+        if let Some(gen) = irlume_camera::intel_ipu_present() {
             println!(
-                "  ⚠ an Intel IPU6 camera is present but exposes no direct V4L2 node.\n     \
-                 These MIPI cameras need the libcamera software-ISP relay; irlume\n     \
-                 cannot open them directly yet. Track: intel-ipu6 driver stack."
+                "  ⚠ this laptop has an Intel {gen} MIPI camera, which irlume cannot use:\n     \
+                 - its capture nodes emit raw Bayer, not a directly-openable YUYV/GREY stream;\n     \
+                 - the IR (Windows Hello) sensor is not exposed on Linux at all, so IR face\n       \
+                 auth and IR liveness are unavailable on this hardware.\n     \
+                 RGB-only webcam use is possible via a libcamera software-ISP + v4l2loopback\n     \
+                 bridge, but irlume needs the IR sensor; an external USB IR camera is the\n     \
+                 supported path on {gen} machines."
             );
         }
     }
@@ -2200,7 +2251,12 @@ fn doctor() -> std::process::ExitCode {
             if !fmts.is_empty() && !decodable {
                 let list: Vec<String> = fmts
                     .iter()
-                    .map(|f| std::str::from_utf8(f).unwrap_or("????").trim_end().to_string())
+                    .map(|f| {
+                        std::str::from_utf8(f)
+                            .unwrap_or("????")
+                            .trim_end()
+                            .to_string()
+                    })
                     .collect();
                 println!(
                     "     ⚠ offers only [{}]; irlume needs an uncompressed format\n       \

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2175,6 +2175,13 @@ fn doctor() -> std::process::ExitCode {
     let nodes = irlume_camera::discover_nodes();
     if nodes.is_empty() {
         println!("  (none found under /dev/video0..9)");
+        if irlume_camera::ipu6_camera_present() {
+            println!(
+                "  ⚠ an Intel IPU6 camera is present but exposes no direct V4L2 node.\n     \
+                 These MIPI cameras need the libcamera software-ISP relay; irlume\n     \
+                 cannot open them directly yet. Track: intel-ipu6 driver stack."
+            );
+        }
     }
     for (path, role) in &nodes {
         let priv_on = if irlume_camera::privacy_engaged(path) {
@@ -2183,6 +2190,25 @@ fn doctor() -> std::process::ExitCode {
             ""
         };
         println!("  {path}: {role:?}{priv_on}");
+        // An RGB node the capture path can't decode (MJPEG-only) classifies as
+        // usable but would fail at capture; warn here instead.
+        if *role == irlume_camera::Role::Rgb {
+            let fmts = irlume_camera::rgb_node_formats(path);
+            let decodable = fmts
+                .iter()
+                .any(|f| f == b"YUYV" || f == b"NV12" || f == b"RGB3" || f == b"BGR3");
+            if !fmts.is_empty() && !decodable {
+                let list: Vec<String> = fmts
+                    .iter()
+                    .map(|f| std::str::from_utf8(f).unwrap_or("????").trim_end().to_string())
+                    .collect();
+                println!(
+                    "     ⚠ offers only [{}]; irlume needs an uncompressed format\n       \
+                     (YUYV or NV12). This camera will detect but fail at capture.",
+                    list.join(", ")
+                );
+            }
+        }
     }
 
     // --- models / runtime --------------------------------------------------
@@ -2229,6 +2255,24 @@ fn doctor() -> std::process::ExitCode {
             );
         }
         _ => println!("[doctor] templates ({user}): unknown (daemon not reachable; run `irlume recovery status`)"),
+    }
+
+    // --- wiring drift ------------------------------------------------------
+    // If the user is enrolled but no greeter is wired, a distro tool most
+    // likely regenerated the PAM stacks (authselect apply on Fedora,
+    // pam-auth-update on Debian) and dropped irlume's lines. Face still falls
+    // back to the password, so this is not a lockout, but face login silently
+    // stopped working. Surface it with the one-command fix.
+    let enrolled = matches!(
+        daemon_request(&irlume_common::Request::ListProfiles { user: user.clone() }),
+        Ok(irlume_common::Response::Enrollment { ref profiles, .. }) if !profiles.is_empty()
+    );
+    if enrolled && !crate::pamwire::login_wired() {
+        println!(
+            "[doctor] ⚠ {user} is enrolled but no login manager is wired for face auth.\n     \
+             A system update (authselect / pam-auth-update) may have regenerated the\n     \
+             PAM stacks. Re-wire with: sudo irlume login enable --apply"
+        );
     }
 
     std::process::ExitCode::SUCCESS

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -305,6 +305,93 @@ fn main() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Consecutive-failure throttle (NIST SP 800-63B-4 s3.2.3 intent).
+//
+// After a run of failed face attempts, stop firing the camera on the gesture
+// for a short cooldown and let PAM fall straight to the password. Deliberately
+// a THROTTLE, not a hard biometric-disable: irlume's password is always the
+// fallback and there is no account lockout, so the standard's disable-and-
+// offer-another-factor tier would only add friction (the "other factor" that
+// re-enables face IS the password the throttled user is already typing). Every
+// platform (Face ID, Android, Windows Hello) also uses ~5 fails then falls to a
+// non-biometric factor. State is per-user and in-memory only; a daemon restart
+// clears it (there is nothing to protect on disk since the password is the
+// floor). Tunable/testable via env; 0 strikes disables the throttle.
+// ---------------------------------------------------------------------------
+#[derive(Default)]
+struct FailState {
+    strikes: u32,
+    cooldown_until: Option<std::time::Instant>,
+}
+
+fn rate_state() -> &'static std::sync::Mutex<std::collections::HashMap<String, FailState>> {
+    static S: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, FailState>>> =
+        std::sync::OnceLock::new();
+    S.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+fn rate_max_strikes() -> u32 {
+    env_or("IRLUME_RATE_LIMIT", "5").parse().unwrap_or(5)
+}
+
+fn rate_cooldown() -> std::time::Duration {
+    std::time::Duration::from_secs(
+        env_or("IRLUME_RATE_COOLDOWN_SECS", "30")
+            .parse()
+            .unwrap_or(30),
+    )
+}
+
+/// True when `user` is in a cooldown window: skip the camera and fall to the
+/// password. Clears an expired window as a side effect.
+fn rate_limited(user: &str) -> bool {
+    if rate_max_strikes() == 0 {
+        return false;
+    }
+    let mut map = rate_state().lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(s) = map.get_mut(user) {
+        if let Some(until) = s.cooldown_until {
+            if std::time::Instant::now() < until {
+                return true;
+            }
+            s.cooldown_until = None;
+            s.strikes = 0;
+        }
+    }
+    false
+}
+
+/// Record a face attempt's outcome. A grant resets the user; a rejected live
+/// presentation is a strike, and `rate_max_strikes()` of them starts a cooldown.
+/// `faced` is false when no face was presented (nobody in frame), so walking
+/// away never counts against the user.
+fn rate_record(user: &str, granted: bool, faced: bool) {
+    if rate_max_strikes() == 0 {
+        return;
+    }
+    let mut map = rate_state().lock().unwrap_or_else(|e| e.into_inner());
+    let s = map.entry(user.to_string()).or_default();
+    if granted {
+        s.strikes = 0;
+        s.cooldown_until = None;
+        return;
+    }
+    if !faced {
+        return;
+    }
+    s.strikes += 1;
+    if s.strikes >= rate_max_strikes() {
+        s.cooldown_until = Some(std::time::Instant::now() + rate_cooldown());
+        s.strikes = 0;
+        eprintln!(
+            "irlumed: '{user}' hit {} consecutive face failures; face throttled for {}s (password still works)",
+            rate_max_strikes(),
+            rate_cooldown().as_secs()
+        );
+    }
+}
+
 fn env_or(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.into())
 }
@@ -571,10 +658,20 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     };
                 }
             }
+            // Too many recent failures: don't fire the camera, fall to password.
+            if rate_limited(&user) {
+                return Response::AuthResult {
+                    granted: false,
+                    score: 0.0,
+                    live: false,
+                    reason: "too many recent face attempts; use your password".into(),
+                };
+            }
             let convenience = engine.tier() == irlume_core::biopolicy::Tier::Convenience;
             let t = std::time::Instant::now();
             match engine.authenticate(&user, service.as_deref()) {
                 Ok(o) => {
+                    rate_record(&user, o.granted, o.live || o.score > 0.0);
                     if convenience || irlume_common::dbglog::on() {
                         // Denied score + reason measurements quantized/redacted
                         // unless tracing (anti-oracle); grants log exact.
@@ -1270,6 +1367,11 @@ fn do_unseal_password(
             "no sealed password for '{user}': run `irlume keyring arm`"
         ));
     }
+    // Same failure throttle as the login/sudo path: after a run of failures,
+    // skip the camera and let PAM fall to the password.
+    if rate_limited(user) {
+        return Response::Error("too many recent face attempts; use your password".into());
+    }
     let outcome = match engine.authenticate(user, service) {
         Ok(o) => o,
         Err(e) => {
@@ -1287,6 +1389,7 @@ fn do_unseal_password(
             return Response::Error(e.to_string());
         }
     };
+    rate_record(user, outcome.granted, outcome.live || outcome.score > 0.0);
     if !outcome.granted {
         // Denied-attempt scores are QUANTIZED to one decimal unless tracing is
         // on: a 4-decimal score after every try is a gradient a journal-reading
@@ -1805,6 +1908,54 @@ mod tests {
             }
             other => panic!("expected PasswordUnsealed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn rate_throttle_trips_after_the_limit_and_resets_on_grant() {
+        let _g = env_lock();
+        std::env::set_var("IRLUME_RATE_LIMIT", "3");
+        std::env::set_var("IRLUME_RATE_COOLDOWN_SECS", "30");
+        // Unique user so the process-global map does not bleed across tests.
+        let u = format!("throttle-{}", std::process::id());
+
+        // Below the limit: strikes accumulate, not yet throttled.
+        assert!(!rate_limited(&u));
+        rate_record(&u, false, true); // strike 1
+        rate_record(&u, false, true); // strike 2
+        assert!(!rate_limited(&u), "under the limit must not throttle");
+        rate_record(&u, false, true); // strike 3 -> cooldown
+        assert!(rate_limited(&u), "at the limit the user is throttled");
+
+        // No-face outcomes (nobody in frame) never count: fresh user stays open
+        // even after many of them.
+        let u2 = format!("noface-{}", std::process::id());
+        for _ in 0..10 {
+            rate_record(&u2, false, false);
+        }
+        assert!(!rate_limited(&u2), "absence must not throttle");
+
+        // A grant clears the throttle immediately.
+        let u3 = format!("grant-{}", std::process::id());
+        rate_record(&u3, false, true);
+        rate_record(&u3, false, true);
+        rate_record(&u3, false, true);
+        assert!(rate_limited(&u3));
+        rate_record(&u3, true, true);
+        assert!(!rate_limited(&u3), "a grant resets the throttle");
+
+        // Limit of 0 disables the throttle entirely.
+        std::env::set_var("IRLUME_RATE_LIMIT", "0");
+        let u4 = format!("disabled-{}", std::process::id());
+        for _ in 0..20 {
+            rate_record(&u4, false, true);
+        }
+        assert!(
+            !rate_limited(&u4),
+            "IRLUME_RATE_LIMIT=0 disables the throttle"
+        );
+
+        std::env::remove_var("IRLUME_RATE_LIMIT");
+        std::env::remove_var("IRLUME_RATE_COOLDOWN_SECS");
     }
 
     #[test]

--- a/crates/irlume-daemon/tests/shutdown.rs
+++ b/crates/irlume-daemon/tests/shutdown.rs
@@ -35,6 +35,10 @@ fn ort_dylib() -> Option<String> {
     None
 }
 
+// The child is killed on every failure path and reaped on success; a panicking
+// test process is itself reaped by the OS (which cleans up the child), so the
+// zombie-process lint does not apply to this integration test.
+#[allow(clippy::zombie_processes)]
 #[test]
 #[ignore = "needs ONNX models + onnxruntime to boot the daemon (CI provides them)"]
 fn daemon_exits_promptly_on_sigterm() {
@@ -84,7 +88,12 @@ fn daemon_exits_promptly_on_sigterm() {
     // this fails loudly if a handler ever swallows it).
     let pid = child.id() as i32;
     let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
-    assert_eq!(rc, 0, "kill(SIGTERM) failed: {}", std::io::Error::last_os_error());
+    assert_eq!(
+        rc,
+        0,
+        "kill(SIGTERM) failed: {}",
+        std::io::Error::last_os_error()
+    );
 
     let stop = Instant::now() + Duration::from_secs(3);
     let mut exited = false;

--- a/crates/irlume-daemon/tests/shutdown.rs
+++ b/crates/irlume-daemon/tests/shutdown.rs
@@ -1,0 +1,108 @@
+//! The daemon must exit promptly on SIGTERM so a package-upgrade restart never
+//! stalls. irlume installs no signal handler, so SIGTERM uses the default
+//! disposition (immediate terminate); this test guards against a future change
+//! that adds a SIGINT-only handler and accidentally swallows SIGTERM, the exact
+//! bug that made a sibling project hang 90s on every restart.
+//!
+//! Gated: needs the ONNX models and libonnxruntime to boot the daemon. CI
+//! provides both; without them the test returns early.
+
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn models_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../models")
+}
+
+fn ort_dylib() -> Option<String> {
+    if let Ok(p) = std::env::var("ORT_DYLIB_PATH") {
+        if PathBuf::from(&p).exists() {
+            return Some(p);
+        }
+    }
+    for c in [
+        "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+        "/usr/lib64/libonnxruntime.so",
+        "/usr/lib/libonnxruntime.so",
+        "/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
+    ] {
+        if PathBuf::from(c).exists() {
+            return Some(c.to_string());
+        }
+    }
+    None
+}
+
+#[test]
+#[ignore = "needs ONNX models + onnxruntime to boot the daemon (CI provides them)"]
+fn daemon_exits_promptly_on_sigterm() {
+    let models = models_dir();
+    let det = models.join("face_detection_yunet_2023mar.onnx");
+    let model = models.join("glintr100.onnx");
+    let mesh = models.join("face_landmark.onnx");
+    let blaze = models.join("blaze_face_short_range.onnx");
+    let Some(ort) = ort_dylib() else {
+        eprintln!("SKIP: no libonnxruntime found");
+        return;
+    };
+    if !det.exists() || !model.exists() {
+        eprintln!("SKIP: models not present (git lfs pull)");
+        return;
+    }
+
+    let dir = std::env::temp_dir().join(format!("irlumed-sigterm-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let socket = dir.join("irlumed.sock");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_irlumed"))
+        .env("IRLUME_SOCKET", &socket)
+        .env("IRLUME_DET_MODEL", &det)
+        .env("IRLUME_MODEL", &model)
+        .env("IRLUME_MESH_MODEL", &mesh)
+        .env("IRLUME_BLAZE_MODEL", &blaze)
+        .env("ORT_DYLIB_PATH", &ort)
+        // No real camera work: point the pair at nonexistent nodes so the
+        // daemon does not contend with a running instance on this machine.
+        .env("IRLUME_RGB_DEVICE", "/nonexistent-rgb")
+        .env("IRLUME_IR_DEVICE", "/nonexistent-ir")
+        .spawn()
+        .expect("spawn irlumed");
+
+    // Wait for the socket (model load can take a few seconds).
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while !socket.exists() && Instant::now() < deadline {
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("daemon exited during startup: {status}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(socket.exists(), "daemon never bound its socket");
+
+    // SIGTERM and require exit within 3s (default disposition is immediate;
+    // this fails loudly if a handler ever swallows it).
+    let pid = child.id() as i32;
+    let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+    assert_eq!(rc, 0, "kill(SIGTERM) failed: {}", std::io::Error::last_os_error());
+
+    let stop = Instant::now() + Duration::from_secs(3);
+    let mut exited = false;
+    while Instant::now() < stop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                exited = true;
+                break;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(e) if e.kind() == ErrorKind::Other => break,
+            Err(e) => panic!("try_wait: {e}"),
+        }
+    }
+    if !exited {
+        let _ = child.kill();
+        let _ = std::fs::remove_dir_all(&dir);
+        panic!("daemon did not exit within 3s of SIGTERM (a signal handler may be swallowing it)");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -166,3 +166,32 @@ with a fabricated print.
   process memory, dropped after use but not explicitly wiped, inside the
   same root daemon that holds the decrypted templates anyway. Nothing
   biometric is logged.
+
+## Intent, throttling, and privilege elevation
+
+- **Face never fires passively.** The camera powers on only when the user
+  submits an empty password field and presses Enter; typing a password never
+  starts a scan. In FIDO terms, that deliberate gesture is the User Presence /
+  intent signal and the face match is User Verification. This is the same shape
+  as macOS Touch ID for `sudo`, where the deliberate fingerprint touch is both
+  the intent act and the verification. It is the specific gap that a passive
+  face-auth tool has for privilege elevation (a face silently approving `sudo`
+  just by being in frame, cf. Howdy issue #1079); irlume does not have it,
+  because presence alone triggers nothing. face-`sudo` therefore requires no
+  extra challenge beyond the gesture and the default IR liveness gate: adding
+  one would impose latency and false rejects on a factor whose fallback (the
+  password) is always one keystroke away.
+- **Consecutive-failure throttle.** After a run of failed face attempts (5 by
+  default, `IRLUME_RATE_LIMIT`), the daemon stops firing the camera on the
+  gesture for a cooldown (30s, `IRLUME_RATE_COOLDOWN_SECS`) and PAM falls
+  straight to the password; a grant resets it, and an empty frame (nobody
+  present) never counts. This satisfies the NIST SP 800-63B-4 §3.2.3 intent
+  (an attacker cannot cheaply grind presentation attacks against the gate)
+  deliberately as a *throttle*, not the standard's hard biometric-disable
+  tier: irlume's password is always the fallback and there is no account
+  lockout, so disabling face until "another factor" would only re-offer the
+  password the throttled user is already typing. State is per-user and
+  in-memory; a daemon restart clears it because the password, not a lockout,
+  is the security floor. Every mainstream authenticator (Face ID, Android,
+  Windows Hello) likewise uses ~5 failures then falls to a non-biometric
+  factor rather than locking the account.

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -19,6 +19,11 @@ Environment="IRLUME_SOCKET=/run/irlume.sock"
 # the target user per request, so no global STATE_DIR is set here.
 Restart=on-failure
 RestartSec=2
+# The socket loop exits promptly on SIGTERM (no long-held camera handle:
+# captures open and drop the device per request). Cap the stop wait so a
+# package-upgrade restart can never stall on the default 90s if a request is
+# mid-flight.
+TimeoutStopSec=10s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Mined the Howdy / visage / linux-enable-ir-emitter issue trackers for problems irlume's users could hit, and hardened three auth-policy defaults against current NIST/FIDO guidance and what Windows Hello / Face ID / Android / macOS Touch-ID actually ship.

**Camera/UX (#1-#6):** MJPEG/NV12 RGB format negotiation + clear diagnosis (was a cryptic 'expected YUYV'); IPU6/IPU7 doctor detection with the accurate 'IR sensor not exposed on Linux' finding; suspend/resume capture warm-up retry; doctor warns when enrolled-but-unwired (authselect/pam-auth-update drift); README liveness footnote; systemd TimeoutStopSec + a SIGTERM regression test.

**Auth policy (#7-#9):** consecutive-failure throttle (5 fails -> 30s cooldown -> password; a throttle not a hard-disable, because the password is always the fallback); anti-spoof blink challenge is now an informed opt-in at enroll (default off, matching every mainstream passive-PAD authenticator); THREAT_MODEL documents that on-demand already supplies sudo intent.

Every claim traces to a competitor issue or a cited standard. Live-validated on real IR hardware (face-sudo grants unaffected). 555 tests green locally; new gated tests wired into CI.
