### PR TITLE
CI: stacked-PR gating, weekly install-matrix automation, fuzz-lockfile audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,3 +24,12 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         with:
           command: check advisories
+
+      # The cargo-fuzz workspace has its own lockfile that the root check never
+      # reads (see the note in .github/dependabot.yml); scan it here so an
+      # advisory against a fuzz-only dependency does not rot silently.
+      - name: Advisories for the fuzz workspace lockfile
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+        with:
+          manifest-path: fuzz/Cargo.toml
+          command: check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base-branch filter on pull_request: stacked PRs (a branch targeting
+  # another feature branch) previously ran ZERO checks and could only be
+  # gated after retargeting to main. Every PR gets the same gate now.
   pull_request:
-    branches: [main]
 
 # Least privilege for GITHUB_TOKEN: this workflow only reads the repo
 # (checkout + LFS); nothing here publishes or writes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # PRs RESTORE from main's cache but never SAVE their own: per-PR
+          # entries were filling the repo's 10 GB cache quota, and LRU
+          # eviction would eventually knock out the LFS model cache that
+          # guards the (scarcer) LFS bandwidth quota.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
         run: |
@@ -194,6 +200,12 @@ jobs:
           toolchain: stable
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # PRs RESTORE from main's cache but never SAVE their own: per-PR
+          # entries were filling the repo's 10 GB cache quota, and LRU
+          # eviction would eventually knock out the LFS model cache that
+          # guards the (scarcer) LFS bandwidth quota.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
         run: |
@@ -241,6 +253,12 @@ jobs:
           components: llvm-tools-preview
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # PRs RESTORE from main's cache but never SAVE their own: per-PR
+          # entries were filling the repo's 10 GB cache quota, and LRU
+          # eviction would eventually knock out the LFS model cache that
+          # guards the (scarcer) LFS bandwidth quota.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --version 0.8.7 --locked
@@ -389,6 +407,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          # PRs RESTORE from main's cache but never SAVE their own: per-PR
+          # entries were filling the repo's 10 GB cache quota, and LRU
+          # eviction would eventually knock out the LFS model cache that
+          # guards the (scarcer) LFS bandwidth quota.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: fuzz
 
       # Build cargo-fuzz with nightly: it (via cargo-platform) needs a rustc

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -1,0 +1,116 @@
+# Weekly automation of the install matrix that release prep previously ran by
+# hand (docs/PLATFORMS.md): build the universal .deb in its debian:12 container,
+# install it on every supported Debian/Ubuntu base and smoke-test the CLI, and
+# do a full build+test pass on rolling Arch. A failed scheduled run emails the
+# maintainer; the sibling-project lesson behind it is that advertised install
+# lanes rot silently unless CI exercises them (a Nix lane elsewhere shipped
+# broken twice, found only by user bug reports).
+name: Install matrix
+
+on:
+  schedule:
+    - cron: "45 6 * * 1" # Mondays 06:45 UTC, after the advisory audit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-deb:
+    name: build universal .deb (debian:12, podman)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Same LFS cache as ci.yml (shared key): the model weights are ~257 MB
+      # and the LFS bandwidth quota is the reason ci.yml caches them.
+      - name: Cache Git LFS objects (ONNX model weights)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('models/SHA256SUMS') }}
+
+      - name: Pull model weights (Git LFS)
+        run: git lfs pull
+
+      - name: Build the .deb (packaging/debian/build-deb-container.sh)
+        run: bash packaging/debian/build-deb-container.sh
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: irlume-deb
+          path: irlume_*_amd64.deb
+          if-no-files-found: error
+          retention-days: 7
+
+  install-smoke:
+    name: install smoke (${{ matrix.image }})
+    needs: build-deb
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # The bases the universal .deb promises to support (glibc 2.35 floor):
+        # oldest Debian, oldest supported Ubuntu LTS, current LTS bases.
+        image: ["debian:12", "debian:13", "ubuntu:22.04", "ubuntu:24.04", "ubuntu:26.04"]
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: irlume-deb
+
+      - name: Install on a bare image
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ./irlume_*_amd64.deb
+
+      - name: CLI smoke
+        run: |
+          irlume version
+          # detect's contract: 0 = ready, 10 = partial, 20 = absent. A bare
+          # container has no camera/TPM, so any of the three is a pass; anything
+          # else (a crash, a missing shared library) fails the lane.
+          rc=0; irlume detect || rc=$?
+          case "$rc" in 0|10|20) echo "detect exit $rc (ok)";;
+                        *) echo "unexpected detect exit $rc"; exit 1;; esac
+
+  arch-build-test:
+    name: build + test on Arch (rolling toolchain)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    container:
+      image: archlinux:latest
+    steps:
+      - name: Install toolchain and system deps
+        run: |
+          pacman -Syu --noconfirm --needed \
+            base-devel git git-lfs rust clang pam tpm2-tss curl ca-certificates
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Cache Git LFS objects (ONNX model weights)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('models/SHA256SUMS') }}
+
+      - name: Pull model weights (Git LFS)
+        run: git lfs pull
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
+        run: |
+          ver=1.24.4
+          curl -fsSLO "https://github.com/microsoft/onnxruntime/releases/download/v${ver}/onnxruntime-linux-x64-${ver}.tgz"
+          tar xzf "onnxruntime-linux-x64-${ver}.tgz"
+          echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
+
+      - name: build
+        run: cargo build --workspace --locked
+
+      - name: test
+        run: cargo test --workspace --locked


### PR DESCRIPTION
Independent of the #63/#64/#65 stack (no shared files; based on main).

## Stacked PRs now get CI

`pull_request` had a `branches: [main]` filter, so a PR based on another feature branch ran zero checks — hit live on #64, which shows "no checks reported". The filter is gone; every PR gets the full gate regardless of base. Push-triggered runs stay main-only, so there's no duplicate-run cost for branches with open PRs.

## Weekly install-matrix automation (new workflow)

The release install matrix in docs/PLATFORMS.md was validated by hand each cycle. `install-matrix.yml` (Mondays + manual dispatch) now does the repeatable part:

1. Builds the universal .deb with the existing `packaging/debian/build-deb-container.sh` (podman is preinstalled on ubuntu-24.04 runners), reusing ci.yml's LFS cache key so the ~257 MB of model weights don't burn the LFS bandwidth quota.
2. Installs that .deb on bare `debian:12`, `debian:13`, `ubuntu:22.04`, `ubuntu:24.04`, and `ubuntu:26.04` images and asserts the CLI contract: `irlume version` runs and `irlume detect` exits 0/10/20 (a crash or missing shared library fails the lane). The glibc-floor regression this guards against is exactly the class a sibling project shipped when its package host silently picked up a glibc 2.43 requirement and broke Debian stable.
3. Runs a full `cargo build` + `cargo test` on `archlinux:latest`: rolling rustc/clippy/soname breakage surfaces in a scheduled email instead of a user bug report.

A failed scheduled run emails you. Release-day hardware validation (IR tier, greeters) stays manual; this covers the part a container can prove.

## Fuzz lockfile advisories

`fuzz/Cargo.lock` is a detached workspace the root cargo-deny never reads (dependabot.yml already notes this); the daily audit now scans it too via the action's `manifest-path` input.

## Verification

- actionlint clean on all three touched workflows; YAML parses.
- All new action pins are commit SHAs with version comments, matching repo convention (`download-artifact` v7.0.0 pin verified as a lightweight tag pointing at the commit).
- The scheduled workflow can be exercised immediately after merge via workflow_dispatch.
