### PR TITLE
fix: log which capture mode ran and where it came from

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -821,13 +821,24 @@ impl Engine {
         // brightness when both of its interfaces stream, the ASUS built-in keeps
         // all of it, and only a measurement on the actual camera can tell which
         // kind is plugged in.
-        let sequential = match std::env::var("IRLUME_SEQUENTIAL_CAPTURE") {
-            Ok(v) => v.trim() == "1",
-            Err(_) => {
-                irlume_camera::stored_capture_mode(&self.rgb_dev)
-                    == Some(irlume_camera::CaptureMode::Sequential)
-            }
+        let (sequential, mode_source) = match std::env::var("IRLUME_SEQUENTIAL_CAPTURE") {
+            Ok(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
+            Err(_) => match irlume_camera::stored_capture_mode(&self.rgb_dev) {
+                Some(m) => (m == irlume_camera::CaptureMode::Sequential, "cameras.conf"),
+                None => (false, "default"),
+            },
         };
+        // Name the mode AND where it came from. Without this the only way to
+        // tell which path ran is to infer it from timings, which is exactly the
+        // guessing this measurement work exists to remove.
+        irlume_common::dlog!(
+            "assess: capture mode {} (from {mode_source})",
+            if sequential {
+                "sequential"
+            } else {
+                "concurrent"
+            }
+        );
         // With held sessions the streams are already running, so a capture is
         // just the frames. Every RETRY below deliberately stays on the one-shot
         // path: a retry exists because something went wrong with this capture,


### PR DESCRIPTION
Small observability gap found while validating the merged capture-mode work during the 0.7.0 soak.

Confirming that a stored capture mode is actually honoured required inferring it from per-stream timings, because nothing logged which path ran. Anyone diagnosing a slow or dim capture in the field would have to repeat that inference.

The new line names both the mode and where it came from, so `cameras.conf`, the `IRLUME_SEQUENTIAL_CAPTURE` override and the default are distinguishable:

```
assess: capture mode sequential (from cameras.conf)
```

**Validated on hardware** by forcing each mode for the same camera identity and watching the engine:

```
STORED = sequential   capture mode sequential (from cameras.conf)
                      rgb 1161ms THEN ir 848ms   (sum ~2.0s)   skew 356ms
STORED = concurrent   capture mode concurrent (from cameras.conf)
                      rgb 1237ms, ir 967ms overlapped (~1.2s)  skew 190ms
```

That also closes the "sequential capture actually being used at auth" row from the validation ledger on #99, which had never run on hardware because this camera measures healthy.