### PR TITLE
Packaging: pin and verify fetched build inputs

### DIFF
--- a/packaging/debian/build-deb-container.sh
+++ b/packaging/debian/build-deb-container.sh
@@ -20,8 +20,15 @@
 #   bash packaging/debian/build-deb-container.sh
 # Output: ./irlume_<version>_amd64.deb (copied out of the container).
 set -euo pipefail
-BASE="${BASE:-debian:12}"        # oldest supported base (sets the glibc floor)
+# Digest-pinned so the glibc floor and toolchain are reproducible: the plain
+# `debian:12` tag tracks every point release. Bump the digest deliberately when
+# moving the base (the tag is `debian:12` as of this digest).
+BASE="${BASE:-debian:12@sha256:9344f8b8992482f80cba753f323adeaf17690076c095ccff6cc9536be98185dc}"
 RUST_VER="${RUST_VER:-1.88.0}"   # >= ort's MSRV (edition 2024)
+# nfpm builds the .deb; pin it and verify its published checksum rather than
+# fetching a floating "latest" (a compromised/behavior-changed nfpm would
+# otherwise silently alter every universal .deb).
+NFPM_VER="${NFPM_VER:-2.47.0}"
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 OUT="${OUT:-$REPO}"
 
@@ -39,14 +46,19 @@ podman run --rm \
   -v "$OUT:/out:z" \
   "docker.io/library/$BASE" bash -euc '
     export DEBIAN_FRONTEND=noninteractive
+    NFPM_VER='"$NFPM_VER"'
     apt-get update -qq
     # clang/libclang-dev: bindgen (v4l2-sys-mit) needs libclang at build time.
     apt-get install -y -qq curl ca-certificates build-essential pkg-config \
         libtss2-dev libpam0g-dev clang libclang-dev git git-lfs xz-utils >/dev/null
     curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain '"$RUST_VER"' --profile minimal >/dev/null
     . "$HOME/.cargo/env"
-    NFPM_VER=$(curl -s https://api.github.com/repos/goreleaser/nfpm/releases/latest | grep -oP "\"tag_name\":\s*\"v\K[^\"]+")
+    # Pinned nfpm, verified against its published (goreleaser-signed) checksums.
     curl -sSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VER}/nfpm_${NFPM_VER}_amd64.deb" -o /tmp/nfpm.deb
+    curl -sSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VER}/checksums.txt" -o /tmp/nfpm.sums
+    ( cd /tmp && want=$(grep "nfpm_${NFPM_VER}_amd64.deb\$" nfpm.sums | awk "{print \$1}"); \
+      got=$(sha256sum nfpm.deb | awk "{print \$1}"); \
+      [ -n "$want" ] && [ "$want" = "$got" ] || { echo "nfpm checksum mismatch"; exit 1; } )
     apt-get install -y -qq /tmp/nfpm.deb >/dev/null
     cp -r /src /build && cd /build
     sed -i "/git lfs pull/d" packaging/debian/build-deb.sh   # models are already real in the mount

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -6,6 +6,9 @@
 set -euo pipefail
 
 ORT_VER="${ORT_VER:-1.24.4}"
+# sha256 of onnxruntime-linux-x64-${ORT_VER}.tgz (bundled .so runs in the
+# privileged daemon); verify rather than trusting HTTPS. Update with ORT_VER.
+ORT_SHA256="${ORT_SHA256:-3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747}"
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 STAGE="$REPO/.deb-staging"
 cd "$REPO"
@@ -36,6 +39,8 @@ rm -rf "$STAGE"; mkdir -p "$STAGE"
 # Bundle onnxruntime.
 curl -fsSL -o "$STAGE/ort.tgz" \
   "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/onnxruntime-linux-x64-${ORT_VER}.tgz"
+echo "${ORT_SHA256}  $STAGE/ort.tgz" | sha256sum -c - \
+  || { echo "onnxruntime tarball failed sha256 check; refusing to bundle."; exit 1; }
 mkdir -p "$STAGE/onnxruntime"
 tar -xzf "$STAGE/ort.tgz" -C "$STAGE/onnxruntime" --strip-components=1
 

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -62,6 +62,10 @@ daemon socket. Only needed on SELinux-enforcing systems (Fedora default).
 
 %prep
 %autosetup -n %{name}-%{version}
+# Verify the bundled onnxruntime (Source1) before unpacking: the .so runs in
+# the privileged daemon, and Copr fetches remote sources without the Fedora
+# lookaside's own integrity check. Update the digest together with ort_ver.
+echo '3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747  %{SOURCE1}' | sha256sum -c -
 # Unpack the bundled onnxruntime (Source1) next to the source tree; installed
 # below into %{_datadir}/%{name}/onnxruntime.
 tar -xzf %{SOURCE1}

--- a/scripts/build-ppa-source.sh
+++ b/scripts/build-ppa-source.sh
@@ -25,6 +25,10 @@ set -euo pipefail
 SERIES="${SERIES:-resolute}"
 PPAREV="${PPAREV:-0ppa1}"
 ORT_VER="${ORT_VER:-1.24.4}"
+# sha256 of onnxruntime-linux-x64-${ORT_VER}.tgz; the bundled .so runs in the
+# privileged daemon, so verify it rather than trusting HTTPS alone. Update
+# together with ORT_VER.
+ORT_SHA256="${ORT_SHA256:-3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747}"
 BUILDROOT="${BUILDROOT:-$HOME/ppa-build}"
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
@@ -55,6 +59,9 @@ echo "==> bundling onnxruntime $ORT_VER"
 ORT_TGZ="$BUILDROOT/onnxruntime-linux-x64-${ORT_VER}.tgz"
 [ -f "$ORT_TGZ" ] || curl -fsSL -o "$ORT_TGZ" \
     "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/onnxruntime-linux-x64-${ORT_VER}.tgz"
+# Verify every time (also re-checks a reused cached tarball).
+echo "${ORT_SHA256}  ${ORT_TGZ}" | sha256sum -c - \
+    || { echo "onnxruntime tarball failed sha256 check; refusing to bundle."; exit 1; }
 mkdir -p "$TREE/ort-prebuilt"
 tar -xzf "$ORT_TGZ" -C "$TREE/ort-prebuilt" --strip-components=1
 rm -rf "$TREE/ort-prebuilt/include"   # headers unused (load-dynamic)


### PR DESCRIPTION
Second follow-up batch from the workflow audit — the build-script supply-chain pins. These are the release-tooling fetches that ran unpinned/unverified.

## Changes
- **nfpm**: pinned to `v2.47.0` and verified against its published `checksums.txt`, replacing the floating `latest` fetch. A compromised or behavior-changed nfpm silently rewrites every universal .deb otherwise.
- **debian:12 base**: digest-pinned (`@sha256:9344f8b8…`), the glibc-floor anchor the whole reproducibility argument rests on.
- **onnxruntime tarball**: sha256-verified after download in all three build paths — `build-deb.sh`, `build-ppa-source.sh` (which also re-checks a reused cached tarball), and the RPM spec `%prep` (Copr fetches remote sources without the Fedora lookaside's integrity check). The bundled `.so` runs in the privileged daemon.

## Validation
- Full container build ran clean with every new pin: `ort.tgz: OK` (ORT verify), `glibc floor ok` (digest base), pinned+verified nfpm built the .deb.
- The produced .deb installs and reports `irlume 0.5.0` on debian:12.
- All three scripts shellcheck-clean; the digest, ORT hash, and nfpm version were each fetched/computed from source, not assumed.

Remaining held: packaging lows (spec %dir, deb prerm upgrade guard, AppArmor complain-vs-enforce) and the dependabot actions-group split — the final small PR.
