### PR TITLE
CI/security hardening from the workflow audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,9 @@ jobs:
             build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0 # stable
+        # @master (declares the `toolchain` input); the version tag branches
+        # (e.g. @1.88.0) have no such input and ignore `with: toolchain:`.
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
 
@@ -250,7 +252,9 @@ jobs:
             build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
 
       - name: Install stable Rust with llvm-tools
-        uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0 # stable
+        # @master (declares the `toolchain` input); the version tag branches
+        # (e.g. @1.88.0) have no such input and ignore `with: toolchain:`.
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
           components: llvm-tools-preview
@@ -404,7 +408,9 @@ jobs:
       # changed nothing and masquerade as a fuzz finding. Bump the date (and
       # the cargo-fuzz version below) when touching the harness.
       - name: Install nightly Rust (cargo-fuzz needs it)
-        uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0 # nightly
+        # @master so `toolchain: nightly-...` is honored (the version-branch pin
+        # ignored it; nightly only worked via the RUSTUP_TOOLCHAIN env fallback).
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: nightly-2026-07-15
 

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -32,6 +32,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # No actions/cache here: on a self-hosted runner the repo's .git (with
       # its LFS objects) persists in the runner work directory between runs,
@@ -61,9 +63,16 @@ jobs:
       # non-destructive on this hardware during the seal-ladder campaigns.
       - name: test (TPM-gated, against the REAL TPM)
         run: |
+          set -o pipefail
+          # Assert the named tests actually ran: `cargo test <names>` exits 0
+          # on a zero-match filter, so a renamed test would silently stop being
+          # exercised on the real TPM this runner exists to cover.
+          out="$(mktemp)"
           cargo test -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale \
-            tpm_key_and_recovery_lifecycle --test-threads=1
+            tpm_key_and_recovery_lifecycle --test-threads=1 2>&1 | tee "$out"
+          ran=$(grep -oE 'test result: ok\. [0-9]+ passed' "$out" | grep -oE '[0-9]+' | awk '{s+=$1} END{print s+0}')
+          [ "$ran" -ge 4 ] || { echo "::error::expected 4 real-TPM tests, ran $ran (renamed/typo'd filter?)"; exit 1; }
 
       # Real-camera smoke: find the IR node by the same classifier users run,
       # then capture a strobe burst and require real frames. Skips cleanly when
@@ -72,7 +81,17 @@ jobs:
       # and are deleted; they are never uploaded (they picture the room).
       - name: IR camera strobe-burst capture
         run: |
-          ir=$(./target/debug/irlume doctor 2>/dev/null | awk -F: '/: Ir$/{print $1}' | tr -d " " | head -1)
+          # Distinguish "camera genuinely absent" from "doctor itself failed":
+          # a doctor crash or a changed output format must NOT read as a clean
+          # skip (that would let a real regression pass green). Run doctor once,
+          # fail loudly if it errors, and only skip when it succeeded AND
+          # reported no IR node.
+          doc="$(mktemp)"
+          if ! ./target/debug/irlume doctor >"$doc" 2>&1; then
+            echo "::error::irlume doctor failed — not a clean camera-absent skip"
+            cat "$doc"; exit 1
+          fi
+          ir=$(awk -F: '/: Ir$/{print $1}' "$doc" | tr -d " " | head -1)
           if [ -z "$ir" ]; then
             echo "::notice::no IR camera present — camera stage skipped (borrowed for the OS bench?)"
             exit 0
@@ -103,6 +122,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Pull model weights (Git LFS)
         run: |

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,25 +1,31 @@
-# Fast pre-merge feedback on the MAINTAINER'S OWN pull requests, using the
-# self-hosted runner's persistent state (incremental cargo target, local LFS,
-# pre-fetched ONNX runtime, pinned MSRV toolchain). ADDITIVE: the required
-# merge gate stays the GitHub-hosted ci.yml, which builds from scratch in a
-# deterministic environment; this job exists to surface breakage in minutes
-# instead of tens, on real hardware-adjacent state (rolling Arch).
+# Fast pre-merge feedback for the maintainer, using the self-hosted runner's
+# persistent state (incremental cargo target, local LFS, pre-fetched ONNX
+# runtime, pinned MSRV toolchain). ADDITIVE: the required merge gate stays the
+# GitHub-hosted ci.yml, which builds from scratch in a deterministic
+# environment; this surfaces breakage in minutes instead of tens, on real
+# hardware-adjacent state (rolling Arch).
 #
-# SECURITY: the job-level guard restricts this to SAME-REPO pull requests —
-# creating one requires push access, so fork PRs (anyone on the internet)
-# never reach the personal-machine runner. They are also behind the
-# repo-wide all-outside-collaborators approval wall, but the guard here must
-# stand on its own: do not remove it.
+# SECURITY: this triggers on `push`, NOT `pull_request`. A `pull_request` run
+# executes the workflow file taken from the PR's own head commit, so a fork PR
+# could edit an `if:` guard to `true` and run on the personal-machine runner if
+# a maintainer ever approved it (and "Approve and run" cannot be scoped to
+# hosted CI alone). A `push` event, by contrast, can only be triggered by
+# someone with push access to THIS repo — a fork cannot push here at all — so no
+# untrusted code ever reaches the runner, with no dependence on the approval
+# wall or an in-file guard. Feedback still appears on same-repo PRs via the
+# commit status. `main` is excluded (it runs the full hosted ci.yml).
 name: Preflight (self-hosted)
 
 on:
-  pull_request:
+  push:
+    branches-ignore:
+      - main
 
 permissions:
   contents: read
 
-# A newer push to the same PR cancels the in-flight preflight: the runner is
-# a single machine, and only the latest commit's verdict matters here.
+# A newer push to the same branch cancels the in-flight preflight: the runner
+# is a single machine, and only the latest commit's verdict matters here.
 concurrency:
   group: preflight-${{ github.ref }}
   cancel-in-progress: true
@@ -27,11 +33,12 @@ concurrency:
 jobs:
   preflight:
     name: preflight · fmt · clippy · test (archhost)
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, arch]
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Pull model weights (Git LFS, local no-op after first run)
         run: |
@@ -70,9 +77,19 @@ jobs:
       # for command parity with ci.yml.
       - name: test (TPM-gated, against the REAL TPM)
         run: |
+          set -o pipefail
+          # Guard against a renamed test silently matching nothing: an explicit
+          # `cargo test <names>` exits 0 when a name matches zero tests, which
+          # would let the real-TPM coverage quietly stop running. Assert the
+          # expected count actually ran.
+          out="$(mktemp)"
           cargo test -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale \
-            tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
+            tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv \
+            --test-threads=1 2>&1 | tee "$out"
+          ran=$(grep -oE 'test result: ok\. [0-9]+ passed' "$out" | grep -oE '[0-9]+' | awk '{s+=$1} END{print s+0}')
+          [ "$ran" -ge 5 ] || { echo "::error::expected 5 real-TPM tests, ran $ran (renamed/typo'd filter?)"; exit 1; }
+          # The daemon tpm_ test self-guards to swtpm-only; kept for parity.
           cargo test -p irlume-daemon --locked -- --ignored tpm_ --test-threads=1
 
       # Same loopback camera matrix as the hosted gate. The nodes are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **The "test (stable)" CI job now actually tests on stable.** Its
+  `dtolnay/rust-toolchain` step was pinned to the action's `1.88.0` version
+  branch, which has no `toolchain` input, so `with: toolchain: stable` was
+  silently ignored and the job installed 1.88.0 (a duplicate of the MSRV job).
+  The stable, coverage, and fuzz jobs now pin `@master`, which declares the
+  input and honors the requested toolchain. Found by a workflow audit.
+- **The `install.sh` installer refuses to run without a verified signature.**
+  It previously fell back to unsigned checksums with a warning when
+  `SHA256SUMS.asc` or `gpg` was absent, so an attacker serving a modified
+  release could strip the signature to disable enforcement. Signature
+  verification is now mandatory (fail-closed); `IRLUME_INSECURE_NO_SIG=1` is
+  the explicit, documented opt-out for installing without gpg.
+
+### Security
+
+- **The self-hosted preflight runner no longer has any path to running fork
+  code.** It triggered on `pull_request` behind a same-repo `if:` guard, but a
+  `pull_request` run executes the fork's own copy of the workflow, so the guard
+  text was attacker-editable and the real control was the fork-approval wall.
+  Preflight now triggers on `push` instead, which a fork cannot fire against
+  this repo at all, removing the untrusted-code path structurally. The
+  self-hosted checkouts also set `persist-credentials: false`.
+
 ## [0.5.0] - 2026-07-21
 
 Driven by a field-research campaign across 25+ sibling projects' issue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,29 +70,40 @@ install_channel() {
   fi
 }
 
-# Fetch SHA256SUMS into $1 (a temp dir) and, when a GPG signature is published,
-# verify it against the pinned key. Aborts on a bad signature; falls back to
-# HTTPS + SHA256 (with a warning) when no signature or no gpg is available.
+# Fetch SHA256SUMS into $1 (a temp dir) and verify its GPG signature against the
+# pinned key. Every published irlume release ships SHA256SUMS.asc, so a MISSING
+# signature is treated as an attack (signature stripping), not a soft fallback:
+# an attacker who can serve a modified release would otherwise just omit the
+# .asc to disable enforcement. The script therefore fails closed by default and
+# aborts when the signature is absent or gpg is missing. IRLUME_INSECURE_NO_SIG=1
+# is the explicit, documented escape hatch for the rare case of installing on a
+# box with no gpg where the user accepts HTTPS+SHA256 only.
 fetch_sums() {
   d="$1"
   curl -fsSL "${RELEASE_BASE}/SHA256SUMS" -o "${d}/SHA256SUMS" \
     || die "could not fetch SHA256SUMS from the latest release."
-  if command -v gpg >/dev/null 2>&1 \
-     && curl -fsSL "${RELEASE_BASE}/SHA256SUMS.asc" -o "${d}/SHA256SUMS.asc" 2>/dev/null; then
-    # Throwaway keyring holding only the pinned key: nothing else can sign,
-    # and the user's own keyring is never read or written.
-    kh="${d}/gnupg"
-    mkdir -p "$kh" && chmod 700 "$kh"
-    printf '%s\n' "$KEY_ASC" | GNUPGHOME="$kh" gpg --batch --import >/dev/null 2>&1 \
-      || { warn "could not import the pinned irlume key; relying on HTTPS + SHA256 only."; return 0; }
-    if GNUPGHOME="$kh" gpg --batch --status-fd 1 --verify "${d}/SHA256SUMS.asc" "${d}/SHA256SUMS" 2>/dev/null \
-         | grep -q "VALIDSIG ${KEY_FP}"; then
-      say "SHA256SUMS GPG signature verified against the pinned irlume key."
-    else
-      die "SHA256SUMS signature did NOT verify against the pinned irlume key ${KEY_FP}; refusing to install."
-    fi
+
+  if [ "${IRLUME_INSECURE_NO_SIG:-}" = "1" ]; then
+    warn "IRLUME_INSECURE_NO_SIG=1 set: skipping GPG signature verification (HTTPS + SHA256 only)."
+    return 0
+  fi
+
+  command -v gpg >/dev/null 2>&1 \
+    || die "gpg is required to verify the release signature. Install gnupg, or (not recommended) set IRLUME_INSECURE_NO_SIG=1 to trust HTTPS + SHA256 only."
+  curl -fsSL "${RELEASE_BASE}/SHA256SUMS.asc" -o "${d}/SHA256SUMS.asc" 2>/dev/null \
+    || die "SHA256SUMS.asc not found for this release. Every irlume release is signed; a missing signature may mean the download was tampered with. Refusing to install. (Override at your own risk with IRLUME_INSECURE_NO_SIG=1.)"
+
+  # Throwaway keyring holding only the pinned key: nothing else can sign,
+  # and the user's own keyring is never read or written.
+  kh="${d}/gnupg"
+  mkdir -p "$kh" && chmod 700 "$kh"
+  printf '%s\n' "$KEY_ASC" | GNUPGHOME="$kh" gpg --batch --import >/dev/null 2>&1 \
+    || die "could not import the pinned irlume key; cannot verify the release signature."
+  if GNUPGHOME="$kh" gpg --batch --status-fd 1 --verify "${d}/SHA256SUMS.asc" "${d}/SHA256SUMS" 2>/dev/null \
+       | grep -q "VALIDSIG ${KEY_FP}"; then
+    say "SHA256SUMS GPG signature verified against the pinned irlume key."
   else
-    warn "no GPG signature checked (gpg absent or unsigned release); relying on HTTPS + SHA256."
+    die "SHA256SUMS signature did NOT verify against the pinned irlume key ${KEY_FP}; refusing to install."
   fi
 }
 


### PR DESCRIPTION
The three verified highs from the 4-agent workflow audit (~/irlume-research/2026-07-21-ci-audit), plus the two loud-failure mediums of the same silent-pass class. No blockers were found; v0.5.0 is unaffected.

## Highs

1. **`test (stable)` never tested stable.** The `dtolnay/rust-toolchain` pin was the action's `1.88.0` *version branch*, which declares no `toolchain` input — verified against the action.yml at that SHA — so `with: toolchain: stable` was discarded and the job installed 1.88.0, a duplicate of the MSRV job. stable/coverage/fuzz now pin `@master` (which declares the input); the MSRV job keeps its version pin.

2. **`install.sh` could be signature-stripped.** It fell back to unsigned checksums with a warning when `SHA256SUMS.asc`/`gpg` was absent, so an attacker serving a modified release just omitted the `.asc`. Verification is now mandatory (fail-closed); `IRLUME_INSECURE_NO_SIG=1` is the documented opt-out for gpg-less boxes.

3. **The self-hosted preflight had a latent fork-code path.** On `pull_request`, GitHub runs the fork's own copy of the workflow, so the same-repo `if:` guard text was attacker-editable and the real control was the approval wall (which can't scope "Approve and run" to hosted CI). Preflight now triggers on `push` (excluding main), which a fork cannot fire against this repo — removing the untrusted-code path structurally, with no dependence on approval or an in-file guard. The misleading comment is corrected; self-hosted checkouts also set `persist-credentials: false`.

## Loud-failure mediums (same silent-pass class)

- The real-TPM test batch (preflight + hardware-suite) now asserts the expected test count actually ran — `cargo test <names>` exits 0 on a zero-match filter, so a renamed test would silently stop being exercised on real silicon.
- The hardware-suite camera-absent skip now distinguishes "no IR node" from "doctor itself crashed", so a doctor regression can't read as a clean skip.

## Verification

- actionlint, shellcheck, and the SHA-pin guard all clean; `cargo test --workspace` green.
- The `master` toolchain SHA verified to declare the `toolchain` input before pinning.
- This branch's push is itself the first live exercise of the new `push`-triggered preflight on archhost.

Held for a follow-up batch (your call on priority): the remaining mediums (verify-release re-fire concurrency, v4l2loopback tag pin, rust-cache/checkout bumps, unpinned nfpm/onnxruntime fetches, dependabot actions grouping, runner disk pruning) and the ~20 low/nit items in the triage.
