### PR TITLE
Field-research hardening: PAM panic firewall, fingerprint wired-check, crypto KAT

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Something broke that is not tied to a specific camera, reader, or TPM
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For camera, IR emitter, fingerprint reader, or TPM problems, the
+        Hardware report template asks for the right details instead.
+  - type: input
+    id: version
+    attributes:
+      label: irlume version and install channel
+      description: "`irlume version`, plus how you installed (Copr, PPA, .deb, AUR, Nix, source)"
+      placeholder: "0.4.0, Fedora Copr"
+    validations:
+      required: true
+  - type: input
+    id: distro
+    attributes:
+      label: Distro and desktop
+      placeholder: "Fedora 44 KDE (Wayland)"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened, and what you expected
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log lines
+      description: "`irlume logs --since \"10 min ago\"` around the failure; doctor output helps too"
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and setup help
+    url: https://github.com/archledger/irlume/discussions
+    about: Ask in Discussions; issues are for bugs, hardware reports, and feature requests.

--- a/.github/ISSUE_TEMPLATE/hardware-report.yml
+++ b/.github/ISSUE_TEMPLATE/hardware-report.yml
@@ -1,0 +1,46 @@
+name: Hardware report
+description: A camera, IR emitter, fingerprint reader, or TPM that misbehaves with irlume
+title: "[hw] "
+labels: ["hardware"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most hardware fixes start from the same three command outputs. Filling them in
+        up front usually saves a full round-trip.
+  - type: input
+    id: machine
+    attributes:
+      label: Machine and camera
+      description: Laptop or camera model, plus the USB ID if you know it (`lsusb | grep -i cam`)
+      placeholder: "ASUS Zenbook S 14, 04f2:b6d9"
+    validations:
+      required: true
+  - type: input
+    id: distro
+    attributes:
+      label: Distro and desktop
+      placeholder: "Fedora 44 KDE (Wayland)"
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Output of `irlume doctor`
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: detect
+    attributes:
+      label: Output of `irlume detect` and `irlume version`
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened, and what you expected
+      description: If login or enrollment failed, add the relevant lines from `irlume logs --since "10 min ago"`
+    validations:
+      required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **`fingerprint enable` no longer disables face auth with nothing wired on
+  Arch-family distros.** On distros without authselect/pam-auth-update the
+  command printed manual wiring instructions and then recorded
+  `method=fingerprint` anyway, so the daemon stood face down while no module
+  drove the fingerprint prompt: the box silently became password-only. The
+  method now changes only after an active `pam_fprintd.so` line actually exists
+  in `/etc/pam.d`; the same check guards the authselect/pam-auth-update paths,
+  which can exit 0 without producing the line (e.g. a custom authselect profile
+  lacking the feature).
+
 - **Tier-1 signed-PCR sealing works.** irlume's strongest TPM tier (a
   `PolicyAuthorize` over systemd's PCR-signing key, the one that survives kernel
   updates without a reseal) never actually engaged. It loaded systemd's public
@@ -16,6 +26,25 @@ All notable changes to irlume are documented here. This project adheres to
   hierarchy fixes it (the key's Name, which the sealed policy commits to, is
   hierarchy-independent, so the policy is unchanged). Verified on a real
   systemd-boot host, including a Tier-1 seal that unseals after a reboot.
+
+### Added
+
+- **Panic firewall in `pam_irlume.so`.** Every PAM entry point now runs behind
+  `catch_unwind`; a panic anywhere in the module or a dependency maps to
+  `PAM_IGNORE`, so the stack falls through to the password. Without it, a panic
+  reaching the `extern "C"` boundary aborts the calling process (sudo or the
+  greeter, since Rust 1.81), and the module's own dependency stack contains
+  reachable panics. Crashing auth modules were the dominant lockout/fail-open
+  class in the pre-2020 generation of face-PAM projects.
+- **NIST known-answer test for the template envelope.** A CAVP AES-256-GCM
+  vector (`gcmEncryptExtIV256.rsp`) is decrypted through the on-disk
+  `nonce ‖ ciphertext ‖ tag` layout in the test suite, and the 28-byte framing
+  overhead is pinned. An `aes-gcm` upgrade that changes the algorithm or the
+  blob layout now fails CI instead of silently orphaning every encrypted
+  enrollment (a sibling project nearly merged exactly that dependency bump).
+- **Hardware-report issue template.** New GitHub issue form that asks for the
+  machine/camera model, distro, and `irlume doctor` / `irlume detect` output up
+  front, so camera and emitter quirks arrive with the data a fix needs.
 
 ### Changed
 

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -153,14 +153,42 @@ fn enable(user: &str) -> ExitCode {
                 && run_cmd("authselect", &["apply-changes"])
         }
         DistroFamily::Debian => run_cmd("pam-auth-update", &["--enable", "fprintd"]),
+        // No supported wiring tool here. Proceed only when the admin has already
+        // added the stanza: recording method=fingerprint with nothing wired
+        // disables face while no biometric drives the prompt, silently leaving
+        // the box password-only.
         DistroFamily::Arch | DistroFamily::Other => {
-            println!("[fingerprint] On this distro, add  'auth sufficient pam_fprintd.so'  above pam_unix");
-            println!("              in your login/sudo PAM stacks (e.g. /etc/pam.d/system-local-login, /etc/pam.d/sudo).");
-            true // method still recorded below; manual stanza is the user's step
+            let already = pam_fprintd_wired(std::path::Path::new(PAM_DIR));
+            if already {
+                println!(
+                    "[fingerprint] found an active pam_fprintd.so line in {PAM_DIR}; using it"
+                );
+            } else {
+                eprintln!("[fingerprint] no wiring tool on this distro; add the line yourself:");
+                eprintln!("                auth  sufficient  pam_fprintd.so");
+                eprintln!("              above pam_unix in your login/sudo PAM stacks");
+                eprintln!("              (e.g. /etc/pam.d/system-local-login, /etc/pam.d/sudo),");
+                eprintln!("              then re-run:  sudo irlume fingerprint enable");
+            }
+            already
         }
     };
     if !wired {
-        eprintln!("[fingerprint] failed to wire pam_fprintd; check the command output above");
+        eprintln!(
+            "[fingerprint] method unchanged: face (irlume) stays active until pam_fprintd is wired"
+        );
+        return ExitCode::FAILURE;
+    }
+    // Verify the line actually landed before switching the method, even on the
+    // tool paths: authselect/pam-auth-update can exit 0 without producing a
+    // pam_fprintd line (e.g. a custom authselect profile lacking the feature).
+    if !pam_fprintd_wired(std::path::Path::new(PAM_DIR)) {
+        eprintln!(
+            "[fingerprint] wiring reported success but {PAM_DIR} has no active pam_fprintd.so line"
+        );
+        eprintln!(
+            "[fingerprint] method unchanged: face (irlume) stays active until pam_fprintd is wired"
+        );
         return ExitCode::FAILURE;
     }
     if let Err(e) = policy::set_method(Method::Fingerprint) {
@@ -196,6 +224,27 @@ fn disable() -> ExitCode {
     }
     println!("[fingerprint] ✓ disabled: face (irlume) is the active method again");
     ExitCode::SUCCESS
+}
+
+/// Where PAM service files live; a const so tests can exercise the scan on a
+/// directory they control.
+const PAM_DIR: &str = "/etc/pam.d";
+
+/// True when any file in `pam_dir` carries an ACTIVE (non-comment) line
+/// referencing `pam_fprintd.so`, i.e. something will actually drive the
+/// fingerprint prompt. Unreadable dirs/files count as not wired.
+fn pam_fprintd_wired(pam_dir: &std::path::Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(pam_dir) else {
+        return false;
+    };
+    entries.flatten().any(|e| {
+        std::fs::read_to_string(e.path()).is_ok_and(|s| {
+            s.lines().any(|l| {
+                let t = l.trim_start();
+                !t.starts_with('#') && t.contains("pam_fprintd.so")
+            })
+        })
+    })
 }
 
 /// Run a system command, echoing it (transparency) and reporting success.
@@ -241,6 +290,37 @@ mod tests {
         assert!(run_cmd("true", &[]));
         assert!(!run_cmd("false", &[]));
         assert!(!run_cmd("irlume-no-such-command-xyz", &["arg"]));
+    }
+
+    #[test]
+    fn pam_fprintd_wired_needs_an_active_line() {
+        let dir = std::env::temp_dir().join(format!("irlume-fpwire-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // Empty directory: nothing wired.
+        assert!(!pam_fprintd_wired(&dir));
+        // A commented-out line does not count.
+        std::fs::write(dir.join("sudo"), "#auth sufficient pam_fprintd.so\n").unwrap();
+        assert!(!pam_fprintd_wired(&dir));
+        // Unrelated modules do not count.
+        std::fs::write(dir.join("login"), "auth required pam_unix.so\n").unwrap();
+        assert!(!pam_fprintd_wired(&dir));
+        // An active line in any file does.
+        std::fs::write(
+            dir.join("system-local-login"),
+            "auth  sufficient  pam_fprintd.so\nauth required pam_unix.so\n",
+        )
+        .unwrap();
+        assert!(pam_fprintd_wired(&dir));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn pam_fprintd_wired_is_false_for_a_missing_dir() {
+        // The enable path must fail closed (method unchanged) when the PAM dir
+        // cannot be read at all.
+        assert!(!pam_fprintd_wired(std::path::Path::new(
+            "/nonexistent-irlume-test-pam.d"
+        )));
     }
 
     #[test]

--- a/crates/irlume-core/src/crypto.rs
+++ b/crates/irlume-core/src/crypto.rs
@@ -130,4 +130,40 @@ mod tests {
         assert!(encrypt(&[0u8; 16], b"x").is_err());
         assert!(decrypt(&[0u8; 16], &[0u8; 40]).is_err());
     }
+
+    fn unhex(s: &str) -> Vec<u8> {
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    /// NIST CAVP known-answer test (gcmEncryptExtIV256.rsp, AES-256-GCM,
+    /// 96-bit IV, no AAD) hand-assembled into this module's on-disk layout
+    /// `nonce ‖ ciphertext ‖ tag`. Pins BOTH the algorithm and the blob layout:
+    /// an aes-gcm upgrade that changes either fails here instead of silently
+    /// orphaning every encrypted enrollment on disk.
+    #[test]
+    fn nist_cavp_vector_decrypts_through_the_blob_layout() {
+        let key = unhex("31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22");
+        let mut blob = unhex("0d18e06c7c725ac9e362e1ce"); // nonce
+        blob.extend(unhex("fa4362189661d163fcd6a56d8bf0405a")); // ciphertext
+        blob.extend(unhex("d636ac1bbedd5cc3ee727dc2ab4a9489")); // tag
+        let plain = decrypt(&key, &blob).expect("NIST vector must decrypt");
+        assert_eq!(
+            &*plain,
+            &unhex("2db5168e932556f8089a0622981d017d")[..],
+            "AES-256-GCM output no longer matches the NIST CAVP vector"
+        );
+    }
+
+    /// The wire layout is load-bearing: nonce is the first 12 bytes, the GCM tag
+    /// the last 16, and the total overhead is exactly 28 bytes. A dependency
+    /// change that alters framing must trip this before it ships.
+    #[test]
+    fn blob_layout_overhead_is_stable() {
+        let key = generate_key();
+        let enc = encrypt(&key, b"x").unwrap();
+        assert_eq!(enc.len(), NONCE_LEN + 1 + TAG_LEN);
+    }
 }

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -46,6 +46,18 @@ const RESEAL_STASH_KEY: &str = "pam_irlume_reseal_authtok";
 
 struct IrlumePam;
 
+/// Panic firewall for the PAM entry points. Unwinding across the C FFI boundary
+/// into libpam is undefined behavior, and a crashing auth module historically
+/// takes the calling process (sudo, the greeter) down with it or wedges the
+/// stack in a fail-open state. Any panic in this module or a dependency maps to
+/// `PAM_IGNORE`: the stack cascades to the password, the floor factor.
+fn firewall(body: impl FnOnce() -> PamError) -> PamError {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {
+        Ok(code) => code,
+        Err(_) => PamError::IGNORE,
+    }
+}
+
 /// True when the PAM transaction is for a remote (non-local) session, so the
 /// local camera must not be engaged. Checks PAM_RHOST first (set by sshd and
 /// other network services to the client host); an empty, "localhost", or
@@ -70,177 +82,181 @@ fn is_remote_session(pamh: &Pam) -> bool {
 
 impl PamServiceModule for IrlumePam {
     fn authenticate(pamh: Pam, _flags: PamFlags, args: Vec<String>) -> PamError {
-        let user = match pamh.get_user(None) {
-            Ok(Some(u)) => u.to_string_lossy().into_owned(),
-            _ => return PamError::IGNORE,
-        };
-        // Remote-session guard: never fire the local camera for an SSH / remote
-        // login or sudo. The camera is physically at the machine, so whoever is
-        // in front of it (not the remote user) would grant the remote session.
-        // A non-empty PAM_RHOST (or the SSH_* env markers) means remote; return
-        // IGNORE so the password/other factor authenticates instead. Always-on,
-        // independent of biopolicy or how the stack is wired (a hand-added
-        // pam_irlume line in system-auth is covered too).
-        if is_remote_session(&pamh) {
-            return PamError::IGNORE;
-        }
-        let unseal = args.iter().any(|a| a == "unseal");
-        let wait = args.iter().any(|a| a == "wait");
-        let reseal = args.iter().any(|a| a == "reseal");
-        let keyring = args.iter().any(|a| a == "keyring");
-        // `kr` (keyring-continue): on a Debian `@include` greeter whose face line
-        // is `sufficient`, a plain SUCCESS short-circuits before pam_gnome_keyring,
-        // so a COLD face login leaves the login keyring locked. With `kr` we
-        // instead return IGNORE on a cold login that released the password;
-        // `sufficient` then CONTINUES, pam_unix authenticates with the token, and
-        // pam_gnome_keyring unlocks the keyring. A WARM lock still returns SUCCESS
-        // (short-circuit: keyring already open, and cosmic's locker needs it).
-        // Opt-in, so the Fedora success=1 layout (no `kr`) is unchanged.
-        let kr = args.iter().any(|a| a == "kr");
-
-        // `keyring` mode: post-auth login-keyring unlock for the FINGERPRINT
-        // path. This line sits at the auth landing, after a trusted factor has
-        // already succeeded. If a password is present (the user typed one, or an
-        // earlier face `unseal` set it) the keyring unlocks from it; do nothing.
-        // If PAM_AUTHTOK is empty (a fingerprint login provides no password), ask
-        // the daemon to release the TPM-sealed password and set it, so a later
-        // pam_gnome_keyring/pam_kwallet opens the wallet. ALWAYS IGNORE: keyring
-        // unlock is best-effort and must never fail or block the login.
-        if keyring {
-            if let Ok(Some(tok)) = pamh.get_cached_authtok() {
-                if !tok.to_bytes().is_empty() {
-                    return PamError::IGNORE; // password present → keyring self-unlocks
-                }
-            }
-            let service = pamh
-                .get_service()
-                .ok()
-                .flatten()
-                .and_then(|c| c.to_str().ok().map(str::to_string));
-            if let Ok(Response::PasswordUnsealed { secret }) = request(&Request::UnsealKeyring {
-                user: user.clone(),
-                service,
-            }) {
-                if let Ok(tok) = CString::new(secret.expose()) {
-                    let _ = pamh.set_authtok(&tok);
-                    // PAM copied the token into its own store; wipe our copy so
-                    // the plaintext password does not linger on this heap.
-                    zeroize::Zeroize::zeroize(&mut tok.into_bytes_with_nul());
-                }
-            }
-            return PamError::IGNORE;
-        }
-        // `facefirst` (GNOME/GDM wiring): GDM's PAM conversation BLOCKS on the
-        // active password probe until the user types (unlike plasmalogin/SDDM,
-        // which answer instantly from the buffered field), so skip the probe and
-        // scan right away; a typed password still wins via the modules after us.
-        let facefirst = args.iter().any(|a| a == "facefirst");
-
-        // `ondemand` (COSMIC / cosmic-greeter): a greeter that DOES answer the
-        // active probe from the buffered field (like plasmalogin) but drives BOTH
-        // the cold login and the live lock screen through ONE service (like GDM).
-        // So we want the on-demand ACTIVE probe (face engages only when the user
-        // submits an empty field; never ambient, never after a typed/rejected
-        // password) AND the warm `unseal→verify` fallback below (so the lock
-        // screen still unlocks). It is `facefirst`'s warm-fallback WITHOUT its
-        // scan-immediately probe. Uses the active-probe path (it never sets
-        // `facefirst`, so the `!facefirst` probe test below stays true).
-        let ondemand = args.iter().any(|a| a == "ondemand");
-
-        // `reseal` AUTH line (placed AFTER password-auth): STASH ONLY. We copy the
-        // current PAM_AUTHTOK into PAM transaction data so the matching `reseal`
-        // SESSION line can re-bind it later. We deliberately do NOT contact the
-        // daemon or touch the TPM here, because this auth line runs even after a
-        // FAILED password attempt; acting on the token here is exactly the bug
-        // that let a typo overwrite the good seal. The mutation happens in
-        // open_session, which PAM only runs once auth has SUCCEEDED, so the token
-        // it acts on is always one pam_unix accepted. Always IGNORE.
-        if reseal {
-            stash_authtok(&pamh);
-            return PamError::IGNORE;
-        }
-
-        // If the user has typed a password, defer to it; don't power up the
-        // camera at all. Scanning a face when they already chose to type would be
-        // a 2-3s annoyance for nothing, and we lose no capability by skipping:
-        // pam_kwallet5/pam_gnome_keyring open the wallet from the typed password
-        // exactly as they would from an unsealed one. Returning IGNORE keeps the
-        // password fallback intact.
-        //
-        // Learning whether they typed depends on the surface:
-        //
-        //  * Active probe (interactive login greeter; `unseal`, no `wait`): the
-        //    plasmalogin/SDDM greeter does NOT pre-set PAM_AUTHTOK; the typed
-        //    password only reaches PAM when a module asks for it. So we ask, once:
-        //    `pam_get_authtok` returns whatever the user already entered (an empty
-        //    string if they submitted a blank field to choose face) WITHOUT
-        //    re-prompting (the greeter answers it immediately from the password
-        //    it buffered on submit) and caches a non-empty answer as PAM_AUTHTOK
-        //    so the downstream pam_unix reuses it with no second prompt. Any
-        //    typed character ⇒ non-empty ⇒ we bail before the camera.
-        //
-        //  * Passive peek (everything else: sudo verify, lock screen `wait`): just
-        //    read PAM_AUTHTOK if some earlier module/greeter already set it. We must
-        //    NOT actively prompt here: in `wait` mode KDE runs us as a PARALLEL
-        //    biometric device (kde-fingerprint) and cancels us natively the moment
-        //    a key is pressed, so an echo-off prompt from us would hijack the
-        //    password field; and a TTY `sudo` should keep "just look at the camera"
-        //    working without forcing the user to press Enter past a prompt first.
-        let typed = if unseal && !wait && !facefirst {
-            pamh.get_authtok(Some("Password: "))
-        } else {
-            pamh.get_cached_authtok()
-        };
-        if let Ok(Some(tok)) = typed {
-            if !tok.to_bytes().is_empty() {
+        firewall(move || {
+            let user = match pamh.get_user(None) {
+                Ok(Some(u)) => u.to_string_lossy().into_owned(),
+                _ => return PamError::IGNORE,
+            };
+            // Remote-session guard: never fire the local camera for an SSH / remote
+            // login or sudo. The camera is physically at the machine, so whoever is
+            // in front of it (not the remote user) would grant the remote session.
+            // A non-empty PAM_RHOST (or the SSH_* env markers) means remote; return
+            // IGNORE so the password/other factor authenticates instead. Always-on,
+            // independent of biopolicy or how the stack is wired (a hand-added
+            // pam_irlume line in system-auth is covered too).
+            if is_remote_session(&pamh) {
                 return PamError::IGNORE;
             }
-        }
+            let unseal = args.iter().any(|a| a == "unseal");
+            let wait = args.iter().any(|a| a == "wait");
+            let reseal = args.iter().any(|a| a == "reseal");
+            let keyring = args.iter().any(|a| a == "keyring");
+            // `kr` (keyring-continue): on a Debian `@include` greeter whose face line
+            // is `sufficient`, a plain SUCCESS short-circuits before pam_gnome_keyring,
+            // so a COLD face login leaves the login keyring locked. With `kr` we
+            // instead return IGNORE on a cold login that released the password;
+            // `sufficient` then CONTINUES, pam_unix authenticates with the token, and
+            // pam_gnome_keyring unlocks the keyring. A WARM lock still returns SUCCESS
+            // (short-circuit: keyring already open, and cosmic's locker needs it).
+            // Opt-in, so the Fedora success=1 layout (no `kr`) is unchanged.
+            let kr = args.iter().any(|a| a == "kr");
 
-        // In `wait` mode, retry until a match or the budget runs out; otherwise
-        // a single attempt. Every non-SUCCESS path returns PAM_IGNORE so the
-        // stack always cascades to the password (NIST: a fallback must exist).
-        let deadline = Instant::now() + WAIT_BUDGET;
-        loop {
-            let mut attempt = if unseal {
-                try_unseal(&pamh, &user)
-            } else {
-                try_verify(&pamh, &user)
-            };
-            // Did the SUCCESSFUL attempt release the sealed password into
-            // PAM_AUTHTOK? Only `try_unseal` does; the verify fallback below does
-            // not. This drives the `kr` cold-login keyring-continue decision.
-            let mut unsealed = unseal && attempt == PamError::SUCCESS;
-            // GDM and cosmic-greeter each drive BOTH the cold greeter and the
-            // live lock screen through one service. Unsealing is refused on the
-            // convenience tier (and on an un-armed keyring); a warm screen unlock
-            // only needs identity, so fall back to a plain verify before giving up
-            // to the password. `try_verify` re-applies biopolicy in the daemon, so
-            // a cold login on a convenience tier still returns Deny here: the
-            // fallback only rescues the identity-only warm-unlock case.
-            if (facefirst || ondemand) && unseal && attempt != PamError::SUCCESS {
-                attempt = try_verify(&pamh, &user);
-                unsealed = false; // the fallback verifies identity, releases no token
+            // `keyring` mode: post-auth login-keyring unlock for the FINGERPRINT
+            // path. This line sits at the auth landing, after a trusted factor has
+            // already succeeded. If a password is present (the user typed one, or an
+            // earlier face `unseal` set it) the keyring unlocks from it; do nothing.
+            // If PAM_AUTHTOK is empty (a fingerprint login provides no password), ask
+            // the daemon to release the TPM-sealed password and set it, so a later
+            // pam_gnome_keyring/pam_kwallet opens the wallet. ALWAYS IGNORE: keyring
+            // unlock is best-effort and must never fail or block the login.
+            if keyring {
+                if let Ok(Some(tok)) = pamh.get_cached_authtok() {
+                    if !tok.to_bytes().is_empty() {
+                        return PamError::IGNORE; // password present → keyring self-unlocks
+                    }
+                }
+                let service = pamh
+                    .get_service()
+                    .ok()
+                    .flatten()
+                    .and_then(|c| c.to_str().ok().map(str::to_string));
+                if let Ok(Response::PasswordUnsealed { secret }) =
+                    request(&Request::UnsealKeyring {
+                        user: user.clone(),
+                        service,
+                    })
+                {
+                    if let Ok(tok) = CString::new(secret.expose()) {
+                        let _ = pamh.set_authtok(&tok);
+                        // PAM copied the token into its own store; wipe our copy so
+                        // the plaintext password does not linger on this heap.
+                        zeroize::Zeroize::zeroize(&mut tok.into_bytes_with_nul());
+                    }
+                }
+                return PamError::IGNORE;
             }
-            if attempt == PamError::SUCCESS {
-                // `kr` + a COLD login that released the password → IGNORE, so the
-                // `sufficient` control CONTINUES and pam_gnome_keyring unlocks the
-                // login keyring (pam_unix accepts the token we set). Every other
-                // success (warm lock, no token, or no `kr`) short-circuits.
-                if kr && unsealed && !irlume_common::platform::user_has_live_session(&user) {
+            // `facefirst` (GNOME/GDM wiring): GDM's PAM conversation BLOCKS on the
+            // active password probe until the user types (unlike plasmalogin/SDDM,
+            // which answer instantly from the buffered field), so skip the probe and
+            // scan right away; a typed password still wins via the modules after us.
+            let facefirst = args.iter().any(|a| a == "facefirst");
+
+            // `ondemand` (COSMIC / cosmic-greeter): a greeter that DOES answer the
+            // active probe from the buffered field (like plasmalogin) but drives BOTH
+            // the cold login and the live lock screen through ONE service (like GDM).
+            // So we want the on-demand ACTIVE probe (face engages only when the user
+            // submits an empty field; never ambient, never after a typed/rejected
+            // password) AND the warm `unseal→verify` fallback below (so the lock
+            // screen still unlocks). It is `facefirst`'s warm-fallback WITHOUT its
+            // scan-immediately probe. Uses the active-probe path (it never sets
+            // `facefirst`, so the `!facefirst` probe test below stays true).
+            let ondemand = args.iter().any(|a| a == "ondemand");
+
+            // `reseal` AUTH line (placed AFTER password-auth): STASH ONLY. We copy the
+            // current PAM_AUTHTOK into PAM transaction data so the matching `reseal`
+            // SESSION line can re-bind it later. We deliberately do NOT contact the
+            // daemon or touch the TPM here, because this auth line runs even after a
+            // FAILED password attempt; acting on the token here is exactly the bug
+            // that let a typo overwrite the good seal. The mutation happens in
+            // open_session, which PAM only runs once auth has SUCCEEDED, so the token
+            // it acts on is always one pam_unix accepted. Always IGNORE.
+            if reseal {
+                stash_authtok(&pamh);
+                return PamError::IGNORE;
+            }
+
+            // If the user has typed a password, defer to it; don't power up the
+            // camera at all. Scanning a face when they already chose to type would be
+            // a 2-3s annoyance for nothing, and we lose no capability by skipping:
+            // pam_kwallet5/pam_gnome_keyring open the wallet from the typed password
+            // exactly as they would from an unsealed one. Returning IGNORE keeps the
+            // password fallback intact.
+            //
+            // Learning whether they typed depends on the surface:
+            //
+            //  * Active probe (interactive login greeter; `unseal`, no `wait`): the
+            //    plasmalogin/SDDM greeter does NOT pre-set PAM_AUTHTOK; the typed
+            //    password only reaches PAM when a module asks for it. So we ask, once:
+            //    `pam_get_authtok` returns whatever the user already entered (an empty
+            //    string if they submitted a blank field to choose face) WITHOUT
+            //    re-prompting (the greeter answers it immediately from the password
+            //    it buffered on submit) and caches a non-empty answer as PAM_AUTHTOK
+            //    so the downstream pam_unix reuses it with no second prompt. Any
+            //    typed character ⇒ non-empty ⇒ we bail before the camera.
+            //
+            //  * Passive peek (everything else: sudo verify, lock screen `wait`): just
+            //    read PAM_AUTHTOK if some earlier module/greeter already set it. We must
+            //    NOT actively prompt here: in `wait` mode KDE runs us as a PARALLEL
+            //    biometric device (kde-fingerprint) and cancels us natively the moment
+            //    a key is pressed, so an echo-off prompt from us would hijack the
+            //    password field; and a TTY `sudo` should keep "just look at the camera"
+            //    working without forcing the user to press Enter past a prompt first.
+            let typed = if unseal && !wait && !facefirst {
+                pamh.get_authtok(Some("Password: "))
+            } else {
+                pamh.get_cached_authtok()
+            };
+            if let Ok(Some(tok)) = typed {
+                if !tok.to_bytes().is_empty() {
                     return PamError::IGNORE;
                 }
-                return PamError::SUCCESS;
             }
-            if !wait || Instant::now() >= deadline {
-                return PamError::IGNORE;
+
+            // In `wait` mode, retry until a match or the budget runs out; otherwise
+            // a single attempt. Every non-SUCCESS path returns PAM_IGNORE so the
+            // stack always cascades to the password (NIST: a fallback must exist).
+            let deadline = Instant::now() + WAIT_BUDGET;
+            loop {
+                let mut attempt = if unseal {
+                    try_unseal(&pamh, &user)
+                } else {
+                    try_verify(&pamh, &user)
+                };
+                // Did the SUCCESSFUL attempt release the sealed password into
+                // PAM_AUTHTOK? Only `try_unseal` does; the verify fallback below does
+                // not. This drives the `kr` cold-login keyring-continue decision.
+                let mut unsealed = unseal && attempt == PamError::SUCCESS;
+                // GDM and cosmic-greeter each drive BOTH the cold greeter and the
+                // live lock screen through one service. Unsealing is refused on the
+                // convenience tier (and on an un-armed keyring); a warm screen unlock
+                // only needs identity, so fall back to a plain verify before giving up
+                // to the password. `try_verify` re-applies biopolicy in the daemon, so
+                // a cold login on a convenience tier still returns Deny here: the
+                // fallback only rescues the identity-only warm-unlock case.
+                if (facefirst || ondemand) && unseal && attempt != PamError::SUCCESS {
+                    attempt = try_verify(&pamh, &user);
+                    unsealed = false; // the fallback verifies identity, releases no token
+                }
+                if attempt == PamError::SUCCESS {
+                    // `kr` + a COLD login that released the password → IGNORE, so the
+                    // `sufficient` control CONTINUES and pam_gnome_keyring unlocks the
+                    // login keyring (pam_unix accepts the token we set). Every other
+                    // success (warm lock, no token, or no `kr`) short-circuits.
+                    if kr && unsealed && !irlume_common::platform::user_has_live_session(&user) {
+                        return PamError::IGNORE;
+                    }
+                    return PamError::SUCCESS;
+                }
+                if !wait || Instant::now() >= deadline {
+                    return PamError::IGNORE;
+                }
+                std::thread::sleep(WAIT_RETRY_GAP);
             }
-            std::thread::sleep(WAIT_RETRY_GAP);
-        }
+        })
     }
 
     fn setcred(_pamh: Pam, _flags: PamFlags, _args: Vec<String>) -> PamError {
-        PamError::SUCCESS
+        firewall(|| PamError::SUCCESS)
     }
 
     /// `reseal` SESSION line: the actual self-heal. Reached ONLY after auth +
@@ -251,16 +267,18 @@ impl PamServiceModule for IrlumePam {
     /// fail because of this, and other modes (unseal/verify/wait) wire no session
     /// line so they fall straight through.
     fn open_session(pamh: Pam, _flags: PamFlags, args: Vec<String>) -> PamError {
-        if args.iter().any(|a| a == "reseal") {
-            if let Ok(Some(u)) = pamh.get_user(None) {
-                try_reseal_session(&pamh, &u.to_string_lossy());
+        firewall(move || {
+            if args.iter().any(|a| a == "reseal") {
+                if let Ok(Some(u)) = pamh.get_user(None) {
+                    try_reseal_session(&pamh, &u.to_string_lossy());
+                }
             }
-        }
-        PamError::IGNORE
+            PamError::IGNORE
+        })
     }
 
     fn close_session(_pamh: Pam, _flags: PamFlags, _args: Vec<String>) -> PamError {
-        PamError::IGNORE
+        firewall(|| PamError::IGNORE)
     }
 }
 
@@ -364,3 +382,26 @@ fn request(req: &Request) -> std::io::Result<Response> {
 }
 
 pam_module!(IrlumePam);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firewall_passes_normal_returns_through() {
+        assert_eq!(firewall(|| PamError::SUCCESS), PamError::SUCCESS);
+        assert_eq!(firewall(|| PamError::IGNORE), PamError::IGNORE);
+    }
+
+    #[test]
+    fn firewall_maps_a_panic_to_ignore() {
+        // A panic must become IGNORE (password fallback), never unwind toward
+        // the pam_module! extern "C" shims: since Rust 1.81 that aborts the
+        // calling process, i.e. kills sudo or the greeter mid-auth.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // keep the test log clean
+        let got = firewall(|| panic!("boom"));
+        std::panic::set_hook(prev);
+        assert_eq!(got, PamError::IGNORE);
+    }
+}


### PR DESCRIPTION
First implementation slice from the competitor issue-tracker research (2026-07-21, ~/irlume-research locally): the confirmed bug plus the two cheapest hardening items, and the issue template.

## Fixed

**`fingerprint enable` could disable face auth with nothing wired.** On Arch-family distros the command printed manual PAM instructions, returned success, and recorded `method=fingerprint`; the daemon then refused face auth while no module drove the fingerprint prompt, so the machine silently became password-only. The method now changes only after `/etc/pam.d` contains an active `pam_fprintd.so` line. The same verification guards the authselect and pam-auth-update paths, since both can exit 0 without producing the line (a custom authselect profile without the feature, for example).

## Added

**Panic firewall in `pam_irlume.so`.** Every PAM entry point runs behind `catch_unwind`; a panic maps to `PAM_IGNORE` so the stack falls to the password. Since Rust 1.81 a panic reaching the `extern "C"` shim aborts the calling process, which here means sudo or the greeter dies mid-auth. pamsm 0.5.5 has no guard of its own and contains a reachable `panic!` (libpam.rs:91). In-process crashes were the dominant lockout and fail-open class across the pre-2020 face-PAM projects (pam-face-authentication #24/#115 among others).

**NIST known-answer test for the template envelope.** A CAVP AES-256-GCM vector (`gcmEncryptExtIV256.rsp`, via the aes-gcm crate's published vectors) is decrypted through the on-disk `nonce ‖ ciphertext ‖ tag` layout, and the 28-byte framing overhead is pinned. A future `aes-gcm` bump that changes the algorithm or layout fails CI instead of orphaning every encrypted enrollment; sovren/visage nearly merged exactly that bump before adding the same guard (their #64).

**Hardware-report issue form** asking for machine/camera model, distro, and `irlume doctor` / `irlume detect` output up front. The `hardware` label it applies now exists on the repo.

## Test plan

- `cargo test --workspace` green; new tests: firewall panic/pass-through, `pam_fprintd_wired` (active line, commented line, unrelated module, missing dir), CAVP decrypt, framing pin.
- clippy clean, fmt clean.
- Not exercised on hardware: the Arch enable path needs a box without authselect; the check itself is covered by unit tests.
