### PR TITLE
CI: SHA-pin guard with scoped SLSA exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
           tar xzf "onnxruntime-linux-x64-${ver}.tgz"
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
 
+      - name: Action pins (SHA-pinned; SLSA generator excepted)
+        run: bash scripts/check-action-pins.sh
+
       - name: rustfmt
         run: cargo fmt --all --check
 

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Enforce SHA-pinning of every GitHub Action `uses:` reference, with ONE
+# documented, scoped exception: the SLSA provenance generator.
+#
+# Why this exists instead of GitHub's native "require actions pinned to a
+# full-length commit SHA" repo setting: that setting applies to ALL actions
+# with no exception mechanism (confirmed against GitHub docs 2026-07), and it
+# rejects the slsa-github-generator, whose own L3 security model requires its
+# internal actions to be referenced by tag so a release can attest to a known,
+# verifiable version. This script keeps the guarantee (nothing else may use a
+# mutable tag/branch ref) while allowing exactly that one generator, which the
+# native toggle cannot express. Runs in CI on every push and PR.
+set -euo pipefail
+
+# The single allowed non-SHA reference: the SLSA generator reusable workflow.
+# It is version-pinned by tag (@vX.Y.Z) by design and is itself provenanced.
+ALLOW_TAG_PREFIX="slsa-framework/slsa-github-generator/"
+
+fail=0
+while IFS= read -r line; do
+  file="${line%%:*}"
+  rest="${line#*:}"
+  # The reference is the token after `uses:` (strip a leading `- `).
+  ref="$(printf '%s' "$rest" | sed -E 's/.*uses:[[:space:]]*//; s/[[:space:]]+#.*//; s/[[:space:]]*$//')"
+  [ -z "$ref" ] && continue
+  # Local actions (./path) carry no external supply-chain risk.
+  case "$ref" in
+    ./*) continue ;;
+    "$ALLOW_TAG_PREFIX"*) continue ;;
+  esac
+  # Everything else must be owner/repo(/path)@<40-hex-sha>.
+  if ! printf '%s' "$ref" | grep -Eq '@[0-9a-f]{40}$'; then
+    echo "NOT SHA-PINNED: $file -> $ref"
+    fail=1
+  fi
+done < <(grep -rnE '^[[:space:]]*(-[[:space:]]+)?uses:' .github/workflows/)
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "All actions must be pinned to a full-length commit SHA."
+  echo "The only allowed tag reference is ${ALLOW_TAG_PREFIX}* (SLSA generator)."
+  exit 1
+fi
+echo "All action references are SHA-pinned (SLSA generator excepted)."


### PR DESCRIPTION
Prerequisite for enabling SLSA provenance without weakening supply-chain posture.

## The conflict (researched against GitHub docs, 2026-07)

The repo has `sha_pinning_required: true`. GitHub's docs are explicit: that setting applies to **all** actions with **no allowlist exception** — "all actions must be pinned to a full-length commit SHA... Reusable workflows can still be referenced by tag." The SLSA generator *reusable workflow* is fine, but it internally calls actions (`.../actions/detect-workflow-js@v2.1.0`) by tag, which the flag rejects. The generator's own L3 security model requires those tag references so a release attests to a known, verifiable version. There is no native way to except just the generator.

## The fix

`scripts/check-action-pins.sh` (run in the CI `check` job) enforces SHA-pinning on every `uses:` with exactly one documented exception: `slsa-framework/slsa-github-generator/*`. Local `./` actions are allowed (no external supply-chain surface). This gives the scoped exception GitHub's native toggle can't.

**Sequencing:** this guard lands first. Only after it's merged does the native `sha_pinning_required` flag get turned off — so SHA-pinning is enforced by CI continuously, never with a gap.

## Verification

- Every first-party action is already SHA-pinned (guard passes on the current tree).
- Negative-tested: the guard flags `actions/checkout@v4`, allows the SLSA generator and local actions.
- actionlint clean.
