### PR TITLE
tui: HIG-guided redesign + full CLI parity + latency/robustness fixes

### DIFF
--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1047,6 +1047,51 @@ pub fn deps(_args: &[String]) -> ExitCode {
 /// stale seal can never be silently overwritten with a typo (the daemon's
 /// automatic reseal only runs in the post-auth session phase for the same
 /// reason). Functionally a re-arm against today's PCRs.
+/// `irlume biopolicy <on|off|status>`: toggle the opt-in operation-class gate
+/// (`enforce_biopolicy` in settings.conf). The daemon reads it live per request,
+/// so no restart is needed. Reversible; the password is always the fallback,
+/// so enabling it can restrict which services a face may satisfy but never
+/// locks anyone out.
+pub fn biopolicy(sub: Option<&str>, _args: &[String]) -> ExitCode {
+    let on = irlume_common::config::read_kv("settings.conf", "enforce_biopolicy")
+        .map(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false);
+    match sub {
+        None | Some("status") => {
+            println!(
+                "[biopolicy] operation-class gate: {}",
+                if on { "ENFORCING" } else { "off (default)" }
+            );
+            ExitCode::SUCCESS
+        }
+        Some(v @ ("on" | "off")) => {
+            if !crate::is_root() {
+                eprintln!("[biopolicy] needs root: sudo irlume biopolicy {v}");
+                return ExitCode::FAILURE;
+            }
+            let val = if v == "on" { "1" } else { "0" };
+            match irlume_common::config::write_kv("settings.conf", "enforce_biopolicy", val) {
+                Ok(()) => {
+                    println!(
+                        "[biopolicy] operation-class gate {} (takes effect on the next face auth; \
+                         the password is always available).",
+                        if v == "on" { "ENABLED" } else { "disabled" }
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("[biopolicy] could not update settings.conf: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        Some(other) => {
+            eprintln!("[biopolicy] usage: irlume biopolicy <on|off|status> (got '{other}')");
+            ExitCode::from(2)
+        }
+    }
+}
+
 pub fn reseal(args: &[String]) -> ExitCode {
     let user = user_arg(args);
     // Only meaningful if already armed (we never auto-arm from here).
@@ -1292,6 +1337,8 @@ SYSTEM INTEGRATION
                         camera picker runs this for you)
   models [enable|disable]         opt-in third-party liveness models: measured,
                         checksum-pinned, deny-only; fetched, never shipped
+  biopolicy <on|off|status>       opt-in operation-class gate: restrict which
+                        services a face may satisfy (advanced; password unaffected)
   update [--check]                update via the channel this was installed from
                         (Copr/PPA: runs it; .deb/pkg/source: shows the steps)
   uninstall [--keep-data]         un-wire PAM, stop the daemon, wipe enrolled

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -110,6 +110,7 @@ fn main() -> std::process::ExitCode {
         (Some("login"), sub) => pamwire::run(sub, &args),
         (Some("logs"), sub) => logs::run(sub, &args),
         (Some("models"), sub) => models::run(sub, &args),
+        (Some("biopolicy"), sub) => commands::biopolicy(sub, &args),
         (Some("calibrate-closure"), _) => calibrate_closure(&args),
         (Some("ir-setup"), _) => ir_setup(&args),
         (Some("set-cameras"), _) => set_cameras(&args),

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2777,7 +2777,7 @@ pub(crate) mod testenv {
 /// `irlume selftest liveness`: run the daemon's IR liveness self-test (fires
 /// the camera through the running daemon, so no camera contention). The daemon
 /// root-gates it (the raw measurements are a spoof-tuning oracle), so this must
-/// run as root — the TUI reaches it via `sudo irlume selftest liveness`.
+/// run as root; the TUI reaches it via `sudo irlume selftest liveness`.
 fn selftest_liveness() -> std::process::ExitCode {
     use irlume_common::{Request, Response, SelfTestKind};
     match daemon_request(&Request::SelfTest {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -73,9 +73,13 @@ fn main() -> std::process::ExitCode {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
     let args: Vec<String> = std::env::args().skip(1).collect();
-    // Gate the developer tools unless IRLUME_DEV is set.
+    // Gate the developer tools unless IRLUME_DEV is set. Exception:
+    // `selftest liveness` goes THROUGH the daemon (no direct camera open), so
+    // it's a normal diagnostic the TUI's [l] uses, not a dev tool.
+    let daemon_selftest = args.first().map(String::as_str) == Some("selftest")
+        && args.get(1).map(String::as_str) == Some("liveness");
     if let Some(cmd) = args.first().map(String::as_str) {
-        if DEV_CMDS.contains(&cmd) && std::env::var_os("IRLUME_DEV").is_none() {
+        if DEV_CMDS.contains(&cmd) && !daemon_selftest && std::env::var_os("IRLUME_DEV").is_none() {
             eprintln!(
                 "[irlume] '{cmd}' is a developer/benchmark tool (opens the camera directly, \
                        not for normal use). Set IRLUME_DEV=1 to enable it."
@@ -88,6 +92,7 @@ fn main() -> std::process::ExitCode {
         args.get(1).map(String::as_str),
     ) {
         (Some("selftest"), Some("align")) => selftest_align(&args),
+        (Some("selftest"), Some("liveness")) => selftest_liveness(),
         (Some("capture"), _) => capture(&args),
         (Some("eval"), _) => eval(&args),
         (Some("irbench"), _) => irbench(&args),
@@ -2769,6 +2774,39 @@ pub(crate) mod testenv {
 /// twice: cosine MUST be ~1.0. Proves the ONNX path is deterministic and the
 /// preprocessing is wired before any matching is trusted. Needs the AuraFace
 /// model file and `libonnxruntime.so` available at runtime.
+/// `irlume selftest liveness`: run the daemon's IR liveness self-test (fires
+/// the camera through the running daemon, so no camera contention). The daemon
+/// root-gates it (the raw measurements are a spoof-tuning oracle), so this must
+/// run as root — the TUI reaches it via `sudo irlume selftest liveness`.
+fn selftest_liveness() -> std::process::ExitCode {
+    use irlume_common::{Request, Response, SelfTestKind};
+    match daemon_request(&Request::SelfTest {
+        kind: SelfTestKind::Liveness,
+    }) {
+        Ok(Response::SelfTest { passed, detail }) => {
+            println!("[selftest liveness] {detail}");
+            if passed {
+                println!("[selftest liveness] PASS");
+                std::process::ExitCode::SUCCESS
+            } else {
+                std::process::ExitCode::FAILURE
+            }
+        }
+        Ok(Response::Error(e)) => {
+            eprintln!("[selftest liveness] {e}");
+            std::process::ExitCode::FAILURE
+        }
+        Ok(o) => {
+            eprintln!("[selftest liveness] unexpected: {o:?}");
+            std::process::ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("[selftest liveness] {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
 fn selftest_align(args: &[String]) -> std::process::ExitCode {
     let model = match flag(args, "--model") {
         Some(p) => p,

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -241,6 +241,40 @@ fn stdin_is_tty() -> bool {
 /// still matches the pin. settings.conf is root-only, so an unprivileged
 /// caller cannot read the enabled key; the weights file (0644) is readable,
 /// so installed-but-unconfirmable gets reported instead of a false "none".
+/// Condensed third-party-model state for a TUI status row, so it can show a
+/// ●/○ icon like the other Settings sections instead of a bare text blob.
+pub(crate) enum TuiState {
+    /// A catalog model is enabled in settings.conf; carries its name and the
+    /// weight health (checksum ok / mismatch).
+    Enabled { name: String, detail: String },
+    /// Weights are installed but the enabled flag is root-only and we are not
+    /// root, so we can report presence but not the on/off state.
+    InstalledUnknown { name: String },
+    /// No third-party model enabled (the default).
+    None,
+}
+
+pub(crate) fn tui_state() -> TuiState {
+    if let Some(name) = enabled_name() {
+        let detail = match thirdparty::by_name(&name) {
+            Some(m) => format!("deny-only cue · {}", file_state(m)),
+            None => "set in settings.conf but NOT in the catalog (daemon ignores it)".into(),
+        };
+        return TuiState::Enabled { name, detail };
+    }
+    if !is_root() {
+        if let Some(m) = thirdparty::CATALOG
+            .iter()
+            .find(|m| thirdparty::model_path(m).exists())
+        {
+            return TuiState::InstalledUnknown {
+                name: m.name.to_string(),
+            };
+        }
+    }
+    TuiState::None
+}
+
 pub fn doctor_line() -> String {
     if let Some(name) = enabled_name() {
         return match thirdparty::by_name(&name) {
@@ -383,6 +417,12 @@ mod tests {
         )
         .unwrap();
         assert_eq!(enabled_name().as_deref(), Some(m.name));
+
+        // tui_state mirrors the same config: an enabled name -> Enabled row.
+        match tui_state() {
+            TuiState::Enabled { name, .. } => assert_eq!(name, m.name),
+            _ => panic!("expected Enabled after setting the config key"),
+        }
 
         match old_cfg {
             Some(v) => std::env::set_var("IRLUME_CONFIG_DIR", v),

--- a/crates/irlume-cli/src/secrets.rs
+++ b/crates/irlume-cli/src/secrets.rs
@@ -124,6 +124,21 @@ fn parse_locked(reply: &str) -> Option<bool> {
 
 /// Print one doctor line about the login keyring, or nothing when there is no
 /// session bus to inspect (e.g. under sudo). Only call for the current user.
+/// For the TUI Repair check: `Some(true)` when a Secret Service provider is up
+/// but the login collection is LOCKED (apps like Bitwarden can't read secrets),
+/// `Some(false)` when unlocked, `None` when there's no session bus or provider
+/// to judge (so Repair stays quiet rather than warning on a headless/no-wallet
+/// box). Only meaningful run as the user (a session bus), like the report.
+pub(crate) fn login_keyring_locked() -> Option<bool> {
+    if !have_session_bus() {
+        return None;
+    }
+    match query_collection() {
+        Collection::Present { locked } => Some(locked),
+        Collection::NoProvider => None,
+    }
+}
+
 pub fn report_keyring_status() {
     if !have_session_bus() {
         return;

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1798,6 +1798,22 @@ impl App {
     /// `ir-setup` leaves no re-checkable state, so we log ✓ on success and raise
     /// the error banner on failure.
     fn sudo_step(&mut self, what: &str, args: &[&str]) {
+        // Invoke OUR OWN binary as root, not whatever `irlume` PATH resolves
+        // to: a running TUI must not shell out to a different (older) installed
+        // build for its privileged half. Resolve the first "irlume" arg to the
+        // current exe; leave non-irlume commands (systemd-pcrlock, sh -c) as is.
+        let self_exe = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.to_str().map(String::from));
+        let resolved: Vec<String> = args
+            .iter()
+            .enumerate()
+            .map(|(i, &a)| match (i, a, &self_exe) {
+                (0, "irlume", Some(exe)) => exe.clone(),
+                _ => a.to_string(),
+            })
+            .collect();
+        let args: Vec<&str> = resolved.iter().map(String::as_str).collect();
         eprintln!("\n{what}; running: sudo {}…", args.join(" "));
         // In the cooked terminal, Ctrl-C goes to the whole foreground group:
         // a user aborting the CHILD (a sudo prompt, the models license flow)

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1217,6 +1217,33 @@ impl App {
             ));
         }
 
+        // Keyring PCR-drift: the seal no longer matches the current PCRs (a
+        // firmware/Secure Boot update moved them), so face login silently stops
+        // opening the wallet until re-bound. Only the Keyring tab drew this;
+        // surface it here too, with the one-key fix (reseal, added to Keyring).
+        if self.keyring_drift == Some(true) {
+            v.push(mk(
+                "Keyring seal",
+                Sev::Warn,
+                "PCRs drifted since sealing; the wallet won't auto-unlock until re-bound".into(),
+                Fix::Manual("Keyring tab → [r] reseal (re-bind to current PCRs)".into()),
+            ));
+        }
+
+        // A third-party liveness model enabled but with a CHECKSUM MISMATCH: the
+        // daemon refuses to load it, so the deny-only cue the user opted into is
+        // silently OFF. doctor reports this; a TUI-only user would never see it.
+        if let crate::models::TuiState::Enabled { name, detail } = crate::models::tui_state() {
+            if detail.contains("MISMATCH") {
+                v.push(mk(
+                    "Third-party model",
+                    Sev::Fail,
+                    format!("'{name}' weights fail their checksum; the daemon refuses them (cue is OFF)"),
+                    Fix::Manual("re-fetch: sudo irlume models disable, then models enable".into()),
+                ));
+            }
+        }
+
         if let Some(r) = self.recovery {
             if r.encrypted && !r.recovery_set {
                 v.push(mk(
@@ -3537,7 +3564,11 @@ impl App {
 
     /// Diagnostic + repair: a live checklist (✓/⚠/✗) of everything irlume needs
     /// to run, with one-key fixes, plus platform trust anchors and a live IR PAD
-    /// self-test. Mirrors `irlume doctor` + `diag` + `deps` and adds remediation.
+    /// self-test. Covers the `irlume doctor`/`diag`/`deps` checks that have a
+    /// remediation or that a TUI-only user would otherwise miss (daemon, models,
+    /// cameras, SELinux/AppArmor, wiring drift, keyring drift, recovery, TPM,
+    /// third-party-model checksum). Some advisory-only doctor lines (fingerprint
+    /// vendor-stack, polkit sandbox, install hygiene) stay in `doctor`.
     fn draw_repair(&self, f: &mut Frame, area: Rect) {
         use irlume_common::secureboot;
         let [list_area, info_area] =
@@ -7025,5 +7056,30 @@ mod tests {
         app.repair_sel = 999;
         app.run_checks();
         assert!(app.repair_sel < app.repair.len());
+    }
+
+    #[test]
+    fn repair_surfaces_keyring_drift_with_the_reseal_fix() {
+        // A TUI-only user never runs `doctor`; PCR drift must show on Repair
+        // and point at the reseal action (the newly-added parity fix).
+        let mut app = test_app();
+        app.keyring_drift = None;
+        app.run_checks();
+        assert!(
+            !app.repair.iter().any(|c| c.label == "Keyring seal"),
+            "no drift, no row"
+        );
+        app.keyring_drift = Some(true);
+        app.run_checks();
+        let row = app
+            .repair
+            .iter()
+            .find(|c| c.label == "Keyring seal")
+            .expect("drift must surface on Repair");
+        assert!(row.sev == Sev::Warn);
+        match &row.fix {
+            Fix::Manual(m) => assert!(m.contains("reseal"), "fix points at reseal: {m}"),
+            _ => panic!("expected a manual fix pointing at reseal"),
+        }
     }
 }

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -330,6 +330,9 @@ struct HealthInfo {
     mesh: bool,
     adapter: bool,
     version: String,
+    /// Loaded third-party PAD cue name (authoritative on/off, since
+    /// settings.conf is root-only and a non-root TUI can't read it).
+    third_party_pad: Option<String>,
 }
 
 /// Template-encryption + recovery status (`RecoveryStatus`).
@@ -669,6 +672,7 @@ impl App {
                     mesh,
                     adapter,
                     version,
+                    third_party_pad,
                 }) => Some(HealthInfo {
                     tier,
                     rgb_dev,
@@ -676,6 +680,7 @@ impl App {
                     mesh,
                     adapter,
                     version,
+                    third_party_pad,
                 }),
                 _ => None, // older daemon / daemon down → Repair falls back to local probes
             };
@@ -1232,15 +1237,23 @@ impl App {
 
         // A third-party liveness model enabled but with a CHECKSUM MISMATCH: the
         // daemon refuses to load it, so the deny-only cue the user opted into is
-        // silently OFF. doctor reports this; a TUI-only user would never see it.
-        if let crate::models::TuiState::Enabled { name, detail } = crate::models::tui_state() {
-            if detail.contains("MISMATCH") {
-                v.push(mk(
-                    "Third-party model",
-                    Sev::Fail,
-                    format!("'{name}' weights fail their checksum; the daemon refuses them (cue is OFF)"),
-                    Fix::Manual("re-fetch: sudo irlume models disable, then models enable".into()),
-                ));
+        // silently OFF. Only flag it when the daemon is up and did NOT load a
+        // cue (if it loaded one, Health.third_party_pad proves the weights were
+        // fine). doctor reports this; a TUI-only user would never see it.
+        let daemon_loaded_pad = self
+            .health
+            .as_ref()
+            .is_some_and(|h| h.third_party_pad.is_some());
+        if self.daemon_up && !daemon_loaded_pad {
+            if let crate::models::TuiState::Enabled { name, detail } = crate::models::tui_state() {
+                if detail.contains("MISMATCH") {
+                    v.push(mk(
+                        "Third-party model",
+                        Sev::Fail,
+                        format!("'{name}' weights fail their checksum; the daemon refuses them (cue is OFF)"),
+                        Fix::Manual("re-fetch: sudo irlume models disable, then models enable".into()),
+                    ));
+                }
             }
         }
 
@@ -3019,21 +3032,37 @@ impl App {
                 section("Third-party liveness models"),
                 {
                     // A ●/○ status row like the sections above, not a text blob.
-                    let (icon, icon_style, label) = match crate::models::tui_state() {
-                        crate::models::TuiState::Enabled { name, detail } => (
-                            "●",
-                            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-                            format!("enabled: {name}   {detail}"),
-                        ),
-                        crate::models::TuiState::InstalledUnknown { name } => (
-                            "◐",
-                            Style::new().fg(th().warn),
-                            format!("{name} weights installed; on/off is root-only"),
-                        ),
-                        crate::models::TuiState::None => {
-                            ("○", Style::new().dim(), "none (default)".to_string())
-                        }
-                    };
+                    // The daemon's loaded-cue name is authoritative (it knows
+                    // what it loaded); fall back to the filesystem probe only
+                    // when the daemon can't answer, since settings.conf is
+                    // root-only and a non-root TUI can't read the flag itself.
+                    let (icon, icon_style, label) =
+                        match self.health.as_ref().and_then(|h| h.third_party_pad.clone()) {
+                            Some(name) => (
+                                "●",
+                                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                                format!("enabled: {name}   (loaded by the daemon, deny-only cue)"),
+                            ),
+                            None => match crate::models::tui_state() {
+                                crate::models::TuiState::Enabled { name, detail } => (
+                                    "●",
+                                    Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                                    format!("enabled: {name}   {detail}"),
+                                ),
+                                // Daemon up and reporting no cue -> authoritative off.
+                                _ if self.daemon_up => {
+                                    ("○", Style::new().dim(), "none (default)".to_string())
+                                }
+                                crate::models::TuiState::InstalledUnknown { name } => (
+                                    "◐",
+                                    Style::new().fg(th().warn),
+                                    format!("{name} weights installed; on/off is root-only"),
+                                ),
+                                crate::models::TuiState::None => {
+                                    ("○", Style::new().dim(), "none (default)".to_string())
+                                }
+                            },
+                        };
                     Line::from(vec![
                         Span::raw("  state  "),
                         Span::styled(format!("{icon} "), icon_style),
@@ -5110,6 +5139,7 @@ mod tests {
             mesh: true,
             adapter: false,
             version: "test".into(),
+            third_party_pad: None,
         });
         let start = std::time::Instant::now();
         app.refresh_light();
@@ -6661,6 +6691,7 @@ mod tests {
             mesh: false,
             adapter: false,
             version: "1.0".into(),
+            third_party_pad: None,
         });
         let text = draw_text(&app);
         assert!(
@@ -6686,6 +6717,41 @@ mod tests {
         app.eyes_open = true;
         let text = draw_text(&app);
         assert!(text.contains("● yes"), "the toggled state must show");
+    }
+
+    #[test]
+    fn settings_third_party_row_prefers_the_daemon_loaded_cue() {
+        // The daemon's loaded-cue name is authoritative: a non-root TUI can't
+        // read the root-only settings.conf flag, so a loaded cue must show as
+        // green enabled (not the ◐ "root-only" filesystem guess).
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.daemon_up = true;
+        app.health = Some(HealthInfo {
+            tier: "secure".into(),
+            rgb_dev: None,
+            ir_dev: None,
+            mesh: true,
+            adapter: false,
+            version: "test".into(),
+            third_party_pad: Some("flir".into()),
+        });
+        let text = draw_text(&app);
+        assert!(
+            text.contains("● ") && text.contains("enabled: flir"),
+            "a daemon-loaded cue shows green enabled:\n{text}"
+        );
+        assert!(
+            !text.contains("root-only"),
+            "the authoritative state replaces the root-only guess"
+        );
+        // Daemon up, no cue loaded -> authoritative OFF, never the ◐ guess.
+        app.health.as_mut().unwrap().third_party_pad = None;
+        let text = draw_text(&app);
+        assert!(
+            !text.contains('◐'),
+            "daemon-up with no cue is a definite off"
+        );
     }
 
     #[test]
@@ -6973,6 +7039,7 @@ mod tests {
             mesh: true,
             adapter: true,
             version: env!("CARGO_PKG_VERSION").into(),
+            third_party_pad: None,
         });
         app.run_checks();
         let find = |label: &str| {
@@ -7019,6 +7086,7 @@ mod tests {
             mesh: false,
             adapter: false,
             version: "0.0.1-old".into(),
+            third_party_pad: None,
         });
         app.challenge = true;
         app.enroll_error = Some("bad ciphertext".into());

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -601,7 +601,11 @@ impl App {
                 SC_PROFILES | SC_RECOVERY => caps.rgb,
                 // Diagnostics/tuning: advanced view only.
                 SC_CAMERAS | SC_IDENTIFY => advanced && caps.rgb,
-                SC_SETTINGS => advanced,
+                // Settings holds user preferences (eyes-open, blink, biopolicy,
+                // third-party models), not diagnostics, so it is always
+                // reachable — hiding config behind "advanced" both buries it and
+                // creates dead-end pointers (a Repair fix references Settings).
+                SC_SETTINGS => true,
                 // Repair: only when something needs attention (or advanced view).
                 SC_REPAIR => advanced || needs_repair,
                 // Keyring unlock: an IR camera (face releases the credential) OR a
@@ -5634,12 +5638,19 @@ mod tests {
         // No biometric hardware: only the always-on steps.
         assert_eq!(
             App::compute_visible(&none, basic, &[]),
-            vec![SC_WELCOME, SC_PAM, SC_DONE]
+            vec![SC_WELCOME, SC_PAM, SC_SETTINGS, SC_DONE]
         );
         // RGB-only adds the face path (Profiles + Recovery), not Keyring.
         assert_eq!(
             App::compute_visible(&rgb, basic, &[]),
-            vec![SC_WELCOME, SC_PROFILES, SC_RECOVERY, SC_PAM, SC_DONE]
+            vec![
+                SC_WELCOME,
+                SC_PROFILES,
+                SC_RECOVERY,
+                SC_PAM,
+                SC_SETTINGS,
+                SC_DONE
+            ]
         );
         // An IR pair earns the Keyring step.
         assert_eq!(
@@ -5650,6 +5661,7 @@ mod tests {
                 SC_KEYRING,
                 SC_RECOVERY,
                 SC_PAM,
+                SC_SETTINGS,
                 SC_DONE
             ]
         );
@@ -5663,7 +5675,14 @@ mod tests {
                 },
                 &[]
             ),
-            vec![SC_WELCOME, SC_KEYRING, SC_FINGERPRINT, SC_PAM, SC_DONE]
+            vec![
+                SC_WELCOME,
+                SC_KEYRING,
+                SC_FINGERPRINT,
+                SC_PAM,
+                SC_SETTINGS,
+                SC_DONE
+            ]
         );
         // Advanced view on full hardware shows every screen.
         assert_eq!(
@@ -5688,7 +5707,7 @@ mod tests {
                 },
                 &[]
             ),
-            vec![SC_WELCOME, SC_REPAIR, SC_PAM, SC_DONE]
+            vec![SC_WELCOME, SC_REPAIR, SC_PAM, SC_SETTINGS, SC_DONE]
         );
         // …and when anything needs reporting — a failure OR an advisory — so the
         // Welcome health summary's "→ open checks & repair" pointer is reachable.
@@ -5731,12 +5750,17 @@ mod tests {
         let mut app = test_app();
         app.advanced = true;
         app.recompute_visible();
-        app.screen = SC_SETTINGS;
+        // Identify is advanced-only; leaving advanced view must snap off it.
+        app.screen = SC_IDENTIFY;
         app.advanced = false;
         app.recompute_visible();
-        assert_eq!(
-            app.screen, SC_PAM,
-            "leaving advanced view must land on the nearest visible step"
+        assert_ne!(
+            app.screen, SC_IDENTIFY,
+            "leaving advanced view must land on a still-visible step"
+        );
+        assert!(
+            app.visible.contains(&app.screen),
+            "the landed screen is visible"
         );
     }
 
@@ -7099,11 +7123,11 @@ mod tests {
 
     #[test]
     fn header_counts_steps_over_visible_screens_only() {
-        let mut app = test_app(); // visible: Welcome, Login wiring, Done
+        let mut app = test_app(); // visible: Welcome, Login wiring, Settings, Done
         app.screen = SC_PAM;
         let text = draw_text(&app);
         assert!(
-            text.contains("step 2/3: Login wiring"),
+            text.contains("step 2/4: Login wiring"),
             "the step counter must track visible tabs, got:\n{text}"
         );
         assert!(text.contains("testuser"), "the managed user is shown");

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -230,6 +230,9 @@ enum Suspend {
     /// so a Tier-2 seal keeps validating. Idempotent (re-predicts the current
     /// PCRs); a system operation, so it is root-gated and clearly labeled.
     PcrlockMakePolicy,
+    /// Toggle the opt-in biopolicy operation-class gate (the bool is the target
+    /// state). Root op; the daemon reads it live, no restart.
+    Biopolicy(bool),
 }
 
 /// What a y/n confirm modal executes on `[y]`: a daemon request (async, the
@@ -1917,6 +1920,14 @@ impl App {
                 "refresh the pcrlock policy (re-predict the boot measurements)",
                 &["systemd-pcrlock", "make-policy"],
             ),
+            Suspend::Biopolicy(on) => self.sudo_step(
+                if on {
+                    "enable the biopolicy gate"
+                } else {
+                    "disable the biopolicy gate"
+                },
+                &["irlume", "biopolicy", if on { "on" } else { "off" }],
+            ),
             Suspend::Logs => self.sudo_step("show the face-auth journal", &["irlume", "logs"]),
             // The TUI already double-confirmed, so pass --yes; the CLI still
             // does the teardown (un-wire PAM, stop daemon, wipe data) as root
@@ -2476,6 +2487,23 @@ impl App {
                     },
                     map_settings,
                 );
+            }
+            // Biopolicy gate: enabling changes the security posture (restricts
+            // which services a face may satisfy), so it is confirmed; disabling
+            // just relaxes back to default and goes straight through.
+            (SC_SETTINGS, KeyCode::Char('b')) => {
+                if biopolicy_on() {
+                    self.log('→', "sudo irlume biopolicy off: relax back to the default (all services may verify)");
+                    self.suspend = Some(Suspend::Biopolicy(false));
+                } else {
+                    self.confirm = Some((
+                        "Enable the biopolicy gate? Only Login/Elevation may then release the \
+                         keyring; lock-screen becomes verify-only. Password stays available."
+                            .into(),
+                        "Enable",
+                        ConfirmAct::Sus(Suspend::Biopolicy(true)),
+                    ));
+                }
             }
             // Third-party PAD model toggle. settings.conf is root-only, so the
             // readable proxy for "enabled" is installed weights (disable
@@ -3129,13 +3157,24 @@ impl App {
                     Style::new().dim(),
                 )),
                 Line::from(Span::styled(
-                    "  is verify-only; remote/unknown services are denied.",
+                    "  is verify-only; remote/unknown services are denied. Advanced; the",
                     Style::new().dim(),
                 )),
                 Line::from(Span::styled(
-                    "  Toggle (root): set enforce_biopolicy=1 in /etc/irlume/settings.conf.",
+                    "  password is always available, so this can restrict but never lock out.",
                     Style::new().dim(),
                 )),
+                Line::from(vec![
+                    Span::styled("  [b]", Style::new().fg(th().accent)),
+                    Span::styled(
+                        if bio {
+                            " turn it off (sudo)"
+                        } else {
+                            " turn it on (sudo; asks first)"
+                        },
+                        Style::new().dim(),
+                    ),
+                ]),
                 Line::raw(""),
                 section("Third-party liveness models"),
                 {
@@ -4272,8 +4311,9 @@ impl App {
                 ("s", "show status"),
             ],
             SC_SETTINGS => &[
-                ("enter", "toggle eyes-open"),
-                ("c", "toggle blink"),
+                ("enter", "eyes-open"),
+                ("c", "blink"),
+                ("b", "biopolicy"),
                 ("m", "3rd-party model"),
             ],
             SC_DONE => &[("w", "wire login"), ("u", "update"), ("r", "refresh")],
@@ -5051,6 +5091,24 @@ mod tests {
         app.screen = SC_DONE;
         app.on_key(KeyCode::Char('u'));
         assert!(matches!(app.suspend, Some(Suspend::Update)));
+        app.suspend = None;
+
+        // Biopolicy [b]: enabling (from off) is confirm-gated; the confirm's
+        // affirmative names the specific verb and carries the enable suspend.
+        app.screen = SC_SETTINGS;
+        app.on_key(KeyCode::Char('b'));
+        assert!(
+            app.suspend.is_none(),
+            "enabling biopolicy must confirm first"
+        );
+        match &app.confirm {
+            Some((q, verb, ConfirmAct::Sus(Suspend::Biopolicy(true)))) => {
+                assert!(q.contains("biopolicy") && *verb == "Enable");
+            }
+            _ => panic!("expected the biopolicy-enable confirm"),
+        }
+        app.on_key(KeyCode::Char('y'));
+        assert!(matches!(app.suspend, Some(Suspend::Biopolicy(true))));
         app.suspend = None;
 
         // The mouse toggle flips state and logs; second press restores.
@@ -7058,7 +7116,7 @@ mod tests {
             (SC_RECOVERY, "set", "forget"),
             (SC_FINGERPRINT, "enroll finger", "reset"),
             (SC_PAM, "wire login (sudo)", "un-wire"),
-            (SC_SETTINGS, "toggle eyes-open", "3rd-party model"),
+            (SC_SETTINGS, "eyes-open", "3rd-party model"),
             (SC_DONE, "wire login", "refresh"),
         ];
         let mut app = app;

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -226,6 +226,10 @@ enum Suspend {
     /// complete authoritative dump (incl. the info-only lines the Repair
     /// checklist omits), copy-pasteable for a bug report.
     Doctor,
+    /// Refresh the systemd-pcrlock policy after a firmware/Secure Boot change
+    /// so a Tier-2 seal keeps validating. Idempotent (re-predicts the current
+    /// PCRs); a system operation, so it is root-gated and clearly labeled.
+    PcrlockMakePolicy,
 }
 
 /// What a y/n confirm modal executes on `[y]`: a daemon request (async, the
@@ -1909,6 +1913,10 @@ impl App {
             Suspend::Doctor => {
                 let _ = crate::doctor();
             }
+            Suspend::PcrlockMakePolicy => self.sudo_step(
+                "refresh the pcrlock policy (re-predict the boot measurements)",
+                &["systemd-pcrlock", "make-policy"],
+            ),
             Suspend::Logs => self.sudo_step("show the face-auth journal", &["irlume", "logs"]),
             // The TUI already double-confirmed, so pass --yes; the CLI still
             // does the teardown (un-wire PAM, stop daemon, wipe data) as root
@@ -2302,6 +2310,18 @@ impl App {
                     String::new(),
                     Pending::KeyringPw(None),
                 ));
+            }
+            // Refresh the pcrlock policy (Tier-2 only): re-predict the boot
+            // measurements after a firmware/Secure Boot change so the seal keeps
+            // validating. Root op; idempotent, so no confirm.
+            (SC_KEYRING, KeyCode::Char('p'))
+                if self
+                    .keyring_policy
+                    .as_deref()
+                    .is_some_and(|p| p.contains("Tier 2")) =>
+            {
+                self.log('→', "sudo systemd-pcrlock make-policy: refreshes the boot-measurement policy your seal is bound to");
+                self.suspend = Some(Suspend::PcrlockMakePolicy);
             }
             // Reseal: re-bind the sealed password to the current PCRs (the CLI
             // `irlume reseal`). Same masked-prompt + SealPassword path as arm;
@@ -3516,11 +3536,15 @@ impl App {
                 .is_some_and(|p| p.contains("Tier 2"));
             if tier2 {
                 lines.push(Line::from(Span::styled(
-                    "  after a firmware/Secure Boot update, re-run `systemd-pcrlock",
+                    "  Tier 2 seal (survives kernel updates). After a firmware or Secure",
                     Style::new().dim(),
                 )));
                 lines.push(Line::from(Span::styled(
-                    "  make-policy` as root; the seal keeps working with no re-arm.",
+                    "  Boot change, the boot measurements move; press [p] to refresh the",
+                    Style::new().dim(),
+                )));
+                lines.push(Line::from(Span::styled(
+                    "  pcrlock policy so face-unlock keeps working (no re-arm needed).",
                     Style::new().dim(),
                 )));
             } else {
@@ -3570,7 +3594,7 @@ impl App {
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
         let rec = self.recovery.unwrap_or_default();
         let all: [(&'static str, bool, usize); 7] = [
-            ("daemon + checks", self.daemon_up, SC_REPAIR),
+            ("checks & repair", self.daemon_up, SC_REPAIR),
             ("cameras", self.caps.rgb, SC_CAMERAS),
             ("enrollment", scans > 0, SC_PROFILES),
             (
@@ -3877,19 +3901,19 @@ impl App {
         ];
         match &self.identify_result {
             Some((true, who)) => {
-                lines.push(Line::from(Span::styled(
-                    "  ┌─ result ───────────────────────────",
-                    Style::new().dim(),
-                )));
                 lines.push(Line::from(vec![
-                    Span::styled("  │ ", Style::new().dim()),
                     Span::styled(
-                        who.clone(),
+                        "  ✓ Recognized  ",
                         Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
                     ),
+                    Span::styled(who.clone(), Style::new().fg(th().ok)),
                 ]));
                 lines.push(Line::from(Span::styled(
-                    "  └────────────────────────────────────",
+                    "    confidence is 0.00-1.00 (higher = surer); this cleared your match",
+                    Style::new().dim(),
+                )));
+                lines.push(Line::from(Span::styled(
+                    "    threshold. Identify is a diagnostic check, not a login.",
                     Style::new().dim(),
                 )));
             }
@@ -4483,7 +4507,10 @@ fn map_identify(resp: Response) -> (bool, String) {
             ..
         } => (
             true,
-            format!("{u} · {} · score {score:.3}", profile.unwrap_or_default()),
+            format!(
+                "{u} · {} · confidence {score:.3}",
+                profile.unwrap_or_default()
+            ),
         ),
         Response::Identified {
             user: None,
@@ -5407,7 +5434,7 @@ mod tests {
             reason: String::new(),
         });
         assert!(ok);
-        assert_eq!(msg, "alice · Face Profile 1 · score 0.812");
+        assert_eq!(msg, "alice · Face Profile 1 · confidence 0.812");
         let (ok, msg) = map_identify(Response::Identified {
             user: None,
             profile: None,
@@ -6631,8 +6658,8 @@ mod tests {
         assert!(text.contains("drifted since sealing"));
         assert!(text.contains("pcrlock NV 0x1a2b (Tier 2)"));
         assert!(
-            text.contains("systemd-pcrlock"),
-            "Tier 2 gets the make-policy guidance, not the re-arm warning"
+            text.contains("press [p]") && text.contains("pcrlock policy"),
+            "Tier 2 offers the [p] pcrlock-refresh action, not the re-arm warning"
         );
         assert!(text.contains("At a face login"));
         // Armed on the plain PCR-7 tier: the dbx re-arm warning instead.
@@ -6712,12 +6739,12 @@ mod tests {
         app.screen = SC_IDENTIFY;
         let text = draw_text(&app);
         assert!(text.contains("press [i] and look at the camera"));
-        app.identify_result = Some((true, "alice · Face Profile 1 · score 0.912".into()));
+        app.identify_result = Some((true, "alice · Face Profile 1 · confidence 0.912".into()));
         let text = draw_text(&app);
-        assert!(text.contains("alice · Face Profile 1 · score 0.912"));
+        assert!(text.contains("alice · Face Profile 1 · confidence 0.912"));
         assert!(
-            text.contains("result"),
-            "the hit renders in the result card"
+            text.contains("✓ Recognized") && text.contains("confidence is 0.00-1.00"),
+            "the hit shows a plain verdict + the confidence scale"
         );
         app.identify_result = Some((false, "no live face (flat depth)".into()));
         let text = draw_text(&app);

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1248,6 +1248,26 @@ impl App {
             ));
         }
 
+        // Login keyring LOCKED: a Secret Service provider is up but its login
+        // collection is locked, so apps (Bitwarden, browsers) can't read their
+        // secrets even after a face login. Only flag it when the keyring is
+        // armed (else it's expected) and a provider actually answered. The TUI
+        // runs as the user, so unlike `sudo doctor` it can see the session bus.
+        if self.keyring_armed == Some(true) {
+            if let Some(true) = crate::secrets::login_keyring_locked() {
+                v.push(mk(
+                    "Login keyring",
+                    Sev::Warn,
+                    "the wallet is locked; apps (Bitwarden, browsers) can't read secrets yet"
+                        .into(),
+                    Fix::Manual(
+                        "unlock it by logging in with your face, or `sudo irlume keyring arm`"
+                            .into(),
+                    ),
+                ));
+            }
+        }
+
         // Keyring PCR-drift: the seal no longer matches the current PCRs (a
         // firmware/Secure Boot update moved them), so face login silently stops
         // opening the wallet until re-bound. Only the Keyring tab drew this;
@@ -3681,8 +3701,10 @@ impl App {
     /// to run, with one-key fixes, plus platform trust anchors and a live IR PAD
     /// self-test. Covers the `irlume doctor`/`diag`/`deps` checks that have a
     /// remediation or that a TUI-only user would otherwise miss (daemon, models,
-    /// cameras, SELinux/AppArmor, wiring drift, keyring drift, recovery, TPM,
-    /// third-party-model checksum). Some advisory-only doctor lines (fingerprint
+    /// cameras, SELinux/AppArmor, wiring drift, keyring drift, login-keyring
+    /// locked, recovery, TPM, third-party-model checksum). The full text
+    /// readout (incl. info-only lines) is one key away via the `[d]` key. Some
+    /// advisory-only doctor lines (fingerprint
     /// vendor-stack, polkit sandbox, install hygiene) stay in `doctor`.
     fn draw_repair(&self, f: &mut Frame, area: Rect) {
         use irlume_common::secureboot;

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -4502,7 +4502,7 @@ fn onoff(on: bool) -> Span<'static> {
 /// A screen state row: 2-space indent, label padded to `w`, then the value
 /// span. One shape for every status line so screens line up the same way.
 fn state_row(label: &str, w: usize, value: Span<'static>) -> Line<'static> {
-    Line::from(vec![Span::raw(format!("  {label:<w$}", w = w)), value])
+    Line::from(vec![Span::raw(format!("  {label:<w$}")), value])
 }
 
 /// An action line: accent `[key]` chips with dim labels, 2-space indent, a

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3008,10 +3008,15 @@ impl App {
     }
 
     fn draw_cameras(&self, f: &mut Frame, area: Rect) {
-        let [list_area, info_area] =
-            Layout::vertical([Constraint::Min(3), Constraint::Length(8)]).areas(area);
         let (argb, air) = irlume_camera::select_pair(); // currently active pair
         let pairs = &self.pairs;
+        // Size the list to its rows (header + one row per camera/note) so the
+        // info block sits right under it instead of a stretched gap; leftover
+        // space stays empty at the bottom (content near the top).
+        let list_rows = self.nodes.len().max(pairs.len()).max(1) as u16 + 1;
+        let [list_area, info_area] =
+            Layout::vertical([Constraint::Length(list_rows + 1), Constraint::Length(9)])
+                .areas(area);
 
         // ---- selectable list of trusted (physical) Hello camera pairs ----
         // No pair ≠ no camera: an RGB-only device still serves the convenience
@@ -3087,19 +3092,23 @@ impl App {
         };
         let mut st = ListState::default()
             .with_selected(Some(self.cam_sel.min(pairs.len().saturating_sub(1))));
-        let blk = Block::bordered()
-            .border_type(BorderType::Rounded)
-            .border_style(Style::new().dim())
-            .title(" cameras (● = active · ↑↓ select · enter = use) ");
-        let inner = blk.inner(list_area);
-        f.render_widget(blk, list_area);
+        // No inner border (whitespace over chrome; the content panel already
+        // frames this). A section header carries what the border title did.
+        let [hdr_area, rows_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(list_area);
+        f.render_widget(
+            Paragraph::new(section(
+                "Cameras  (● = active · ↑↓ select · Enter uses one)",
+            )),
+            hdr_area,
+        );
         f.render_stateful_widget(
             List::new(items).highlight_style(
                 Style::new()
                     .bg(Color::Rgb(0x20, 0x30, 0x40))
                     .add_modifier(Modifier::BOLD),
             ),
-            inner,
+            rows_area,
             &mut st,
         );
 
@@ -3144,13 +3153,8 @@ impl App {
             Span::styled("[p]", Style::new().fg(th().accent)),
             Span::styled(" probe XU controls", Style::new().dim()),
         ]));
-        let iblk = Block::bordered()
-            .border_type(BorderType::Rounded)
-            .border_style(Style::new().dim());
-        f.render_widget(
-            Paragraph::new(lines).block(iblk).wrap(Wrap { trim: true }),
-            info_area,
-        );
+        // Borderless (no box-in-box); the content panel is the only frame.
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), info_area);
     }
 
     fn draw_fingerprint(&self, f: &mut Frame, area: Rect) {

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -688,26 +688,6 @@ impl App {
                 }),
                 _ => None, // older daemon / daemon down → Repair falls back to local probes
             };
-            match crate::daemon_poll(&Request::ListProfiles {
-                user: self.user.clone(),
-            }) {
-                Ok(Response::Enrollment {
-                    profiles,
-                    require_eyes_open,
-                    require_challenge,
-                    ..
-                }) => {
-                    self.profiles = profiles;
-                    self.eyes_open = require_eyes_open;
-                    self.challenge = require_challenge;
-                    self.enroll_error = None;
-                }
-                // A corrupt/unreadable enrollment (or a missing template key for an
-                // encrypted file) surfaces as an Error, not empty; don't silently
-                // show "no face enrolled"; capture it so Repair can flag+fix it.
-                Ok(Response::Error(e)) => self.enroll_error = Some(e),
-                _ => {}
-            }
             // KeyringInfo adds the seal tier and PCR drift; an older daemon
             // answers it with an error, so fall back to the plain armed bit.
             match crate::daemon_poll(&Request::KeyringInfo {
@@ -768,7 +748,42 @@ impl App {
     /// the Repair diagnostics which spawn `ls -Z` etc.). Runs on the slow timer,
     /// on demand (`[r]`), after an op, and when opening Repair/Fingerprint, but
     /// NOT every fast tick, so fprintd/subprocess calls can't hitch the UI.
-    fn refresh(&mut self) {
+    /// Poll the enrollment list. This is the ONE slow read (a ListProfiles
+    /// triggers a TPM unseal of the template key to decrypt the profiles,
+    /// ~350ms measured), so it is kept OUT of the frequent refresh paths and
+    /// out of tab switches. Called only where a change can have happened: at
+    /// startup, after a TUI mutation, when entering the Profiles tab, and on
+    /// the slow heavy timer (for external `irlume enroll` changes).
+    fn refresh_profiles(&mut self) {
+        if !self.daemon_up {
+            return;
+        }
+        match crate::daemon_poll(&Request::ListProfiles {
+            user: self.user.clone(),
+        }) {
+            Ok(Response::Enrollment {
+                profiles,
+                require_eyes_open,
+                require_challenge,
+                ..
+            }) => {
+                self.profiles = profiles;
+                self.eyes_open = require_eyes_open;
+                self.challenge = require_challenge;
+                self.enroll_error = None;
+            }
+            // A corrupt/unreadable enrollment (or a missing template key for an
+            // encrypted file) surfaces as an Error, not empty; don't silently
+            // show "no face enrolled"; capture it so Repair can flag+fix it.
+            Ok(Response::Error(e)) => self.enroll_error = Some(e),
+            _ => {}
+        }
+    }
+
+    /// Diagnostics without the slow profile poll: fast daemon reads + hardware
+    /// caps + fingerprint + the Repair checks. Tab switches use this so moving
+    /// between tabs never pays the ListProfiles TPM-unseal cost.
+    fn refresh_diagnostics(&mut self) {
         self.refresh_light();
         // Re-derive hardware capabilities so a camera or reader hot-plugged
         // after launch reveals its tabs (caps/fp_present drive `visible` and the
@@ -785,6 +800,13 @@ impl App {
         // Visibility is state-driven (Repair appears when something fails);
         // re-derive it from the fresh diagnostics.
         self.recompute_visible();
+    }
+
+    /// Full refresh incl. the slow profile poll: startup, after mutations, and
+    /// the heavy timer. Callers that just switched tabs use refresh_diagnostics.
+    fn refresh(&mut self) {
+        self.refresh_profiles();
+        self.refresh_diagnostics();
     }
 
     /// Build the Repair-tab diagnostics from current state + quick local probes.
@@ -1641,7 +1663,11 @@ impl App {
                 && self.confirm.is_none()
             {
                 if last_heavy.elapsed() >= Duration::from_millis(HEAVY_REFRESH_MS) {
-                    self.refresh(); // cheap + fingerprint + diagnostics
+                    // Diagnostics only, NOT the slow profile poll: keeping the
+                    // ListProfiles TPM-unseal off every timer tick is what makes
+                    // the UI stay smooth. Profiles refresh on mutation / Profiles
+                    // tab / startup instead.
+                    self.refresh_diagnostics();
                     last_heavy = std::time::Instant::now();
                     last_light = std::time::Instant::now();
                 } else if last_light.elapsed() >= Duration::from_millis(LIGHT_REFRESH_MS) {
@@ -2069,8 +2095,13 @@ impl App {
         let new_pos = (((pos + d) % n + n) % n) as usize;
         self.screen = self.visible[new_pos];
         self.sel = 0;
+        // Fast diagnostics on entering Repair/Fingerprint (no slow profile
+        // poll, so the switch is instant); a fresh profile poll only when
+        // landing on Profiles, where an external `irlume enroll` should show.
         if self.screen == SC_REPAIR || self.screen == SC_FINGERPRINT {
-            self.refresh();
+            self.refresh_diagnostics();
+        } else if self.screen == SC_PROFILES {
+            self.refresh_profiles();
         }
     }
 
@@ -2098,8 +2129,12 @@ impl App {
                 if let Some((_, _, target)) = self.hub_rows().get(self.hub_sel).copied() {
                     self.screen = target;
                     self.sel = 0;
+                    // Same fast paths as a Tab switch: diagnostics for
+                    // Repair/Fingerprint, a fresh profile poll for Profiles.
                     if target == SC_REPAIR || target == SC_FINGERPRINT {
-                        self.refresh();
+                        self.refresh_diagnostics();
+                    } else if target == SC_PROFILES {
+                        self.refresh_profiles();
                     }
                 }
             }

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -35,7 +35,7 @@ struct Theme {
     ok: Color,
     err: Color,
     warn: Color,
-    /// Key-chip style for the footer ([w], [?]…): colored chip normally,
+    /// Key-chip style for the footer (`[w]`, `[?]`…): colored chip normally,
     /// REVERSED under NO_COLOR (a black-on-Reset chip would be invisible).
     chip: Style,
 }
@@ -232,6 +232,11 @@ enum ConfirmAct {
     Sus(Suspend),
 }
 
+/// A y/n confirm with a SPECIFIC verb on the affirmative (GNOME HIG: "Label
+/// the affirmative button with a specific imperative verb… clearer than a
+/// generic label"): question, verb, action.
+type Confirm = (String, &'static str, ConfirmAct);
+
 /// Severity of a Repair-tab diagnostic.
 #[derive(Clone, Copy, PartialEq)]
 enum Sev {
@@ -409,12 +414,14 @@ struct App {
     pairs: Vec<irlume_camera::CameraPair>,
     activity: Vec<(char, String)>,
     input: Option<(String, String, Pending)>,
-    confirm: Option<(String, ConfirmAct)>,
+    confirm: Option<Confirm>,
     /// True while mouse capture is released so the terminal's own selection
     /// works (the `[M]` toggle); wheel scroll is unavailable meanwhile.
     mouse_select: bool,
     /// The [?] full-keymap overlay (tier two of the disclosure ladder).
     show_help: bool,
+    /// Selected row of the Welcome hub (Enter jumps to its screen).
+    hub_sel: usize,
     op: Option<Op>,
     enroll: Option<EnrollUi>,
     /// A pending merge confirmation (scan 1 matched an existing profile).
@@ -524,6 +531,7 @@ impl App {
             confirm: None,
             mouse_select: false,
             show_help: false,
+            hub_sel: 0,
             op: None,
             enroll: None,
             enroll_merge: None,
@@ -1911,7 +1919,7 @@ impl App {
         if self.confirm.is_some() {
             match code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    let (_, act) = self.confirm.take().unwrap();
+                    let (_, _, act) = self.confirm.take().unwrap();
                     match act {
                         // Async so the UI keeps animating; poll() logs the
                         // result (✓/error banner) and refreshes. map_confirm
@@ -2017,12 +2025,14 @@ impl App {
         let len = match self.screen {
             SC_REPAIR => self.repair.len(),
             SC_CAMERAS => self.pairs.len(),
+            SC_WELCOME => self.hub_rows().len(),
             _ => self.rows().len(),
         };
         let n = len.max(1) as i32;
         let cur = match self.screen {
             SC_REPAIR => &mut self.repair_sel,
             SC_CAMERAS => &mut self.cam_sel,
+            SC_WELCOME => &mut self.hub_sel,
             _ => &mut self.sel,
         };
         *cur = (((*cur as i32 + d) % n + n) % n) as usize;
@@ -2030,6 +2040,16 @@ impl App {
 
     fn on_action(&mut self, code: KeyCode) {
         match (self.screen, code) {
+            // Hub: Enter opens the selected section (the summary IS the nav).
+            (SC_WELCOME, KeyCode::Enter) => {
+                if let Some((_, _, target)) = self.hub_rows().get(self.hub_sel).copied() {
+                    self.screen = target;
+                    self.sel = 0;
+                    if target == SC_REPAIR || target == SC_FINGERPRINT {
+                        self.refresh();
+                    }
+                }
+            }
             // Welcome / Done: refresh the whole snapshot.
             (SC_WELCOME, KeyCode::Char('r')) | (SC_DONE, KeyCode::Char('r')) => {
                 self.log('·', "refreshing status…");
@@ -2158,6 +2178,7 @@ impl App {
             (SC_KEYRING, KeyCode::Char('f')) => {
                 self.confirm = Some((
                     "Erase the TPM-sealed login password?".into(),
+                    "Erase",
                     ConfirmAct::Daemon(Request::ForgetPassword {
                         user: self.user.clone(),
                     }),
@@ -2181,6 +2202,7 @@ impl App {
             (SC_RECOVERY, KeyCode::Char('f')) => {
                 self.confirm = Some((
                     "Erase the recovery passphrase? (templates stay encrypted)".into(),
+                    "Erase",
                     ConfirmAct::Daemon(Request::RecoveryForget {
                         user: self.user.clone(),
                     }),
@@ -2214,6 +2236,7 @@ impl App {
             (SC_FINGERPRINT, KeyCode::Char('x')) => {
                 self.confirm = Some((
                     "Delete ALL enrolled fingerprints from the reader?".into(),
+                    "Delete",
                     ConfirmAct::Sus(Suspend::FingerprintReset),
                 ));
             }
@@ -2248,6 +2271,7 @@ impl App {
                 self.confirm = Some((
                     "Un-wire face auth from login/lock/sudo/apps? (password logins are untouched)"
                         .into(),
+                    "Un-wire",
                     ConfirmAct::Sus(Suspend::LoginDisable),
                 ));
             }
@@ -2311,6 +2335,7 @@ impl App {
                                 "Disable third-party model '{}'? (its weights are deleted)",
                                 m.name
                             ),
+                            "Disable",
                             ConfirmAct::Sus(Suspend::ModelsDisable),
                         ));
                     }
@@ -2423,6 +2448,7 @@ impl App {
                 let p = self.profiles[pi].name.clone();
                 self.confirm = Some((
                     format!("Delete profile '{p}' and all its scans?"),
+                    "Delete",
                     ConfirmAct::Daemon(Request::DeleteProfile {
                         user: self.user.clone(),
                         profile: p,
@@ -2436,6 +2462,7 @@ impl App {
                 );
                 self.confirm = Some((
                     format!("Delete scan '{s}' from '{p}'?"),
+                    "Delete",
                     ConfirmAct::Daemon(Request::DeleteScan {
                         user: self.user.clone(),
                         profile: p,
@@ -2611,10 +2638,15 @@ impl App {
             // Prompt in the wrapping body (a long name/prompt would truncate as a
             // border title); the typed field on its own line below it.
             self.modal(f, "Input", &format!("{prompt}\n{shown}▏"));
-        } else if let Some((what, _)) = &self.confirm {
+        } else if let Some((what, _, _)) = &self.confirm {
             // Question in the body so a long target name isn't clipped by the
             // single-line border title.
-            self.modal(f, "Confirm", &format!("{what}\n[y] yes    [n] no"));
+            let verb = self.confirm.as_ref().map(|c| c.1).unwrap_or("Confirm");
+            self.modal(
+                f,
+                "Confirm",
+                &format!("{what}\n[n]/Esc Cancel    [y] {verb}"),
+            );
         } else if let Some(mc) = &self.enroll_merge {
             // Keep the message in the wrapping body, not the border title (which
             // is a single line clamped to the box width and would truncate).
@@ -3353,9 +3385,36 @@ impl App {
         f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
     }
 
-    fn draw_welcome(&self, f: &mut Frame, area: Rect) {
+    /// Hub rows for the Welcome screen: each visible section with its live
+    /// state, selectable and Enter-jumpable (hub-and-spoke: the summary IS
+    /// the navigation, the tab ribbon stays for direct access).
+    fn hub_rows(&self) -> Vec<(&'static str, bool, usize)> {
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
         let rec = self.recovery.unwrap_or_default();
+        let all: [(&'static str, bool, usize); 7] = [
+            ("daemon + checks", self.daemon_up, SC_REPAIR),
+            ("cameras", self.caps.rgb, SC_CAMERAS),
+            ("enrollment", scans > 0, SC_PROFILES),
+            (
+                "keyring unlock",
+                self.keyring_armed.unwrap_or(false),
+                SC_KEYRING,
+            ),
+            (
+                "recovery + encryption",
+                rec.encrypted && rec.recovery_set,
+                SC_RECOVERY,
+            ),
+            ("login wiring", crate::pamwire::login_wired(), SC_PAM),
+            ("settings", true, SC_SETTINGS),
+        ];
+        all.into_iter()
+            .filter(|(_, _, sc)| self.visible.contains(sc))
+            .collect()
+    }
+
+    fn draw_welcome(&self, f: &mut Frame, area: Rect) {
+        let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
         let lines = vec![
             Line::from(Span::styled(
                 "  irlume - local face authentication",
@@ -3375,19 +3434,7 @@ impl App {
                 Style::new().dim(),
             )),
             Line::raw(""),
-            section("At a glance"),
-            Line::from(vec![Span::raw("  daemon       "), onoff(self.daemon_up)]),
-            Line::from(vec![
-                Span::raw("  enrolled     "),
-                count_badge(self.profiles.len(), scans),
-            ]),
-            Line::from(vec![
-                Span::raw("  keyring      "),
-                onoff(self.keyring_armed.unwrap_or(false)),
-            ]),
-            Line::from(vec![Span::raw("  encrypted    "), onoff(rec.encrypted)]),
-            Line::from(vec![Span::raw("  biopolicy    "), onoff(biopolicy_on())]),
-            Line::raw(""),
+            section("At a glance  (↑↓ pick a section, Enter opens it)"),
             Line::from(vec![
                 Span::styled("  Recommended  ", Style::new().add_modifier(Modifier::BOLD)),
                 Span::styled(self.recommended(), Style::new().fg(th().ok)),
@@ -3421,7 +3468,39 @@ impl App {
                 Style::new().dim(),
             )),
         ];
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        let mut lines = lines;
+        // Splice the selectable hub rows just under the "At a glance" header.
+        let at = lines
+            .iter()
+            .position(|l| l.spans.iter().any(|sp| sp.content.contains("At a glance")))
+            .map(|i| i + 1)
+            .unwrap_or(lines.len());
+        let rows = self.hub_rows();
+        let n = rows.len();
+        for (i, (label, ok, _)) in rows.into_iter().enumerate() {
+            let selected = i == self.hub_sel;
+            let mut style = Style::new();
+            if selected {
+                style = style.fg(th().accent).add_modifier(Modifier::BOLD);
+            }
+            let badge = if label == "enrollment" {
+                count_badge(self.profiles.len(), scans)
+            } else {
+                onoff(ok)
+            };
+            let marker = if selected { '▸' } else { ' ' };
+            lines.insert(
+                at + i,
+                Line::from(vec![
+                    Span::styled(format!("  {marker} {label:<24}"), style),
+                    badge,
+                ]),
+            );
+        }
+        lines.insert(at + n, Line::raw(""));
+        // trim:false: leading spaces are the marker column of the hub rows;
+        // trim would collapse unselected rows against the ▸ rows.
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     /// Diagnostic + repair: a live checklist (✓/⚠/✗) of everything irlume needs
@@ -3875,6 +3954,16 @@ impl App {
         f.render_widget(blk, area);
         let h = inner.height as usize;
         // Window ends `act_scroll` lines up from the newest entry.
+        // Designed empty state (HIG placeholders): say what will appear, not
+        // nothing.
+        if self.activity.is_empty() {
+            f.render_widget(
+                Paragraph::new("Actions you take show up here, newest last.")
+                    .style(Style::new().dim()),
+                inner,
+            );
+            return;
+        }
         let end = self.activity.len().saturating_sub(self.act_scroll);
         let start = end.saturating_sub(h);
         let lines: Vec<Line> = self.activity[start..end]
@@ -4406,6 +4495,7 @@ mod tests {
             confirm: None,
             mouse_select: false,
             show_help: false,
+            hub_sel: 0,
             op: None,
             enroll: None,
             enroll_merge: None,
@@ -4620,6 +4710,29 @@ mod tests {
     // cut off. It must render inside the wrapping body, with the deliberate
     // [y] yes / [n] no hint from 093dc56.
     #[test]
+    fn hub_selection_and_enter_jump_to_the_picked_screen() {
+        let mut app = test_app();
+        app.screen = SC_WELCOME;
+        app.visible = (0..SCREENS.len()).collect();
+        app.daemon_up = true;
+        let rows = app.hub_rows();
+        assert!(rows.len() >= 6, "hub rows: {rows:?}");
+        // 5 downs from 0 select row 5; Enter opens exactly that screen.
+        for _ in 0..5 {
+            app.move_sel(1);
+        }
+        assert_eq!(app.hub_sel, 5);
+        let target = app.hub_rows()[5].2;
+        app.on_key(KeyCode::Enter);
+        assert_eq!(app.screen, target);
+        // Wrap: one Up from row 0 lands on the last row.
+        app.screen = SC_WELCOME;
+        app.hub_sel = 0;
+        app.move_sel(-1);
+        assert_eq!(app.hub_sel, app.hub_rows().len() - 1);
+    }
+
+    #[test]
     fn parity_keys_route_to_the_right_actions() {
         // The new per-screen actions: keys must set the right suspend/confirm,
         // and destructive ones must go through the y/n gate, not act directly.
@@ -4639,7 +4752,7 @@ mod tests {
         assert!(app.suspend.is_none());
         assert!(matches!(
             app.confirm,
-            Some((_, ConfirmAct::Sus(Suspend::LoginDisable)))
+            Some((_, _, ConfirmAct::Sus(Suspend::LoginDisable)))
         ));
         app.on_key(KeyCode::Char('y'));
         assert!(matches!(app.suspend, Some(Suspend::LoginDisable)));
@@ -4657,7 +4770,7 @@ mod tests {
         app.on_key(KeyCode::Char('x'));
         assert!(matches!(
             app.confirm,
-            Some((_, ConfirmAct::Sus(Suspend::FingerprintReset)))
+            Some((_, _, ConfirmAct::Sus(Suspend::FingerprintReset)))
         ));
         app.on_key(KeyCode::Esc); // cancel path leaves nothing armed
         assert!(app.confirm.is_none() && app.suspend.is_none());
@@ -4687,7 +4800,7 @@ mod tests {
             "Delete profile '{}ZZTARGETZZ' and all its scans?",
             ["word"; 20].join(" ")
         );
-        app.confirm = Some((question, ConfirmAct::Daemon(Request::Ping)));
+        app.confirm = Some((question, "Confirm", ConfirmAct::Daemon(Request::Ping)));
         let mut term = Terminal::new(TestBackend::new(80, 30)).unwrap();
         term.draw(|f| app.draw(f)).unwrap();
         let text = rendered(&term);
@@ -4695,7 +4808,12 @@ mod tests {
             text.contains("ZZTARGETZZ"),
             "end of a long confirm question was clipped:\n{text}"
         );
-        assert!(text.contains("[y] yes"), "deliberate-confirm hint missing");
+        // The affirmative carries the verb now (GNOME HIG), cancel is first.
+        assert!(
+            text.contains("[y] Confirm"),
+            "deliberate-confirm hint missing"
+        );
+        assert!(text.contains("Cancel"), "cancel option missing");
     }
 
     // Regression: f00f316. At MAX_PROFILES the guidance said only "delete one
@@ -4728,6 +4846,7 @@ mod tests {
         let mut app = test_app();
         app.confirm = Some((
             "Delete profile 'x'?".into(),
+            "Confirm",
             ConfirmAct::Daemon(Request::Ping),
         ));
         app.on_key(KeyCode::Char('x'));
@@ -4739,7 +4858,11 @@ mod tests {
         );
         app.on_key(KeyCode::Char('n'));
         assert!(app.confirm.is_none(), "[n] cancels");
-        app.confirm = Some(("Delete scan 's'?".into(), ConfirmAct::Daemon(Request::Ping)));
+        app.confirm = Some((
+            "Delete scan 's'?".into(),
+            "Delete",
+            ConfirmAct::Daemon(Request::Ping),
+        ));
         app.on_key(KeyCode::Esc);
         assert!(app.confirm.is_none(), "Esc cancels");
     }
@@ -5506,7 +5629,7 @@ mod tests {
         app.sel = 0;
         app.on_key(KeyCode::Char('d'));
         match &app.confirm {
-            Some((q, ConfirmAct::Daemon(Request::DeleteProfile { user, profile }))) => {
+            Some((q, _, ConfirmAct::Daemon(Request::DeleteProfile { user, profile }))) => {
                 assert!(q.contains("Delete profile 'p1'"), "got: {q}");
                 assert_eq!((user.as_str(), profile.as_str()), ("testuser", "p1"));
             }
@@ -5516,7 +5639,7 @@ mod tests {
         app.sel = 1;
         app.on_key(KeyCode::Char('d'));
         match &app.confirm {
-            Some((q, ConfirmAct::Daemon(Request::DeleteScan { profile, scan, .. }))) => {
+            Some((q, _, ConfirmAct::Daemon(Request::DeleteScan { profile, scan, .. }))) => {
                 assert!(q.contains("Delete scan 's1' from 'p1'"), "got: {q}");
                 assert_eq!((profile.as_str(), scan.as_str()), ("p1", "s1"));
             }
@@ -5538,7 +5661,7 @@ mod tests {
         app.input = None;
         app.on_key(KeyCode::Char('f'));
         match &app.confirm {
-            Some((q, ConfirmAct::Daemon(Request::ForgetPassword { user }))) => {
+            Some((q, _, ConfirmAct::Daemon(Request::ForgetPassword { user }))) => {
                 assert!(q.contains("Erase the TPM-sealed"), "got: {q}");
                 assert_eq!(user, "testuser");
             }
@@ -5558,7 +5681,7 @@ mod tests {
         app.on_key(KeyCode::Char('f'));
         assert!(matches!(
             app.confirm,
-            Some((_, ConfirmAct::Daemon(Request::RecoveryForget { .. })))
+            Some((_, _, ConfirmAct::Daemon(Request::RecoveryForget { .. })))
         ));
     }
 
@@ -5946,6 +6069,7 @@ mod tests {
         let mut app = test_app();
         app.confirm = Some((
             "Delete profile 'x'?".into(),
+            "Confirm",
             ConfirmAct::Daemon(Request::Ping),
         ));
         app.on_key(KeyCode::Char('y'));

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1130,7 +1130,7 @@ impl App {
                         "Method wiring",
                         Sev::Fail,
                         "method is fingerprint but pam_fprintd is not wired".into(),
-                        Fix::Manual("sudo irlume fingerprint enable --user <you>".into()),
+                        Fix::Manual("Fingerprint tab → [e] unlock with face OR fingerprint".into()),
                     ));
                 } else if self.fp.enrolled.is_empty() {
                     v.push(mk(
@@ -1313,7 +1313,7 @@ impl App {
                         "Third-party model",
                         Sev::Fail,
                         format!("'{name}' weights fail their checksum; the daemon refuses them (cue is OFF)"),
-                        Fix::Manual("re-fetch: sudo irlume models disable, then models enable".into()),
+                        Fix::Manual("Settings tab → [m] disable then re-enable the model".into()),
                     ));
                 }
             }
@@ -1325,7 +1325,7 @@ impl App {
                     "Recovery backstop",
                     Sev::Warn,
                     "templates encrypted but no recovery passphrase".into(),
-                    Fix::Manual("run `irlume recovery setup`".into()),
+                    Fix::Manual("Recovery tab → [s] set a recovery passphrase".into()),
                 ));
             } else {
                 v.push(mk(

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2979,10 +2979,29 @@ impl App {
                 )),
                 Line::raw(""),
                 section("Third-party liveness models"),
-                Line::from(vec![
-                    Span::raw("  state  "),
-                    Span::styled(crate::models::doctor_line(), Style::new().dim()),
-                ]),
+                {
+                    // A ●/○ status row like the sections above, not a text blob.
+                    let (icon, icon_style, label) = match crate::models::tui_state() {
+                        crate::models::TuiState::Enabled { name, detail } => (
+                            "●",
+                            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                            format!("enabled: {name}   {detail}"),
+                        ),
+                        crate::models::TuiState::InstalledUnknown { name } => (
+                            "◐",
+                            Style::new().fg(th().warn),
+                            format!("{name} weights installed; on/off is root-only"),
+                        ),
+                        crate::models::TuiState::None => {
+                            ("○", Style::new().dim(), "none (default)".to_string())
+                        }
+                    };
+                    Line::from(vec![
+                        Span::raw("  state  "),
+                        Span::styled(format!("{icon} "), icon_style),
+                        Span::styled(label, Style::new().dim()),
+                    ])
+                },
                 Line::from(Span::styled(
                     "  Opt-in, measured, deny-only extra anti-spoof cue; fetched from the",
                     Style::new().dim(),
@@ -2991,10 +3010,13 @@ impl App {
                     "  publisher, checksum-pinned, never shipped by irlume.",
                     Style::new().dim(),
                 )),
-                Line::from(Span::styled(
-                    "  [m] enables or disables one (sudo; the license confirm runs in the terminal)",
-                    Style::new().dim(),
-                )),
+                Line::from(vec![
+                    Span::styled("  [m]", Style::new().fg(th().accent)),
+                    Span::styled(
+                        " enable or disable one (sudo; the license confirm runs in the terminal)",
+                        Style::new().dim(),
+                    ),
+                ]),
                 Line::raw(""),
                 section("Match thresholds (read-only)"),
                 Line::from(Span::styled(

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -23,11 +23,61 @@ use std::time::Duration;
 
 use irlume_common::{PositionReport, ProfileSummary, Request, Response};
 
-const ACCENT: Color = Color::Rgb(0x6c, 0xb6, 0xff);
-const BLUE: Color = Color::Rgb(0x4a, 0x90, 0xd9);
-const OK: Color = Color::Rgb(0x73, 0xc9, 0x91);
-const ERR: Color = Color::Rgb(0xe8, 0x7a, 0x7a);
-const WARN: Color = Color::Rgb(0xe6, 0xc0, 0x7a);
+/// Semantic color slots, resolved once at startup down a capability ladder:
+/// NO_COLOR (no-color.org) gets none and the glyphs carry all state; plain
+/// terminals get ANSI names so the USER'S terminal theme is the palette
+/// (light themes stay readable); truecolor terminals get the soft irlume
+/// palette as polish. Every use is a semantic slot (accent/ok/warn/err),
+/// never decoration, so the ladder degrades without losing information.
+struct Theme {
+    accent: Color,
+    blue: Color,
+    ok: Color,
+    err: Color,
+    warn: Color,
+    /// Key-chip style for the footer ([w], [?]…): colored chip normally,
+    /// REVERSED under NO_COLOR (a black-on-Reset chip would be invisible).
+    chip: Style,
+}
+
+fn th() -> &'static Theme {
+    static T: std::sync::OnceLock<Theme> = std::sync::OnceLock::new();
+    T.get_or_init(|| {
+        if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+            return Theme {
+                accent: Color::Reset,
+                blue: Color::Reset,
+                ok: Color::Reset,
+                err: Color::Reset,
+                warn: Color::Reset,
+                chip: Style::new().add_modifier(Modifier::REVERSED),
+            };
+        }
+        let truecolor = std::env::var("COLORTERM")
+            .map(|v| v.contains("truecolor") || v.contains("24bit"))
+            .unwrap_or(false);
+        if truecolor {
+            let accent = Color::Rgb(0x6c, 0xb6, 0xff);
+            Theme {
+                accent,
+                blue: Color::Rgb(0x4a, 0x90, 0xd9),
+                ok: Color::Rgb(0x73, 0xc9, 0x91),
+                err: Color::Rgb(0xe8, 0x7a, 0x7a),
+                warn: Color::Rgb(0xe6, 0xc0, 0x7a),
+                chip: Style::new().fg(Color::Black).bg(accent),
+            }
+        } else {
+            Theme {
+                accent: Color::Cyan,
+                blue: Color::Blue,
+                ok: Color::Green,
+                err: Color::Red,
+                warn: Color::Yellow,
+                chip: Style::new().fg(Color::Black).bg(Color::Cyan),
+            }
+        }
+    })
+}
 const SPIN: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const SCREENS: [&str; 11] = [
     "Welcome",
@@ -363,6 +413,8 @@ struct App {
     /// True while mouse capture is released so the terminal's own selection
     /// works (the `[M]` toggle); wheel scroll is unavailable meanwhile.
     mouse_select: bool,
+    /// The [?] full-keymap overlay (tier two of the disclosure ladder).
+    show_help: bool,
     op: Option<Op>,
     enroll: Option<EnrollUi>,
     /// A pending merge confirmation (scan 1 matched an existing profile).
@@ -471,6 +523,7 @@ impl App {
             input: None,
             confirm: None,
             mouse_select: false,
+            show_help: false,
             op: None,
             enroll: None,
             enroll_merge: None,
@@ -1895,8 +1948,17 @@ impl App {
             }
             return;
         }
+        if self.show_help {
+            // Any of the closers dismisses; other keys are ignored so the
+            // overlay can't trigger actions the user can't see.
+            if matches!(code, KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q')) {
+                self.show_help = false;
+            }
+            return;
+        }
         match code {
             KeyCode::Char('q') | KeyCode::Esc => self.quit = true,
+            KeyCode::Char('?') => self.show_help = true,
             // Release/recapture the mouse: captured, the wheel scrolls the TUI
             // but the terminal cannot select text; released, highlight-to-copy
             // works. A toggle because both are legitimate wants.
@@ -2563,6 +2625,11 @@ impl App {
             );
             self.modal(f, "Already enrolled", &body);
         }
+        // Tier two of the key-disclosure ladder; drawn last so it sits above
+        // everything except nothing (help is always answerable).
+        if self.show_help {
+            self.modal(f, "Keys  ([?] or Esc to close)", &self.help_body());
+        }
     }
 
     /// A red, dismissible error banner centred on screen.
@@ -2580,11 +2647,11 @@ impl App {
         let blk = Block::bordered()
             .title(" ⚠ Problem ")
             .border_type(BorderType::Rounded)
-            .border_style(Style::new().fg(ERR).add_modifier(Modifier::BOLD))
+            .border_style(Style::new().fg(th().err).add_modifier(Modifier::BOLD))
             .padding(ratatui::widgets::Padding::horizontal(1));
         let body = vec![
             Line::raw(""),
-            Line::from(Span::styled(msg.to_string(), Style::new().fg(ERR))),
+            Line::from(Span::styled(msg.to_string(), Style::new().fg(th().err))),
             Line::raw(""),
             Line::from(Span::styled("[any key] dismiss", Style::new().dim())),
         ];
@@ -2603,7 +2670,7 @@ impl App {
                 " irlume ",
                 Style::new()
                     .fg(Color::Black)
-                    .bg(ACCENT)
+                    .bg(th().accent)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw("  "),
@@ -2620,7 +2687,7 @@ impl App {
             ),
             Span::styled(
                 SCREENS[self.screen],
-                Style::new().fg(ACCENT).add_modifier(Modifier::BOLD),
+                Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
             ),
         ]);
         let right =
@@ -2667,8 +2734,11 @@ impl App {
             }
         };
         let line = Line::from(vec![
-            Span::styled("  ℹ ", Style::new().fg(ACCENT).add_modifier(Modifier::BOLD)),
-            Span::styled(text, Style::new().fg(ACCENT)),
+            Span::styled(
+                "  ℹ ",
+                Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(text, Style::new().fg(th().accent)),
         ]);
         f.render_widget(Paragraph::new(line), area);
     }
@@ -2677,8 +2747,10 @@ impl App {
         let blk = Block::bordered()
             .title(format!(" {} ", SCREENS[self.screen]))
             .border_type(BorderType::Rounded)
-            .border_style(Style::new().fg(ACCENT))
-            .padding(ratatui::widgets::Padding::horizontal(1));
+            .border_style(Style::new().fg(th().accent))
+            // Breathing room (whitespace over chrome): content never touches
+            // the frame.
+            .padding(ratatui::widgets::Padding::new(2, 2, 1, 0));
         let inner = blk.inner(area);
         f.render_widget(blk, area);
         if self.enroll.is_some() {
@@ -2709,7 +2781,7 @@ impl App {
                 Span::styled(
                     if ok { "  ✓ " } else { "  ○ " },
                     if ok {
-                        Style::new().fg(OK)
+                        Style::new().fg(th().ok)
                     } else {
                         Style::new().dim()
                     },
@@ -2736,7 +2808,7 @@ impl App {
                 Span::raw("  Quality  "),
                 Span::styled(
                     quality_bar(q),
-                    Style::new().fg(if q >= 70 { OK } else { ACCENT }),
+                    Style::new().fg(if q >= 70 { th().ok } else { th().accent }),
                 ),
             ]),
             Line::raw(""),
@@ -2760,14 +2832,14 @@ impl App {
         if let Some(c) = e.count {
             lines.push(Line::from(Span::styled(
                 format!("  ● Hold still; capturing in {c}…",),
-                Style::new().fg(OK).add_modifier(Modifier::BOLD),
+                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
             )));
         } else {
             let g = r
                 .map(|x| x.guidance.clone())
                 .unwrap_or_else(|| "Starting camera…".into());
             lines.push(Line::from(vec![
-                Span::styled("  → ", Style::new().fg(ACCENT)),
+                Span::styled("  → ", Style::new().fg(th().accent)),
                 Span::styled(g, Style::new().add_modifier(Modifier::BOLD)),
             ]));
         }
@@ -2794,7 +2866,7 @@ impl App {
                     ListItem::new(Line::from(vec![
                         Span::styled(
                             format!("● {}", p.name),
-                            Style::new().fg(ACCENT).add_modifier(Modifier::BOLD),
+                            Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
                         ),
                         Span::styled(format!("   ({} scans)", p.scans.len()), Style::new().dim()),
                     ]))
@@ -2845,7 +2917,7 @@ impl App {
                     Style::new().dim(),
                 )),
                 Line::from(vec![
-                    Span::styled("  [enter]", Style::new().fg(ACCENT)),
+                    Span::styled("  [enter]", Style::new().fg(th().accent)),
                     Span::styled(" toggle", Style::new().dim()),
                 ]),
                 Line::raw(""),
@@ -2855,7 +2927,7 @@ impl App {
                     if bio {
                         Span::styled(
                             "● ENFORCING",
-                            Style::new().fg(OK).add_modifier(Modifier::BOLD),
+                            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
                         )
                     } else {
                         Span::styled("○ off (default)", Style::new().dim())
@@ -2917,7 +2989,7 @@ impl App {
             for (path, role) in &self.nodes {
                 if matches!(role, irlume_camera::Role::Rgb) {
                     v.push(ListItem::new(Line::from(vec![
-                        Span::styled(" ● ", Style::new().fg(OK)),
+                        Span::styled(" ● ", Style::new().fg(th().ok)),
                         Span::styled(
                             format!("{:<16}", path.trim_start_matches("/dev/")),
                             Style::new().add_modifier(Modifier::BOLD),
@@ -2953,7 +3025,7 @@ impl App {
                     ListItem::new(Line::from(vec![
                         Span::styled(
                             if active { " ● " } else { " ○ " },
-                            Style::new().fg(if active { OK } else { Color::DarkGray }),
+                            Style::new().fg(if active { th().ok } else { Color::DarkGray }),
                         ),
                         Span::styled(
                             format!(
@@ -2970,10 +3042,10 @@ impl App {
                                 Style::new()
                             },
                         ),
-                        Span::styled(format!("{kind:<10}"), Style::new().fg(ACCENT)),
+                        Span::styled(format!("{kind:<10}"), Style::new().fg(th().accent)),
                         Span::styled(format!("[{id}]"), Style::new().dim()),
                         if priv_on {
-                            Span::styled("  ⚠ privacy ON", Style::new().fg(ERR))
+                            Span::styled("  ⚠ privacy ON", Style::new().fg(th().err))
                         } else {
                             Span::raw("")
                         },
@@ -3010,14 +3082,17 @@ impl App {
         };
         let mut lines = vec![Line::from(vec![
             Span::styled("  active   ", Style::new().dim()),
-            Span::styled(active, Style::new().fg(OK).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                active,
+                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+            ),
         ])];
         if let Some(p) = pairs.get(self.cam_sel) {
             if p.rgb != argb || p.ir != air {
                 lines.push(Line::from(vec![
                     Span::styled("  selected ", Style::new().dim()),
                     Span::styled(format!("{} + {}", p.rgb, p.ir), Style::new()),
-                    Span::styled("   [enter] to switch", Style::new().fg(ACCENT)),
+                    Span::styled("   [enter] to switch", Style::new().fg(th().accent)),
                 ]));
             }
         }
@@ -3032,9 +3107,9 @@ impl App {
             Style::new().dim(),
         )));
         lines.push(Line::from(vec![
-            Span::styled("  [s]", Style::new().fg(ACCENT)),
+            Span::styled("  [s]", Style::new().fg(th().accent)),
             Span::styled(" auto-setup emitter   ", Style::new().dim()),
-            Span::styled("[p]", Style::new().fg(ACCENT)),
+            Span::styled("[p]", Style::new().fg(th().accent)),
             Span::styled(" probe XU controls", Style::new().dim()),
         ]));
         let iblk = Block::bordered()
@@ -3048,8 +3123,8 @@ impl App {
 
     fn draw_fingerprint(&self, f: &mut Frame, area: Rect) {
         let reader = match (&self.fp.device, self.fp.available) {
-            (Some(n), _) => Span::styled(format!("● {n}"), Style::new().fg(OK)),
-            (None, true) => Span::styled("● present (unnamed)", Style::new().fg(OK)),
+            (Some(n), _) => Span::styled(format!("● {n}"), Style::new().fg(th().ok)),
+            (None, true) => Span::styled("● present (unnamed)", Style::new().fg(th().ok)),
             (None, false) => Span::styled("○ none detected", Style::new().dim()),
         };
         let enrolled = if self.fp.enrolled.is_empty() {
@@ -3061,7 +3136,7 @@ impl App {
                     self.fp.enrolled.len(),
                     self.fp.enrolled.join(", ")
                 ),
-                Style::new().fg(OK),
+                Style::new().fg(th().ok),
             )
         };
         let mut lines = vec![
@@ -3107,13 +3182,16 @@ impl App {
         let enc = if r.encrypted {
             Span::styled(
                 "● encrypted",
-                Style::new().fg(OK).add_modifier(Modifier::BOLD),
+                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
             )
         } else {
             Span::styled("○ plaintext at rest", Style::new().dim())
         };
         let rec = if r.recovery_set {
-            Span::styled("● set", Style::new().fg(OK).add_modifier(Modifier::BOLD))
+            Span::styled(
+                "● set",
+                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+            )
         } else {
             Span::styled("○ not set", Style::new().dim())
         };
@@ -3147,12 +3225,12 @@ impl App {
         if !r.tpm_present {
             lines.push(Line::from(Span::styled(
                 "No TPM on this host: templates stay plaintext; recovery N/A.",
-                Style::new().fg(ERR),
+                Style::new().fg(th().err),
             )));
         } else if r.encrypted && !r.recovery_set {
             lines.push(Line::from(Span::styled(
                 "⚠ No backstop: set one now, or a broken seal means re-enrolling.",
-                Style::new().fg(ERR),
+                Style::new().fg(th().err),
             )));
         }
         lines.push(Line::raw(""));
@@ -3166,7 +3244,10 @@ impl App {
     fn draw_keyring(&self, f: &mut Frame, area: Rect) {
         let armed = self.keyring_armed.unwrap_or(false);
         let status = match self.keyring_armed {
-            Some(true) => Span::styled("● armed", Style::new().fg(OK).add_modifier(Modifier::BOLD)),
+            Some(true) => Span::styled(
+                "● armed",
+                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+            ),
             Some(false) => Span::styled("○ not armed", Style::new().dim()),
             None => Span::styled("unknown (daemon unreachable)", Style::new().dim()),
         };
@@ -3180,7 +3261,7 @@ impl App {
                 Span::raw("  PCRs     "),
                 Span::styled(
                     "drifted since sealing; re-arm to rebind",
-                    Style::new().fg(WARN),
+                    Style::new().fg(th().warn),
                 ),
             ]));
         }
@@ -3195,9 +3276,9 @@ impl App {
             Line::from(vec![
                 Span::raw("  TPM      "),
                 if tpm {
-                    Span::styled("● present", Style::new().fg(OK))
+                    Span::styled("● present", Style::new().fg(th().ok))
                 } else {
-                    Span::styled("✗ none", Style::new().fg(ERR))
+                    Span::styled("✗ none", Style::new().fg(th().err))
                 },
             ]),
             Line::from(vec![
@@ -3244,7 +3325,7 @@ impl App {
             } else {
                 lines.push(Line::from(Span::styled(
                     "  ⚠ if a firmware/dbx update moves the bound PCRs, unseal fails →",
-                    Style::new().fg(WARN),
+                    Style::new().fg(th().warn),
                 )));
                 lines.push(Line::from(Span::styled(
                     "    use the Repair tab or `irlume reseal` to re-bind to current PCRs.",
@@ -3264,9 +3345,9 @@ impl App {
         }
         lines.push(Line::raw(""));
         lines.push(Line::from(vec![
-            Span::styled("  [a]", Style::new().fg(ACCENT)),
+            Span::styled("  [a]", Style::new().fg(th().accent)),
             Span::styled(" arm (enter your login password)   ", Style::new().dim()),
-            Span::styled("[f]", Style::new().fg(ACCENT)),
+            Span::styled("[f]", Style::new().fg(th().accent)),
             Span::styled(" forget", Style::new().dim()),
         ]));
         f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
@@ -3278,7 +3359,7 @@ impl App {
         let lines = vec![
             Line::from(Span::styled(
                 "  irlume - local face authentication",
-                Style::new().fg(ACCENT).add_modifier(Modifier::BOLD),
+                Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
             )),
             Line::from(Span::styled(
                 "  IR + lume · clean-BOM · TPM-sealed · privacy by design",
@@ -3309,7 +3390,7 @@ impl App {
             Line::raw(""),
             Line::from(vec![
                 Span::styled("  Recommended  ", Style::new().add_modifier(Modifier::BOLD)),
-                Span::styled(self.recommended(), Style::new().fg(OK)),
+                Span::styled(self.recommended(), Style::new().fg(th().ok)),
             ]),
             Line::from(Span::styled(
                 "  (you can change the method any time; [v] shows every tab)",
@@ -3318,20 +3399,20 @@ impl App {
             Line::raw(""),
             if self.visible.contains(&SC_IDENTIFY) {
                 Line::from(vec![
-                    Span::styled("  [e]", Style::new().fg(ACCENT)),
+                    Span::styled("  [e]", Style::new().fg(th().accent)),
                     Span::styled(" enroll now   ", Style::new().dim()),
-                    Span::styled("[i]", Style::new().fg(ACCENT)),
+                    Span::styled("[i]", Style::new().fg(th().accent)),
                     Span::styled(" identify   ", Style::new().dim()),
-                    Span::styled("Tab", Style::new().fg(ACCENT)),
+                    Span::styled("Tab", Style::new().fg(th().accent)),
                     Span::styled(" walk the steps", Style::new().dim()),
                 ])
             } else {
                 Line::from(vec![
-                    Span::styled("  [e]", Style::new().fg(ACCENT)),
+                    Span::styled("  [e]", Style::new().fg(th().accent)),
                     Span::styled(" enroll now   ", Style::new().dim()),
-                    Span::styled("Tab", Style::new().fg(ACCENT)),
+                    Span::styled("Tab", Style::new().fg(th().accent)),
                     Span::styled(" walk the steps   ", Style::new().dim()),
-                    Span::styled("[v]", Style::new().fg(ACCENT)),
+                    Span::styled("[v]", Style::new().fg(th().accent)),
                     Span::styled(" all tabs", Style::new().dim()),
                 ])
             },
@@ -3360,9 +3441,9 @@ impl App {
             .iter()
             .map(|c| {
                 let (icon, color) = match c.sev {
-                    Sev::Ok => ("✓", OK),
-                    Sev::Warn => ("⚠", WARN),
-                    Sev::Fail => ("✗", ERR),
+                    Sev::Ok => ("✓", th().ok),
+                    Sev::Warn => ("⚠", th().warn),
+                    Sev::Fail => ("✗", th().err),
                 };
                 let tag = match &c.fix {
                     Fix::None => "",
@@ -3379,7 +3460,7 @@ impl App {
                         Style::new().add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(c.detail.clone(), Style::new().dim()),
-                    Span::styled(tag.to_string(), Style::new().fg(ACCENT)),
+                    Span::styled(tag.to_string(), Style::new().fg(th().accent)),
                 ]))
             })
             .collect();
@@ -3398,18 +3479,18 @@ impl App {
 
         // ---- info / platform / live test --------------------------------
         let sb = if secureboot::is_secure_boot_enabled() {
-            ("enabled", OK)
+            ("enabled", th().ok)
         } else if secureboot::is_setup_mode() {
-            ("setup mode", WARN)
+            ("setup mode", th().warn)
         } else if secureboot::secure_boot_present() {
-            ("disabled", WARN)
+            ("disabled", th().warn)
         } else {
-            ("n/a", WARN)
+            ("n/a", th().warn)
         };
         let mut lines = vec![Line::from(vec![
-            Span::styled(format!("  {ok} ok"), Style::new().fg(OK)),
-            Span::styled(format!("   {warn} warn"), Style::new().fg(WARN)),
-            Span::styled(format!("   {fail} fail"), Style::new().fg(ERR)),
+            Span::styled(format!("  {ok} ok"), Style::new().fg(th().ok)),
+            Span::styled(format!("   {warn} warn"), Style::new().fg(th().warn)),
+            Span::styled(format!("   {fail} fail"), Style::new().fg(th().err)),
             Span::styled(
                 "      [f] fix selected   [r] re-check   [l] IR self-test   [g] logs",
                 Style::new().dim(),
@@ -3427,7 +3508,7 @@ impl App {
                 Fix::Root(_) => "press [f]: irlume runs the fix with sudo".to_string(),
             };
             lines.push(Line::from(vec![
-                Span::styled("  → ", Style::new().fg(ACCENT)),
+                Span::styled("  → ", Style::new().fg(th().accent)),
                 Span::styled(hint, Style::new()),
             ]));
         }
@@ -3465,7 +3546,10 @@ impl App {
         match &self.selftest_result {
             Some((ok, d)) => lines.push(Line::from(vec![
                 Span::styled("  IR test   ", Style::new().dim()),
-                Span::styled(d.clone(), Style::new().fg(if *ok { OK } else { ERR })),
+                Span::styled(
+                    d.clone(),
+                    Style::new().fg(if *ok { th().ok } else { th().err }),
+                ),
             ])),
             None => lines.push(Line::from(Span::styled(
                 "  IR test    press [l] to run the IR PAD self-test (look at the camera)",
@@ -3505,7 +3589,7 @@ impl App {
                     Span::styled("  │ ", Style::new().dim()),
                     Span::styled(
                         who.clone(),
-                        Style::new().fg(OK).add_modifier(Modifier::BOLD),
+                        Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
                     ),
                 ]));
                 lines.push(Line::from(Span::styled(
@@ -3514,8 +3598,8 @@ impl App {
                 )));
             }
             Some((false, why)) => lines.push(Line::from(vec![
-                Span::styled("  ✗ ", Style::new().fg(ERR)),
-                Span::styled(why.clone(), Style::new().fg(ERR)),
+                Span::styled("  ✗ ", Style::new().fg(th().err)),
+                Span::styled(why.clone(), Style::new().fg(th().err)),
             ])),
             None => lines.push(Line::from(Span::styled(
                 "  press [i] and look at the camera",
@@ -3524,7 +3608,7 @@ impl App {
         }
         lines.push(Line::raw(""));
         lines.push(Line::from(vec![
-            Span::styled("  [i]", Style::new().fg(ACCENT)),
+            Span::styled("  [i]", Style::new().fg(th().accent)),
             Span::styled(" identify now", Style::new().dim()),
         ]));
         f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
@@ -3537,7 +3621,10 @@ impl App {
             let val = if !present {
                 Span::styled("(not present)", Style::new().dim())
             } else if wired {
-                Span::styled("● wired", Style::new().fg(OK).add_modifier(Modifier::BOLD))
+                Span::styled(
+                    "● wired",
+                    Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                )
             } else {
                 Span::styled("○ not wired", Style::new().dim())
             };
@@ -3548,8 +3635,8 @@ impl App {
         // SELinux row on a non-SELinux system reads as a fault that isn't one.
         if std::path::Path::new("/sys/fs/selinux").exists() {
             let sel = match crate::pamwire::selinux_state() {
-                Some(true) => Span::styled("● loaded", Style::new().fg(OK)),
-                Some(false) => Span::styled("✗ not loaded", Style::new().fg(ERR)),
+                Some(true) => Span::styled("● loaded", Style::new().fg(th().ok)),
+                Some(false) => Span::styled("✗ not loaded", Style::new().fg(th().err)),
                 None => Span::styled("unknown (needs root)", Style::new().dim()),
             };
             lines.push(Line::from(vec![
@@ -3564,7 +3651,7 @@ impl App {
             lines.push(Line::from(vec![
                 Span::raw(format!("  {:<16}", "AppArmor")),
                 if profiled {
-                    Span::styled("● irlume profile installed", Style::new().fg(OK))
+                    Span::styled("● irlume profile installed", Style::new().fg(th().ok))
                 } else {
                     Span::styled(
                         "active; irlume unconfined (profile optional)",
@@ -3612,7 +3699,7 @@ impl App {
         lines.push(Line::raw(""));
         lines.push(section("Change (root)"));
         lines.push(Line::from(vec![
-            Span::styled("  [w]", Style::new().fg(ACCENT)),
+            Span::styled("  [w]", Style::new().fg(th().accent)),
             Span::styled(
                 " wire the login stack now (runs sudo irlume login enable --apply)",
                 Style::new(),
@@ -3624,7 +3711,7 @@ impl App {
         )));
         lines.push(Line::from(vec![
             Span::styled("  face-sudo ", Style::new()),
-            Span::styled("[u]", Style::new().fg(ACCENT)),
+            Span::styled("[u]", Style::new().fg(th().accent)),
             Span::styled(
                 " wire it (opt-in, not part of [w]; face approves sudo prompts)",
                 Style::new().dim(),
@@ -3632,7 +3719,7 @@ impl App {
         ]));
         lines.push(Line::from(vec![
             Span::styled("  app prompts ", Style::new()),
-            Span::styled("[p]", Style::new().fg(ACCENT)),
+            Span::styled("[p]", Style::new().fg(th().accent)),
             Span::styled(
                 " wire them (opt-in; face approves Bitwarden/pkexec)",
                 Style::new().dim(),
@@ -3653,7 +3740,7 @@ impl App {
             None => {}
             Some(crate::bitwarden::TuiState::Ready) => lines.push(Line::from(vec![
                 Span::styled("  Bitwarden ", Style::new()),
-                Span::styled("● polkit action installed", Style::new().fg(OK)),
+                Span::styled("● polkit action installed", Style::new().fg(th().ok)),
                 Span::styled(
                     "  (enable \"unlock with system authentication\" in its settings)",
                     Style::new().dim(),
@@ -3661,7 +3748,7 @@ impl App {
             ])),
             Some(crate::bitwarden::TuiState::SnapMissing) => lines.push(Line::from(vec![
                 Span::styled("  Bitwarden ", Style::new()),
-                Span::styled("○ snap action missing", Style::new().fg(WARN)),
+                Span::styled("○ snap action missing", Style::new().fg(th().warn)),
                 Span::styled(
                     "  fix: sudo snap connect bitwarden:polkit",
                     Style::new().dim(),
@@ -3669,21 +3756,21 @@ impl App {
             ])),
             Some(crate::bitwarden::TuiState::NeedsSetup) => lines.push(Line::from(vec![
                 Span::styled("  Bitwarden ", Style::new()),
-                Span::styled("○ biometric unlock not set up", Style::new().fg(WARN)),
-                Span::styled("  [b]", Style::new().fg(ACCENT)),
+                Span::styled("○ biometric unlock not set up", Style::new().fg(th().warn)),
+                Span::styled("  [b]", Style::new().fg(th().accent)),
                 Span::styled(" set it up (sudo; optional)", Style::new().dim()),
             ])),
         }
         lines.push(Line::from(vec![
             Span::styled("  disable ", Style::new()),
-            Span::styled("[x]", Style::new().fg(ACCENT)),
+            Span::styled("[x]", Style::new().fg(th().accent)),
             Span::styled(
                 " un-wires face auth everywhere (confirmed first)",
                 Style::new().dim(),
             ),
         ]));
         lines.push(Line::from(vec![
-            Span::styled("  [s]", Style::new().fg(ACCENT)),
+            Span::styled("  [s]", Style::new().fg(th().accent)),
             Span::styled(" open full status in a console view", Style::new().dim()),
         ]));
         f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
@@ -3696,7 +3783,7 @@ impl App {
         let lines = vec![
             Line::from(Span::styled(
                 "  Setup dashboard",
-                Style::new().fg(ACCENT).add_modifier(Modifier::BOLD),
+                Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
             )),
             Line::raw(""),
             Line::from(vec![
@@ -3705,7 +3792,7 @@ impl App {
             ]),
             Line::from(vec![
                 Span::raw("  auth method       "),
-                Span::styled(method_label(&self.fp.method), Style::new().fg(ACCENT)),
+                Span::styled(method_label(&self.fp.method), Style::new().fg(th().accent)),
             ]),
             Line::from(vec![
                 Span::raw("  enrollment        "),
@@ -3757,12 +3844,12 @@ impl App {
             )),
             if !self.profiles.is_empty() && !wired {
                 Line::from(vec![
-                    Span::styled("  [w]", Style::new().fg(ACCENT)),
+                    Span::styled("  [w]", Style::new().fg(th().accent)),
                     Span::styled(" wire login    [r] refresh    [q] quit", Style::new().dim()),
                 ])
             } else {
                 Line::from(vec![
-                    Span::styled("  [r]", Style::new().fg(ACCENT)),
+                    Span::styled("  [r]", Style::new().fg(th().accent)),
                     Span::styled(" refresh    [q] quit", Style::new().dim()),
                 ])
             },
@@ -3783,7 +3870,7 @@ impl App {
         let blk = Block::bordered()
             .title(title)
             .border_type(BorderType::Rounded)
-            .border_style(Style::new().fg(if scrolled { ACCENT } else { BLUE }));
+            .border_style(Style::new().fg(if scrolled { th().accent } else { th().blue }));
         let inner = blk.inner(area);
         f.render_widget(blk, area);
         let h = inner.height as usize;
@@ -3794,9 +3881,9 @@ impl App {
             .iter()
             .map(|(g, m)| {
                 let gs = match g {
-                    '→' => Style::new().fg(ACCENT),
-                    '✓' => Style::new().fg(OK),
-                    '✗' => Style::new().fg(ERR),
+                    '→' => Style::new().fg(th().accent),
+                    '✓' => Style::new().fg(th().ok),
+                    '✗' => Style::new().fg(th().err),
                     _ => Style::new().dim(),
                 };
                 Line::from(vec![
@@ -3808,36 +3895,10 @@ impl App {
         f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     }
 
-    fn draw_footer(&self, f: &mut Frame, area: Rect) {
-        let key =
-            |k: &str| Span::styled(format!(" {k} "), Style::new().fg(Color::Black).bg(ACCENT));
-        // Guided enrollment swallows every key but Esc; show only that, so the
-        // footer doesn't advertise dead nav/action keys during a capture.
-        if self.enroll.is_some() {
-            let spans = vec![
-                key("esc"),
-                Span::styled(" cancel enrollment", Style::new().dim()),
-            ];
-            let blk = Block::bordered()
-                .border_type(BorderType::Rounded)
-                .border_style(Style::new().dim());
-            f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
-            return;
-        }
-        // A running op (Identify / IR self-test) also swallows every key but
-        // q/Esc, so don't advertise the live nav/action keys during it.
-        if self.op.is_some() {
-            let spans = vec![
-                key("q / esc"),
-                Span::styled(" cancel · working…", Style::new().dim()),
-            ];
-            let blk = Block::bordered()
-                .border_type(BorderType::Rounded)
-                .border_style(Style::new().dim());
-            f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
-            return;
-        }
-        let actions: &[(&str, &str)] = match self.screen {
+    /// Per-screen action keys, ordered primary-first: the footer shows
+    /// the first three, the [?] overlay shows them all.
+    fn screen_actions(&self) -> &'static [(&'static str, &'static str)] {
+        match self.screen {
             SC_WELCOME => &[
                 ("e", "enroll"),
                 ("i", "identify"),
@@ -3884,34 +3945,74 @@ impl App {
             ],
             SC_DONE => &[("w", "wire login"), ("u", "update"), ("r", "refresh")],
             _ => &[("r", "refresh")],
-        };
-        let mut spans = vec![
-            key("Tab / ← →"),
-            Span::styled(" switch tab  ", Style::new().dim()),
-            key("↑↓"),
-            Span::styled(" select  ", Style::new().dim()),
-            key("v"),
-            Span::styled(
-                if self.advanced {
-                    " basic  "
-                } else {
-                    " all tabs  "
-                },
-                Style::new().dim(),
-            ),
-            key("PgUp/Dn"),
-            Span::styled(" activity  ", Style::new().dim()),
-            key("q"),
-            Span::styled(" quit    ", Style::new().dim()),
-        ];
-        for (k, d) in actions {
-            spans.push(key(k));
-            spans.push(Span::styled(format!(" {d}  "), Style::new().dim()));
         }
+    }
+
+    fn draw_footer(&self, f: &mut Frame, area: Rect) {
+        let key = |k: &str| Span::styled(format!(" {k} "), th().chip);
+        // Guided enrollment swallows every key but Esc; show only that, so the
+        // footer doesn't advertise dead nav/action keys during a capture.
+        if self.enroll.is_some() {
+            let spans = vec![
+                key("esc"),
+                Span::styled(" cancel enrollment", Style::new().dim()),
+            ];
+            let blk = Block::bordered()
+                .border_type(BorderType::Rounded)
+                .border_style(Style::new().dim());
+            f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
+            return;
+        }
+        // A running op (Identify / IR self-test) also swallows every key but
+        // q/Esc, so don't advertise the live nav/action keys during it.
+        if self.op.is_some() {
+            let spans = vec![
+                key("q / esc"),
+                Span::styled(" cancel · working…", Style::new().dim()),
+            ];
+            let blk = Block::bordered()
+                .border_type(BorderType::Rounded)
+                .border_style(Style::new().dim());
+            f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
+            return;
+        }
+        let actions = self.screen_actions();
+        // Three-tier disclosure (GNOME HIG): the footer shows the primary
+        // action plus at most two more; [?] opens the full keymap overlay;
+        // docs hold the rest. The first action is THE action for the screen,
+        // so it alone gets the emphasized label.
+        let mut spans = vec![key("Tab"), Span::styled(" tabs  ", Style::new().dim())];
+        for (i, (k, d)) in actions.iter().take(3).enumerate() {
+            spans.push(key(k));
+            if i == 0 {
+                spans.push(Span::styled(
+                    format!(" {d}  "),
+                    Style::new().add_modifier(Modifier::BOLD),
+                ));
+            } else {
+                spans.push(Span::styled(format!(" {d}  "), Style::new().dim()));
+            }
+        }
+        spans.push(key("?"));
+        spans.push(Span::styled(" all keys  ", Style::new().dim()));
+        spans.push(key("q"));
+        spans.push(Span::styled(" quit", Style::new().dim()));
         let blk = Block::bordered()
             .border_type(BorderType::Rounded)
             .border_style(Style::new().dim());
         f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
+    }
+
+    /// The full keymap for the [?] overlay: the global keys plus every action
+    /// of the CURRENT screen (tier two of the disclosure ladder).
+    fn help_body(&self) -> String {
+        let mut b = String::from(
+            "Global\n  Tab / \u{2190}\u{2192}  switch tab      \u{2191}\u{2193}  select\n               v  basic/all tabs       PgUp/Dn  activity log\n               M  release mouse (highlight/copy)   q  quit\n\nThis screen\n",
+        );
+        for (k, d) in self.screen_actions() {
+            b.push_str(&format!("  {k:<7} {d}\n"));
+        }
+        b
     }
 
     fn modal(&self, f: &mut Frame, title: &str, body: &str) {
@@ -3932,7 +4033,7 @@ impl App {
         let blk = Block::bordered()
             .title(format!(" {title} "))
             .border_type(BorderType::Rounded)
-            .border_style(Style::new().fg(ACCENT))
+            .border_style(Style::new().fg(th().accent))
             .padding(ratatui::widgets::Padding::horizontal(1));
         f.render_widget(
             Paragraph::new(body.to_string())
@@ -3986,14 +4087,17 @@ fn quality_bar(q: u8) -> String {
 fn section(title: &str) -> Line<'static> {
     Line::from(Span::styled(
         title.to_string(),
-        Style::new().fg(ACCENT).add_modifier(Modifier::BOLD),
+        Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
     ))
 }
 
 /// Green ● ON / dim ○ off badge.
 fn onoff(on: bool) -> Span<'static> {
     if on {
-        Span::styled("● yes", Style::new().fg(OK).add_modifier(Modifier::BOLD))
+        Span::styled(
+            "● yes",
+            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+        )
     } else {
         Span::styled("○ no", Style::new().dim())
     }
@@ -4018,7 +4122,7 @@ fn count_badge(profiles: usize, scans: usize) -> Span<'static> {
     } else {
         Span::styled(
             format!("● {profiles} profile(s), {scans} scan(s)"),
-            Style::new().fg(OK).add_modifier(Modifier::BOLD),
+            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
         )
     }
 }
@@ -4301,6 +4405,7 @@ mod tests {
             input: None,
             confirm: None,
             mouse_select: false,
+            show_help: false,
             op: None,
             enroll: None,
             enroll_merge: None,
@@ -4703,10 +4808,12 @@ mod tests {
             !text.contains("switch tab"),
             "footer advertises dead nav keys during an op:\n{text}"
         );
-        // Sanity: the full footer returns once the op is gone.
+        // Sanity: the normal footer returns once the op is gone (trimmed
+        // design: tabs hint + primary action + the [?] disclosure chip).
         app.op = None;
         term.draw(|f| app.draw_footer(f, f.area())).unwrap();
-        assert!(rendered(&term).contains("switch tab"));
+        let text = rendered(&term);
+        assert!(text.contains("tabs") && text.contains("all keys"), "{text}");
     }
 
     // Regression: cae2eea. caps/fp_present were captured once at startup, so a
@@ -6482,35 +6589,41 @@ mod tests {
             term.draw(|f| app.draw_footer(f, f.area())).unwrap();
             rendered(&term)
         };
-        let cases: [(usize, &str); 11] = [
-            (SC_WELCOME, "uninstall"),
-            (SC_REPAIR, "IR test"),
-            (SC_CAMERAS, "setup emitter"),
-            (SC_PROFILES, "add scan"),
-            (SC_IDENTIFY, "identify"),
-            (SC_KEYRING, "arm"),
-            (SC_RECOVERY, "restore"),
-            (SC_FINGERPRINT, "enroll finger"),
-            (SC_PAM, "wire login (sudo)"),
-            (SC_SETTINGS, "toggle eyes-open"),
-            (SC_DONE, "wire login"),
+        // Footer = primary action only (trimmed, three-tier disclosure);
+        // the [?] overlay must list EVERY action of the screen.
+        let cases: [(usize, &str, &str); 11] = [
+            (SC_WELCOME, "enroll", "uninstall"),
+            (SC_REPAIR, "fix", "debug logs"),
+            (SC_CAMERAS, "use", "probe"),
+            (SC_PROFILES, "enroll", "delete"),
+            (SC_IDENTIFY, "identify", "identify"),
+            (SC_KEYRING, "arm", "forget"),
+            (SC_RECOVERY, "set", "forget"),
+            (SC_FINGERPRINT, "enroll finger", "reset"),
+            (SC_PAM, "wire login (sudo)", "un-wire"),
+            (SC_SETTINGS, "toggle eyes-open", "3rd-party model"),
+            (SC_DONE, "wire login", "refresh"),
         ];
         let mut app = app;
-        for (screen, needle) in cases {
+        for (screen, primary, in_overlay) in cases {
             app.screen = screen;
+            assert!(
+                app.help_body().contains(in_overlay),
+                "[?] overlay for screen {screen} misses '{in_overlay}':\n{}",
+                app.help_body()
+            );
+            let needle = primary;
             let text = footer(&app);
             assert!(
                 text.contains(needle),
                 "footer for {} must advertise '{needle}', got:\n{text}",
                 SCREENS[screen]
             );
-            assert!(text.contains("switch tab"), "global nav keys always show");
+            assert!(
+                text.contains("all keys"),
+                "the [?] disclosure chip always shows"
+            );
         }
-        // The [v] label flips with the view mode.
-        app.screen = SC_WELCOME;
-        assert!(footer(&app).contains("all tabs"));
-        app.advanced = true;
-        assert!(footer(&app).contains("basic"));
         // Guided enrollment swallows everything but Esc: only that shows.
         let (_tx, enroll) = fake_enroll(0, 4);
         app.enroll = Some(enroll);

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2175,6 +2175,17 @@ impl App {
                     Pending::KeyringPw(None),
                 ));
             }
+            // Reseal: re-bind the sealed password to the current PCRs (the CLI
+            // `irlume reseal`). Same masked-prompt + SealPassword path as arm;
+            // the distinct entry point and copy are the discoverability the
+            // drift-recovery workflow needs.
+            (SC_KEYRING, KeyCode::Char('r')) if self.keyring_armed == Some(true) => {
+                self.input = Some((
+                    "Login password to re-seal to current PCRs (••):".into(),
+                    String::new(),
+                    Pending::KeyringPw(None),
+                ));
+            }
             (SC_KEYRING, KeyCode::Char('f')) => {
                 self.confirm = Some((
                     "Erase the TPM-sealed login password?".into(),
@@ -2880,13 +2891,13 @@ impl App {
             "  [esc] cancel",
             Style::new().dim(),
         )));
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     fn draw_profiles(&self, f: &mut Frame, area: Rect) {
         if self.profiles.is_empty() {
             f.render_widget(Paragraph::new("\nNo face profiles yet.\n\nPress [e] to enroll; irlume will guide your framing and capture automatically.")
-                .wrap(Wrap { trim: true }).dim(), area);
+                .wrap(Wrap { trim: false }).dim(), area);
             return;
         }
         let rows = self.rows();
@@ -3024,7 +3035,7 @@ impl App {
                     Style::new().dim(),
                 )),
             ])
-            .wrap(Wrap { trim: true }),
+            .wrap(Wrap { trim: false }),
             area,
         );
     }
@@ -3176,7 +3187,7 @@ impl App {
             Span::styled(" probe XU controls", Style::new().dim()),
         ]));
         // Borderless (no box-in-box); the content panel is the only frame.
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), info_area);
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), info_area);
     }
 
     fn draw_fingerprint(&self, f: &mut Frame, area: Rect) {
@@ -3198,41 +3209,38 @@ impl App {
             )
         };
         let mut lines = vec![
-            Line::raw(""),
-            Line::from(vec![
-                Span::styled("Reader        ", Style::new().add_modifier(Modifier::BOLD)),
-                reader,
-            ]),
-            Line::from(vec![
-                Span::styled("Enrolled      ", Style::new().add_modifier(Modifier::BOLD)),
-                enrolled,
-            ]),
-            Line::from(vec![
-                Span::styled("Active method ", Style::new().add_modifier(Modifier::BOLD)),
+            section("Fingerprint (companion factor)"),
+            state_row("reader", 14, reader),
+            state_row("enrolled", 14, enrolled),
+            state_row(
+                "active method",
+                14,
                 Span::raw(method_label(&self.fp.method)),
-            ]),
+            ),
             Line::raw(""),
         ];
         if self.fp.available {
             lines.push(Line::from(Span::styled(
-                "Fingerprint is a companion factor via stock fprintd + pam_fprintd.",
+                "  Stock fprintd + pam_fprintd; unlocks alongside face, never instead.",
                 Style::new().dim(),
             )));
-            lines.push(Line::from(Span::styled(
-                "  [a] enroll a finger · [t] test a finger · [x] wipe all enrolled fingers",
-                Style::new().dim(),
-            )));
-            lines.push(Line::from(Span::styled(
-                "  [e] unlock with face OR fingerprint (sudo) · [d] remove fingerprint from login",
-                Style::new().dim(),
-            )));
+            lines.push(Line::raw(""));
+            lines.push(action_line(&[
+                ("a", "enroll a finger"),
+                ("t", "test a finger"),
+                ("x", "wipe all"),
+            ]));
+            lines.push(action_line(&[
+                ("e", "face OR fingerprint (sudo)"),
+                ("d", "remove from login"),
+            ]));
         } else {
             lines.push(Line::from(Span::styled(
-                "No usable reader on this device; fingerprint unavailable.",
+                "  No usable reader on this device; fingerprint unavailable.",
                 Style::new().dim(),
             )));
         }
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     fn draw_recovery(&self, f: &mut Frame, area: Rect) {
@@ -3254,49 +3262,38 @@ impl App {
             Span::styled("○ not set", Style::new().dim())
         };
         let mut lines = vec![
-            Line::raw(""),
-            Line::from(vec![
-                Span::styled(
-                    "Templates at rest    ",
-                    Style::new().add_modifier(Modifier::BOLD),
-                ),
-                enc,
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "Recovery passphrase  ",
-                    Style::new().add_modifier(Modifier::BOLD),
-                ),
-                rec,
-            ]),
+            section("Recovery + template encryption"),
+            state_row("templates", 12, enc),
+            state_row("passphrase", 12, rec),
             Line::raw(""),
             Line::from(Span::styled(
-                "A recovery passphrase backs up the face-template key, the manual",
+                "  A recovery passphrase backs up the face-template key, the manual",
                 Style::new().dim(),
             )),
             Line::from(Span::styled(
-                "backstop after a TPM clear, firmware/dbx update, or disk move.",
+                "  backstop after a TPM clear, firmware/dbx update, or disk move.",
                 Style::new().dim(),
             )),
             Line::raw(""),
         ];
         if !r.tpm_present {
             lines.push(Line::from(Span::styled(
-                "No TPM on this host: templates stay plaintext; recovery N/A.",
+                "  No TPM on this host: templates stay plaintext; recovery N/A.",
                 Style::new().fg(th().err),
             )));
         } else if r.encrypted && !r.recovery_set {
             lines.push(Line::from(Span::styled(
-                "⚠ No backstop: set one now, or a broken seal means re-enrolling.",
+                "  ⚠ No backstop: set one now, or a broken seal means re-enrolling.",
                 Style::new().fg(th().err),
             )));
         }
         lines.push(Line::raw(""));
-        lines.push(Line::from(Span::styled(
-            "  [s] set passphrase   [t] restore from passphrase   [f] forget",
-            Style::new().dim(),
-        )));
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        lines.push(action_line(&[
+            ("s", "set passphrase"),
+            ("t", "restore"),
+            ("f", "forget"),
+        ]));
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     fn draw_keyring(&self, f: &mut Frame, area: Rect) {
@@ -3386,7 +3383,7 @@ impl App {
                     Style::new().fg(th().warn),
                 )));
                 lines.push(Line::from(Span::styled(
-                    "    use the Repair tab or `irlume reseal` to re-bind to current PCRs.",
+                    "    press [r] to reseal (re-bind to the current PCRs, same password).",
                     Style::new().dim(),
                 )));
             }
@@ -3402,13 +3399,22 @@ impl App {
             )));
         }
         lines.push(Line::raw(""));
-        lines.push(Line::from(vec![
-            Span::styled("  [a]", Style::new().fg(th().accent)),
-            Span::styled(" arm (enter your login password)   ", Style::new().dim()),
-            Span::styled("[f]", Style::new().fg(th().accent)),
-            Span::styled(" forget", Style::new().dim()),
-        ]));
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        // [r] reseal is shown only once armed (re-bind needs an existing seal);
+        // it re-enters the password and re-seals to the current PCRs, the CLI
+        // `irlume reseal` a keyboard-only user would otherwise have no way to run.
+        if armed {
+            lines.push(action_line(&[
+                ("a", "re-arm (new password)"),
+                ("r", "reseal (re-bind to current PCRs)"),
+                ("f", "forget"),
+            ]));
+        } else {
+            lines.push(action_line(&[
+                ("a", "arm (enter your login password)"),
+                ("f", "forget"),
+            ]));
+        }
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     /// Hub rows for the Welcome screen: each visible section with its live
@@ -3596,11 +3602,14 @@ impl App {
             Span::styled(format!("  {ok} ok"), Style::new().fg(th().ok)),
             Span::styled(format!("   {warn} warn"), Style::new().fg(th().warn)),
             Span::styled(format!("   {fail} fail"), Style::new().fg(th().err)),
-            Span::styled(
-                "      [f] fix selected   [r] re-check   [l] IR self-test   [g] logs",
-                Style::new().dim(),
-            ),
         ])];
+        lines.push(action_line(&[
+            ("f", "fix selected"),
+            ("r", "re-check"),
+            ("l", "IR self-test"),
+            ("g", "logs"),
+        ]));
+        lines.push(Line::raw(""));
         if let Some(c) = self.repair.get(self.repair_sel) {
             let hint = match &c.fix {
                 // "no action needed" next to a non-zero fail count reads as a
@@ -3666,7 +3675,7 @@ impl App {
             .border_style(Style::new().dim())
             .title(" diagnosis ");
         f.render_widget(
-            Paragraph::new(lines).block(blk).wrap(Wrap { trim: true }),
+            Paragraph::new(lines).block(blk).wrap(Wrap { trim: false }),
             info_area,
         );
     }
@@ -3716,7 +3725,7 @@ impl App {
             Span::styled("  [i]", Style::new().fg(th().accent)),
             Span::styled(" identify now", Style::new().dim()),
         ]));
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     fn draw_pam(&self, f: &mut Frame, area: Rect) {
@@ -3891,10 +3900,7 @@ impl App {
         let rec = self.recovery.unwrap_or_default();
         let wired = crate::pamwire::login_wired();
         let lines = vec![
-            Line::from(Span::styled(
-                "  Setup dashboard",
-                Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
-            )),
+            section("Setup dashboard"),
             Line::raw(""),
             Line::from(vec![
                 Span::raw("  daemon            "),
@@ -3964,7 +3970,7 @@ impl App {
                 ])
             },
         ];
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     fn draw_activity(&self, f: &mut Frame, area: Rect) {
@@ -4040,7 +4046,7 @@ impl App {
                 ("d", "delete"),
             ],
             SC_IDENTIFY => &[("i", "identify")],
-            SC_KEYRING => &[("a", "arm"), ("f", "forget")],
+            SC_KEYRING => &[("a", "arm"), ("r", "reseal"), ("f", "forget")],
             SC_RECOVERY => &[("s", "set"), ("t", "restore"), ("f", "forget")],
             SC_FINGERPRINT => &[
                 ("a", "enroll finger"),
@@ -4221,6 +4227,27 @@ fn onoff(on: bool) -> Span<'static> {
     } else {
         Span::styled("○ no", Style::new().dim())
     }
+}
+
+/// A screen state row: 2-space indent, label padded to `w`, then the value
+/// span. One shape for every status line so screens line up the same way.
+fn state_row(label: &str, w: usize, value: Span<'static>) -> Line<'static> {
+    Line::from(vec![Span::raw(format!("  {label:<w$}", w = w)), value])
+}
+
+/// An action line: accent `[key]` chips with dim labels, 2-space indent, a
+/// gap between actions. THE way action keys render, so a key is never a dim
+/// mid-sentence token or a whole dim line.
+fn action_line(items: &[(&str, &str)]) -> Line<'static> {
+    let mut spans = vec![Span::raw("  ")];
+    for (i, (k, d)) in items.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw("   "));
+        }
+        spans.push(Span::styled(format!("[{k}]"), Style::new().fg(th().accent)));
+        spans.push(Span::styled(format!(" {d}"), Style::new().dim()));
+    }
+    Line::from(spans)
 }
 
 /// Human label for the stored auth method string (`Method::as_str()`): the raw
@@ -5688,6 +5715,20 @@ mod tests {
                 assert!(p.masked(), "a password prompt must render masked")
             }
             _ => panic!("expected the keyring password prompt"),
+        }
+        app.input = None;
+        // [r] reseal opens the masked prompt ONLY when armed (re-bind needs an
+        // existing seal); the CLI `irlume reseal` reachable from the TUI.
+        app.keyring_armed = Some(false);
+        app.on_key(KeyCode::Char('r'));
+        assert!(app.input.is_none(), "reseal is inert when not armed");
+        app.keyring_armed = Some(true);
+        app.on_key(KeyCode::Char('r'));
+        match &app.input {
+            Some((prompt, _, p @ Pending::KeyringPw(None))) => {
+                assert!(p.masked() && prompt.contains("re-seal"), "got: {prompt}");
+            }
+            _ => panic!("expected the reseal password prompt"),
         }
         app.input = None;
         app.on_key(KeyCode::Char('f'));

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3777,82 +3777,87 @@ impl App {
         )));
         lines.push(Line::raw(""));
         lines.push(section("Change (root)"));
-        lines.push(Line::from(vec![
-            Span::styled("  [w]", Style::new().fg(th().accent)),
-            Span::styled(
-                " wire the login stack now (runs sudo irlume login enable --apply)",
-                Style::new(),
-            ),
-        ]));
-        lines.push(Line::from(Span::styled(
-            "  empty password + Enter fires face (greeter login = IR/secure tier; RGB-only = lock screen only)",
-            Style::new().dim(),
-        )));
-        lines.push(Line::from(vec![
-            Span::styled("  face-sudo ", Style::new()),
-            Span::styled("[u]", Style::new().fg(th().accent)),
-            Span::styled(
-                " wire it (opt-in, not part of [w]; face approves sudo prompts)",
-                Style::new().dim(),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::styled("  app prompts ", Style::new()),
-            Span::styled("[p]", Style::new().fg(th().accent)),
-            Span::styled(
-                " wire them (opt-in; face approves Bitwarden/pkexec)",
-                Style::new().dim(),
-            ),
-        ]));
-        lines.push(Line::from(Span::styled(
-            "    an app prompt needs a deliberate NOD to approve (no calibration); or an eye",
-            Style::new().dim(),
-        )));
-        lines.push(Line::from(Span::styled(
-            "    closure, taught once with [c].  See docs/APP-INTEGRATION.md",
-            Style::new().dim(),
-        )));
-        // Bitwarden app-unlock row: only rendered when Bitwarden is installed
-        // (invisible for everyone else), and never acts on its own — [b] is
-        // the user's explicit opt-in.
-        match crate::bitwarden::tui_state() {
-            None => {}
-            Some(crate::bitwarden::TuiState::Ready) => lines.push(Line::from(vec![
-                Span::styled("  Bitwarden ", Style::new()),
-                Span::styled("● polkit action installed", Style::new().fg(th().ok)),
-                Span::styled(
-                    "  (enable \"unlock with system authentication\" in its settings)",
-                    Style::new().dim(),
-                ),
-            ])),
-            Some(crate::bitwarden::TuiState::SnapMissing) => lines.push(Line::from(vec![
-                Span::styled("  Bitwarden ", Style::new()),
-                Span::styled("○ snap action missing", Style::new().fg(th().warn)),
-                Span::styled(
-                    "  fix: sudo snap connect bitwarden:polkit",
-                    Style::new().dim(),
-                ),
-            ])),
-            Some(crate::bitwarden::TuiState::NeedsSetup) => lines.push(Line::from(vec![
-                Span::styled("  Bitwarden ", Style::new()),
-                Span::styled("○ biometric unlock not set up", Style::new().fg(th().warn)),
-                Span::styled("  [b]", Style::new().fg(th().accent)),
-                Span::styled(" set it up (sudo; optional)", Style::new().dim()),
-            ])),
+        // One consistent shape per action: [key] in a fixed accent column, a
+        // verb-first label padded to a common width, then a dim detail column.
+        // Scannable as a command list instead of a paragraph; the key never
+        // wanders into the middle of a sentence.
+        let act = |key: &str, label: &str, detail: &str| {
+            Line::from(vec![
+                Span::styled(format!("  {key:<4}"), Style::new().fg(th().accent)),
+                Span::styled(format!("{label:<22}"), Style::new()),
+                Span::styled(detail.to_string(), Style::new().dim()),
+            ])
+        };
+        lines.push(act(
+            "[w]",
+            "Wire login + lock",
+            "the core action; leave the password empty then Enter to use your face",
+        ));
+        lines.push(act(
+            "[u]",
+            "Wire face-sudo",
+            "opt-in; face approves sudo prompts",
+        ));
+        lines.push(act(
+            "[p]",
+            "Wire app prompts",
+            "opt-in; face approves Bitwarden and pkexec",
+        ));
+        lines.push(act(
+            "[c]",
+            "Calibrate gesture",
+            "approve app prompts by closing your eyes ~1s (the nod needs none)",
+        ));
+        // [b] is an ACTION only when Bitwarden is installed without its polkit
+        // action; otherwise its state shows as a status line below.
+        if matches!(
+            crate::bitwarden::tui_state(),
+            Some(crate::bitwarden::TuiState::NeedsSetup)
+        ) {
+            lines.push(act(
+                "[b]",
+                "Set up Bitwarden",
+                "installs its polkit action so your face unlocks the vault",
+            ));
         }
-        lines.push(Line::from(vec![
-            Span::styled("  disable ", Style::new()),
-            Span::styled("[x]", Style::new().fg(th().accent)),
-            Span::styled(
-                " un-wires face auth everywhere (confirmed first)",
-                Style::new().dim(),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::styled("  [s]", Style::new().fg(th().accent)),
-            Span::styled(" open full status in a console view", Style::new().dim()),
-        ]));
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+        lines.push(act(
+            "[x]",
+            "Un-wire everything",
+            "removes face auth from login/lock/sudo/apps; asks first",
+        ));
+        lines.push(act(
+            "[s]",
+            "Show full status",
+            "opens the detailed console status view",
+        ));
+        // Bitwarden status line (not an action): only when installed and the
+        // action is present or snapd owns it. Set apart by a blank line.
+        match crate::bitwarden::tui_state() {
+            Some(crate::bitwarden::TuiState::Ready) => {
+                lines.push(Line::raw(""));
+                lines.push(Line::from(vec![
+                    Span::raw("  Bitwarden   "),
+                    Span::styled("● polkit action installed", Style::new().fg(th().ok)),
+                    Span::styled(
+                        "  (turn on \"unlock with system authentication\" in its settings)",
+                        Style::new().dim(),
+                    ),
+                ]));
+            }
+            Some(crate::bitwarden::TuiState::SnapMissing) => {
+                lines.push(Line::raw(""));
+                lines.push(Line::from(vec![
+                    Span::raw("  Bitwarden   "),
+                    Span::styled("○ snap action missing", Style::new().fg(th().warn)),
+                    Span::styled(
+                        "  run: sudo snap connect bitwarden:polkit",
+                        Style::new().dim(),
+                    ),
+                ]));
+            }
+            _ => {}
+        }
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
     fn draw_done(&self, f: &mut Frame, area: Rect) {
@@ -6548,7 +6553,9 @@ mod tests {
             text.contains("tier unknown (daemon unreachable)"),
             "no tier claim without the daemon"
         );
-        assert!(text.contains("wire the login stack now"));
+        // The aligned action list: the primary wire action plus the un-wire.
+        assert!(text.contains("[w]") && text.contains("Wire login + lock"));
+        assert!(text.contains("[x]") && text.contains("Un-wire everything"));
         app.health = Some(HealthInfo {
             tier: "convenience".into(),
             rgb_dev: Some("/dev/video0".into()),

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -222,6 +222,10 @@ enum Suspend {
     /// Origin-aware updater; runs unprivileged (it invokes sudo itself for
     /// the package-manager step when one is needed).
     Update,
+    /// The full `irlume doctor` text readout in the cooked terminal: the
+    /// complete authoritative dump (incl. the info-only lines the Repair
+    /// checklist omits), copy-pasteable for a bug report.
+    Doctor,
 }
 
 /// What a y/n confirm modal executes on `[y]`: a daemon request (async, the
@@ -1844,6 +1848,9 @@ impl App {
             Suspend::Update => {
                 crate::commands::update(&none);
             }
+            Suspend::Doctor => {
+                let _ = crate::doctor();
+            }
             Suspend::Logs => self.sudo_step("show the face-auth journal", &["irlume", "logs"]),
             // The TUI already double-confirmed, so pass --yes; the CLI still
             // does the teardown (un-wire PAM, stop daemon, wipe data) as root
@@ -2007,6 +2014,12 @@ impl App {
         match code {
             KeyCode::Char('q') | KeyCode::Esc => self.quit = true,
             KeyCode::Char('?') => self.show_help = true,
+            // Home: jump back to the Welcome hub from any tab, so the "at a
+            // glance" summary is one key away instead of a Tab walk. (Home the
+            // KEY is taken by activity scroll; 'h' for home is unused globally.)
+            KeyCode::Char('h') if self.visible.contains(&SC_WELCOME) => {
+                self.screen = SC_WELCOME;
+            }
             // Release/recapture the mouse: captured, the wheel scrolls the TUI
             // but the terminal cannot select text; released, highlight-to-copy
             // works. A toggle because both are legitimate wants.
@@ -2171,6 +2184,14 @@ impl App {
                 );
                 self.log('·', "deeper: `sudo irlume logs debug on` traces each pipeline stage (turn off after)");
                 self.suspend = Some(Suspend::Logs);
+            }
+            // Full `irlume doctor` readout: the complete authoritative dump,
+            // including the info-only lines the Repair checklist omits, for a
+            // bug report. Runs as the user (no sudo prompt); root-only lines
+            // say so.
+            (SC_REPAIR, KeyCode::Char('d')) => {
+                self.log('→', "irlume doctor: the complete platform readout (copy-pasteable)");
+                self.suspend = Some(Suspend::Doctor);
             }
             (SC_REPAIR, KeyCode::Char('l')) => self.start_async(
                 "SelfTest (IR liveness)",
@@ -3522,6 +3543,36 @@ impl App {
                 Style::new().dim(),
             )),
             Line::raw(""),
+            {
+                // A one-line health summary from the same run_checks() the
+                // Repair tab uses, so a healthy user never needs to open Repair
+                // and an unhealthy one is pointed straight at it.
+                let fails = self.repair.iter().filter(|c| c.sev == Sev::Fail).count();
+                let warns = self.repair.iter().filter(|c| c.sev == Sev::Warn).count();
+                if fails > 0 {
+                    Line::from(vec![
+                        Span::styled(
+                            format!("  ✗ {fails} issue(s) need attention"),
+                            Style::new().fg(th().err).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(" → open Repair (or [h] returns here)", Style::new().dim()),
+                    ])
+                } else if warns > 0 {
+                    Line::from(vec![
+                        Span::styled(
+                            format!("  ⚠ {warns} advisory item(s)"),
+                            Style::new().fg(th().warn),
+                        ),
+                        Span::styled(" → see Repair", Style::new().dim()),
+                    ])
+                } else {
+                    Line::from(Span::styled(
+                        "  ✓ all checks pass",
+                        Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                    ))
+                }
+            },
+            Line::raw(""),
             section("At a glance  (↑↓ pick a section, Enter opens it)"),
             Line::from(vec![
                 Span::styled("  Recommended  ", Style::new().add_modifier(Modifier::BOLD)),
@@ -4094,6 +4145,7 @@ impl App {
             SC_REPAIR => &[
                 ("f", "fix"),
                 ("r", "re-check"),
+                ("d", "full doctor"),
                 ("l", "IR test"),
                 ("g", "logs"),
                 ("t", "debug logs"),

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3131,16 +3131,18 @@ impl App {
                                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
                                 format!("enabled: {name}   (loaded by the daemon, deny-only cue)"),
                             ),
+                            // No daemon-reported cue: could be a daemon too old
+                            // to report the field (0.6.0 and earlier) OR genuinely
+                            // none. We can't tell the two apart (both deserialize
+                            // to None), so trust the filesystem probe rather than
+                            // claim "off" — an older daemon with flir loaded must
+                            // not read as ○ none (regression fixed here).
                             None => match crate::models::tui_state() {
                                 crate::models::TuiState::Enabled { name, detail } => (
                                     "●",
                                     Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
                                     format!("enabled: {name}   {detail}"),
                                 ),
-                                // Daemon up and reporting no cue -> authoritative off.
-                                _ if self.daemon_up => {
-                                    ("○", Style::new().dim(), "none (default)".to_string())
-                                }
                                 crate::models::TuiState::InstalledUnknown { name } => (
                                     "◐",
                                     Style::new().fg(th().warn),
@@ -6866,13 +6868,25 @@ mod tests {
             !text.contains("root-only"),
             "the authoritative state replaces the root-only guess"
         );
-        // Daemon up, no cue loaded -> authoritative OFF, never the ◐ guess.
+        // No daemon-reported cue: fall back to the filesystem probe (we can't
+        // tell "old daemon didn't report" from "new daemon reports none"). With
+        // no weights on disk (empty state dir) that is a clean ○ none. This also
+        // proves an older daemon with weights present is NOT falsely shown off.
+        let _g = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let empty = std::env::temp_dir().join(format!("irlume-tp-empty-{}", std::process::id()));
+        std::fs::create_dir_all(&empty).unwrap();
+        let old = std::env::var_os("IRLUME_STATE_DIR");
+        std::env::set_var("IRLUME_STATE_DIR", &empty);
         app.health.as_mut().unwrap().third_party_pad = None;
         let text = draw_text(&app);
-        assert!(
-            !text.contains('◐'),
-            "daemon-up with no cue is a definite off"
-        );
+        assert!(text.contains("none (default)"), "empty state dir -> ○ none");
+        match old {
+            Some(v) => std::env::set_var("IRLUME_STATE_DIR", v),
+            None => std::env::remove_var("IRLUME_STATE_DIR"),
+        }
+        let _ = std::fs::remove_dir_all(&empty);
     }
 
     #[test]

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -588,7 +588,13 @@ impl App {
             advanced,
             daemon_down,
         } = state;
-        let needs_repair = daemon_down || checks.iter().any(|c| c.sev == Sev::Fail);
+        // Repair surfaces whenever there is ANYTHING to report (a failure OR an
+        // advisory), so the Welcome health summary's "→ see checks & repair"
+        // pointer is always reachable — a warning used to point at a hidden tab.
+        let needs_repair = daemon_down
+            || checks
+                .iter()
+                .any(|c| c.sev == Sev::Fail || c.sev == Sev::Warn);
         (0..SCREENS.len())
             .filter(|&i| match i {
                 // Essential face path requires a camera.
@@ -3681,13 +3687,16 @@ impl App {
                 // and an unhealthy one is pointed straight at it.
                 let fails = self.repair.iter().filter(|c| c.sev == Sev::Fail).count();
                 let warns = self.repair.iter().filter(|c| c.sev == Sev::Warn).count();
+                // needs_repair (compute_visible) surfaces the "checks & repair"
+                // hub row on any warn/fail, so this always points at a row that
+                // is right below and Enter-openable — no "switch to advanced" step.
                 if fails > 0 {
                     Line::from(vec![
                         Span::styled(
                             format!("  ✗ {fails} issue(s) need attention"),
                             Style::new().fg(th().err).add_modifier(Modifier::BOLD),
                         ),
-                        Span::styled(" → open Repair (or [h] returns here)", Style::new().dim()),
+                        Span::styled(" → open \"checks & repair\" below", Style::new().dim()),
                     ])
                 } else if warns > 0 {
                     Line::from(vec![
@@ -3695,7 +3704,7 @@ impl App {
                             format!("  ⚠ {warns} advisory item(s)"),
                             Style::new().fg(th().warn),
                         ),
-                        Span::styled(" → see Repair", Style::new().dim()),
+                        Span::styled(" → open \"checks & repair\" below", Style::new().dim()),
                     ])
                 } else {
                     Line::from(Span::styled(
@@ -5681,11 +5690,15 @@ mod tests {
             ),
             vec![SC_WELCOME, SC_REPAIR, SC_PAM, SC_DONE]
         );
-        // …or when any check fails, but not for a mere warning.
+        // …and when anything needs reporting — a failure OR an advisory — so the
+        // Welcome health summary's "→ open checks & repair" pointer is reachable.
         let fail = [check_row("x", Sev::Fail, Fix::None)];
         assert!(App::compute_visible(&none, basic, &fail).contains(&SC_REPAIR));
         let warn = [check_row("x", Sev::Warn, Fix::None)];
-        assert!(!App::compute_visible(&none, basic, &warn).contains(&SC_REPAIR));
+        assert!(App::compute_visible(&none, basic, &warn).contains(&SC_REPAIR));
+        // But an all-clear basic view hides it.
+        let ok = [check_row("x", Sev::Ok, Fix::None)];
+        assert!(!App::compute_visible(&none, basic, &ok).contains(&SC_REPAIR));
     }
 
     #[test]

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -233,6 +233,9 @@ enum Suspend {
     /// Toggle the opt-in biopolicy operation-class gate (the bool is the target
     /// state). Root op; the daemon reads it live, no restart.
     Biopolicy(bool),
+    /// IR liveness self-test via `sudo irlume selftest liveness` (the daemon
+    /// root-gates it; the raw measurements are a spoof-tuning oracle).
+    SelfTestLiveness,
 }
 
 /// What a y/n confirm modal executes on `[y]`: a daemon request (async, the
@@ -320,7 +323,6 @@ struct VisibilityInputs {
 enum OpTag {
     Generic,
     Identify,
-    Calibrate,
 }
 
 /// Fingerprint snapshot for the Fingerprint screen.
@@ -449,7 +451,6 @@ struct App {
     /// Last 1:N identify result, shown as a card on the Identify screen.
     identify_result: Option<(bool, String)>,
     /// Last IR liveness self-test result, shown on the Repair screen.
-    selftest_result: Option<(bool, String)>,
     /// Repair-tab diagnostics + selection.
     repair: Vec<Check>,
     repair_sel: usize,
@@ -554,7 +555,6 @@ impl App {
             suspend: None,
             resume_enroll: None,
             identify_result: None,
-            selftest_result: None,
             repair: Vec::new(),
             repair_sel: 0,
             cam_sel: 0,
@@ -1591,14 +1591,13 @@ impl App {
                 // camera). Identify/Generic keep the modal on failure.
                 if ok {
                     self.log('✓', msg.clone());
-                } else if !matches!(tag, OpTag::Calibrate | OpTag::Identify) {
+                } else if !matches!(tag, OpTag::Identify) {
                     self.set_error(msg.clone());
                 } else {
                     self.log('·', msg.clone());
                 }
                 match tag {
                     OpTag::Identify => self.identify_result = Some((ok, msg)),
-                    OpTag::Calibrate => self.selftest_result = Some((ok, msg)),
                     OpTag::Generic => {}
                 }
                 self.op = None;
@@ -1937,6 +1936,10 @@ impl App {
                     "disable the biopolicy gate"
                 },
                 &["irlume", "biopolicy", if on { "on" } else { "off" }],
+            ),
+            Suspend::SelfTestLiveness => self.sudo_step(
+                "run the IR liveness self-test",
+                &["irlume", "selftest", "liveness"],
             ),
             Suspend::Logs => self.sudo_step("show the face-auth journal", &["irlume", "logs"]),
             // The TUI already double-confirmed, so pass --yes; the CLI still
@@ -2289,14 +2292,14 @@ impl App {
                 self.log('→', "irlume doctor: the complete platform readout (copy-pasteable)");
                 self.suspend = Some(Suspend::Doctor);
             }
-            (SC_REPAIR, KeyCode::Char('l')) => self.start_async(
-                "SelfTest (IR liveness)",
-                OpTag::Calibrate,
-                Request::SelfTest {
-                    kind: irlume_common::SelfTestKind::Liveness,
-                },
-                map_selftest,
-            ),
+            // IR liveness self-test: the daemon root-gates it (the raw
+            // measurements are a spoof-tuning oracle), so like every other root
+            // action it suspends to sudo instead of failing with a peer-uid
+            // error on the direct socket call.
+            (SC_REPAIR, KeyCode::Char('l')) => {
+                self.log('→', "sudo irlume selftest liveness: fires the IR camera through the daemon and reports the liveness measurements");
+                self.suspend = Some(Suspend::SelfTestLiveness);
+            }
             // Cameras: IR emitter auto-setup (root; writes the persisted UVC
             // control) suspends to sudo; the [p] probe below is read-only.
             (SC_CAMERAS, KeyCode::Char('s')) => {
@@ -3915,19 +3918,10 @@ impl App {
                 Style::new().dim(),
             ),
         ]));
-        match &self.selftest_result {
-            Some((ok, d)) => lines.push(Line::from(vec![
-                Span::styled("  IR test   ", Style::new().dim()),
-                Span::styled(
-                    d.clone(),
-                    Style::new().fg(if *ok { th().ok } else { th().err }),
-                ),
-            ])),
-            None => lines.push(Line::from(Span::styled(
-                "  IR test    press [l] to run the IR PAD self-test (look at the camera)",
-                Style::new().dim(),
-            ))),
-        }
+        lines.push(Line::from(Span::styled(
+            "  IR test    press [l] to run the IR PAD self-test (sudo; look at the camera)",
+            Style::new().dim(),
+        )));
         let blk = Block::bordered()
             .border_type(BorderType::Rounded)
             .border_style(Style::new().dim())
@@ -4583,14 +4577,6 @@ fn map_identify(resp: Response) -> (bool, String) {
     }
 }
 
-fn map_selftest(resp: Response) -> (bool, String) {
-    match resp {
-        Response::SelfTest { passed, detail } => (passed, detail),
-        Response::Error(e) => (false, e),
-        o => (false, format!("unexpected: {o:?}")),
-    }
-}
-
 /// Confirm-flow ops (delete profile/scan, forget keyring/recovery). Delete and
 /// recovery-forget ack with `Ok`; keyring-forget acks with `PasswordForgotten`.
 fn map_confirm(resp: Response) -> (bool, String) {
@@ -4825,7 +4811,6 @@ mod tests {
             suspend: None,
             resume_enroll: None,
             identify_result: None,
-            selftest_result: None,
             repair: Vec::new(),
             repair_sel: 0,
             cam_sel: 0,
@@ -5528,24 +5513,6 @@ mod tests {
     }
 
     #[test]
-    fn map_selftest_passes_through_verdict() {
-        assert_eq!(
-            map_selftest(Response::SelfTest {
-                passed: true,
-                detail: "depth 0.7".into()
-            }),
-            (true, "depth 0.7".into())
-        );
-        assert_eq!(
-            map_selftest(Response::SelfTest {
-                passed: false,
-                detail: "too flat".into()
-            }),
-            (false, "too flat".into())
-        );
-    }
-
-    #[test]
     fn map_confirm_accepts_ok_and_password_forgotten() {
         assert!(map_confirm(Response::Ok("deleted".into())).0);
         let (ok, msg) = map_confirm(Response::PasswordForgotten);
@@ -6169,22 +6136,15 @@ mod tests {
     }
 
     #[test]
-    fn repair_ir_selftest_lands_on_the_card_without_the_error_modal() {
-        let _sock = dead_socket();
+    fn repair_ir_selftest_suspends_to_sudo_not_a_direct_daemon_call() {
+        // The daemon root-gates SelfTest (spoof-tuning oracle), so [l] must run
+        // it via sudo like every other root action, not fail on a peer-uid
+        // error from a direct socket call.
         let mut app = test_app();
         app.screen = SC_REPAIR;
         app.on_key(KeyCode::Char('l'));
-        assert!(app.op.is_some());
-        wait_op_done(&mut app);
-        let (ok, _) = app
-            .selftest_result
-            .as_ref()
-            .expect("the self-test verdict must land on the Repair card");
-        assert!(!ok);
-        assert!(
-            app.error.is_none(),
-            "a self-test miss is a card result, not an error modal"
-        );
+        assert!(matches!(app.suspend, Some(Suspend::SelfTestLiveness)));
+        assert!(app.op.is_none() && app.error.is_none());
     }
 
     #[test]
@@ -6881,11 +6841,9 @@ mod tests {
         app.repair_sel = 2;
         let text = draw_text(&app);
         assert!(text.contains("press [f]: irlume runs the fix with sudo"));
-        // The IR self-test card: idle prompt, then the verdict.
+        // The IR self-test prompt (the result now shows in the terminal, run
+        // via sudo, so the card is a static "press [l]" prompt).
         assert!(text.contains("press [l] to run the IR PAD self-test"));
-        app.selftest_result = Some((true, "PAD pass: depth 0.71".into()));
-        let text = draw_text(&app);
-        assert!(text.contains("PAD pass: depth 0.71"));
     }
 
     #[test]

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -590,7 +590,7 @@ impl App {
         } = state;
         // Repair surfaces whenever there is ANYTHING to report (a failure OR an
         // advisory), so the Welcome health summary's "→ see checks & repair"
-        // pointer is always reachable — a warning used to point at a hidden tab.
+        // pointer is always reachable; a warning used to point at a hidden tab.
         let needs_repair = daemon_down
             || checks
                 .iter()
@@ -603,7 +603,7 @@ impl App {
                 SC_CAMERAS | SC_IDENTIFY => advanced && caps.rgb,
                 // Settings holds user preferences (eyes-open, blink, biopolicy,
                 // third-party models), not diagnostics, so it is always
-                // reachable — hiding config behind "advanced" both buries it and
+                // reachable; hiding config behind "advanced" both buries it and
                 // creates dead-end pointers (a Repair fix references Settings).
                 SC_SETTINGS => true,
                 // Repair: only when something needs attention (or advanced view).
@@ -1226,8 +1226,8 @@ impl App {
             _ => {}
         }
         // Wiring drift: login WAS enabled (marker) but the active greeter's
-        // stack lost the module — authselect/pam-auth-update regenerated the
-        // PAM files. Face silently falls back to password until re-applied.
+        // stack lost the module (authselect/pam-auth-update regenerated the
+        // PAM files). Face silently falls back to password until re-applied.
         if crate::pamwire::reconcile_needed() {
             v.push(mk(
                 "Login wiring",
@@ -3223,7 +3223,7 @@ impl App {
                             // to report the field (0.6.0 and earlier) OR genuinely
                             // none. We can't tell the two apart (both deserialize
                             // to None), so trust the filesystem probe rather than
-                            // claim "off" — an older daemon with flir loaded must
+                            // claim "off": an older daemon with flir loaded must
                             // not read as ○ none (regression fixed here).
                             None => match crate::models::tui_state() {
                                 crate::models::TuiState::Enabled { name, detail } => (
@@ -3712,7 +3712,7 @@ impl App {
                 let warns = self.repair.iter().filter(|c| c.sev == Sev::Warn).count();
                 // needs_repair (compute_visible) surfaces the "checks & repair"
                 // hub row on any warn/fail, so this always points at a row that
-                // is right below and Enter-openable — no "switch to advanced" step.
+                // is right below and Enter-openable, no "switch to advanced" step.
                 if fails > 0 {
                     Line::from(vec![
                         Span::styled(
@@ -5692,7 +5692,7 @@ mod tests {
             ),
             vec![SC_WELCOME, SC_REPAIR, SC_PAM, SC_SETTINGS, SC_DONE]
         );
-        // …and when anything needs reporting — a failure OR an advisory — so the
+        // …and when anything needs reporting (a failure OR an advisory), so the
         // Welcome health summary's "→ open checks & repair" pointer is reachable.
         let fail = [check_row("x", Sev::Fail, Fix::None)];
         assert!(App::compute_visible(&none, basic, &fail).contains(&SC_REPAIR));

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -780,11 +780,11 @@ impl App {
         }
     }
 
-    /// Diagnostics without the slow profile poll: fast daemon reads + hardware
-    /// caps + fingerprint + the Repair checks. Tab switches use this so moving
-    /// between tabs never pays the ListProfiles TPM-unseal cost.
-    fn refresh_diagnostics(&mut self) {
-        self.refresh_light();
+    /// Re-derive hardware caps + fingerprint + the Repair checklist from the
+    /// CURRENT state (daemon reads + self.profiles). Split out so both refresh
+    /// paths run it AFTER their state reads, and run_checks never sees stale
+    /// profiles (a startup ordering bug showed a spurious "no enrollment" warn).
+    fn recompute_checks(&mut self) {
         // Re-derive hardware capabilities so a camera or reader hot-plugged
         // after launch reveals its tabs (caps/fp_present drive `visible` and the
         // Welcome gates, and were otherwise frozen at startup).
@@ -802,11 +802,23 @@ impl App {
         self.recompute_visible();
     }
 
+    /// Diagnostics without the slow profile poll: fast daemon reads + hardware
+    /// caps + fingerprint + the Repair checks (with the CACHED profile list).
+    /// Tab switches use this so moving between tabs never pays the ListProfiles
+    /// TPM-unseal cost.
+    fn refresh_diagnostics(&mut self) {
+        self.refresh_light();
+        self.recompute_checks();
+    }
+
     /// Full refresh incl. the slow profile poll: startup, after mutations, and
-    /// the heavy timer. Callers that just switched tabs use refresh_diagnostics.
+    /// suspend-return. Order matters: refresh_light sets `daemon_up` (which
+    /// refresh_profiles needs), profiles load, THEN recompute_checks runs so
+    /// run_checks sees the fresh profile list (not the stale/empty one).
     fn refresh(&mut self) {
+        self.refresh_light();
         self.refresh_profiles();
-        self.refresh_diagnostics();
+        self.recompute_checks();
     }
 
     /// Build the Repair-tab diagnostics from current state + quick local probes.

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1453,6 +1453,7 @@ fn setup_walks_every_step_noninteractively() {
             mesh: true,
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
+            third_party_pad: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: Vec::new(),

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -419,6 +419,7 @@ fn setup_already_enrolled_skips_reenroll_and_reports_arm_failure() {
             mesh: true,
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
+            third_party_pad: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: one_profile(),
@@ -454,6 +455,7 @@ fn setup_enroll_merge_and_enroll_failure_paths() {
             mesh: true,
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
+            third_party_pad: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: Vec::new(),
@@ -489,6 +491,7 @@ fn setup_enroll_merge_and_enroll_failure_paths() {
             mesh: true,
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
+            third_party_pad: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: Vec::new(),

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -392,6 +392,12 @@ pub enum Response {
         /// build (daemon predating the CLI it's talking to).
         #[serde(default)]
         version: String,
+        /// Name of the loaded opt-in third-party PAD cue, if any. The
+        /// authoritative enabled-state: settings.conf is root-only, so a
+        /// non-root TUI can only see the weights file otherwise. `None` when
+        /// no cue is loaded (or an older daemon that predates this field).
+        #[serde(default)]
+        third_party_pad: Option<String>,
     },
     /// A framing-guide sample (`PositionSample`).
     Position(PositionReport),

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -637,6 +637,9 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 mesh: engine.has_mesh(),
                 adapter: engine.has_ir_adapter(),
                 version: env!("CARGO_PKG_VERSION").into(),
+                // Authoritative loaded-cue name so a non-root TUI can show the
+                // real on/off state (settings.conf is root-only).
+                third_party_pad: engine.thirdparty_pad_name().map(String::from),
             }
         }
         // Only tune the band to a user the peer may act for (root, or their own
@@ -2505,6 +2508,7 @@ mod tests {
                 mesh,
                 adapter,
                 version,
+                third_party_pad,
                 ..
             } => {
                 // IRLUME_FORCE_NO_IR=1 (set by the shared engine init) forces
@@ -2514,6 +2518,9 @@ mod tests {
                 assert_eq!(ir_dev, None);
                 // The bare shared engine loaded no optional models.
                 assert!(!mesh && !adapter);
+                // No opt-in PAD cue loaded -> Health reports None (the field
+                // the TUI uses for the authoritative on/off state).
+                assert_eq!(third_party_pad, None);
                 assert_eq!(version, env!("CARGO_PKG_VERSION"));
             }
             other => panic!("Health must answer Response::Health, got {other:?}"),


### PR DESCRIPTION
## What

A ground-up redesign of the `irlume tui`, guided by the Apple/GNOME HIG and modern TUI design work, plus a push to make the TUI a complete, safe front-end so a non-CLI user can do and understand everything.

### Design system
- **Semantic theme ladder**: color resolves down a capability ladder. `NO_COLOR` → glyphs carry state (chips reversed), plain terminals → ANSI names so the user's terminal theme is the palette, truecolor → the soft irlume palette. Replaces five hardcoded RGBs.
- **Hub navigation**: Welcome's "At a glance" is a selectable summary; ↑↓ picks a section, Enter opens it. `[h]` jumps home from any tab. A one-line health summary (`✓ all checks pass` / `⚠ N advisory → open "checks & repair" below`) sourced from the Repair checks.
- **Three-tier disclosure**: footer shows the primary action + a `[?]` overlay for the full keymap. `[d]` on Repair drops to the full `irlume doctor` text.
- **Verb-labeled confirms** (`[n]/Esc Cancel   [y] Un-wire`), designed empty states, flattened the Cameras box-in-box, and uniform spacing across every tab (section headers at indent 2, content at 4).

### CLI ↔ TUI parity (do everything in the TUI)
Every CLI action is reachable by keypress; every "go run this command" was converted to an in-TUI action or tab-pointer:
- `reseal` (Keyring `[r]`), `biopolicy on/off` (new CLI command + Settings `[b]`, confirmed), `bitwarden setup`, `selftest liveness` (new CLI command), pcrlock make-policy (Keyring `[p]`), calibrate-closure, all fingerprint subcommands, model enable/disable, debug-log toggle, updater, login wiring extras.
- **Idiot-proof**: every destructive action is confirm-gated (delete/forget/un-wire/reset/disable) or typed-word-gated (uninstall); a stray keypress can't break irlume.

### Correctness / bug fixes (found by measurement and container/hardware testing)
- **Tab-switch latency 513ms → 43ms**: the `ListProfiles` poll TPM-unseals the templates by ~376ms; moved it off the hot path (mutations / Profiles-tab / startup only).
- **IR self-test `[l]`** ran a root-gated request directly and errored; now suspends to `sudo` like every other root action.
- **`sudo` runs our own binary** (`current_exe`), not whatever `irlume` PATH resolves to, so there is no TUI-vs-CLI version skew.
- **Dead-end pointers**: an advisory now surfaces Repair (not a pointer to a hidden tab); Settings is always reachable (config, not a diagnostic).
- **Third-party model state** comes from the daemon (green `●` when loaded) instead of a root-only filesystem guess.
- Ctrl-C no longer kills the TUI during a suspended action; Ctrl-modified letters no longer alias to plain-letter actions; startup check ordering fixed; Repair gained keyring-drift / model-checksum / locked-login-keyring checks.

## Testing
- 617 workspace tests, clippy, fmt, rustdoc `-D warnings` all clean; no emdashes (house style).
- Recovery flow container-tested against swtpm; every screen swept repeatedly (0 theme leaks, borders balanced, `NO_COLOR` + 80×24 verified); the IR self-test, biopolicy, reseal, hub jumps, and doctor drill-down hardware-validated on the Zenbook.

## Notes
- The Settings model green `●` and any daemon-reported state need this build's **daemon** running; against an older daemon they degrade gracefully (`◐`).
