### PR TITLE
bitwarden: one-command polkit-action setup, flavor-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **`irlume bitwarden setup`: one command replaces the copy-paste Bitwarden
+  polkit setup.** Detects how Bitwarden was installed and acts per flavor:
+  flatpak and native installs get the action file written host-side (content
+  ships inside irlume, byte-identical to bitwarden/clients' resource file, so
+  nothing is downloaded at install time); snap is left to snapd, which
+  installs the action itself on plug connect; ostree/immutable hosts get the
+  rpm-layering steps instead of a doomed write to read-only /usr. Dry-run by
+  default, `--apply` to act. An existing action file with different content
+  is never overwritten (Bitwarden's own setup may have written a newer one),
+  and after installing, the command confirms registration with polkit itself
+  (`pkaction`), catching the mislabeled-file failures a file check misses.
+  `irlume doctor` now points at the command when Bitwarden is installed with
+  polkit wired but no action registered. docs/APP-INTEGRATION.md rewritten
+  around it; the old manual wget flow also mislabeled snap as needing manual
+  setup, which snapd has handled since Bitwarden 2025.3.
+
 - **`irlume doctor` reports install-hygiene drift.** Two related checks, both
   report-only: stray irlume-named files next to the managed binaries and the
   PAM module that no package owns (the backups a manual branch install leaves

--- a/crates/irlume-cli/resources/com.bitwarden.Bitwarden.policy
+++ b/crates/irlume-cli/resources/com.bitwarden.Bitwarden.policy
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+
+<policyconfig>
+    <action id="com.bitwarden.Bitwarden.unlock">
+      <description>Unlock Bitwarden</description>
+      <message>Authenticate to unlock Bitwarden</message>
+      <defaults>
+        <allow_any>no</allow_any>
+        <allow_inactive>no</allow_inactive>
+        <allow_active>auth_self</allow_active>
+      </defaults>
+    </action>
+</policyconfig>

--- a/crates/irlume-cli/src/bitwarden.rs
+++ b/crates/irlume-cli/src/bitwarden.rs
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! `irlume bitwarden`: set up Bitwarden's biometric-unlock polkit action so
+//! its prompt can be face-approved (docs/APP-INTEGRATION.md).
+//!
+//! Bitwarden's "unlock with system authentication" is a polkit
+//! CheckAuthorization on `com.bitwarden.Bitwarden.unlock`, which only exists
+//! once its action file sits in `/usr/share/polkit-1/actions/`. Who puts it
+//! there depends on the install flavor (verified against bitwarden/clients
+//! `os-biometrics-linux.service.ts` and the shipped artifacts, 2026-07):
+//!
+//! - **Flatpak**: never. The Flathub package repacks the release tarball,
+//!   which contains no .policy, and the sandbox cannot write /usr. Manual
+//!   host install is always required; that is the gap this command fills.
+//! - **Snap**: snapd itself. The snap ships the policy under `meta/polkit/`
+//!   and snapd's polkit interface installs it host-side on plug connect as
+//!   `snap.bitwarden.interface.polkit.*.policy`. Nothing for us to do.
+//! - **Native (.deb/.rpm/Arch/AUR)**: the app self-installs via a pkexec
+//!   one-liner when the user first enables the setting. That flow chains an
+//!   unconditional `chcon` with `&&`, so it fails on hosts without SELinux
+//!   tooling; pre-installing here also spares the pkexec prompt.
+//! - **ostree/immutable**: /usr is read-only and polkitd compiles in exactly
+//!   one actions directory (no /etc or XDG fallback), so there is nothing an
+//!   installer can honestly do; we explain the rpm-layering workaround.
+//!
+//! The policy content is EMBEDDED (resources/com.bitwarden.Bitwarden.policy,
+//! byte-identical to bitwarden/clients `apps/desktop/resources/`): the
+//! upstream-documented flow wgets it from their main branch at install time,
+//! and a root-installed file should not depend on a moving branch or the
+//! network. If a file is already present with different content we leave it
+//! alone; Bitwarden's own self-install may have written a newer version.
+//!
+//! polkitd watches the actions directory (GFileMonitor), so a newly written
+//! file is live immediately; no service restart.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+/// Byte-identical copy of bitwarden/clients apps/desktop/resources/
+/// com.bitwarden.desktop.policy (the app installs it under the
+/// com.bitwarden.Bitwarden.policy name; we mirror that). GPL-3.0 like the
+/// clients repo. sha256 e0e0be0c…; matches the copy live-validated on real
+/// hardware 2026-07-22.
+const POLICY: &str = include_str!("../resources/com.bitwarden.Bitwarden.policy");
+
+/// Where polkitd's single compiled-in actions directory lives on every
+/// mainstream distro build (PACKAGE_DATA_DIR /polkit-1/actions).
+const ACTIONS_DIR: &str = "/usr/share/polkit-1/actions";
+
+/// The filename Bitwarden's own self-install writes (NOT the repo resource
+/// name); doctor and the app's needsSetup probe both key on this action.
+const POLICY_FILE: &str = "com.bitwarden.Bitwarden.policy";
+
+/// What snapd's polkit interface names the host-side copy it installs from
+/// the snap's meta/polkit/ (`snap.<name>.interface.<basename>.policy`).
+const SNAPD_POLICY_FILE: &str = "snap.bitwarden.interface.polkit.com.bitwarden.desktop.policy";
+
+// ---- CLI entry ---------------------------------------------------------------
+
+pub fn run(action: Option<&str>, args: &[String]) -> ExitCode {
+    let apply = args.iter().any(|a| a == "--apply");
+    match action {
+        None | Some("status") => status(),
+        Some("setup") => setup(apply),
+        _ => {
+            eprintln!("usage: irlume bitwarden <status|setup> [--apply]");
+            eprintln!("  (setup without --apply prints what it WOULD change: a dry run)");
+            ExitCode::from(2)
+        }
+    }
+}
+
+// ---- detection ---------------------------------------------------------------
+
+/// How Bitwarden got onto this system. Multiple can coexist (a flatpak next
+/// to a .deb); detection returns all of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Flavor {
+    /// Flathub com.bitwarden.desktop, system-wide or per-user install.
+    Flatpak,
+    /// Snap Store bitwarden (snapd owns the polkit action host-side).
+    Snap,
+    /// .deb/.rpm/Arch extra/AUR bitwarden-bin (all land in /opt/Bitwarden or
+    /// /usr/lib/bitwarden).
+    Native,
+}
+
+/// Detect installed Bitwarden flavors by their deployment directories,
+/// rooted at `root` so tests can build a fake filesystem ("/" in production).
+fn detect_flavors(root: &Path, user_home: Option<&Path>) -> Vec<Flavor> {
+    let mut found = Vec::new();
+    let system_flatpak = root.join("var/lib/flatpak/app/com.bitwarden.desktop");
+    let user_flatpak = user_home.map(|h| h.join(".local/share/flatpak/app/com.bitwarden.desktop"));
+    if system_flatpak.is_dir() || user_flatpak.is_some_and(|p| p.is_dir()) {
+        found.push(Flavor::Flatpak);
+    }
+    // Classic /snap plus Fedora's /var/lib/snapd/snap mount point.
+    if root.join("snap/bitwarden").is_dir() || root.join("var/lib/snapd/snap/bitwarden").is_dir() {
+        found.push(Flavor::Snap);
+    }
+    // /opt/Bitwarden: electron-builder .deb/.rpm and the AUR repack of the
+    // .deb. /usr/lib/bitwarden: Arch's from-source extra/bitwarden package.
+    if root.join("opt/Bitwarden").is_dir() || root.join("usr/lib/bitwarden").is_dir() {
+        found.push(Flavor::Native);
+    }
+    found
+}
+
+/// Whether any Bitwarden install is present at all (doctor's gate for the
+/// "installed but no polkit action" advisory).
+pub(crate) fn app_detected() -> bool {
+    !detect_flavors(Path::new("/"), detection_home().as_deref()).is_empty()
+}
+
+/// The invoking user's home for per-user flatpak detection: under sudo the
+/// real user's, not root's.
+fn detection_home() -> Option<PathBuf> {
+    if crate::is_root() {
+        if let Ok(u) = std::env::var("SUDO_USER") {
+            if !u.is_empty() {
+                return Some(PathBuf::from(format!("/home/{u}")));
+            }
+        }
+    }
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+// ---- policy-file state -------------------------------------------------------
+
+#[derive(Debug, PartialEq, Eq)]
+enum PolicyState {
+    /// No action file on the host.
+    Absent,
+    /// Present and byte-identical to the copy we ship.
+    Installed,
+    /// Present with other content: Bitwarden's own (possibly newer) install,
+    /// or a hand-edited file. Not ours to overwrite.
+    Differs,
+}
+
+fn classify_policy(existing: Option<&str>) -> PolicyState {
+    match existing {
+        None => PolicyState::Absent,
+        Some(s) if s == POLICY => PolicyState::Installed,
+        Some(_) => PolicyState::Differs,
+    }
+}
+
+fn read_policy_state(actions_dir: &Path) -> PolicyState {
+    let existing = std::fs::read_to_string(actions_dir.join(POLICY_FILE)).ok();
+    classify_policy(existing.as_deref())
+}
+
+/// Whether this boot is an ostree/immutable system (Silverblue, Kinoite…),
+/// where /usr is read-only and no writable actions directory exists.
+fn ostree_booted() -> bool {
+    Path::new("/run/ostree-booted").exists()
+}
+
+// ---- status ------------------------------------------------------------------
+
+fn status() -> ExitCode {
+    let flavors = detect_flavors(Path::new("/"), detection_home().as_deref());
+    if flavors.is_empty() {
+        println!("[bitwarden] app: not detected (flatpak/snap/native paths all absent)");
+    }
+    for f in &flavors {
+        let label = match f {
+            Flavor::Flatpak => "flatpak (com.bitwarden.desktop)",
+            Flavor::Snap => "snap (polkit action managed by snapd)",
+            Flavor::Native => "native package (/opt/Bitwarden or /usr/lib/bitwarden)",
+        };
+        println!("[bitwarden] app: {label} ✓");
+    }
+    let actions = Path::new(ACTIONS_DIR);
+    match read_policy_state(actions) {
+        PolicyState::Installed => {
+            println!("[bitwarden] polkit action: installed ✓ (matches the copy irlume ships)")
+        }
+        PolicyState::Differs => println!(
+            "[bitwarden] polkit action: installed ✓ (content differs from the copy irlume \
+             ships; Bitwarden's own setup may have written a newer one; leaving it alone)"
+        ),
+        PolicyState::Absent if flavors.contains(&Flavor::Snap) => {
+            if actions.join(SNAPD_POLICY_FILE).exists() {
+                println!("[bitwarden] polkit action: installed by snapd ✓");
+            } else {
+                println!(
+                    "[bitwarden] polkit action: MISSING and snapd has not installed its copy; \
+                     try: sudo snap connect bitwarden:polkit"
+                );
+            }
+        }
+        PolicyState::Absent => println!(
+            "[bitwarden] polkit action: not installed (biometric unlock will not work); \
+             run: sudo irlume bitwarden setup --apply"
+        ),
+    }
+    match crate::pamwire::polkit_wired() {
+        Some(true) => println!("[bitwarden] polkit face auth: wired ✓"),
+        Some(false) => println!(
+            "[bitwarden] polkit face auth: not wired; the prompt will ask for the password. \
+             Enable: sudo irlume login enable --with-polkit --apply"
+        ),
+        None => {}
+    }
+    ExitCode::SUCCESS
+}
+
+// ---- setup -------------------------------------------------------------------
+
+fn setup(apply: bool) -> ExitCode {
+    let flavors = detect_flavors(Path::new("/"), detection_home().as_deref());
+    if flavors.is_empty() {
+        println!(
+            "[bitwarden] app not detected; installing the polkit action anyway is harmless \
+             (it is inert until Bitwarden uses it), continuing."
+        );
+    }
+
+    // Snap-only: snapd owns the host-side action; installing our copy too
+    // would leave two files declaring overlapping intent. Report and stop.
+    if flavors == [Flavor::Snap] {
+        return if Path::new(ACTIONS_DIR).join(SNAPD_POLICY_FILE).exists() {
+            println!("[bitwarden] snap install: snapd already installed the polkit action ✓");
+            print_app_steps();
+            ExitCode::SUCCESS
+        } else {
+            println!(
+                "[bitwarden] snap install, but snapd's action file is missing. irlume does \
+                 not write it (snapd owns that file); try: sudo snap connect bitwarden:polkit"
+            );
+            ExitCode::FAILURE
+        };
+    }
+
+    match read_policy_state(Path::new(ACTIONS_DIR)) {
+        PolicyState::Installed => {
+            println!("[bitwarden] polkit action already installed ✓ (nothing to change)");
+            print_app_steps();
+            return ExitCode::SUCCESS;
+        }
+        PolicyState::Differs => {
+            println!(
+                "[bitwarden] a polkit action file is already present with different content; \
+                 leaving it alone (Bitwarden's own setup may have written a newer version). \
+                 Nothing to change."
+            );
+            print_app_steps();
+            return ExitCode::SUCCESS;
+        }
+        PolicyState::Absent => {}
+    }
+
+    // ostree: /usr is read-only and polkitd reads actions ONLY from
+    // /usr/share/polkit-1/actions (compiled in; no /etc fallback). Writing
+    // would just fail with EROFS; explain the supported route instead.
+    if ostree_booted() {
+        println!(
+            "[bitwarden] this is an ostree/immutable system: /usr is read-only and polkit \
+             has no other actions directory. Install the policy by layering a small rpm \
+             that owns {ACTIONS_DIR}/{POLICY_FILE} (rpm-ostree install --apply-live), \
+             then restart polkit. See docs/APP-INTEGRATION.md."
+        );
+        return ExitCode::FAILURE;
+    }
+
+    if !apply {
+        println!("[bitwarden] DRY RUN: showing what `--apply` would change (nothing is written):");
+        println!("  write {ACTIONS_DIR}/{POLICY_FILE} (root:root 0644, content shipped in irlume)");
+        println!("  restore its SELinux label (Fedora-family; no-op elsewhere)");
+        println!("[bitwarden] re-run with --apply (as root) to perform these changes.");
+        return ExitCode::SUCCESS;
+    }
+    if !crate::is_root() {
+        eprintln!(
+            "[bitwarden] applying changes needs root; run: sudo irlume bitwarden setup --apply"
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let target = Path::new(ACTIONS_DIR).join(POLICY_FILE);
+    if let Err(e) = std::fs::write(&target, POLICY) {
+        eprintln!("[bitwarden] writing {} failed: {e}", target.display());
+        return ExitCode::FAILURE;
+    }
+    // polkitd runs unprivileged (User=polkitd) and silently skips files it
+    // cannot read, so 0644 is a requirement, set explicitly rather than
+    // trusting the caller's umask.
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644));
+    // SELinux: a file CREATED in this directory inherits the default usr_t
+    // label already; restorecon covers the remaining edge (a pre-staged file
+    // moved into place keeps its old label, which makes polkitd skip it).
+    // Failure or absence (non-SELinux hosts) is fine, unlike Bitwarden's own
+    // setup whose hard-chained `chcon` breaks there (clients#16671).
+    let _ = std::process::Command::new("restorecon")
+        .arg(&target)
+        .status();
+    println!(
+        "[bitwarden] polkit action installed ✓ ({}). polkit picks it up immediately \
+         (no restart needed).",
+        target.display()
+    );
+    // Confirm from polkitd's side, not the filesystem's: pkaction resolves
+    // the action only if the daemon parsed and registered the file. Catches
+    // the file-present-but-unreadable/mislabeled class of failure.
+    match std::process::Command::new("pkaction")
+        .args(["--action-id", "com.bitwarden.Bitwarden.unlock"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            println!("[bitwarden] polkit registered the action ✓ (pkaction sees it)")
+        }
+        Ok(_) => println!(
+            "[bitwarden] ⚠ polkit has not registered the action yet. Remedies: \
+             sudo systemctl restart polkit; on SELinux hosts check the label \
+             (restorecon -v {})",
+            target.display()
+        ),
+        Err(_) => {} // pkaction not installed; skip the verification quietly
+    }
+
+    if crate::pamwire::polkit_wired() != Some(true) {
+        println!(
+            "[bitwarden] polkit face auth is not wired yet; without it the prompt asks for \
+             your password. Enable: sudo irlume login enable --with-polkit --apply"
+        );
+    }
+    print_app_steps();
+    ExitCode::SUCCESS
+}
+
+/// The two steps that live inside Bitwarden's own UI and cannot be automated.
+fn print_app_steps() {
+    println!("[bitwarden] finish inside the app:");
+    println!("  1. File > Settings > Security > \"Unlock with system authentication\"");
+    println!("  2. unlock the vault once with your master password (biometrics never replace");
+    println!("     the first unlock; Bitwarden keeps the vault key in memory)");
+    println!("  then the unlock prompt is a polkit dialog your consent gesture satisfies.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_policy, detect_flavors, Flavor, PolicyState, POLICY};
+    use std::path::Path;
+
+    #[test]
+    fn embedded_policy_declares_the_expected_action() {
+        // The action id is the contract with Bitwarden's CheckAuthorization
+        // call and with doctor's detection; a drifted resource file must fail.
+        assert!(POLICY.contains(r#"<action id="com.bitwarden.Bitwarden.unlock">"#));
+        assert!(POLICY.contains("<allow_active>auth_self</allow_active>"));
+        assert!(POLICY.contains("<allow_any>no</allow_any>"));
+    }
+
+    #[test]
+    fn policy_state_classification() {
+        assert_eq!(classify_policy(None), PolicyState::Absent);
+        assert_eq!(classify_policy(Some(POLICY)), PolicyState::Installed);
+        assert_eq!(
+            classify_policy(Some("<policyconfig/>")),
+            PolicyState::Differs
+        );
+    }
+
+    #[test]
+    fn flavor_detection_from_a_fake_root() {
+        let base = std::env::temp_dir().join(format!("irlume-bw-test-{}", std::process::id()));
+        let home = base.join("home/user");
+        std::fs::create_dir_all(base.join("opt/Bitwarden")).unwrap();
+        std::fs::create_dir_all(base.join("var/lib/snapd/snap/bitwarden")).unwrap();
+        std::fs::create_dir_all(home.join(".local/share/flatpak/app/com.bitwarden.desktop"))
+            .unwrap();
+
+        let all = detect_flavors(&base, Some(&home));
+        assert_eq!(all, vec![Flavor::Flatpak, Flavor::Snap, Flavor::Native]);
+
+        // Per-user flatpak alone is enough; an unrelated home is not.
+        let none = detect_flavors(Path::new("/nonexistent-bw-root"), Some(Path::new("/tmp")));
+        assert!(none.is_empty());
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+}

--- a/crates/irlume-cli/src/bitwarden.rs
+++ b/crates/irlume-cli/src/bitwarden.rs
@@ -113,6 +113,35 @@ pub(crate) fn app_detected() -> bool {
     !detect_flavors(Path::new("/"), detection_home().as_deref()).is_empty()
 }
 
+/// Condensed state for the TUI's app-unlock row. `None` when Bitwarden is not
+/// installed at all, so the row disappears entirely for everyone else (the
+/// feature stays invisible until it is relevant: opt-in by presence).
+pub(crate) enum TuiState {
+    /// Action file present (ours, Bitwarden's own, or snapd's). Ready.
+    Ready,
+    /// Snap install whose snapd-managed action is missing; irlume must not
+    /// write it, the fix is `snap connect bitwarden:polkit`.
+    SnapMissing,
+    /// Action file absent and `irlume bitwarden setup --apply` would fix it.
+    NeedsSetup,
+}
+
+pub(crate) fn tui_state() -> Option<TuiState> {
+    let flavors = detect_flavors(Path::new("/"), detection_home().as_deref());
+    if flavors.is_empty() {
+        return None;
+    }
+    let actions = Path::new(ACTIONS_DIR);
+    match read_policy_state(actions) {
+        // A differing file is Bitwarden's own (possibly newer) install; from
+        // the user's seat that is just as ready as ours.
+        PolicyState::Installed | PolicyState::Differs => Some(TuiState::Ready),
+        PolicyState::Absent if actions.join(SNAPD_POLICY_FILE).exists() => Some(TuiState::Ready),
+        PolicyState::Absent if flavors == [Flavor::Snap] => Some(TuiState::SnapMissing),
+        PolicyState::Absent => Some(TuiState::NeedsSetup),
+    }
+}
+
 /// The invoking user's home for per-user flatpak detection: under sudo the
 /// real user's, not root's.
 fn detection_home() -> Option<PathBuf> {

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1271,6 +1271,9 @@ SYSTEM INTEGRATION
   fingerprint <status|add|verify|reset|enable|disable> [--fingerprint-only]
                         fprintd companion; enable = face OR fingerprint (both),
                         --fingerprint-only replaces face with fingerprint
+  bitwarden <status|setup> [--apply]
+                        install Bitwarden's biometric-unlock polkit action
+                        (flatpak/native; snap is handled by snapd already)
   selinux <status|load>           SELinux module for the login greeter
   ir-setup [--dry-run]            auto-configure the IR emitter (sudo; rarely
                         needed; enroll auto-runs it when IR frames are dark)

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -20,6 +20,7 @@
 //!   irlume logs [-f] [debug on|off]              face-auth journal view + tracing switch
 //!   irlume tui                                   interactive setup/management UI
 
+mod bitwarden;
 mod blinkcap;
 mod commands;
 mod fingerprint;
@@ -104,6 +105,7 @@ fn main() -> std::process::ExitCode {
         (Some("enrolldev"), _) => enrolldev(&args),
         (Some("keyring"), sub) => keyring(sub, &args),
         (Some("recovery"), sub) => recovery::run(sub, &args),
+        (Some("bitwarden"), sub) => bitwarden::run(sub, &args),
         (Some("fingerprint"), sub) => fingerprint::run(sub, &args),
         (Some("login"), sub) => pamwire::run(sub, &args),
         (Some("logs"), sub) => logs::run(sub, &args),
@@ -2582,6 +2584,15 @@ fn doctor() -> std::process::ExitCode {
     // tightening that hid /run/irlume.sock would be visible.
     if crate::pamwire::polkit_wired() == Some(true) {
         report_polkit_sandbox();
+        // The inverse of the wired-check above: face auth answers polkit, but
+        // Bitwarden is installed without its polkit action, so its biometric
+        // unlock silently falls back to the password. One command fixes it.
+        if !bitwarden_action && bitwarden::app_detected() {
+            println!(
+                "[doctor] Bitwarden is installed but its polkit action is not; its biometric \
+                 unlock\n     falls back to the password. Fix: sudo irlume bitwarden setup --apply"
+            );
+        }
     }
     // The login keyring an app like Bitwarden reads from: report whether a
     // Secret Service provider is up and the collection is unlocked. Self-gates

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -142,6 +142,9 @@ enum Suspend {
     /// suspends to `sudo irlume uninstall --yes` (the TUI already double-
     /// confirmed, so --yes skips the CLI's own prompts).
     Uninstall,
+    /// Install Bitwarden's biometric-unlock polkit action; root op, suspends
+    /// to `sudo irlume bitwarden setup --apply` (non-interactive, flavor-aware).
+    BitwardenSetup,
 }
 
 /// Severity of a Repair-tab diagnostic.
@@ -1571,6 +1574,10 @@ impl App {
                 &["irlume", "set-cameras", &rgb, &ir],
             ),
             Suspend::IrSetup => self.sudo_step("enable the IR emitter", &["irlume", "ir-setup"]),
+            Suspend::BitwardenSetup => self.sudo_step(
+                "install Bitwarden's polkit action",
+                &["irlume", "bitwarden", "setup", "--apply"],
+            ),
             Suspend::Logs => self.sudo_step("show the face-auth journal", &["irlume", "logs"]),
             // The TUI already double-confirmed, so pass --yes; the CLI still
             // does the teardown (un-wire PAM, stop daemon, wipe data) as root
@@ -1961,6 +1968,21 @@ impl App {
             }
             // Login wiring (PAM): show status outside the alt-screen.
             (SC_PAM, KeyCode::Char('s')) => self.suspend = Some(Suspend::LoginStatus),
+            // Bitwarden app unlock: install its polkit action, only ever on
+            // explicit request and only useful when the row says so.
+            (SC_PAM, KeyCode::Char('b')) => match crate::bitwarden::tui_state() {
+                Some(crate::bitwarden::TuiState::NeedsSetup) => {
+                    self.log('→', "sudo irlume bitwarden setup --apply: installs Bitwarden's polkit action (host-side; the flatpak cannot)");
+                    self.suspend = Some(Suspend::BitwardenSetup);
+                }
+                Some(crate::bitwarden::TuiState::Ready) => {
+                    self.log('·', "Bitwarden's polkit action is already installed; enable \"unlock with system authentication\" in its settings")
+                }
+                Some(crate::bitwarden::TuiState::SnapMissing) => {
+                    self.log('·', "snap install: snapd owns that file; run: sudo snap connect bitwarden:polkit")
+                }
+                None => self.log('·', "Bitwarden is not installed on this system"),
+            },
             // Settings.
             (SC_SETTINGS, KeyCode::Enter) | (SC_SETTINGS, KeyCode::Char(' ')) => {
                 let on = !self.eyes_open;
@@ -3358,6 +3380,34 @@ impl App {
             "    closure after `sudo irlume calibrate-closure`.  See docs/APP-INTEGRATION.md",
             Style::new().dim(),
         )));
+        // Bitwarden app-unlock row: only rendered when Bitwarden is installed
+        // (invisible for everyone else), and never acts on its own — [b] is
+        // the user's explicit opt-in.
+        match crate::bitwarden::tui_state() {
+            None => {}
+            Some(crate::bitwarden::TuiState::Ready) => lines.push(Line::from(vec![
+                Span::styled("  Bitwarden ", Style::new()),
+                Span::styled("● polkit action installed", Style::new().fg(OK)),
+                Span::styled(
+                    "  (enable \"unlock with system authentication\" in its settings)",
+                    Style::new().dim(),
+                ),
+            ])),
+            Some(crate::bitwarden::TuiState::SnapMissing) => lines.push(Line::from(vec![
+                Span::styled("  Bitwarden ", Style::new()),
+                Span::styled("○ snap action missing", Style::new().fg(WARN)),
+                Span::styled(
+                    "  fix: sudo snap connect bitwarden:polkit",
+                    Style::new().dim(),
+                ),
+            ])),
+            Some(crate::bitwarden::TuiState::NeedsSetup) => lines.push(Line::from(vec![
+                Span::styled("  Bitwarden ", Style::new()),
+                Span::styled("○ biometric unlock not set up", Style::new().fg(WARN)),
+                Span::styled("  [b]", Style::new().fg(ACCENT)),
+                Span::styled(" set it up (sudo; optional)", Style::new().dim()),
+            ])),
+        }
         lines.push(Line::from(vec![
             Span::styled("  disable ", Style::new()),
             Span::styled("sudo irlume login disable --apply", Style::new().dim()),
@@ -3541,7 +3591,11 @@ impl App {
             SC_KEYRING => &[("a", "arm"), ("f", "forget")],
             SC_RECOVERY => &[("s", "set"), ("t", "restore"), ("f", "forget")],
             SC_FINGERPRINT => &[("a", "enroll finger")],
-            SC_PAM => &[("w", "wire login (sudo)"), ("s", "show status")],
+            SC_PAM => &[
+                ("w", "wire login (sudo)"),
+                ("s", "show status"),
+                ("b", "app unlock"),
+            ],
             SC_SETTINGS => &[("enter", "toggle eyes-open"), ("c", "toggle blink")],
             SC_DONE => &[("w", "wire login"), ("r", "refresh")],
             _ => &[("r", "refresh")],

--- a/docs/APP-INTEGRATION.md
+++ b/docs/APP-INTEGRATION.md
@@ -67,19 +67,37 @@ PAM stack that irlume wires. First wire irlume for polkit if you have not:
 sudo irlume login enable --with-polkit --apply
 ```
 
-The non-sandboxed Bitwarden packages register their polkit action themselves.
-The **flatpak and snap cannot** write to `/usr/share/polkit-1/actions`, and the
-flatpak gives no in-product prompt for the manual step, so install the action on
-the host yourself:
+Then let irlume install Bitwarden's polkit action (it detects how Bitwarden
+was installed and does the right thing per flavor):
 
 ```console
-# Install Bitwarden's polkit action (the sandbox cannot do this itself)
-sudo wget -O /usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy \
-  https://raw.githubusercontent.com/bitwarden/clients/main/apps/desktop/resources/com.bitwarden.desktop.policy
-sudo chown root:root /usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
-# Fedora / SELinux only: label it so polkit can read it
-sudo chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
+irlume bitwarden status              # what is installed, what is missing
+sudo irlume bitwarden setup --apply  # dry-run first by omitting --apply
 ```
+
+What it does per install flavor:
+
+- **Flatpak**: installs the action file on the host. The flatpak bundles no
+  policy file and its sandbox cannot write `/usr/share/polkit-1/actions`, so
+  a host-side install is always required; this is the main case.
+- **Snap**: nothing. snapd installs the action itself when the snap's polkit
+  plug connects (auto-connected from the store since Bitwarden 2025.3). If
+  the action is missing there, the fix is `sudo snap connect bitwarden:polkit`.
+- **.deb / .rpm / Arch**: installs the same file the app would self-install
+  on first toggle, sparing the pkexec prompt (the app's own setup also breaks
+  on hosts without SELinux tooling; irlume's does not).
+- **ostree / immutable (Silverblue, Kinoite)**: explains instead of writing.
+  `/usr` is read-only and polkit reads actions from exactly one directory,
+  so the supported route is layering a small rpm that owns the file
+  (`rpm-ostree install --apply-live`), then restarting polkit.
+
+The policy content ships inside irlume (byte-identical to
+`apps/desktop/resources/com.bitwarden.desktop.policy` in bitwarden/clients),
+so nothing is downloaded at install time. An already-present action file with
+different content is left alone: Bitwarden's own setup may have written a
+newer one. After installing, the command asks polkit itself (`pkaction`)
+whether the action registered, which catches label problems a plain file
+check misses.
 
 Then in Bitwarden: **File > Settings > Security > Unlock with system
 authentication**. `irlume doctor` confirms the action is registered.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -57,6 +57,7 @@ Conventions that apply everywhere:
 | `irlume logs [-f] [--since T]` | sometimes | the face-auth journal in one view (daemon, PAM, keyring); `-f` follows live, `--since "10 min ago"` widens the window |
 | `irlume logs debug <on\|off>` | yes | per-stage pipeline tracing in the daemon (numbers only, never frames) |
 | `irlume fingerprint <status\|add\|verify\|reset\|enable\|disable> [--fingerprint-only]` | for wiring | fprintd companion; `enable` = unlock with face OR fingerprint (both), `--fingerprint-only` replaces face |
+| `irlume bitwarden <status\|setup> [--apply]` | for setup | install Bitwarden's biometric-unlock polkit action, flavor-aware (flatpak/native install it; snap is snapd's job; ostree gets the layering steps); see docs/APP-INTEGRATION.md |
 | `irlume selinux <status\|load>` | for load | SELinux module for the login greeter (Fedora) |
 | `irlume ir-setup [--dry-run]` | yes | auto-configure the IR emitter; rarely needed, enroll runs it itself when IR frames come back dark |
 | `irlume set-cameras <rgb> <ir>` | yes | persist the RGB+IR camera pair, e.g. `/dev/video0 /dev/video2`; the TUI camera picker runs this for you |


### PR DESCRIPTION
## What

`irlume bitwarden <status|setup> [--apply]`: replaces the copy-paste wget flow in docs/APP-INTEGRATION.md with one flavor-aware command. Dry-run by default, `--apply` to act, mirroring `irlume login`.

| Flavor | Behavior |
|---|---|
| flatpak | installs the action file host-side (the flatpak bundles no policy and cannot write /usr; this is the case that always needs help) |
| snap | hands off: snapd installs the action itself on plug connect (auto-connected since Bitwarden 2025.3); if missing, the fix is `snap connect bitwarden:polkit` |
| .deb / .rpm / Arch | installs the same file the app would self-install via pkexec on first toggle; the app's own setup chains an unconditional `chcon` with `&&` and fails on hosts without SELinux tooling (clients#16671), ours does not |
| ostree / immutable | refuses to write (polkitd reads exactly one compiled-in actions dir; /usr is read-only) and prints the rpm-layering route |

Design points:

- **Embedded policy, no runtime download.** The content ships in `resources/`, byte-identical to `apps/desktop/resources/com.bitwarden.desktop.policy` in bitwarden/clients and to the copy live-validated on hardware during 0.6.0. A root-installed file should not depend on fetching a moving branch.
- **Never overwrites a differing file.** Bitwarden's own self-install may have written a newer version; setup reports and leaves it.
- **Verifies with polkitd, not the filesystem.** After install, `pkaction --action-id com.bitwarden.Bitwarden.unlock` confirms registration, catching the mislabeled-file failures a file check misses. polkitd file-monitors the actions dir, so no restart step.
- **doctor tie-in:** app installed + polkit wired + action missing now points at this command.
- docs/APP-INTEGRATION.md rewritten around the command; it also corrects our old claim that snap needs manual setup (snapd has handled it since Bitwarden 2025.3).

## Research basis

Two research agents with primary sources: bitwarden/clients `os-biometrics-linux.service.ts` (self-install gating: `canAutoSetup()` false for flatpak/snap), Flathub manifest + release-tarball listing (no bundled policy), snapd `interfaces/builtin/polkit.go` (host-side install naming), polkit `polkitbackendactionpool.c` (single compiled-in actions dir, GFileMonitor live pickup, malformed files skipped per-file), goldwarden's setup flow (the mv-from-tmp SELinux label trap our in-place write avoids), issue #19571 (ostree).

## Testing

- 3 unit tests: embedded-policy contract (action id, auth_self), policy-state classification, flavor detection against a fake root.
- Container E2E (fedora:44): not-detected status, dry-run, apply (file 0644 root:root), idempotent re-apply, foreign-content file left intact, status reflecting each state.
- Live on the Zenbook (flatpak + already-installed action): status correct, setup correctly reports nothing to change.
- Full irlume-cli suite 264 tests, clippy, fmt, rustdoc -D warnings all clean.

## HW validation suggested before merge

On a box where the action is absent (or after `sudo rm /usr/share/polkit-1/actions/com.bitwarden.Bitwarden.policy`): `sudo irlume bitwarden setup --apply`, confirm `pkaction` registration line, then a real Bitwarden unlock with the consent gesture.
