### PR TITLE
packaging: sync lagging version fields to 0.6.1

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -57,7 +57,9 @@
 
 rustPlatform.buildRustPackage {
   pname = "irlume";
-  version = "0.4.0";
+  # Derive from Cargo.toml so it never lags the released version (it had gone
+  # stale at 0.4.0). The workspace crates all use version.workspace = true.
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).workspace.package.version;
   inherit src;
 
   # Vendored via importCargoLock. The two tss-esapi crates come from our

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.6.0
+pkgver=0.6.1
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.6.0
+version: 0.6.1
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -1,7 +1,7 @@
 %global ort_ver 1.24.4
 
 Name:           irlume
-Version:        0.6.0
+Version:        0.6.1
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -184,6 +184,15 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Thu Jul 24 2026 archledger <archledger236@gmail.com> - 0.6.1-1
+- Update resilience: login self-heal survives an inactive watcher and a
+  pre-marker upgrade; doctor warns on an unrecognized display manager; a pinned
+  camera pair re-anchors by device identity after a udev renumber.
+- Pre-release audit hardening (bitwarden setup, doctor install-hygiene, TUI
+  Ctrl-C, recovery passphrase floor) and liveness fail-closed on a missing
+  challenge model.
+- Model weights are fetched from the models-v1 release (Source2-5), off Git LFS.
+
 * Thu Jul 23 2026 archledger <archledger236@gmail.com> - 0.6.0-1
 - Face-approve app prompts via polkit (Bitwarden biometric unlock, pkexec) with
   a deliberate consent gesture (head nod, or eye closure after calibrate-closure);


### PR DESCRIPTION
Per-lane version fields were hardcoded and had drifted behind the released version. Found while producing the v0.6.1 release assets: the universal `.deb` was being built as `0.6.0` because `nfpm.yaml` still said `0.6.0`.

- `nfpm.yaml`, `PKGBUILD`, spec `Version`: bump to 0.6.1 (+ a spec `%changelog` entry).
- `nix/package.nix`: derive the version from `Cargo.toml` so it never lags again (was stale at 0.4.0; the PPA scripts already derive it this way).

Copr was unaffected (Packit overrides the spec Version from the tag), and the AUR is already correct at 0.6.1. `rpmspec -P` parses; `nix eval .#packages.default.version` -> "0.6.1".
