### PR TITLE
feat: add stable face record IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **Face profiles and scans now carry stable opaque IDs.** Fresh records receive
+  random 128-bit identifiers that survive display-name changes. Existing
+  enrollments are backfilled deterministically from user and record order,
+  never names or biometric templates, and the typed daemon profile summary
+  exposes the IDs without breaking older clients. This is the storage boundary
+  required for safe machine-facing rename, delete, and improve-recognition
+  operations.
+
 - **`sudo irlume camera-tune` measures whether your camera can read both sensors
   at once.** Some Hello modules stop exposing their colour stream properly while
   their infrared sibling is streaming. On a NexiGo HelloCam N930W the colour

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2328,6 +2328,7 @@ impl Engine {
                 added_scans.push(sname.clone());
                 let ir_space = s.ir.as_ref().map(|_| self.ir_space.clone());
                 enr.profiles[idx].scans.push(FaceScan {
+                    id: storage::new_scan_id(),
                     name: sname,
                     rgb: s.rgb,
                     ir: s.ir,
@@ -2354,6 +2355,7 @@ impl Engine {
         }
         let name = profile_name.unwrap_or_else(|| enr.next_profile_name());
         let mut prof = FaceProfile {
+            id: storage::new_profile_id(),
             ir_calib: None,
             name: name.clone(),
             scans: Vec::new(),
@@ -2362,6 +2364,7 @@ impl Engine {
             let sname = prof.next_scan_name();
             let ir_space = s.ir.as_ref().map(|_| self.ir_space.clone());
             prof.scans.push(FaceScan {
+                id: storage::new_scan_id(),
                 name: sname,
                 rgb: s.rgb,
                 ir: s.ir,
@@ -2460,6 +2463,7 @@ impl Engine {
         let sname = enr.profiles[idx].next_scan_name();
         let ir_space = captured.ir.as_ref().map(|_| self.ir_space.clone());
         enr.profiles[idx].scans.push(FaceScan {
+            id: storage::new_scan_id(),
             name: sname.clone(),
             rgb: captured.rgb,
             ir: captured.ir,
@@ -3003,6 +3007,7 @@ mod tests {
             .iter()
             .zip(&rgb_rows)
             .map(|(ir, rgb)| FaceScan {
+                id: String::new(),
                 name: "s".into(),
                 rgb: rgb.clone(),
                 ir: Some(ir.clone()),
@@ -3016,6 +3021,7 @@ mod tests {
         let probe = mk(6, 0.4);
         (
             FaceProfile {
+                id: String::new(),
                 name: "p".into(),
                 scans,
                 ir_calib: calib,
@@ -3195,6 +3201,7 @@ mod tests {
 
     fn scan(v: Vec<f32>) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: "s".into(),
             rgb: v,
             ir: None,
@@ -3308,11 +3315,13 @@ mod tests {
             closure_calibration: None,
             profiles: vec![
                 FaceProfile {
+                    id: String::new(),
                     ir_calib: None,
                     name: "Face Profile 1".into(),
                     scans: vec![scan(face1.clone())],
                 },
                 FaceProfile {
+                    id: String::new(),
                     ir_calib: None,
                     name: "Face Profile 2".into(),
                     scans: vec![scan(face2.clone())],
@@ -3336,6 +3345,7 @@ mod tests {
         let face2 = vec![0.0, 1.0, 0.0];
         let novel = vec![0.0, 0.0, 1.0];
         let ir_scan = |v: Vec<f32>, space: Option<&str>| FaceScan {
+            id: String::new(),
             ir: Some(vec![0.5; 3]),
             ir_space: space.map(String::from),
             ..scan(v)
@@ -3343,6 +3353,7 @@ mod tests {
         let enr_with = |scans: Vec<FaceScan>| {
             let mut enr = Enrollment::new("u");
             enr.profiles.push(FaceProfile {
+                id: String::new(),
                 ir_calib: None,
                 name: "P1".into(),
                 scans,
@@ -3385,6 +3396,7 @@ mod tests {
         // Captures matching two different profiles: refused outright.
         let mut enr = enr_with(vec![ir_scan(face1.clone(), Some("adapter:deadbeef0123"))]);
         enr.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "P2".into(),
             scans: vec![ir_scan(face2.clone(), Some("adapter:deadbeef0123"))],
@@ -3517,9 +3529,11 @@ mod tests {
         let a = unit(vec![1.0, 0.0, 0.0, 0.0]);
         let b = unit(vec![0.0, 1.0, 0.0, 0.0]);
         let mk_prof = |name: &str, v: &[f32]| FaceProfile {
+            id: String::new(),
             name: name.into(),
             ir_calib: None,
             scans: vec![FaceScan {
+                id: String::new(),
                 name: "s".into(),
                 rgb: vec![0.0; 4],
                 ir: Some(v.to_vec()),
@@ -3868,6 +3882,7 @@ mod engine_tests {
 
     fn scan512(seed: usize, ir: bool, space: Option<&str>) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: format!("Face Scan {seed}"),
             rgb: unit512(seed),
             ir: ir.then(|| unit512(seed + 100)),
@@ -3917,6 +3932,7 @@ mod engine_tests {
         let mut s = shared();
         // Healthy paired 512-D scans in the current space: calibration fits.
         let mut prof = FaceProfile {
+            id: String::new(),
             name: "p".into(),
             ir_calib: None,
             scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
@@ -3926,10 +3942,12 @@ mod engine_tests {
         assert_eq!(calib.fitted_pairs, 5);
         // Wrong-dimension IR templates are quarantined: nothing to fit.
         let mut bad = FaceProfile {
+            id: String::new(),
             name: "bad".into(),
             ir_calib: None,
             scans: (0..5)
                 .map(|i| FaceScan {
+                    id: String::new(),
                     ir: Some(vec![0.1; 256]),
                     ..scan512(i, true, Some("raw"))
                 })
@@ -3939,6 +3957,7 @@ mod engine_tests {
         assert!(bad.ir_calib.is_none());
         // Foreign-space templates (stranded by an adapter change) are skipped.
         let mut foreign = FaceProfile {
+            id: String::new(),
             name: "foreign".into(),
             ir_calib: None,
             scans: (0..5)
@@ -3959,6 +3978,7 @@ mod engine_tests {
             "adapter mode must not refit"
         );
         let mut fresh = FaceProfile {
+            id: String::new(),
             name: "fresh".into(),
             ir_calib: None,
             scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
@@ -4021,6 +4041,7 @@ mod engine_tests {
         // Enrolled but with zero scans.
         let mut e = Enrollment::new("irlume-test-empty");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![],
             ir_calib: None,
@@ -4033,6 +4054,7 @@ mod engine_tests {
         // Camera binding mismatch: anti-swap refusal before any capture.
         let mut e = Enrollment::new("irlume-test-bound");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4054,6 +4076,7 @@ mod engine_tests {
         // on the nonexistent device (never a silent grant/deny).
         let mut e = Enrollment::new("irlume-test-cam");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4342,6 +4365,7 @@ mod engine_tests {
         // Duplicate explicit profile name fails BEFORE the camera opens.
         let mut e = Enrollment::new("irlume-test-enroll");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "Work Laptop".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4372,6 +4396,7 @@ mod engine_tests {
         // Known user, unknown profile.
         let mut e = Enrollment::new("irlume-test-add");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4382,6 +4407,7 @@ mod engine_tests {
         // Full profile: refused before any capture.
         let mut e = Enrollment::new("irlume-test-full");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: (0..irlume_core::storage::MAX_SCANS_PER_PROFILE)
                 .map(|i| scan512(i, false, None))
@@ -4533,6 +4559,7 @@ mod engine_tests {
                 camera_binding: None,
                 closure_calibration: None,
                 profiles: vec![FaceProfile {
+                    id: String::new(),
                     ir_calib: None,
                     name: "Face Profile 1".into(),
                     scans: vec![scan512(1, false, None)],

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -5172,8 +5172,10 @@ mod tests {
 
     fn profile(name: &str, scans: &[&str]) -> ProfileSummary {
         ProfileSummary {
+            id: String::new(),
             name: name.into(),
             scans: scans.iter().map(|s| s.to_string()).collect(),
+            scan_ids: Vec::new(),
         }
     }
 
@@ -5460,8 +5462,10 @@ mod tests {
         app.daemon_up = true; // skip the daemon gate; the cap check is next
         app.profiles = (0..MAX_PROFILES)
             .map(|i| ProfileSummary {
+                id: String::new(),
                 name: format!("p{i}"),
                 scans: Vec::new(),
+                scan_ids: Vec::new(),
             })
             .collect();
         app.begin_enroll();

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1211,8 +1211,10 @@ fn profiles_listing_renders_profiles_and_toggle_state() {
     serve(&sock(&sb), |req| match req {
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: vec![ProfileSummary {
+                id: String::new(),
                 name: "Face Profile 1".into(),
                 scans: vec!["Scan 1".into(), "Glasses".into()],
+                scan_ids: Vec::new(),
             }],
             require_eyes_open: true,
             require_challenge: false,
@@ -1354,8 +1356,10 @@ fn status_renders_the_full_dashboard_from_daemon_answers() {
         Request::Ping => Response::Pong,
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: vec![ProfileSummary {
+                id: String::new(),
                 name: "Face Profile 1".into(),
                 scans: vec!["Scan 1".into(), "Scan 2".into()],
+                scan_ids: Vec::new(),
             }],
             require_eyes_open: false,
             require_challenge: true,

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -197,8 +197,10 @@ fn serve(sock: &Path, respond: impl Fn(&Request) -> Response + Send + 'static) {
 
 fn one_profile() -> Vec<ProfileSummary> {
     vec![ProfileSummary {
+        id: String::new(),
         name: "Face Profile 1".into(),
         scans: vec!["Scan 1".into(), "Scan 2".into()],
+        scan_ids: Vec::new(),
     }]
 }
 

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -366,8 +366,16 @@ pub enum SelfTestKind {
 /// A profile and the names of its scans, for `ListProfiles`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileSummary {
+    /// Stable opaque profile identifier. Empty when talking to a daemon that
+    /// predates record IDs.
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub scans: Vec<String>,
+    /// Stable opaque IDs corresponding positionally to [`Self::scans`]. Empty
+    /// when talking to an older daemon.
+    #[serde(default)]
+    pub scan_ids: Vec<String>,
 }
 
 /// Framing-guide sample for guided enrollment; no raw image, safe to poll. The
@@ -758,6 +766,14 @@ mod tests {
             }
             other => panic!("expected Health, got {other:?}"),
         }
+        // Profile summaries from a daemon predating opaque record IDs still
+        // deserialize; the new fields default empty so callers can fail closed
+        // for mutation while retaining the human read-only listing.
+        let p: ProfileSummary =
+            serde_json::from_str(r#"{"name":"Face Profile 1","scans":["Face Scan 1"]}"#).unwrap();
+        assert!(p.id.is_empty());
+        assert!(p.scan_ids.is_empty());
+        assert_eq!(p.scans, vec!["Face Scan 1"]);
     }
 
     #[test]

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -9,7 +9,9 @@
 
 use crate::{crypto, template_key};
 use base64::{engine::general_purpose::STANDARD, Engine};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::PathBuf;
 use zeroize::Zeroizing;
@@ -39,6 +41,13 @@ pub const IMPROVE_SCANS: usize = 5;
 /// AuraFace embedding; `ir` is the IR-face embedding for dark operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FaceScan {
+    /// Stable opaque identifier for machine-facing operations. It is random,
+    /// carries no biometric or user information, and does not change on rename.
+    /// Empty only while loading enrollments written before IDs were introduced;
+    /// [`Enrollment::ensure_record_ids`] backfills it before the value escapes
+    /// the storage boundary.
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub rgb: Vec<f32>,
     #[serde(default)]
@@ -70,6 +79,10 @@ pub struct FaceScan {
 /// A face profile: a named set of scans of one face.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FaceProfile {
+    /// Stable opaque identifier for machine-facing operations. See
+    /// [`FaceScan::id`].
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub scans: Vec<FaceScan>,
     /// Per-profile IR calibration (ADR-0004), fitted from this profile's own
@@ -130,6 +143,33 @@ impl Enrollment {
             camera_binding: None,
             closure_calibration: None,
         }
+    }
+
+    /// Backfill stable opaque IDs for enrollments written by older versions.
+    ///
+    /// Existing valid unique IDs are preserved byte-for-byte. Empty, malformed,
+    /// or duplicate IDs are replaced. Returns the number of repaired records so
+    /// callers can persist a migration when appropriate.
+    pub fn ensure_record_ids(&mut self) -> usize {
+        let mut repaired = 0;
+        let user = self.user.clone();
+        let mut profile_ids = std::collections::HashSet::new();
+        let mut scan_ids = std::collections::HashSet::new();
+        for (profile_index, profile) in self.profiles.iter_mut().enumerate() {
+            if !valid_record_id(&profile.id, "profile") || !profile_ids.insert(profile.id.clone()) {
+                profile.id = legacy_record_id("profile", &user, profile_index, None);
+                profile_ids.insert(profile.id.clone());
+                repaired += 1;
+            }
+            for (scan_index, scan) in profile.scans.iter_mut().enumerate() {
+                if !valid_record_id(&scan.id, "scan") || !scan_ids.insert(scan.id.clone()) {
+                    scan.id = legacy_record_id("scan", &user, profile_index, Some(scan_index));
+                    scan_ids.insert(scan.id.clone());
+                    repaired += 1;
+                }
+            }
+        }
+        repaired
     }
 
     /// Total scans across all profiles (drives threshold scaling).
@@ -293,6 +333,73 @@ impl Enrollment {
     }
 }
 
+/// Mint a random stable identifier for a face profile.
+pub fn new_profile_id() -> String {
+    new_record_id("profile")
+}
+
+/// Mint a random stable identifier for a face scan.
+pub fn new_scan_id() -> String {
+    new_record_id("scan")
+}
+
+/// Mint a random 128-bit identifier with a type prefix. The alphabet matches
+/// the public CLI's safe opaque-ID grammar and remains comfortably below its
+/// length bound.
+fn new_record_id(kind: &str) -> String {
+    let mut random = [0u8; 16];
+    rand::rng().fill_bytes(&mut random);
+    let mut id = String::with_capacity(kind.len() + 1 + random.len() * 2);
+    id.push_str(kind);
+    id.push('-');
+    for byte in random {
+        use std::fmt::Write;
+        write!(id, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    id
+}
+
+fn valid_record_id(id: &str, kind: &str) -> bool {
+    let Some(hex) = id
+        .strip_prefix(kind)
+        .and_then(|rest| rest.strip_prefix('-'))
+    else {
+        return false;
+    };
+    hex.len() == 32 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Stable migration ID for records that predate stored random IDs. It uses only
+/// the enrollment owner and record ordinals, never names or biometric data.
+/// The first ID-aware mutation persists these values, so later deletes or
+/// reordering cannot change them.
+fn legacy_record_id(
+    kind: &str,
+    user: &str,
+    profile_index: usize,
+    scan_index: Option<usize>,
+) -> String {
+    let mut hash = Sha256::new();
+    hash.update(b"irlume-record-id-v1\0");
+    hash.update(kind.as_bytes());
+    hash.update(b"\0");
+    hash.update(user.as_bytes());
+    hash.update(b"\0");
+    hash.update(profile_index.to_le_bytes());
+    if let Some(index) = scan_index {
+        hash.update(index.to_le_bytes());
+    }
+    let digest = hash.finalize();
+    let mut id = String::with_capacity(kind.len() + 1 + 32);
+    id.push_str(kind);
+    id.push('-');
+    for byte in &digest[..16] {
+        use std::fmt::Write;
+        write!(id, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    id
+}
+
 impl FaceProfile {
     /// Default name for the next scan ("Face Scan N", first free slot).
     pub fn next_scan_name(&self) -> String {
@@ -321,11 +428,13 @@ struct LegacyProfile {
 }
 
 fn migrate(old: LegacyProfile) -> Enrollment {
+    let user = old.user;
     let scans = old
         .templates
         .iter()
         .enumerate()
         .map(|(i, t)| FaceScan {
+            id: legacy_record_id("scan", &user, 0, Some(i)),
             name: format!("Face Scan {}", i + 1),
             rgb: t.clone(),
             ir: old.ir_templates.get(i).cloned(),
@@ -337,8 +446,9 @@ fn migrate(old: LegacyProfile) -> Enrollment {
         })
         .collect();
     Enrollment {
-        user: old.user,
+        user: user.clone(),
         profiles: vec![FaceProfile {
+            id: legacy_record_id("profile", &user, 0, None),
             ir_calib: None,
             name: "Face Profile 1".into(),
             scans,
@@ -409,7 +519,7 @@ fn serialize_enrollment(e: &Enrollment, key: Option<&[u8]>) -> irlume_common::Re
 fn deserialize_enrollment(data: &[u8], key: Option<&[u8]>) -> irlume_common::Result<Enrollment> {
     let v: serde_json::Value =
         serde_json::from_slice(data).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
-    if v.get("enc").is_some() {
+    let mut enrollment = if v.get("enc").is_some() {
         let env: EncEnvelope =
             serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
         let key = key.ok_or_else(|| {
@@ -421,14 +531,16 @@ fn deserialize_enrollment(data: &[u8], key: Option<&[u8]>) -> irlume_common::Res
             .decode(env.enc.as_bytes())
             .map_err(|e| irlume_common::Error::Protocol(format!("bad enc blob: {e}")))?;
         let plain = crypto::decrypt(key, &blob)?;
-        serde_json::from_slice(&plain).map_err(|e| irlume_common::Error::Protocol(e.to_string()))
+        serde_json::from_slice(&plain).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?
     } else if v.get("profiles").is_some() {
-        serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))
+        serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?
     } else {
         let old: LegacyProfile =
             serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
-        Ok(migrate(old))
-    }
+        migrate(old)
+    };
+    enrollment.ensure_record_ids();
+    Ok(enrollment)
 }
 
 /// Resolve the key to encrypt `user`'s templates with: the TPM-sealed template
@@ -540,9 +652,11 @@ mod tests {
         Enrollment {
             user: "u".into(),
             profiles: vec![FaceProfile {
+                id: String::new(),
                 ir_calib: None,
                 name: "Face Profile 1".into(),
                 scans: vec![FaceScan {
+                    id: String::new(),
                     name: "Face Scan 1".into(),
                     rgb: vec![0.1, 0.2, 0.3, 0.4],
                     ir: Some(vec![0.5, 0.6]),
@@ -594,6 +708,7 @@ mod tests {
 
     fn scan_with_ir(ratio: f32, bright: f32) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: "s".into(),
             rgb: vec![0.1; 4],
             ir: Some(vec![0.2; 4]),
@@ -606,6 +721,7 @@ mod tests {
 
     fn scan_with_pitch(pitch: f32) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: "s".into(),
             rgb: vec![0.1; 4],
             ir: None,
@@ -621,6 +737,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         // One calibrated scan -> not enough.
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![scan_with_pitch(0.60)],
@@ -640,6 +757,7 @@ mod tests {
         // One IR scan -> not enough to characterise the user's rig.
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![scan_with_ir(1.5, 100.0)],
@@ -655,6 +773,7 @@ mod tests {
 
     fn scan_in_space(name: &str, dim: usize, space: Option<&str>) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: name.into(),
             rgb: vec![0.1; 4],
             ir: Some(vec![0.2; dim]),
@@ -669,6 +788,7 @@ mod tests {
     fn ir_scans_for_filters_space_and_dimension() {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![
@@ -698,6 +818,7 @@ mod tests {
     fn retag_untagged_ir_stamps_only_matching_legacy_scans() {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![
@@ -722,8 +843,104 @@ mod tests {
         // Enrollments written before space tagging must load unchanged.
         let json = r#"{"name":"s","rgb":[0.1],"ir":[0.2]}"#;
         let s: FaceScan = serde_json::from_str(json).unwrap();
+        assert!(s.id.is_empty());
         assert!(s.ir_space.is_none());
         assert_eq!(s.ir.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn legacy_records_get_stable_opaque_ids_without_biometric_input() {
+        let json = br#"{
+            "user":"alice",
+            "profiles":[{
+                "name":"Renamable profile",
+                "scans":[
+                    {"name":"First scan","rgb":[0.1,0.2]},
+                    {"name":"Second scan","rgb":[0.9,0.8]}
+                ]
+            }]
+        }"#;
+        let first = deserialize_enrollment(json, None).unwrap();
+        let second = deserialize_enrollment(json, None).unwrap();
+
+        assert_eq!(first.profiles[0].id, second.profiles[0].id);
+        assert_eq!(
+            first.profiles[0].scans[0].id,
+            second.profiles[0].scans[0].id
+        );
+        assert_ne!(first.profiles[0].scans[0].id, first.profiles[0].scans[1].id);
+        assert!(valid_record_id(&first.profiles[0].id, "profile"));
+        assert!(first.profiles[0]
+            .scans
+            .iter()
+            .all(|scan| valid_record_id(&scan.id, "scan")));
+
+        // Names and embeddings are deliberately absent from the migration ID:
+        // changing either cannot silently change a record's public identity.
+        let renamed = br#"{
+            "user":"alice",
+            "profiles":[{
+                "name":"Different display name",
+                "scans":[
+                    {"name":"Renamed scan","rgb":[0.7,0.6]},
+                    {"name":"Other renamed scan","rgb":[0.4,0.3]}
+                ]
+            }]
+        }"#;
+        let renamed = deserialize_enrollment(renamed, None).unwrap();
+        assert_eq!(first.profiles[0].id, renamed.profiles[0].id);
+        assert_eq!(
+            first.profiles[0].scans[0].id,
+            renamed.profiles[0].scans[0].id
+        );
+    }
+
+    #[test]
+    fn stored_ids_survive_rename_and_round_trip() {
+        let mut enrollment = sample();
+        assert_eq!(enrollment.ensure_record_ids(), 2);
+        let profile_id = enrollment.profiles[0].id.clone();
+        let scan_id = enrollment.profiles[0].scans[0].id.clone();
+        enrollment.profiles[0].name = "Renamed profile".into();
+        enrollment.profiles[0].scans[0].name = "Renamed scan".into();
+
+        let bytes = serialize_enrollment(&enrollment, None).unwrap();
+        let mut loaded = deserialize_enrollment(&bytes, None).unwrap();
+        assert_eq!(loaded.profiles[0].id, profile_id);
+        assert_eq!(loaded.profiles[0].scans[0].id, scan_id);
+        assert_eq!(loaded.ensure_record_ids(), 0);
+    }
+
+    #[test]
+    fn malformed_and_duplicate_ids_are_repaired_deterministically() {
+        let mut enrollment = sample();
+        enrollment.profiles.push(enrollment.profiles[0].clone());
+        enrollment.profiles[0].id = "not-an-id".into();
+        enrollment.profiles[1].id = "not-an-id".into();
+        enrollment.profiles[0].scans[0].id = "scan-00000000000000000000000000000000".into();
+        enrollment.profiles[1].scans[0].id = "scan-00000000000000000000000000000000".into();
+
+        assert_eq!(enrollment.ensure_record_ids(), 3);
+        assert_ne!(enrollment.profiles[0].id, enrollment.profiles[1].id);
+        assert_ne!(
+            enrollment.profiles[0].scans[0].id,
+            enrollment.profiles[1].scans[0].id
+        );
+        assert_eq!(enrollment.ensure_record_ids(), 0);
+    }
+
+    #[test]
+    fn fresh_record_ids_are_typed_unique_and_machine_safe() {
+        let profile_a = new_record_id("profile");
+        let profile_b = new_record_id("profile");
+        let scan = new_record_id("scan");
+        assert!(valid_record_id(&profile_a, "profile"));
+        assert!(valid_record_id(&profile_b, "profile"));
+        assert!(valid_record_id(&scan, "scan"));
+        assert_ne!(profile_a, profile_b);
+        assert!(profile_a
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-'));
     }
 
     #[test]
@@ -731,10 +948,12 @@ mod tests {
         // RGB-only scans (no IR) must not count toward the floor.
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![
                 FaceScan {
+                    id: String::new(),
                     name: "a".into(),
                     rgb: vec![0.1; 4],
                     ir: None,
@@ -754,6 +973,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         assert_eq!(e.next_profile_name(), "Face Profile 1");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "Face Profile 1".into(),
             scans: vec![],
@@ -846,6 +1066,7 @@ mod tests {
     #[test]
     fn stale_and_usable_ir_counts_partition_the_scans() {
         let ir_scan = |name: &str, space: Option<&str>| FaceScan {
+            id: String::new(),
             name: name.into(),
             rgb: vec![0.0; 4],
             ir: Some(vec![0.0; 4]),
@@ -856,6 +1077,7 @@ mod tests {
         };
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "P".into(),
             scans: vec![
@@ -873,6 +1095,7 @@ mod tests {
         assert_eq!(e.usable_ir_scans("raw"), 0);
         // An RGB-only scan (no ir) counts for neither side.
         e.profiles[0].scans.push(FaceScan {
+            id: String::new(),
             ir: None,
             ..ir_scan("rgb-only", None)
         });

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1361,8 +1361,10 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                         .profiles
                         .iter()
                         .map(|p| irlume_common::ProfileSummary {
+                            id: p.id.clone(),
                             name: p.name.clone(),
                             scans: p.scans.iter().map(|s| s.name.clone()).collect(),
+                            scan_ids: p.scans.iter().map(|s| s.id.clone()).collect(),
                         })
                         .collect(),
                     require_eyes_open: enr.require_eyes_open,
@@ -2728,6 +2730,7 @@ mod tests {
 
     fn rgb_scan(name: &str, seed: usize) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: name.into(),
             rgb: unit512(seed),
             ir: None,
@@ -2743,6 +2746,7 @@ mod tests {
         Enrollment {
             user: user.into(),
             profiles: vec![FaceProfile {
+                id: String::new(),
                 name: "Face Profile 1".into(),
                 ir_calib: None,
                 scans: scans
@@ -3026,6 +3030,12 @@ mod tests {
                     profiles[0].scans,
                     vec!["Face Scan 1".to_string(), "Face Scan 2".to_string()]
                 );
+                assert!(profiles[0].id.starts_with("profile-"));
+                assert_eq!(profiles[0].scan_ids.len(), profiles[0].scans.len());
+                assert!(profiles[0]
+                    .scan_ids
+                    .iter()
+                    .all(|id| id.starts_with("scan-")));
                 assert!(require_eyes_open);
                 assert!(!require_challenge);
             }


### PR DESCRIPTION
## What & why

Adds stable opaque identifiers to face profiles and scans as a prerequisite for the safe machine-facing profile mutations requested in #108 and proposed in #109.

- Fresh records receive random, type-prefixed 128-bit IDs.
- Legacy enrollments receive deterministic migration IDs derived from owner and record ordinals, never display names or biometric templates.
- Existing valid unique IDs survive rename and serialization; malformed or duplicate IDs are repaired deterministically.
- `ProfileSummary` exposes profile and positional scan IDs while retaining the existing `scans` field and defaulting new fields for old-daemon wire compatibility.
- No existing name-based CLI mutation behavior changes in this PR.

This PR is intentionally independent of #109 so the storage and daemon identity boundary can be reviewed on its own.

## Testing

Validated in a Fedora 44 container:

- `cargo test -p irlume-common` — 44 passed
- `cargo test -p irlume-core` — 98 passed, 20 hardware/fault-injection tests ignored
- `cargo test -p irlume-cli` — 272 passed, 12 model/camera tests ignored
- `cargo check --workspace --all-targets` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean

The full workspace model-backed daemon suite was not run locally because the ONNX assets are not present; upstream CI fetches those assets. No PAM, authentication decision, or capture behavior is changed.

- [ ] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs/CHANGELOG updated if user-facing
- [ ] Hardware-validated (if it touches PAM, the daemon, or capture)
