### PR TITLE
CI workflow mediums: action bumps + loud-failure hardening

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,18 +18,21 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories
 
       # The cargo-fuzz workspace has its own lockfile that the root check never
       # reads (see the note in .github/dependabot.yml); scan it here so an
-      # advisory against a fuzz-only dependency does not rot silently.
+      # advisory against a fuzz-only dependency does not rot silently. `always`
+      # so a root-lockfile advisory doesn't hide whether the fuzz workspace has
+      # one too — both are reported in a single run.
       - name: Advisories for the fuzz workspace lockfile
-        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+        if: always()
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           manifest-path: fuzz/Cargo.toml
           command: check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       # Actions are pinned to a commit SHA (the tag in the comment is what it
       # was) so a moved tag cannot change what runs. Dependabot bumps these.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # Credentials stay persisted on this job only: `git lfs pull` below
         # needs them on a cache miss. The token is contents:read.
 
@@ -69,7 +69,7 @@ jobs:
           toolchain: "1.88.0"
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # PRs RESTORE from main's cache but never SAVE their own: per-PR
           # entries were filling the repo's 10 GB cache quota, and LRU
@@ -133,8 +133,8 @@ jobs:
           # for the PAM FFI tests. video8/9 are fed by ffmpeg; video10 is a
           # spare the camera streaming tests feed themselves.
           sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg libpam-wrapper pamtester
-          git clone https://github.com/umlaeute/v4l2loopback /tmp/v4l2loopback
-          git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
+          git clone https://github.com/v4l2loopback/v4l2loopback /tmp/v4l2loopback
+          git -C /tmp/v4l2loopback checkout 0f9ee86760b7f2bea174b7e3e7a1d38845da0ab4 # v0.15.4
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
           sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=3 video_nr=8,9,10 exclusive_caps=0
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache Git LFS objects (ONNX model weights)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -204,7 +204,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # PRs RESTORE from main's cache but never SAVE their own: per-PR
           # entries were filling the repo's 10 GB cache quota, and LRU
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache Git LFS objects (ONNX model weights)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -259,7 +259,7 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # PRs RESTORE from main's cache but never SAVE their own: per-PR
           # entries were filling the repo's 10 GB cache quota, and LRU
@@ -295,8 +295,8 @@ jobs:
           # for the PAM FFI tests. video8/9 are fed by ffmpeg; video10 is a
           # spare the camera streaming tests feed themselves.
           sudo apt-get install -y --no-install-recommends "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" ffmpeg libpam-wrapper pamtester
-          git clone https://github.com/umlaeute/v4l2loopback /tmp/v4l2loopback
-          git -C /tmp/v4l2loopback checkout 9ef83fb9bc88e8f841786753c362ac52c580defc
+          git clone https://github.com/v4l2loopback/v4l2loopback /tmp/v4l2loopback
+          git -C /tmp/v4l2loopback checkout 0f9ee86760b7f2bea174b7e3e7a1d38845da0ab4 # v0.15.4
           make -C /tmp/v4l2loopback -j"$(nproc)"
           sudo modprobe videodev
           sudo insmod /tmp/v4l2loopback/v4l2loopback.ko devices=3 video_nr=8,9,10 exclusive_caps=0
@@ -326,6 +326,10 @@ jobs:
           # verify_pinned accept just these (see THREAT_MODEL.md).
           IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
         run: |
+          # Discard any .profraw restored in target/ by rust-cache before the
+          # first --no-report, so a prior build's coverage can't contaminate
+          # this run's merged report.
+          cargo llvm-cov clean --workspace
           cargo llvm-cov --no-report --workspace --locked
           IRLUME_TCTI="swtpm:host=127.0.0.1,port=2321" cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
@@ -342,10 +346,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories bans licenses sources
 
@@ -358,7 +362,7 @@ jobs:
       # (flake structure, the package derivation, the NixOS module, the dev
       # shell); it never reads the ONNX model contents, so the LFS pointer
       # files left by a plain checkout are enough and the job stays fast.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -394,7 +398,7 @@ jobs:
       # stable and rejects the -Z sanitizer flags) uses the pinned nightly.
       RUSTUP_TOOLCHAIN: nightly-2026-07-15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -414,7 +418,7 @@ jobs:
         with:
           toolchain: nightly-2026-07-15
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # PRs RESTORE from main's cache but never SAVE their own: per-PR
           # entries were filling the repo's 10 GB cache quota, and LRU
@@ -433,8 +437,15 @@ jobs:
       # The generated corpus accumulates across runs via the cache below, so
       # each 45-second round explores from everything earlier rounds found
       # instead of restarting from the 5 seed files.
+      # Restore on every run (PRs seed from the latest main corpus via
+      # restore-keys), but SAVE only from main. Keyed on run_id, saving on
+      # every PR would append a fresh entry each run and refill the 10 GB cache
+      # quota — the same pressure the rust-cache `save-if` guard prevents (it
+      # would LRU-evict the LFS model cache guarding the scarcer LFS bandwidth
+      # quota). Restore/save are split so the save can be gated to main.
       - name: Restore fuzz corpus from previous runs
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: fuzz-corpus
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.run_id }}
@@ -454,6 +465,14 @@ jobs:
             cargo fuzz run "$t" -- -max_total_time=45 -rss_limit_mb=4096
             echo "::endgroup::"
           done
+
+      # Persist the grown corpus only from main (see the restore step's note).
+      - name: Save fuzz corpus
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-${{ github.run_id }}
 
       - name: Upload crashing inputs
         if: failure()

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: [self-hosted, tpm, ir-camera]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -121,7 +121,7 @@ jobs:
     runs-on: [self-hosted, tpm, ir-camera]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Same LFS cache as ci.yml (shared key): the model weights are ~257 MB
       # and the LFS bandwidth quota is the reason ci.yml caches them.
@@ -89,7 +89,7 @@ jobs:
           pacman -Syu --noconfirm --needed \
             base-devel git git-lfs rust clang pam tpm2-tss curl ca-certificates
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache Git LFS objects (ONNX model weights)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -115,7 +115,7 @@ jobs:
             exit 1
           fi
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
         run: |

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: [self-hosted, arch]
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
       security-events: write # upload the SARIF result to code scanning
       id-token: write # sign the result for the public Scorecard API
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -54,6 +54,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -17,6 +17,7 @@ jobs:
   # base64 subjects blob the generator signs over.
   hashes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -43,6 +44,10 @@ jobs:
       actions: read # read this run's metadata for the provenance
       id-token: write # Sigstore/Fulcio keyless signing (no stored secret)
       contents: write # upload the provenance file to the release
+    # MUST be referenced by an @vX.Y.Z tag, not a SHA: the generator's L3 model
+    # embeds this tag in the signed provenance identity, and slsa-verifier
+    # validates it. scripts/check-action-pins.sh excepts slsa-framework/* for
+    # exactly this reason — do not "pin" this to a commit SHA.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.hashes.outputs.digests }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Nix with flakes
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -9,16 +9,28 @@ name: Verify release assets
 on:
   release:
     types: [published, edited]
+  # Assets are GPG-signed off-CI and uploaded one at a time; a re-verify from
+  # the complete state can always be requested here.
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+# Assets upload one at a time, so `edited` fires several times mid-upload while
+# SHA256SUMS / the .deb don't yet exist. Without this, each intermediate event
+# ran to a red failure and emailed the maintainer (4 false failures on v0.5.0),
+# training them to ignore the check. Cancelling supersedes the intermediate
+# runs (grey, no email); only the final complete state is verified.
+concurrency:
+  group: verify-release-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   verify:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -27,9 +39,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets
 
-      - name: Verify signature, checksums, and coverage
+      - name: Skip until the signed checksums are present
         working-directory: assets
         run: |
+          # An `edited` event mid-upload can fire before SHA256SUMS(.asc) land.
+          # That is an incomplete state, not a bad release: exit neutrally
+          # (the final upload's run does the real verification, and
+          # workflow_dispatch can force it). Only treat a genuinely absent
+          # sums file after all uploads as the maintainer's problem to notice.
+          if [ ! -f SHA256SUMS ] || [ ! -f SHA256SUMS.asc ]; then
+            echo "::notice::SHA256SUMS/.asc not present yet — assets still uploading; skipping this run"
+            echo "incomplete=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify signature, checksums, and coverage
+        if: env.incomplete != '1'
+        working-directory: assets
+        run: |
+          set -euo pipefail
           # The release public key is committed, not fetched from a keyserver:
           # a keyserver lookup could be poisoned, the repo copy is reviewed.
           gpg --import ../.github/release-signing-key.asc
@@ -42,11 +69,20 @@ jobs:
           # must be listed in SHA256SUMS.
           for f in *; do
             case "$f" in SHA256SUMS|SHA256SUMS.asc|*.intoto.jsonl) continue;; esac
-            grep -q "  $f\$" SHA256SUMS || { echo "asset not covered by SHA256SUMS: $f"; exit 1; }
+            grep -qF -- "  $f" SHA256SUMS || { echo "asset not covered by SHA256SUMS: $f"; exit 1; }
           done
 
-      - name: Sanity-check the .deb
+      - name: Sanity-check the packages
+        if: env.incomplete != '1'
         working-directory: assets
         run: |
+          set -euo pipefail
           dpkg-deb --info irlume_*.deb
           dpkg-deb --contents irlume_*.deb >/dev/null
+          # The SELinux .rpm is integrity-covered by the signed sums; also give
+          # it a structural check symmetric with the .deb.
+          for rpm in irlume-selinux-*.rpm; do
+            [ -e "$rpm" ] || continue
+            rpm -qip "$rpm"
+            rpm -qlp "$rpm" >/dev/null
+          done


### PR DESCRIPTION
Follow-up batch from the workflow audit — the CI-YAML mediums. All SHAs verified against upstream tags before pinning; nothing here touches product code.

## Action bumps
- checkout v7.0.1, rust-cache v2.9.1 (hash-calc fix), codeql upload-sarif v4.37.2, cargo-deny comment corrected to # v2.1.1.
- **v4l2loopback**: moved to the current org URL (`v4l2loopback/v4l2loopback`, was the old `umlaeute/` personal path that only works via redirect) and pinned to the **v0.15.4** commit instead of an untagged one — the audit flagged this as the likeliest future `insmod` break as the runner kernel advances.

## Loud-failure / correctness
- **verify-release**: `concurrency: cancel-in-progress` so the mid-upload `edited` events supersede each other (grey) instead of each failing red and emailing — the "4 false failures on v0.5.0" pattern. Plus a neutral skip until `SHA256SUMS`/`.asc` are present, a structural `.rpm` check symmetric with the `.deb`, `grep -F`, `set -euo pipefail`, and a `workflow_dispatch` for on-demand re-verify.
- **audit.yml**: `if: always()` so a root-lockfile advisory doesn't hide a fuzz-only one.
- **ci.yml fuzz corpus**: split into cache/restore (all runs) + cache/save (main only). The `run_id`-keyed save appended a new entry every PR, refilling the 10 GB quota the rust-cache `save-if` guard was added to protect.
- **ci.yml coverage**: `cargo llvm-cov clean` before the first `--no-report` so a cached `.profraw` can't contaminate the merged number.
- **slsa-provenance**: `hashes` job timeout, and a comment that `@v2.1.0` must stay a tag (the generator's L3 model requires it; the pin-guard excepts it).

## Verification
- actionlint + SHA-pin guard clean; every bumped SHA dereferenced from its tag.
- This branch's push runs the self-hosted preflight (the new push trigger); hosted CI is the gate.

Remaining held: the build-script supply-chain pins (nfpm/onnxruntime/base digest) as the next PR, plus packaging lows and runner disk pruning.
