### PR TITLE
doctor: report stray backups and overlaid binaries (install hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to irlume are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`irlume doctor` reports install-hygiene drift.** Two related checks, both
+  report-only: stray irlume-named files next to the managed binaries and the
+  PAM module that no package owns (the backups a manual branch install leaves
+  behind — they outlive every later package update and a stale
+  `pam_irlume.so.*` in the module directory muddies auth debugging), and a
+  managed binary whose content no longer matches the installed package (a
+  hand-installed build overlaying it, which the next package update will
+  silently replace — doctor names the file and the reinstall command). Both
+  checks stay silent when the install is clean. Content drift is detected via
+  the package manager's own verify (`rpm -V` / `dpkg --verify` /
+  `pacman -Qkk`); mtime-only drift is ignored.
+
 ## [0.6.0] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ All notable changes to irlume are documented here. This project adheres to
 - **`irlume doctor` reports install-hygiene drift.** Two related checks, both
   report-only: stray irlume-named files next to the managed binaries and the
   PAM module that no package owns (the backups a manual branch install leaves
-  behind — they outlive every later package update and a stale
+  behind: they outlive every later package update and a stale
   `pam_irlume.so.*` in the module directory muddies auth debugging), and a
   managed binary whose content no longer matches the installed package (a
   hand-installed build overlaying it, which the next package update will
-  silently replace — doctor names the file and the reinstall command). Both
+  silently replace; doctor names the file and the reinstall command). Both
   checks stay silent when the install is clean. Content drift is detected via
   the package manager's own verify (`rpm -V` / `dpkg --verify` /
   `pacman -Qkk`); mtime-only drift is ignored.

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -914,7 +914,7 @@ pub fn capture_ir_with_stats(device: &str) -> irlume_common::Result<(Frame, IrCa
     // strobing emitter the frame adjacent to the brightest is an emitter-OFF
     // exposure that captured only ambient IR. Subtracting it isolates the
     // emitter's own reflected light, the same illuminated/ambient-pair step
-    // Hello uses. Its purpose is EXPOSURE ROBUSTNESS: under strong ambient IR
+    // Hello uses. Its purpose is SURVIVING EXPOSURE EXTREMES: under strong ambient IR
     // (sunlight) the pedestal would otherwise wash out the emitter reflection.
     // It is not primarily a spoof control (Hello credits spoof resistance to the
     // IR wavelength plus a separate liveness stage, which is where irlume's
@@ -1035,7 +1035,7 @@ pub mod ir_probe {
     /// ambient IR pedestal (Hello's ambient-subtraction step) so the emitter's own
     /// reflection survives a bright-ambient exposure: light present in both frames
     /// (sunlight, a screen's own IR) cancels; the emitter-lit face does not. This
-    /// is an exposure-robustness step, not a standalone spoof control. Falls back
+    /// is an exposure-compensation step, not a standalone spoof control. Falls back
     /// to `lit` on a size mismatch.
     pub fn subtract(lit: &[u8], ambient: &[u8]) -> Vec<u8> {
         if lit.len() != ambient.len() {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -682,7 +682,7 @@ pub(crate) enum IrPixel {
     Grey8,
     /// Y16 / Y10 / Y12: 16-bit little-endian words, sample data LSB-aligned
     /// (per the V4L2 spec, which also allows Y16 to carry fewer than 16 real
-    /// bits — a 10-bit sensor delivers 0..1023 in Y16).
+    /// bits; a 10-bit sensor delivers 0..1023 in Y16).
     Grey16,
     /// NV12: the leading `w*h` bytes are a plain 8-bit luma plane; an IR sensor
     /// behind bridge firmware that only speaks NV12 is fully usable through it.

--- a/crates/irlume-cli/src/blinkcap.rs
+++ b/crates/irlume-cli/src/blinkcap.rs
@@ -6,7 +6,7 @@
 //!
 //! The deliberate held-closure gate ([`irlume_liveness::detect_deliberate_closure`])
 //! has a provisional frame threshold and no on-hardware validation of its
-//! strobe / auto-exposure-settle robustness. Tuning it by re-capturing on every
+//! strobe / auto-exposure-settle behavior. Tuning it by re-capturing on every
 //! change wastes a live face each time; instead this records the exact
 //! [`irlume_liveness::EarSample`] sequence the live gate sees, tagged with the
 //! gesture performed, so the detectors can be swept against a fixed dataset.

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -85,7 +85,7 @@ fn status(user: &str) -> ExitCode {
             println!("[fingerprint] enrolled       : (fprintd reports no reader)");
         }
         fp::ListOutcome::Error(e) => {
-            println!("[fingerprint] enrolled       : could not list — {e}");
+            println!("[fingerprint] enrolled       : could not list: {e}");
             list_error = Some(e.clone());
         }
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -29,6 +29,7 @@ mod pad;
 mod pamwire;
 mod recovery;
 mod secrets;
+mod strays;
 mod suncal;
 mod tui;
 mod uninstall;
@@ -2342,10 +2343,8 @@ fn doctor() -> std::process::ExitCode {
         "[doctor] platform: {}",
         irlume_common::platform::distro_family().as_str()
     );
-    println!(
-        "[doctor] install origin: {}",
-        commands::install_origin().describe()
-    );
+    let origin = commands::install_origin();
+    println!("[doctor] install origin: {}", origin.describe());
     match tpm_device() {
         Some(d) => println!("[doctor] TPM 2.0: {d} ✓"),
         None => println!("[doctor] TPM 2.0: none (/dev/tpmrm0 absent) ✗; required for sealing"),
@@ -2615,6 +2614,9 @@ fn doctor() -> std::process::ExitCode {
     if crate::pamwire::login_wired() {
         report_pam_regeneration_guard();
     }
+    // Leftover backups next to the managed binaries, and hand-installed builds
+    // overlaying the packaged ones (silent when clean).
+    strays::report(&origin);
 
     std::process::ExitCode::SUCCESS
 }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -425,7 +425,7 @@ fn calibrate_closure(args: &[String]) -> std::process::ExitCode {
 
     // Capture one phase, returning the median EAR or a printed error.
     let capture_phase = |label: &str| -> Result<f32, String> {
-        print!("[calibrate] {label} — hold still, capturing in 3");
+        print!("[calibrate] {label}: hold still, capturing in 3");
         let _ = std::io::Write::flush(&mut std::io::stdout());
         for n in [2, 1] {
             std::thread::sleep(std::time::Duration::from_millis(800));
@@ -2491,7 +2491,7 @@ fn doctor() -> std::process::ExitCode {
         if irlume_fingerprint::reader_stuck(&user) {
             println!(
                 "  ⚠ the reader is held by a stale fprintd claim (finger prompts will not \
-                 appear; common after suspend/resume) — fix: sudo systemctl restart fprintd"
+                 appear; common after suspend/resume); fix: sudo systemctl restart fprintd"
             );
         }
         let pam_dir = std::path::Path::new("/etc/pam.d");
@@ -2549,7 +2549,7 @@ fn doctor() -> std::process::ExitCode {
             "[doctor] polkit app prompts: wired ✓ (NOD your head to approve Bitwarden unlock,\n     \
              pkexec, …; no calibration needed{})",
             if closure_calibrated {
-                " — closing your eyes ~1s also works"
+                "; closing your eyes ~1s also works"
             } else {
                 ", or run calibrate-closure to also allow the eye-closure gesture"
             }
@@ -2559,7 +2559,7 @@ fn doctor() -> std::process::ExitCode {
              approve; consent_gesture=closure)"
         ),
         Some(true) => println!(
-            "[doctor] polkit app prompts: wired ✓ but consent_gesture=closure and NOT calibrated —\n     \
+            "[doctor] polkit app prompts: wired ✓ but consent_gesture=closure and NOT calibrated;\n     \
              prompts fall back to the password. Calibrate (sudo irlume calibrate-closure) or unset\n     \
              consent_gesture in settings.conf to use the no-calibration head nod."
         ),
@@ -2664,7 +2664,7 @@ fn report_pam_regeneration_guard() {
     } else {
         println!(
             "[doctor] ⚠ {tool} manages this host's PAM stacks, but the irlume-reconcile.path\n     \
-             self-heal watcher is not active — a future regeneration could silently drop\n     \
+             self-heal watcher is not active; a future regeneration could silently drop\n     \
              face login. Enable it: sudo systemctl enable --now irlume-reconcile.path"
         );
     }

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -399,7 +399,7 @@ fn dm_profile(greeter_etc: &str, gnome: Option<u32>) -> DmProfile {
 }
 
 /// The PAM services THIS login manager actually uses, so wiring targets what the
-/// DM will really consult (and, crucially, its separate FINGERPRINT service).
+/// DM will really consult (and, above all, its separate FINGERPRINT service).
 /// Returns `(greeter_label, fingerprint_label_or_none)`.
 fn dm_pam_services(dm: &str) -> (&'static str, Option<&'static str>) {
     match dm {

--- a/crates/irlume-cli/src/secrets.rs
+++ b/crates/irlume-cli/src/secrets.rs
@@ -147,7 +147,7 @@ pub fn report_keyring_status() {
         ),
         Collection::Present { locked: true } => println!(
             "[doctor] login keyring{who}: LOCKED. A face login should unlock it {via}.\n     \
-             If it stays locked, the sealed keyring password is stale — re-run: \
+             If it stays locked, the sealed keyring password is stale; re-run: \
              sudo irlume keyring arm"
         ),
         Collection::NoProvider => println!(

--- a/crates/irlume-cli/src/strays.rs
+++ b/crates/irlume-cli/src/strays.rs
@@ -51,6 +51,18 @@ fn report_strays() {
     for dir in PAM_DIRS {
         collect_strays(dir, "pam_irlume", &["pam_irlume.so"], &mut strays);
     }
+    // On merged-usr hosts two scanned directories can be the same place
+    // (Arch: /usr/lib64 -> /usr/lib), listing one file under both names;
+    // keep the first path per canonical target. Found in container E2E.
+    let mut seen: Vec<std::path::PathBuf> = Vec::new();
+    strays.retain(|p| {
+        let canon = std::fs::canonicalize(p).unwrap_or_else(|_| p.into());
+        if seen.contains(&canon) {
+            return false;
+        }
+        seen.push(canon);
+        true
+    });
     // Only files no package owns are leftovers; a package-owned neighbour
     // (whatever it is) is some package's business, not ours.
     strays.retain(|p| !package_owns(p).unwrap_or(false));

--- a/crates/irlume-cli/src/strays.rs
+++ b/crates/irlume-cli/src/strays.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Doctor check: stray files sitting next to the managed irlume binaries, and
+//! hand-installed builds overlaying the packaged ones.
+//!
+//! Both come from the same workflow: installing a dev/branch build over a
+//! package install, with a `cp irlume irlume.bak`-style backup first. The
+//! backups accumulate (they outlive every later package update), and a stale
+//! copy of `pam_irlume.so` sitting in the PAM module directory invites "which
+//! module is actually loaded?" confusion during auth debugging. The overlay is
+//! the dangerous half: the next package update silently replaces the
+//! hand-installed binary, which has bitten this project before.
+//!
+//! Report-only by design. Deleting files the package manager does not own is
+//! how backups made on purpose get destroyed; doctor names them and lets the
+//! admin decide.
+
+use crate::commands::InstallOrigin;
+
+/// Where the managed binaries live. Deliberately NOT the running exe's
+/// directory: a dev running `target/release/irlume doctor` would otherwise see
+/// every cargo artifact next to the binary as a stray.
+const BIN_DIRS: &[&str] = &["/usr/bin", "/usr/local/bin"];
+
+/// PAM module directories across the packaged distro families (same list the
+/// uninstaller sweeps).
+const PAM_DIRS: &[&str] = &[
+    "/usr/lib/security",
+    "/usr/lib64/security",
+    "/lib/security",
+    "/lib/x86_64-linux-gnu/security",
+];
+
+/// Print doctor lines for stray irlume-named files and overlaid managed
+/// binaries. Silent when everything is clean (matching the wiring-drift
+/// check: doctor stays quiet unless something needs attention).
+pub fn report(origin: &InstallOrigin) {
+    report_strays();
+    report_overlay(origin);
+}
+
+/// Stray = a file whose name starts with an irlume prefix, in a directory we
+/// manage files in, that is not one of the managed names themselves and that
+/// no package owns.
+fn report_strays() {
+    let mut strays: Vec<String> = Vec::new();
+    for dir in BIN_DIRS {
+        collect_strays(dir, "irlume", &["irlume", "irlumed"], &mut strays);
+    }
+    for dir in PAM_DIRS {
+        collect_strays(dir, "pam_irlume", &["pam_irlume.so"], &mut strays);
+    }
+    // Only files no package owns are leftovers; a package-owned neighbour
+    // (whatever it is) is some package's business, not ours.
+    strays.retain(|p| !package_owns(p).unwrap_or(false));
+    if strays.is_empty() {
+        return;
+    }
+    let claim = if package_query_available() {
+        "not owned by any package; "
+    } else {
+        ""
+    };
+    println!(
+        "[doctor] ⚠ stray file(s) next to the managed irlume files ({claim}likely \
+         backups\n     from a manual install — safe to remove once you no longer need them):"
+    );
+    for p in &strays {
+        println!("       {p}");
+    }
+}
+
+/// Push every regular file in `dir` whose name starts with `prefix` but is not
+/// one of the `managed` names.
+fn collect_strays(dir: &str, prefix: &str, managed: &[&str], out: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return; // directory absent on this distro; nothing to scan
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !is_stray_name(name, prefix, managed) {
+            continue;
+        }
+        // Only regular files: a directory or socket named irlume-something is
+        // not a binary backup.
+        if entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            out.push(format!("{dir}/{name}"));
+        }
+    }
+}
+
+/// Name-level stray test, separated from the filesystem walk so it is unit
+/// testable: prefix match minus the managed names.
+fn is_stray_name(name: &str, prefix: &str, managed: &[&str]) -> bool {
+    name.starts_with(prefix) && !managed.contains(&name)
+}
+
+/// Whether any package owns `path`. `None` when this host has no package
+/// manager we know how to ask (then the stray wording drops the ownership
+/// claim rather than asserting something unverified).
+fn package_owns(path: &str) -> Option<bool> {
+    use irlume_common::platform::{distro_family, DistroFamily};
+    // Each of these exits non-zero when no package owns the path.
+    let (prog, args): (&str, &[&str]) = match distro_family() {
+        DistroFamily::Fedora => ("rpm", &["-qf", path]),
+        DistroFamily::Debian => ("dpkg", &["-S", path]),
+        DistroFamily::Arch => ("pacman", &["-Qo", path]),
+        DistroFamily::Other => return None,
+    };
+    Some(
+        std::process::Command::new(prog)
+            .args(args)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false),
+    )
+}
+
+/// Whether this host has an ownership query at all (drives the wording of the
+/// stray report).
+fn package_query_available() -> bool {
+    use irlume_common::platform::{distro_family, DistroFamily};
+    distro_family() != DistroFamily::Other
+}
+
+/// Overlay = the package manager's verify says a managed binary's CONTENT no
+/// longer matches the package (someone hand-installed over it). mtime-only
+/// drift is ignored: it is what a `touch` or a backup-restore does and the
+/// binary is still the packaged one.
+fn report_overlay(origin: &InstallOrigin) {
+    let (verify, reinstall): (&[&str], &str) = match origin {
+        InstallOrigin::Copr | InstallOrigin::LocalRpm(_) => {
+            (&["rpm", "-V", "irlume"], "sudo dnf reinstall irlume")
+        }
+        InstallOrigin::Ppa | InstallOrigin::LocalDeb => (
+            &["dpkg", "--verify", "irlume"],
+            "sudo apt install --reinstall irlume",
+        ),
+        InstallOrigin::ArchPkg => (&["pacman", "-Qkk", "irlume"], "sudo pacman -S irlume"),
+        // No package to verify against; a source install IS the hand-install.
+        InstallOrigin::Source => return,
+    };
+    let Some(out) = cmd_output_lossy(verify[0], &verify[1..]) else {
+        return; // verify clean (no output) or tool failed: nothing to report
+    };
+    let modified = overlaid_paths(&out);
+    if modified.is_empty() {
+        return;
+    }
+    for path in &modified {
+        println!(
+            "[doctor] ⚠ {path} differs from the packaged file: a hand-installed build is\n     \
+             overlaying the package, and the next package update will silently replace it.\n     \
+             Restore the packaged build with: {reinstall}"
+        );
+    }
+}
+
+/// Parse a package-verify report (rpm -V / dpkg --verify / pacman -Qkk) down
+/// to the managed irlume paths whose content changed.
+///
+/// rpm and dpkg share the attribute-column format: a 9-character flag string
+/// where position 3 ('5') marks a digest mismatch, then an optional one-char
+/// file-type marker (`c` config etc.), then the path; only failing files are
+/// printed, and dpkg's only functional check IS the md5 digest (rpm(8) VERIFY
+/// OPTIONS; dpkg(1) --verify). A line whose flags lack '5' is mtime/mode
+/// drift only, and `missing` lines carry no flags at all. pacman -Qkk prints
+/// `warning: pkg: /path (<Kind>)` per finding — on STDERR, with the summary
+/// count on stdout (pacman(8) -k; src/pacman/check.c). Of its kinds, only
+/// "… checksum mismatch" and "Size mismatch" mean the file content changed;
+/// mtime/permission/owner drift does not make a file an overlay.
+fn overlaid_paths(verify_output: &str) -> Vec<String> {
+    const WATCHED: &[&str] = &["/irlume", "/irlumed", "/pam_irlume.so"];
+    let mut hits = Vec::new();
+    for line in verify_output.lines() {
+        let toks: Vec<&str> = line.split_whitespace().collect();
+        // pacman per-file shape: `warning: irlume: /path (Kind)`. (The stdout
+        // summary line `irlume: N total files, …` has no absolute-path token,
+        // so it can never match a watched name.)
+        let (content_changed, path) = if toks.first() == Some(&"warning:") {
+            let Some(path) = toks.get(2) else { continue };
+            (
+                line.contains("checksum mismatch") || line.contains("(Size mismatch)"),
+                *path,
+            )
+        } else {
+            // rpm/dpkg shape: flags first, path last (the file-type marker
+            // between them is skipped by taking the final token).
+            let (Some(flags), Some(path)) = (toks.first(), toks.last()) else {
+                continue;
+            };
+            (flags.contains('5'), *path)
+        };
+        let watched = WATCHED.iter().any(|w| path.ends_with(w));
+        if content_changed && watched && !hits.contains(&path.to_string()) {
+            hits.push(path.to_string());
+        }
+    }
+    hits
+}
+
+/// Run a command, returning its combined stdout+stderr when any was produced.
+/// Both streams because pacman -Qkk reports per-file findings on stderr with
+/// only the summary on stdout, while rpm/dpkg report on stdout. `None` for
+/// clean (no output) or unrunnable. Exit codes are useless here: dpkg
+/// --verify exits 0 even with failing files, so presence of parseable lines
+/// is the only signal.
+fn cmd_output_lossy(prog: &str, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new(prog).args(args).output().ok()?;
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    (!s.trim().is_empty()).then_some(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_strays, is_stray_name, overlaid_paths};
+
+    #[test]
+    fn collect_finds_backup_files_but_not_managed_names_or_dirs() {
+        let dir = std::env::temp_dir().join(format!("irlume-strays-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        for f in [
+            "irlume",
+            "irlumed",
+            "irlume.rpm-0.5.0",
+            "irlumed.pre-gesture",
+        ] {
+            std::fs::write(dir.join(f), b"x").unwrap();
+        }
+        // A directory with a stray-looking name is not a file backup.
+        std::fs::create_dir_all(dir.join("irlume.d")).unwrap();
+
+        let mut out = Vec::new();
+        collect_strays(
+            dir.to_str().unwrap(),
+            "irlume",
+            &["irlume", "irlumed"],
+            &mut out,
+        );
+        out.sort();
+        let expected: Vec<String> = ["irlume.rpm-0.5.0", "irlumed.pre-gesture"]
+            .iter()
+            .map(|f| dir.join(f).to_str().unwrap().to_string())
+            .collect();
+        assert_eq!(out, expected);
+
+        // An absent directory is silently skipped, not an error.
+        let mut none = Vec::new();
+        collect_strays("/nonexistent-irlume-test-dir", "irlume", &[], &mut none);
+        assert!(none.is_empty());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn stray_names_are_prefix_matches_minus_the_managed_set() {
+        let managed = &["irlume", "irlumed"];
+        assert!(is_stray_name("irlume.rpm-0.5.0", "irlume", managed));
+        assert!(is_stray_name("irlumed.pre-gesture", "irlume", managed));
+        assert!(is_stray_name("irlume.bak", "irlume", managed));
+        assert!(!is_stray_name("irlume", "irlume", managed));
+        assert!(!is_stray_name("irlumed", "irlume", managed));
+        // Unrelated neighbours never match.
+        assert!(!is_stray_name("iridium", "irlume", managed));
+        assert!(!is_stray_name("pam_irlume.so", "irlume", managed)); // wrong dir class
+        assert!(is_stray_name(
+            "pam_irlume.so.rpm-0.5.0",
+            "pam_irlume",
+            &["pam_irlume.so"]
+        ));
+        assert!(!is_stray_name(
+            "pam_irlume.so",
+            "pam_irlume",
+            &["pam_irlume.so"]
+        ));
+    }
+
+    #[test]
+    fn rpm_verify_flags_content_changes_only() {
+        // Digest mismatch on a managed binary → reported.
+        let digest = "S.5....T.    /usr/bin/irlumed\n";
+        assert_eq!(overlaid_paths(digest), vec!["/usr/bin/irlumed"]);
+        // mtime-only drift → not an overlay.
+        let mtime = ".......T.    /usr/bin/irlume\n";
+        assert!(overlaid_paths(mtime).is_empty());
+        // Config-file marker between flags and path parses to the last token.
+        let with_marker = "S.5....T.  c /usr/lib64/security/pam_irlume.so\n";
+        assert_eq!(
+            overlaid_paths(with_marker),
+            vec!["/usr/lib64/security/pam_irlume.so"]
+        );
+        // A digest change on a file we don't watch is someone else's business.
+        let other = "S.5....T.    /usr/share/irlume/models/x.onnx\n";
+        assert!(overlaid_paths(other).is_empty());
+    }
+
+    #[test]
+    fn dpkg_verify_shares_the_flag_column_shape() {
+        let line = "??5??????   /usr/bin/irlume\n";
+        assert_eq!(overlaid_paths(line), vec!["/usr/bin/irlume"]);
+        let clean_style = "??.??????   /usr/bin/irlume\n";
+        assert!(overlaid_paths(clean_style).is_empty());
+    }
+
+    #[test]
+    fn pacman_qkk_flags_content_kinds_only() {
+        // Real -Qkk shapes (stderr lines carry a `warning:` prefix; a content
+        // edit emits checksum + mtime lines for the same file — dedup'd).
+        let edit = "warning: irlume: /usr/bin/irlumed (SHA256 checksum mismatch)\n\
+                    warning: irlume: /usr/bin/irlumed (Modification time mismatch)\n";
+        assert_eq!(overlaid_paths(edit), vec!["/usr/bin/irlumed"]);
+        assert_eq!(
+            overlaid_paths("warning: irlume: /usr/bin/irlume (Size mismatch)\n"),
+            vec!["/usr/bin/irlume"]
+        );
+        // Non-content drift is not an overlay.
+        for kind in [
+            "Modification time mismatch",
+            "Permissions mismatch",
+            "UID mismatch",
+        ] {
+            let line = format!("warning: irlume: /usr/bin/irlumed ({kind})\n");
+            assert!(overlaid_paths(&line).is_empty(), "{kind}");
+        }
+        // The stdout summary line has no absolute-path token to match.
+        let summary = "irlume: 312 total files, 1 altered file\n";
+        assert!(overlaid_paths(summary).is_empty());
+        // A missing mtree makes -Qkk print this to stdout; not an overlay.
+        assert!(overlaid_paths("irlume: no mtree file\n").is_empty());
+    }
+
+    #[test]
+    fn watched_suffix_must_be_a_whole_filename() {
+        // `/usr/bin/foo-irlume` ends with "/irlume"? No: suffix check is on
+        // the path, "/irlume" only matches when it is the final component.
+        let line = "S.5....T.    /usr/bin/not-irlume\n";
+        assert!(overlaid_paths(line).is_empty());
+        let nested = "S.5....T.    /opt/x/irlume\n";
+        assert_eq!(overlaid_paths(nested), vec!["/opt/x/irlume"]);
+    }
+}

--- a/crates/irlume-cli/src/strays.rs
+++ b/crates/irlume-cli/src/strays.rs
@@ -64,7 +64,7 @@ fn report_strays() {
     };
     println!(
         "[doctor] ⚠ stray file(s) next to the managed irlume files ({claim}likely \
-         backups\n     from a manual install — safe to remove once you no longer need them):"
+         backups\n     from a manual install; safe to remove once you no longer need them):"
     );
     for p in &strays {
         println!("       {p}");
@@ -169,7 +169,7 @@ fn report_overlay(origin: &InstallOrigin) {
 /// printed, and dpkg's only functional check IS the md5 digest (rpm(8) VERIFY
 /// OPTIONS; dpkg(1) --verify). A line whose flags lack '5' is mtime/mode
 /// drift only, and `missing` lines carry no flags at all. pacman -Qkk prints
-/// `warning: pkg: /path (<Kind>)` per finding — on STDERR, with the summary
+/// `warning: pkg: /path (<Kind>)` per finding, on STDERR, with the summary
 /// count on stdout (pacman(8) -k; src/pacman/check.c). Of its kinds, only
 /// "… checksum mismatch" and "Size mismatch" mean the file content changed;
 /// mtime/permission/owner drift does not make a file an overlay.
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn pacman_qkk_flags_content_kinds_only() {
         // Real -Qkk shapes (stderr lines carry a `warning:` prefix; a content
-        // edit emits checksum + mtime lines for the same file — dedup'd).
+        // edit emits checksum + mtime lines for the same file; dedup'd).
         let edit = "warning: irlume: /usr/bin/irlumed (SHA256 checksum mismatch)\n\
                     warning: irlume: /usr/bin/irlumed (Modification time mismatch)\n";
         assert_eq!(overlaid_paths(edit), vec!["/usr/bin/irlumed"]);

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -473,7 +473,7 @@ extern "C" {
 /// wrong seal is never caught at auth time, only when ksecretd tries to open the
 /// wallet). Returns `Some(true/false)` on a verifiable hash, or `None` when it
 /// cannot verify (no `/etc/shadow` access, no such user, or a locked / empty /
-/// non-password field) — in which case the caller does NOT block, since absence
+/// non-password field), in which case the caller does NOT block, since absence
 /// of proof is not proof of a wrong password. Root-only (`/etc/shadow`).
 fn password_matches_login(user: &str, password: &[u8]) -> Option<bool> {
     let shadow = std::fs::read_to_string("/etc/shadow").ok()?;

--- a/crates/irlume-fingerprint/src/lib.rs
+++ b/crates/irlume-fingerprint/src/lib.rs
@@ -170,7 +170,7 @@ pub fn available() -> bool {
 
 /// What `fprintd-list` actually said, beyond "a list of fingers". `fprintd-list`
 /// exits 0 even with no reader ("No devices available"), and a claim or polkit
-/// failure otherwise reads as "no fingers enrolled" — the wrong advice follows.
+/// failure otherwise reads as "no fingers enrolled", and the wrong advice follows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ListOutcome {
     Fingers(Vec<String>),
@@ -414,7 +414,7 @@ fn classify_enroll(run: &StreamedRun) -> EnrollOutcome {
     match run.status {
         None => EnrollOutcome::Failed(format!(
             "no completion from the reader within {}s; the sensor or its claim may be \
-             wedged — try: sudo systemctl restart fprintd, then re-run",
+             wedged; try: sudo systemctl restart fprintd, then re-run",
             ENROLL_DEADLINE.as_secs()
         )),
         Some(s) if s.success() => EnrollOutcome::Enrolled,
@@ -509,7 +509,7 @@ pub fn verify_once(user: &str) -> VerifyOutcome {
 /// Delete ALL of `user`'s enrolled prints (`fprintd-delete <user>`): the remedy
 /// for chip/host template desync, where the sensor's on-chip storage holds
 /// prints the host database no longer matches (dual-boot Windows enrollment,
-/// OS reinstall, BIOS "clear fingerprints" — libfprint#301, fprintd#126).
+/// OS reinstall, BIOS "clear fingerprints"; libfprint#301, fprintd#126).
 pub fn delete_all(user: &str) -> Result<(), String> {
     let Some(del) = tool("fprintd-delete") else {
         return Err("fprintd-delete not installed".into());

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -531,8 +531,8 @@ pub struct EarSample {
 
 /// One observation of HEAD POSE from an IR capture frame, for the head-nod
 /// consent gesture. Pose comes from the DETECTOR's 5-point landmarks (not the
-/// FaceMesh), so unlike [`EarSample`] it does not depend on eye landmarks and is
-/// robust to head angle and lighting: a nod reads the same reclined or upright.
+/// FaceMesh), so unlike [`EarSample`] it does not depend on eye landmarks and stays
+/// reliable across head angle and lighting: a nod reads the same reclined or upright.
 /// `pitch_frac`/`yaw_signed` are `None` when no face was detected in the frame.
 #[derive(Clone, Copy, Debug)]
 pub struct PoseSample {
@@ -1092,7 +1092,7 @@ pub fn calibrate_open_ear(samples: &[EarSample]) -> Option<f32> {
 /// back up past [`ClosureCalibration::reopen_threshold`]) within
 /// [`CLOSURE_REOPEN_WINDOW`] frames.
 ///
-/// The bounds and the reopen are what make this robust, learned from a hardware
+/// The bounds and the reopen are what make this hold up, learned from a hardware
 /// capture campaign 2026-07-22: a deliberately HELD SQUINT is physically the
 /// same as a held eye-closure (it goes just as deep on EAR), so neither depth
 /// nor a duration floor alone can separate them. What separates them is SHAPE: a

--- a/docs/APP-INTEGRATION.md
+++ b/docs/APP-INTEGRATION.md
@@ -20,7 +20,7 @@ pieces:
    `polkit-1` service.
 3. `pam_irlume` in that stack asks `irlumed` to verify your face. For a polkit
    prompt the daemon also requires a deliberate consent gesture: **nod your
-   head**, or **close your eyes for about a second then open them** — whichever
+   head**, or **close your eyes for about a second then open them**, whichever
    suits your position (see the security section). It then answers yes or no;
    the app learns only the verdict.
 
@@ -42,7 +42,7 @@ This adds one verify-only line to the `polkit-1` PAM stack (Fedora gets an
 edit-in-place with a `.pre-irlume` backup). `sudo irlume login disable --apply`
 removes it along with everything else, flag or no flag.
 
-**The consent gesture is a head NOD by default** — pose-defined, so it works at
+**The consent gesture is a head NOD by default**: pose-defined, so it works at
 any head angle or lighting (upright, reclined, in bed) and needs no calibration.
 If you'd also like to approve by closing your eyes, run `sudo irlume
 calibrate-closure` once (it captures your eyes-open and eyes-closed EAR); after
@@ -106,7 +106,7 @@ works the same day it ships.
 - **Deliberate gesture required.** polkit agents run the PAM conversation with
   no user action, so a bare face match would approve a prompt the user never
   acknowledged. For polkit-class services the daemon requires a deliberate
-  gesture — a head nod, or an eye closure — even for users who did not opt into
+  gesture (a head nod, or an eye closure) even for users who did not opt into
   any per-enrollment liveness, and fails closed if it cannot run (no IR camera;
   or, for the closure gesture specifically, no FaceMesh model or no stored
   calibration). Disable the forced gesture with `polkit_gesture=0` in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,7 +138,7 @@ discarded: with `IRLUME_IR_AMBIENT_SUBTRACT=1` the daemon subtracts the
 off-frame adjacent to the lit one, isolating the emitter's own reflected light.
 This is the same illuminated/ambient pairing Windows Hello uses.
 
-Subtraction is experimental and off by default. Its job is exposure robustness
+Subtraction is experimental and off by default. Its job is surviving exposure extremes
 under strong ambient IR (sunlight), not spoof detection; the depth and glint
 cues in the liveness gate carry that. Field captures set the gates it runs
 behind (`crates/irlume-camera/src/lib.rs`):
@@ -197,7 +197,7 @@ flowchart LR
     linkStyle default stroke:#b0b0b8,stroke-width:1.5px;
 ```
 
-## Why these choices
+## Defense-to-threat mapping
 
 See [THREAT_MODEL.md](THREAT_MODEL.md) for the Windows Hello bypass classes
 (CVE-2021-34466 IR injection; ESS device-trust) each defense maps to.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@
 - [IR capture: strobe and ambient subtraction](#ir-capture-strobe-and-ambient-subtraction)
 - [Face login → keyring unlock](#face-login--keyring-unlock): the
   TPM-sealed-password path
-- [Why these choices](#why-these-choices)
+- [Defense-to-threat mapping](#defense-to-threat-mapping)
 
 ## Privilege separation
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -22,7 +22,7 @@ Conventions that apply everywhere:
 | `irlume setup` | scripted onboarding: enroll, keyring, recovery, PAM wiring, each step prompted y/N |
 | `irlume status` | health dashboard: daemon, enrollment, keyring, cameras |
 | `irlume detect` | script-friendly probe; exit `0` = ready, `10` = partial, `20` = absent |
-| `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), and the authselect/pam-auth-update regeneration guard |
+| `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), the authselect/pam-auth-update regeneration guard, and install hygiene (leftover backup files next to the managed binaries, hand-installed builds overlaying the packaged ones) |
 | `irlume deps` | verify runtime dependencies (onnxruntime, models, TPM) |
 | `irlume version` | print the installed version (`--version` / `-V` also work) |
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -6,7 +6,7 @@ does what the docs claim. Nothing in this guide can weaken auth: traces log
 **numbers only** (scores, thresholds, cue values, timings), never camera
 frames, embeddings, passwords, or anything reusable.
 
-## The journal, in one view
+## Reading the journal with `irlume logs`
 
 All auth decisions land in the system journal. `irlume logs` shows the whole
 story in one stream: daemon lines, the PAM audit records that say what the

--- a/docs/FAIRNESS.md
+++ b/docs/FAIRNESS.md
@@ -40,7 +40,7 @@ to +0.10; the IR path uses 0.55 native / 0.40 adapted, and calibrated RGB+IR
 fusion grants at probability ≥ 0.50), and the mandatory password fallback
 bounds the residual either way.
 
-## The recognizer trade-off: why we keep AuraFace
+## Recognizer trade-off: AuraFace vs buffalo_l
 
 A stronger recognizer narrows the gap. **buffalo_l** (InsightFace, Glint360K) on
 the identical protocol cut the spread to ≈ 4.5× and halved the worst-group FAR;


### PR DESCRIPTION
## What

Two new report-only doctor checks, both silent when the install is clean:

1. **Stray files**: irlume-named regular files in `/usr/bin`, `/usr/local/bin`, and the PAM module directories that are not the managed names (`irlume`, `irlumed`, `pam_irlume.so`) and that no package owns. These are the backups a manual branch install leaves behind (`irlume.rpm-0.5.0`, `irlumed.pre-gesture`, and so on). Doctor lists them with a "safe to remove" note.
2. **Overlaid binaries**: a managed file whose content no longer matches the installed package, detected via the package manager's own verify (`rpm -V` / `dpkg --verify` / `pacman -Qkk`). This is the dangerous case: the next package update replaces the hand-installed build silently. Doctor names the file and the per-family reinstall command.

## Why

One dev box accumulated seven stray backups in two weeks, including a stale `pam_irlume.so.rpm-0.5.0` sitting in the PAM module directory, and hand-installed builds being clobbered by package updates is a failure mode this project has hit before. Report-only by design: deleting files the package manager does not own is how backups made on purpose get destroyed.

## Format facts (researched, not assumed)

Verified against live runs in Fedora 44 / Debian bookworm+trixie / Arch containers, cross-checked with rpm(8), dpkg(1), pacman(8):

- rpm/dpkg verify lines: 9-char flag string, `5` = digest mismatch, optional file-type marker, then path; only failing files print.
- `dpkg --verify` **exits 0 even with failing files**; output presence is the only signal.
- `pacman -Qkk` prints per-file findings on **stderr** (`warning: pkg: /path (Kind)`) with only the summary on stdout, so the runner captures both streams. Only `checksum mismatch` and `Size mismatch` count as content changes.
- `rpm -qf` / `dpkg -S` / `pacman -Qo` all exit non-zero for unowned paths (the ownership gate).

## Testing

- 6 unit tests: name filter, tempdir directory walk, and all three verify-format parsers (including mtime-only drift ignored, config-file markers, pacman summary/no-mtree lines).
- Full irlume-cli suite green; clippy, fmt, rustdoc `-D warnings` clean.
- Live on the Zenbook (Copr rpm 0.6.0): doctor silent on the clean install, and HW-validated with a planted `/usr/bin/irlume.rpm-test-stray`, which doctor listed with the removal note.
