### PR TITLE
Fix audit findings: throttle signal, remote guard, fusion weight, panics

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -151,7 +151,11 @@ fn grace_window_ms(service: Option<&str>) -> u64 {
 /// 2026-07-15: without this, settling into frame can be denied on the
 /// transient mismatch. Other Spoof reasons (flat/depth/2D) are NOT retried,
 /// and a below-threshold MATCH is never retried (that would multiply FAR).
-fn presence_retryable(o: &Outcome) -> bool {
+/// True when an outcome is a mere "no usable face yet" (nobody in frame, or
+/// liveness inconclusive): the grace loop retries these, and the daemon
+/// throttle must NOT count them as failed attempts. A real rejection (wrong
+/// person, a caught spoof that produced a live face) is NOT presence-retryable.
+pub fn presence_retryable(o: &Outcome) -> bool {
     !o.granted
         && !o.live
         && (o.reason.starts_with("no face:")
@@ -741,6 +745,17 @@ impl Engine {
         let pose = rgb_top
             .as_ref()
             .map(|f| irlume_vision::head_pose(&f.landmarks));
+        // Real RGB face luma: the cross-spectrum liveness gate does not read it,
+        // but stage-2 fusion's `rgb_quality_weight` does. Hardcoding 0.0 here
+        // made fusion always treat the RGB modality as pitch-dark (minimal
+        // weight), collapsing the fused score toward IR regardless of actual
+        // ambient light and weakening the "must fool both modalities" bound.
+        // Measure it exactly as the RGB-only path does. The PAD-specific
+        // moiré/specular cues stay 0.0 (the IR gate doesn't use them).
+        let rgb_brightness = rgb_top
+            .as_ref()
+            .map(|f| rgb_luma_stats(&rgb.data, rgb.width, rgb.height, &f.bbox).0)
+            .unwrap_or(0.0);
         let signals = Signals {
             rgb_face: rgb_top.as_ref().map(|f| fbox(f, rgb.width, rgb.height)),
             ir_face: ir_top.as_ref().map(|f| fbox(f, ir.width, ir.height)),
@@ -753,7 +768,7 @@ impl Engine {
             head_yaw_asym: pose.map(|p| p.yaw_asym).unwrap_or(0.0),
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: ir_stats.ambient_mean,
-            rgb_face_brightness: 0.0, // IR path doesn't use the RGB-PAD cues
+            rgb_face_brightness: rgb_brightness,
             rgb_moire_score: 0.0,
             rgb_specular_frac: 0.0,
         };
@@ -1196,6 +1211,30 @@ impl Engine {
                     score: 0.0,
                     reason: format!("dark liveness {verdict:?}: {reason}"),
                 });
+            }
+            // Per-user calibrated IR depth floor, same as the RGB primary path.
+            // `evaluate_ir_only` uses the lenient global DEPTH_MIN_RATIO; the
+            // per-user floor is stricter and ambient-independent, so a curved
+            // warm spoof that sits between the global ratio and this user's
+            // enrolled 3D structure is caught in lit conditions but must not
+            // slip through in the dark. Apply it here too before the IR match.
+            if let Some(depth_floor) = enr.ir_calibration().filter(|_| self.ir_available) {
+                irlume_common::dlog!(
+                    "gate(per-user depth floor, dark): live {:.2} vs floor {:.2}",
+                    a.ir_depth,
+                    depth_floor
+                );
+                if a.ir_depth < depth_floor {
+                    return Ok(Outcome {
+                        granted: false,
+                        live: false,
+                        score: 0.0,
+                        reason: format!(
+                            "IR depth {:.2} below your calibrated floor {:.2}; looks 2D (screen/photo)",
+                            a.ir_depth, depth_floor
+                        ),
+                    });
+                }
             }
             // Opt-in third-party PAD cue, deny-only (scored in assess_full on
             // the lit IR frame; the dark path re-derives its own gate verdict,
@@ -2035,6 +2074,12 @@ fn rgb_luma_stats(rgb: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> (f32, f32) {
 }
 
 pub fn mean_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
+    // The pixel loop assumes grey.len() == w*h (the invariant the camera crate
+    // upholds). Guard once so a truncated/mismatched IR frame degrades to 0.0
+    // (treated as "too dark", a safe deny) instead of panicking the daemon.
+    if grey.len() < (w as usize).saturating_mul(h as usize) {
+        return 0.0;
+    }
     let x1 = (bbox[0].max(0.0) as u32).min(w.saturating_sub(1));
     let y1 = (bbox[1].max(0.0) as u32).min(h.saturating_sub(1));
     let x2 = (bbox[2].max(0.0) as u32).min(w);
@@ -2705,6 +2750,9 @@ mod tests {
         // Out-of-frame bbox clamps to the frame.
         assert!((mean_in_bbox(&grey, w, h, &[-9.0, -9.0, 99.0, 99.0]) - 45.0).abs() < 1e-4);
         assert_eq!(mean_in_bbox(&grey, w, h, &[3.0, 1.0, 3.0, 1.0]), 0.0);
+        // A frame shorter than w*h (truncated/mismatched capture) must degrade
+        // to 0.0, not panic on the out-of-bounds index.
+        assert_eq!(mean_in_bbox(&grey[..3], w, h, &[0.0, 0.0, 4.0, 2.0]), 0.0);
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2244,10 +2244,10 @@ fn doctor() -> std::process::ExitCode {
         // An RGB node the capture path can't decode (MJPEG-only) classifies as
         // usable but would fail at capture; warn here instead.
         if *role == irlume_camera::Role::Rgb {
+            // Must match the capture path's DECODABLE_RGB (YUYV, NV12); listing
+            // RGB3/BGR3 here would pass doctor then fail at capture.
             let fmts = irlume_camera::rgb_node_formats(path);
-            let decodable = fmts
-                .iter()
-                .any(|f| f == b"YUYV" || f == b"NV12" || f == b"RGB3" || f == b"BGR3");
+            let decodable = fmts.iter().any(|f| f == b"YUYV" || f == b"NV12");
             if !fmts.is_empty() && !decodable {
                 let list: Vec<String> = fmts
                     .iter()

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1888,6 +1888,21 @@ impl App {
                     map_settings,
                 );
             }
+            // Blink challenge is a per-user opt-in gate, togglable exactly like
+            // eyes-open; [c] flips it so the anti-spoof stage no longer needs a
+            // drop to the shell (`irlume profiles challenge on|off`).
+            (SC_SETTINGS, KeyCode::Char('c')) => {
+                let on = !self.challenge;
+                self.start_async(
+                    "toggle require-challenge",
+                    OpTag::Generic,
+                    Request::SetRequireChallenge {
+                        user: self.user.clone(),
+                        on,
+                    },
+                    map_settings,
+                );
+            }
             _ => {}
         }
     }
@@ -2271,7 +2286,7 @@ impl App {
                 SC_FINGERPRINT => "Optional backup: press [a] to add a fingerprint too.",
                 SC_PAM => "Turn on face login for your screen: press [w] (asks for your password).",
                 SC_SETTINGS => {
-                    "Press [enter] to toggle the eyes-open check; other settings are root or read-only."
+                    "[enter] toggles the eyes-open check, [c] the blink challenge; other settings are root or read-only."
                 }
                 SC_DONE => {
                     "Green = done; anything left shows its key. Press [q] to close."
@@ -3423,7 +3438,7 @@ impl App {
             SC_RECOVERY => &[("s", "set"), ("t", "restore"), ("f", "forget")],
             SC_FINGERPRINT => &[("a", "enroll finger")],
             SC_PAM => &[("w", "wire login (sudo)"), ("s", "show status")],
-            SC_SETTINGS => &[("enter", "toggle eyes-open")],
+            SC_SETTINGS => &[("enter", "toggle eyes-open"), ("c", "toggle blink")],
             SC_DONE => &[("w", "wire login"), ("r", "refresh")],
             _ => &[("r", "refresh")],
         };
@@ -4975,6 +4990,24 @@ mod tests {
         assert_eq!(
             app.op.as_ref().map(|o| o.label.as_str()),
             Some("toggle require-eyes-open")
+        );
+        wait_op_done(&mut app);
+        assert!(
+            app.error.is_some(),
+            "a failed toggle must raise the error banner, not vanish"
+        );
+    }
+
+    #[test]
+    fn settings_c_toggles_blink_challenge_via_the_daemon() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.on_key(KeyCode::Char('c'));
+        assert_eq!(
+            app.op.as_ref().map(|o| o.label.as_str()),
+            Some("toggle require-challenge"),
+            "[c] must fire the SetRequireChallenge toggle, not fall through"
         );
         wait_op_done(&mut app);
         assert!(

--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -99,9 +99,32 @@ impl SealedEnvelope {
             fs::create_dir_all(parent).map_err(|e| Error::Io(e.to_string()))?;
         }
         let s = serde_json::to_string_pretty(self).map_err(|e| Error::Protocol(e.to_string()))?;
-        fs::write(path, s).map_err(|e| Error::Io(e.to_string()))?;
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+        // Create at 0600 atomically (mode on open) rather than write-then-chmod,
+        // so the sealed envelope is never briefly readable under a lax umask.
+        // The payload is TPM-sealed / passphrase-wrapped, so the window was
+        // low-value, but there is no reason to leave it open.
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut f = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(path)
+                .map_err(|e| Error::Io(e.to_string()))?;
+            f.write_all(s.as_bytes())
+                .map_err(|e| Error::Io(e.to_string()))?;
+            // Re-assert the mode in case the file pre-existed at a wider mode
+            // (open with an existing file keeps its permissions).
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+        }
+        #[cfg(not(unix))]
+        {
+            fs::write(path, s).map_err(|e| Error::Io(e.to_string()))?;
+        }
         Ok(())
     }
 }

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -810,6 +810,21 @@ fn parse_pcrlock_json(raw: &[u8]) -> Result<PcrlockJson> {
 }
 
 fn hex32(s: &str) -> Result<[u8; 32]> {
+    // Guard BEFORE the byte-indexed slice below: a multibyte UTF-8 char (with
+    // s.len() still even) or an odd length would make `s[i..i+2]` split a char
+    // boundary or run past the end and PANIC, turning a corrupt/partial
+    // pcrlock.json into a login outage instead of a clean password fallback.
+    // Same hardening as pcrsig::from_hex (a fuzzer found this class there).
+    if !s.is_ascii() {
+        return Err(Error::Policy(
+            "non-hex characters in pcrlock.json PCR value".into(),
+        ));
+    }
+    if !s.len().is_multiple_of(2) {
+        return Err(Error::Policy(
+            "odd-length hex in pcrlock.json PCR value".into(),
+        ));
+    }
     let bytes = (0..s.len())
         .step_by(2)
         .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
@@ -1142,6 +1157,21 @@ mod tests {
         let b = a_hash(&[0xaa; 32], &[0x01]).unwrap();
         assert_eq!(a.value().len(), 32);
         assert_ne!(a.value(), b.value());
+    }
+
+    #[test]
+    fn hex32_rejects_malformed_without_panicking() {
+        // 64 valid hex chars -> 32 bytes.
+        let good: String = "ab".repeat(32);
+        assert!(hex32(&good).is_ok());
+        // Odd length must error, not panic on the trailing slice.
+        assert!(hex32("abc").is_err());
+        // A multibyte char (even byte length) must error, not split a boundary.
+        assert!(hex32("aé").is_err());
+        // Right length, non-hex digits.
+        assert!(hex32(&"zz".repeat(32)).is_err());
+        // Valid hex but wrong byte count.
+        assert!(hex32("aabb").is_err());
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -362,10 +362,15 @@ fn rate_limited(user: &str) -> bool {
     false
 }
 
-/// Record a face attempt's outcome. A grant resets the user; a rejected live
+/// Record a face attempt's outcome. A grant resets the user; a rejected real
 /// presentation is a strike, and `rate_max_strikes()` of them starts a cooldown.
-/// `faced` is false when no face was presented (nobody in frame), so walking
-/// away never counts against the user.
+/// `faced` is the *strike-worthy* signal: it must be true for a genuine failed
+/// presentation, which includes a hard spoof rejection (those return
+/// `live=false, score=0`, so an earlier `live || score>0` test never struck on
+/// the actual attack it is meant to throttle). Callers pass
+/// `!presence_retryable(&outcome)`: false only for the retryable no-face /
+/// uncertain-liveness outcomes (nobody in frame, walk-away, transient
+/// uncertainty), which must never count against the user.
 fn rate_record(user: &str, granted: bool, faced: bool) {
     if rate_max_strikes() == 0 {
         return;
@@ -671,7 +676,7 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             let t = std::time::Instant::now();
             match engine.authenticate(&user, service.as_deref()) {
                 Ok(o) => {
-                    rate_record(&user, o.granted, o.live || o.score > 0.0);
+                    rate_record(&user, o.granted, !irlume_auth::presence_retryable(&o));
                     if convenience || irlume_common::dbglog::on() {
                         // Denied score + reason measurements quantized/redacted
                         // unless tracing (anti-oracle); grants log exact.
@@ -1389,7 +1394,11 @@ fn do_unseal_password(
             return Response::Error(e.to_string());
         }
     };
-    rate_record(user, outcome.granted, outcome.live || outcome.score > 0.0);
+    rate_record(
+        user,
+        outcome.granted,
+        !irlume_auth::presence_retryable(&outcome),
+    );
     if !outcome.granted {
         // Denied-attempt scores are QUANTIZED to one decimal unless tracing is
         // on: a 4-decimal score after every try is a gradient a journal-reading

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -43,12 +43,39 @@ const RESEAL_STASH_KEY: &str = "pam_irlume_reseal_authtok";
 
 struct IrlumePam;
 
+/// True when the PAM transaction is for a remote (non-local) session, so the
+/// local camera must not be engaged. Checks PAM_RHOST first (set by sshd and
+/// other network services to the client host); an empty or "localhost" rhost is
+/// local. Falls back to the SSH_CONNECTION / SSH_TTY environment markers for
+/// services that do not set rhost but run under an ssh session (e.g. `sudo` in
+/// an ssh shell).
+fn is_remote_session(pamh: &Pam) -> bool {
+    if let Ok(Some(rhost)) = pamh.get_rhost() {
+        let h = rhost.to_string_lossy();
+        let h = h.trim();
+        if !h.is_empty() && h != "localhost" && h != "localhost.localdomain" {
+            return true;
+        }
+    }
+    std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some()
+}
+
 impl PamServiceModule for IrlumePam {
     fn authenticate(pamh: Pam, _flags: PamFlags, args: Vec<String>) -> PamError {
         let user = match pamh.get_user(None) {
             Ok(Some(u)) => u.to_string_lossy().into_owned(),
             _ => return PamError::IGNORE,
         };
+        // Remote-session guard: never fire the local camera for an SSH / remote
+        // login or sudo. The camera is physically at the machine, so whoever is
+        // in front of it (not the remote user) would grant the remote session.
+        // A non-empty PAM_RHOST (or the SSH_* env markers) means remote; return
+        // IGNORE so the password/other factor authenticates instead. Always-on,
+        // independent of biopolicy or how the stack is wired (a hand-added
+        // pam_irlume line in system-auth is covered too).
+        if is_remote_session(&pamh) {
+            return PamError::IGNORE;
+        }
         let unseal = args.iter().any(|a| a == "unseal");
         let wait = args.iter().any(|a| a == "wait");
         let reseal = args.iter().any(|a| a == "reseal");

--- a/crates/irlume-vision/src/detect.rs
+++ b/crates/irlume-vision/src/detect.rs
@@ -70,7 +70,10 @@ pub fn decode_stride(
     let mut out = Vec::new();
     for idx in 0..cls.len() {
         let score = (cls[idx].clamp(0.0, 1.0) * obj[idx].clamp(0.0, 1.0)).sqrt();
-        if score < score_thresh {
+        // A NaN score (from a NaN model logit) would pass `< thresh` (false for
+        // NaN) and then rank highest under `total_cmp`, hiding the real face and
+        // forcing a false-reject. Drop non-finite scores outright.
+        if !score.is_finite() || score < score_thresh {
             continue;
         }
         let (r, c) = ((idx / feat_w) as f32, (idx % feat_w) as f32);

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -25,5 +25,36 @@ RestartSec=2
 # mid-flight.
 TimeoutStopSec=10s
 
+# Sandboxing, layered UNDER the SELinux/AppArmor policies (defense in depth).
+# Scoped to what the daemon actually needs: it opens /dev/video* and the TPM,
+# binds a Unix socket, and reads/writes each target user's enrollment (which is
+# why ProtectHome and PrivateDevices are deliberately NOT set, and CAP_CHOWN et
+# al are kept so it can own enrolled files to the user). MemoryDenyWriteExecute
+# stays off because the ONNX runtime JITs.
+NoNewPrivileges=yes
+# No network in the auth loop: the daemon speaks only a local Unix socket.
+# AF_NETLINK is kept for kernel device/uevent queries; no AF_INET/AF_INET6.
+RestrictAddressFamilies=AF_UNIX AF_NETLINK
+IPAddressDeny=any
+# /usr, /boot, /etc read-only; /var, /run, /home stay writable (state + socket
+# + per-user enrollment live there). Not =strict, which would need the enrolled
+# users' homes in ReadWritePaths.
+ProtectSystem=full
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+# The daemon chowns enrolled files to the target user; keep only those caps.
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER
+UMask=0027
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Batch of fixes from the whole-codebase + CLI/TUI + auth-pipeline audit. All local gates green (fmt, clippy `-D warnings`, 560 tests). Auth-path changes (fusion brightness, dark-path depth floor) still want a live hardware pass on the Zenbook before merge.

## Security / correctness
- **pam remote guard** — never fire the local camera for an SSH/remote login or `sudo`. A non-empty `PAM_RHOST` (or the `SSH_*` env markers) returns `IGNORE`, so a person physically at the machine can't grant a remote attacker's session.
- **daemon throttle signal (inverted)** — spoof rejections return `live=false, score=0`, so the old `live || score>0` test never struck on the actual attack it's meant to throttle. Now strikes on `!presence_retryable(&outcome)`.
- **fusion RGB weight** — `assess_full` fed `rgb_face_brightness = 0.0` into stage-2 fusion, so `rgb_quality_weight` always treated RGB as pitch-dark, collapsing the fused score toward IR and weakening the "must fool both modalities" bound. Now measures real RGB face luma; the liveness gate is unaffected.
- **dark-path depth floor** — the per-user calibrated IR depth floor was applied on the RGB path but not the dark (IR-only) path. A curved warm spoof between the global ratio and the user's floor could slip through in the dark. Applied on both.
- **tpm hex32 panic** — panicked on odd-length / non-ASCII `pcrlock.json` PCR values; added ASCII + even-length guards mirroring `pcrsig::from_hex`.
- **envelope 0600 race** — sealed key / recovery files are now created at `0600` atomically (mode-on-open) instead of write-then-chmod.
- **detect NaN score** — a NaN model logit passed `< thresh` (false for NaN) and then ranked highest under `total_cmp`, hiding the real face (false-reject/DoS). Non-finite scores are dropped.
- **mean_in_bbox** — length-guard against a truncated IR frame (safe deny instead of an index panic).

## UX / consistency
- **doctor decodable list** — only `YUYV`/`NV12` count as decodable RGB now, matching the capture path's `DECODABLE_RGB`. `RGB3`/`BGR3` previously passed doctor then failed at capture.
- **TUI blink toggle** — added a `[c]` toggle for the blink challenge on the Settings screen, mirroring the eyes-open toggle (was status-only, required dropping to `irlume profiles challenge on|off`).

## Hardening
- **systemd sandbox** — `NoNewPrivileges`, `RestrictAddressFamilies=AF_UNIX AF_NETLINK`, `ProtectSystem=full`, `ProtectKernel*`, `CapabilityBoundingSet` scoped to `CAP_CHOWN`/`CAP_DAC_OVERRIDE`/`CAP_FOWNER`, etc. Validated live: daemon starts, loads models (ORT JIT works under `LockPersonality`+`SystemCallArchitectures=native`), binds the socket, **zero AVCs**. `ProtectHome`/`PrivateDevices`/`MemoryDenyWriteExecute` deliberately left off (per-user `$HOME` state, camera/TPM access, ORT JIT).
