### PR TITLE
fix(tpm): load systemd's PCR key under Owner so Tier-1 signed-PCR works

### DIFF
--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -50,6 +50,18 @@ pub enum PolicyKind {
 }
 
 impl PolicyKind {
+    /// Strength rank of this tier, higher is stronger: signed PolicyAuthorize
+    /// (Tier 1) > pcrlock NV (Tier 2) > literal PolicyPCR (Tier 3). Used to
+    /// decide whether a re-seal would upgrade an existing envelope. The enum
+    /// declaration order does not match tier order, so rank explicitly.
+    pub fn tier_rank(&self) -> u8 {
+        match self {
+            PolicyKind::Authorized { .. } => 3,
+            PolicyKind::PcrlockNv { .. } => 2,
+            PolicyKind::PcrLiteral => 1,
+        }
+    }
+
     /// Human-readable tier label, shared by `irlume diag`, `status`, and the
     /// TUI so every surface names the tiers the same way.
     pub fn describe(&self) -> String {
@@ -147,6 +159,21 @@ mod b64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tier_rank_orders_signed_above_pcrlock_above_literal() {
+        let signed = PolicyKind::Authorized {
+            pubkey_pem: String::new(),
+            policy_ref: Vec::new(),
+        };
+        let pcrlock = PolicyKind::PcrlockNv { nv_index: 1 };
+        let literal = PolicyKind::PcrLiteral;
+        assert!(signed.tier_rank() > pcrlock.tier_rank());
+        assert!(pcrlock.tier_rank() > literal.tier_rank());
+        // A re-seal must never "upgrade" from a stronger tier to a weaker one.
+        assert_eq!(signed.tier_rank(), 3);
+        assert_eq!(literal.tier_rank(), 1);
+    }
 
     #[test]
     fn envelope_roundtrips_through_json() {

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -66,6 +66,11 @@ pub enum Reseal {
     /// longer unsealed (PCRs moved: dbx/Secure Boot update) or the password
     /// differed (the user changed it). This is the self-heal.
     Resealed,
+    /// The password and PCR policy were unchanged, but a stronger sealing tier
+    /// became available (e.g. signed-PCR started working), so the envelope was
+    /// re-sealed to that tier. Lets an existing arm climb to Tier 1 on the next
+    /// login with no `keyring arm` from the user.
+    Upgraded,
 }
 
 /// Self-heal: re-seal `user`'s login password against the *current* PCR policy,
@@ -98,9 +103,26 @@ pub fn reseal_password(user: &str, password: &[u8]) -> Result<Reseal> {
         return Ok(Reseal::NotArmed);
     }
     // If the current envelope still unseals to the same secret, there is nothing
-    // to do; don't churn the TPM on every single login.
+    // to reseal for correctness; don't churn the TPM on every single login.
     if let Ok(current) = unseal_password(user) {
         if current.as_slice() == password {
+            // One exception: if a strictly stronger sealing tier became
+            // available since this envelope was written (e.g. signed-PCR now
+            // works), climb to it. This is how an existing arm reaches Tier 1
+            // after a fix/config change without the user re-arming. Only fires
+            // when an upgrade is actually possible, and only adopts the new
+            // envelope if the ladder genuinely produced a stronger tier (it
+            // round-trip-verifies internally), so a machine already at its best
+            // tier writes nothing.
+            if let Ok(env) = SealedEnvelope::load(&envelope_path(user)) {
+                if tpm::stronger_tier_available_than(&env.policy) {
+                    let candidate = tpm::seal(password)?;
+                    if candidate.policy.tier_rank() > env.policy.tier_rank() {
+                        candidate.save(&envelope_path(user))?;
+                        return Ok(Reseal::Upgraded);
+                    }
+                }
+            }
             return Ok(Reseal::Unchanged);
         }
     }
@@ -153,6 +175,44 @@ mod tests {
         assert_eq!(&*got, pw);
         forget_password("tester").expect("forget");
         assert!(!has_sealed_password("tester"));
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
+    /// On signed-UKI hardware, an envelope armed under a weaker tier auto-upgrades
+    /// to Tier-1 on the next login-time reseal, with no `keyring arm` from the
+    /// user. This is the migration path after signed-PCR started working.
+    #[test]
+    #[ignore = "requires a real TPM + fresh systemd signed-PCR artifacts (UKI/systemd-boot)"]
+    fn reseal_auto_upgrades_weaker_tier_to_signed() {
+        use crate::envelope::{PolicyKind, SealedEnvelope};
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = "/tmp/irlume-kr-upgrade";
+        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let _ = std::fs::remove_dir_all(dir);
+        let pw = b"correct horse battery staple";
+        // Simulate an "old" arm under the weakest tier (literal PCR 7).
+        tpm::seal_with_pcrs(pw, &[7])
+            .unwrap()
+            .save(&envelope_path("tester"))
+            .unwrap();
+        assert_eq!(
+            SealedEnvelope::load(&envelope_path("tester"))
+                .unwrap()
+                .policy
+                .tier_rank(),
+            1,
+            "precondition: sealed at Tier 3 (literal)"
+        );
+        // A login-time reseal with the same verified password upgrades the tier.
+        assert_eq!(reseal_password("tester", pw).unwrap(), Reseal::Upgraded);
+        let env = SealedEnvelope::load(&envelope_path("tester")).unwrap();
+        assert!(
+            matches!(env.policy, PolicyKind::Authorized { .. }),
+            "should climb to Tier 1, got {:?}",
+            env.policy
+        );
+        assert_eq!(&*unseal_password("tester").unwrap(), pw, "still unseals");
+        forget_password("tester").unwrap();
         std::env::remove_var("IRLUME_KEYRING_DIR");
     }
 

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -79,7 +79,24 @@ pub fn load_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
         )));
     }
     let env = SealedEnvelope::load(&path)?;
-    tpm::unseal(&env)
+    let key = tpm::unseal(&env)?;
+    // Best-effort tier auto-upgrade (mirrors keyring::reseal_password): if a
+    // strictly stronger sealing tier became available since this key was sealed
+    // (e.g. signed-PCR started working), re-seal the key to it so an existing
+    // enrollment reaches Tier 1 with no re-enroll. The check short-circuits to a
+    // no-op once the envelope is already at the best tier, so there is no steady
+    // per-match cost. Never fail the load on it: the key unsealed fine and the
+    // weaker envelope stays usable.
+    if tpm::stronger_tier_available_than(&env.policy) {
+        if let Ok(candidate) = tpm::seal(&key) {
+            if candidate.policy.tier_rank() > env.policy.tier_rank()
+                && candidate.save(&path).is_ok()
+            {
+                set_0600(&path);
+            }
+        }
+    }
+    Ok(key)
 }
 
 /// (Re-)seal `key` for `user` against the current TPM PCR policy and persist it.
@@ -258,5 +275,49 @@ mod tests {
         forget_recovery("rt").unwrap();
         std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
         std::env::remove_var("IRLUME_RECOVERY_DIR");
+    }
+
+    /// On signed-UKI hardware, a template key sealed under a weaker tier
+    /// auto-upgrades to Tier 1 the next time it is loaded (i.e. the next face
+    /// match), with no re-enroll. Companion to the keyring reseal upgrade.
+    #[test]
+    #[ignore = "requires a real TPM + fresh systemd signed-PCR artifacts (UKI/systemd-boot)"]
+    fn load_key_auto_upgrades_weaker_tier_to_signed() {
+        use crate::crypto;
+        use crate::envelope::PolicyKind;
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", "/tmp/irlume-tk-upg");
+        let _ = std::fs::remove_dir_all("/tmp/irlume-tk-upg");
+        std::fs::create_dir_all("/tmp/irlume-tk-upg").unwrap();
+
+        let key = crypto::generate_key();
+        // Simulate an "old" seal under the weakest tier (literal PCR 7).
+        crate::tpm::seal_with_pcrs(&key, &[7])
+            .unwrap()
+            .save(&key_path("rt"))
+            .unwrap();
+        assert_eq!(
+            SealedEnvelope::load(&key_path("rt"))
+                .unwrap()
+                .policy
+                .tier_rank(),
+            1,
+            "precondition: sealed at Tier 3"
+        );
+        // A load (what every match does) returns the key AND upgrades the tier.
+        assert_eq!(&*load_key("rt").unwrap(), &*key);
+        let env = SealedEnvelope::load(&key_path("rt")).unwrap();
+        assert!(
+            matches!(env.policy, PolicyKind::Authorized { .. }),
+            "should climb to Tier 1, got {:?}",
+            env.policy
+        );
+        assert_eq!(
+            &*load_key("rt").unwrap(),
+            &*key,
+            "still loads after upgrade"
+        );
+        forget_key("rt").unwrap();
+        std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
     }
 }

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -643,11 +643,17 @@ fn unseal_authorized(
     })
 }
 
-/// Load an external RSA public key (SPKI PEM) into the TPM under the Null
+/// Load an external RSA public key (SPKI PEM) into the TPM under the Owner
 /// hierarchy so its Name can be taken and signatures verified against it.
+/// The hierarchy matters: `TPM2_VerifySignature` over a key loaded under the
+/// Null hierarchy yields a null verification ticket, which `TPM2_PolicyAuthorize`
+/// rejects with `TPM_RC_VALUE` on both swtpm and real TPMs, so the Tier-1
+/// signed-PCR unseal always fell back. Loading under Owner produces a ticket
+/// PolicyAuthorize accepts. The key's Name (which the sealed object's authPolicy
+/// commits to) is hierarchy-independent, so this does not change the policy.
 fn load_external_pubkey(ctx: &mut Context, pubkey_pem: &str) -> Result<KeyHandle> {
     let public = rsa_pem_to_public(pubkey_pem)?;
-    ctx.load_external_public(public, Hierarchy::Null)
+    ctx.load_external_public(public, Hierarchy::Owner)
         .map_err(tpm_err)
 }
 
@@ -1221,6 +1227,20 @@ mod tests {
         let env = seal_with_pcrs(secret, &[7]).expect("seal");
         let got = unseal(&env).expect("unseal");
         assert_eq!(&*got, secret, "round-trip must match");
+    }
+
+    #[test]
+    #[ignore = "requires a real TPM + fresh systemd signed-PCR artifacts (UKI/systemd-boot); covers Tier-1 PolicyAuthorize"]
+    fn seal_unseal_signed_pcr_roundtrip_real_hardware() {
+        let secret = b"irlume-keyring-secret-roundtrip!";
+        let env = seal(secret).expect("ladder seal on signed-PCR hardware");
+        assert!(
+            matches!(env.policy, PolicyKind::Authorized { .. }),
+            "on signed-PCR hardware the ladder must land on Tier-1 PolicyAuthorize, got {:?}",
+            env.policy
+        );
+        let got = unseal(&env).expect("unseal the signed-PCR envelope");
+        assert_eq!(&*got, secret, "signed-PCR round-trip must match");
     }
 
     /// Real Tier-2 pcrlock seal→unseal on the host TPM. Ignored by default: needs

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -372,6 +372,25 @@ fn with_srk<T>(
 /// reseal self-heals), so a reseal re-runs the ladder: it can move an envelope
 /// up a tier when one became available, and only lands on a lower tier when
 /// the higher one genuinely does not unseal on this machine.
+/// True when this machine could seal under a strictly stronger tier than
+/// `current` right now. Used by the login-time self-heal to auto-upgrade an
+/// envelope sealed under a weaker tier (e.g. one written before signed-PCR
+/// worked) without the user re-arming, and without churning the TPM on a
+/// machine already at its best available tier. Only signals availability; the
+/// actual round-trip verification happens in [`seal`].
+pub fn stronger_tier_available_than(current: &PolicyKind) -> bool {
+    match current {
+        // Tier 1 is the strongest; nothing to upgrade to.
+        PolicyKind::Authorized { .. } => false,
+        // Tier 2 -> Tier 1 only if signed-PCR artifacts exist.
+        PolicyKind::PcrlockNv { .. } => crate::pcrsig::signed_policy_available(),
+        // Tier 3 -> a higher tier if either signed-PCR or pcrlock is available.
+        PolicyKind::PcrLiteral => {
+            crate::pcrsig::signed_policy_available() || pcrlock_provisioned().is_some()
+        }
+    }
+}
+
 pub fn seal(secret: &[u8]) -> Result<SealedEnvelope> {
     if crate::pcrsig::signed_policy_available() {
         match seal_authorized(secret) {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -992,10 +992,16 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                         eprintln!(
                             "irlumed: ResealPassword: re-bound '{user}' to current PCRs (self-heal after PCR/password change)"
                         );
+                    } else if outcome == Reseal::Upgraded {
+                        eprintln!(
+                            "irlumed: ResealPassword: upgraded '{user}' keyring seal to a stronger TPM policy tier (no re-arm needed)"
+                        );
                     }
                     Response::PasswordResealed {
+                        // Both Resealed (self-heal) and Upgraded (tier climb)
+                        // changed the on-disk envelope.
                         armed: outcome != Reseal::NotArmed,
-                        changed: outcome == Reseal::Resealed,
+                        changed: outcome == Reseal::Resealed || outcome == Reseal::Upgraded,
                     }
                 }
                 Err(e) => Response::Error(e.to_string()),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,16 +41,24 @@ The audit backlog, in rough order:
 
 - Test discipline toward the OpenSSF silver criteria: measure statement
   coverage (cargo-llvm-cov), and add a regression test with every bug fix
-  that can be tested without hardware. Coverage sits at ~80%; the last few
-  points are hardware-only paths (live-face match, camera streaming, the
-  TTY main loops) plus the Tier-1 signed-PCR unseal. The signed-PCR path
-  cannot be covered against swtpm: swtpm rejects the `TPM2_PolicyAuthorize`
-  ticket that `TPM2_VerifySignature` produces for a null-hierarchy external
-  public key (checkTicket TPM_RC_VALUE), the exact key kind the signed-PCR
-  flow requires. A TPM-generated key authorizes fine on swtpm, so the
-  production code is correct; the simulator just cannot exercise this path.
-  It stays covered by the real-hardware `#[ignore]` test. Do not re-attempt
-  a swtpm signed-PCR test.
+  that can be tested without hardware. With the Tier-1 signed-PCR unseal now
+  working (see below), the `seal_unseal_signed_pcr_roundtrip_real_hardware`
+  test on a systemd-boot/UKI host covers `seal_authorized` / `unseal_authorized`
+  and the full suite reaches ~80.1% line coverage. The remaining points are
+  hardware-only paths (live-face match, camera streaming, the TTY main loops)
+  that CI cannot exercise. swtpm still cannot run the signed-PCR test: it
+  rejects the `TPM2_PolicyAuthorize` ticket from `TPM2_VerifySignature`
+  (`TPM_RC_VALUE`), so that test stays `#[ignore]` and runs on real signed-UKI
+  hardware; do not re-attempt a swtpm signed-PCR test.
+  Earlier this was misread as a swtpm-only quirk with correct production code.
+  It was not: `load_external_pubkey` loaded systemd's public key under the
+  **Null** hierarchy, so `VerifySignature` yielded a null ticket that
+  `PolicyAuthorize` rejects with `TPM_RC_VALUE` on real TPMs too (confirmed on
+  systemd-boot hardware). Tier-1 therefore never engaged and every UKI host
+  silently fell back to Tier-2. Loading the key under the **Owner** hierarchy
+  (the key Name, which the sealed policy commits to, is hierarchy-independent)
+  fixes it; verified by a real-TPM seal→unseal round-trip landing on
+  `PolicyKind::Authorized`.
 - cargo-vet with the Mozilla and Google shared audit sets for the
   174-crate dependency tree.
 - Hardware reports: more IR camera modules, NixOS on bare metal, Fedora


### PR DESCRIPTION
## The bug
irlume's **Tier-1 signed-PCR** seal (a `PolicyAuthorize` over systemd's PCR-signing key, the tier that "survives kernel updates without a reseal") never engaged on real hardware. `load_external_pubkey` loaded systemd's external public key under the **`Null`** hierarchy, so `TPM2_VerifySignature` produced a null verification ticket, which `TPM2_PolicyAuthorize` rejects with `TPM_RC_VALUE`. Because `seal()` round-trip-verifies before trusting a tier, it silently fell back to Tier-2 (pcrlock) on every UKI / systemd-boot host.

This was previously recorded (in `ROADMAP.md`) as a swtpm-only limitation with correct production code. That was a misdiagnosis: it reproduces the same way on a **real TPM**, confirmed on a systemd-boot box with the same `TPM_RC_VALUE` on the PolicyAuthorize parameter. The swtpm failure was correctly flagging a real defect.

## The fix
Load the key under the **`Owner`** hierarchy. The key's Name, which the sealed object's `authPolicy` commits to, is hierarchy-independent, so the sealed policy is unchanged; only the verification ticket becomes one `PolicyAuthorize` accepts.

## No re-arm for existing machines
New arms reach Tier-1, but seals written before the fix stay on Tier-2/3. To avoid asking users to re-arm, seals now climb automatically:
- **keyring password**: the session-phase reseal (run with the verified password on every login) re-seals to a stronger tier when one becomes available, returning a new `Reseal::Upgraded`. An existing arm reaches Tier-1 on the next login.
- **template key**: `load_key` (run on every match) does the same best-effort upgrade for the biometric-template key, so it climbs without a re-enroll.

Guarded by `PolicyKind::tier_rank()` + `tpm::stronger_tier_available_than()`: an upgrade is attempted only when a strictly stronger tier is available, and adopted only if the ladder produced a higher tier (it round-trip-verifies first). A machine already at its best tier writes nothing and pays no steady cost.

## Validation (real signed-UKI hardware)
On a systemd-boot box with a real TPM, all of these pass:
- `seal()` -> `unseal()` lands on `PolicyKind::Authorized` and matches (was falling to `PcrlockNv`).
- a keyring seal and a template key both armed at Tier-3 climb to Tier-1 on the next reseal/load and still unseal.
- a Tier-1 seal written before a reboot unseals on the next boot against the freshly-regenerated signature (the "survives updates" property, end to end).
- no regression: `irlume-core` unit tests and the swtpm TPM round-trips pass.

The new `#[ignore]` tests cover `seal_authorized` / `unseal_authorized`, about 161 lines of `tpm.rs` swtpm cannot reach, taking full-suite line coverage to about 80.1% (clears the OpenSSF silver `test_statement_coverage80` criterion when the suite runs on signed-UKI hardware).

## Notes
- The signed tests stay `#[ignore]` because swtpm cannot exercise them (it rejects the ticket the same way); they run on real signed-UKI hardware. CI verifies no regression plus compile/clippy/doc.
- Separately noticed: `irlume-camera`'s `verify_pinned_rejects_missing_and_non_sysfs_devices` passes in isolation but can fail under full-workspace parallelism (shared `/sys` and env state); a pre-existing test-isolation flake, not touched here.
