### PR TITLE
chore: SPDX + copyright header on every source file

### DIFF
--- a/crates/irlume-auth/examples/assess_probe.rs
+++ b/crates/irlume-auth/examples/assess_probe.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Drive the real Engine::assess (assess_full, the overlapped-capture +
 //! cross-spectrum self-heal path) N times on a given camera pair and report
 //! the liveness verdict and whether the RGB self-heal fired (from the

--- a/crates/irlume-auth/examples/embed_parity.rs
+++ b/crates/irlume-auth/examples/embed_parity.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Decisive test for the overlapped-capture change: does the concurrent-load
 //! RGB dimming shift the face embedding enough to hurt recognition?
 //!

--- a/crates/irlume-auth/examples/landmark_dump.rs
+++ b/crates/irlume-auth/examples/landmark_dump.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Capture a raw IR strobe burst and dump, per frame, the FaceMesh landmark
 //! coordinates plus the IR brightness sampled at each landmark, the input a
 //! landmark-anchored relief prototype needs (nose vs cheek vs eye-socket

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Shared authentication orchestration: the one place the security-critical
 //! pipeline lives. Both the CLI and the `irlumed` daemon drive this.
 //!

--- a/crates/irlume-camera/examples/ambient_ab.rs
+++ b/crates/irlume-camera/examples/ambient_ab.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! A/B harness for ambient subtraction under a real ambient-IR or spoof
 //! condition. For the given IR device it captures a raw strobe burst and
 //! reports the emitter-OFF (ambient) frame brightness (the whole question: is

--- a/crates/irlume-camera/examples/burst_dump.rs
+++ b/crates/irlume-camera/examples/burst_dump.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Dump a raw IR strobe burst to disk as PGM frames plus a means index, so
 //! ambient-subtraction and depth-cue tuning can be done offline against real
 //! captured conditions (e.g. direct sunlight) long after the light is gone.

--- a/crates/irlume-camera/examples/capture_bench.rs
+++ b/crates/irlume-camera/examples/capture_bench.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Data-gathering harness for the overlapped-capture change: runs N rounds of
 //! sequential (RGB then IR) and N rounds of concurrent (RGB+IR on two threads)
 //! capture on a given camera pair, and reports per-stream timing and mean

--- a/crates/irlume-camera/examples/concurrency_probe.rs
+++ b/crates/irlume-camera/examples/concurrency_probe.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Measure whether this Hello module really starves when the RGB and IR
 //! streams run at the same time (the module doc's "never concurrently" claim).
 //!

--- a/crates/irlume-camera/examples/ir_strobe_probe.rs
+++ b/crates/irlume-camera/examples/ir_strobe_probe.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Ambient-subtraction feasibility probe. Captures a raw IR burst with the
 //! emitter enabled and prints each frame's mean brightness, so we can see
 //! whether the module STROBES the 850nm emitter (interleaved bright/dark

--- a/crates/irlume-camera/examples/rgb_burst_dump.rs
+++ b/crates/irlume-camera/examples/rgb_burst_dump.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Dump RGB frames to disk as PPM, the color-side companion to `burst_dump`:
 //! sun-blown or backlit RGB captures feed the detection-floor and fusion
 //! analysis offline.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Active-IR emitter activation for Windows-Hello-class UVC cameras.
 //!
 //! Hello camera modules pair a greyscale NIR sensor with an 850nm illuminator

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! V4L2 capture for the paired RGB + IR cameras, and active-IR-emitter control.
 //!
 //! Hardware model (Windows-Hello-class module): one RGB sensor (`/dev/video0`)

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Extra operational CLI commands layered over the existing daemon protocol:
 //! observability (`status`, `detect`, `identify`), diagnostics (`diag`,
 //! `selinux`, `deps`), the safe manual re-bind (`reseal`), and the guided

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume fingerprint <status|add|enable|disable>`: fingerprint as a companion
 //! auth modality via stock fprintd + pam_fprintd. irlume never claims the sensor;
 //! it orchestrates enrollment (fprintd CLI) and wires pam_fprintd per distro.

--- a/crates/irlume-cli/src/logs.rs
+++ b/crates/irlume-cli/src/logs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume logs`: one journal view for diagnosing auth problems, and the
 //! switch for the daemon's diagnostic tracing.
 //!

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume`: operator CLI. A thin, unprivileged client of `irlumed` (same socket
 //! protocol as the PAM module). Enrollment requests are authorized by the daemon
 //! via SO_PEERCRED, not by this binary.

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume models`: opt-in third-party model management.
 //!
 //!   irlume models                 list the catalog + what is enabled

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume padcapture` / `irlume padreport`: the ISO/IEC 30107-3 presentation-
 //! attack-detection (PAD) self-test harness.
 //!

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume login <status|enable|disable>`: wire face auth into the login
 //! greeters (GDM/SDDM/LightDM/plasmalogin), the KDE lock screen, and (opt-in)
 //! sudo. The Rust replacement for scripts/deploy-keyring-unlock.sh. Ported from

--- a/crates/irlume-cli/src/recovery.rs
+++ b/crates/irlume-cli/src/recovery.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume recovery <status|setup|restore|forget>`: manage the recovery
 //! passphrase that backs up the per-user template key (the AES key encrypting
 //! enrolled faces at rest). It's the manual backstop for when the TPM seal can

--- a/crates/irlume-cli/src/suncal.rs
+++ b/crates/irlume-cli/src/suncal.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Offline analysis of the sunlight/ambient burst dataset captured by the
 //! `burst_dump` example. For each burst directory it runs the real detection +
 //! depth-cue path over the brightest (lit) frame and over the ambient-subtracted

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume tui`: keyboard-driven setup/management over the `irlumed` socket.
 //!
 //! Layout & feel follow linhello: a step-wizard (Tab/⇧Tab between steps, a

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlume uninstall`: the safe teardown a package `remove` cannot do.
 //!
 //! Removing the distro package deletes the binary and `pam_irlume.so`, but the

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Black-box tests of the `irlume` binary: argument dispatch, usage errors,
 //! exit codes, and the offline failure paths of every daemon-backed command.
 //!

--- a/crates/irlume-cli/tests/cli_bench.rs
+++ b/crates/irlume-cli/tests/cli_bench.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Black-box tests of the IMAGE-DATASET benchmark/dev tools in `irlume`:
 //! `irbench`, `eval`, `normprobe`, `enrolldev`. These tools take directories
 //! (or a single file) of images rather than a live camera, so their offline

--- a/crates/irlume-cli/tests/cli_capture.rs
+++ b/crates/irlume-cli/tests/cli_capture.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Black-box tests of the IRLUME_DEV camera/benchmark subcommands (`capture`,
 //! `liveness`, `meshprobe`, `calcapture`, `padcapture`, `genuine`, `suncal`)
 //! against the v4l2loopback virtual-camera harness CI provides.

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Black-box tests for the `irlume` binary's dispatch / usage / error arms that
 //! `tests/cli.rs` does not already reach. These target the `ExitCode`-returning
 //! branches that a unit test cannot assert (`std::process::ExitCode` is not

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Blocking client for the `irlumed` socket, shared by the CLI (user session)
 //! and the PAM module (root, inside the auth stack). One request per
 //! connection: send a newline-terminated JSON [`Request`], read a

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Tiny `key=value` config files under the config dir (`/etc/irlume`, override
 //! `IRLUME_CONFIG_DIR`), e.g. `cameras.conf`, `settings.conf`. Blank lines and
 //! `#` comments are ignored. These hold operator-tunable knobs the setup flow

--- a/crates/irlume-common/src/dbglog.rs
+++ b/crates/irlume-common/src/dbglog.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Opt-in diagnostic tracing, shared by the daemon and CLI.
 //!
 //! `IRLUME_LOG=debug` turns on per-stage pipeline traces (capture timings,

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Shared types: the daemon<->client IPC protocol, well-known paths, errors.
 //!
 //! Trust boundary (see docs/ARCHITECTURE.md): the thin `pam_irlume` module and the

--- a/crates/irlume-common/src/memlock.rs
+++ b/crates/irlume-common/src/memlock.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Memory-protection helper: `mlock` + `MADV_DONTDUMP` on the pages backing a
 //! secret, so the plaintext can't be swapped to disk or captured in a core
 //! dump while it's live. This complements (does not replace) `Zeroize`, which

--- a/crates/irlume-common/src/platform.rs
+++ b/crates/irlume-common/src/platform.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Per-distro abstraction. A minimal port of linhello's platform layer: just
 //! the distro-family detection that the fingerprint (and, later, login) wiring
 //! needs to pick the right mechanism (authselect vs pam-auth-update vs direct).

--- a/crates/irlume-common/src/secureboot.rs
+++ b/crates/irlume-common/src/secureboot.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Boot-mode and Secure Boot detection via Linux efivarfs + procfs.
 //!
 //! Best-effort and never panics: on a non-EFI system, missing efivars, or

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Catalog of OPTIONAL third-party models irlume can fetch on the operator's
 //! own machine, but does not ship, mirror, or warrant.
 //!

--- a/crates/irlume-core/src/biopolicy.rs
+++ b/crates/irlume-core/src/biopolicy.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Tiered biometric decision policy (opt-in).
 //!
 //! Two axes decide what a face match is allowed to do:

--- a/crates/irlume-core/src/calib.rs
+++ b/crates/irlume-core/src/calib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Per-enrollment IR calibration (ADR-0004): a ridge-regularized linear map
 //! fitted on-device from one profile's own enrollment scans, pulling that
 //! person's IR embeddings toward their RGB embeddings. Replaces the shipped

--- a/crates/irlume-core/src/crypto.rs
+++ b/crates/irlume-core/src/crypto.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! AES-256-GCM encryption for face-template storage at rest.
 //!
 //! Blob format: `[12-byte nonce][ciphertext + 16-byte GCM tag]`. The nonce is

--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! On-disk TPM envelope format for a sealed secret.
 //!
 //! ```json

--- a/crates/irlume-core/src/fusion.rs
+++ b/crates/irlume-core/src/fusion.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Stage-2 lighting-adaptive RGB+IR score fusion.
 //!
 //! Each modality's cosine is mapped to a *calibrated* genuine-probability (Platt

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! TPM-sealed login password for keyring/wallet unlock.
 //!
 //! After a face login there is no typed password for `pam_gnome_keyring` /

--- a/crates/irlume-core/src/lib.rs
+++ b/crates/irlume-core/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Matching, template storage, and TPM-bound secret release.
 //!
 //! Decision rule (NIST SP 800-63B-4 aligned): grant only if the liveness gate

--- a/crates/irlume-core/src/pad.rs
+++ b/crates/irlume-core/src/pad.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! ISO/IEC 30107-3 presentation-attack-detection (PAD) metrics.
 //!
 //! Pure, hardware-free aggregation of labeled presentation trials into the

--- a/crates/irlume-core/src/pcrsig.rs
+++ b/crates/irlume-core/src/pcrsig.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Consume systemd's signed-PCR-policy artifacts (the Tier-1 / UKI path).
 //!
 //! When a Unified Kernel Image is built with `ukify --pcr-private-key` /

--- a/crates/irlume-core/src/policy.rs
+++ b/crates/irlume-core/src/policy.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! System auth-method policy: which biometric modality is active. Set by
 //! `irlume fingerprint enable/disable`; read by the daemon so it can stay silent
 //! (let `pam_fprintd` drive) when the user has chosen fingerprint.

--- a/crates/irlume-core/src/recovery.rs
+++ b/crates/irlume-core/src/recovery.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Dedicated recovery passphrase for the per-user template key.
 //!
 //! This is the deliberate, manual backstop for the cases TPM-sealing cannot

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Per-user face enrollment: up to 3 named face profiles, each holding multiple
 //! named scans (Windows-Hello-style "improve recognition"). Stored as JSON under
 //! the state dir (`IRLUME_STATE_DIR`, else `$HOME/.local/share/irlume` for dev,

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Per-user template key: the AES-256-GCM key that [`crate::storage`] uses to
 //! encrypt enrolled face templates at rest.
 //!

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! TPM 2.0 sealing of the unlock secret (not the template).
 //!
 //! We seal a secret (the user's login password, used to unlock the

--- a/crates/irlume-core/src/tpm_pcrlock.rs
+++ b/crates/irlume-core/src/tpm_pcrlock.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Tier 2: bind the sealed secret to a systemd-pcrlock NV-index policy via
 //! `TPM2_PolicyAuthorizeNV`.
 //!

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `irlumed`: the privileged daemon. Owns the camera + models and is the only
 //! component that runs the biometric pipeline. Untrusted clients (`pam_irlume`,
 //! the CLI) connect over a Unix socket and send line-delimited JSON requests;

--- a/crates/irlume-daemon/src/users.rs
+++ b/crates/irlume-daemon/src/users.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Thread-safe passwd/group lookups via libc reentrant calls.
 //!
 //! Two uses: (a) resolve the `irlume` group so the socket can be `0660

--- a/crates/irlume-daemon/tests/shutdown.rs
+++ b/crates/irlume-daemon/tests/shutdown.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! The daemon must exit promptly on SIGTERM so a package-upgrade restart never
 //! stalls. irlume installs no signal handler, so SIGTERM uses the default
 //! disposition (immediate terminate); this test guards against a future change

--- a/crates/irlume-fingerprint/src/lib.rs
+++ b/crates/irlume-fingerprint/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Fingerprint modality, backed by **fprintd** (the standard Linux fingerprint
 //! service). irlume does not talk to the sensor directly; it drives fprintd,
 //! which owns libfprint and the device. Verification is performed by

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Algorithmic IR presentation-attack detection (PAD): NO trained weights.
 //!
 //! Why no model: every public anti-spoof dataset is non-commercial, so a trained

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! `pam_irlume.so`: the thin, UNPRIVILEGED PAM module.
 //!
 //! It does almost nothing itself: open the Unix socket to `irlumed`, send a

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! End-to-end tests of the real `pam_irlume.so` driven through a real PAM
 //! stack, no root and no daemon binary required.
 //!

--- a/crates/irlume-vision/src/align.rs
+++ b/crates/irlume-vision/src/align.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Face alignment to the canonical ArcFace 112x112 template, plus the
 //! preprocessing and similarity scoring around it.
 //!

--- a/crates/irlume-vision/src/detect.rs
+++ b/crates/irlume-vision/src/detect.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! YuNet face-detection decode: anchor-free, strides 8/16/32.
 //!
 //! The pure decode (priors, score, bbox/landmark recovery, NMS) lives here and

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! The ML pipeline: detect -> align -> embed. CPU-first ONNX via `ort`.
 //!
 //! Commercially-clean, GPL-3.0-compatible bill of materials (all permissive):

--- a/crates/irlume-vision/src/light.rs
+++ b/crates/irlume-vision/src/light.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Illumination normalization for low-light RGB chips, applied to the aligned
 //! 112×112 chip just before embedding. Goal: make a DIM probe embed closer to a
 //! BRIGHT enrolled template (recover recognition in poor ambient light), without

--- a/crates/irlume-vision/src/moire.rs
+++ b/crates/irlume-vision/src/moire.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
 //! Frequency-domain screen/replay deterrent for the RGB-only (convenience) path.
 //!
 //! A camera pointed at a *display* captures the panel's regular pixel grid (and


### PR DESCRIPTION
Adds `// SPDX-License-Identifier: GPL-3.0-or-later` and `// Copyright the irlume contributors.` to all 62 Rust source files.

- Satisfies the OpenSSF gold criteria `license_per_file` and `copyright_per_file`.
- Makes each file's license machine-readable for SPDX/reuse tooling, independent of the top-level LICENSE.
- Comments only; fmt, clippy (`-D warnings`), and the full test suite are unaffected.
