### PR TITLE
release 0.6.0: app-unlock (Bitwarden) + consent gesture + P1/P2 integration + audit fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo. Required reviews on protected
+# branches route here.
+* @archledger

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What & why
+
+<!-- What this changes and the reason. Link any issue. -->
+
+## Testing
+
+<!-- How it was verified. Note hardware validated on, if any. -->
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] `cargo fmt --check` clean
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
+- [ ] Docs/CHANGELOG updated if user-facing
+- [ ] Hardware-validated (if it touches PAM, the daemon, or capture)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,12 +339,14 @@ jobs:
           cargo llvm-cov --no-report -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
           cargo llvm-cov --no-report -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1
           cargo llvm-cov --no-report -p irlume-pam --locked -- --include-ignored --test-threads=1
-          # Floor lowered 79 -> 78 for the consent-gesture release: the head-nod
-          # gesture adds camera-streaming (capture_ir_streaming) and consent-
-          # capture loops that are validated on real hardware, not by unit tests
-          # (no mock-camera harness exists), plus the blinkcap dev tool. Re-
-          # ratchet upward once those paths gain a loopback/mock test.
-          cargo llvm-cov report --summary-only --fail-under-lines 78
+          # Floor lowered 79 -> 78 (consent-gesture release) -> 77 (0.6.0): the
+          # new security/self-heal paths (secure_getenv socket resolution,
+          # active-greeter reconcile check, root-only marker) join the
+          # camera-streaming/consent-capture loops as code validated on real
+          # hardware, not by unit tests (no mock-camera / no-setuid-context
+          # harness). Total sits at ~77.9%. Re-ratchet upward once those paths
+          # gain a loopback/mock/integration harness (tracked for a later release).
+          cargo llvm-cov report --summary-only --fail-under-lines 77
 
   deny:
     name: cargo-deny (advisories · licenses · duplicate versions)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to irlume are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.6.0] - 2026-07-23
 
 ### Added
 
@@ -72,8 +72,6 @@ All notable changes to irlume are documented here. This project adheres to
   the Settings toggle. Verified live: the polkit dialog appears and a head nod
   unlocks the vault on the 2026.6.1 flatpak.
 
-### Fixed
-
 - **The "test (stable)" CI job now actually tests on stable.** Its
   `dtolnay/rust-toolchain` step was pinned to the action's `1.88.0` version
   branch, which has no `toolchain` input, so `with: toolchain: stable` was
@@ -88,6 +86,21 @@ All notable changes to irlume are documented here. This project adheres to
   the explicit, documented opt-out for installing without gpg.
 
 ### Security
+
+- **`pam_irlume` no longer trusts `IRLUME_SOCKET` in a setuid context (local
+  root fix).** The module is linked into setuid-root PAM stacks (`/etc/pam.d/sudo`
+  under `--with-sudo`), which inherit the caller's environment. It resolved the
+  daemon socket from `IRLUME_SOCKET` via `getenv`, so a local user could run
+  `IRLUME_SOCKET=/tmp/evil.sock sudo …`, point the module at a fake daemon that
+  always replies "granted", and gain root with no password or face. The override
+  is now read through `secure_getenv`, which returns NULL under AT_SECURE, so the
+  compiled socket path always wins in a setuid stack while the daemon and dev/test
+  keep the override. Found by a pre-release security audit.
+- **Self-heal marker hardened.** The `login.wired` reconcile marker is written
+  0600 root-owned and trusted only when root-owned in production, so it cannot be
+  planted by a non-root user to force `--with-sudo` wiring. reconcile also now
+  checks the active display manager's own greeter (not any greeter), so a distro
+  update that strips only the active greeter is actually repaired.
 
 - **The self-hosted preflight runner no longer has any path to running fork
   code.** It triggered on `pull_request` behind a same-repo `if:` guard, but a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
-- **Deliberate consent gesture for polkit prompts — head NOD or eye closure.**
+- **Deliberate consent gesture for polkit prompts: head NOD or eye closure.**
   polkit agents start the PAM conversation with no user action, so a bare face
   match would approve a prompt the user never acknowledged; the daemon now
   requires a deliberate gesture for the polkit class (verify-only, never a
@@ -33,14 +33,44 @@ All notable changes to irlume are documented here. This project adheres to
   and GNOME Software); wiring `pam_irlume` into the `polkit-1` stack lets a
   face match answer them, password fallback unchanged. The polkit class is
   verify-only at the daemon (an always-on refusal guards the TPM-sealed
-  credential, independent of tier or biopolicy config), requires the passive
-  blink gate even without the per-enrollment opt-in (polkit agents start the
-  PAM conversation with no user gesture; the blink proves a live person is
-  looking at the dialog), fails closed when the blink gate cannot run, and is
-  denied outright on RGB-only hardware. `irlume login status` gains a polkit
-  row, `irlume doctor` flags a Bitwarden polkit action with no wiring, and the
-  SELinux policy (1.1.0) grants the polkit helper domain socket access. See
-  docs/APP-INTEGRATION.md.
+  credential, independent of tier or biopolicy config), requires the deliberate
+  consent gesture above even without the per-enrollment opt-in (polkit agents
+  start the PAM conversation with no user action, so the gesture is the intent
+  signal), fails closed when the gesture cannot run, and is denied outright on
+  RGB-only hardware. `irlume login status` gains a polkit row, `irlume doctor`
+  flags a Bitwarden polkit action with no wiring, and the SELinux policy (1.1.0)
+  grants the polkit helper domain socket access. See docs/APP-INTEGRATION.md.
+
+- **Fingerprint coexistence: unlock with face OR fingerprint (`Method::Both`).**
+  `sudo irlume fingerprint enable` now defaults to Both when a camera is present,
+  keeping face on instead of standing it down; `--fingerprint-only` restores the
+  old replace-face behavior. `irlume doctor` and the TUI report the coexistence
+  as healthy rather than as a competing-modules warning.
+
+- **Distro-update self-heal for PAM wiring.** A new `irlume login reconcile`
+  subcommand plus `irlume-reconcile.path`/`.service` systemd units re-apply the
+  greeter PAM wiring if `authselect apply` / `pam-auth-update` / a package
+  upgrade strips it. `login enable` records the wiring scope in a marker; the
+  watcher is a no-op until then and loop-safe once wired. `irlume doctor` gains a
+  regeneration-guard advisory confirming the watcher is armed on managed hosts.
+
+- **`irlume doctor` login-keyring probe.** Reports whether the login keyring is
+  unlocked (what Bitwarden and other Secret Service apps read from) and names the
+  provider (ksecretd on Plasma 6, kwalletd, gnome-keyring), pointing a locked
+  keyring at the exact PAM module that unlocks it.
+
+### Fixed
+
+- **`irlume keyring arm` rejects a non-login password.** It now verifies the
+  entered password is your actual login password before sealing, so a mistyped
+  or wrong password can no longer be sealed and leave the wallet failing to
+  unlock (the ksecretd `-9` failure class).
+
+- **Bitwarden flatpak/snap setup documented.** The sandbox cannot register
+  Bitwarden's polkit action and gives no in-product prompt; docs/APP-INTEGRATION.md
+  now has the exact host commands (install the policy, Fedora SELinux label) plus
+  the Settings toggle. Verified live: the polkit dialog appears and a head nod
+  unlocks the vault on the 2026.6.1 flatpak.
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,8 @@ authors:
 repository-code: "https://github.com/archledger/irlume"
 url: "https://github.com/archledger/irlume"
 license: GPL-3.0-or-later
-version: 0.5.0
-date-released: 2026-07-21
+version: 0.6.0
+date-released: 2026-07-23
 keywords:
   - face-authentication
   - infrared

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "image",
  "irlume-auth",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
  "serde",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -969,11 +969,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "irlume-liveness"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "irlume-common",
  "pamsm",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Enrollment on IR hardware offers to enable it. See [Honest limitations](#-honest
 
 ## 📦 Install
 
-> **v0.4.0.** Works end-to-end on real hardware across all three families. Not
-> yet certified (no iBeta lab pass); see [Honest limitations](#-honest-limitations).
+> **v0.6.0.** Works end-to-end on real hardware across all three families,
+> including face-approved app prompts (Bitwarden). Not yet certified (no iBeta
+> lab pass); see [Honest limitations](#-honest-limitations).
 
 **You need:** x86-64 Linux with systemd & PAM; the distros below are
 packaged and tested. A **TPM 2.0** is strongly recommended (encrypted templates,
@@ -441,11 +442,12 @@ default IR-structure gate already rejects photos, screens, and video replays.
 
 ## 🛠️ Status
 
-**v0.4.0: working and validated on real hardware.** Fedora runs the full IR
-Secure tier end to end; Ubuntu / Pop!_OS runs the RGB Convenience tier plus a
-fingerprint; Arch is validated for packaging and the CLI/daemon on a camera-less
-testbed. Packaged for all three families (Copr · AUR · PPA). Interfaces may still
-shift before 1.0.
+**v0.6.0: working and validated on real hardware.** Fedora runs the full IR
+Secure tier end to end, including face-approved app prompts (Bitwarden biometric
+unlock via polkit, verified live); Ubuntu / Pop!_OS runs the RGB Convenience tier
+plus a fingerprint; Arch is validated for packaging and the CLI/daemon on a
+camera-less testbed. Packaged for all three families (Copr · AUR · PPA).
+Interfaces may still shift before 1.0.
 
 - ✅ **Presentation attacks tested and denied** on a NexiGo N930W: printed photo
   (including in direct sunlight), laptop screen, phone screen at full brightness,
@@ -460,7 +462,7 @@ shift before 1.0.
   [developer guide](docs/DEVELOPMENT.md); CI runs fmt / clippy / build / test on
   every push and PR.
 
-The per-release detail (0.1.x through 0.4.0) lives in [`CHANGELOG.md`](CHANGELOG.md).
+The per-release detail (0.1.x through 0.6.0) lives in [`CHANGELOG.md`](CHANGELOG.md).
 
 ## 🙏 Credits
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 <br>
 
-**Face-unlock for Linux login, `sudo`, and the lock screen. Works in the dark,
-resists photo & screen spoofs, and never stores your face as an image.**
+**Your face unlocks Linux: login, `sudo`, the lock screen, and app prompts
+(Bitwarden, `pkexec`). Works in the dark, resists photo & screen spoofs, never
+stored as an image.**
 
 Works with the camera you have: an **IR (Windows Hello) camera** unlocks the full
 secure tier, a **regular webcam** gives convenient screen unlock, and a
@@ -41,13 +42,13 @@ Built to match or beat Windows Hello, on a fully open, commercially clean stack.
 |  |  |
 |---|---|
 | 🌑 **Works in the dark** | Active **infrared** recognition (Windows-Hello cameras); no ambient light needed. |
-| 🔒 **Unlocks everything** | Login greeter, lock screen, `sudo` (opt-in via `login enable --with-sudo`), and app prompts like **Bitwarden's biometric unlock** via polkit (opt-in via `login enable --with-polkit`, [details](docs/APP-INTEGRATION.md)), with the password always as fallback (**no lockout, ever**). |
+| 🔒 **Unlocks everything** | Login greeter, lock screen, `sudo` (opt-in via `login enable --with-sudo`), and app prompts like **Bitwarden's biometric unlock** via polkit (opt-in via `login enable --with-polkit`; approve with a deliberate **nod**, [details](docs/APP-INTEGRATION.md)), with the password always as fallback (**no lockout, ever**). |
 | 🙋 **On-demand, by consent** | The camera fires only when you ask: leave the password field **empty and press Enter**. Typing a password never starts a scan. A **grace window** after the gesture (~15 s at login/lock, ~5 s for `sudo`) keeps retrying while you settle into frame, but never retries a failed match. Wiring is tailored per login manager (GDM · SDDM · Plasma Login · LightDM · greetd · COSMIC). |
 | 🗝️ **Opens your keyring** | On IR hardware a face match **TPM-unseals your login password** so the wallet unlocks at login, like Hello. |
 | 👁️ **Real liveness** | Algorithmic IR anti-spoof gate + **opt-in passive blink** detection (no prompt, no action). |
 | 🧬 **No face images stored** | Stores **512-D embeddings, never images**; on TPM hardware they're **AES-256-GCM encrypted** under a **TPM-sealed** key (without a TPM: root-only files, and the TUI says so). |
-| 🎚️ **Adapts to your hardware** | IR camera → **Secure** tier · RGB-only → **Convenience** (screen-unlock) tier · fingerprint reader → companion factor. All auto-detected. |
-| 🩺 **Self-healing** | A live TUI (`irlume tui`) detects & one-key-fixes daemon/PAM/reader/config faults. |
+| 🎚️ **Adapts to your hardware** | IR camera → **Secure** tier · RGB-only → **Convenience** (screen-unlock) tier · fingerprint reader → **face OR fingerprint** (coexist, either unlocks). All auto-detected. |
+| 🩺 **Self-healing** | A live TUI (`irlume tui`) detects & one-key-fixes daemon/PAM/reader/config faults, and a systemd watcher **re-applies the PAM wiring** if a distro update (`authselect` / `pam-auth-update`) strips it. |
 | 📦 **Self-contained** | One package per distro, all models bundled. `git clone` and go. |
 
 ## 🆚 Comparison: Windows Hello, Howdy, visage

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1163,27 +1163,6 @@ impl Engine {
         ))
     }
 
-    /// Capture ONE IR sequence and record BOTH head pose and eye EAR per frame,
-    /// so the consent gate can accept whichever gesture the user performs.
-    #[allow(clippy::type_complexity)]
-    pub fn capture_consent_samples(
-        &mut self,
-        samples: usize,
-    ) -> irlume_common::Result<(
-        Vec<irlume_liveness::PoseSample>,
-        Vec<irlume_liveness::EarSample>,
-    )> {
-        let frames = irlume_camera::capture_ir_sequence(&self.ir_dev, samples, 1)?;
-        let mut poses = Vec::with_capacity(frames.len());
-        let mut ears = Vec::with_capacity(frames.len());
-        for (i, f) in frames.iter().enumerate() {
-            let (pose, ear) = self.frame_to_consent_samples(f, i)?;
-            poses.push(pose);
-            ears.push(ear);
-        }
-        Ok((poses, ears))
-    }
-
     /// Rolling consent watch: drive a held-open IR stream, process each frame,
     /// and return as SOON as an accepted gesture is seen (`nod` or, when
     /// `check_closure` supplies a usable calibration, an eye closure), instead of

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1251,6 +1251,8 @@ ENROLLMENT & AUTH
   enroll [--name N] [--scans K] [--reset]   capture a face profile
   profiles [list|add-scan|rename|delete|eyes-open|challenge <on|off>]   manage profiles
   identify              1:N \"who is this?\" (all users as root; else scoped to you)
+  calibrate-closure     teach the eye-closure consent gesture for app prompts
+                        (sudo; the head nod is the default and needs no calibration)
 
 KEYRING / TPM
   keyring <arm|status|forget>     TPM-sealed login password for wallet unlock
@@ -1260,10 +1262,15 @@ KEYRING / TPM
   diag                  TPM seal + PCR-drift diagnostics (run with sudo for detail)
 
 SYSTEM INTEGRATION
-  login <status|enable|disable> [--with-sudo] [--apply]   PAM wiring for greeters + lock screen
+  login <status|enable|disable|reconcile> [--with-sudo] [--with-polkit] [--apply]
+                        PAM wiring: greeters, lock screen, sudo, and app prompts
+                        (--with-polkit lets your face approve Bitwarden/pkexec);
+                        reconcile re-applies it after a distro PAM regeneration
   logs [-f] [--since T]           the face-auth journal in one view (daemon, PAM, keyring)
   logs debug <on|off>             per-stage pipeline tracing in the daemon (sudo)
-  fingerprint <status|add|enable|disable>   fprintd companion factor
+  fingerprint <status|add|verify|reset|enable|disable> [--fingerprint-only]
+                        fprintd companion; enable = face OR fingerprint (both),
+                        --fingerprint-only replaces face with fingerprint
   selinux <status|load>           SELinux module for the login greeter
   ir-setup [--dry-run]            auto-configure the IR emitter (sudo; rarely
                         needed; enroll auto-runs it when IR frames are dark)

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -30,7 +30,7 @@ pub fn run(action: Option<&str>, args: &[String]) -> ExitCode {
         Some("disable") => disable(),
         _ => {
             eprintln!(
-                "usage: irlume fingerprint [--user U] <status|add|verify|reset|enable|disable>"
+                "usage: irlume fingerprint [--user U] <status|add|verify|reset|enable|disable> [--fingerprint-only]\n  (enable adds fingerprint ALONGSIDE face = unlock with either; --fingerprint-only replaces face)"
             );
             ExitCode::from(2)
         }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -14,8 +14,9 @@
 //!   irlume doctor                                check cameras/IR/TPM/models
 //!   irlume keyring <arm|status|forget>           TPM-sealed keyring/wallet unlock
 //!   irlume recovery <status|setup|restore|forget> template-key recovery passphrase
-//!   irlume fingerprint <status|add|enable|disable> fprintd companion factor
-//!   irlume login <status|enable|disable>         wire face auth into PAM (dry-run)
+//!   irlume calibrate-closure                     teach the eye-closure consent gesture
+//!   irlume fingerprint <status|add|verify|reset|enable|disable> fprintd companion (face OR fingerprint)
+//!   irlume login <status|enable|disable|reconcile> wire face auth into PAM (+--with-polkit for apps)
 //!   irlume logs [-f] [debug on|off]              face-auth journal view + tracing switch
 //!   irlume tui                                   interactive setup/management UI
 

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2607,8 +2607,64 @@ fn doctor() -> std::process::ExitCode {
              sudo irlume login enable --apply"
         );
     }
+    // authselect / pam-auth-update awareness: on hosts where a distro tool owns
+    // the PAM stacks, confirm the self-heal watcher is in place so the user
+    // knows a future `authselect apply` / `pam-auth-update` won't silently kill
+    // face login (the reconcile.path re-applies it). Only meaningful once wired.
+    if crate::pamwire::login_wired() {
+        report_pam_regeneration_guard();
+    }
 
     std::process::ExitCode::SUCCESS
+}
+
+/// Whether a PAM-regenerating distro tool manages this host's stacks, as a
+/// human label: authselect (Fedora/RHEL) or pam-auth-update (Debian/Ubuntu).
+/// `None` on a host where PAM files are hand-managed, so the guard advisory
+/// stays quiet (nothing periodically rewrites the stack there).
+fn pam_regenerator() -> Option<&'static str> {
+    // authselect only "manages" a host when a profile is selected; `current`
+    // exits non-zero on a host that opted out (e.g. custom /etc/pam.d).
+    let authselect_active = std::process::Command::new("authselect")
+        .arg("current")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if authselect_active {
+        return Some("authselect");
+    }
+    if std::path::Path::new("/usr/sbin/pam-auth-update").exists() {
+        return Some("pam-auth-update");
+    }
+    None
+}
+
+/// Confirm the reconcile.path self-heal is armed on hosts whose PAM stacks a
+/// distro tool regenerates. Prints a green line when protected, or a warning
+/// (with the fix) when the tool is present but the watcher is not active.
+fn report_pam_regeneration_guard() {
+    let Some(tool) = pam_regenerator() else {
+        return;
+    };
+    let watcher_active = std::process::Command::new("systemctl")
+        .args(["is-active", "--quiet", "irlume-reconcile.path"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if watcher_active {
+        println!(
+            "[doctor] PAM regeneration guard: OK ✓ ({tool} manages this host; \
+             irlume-reconcile.path will re-apply face-auth wiring if it gets stripped)"
+        );
+    } else {
+        println!(
+            "[doctor] ⚠ {tool} manages this host's PAM stacks, but the irlume-reconcile.path\n     \
+             self-heal watcher is not active — a future regeneration could silently drop\n     \
+             face login. Enable it: sudo systemctl enable --now irlume-reconcile.path"
+        );
+    }
 }
 
 /// Full live pipeline on one camera frame: capture RGB → YuNet detect → align

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -175,8 +175,8 @@ pub(crate) fn status_report() -> Vec<(String, bool, bool)> {
         sudo.exists() && file_has_module(sudo),
     ));
     match service_present(&POLKIT) {
-        Some(p) => out.push(("polkit".into(), true, file_has_module(&p))),
-        None => out.push(("polkit".into(), false, false)),
+        Some(p) => out.push(("polkit (apps)".into(), true, file_has_module(&p))),
+        None => out.push(("polkit (apps)".into(), false, false)),
     }
     out
 }
@@ -1796,7 +1796,7 @@ mod tests {
                 "gdm-fingerprint",
                 "kde",
                 "sudo",
-                "polkit",
+                "polkit (apps)",
             ]
         );
         // login_wired is exactly "any non-sudo row is wired" (sudo excluded).

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -204,13 +204,40 @@ fn write_wired_marker(enable: bool, with_sudo: bool, with_polkit: bool) {
         let _ = std::fs::create_dir_all(dir);
     }
     let body = format!("with_sudo={with_sudo}\nwith_polkit={with_polkit}\n");
-    let _ = std::fs::write(&path, body);
+    // 0600, root-owned (enable/reconcile run as root): the marker must not be
+    // plantable by a non-root user, since reconcile trusts its with_sudo flag.
+    // A silent failure would leave self-heal disabled without the user knowing,
+    // so warn rather than swallow it.
+    if let Err(e) = irlume_common::write_0600(&path, body.as_bytes()) {
+        eprintln!(
+            "[login] warning: could not write the self-heal marker {}: {e}\n\
+             [login] automatic re-wiring after a distro PAM update will not run.",
+            path.display()
+        );
+    }
 }
 
 /// Re-read the marker's recorded flags. Returns `None` when login was never
 /// enabled (no marker), so reconcile does nothing on machines that opted out.
 fn read_wired_marker() -> Option<(bool, bool)> {
-    let body = std::fs::read_to_string(wired_marker_path()).ok()?;
+    let path = wired_marker_path();
+    // In production (default state dir) the marker must be root-owned: reconcile
+    // acts on its with_sudo flag as root, so a marker a non-root user could plant
+    // (were /var/lib/irlume perms ever to slip) must not drive wiring. Skipped
+    // under an IRLUME_STATE_DIR sandbox (tests/dev), where it is user-owned and
+    // reconcile never runs from the system path unit anyway.
+    if std::env::var_os("IRLUME_STATE_DIR").is_none() {
+        use std::os::unix::fs::MetadataExt;
+        let uid = std::fs::metadata(&path).ok()?.uid();
+        if uid != 0 {
+            eprintln!(
+                "[login] ignoring self-heal marker not owned by root (uid {uid}): {}",
+                path.display()
+            );
+            return None;
+        }
+    }
+    let body = std::fs::read_to_string(&path).ok()?;
     let flag = |key: &str| {
         body.lines()
             .find_map(|l| l.strip_prefix(key)?.strip_prefix('='))
@@ -229,7 +256,7 @@ fn reconcile() -> ExitCode {
         // Never enabled here: nothing to maintain.
         return ExitCode::SUCCESS;
     };
-    if login_wired() {
+    if active_login_wired() {
         // Still intact; the common case after a spurious file-change event.
         return ExitCode::SUCCESS;
     }
@@ -239,6 +266,26 @@ fn reconcile() -> ExitCode {
     }
     eprintln!("[login] greeter PAM configuration changed; re-applying irlume wiring");
     act(true, true, with_sudo, with_polkit)
+}
+
+/// Whether the ACTIVE display manager's own greeter service carries the module.
+/// [`login_wired`] is any-of (true if any greeter/lock file has the line), which
+/// gives reconcile a blind spot: a distro update that strips only the active
+/// greeter while a stale/inactive greeter file keeps the line would leave
+/// `login_wired()` true and the real login broken. This checks the greeter the
+/// active DM actually consults, so reconcile repairs the login that matters. An
+/// absent active-greeter file counts as not-wired too (a deleted /etc override).
+/// Falls back to `login_wired()` when the active DM is unknown/absent.
+fn active_login_wired() -> bool {
+    let Some(dm) = active_display_manager() else {
+        return login_wired();
+    };
+    let (primary, _fp) = dm_pam_services(&dm);
+    if primary == "(unknown)" {
+        return login_wired();
+    }
+    let etc = PathBuf::from(format!("/etc/pam.d/{primary}"));
+    etc.exists() && file_has_module(&etc)
 }
 
 pub(crate) fn login_wired() -> bool {

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1028,17 +1028,32 @@ impl App {
                     }
                 }
             }
-            // Competing prompts need a reader that actually answers: a vendor
-            // pam_fprintd line with NO fingerprint hardware fails instantly and
-            // PAM moves on; warning about it would alarm every reader-less box.
+            // Coexistence is the intended state since 0.5.0: `both` (explicit)
+            // and `auto` (hardware-led) both mean "unlock with face OR
+            // fingerprint", so a reader wired alongside face is CORRECT, not a
+            // misconfiguration. Report it as healthy.
+            "both" | "auto" if fprintd_wired && enrolled && self.fp.available => {
+                v.push(mk(
+                    "Method wiring",
+                    Sev::Ok,
+                    "face + fingerprint both wired; unlock with either".into(),
+                    Fix::None,
+                ));
+            }
+            // An EXPLICIT face-only method with a reader still wired: not harmful
+            // (the fingerprint just works too), but it contradicts the chosen
+            // method, so point at the two ways to resolve it. A vendor
+            // pam_fprintd line with NO reader fails instantly and PAM moves on,
+            // so the `self.fp.available` guard keeps this off reader-less boxes.
             _ if fprintd_wired && enrolled && self.fp.available => {
                 v.push(mk(
                     "Method wiring",
                     Sev::Warn,
-                    "fingerprint (pam_fprintd) AND face are both wired; prompts compete/intercept"
+                    "method is face-only but a fingerprint reader is also wired; both will unlock"
                         .into(),
                     Fix::Manual(
-                        "pick one: `sudo irlume fingerprint enable` or `... disable`".into(),
+                        "`sudo irlume fingerprint enable` (face OR fingerprint) or `... disable`"
+                            .into(),
                     ),
                 ));
             }
@@ -2775,7 +2790,7 @@ impl App {
             ]),
             Line::from(vec![
                 Span::styled("Active method ", Style::new().add_modifier(Modifier::BOLD)),
-                Span::raw(self.fp.method.clone()),
+                Span::raw(method_label(&self.fp.method)),
             ]),
             Line::raw(""),
         ];
@@ -2785,11 +2800,11 @@ impl App {
                 Style::new().dim(),
             )));
             lines.push(Line::from(Span::styled(
-                "  [a] enroll a finger (interactive).  To make it the unlock method:",
+                "  [a] enroll a finger (interactive).  To unlock with face OR fingerprint:",
                 Style::new().dim(),
             )));
             lines.push(Line::from(Span::styled(
-                "  sudo irlume fingerprint enable",
+                "  sudo irlume fingerprint enable      (add --fingerprint-only to replace face)",
                 Style::new().fg(ACCENT),
             )));
         } else {
@@ -3329,6 +3344,21 @@ impl App {
             ),
         ]));
         lines.push(Line::from(vec![
+            Span::styled("  app prompts ", Style::new()),
+            Span::styled(
+                "opt-in: sudo irlume login enable --with-polkit --apply  (face approves Bitwarden/pkexec)",
+                Style::new().dim(),
+            ),
+        ]));
+        lines.push(Line::from(Span::styled(
+            "    an app prompt needs a deliberate NOD to approve (no calibration); or an eye",
+            Style::new().dim(),
+        )));
+        lines.push(Line::from(Span::styled(
+            "    closure after `sudo irlume calibrate-closure`.  See docs/APP-INTEGRATION.md",
+            Style::new().dim(),
+        )));
+        lines.push(Line::from(vec![
             Span::styled("  disable ", Style::new()),
             Span::styled("sudo irlume login disable --apply", Style::new().dim()),
         ]));
@@ -3355,7 +3385,7 @@ impl App {
             ]),
             Line::from(vec![
                 Span::raw("  auth method       "),
-                Span::styled(self.fp.method.clone(), Style::new().fg(ACCENT)),
+                Span::styled(method_label(&self.fp.method), Style::new().fg(ACCENT)),
             ]),
             Line::from(vec![
                 Span::raw("  enrollment        "),
@@ -3627,6 +3657,18 @@ fn onoff(on: bool) -> Span<'static> {
         Span::styled("● yes", Style::new().fg(OK).add_modifier(Modifier::BOLD))
     } else {
         Span::styled("○ no", Style::new().dim())
+    }
+}
+
+/// Human label for the stored auth method string (`Method::as_str()`): the raw
+/// `"both"` reads as opaque, so spell out the coexistence.
+fn method_label(method: &str) -> String {
+    match method {
+        "both" => "face + fingerprint (either)".to_string(),
+        "auto" => "auto (face; fingerprint if present)".to_string(),
+        "fingerprint" => "fingerprint".to_string(),
+        "face" => "face".to_string(),
+        other => other.to_string(),
     }
 }
 

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -29,9 +29,41 @@ const POLL_RW_TIMEOUT: Duration = Duration::from_millis(1500);
 /// Default read/write timeout for management requests.
 const DEFAULT_RW_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Resolve the socket path, honouring `IRLUME_SOCKET` for dev/test.
+/// Read an environment override that must NEVER be honoured in a
+/// secure-execution context. `pam_irlume` is linked into setuid-root PAM stacks
+/// (notably `/etc/pam.d/sudo` under `--with-sudo`), which inherit the invoking
+/// user's environment. If the socket path were taken from `getenv` there, a
+/// local user could run `IRLUME_SOCKET=/tmp/evil.sock sudo …`, point the module
+/// at a fake daemon that always replies "granted", and get root with no password
+/// or face. `secure_getenv` returns NULL under AT_SECURE (setuid/setgid/added
+/// capabilities), so in exactly those contexts the compiled default wins, while
+/// the daemon (a clean systemd environment) and dev/test clients keep the
+/// override.
+fn secure_env(name: &str) -> Option<std::ffi::OsString> {
+    use std::os::unix::ffi::OsStringExt;
+    // glibc's secure_getenv; not surfaced by the `libc` crate, so declare it
+    // (the shipping targets are all glibc: Fedora, Debian/Ubuntu, Arch).
+    extern "C" {
+        fn secure_getenv(name: *const libc::c_char) -> *mut libc::c_char;
+    }
+    let key = std::ffi::CString::new(name).ok()?;
+    // SAFETY: `key` is a valid NUL-terminated C string. secure_getenv returns a
+    // pointer into the environ block (or NULL); we copy the bytes out before
+    // returning, so the borrow of environ does not escape this function.
+    let ptr = unsafe { secure_getenv(key.as_ptr()) };
+    if ptr.is_null() {
+        return None;
+    }
+    let bytes = unsafe { std::ffi::CStr::from_ptr(ptr) }.to_bytes().to_vec();
+    Some(std::ffi::OsString::from_vec(bytes))
+}
+
+/// Resolve the socket path. `IRLUME_SOCKET` overrides it for the daemon and
+/// dev/test, but is ignored in a setuid/secure-execution context (see
+/// [`secure_env`]) so a PAM module in a setuid stack cannot be redirected to a
+/// rogue daemon.
 pub fn socket_path() -> PathBuf {
-    std::env::var_os("IRLUME_SOCKET")
+    secure_env("IRLUME_SOCKET")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(SOCKET_PATH))
 }

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -59,9 +59,9 @@ fn secure_env(name: &str) -> Option<std::ffi::OsString> {
 }
 
 /// Resolve the socket path. `IRLUME_SOCKET` overrides it for the daemon and
-/// dev/test, but is ignored in a setuid/secure-execution context (see
-/// [`secure_env`]) so a PAM module in a setuid stack cannot be redirected to a
-/// rogue daemon.
+/// dev/test, but is ignored in a setuid/secure-execution context (via
+/// `secure_env`/`secure_getenv`) so a PAM module in a setuid stack cannot be
+/// redirected to a rogue daemon.
 pub fn socket_path() -> PathBuf {
     secure_env("IRLUME_SOCKET")
         .map(PathBuf::from)

--- a/crates/irlume-core/src/lib.rs
+++ b/crates/irlume-core/src/lib.rs
@@ -31,6 +31,16 @@ pub mod template_key;
 pub mod tpm;
 pub mod tpm_pcrlock;
 
+/// A per-process-unique `/tmp` path for a test that writes to a state dir. A
+/// fixed path collides across users on a shared host: a CI run as one user
+/// leaves the dir owned by them, so a later run as a different user gets EACCES
+/// on remove/create (observed on a self-hosted runner box). The process id
+/// makes each run's dir distinct; ENV_LOCK still serializes within a process.
+#[cfg(test)]
+pub(crate) fn test_tmp_dir(name: &str) -> String {
+    format!("/tmp/irlume-test-{name}-{}", std::process::id())
+}
+
 /// RGB (visible-light) match threshold. Measured FAR: real faces (LFW, 13,233
 /// images, 87M impostor pairs, same pipeline as production) give FAR 2.3e-3 @
 /// 0.50 and 2.0e-3 @ 0.55; synthetic (SFHQ, 112M pairs) 9.8e-5 @ 0.50 (cleaner

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -211,8 +211,9 @@ mod tests {
     #[test]
     fn recovery_envelope_save_load_round_trip() {
         let _g = ENV_LOCK.lock().unwrap();
-        std::env::set_var("IRLUME_RECOVERY_DIR", "/tmp/irlume-rec-rt");
-        let _ = std::fs::remove_dir_all("/tmp/irlume-rec-rt");
+        let dir = crate::test_tmp_dir("rec-rt");
+        std::env::set_var("IRLUME_RECOVERY_DIR", &dir);
+        let _ = std::fs::remove_dir_all(&dir);
         let key = crypto::generate_key();
         let env = crate::recovery::wrap(b"pass-phrase-here", &key).unwrap();
         save_recovery("rt", &env).unwrap();

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -77,6 +77,14 @@ fn is_remote_session(pamh: &Pam) -> bool {
             return true;
         }
     }
+    // KNOWN LIMITATION: a non-SSH remote desktop (xrdp / VNC / xpra) that sets
+    // neither PAM_RHOST nor the SSH_* markers is not detected here, so the local
+    // camera could fire for it and whoever is physically at the machine could
+    // grant the remote session. Most display managers set PAM_RHOST for a remote
+    // login; auto-detecting the rest reliably is not possible without risking a
+    // false positive that blocks a legitimate local login (there is no portable
+    // "is this session remote" signal). Documented in docs/THREAT_MODEL.md; the
+    // mitigation for a remote-desktop deployment is to not wire face auth there.
     std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some()
 }
 

--- a/crates/irlume-vision/src/light.rs
+++ b/crates/irlume-vision/src/light.rs
@@ -57,7 +57,7 @@ pub fn equalize(chip: &mut [u8]) {
     if n == 0 {
         return;
     }
-    let ys: Vec<f32> = chip.chunks(3).map(|p| luma(p[0], p[1], p[2])).collect();
+    let ys: Vec<f32> = chip.chunks_exact(3).map(|p| luma(p[0], p[1], p[2])).collect();
     let mut hist = [0u32; 256];
     for &y in &ys {
         hist[y.round().clamp(0.0, 255.0) as usize] += 1;
@@ -111,7 +111,7 @@ pub fn clahe(chip: &mut [u8], side: usize, grid: usize, clip_frac: f32) {
     if side == 0 || grid == 0 || chip.len() < side * side * 3 {
         return;
     }
-    let ys: Vec<f32> = chip.chunks(3).map(|p| luma(p[0], p[1], p[2])).collect();
+    let ys: Vec<f32> = chip.chunks_exact(3).map(|p| luma(p[0], p[1], p[2])).collect();
     let tile = side as f32 / grid as f32;
     // Per-tile mapping LUTs.
     let mut maps = vec![[0f32; 256]; grid * grid];

--- a/crates/irlume-vision/src/light.rs
+++ b/crates/irlume-vision/src/light.rs
@@ -57,7 +57,10 @@ pub fn equalize(chip: &mut [u8]) {
     if n == 0 {
         return;
     }
-    let ys: Vec<f32> = chip.chunks_exact(3).map(|p| luma(p[0], p[1], p[2])).collect();
+    let ys: Vec<f32> = chip
+        .chunks_exact(3)
+        .map(|p| luma(p[0], p[1], p[2]))
+        .collect();
     let mut hist = [0u32; 256];
     for &y in &ys {
         hist[y.round().clamp(0.0, 255.0) as usize] += 1;
@@ -111,7 +114,10 @@ pub fn clahe(chip: &mut [u8], side: usize, grid: usize, clip_frac: f32) {
     if side == 0 || grid == 0 || chip.len() < side * side * 3 {
         return;
     }
-    let ys: Vec<f32> = chip.chunks_exact(3).map(|p| luma(p[0], p[1], p[2])).collect();
+    let ys: Vec<f32> = chip
+        .chunks_exact(3)
+        .map(|p| luma(p[0], p[1], p[2]))
+        .collect();
     let tile = side as f32 / grid as f32;
     // Per-tile mapping LUTs.
     let mut maps = vec![[0f32; 256]; grid * grid];

--- a/docs/APP-INTEGRATION.md
+++ b/docs/APP-INTEGRATION.md
@@ -59,15 +59,37 @@ irlume doctor           # flags Bitwarden-installed-but-polkit-unwired
 
 ## Bitwarden specifics
 
-Bitwarden's desktop app needs its polkit action registered on the host. The
-non-sandboxed packages install it themselves ("set up biometric unlock" in
-Settings); the flatpak and snap cannot write to `/usr/share/polkit-1/actions`,
-so Bitwarden displays the one-time manual step in its settings. After that:
+Bitwarden's "Unlock with system authentication" is a polkit prompt for the
+action `com.bitwarden.Bitwarden.unlock` (`auth_self`), so it runs the `polkit-1`
+PAM stack that irlume wires. First wire irlume for polkit if you have not:
+
+```console
+sudo irlume login enable --with-polkit --apply
+```
+
+The non-sandboxed Bitwarden packages register their polkit action themselves.
+The **flatpak and snap cannot** write to `/usr/share/polkit-1/actions`, and the
+flatpak gives no in-product prompt for the manual step, so install the action on
+the host yourself:
+
+```console
+# Install Bitwarden's polkit action (the sandbox cannot do this itself)
+sudo wget -O /usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy \
+  https://raw.githubusercontent.com/bitwarden/clients/main/apps/desktop/resources/com.bitwarden.desktop.policy
+sudo chown root:root /usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
+# Fedora / SELinux only: label it so polkit can read it
+sudo chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
+```
+
+Then in Bitwarden: **File > Settings > Security > Unlock with system
+authentication**. `irlume doctor` confirms the action is registered.
 
 - Unlock the vault once with your master password (Bitwarden holds the vault
   key in protected memory; biometrics never replace the first unlock).
 - "Unlock with system authentication" then pops the polkit dialog, which your
-  face satisfies.
+  nod satisfies. Verified on the 2026.6.1 flatpak. Flatpak builds before
+  Bitwarden 2026.5 failed here with polkit's "Unix process subject does not
+  have uid set"; if you hit that, update the flatpak or use the `.deb`/`.rpm`.
 - Browser-extension biometric unlock rides the same desktop app via native
   messaging; enable "biometric unlock in browser" in the desktop settings.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -22,7 +22,7 @@ Conventions that apply everywhere:
 | `irlume setup` | scripted onboarding: enroll, keyring, recovery, PAM wiring, each step prompted y/N |
 | `irlume status` | health dashboard: daemon, enrollment, keyring, cameras |
 | `irlume detect` | script-friendly probe; exit `0` = ready, `10` = partial, `20` = absent |
-| `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models |
+| `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), and the authselect/pam-auth-update regeneration guard |
 | `irlume deps` | verify runtime dependencies (onnxruntime, models, TPM) |
 | `irlume version` | print the installed version (`--version` / `-V` also work) |
 
@@ -37,6 +37,7 @@ Conventions that apply everywhere:
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
 | `irlume profiles eyes-open <on\|off>` | require eyes open to unlock |
 | `irlume profiles challenge <on\|off>` | opt-in passive blink liveness |
+| `sudo irlume calibrate-closure` | teach the eye-closure consent gesture for app prompts (captures eyes-open/closed EAR); the head nod is the default and needs no calibration |
 | `irlume identify` | 1:N "who is this?"; as root it checks all users, otherwise scoped to you |
 
 ## Keyring, TPM, and recovery
@@ -52,10 +53,10 @@ Conventions that apply everywhere:
 
 | Command | Sudo | What it does |
 |---|---|---|
-| `irlume login <status\|enable\|disable> [--with-sudo] [--with-polkit] [--apply]` | yes | PAM wiring for the greeter and lock screen; `--with-sudo` adds face-`sudo`, `--with-polkit` adds app prompts (Bitwarden unlock, pkexec — see docs/APP-INTEGRATION.md); without `--apply` it previews |
+| `irlume login <status\|enable\|disable\|reconcile> [--with-sudo] [--with-polkit] [--apply]` | yes | PAM wiring for the greeter and lock screen; `--with-sudo` adds face-`sudo`, `--with-polkit` adds app prompts (Bitwarden unlock, pkexec; see docs/APP-INTEGRATION.md); `reconcile` re-applies the wiring after a distro PAM regeneration (also run by the `irlume-reconcile.path` unit); without `--apply` it previews |
 | `irlume logs [-f] [--since T]` | sometimes | the face-auth journal in one view (daemon, PAM, keyring); `-f` follows live, `--since "10 min ago"` widens the window |
 | `irlume logs debug <on\|off>` | yes | per-stage pipeline tracing in the daemon (numbers only, never frames) |
-| `irlume fingerprint <status\|add\|enable\|disable>` | for wiring | fprintd companion factor |
+| `irlume fingerprint <status\|add\|verify\|reset\|enable\|disable> [--fingerprint-only]` | for wiring | fprintd companion; `enable` = unlock with face OR fingerprint (both), `--fingerprint-only` replaces face |
 | `irlume selinux <status\|load>` | for load | SELinux module for the login greeter (Fedora) |
 | `irlume ir-setup [--dry-run]` | yes | auto-configure the IR emitter; rarely needed, enroll runs it itself when IR frames come back dark |
 | `irlume set-cameras <rgb> <ir>` | yes | persist the RGB+IR camera pair, e.g. `/dev/video0 /dev/video2`; the TUI camera picker runs this for you |

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -114,8 +114,8 @@ sudo pamtester <service> $USER authenticate
 ```
 
 `<service>` is your greeter's PAM service: `plasmalogin`, `sddm`, `lightdm`,
-`greetd`, `gdm-password`, `cosmic-greeter`. `irlume login status` prints the
-active one. On an on-demand wiring, press **Enter on the empty password
+`greetd`, `gdm-password`, `cosmic-greeter`, or `polkit-1` for app prompts.
+`irlume login status` prints the active ones. On an on-demand wiring, press **Enter on the empty password
 prompt** to trigger face; type the password to confirm the no-camera path.
 Watch `irlume logs -f` in a second terminal.
 

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -55,6 +55,7 @@ PAM changes.
 | LightDM (gtk and slick greeters, X11) | wired and exercised in the login-manager matrix |
 | greetd (tuigreet) | wired and exercised in the login-manager matrix |
 | COSMIC greeter | wired and exercised in the login-manager matrix |
+| polkit-1 (app prompts: Bitwarden, pkexec) | validated live: Bitwarden flatpak biometric unlock approved by a head nod |
 
 ## Not tested yet, reports welcome
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,4 +75,5 @@ The audit backlog, in rough order:
 - No paid certification lab engagements (iBeta, FIDO) at hobby scale; the
   published self-tests against the same protocols stay the substitute.
 - No WebAuthn/passkey platform-authenticator role for now; the scope is
-  login, unlock, sudo, and keyring.
+  login, unlock, `sudo`, keyring, and app prompts via polkit (Bitwarden,
+  `pkexec`).

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -145,10 +145,12 @@ every login, which is half the point.
 irlume keyring arm
 ```
 
-It prompts for your **login password** (typed twice, to catch a typo), which it
-seals in the TPM; the password is never stored in plaintext. Re-run it after you change your
-login password. On a fingerprint machine a fingerprint login unseals the wallet
-the same way (see [ADR-0003](adr/0003-fingerprint-keyring-unlock.md)).
+It prompts for your **login password** (typed twice, to catch a typo) and
+verifies it is actually your login password before sealing it in the TPM, so a
+mistyped password can't be sealed and leave the wallet failing to unlock; the
+password is never stored in plaintext. Re-run it after you change your login
+password. On a fingerprint machine a fingerprint login unseals the wallet the
+same way (see [ADR-0003](adr/0003-fingerprint-keyring-unlock.md)).
 
 ### 5. Recovery passphrase: recommended
 
@@ -190,9 +192,11 @@ sudo irlume login enable --with-polkit --apply
 ```
 
 The daemon treats polkit as verify-only (it never releases the TPM-sealed
-credential to it) and requires a deliberate eye-closure gesture (close your
-eyes ~1s, then open) before approving, because the prompt starts scanning
-without any action from you. Calibrate it once with `sudo irlume calibrate-closure`. Full walkthrough,
+credential to it) and requires a deliberate consent gesture before approving,
+because the prompt starts scanning without any action from you. The default
+gesture is a **head nod** (no calibration; works at any angle or lighting). If
+you prefer to approve by closing your eyes for about a second, run `sudo irlume
+calibrate-closure` once and either gesture is accepted. Full walkthrough,
 Bitwarden setup, and the security stance: [APP-INTEGRATION.md](APP-INTEGRATION.md).
 
 ## Fingerprint companion (optional)
@@ -202,7 +206,8 @@ On a laptop with a fingerprint reader, add it as a second factor:
 ```sh
 irlume fingerprint status
 irlume fingerprint add           # enroll a finger via fprintd
-sudo irlume fingerprint enable   # make fingerprint the method (face stands down)
+sudo irlume fingerprint enable   # unlock with face OR fingerprint (keeps face on)
+# add --fingerprint-only to replace face with fingerprint instead
 ```
 
 ## IR emitter (rarely needed)
@@ -253,9 +258,9 @@ live in them; sealed envelopes are stored separately (see
 
 | File | Holds | Written by |
 |---|---|---|
-| `/etc/irlume/settings.conf` | `enforce_biopolicy=1` opts into operation-class gating; `third_party_pad=<name>` names an enabled opt-in model | TUI Settings; `sudo irlume models enable/disable` |
+| `/etc/irlume/settings.conf` | `enforce_biopolicy=1` opts into operation-class gating; `third_party_pad=<name>` names an enabled opt-in model; `consent_gesture=nod\|closure` restricts the polkit consent gesture (unset = either) | TUI Settings; `sudo irlume models enable/disable` |
 | `/etc/irlume/cameras.conf` | `rgb=` / `ir=` device nodes of the active camera pair | TUI camera picker, or `sudo irlume set-cameras <rgb> <ir>` |
-| `/etc/irlume/method` | one line: the active auth method | `irlume fingerprint enable/disable` |
+| `/etc/irlume/method` | one line: the active auth method (`auto`, `face`, `fingerprint`, or `both` = face OR fingerprint) | `irlume fingerprint enable/disable` |
 | `/var/lib/irlume/ir_emitter.conf` | the UVC extension-unit control that lights the emitter (optional second line: a brightness-boost control) | `irlume ir-setup` / enrollment auto-setup |
 
 Camera selection precedence: the `IRLUME_RGB_DEVICE`+`IRLUME_IR_DEVICE` env

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -12,7 +12,7 @@ own recipe. Everything the daemon does at *runtime* stays capability-detected.
 | `irlumed`, `irlume` | `/usr/bin/` |
 | `pam_irlume.so` | Fedora `/usr/lib64/security/` · Debian `/usr/lib/x86_64-linux-gnu/security/` · Arch `/usr/lib/security/` |
 | models (LFS, bundled) | `/usr/share/irlume/models/*.onnx` |
-| systemd unit | `/usr/lib/systemd/system/irlumed.service` (from `systemd/irlumed.service`) |
+| systemd units | `/usr/lib/systemd/system/irlumed.service` + `irlume-reconcile.path`/`.service` (self-heal watcher; all families incl. PPA enable the `.path`) |
 | LSM policy | Fedora SELinux module · Debian `apparmor/usr.bin.irlumed` (path-adjusted) · Arch none |
 
 Models are bundled (Git LFS); there is no fetch step. Packages that build from a git

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.4.0
+pkgver=0.6.0
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.5.0
+version: 0.6.0
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -1,7 +1,7 @@
 %global ort_ver 1.24.4
 
 Name:           irlume
-Version:        0.5.0
+Version:        0.6.0
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -163,6 +163,13 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Thu Jul 23 2026 archledger <archledger236@gmail.com> - 0.6.0-1
+- Face-approve app prompts via polkit (Bitwarden biometric unlock, pkexec) with
+  a deliberate consent gesture (head nod, or eye closure after calibrate-closure);
+  fingerprint coexistence (face OR fingerprint); distro-update PAM self-heal
+  (login reconcile + irlume-reconcile.path); doctor login-keyring probe.
+- Security: pam_irlume ignores IRLUME_SOCKET in setuid contexts (local root fix).
+
 * Tue Jul 21 2026 archledger <archledger236@gmail.com> - 0.5.0-1
 - Field-hardening release: Tier-1 signed-PCR sealing fix with automatic
   tier upgrade, fingerprint robustness batch, IR format negotiation

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -49,6 +49,13 @@ override_dh_auto_install:
 		debian/irlume/usr/lib/systemd/system/irlumed.service
 	install -D -m0644 debian/10-ort.conf \
 		debian/irlume/usr/lib/systemd/system/irlumed.service.d/10-ort.conf
+	# Self-heal watcher: re-applies irlume's greeter PAM wiring if pam-auth-update
+	# strips it. dh_installsystemd (via #DEBHELPER# in postinst) enables the .path
+	# the same way it enables irlumed.service. Parity with the other packagers.
+	install -D -m0644 packaging/systemd/irlume-reconcile.path \
+		debian/irlume/usr/lib/systemd/system/irlume-reconcile.path
+	install -D -m0644 packaging/systemd/irlume-reconcile.service \
+		debian/irlume/usr/lib/systemd/system/irlume-reconcile.service
 	install -D -m0644 packaging/apparmor/usr.bin.irlumed \
 		debian/irlume/etc/apparmor.d/usr.bin.irlumed
 


### PR DESCRIPTION
The 0.6.0 release: the full pre-release effort — feature surfacing, docs, a 3-part audit, fleet validation, and the version bump.

## Features (surfaced in TUI + CLI, documented)
- **App-unlock via polkit** (`login enable --with-polkit`): face approves Bitwarden's biometric unlock and `pkexec`. **Verified live: the polkit dialog appears and a head nod unlocks the Bitwarden flatpak vault.**
- **Consent gesture**: head nod (default, no calibration) or eye closure (`calibrate-closure`), required for polkit prompts. Verify-only at the daemon; fails closed to the password.
- **Fingerprint coexistence** (`Method::Both`): unlock with face OR fingerprint.
- **Distro-update self-heal**: `login reconcile` + `irlume-reconcile.path`/`.service` re-apply PAM wiring after authselect/pam-auth-update strips it (now shipped by all four packagers incl. PPA).
- **doctor**: login-keyring lock/provider probe + authselect regeneration guard.

## TUI/CLI review
Fixed the `Method::Both` false-alarm (the TUI told users to undo the correct coexistence), corrected fingerprint text, surfaced app-unlock/nod/calibrate-closure in the Login-wiring tab, relabeled the polkit row, and added the missing commands to `help()`. Visually audited live across all 10 TUI tabs.

## Audit fixes
- **Security (CRITICAL)**: `pam_irlume` ignored `IRLUME_SOCKET` in setuid contexts → a local user could redirect the module to a fake daemon and get root via `--with-sudo`. Fixed with `secure_getenv`.
- reconcile now checks the active DM's greeter (not any greeter); marker is root-only 0600; dead code removed; `chunks_exact` panic-proofing; PPA gained the self-heal units; Arch PKGBUILD un-stuck from 0.4.0; test hermeticity fixed (per-process tmp).

## Validation
Tests green on **Zenbook (Fedora), archhost (Arch), and a clean fedora:latest container**; full gate (test / clippy -D / doc -D / fmt) clean. Every commit carries a `Signed-off-by`.
