### PR TITLE
build: host model weights as release assets, off Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-models/*.onnx filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,20 +40,19 @@ jobs:
       # Actions are pinned to a commit SHA (the tag in the comment is what it
       # was) so a moved tag cannot change what runs. Dependabot bumps these.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        # Credentials stay persisted on this job only: `git lfs pull` below
-        # needs them on a cache miss. The token is contents:read.
 
-      # The ONNX models are ~257 MB of Git LFS objects; cache them keyed on
-      # models/SHA256SUMS (changes exactly when the weights do) instead of
-      # re-downloading against the LFS bandwidth quota every run.
-      - name: Cache Git LFS objects (ONNX model weights)
+      # The ONNX weights (~257 MB) are fetched from the models-v1 release, not
+      # Git LFS; cache them keyed on models/SHA256SUMS (changes exactly when the
+      # weights do) so a warm run skips the download (fetch-models.sh verifies
+      # the cached copies and no-ops).
+      - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('models/SHA256SUMS') }}
+          path: models
+          key: models-${{ hashFiles('models/SHA256SUMS') }}
 
-      - name: Pull model weights (Git LFS)
-        run: git lfs pull
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
 
       - name: Install system build dependencies
         run: |
@@ -182,14 +181,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Cache Git LFS objects (ONNX model weights)
+      - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('models/SHA256SUMS') }}
+          path: models
+          key: models-${{ hashFiles('models/SHA256SUMS') }}
 
-      - name: Pull model weights (Git LFS)
-        run: git lfs pull
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
 
       - name: Install system build dependencies
         run: |
@@ -236,14 +235,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Cache Git LFS objects (ONNX model weights)
+      - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('models/SHA256SUMS') }}
+          path: models
+          key: models-${{ hashFiles('models/SHA256SUMS') }}
 
-      - name: Pull model weights (Git LFS)
-        run: git lfs pull
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
 
       - name: Install system build dependencies
         run: |
@@ -369,10 +368,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      # No lfs: true here. flake check --no-build only evaluates the outputs
+      # No model fetch here: flake check --no-build only evaluates the outputs
       # (flake structure, the package derivation, the NixOS module, the dev
-      # shell); it never reads the ONNX model contents, so the LFS pointer
-      # files left by a plain checkout are enough and the job stays fast.
+      # shell); it never reads the ONNX model contents, so a checkout without
+      # the weights (they are fetched by the build, not committed) is enough
+      # and the job stays fast.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -35,21 +35,14 @@ jobs:
         with:
           persist-credentials: false
 
-      # No actions/cache here: on a self-hosted runner the repo's .git (with
-      # its LFS objects) persists in the runner work directory between runs,
-      # so this pull is a no-op after the first run; a round-trip to the
-      # Actions cache service would be pure overhead. Incremental build state
+      # No actions/cache here: on a self-hosted runner the fetched models/
+      # (gitignored, so a clean checkout leaves them) persist in the runner work
+      # directory between runs, so fetch-models.sh is a no-op after the first
+      # run; a round-trip to the Actions cache service would be pure overhead. Incremental build state
       # likewise persists via the runner-level CARGO_TARGET_DIR (set in the
       # runner's .env, outside the work dir so checkout's clean never wipes it).
-      - name: Pull model weights (Git LFS)
-        run: |
-          git lfs pull
-          # Guard against silent smudge-skip (exit 0 with pointer files left in
-          # the tree) — the failure mode of an unconfigured runner user.
-          if head -c 40 models/glintr100.onnx | grep -q "git-lfs"; then
-            echo "::error::model weights are LFS pointers — run 'git lfs install' for the runner user"
-            exit 1
-          fi
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
 
       - name: build (system rust, rolling Arch)
         run: cargo build --workspace --locked
@@ -125,13 +118,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Pull model weights (Git LFS)
-        run: |
-          git lfs pull
-          if head -c 40 models/glintr100.onnx | grep -q "git-lfs"; then
-            echo "::error::model weights are LFS pointers — run 'git lfs install' for the runner user"
-            exit 1
-          fi
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
 
       - name: Coverage (workspace + real-TPM + loopback cameras + PAM FFI)
         env:

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -23,16 +23,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Same LFS cache as ci.yml (shared key): the model weights are ~257 MB
-      # and the LFS bandwidth quota is the reason ci.yml caches them.
-      - name: Cache Git LFS objects (ONNX model weights)
+      # Same model cache as ci.yml (shared key): the ~257 MB weights are
+      # fetched from the models-v1 release, cached so warm runs skip the pull.
+      - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('models/SHA256SUMS') }}
+          path: models
+          key: models-${{ hashFiles('models/SHA256SUMS') }}
 
-      - name: Pull model weights (Git LFS)
-        run: git lfs pull
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
 
       - name: Build the .deb (packaging/debian/build-deb-container.sh)
         run: bash packaging/debian/build-deb-container.sh
@@ -87,33 +87,24 @@ jobs:
       - name: Install toolchain and system deps
         run: |
           pacman -Syu --noconfirm --needed \
-            base-devel git git-lfs rust clang pam tpm2-tss curl ca-certificates
+            base-devel git rust clang pam tpm2-tss curl ca-certificates
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Cache Git LFS objects (ONNX model weights)
+      - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('models/SHA256SUMS') }}
+          path: models
+          key: models-${{ hashFiles('models/SHA256SUMS') }}
 
-      - name: Pull model weights (Git LFS)
+      - name: Fetch model weights (models-v1 release, sha256-verified)
         run: |
           # Container job: checkout writes safe.directory into a temporary
-          # HOME, so later steps' git sees "dubious ownership" and git-lfs
-          # reports it as "Not in a Git repository" (first dispatch failed
+          # HOME, so later steps' git sees "dubious ownership" and git
+          # operations report "Not in a Git repository" (first dispatch failed
           # exactly here). Re-assert it in this step's real HOME.
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          # Arch's git-lfs package does not preconfigure the smudge filters
-          # (Ubuntu runner images do), so a bare pull downloads objects but
-          # SKIPS checkout with exit 0 — pointer files remain and the engine
-          # tests fail with a cryptic protobuf error (second dispatch).
-          git lfs install --skip-repo
-          git lfs pull
-          if head -c 40 models/glintr100.onnx | grep -q "git-lfs"; then
-            echo "::error::model weights are still LFS pointers after pull"
-            exit 1
-          fi
+          bash scripts/fetch-models.sh
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -40,16 +40,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Pull model weights (Git LFS, local no-op after first run)
-        run: |
-          git lfs pull
-          # `git lfs pull` exits 0 even when smudging was skipped ("Git LFS is
-          # not installed for this repository" — bitten on the first live run);
-          # a pointer file then fails 175 tests with a cryptic protobuf error.
-          if head -c 40 models/glintr100.onnx | grep -q "git-lfs"; then
-            echo "::error::model weights are LFS pointers — run 'git lfs install' for the runner user"
-            exit 1
-          fi
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
 
       - name: rustfmt
         run: cargo fmt --all --check

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@
 *.embedding
 *.template
 
-# Model weights are ALL bundled in-repo via Git LFS (see .gitattributes +
-# models/README.md) so a clone/package is self-contained. The exceptions:
-# superseded model backups, kept locally for revert, never shipped.
+# Model weights are fetched from the models-v1 GitHub release
+# (scripts/fetch-models.sh, sha256-verified), NOT committed, so a clone stays
+# small and no build touches the Git LFS bandwidth quota. Ignore the downloaded
+# weights and the superseded backups kept locally for revert.
+models/*.onnx
 models/ir_adapter.onnx.v1-256
 models/face_landmark.onnx.legacy-192
 .deb-staging

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,18 +1,11 @@
 # Packit: build irlume RPMs in Copr from signed GitHub tags (the linhello
-# pipeline). Models are Git LFS; Copr's srpm build must pull them.
+# pipeline). Model weights are release assets (Source2-5 in the spec, fetched
+# with net-on), not Git LFS, so there is nothing to pull at clone time.
 specfile_path: packaging/fedora/irlume.spec
 upstream_package_name: irlume
 downstream_package_name: irlume
 # Tags are v-prefixed (v0.1.1); without this the RPM Version keeps the "v".
 upstream_tag_template: "v{version}"
-
-srpm_build_deps:
-  - git-lfs
-
-actions:
-  post-upstream-clone:
-    - git lfs install
-    - git lfs pull
 
 jobs:
   - job: copr_build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,9 @@ See [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) for the full walkthrough. The
 quickest path is Nix: `nix develop` gives you the whole pinned toolchain
 (Rust, libclang, TPM/PAM libs, the ONNX runtime) on any distro with one
 command; the guide also lists the per-distro `dnf`/`apt`/`pacman` dependencies
-if you'd rather install them by hand. Note the models live in Git LFS
-(`git lfs pull`), and real face/camera/TPM/PAM testing needs a physical machine.
+if you'd rather install them by hand. Note the models are fetched from a
+release (`bash scripts/fetch-models.sh`), and real face/camera/TPM/PAM testing
+needs a physical machine.
 
 ## Where to start
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ body. If the project grows more maintainers, this file changes first.
 ## Continuity
 
 Everything needed to continue the project is public: the source, the model
-weights (Git LFS in this repository), the packaging for every distribution
+weights (the models-v1 release assets), the packaging for every distribution
 lane (`packaging/`), the release process (`scripts/`), and the documentation.
 The license (GPL-3.0-or-later) permits anyone to fork and carry on. The only
 things a successor cannot inherit are the maintainer's accounts and signing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,8 +41,9 @@ Full detail in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). Primary concerns:
   template).
 - **Side channels**: the match comparison is value-independent in timing so a
   similarity score cannot be inferred from response time.
-- **Model integrity**: model weights are content-addressed in Git LFS
-  (SHA-256 object ids pinned in the repo) and ship inside the distro packages,
+- **Model integrity**: model weights are pinned by SHA-256 (committed in
+  `models/SHA256SUMS`; `scripts/fetch-models.sh` verifies each release-hosted
+  weight against its hash before use) and ship inside the distro packages,
   whose own integrity checking covers them; only the permissive, audited BOM is
   shipped. At startup the daemon re-hashes each configured model against the
   release manifest (`models/SHA256SUMS`, embedded at build time) and logs a

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -3327,7 +3327,8 @@ mod thirdparty_cue_tests {
     }
 }
 
-/// Engine tests against the REAL shipped models (Git LFS under `models/`), with
+/// Engine tests against the REAL shipped models (fetched under `models/` by
+/// scripts/fetch-models.sh), with
 /// the camera devices pointed at nonexistent nodes so no capture can ever run:
 /// everything from the capture boundary inward errors with "no camera found",
 /// and everything decided BEFORE the camera (enrollment state, bindings,

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -124,7 +124,7 @@ pub fn update(args: &[String]) -> ExitCode {
                 "    git -C <clone> fetch --tags && git checkout {}",
                 latest.as_deref().unwrap_or("<latest>")
             );
-            println!("    git lfs pull && cargo build --release && sudo bash scripts/install-host.sh --ort <libonnxruntime.so>");
+            println!("    bash scripts/fetch-models.sh && cargo build --release && sudo bash scripts/install-host.sh --ort <libonnxruntime.so>");
         }
     }
     println!("  Release notes: https://github.com/archledger/irlume/releases");

--- a/crates/irlume-daemon/tests/shutdown.rs
+++ b/crates/irlume-daemon/tests/shutdown.rs
@@ -55,7 +55,7 @@ fn daemon_exits_promptly_on_sigterm() {
         return;
     };
     if !det.exists() || !model.exists() {
-        eprintln!("SKIP: models not present (git lfs pull)");
+        eprintln!("SKIP: models not present (bash scripts/fetch-models.sh)");
         return;
     }
 

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The weights ship inside the distro packages (installed to
 //! /usr/share/irlume/models and loaded from disk at daemon start; a git clone
-//! carries them via Git LFS, so there is no fetch-models step). Do NOT swap
+//! fetches them from the models-v1 release via scripts/fetch-models.sh). Do NOT swap
 //! in InsightFace buffalo_l/antelopev2 or YuNet's bundled SCRFD: their weights
 //! are non-commercial, which CONFLICTS with GPL's downstream-commercial freedom.
 
@@ -814,8 +814,8 @@ pub use onnx::{
     PadIr, BLAZE_SCORE_THRESHOLD, EAR_LEFT, EAR_RIGHT, MESH_INPUT, MESH_N, MESH_N_IRIS,
 };
 
-/// Model-backed pipeline tests: run the REAL shipped ONNX models (Git LFS,
-/// under `models/` at the repo root) on synthetic frames, asserting output
+/// Model-backed pipeline tests: run the REAL shipped ONNX models (fetched to
+/// `models/` at the repo root by scripts/fetch-models.sh) on synthetic frames, asserting output
 /// dimensions, value ranges, and determinism. Session creation is expensive, so
 /// each model is built once per test binary and shared behind a `OnceLock`.
 #[cfg(all(test, feature = "onnx"))]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -18,15 +18,15 @@ biometric-data and model-license policy, PAD self-tests), read
 
 ## Get the source (with model weights)
 
-The ONNX models live in **Git LFS**, so a plain clone gives you pointer stubs,
-not real weights. You need the weights to *run* irlume or run tests that load a
-model (you can compile without them).
+The ONNX models are hosted as release assets (on the version-independent
+`models-v1` release), not committed to the repo, so a plain clone stays small
+and a fetch pulls the real weights. You need them to *run* irlume or run tests
+that load a model (you can compile without them).
 
 ```sh
 git clone https://github.com/archledger/irlume.git
 cd irlume
-git lfs install
-git lfs pull            # fetch the real models/*.onnx
+bash scripts/fetch-models.sh   # download + sha256-verify models/*.onnx
 ```
 
 ## Option A: Nix (recommended)
@@ -83,7 +83,7 @@ Install the build dependencies, then use `cargo` as usual.
 
 ```sh
 sudo dnf install cargo rust clang-devel pkgconf-pkg-config gcc \
-    pam-devel tpm2-tss-devel kernel-headers git-lfs
+    pam-devel tpm2-tss-devel kernel-headers curl
 ```
 
 **Ubuntu / Debian**: the archive's `rustc` is usually too old (the `ort`
@@ -92,14 +92,14 @@ binding needs Rust ≥ 1.88), so install the toolchain with
 
 ```sh
 sudo apt install build-essential pkg-config clang libclang-dev \
-    libpam0g-dev libtss2-dev git-lfs
+    libpam0g-dev libtss2-dev curl
 rustup toolchain install 1.88.0   # or newer stable
 ```
 
 **Arch**
 
 ```sh
-sudo pacman -S --needed base-devel rust clang tpm2-tss pam onnxruntime-cpu git-lfs
+sudo pacman -S --needed base-devel rust clang tpm2-tss pam onnxruntime-cpu curl
 ```
 
 ### ONNX runtime (non-Nix)
@@ -243,7 +243,7 @@ load-failure message re-enters the API lock being initialized.
 ### Using landmark_dump
 
 ```sh
-git lfs pull                                     # real model weights
+bash scripts/fetch-models.sh                                     # real model weights
 export ORT_DYLIB_PATH=/path/to/libonnxruntime.so # see above
 cargo run --release -p irlume-auth --example landmark_dump -- \
   models/face_detection_yunet_2023mar.onnx models/face_landmark.onnx \

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -144,19 +144,12 @@ headless SPICE host.
 
 ## Model weights and building from a remote flake
 
-The four ONNX model files ship in the repository through Git LFS, and the
-package installs them from the source tree into
-`$out/share/irlume/models/`. Building from a local checkout works as long as the
-LFS objects are present (`git lfs pull`), which they are after a normal clone
-with git-lfs installed.
-
-Fetching the flake straight from GitHub is the one case to watch: nix reads the
-git tree without running the LFS smudge filter, so a `nix build github:archledger/irlume`
-can land LFS pointer files instead of the real weights. Build from a checkout
-that has run `git lfs pull`, or add the model files to your own flake inputs, if
-you hit that. The daemon refuses to start on a truncated model when
-`IRLUME_MODELS_STRICT=1` is set, so a pointer file fails loudly rather than
-silently.
+The four ONNX model files are fetched by the flake from the `models-v1` GitHub
+release as hash-pinned `fetchurl` inputs, and the package installs them into
+`$out/share/irlume/models/`. Because they are fixed-output fetches keyed by
+sha256 (not Git LFS), `nix build github:archledger/irlume` gets the real weights
+with no smudge-filter caveat and no LFS bandwidth cost. The daemon still refuses
+to start on a truncated model when `IRLUME_MODELS_STRICT=1` is set.
 
 ## What was validated
 

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -13,7 +13,7 @@ anywhere not listed, an issue report with your distro, camera, and
 | Fedora, current stable releases + rawhide | Copr `archledger/irlume` (`dnf copr enable` + `dnf install irlume`) | SELinux module ships as the `irlume-selinux` subpackage |
 | Ubuntu, current LTS | PPA `ppa:archledger/irlume` | the PPA carries the current LTS only |
 | Debian 12+, Ubuntu derivatives (Mint, Pop!\_OS, Zorin, elementary), older Ubuntu LTS | `.deb` from [Releases](https://github.com/archledger/irlume/releases) | needs glibc 2.35+; the package refuses anything older |
-| Arch | AUR package [`irlume`](https://aur.archlinux.org/packages/irlume) | builds from the signed release tag; models come via Git LFS |
+| Arch | AUR package [`irlume`](https://aur.archlinux.org/packages/irlume) | builds from the signed release tag; models come from the models-v1 release |
 | NixOS | `nixosModules.irlume` from this flake | declarative daemon + PAM wiring, see [NIXOS.md](NIXOS.md) |
 | anything else | from source | see [DEVELOPMENT.md](DEVELOPMENT.md); Rust 1.88+, onnxruntime 1.24+ |
 

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -73,7 +73,7 @@ sudo systemctl revert irlumed && sudo systemctl restart irlumed
 
 ```sh
 git clone https://github.com/archledger/irlume
-cd irlume && git lfs pull
+cd irlume && bash scripts/fetch-models.sh
 cargo test --workspace
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,9 @@
         };
       in {
         # `nix build` / `nix run .#irlume`: build irlume from source. The model
-        # weights (Git LFS) install into the result; the NixOS module points the
-        # daemon at them. `src = self` uses the flake's own tree.
+        # weights are fetched by hash inside nix/package.nix (from the models-v1
+        # release, not Git LFS) and install into the result; the NixOS module
+        # points the daemon at them. `src = self` uses the flake's own tree.
         packages.default = pkgs.callPackage ./nix/package.nix { src = self; };
         packages.irlume = self.packages.${system}.default;
         # Exposed so CI can realize this fixed-output fetch and catch a stale

--- a/models/README.md
+++ b/models/README.md
@@ -1,15 +1,19 @@
 # Models
 
-irlume bundles a **permissive, GPLv3-compatible** model stack. All weights are
-committed to this repo via **Git LFS** (see `../.gitattributes`) and loaded from
-`/usr/share/irlume/models/` (packages) or this dir (dev); a clone or package is
-self-contained, no runtime download or fetch step. After cloning, run
-`git lfs pull` if your client didn't fetch LFS objects automatically.
+irlume bundles a **permissive, GPLv3-compatible** model stack. The weights are
+hosted as release assets on the version-independent `models-v1` release (kept
+OUT of Git LFS so builds do not consume the account's LFS bandwidth quota) and
+loaded from `/usr/share/irlume/models/` (packages) or this dir (dev). After a
+clone, fetch and sha256-verify them with `bash ../scripts/fetch-models.sh`; a
+distro package bundles them, so an installed system needs no download.
 
 `SHA256SUMS` holds the release checksums; the daemon embeds it at build time
 and warns at startup when a loaded model doesn't match (see ../SECURITY.md).
-After changing any shipped model, regenerate it and commit both:
-`cd models && sha256sum face_detection_yunet_2023mar.onnx face_landmark.onnx glintr100.onnx blaze_face_short_range.onnx > SHA256SUMS`.
+The same hashes are pinned in `scripts/fetch-models.sh`, the Fedora spec, the
+Arch PKGBUILD, and `flake.nix`. To change a shipped model: upload the new file
+to a fresh `models-vN` release, regenerate `SHA256SUMS`
+(`cd models && sha256sum *.onnx > SHA256SUMS`), and update the hash in all four
+places above plus the `models-vN` reference.
 
 | File | Stage | Source | License | Notes |
 |---|---|---|---|---|

--- a/models/blaze_face_short_range.onnx
+++ b/models/blaze_face_short_range.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5453678015f6289c1d77bda88a8ba9c87574f01de1a05ba1909b9a7e08b237b
-size 418463

--- a/models/face_detection_yunet_2023mar.onnx
+++ b/models/face_detection_yunet_2023mar.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f2383e4dd3cfbb4553ea8718107fc0423210dc964f9f4280604804ed2552fa4
-size 232589

--- a/models/face_landmark.onnx
+++ b/models/face_landmark.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:821683be088447839638f79d64268bd501bdb72e5d9e262ec981c7e252956caf
-size 4920995

--- a/models/glintr100.onnx
+++ b/models/glintr100.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60
-size 260694151

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,10 +18,41 @@
   tpm2-tss,
   linux-pam,
   linuxHeaders,
+  fetchurl,
+  runCommand,
   # Source tree. The flake passes `self`; a plain `nix-build` falls back to a
-  # cleaned copy of the repo root (drops target/ and .git, keeps the LFS-pulled
-  # models/ which the package installs).
+  # cleaned copy of the repo root (drops target/ and .git).
   src ? lib.cleanSource ../.,
+  # The ONNX model weights are NOT in the source tree (moved out of Git LFS so
+  # builds do not consume the account's LFS bandwidth quota); fetch them by hash
+  # from the models-v1 release. A directory of the four *.onnx files that
+  # postInstall copies into the result. Keep these hashes in step with
+  # models/SHA256SUMS (nix prints the correct hash on a mismatch).
+  models ?
+    runCommand "irlume-models" {
+      glintr100 = fetchurl {
+        url = "https://github.com/archledger/irlume/releases/download/models-v1/glintr100.onnx";
+        sha256 = "a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60";
+      };
+      yunet = fetchurl {
+        url = "https://github.com/archledger/irlume/releases/download/models-v1/face_detection_yunet_2023mar.onnx";
+        sha256 = "8f2383e4dd3cfbb4553ea8718107fc0423210dc964f9f4280604804ed2552fa4";
+      };
+      landmark = fetchurl {
+        url = "https://github.com/archledger/irlume/releases/download/models-v1/face_landmark.onnx";
+        sha256 = "821683be088447839638f79d64268bd501bdb72e5d9e262ec981c7e252956caf";
+      };
+      blaze = fetchurl {
+        url = "https://github.com/archledger/irlume/releases/download/models-v1/blaze_face_short_range.onnx";
+        sha256 = "c5453678015f6289c1d77bda88a8ba9c87574f01de1a05ba1909b9a7e08b237b";
+      };
+    } ''
+      mkdir -p "$out"
+      cp "$glintr100" "$out/glintr100.onnx"
+      cp "$yunet" "$out/face_detection_yunet_2023mar.onnx"
+      cp "$landmark" "$out/face_landmark.onnx"
+      cp "$blaze" "$out/blaze_face_short_range.onnx"
+    '',
 }:
 
 rustPlatform.buildRustPackage {
@@ -71,7 +102,7 @@ rustPlatform.buildRustPackage {
       "$out/lib/security/pam_irlume.so"
 
     install -d "$out/share/irlume/models"
-    install -m0644 models/*.onnx "$out/share/irlume/models/"
+    install -m0644 ${models}/*.onnx "$out/share/irlume/models/"
   '';
 
   meta = {

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -15,8 +15,10 @@ own recipe. Everything the daemon does at *runtime* stays capability-detected.
 | systemd units | `/usr/lib/systemd/system/irlumed.service` + `irlume-reconcile.path`/`.service` (self-heal watcher; all families incl. PPA enable the `.path`) |
 | LSM policy | Fedora SELinux module · Debian `apparmor/usr.bin.irlumed` (path-adjusted) · Arch none |
 
-Models are bundled (Git LFS); there is no fetch step. Packages that build from a git
-checkout must `git lfs pull` first so the real weights (not pointers) are staged.
+Models are hosted as release assets (the `models-v1` release), not Git LFS; each
+lane fetches and sha256-verifies them at build time (`scripts/fetch-models.sh`,
+or the Source URLs in the spec / PKGBUILD / flake). An installed package bundles
+the weights, so a running system needs no download.
 
 ## Per-family
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -14,20 +14,31 @@ depends=('onnxruntime' 'tpm2-tss' 'pam')
 optdepends=('fprintd: fingerprint companion factor')
 # clang: v4l2-sys-mit generates its V4L2 bindings with bindgen, which needs
 # libclang at build time; without it makepkg fails on a clean system.
-makedepends=('rust' 'cargo' 'gcc' 'clang' 'git-lfs')
-# Models ride in the tag via Git LFS. GitHub's auto-generated tag tarballs do
-# NOT include LFS objects (they ship 131-byte pointer stubs); that is exactly
-# why this PKGBUILD clones the git tag and runs `git lfs pull` instead of using
-# the tarball. Do not "simplify" to the archive URL.
-source=("git+https://github.com/archledger/irlume.git#tag=v${pkgver}")
-sha256sums=('SKIP')
+makedepends=('rust' 'cargo' 'gcc' 'clang')
+# The code comes from the signed git tag. The ONNX model weights are NOT in the
+# tag; they are hosted as release assets on the version-independent `models-v1`
+# release (kept out of Git LFS so builds do not consume the account's LFS
+# bandwidth quota). makepkg downloads and checksum-verifies them as extra
+# sources here, and prepare() stages them into the build tree.
+source=("git+https://github.com/archledger/irlume.git#tag=v${pkgver}"
+        "glintr100.onnx::https://github.com/archledger/irlume/releases/download/models-v1/glintr100.onnx"
+        "face_detection_yunet_2023mar.onnx::https://github.com/archledger/irlume/releases/download/models-v1/face_detection_yunet_2023mar.onnx"
+        "face_landmark.onnx::https://github.com/archledger/irlume/releases/download/models-v1/face_landmark.onnx"
+        "blaze_face_short_range.onnx::https://github.com/archledger/irlume/releases/download/models-v1/blaze_face_short_range.onnx")
+sha256sums=('SKIP'
+            'a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60'
+            '8f2383e4dd3cfbb4553ea8718107fc0423210dc964f9f4280604804ed2552fa4'
+            '821683be088447839638f79d64268bd501bdb72e5d9e262ec981c7e252956caf'
+            'c5453678015f6289c1d77bda88a8ba9c87574f01de1a05ba1909b9a7e08b237b')
 install=irlume.install
 
 prepare() {
     cd "$srcdir/$pkgname"
-    git lfs install --local
-    git config lfs.url https://github.com/archledger/irlume.git/info/lfs
-    git lfs pull
+    # Stage the release-hosted weights (makepkg already downloaded and verified
+    # them from the sources above) into the tree the build expects.
+    mkdir -p models
+    cp "$srcdir"/glintr100.onnx "$srcdir"/face_detection_yunet_2023mar.onnx \
+       "$srcdir"/face_landmark.onnx "$srcdir"/blaze_face_short_range.onnx models/
 }
 
 build() {

--- a/packaging/arch/build-pkg.sh
+++ b/packaging/arch/build-pkg.sh
@@ -15,11 +15,8 @@ cd "$REPO"
 
 command -v makepkg >/dev/null || { echo "run on Arch (needs makepkg)"; exit 1; }
 
-# Ensure real model weights (LFS). Tolerate a non-git export where they're
-# already present as real files.
-git lfs pull 2>/dev/null || true
-[ "$(stat -c%s models/glintr100.onnx 2>/dev/null || echo 0)" -gt 1000000 ] \
-  || { echo "models/glintr100.onnx missing/pointer; run 'git lfs pull' first"; exit 1; }
+# Fetch + verify the release-hosted model weights (not Git LFS).
+bash scripts/fetch-models.sh
 cargo build --release --locked 2>/dev/null || cargo build --release
 
 rm -rf "$BUILD"; mkdir -p "$BUILD"

--- a/packaging/debian/build-deb-container.sh
+++ b/packaging/debian/build-deb-container.sh
@@ -33,12 +33,9 @@ REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 OUT="${OUT:-$REPO}"
 
 command -v podman >/dev/null || { echo "need podman"; exit 1; }
-# Models must be real weights, not LFS pointer stubs (bundled into the .deb).
-for m in "$REPO"/models/*.onnx; do
-    if [ "$(stat -c%s "$m")" -lt 1000000 ] && grep -q git-lfs "$m" 2>/dev/null; then
-        echo "$m is an LFS pointer; run: git lfs pull"; exit 1
-    fi
-done
+# Models are hosted as release assets (not Git LFS); fetch + verify them so a
+# fresh checkout (CI, a clean clone) has real weights to bundle into the .deb.
+bash "$REPO/scripts/fetch-models.sh"
 
 echo "==> building universal .deb in $BASE (rustup $RUST_VER)"
 podman run --rm \
@@ -50,7 +47,7 @@ podman run --rm \
     apt-get update -qq
     # clang/libclang-dev: bindgen (v4l2-sys-mit) needs libclang at build time.
     apt-get install -y -qq curl ca-certificates build-essential pkg-config \
-        libtss2-dev libpam0g-dev clang libclang-dev git git-lfs xz-utils >/dev/null
+        libtss2-dev libpam0g-dev clang libclang-dev git xz-utils >/dev/null
     curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain '"$RUST_VER"' --profile minimal >/dev/null
     . "$HOME/.cargo/env"
     # Pinned nfpm, verified against its published (goreleaser-signed) checksums.
@@ -61,7 +58,6 @@ podman run --rm \
       [ -n "$want" ] && [ "$want" = "$got" ] || { echo "nfpm checksum mismatch"; exit 1; } )
     apt-get install -y -qq /tmp/nfpm.deb >/dev/null
     cp -r /src /build && cd /build
-    sed -i "/git lfs pull/d" packaging/debian/build-deb.sh   # models are already real in the mount
     bash packaging/debian/build-deb.sh
     cp -v *.deb /out/
   '

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -15,8 +15,8 @@ cd "$REPO"
 
 command -v nfpm >/dev/null || { echo "need nfpm (https://nfpm.goreleaser.com)"; exit 1; }
 
-# Real model weights, not LFS pointers.
-git lfs pull
+# Real model weights (from the models-v1 release, not Git LFS).
+bash "$REPO/scripts/fetch-models.sh"
 
 cargo build --release --locked
 

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -43,7 +43,7 @@ contents:
     dst: /usr/bin/irlume
   - src: ../../target/release/libpam_irlume.so
     dst: /usr/lib/x86_64-linux-gnu/security/pam_irlume.so
-  # Bundled models (Git LFS pulled before build)
+  # Bundled models (fetched from the models-v1 release by build-deb.sh)
   - src: ../../models/glintr100.onnx
     dst: /usr/share/irlume/models/glintr100.onnx
   - src: ../../models/face_detection_yunet_2023mar.onnx

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -7,8 +7,15 @@ Summary:        Windows Hello-style face login for Linux
 
 License:        GPL-3.0-or-later
 URL:            https://github.com/archledger/irlume
-# Packit fills VCS source from the signed tag; models come via Git LFS.
+# Packit fills VCS source from the signed tag.
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+# Model weights: release assets on the version-independent models-v1 release,
+# kept OUT of Git LFS so builds do not consume the account's LFS bandwidth
+# quota. Packit/Copr fetch remote sources (net-on); verified by sha256 in %prep.
+Source2:        %{url}/releases/download/models-v1/glintr100.onnx
+Source3:        %{url}/releases/download/models-v1/face_detection_yunet_2023mar.onnx
+Source4:        %{url}/releases/download/models-v1/face_landmark.onnx
+Source5:        %{url}/releases/download/models-v1/blaze_face_short_range.onnx
 # Bundled onnxruntime runtime (MIT). irlume needs the api-24 ABI (>=1.24);
 # Fedora's own onnxruntime is below that in every release we build for
 # (verified 2026-07-16: f43 1.20.1, f44 1.22.2; rawhide's 1.26 is the first
@@ -69,6 +76,13 @@ echo '3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747  %{SOURCE
 # Unpack the bundled onnxruntime (Source1) next to the source tree; installed
 # below into %{_datadir}/%{name}/onnxruntime.
 tar -xzf %{SOURCE1}
+# Verify the release-hosted model weights (Source2-5) the same way: they load in
+# the privileged daemon, and Copr fetches remote sources without a lookaside
+# checksum. Keep these in sync with models/SHA256SUMS.
+echo 'a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60  %{SOURCE2}' | sha256sum -c -
+echo '8f2383e4dd3cfbb4553ea8718107fc0423210dc964f9f4280604804ed2552fa4  %{SOURCE3}' | sha256sum -c -
+echo '821683be088447839638f79d64268bd501bdb72e5d9e262ec981c7e252956caf  %{SOURCE4}' | sha256sum -c -
+echo 'c5453678015f6289c1d77bda88a8ba9c87574f01de1a05ba1909b9a7e08b237b  %{SOURCE5}' | sha256sum -c -
 
 %build
 cargo build --release --locked
@@ -80,10 +94,11 @@ make -f %{_datadir}/selinux/devel/Makefile -C packaging/selinux irlume.pp
 install -Dm0755 target/release/irlumed %{buildroot}%{_bindir}/irlumed
 install -Dm0755 target/release/irlume  %{buildroot}%{_bindir}/irlume
 install -Dm0644 target/release/libpam_irlume.so %{buildroot}%{_libdir}/security/pam_irlume.so
-# Bundled models (Git LFS) → /usr/share/irlume/models
-for m in glintr100 face_detection_yunet_2023mar face_landmark blaze_face_short_range; do
-    install -Dm0644 models/$m.onnx %{buildroot}%{_datadir}/%{name}/models/$m.onnx
-done
+# Bundled models (release assets, verified in %prep) → /usr/share/irlume/models
+install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/%{name}/models/glintr100.onnx
+install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/%{name}/models/face_detection_yunet_2023mar.onnx
+install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/%{name}/models/face_landmark.onnx
+install -Dm0644 %{SOURCE5} %{buildroot}%{_datadir}/%{name}/models/blaze_face_short_range.onnx
 install -Dm0644 packaging/systemd/irlumed.service %{buildroot}%{_unitdir}/irlumed.service
 # Self-heal wiring watcher: re-applies irlume's greeter PAM lines if a distro
 # update strips them (no-op unless `login enable` was run and the lines went

--- a/packaging/ppa/build-ppa-container.sh
+++ b/packaging/ppa/build-ppa-container.sh
@@ -37,12 +37,9 @@ TAG="v${VERSION}"
 command -v podman >/dev/null || { echo "need podman"; exit 1; }
 git -C "$REPO" rev-parse "$TAG" >/dev/null 2>&1 || { echo "no git tag $TAG in $REPO"; exit 1; }
 
-# Models must be real weights (they ride in the orig tarball), not LFS pointers.
-for m in "$REPO"/models/*.onnx; do
-    if [ "$(stat -c%s "$m")" -lt 1000000 ] && grep -q git-lfs "$m" 2>/dev/null; then
-        echo "$m is an LFS pointer; run: git lfs pull"; exit 1
-    fi
-done
+# Models are release assets (not Git LFS); fetch + verify them so the orig
+# tarball carries real weights.
+bash "$REPO/scripts/fetch-models.sh"
 
 # Deterministic mtime for the orig tarball: the tag's commit date, same value a
 # native build derives, so re-runs on the same host are byte-identical.

--- a/scripts/build-ppa-source.sh
+++ b/scripts/build-ppa-source.sh
@@ -3,9 +3,10 @@
 #
 # Launchpad builders have NO network, so the orig tarball must be
 # self-contained: vendored crates (cargo vendor), the bundled onnxruntime
-# release libs, and the real ONNX model weights (not LFS pointers).
+# release libs, and the real ONNX model weights (fetched from the models-v1
+# release, see scripts/fetch-models.sh).
 #
-# Run on an Ubuntu/Debian box from a repo checkout with real LFS models.
+# Run on an Ubuntu/Debian box from a repo checkout (the script fetches models).
 #
 # The PPA targets ONLY the current Ubuntu LTS (its cargo is new enough for our
 # ort/edition-2024 deps). Older LTSs like noble (24.04, cargo 1.75) can't build
@@ -40,12 +41,8 @@ for tool in rsync cargo dpkg-buildpackage curl; do
     command -v "$tool" >/dev/null || { echo "need $tool"; exit 1; }
 done
 
-# Models must be real weights, not LFS pointer stubs.
-for m in "$REPO"/models/*.onnx; do
-    if [ "$(stat -c%s "$m")" -lt 1000000 ] && grep -q git-lfs "$m" 2>/dev/null; then
-        echo "$m is an LFS pointer - run: git lfs pull"; exit 1
-    fi
-done
+# Models are release assets (not Git LFS); fetch + verify them.
+bash "$REPO/scripts/fetch-models.sh"
 
 echo "==> staging source tree $TREE (irlume $DEBVER)"
 mkdir -p "$BUILDROOT"

--- a/scripts/fetch-models.sh
+++ b/scripts/fetch-models.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fetch irlume's ONNX model weights from the `models-v1` GitHub release and
+# verify them by sha256. This replaces `git lfs pull`: the weights are static
+# (they do not change between releases) and are hosted as release assets, which
+# are NOT counted against the account's Git LFS bandwidth quota. So CI, the AUR
+# PKGBUILD, and the .deb/PPA builds get the models without draining the 10 GB/mo
+# LFS bandwidth (a full pull is ~266 MB, so a few dozen builds exhausted it).
+#
+# Idempotent: a model already present with the right hash is left untouched, so
+# a local dev tree that already has the weights does no network at all.
+#
+# Usage: bash scripts/fetch-models.sh [DEST_DIR]   (DEST_DIR defaults to ./models)
+# Override the source with IRLUME_MODELS_REPO / IRLUME_MODELS_TAG.
+set -euo pipefail
+
+REPO="${IRLUME_MODELS_REPO:-archledger/irlume}"
+TAG="${IRLUME_MODELS_TAG:-models-v1}"
+BASE="https://github.com/${REPO}/releases/download/${TAG}"
+DEST="${1:-$(cd "$(dirname "$0")/.." && pwd)/models}"
+
+command -v curl >/dev/null || { echo "fetch-models: need curl" >&2; exit 1; }
+command -v sha256sum >/dev/null || { echo "fetch-models: need sha256sum" >&2; exit 1; }
+
+# name  sha256 (must match the assets on the models-v1 release; bump the tag to
+# models-v2 and update these if a weight ever changes).
+verify_or_fetch() {
+    local name="$1" sha="$2" out="$DEST/$1"
+    if [ -f "$out" ] && [ "$(sha256sum "$out" | cut -d' ' -f1)" = "$sha" ]; then
+        echo "fetch-models: $name present and verified"
+        return 0
+    fi
+    echo "fetch-models: downloading $name"
+    curl -fSL --retry 3 --retry-delay 2 -o "$out.tmp" "$BASE/$name"
+    local got
+    got=$(sha256sum "$out.tmp" | cut -d' ' -f1)
+    if [ "$got" != "$sha" ]; then
+        echo "fetch-models: CHECKSUM MISMATCH for $name (want $sha, got $got)" >&2
+        rm -f "$out.tmp"
+        return 1
+    fi
+    mv -f "$out.tmp" "$out"
+    echo "fetch-models: $name OK"
+}
+
+mkdir -p "$DEST"
+verify_or_fetch glintr100.onnx                   a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60
+verify_or_fetch face_detection_yunet_2023mar.onnx 8f2383e4dd3cfbb4553ea8718107fc0423210dc964f9f4280604804ed2552fa4
+verify_or_fetch face_landmark.onnx               821683be088447839638f79d64268bd501bdb72e5d9e262ec981c7e252956caf
+verify_or_fetch blaze_face_short_range.onnx      c5453678015f6289c1d77bda88a8ba9c87574f01de1a05ba1909b9a7e08b237b
+echo "fetch-models: all model weights present in $DEST"


### PR DESCRIPTION
## Why

The four ONNX weights (~257 MB, `glintr100.onnx` alone is 261 MB) were in Git LFS, and CI (`ci.yml`, `preflight`, `hardware-suite`, `install-matrix`) plus every AUR build ran `git lfs pull` per run. That exhausted the account's 10 GB/month LFS bandwidth; a `$0` "stop usage" budget then hard-blocked further pulls, breaking AUR installs and the LFS-pulling CI jobs.

The weights are static (added once, never changed), so they belong outside Git. This moves them to a version-independent `models-v1` GitHub release and fetches them by sha256 in every lane. Release-asset bandwidth is separate from the LFS quota, so the drain stops permanently and clones shrink.

## What changed

- **`scripts/fetch-models.sh`**: download + sha256-verify the four weights from the `models-v1` release; idempotent.
- **Stop LFS tracking**: remove `.gitattributes`, gitignore `models/*.onnx`, untrack them. `models/SHA256SUMS` stays as the manifest.
- **CI**: `git lfs pull` -> `fetch-models.sh` in all four workflows; the LFS-object cache becomes a `models/` cache keyed on `SHA256SUMS`.
- **Arch/AUR**: fetch weights as extra `source=()` release URLs (makepkg verifies), drop the `git-lfs` makedepend.
- **Fedora**: weights as `Source2-5` release URLs verified in `%prep` (mirrors the `Source1` onnxruntime pattern); `.packit.yaml` drops `git-lfs` and the `git lfs pull` clone action.
- **Debian/PPA**: `fetch-models.sh` before nfpm / the orig tarball.
- **Nix**: `nix/package.nix` fetches the weights by hash (`fetchurl`), so `nix build github:...` no longer needs the LFS smudge filter.
- Docs + code comments updated.

Hashes are pinned in five places kept in step: `models/SHA256SUMS`, `scripts/fetch-models.sh`, the spec, the PKGBUILD, and `nix/package.nix`.

## Validated locally

`cargo test --workspace` (621, model-backed tests find the fetched weights), `cargo clippy -D warnings`, `cargo fmt --check`, `nix flake check --no-build` (all outputs evaluate), `rpmspec -P` parses, all changed shell scripts `bash -n` clean, `fetch-models.sh` downloads + verifies from the release. This PR's own CI uses `fetch-models.sh`, so it is green without the (currently blocked) LFS quota.
