### PR TITLE
CI: Arch container git-lfs filters + pointer guard

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -104,7 +104,16 @@ jobs:
           # reports it as "Not in a Git repository" (first dispatch failed
           # exactly here). Re-assert it in this step's real HOME.
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          # Arch's git-lfs package does not preconfigure the smudge filters
+          # (Ubuntu runner images do), so a bare pull downloads objects but
+          # SKIPS checkout with exit 0 — pointer files remain and the engine
+          # tests fail with a cryptic protobuf error (second dispatch).
+          git lfs install --skip-repo
           git lfs pull
+          if head -c 40 models/glintr100.onnx | grep -q "git-lfs"; then
+            echo "::error::model weights are still LFS pointers after pull"
+            exit 1
+          fi
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 


### PR DESCRIPTION
Third piece of the Arch-container lane: `git lfs install --skip-repo` before the pull (Arch's package does not preconfigure smudge filters; Ubuntu images do), plus the same loud pointer-file guard the self-hosted workflows carry. Will re-dispatch install-matrix after merge.
