### PR TITLE
fix: close three self-heal blind spots found by testing the lifecycle on hardware

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -821,13 +821,24 @@ impl Engine {
         // brightness when both of its interfaces stream, the ASUS built-in keeps
         // all of it, and only a measurement on the actual camera can tell which
         // kind is plugged in.
-        let sequential = match std::env::var("IRLUME_SEQUENTIAL_CAPTURE") {
-            Ok(v) => v.trim() == "1",
-            Err(_) => {
-                irlume_camera::stored_capture_mode(&self.rgb_dev)
-                    == Some(irlume_camera::CaptureMode::Sequential)
-            }
+        let (sequential, mode_source) = match std::env::var("IRLUME_SEQUENTIAL_CAPTURE") {
+            Ok(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
+            Err(_) => match irlume_camera::stored_capture_mode(&self.rgb_dev) {
+                Some(m) => (m == irlume_camera::CaptureMode::Sequential, "cameras.conf"),
+                None => (false, "default"),
+            },
         };
+        // Name the mode AND where it came from. Without this the only way to
+        // tell which path ran is to infer it from timings, which is exactly the
+        // guessing this measurement work exists to remove.
+        irlume_common::dlog!(
+            "assess: capture mode {} (from {mode_source})",
+            if sequential {
+                "sequential"
+            } else {
+                "concurrent"
+            }
+        );
         // With held sessions the streams are already running, so a capture is
         // just the frames. Every RETRY below deliberately stays on the one-shot
         // path: a retry exists because something went wrong with this capture,

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -295,11 +295,14 @@ fn reconcile() -> ExitCode {
         );
         return ExitCode::SUCCESS;
     };
-    if active_login_wired() && !lockscreen_regressed(with_lock) {
+    if active_login_wired()
+        && !lockscreen_regressed(with_lock)
+        && !wired_surface_regressed(with_sudo, with_polkit)
+    {
         // Still intact; the common case after a spurious file-change event.
-        // Also re-apply when only the KDE lock screen regressed (its file is
-        // watched too, but active_login_wired alone would treat the login
-        // greeter staying wired as "nothing to do").
+        // Every surface the marker claims must be checked, not just the login
+        // greeter: sudo, polkit and the fingerprint-keyring service can be
+        // stripped on their own while the greeter stays wired.
         return ExitCode::SUCCESS;
     }
     if effective_uid() != 0 {
@@ -359,9 +362,54 @@ fn lock_regressed(etc: &Path, vendor: Option<&Path>) -> bool {
     vendor.is_some_and(|v| v.exists()) // deleted, but re-materializable from vendor
 }
 
-#[cfg(test)]
 fn path_regressed(etc: &Path) -> bool {
     etc.exists() && !file_has_module(etc)
+}
+
+/// Whether a surface we RECORDED as wired has since lost the module.
+///
+/// The login greeter and the KDE lock screen were checked; `sudo`, polkit and
+/// the fingerprint-keyring service were not. That left the self-heal half open:
+/// a distro update that rewrote only one of those healed nothing, because
+/// reconcile saw the login greeter intact and returned "still intact" without
+/// looking further. The feature then stopped working silently, which is the
+/// exact failure mode the self-heal exists to prevent (issue #93).
+///
+/// Found on hardware: stripping `/etc/pam.d/gdm-fingerprint` on a wired box left
+/// it stripped through both a manual `login reconcile` and the path unit's
+/// automatic run.
+///
+/// Each surface is only maintained if the marker says we wired it, so a file
+/// that was never ours cannot make reconcile loop forever.
+fn wired_surface_regressed(with_sudo: bool, with_polkit: bool) -> bool {
+    let fp: Vec<&Path> = FP_GREETERS.iter().map(|s| Path::new(s.etc)).collect();
+    surfaces_regressed(
+        with_sudo.then(|| Path::new(SUDO)),
+        with_polkit.then(|| (Path::new(POLKIT.etc), POLKIT.vendor.map(Path::new))),
+        &fp,
+    )
+}
+
+/// Testable core of [`wired_surface_regressed`], taking the paths so a temp
+/// directory can drive it. `sudo`/`polkit` are `None` when the marker says we
+/// never wired them.
+fn surfaces_regressed(
+    sudo: Option<&Path>,
+    polkit: Option<(&Path, Option<&Path>)>,
+    fp_services: &[&Path],
+) -> bool {
+    if sudo.is_some_and(path_regressed) {
+        return true;
+    }
+    // polkit is materialized from a vendor copy on Fedora, so a DELETED /etc
+    // override is a regression there exactly as it is for the lock screen.
+    if polkit.is_some_and(|(etc, vendor)| lock_regressed(etc, vendor)) {
+        return true;
+    }
+    // The fingerprint-keyring line rides on a service the display manager owns;
+    // we only ever add to a file that already exists, so a missing file is not a
+    // regression, only a stripped one.
+    fp_services.iter().copied().any(path_regressed)
 }
 
 /// Whether the self-heal marker says login WAS wired but the wiring no longer
@@ -371,7 +419,11 @@ fn path_regressed(etc: &Path) -> bool {
 /// the fix.
 pub(crate) fn reconcile_needed() -> bool {
     match read_wired_marker() {
-        Some((_, _, with_lock)) => !active_login_wired() || lockscreen_regressed(with_lock),
+        Some((with_sudo, with_polkit, with_lock)) => {
+            !active_login_wired()
+                || lockscreen_regressed(with_lock)
+                || wired_surface_regressed(with_sudo, with_polkit)
+        }
         None => false,
     }
 }
@@ -1976,6 +2028,45 @@ mod tests {
         );
         // The `session pam_env` line above it is not an auth anchor.
         assert!(stanza > 1, "{wired}");
+    }
+
+    // Regression found on hardware during the 0.7.0 soak: stripping
+    // /etc/pam.d/gdm-fingerprint on a wired box survived BOTH a manual
+    // `login reconcile` and the path unit's automatic run, because the
+    // "is anything broken?" check only looked at the login greeter and the
+    // lock screen. sudo and polkit had the same blind spot.
+    #[test]
+    fn every_wired_surface_counts_as_a_regression_not_just_the_greeter() {
+        let dir = TestDir::new("surfaces");
+        let wired = dir.0.join("wired");
+        let stripped = dir.0.join("stripped");
+        let vendor = dir.0.join("vendor");
+        std::fs::write(&wired, "auth sufficient pam_irlume.so\n").unwrap();
+        std::fs::write(&stripped, "auth include system-auth\n").unwrap();
+        std::fs::write(&vendor, "auth include system-auth\n").unwrap();
+        let gone = dir.0.join("gone");
+
+        // Nothing recorded as wired: nothing to maintain.
+        assert!(!surfaces_regressed(None, None, &[]));
+        // Intact surfaces are not regressions.
+        assert!(!surfaces_regressed(
+            Some(&wired),
+            Some((&wired, None)),
+            &[&wired]
+        ));
+        // Each surface on its own must trigger a repair.
+        assert!(surfaces_regressed(Some(&stripped), None, &[]));
+        assert!(surfaces_regressed(None, Some((&stripped, None)), &[]));
+        assert!(surfaces_regressed(None, None, &[&stripped]));
+        // polkit deleted while a vendor copy remains is re-materializable, so it
+        // IS a regression; deleted with no vendor is not ours to restore.
+        assert!(surfaces_regressed(None, Some((&gone, Some(&vendor))), &[]));
+        assert!(!surfaces_regressed(None, Some((&gone, None)), &[]));
+        // A fingerprint service that does not exist is not a regression: we only
+        // ever add a line to a file the display manager already ships.
+        assert!(!surfaces_regressed(None, None, &[&gone]));
+        // A surface we never wired is ignored even when stripped.
+        assert!(!surfaces_regressed(None, None, &[]));
     }
 
     #[test]

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -261,9 +261,20 @@ pub fn perform_teardown(keep_data: bool) -> TeardownReport {
     );
     let pam_unwired = !pamwire::login_wired();
 
-    // 2. Stop and disable the daemon.
+    // 2. Stop and disable the daemon, and the self-heal units with it. Leaving
+    //    those enabled means a uninstalled irlume still wakes up on a PAM change
+    //    or on the timer; they self-gate on the marker so they would no-op, but
+    //    an uninstall should not leave units armed. Their failure is not counted
+    //    against the daemon's: a box that never enabled login never had them.
     let stop = systemctl(&["stop", "irlumed.service"]);
     let disable = systemctl(&["disable", "irlumed.service"]);
+    for unit in [
+        "irlume-reconcile.path",
+        "irlume-reconcile.timer",
+        "irlume-reconcile.service",
+    ] {
+        let _ = systemctl(&["disable", "--now", unit]);
+    }
     let service_stopped = stop && disable;
 
     // 3. Disarm each enrolled user's keyring seal (idempotent), and 4. wipe the

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -59,6 +59,7 @@ package() {
     # them. No-op until `irlume login enable` writes its marker.
     install -Dm0644 packaging/systemd/irlume-reconcile.path "$pkgdir/usr/lib/systemd/system/irlume-reconcile.path"
     install -Dm0644 packaging/systemd/irlume-reconcile.service "$pkgdir/usr/lib/systemd/system/irlume-reconcile.service"
+    install -Dm0644 packaging/systemd/irlume-reconcile.timer "$pkgdir/usr/lib/systemd/system/irlume-reconcile.timer"
     # The `irlume` system group (socket 0660 root:irlume); irlume.install runs
     # systemd-sysusers to create it.
     install -Dm0644 packaging/systemd/irlume.sysusers "$pkgdir/usr/lib/sysusers.d/irlume.conf"

--- a/packaging/arch/irlume.install
+++ b/packaging/arch/irlume.install
@@ -15,6 +15,7 @@ post_install() {
     # runs at boot to catch an offline strip and to adopt an existing wiring on
     # upgrade; --now runs one reconcile immediately.
     systemctl enable --now irlume-reconcile.path 2>/dev/null || true
+    systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
     systemctl enable --now irlume-reconcile.service 2>/dev/null || true
     cat <<'EOF'
 irlume installed. Next steps:
@@ -42,6 +43,13 @@ post_upgrade() {
     systemctl enable --now irlume-reconcile.path 2>/dev/null || true
     systemctl enable --now irlume-reconcile.service 2>/dev/null || true
     systemctl start irlume-reconcile.service 2>/dev/null || true
+    # The timer is NEW in 0.7.0; arm it once for upgraders too, recorded by a
+    # marker so a later deliberate disable is respected.
+    if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
+        mkdir -p /var/lib/irlume
+        systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
+        : > /var/lib/irlume/.reconcile-timer-armed
+    fi
     # 0.1.x -> 0.2.0 removed the IR adapter; IR templates enrolled before 0.2.0
     # no longer match. Bright-light (RGB) login still works; the password is
     # unaffected. Compare the just-installed version against the old one.
@@ -57,5 +65,6 @@ EOF
 pre_remove() {
     systemctl disable --now irlumed.service 2>/dev/null || true
     systemctl disable --now irlume-reconcile.path 2>/dev/null || true
+    systemctl disable --now irlume-reconcile.timer 2>/dev/null || true
     systemctl disable --now irlume-reconcile.service 2>/dev/null || true
 }

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -67,6 +67,8 @@ contents:
     dst: /usr/lib/systemd/system/irlume-reconcile.path
   - src: ../systemd/irlume-reconcile.service
     dst: /usr/lib/systemd/system/irlume-reconcile.service
+  - src: ../systemd/irlume-reconcile.timer
+    dst: /usr/lib/systemd/system/irlume-reconcile.timer
   # The `irlume` system group (socket 0660 root:irlume); postinstall runs
   # systemd-sysusers to create it.
   - src: ../systemd/irlume.sysusers

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -20,10 +20,22 @@ if [ -z "${2:-}" ]; then
     # update strips it. Self-gates on the login.wired marker, so it stays idle
     # until `irlume login enable` runs.
     systemctl enable --now irlume-reconcile.path 2>/dev/null || true
+    # Backstop: the path unit does not see a file replaced by rename.
+    systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
     # The .service runs at boot + on PAM change; --now runs one reconcile so an
     # upgrade adopts an already-wired install into the self-heal marker and a
     # same-transaction strip is re-applied. Self-gates; no-op on a fresh box.
     systemctl enable --now irlume-reconcile.service 2>/dev/null || true
+fi
+# The timer is NEW in 0.7.0, and the block above only enables units on FIRST
+# install so an upgrade cannot re-enable something the admin turned off. That
+# would leave every upgrader without the backstop, which is exactly the
+# population the self-heal exists for (issue #93). Arm it ONCE, recorded by a
+# marker, so a later deliberate `systemctl disable` is still respected.
+if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
+    mkdir -p /var/lib/irlume
+    systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
+    : > /var/lib/irlume/.reconcile-timer-armed
 fi
 systemctl try-restart irlumed.service 2>/dev/null || true
 cat <<'EOF'

--- a/packaging/debian/preremove.sh
+++ b/packaging/debian/preremove.sh
@@ -7,5 +7,6 @@ set -e
 if [ "$1" = remove ]; then
     systemctl disable --now irlumed.service 2>/dev/null || true
     systemctl disable --now irlume-reconcile.path 2>/dev/null || true
+    systemctl disable --now irlume-reconcile.timer 2>/dev/null || true
     systemctl disable --now irlume-reconcile.service 2>/dev/null || true
 fi

--- a/packaging/fedora/90-irlume.preset
+++ b/packaging/fedora/90-irlume.preset
@@ -6,3 +6,6 @@ enable irlumed.service
 # strips it. Self-gates on the login.wired marker, so it stays idle until
 # `irlume login enable` runs.
 enable irlume-reconcile.path
+# Backstop for the path unit, which does not see a file replaced by rename
+# (measured: `sed -i` triggers nothing). Same reconcile, on a schedule.
+enable irlume-reconcile.timer

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -105,6 +105,7 @@ install -Dm0644 packaging/systemd/irlumed.service %{buildroot}%{_unitdir}/irlume
 # missing). Enabled by preset; harmless when login was never wired.
 install -Dm0644 packaging/systemd/irlume-reconcile.path %{buildroot}%{_unitdir}/irlume-reconcile.path
 install -Dm0644 packaging/systemd/irlume-reconcile.service %{buildroot}%{_unitdir}/irlume-reconcile.service
+install -Dm0644 packaging/systemd/irlume-reconcile.timer %{buildroot}%{_unitdir}/irlume-reconcile.timer
 # The `irlume` system group (socket 0660 root:irlume). The systemd file trigger
 # runs systemd-sysusers on install to create it.
 install -Dm0644 packaging/systemd/irlume.sysusers %{buildroot}%{_sysusersdir}/irlume.conf
@@ -121,7 +122,7 @@ install -Dm0644 packaging/fedora/90-irlume.preset %{buildroot}%{_presetdir}/90-i
 %post
 # %%systemd_post honours our shipped preset → enables irlumed + the PAM-wiring
 # self-heal path unit on first install.
-%systemd_post irlumed.service irlume-reconcile.path irlume-reconcile.service
+%systemd_post irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
 # Also start it now so `irlume tui` works immediately after `dnf install`
 # (no-op in chroots/containers where systemd isn't running).
 if [ $1 -eq 1 ]; then
@@ -132,6 +133,15 @@ fi
 # the self-heal marker, and re-applies wiring a same-transaction strip removed.
 # Both self-gate and no-op on a fresh/un-wired box.
 systemctl start irlume-reconcile.path &>/dev/null || :
+systemctl start irlume-reconcile.timer &>/dev/null || :
+# The timer is NEW in 0.7.0 and %%systemd_post only applies presets on a FRESH
+# install, so an upgrader would never get the backstop. Arm it once, recorded by
+# a marker, leaving a later deliberate disable alone.
+if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
+    mkdir -p /var/lib/irlume
+    systemctl enable --now irlume-reconcile.timer &>/dev/null || :
+    : > /var/lib/irlume/.reconcile-timer-armed
+fi
 systemctl start irlume-reconcile.service &>/dev/null || :
 # PAM wiring is opt-in (irlume login enable); never auto-wire auth on install.
 # Upgrade from a version that shipped the IR adapter (< 0.2.0): dark/dim IR

--- a/packaging/systemd/irlume-reconcile.timer
+++ b/packaging/systemd/irlume-reconcile.timer
@@ -1,0 +1,26 @@
+[Unit]
+Description=Periodically re-apply irlume face-auth PAM wiring if a distro update stripped it
+Documentation=https://github.com/archledger/irlume
+
+[Timer]
+# Backstop for irlume-reconcile.path, which cannot see every kind of edit.
+# Measured 2026-07-26 on Ubuntu 26.04: appending to a watched greeter file
+# triggered the path unit within a second, and so did an `install` over it, but
+# replacing the file the way `sed -i` does (write a temp file, rename it over
+# the target) triggered nothing at all. A rename replaces the inode, so the
+# watch is left pointing at the old one. Adding a directory watch did not help.
+#
+# Config regenerators commonly replace files by rename, which is exactly the
+# case the self-heal exists for, so the wiring must not depend on the watcher
+# noticing. This runs the same reconcile on a schedule; it is a no-op unless the
+# wiring actually went missing, and it self-gates on the login.wired marker, so
+# it stays idle on a box that never ran `irlume login enable`.
+OnBootSec=3min
+OnUnitActiveSec=30min
+# Catch up after the machine was asleep or off rather than silently skipping.
+Persistent=true
+AccuracySec=1min
+Unit=irlume-reconcile.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Found during the 0.7.0 soak by running the full PAM wiring lifecycle on Ubuntu 26.04: enable, strip, reconcile, path-unit heal, disable, pristine. No enrolment needed to reproduce any of it.

## 1. Reconcile only looked at two surfaces

The "is anything broken?" check tested the active login greeter and the KDE lock screen. `sudo`, polkit and the fingerprint-keyring service were never checked, even though the marker records that we wired them. A strip of one of those returned "still intact" and healed nothing.

Measured before the fix:

```
== 3. irlume login reconcile ==
  reconcile restored it byte-identically               FAIL
5d4
< auth       optional                     pam_irlume.so keyring
```

After: `reconcile restored it BYTE-IDENTICALLY  OK`.

Each surface stays gated on having been wired, so a file that was never ours cannot make reconcile loop.

## 2. The path unit cannot see a file replaced by rename

This is the one worth reading twice. Measured on the same box, watching `ExecMainStartTimestampMonotonic` on the service:

```
append in place (echo >>)                    TRIGGERED after 1s
sed -i (writes temp, renames over)           NO TRIGGER (10s)
install (renames over)                       TRIGGERED after 1s
```

A rename replaces the inode the watch points at, so the watch is left on the old one. (`install` triggered because GNU install writes into the destination rather than renaming.) Adding `PathModified=/etc/pam.d` did not help either.

Config regenerators commonly replace files by rename, and that is exactly the scenario the self-heal exists for, so the wiring must not depend on the watcher noticing. `irlume-reconcile.timer` now runs the same reconcile every 30 minutes as a backstop. It is a no-op unless the wiring actually went missing, and it self-gates on the `login.wired` marker, so it stays idle on a box that never ran `login enable`.

## 3. A new unit would never reach upgraders

All three packaging hooks enable units only on first install, deliberately, so an upgrade cannot re-enable something an admin turned off. The consequence is that a unit added in a release stays disabled forever for everyone who upgrades, which is precisely the population #93 came from.

The timer is armed once, recorded by a marker under the state dir, so a later deliberate `systemctl disable` is still respected. Verified by upgrading the `.deb` with the marker removed:

```
timer enabled: enabled
timer active:  active
stripped (sed -i, rename-over)
HEALED byte-identically ✓
```

## Also

`irlume uninstall` stopped only the daemon and left the reconcile units armed on a box with no irlume. It now disables all three.

## Validation

Hardware, Ubuntu 26.04, 0.7.0 built from main: full lifecycle green after the fix, `/etc/pam.d` restored pristine against a backup at the end of every run. Unit test added for the widened regression check. 646 tests, clippy `-D warnings` and rustdoc clean.