### PR TITLE
chore: changelog Unreleased, spec weekdays, least-privilege workflow token

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -13,14 +13,18 @@ on:
     - cron: "15 6 1 * *"
   workflow_dispatch:
 
+# Least privilege at the top; the one job that commits and opens a PR
+# escalates below (Scorecard Token-Permissions best practice).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to irlume are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Tier-1 signed-PCR sealing works.** irlume's strongest TPM tier (a
+  `PolicyAuthorize` over systemd's PCR-signing key, the one that survives kernel
+  updates without a reseal) never actually engaged. It loaded systemd's public
+  key under the Null hierarchy, so the TPM rejected the resulting
+  `PolicyAuthorize` ticket with `TPM_RC_VALUE`, and every UKI / systemd-boot
+  host silently fell back to Tier-2 (pcrlock). Loading the key under the Owner
+  hierarchy fixes it (the key's Name, which the sealed policy commits to, is
+  hierarchy-independent, so the policy is unchanged). Verified on a real
+  systemd-boot host, including a Tier-1 seal that unseals after a reboot.
+
+### Changed
+
+- **Existing seals climb to the strongest available tier automatically, with no
+  re-arm.** After the fix above a machine that was sealed under a weaker tier
+  upgrades on its own: the keyring seal on the next login, and the template key
+  on the next face match. The upgrade fires only when a strictly stronger tier
+  is available and the ladder round-trip-verifies it, so a machine already at
+  its best tier does nothing. New enrollments seal at Tier-1 directly.
+
 ## [0.4.0] - 2026-07-21
 
 Two batches: preempting camera and UX failure classes mined from other Linux

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -178,7 +178,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
   correct merge-prompt rendering, a static footer with a scrollable activity
   panel, and scroll-handling fixes.
 
-* Wed Jul 16 2026 archledger <archledger236@gmail.com> - 0.2.1-1
+* Thu Jul 16 2026 archledger <archledger236@gmail.com> - 0.2.1-1
 - irlume enroll now merges into the profile the captured face already matches,
   adding the scans instead of refusing with "this face is already enrolled".
   This makes plain `irlume enroll` the working upgrade remedy the 0.2.0 notes
@@ -187,7 +187,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
   profile with 5 slots left gets a 5-scan top-up instead of a 10-scan session
   that discards half, and a full profile is refused after one probe scan.
 
-* Tue Jul 15 2026 archledger <archledger236@gmail.com> - 0.2.0-1
+* Wed Jul 15 2026 archledger <archledger236@gmail.com> - 0.2.0-1
 - BREAKING: re-enroll needed for dark/dim (IR) login. The IR adapter was
   removed (its training data was research-only), so IR templates enrolled under
   0.1.x no longer match. Bright-light (RGB) login keeps working and the password


### PR DESCRIPTION
Repo hygiene:

- **CHANGELOG**: adds an `[Unreleased]` section for the Tier-1 signed-PCR fix and the automatic tier-upgrade (no re-arm) that landed since 0.4.0.
- **packaging/fedora/irlume.spec**: corrects two `%changelog` weekdays that rpmbuild flagged as bogus (0.2.1 is Thu Jul 16 2026, 0.2.0 is Wed Jul 15 2026).
- **update-flake-lock.yml**: drops the top-level token to `contents: read` and escalates the write permissions to the single job that commits and opens the PR (OpenSSF Scorecard Token-Permissions best practice).
