### PR TITLE
feat: add machine API foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **Desktop integrations now have a small, versioned JSON foundation.**
+  `irlume version --json` advertises only implemented public capabilities, and
+  `irlume profiles list --json` exposes the existing read-only enrollment
+  summary without daemon prose or private socket access. The documented
+  contract keeps stdout machine-only, uses stable error codes, and deliberately
+  withholds mutation capabilities until the enrollment store owns opaque IDs.
+
 - **`sudo irlume camera-tune` measures whether your camera can read both sensors
   at once.** Some Hello modules stop exposing their colour stream properly while
   their infrared sibling is streaming. On a NexiGo HelloCam N930W the colour

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ default IR-structure gate already rejects photos, screens, and video replays.
 |---|---|
 | **Install and set up**, guided or by hand | [`docs/SETUP.md`](docs/SETUP.md) |
 | Look up **every command and flag** | [`docs/COMMANDS.md`](docs/COMMANDS.md) |
+| Integrate through the versioned **machine API** | [`docs/MACHINE-API.md`](docs/MACHINE-API.md) |
 | Understand the **architecture** | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
 | Read the **threat model** and standards mapping | [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) · [`docs/STANDARDS.md`](docs/STANDARDS.md) |
 | **Verify the claims** on my own machine | [`docs/VERIFY.md`](docs/VERIFY.md) |

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -82,7 +82,11 @@ pub fn version(args: &[String]) -> ExitCode {
             json!({
                 "capabilities": CAPABILITIES,
                 "limits": {
-                    "max_profiles": 3
+                    // Read the engine's own constant rather than repeating the
+                    // number. A consumer displays this as the enrollment limit,
+                    // so a literal here would silently start lying the day the
+                    // store's limit changes.
+                    "max_profiles": irlume_core::storage::MAX_PROFILES
                 }
             }),
         ),

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Public, versioned machine output for desktop integrations.
+//!
+//! Keep this module deliberately narrower than the daemon's private wire
+//! protocol. A capability is advertised only after its public command, output
+//! shape, and compatibility rules are covered here and in `docs/MACHINE-API.md`.
+
+use irlume_common::{ProfileSummary, Request, Response};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::process::ExitCode;
+
+pub const CONTRACT_VERSION: u32 = 1;
+
+const CAPABILITIES: &[&str] = &["version-json", "profiles-list-json"];
+
+#[derive(Serialize)]
+struct Document {
+    contract_version: u32,
+    engine_version: &'static str,
+    command: &'static str,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<MachineError>,
+}
+
+#[derive(Serialize)]
+struct MachineError {
+    code: &'static str,
+    retryable: bool,
+}
+
+fn success(command: &'static str, data: Value) -> Document {
+    Document {
+        contract_version: CONTRACT_VERSION,
+        engine_version: env!("CARGO_PKG_VERSION"),
+        command,
+        ok: true,
+        data: Some(data),
+        error: None,
+    }
+}
+
+fn failure(command: &'static str, code: &'static str, retryable: bool) -> Document {
+    Document {
+        contract_version: CONTRACT_VERSION,
+        engine_version: env!("CARGO_PKG_VERSION"),
+        command,
+        ok: false,
+        data: None,
+        error: Some(MachineError { code, retryable }),
+    }
+}
+
+fn emit(document: &Document, exit: ExitCode) -> ExitCode {
+    // Serialization only contains compile-time strings and serde_json values,
+    // so failure would be a programming error. Keep stdout machine-only even
+    // in that case and report the detail on stderr.
+    match serde_json::to_string(document) {
+        Ok(line) => {
+            println!("{line}");
+            exit
+        }
+        Err(error) => {
+            eprintln!("irlume machine output serialization failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+pub fn version(args: &[String]) -> ExitCode {
+    if args != ["version", "--json"] {
+        return emit(&failure("version", "usage-error", false), ExitCode::from(2));
+    }
+    emit(
+        &success(
+            "version",
+            json!({
+                "capabilities": CAPABILITIES,
+                "limits": {
+                    "max_profiles": 3
+                }
+            }),
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
+pub fn profiles_list(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "profiles.list";
+    if !valid_profiles_list_args(args) {
+        return emit(&failure(COMMAND, "usage-error", false), ExitCode::from(2));
+    }
+    let user = crate::user_arg(args);
+    match crate::daemon_request(&Request::ListProfiles { user }) {
+        Ok(Response::Enrollment {
+            profiles,
+            require_eyes_open,
+            require_challenge,
+            ..
+        }) => emit(
+            &success(
+                COMMAND,
+                profiles_data(profiles, require_eyes_open, require_challenge),
+            ),
+            ExitCode::SUCCESS,
+        ),
+        Ok(Response::Error(_)) => emit(
+            &failure(COMMAND, "operation-failed", false),
+            ExitCode::FAILURE,
+        ),
+        Ok(_) => emit(
+            &failure(COMMAND, "protocol-error", false),
+            ExitCode::FAILURE,
+        ),
+        Err(_) => emit(
+            &failure(COMMAND, "daemon-unavailable", true),
+            ExitCode::FAILURE,
+        ),
+    }
+}
+
+fn valid_profiles_list_args(args: &[String]) -> bool {
+    if args.first().map(String::as_str) != Some("profiles")
+        || args.get(1).map(String::as_str) != Some("list")
+    {
+        return false;
+    }
+    let mut saw_json = false;
+    let mut saw_user = false;
+    let mut index = 2;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" if !saw_json => {
+                saw_json = true;
+                index += 1;
+            }
+            "--user" if !saw_user => {
+                saw_user = true;
+                let Some(user) = args.get(index + 1) else {
+                    return false;
+                };
+                if user.is_empty() || user.starts_with('-') {
+                    return false;
+                }
+                index += 2;
+            }
+            _ => return false,
+        }
+    }
+    saw_json
+}
+
+fn profiles_data(
+    profiles: Vec<ProfileSummary>,
+    require_eyes_open: bool,
+    require_challenge: bool,
+) -> Value {
+    // The current enrollment store identifies profiles and scans by their
+    // names. Do not falsely present those names as opaque stable IDs. A later
+    // contract capability can add mutation-safe IDs after the store owns them.
+    let profiles = profiles
+        .into_iter()
+        .map(|profile| {
+            json!({
+                "display_name": profile.name,
+                "scans": profile.scans.into_iter().map(|name| {
+                    json!({ "display_name": name })
+                }).collect::<Vec<_>>()
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "profiles": profiles,
+        "require_eyes_open": require_eyes_open,
+        "require_challenge": require_challenge
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_freezes_the_public_envelope_and_capabilities() {
+        let document = serde_json::to_value(success(
+            "version",
+            json!({
+                "capabilities": CAPABILITIES,
+                "limits": { "max_profiles": 3 }
+            }),
+        ))
+        .unwrap();
+
+        assert_eq!(document["contract_version"], 1);
+        assert_eq!(document["command"], "version");
+        assert_eq!(document["ok"], true);
+        assert_eq!(
+            document["data"]["capabilities"],
+            json!(["version-json", "profiles-list-json"])
+        );
+        assert!(document.get("error").is_none());
+    }
+
+    #[test]
+    fn profile_listing_does_not_claim_unimplemented_opaque_ids() {
+        let data = profiles_data(
+            vec![ProfileSummary {
+                name: "Face Profile 1".into(),
+                scans: vec!["Scan 1".into()],
+            }],
+            true,
+            false,
+        );
+
+        assert_eq!(data["profiles"][0]["display_name"], "Face Profile 1");
+        assert_eq!(data["profiles"][0]["scans"][0]["display_name"], "Scan 1");
+        assert!(data["profiles"][0].get("profile_id").is_none());
+        assert!(data["profiles"][0]["scans"][0].get("scan_id").is_none());
+        assert_eq!(data["require_eyes_open"], true);
+        assert_eq!(data["require_challenge"], false);
+    }
+
+    #[test]
+    fn errors_have_stable_codes_without_daemon_prose() {
+        let document =
+            serde_json::to_value(failure("profiles.list", "daemon-unavailable", true)).unwrap();
+
+        assert_eq!(document["ok"], false);
+        assert_eq!(document["error"]["code"], "daemon-unavailable");
+        assert_eq!(document["error"]["retryable"], true);
+        assert!(document.get("data").is_none());
+    }
+
+    #[test]
+    fn profiles_list_rejects_unknown_missing_and_duplicate_flags() {
+        let args = |values: &[&str]| {
+            values
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+        };
+        assert!(valid_profiles_list_args(&args(&[
+            "profiles", "list", "--json"
+        ])));
+        assert!(valid_profiles_list_args(&args(&[
+            "profiles", "list", "--user", "alice", "--json"
+        ])));
+        assert!(!valid_profiles_list_args(&args(&["profiles", "list"])));
+        assert!(!valid_profiles_list_args(&args(&[
+            "profiles",
+            "list",
+            "--json",
+            "--verbose"
+        ])));
+        assert!(!valid_profiles_list_args(&args(&[
+            "profiles", "list", "--json", "--json"
+        ])));
+        assert!(!valid_profiles_list_args(&args(&[
+            "profiles", "list", "--json", "--user"
+        ])));
+    }
+}

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -25,6 +25,7 @@ mod blinkcap;
 mod commands;
 mod fingerprint;
 mod logs;
+mod machine;
 mod models;
 mod pad;
 mod pamwire;
@@ -105,6 +106,9 @@ fn main() -> std::process::ExitCode {
         (Some("liveness"), _) => liveness_probe(&args),
         (Some("meshprobe"), _) => meshprobe(&args),
         (Some("enroll"), _) => enroll(&args),
+        (Some("profiles"), Some("list")) if args.iter().any(|arg| arg == "--json") => {
+            machine::profiles_list(&args)
+        }
         (Some("profiles"), sub) => profiles(sub, &args),
         (Some("verify"), _) => verify(&args),
         (Some("enrolldev"), _) => enrolldev(&args),
@@ -125,6 +129,7 @@ fn main() -> std::process::ExitCode {
         (Some("set-cameras"), _) => set_cameras(&args),
         (Some("update"), _) => commands::update(&args),
         (Some("uninstall"), _) => uninstall::run(&args),
+        (Some("version"), _) if args.iter().any(|arg| arg == "--json") => machine::version(&args),
         (Some("version"), _) | (Some("--version"), _) | (Some("-V"), _) => {
             println!("irlume {}", env!("CARGO_PKG_VERSION"));
             std::process::ExitCode::SUCCESS

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -28,6 +28,24 @@ fn version_json_is_one_machine_document() {
 }
 
 #[test]
+fn advertised_limits_track_the_engine_constants() {
+    // Not a tautology: this runs the real binary and compares its published
+    // limit against the engine's own constant, so reverting to a literal in
+    // machine.rs fails here rather than silently misinforming a consumer that
+    // renders this as the enrollment limit.
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["version", "--json"])
+        .output()
+        .expect("run irlume");
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(
+        document["data"]["limits"]["max_profiles"],
+        serde_json::json!(irlume_core::storage::MAX_PROFILES),
+        "published max_profiles must come from irlume_core::storage::MAX_PROFILES"
+    );
+}
+
+#[test]
 fn unavailable_daemon_is_a_typed_json_error() {
     let socket = std::env::temp_dir().join(format!(
         "irlume-machine-api-no-daemon-{}",

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use serde_json::Value;
+use std::process::Command;
+
+#[test]
+fn version_json_is_one_machine_document() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["version", "--json"])
+        .output()
+        .expect("run irlume");
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        output.stdout.iter().filter(|&&byte| byte == b'\n').count(),
+        1
+    );
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["contract_version"], 1);
+    assert_eq!(document["command"], "version");
+    assert_eq!(document["ok"], true);
+    assert_eq!(
+        document["data"]["capabilities"],
+        serde_json::json!(["version-json", "profiles-list-json"])
+    );
+}
+
+#[test]
+fn unavailable_daemon_is_a_typed_json_error() {
+    let socket = std::env::temp_dir().join(format!(
+        "irlume-machine-api-no-daemon-{}",
+        std::process::id()
+    ));
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["profiles", "list", "--json"])
+        .env("IRLUME_SOCKET", socket)
+        .output()
+        .expect("run irlume");
+
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        output.stdout.iter().filter(|&&byte| byte == b'\n').count(),
+        1
+    );
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "profiles.list");
+    assert_eq!(document["ok"], false);
+    assert_eq!(document["error"]["code"], "daemon-unavailable");
+    assert_eq!(document["error"]["retryable"], true);
+}
+
+#[test]
+fn unknown_machine_flags_are_a_typed_usage_error() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["version", "--json", "--verbose"])
+        .output()
+        .expect("run irlume");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "version");
+    assert_eq!(document["ok"], false);
+    assert_eq!(document["error"]["code"], "usage-error");
+    assert_eq!(document["error"]["retryable"], false);
+}

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -24,14 +24,14 @@ Conventions that apply everywhere:
 | `irlume detect` | script-friendly probe; exit `0` = ready, `10` = partial, `20` = absent |
 | `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), the authselect/pam-auth-update regeneration guard, and install hygiene (leftover backup files next to the managed binaries, hand-installed builds overlaying the packaged ones) |
 | `irlume deps` | verify runtime dependencies (onnxruntime, models, TPM) |
-| `irlume version` | print the installed version (`--version` / `-V` also work) |
+| `irlume version` | print the installed version (`--version` / `-V` also work); `version --json` uses the public [machine API](MACHINE-API.md) |
 
 ## Enrollment and profiles
 
 | Command | What it does |
 |---|---|
 | `irlume enroll [--name N] [--scans K] [--reset]` | capture a face profile; `--reset` starts the profile space over |
-| `irlume profiles` (or `profiles list`) | list profiles and their scans |
+| `irlume profiles` (or `profiles list`) | list profiles and their scans; `profiles list --json` uses the read-only public [machine API](MACHINE-API.md) |
 | `irlume profiles add-scan --profile P` | add a scan to profile P (improves recognition in new conditions) |
 | `irlume profiles rename --profile P [--scan S] --name N` | rename a profile, or one scan inside it |
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
@@ -85,5 +85,6 @@ calibration analyzer.
 ## Where to go next
 
 - First-time setup, step by step: [SETUP.md](SETUP.md)
+- Versioned JSON for desktop integrations: [MACHINE-API.md](MACHINE-API.md)
 - Reading scores, gate reasons, and PAM decisions: [DEBUGGING.md](DEBUGGING.md)
 - NixOS module instead of imperative wiring: [NIXOS.md](NIXOS.md)

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -1,0 +1,74 @@
+# Machine API
+
+`irlume` exposes a deliberately small, versioned JSON interface for desktop
+integrations. Human-facing output remains the default.
+
+## Compatibility
+
+Every document contains:
+
+```json
+{
+  "contract_version": 1,
+  "engine_version": "0.6.1",
+  "command": "version",
+  "ok": true,
+  "data": {}
+}
+```
+
+Machine-mode standard output contains exactly one JSON document. Diagnostics
+go to standard error. A successful command exits with zero. Usage errors exit
+with 2, while unavailable or failed operations exit nonzero and return:
+
+```json
+{
+  "contract_version": 1,
+  "engine_version": "0.6.1",
+  "command": "profiles.list",
+  "ok": false,
+  "error": {
+    "code": "daemon-unavailable",
+    "retryable": true
+  }
+}
+```
+
+Fields may be added within a contract version. Removing a field or changing its
+meaning requires a new contract version. Consumers must first call
+`irlume version --json` and use only advertised capabilities.
+
+The machine API is not the daemon socket protocol. The socket remains private,
+and its serialized Rust enums are not a public compatibility promise.
+
+## Commands
+
+### `irlume version --json`
+
+Does not contact the daemon. It returns the engine version, contract version,
+advertised capabilities, and public limits.
+
+### `irlume profiles list --json [--user USER]`
+
+Capability: `profiles-list-json`.
+
+Returns display names, scan display names, and the two per-user liveness policy
+flags. The current enrollment store identifies these records by mutable names,
+so this first read-only contract intentionally does not invent opaque IDs or
+advertise profile mutations. Mutation-safe IDs must originate in the engine
+store before a later capability can expose them.
+
+## Security and privacy
+
+Ordinary JSON output never includes camera frames, embeddings, templates,
+passwords, credential material, TPM secrets, device paths, or usernames.
+Errors contain stable codes instead of daemon prose.
+
+The following are not part of contract version 1 yet and must not be inferred
+from human output or the private socket protocol:
+
+- enrollment or authentication-test event streams;
+- preview images and cancellation semantics;
+- profile or scan mutation;
+- camera configuration mutation;
+- login plan, apply, verify, or rollback transactions.

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -10,7 +10,7 @@ Every document contains:
 ```json
 {
   "contract_version": 1,
-  "engine_version": "0.6.1",
+  "engine_version": "0.7.0",
   "command": "version",
   "ok": true,
   "data": {}
@@ -24,7 +24,7 @@ with 2, while unavailable or failed operations exit nonzero and return:
 ```json
 {
   "contract_version": 1,
-  "engine_version": "0.6.1",
+  "engine_version": "0.7.0",
   "command": "profiles.list",
   "ok": false,
   "error": {
@@ -40,6 +40,47 @@ meaning requires a new contract version. Consumers must first call
 
 The machine API is not the daemon socket protocol. The socket remains private,
 and its serialized Rust enums are not a public compatibility promise.
+
+### A capability is not a compatibility promise
+
+`capabilities` says a command exists and is reachable. It does not say the
+engine's version is one a consumer has been tested against, and it is not a
+substitute for `contract_version`. Gate on the contract version you implement;
+treat a capability as an availability check on top of that.
+
+Read this the way irlume writes it: a name in that list is permanent public API.
+Once a name ships, consumers in the field may enable behaviour on seeing it, and
+irlume cannot know which versions those are. So a name is never reused for
+different semantics, and never appears before the command behind it is finished.
+
+### Authorization
+
+Every operation is authorized by the daemon from the connecting process's
+credentials, not from anything the caller says about itself. An operation is
+permitted for `root`, or for the user that owns the records being touched.
+`--user` names which account to act on; it does not grant anything. An ordinary
+user naming another account is refused.
+
+Consumers should not attempt to pre-check permission. Call the command and read
+the error.
+
+### Timeouts and cancellation
+
+Commands that only read state return promptly. Commands that use the camera take
+as long as a capture takes, and irlume applies its own internal bounds. A
+consumer should set its own timeout, and should treat terminating the process as
+the cancellation mechanism for this contract version. There is no cancel
+command in contract version 1.
+
+### Deprecation
+
+Within a contract version, no command or documented field is removed and no
+documented meaning changes. If a command must change incompatibly, the new shape
+arrives under a new `contract_version` and the previous one keeps working for at
+least one minor release series, so a consumer has a window in which both are
+available. Capability names are not removed once published; a capability that
+becomes unavailable on a given machine simply stops being listed by that
+machine.
 
 ## Commands
 
@@ -57,6 +98,31 @@ flags. The current enrollment store identifies these records by mutable names,
 so this first read-only contract intentionally does not invent opaque IDs or
 advertise profile mutations. Mutation-safe IDs must originate in the engine
 store before a later capability can expose them.
+
+Display names are chosen by the user, so treat them as user text rather than
+identifiers: they may contain anything the user typed.
+
+### Error codes
+
+| Code | Meaning | `retryable` |
+|---|---|---|
+| `usage-error` | The command line was not one this contract accepts. Exits 2. | no |
+| `daemon-unavailable` | The daemon could not be reached. | yes |
+| `operation-failed` | The daemon refused or could not complete the request. | no |
+| `protocol-error` | The daemon replied with something this command did not expect. | no |
+
+`operation-failed` is deliberately coarse in contract version 1, and a consumer
+should know what it hides: a request refused because the caller may not act on
+that account, a request naming an account that does not exist, and a genuine
+engine failure all report it identically, because the daemon reports those to the
+CLI as prose rather than as typed outcomes. A consumer therefore cannot yet tell
+"you are not permitted" from "something broke", and should present a neutral
+failure rather than guessing. A distinct authorization code is planned for when
+the daemon reports typed outcomes for this path; it will be additive.
+
+The one thing that identical treatment does buy today is that an unprivileged
+caller cannot use this command to discover which accounts exist or which are
+enrolled.
 
 ## Security and privacy
 


### PR DESCRIPTION
## What & why

Add the first public, versioned machine-facing CLI surface for desktop
integrations, as a deliberately read-only foundation for #108.

- `irlume version --json` returns the contract and engine versions, public
  limits, and only capabilities that are implemented now.
- `irlume profiles list --json [--user USER]` wraps the existing typed daemon
  response without exposing daemon prose or the private socket protocol.
- Machine stdout is exactly one JSON document; usage, daemon availability,
  protocol, and operation failures use stable codes.
- Unknown, missing, and duplicate machine flags fail closed.
- `docs/MACHINE-API.md` freezes the compatibility and privacy rules.

This intentionally does **not** advertise enrollment streams, previews,
mutations, or login transactions. The current enrollment store identifies
profiles and scans by mutable names; inventing opaque IDs in the CLI would make
rename semantics unstable. Those remaining parts of #108 need engine/store and
daemon lifecycle work first.

## Testing

Fedora 44 container:

- `cargo fmt --all -- --check`
- `cargo test -p irlume-cli` — 279 passed, 12 hardware/model tests ignored
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

The unfiltered workspace test command was also attempted locally. Its
`irlume-auth` engine tests require the repository's separately downloaded ONNX
weights and runtime; 15 tests stopped at model load in this model-free
container. The repository CI fetches and checksum-verifies those assets before
running the same workspace suite.

- [ ] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs/CHANGELOG updated if user-facing
- [ ] Hardware-validated (not applicable: no PAM, daemon, or capture change)
