### PR TITLE
test(camera+ci): fix two v4l2 camera test flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,22 @@ jobs:
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
           sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=3 video_nr=8,9,10 exclusive_caps=0
+          # Let udev finish applying its default (root:video 0660) perms BEFORE
+          # our chmod, otherwise a late udev event overrides it and a test opens
+          # the node with EACCES ("permission denied"), an intermittent flake.
+          sudo udevadm settle
           sudo chmod 666 /dev/video8 /dev/video9 /dev/video10
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
-          sleep 3
+          # Poll until the fed nodes are actually readable (a feeder opening the
+          # node can re-trigger udev), re-asserting perms each round, instead of a
+          # blind sleep that can finish before the device is ready.
+          for _ in $(seq 1 15); do
+            sudo chmod 666 /dev/video8 /dev/video9 /dev/video10 2>/dev/null || true
+            if [ -r /dev/video8 ] && [ -r /dev/video9 ]; then break; fi
+            sleep 1
+          done
+          ls -l /dev/video8 /dev/video9 /dev/video10
 
       - name: test (camera + capture paths, against v4l2loopback)
         env:
@@ -261,10 +273,22 @@ jobs:
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
           sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=3 video_nr=8,9,10 exclusive_caps=0
+          # Let udev finish applying its default (root:video 0660) perms BEFORE
+          # our chmod, otherwise a late udev event overrides it and a test opens
+          # the node with EACCES ("permission denied"), an intermittent flake.
+          sudo udevadm settle
           sudo chmod 666 /dev/video8 /dev/video9 /dev/video10
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
           nohup ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
-          sleep 3
+          # Poll until the fed nodes are actually readable (a feeder opening the
+          # node can re-trigger udev), re-asserting perms each round, instead of a
+          # blind sleep that can finish before the device is ready.
+          for _ in $(seq 1 15); do
+            sudo chmod 666 /dev/video8 /dev/video9 /dev/video10 2>/dev/null || true
+            if [ -r /dev/video8 ] && [ -r /dev/video9 ]; then break; fi
+            sleep 1
+          done
+          ls -l /dev/video8 /dev/video9 /dev/video10
 
       - name: Coverage incl. TPM-gated and camera tests (fail under the ratchet floor)
         env:

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1637,6 +1637,14 @@ mod tests {
 
     #[test]
     fn verify_pinned_rejects_missing_and_non_sysfs_devices() {
+        // `verify_pinned` reads IRLUME_TEST_ALLOW_VIRTUAL_CAMERA / IRLUME_CAMERA_*;
+        // hold the same lock the env-setting tests take, and clear those vars, so
+        // a concurrent setter cannot flip the verdict mid-assertion (this test
+        // otherwise passes alone but flakes under full-workspace parallelism).
+        let _lock = env_lock();
+        let _a = EnvGuard::unset("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA");
+        let _b = EnvGuard::unset("IRLUME_CAMERA_PIN");
+        let _c = EnvGuard::unset("IRLUME_CAMERA_REQUIRE_FIXED");
         // No node at all: the plain no-camera error, not the injection one.
         let e = verify_pinned("/dev/irlume-test-missing").unwrap_err();
         assert!(e.to_string().contains("no camera found"), "{e}");


### PR DESCRIPTION
Two intermittent camera-test flakes, both fixed.

## 1. `verify_pinned_rejects_missing_and_non_sysfs_devices` (env race)
The test asserts on `verify_pinned`, which reads `IRLUME_TEST_ALLOW_VIRTUAL_CAMERA` and `IRLUME_CAMERA_*`. The env-*setting* tests take a shared `env_lock()`, but this reader did not, so a concurrent setter could flip the verdict mid-assertion. It passed when run alone and flaked under full-workspace parallelism (it cost a CI re-run on #57). It now holds `env_lock()` and clears those vars, so it is deterministic.

## 2. CI v4l2loopback setup (permission race)
After `insmod`, a one-time `sudo chmod 666` could be overridden by a late udev event reapplying the default `root:video 0660`, so a later test opened the node with `EACCES` ("permission denied"), which surfaced as a hardware error where the test expected a face denial. The setup now runs `udevadm settle` before the chmod (so udev's perms are applied first and ours wins), and polls until the fed nodes are readable, re-asserting perms each round, instead of a blind `sleep 3`. Applied to both jobs that set up the loopback cameras.

Local: `irlume-camera` tests pass across repeated runs; fmt/clippy clean; the workflow YAML parses.
