### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-21
+
+Driven by a field-research campaign across 25+ sibling projects' issue
+trackers (Howdy alone contributed 1,124 mined issues): the release fixes the
+failure classes their users hit before irlume users can, hardens the
+fingerprint path against everything the libfprint/fprintd corpus documents,
+and stands up hardware-in-the-loop CI: a self-hosted runner with a real TPM
+and IR camera that validates every change on silicon. That runner found and
+fixed its first kernel-drift bug before this release shipped.
+
 ### Fixed
 
 - **`fingerprint enable` no longer disables face auth with nothing wired on
@@ -70,7 +80,7 @@ All notable changes to irlume are documented here. This project adheres to
 
 - **Real-hardware validation joins CI.** A self-hosted runner with a real TPM
   and a real IR camera now runs the TPM seal/unseal tests against silicon
-  rather than a software TPM, and captures a live emitter strobe burst —
+  rather than a software TPM, and captures a live emitter strobe burst,
   nightly and on every maintainer pull request. The distinction matters: the
   Tier-1 sealing fix above is a bug class that passed software-TPM CI
   completely and only ever failed on real hardware. The universal `.deb` is
@@ -98,7 +108,7 @@ All notable changes to irlume are documented here. This project adheres to
   its own actionable message: reader claimed by another session, on-sensor
   storage full, reader disconnected mid-enroll, polkit refusal, no device.
 - Listing enrolled fingers now distinguishes "no fingers enrolled" from "the
-  listing failed" (stale claim, polkit refusal, readerless box —
+  listing failed" (stale claim, polkit refusal, readerless box;
   `fprintd-list` exits 0 in all of them). Found live: over SSH, polkit refuses
   the listing, and status/verify used to answer "no finger enrolled; run
   irlume fingerprint add", pointing exactly the wrong way.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,7 +17,7 @@ authors:
 repository-code: "https://github.com/archledger/irlume"
 url: "https://github.com/archledger/irlume"
 license: GPL-3.0-or-later
-version: 0.4.0
+version: 0.5.0
 date-released: 2026-07-21
 keywords:
   - face-authentication

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "image",
  "irlume-auth",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "libc",
  "serde",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -967,11 +967,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "irlume-liveness"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "irlume-common",
  "pamsm",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.4.0
+version: 0.5.0
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -1,7 +1,7 @@
 %global ort_ver 1.24.4
 
 Name:           irlume
-Version:        0.4.0
+Version:        0.5.0
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -144,6 +144,11 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Tue Jul 21 2026 archledger <archledger236@gmail.com> - 0.5.0-1
+- Field-hardening release: Tier-1 signed-PCR sealing fix with automatic
+  tier upgrade, fingerprint robustness batch, IR format negotiation
+  (Y16/NV12/YUYV), PAM panic firewall, hardware-validated in CI
+
 * Tue Jul 21 2026 archledger <archledger236@gmail.com> - 0.4.0-1
 - New: RGB pixel-format negotiation (NV12 alongside YUYV); MJPEG-only cameras
   get a clear error and an `irlume doctor` diagnosis instead of failing at


### PR DESCRIPTION
Version bump + changelog roll for 0.5.0. Assets and signed tag follow the merge; see the changelog intro for the release story.
