### PR TITLE
fix: make the daemon control socket reachable again (0.7.0 blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **Face unlock on the KDE lock screen works again, and `irlume detect` stops
+  lying to unprivileged callers.** An earlier change in this development cycle
+  had packaging create an `irlume` system group, which made the daemon restrict
+  its control socket to `0660 root:irlume`. Nothing ever added a member to that
+  group. `kscreenlocker_greet` is not setuid, so the lock screen's PAM
+  conversation runs as you, its `connect()` to the socket returned EACCES, and
+  face unlock silently fell through to the password along with the keyring
+  unseal that rides on it. `irlume detect` exited 10 (partial) as a user and 0
+  (ready) as root on the same healthy, enrolled machine, and `irlume status`
+  reported "daemon NOT reachable" while the daemon was serving requests
+  normally. `sudo`, the login greeter and polkit prompts were unaffected because
+  all three run as root.
+
+  The socket is now mode 0666 and the group is gone. Reachability was never the
+  authorization boundary: `SO_PEERCRED` is, it is supplied by the kernel at
+  connect time, and every request still requires either root or a target that
+  matches the calling uid. This is the ordinary arrangement for a local system
+  daemon. It is systemd's own documented default for filesystem sockets
+  (`SocketMode=` in `systemd.socket(5)`), pcscd ships the same, and fprintd
+  keeps its endpoint reachable and authorizes per operation. Group membership
+  could not have fixed it either: supplementary groups are process credentials
+  fixed at login, so adding your uid does not reach the desktop you are already
+  in, and greeter account names differ across display managers.
+
+  Requests remain bounded (64 KiB, read and write deadlines), each connection
+  stays isolated behind `catch_unwind`, and the unauthenticated dry-run emitter
+  probe now shares the per-uid camera interval that already covered `Identify`.
+  On Fedora the SELinux module is still the mandatory-access layer.
+
+- Connect failures now distinguish "nothing is listening" from "this uid may not
+  connect". EACCES no longer prints "irlumed is not running" or points you at
+  `systemctl status` for a healthy service, and it deliberately does not tell
+  you to run `sudo` or change the socket mode, because both hide whatever set it.
+
+- `irlume-reconcile.timer` is packaged on Fedora. It was installed into the
+  buildroot but never listed in `%files`, which fails the rpm build on an
+  unpackaged file, and it was missing from `%preun`/`%postun`, so an uninstall
+  left it enabled.
+
 ### Changed
 
 - **Releasing your keyring password now asks for a gesture, by default.** On a

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -543,8 +543,37 @@ const WARN: &str = "\u{26a0}";
 const NO: &str = "\u{2717}";
 
 /// Reachability: a Ping that returns true iff `irlumed` answered.
+/// What a `Ping` established about the daemon.
+///
+/// This used to be a bare bool, and that lost the one distinction that matters:
+/// a user whose uid could not open the socket was told "NOT reachable
+/// (systemctl status irlumed)" and sent to inspect a service that was running
+/// normally. EACCES and "nothing is listening" are different answers and get
+/// different words.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaemonReach {
+    Running,
+    /// The socket is there but this uid may not connect. Carries no information
+    /// about whether the daemon is healthy, so never report it as "down".
+    AccessDenied,
+    /// Nothing is listening, or the reply was unusable.
+    Down,
+}
+
+/// Probe the daemon. Goes through the shared client directly rather than
+/// `daemon_request`, because the errno kind is the point here and the string
+/// conversion throws it away.
+pub(crate) fn daemon_reach() -> DaemonReach {
+    match irlume_common::client::request(&Request::Ping) {
+        Ok(Response::Pong) => DaemonReach::Running,
+        Ok(_) => DaemonReach::Down,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => DaemonReach::AccessDenied,
+        Err(_) => DaemonReach::Down,
+    }
+}
+
 fn daemon_up() -> bool {
-    matches!(daemon_request(&Request::Ping), Ok(Response::Pong))
+    daemon_reach() == DaemonReach::Running
 }
 
 /// `irlume status`: one-shot health dashboard. Always exits 0 (it reports state,
@@ -554,13 +583,16 @@ pub fn status(args: &[String]) -> ExitCode {
     println!("irlume status for '{user}'");
 
     // Daemon + method.
-    let up = daemon_up();
+    let reach = daemon_reach();
     println!(
         "  daemon        : {}",
-        if up {
-            format!("running {OK}")
-        } else {
-            format!("NOT reachable {NO} (systemctl status irlumed)")
+        match reach {
+            DaemonReach::Running => format!("running {OK}"),
+            DaemonReach::AccessDenied => format!(
+                "running, but this user may not connect {WARN} (EACCES on {})",
+                irlume_common::client::socket_path().display()
+            ),
+            DaemonReach::Down => format!("NOT reachable {NO} (systemctl status irlumed)"),
         }
     );
     let method = irlume_core::policy::method();
@@ -721,7 +753,19 @@ pub fn detect(args: &[String]) -> ExitCode {
         println!("absent: irlumed is not installed");
         return ExitCode::from(20);
     }
-    let up = daemon_up();
+    let reach = daemon_reach();
+    // Without socket access neither readiness nor enrollment is knowable, and
+    // claiming "not enrolled" would be a guess. Report the real obstacle and
+    // stay at 10 (partial): 0 would assert a readiness we cannot see.
+    if reach == DaemonReach::AccessDenied {
+        println!(
+            "partial: cannot determine readiness; not permitted to connect to {} (EACCES). \
+             The daemon may be running fine.",
+            irlume_common::client::socket_path().display()
+        );
+        return ExitCode::from(10);
+    }
+    let up = reach == DaemonReach::Running;
     let enrolled = matches!(
         daemon_request(&Request::ListProfiles { user }),
         Ok(Response::Enrollment { ref profiles, .. }) if !profiles.is_empty()

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -86,14 +86,23 @@ pub fn request_with_timeout(req: &Request, rw_timeout: Duration) -> io::Result<R
     request_with_timeouts(req, CONNECT_TIMEOUT, rw_timeout)
 }
 
-/// Map a "nobody is listening" error to the actionable start-the-daemon
-/// message. A missing socket / dead peer is the #1 first-run failure (fresh
-/// package install, unit disabled by distro preset policy), so name the daemon
-/// and the exact command instead of a raw errno. Covers every errno the
-/// no-listener case produces across kernels: ENOENT (no socket file),
-/// ECONNREFUSED (socket file, no accept), ECONNRESET / EPIPE (stale socket that
-/// connects then resets on first I/O, seen on newer kernels).
-fn map_not_running(e: io::Error) -> io::Error {
+/// Map a connect failure to an actionable message.
+///
+/// Two cases, and conflating them was a real bug: a user whose uid could not
+/// open the socket was told the daemon was down and sent to `systemctl status`
+/// on a healthy service.
+///
+/// "Nobody is listening" is the #1 first-run failure (fresh package install,
+/// unit disabled by distro preset policy), so name the daemon and the exact
+/// command instead of a raw errno. Covers every errno that case produces across
+/// kernels: ENOENT (no socket file), ECONNREFUSED (socket file, no accept),
+/// ECONNRESET / EPIPE (stale socket that connects then resets on first I/O,
+/// seen on newer kernels).
+///
+/// EACCES/EPERM means the opposite: the socket is there and the daemon is very
+/// likely fine, but this uid may not connect. Say that, and do not suggest
+/// `sudo` or a chmod, because both hide whatever set the mode.
+fn map_connect_failure(e: io::Error) -> io::Error {
     match e.kind() {
         io::ErrorKind::NotFound
         | io::ErrorKind::ConnectionRefused
@@ -101,6 +110,15 @@ fn map_not_running(e: io::Error) -> io::Error {
         | io::ErrorKind::BrokenPipe => io::Error::new(
             e.kind(),
             "irlumed is not running; start it with: sudo systemctl enable --now irlumed",
+        ),
+        io::ErrorKind::PermissionDenied => io::Error::new(
+            e.kind(),
+            format!(
+                "not permitted to connect to irlumed at {} (EACCES); the daemon may be \
+                 running fine. Check the socket permissions and, on SELinux systems, the \
+                 audit log for a denial.",
+                socket_path().display()
+            ),
         ),
         _ => e,
     }
@@ -111,7 +129,8 @@ fn request_with_timeouts(
     connect_timeout: Duration,
     rw_timeout: Duration,
 ) -> io::Result<Response> {
-    let stream = connect_with_timeout(&socket_path(), connect_timeout).map_err(map_not_running)?;
+    let stream =
+        connect_with_timeout(&socket_path(), connect_timeout).map_err(map_connect_failure)?;
     stream.set_read_timeout(Some(rw_timeout))?;
     stream.set_write_timeout(Some(rw_timeout))?;
 
@@ -123,14 +142,14 @@ fn request_with_timeouts(
     // successfully and only resets on the first write/read, so a connect-only
     // mapping left a raw ECONNRESET. Before any bytes are exchanged, a reset or
     // broken pipe still means "nobody is really listening".
-    (&stream).write_all(&line).map_err(map_not_running)?;
-    (&stream).flush().map_err(map_not_running)?;
+    (&stream).write_all(&line).map_err(map_connect_failure)?;
+    (&stream).flush().map_err(map_connect_failure)?;
     // The request may carry a password (SealPassword/RecoverySetup); wipe it.
     line.zeroize();
 
     let mut reader = BufReader::new(&stream);
     let mut buf = String::new();
-    reader.read_line(&mut buf).map_err(map_not_running)?;
+    reader.read_line(&mut buf).map_err(map_connect_failure)?;
     if buf.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
@@ -392,5 +411,37 @@ mod tests {
         std::env::remove_var("IRLUME_SOCKET");
         unsafe { libc::close(fd) };
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn eacces_does_not_claim_the_daemon_is_down() {
+        // Regression: a mode-restricted socket made every unprivileged client
+        // report "irlumed is not running" and point the user at `systemctl
+        // status` for a healthy service. EACCES means the opposite.
+        let denied = io::Error::from_raw_os_error(libc::EACCES);
+        let mapped = map_connect_failure(denied);
+        assert_eq!(mapped.kind(), io::ErrorKind::PermissionDenied);
+        let text = mapped.to_string();
+        assert!(text.contains("not permitted to connect"), "got: {text}");
+        assert!(text.contains("EACCES"), "got: {text}");
+        // Must not tell the user to start a running daemon, and must not
+        // prescribe sudo or a chmod: both hide whatever set the mode.
+        assert!(!text.contains("is not running"), "got: {text}");
+        assert!(!text.contains("systemctl enable"), "got: {text}");
+        assert!(!text.contains("chmod"), "got: {text}");
+
+        // The no-listener errnos keep their actionable start-the-daemon message.
+        for kind in [
+            io::ErrorKind::NotFound,
+            io::ErrorKind::ConnectionRefused,
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::BrokenPipe,
+        ] {
+            let mapped = map_connect_failure(io::Error::new(kind, "x"));
+            assert!(
+                mapped.to_string().contains("irlumed is not running"),
+                "{kind:?} lost its message"
+            );
+        }
     }
 }

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -21,7 +21,8 @@ pub mod thirdparty;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
-/// Unix domain socket the daemon listens on. Root-owned, mode 0660, group-gated.
+/// Unix domain socket the daemon listens on. Root-owned, mode 0666: every local
+/// uid may connect, and `SO_PEERCRED` authorizes each request.
 pub const SOCKET_PATH: &str = "/run/irlume.sock";
 
 /// A byte secret (e.g. the login password) that zeroizes on drop and whose

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -210,7 +210,9 @@ pub enum Request {
     /// enrolled user, no claimed identity. Unprivileged (no credential release).
     Identify,
     /// Switch the active RGB+IR camera pair, persisting it (cameras.conf) so it
-    /// survives a daemon restart. PRIVILEGED (root or self); writes /etc/irlume.
+    /// survives a daemon restart. ROOT ONLY: it writes a system-wide setting
+    /// under /etc/irlume, which is not an arbitrary peer's to change. (This said
+    /// "root or self", which never matched the dispatch gate.)
     SetCameras { rgb: String, ir: String },
     /// Add one scan to an existing profile ("improve recognition"). PRIVILEGED.
     AddScan { user: String, profile: String },

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -280,8 +280,16 @@ fn main() {
     //
     // Membership cannot fix it either: supplementary GIDs are process
     // credentials set at login, so adding a uid to the group does not reach an
-    // already-running desktop (see newgrp(1)), and greeter account names differ
-    // per display manager (`sddm`, `plasmalogin`, `gdm`, `Debian-gdm`).
+    // already-running desktop (see newgrp(1)).
+    //
+    // Note what the affected surface actually is, because it is not the login
+    // greeters. SDDM authenticates in `sddm-helper`, GDM in
+    // `gdm-session-worker`, LightDM in `lightdm --session-child`, and greetd in
+    // its session worker; all four keep uid 0 through `pam_authenticate` and
+    // drop privileges only when starting the session, so a dedicated `sddm` or
+    // `gdm` account never reached this socket in the first place. The surfaces
+    // that broke are the ones where the user's own process drives PAM: the KDE
+    // lock screen, and the CLI.
     //
     // 0666 plus connect-time peer credentials is the ordinary Linux pattern for
     // this: it is systemd's own documented default for filesystem sockets
@@ -1528,8 +1536,9 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             })
         }
         Request::CaptureEarMedian { user: _ } => {
-            // Fires the camera; root-gate like the other camera-bearing requests
-            // (on the 0666 socket fallback this is what keeps other uids out).
+            // Fires the camera; root-gate like the other camera-bearing requests.
+            // The socket is world-connectable, so this gate is what keeps other
+            // uids out.
             if peer.uid != 0 {
                 return Response::Error(format!(
                     "capture_ear_median requires root (peer uid {})",
@@ -1563,8 +1572,8 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             // Fires the camera and returns raw liveness/alignment measurements
             // (IR brightness, center/edge, glint), which are a spoof-tuning oracle and
             // a way to tie up the single-threaded daemon. Gate to root, like the
-            // other camera-bearing requests; on the 0666 socket fallback this is
-            // the only thing keeping an arbitrary local uid out.
+            // other camera-bearing requests. The socket is world-connectable, so
+            // this gate is the only thing keeping an arbitrary local uid out.
             if peer.uid != 0 {
                 return Response::Error(format!("self_test requires root (peer uid {})", peer.uid));
             }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -266,36 +266,39 @@ fn main() {
             std::process::exit(1);
         }
     };
-    // SO_PEERCRED is the real trust boundary. Defence-in-depth: if the `irlume`
-    // group exists, restrict the socket to `0660 root:irlume` so only group
-    // members (greeters, the user) can even connect; otherwise fall back to
-    // 0666 so a box without the group set up still works (greeters run as
-    // varied uids). Privileged ops are gated by the peer-credential check either way.
-    match users::gid_for_group("irlume") {
-        Some(gid) => {
-            if let Err(e) = users::chown(std::path::Path::new(&socket), Some(0), Some(gid)) {
-                eprintln!("irlumed: could not chown socket to root:irlume ({e}); leaving 0666");
-                set_mode(&socket, 0o666);
-            } else {
-                set_mode(&socket, 0o660);
-                eprintln!("irlumed: socket restricted to root:irlume (0660)");
-            }
-        }
-        None => {
-            // No `irlume` group: the socket is world-connectable. Privileged ops
-            // still require the peer-credential check, but the unprivileged
-            // endpoints (health tier, self-scoped identify) are now open to any
-            // local uid. A normal packaged install creates the group; warn loudly
-            // so a hand-rolled deployment notices it skipped that step.
-            eprintln!(
-                "irlumed: WARNING: no `irlume` group; socket left world-connectable (0666). \
-                 Create the group and restart so only greeters/users can connect: \
-                 groupadd -r irlume"
-            );
-            set_mode(&socket, 0o666);
-        }
-    }
-    eprintln!("irlumed: listening on {socket}");
+    // SO_PEERCRED is the authorization boundary, and the socket mode must not
+    // pretend to be a second one.
+    //
+    // This was `0660 root:irlume` whenever an `irlume` group existed. That gate
+    // blocked every client it was supposed to admit. The group is created by
+    // packaging with no members, and nothing adds any: the KDE lock screen runs
+    // `kscreenlocker_greet` (not setuid) as the user, so its `pam_irlume.so`
+    // got `connect() = EACCES` and face unlock silently fell through to the
+    // password. `irlume detect` exited 10 (partial) as a user and 0 (ready) as
+    // root on the same healthy box. A gate that stops every intended non-root
+    // client is not defence in depth.
+    //
+    // Membership cannot fix it either: supplementary GIDs are process
+    // credentials set at login, so adding a uid to the group does not reach an
+    // already-running desktop (see newgrp(1)), and greeter account names differ
+    // per display manager (`sddm`, `plasmalogin`, `gdm`, `Debian-gdm`).
+    //
+    // 0666 plus connect-time peer credentials is the ordinary Linux pattern for
+    // this: it is systemd's own documented default for filesystem sockets
+    // (`SocketMode=` in systemd.socket(5)), pcscd ships the same, and the D-Bus
+    // system bus is world-connectable with authorization done in the service.
+    // `SO_PEERCRED` is supplied by the kernel at connect() time and a client
+    // cannot forge it through protocol input (unix(7)). fprintd, the closest
+    // analogue, likewise keeps its endpoint reachable and authorizes per method.
+    //
+    // What this widens is reachability, not authority: every request still
+    // requires peer uid 0 or `target == peer`, root-only operations stay
+    // root-only, requests are bounded to MAX_REQUEST_BYTES with read/write
+    // deadlines, each connection is isolated behind catch_unwind, and camera
+    // work carries a per-uid throttle. On Fedora the SELinux module remains the
+    // mandatory-access layer.
+    set_mode(&socket, DAEMON_SOCKET_MODE);
+    eprintln!("irlumed: listening on {socket} (0666; SO_PEERCRED authorizes every request)");
     if irlume_common::dbglog::on() {
         eprintln!("irlumed: diagnostic tracing ON (IRLUME_LOG=debug): per-stage pipeline lines follow; numbers only, never frames/embeddings");
     }
@@ -460,39 +463,57 @@ fn rate_record(user: &str, granted: bool, faced: bool) {
     }
 }
 
-/// Minimum interval in seconds between unprivileged Identify captures. Two
-/// seconds bounds how often one local peer can occupy the camera pipeline
-/// without affecting a real login.
-const IDENTIFY_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+/// Minimum interval in seconds between unprivileged camera probes. Two seconds
+/// bounds how often one local peer can occupy the camera pipeline without
+/// affecting a real login.
+const CAMERA_PROBE_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 
-// Keep this separate from the failure throttle: Identify has no authentication
-// outcome to strike or reset, and its caller identity is the peer uid.
-type IdentifyRateState = std::sync::Mutex<std::collections::HashMap<u32, std::time::Instant>>;
+// Keep this separate from the failure throttle: these probes have no
+// authentication outcome to strike or reset, and their caller identity is the
+// peer uid.
+type CameraProbeRateState = std::sync::Mutex<std::collections::HashMap<u32, std::time::Instant>>;
 
-fn identify_rate_state() -> &'static IdentifyRateState {
-    static S: std::sync::OnceLock<IdentifyRateState> = std::sync::OnceLock::new();
+fn camera_probe_rate_state() -> &'static CameraProbeRateState {
+    static S: std::sync::OnceLock<CameraProbeRateState> = std::sync::OnceLock::new();
     S.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
-/// Admit and record an Identify attempt atomically. Root is the PAM/greeter
-/// trust boundary and must never be delayed by an unprivileged convenience
-/// request.
-fn identify_rate_limited(uid: u32) -> bool {
+/// Admit and record one unprivileged camera probe atomically. Root is the
+/// PAM/greeter trust boundary and must never be delayed by an unprivileged
+/// convenience request.
+///
+/// Covers `Identify` and the dry-run emitter probe: both open the shared camera
+/// node, neither has an interactive frame-rate requirement, and both are now
+/// reachable by any local uid. Deliberately NOT applied to `Authenticate` (the
+/// real login path, throttled instead by consecutive-failure strikes) or to
+/// `PositionSample` (the framing guide needs continuous samples to give live
+/// feedback, so an interval here would break enrollment).
+fn camera_probe_rate_limited(uid: u32) -> bool {
     if uid == 0 {
         return false;
     }
     let now = std::time::Instant::now();
-    let mut map = identify_rate_state()
+    let mut map = camera_probe_rate_state()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     if map
         .get(&uid)
-        .is_some_and(|last| now.duration_since(*last) < IDENTIFY_MIN_INTERVAL)
+        .is_some_and(|last| now.duration_since(*last) < CAMERA_PROBE_MIN_INTERVAL)
     {
         return true;
     }
     map.insert(uid, now);
     false
+}
+
+/// Forget every recorded probe. The state is process-global, so one test's
+/// dispatch would otherwise throttle the next test that uses the same uid.
+#[cfg(test)]
+fn clear_camera_probe_rate_state() {
+    camera_probe_rate_state()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
 }
 
 fn env_or(key: &str, default: &str) -> String {
@@ -895,7 +916,7 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             }
         }
         Request::Identify => {
-            if identify_rate_limited(peer.uid) {
+            if camera_probe_rate_limited(peer.uid) {
                 return Response::Error("rate limited; try again shortly".into());
             }
             // 1:N identify returns an exact similarity score, so an ungated
@@ -1039,6 +1060,12 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
         Request::SetupIrEmitter { dry_run } => {
             // Hardware fix on the shared camera; non-destructive on failure.
             if dry_run {
+                // Enumerating XU controls opens the shared camera node. Harmless
+                // once, but it is unauthenticated and now reachable by any local
+                // uid, so it shares the camera-probe interval.
+                if camera_probe_rate_limited(peer.uid) {
+                    return Response::Error("rate limited; try again shortly".into());
+                }
                 match irlume_auth::list_ir_controls(engine.ir_device()) {
                     Ok(c) if c.is_empty() => {
                         Response::Ok("no UVC extension-unit controls found".into())
@@ -1826,6 +1853,11 @@ fn respond(mut stream: UnixStream, resp: &Response) -> std::io::Result<()> {
     r
 }
 
+/// Mode for the control socket. Every local uid may connect; `SO_PEERCRED`
+/// decides what each one may then do. See the note at the bind site for why a
+/// group-restricted mode was removed rather than repaired.
+const DAEMON_SOCKET_MODE: u32 = 0o666;
+
 fn set_mode(path: &str, mode: u32) {
     use std::os::unix::fs::PermissionsExt;
     let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
@@ -1909,15 +1941,52 @@ mod tests {
     }
 
     #[test]
+    fn dry_run_emitter_probe_shares_the_camera_interval() {
+        let _g = env_lock();
+        let mut e = engine();
+        clear_camera_probe_rate_state();
+        // The probe opens the shared camera node, is unauthenticated, and is
+        // reachable by any local uid now that the socket admits them, so a
+        // second immediate attempt from the same uid must be refused.
+        let first = dispatch(
+            Request::SetupIrEmitter { dry_run: true },
+            &peer(NOBODY),
+            &mut e,
+        );
+        let Response::Error(first) = first else {
+            panic!("expected the absent-camera error, got {first:?}");
+        };
+        assert!(!first.contains("rate limited"), "first attempt: {first}");
+
+        match dispatch(
+            Request::SetupIrEmitter { dry_run: true },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("rate limited"), "{msg}"),
+            other => panic!("second immediate probe must be throttled, got {other:?}"),
+        }
+
+        // Root is the PAM/greeter path and is never delayed.
+        clear_camera_probe_rate_state();
+        for _ in 0..2 {
+            match dispatch(Request::SetupIrEmitter { dry_run: true }, &peer(0), &mut e) {
+                Response::Error(msg) => assert!(!msg.contains("rate limited"), "{msg}"),
+                other => panic!("unexpected {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn identify_rate_limit_is_per_uid_and_exempts_root() {
         let uid = 0xfffe_fffd;
         let other_uid = 0xfffe_fffc;
 
-        assert!(!identify_rate_limited(uid));
-        assert!(identify_rate_limited(uid));
-        assert!(!identify_rate_limited(other_uid));
-        assert!(!identify_rate_limited(0));
-        assert!(!identify_rate_limited(0));
+        assert!(!camera_probe_rate_limited(uid));
+        assert!(camera_probe_rate_limited(uid));
+        assert!(!camera_probe_rate_limited(other_uid));
+        assert!(!camera_probe_rate_limited(0));
+        assert!(!camera_probe_rate_limited(0));
     }
 
     // Regression: 834c71e. IRLUME_MODELS_STRICT=1 refused to start because the
@@ -2590,6 +2659,31 @@ mod tests {
         assert_eq!(mode, 0o660);
         // Best-effort on a missing path: must not panic.
         set_mode("/nonexistent/irlume-test/sock", 0o666);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn socket_mode_admits_every_local_uid_because_peercred_is_the_gate() {
+        use std::os::unix::fs::PermissionsExt;
+        // Regression: a 0660 root:irlume socket blocked the clients it was meant
+        // to admit. kscreenlocker_greet is not setuid, so the KDE lock screen's
+        // pam_irlume got EACCES and face unlock fell through to the password,
+        // and `irlume detect` exited 10 as a user against 0 as root on the same
+        // healthy box. Assert the mode a real bind produces, not just the
+        // constant, so removing the set_mode call fails this test.
+        let dir = std::env::temp_dir().join(format!("irlume-sockmode-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("irlume.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        set_mode(path.to_str().unwrap(), DAEMON_SOCKET_MODE);
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o666, "every local uid must be able to connect");
+        // Group-restricted modes are the exact regression; spell it out.
+        assert_ne!(mode, 0o660);
+        assert_ne!(mode & 0o006, 0, "other-rw is what admits a user session");
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -3892,6 +3986,9 @@ mod tests {
     fn setup_ir_emitter_gates_root_and_surfaces_a_missing_camera() {
         let _g = env_lock();
         let mut e = engine();
+        // The dry-run probe shares the per-uid camera-probe interval, and another
+        // test may have just spent this uid's slot.
+        clear_camera_probe_rate_state();
         // Dry-run is open to any peer but needs the (absent) IR node.
         match dispatch(
             Request::SetupIrEmitter { dry_run: true },

--- a/crates/irlume-daemon/src/users.rs
+++ b/crates/irlume-daemon/src/users.rs
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright the irlume contributors.
 
-//! Thread-safe passwd/group lookups via libc reentrant calls.
+//! Thread-safe passwd lookups via libc reentrant calls.
 //!
-//! Two uses: (a) resolve the `irlume` group so the socket can be `0660
-//! root:irlume` instead of world-writable, and (b) map a connecting peer's uid
-//! to the username it may act on, via NSS, so LDAP/SSSD/systemd-homed users
-//! resolve too (the old hand-rolled `/etc/passwd` parse missed them). The
-//! plain `getpwnam`/`getgrnam` share a static buffer and aren't safe under
-//! concurrent request handling, so we use the `_r` variants with our own buffer.
+//! One use: map a connecting peer's uid to the username it may act on, via NSS,
+//! so LDAP/SSSD/systemd-homed users resolve too (the old hand-rolled
+//! `/etc/passwd` parse missed them). Plain `getpwnam` shares a static buffer
+//! and isn't safe under concurrent request handling, so we use the `_r`
+//! variants with our own buffer.
 
 use std::ffi::CString;
-use std::os::unix::ffi::OsStrExt;
 
 /// Resolve a username to its uid via NSS. `None` if absent / un-encodable.
 pub fn uid_for_name(name: &str) -> Option<u32> {
@@ -53,42 +51,6 @@ pub fn name_for_uid(uid: u32) -> Option<String> {
     name.to_str().ok().map(|s| s.to_owned())
 }
 
-/// Resolve a group name to its gid via NSS. `None` if absent.
-pub fn gid_for_group(name: &str) -> Option<u32> {
-    let cname = CString::new(name).ok()?;
-    let mut grp: libc::group = unsafe { std::mem::zeroed() };
-    let mut buf = vec![0 as libc::c_char; 4096];
-    let mut result: *mut libc::group = std::ptr::null_mut();
-    // SAFETY: see `uid_for_name`.
-    let rc = unsafe {
-        libc::getgrnam_r(
-            cname.as_ptr(),
-            &mut grp,
-            buf.as_mut_ptr(),
-            buf.len(),
-            &mut result,
-        )
-    };
-    if rc != 0 || result.is_null() {
-        return None;
-    }
-    Some(grp.gr_gid)
-}
-
-/// `chown` a path, leaving uid/gid unchanged where `None`.
-pub fn chown(path: &std::path::Path, uid: Option<u32>, gid: Option<u32>) -> std::io::Result<()> {
-    let cpath = CString::new(path.as_os_str().as_bytes())
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains NUL"))?;
-    let uid = uid.unwrap_or(u32::MAX); // (uid_t)-1 == "no change"
-    let gid = gid.unwrap_or(u32::MAX);
-    // SAFETY: `cpath` is a valid NUL-terminated string for the call's duration.
-    let rc = unsafe { libc::chown(cpath.as_ptr(), uid, gid) };
-    if rc != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -113,47 +75,5 @@ mod tests {
         // 4294967294 = (uid_t)-2, the "nobody owns this" sentinel (used by
         // idmapped mounts); it must never resolve to an account name.
         assert_eq!(name_for_uid(4294967294), None);
-    }
-
-    #[test]
-    fn group_lookup_resolves_root_and_rejects_absent_groups() {
-        // The root group is gid 0 on Linux (the socket-permission fallback
-        // logic relies on a failed "irlume" lookup being None, not an error).
-        assert_eq!(gid_for_group("root"), Some(0));
-        assert_eq!(gid_for_group("no-such-group-irlume-test"), None);
-        assert_eq!(gid_for_group("a\0b"), None);
-    }
-
-    #[test]
-    fn chown_no_change_succeeds_and_bad_paths_error() {
-        let dir = std::env::temp_dir().join(format!("irlume-chown-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let f = dir.join("f");
-        std::fs::write(&f, b"x").unwrap();
-
-        // None/None maps to (uid_t)-1/(gid_t)-1 = "no change": always allowed
-        // on a file we own, even unprivileged.
-        chown(&f, None, None).unwrap();
-        // Re-asserting our own uid/gid is also a no-op chown and must succeed.
-        let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
-        chown(&f, Some(uid), Some(gid)).unwrap();
-        use std::os::unix::fs::MetadataExt;
-        let md = std::fs::metadata(&f).unwrap();
-        assert_eq!((md.uid(), md.gid()), (uid, gid));
-
-        // A missing path surfaces the OS error instead of pretending success.
-        assert!(chown(
-            std::path::Path::new("/nonexistent/irlume-test/f"),
-            None,
-            None
-        )
-        .is_err());
-        // A path with an interior NUL is rejected before touching libc.
-        let nul_path = std::path::Path::new("has\0nul");
-        let err = chown(nul_path, None, None).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -211,8 +211,8 @@ in
         TimeoutStopSec = "10s";
         # Sandboxing, mirroring packaging/systemd/irlumed.service so the hardening
         # holds on NixOS too. Scoped to what the daemon needs: it opens
-        # /dev/video* and the TPM, binds a Unix socket, and chowns each target
-        # user's enrollment. ProtectHome / PrivateDevices / MemoryDenyWriteExecute
+        # /dev/video* and the TPM, binds a Unix socket, and writes root-owned
+        # state at mode 0600. ProtectHome / PrivateDevices / MemoryDenyWriteExecute
         # are deliberately NOT set (per-user $HOME state, camera + TPM access, and
         # the ONNX runtime JITs).
         NoNewPrivileges = true;
@@ -234,8 +234,10 @@ in
         RestrictSUIDSGID = true;
         LockPersonality = true;
         SystemCallArchitectures = "native";
+        # CAP_CHOWN is deliberately absent: nothing chowns. See the longer note in
+        # packaging/systemd/irlumed.service, including why this list must not be
+        # emptied (for a uid-0 service that would grant the full root set).
         CapabilityBoundingSet = [
-          "CAP_CHOWN"
           "CAP_DAC_OVERRIDE"
           "CAP_FOWNER"
         ];

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -60,9 +60,6 @@ package() {
     install -Dm0644 packaging/systemd/irlume-reconcile.path "$pkgdir/usr/lib/systemd/system/irlume-reconcile.path"
     install -Dm0644 packaging/systemd/irlume-reconcile.service "$pkgdir/usr/lib/systemd/system/irlume-reconcile.service"
     install -Dm0644 packaging/systemd/irlume-reconcile.timer "$pkgdir/usr/lib/systemd/system/irlume-reconcile.timer"
-    # The `irlume` system group (socket 0660 root:irlume); irlume.install runs
-    # systemd-sysusers to create it.
-    install -Dm0644 packaging/systemd/irlume.sysusers "$pkgdir/usr/lib/sysusers.d/irlume.conf"
     # AppArmor profile for the daemon. Arch does not run AppArmor by default, so
     # it sits inert unless the user boots with `lsm=...,apparmor`; irlume.install
     # loads it only when apparmor_parser is present. The profile confines the

--- a/packaging/arch/irlume.install
+++ b/packaging/arch/irlume.install
@@ -1,8 +1,5 @@
 post_install() {
     systemctl daemon-reload
-    # Create the `irlume` system group so the daemon restricts its socket to
-    # 0660 root:irlume instead of falling back to 0666.
-    systemd-sysusers 2>/dev/null || true
     # Load the AppArmor profile before the daemon starts, but only if this box
     # actually runs AppArmor (Arch does not by default). apparmor_parser is
     # absent unless the user opted in, so this is a no-op on a stock install.
@@ -23,17 +20,15 @@ irlume installed. Next steps:
   sudo irlume login enable --apply   # opt-in: wire greeter/lock screen
 (enrollment auto-enables the 850nm IR emitter when IR frames are black;
  manual fallback for IR cameras: sudo irlume ir-setup)
-Arch runs no LSM policy by default; SO_PEERCRED plus the 0660 root:irlume
-socket group are the daemon's protection. If you boot with AppArmor, the
-bundled profile (/etc/apparmor.d/usr.bin.irlumed) is loaded automatically.
+Arch runs no LSM policy by default; SO_PEERCRED authorizes every daemon
+request. If you boot with AppArmor, the bundled profile
+(/etc/apparmor.d/usr.bin.irlumed) is loaded automatically.
 Password is always the fallback.
 EOF
 }
 
 post_upgrade() {
     systemctl daemon-reload
-    # Create the `irlume` group if an older version predated it (idempotent).
-    systemd-sysusers 2>/dev/null || true
     if command -v apparmor_parser >/dev/null 2>&1; then
         apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
     fi

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -69,10 +69,6 @@ contents:
     dst: /usr/lib/systemd/system/irlume-reconcile.service
   - src: ../systemd/irlume-reconcile.timer
     dst: /usr/lib/systemd/system/irlume-reconcile.timer
-  # The `irlume` system group (socket 0660 root:irlume); postinstall runs
-  # systemd-sysusers to create it.
-  - src: ../systemd/irlume.sysusers
-    dst: /usr/lib/sysusers.d/irlume.conf
   # AppArmor profile (ships in complain mode; see the profile header)
   - src: ../apparmor/usr.bin.irlumed
     dst: /etc/apparmor.d/usr.bin.irlumed

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -7,9 +7,6 @@ set -e
 if command -v apparmor_parser >/dev/null 2>&1; then
     apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
 fi
-# Create the `irlume` system group so the daemon can restrict its socket to
-# 0660 root:irlume (Debian/Ubuntu do not run sysusers.d automatically).
-systemd-sysusers /usr/lib/sysusers.d/irlume.conf 2>/dev/null || true
 systemctl daemon-reload 2>/dev/null || true
 # Enable + start ONLY on first install ($2 empty). On an upgrade, re-enabling
 # would override a unit the user deliberately disabled; try-restart below picks

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -106,9 +106,6 @@ install -Dm0644 packaging/systemd/irlumed.service %{buildroot}%{_unitdir}/irlume
 install -Dm0644 packaging/systemd/irlume-reconcile.path %{buildroot}%{_unitdir}/irlume-reconcile.path
 install -Dm0644 packaging/systemd/irlume-reconcile.service %{buildroot}%{_unitdir}/irlume-reconcile.service
 install -Dm0644 packaging/systemd/irlume-reconcile.timer %{buildroot}%{_unitdir}/irlume-reconcile.timer
-# The `irlume` system group (socket 0660 root:irlume). The systemd file trigger
-# runs systemd-sysusers on install to create it.
-install -Dm0644 packaging/systemd/irlume.sysusers %{buildroot}%{_sysusersdir}/irlume.conf
 # Bundled onnxruntime runtime + a drop-in pointing ORT_DYLIB_PATH at it (cp -a
 # to preserve the .so version symlinks).
 install -d %{buildroot}%{_datadir}/%{name}/onnxruntime/lib
@@ -153,11 +150,11 @@ if [ $1 -gt 1 ]; then
 fi
 
 %preun
-%systemd_preun irlumed.service irlume-reconcile.path irlume-reconcile.service
+%systemd_preun irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
 
 %postun
 %systemd_postun_with_restart irlumed.service
-%systemd_postun irlume-reconcile.path irlume-reconcile.service
+%systemd_postun irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
 
 %post selinux
 semodule -i %{_datadir}/selinux/packages/irlume.pp 2>/dev/null || :
@@ -191,7 +188,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_unitdir}/irlumed.service.d/10-ort.conf
 %{_unitdir}/irlume-reconcile.path
 %{_unitdir}/irlume-reconcile.service
-%{_sysusersdir}/irlume.conf
+%{_unitdir}/irlume-reconcile.timer
 %{_presetdir}/90-irlume.preset
 
 %files selinux

--- a/packaging/selinux/irlume.te
+++ b/packaging/selinux/irlume.te
@@ -13,8 +13,12 @@ policy_module(irlume, 1.1.0)
 #   avc: denied { write } ... comm="plasmalogin-hel" name="irlume.sock"
 #        scontext=...:xdm_t tcontext=...:var_run_t tclass=sock_file
 #
-# sudo and the KDE lock screen work without this module because both run in
-# the user's UNCONFINED domain, which is already allowed.
+# sudo and the KDE lock screen need no rule here because both run in the user's
+# UNCONFINED domain, which SELinux already allows. Read that narrowly: it means
+# SELinux does not block them, and nothing more. It says nothing about the
+# socket's permission bits, and that gap is exactly how a `0660 root:irlume`
+# socket once broke lock-screen face unlock while this comment claimed the path
+# "works". DAC and MAC are independent; both have to permit the connect.
 #
 # We give the socket its own type via a name-based transition so the grant to
 # xdm_t is scoped to *our* socket rather than every var_run_t sock_file.

--- a/packaging/systemd/irlume.sysusers
+++ b/packaging/systemd/irlume.sysusers
@@ -1,5 +1,0 @@
-# Create the `irlume` system group. The daemon restricts its control socket to
-# 0660 root:irlume when this group exists (only greeters and members can connect;
-# SO_PEERCRED is still the real authorization boundary). Without the group the
-# socket falls back to 0666 (world-connectable) and irlumed warns at startup.
-g irlume -

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -52,8 +52,23 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
 SystemCallArchitectures=native
-# The daemon chowns enrolled files to the target user; keep only those caps.
-CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER
+# Keep only the caps the daemon uses. CAP_CHOWN is deliberately absent: nothing
+# chowns. The old comment here claimed the daemon "chowns enrolled files to the
+# target user", which was never implemented; enrollment files are created by the
+# root daemon and left root-owned at mode 0600. The capability's one real user
+# was the socket's `root:irlume` chown, and that is gone.
+#
+# Do not delete this directive to "simplify" it. For a uid-0 service systemd
+# clears everything not listed before exec, and the root exec rule then makes
+# the listed set permitted and effective, so an empty or absent directive hands
+# the daemon the full root capability set (capabilities(7)). Removing the line
+# is a privilege expansion, not a cleanup.
+#
+# CAP_DAC_OVERRIDE and CAP_FOWNER stay: field installs may still hold state
+# created by older CLI or development workflows that is not root-owned, and
+# reading or re-moding that needs them. Dropping those two is a separate change
+# that needs a legacy-state migration test first.
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER
 UMask=0027
 
 [Install]


### PR DESCRIPTION
Release blocker for 0.7.0. Found by the soak, not by a user: this never shipped.

## What broke

Adding `packaging/systemd/irlume.sysusers` created an `irlume` system group, which flipped the daemon into its `0660 root:irlume` socket branch. Nothing ever added a member to that group, and no documentation asked anyone to. The daemon-side branch itself predates this and shipped in 0.6.1; it stayed dormant there because packaging never created the group, so 0.6.1 installs got 0666 and worked.

Measured on Fedora 44 KDE, daemon healthy, face enrolled:

```
/run/irlume.sock                srw-rw---- root irlume
getent group irlume             irlume:x:965:        (no members)
connect() as the desktop user   EACCES
```

**The lock screen was broken.** `kscreenlocker_greet` is not setuid, so the `/etc/pam.d/kde` conversation runs as the user. Under strace, against the real stack:

```
connect(3, {sa_family=AF_UNIX, sun_path="/run/irlume.sock"}, 19) = -1 EACCES
```

Face unlock, and the keyring unseal that rides on it, silently fell through to the password. Alongside that, `irlume detect` exited 10 (partial) as a user and 0 (ready) as root on the same machine, and `status` reported "daemon NOT reachable" for a daemon serving requests. `sudo`, the login greeter and polkit were unaffected: all three run as root, which is why this survived earlier testing.

Our own `packaging/selinux/irlume.te` records the reasoning that missed it: "sudo and the KDE lock screen work without this module because both run in the user's UNCONFINED domain, which is already allowed." True of SELinux, silent on the permission bits.

## The fix

Socket is 0666; the group is gone from all three lanes. Reachability was never the authorization boundary. `SO_PEERCRED` is: kernel-supplied at connect time, unforgeable through protocol input (`unix(7)`), and every request already requires peer uid 0 or a target matching the peer uid.

This is the ordinary arrangement for a local system daemon. It is systemd's documented default for filesystem sockets (`SocketMode=`, `systemd.socket(5)`), pcscd ships the same, and fprintd, the closest analogue, keeps its endpoint reachable and authorizes per operation rather than by group.

Group membership could not have fixed it: supplementary GIDs are process credentials set at login, so adding a uid does not reach a running desktop (`newgrp(1)`), and greeter accounts differ per display manager (`sddm`, `plasmalogin`, `gdm`, `Debian-gdm`).

Reachability widened, authority did not. Requests stay bounded (64 KiB, read/write deadlines), connections stay isolated behind `catch_unwind`, and the unauthenticated dry-run emitter probe now shares the per-uid camera interval that already covered `Identify`. That interval is deliberately **not** applied to `Authenticate` (the real login path, throttled by consecutive-failure strikes) or `PositionSample` (the framing guide needs continuous samples).

Also fixes EACCES reporting, which was telling users a healthy daemon was down and sending them to `systemctl status`. `daemon_up() -> bool` became a typed `DaemonReach`. `detect` stays at exit 10 under EACCES, because readiness is genuinely unknown there and 0 would assert what it cannot see, but it names the real obstacle instead of guessing "not enrolled".

And packages `irlume-reconcile.timer` on Fedora: #103 installed it into the buildroot without a `%files` entry, which fails the rpm build on an unpackaged file, and left it out of `%preun`/`%postun`. The Packit check that would have caught this never ran on #103 (Copr backend: "Giving up waiting for copr_base repository").

## Hardware validation

Branch daemon on the real socket with the real enrolment, real PAM stacks driven with `pamtester`, packaged daemon restored on exit. Nothing on disk modified. **9/9 passed:**

| Check | Result |
|---|---|
| socket mode | `666 root:root` |
| real `/etc/pam.d/kde` as the user | `connect(...) = 0`, was EACCES |
| daemon served the lock-screen request | yes |
| `detect` as an unprivileged user | exit 0, "ready: daemon running and a face is enrolled" |
| `status` as an unprivileged user | "daemon: running", enrollment shown |
| `profiles` as an unprivileged user | lists profiles |
| real `/etc/pam.d/sudo` face path | `pamtester: successfully authenticated` |
| dry-run emitter probe, 1st then 2nd | XU controls listed, then "rate limited" |
| root exempt from the interval | yes |

Harness note: an earlier run reported this fix broken. A fixed 6-second sleep measured the stale 0660 socket file the stopped service leaves behind, before the branch daemon had finished loading models, so `connect` gave EACCES with no listener present. The harness now gates on the daemon listening and on our pid owning the socket.

Workspace: fmt clean, clippy `-D warnings` clean, all tests pass.

## Follow-ups, deliberately not in here

- `irlumed.service` still grants `CAP_CHOWN`, which existed only for the socket group chown. Nothing chowns anymore, so it can go, but reducing capabilities deserves its own validation pass rather than riding along in a blocker fix.
- Camera fairness across local uids is a real residual of wider reachability. The per-uid interval covers the unauthenticated probes; a general fair-share design for `PositionSample` and enrollment is separate work.
- Fleet confirmation is owed: a display manager whose greeter runs as a non-root account (SDDM as `sddm`, confined `xdm_t`) hit the same DAC gate, so greeter face login was likely broken there too. archhost and thinkpad were both unreachable while testing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>