### PR TITLE
polkit app prompts: face-approve Bitwarden unlock and pkexec (opt-in --with-polkit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **polkit app prompts can be face-approved (opt-in): `sudo irlume login
+  enable --with-polkit --apply`.** Desktop apps ask polkit to verify the user
+  (Bitwarden's "unlock with biometrics" is a polkit prompt, as are `pkexec`
+  and GNOME Software); wiring `pam_irlume` into the `polkit-1` stack lets a
+  face match answer them, password fallback unchanged. The polkit class is
+  verify-only at the daemon (an always-on refusal guards the TPM-sealed
+  credential, independent of tier or biopolicy config), requires the passive
+  blink gate even without the per-enrollment opt-in (polkit agents start the
+  PAM conversation with no user gesture; the blink proves a live person is
+  looking at the dialog), fails closed when the blink gate cannot run, and is
+  denied outright on RGB-only hardware. `irlume login status` gains a polkit
+  row, `irlume doctor` flags a Bitwarden polkit action with no wiring, and the
+  SELinux policy (1.1.0) grants the polkit helper domain socket access. See
+  docs/APP-INTEGRATION.md.
+
 ### Fixed
 
 - **The "test (stable)" CI job now actually tests on stable.** Its

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built to match or beat Windows Hello, on a fully open, commercially clean stack.
 |  |  |
 |---|---|
 | 🌑 **Works in the dark** | Active **infrared** recognition (Windows-Hello cameras); no ambient light needed. |
-| 🔒 **Unlocks everything** | Login greeter, lock screen, and `sudo` (opt-in via `login enable --with-sudo`), with the password always as fallback (**no lockout, ever**). |
+| 🔒 **Unlocks everything** | Login greeter, lock screen, `sudo` (opt-in via `login enable --with-sudo`), and app prompts like **Bitwarden's biometric unlock** via polkit (opt-in via `login enable --with-polkit`, [details](docs/APP-INTEGRATION.md)), with the password always as fallback (**no lockout, ever**). |
 | 🙋 **On-demand, by consent** | The camera fires only when you ask: leave the password field **empty and press Enter**. Typing a password never starts a scan. A **grace window** after the gesture (~15 s at login/lock, ~5 s for `sudo`) keeps retrying while you settle into frame, but never retries a failed match. Wiring is tailored per login manager (GDM · SDDM · Plasma Login · LightDM · greetd · COSMIC). |
 | 🗝️ **Opens your keyring** | On IR hardware a face match **TPM-unseals your login password** so the wallet unlocks at login, like Hello. |
 | 👁️ **Real liveness** | Algorithmic IR anti-spoof gate + **opt-in passive blink** detection (no prompt, no action). |

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -51,6 +51,12 @@ pub struct Engine {
     /// RGB-only device → face runs in CONVENIENCE tier (lock-screen unlock only,
     /// RGB-only liveness, never releases credentials / logs in / elevates).
     ir_available: bool,
+    /// Set per-[`authenticate`] call from the PAM service's operation class:
+    /// true while serving a service that forces the passive blink gate even
+    /// without the per-enrollment opt-in (polkit prompts; see
+    /// `biopolicy::requires_consent_gesture`). Unlike the opt-in flag, a
+    /// forced gate FAILS CLOSED when it can't run (no IR / no mesh model).
+    forced_consent: bool,
 }
 
 /// Assurance tier of this engine, derived from the available camera hardware.
@@ -125,8 +131,11 @@ fn is_sudo_like(service: &str) -> bool {
 }
 
 /// Grace window for a given PAM service. `IRLUME_GRACE_MS` overrides everything
-/// (testing); otherwise sudo/su get the short window and every login/lock
-/// service (and an unknown/absent service) gets the full login window.
+/// (testing); otherwise sudo/su and polkit get the short window (the user is
+/// already at the machine, and the KDE polkit agent re-runs the stack up to 3
+/// times on failure, so a long window would just hold its dialog busy) and
+/// every login/lock service (and an unknown/absent service) gets the full
+/// login window.
 fn grace_window_ms(service: Option<&str>) -> u64 {
     if let Some(v) = std::env::var("IRLUME_GRACE_MS")
         .ok()
@@ -135,9 +144,20 @@ fn grace_window_ms(service: Option<&str>) -> u64 {
         return v;
     }
     match service {
-        Some(s) if is_sudo_like(s) => SUDO_GRACE_WINDOW_MS,
+        Some(s) if is_sudo_like(s) || s == "polkit-1" || s == "polkit" => SUDO_GRACE_WINDOW_MS,
         _ => GRACE_WINDOW_MS,
     }
+}
+
+/// Escape hatch for the forced polkit blink gate: default ON; disable with
+/// `IRLUME_POLKIT_GESTURE=0` or `polkit_gesture=0` in settings.conf. Verify
+/// stays face-gated either way; this only controls the extra blink.
+fn consent_gesture_enabled() -> bool {
+    let falsy = |v: &str| matches!(v.trim(), "0" | "false" | "no" | "off");
+    if let Ok(v) = std::env::var("IRLUME_POLKIT_GESTURE") {
+        return !falsy(&v);
+    }
+    !irlume_common::config::read_kv("settings.conf", "polkit_gesture").is_some_and(|v| falsy(&v))
 }
 
 /// Presence-class failure: the attempt never reached a match verdict because
@@ -281,6 +301,7 @@ impl Engine {
             rgb_dev: irlume_camera::DEFAULT_RGB_DEVICE.into(),
             ir_dev: irlume_camera::DEFAULT_IR_DEVICE.into(),
             ir_available: irlume_camera::capabilities().ir_pair,
+            forced_consent: false,
         })
     }
 
@@ -922,22 +943,38 @@ impl Engine {
         Ok(irlume_liveness::detect_blink(&samples))
     }
 
-    /// If the user opted into passive liveness and we're about to grant, require a
-    /// natural blink before releasing anything. Failure downgrades to a non-grant
-    /// with an Uncertain-style reason (PAM cascades to the password fallback, never
-    /// a lockout). No-op unless the outcome is a grant, the flag is on, IR is
-    /// available, and the FaceMesh model is loaded (else the gate can't run; we log
-    /// and skip rather than lock the user out of an undeployed model).
+    /// If the passive blink gate is wanted and we're about to grant, require a
+    /// natural blink before releasing anything. Wanted = the user's enrollment
+    /// opted in (`require_challenge`) OR the current service forces it
+    /// (`forced_consent`, polkit prompts). Failure downgrades to a non-grant
+    /// with an Uncertain-style reason (PAM cascades to the password fallback,
+    /// never a lockout). When IR or the FaceMesh model is missing the opt-in
+    /// path logs and skips (never lock a user out of an undeployed model); the
+    /// forced path fails closed instead.
     fn challenge_if_required(
         &mut self,
         enr: &irlume_core::storage::Enrollment,
         outcome: Outcome,
     ) -> irlume_common::Result<Outcome> {
-        if !outcome.granted || !enr.require_challenge || !self.ir_available {
+        if !outcome.granted || !(enr.require_challenge || self.forced_consent) {
             return Ok(outcome);
         }
-        if self.mesh.is_none() {
-            eprintln!("irlumed: passive liveness (require-challenge) is on but face_landmark.onnx is not loaded; skipping (set IRLUME_MESH_MODEL)");
+        // The gate needs IR frames and the FaceMesh model. When either is
+        // missing, the per-enrollment OPT-IN keeps its historical skip (never
+        // lock a user out of an undeployed model), but a FORCED gate (polkit
+        // consent) fails closed: the blink is the whole point of allowing face
+        // on that service, so without it the grant is withdrawn and PAM
+        // cascades to the password.
+        if !self.ir_available || self.mesh.is_none() {
+            if self.forced_consent {
+                return Ok(Outcome {
+                    granted: false, live: outcome.live, score: outcome.score,
+                    reason: "consent gesture required for this service but the blink gate can't run (IR or face_landmark.onnx missing); use your password".into(),
+                });
+            }
+            if self.ir_available {
+                eprintln!("irlumed: passive liveness (require-challenge) is on but face_landmark.onnx is not loaded; skipping (set IRLUME_MESH_MODEL)");
+            }
             return Ok(outcome);
         }
         use irlume_liveness::BlinkResult;
@@ -977,6 +1014,16 @@ impl Engine {
         user: &str,
         service: Option<&str>,
     ) -> irlume_common::Result<Outcome> {
+        // Consent-class services (polkit) force the passive blink gate for this
+        // call; see `challenge_if_required`. Set fresh on every call so a
+        // polkit verify can never leak the flag into a later login/lock verify.
+        self.forced_consent = service
+            .map(|s| {
+                irlume_core::biopolicy::requires_consent_gesture(irlume_core::biopolicy::classify(
+                    s, false,
+                )) && consent_gesture_enabled()
+            })
+            .unwrap_or(false);
         let window = grace_window_ms(service);
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(window);
         let mut attempt = 0u32;
@@ -3203,6 +3250,51 @@ mod engine_tests {
         write_enrollment(&dir, &e);
         let err = s.engine.authenticate("irlume-test-cam", None).unwrap_err();
         assert!(err.to_string().contains("no camera found"), "{err}");
+
+        teardown_sandbox(&dir);
+    }
+
+    #[test]
+    fn polkit_service_forces_the_consent_gesture_and_it_fails_closed() {
+        let _g = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("consent");
+
+        // authenticate() derives the forced flag from the service class, fresh
+        // per call: polkit-1 sets it, sudo (and None) clear it. The not-enrolled
+        // early return keeps the camera out of this test.
+        let _ = s.engine.authenticate("irlume-test-ghost", Some("polkit-1"));
+        assert!(s.engine.forced_consent);
+        let _ = s.engine.authenticate("irlume-test-ghost", Some("sudo"));
+        assert!(!s.engine.forced_consent);
+        // Escape hatch: IRLUME_POLKIT_GESTURE=0 turns the forcing off.
+        std::env::set_var("IRLUME_POLKIT_GESTURE", "0");
+        let _ = s.engine.authenticate("irlume-test-ghost", Some("polkit-1"));
+        assert!(!s.engine.forced_consent);
+        std::env::remove_var("IRLUME_POLKIT_GESTURE");
+
+        // The shared engine runs IR-less (IRLUME_FORCE_NO_IR), where the blink
+        // gate cannot run. A FORCED gate must then withdraw the grant (fail
+        // closed) while the per-enrollment opt-in keeps its historical skip.
+        let enr = Enrollment::new("irlume-test-consent");
+        let granted = || Outcome {
+            granted: true,
+            live: true,
+            score: 0.9,
+            reason: "match".into(),
+        };
+        s.engine.forced_consent = true;
+        let out = s.engine.challenge_if_required(&enr, granted()).unwrap();
+        assert!(!out.granted, "forced gate must fail closed without IR");
+        assert!(out.reason.contains("consent gesture"), "{}", out.reason);
+        s.engine.forced_consent = false;
+        let mut opt_in = Enrollment::new("irlume-test-consent");
+        opt_in.require_challenge = true;
+        let out = s.engine.challenge_if_required(&opt_in, granted()).unwrap();
+        assert!(
+            out.granted,
+            "opt-in path keeps its skip when the gate can't run"
+        );
 
         teardown_sandbox(&dir);
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2360,6 +2360,30 @@ fn doctor() -> std::process::ExitCode {
         _ => println!("[doctor] templates ({user}): unknown (daemon not reachable; run `irlume recovery status`)"),
     }
 
+    // --- polkit app prompts ------------------------------------------------
+    // Apps like Bitwarden implement "biometric unlock" on Linux as a polkit
+    // prompt; wiring pam_irlume into polkit-1 is what lets a face satisfy it.
+    // Bitwarden's polkit action file doubles as the tell that the user expects
+    // biometric unlock to work (its flatpak/snap can't install it themselves).
+    let bitwarden_action =
+        std::path::Path::new("/usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy").exists();
+    match crate::pamwire::polkit_wired() {
+        Some(true) => println!(
+            "[doctor] polkit app prompts: wired ✓ (face + blink can approve Bitwarden unlock, \
+             pkexec, …)"
+        ),
+        Some(false) if bitwarden_action => println!(
+            "[doctor] polkit app prompts: NOT wired, but Bitwarden's polkit action is installed.\n     \
+             Its biometric unlock will fall back to the password prompt. Enable with:\n     \
+             sudo irlume login enable --with-polkit --apply"
+        ),
+        Some(false) => println!(
+            "[doctor] polkit app prompts: not wired (opt-in: sudo irlume login enable \
+             --with-polkit --apply)"
+        ),
+        None => {}
+    }
+
     // --- wiring drift ------------------------------------------------------
     // If the user is enrolled but no greeter is wired, a distro tool most
     // likely regenerated the PAM stacks (authselect apply on Fedora,

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -3,7 +3,8 @@
 
 //! `irlume login <status|enable|disable>`: wire face auth into the login
 //! greeters (GDM/SDDM/LightDM/plasmalogin), the KDE lock screen, and (opt-in)
-//! sudo. The Rust replacement for scripts/deploy-keyring-unlock.sh. Ported from
+//! sudo and polkit. The Rust replacement for scripts/deploy-keyring-unlock.sh.
+//! Ported from
 //! linhello's pamwire framework, adapted to irlume's keyring-unlock greeter
 //! BLOCK (unseal + a pam_permit landing for the success=1 jump + a reseal
 //! self-heal) and the `wait` lock stanza.
@@ -60,6 +61,12 @@ const RESEAL_AUTH: &str = "auth       optional                     pam_irlume.so
 const KEYRING_UNSEAL: &str = "auth       optional                     pam_irlume.so keyring";
 const RESEAL_SESSION: &str = "session    optional                     pam_irlume.so reseal";
 const SUDO_STANZA: &str = "auth       sufficient                   pam_irlume.so";
+/// polkit prompts (Bitwarden vault unlock, pkexec, systemd unit control) get the
+/// same plain verify stanza as sudo: no `unseal` (the daemon refuses credential
+/// release for the polkit class anyway) and no mode arg (the polkit agent runs
+/// the conversation as soon as its dialog opens, which IS the face-first
+/// trigger; the daemon adds the forced blink gate on top).
+const POLKIT_STANZA: &str = SUDO_STANZA;
 
 /// A PAM service to wire. `vendor=Some` → materialize an /etc override from the
 /// vendor copy; `vendor=None` → back up and edit the real /etc file.
@@ -116,18 +123,30 @@ const FP_GREETERS: &[Svc] = &[Svc {
     vendor: None,
 }];
 const SUDO: &str = "/etc/pam.d/sudo";
+/// polkit's agent helper always authenticates through the `polkit-1` PAM
+/// service. Debian/Arch ship a real /etc file (edit-in-place with backup);
+/// Fedora ships only the vendor copy (materialize an /etc override from it,
+/// like plasmalogin). Opt-in via `--with-polkit`; this is what lets a face
+/// match satisfy app prompts such as Bitwarden's biometric unlock.
+const POLKIT: Svc = Svc {
+    etc: "/etc/pam.d/polkit-1",
+    vendor: Some("/usr/lib/pam.d/polkit-1"),
+};
 
 // ---- CLI entry ---------------------------------------------------------------
 
 pub fn run(action: Option<&str>, args: &[String]) -> ExitCode {
     let apply = args.iter().any(|a| a == "--apply");
     let with_sudo = args.iter().any(|a| a == "--with-sudo");
+    let with_polkit = args.iter().any(|a| a == "--with-polkit");
     match action {
         None | Some("status") => status(),
-        Some("enable") => act(true, apply, with_sudo),
-        Some("disable") => act(false, apply, with_sudo),
+        Some("enable") => act(true, apply, with_sudo, with_polkit),
+        Some("disable") => act(false, apply, with_sudo, with_polkit),
         _ => {
-            eprintln!("usage: irlume login <status|enable|disable> [--with-sudo] [--apply]");
+            eprintln!(
+                "usage: irlume login <status|enable|disable> [--with-sudo] [--with-polkit] [--apply]"
+            );
             eprintln!("  (without --apply, prints what it WOULD change: a dry run)");
             ExitCode::from(2)
         }
@@ -154,6 +173,10 @@ pub(crate) fn status_report() -> Vec<(String, bool, bool)> {
         sudo.exists(),
         sudo.exists() && file_has_module(sudo),
     ));
+    match service_present(&POLKIT) {
+        Some(p) => out.push(("polkit".into(), true, file_has_module(&p))),
+        None => out.push(("polkit".into(), false, false)),
+    }
     out
 }
 
@@ -173,6 +196,12 @@ pub(crate) fn login_wired() -> bool {
         }
     }
     false
+}
+
+/// polkit-1 wiring state for doctor: `None` when the service file is absent
+/// (no polkit on this host), else whether it carries the irlume line.
+pub(crate) fn polkit_wired() -> Option<bool> {
+    service_present(&POLKIT).map(|p| file_has_module(&p))
 }
 
 /// Short label from an /etc/pam.d path (e.g. "/etc/pam.d/gdm-password" → "gdm-password").
@@ -376,6 +405,18 @@ fn status() -> ExitCode {
             }
         );
     }
+    if let Some(p) = service_present(&POLKIT) {
+        let wired = file_has_module(&p);
+        println!(
+            "  {:<34} {}",
+            p.display(),
+            if wired {
+                "● wired (polkit app prompts)"
+            } else {
+                "○ not wired (polkit app prompts)"
+            }
+        );
+    }
     if any_ondemand {
         println!("  on-demand: {ONDEMAND_HINT}");
     }
@@ -389,13 +430,14 @@ fn status() -> ExitCode {
     );
     if !any {
         println!(
-            "  → enable with:  sudo irlume login enable --apply   (add --with-sudo for face-sudo)"
+            "  → enable with:  sudo irlume login enable --apply   (add --with-sudo for face-sudo, \
+             --with-polkit for app prompts like Bitwarden)"
         );
     }
     ExitCode::SUCCESS
 }
 
-fn act(enable: bool, apply: bool, with_sudo: bool) -> ExitCode {
+fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCode {
     if apply && effective_uid() != 0 {
         eprintln!(
             "[login] applying changes needs root; run: sudo irlume login {} --apply",
@@ -522,6 +564,23 @@ fn act(enable: bool, apply: bool, with_sudo: bool) -> ExitCode {
             }
         }
     }
+    if polkit_in_scope(enable, with_polkit) {
+        match wire_service(&POLKIT, enable, apply, &wire_polkit) {
+            Ok(msg) => {
+                println!("  {msg}");
+                if enable && apply {
+                    println!(
+                        "    polkit prompts (Bitwarden unlock, pkexec) now accept your face; \
+                         a natural blink is required before the prompt is approved."
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("  ✗ {e}");
+                errs += 1;
+            }
+        }
+    }
     // SELinux (Fedora): the confined GDM/greeter needs the policy to reach the socket.
     if matches!(distro_family(), DistroFamily::Fedora) {
         match selinux(enable, apply) {
@@ -551,6 +610,12 @@ fn act(enable: bool, apply: bool, with_sudo: bool) -> ExitCode {
 /// inline in `act`) so the promise stays unit-testable.
 fn sudo_in_scope(enable: bool, with_sudo: bool) -> bool {
     with_sudo || !enable
+}
+
+/// Same promise for the polkit stack: opt-in on enable (`--with-polkit`),
+/// always unwired on disable.
+fn polkit_in_scope(enable: bool, with_polkit: bool) -> bool {
+    with_polkit || !enable
 }
 
 /// Wire (or unwire) one service, choosing override-materialize vs edit-in-place.
@@ -900,6 +965,33 @@ fn wire_fp_keyring(content: &str) -> (String, bool) {
 }
 fn wire_sudo(content: &str) -> (String, bool) {
     wire_single(content, SUDO_STANZA)
+}
+/// Wire the polkit-1 stack: the verify stanza goes ABOVE the first auth-phase
+/// line, whether that is Fedora's `auth include system-auth` or Debian's
+/// `@include common-auth` (which `wire_single`'s auth-token anchor misses; an
+/// appended-at-end line would run after the password modules). No anchor →
+/// no wiring: appending to a file with no auth phase would leave pam_irlume as
+/// the only auth module, and its IGNORE on a failed face would then fail the
+/// whole prompt instead of falling back to the password.
+fn wire_polkit(content: &str) -> (String, bool) {
+    if content_has_module(content) {
+        return (content.to_string(), false);
+    }
+    let lines: Vec<&str> = content.lines().collect();
+    let anchor = lines
+        .iter()
+        .position(|l| is_include_auth_layout(l) || is_auth_directive(l));
+    let Some(anchor) = anchor else {
+        return (content.to_string(), false);
+    };
+    let mut out = Vec::with_capacity(lines.len() + 1);
+    for (i, l) in lines.iter().enumerate() {
+        if i == anchor {
+            out.push(POLKIT_STANZA.to_string());
+        }
+        out.push((*l).to_string());
+    }
+    (format!("{}\n", out.join("\n")), true)
 }
 
 /// Remove every irlume line AND the pam_permit landing we added (used only when
@@ -1317,6 +1409,70 @@ mod tests {
         assert!(!sudo_in_scope(true, false)); // enable stays opt-in
     }
 
+    #[test]
+    fn disable_always_unwires_polkit_even_without_the_flag() {
+        assert!(polkit_in_scope(false, false));
+        assert!(polkit_in_scope(false, true));
+        assert!(polkit_in_scope(true, true));
+        assert!(!polkit_in_scope(true, false)); // enable stays opt-in
+    }
+
+    #[test]
+    fn wire_polkit_inserts_the_verify_stanza_before_the_first_auth_line() {
+        // Fedora vendor layout (include system-auth) and Debian's @include
+        // layout both anchor on the first auth directive; the stanza must land
+        // above it so the face runs before the password modules, and the line
+        // must be plain verify: no `unseal` (the daemon refuses credential
+        // release for polkit anyway) and no mode arg.
+        for stock in [
+            "#%PAM-1.0\nauth       include      system-auth\naccount    include      system-auth\n",
+            "#%PAM-1.0\n@include common-auth\n@include common-account\n",
+        ] {
+            let (wired, changed) = wire_polkit(stock);
+            assert!(changed, "{stock:?}");
+            let face = wired
+                .lines()
+                .position(|l| l.contains(MODULE))
+                .expect("stanza present");
+            let first_auth = wired
+                .lines()
+                .position(|l| {
+                    !l.contains(MODULE) && (l.starts_with("auth") || l.starts_with("@include"))
+                })
+                .unwrap();
+            assert!(face < first_auth, "{wired}");
+            let line = wired.lines().nth(face).unwrap();
+            assert!(
+                !line.contains("unseal") && !line.contains("ondemand"),
+                "{line}"
+            );
+            // Idempotent and fully reversible.
+            assert!(!wire_polkit(&wired).1);
+            let (back, undone) = unwire_lines(&wired);
+            assert!(undone && !content_has_module(&back));
+        }
+    }
+
+    #[test]
+    fn wire_polkit_skips_a_file_with_no_auth_phase() {
+        // With no auth anchor the stanza would become the ONLY auth module, and
+        // a failed face (IGNORE) would then fail the prompt outright instead of
+        // cascading to the password. Must skip, not append.
+        let stock = "#%PAM-1.0\nsession    include      system-auth\n";
+        let (out, changed) = wire_polkit(stock);
+        assert!(!changed);
+        assert_eq!(out, stock);
+    }
+
+    #[test]
+    fn polkit_service_carries_the_fedora_vendor_path() {
+        // Fedora ships polkit-1 only in /usr/lib/pam.d; without the vendor
+        // path, wire_service would skip it there instead of materializing the
+        // /etc override.
+        assert_eq!(POLKIT.etc, "/etc/pam.d/polkit-1");
+        assert_eq!(POLKIT.vendor, Some("/usr/lib/pam.d/polkit-1"));
+    }
+
     // Regression: 7ec33fa. Arch/Plasma ships the locker service only in
     // /usr/lib/pam.d, and LOCKSCREEN had vendor: None, so the lock screen was
     // skipped entirely on the Arch layout. The vendor path is what lets
@@ -1560,7 +1716,8 @@ mod tests {
     #[test]
     fn status_report_labels_and_login_wired_agree() {
         // The report's rows are the greeters, the fingerprint service, the lock
-        // screen, then sudo, in that order; labels come from the constant paths.
+        // screen, then sudo and polkit, in that order; labels come from the
+        // constant paths.
         let rows = status_report();
         let labels: Vec<&str> = rows.iter().map(|(l, _, _)| l.as_str()).collect();
         assert_eq!(
@@ -1575,6 +1732,7 @@ mod tests {
                 "gdm-fingerprint",
                 "kde",
                 "sudo",
+                "polkit",
             ]
         );
         // login_wired is exactly "any non-sudo row is wired" (sudo excluded).

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -251,7 +251,8 @@ fn remove_repo_files(dir: &str) {
 /// Run the four teardown steps in the lockout-safe order. Public so the TUI
 /// calls the identical sequence behind its own confirmation.
 pub fn perform_teardown(keep_data: bool) -> TeardownReport {
-    // 1. PAM FIRST. Un-wire every greeter, the lock screen, and sudo so no
+    // 1. PAM FIRST. Un-wire every greeter, the lock screen, sudo, and polkit
+    //    (disable puts the opt-in stacks in scope regardless of flags) so no
     //    stack references pam_irlume.so once the module is removed.
     let _ = pamwire::run(
         Some("disable"),

--- a/crates/irlume-core/src/biopolicy.rs
+++ b/crates/irlume-core/src/biopolicy.rs
@@ -15,8 +15,8 @@
 //! [`decide`] maps `(class, tier)` to an [`Action`]: release the sealed
 //! credential (`Unseal`), only verify identity without releasing it (`Verify`),
 //! or refuse (`Deny`). The headline rules: a credential is only released to a
-//! `Secure`-tier match, a screen-unlock never releases a credential, and an
-//! unknown / remote service is always denied.
+//! `Secure`-tier match, a screen-unlock or polkit prompt never releases a
+//! credential, and an unknown / remote service is always denied.
 //!
 //! This is pure logic with no I/O; the daemon consults it only when biopolicy
 //! enforcement is enabled (default off; see the daemon), so it never changes
@@ -40,8 +40,16 @@ pub enum OperationClass {
     /// A cold login at a display-manager greeter: releasing the sealed password
     /// lets the keyring/wallet open.
     Login,
-    /// Privilege elevation (sudo/polkit): verify identity; no keyring.
+    /// Privilege elevation (sudo/su): verify identity; no keyring.
     Elevation,
+    /// A polkit prompt approving an action for an application (Bitwarden vault
+    /// unlock, pkexec, systemd unit control). Verify-only, and the sealed
+    /// credential is NEVER released to it: the polkit agent starts the PAM
+    /// conversation the moment its dialog opens, with no user gesture, so this
+    /// class must not be able to pull anything out of the TPM. The engine also
+    /// forces the passive-liveness blink gate for it (see
+    /// [`requires_consent_gesture`]).
+    AppConsent,
     /// Remote access (sshd, etc.); face auth must never satisfy this.
     Remote,
     /// Unrecognised service; fail closed.
@@ -82,7 +90,10 @@ pub fn classify(service: &str, warm: bool) -> OperationClass {
             }
         }
         // Elevation.
-        "sudo" | "sudo-i" | "polkit-1" | "su" | "su-l" | "doas" => OperationClass::Elevation,
+        "sudo" | "sudo-i" | "su" | "su-l" | "doas" => OperationClass::Elevation,
+        // polkit's agent helper hardcodes pam_start("polkit-1", ...); "polkit"
+        // is kept for any downstream that renames the service file.
+        "polkit-1" | "polkit" => OperationClass::AppConsent,
         // Remote / network: never satisfiable by face.
         "sshd" | "remote" | "cockpit" => OperationClass::Remote,
         _ => OperationClass::Unknown,
@@ -96,12 +107,29 @@ pub fn decide(class: OperationClass, tier: Tier) -> Action {
         OperationClass::Remote | OperationClass::Unknown => Action::Deny,
         // A live-session unlock only needs identity, never a credential release.
         OperationClass::ScreenUnlock => Action::Verify,
+        // A polkit approval only needs identity, and only from the IR tier: an
+        // RGB-only match must not approve app actions (a printed photo held up
+        // to a webcam would satisfy every polkit prompt in the session).
+        OperationClass::AppConsent => match tier {
+            Tier::Secure => Action::Verify,
+            Tier::Convenience => Action::Deny,
+        },
         // Credential-releasing operations require the Secure (IR) tier.
         OperationClass::Login | OperationClass::Elevation => match tier {
             Tier::Secure => Action::Unseal,
             Tier::Convenience => Action::Deny,
         },
     }
+}
+
+/// True for classes where a face grant must additionally pass the passive
+/// blink gate even when the user's enrollment did not opt in. polkit agents
+/// (KDE, GNOME Shell) start the PAM conversation as soon as their dialog
+/// opens, so without this a face match completes with no user action at all;
+/// requiring a natural blink guarantees a live person is looking at the
+/// dialog that names what is being approved.
+pub fn requires_consent_gesture(class: OperationClass) -> bool {
+    matches!(class, OperationClass::AppConsent)
 }
 
 #[cfg(test)]
@@ -178,5 +206,31 @@ mod tests {
             decide(OperationClass::Elevation, Tier::Secure),
             Action::Unseal
         );
+    }
+
+    #[test]
+    fn polkit_verifies_but_never_unseals() {
+        // The B6 stance: a polkit prompt may be satisfied by a face match
+        // (verify) but must never release the TPM-sealed credential, on any
+        // tier, warm or cold.
+        for warm in [false, true] {
+            assert_eq!(classify("polkit-1", warm), OperationClass::AppConsent);
+        }
+        assert_eq!(
+            decide(OperationClass::AppConsent, Tier::Secure),
+            Action::Verify
+        );
+        assert_eq!(
+            decide(OperationClass::AppConsent, Tier::Convenience),
+            Action::Deny
+        );
+    }
+
+    #[test]
+    fn polkit_requires_the_consent_gesture_and_others_do_not() {
+        assert!(requires_consent_gesture(classify("polkit-1", false)));
+        for svc in ["sudo", "kde", "plasmalogin", "sshd", "nonsense"] {
+            assert!(!requires_consent_gesture(classify(svc, false)), "{svc}");
+        }
     }
 }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -857,6 +857,22 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     "face auth disabled: the configured method is fingerprint".into(),
                 );
             }
+            // ALWAYS-ON: a polkit prompt never releases the sealed credential,
+            // independent of the tier and the opt-in biopolicy below. The
+            // polkit agent runs its PAM conversation with no user gesture, so a
+            // `unseal`-arg line (mis)wired into polkit-1 must not be able to
+            // pull the login password out of the TPM; polkit gets verify-only
+            // (Authenticate).
+            {
+                use irlume_core::biopolicy::{classify, OperationClass};
+                let svc = service.as_deref().unwrap_or("");
+                if classify(svc, false) == OperationClass::AppConsent {
+                    eprintln!("irlumed: UnsealPassword refused for polkit service '{svc}' (verify-only class)");
+                    return Response::Error(format!(
+                        "'{svc}' is verify-only: a polkit prompt never releases the credential"
+                    ));
+                }
+            }
             // Smart-Auto: an RGB-only (convenience) device NEVER releases the
             // sealed credential: no cold-login / keyring unlock by RGB-only face.
             if engine.tier() == irlume_core::biopolicy::Tier::Convenience {
@@ -3053,6 +3069,28 @@ mod tests {
                 "RGB-only convenience: face cannot release the login credential"
             ),
             other => panic!("convenience tier must refuse unseal, got {other:?}"),
+        }
+        // A polkit service NEVER releases the credential, on any tier, with or
+        // without the opt-in biopolicy: the polkit agent starts its PAM
+        // conversation with no user gesture, so this fires before every other
+        // consideration except root and method.
+        for svc in ["polkit-1", "polkit"] {
+            match dispatch(
+                Request::UnsealPassword {
+                    user: "carol".into(),
+                    service: Some(svc.into()),
+                },
+                &peer(0),
+                &mut e,
+            ) {
+                Response::Error(msg) => assert_eq!(
+                    msg,
+                    format!(
+                        "'{svc}' is verify-only: a polkit prompt never releases the credential"
+                    )
+                ),
+                other => panic!("polkit unseal must be refused, got {other:?}"),
+            }
         }
     }
 

--- a/docs/APP-INTEGRATION.md
+++ b/docs/APP-INTEGRATION.md
@@ -1,0 +1,97 @@
+# App integration: face-approve polkit prompts (Bitwarden, pkexec)
+
+irlume can satisfy polkit authentication prompts, which is how desktop apps on
+Linux ask the OS to verify you. Bitwarden's "unlock with biometrics" is a
+polkit prompt; so are `pkexec`, GNOME Software's install dialog, and systemd
+unit operations from your desktop. Wire it once and every polkit prompt in
+your session accepts your face, with your password as the unchanged fallback.
+
+## How it works
+
+An app never talks to irlume, the camera, or your face templates. The chain
+is the same middleman model Windows Hello uses, built from standard Linux
+pieces:
+
+1. The app asks polkit for authorization
+   (`org.freedesktop.PolicyKit1.Authority.CheckAuthorization`). Bitwarden does
+   exactly this with its `com.bitwarden.Bitwarden.unlock` action.
+2. Your desktop's polkit agent (KDE or GNOME) opens its dialog, which names
+   the app and the action being approved, and starts a PAM conversation on the
+   `polkit-1` service.
+3. `pam_irlume` in that stack asks `irlumed` to verify your face. The daemon
+   requires a natural blink before it grants (see the security section), then
+   answers yes or no. The app learns only the verdict.
+
+Both the KDE and GNOME agents start the PAM conversation the moment the
+dialog appears, so the camera fires immediately and the dialog closes itself
+on a match: no typing, no clicking.
+
+## Enabling
+
+```console
+sudo irlume login enable --with-polkit --apply
+```
+
+This adds one verify-only line to the `polkit-1` PAM stack (Fedora gets an
+`/etc/pam.d/polkit-1` override of the vendor file; Debian and Arch get an
+edit-in-place with a `.pre-irlume` backup). `sudo irlume login disable
+--apply` removes it along with everything else, flag or no flag.
+
+Check the state any time:
+
+```console
+irlume login status     # shows a "polkit app prompts" row
+irlume doctor           # flags Bitwarden-installed-but-polkit-unwired
+```
+
+## Bitwarden specifics
+
+Bitwarden's desktop app needs its polkit action registered on the host. The
+non-sandboxed packages install it themselves ("set up biometric unlock" in
+Settings); the flatpak and snap cannot write to `/usr/share/polkit-1/actions`,
+so Bitwarden displays the one-time manual step in its settings. After that:
+
+- Unlock the vault once with your master password (Bitwarden holds the vault
+  key in protected memory; biometrics never replace the first unlock).
+- "Unlock with system authentication" then pops the polkit dialog, which your
+  face satisfies.
+- Browser-extension biometric unlock rides the same desktop app via native
+  messaging; enable "biometric unlock in browser" in the desktop settings.
+
+There is no Bitwarden-specific code in irlume. Any app using polkit this way
+works the same day it ships.
+
+## Security stance
+
+- **Verify-only, always.** The daemon refuses to release the TPM-sealed login
+  password to a polkit service unconditionally: not tier-dependent, not
+  config-dependent. A polkit prompt gets a yes/no and nothing else, so a
+  misconfigured or malicious stack cannot use a polkit dialog to extract a
+  credential.
+- **Blink required.** polkit agents run the PAM conversation with no user
+  gesture, so a bare face match would approve a prompt the user never
+  acknowledged. For polkit-class services the daemon forces the passive blink
+  gate (the same one `require-challenge` enrolls opt into) even for users who
+  did not opt in, and fails closed if the gate cannot run (no IR camera or no
+  FaceMesh model). Disable the extra blink with `polkit_gesture=0` in
+  `settings.conf` if you accept that trade.
+- **IR tier only.** RGB-only (convenience) devices never satisfy polkit
+  prompts; a printed photo in front of a webcam must not approve app actions.
+- **What this does not protect against.** Any process in your active session
+  can pop a polkit prompt at any time; the dialog itself is your notice of
+  what is being approved. Read it. This matches the Windows Hello model, where
+  the consent is your attention to the prompt on screen. The password prompt
+  remains for anything you decline or the camera cannot verify.
+
+## Troubleshooting
+
+- Prompt appears but the camera never fires: check `irlume login status` for
+  the polkit row, then `sudo ausearch -m avc -ts recent | grep irlume` on
+  SELinux systems; the shipped policy (1.1.0) grants the polkit helper domain
+  access to the daemon socket.
+- Face matches but the prompt stays: the blink gate wants a natural blink;
+  keep looking at the dialog for a moment. `irlume logs` shows the deny
+  reason.
+- Bitwarden says biometrics are unavailable: its polkit action file is
+  missing (`irlume doctor` reports this) or the desktop app needs the
+  Secret Service (GNOME Keyring / KWallet) running.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -52,7 +52,7 @@ Conventions that apply everywhere:
 
 | Command | Sudo | What it does |
 |---|---|---|
-| `irlume login <status\|enable\|disable> [--with-sudo] [--apply]` | yes | PAM wiring for the greeter and lock screen; `--with-sudo` adds face-`sudo`; without `--apply` it previews |
+| `irlume login <status\|enable\|disable> [--with-sudo] [--with-polkit] [--apply]` | yes | PAM wiring for the greeter and lock screen; `--with-sudo` adds face-`sudo`, `--with-polkit` adds app prompts (Bitwarden unlock, pkexec — see docs/APP-INTEGRATION.md); without `--apply` it previews |
 | `irlume logs [-f] [--since T]` | sometimes | the face-auth journal in one view (daemon, PAM, keyring); `-f` follows live, `--since "10 min ago"` widens the window |
 | `irlume logs debug <on\|off>` | yes | per-stage pipeline tracing in the daemon (numbers only, never frames) |
 | `irlume fingerprint <status\|add\|enable\|disable>` | for wiring | fprintd companion factor |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -180,6 +180,20 @@ The password still works for `sudo` too; face is `sufficient`, not required.
 Test it in a fresh terminal with `sudo -k` (clear the cached credential) then
 `sudo true`.
 
+## App prompts via polkit (optional)
+
+Desktop apps ask polkit to verify you; Bitwarden's biometric unlock and
+`pkexec` are polkit prompts. Opt in with:
+
+```sh
+sudo irlume login enable --with-polkit --apply
+```
+
+The daemon treats polkit as verify-only (it never releases the TPM-sealed
+credential to it) and requires a natural blink before approving, because the
+prompt starts scanning without any gesture from you. Full walkthrough,
+Bitwarden setup, and the security stance: [APP-INTEGRATION.md](APP-INTEGRATION.md).
+
 ## Fingerprint companion (optional)
 
 On a laptop with a fingerprint reader, add it as a second factor:

--- a/packaging/selinux/irlume.te
+++ b/packaging/selinux/irlume.te
@@ -1,4 +1,4 @@
-policy_module(irlume, 1.0.0)
+policy_module(irlume, 1.1.0)
 
 ########################################
 #
@@ -23,6 +23,7 @@ policy_module(irlume, 1.0.0)
 
 require {
 	type xdm_t;
+	type policykit_auth_t;
 	type unconfined_service_t;
 	type var_run_t;
 	class sock_file { create write unlink getattr setattr };
@@ -43,3 +44,13 @@ allow unconfined_service_t irlume_runtime_t:sock_file { create write unlink geta
 # The display manager / greeter may connect to irlumed to do face auth at login.
 allow xdm_t irlume_runtime_t:sock_file write;
 allow xdm_t unconfined_service_t:unix_stream_socket connectto;
+
+# polkit's PAM helper (polkit-agent-helper-1, domain policykit_auth_t) may
+# connect so a polkit prompt (Bitwarden unlock, pkexec) can be satisfied by
+# face verify. Same scoped grant as xdm_t: only irlume's socket, nothing else.
+# NOTE: when the helper is spawned setuid from an unconfined user session it
+# may stay unconfined (already allowed); this rule covers the confined domain
+# Fedora assigns it under the socket-activated polkit-agent-helper@.service
+# and any domtrans a future policy adds.
+allow policykit_auth_t irlume_runtime_t:sock_file write;
+allow policykit_auth_t unconfined_service_t:unix_stream_socket connectto;


### PR DESCRIPTION
## What

Third-party apps on Linux do "biometric unlock" through polkit: the app calls `CheckAuthorization`, the desktop's polkit agent runs the `polkit-1` PAM stack, and whatever that stack accepts approves the prompt. Bitwarden's biometric unlock is exactly this (their clients PR #4586). This PR wires irlume into that lane, opt-in:

```
sudo irlume login enable --with-polkit --apply
```

## Security design

- New `AppConsent` operation class for `polkit-1`: verify-only on the IR tier, denied on RGB-only hardware, and an **always-on** daemon refusal for `UnsealPassword` (independent of tier and the opt-in biopolicy). A polkit prompt can get a yes/no and nothing else.
- The polkit agents start the PAM conversation with zero user gesture the moment the dialog opens, so the engine **forces the passive blink gate** for this class even for enrollments that did not opt in, and **fails closed** when the gate cannot run. `polkit_gesture=0` in settings.conf is the escape hatch.
- This resolves gap-analysis item B6 as "verify-only + consent hardening" rather than refusal.

## Wiring

- Vendor-override strategy on Fedora (`/usr/lib/pam.d/polkit-1` → `/etc/pam.d/polkit-1`), edit-in-place with backup on Debian/Arch. Dedicated anchor logic: the stanza lands above `@include common-auth` too, and a file with no auth phase is skipped so pam_irlume can never become the only auth module (no lockout, ever).
- `disable` and uninstall always unwire regardless of flags (same promise as sudo).
- SELinux 1.1.0: `policykit_auth_t` gets the same scoped socket grant as `xdm_t`; `.pp` rebuilt.
- `login status` and the TUI report gain a polkit row; `doctor` flags a Bitwarden action file with no wiring.

## Testing

- 11 test binaries green, clippy clean, fmt clean. New tests: biopolicy classification + gesture forcing, daemon unseal refusal (both service spellings), engine fail-closed vs opt-in skip semantics, pamwire anchor/idempotence/reversal/no-anchor-skip, scope promises, status row.
- Dry run validated on the Zenbook (Fedora 44 KDE, wired plasmalogin/kde/sudo untouched; polkit override correctly planned from the vendor copy).
- **Not yet live-validated** (needs root + a face): apply on the Zenbook, KDE polkit dialog closes on face+blink for `pkexec true`, Bitwarden flatpak unlock after installing its polkit action, `ausearch -m avc` clean. Hardware validation checklist before merge, per project policy.

## Docs

`docs/APP-INTEGRATION.md` (flow, Bitwarden walkthrough incl. the flatpak manual action-install step, security stance, troubleshooting), README row, SETUP section, COMMANDS row, CHANGELOG.
