### PR TITLE
release: irlume 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-24
+
 ### Added
 
 - **TUI feature parity: every CLI action is now reachable by keypress.** A

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "image",
  "irlume-auth",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "libc",
  "serde",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -969,11 +969,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.6.0"
+version = "0.6.1"
 
 [[package]]
 name = "irlume-liveness"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "irlume-common",
  "pamsm",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "irlume-camera",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Version bump to 0.6.1 and the CHANGELOG `[Unreleased]` header stamped as
`[0.6.1] - 2026-07-24`. Content merged in #95; this is the release cut.

After merge: the merged commit is signed-tagged `v0.6.1` and the GitHub
release is published from CHANGELOG/RELEASE notes.
