### PR TITLE
CI: fix Arch container job git-lfs (safe.directory)

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -98,7 +98,13 @@ jobs:
           key: lfs-${{ hashFiles('models/SHA256SUMS') }}
 
       - name: Pull model weights (Git LFS)
-        run: git lfs pull
+        run: |
+          # Container job: checkout writes safe.directory into a temporary
+          # HOME, so later steps' git sees "dubious ownership" and git-lfs
+          # reports it as "Not in a Git repository" (first dispatch failed
+          # exactly here). Re-assert it in this step's real HOME.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git lfs pull
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 


### PR DESCRIPTION
First install-matrix dispatch: .deb build green, all five install-smoke lanes green (debian:12/13, ubuntu:22.04/24.04/26.04) — but the Arch build+test job failed at `git lfs pull` with "Not in a Git repository". In container jobs, actions/checkout writes its `safe.directory` entry into a temporary HOME, so later steps' git hits the dubious-ownership check and git-lfs surfaces it as exit 128. The step now re-asserts `safe.directory` for `$GITHUB_WORKSPACE` before pulling.

Will re-dispatch the workflow after merge to confirm the sixth lane goes green.
