### PR TITLE
feat: expose opaque profile machine API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ All notable changes to irlume are documented here. This project adheres to
   exposes the IDs without breaking older clients. This is the storage boundary
   required for safe machine-facing rename, delete, and improve-recognition
   operations.
+- **Profile mutations can target opaque IDs and return typed results.** New
+  daemon requests add scans, rename profiles or scans, and delete profiles or
+  scans without resolving mutable display names in an untrusted client. Legacy
+  name-based requests remain wire-compatible for existing human CLI clients.
 
 - **`sudo irlume camera-tune` measures whether your camera can read both sensors
   at once.** Some Hello modules stop exposing their colour stream properly while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **Face profiles and scans now carry stable opaque IDs.** Fresh records receive
+  random 128-bit identifiers that survive display-name changes. Existing
+  enrollments are backfilled deterministically from user and record order,
+  never names or biometric templates, and the typed daemon profile summary
+  exposes the IDs without breaking older clients. This is the storage boundary
+  required for safe machine-facing rename, delete, and improve-recognition
+  operations.
+
 - **`sudo irlume camera-tune` measures whether your camera can read both sensors
   at once.** Some Hello modules stop exposing their colour stream properly while
   their infrared sibling is streaming. On a NexiGo HelloCam N930W the colour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ All notable changes to irlume are documented here. This project adheres to
   daemon requests add scans, rename profiles or scans, and delete profiles or
   scans without resolving mutable display names in an untrusted client. Legacy
   name-based requests remain wire-compatible for existing human CLI clients.
+- **Desktop integrations now have a small, versioned JSON foundation.**
+  `irlume version --json` advertises only implemented public capabilities, and
+  `irlume profiles list --json` exposes the existing read-only enrollment
+  summary without daemon prose or private socket access. The documented
+  contract keeps stdout machine-only, uses stable error codes, and deliberately
+  withholds mutation capabilities until the enrollment store owns opaque IDs.
 
 - **`sudo irlume camera-tune` measures whether your camera can read both sensors
   at once.** Some Hello modules stop exposing their colour stream properly while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,11 @@ All notable changes to irlume are documented here. This project adheres to
   `irlume version --json` advertises only implemented public capabilities, and
   `irlume profiles list --json` exposes the existing read-only enrollment
   summary without daemon prose or private socket access. The documented
-  contract keeps stdout machine-only, uses stable error codes, and deliberately
-  withholds mutation capabilities until the enrollment store owns opaque IDs.
+  contract keeps stdout machine-only and uses stable error codes.
+- **The public machine API now exposes opaque profile IDs and safe JSON
+  mutations.** Profile and scan rename/delete commands target IDs, validate
+  bounded inputs, and return typed before/after identity without exposing the
+  private daemon socket.
 
 - **`sudo irlume camera-tune` measures whether your camera can read both sensors
   at once.** Some Hello modules stop exposing their colour stream properly while

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ default IR-structure gate already rejects photos, screens, and video replays.
 |---|---|
 | **Install and set up**, guided or by hand | [`docs/SETUP.md`](docs/SETUP.md) |
 | Look up **every command and flag** | [`docs/COMMANDS.md`](docs/COMMANDS.md) |
+| Integrate through the versioned **machine API** | [`docs/MACHINE-API.md`](docs/MACHINE-API.md) |
 | Understand the **architecture** | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
 | Read the **threat model** and standards mapping | [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) · [`docs/STANDARDS.md`](docs/STANDARDS.md) |
 | **Verify the claims** on my own machine | [`docs/VERIFY.md`](docs/VERIFY.md) |

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2328,6 +2328,7 @@ impl Engine {
                 added_scans.push(sname.clone());
                 let ir_space = s.ir.as_ref().map(|_| self.ir_space.clone());
                 enr.profiles[idx].scans.push(FaceScan {
+                    id: storage::new_scan_id(),
                     name: sname,
                     rgb: s.rgb,
                     ir: s.ir,
@@ -2354,6 +2355,7 @@ impl Engine {
         }
         let name = profile_name.unwrap_or_else(|| enr.next_profile_name());
         let mut prof = FaceProfile {
+            id: storage::new_profile_id(),
             ir_calib: None,
             name: name.clone(),
             scans: Vec::new(),
@@ -2362,6 +2364,7 @@ impl Engine {
             let sname = prof.next_scan_name();
             let ir_space = s.ir.as_ref().map(|_| self.ir_space.clone());
             prof.scans.push(FaceScan {
+                id: storage::new_scan_id(),
                 name: sname,
                 rgb: s.rgb,
                 ir: s.ir,
@@ -2460,6 +2463,7 @@ impl Engine {
         let sname = enr.profiles[idx].next_scan_name();
         let ir_space = captured.ir.as_ref().map(|_| self.ir_space.clone());
         enr.profiles[idx].scans.push(FaceScan {
+            id: storage::new_scan_id(),
             name: sname.clone(),
             rgb: captured.rgb,
             ir: captured.ir,
@@ -3003,6 +3007,7 @@ mod tests {
             .iter()
             .zip(&rgb_rows)
             .map(|(ir, rgb)| FaceScan {
+                id: String::new(),
                 name: "s".into(),
                 rgb: rgb.clone(),
                 ir: Some(ir.clone()),
@@ -3016,6 +3021,7 @@ mod tests {
         let probe = mk(6, 0.4);
         (
             FaceProfile {
+                id: String::new(),
                 name: "p".into(),
                 scans,
                 ir_calib: calib,
@@ -3195,6 +3201,7 @@ mod tests {
 
     fn scan(v: Vec<f32>) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: "s".into(),
             rgb: v,
             ir: None,
@@ -3308,11 +3315,13 @@ mod tests {
             closure_calibration: None,
             profiles: vec![
                 FaceProfile {
+                    id: String::new(),
                     ir_calib: None,
                     name: "Face Profile 1".into(),
                     scans: vec![scan(face1.clone())],
                 },
                 FaceProfile {
+                    id: String::new(),
                     ir_calib: None,
                     name: "Face Profile 2".into(),
                     scans: vec![scan(face2.clone())],
@@ -3336,6 +3345,7 @@ mod tests {
         let face2 = vec![0.0, 1.0, 0.0];
         let novel = vec![0.0, 0.0, 1.0];
         let ir_scan = |v: Vec<f32>, space: Option<&str>| FaceScan {
+            id: String::new(),
             ir: Some(vec![0.5; 3]),
             ir_space: space.map(String::from),
             ..scan(v)
@@ -3343,6 +3353,7 @@ mod tests {
         let enr_with = |scans: Vec<FaceScan>| {
             let mut enr = Enrollment::new("u");
             enr.profiles.push(FaceProfile {
+                id: String::new(),
                 ir_calib: None,
                 name: "P1".into(),
                 scans,
@@ -3385,6 +3396,7 @@ mod tests {
         // Captures matching two different profiles: refused outright.
         let mut enr = enr_with(vec![ir_scan(face1.clone(), Some("adapter:deadbeef0123"))]);
         enr.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "P2".into(),
             scans: vec![ir_scan(face2.clone(), Some("adapter:deadbeef0123"))],
@@ -3517,9 +3529,11 @@ mod tests {
         let a = unit(vec![1.0, 0.0, 0.0, 0.0]);
         let b = unit(vec![0.0, 1.0, 0.0, 0.0]);
         let mk_prof = |name: &str, v: &[f32]| FaceProfile {
+            id: String::new(),
             name: name.into(),
             ir_calib: None,
             scans: vec![FaceScan {
+                id: String::new(),
                 name: "s".into(),
                 rgb: vec![0.0; 4],
                 ir: Some(v.to_vec()),
@@ -3868,6 +3882,7 @@ mod engine_tests {
 
     fn scan512(seed: usize, ir: bool, space: Option<&str>) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: format!("Face Scan {seed}"),
             rgb: unit512(seed),
             ir: ir.then(|| unit512(seed + 100)),
@@ -3917,6 +3932,7 @@ mod engine_tests {
         let mut s = shared();
         // Healthy paired 512-D scans in the current space: calibration fits.
         let mut prof = FaceProfile {
+            id: String::new(),
             name: "p".into(),
             ir_calib: None,
             scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
@@ -3926,10 +3942,12 @@ mod engine_tests {
         assert_eq!(calib.fitted_pairs, 5);
         // Wrong-dimension IR templates are quarantined: nothing to fit.
         let mut bad = FaceProfile {
+            id: String::new(),
             name: "bad".into(),
             ir_calib: None,
             scans: (0..5)
                 .map(|i| FaceScan {
+                    id: String::new(),
                     ir: Some(vec![0.1; 256]),
                     ..scan512(i, true, Some("raw"))
                 })
@@ -3939,6 +3957,7 @@ mod engine_tests {
         assert!(bad.ir_calib.is_none());
         // Foreign-space templates (stranded by an adapter change) are skipped.
         let mut foreign = FaceProfile {
+            id: String::new(),
             name: "foreign".into(),
             ir_calib: None,
             scans: (0..5)
@@ -3959,6 +3978,7 @@ mod engine_tests {
             "adapter mode must not refit"
         );
         let mut fresh = FaceProfile {
+            id: String::new(),
             name: "fresh".into(),
             ir_calib: None,
             scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
@@ -4021,6 +4041,7 @@ mod engine_tests {
         // Enrolled but with zero scans.
         let mut e = Enrollment::new("irlume-test-empty");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![],
             ir_calib: None,
@@ -4033,6 +4054,7 @@ mod engine_tests {
         // Camera binding mismatch: anti-swap refusal before any capture.
         let mut e = Enrollment::new("irlume-test-bound");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4054,6 +4076,7 @@ mod engine_tests {
         // on the nonexistent device (never a silent grant/deny).
         let mut e = Enrollment::new("irlume-test-cam");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4342,6 +4365,7 @@ mod engine_tests {
         // Duplicate explicit profile name fails BEFORE the camera opens.
         let mut e = Enrollment::new("irlume-test-enroll");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "Work Laptop".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4372,6 +4396,7 @@ mod engine_tests {
         // Known user, unknown profile.
         let mut e = Enrollment::new("irlume-test-add");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
@@ -4382,6 +4407,7 @@ mod engine_tests {
         // Full profile: refused before any capture.
         let mut e = Enrollment::new("irlume-test-full");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             name: "P1".into(),
             scans: (0..irlume_core::storage::MAX_SCANS_PER_PROFILE)
                 .map(|i| scan512(i, false, None))
@@ -4533,6 +4559,7 @@ mod engine_tests {
                 camera_binding: None,
                 closure_calibration: None,
                 profiles: vec![FaceProfile {
+                    id: String::new(),
                     ir_calib: None,
                     name: "Face Profile 1".into(),
                     scans: vec![scan512(1, false, None)],

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -7,14 +7,14 @@
 //! protocol. A capability is advertised only after its public command, output
 //! shape, and compatibility rules are covered here and in `docs/MACHINE-API.md`.
 
-use irlume_common::{ProfileSummary, Request, Response};
+use irlume_common::{ProfileMutationKind, ProfileSummary, Request, Response};
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::process::ExitCode;
 
 pub const CONTRACT_VERSION: u32 = 1;
 
-const CAPABILITIES: &[&str] = &["version-json", "profiles-list-json"];
+const CAPABILITIES: &[&str] = &["version-json", "profiles-json", "profile-mutations-json"];
 
 #[derive(Serialize)]
 struct Document {
@@ -82,7 +82,8 @@ pub fn version(args: &[String]) -> ExitCode {
             json!({
                 "capabilities": CAPABILITIES,
                 "limits": {
-                    "max_profiles": 3
+                    "max_profiles": 3,
+                    "max_scans_per_profile": 20
                 }
             }),
         ),
@@ -102,13 +103,10 @@ pub fn profiles_list(args: &[String]) -> ExitCode {
             require_eyes_open,
             require_challenge,
             ..
-        }) => emit(
-            &success(
-                COMMAND,
-                profiles_data(profiles, require_eyes_open, require_challenge),
-            ),
-            ExitCode::SUCCESS,
-        ),
+        }) => match profiles_data(profiles, require_eyes_open, require_challenge) {
+            Ok(data) => emit(&success(COMMAND, data), ExitCode::SUCCESS),
+            Err(code) => emit(&failure(COMMAND, code, false), ExitCode::FAILURE),
+        },
         Ok(Response::Error(_)) => emit(
             &failure(COMMAND, "operation-failed", false),
             ExitCode::FAILURE,
@@ -122,6 +120,202 @@ pub fn profiles_list(args: &[String]) -> ExitCode {
             ExitCode::FAILURE,
         ),
     }
+}
+
+pub fn profiles_delete(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "profiles.delete";
+    let Some(parsed) = parse_profile_mutation_args(args, false) else {
+        return emit(&failure(COMMAND, "usage-error", false), ExitCode::from(2));
+    };
+    let user = crate::user_arg(args);
+    let request = match parsed.scan_id {
+        Some(scan_id) => Request::DeleteScanById {
+            user,
+            profile_id: parsed.profile_id,
+            scan_id,
+        },
+        None => Request::DeleteProfileById {
+            user,
+            profile_id: parsed.profile_id,
+        },
+    };
+    emit_profile_mutation(COMMAND, request)
+}
+
+pub fn profiles_rename(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "profiles.rename";
+    let Some(parsed) = parse_profile_mutation_args(args, true) else {
+        return emit(&failure(COMMAND, "usage-error", false), ExitCode::from(2));
+    };
+    let user = crate::user_arg(args);
+    let new_name = parsed.new_name.expect("rename parser requires a name");
+    let request = match parsed.scan_id {
+        Some(scan_id) => Request::RenameScanById {
+            user,
+            profile_id: parsed.profile_id,
+            scan_id,
+            new_name,
+        },
+        None => Request::RenameProfileById {
+            user,
+            profile_id: parsed.profile_id,
+            new_name,
+        },
+    };
+    emit_profile_mutation(COMMAND, request)
+}
+
+fn emit_profile_mutation(command: &'static str, request: Request) -> ExitCode {
+    match crate::daemon_request(&request) {
+        Ok(Response::ProfileMutation {
+            operation,
+            profile_id,
+            profile_name_before,
+            profile_name_after,
+            scan_id,
+            scan_name_before,
+            scan_name_after,
+            total_scans,
+        }) => emit(
+            &success(
+                command,
+                mutation_data(
+                    operation,
+                    profile_id,
+                    profile_name_before,
+                    profile_name_after,
+                    scan_id,
+                    scan_name_before,
+                    scan_name_after,
+                    total_scans,
+                ),
+            ),
+            ExitCode::SUCCESS,
+        ),
+        Ok(Response::Error(_)) => emit(
+            &failure(command, "operation-failed", false),
+            ExitCode::FAILURE,
+        ),
+        Ok(_) => emit(
+            &failure(command, "protocol-error", false),
+            ExitCode::FAILURE,
+        ),
+        Err(_) => emit(
+            &failure(command, "daemon-unavailable", true),
+            ExitCode::FAILURE,
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mutation_data(
+    operation: ProfileMutationKind,
+    profile_id: String,
+    profile_name_before: Option<String>,
+    profile_name_after: Option<String>,
+    scan_id: Option<String>,
+    scan_name_before: Option<String>,
+    scan_name_after: Option<String>,
+    total_scans: Option<usize>,
+) -> Value {
+    let record = |profile_name: Option<String>, scan_name: Option<String>| {
+        profile_name.map(|profile_name| {
+            json!({
+                "profile_id": profile_id,
+                "profile_name": profile_name,
+                "scan_id": scan_id,
+                "scan_name": scan_name
+            })
+        })
+    };
+    let before = record(profile_name_before, scan_name_before);
+    let after = record(profile_name_after, scan_name_after);
+    let deleted = matches!(
+        operation,
+        ProfileMutationKind::DeleteProfile | ProfileMutationKind::DeleteScan
+    );
+    json!({
+        "operation": operation,
+        "profile_id": profile_id,
+        "scan_id": scan_id,
+        "before": before,
+        "after": after,
+        "total_scans": total_scans,
+        "deleted": deleted,
+        "mutated_other_profiles": false
+    })
+}
+
+struct MutationArgs {
+    profile_id: String,
+    scan_id: Option<String>,
+    new_name: Option<String>,
+}
+
+fn parse_profile_mutation_args(args: &[String], rename: bool) -> Option<MutationArgs> {
+    let expected_subcommand = if rename { "rename" } else { "delete" };
+    if args.first().map(String::as_str) != Some("profiles")
+        || args.get(1).map(String::as_str) != Some(expected_subcommand)
+    {
+        return None;
+    }
+    let mut profile_id = None;
+    let mut scan_id = None;
+    let mut new_name = None;
+    let mut saw_json = false;
+    let mut saw_user = false;
+    let mut index = 2;
+    while index < args.len() {
+        let (slot, validate_id): (&mut Option<String>, bool) = match args[index].as_str() {
+            "--profile-id" if profile_id.is_none() => (&mut profile_id, true),
+            "--scan-id" if scan_id.is_none() => (&mut scan_id, true),
+            "--name" if rename && new_name.is_none() => (&mut new_name, false),
+            "--user" if !saw_user => {
+                saw_user = true;
+                let user = args.get(index + 1)?;
+                if user.is_empty() || user.starts_with('-') {
+                    return None;
+                }
+                index += 2;
+                continue;
+            }
+            "--json" if !saw_json => {
+                saw_json = true;
+                index += 1;
+                continue;
+            }
+            _ => return None,
+        };
+        let value = args.get(index + 1)?;
+        if value.is_empty() || value.starts_with('-') {
+            return None;
+        }
+        if validate_id {
+            let valid = if args[index] == "--profile-id" {
+                irlume_core::storage::valid_profile_id(value)
+            } else {
+                irlume_core::storage::valid_scan_id(value)
+            };
+            if !valid {
+                return None;
+            }
+        } else if value.trim() != value
+            || value.chars().count() > 80
+            || value.chars().any(char::is_control)
+        {
+            return None;
+        }
+        *slot = Some(value.clone());
+        index += 2;
+    }
+    if !saw_json || profile_id.is_none() || rename != new_name.is_some() {
+        return None;
+    }
+    Some(MutationArgs {
+        profile_id: profile_id.expect("checked"),
+        scan_id,
+        new_name,
+    })
 }
 
 fn valid_profiles_list_args(args: &[String]) -> bool {
@@ -159,26 +353,35 @@ fn profiles_data(
     profiles: Vec<ProfileSummary>,
     require_eyes_open: bool,
     require_challenge: bool,
-) -> Value {
-    // The current enrollment store identifies profiles and scans by their
-    // names. Do not falsely present those names as opaque stable IDs. A later
-    // contract capability can add mutation-safe IDs after the store owns them.
-    let profiles = profiles
-        .into_iter()
-        .map(|profile| {
-            json!({
-                "display_name": profile.name,
-                "scans": profile.scans.into_iter().map(|name| {
-                    json!({ "display_name": name })
-                }).collect::<Vec<_>>()
-            })
-        })
-        .collect::<Vec<_>>();
-    json!({
-        "profiles": profiles,
+) -> Result<Value, &'static str> {
+    let mut output = Vec::with_capacity(profiles.len());
+    for profile in profiles {
+        if !irlume_core::storage::valid_profile_id(&profile.id)
+            || profile.scans.len() != profile.scan_ids.len()
+        {
+            return Err("unsupported-daemon");
+        }
+        let mut scans = Vec::with_capacity(profile.scans.len());
+        for (name, id) in profile.scans.into_iter().zip(profile.scan_ids) {
+            if !irlume_core::storage::valid_scan_id(&id) {
+                return Err("unsupported-daemon");
+            }
+            scans.push(json!({
+                "scan_id": id,
+                "display_name": name
+            }));
+        }
+        output.push(json!({
+            "profile_id": profile.id,
+            "display_name": profile.name,
+            "scans": scans
+        }));
+    }
+    Ok(json!({
+        "profiles": output,
         "require_eyes_open": require_eyes_open,
         "require_challenge": require_challenge
-    })
+    }))
 }
 
 #[cfg(test)]
@@ -201,28 +404,107 @@ mod tests {
         assert_eq!(document["ok"], true);
         assert_eq!(
             document["data"]["capabilities"],
-            json!(["version-json", "profiles-list-json"])
+            json!(["version-json", "profiles-json", "profile-mutations-json"])
         );
         assert!(document.get("error").is_none());
     }
 
     #[test]
-    fn profile_listing_does_not_claim_unimplemented_opaque_ids() {
+    fn profile_listing_exposes_stored_opaque_ids() {
         let data = profiles_data(
             vec![ProfileSummary {
+                id: "profile-0123456789abcdef0123456789abcdef".into(),
                 name: "Face Profile 1".into(),
                 scans: vec!["Scan 1".into()],
+                scan_ids: vec!["scan-fedcba9876543210fedcba9876543210".into()],
             }],
             true,
             false,
-        );
+        )
+        .unwrap();
 
+        assert_eq!(
+            data["profiles"][0]["profile_id"],
+            "profile-0123456789abcdef0123456789abcdef"
+        );
         assert_eq!(data["profiles"][0]["display_name"], "Face Profile 1");
         assert_eq!(data["profiles"][0]["scans"][0]["display_name"], "Scan 1");
-        assert!(data["profiles"][0].get("profile_id").is_none());
-        assert!(data["profiles"][0]["scans"][0].get("scan_id").is_none());
+        assert_eq!(
+            data["profiles"][0]["scans"][0]["scan_id"],
+            "scan-fedcba9876543210fedcba9876543210"
+        );
         assert_eq!(data["require_eyes_open"], true);
         assert_eq!(data["require_challenge"], false);
+    }
+
+    #[test]
+    fn profile_listing_refuses_missing_or_misaligned_ids() {
+        let profile = |scan_ids| ProfileSummary {
+            id: "profile-0123456789abcdef0123456789abcdef".into(),
+            name: "Primary".into(),
+            scans: vec!["Scan 1".into()],
+            scan_ids,
+        };
+        assert_eq!(
+            profiles_data(vec![profile(vec![])], false, false).unwrap_err(),
+            "unsupported-daemon"
+        );
+        let mut missing = profile(vec!["scan-fedcba9876543210fedcba9876543210".into()]);
+        missing.id.clear();
+        assert_eq!(
+            profiles_data(vec![missing], false, false).unwrap_err(),
+            "unsupported-daemon"
+        );
+    }
+
+    #[test]
+    fn mutation_args_require_safe_ids_json_and_bounded_names() {
+        let args = |values: &[&str]| {
+            values
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+        };
+        let profile = "profile-0123456789abcdef0123456789abcdef";
+        let scan = "scan-fedcba9876543210fedcba9876543210";
+        assert!(parse_profile_mutation_args(
+            &args(&[
+                "profiles",
+                "rename",
+                "--profile-id",
+                profile,
+                "--scan-id",
+                scan,
+                "--name",
+                "Glasses",
+                "--json"
+            ]),
+            true
+        )
+        .is_some());
+        assert!(parse_profile_mutation_args(
+            &args(&["profiles", "delete", "--profile-id", profile, "--json"]),
+            false
+        )
+        .is_some());
+        assert!(parse_profile_mutation_args(
+            &args(&["profiles", "delete", "--profile-id", "../unsafe", "--json"]),
+            false
+        )
+        .is_none());
+        assert!(parse_profile_mutation_args(
+            &args(&[
+                "profiles",
+                "rename",
+                "--profile-id",
+                profile,
+                "--name",
+                " padded ",
+                "--json"
+            ]),
+            true
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Public, versioned machine output for desktop integrations.
+//!
+//! Keep this module deliberately narrower than the daemon's private wire
+//! protocol. A capability is advertised only after its public command, output
+//! shape, and compatibility rules are covered here and in `docs/MACHINE-API.md`.
+
+use irlume_common::{ProfileSummary, Request, Response};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::process::ExitCode;
+
+pub const CONTRACT_VERSION: u32 = 1;
+
+const CAPABILITIES: &[&str] = &["version-json", "profiles-list-json"];
+
+#[derive(Serialize)]
+struct Document {
+    contract_version: u32,
+    engine_version: &'static str,
+    command: &'static str,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<MachineError>,
+}
+
+#[derive(Serialize)]
+struct MachineError {
+    code: &'static str,
+    retryable: bool,
+}
+
+fn success(command: &'static str, data: Value) -> Document {
+    Document {
+        contract_version: CONTRACT_VERSION,
+        engine_version: env!("CARGO_PKG_VERSION"),
+        command,
+        ok: true,
+        data: Some(data),
+        error: None,
+    }
+}
+
+fn failure(command: &'static str, code: &'static str, retryable: bool) -> Document {
+    Document {
+        contract_version: CONTRACT_VERSION,
+        engine_version: env!("CARGO_PKG_VERSION"),
+        command,
+        ok: false,
+        data: None,
+        error: Some(MachineError { code, retryable }),
+    }
+}
+
+fn emit(document: &Document, exit: ExitCode) -> ExitCode {
+    // Serialization only contains compile-time strings and serde_json values,
+    // so failure would be a programming error. Keep stdout machine-only even
+    // in that case and report the detail on stderr.
+    match serde_json::to_string(document) {
+        Ok(line) => {
+            println!("{line}");
+            exit
+        }
+        Err(error) => {
+            eprintln!("irlume machine output serialization failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+pub fn version(args: &[String]) -> ExitCode {
+    if args != ["version", "--json"] {
+        return emit(&failure("version", "usage-error", false), ExitCode::from(2));
+    }
+    emit(
+        &success(
+            "version",
+            json!({
+                "capabilities": CAPABILITIES,
+                "limits": {
+                    "max_profiles": 3
+                }
+            }),
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
+pub fn profiles_list(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "profiles.list";
+    if !valid_profiles_list_args(args) {
+        return emit(&failure(COMMAND, "usage-error", false), ExitCode::from(2));
+    }
+    let user = crate::user_arg(args);
+    match crate::daemon_request(&Request::ListProfiles { user }) {
+        Ok(Response::Enrollment {
+            profiles,
+            require_eyes_open,
+            require_challenge,
+            ..
+        }) => emit(
+            &success(
+                COMMAND,
+                profiles_data(profiles, require_eyes_open, require_challenge),
+            ),
+            ExitCode::SUCCESS,
+        ),
+        Ok(Response::Error(_)) => emit(
+            &failure(COMMAND, "operation-failed", false),
+            ExitCode::FAILURE,
+        ),
+        Ok(_) => emit(
+            &failure(COMMAND, "protocol-error", false),
+            ExitCode::FAILURE,
+        ),
+        Err(_) => emit(
+            &failure(COMMAND, "daemon-unavailable", true),
+            ExitCode::FAILURE,
+        ),
+    }
+}
+
+fn valid_profiles_list_args(args: &[String]) -> bool {
+    if args.first().map(String::as_str) != Some("profiles")
+        || args.get(1).map(String::as_str) != Some("list")
+    {
+        return false;
+    }
+    let mut saw_json = false;
+    let mut saw_user = false;
+    let mut index = 2;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" if !saw_json => {
+                saw_json = true;
+                index += 1;
+            }
+            "--user" if !saw_user => {
+                saw_user = true;
+                let Some(user) = args.get(index + 1) else {
+                    return false;
+                };
+                if user.is_empty() || user.starts_with('-') {
+                    return false;
+                }
+                index += 2;
+            }
+            _ => return false,
+        }
+    }
+    saw_json
+}
+
+fn profiles_data(
+    profiles: Vec<ProfileSummary>,
+    require_eyes_open: bool,
+    require_challenge: bool,
+) -> Value {
+    // The current enrollment store identifies profiles and scans by their
+    // names. Do not falsely present those names as opaque stable IDs. A later
+    // contract capability can add mutation-safe IDs after the store owns them.
+    let profiles = profiles
+        .into_iter()
+        .map(|profile| {
+            json!({
+                "display_name": profile.name,
+                "scans": profile.scans.into_iter().map(|name| {
+                    json!({ "display_name": name })
+                }).collect::<Vec<_>>()
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "profiles": profiles,
+        "require_eyes_open": require_eyes_open,
+        "require_challenge": require_challenge
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_freezes_the_public_envelope_and_capabilities() {
+        let document = serde_json::to_value(success(
+            "version",
+            json!({
+                "capabilities": CAPABILITIES,
+                "limits": { "max_profiles": 3 }
+            }),
+        ))
+        .unwrap();
+
+        assert_eq!(document["contract_version"], 1);
+        assert_eq!(document["command"], "version");
+        assert_eq!(document["ok"], true);
+        assert_eq!(
+            document["data"]["capabilities"],
+            json!(["version-json", "profiles-list-json"])
+        );
+        assert!(document.get("error").is_none());
+    }
+
+    #[test]
+    fn profile_listing_does_not_claim_unimplemented_opaque_ids() {
+        let data = profiles_data(
+            vec![ProfileSummary {
+                name: "Face Profile 1".into(),
+                scans: vec!["Scan 1".into()],
+            }],
+            true,
+            false,
+        );
+
+        assert_eq!(data["profiles"][0]["display_name"], "Face Profile 1");
+        assert_eq!(data["profiles"][0]["scans"][0]["display_name"], "Scan 1");
+        assert!(data["profiles"][0].get("profile_id").is_none());
+        assert!(data["profiles"][0]["scans"][0].get("scan_id").is_none());
+        assert_eq!(data["require_eyes_open"], true);
+        assert_eq!(data["require_challenge"], false);
+    }
+
+    #[test]
+    fn errors_have_stable_codes_without_daemon_prose() {
+        let document =
+            serde_json::to_value(failure("profiles.list", "daemon-unavailable", true)).unwrap();
+
+        assert_eq!(document["ok"], false);
+        assert_eq!(document["error"]["code"], "daemon-unavailable");
+        assert_eq!(document["error"]["retryable"], true);
+        assert!(document.get("data").is_none());
+    }
+
+    #[test]
+    fn profiles_list_rejects_unknown_missing_and_duplicate_flags() {
+        let args = |values: &[&str]| {
+            values
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+        };
+        assert!(valid_profiles_list_args(&args(&[
+            "profiles", "list", "--json"
+        ])));
+        assert!(valid_profiles_list_args(&args(&[
+            "profiles", "list", "--user", "alice", "--json"
+        ])));
+        assert!(!valid_profiles_list_args(&args(&["profiles", "list"])));
+        assert!(!valid_profiles_list_args(&args(&[
+            "profiles",
+            "list",
+            "--json",
+            "--verbose"
+        ])));
+        assert!(!valid_profiles_list_args(&args(&[
+            "profiles", "list", "--json", "--json"
+        ])));
+        assert!(!valid_profiles_list_args(&args(&[
+            "profiles", "list", "--json", "--user"
+        ])));
+    }
+}

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -25,6 +25,7 @@ mod blinkcap;
 mod commands;
 mod fingerprint;
 mod logs;
+mod machine;
 mod models;
 mod pad;
 mod pamwire;
@@ -105,6 +106,9 @@ fn main() -> std::process::ExitCode {
         (Some("liveness"), _) => liveness_probe(&args),
         (Some("meshprobe"), _) => meshprobe(&args),
         (Some("enroll"), _) => enroll(&args),
+        (Some("profiles"), Some("list")) if args.iter().any(|arg| arg == "--json") => {
+            machine::profiles_list(&args)
+        }
         (Some("profiles"), sub) => profiles(sub, &args),
         (Some("verify"), _) => verify(&args),
         (Some("enrolldev"), _) => enrolldev(&args),
@@ -125,6 +129,7 @@ fn main() -> std::process::ExitCode {
         (Some("set-cameras"), _) => set_cameras(&args),
         (Some("update"), _) => commands::update(&args),
         (Some("uninstall"), _) => uninstall::run(&args),
+        (Some("version"), _) if args.iter().any(|arg| arg == "--json") => machine::version(&args),
         (Some("version"), _) | (Some("--version"), _) | (Some("-V"), _) => {
             println!("irlume {}", env!("CARGO_PKG_VERSION"));
             std::process::ExitCode::SUCCESS

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -109,6 +109,12 @@ fn main() -> std::process::ExitCode {
         (Some("profiles"), Some("list")) if args.iter().any(|arg| arg == "--json") => {
             machine::profiles_list(&args)
         }
+        (Some("profiles"), Some("delete")) if args.iter().any(|arg| arg == "--json") => {
+            machine::profiles_delete(&args)
+        }
+        (Some("profiles"), Some("rename")) if args.iter().any(|arg| arg == "--json") => {
+            machine::profiles_rename(&args)
+        }
         (Some("profiles"), sub) => profiles(sub, &args),
         (Some("verify"), _) => verify(&args),
         (Some("enrolldev"), _) => enrolldev(&args),

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -5172,8 +5172,10 @@ mod tests {
 
     fn profile(name: &str, scans: &[&str]) -> ProfileSummary {
         ProfileSummary {
+            id: String::new(),
             name: name.into(),
             scans: scans.iter().map(|s| s.to_string()).collect(),
+            scan_ids: Vec::new(),
         }
     }
 
@@ -5460,8 +5462,10 @@ mod tests {
         app.daemon_up = true; // skip the daemon gate; the cap check is next
         app.profiles = (0..MAX_PROFILES)
             .map(|i| ProfileSummary {
+                id: String::new(),
                 name: format!("p{i}"),
                 scans: Vec::new(),
+                scan_ids: Vec::new(),
             })
             .collect();
         app.begin_enroll();

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1211,8 +1211,10 @@ fn profiles_listing_renders_profiles_and_toggle_state() {
     serve(&sock(&sb), |req| match req {
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: vec![ProfileSummary {
+                id: String::new(),
                 name: "Face Profile 1".into(),
                 scans: vec!["Scan 1".into(), "Glasses".into()],
+                scan_ids: Vec::new(),
             }],
             require_eyes_open: true,
             require_challenge: false,
@@ -1354,8 +1356,10 @@ fn status_renders_the_full_dashboard_from_daemon_answers() {
         Request::Ping => Response::Pong,
         Request::ListProfiles { .. } => Response::Enrollment {
             profiles: vec![ProfileSummary {
+                id: String::new(),
                 name: "Face Profile 1".into(),
                 scans: vec!["Scan 1".into(), "Scan 2".into()],
+                scan_ids: Vec::new(),
             }],
             require_eyes_open: false,
             require_challenge: true,

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -197,8 +197,10 @@ fn serve(sock: &Path, respond: impl Fn(&Request) -> Response + Send + 'static) {
 
 fn one_profile() -> Vec<ProfileSummary> {
     vec![ProfileSummary {
+        id: String::new(),
         name: "Face Profile 1".into(),
         scans: vec!["Scan 1".into(), "Scan 2".into()],
+        scan_ids: Vec::new(),
     }]
 }
 

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -2,7 +2,27 @@
 // Copyright the irlume contributors.
 
 use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
 use std::process::Command;
+use std::thread;
+
+fn serve_once(
+    socket: &std::path::Path,
+    respond: impl Fn(irlume_common::Request) -> irlume_common::Response + Send + 'static,
+) -> thread::JoinHandle<()> {
+    let listener = UnixListener::bind(socket).expect("bind test socket");
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept client");
+        let mut line = String::new();
+        BufReader::new(stream.try_clone().unwrap())
+            .read_line(&mut line)
+            .expect("read request");
+        let request = serde_json::from_str(&line).expect("parse request");
+        let response = serde_json::to_string(&respond(request)).expect("serialize response");
+        writeln!(stream, "{response}").expect("write response");
+    })
+}
 
 #[test]
 fn version_json_is_one_machine_document() {
@@ -23,7 +43,7 @@ fn version_json_is_one_machine_document() {
     assert_eq!(document["ok"], true);
     assert_eq!(
         document["data"]["capabilities"],
-        serde_json::json!(["version-json", "profiles-list-json"])
+        serde_json::json!(["version-json", "profiles-json", "profile-mutations-json"])
     );
 }
 
@@ -66,4 +86,65 @@ fn unknown_machine_flags_are_a_typed_usage_error() {
     assert_eq!(document["ok"], false);
     assert_eq!(document["error"]["code"], "usage-error");
     assert_eq!(document["error"]["retryable"], false);
+}
+
+#[test]
+fn unsafe_profile_mutation_ids_are_typed_usage_errors() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["profiles", "delete", "--profile-id", "../unsafe", "--json"])
+        .output()
+        .expect("run irlume");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "profiles.delete");
+    assert_eq!(document["ok"], false);
+    assert_eq!(document["error"]["code"], "usage-error");
+}
+
+#[test]
+fn profile_delete_json_targets_the_opaque_id_and_returns_exact_identity() {
+    let profile_id = "profile-0123456789abcdef0123456789abcdef";
+    let socket =
+        std::env::temp_dir().join(format!("irlume-machine-api-delete-{}", std::process::id()));
+    let server = serve_once(&socket, move |request| match request {
+        irlume_common::Request::DeleteProfileById {
+            user,
+            profile_id: requested,
+        } => {
+            assert!(!user.is_empty());
+            assert_eq!(requested, profile_id);
+            irlume_common::Response::ProfileMutation {
+                operation: irlume_common::ProfileMutationKind::DeleteProfile,
+                profile_id: requested,
+                profile_name_before: Some("Primary".into()),
+                profile_name_after: None,
+                scan_id: None,
+                scan_name_before: None,
+                scan_name_after: None,
+                total_scans: None,
+            }
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["profiles", "delete", "--profile-id", profile_id, "--json"])
+        .env("IRLUME_SOCKET", &socket)
+        .output()
+        .expect("run irlume");
+    server.join().expect("server thread");
+    let _ = std::fs::remove_file(socket);
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "profiles.delete");
+    assert_eq!(document["ok"], true);
+    assert_eq!(document["data"]["profile_id"], profile_id);
+    assert_eq!(document["data"]["before"]["profile_name"], "Primary");
+    assert!(document["data"]["after"].is_null());
+    assert_eq!(document["data"]["deleted"], true);
+    assert_eq!(document["data"]["mutated_other_profiles"], false);
 }

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use serde_json::Value;
+use std::process::Command;
+
+#[test]
+fn version_json_is_one_machine_document() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["version", "--json"])
+        .output()
+        .expect("run irlume");
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        output.stdout.iter().filter(|&&byte| byte == b'\n').count(),
+        1
+    );
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["contract_version"], 1);
+    assert_eq!(document["command"], "version");
+    assert_eq!(document["ok"], true);
+    assert_eq!(
+        document["data"]["capabilities"],
+        serde_json::json!(["version-json", "profiles-list-json"])
+    );
+}
+
+#[test]
+fn unavailable_daemon_is_a_typed_json_error() {
+    let socket = std::env::temp_dir().join(format!(
+        "irlume-machine-api-no-daemon-{}",
+        std::process::id()
+    ));
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["profiles", "list", "--json"])
+        .env("IRLUME_SOCKET", socket)
+        .output()
+        .expect("run irlume");
+
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        output.stdout.iter().filter(|&&byte| byte == b'\n').count(),
+        1
+    );
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "profiles.list");
+    assert_eq!(document["ok"], false);
+    assert_eq!(document["error"]["code"], "daemon-unavailable");
+    assert_eq!(document["error"]["retryable"], true);
+}
+
+#[test]
+fn unknown_machine_flags_are_a_typed_usage_error() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["version", "--json", "--verbose"])
+        .output()
+        .expect("run irlume");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "version");
+    assert_eq!(document["ok"], false);
+    assert_eq!(document["error"]["code"], "usage-error");
+    assert_eq!(document["error"]["retryable"], false);
+}

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -366,8 +366,16 @@ pub enum SelfTestKind {
 /// A profile and the names of its scans, for `ListProfiles`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileSummary {
+    /// Stable opaque profile identifier. Empty when talking to a daemon that
+    /// predates record IDs.
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub scans: Vec<String>,
+    /// Stable opaque IDs corresponding positionally to [`Self::scans`]. Empty
+    /// when talking to an older daemon.
+    #[serde(default)]
+    pub scan_ids: Vec<String>,
 }
 
 /// Framing-guide sample for guided enrollment; no raw image, safe to poll. The
@@ -758,6 +766,14 @@ mod tests {
             }
             other => panic!("expected Health, got {other:?}"),
         }
+        // Profile summaries from a daemon predating opaque record IDs still
+        // deserialize; the new fields default empty so callers can fail closed
+        // for mutation while retaining the human read-only listing.
+        let p: ProfileSummary =
+            serde_json::from_str(r#"{"name":"Face Profile 1","scans":["Face Scan 1"]}"#).unwrap();
+        assert!(p.id.is_empty());
+        assert!(p.scan_ids.is_empty());
+        assert_eq!(p.scans, vec!["Face Scan 1"]);
     }
 
     #[test]

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -213,15 +213,26 @@ pub enum Request {
     SetCameras { rgb: String, ir: String },
     /// Add one scan to an existing profile ("improve recognition"). PRIVILEGED.
     AddScan { user: String, profile: String },
+    /// Add one scan to an existing profile selected by stable opaque ID.
+    /// PRIVILEGED. Machine clients should prefer this over display names.
+    AddScanById { user: String, profile_id: String },
     /// List enrolled profiles + their scans for `user`.
     ListProfiles { user: String },
     /// Delete a whole profile (and its scans). PRIVILEGED, same rule as Enroll.
     DeleteProfile { user: String, profile: String },
+    /// Delete a whole profile selected by stable opaque ID. PRIVILEGED.
+    DeleteProfileById { user: String, profile_id: String },
     /// Delete one scan from a profile. PRIVILEGED.
     DeleteScan {
         user: String,
         profile: String,
         scan: String,
+    },
+    /// Delete one scan selected by stable opaque IDs. PRIVILEGED.
+    DeleteScanById {
+        user: String,
+        profile_id: String,
+        scan_id: String,
     },
     /// Rename a profile. PRIVILEGED.
     RenameProfile {
@@ -229,11 +240,24 @@ pub enum Request {
         profile: String,
         new_name: String,
     },
+    /// Rename a profile selected by stable opaque ID. PRIVILEGED.
+    RenameProfileById {
+        user: String,
+        profile_id: String,
+        new_name: String,
+    },
     /// Rename a scan within a profile. PRIVILEGED.
     RenameScan {
         user: String,
         profile: String,
         scan: String,
+        new_name: String,
+    },
+    /// Rename a scan selected by stable opaque IDs. PRIVILEGED.
+    RenameScanById {
+        user: String,
+        profile_id: String,
+        scan_id: String,
         new_name: String,
     },
     /// Toggle the per-user "require eyes open to unlock" gate. PRIVILEGED.
@@ -378,6 +402,17 @@ pub struct ProfileSummary {
     pub scan_ids: Vec<String>,
 }
 
+/// Stable operation name for an ID-addressed profile mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProfileMutationKind {
+    AddScan,
+    DeleteProfile,
+    DeleteScan,
+    RenameProfile,
+    RenameScan,
+}
+
 /// Framing-guide sample for guided enrollment; no raw image, safe to poll. The
 /// gates that set `well_framed` mirror the enroll/auth path, so "well framed"
 /// implies a capture will succeed.
@@ -444,6 +479,19 @@ pub enum Response {
     },
     /// Generic success ack for management operations, with a human message.
     Ok(String),
+    /// Typed success result for an ID-addressed profile mutation.
+    ProfileMutation {
+        operation: ProfileMutationKind,
+        profile_id: String,
+        profile_name_before: Option<String>,
+        profile_name_after: Option<String>,
+        scan_id: Option<String>,
+        scan_name_before: Option<String>,
+        scan_name_after: Option<String>,
+        /// Number of scans remaining in the profile. `None` after deleting the
+        /// complete profile.
+        total_scans: Option<usize>,
+    },
     /// Result of an Enroll capture, carrying the profile the scans actually
     /// landed on. `created` distinguishes a brand-new profile from a merge into
     /// an existing identity (the engine auto-merges a face that already owns a
@@ -774,6 +822,41 @@ mod tests {
         assert!(p.id.is_empty());
         assert!(p.scan_ids.is_empty());
         assert_eq!(p.scans, vec!["Face Scan 1"]);
+
+        let request = Request::RenameScanById {
+            user: "alice".into(),
+            profile_id: "profile-0123456789abcdef0123456789abcdef".into(),
+            scan_id: "scan-fedcba9876543210fedcba9876543210".into(),
+            new_name: "Glasses".into(),
+        };
+        let encoded = serde_json::to_string(&request).unwrap();
+        assert!(matches!(
+            serde_json::from_str(&encoded).unwrap(),
+            Request::RenameScanById { .. }
+        ));
+
+        let response = Response::ProfileMutation {
+            operation: ProfileMutationKind::RenameScan,
+            profile_id: "profile-0123456789abcdef0123456789abcdef".into(),
+            profile_name_before: Some("Primary".into()),
+            profile_name_after: Some("Primary".into()),
+            scan_id: Some("scan-fedcba9876543210fedcba9876543210".into()),
+            scan_name_before: Some("Default".into()),
+            scan_name_after: Some("Glasses".into()),
+            total_scans: Some(2),
+        };
+        let encoded = serde_json::to_string(&response).unwrap();
+        match serde_json::from_str(&encoded).unwrap() {
+            Response::ProfileMutation {
+                operation,
+                total_scans,
+                ..
+            } => {
+                assert_eq!(operation, ProfileMutationKind::RenameScan);
+                assert_eq!(total_scans, Some(2));
+            }
+            other => panic!("expected ProfileMutation, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -9,7 +9,9 @@
 
 use crate::{crypto, template_key};
 use base64::{engine::general_purpose::STANDARD, Engine};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::PathBuf;
 use zeroize::Zeroizing;
@@ -39,6 +41,13 @@ pub const IMPROVE_SCANS: usize = 5;
 /// AuraFace embedding; `ir` is the IR-face embedding for dark operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FaceScan {
+    /// Stable opaque identifier for machine-facing operations. It is random,
+    /// carries no biometric or user information, and does not change on rename.
+    /// Empty only while loading enrollments written before IDs were introduced;
+    /// [`Enrollment::ensure_record_ids`] backfills it before the value escapes
+    /// the storage boundary.
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub rgb: Vec<f32>,
     #[serde(default)]
@@ -70,6 +79,10 @@ pub struct FaceScan {
 /// A face profile: a named set of scans of one face.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FaceProfile {
+    /// Stable opaque identifier for machine-facing operations. See
+    /// [`FaceScan::id`].
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub scans: Vec<FaceScan>,
     /// Per-profile IR calibration (ADR-0004), fitted from this profile's own
@@ -130,6 +143,33 @@ impl Enrollment {
             camera_binding: None,
             closure_calibration: None,
         }
+    }
+
+    /// Backfill stable opaque IDs for enrollments written by older versions.
+    ///
+    /// Existing valid unique IDs are preserved byte-for-byte. Empty, malformed,
+    /// or duplicate IDs are replaced. Returns the number of repaired records so
+    /// callers can persist a migration when appropriate.
+    pub fn ensure_record_ids(&mut self) -> usize {
+        let mut repaired = 0;
+        let user = self.user.clone();
+        let mut profile_ids = std::collections::HashSet::new();
+        let mut scan_ids = std::collections::HashSet::new();
+        for (profile_index, profile) in self.profiles.iter_mut().enumerate() {
+            if !valid_record_id(&profile.id, "profile") || !profile_ids.insert(profile.id.clone()) {
+                profile.id = legacy_record_id("profile", &user, profile_index, None);
+                profile_ids.insert(profile.id.clone());
+                repaired += 1;
+            }
+            for (scan_index, scan) in profile.scans.iter_mut().enumerate() {
+                if !valid_record_id(&scan.id, "scan") || !scan_ids.insert(scan.id.clone()) {
+                    scan.id = legacy_record_id("scan", &user, profile_index, Some(scan_index));
+                    scan_ids.insert(scan.id.clone());
+                    repaired += 1;
+                }
+            }
+        }
+        repaired
     }
 
     /// Total scans across all profiles (drives threshold scaling).
@@ -293,6 +333,73 @@ impl Enrollment {
     }
 }
 
+/// Mint a random stable identifier for a face profile.
+pub fn new_profile_id() -> String {
+    new_record_id("profile")
+}
+
+/// Mint a random stable identifier for a face scan.
+pub fn new_scan_id() -> String {
+    new_record_id("scan")
+}
+
+/// Mint a random 128-bit identifier with a type prefix. The alphabet matches
+/// the public CLI's safe opaque-ID grammar and remains comfortably below its
+/// length bound.
+fn new_record_id(kind: &str) -> String {
+    let mut random = [0u8; 16];
+    rand::rng().fill_bytes(&mut random);
+    let mut id = String::with_capacity(kind.len() + 1 + random.len() * 2);
+    id.push_str(kind);
+    id.push('-');
+    for byte in random {
+        use std::fmt::Write;
+        write!(id, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    id
+}
+
+fn valid_record_id(id: &str, kind: &str) -> bool {
+    let Some(hex) = id
+        .strip_prefix(kind)
+        .and_then(|rest| rest.strip_prefix('-'))
+    else {
+        return false;
+    };
+    hex.len() == 32 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Stable migration ID for records that predate stored random IDs. It uses only
+/// the enrollment owner and record ordinals, never names or biometric data.
+/// The first ID-aware mutation persists these values, so later deletes or
+/// reordering cannot change them.
+fn legacy_record_id(
+    kind: &str,
+    user: &str,
+    profile_index: usize,
+    scan_index: Option<usize>,
+) -> String {
+    let mut hash = Sha256::new();
+    hash.update(b"irlume-record-id-v1\0");
+    hash.update(kind.as_bytes());
+    hash.update(b"\0");
+    hash.update(user.as_bytes());
+    hash.update(b"\0");
+    hash.update(profile_index.to_le_bytes());
+    if let Some(index) = scan_index {
+        hash.update(index.to_le_bytes());
+    }
+    let digest = hash.finalize();
+    let mut id = String::with_capacity(kind.len() + 1 + 32);
+    id.push_str(kind);
+    id.push('-');
+    for byte in &digest[..16] {
+        use std::fmt::Write;
+        write!(id, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    id
+}
+
 impl FaceProfile {
     /// Default name for the next scan ("Face Scan N", first free slot).
     pub fn next_scan_name(&self) -> String {
@@ -321,11 +428,13 @@ struct LegacyProfile {
 }
 
 fn migrate(old: LegacyProfile) -> Enrollment {
+    let user = old.user;
     let scans = old
         .templates
         .iter()
         .enumerate()
         .map(|(i, t)| FaceScan {
+            id: legacy_record_id("scan", &user, 0, Some(i)),
             name: format!("Face Scan {}", i + 1),
             rgb: t.clone(),
             ir: old.ir_templates.get(i).cloned(),
@@ -337,8 +446,9 @@ fn migrate(old: LegacyProfile) -> Enrollment {
         })
         .collect();
     Enrollment {
-        user: old.user,
+        user: user.clone(),
         profiles: vec![FaceProfile {
+            id: legacy_record_id("profile", &user, 0, None),
             ir_calib: None,
             name: "Face Profile 1".into(),
             scans,
@@ -409,7 +519,7 @@ fn serialize_enrollment(e: &Enrollment, key: Option<&[u8]>) -> irlume_common::Re
 fn deserialize_enrollment(data: &[u8], key: Option<&[u8]>) -> irlume_common::Result<Enrollment> {
     let v: serde_json::Value =
         serde_json::from_slice(data).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
-    if v.get("enc").is_some() {
+    let mut enrollment = if v.get("enc").is_some() {
         let env: EncEnvelope =
             serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
         let key = key.ok_or_else(|| {
@@ -421,14 +531,16 @@ fn deserialize_enrollment(data: &[u8], key: Option<&[u8]>) -> irlume_common::Res
             .decode(env.enc.as_bytes())
             .map_err(|e| irlume_common::Error::Protocol(format!("bad enc blob: {e}")))?;
         let plain = crypto::decrypt(key, &blob)?;
-        serde_json::from_slice(&plain).map_err(|e| irlume_common::Error::Protocol(e.to_string()))
+        serde_json::from_slice(&plain).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?
     } else if v.get("profiles").is_some() {
-        serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))
+        serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?
     } else {
         let old: LegacyProfile =
             serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
-        Ok(migrate(old))
-    }
+        migrate(old)
+    };
+    enrollment.ensure_record_ids();
+    Ok(enrollment)
 }
 
 /// Resolve the key to encrypt `user`'s templates with: the TPM-sealed template
@@ -540,9 +652,11 @@ mod tests {
         Enrollment {
             user: "u".into(),
             profiles: vec![FaceProfile {
+                id: String::new(),
                 ir_calib: None,
                 name: "Face Profile 1".into(),
                 scans: vec![FaceScan {
+                    id: String::new(),
                     name: "Face Scan 1".into(),
                     rgb: vec![0.1, 0.2, 0.3, 0.4],
                     ir: Some(vec![0.5, 0.6]),
@@ -594,6 +708,7 @@ mod tests {
 
     fn scan_with_ir(ratio: f32, bright: f32) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: "s".into(),
             rgb: vec![0.1; 4],
             ir: Some(vec![0.2; 4]),
@@ -606,6 +721,7 @@ mod tests {
 
     fn scan_with_pitch(pitch: f32) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: "s".into(),
             rgb: vec![0.1; 4],
             ir: None,
@@ -621,6 +737,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         // One calibrated scan -> not enough.
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![scan_with_pitch(0.60)],
@@ -640,6 +757,7 @@ mod tests {
         // One IR scan -> not enough to characterise the user's rig.
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![scan_with_ir(1.5, 100.0)],
@@ -655,6 +773,7 @@ mod tests {
 
     fn scan_in_space(name: &str, dim: usize, space: Option<&str>) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: name.into(),
             rgb: vec![0.1; 4],
             ir: Some(vec![0.2; dim]),
@@ -669,6 +788,7 @@ mod tests {
     fn ir_scans_for_filters_space_and_dimension() {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![
@@ -698,6 +818,7 @@ mod tests {
     fn retag_untagged_ir_stamps_only_matching_legacy_scans() {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![
@@ -722,8 +843,104 @@ mod tests {
         // Enrollments written before space tagging must load unchanged.
         let json = r#"{"name":"s","rgb":[0.1],"ir":[0.2]}"#;
         let s: FaceScan = serde_json::from_str(json).unwrap();
+        assert!(s.id.is_empty());
         assert!(s.ir_space.is_none());
         assert_eq!(s.ir.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn legacy_records_get_stable_opaque_ids_without_biometric_input() {
+        let json = br#"{
+            "user":"alice",
+            "profiles":[{
+                "name":"Renamable profile",
+                "scans":[
+                    {"name":"First scan","rgb":[0.1,0.2]},
+                    {"name":"Second scan","rgb":[0.9,0.8]}
+                ]
+            }]
+        }"#;
+        let first = deserialize_enrollment(json, None).unwrap();
+        let second = deserialize_enrollment(json, None).unwrap();
+
+        assert_eq!(first.profiles[0].id, second.profiles[0].id);
+        assert_eq!(
+            first.profiles[0].scans[0].id,
+            second.profiles[0].scans[0].id
+        );
+        assert_ne!(first.profiles[0].scans[0].id, first.profiles[0].scans[1].id);
+        assert!(valid_record_id(&first.profiles[0].id, "profile"));
+        assert!(first.profiles[0]
+            .scans
+            .iter()
+            .all(|scan| valid_record_id(&scan.id, "scan")));
+
+        // Names and embeddings are deliberately absent from the migration ID:
+        // changing either cannot silently change a record's public identity.
+        let renamed = br#"{
+            "user":"alice",
+            "profiles":[{
+                "name":"Different display name",
+                "scans":[
+                    {"name":"Renamed scan","rgb":[0.7,0.6]},
+                    {"name":"Other renamed scan","rgb":[0.4,0.3]}
+                ]
+            }]
+        }"#;
+        let renamed = deserialize_enrollment(renamed, None).unwrap();
+        assert_eq!(first.profiles[0].id, renamed.profiles[0].id);
+        assert_eq!(
+            first.profiles[0].scans[0].id,
+            renamed.profiles[0].scans[0].id
+        );
+    }
+
+    #[test]
+    fn stored_ids_survive_rename_and_round_trip() {
+        let mut enrollment = sample();
+        assert_eq!(enrollment.ensure_record_ids(), 2);
+        let profile_id = enrollment.profiles[0].id.clone();
+        let scan_id = enrollment.profiles[0].scans[0].id.clone();
+        enrollment.profiles[0].name = "Renamed profile".into();
+        enrollment.profiles[0].scans[0].name = "Renamed scan".into();
+
+        let bytes = serialize_enrollment(&enrollment, None).unwrap();
+        let mut loaded = deserialize_enrollment(&bytes, None).unwrap();
+        assert_eq!(loaded.profiles[0].id, profile_id);
+        assert_eq!(loaded.profiles[0].scans[0].id, scan_id);
+        assert_eq!(loaded.ensure_record_ids(), 0);
+    }
+
+    #[test]
+    fn malformed_and_duplicate_ids_are_repaired_deterministically() {
+        let mut enrollment = sample();
+        enrollment.profiles.push(enrollment.profiles[0].clone());
+        enrollment.profiles[0].id = "not-an-id".into();
+        enrollment.profiles[1].id = "not-an-id".into();
+        enrollment.profiles[0].scans[0].id = "scan-00000000000000000000000000000000".into();
+        enrollment.profiles[1].scans[0].id = "scan-00000000000000000000000000000000".into();
+
+        assert_eq!(enrollment.ensure_record_ids(), 3);
+        assert_ne!(enrollment.profiles[0].id, enrollment.profiles[1].id);
+        assert_ne!(
+            enrollment.profiles[0].scans[0].id,
+            enrollment.profiles[1].scans[0].id
+        );
+        assert_eq!(enrollment.ensure_record_ids(), 0);
+    }
+
+    #[test]
+    fn fresh_record_ids_are_typed_unique_and_machine_safe() {
+        let profile_a = new_record_id("profile");
+        let profile_b = new_record_id("profile");
+        let scan = new_record_id("scan");
+        assert!(valid_record_id(&profile_a, "profile"));
+        assert!(valid_record_id(&profile_b, "profile"));
+        assert!(valid_record_id(&scan, "scan"));
+        assert_ne!(profile_a, profile_b);
+        assert!(profile_a
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-'));
     }
 
     #[test]
@@ -731,10 +948,12 @@ mod tests {
         // RGB-only scans (no IR) must not count toward the floor.
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "p".into(),
             scans: vec![
                 FaceScan {
+                    id: String::new(),
                     name: "a".into(),
                     rgb: vec![0.1; 4],
                     ir: None,
@@ -754,6 +973,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         assert_eq!(e.next_profile_name(), "Face Profile 1");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "Face Profile 1".into(),
             scans: vec![],
@@ -846,6 +1066,7 @@ mod tests {
     #[test]
     fn stale_and_usable_ir_counts_partition_the_scans() {
         let ir_scan = |name: &str, space: Option<&str>| FaceScan {
+            id: String::new(),
             name: name.into(),
             rgb: vec![0.0; 4],
             ir: Some(vec![0.0; 4]),
@@ -856,6 +1077,7 @@ mod tests {
         };
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
+            id: String::new(),
             ir_calib: None,
             name: "P".into(),
             scans: vec![
@@ -873,6 +1095,7 @@ mod tests {
         assert_eq!(e.usable_ir_scans("raw"), 0);
         // An RGB-only scan (no ir) counts for neither side.
         e.profiles[0].scans.push(FaceScan {
+            id: String::new(),
             ir: None,
             ..ir_scan("rgb-only", None)
         });

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -343,6 +343,16 @@ pub fn new_scan_id() -> String {
     new_record_id("scan")
 }
 
+/// Whether `id` is a well-formed opaque profile identifier.
+pub fn valid_profile_id(id: &str) -> bool {
+    valid_record_id(id, "profile")
+}
+
+/// Whether `id` is a well-formed opaque scan identifier.
+pub fn valid_scan_id(id: &str) -> bool {
+    valid_record_id(id, "scan")
+}
+
 /// Mint a random 128-bit identifier with a type prefix. The alphabet matches
 /// the public CLI's safe opaque-ID grammar and remains comfortably below its
 /// length bound.

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1361,8 +1361,10 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                         .profiles
                         .iter()
                         .map(|p| irlume_common::ProfileSummary {
+                            id: p.id.clone(),
                             name: p.name.clone(),
                             scans: p.scans.iter().map(|s| s.name.clone()).collect(),
+                            scan_ids: p.scans.iter().map(|s| s.id.clone()).collect(),
                         })
                         .collect(),
                     require_eyes_open: enr.require_eyes_open,
@@ -2728,6 +2730,7 @@ mod tests {
 
     fn rgb_scan(name: &str, seed: usize) -> FaceScan {
         FaceScan {
+            id: String::new(),
             name: name.into(),
             rgb: unit512(seed),
             ir: None,
@@ -2743,6 +2746,7 @@ mod tests {
         Enrollment {
             user: user.into(),
             profiles: vec![FaceProfile {
+                id: String::new(),
                 name: "Face Profile 1".into(),
                 ir_calib: None,
                 scans: scans
@@ -3026,6 +3030,12 @@ mod tests {
                     profiles[0].scans,
                     vec!["Face Scan 1".to_string(), "Face Scan 2".to_string()]
                 );
+                assert!(profiles[0].id.starts_with("profile-"));
+                assert_eq!(profiles[0].scan_ids.len(), profiles[0].scans.len());
+                assert!(profiles[0]
+                    .scan_ids
+                    .iter()
+                    .all(|id| id.starts_with("scan-")));
                 assert!(require_eyes_open);
                 assert!(!require_challenge);
             }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -709,6 +709,13 @@ fn valid_username(u: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'$'))
 }
 
+fn valid_display_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.trim() == name
+        && name.chars().count() <= 80
+        && !name.chars().any(char::is_control)
+}
+
 /// The `user` field of a request, if it carries one (for the traversal guard).
 fn request_user(req: &Request) -> Option<&str> {
     use Request::*;
@@ -717,10 +724,15 @@ fn request_user(req: &Request) -> Option<&str> {
         | Enroll { user, .. }
         | ListProfiles { user }
         | DeleteProfile { user, .. }
+        | DeleteProfileById { user, .. }
         | DeleteScan { user, .. }
+        | DeleteScanById { user, .. }
         | RenameProfile { user, .. }
+        | RenameProfileById { user, .. }
         | RenameScan { user, .. }
+        | RenameScanById { user, .. }
         | AddScan { user, .. }
+        | AddScanById { user, .. }
         | SetRequireEyesOpen { user, .. }
         | SetRequireChallenge { user, .. }
         | CaptureEarMedian { user }
@@ -1081,6 +1093,53 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 Err(e) => Response::Error(e.to_string()),
             }
         }
+        Request::AddScanById { user, profile_id } => {
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!("not authorized to modify '{user}'"));
+            }
+            if !irlume_core::storage::valid_profile_id(&profile_id) {
+                return Response::Error("invalid profile ID".into());
+            }
+            let profile_name = match irlume_core::storage::load(&user) {
+                Ok(Some(enr)) => match enr.profiles.iter().find(|p| p.id == profile_id) {
+                    Some(profile) => profile.name.clone(),
+                    None => return Response::Error(format!("no face profile ID '{profile_id}'")),
+                },
+                Ok(None) => return Response::Error(format!("'{user}' is not enrolled")),
+                Err(e) => return Response::Error(e.to_string()),
+            };
+            match engine.add_scan(&user, &profile_name) {
+                Ok((scan_name, total)) => match irlume_core::storage::load(&user) {
+                    Ok(Some(enr)) => {
+                        let Some(profile) = enr.profiles.iter().find(|p| p.id == profile_id) else {
+                            return Response::Error(
+                                "profile disappeared after adding the scan".into(),
+                            );
+                        };
+                        let Some(scan) = profile.scans.iter().find(|s| s.name == scan_name) else {
+                            return Response::Error(
+                                "new scan missing after successful enrollment".into(),
+                            );
+                        };
+                        Response::ProfileMutation {
+                            operation: irlume_common::ProfileMutationKind::AddScan,
+                            profile_id,
+                            profile_name_before: Some(profile.name.clone()),
+                            profile_name_after: Some(profile.name.clone()),
+                            scan_id: Some(scan.id.clone()),
+                            scan_name_before: None,
+                            scan_name_after: Some(scan.name.clone()),
+                            total_scans: Some(total),
+                        }
+                    }
+                    Ok(None) => {
+                        Response::Error("enrollment disappeared after adding the scan".into())
+                    }
+                    Err(e) => Response::Error(e.to_string()),
+                },
+                Err(e) => Response::Error(e.to_string()),
+            }
+        }
         // --- keyring unlock (TPM-sealed password) ---------------------------
         Request::SealPassword { user, password } => {
             // Arming the keyring: root or the user themselves. `password`
@@ -1405,6 +1464,15 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 }
             })
         }
+        Request::DeleteProfileById { user, profile_id } => {
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!("not authorized to modify '{user}'"));
+            }
+            if !irlume_core::storage::valid_profile_id(&profile_id) {
+                return Response::Error("invalid profile ID".into());
+            }
+            mutate_enrollment_response(&user, |enr| delete_profile_by_id(enr, &profile_id))
+        }
         Request::DeleteScan {
             user,
             profile,
@@ -1430,6 +1498,22 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 }
             })
         }
+        Request::DeleteScanById {
+            user,
+            profile_id,
+            scan_id,
+        } => {
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!("not authorized to modify '{user}'"));
+            }
+            if !irlume_core::storage::valid_profile_id(&profile_id) {
+                return Response::Error("invalid profile ID".into());
+            }
+            if !irlume_core::storage::valid_scan_id(&scan_id) {
+                return Response::Error("invalid scan ID".into());
+            }
+            mutate_enrollment_response(&user, |enr| delete_scan_by_id(enr, &profile_id, &scan_id))
+        }
         Request::RenameProfile {
             user,
             profile,
@@ -1449,6 +1533,24 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     .ok_or(format!("no face profile '{profile}'"))?;
                 p.name = new_name.clone();
                 Ok(format!("renamed profile to '{new_name}'"))
+            })
+        }
+        Request::RenameProfileById {
+            user,
+            profile_id,
+            new_name,
+        } => {
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!("not authorized to modify '{user}'"));
+            }
+            if !irlume_core::storage::valid_profile_id(&profile_id) {
+                return Response::Error("invalid profile ID".into());
+            }
+            if !valid_display_name(&new_name) {
+                return Response::Error("invalid profile name".into());
+            }
+            mutate_enrollment_response(&user, |enr| {
+                rename_profile_by_id(enr, &profile_id, new_name)
             })
         }
         Request::RenameScan {
@@ -1476,6 +1578,28 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     .ok_or(format!("no scan '{scan}' in '{profile}'"))?;
                 s.name = new_name.clone();
                 Ok(format!("renamed scan to '{new_name}'"))
+            })
+        }
+        Request::RenameScanById {
+            user,
+            profile_id,
+            scan_id,
+            new_name,
+        } => {
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!("not authorized to modify '{user}'"));
+            }
+            if !irlume_core::storage::valid_profile_id(&profile_id) {
+                return Response::Error("invalid profile ID".into());
+            }
+            if !irlume_core::storage::valid_scan_id(&scan_id) {
+                return Response::Error("invalid scan ID".into());
+            }
+            if !valid_display_name(&new_name) {
+                return Response::Error("invalid scan name".into());
+            }
+            mutate_enrollment_response(&user, |enr| {
+                rename_scan_by_id(enr, &profile_id, &scan_id, new_name)
             })
         }
         Request::SetRequireEyesOpen { user, on } => {
@@ -1608,8 +1732,124 @@ fn enroll_response(outcome: irlume_auth::EnrollOutcome) -> Response {
     }
 }
 
-/// Load `user`'s enrollment, apply `f`, and save. `f` returns an Ok message or an
-/// error string. Used by the storage-only management operations.
+/// ID-addressed mutation primitives shared by dispatch and storage-only tests.
+fn delete_profile_by_id(
+    enrollment: &mut irlume_core::storage::Enrollment,
+    profile_id: &str,
+) -> Result<Response, String> {
+    let index = enrollment
+        .profiles
+        .iter()
+        .position(|profile| profile.id == profile_id)
+        .ok_or_else(|| format!("no face profile ID '{profile_id}'"))?;
+    let profile = enrollment.profiles.remove(index);
+    Ok(Response::ProfileMutation {
+        operation: irlume_common::ProfileMutationKind::DeleteProfile,
+        profile_id: profile.id,
+        profile_name_before: Some(profile.name),
+        profile_name_after: None,
+        scan_id: None,
+        scan_name_before: None,
+        scan_name_after: None,
+        total_scans: None,
+    })
+}
+
+fn delete_scan_by_id(
+    enrollment: &mut irlume_core::storage::Enrollment,
+    profile_id: &str,
+    scan_id: &str,
+) -> Result<Response, String> {
+    let profile = enrollment
+        .profiles
+        .iter_mut()
+        .find(|profile| profile.id == profile_id)
+        .ok_or_else(|| format!("no face profile ID '{profile_id}'"))?;
+    if profile.scans.len() == 1 && profile.scans[0].id == scan_id {
+        return Err("a profile must keep at least one scan; delete the profile instead".into());
+    }
+    let index = profile
+        .scans
+        .iter()
+        .position(|scan| scan.id == scan_id)
+        .ok_or_else(|| format!("no scan ID '{scan_id}' in profile '{profile_id}'"))?;
+    let scan = profile.scans.remove(index);
+    Ok(Response::ProfileMutation {
+        operation: irlume_common::ProfileMutationKind::DeleteScan,
+        profile_id: profile.id.clone(),
+        profile_name_before: Some(profile.name.clone()),
+        profile_name_after: Some(profile.name.clone()),
+        scan_id: Some(scan.id),
+        scan_name_before: Some(scan.name),
+        scan_name_after: None,
+        total_scans: Some(profile.scans.len()),
+    })
+}
+
+fn rename_profile_by_id(
+    enrollment: &mut irlume_core::storage::Enrollment,
+    profile_id: &str,
+    new_name: String,
+) -> Result<Response, String> {
+    if enrollment
+        .profiles
+        .iter()
+        .any(|profile| profile.name == new_name)
+    {
+        return Err(format!("'{new_name}' already exists"));
+    }
+    let profile = enrollment
+        .profiles
+        .iter_mut()
+        .find(|profile| profile.id == profile_id)
+        .ok_or_else(|| format!("no face profile ID '{profile_id}'"))?;
+    let old_name = profile.name.clone();
+    profile.name = new_name;
+    Ok(Response::ProfileMutation {
+        operation: irlume_common::ProfileMutationKind::RenameProfile,
+        profile_id: profile.id.clone(),
+        profile_name_before: Some(old_name),
+        profile_name_after: Some(profile.name.clone()),
+        scan_id: None,
+        scan_name_before: None,
+        scan_name_after: None,
+        total_scans: Some(profile.scans.len()),
+    })
+}
+
+fn rename_scan_by_id(
+    enrollment: &mut irlume_core::storage::Enrollment,
+    profile_id: &str,
+    scan_id: &str,
+    new_name: String,
+) -> Result<Response, String> {
+    let profile = enrollment
+        .profiles
+        .iter_mut()
+        .find(|profile| profile.id == profile_id)
+        .ok_or_else(|| format!("no face profile ID '{profile_id}'"))?;
+    if profile.scans.iter().any(|scan| scan.name == new_name) {
+        return Err(format!("'{new_name}' already exists in '{}'", profile.name));
+    }
+    let scan = profile
+        .scans
+        .iter_mut()
+        .find(|scan| scan.id == scan_id)
+        .ok_or_else(|| format!("no scan ID '{scan_id}' in profile '{profile_id}'"))?;
+    let old_name = scan.name.clone();
+    scan.name = new_name;
+    Ok(Response::ProfileMutation {
+        operation: irlume_common::ProfileMutationKind::RenameScan,
+        profile_id: profile.id.clone(),
+        profile_name_before: Some(profile.name.clone()),
+        profile_name_after: Some(profile.name.clone()),
+        scan_id: Some(scan.id.clone()),
+        scan_name_before: Some(old_name),
+        scan_name_after: Some(scan.name.clone()),
+        total_scans: Some(profile.scans.len()),
+    })
+}
+
 fn mutate_enrollment(
     user: &str,
     f: impl FnOnce(&mut irlume_core::storage::Enrollment) -> Result<String, String>,
@@ -1629,6 +1869,32 @@ fn mutate_enrollment(
             };
             match save {
                 Ok(()) => Response::Ok(msg),
+                Err(e) => Response::Error(e.to_string()),
+            }
+        }
+        Err(e) => Response::Error(e),
+    }
+}
+
+/// Variant of [`mutate_enrollment`] for operations with a typed success reply.
+fn mutate_enrollment_response(
+    user: &str,
+    f: impl FnOnce(&mut irlume_core::storage::Enrollment) -> Result<Response, String>,
+) -> Response {
+    let mut enr = match irlume_core::storage::load(user) {
+        Ok(Some(e)) => e,
+        Ok(None) => return Response::Error(format!("'{user}' is not enrolled")),
+        Err(e) => return Response::Error(e.to_string()),
+    };
+    match f(&mut enr) {
+        Ok(response) => {
+            let save = if enr.profiles.is_empty() {
+                irlume_core::storage::delete(user).map(|_| ())
+            } else {
+                irlume_core::storage::save(&enr)
+            };
+            match save {
+                Ok(()) => response,
                 Err(e) => Response::Error(e.to_string()),
             }
         }
@@ -2113,6 +2379,23 @@ mod tests {
     }
 
     #[test]
+    fn display_names_are_bounded_and_reject_control_or_padding() {
+        for valid in ["Primary", "Glasses on", "Ansikte 1", &"a".repeat(80)] {
+            assert!(valid_display_name(valid), "{valid:?} must be accepted");
+        }
+        for invalid in [
+            "",
+            " leading",
+            "trailing ",
+            "new\nline",
+            "tab\tname",
+            &"a".repeat(81),
+        ] {
+            assert!(!valid_display_name(invalid), "{invalid:?} must be rejected");
+        }
+    }
+
+    #[test]
     fn request_user_extracts_the_user_from_every_user_bearing_variant() {
         use irlume_common::SecretBytes;
         let u = || "carol".to_string();
@@ -2133,14 +2416,28 @@ mod tests {
                 user: u(),
                 profile: "p".into(),
             },
+            Request::DeleteProfileById {
+                user: u(),
+                profile_id: "profile-00000000000000000000000000000000".into(),
+            },
             Request::DeleteScan {
                 user: u(),
                 profile: "p".into(),
                 scan: "s".into(),
             },
+            Request::DeleteScanById {
+                user: u(),
+                profile_id: "profile-00000000000000000000000000000000".into(),
+                scan_id: "scan-00000000000000000000000000000000".into(),
+            },
             Request::RenameProfile {
                 user: u(),
                 profile: "p".into(),
+                new_name: "q".into(),
+            },
+            Request::RenameProfileById {
+                user: u(),
+                profile_id: "profile-00000000000000000000000000000000".into(),
                 new_name: "q".into(),
             },
             Request::RenameScan {
@@ -2149,9 +2446,19 @@ mod tests {
                 scan: "s".into(),
                 new_name: "t".into(),
             },
+            Request::RenameScanById {
+                user: u(),
+                profile_id: "profile-00000000000000000000000000000000".into(),
+                scan_id: "scan-00000000000000000000000000000000".into(),
+                new_name: "t".into(),
+            },
             Request::AddScan {
                 user: u(),
                 profile: "p".into(),
+            },
+            Request::AddScanById {
+                user: u(),
+                profile_id: "profile-00000000000000000000000000000000".into(),
             },
             Request::SetRequireEyesOpen {
                 user: u(),
@@ -3387,6 +3694,117 @@ mod tests {
             !sb.dir.join("carol.json").exists(),
             "Enroll{{reset:true}} must delete the previous enrollment first"
         );
+    }
+
+    #[test]
+    fn opaque_id_mutations_target_exact_records_and_return_typed_results() {
+        if irlume_core::template_key::tpm_available() {
+            eprintln!("skipping: TPM present; storage::save would touch real hardware");
+            return;
+        }
+        let _g = env_lock();
+        let sb = sandbox("id-mutations");
+        write_enrollment(
+            &sb.dir,
+            &enrollment_with("carol", &["Face Scan 1", "Face Scan 2"]),
+        );
+        let initial = irlume_core::storage::load("carol").unwrap().unwrap();
+        let profile_id = initial.profiles[0].id.clone();
+        let first_scan_id = initial.profiles[0].scans[0].id.clone();
+        let second_scan_id = initial.profiles[0].scans[1].id.clone();
+        match mutate_enrollment_response("carol", |enrollment| {
+            rename_scan_by_id(enrollment, &profile_id, &first_scan_id, "Front".into())
+        }) {
+            Response::ProfileMutation {
+                operation,
+                profile_id: returned_profile,
+                scan_id,
+                scan_name_before,
+                scan_name_after,
+                total_scans,
+                ..
+            } => {
+                assert_eq!(operation, irlume_common::ProfileMutationKind::RenameScan);
+                assert_eq!(returned_profile, profile_id);
+                assert_eq!(scan_id.as_deref(), Some(first_scan_id.as_str()));
+                assert_eq!(scan_name_before.as_deref(), Some("Face Scan 1"));
+                assert_eq!(scan_name_after.as_deref(), Some("Front"));
+                assert_eq!(total_scans, Some(2));
+            }
+            other => panic!("expected typed rename result, got {other:?}"),
+        }
+
+        match mutate_enrollment_response("carol", |enrollment| {
+            delete_scan_by_id(enrollment, &profile_id, &second_scan_id)
+        }) {
+            Response::ProfileMutation {
+                operation,
+                scan_id,
+                total_scans,
+                ..
+            } => {
+                assert_eq!(operation, irlume_common::ProfileMutationKind::DeleteScan);
+                assert_eq!(scan_id.as_deref(), Some(second_scan_id.as_str()));
+                assert_eq!(total_scans, Some(1));
+            }
+            other => panic!("expected typed delete result, got {other:?}"),
+        }
+
+        match mutate_enrollment_response("carol", |enrollment| {
+            rename_profile_by_id(enrollment, &profile_id, "Work".into())
+        }) {
+            Response::ProfileMutation {
+                operation,
+                profile_id: returned_profile,
+                profile_name_before,
+                profile_name_after,
+                total_scans,
+                ..
+            } => {
+                assert_eq!(operation, irlume_common::ProfileMutationKind::RenameProfile);
+                assert_eq!(returned_profile, profile_id);
+                assert_eq!(profile_name_before.as_deref(), Some("Face Profile 1"));
+                assert_eq!(profile_name_after.as_deref(), Some("Work"));
+                assert_eq!(total_scans, Some(1));
+            }
+            other => panic!("expected typed profile rename result, got {other:?}"),
+        }
+
+        let saved = irlume_core::storage::load("carol").unwrap().unwrap();
+        assert_eq!(saved.profiles[0].id, profile_id);
+        assert_eq!(saved.profiles[0].name, "Work");
+        assert_eq!(saved.profiles[0].scans[0].id, first_scan_id);
+        assert_eq!(saved.profiles[0].scans[0].name, "Front");
+    }
+
+    #[test]
+    fn opaque_id_mutations_fail_closed_on_bad_or_cross_profile_ids() {
+        let _g = env_lock();
+        let sb = sandbox("id-mutation-errors");
+        write_enrollment(
+            &sb.dir,
+            &enrollment_with("carol", &["Face Scan 1", "Face Scan 2"]),
+        );
+        let initial = irlume_core::storage::load("carol").unwrap().unwrap();
+        let profile_id = initial.profiles[0].id.clone();
+        let scan_id = initial.profiles[0].scans[0].id.clone();
+        assert!(!irlume_core::storage::valid_profile_id("../profile"));
+        assert!(!irlume_core::storage::valid_scan_id("scan-not-hex"));
+        let mut unchanged = initial.clone();
+        assert_eq!(
+            delete_scan_by_id(
+                &mut unchanged,
+                "profile-ffffffffffffffffffffffffffffffff",
+                &scan_id,
+            )
+            .unwrap_err(),
+            "no face profile ID 'profile-ffffffffffffffffffffffffffffffff'"
+        );
+
+        let saved = irlume_core::storage::load("carol").unwrap().unwrap();
+        assert_eq!(saved.profiles[0].id, profile_id);
+        assert_eq!(saved.profiles[0].scans[0].id, scan_id);
+        assert_eq!(saved.profiles[0].scans.len(), 2);
     }
 
     #[test]

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -31,7 +31,7 @@ Conventions that apply everywhere:
 | Command | What it does |
 |---|---|
 | `irlume enroll [--name N] [--scans K] [--reset]` | capture a face profile; `--reset` starts the profile space over |
-| `irlume profiles` (or `profiles list`) | list profiles and their scans; `profiles list --json` uses the read-only public [machine API](MACHINE-API.md) |
+| `irlume profiles` (or `profiles list`) | list profiles and their scans; `profiles list --json` uses the public [machine API](MACHINE-API.md) |
 | `irlume profiles add-scan --profile P` | add a scan to profile P (improves recognition in new conditions) |
 | `irlume profiles rename --profile P [--scan S] --name N` | rename a profile, or one scan inside it |
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
@@ -39,6 +39,9 @@ Conventions that apply everywhere:
 | `irlume profiles challenge <on\|off>` | opt-in passive blink liveness |
 | `sudo irlume calibrate-closure` | teach the eye-closure consent gesture for app prompts (captures eyes-open/closed EAR); the head nod is the default and needs no calibration |
 | `irlume identify` | 1:N "who is this?"; as root it checks all users, otherwise scoped to you |
+
+Desktop integrations use opaque IDs with `--profile-id` / `--scan-id` plus
+`--json`; human commands continue to use display names.
 
 ## Keyring, TPM, and recovery
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -24,14 +24,14 @@ Conventions that apply everywhere:
 | `irlume detect` | script-friendly probe; exit `0` = ready, `10` = partial, `20` = absent |
 | `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), the authselect/pam-auth-update regeneration guard, and install hygiene (leftover backup files next to the managed binaries, hand-installed builds overlaying the packaged ones) |
 | `irlume deps` | verify runtime dependencies (onnxruntime, models, TPM) |
-| `irlume version` | print the installed version (`--version` / `-V` also work) |
+| `irlume version` | print the installed version (`--version` / `-V` also work); `version --json` uses the public [machine API](MACHINE-API.md) |
 
 ## Enrollment and profiles
 
 | Command | What it does |
 |---|---|
 | `irlume enroll [--name N] [--scans K] [--reset]` | capture a face profile; `--reset` starts the profile space over |
-| `irlume profiles` (or `profiles list`) | list profiles and their scans |
+| `irlume profiles` (or `profiles list`) | list profiles and their scans; `profiles list --json` uses the read-only public [machine API](MACHINE-API.md) |
 | `irlume profiles add-scan --profile P` | add a scan to profile P (improves recognition in new conditions) |
 | `irlume profiles rename --profile P [--scan S] --name N` | rename a profile, or one scan inside it |
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
@@ -85,5 +85,6 @@ calibration analyzer.
 ## Where to go next
 
 - First-time setup, step by step: [SETUP.md](SETUP.md)
+- Versioned JSON for desktop integrations: [MACHINE-API.md](MACHINE-API.md)
 - Reading scores, gate reasons, and PAM decisions: [DEBUGGING.md](DEBUGGING.md)
 - NixOS module instead of imperative wiring: [NIXOS.md](NIXOS.md)

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -1,0 +1,74 @@
+# Machine API
+
+`irlume` exposes a deliberately small, versioned JSON interface for desktop
+integrations. Human-facing output remains the default.
+
+## Compatibility
+
+Every document contains:
+
+```json
+{
+  "contract_version": 1,
+  "engine_version": "0.6.1",
+  "command": "version",
+  "ok": true,
+  "data": {}
+}
+```
+
+Machine-mode standard output contains exactly one JSON document. Diagnostics
+go to standard error. A successful command exits with zero. Usage errors exit
+with 2, while unavailable or failed operations exit nonzero and return:
+
+```json
+{
+  "contract_version": 1,
+  "engine_version": "0.6.1",
+  "command": "profiles.list",
+  "ok": false,
+  "error": {
+    "code": "daemon-unavailable",
+    "retryable": true
+  }
+}
+```
+
+Fields may be added within a contract version. Removing a field or changing its
+meaning requires a new contract version. Consumers must first call
+`irlume version --json` and use only advertised capabilities.
+
+The machine API is not the daemon socket protocol. The socket remains private,
+and its serialized Rust enums are not a public compatibility promise.
+
+## Commands
+
+### `irlume version --json`
+
+Does not contact the daemon. It returns the engine version, contract version,
+advertised capabilities, and public limits.
+
+### `irlume profiles list --json [--user USER]`
+
+Capability: `profiles-list-json`.
+
+Returns display names, scan display names, and the two per-user liveness policy
+flags. The current enrollment store identifies these records by mutable names,
+so this first read-only contract intentionally does not invent opaque IDs or
+advertise profile mutations. Mutation-safe IDs must originate in the engine
+store before a later capability can expose them.
+
+## Security and privacy
+
+Ordinary JSON output never includes camera frames, embeddings, templates,
+passwords, credential material, TPM secrets, device paths, or usernames.
+Errors contain stable codes instead of daemon prose.
+
+The following are not part of contract version 1 yet and must not be inferred
+from human output or the private socket protocol:
+
+- enrollment or authentication-test event streams;
+- preview images and cancellation semantics;
+- profile or scan mutation;
+- camera configuration mutation;
+- login plan, apply, verify, or rollback transactions.

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -50,13 +50,29 @@ advertised capabilities, and public limits.
 
 ### `irlume profiles list --json [--user USER]`
 
-Capability: `profiles-list-json`.
+Capability: `profiles-json`.
 
-Returns display names, scan display names, and the two per-user liveness policy
-flags. The current enrollment store identifies these records by mutable names,
-so this first read-only contract intentionally does not invent opaque IDs or
-advertise profile mutations. Mutation-safe IDs must originate in the engine
-store before a later capability can expose them.
+Returns stable opaque profile and scan IDs, display names, and the two per-user
+liveness policy flags. An older daemon that cannot supply valid aligned IDs is
+rejected with `unsupported-daemon`; mutable display names are never substituted.
+
+### Profile mutations
+
+Capability: `profile-mutations-json`.
+
+```text
+irlume profiles rename --profile-id ID --name NAME --json
+irlume profiles rename --profile-id ID --scan-id ID --name NAME --json
+irlume profiles delete --profile-id ID --json
+irlume profiles delete --profile-id ID --scan-id ID --json
+```
+
+Mutation targets are stable opaque IDs. The daemon resolves them inside its
+privileged storage boundary and returns the exact affected IDs, typed operation,
+explicit before/after display identity, remaining scan count, and
+`mutated_other_profiles: false`. IDs and names are bounded and validated before
+the request is sent. Deleting the final scan is refused; callers must delete the
+profile instead.
 
 ## Security and privacy
 
@@ -69,6 +85,6 @@ from human output or the private socket protocol:
 
 - enrollment or authentication-test event streams;
 - preview images and cancellation semantics;
-- profile or scan mutation;
+- streaming improve-recognition capture;
 - camera configuration mutation;
 - login plan, apply, verify, or rollback transactions.


### PR DESCRIPTION
## What & why

Extends the public machine API from #109 with the stable IDs from #110 and ID-addressed mutations from #111. This provides the first complete, safe profile-management slice requested by #108.

- `profiles list --json` now returns stored opaque profile and scan IDs and refuses an older daemon with missing/misaligned IDs.
- Advertises `profiles-json` and `profile-mutations-json` only because their public commands and stored identity now exist.
- Adds JSON profile/scan rename and delete commands using `--profile-id` / `--scan-id`.
- Validates bounded IDs and display names before contacting the daemon.
- Returns exact affected IDs, typed operation, explicit before/after identity, remaining scan count, `deleted`, and `mutated_other_profiles: false`.
- Keeps stdout to one JSON document and never exposes daemon prose, usernames, paths, templates, embeddings, or secrets.
- Retains all human name-based commands unchanged.

This is a stacked integration PR containing #109, #110, and #111 plus one profile-machine-API commit. It should be rebased after those prerequisites merge.

## Testing

Validated in a Fedora 44 container:

- `cargo fmt --all -- --check` — clean
- `cargo test -p irlume-common` — 44 passed
- `cargo test -p irlume-core` — 98 passed, 20 hardware/fault tests ignored
- `cargo test -p irlume-cli` — 283 passed, 12 model/camera tests ignored
- targeted daemon opaque-mutation/display-name tests — 3 passed
- end-to-end CLI/socket mutation test verifies the exact opaque ID and JSON before/after result
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean

The full ONNX-backed daemon suite remains delegated to upstream CI; the new storage mutation tests deliberately do not initialize camera models. No PAM or authentication-decision behavior changes.

- [ ] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs/CHANGELOG updated if user-facing
- [ ] Hardware-validated (if it touches PAM, the daemon, or capture)
