### PR TITLE
Packaging lows: dependabot split, deb upgrade guards, spec %dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,22 @@
 # bumps are collapsed into one grouped PR per ecosystem per week. Major bumps
 # come as their own PR because they can break the build. Dependabot does not
 # touch the two git-sourced crates (the tss-esapi fork); those are bumped by
-# hand when the fork moves.
+# hand when the fork moves. INVARIANT: this relies on Dependabot's cargo
+# ecosystem not updating rev-pinned git deps — keep the fork pinned by exact
+# `rev`. Switching it to a `tag`/`branch` would let Dependabot start proposing
+# bumps (dependabot-core#10913), and name-based `ignore` does not work for git
+# deps (dependabot-core#4388), so the rev pin is the only reliable guard.
 version: 2
 updates:
-  # GitHub Actions used by .github/workflows/ci.yml. These change rarely and
-  # every bump is worth seeing (a moved tag is a supply-chain event).
+  # GitHub Actions across all workflows. Deliberately NOT grouped: the header
+  # says every bump is worth seeing because a moved action is a supply-chain
+  # event, and a grouped PR would review a possibly-compromised action bump
+  # alongside benign ones. Actions are few and change rarely, so per-action
+  # PRs cost little noise for a clear per-bump audit trail.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    groups:
-      actions:
-        patterns: ["*"]
     commit-message:
       prefix: "ci"
 

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -8,7 +8,12 @@ if command -v apparmor_parser >/dev/null 2>&1; then
     apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
 fi
 systemctl daemon-reload 2>/dev/null || true
-systemctl enable --now irlumed.service 2>/dev/null || true
+# Enable + start ONLY on first install ($2 empty). On an upgrade, re-enabling
+# would override a unit the user deliberately disabled; try-restart below picks
+# up the new binary/unit for a running daemon and is a no-op for a stopped one.
+if [ -z "${2:-}" ]; then
+    systemctl enable --now irlumed.service 2>/dev/null || true
+fi
 systemctl try-restart irlumed.service 2>/dev/null || true
 cat <<'EOF'
 irlume installed. Next steps:

--- a/packaging/debian/preremove.sh
+++ b/packaging/debian/preremove.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 set -e
-systemctl disable --now irlumed.service 2>/dev/null || true
+# Only disable/stop on an actual removal, not on an upgrade (dpkg runs prerm
+# with "upgrade" too): tearing the daemon down mid-upgrade, then having
+# postinst re-enable it, churns state and would re-enable a unit the user
+# deliberately disabled. On upgrade, postinst's try-restart handles the swap.
+if [ "$1" = remove ]; then
+    systemctl disable --now irlumed.service 2>/dev/null || true
+fi

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -138,6 +138,12 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_bindir}/irlumed
 %{_bindir}/irlume
 %{_libdir}/security/pam_irlume.so
+# Own the directories the globs populate (rpmlint: "directory not owned by a
+# package"; also leaves them behind on erase otherwise).
+%dir %{_datadir}/%{name}
+%dir %{_datadir}/%{name}/models
+%dir %{_datadir}/%{name}/onnxruntime
+%dir %{_datadir}/%{name}/onnxruntime/lib
 %{_datadir}/%{name}/models/*.onnx
 %{_datadir}/%{name}/onnxruntime/lib/*
 %{_unitdir}/irlumed.service


### PR DESCRIPTION
Final follow-up batch from the workflow audit — the low-severity packaging items. No product code.

- **dependabot**: removed the `actions` group so each action bump gets its own reviewable PR (the config's own comment says a moved action is a supply-chain event worth seeing individually). Documented the rev-pin invariant that keeps Dependabot from touching the tss-esapi fork.
- **deb preremove**: guard the disable/stop on `[ "$1" = remove ]` — dpkg runs prerm on upgrades too, and the churn re-enabled a deliberately-disabled unit.
- **deb postinstall**: enable+start only on first install (`$2` empty); upgrades respect the user's enable/disable state and just try-restart.
- **spec**: `%dir`-own the models/onnxruntime directories (rpmlint "directory not owned by a package"; also leaves them on erase otherwise).

shellcheck-clean, dependabot YAML validates. That closes the audit follow-up: 3 highs (#75), CI mediums (#76), build-script pins (#77), the runner-found client fix (#78), runner disk pruning (on archhost), and these lows. The remaining nits in the triage are cosmetic and not worth PR churn.
