### PR TITLE
deps: bump base64 to 0.23 without its default simd-unsafe feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,7 +946,7 @@ version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "argon2",
- "base64",
+ "base64 0.23.0",
  "irlume-common",
  "irlume-vision",
  "rand 0.10.2",
@@ -1597,7 +1603,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "859d4117bd1b1dc5646359ee7243c50c5000c0920ea2d1fb120335a2f4c684b8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "oid",
  "picky-asn1",
  "picky-asn1-der",
@@ -2351,7 +2357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1"
 thiserror  = "2"
 zeroize    = { version = "1", features = ["derive"] }
 tss-esapi  = "7.5"      # TPM 2.0 seal/unseal of the keyring secret
-base64     = "0.22"     # envelope blob encoding
+base64     = { version = "0.23", default-features = false, features = ["std"] }  # envelope blob encoding
 sha2       = "0.11"     # PolicyAuthorize digest math (signed-PCR path)
 rsa        = { version = "0.9", features = ["sha2"] }  # parse systemd PCR-signing pubkey
 aes-gcm    = "0.11"     # AES-256-GCM for template-at-rest encryption


### PR DESCRIPTION
Replaces #106 and #107, which dependabot split across the workspace and fuzz lockfiles. One deliberate difference from what it proposed.

## Why not merge dependabot's version as-is

base64 0.23.0 adds a third cargo feature, **`simd-unsafe`, enabled by default**. 0.22.1 had only `std` and `alloc`, so this is a new default-on unsafe code path, not a like-for-like bump.

That crate decodes the TPM-sealed, AES-GCM-encrypted enrollment envelope and encodes the preview JPEG that crosses the IPC boundary. Adopting default-on unsafe SIMD there should be a decision, not a side effect. irlume also gains nothing from it: envelope blobs are small and the preview is capped at 96 KiB, so SIMD throughput is not a constraint.

Declared with `default-features = false, features = ["std"]`. `cargo tree -e features` confirms the resolved graph:

```
base64 v0.23.0
├── base64 feature "alloc"
│   └── base64 feature "std"
```

No `simd-unsafe`.

## Verified, not assumed

- **MSRV**: 0.23.0 raises its floor to 1.71.0. This workspace requires 1.88, so it is a non-issue.
- **Decode behaviour**: upstream release notes document no change to the STANDARD engine's encode/decode, padding, or strictness.
- **Proven on hardware anyway**, because a decode regression here is the issue-#93 lockout class: a daemon built against 0.23 read the real on-disk enrollment written by the 0.22 build, listed all ten scans, and left the file byte-identical (`317dcfb2c46a9858` before and after).
- **`cargo deny check`**: advisories, bans, licenses and sources all ok. base64 0.22.1 remains in the graph via `picky-asn1-x509` through our tss-esapi fork; the duplicate is tolerated.
- 647 workspace tests pass, fmt clean, clippy `-D warnings` clean.

## Why `fuzz/Cargo.lock` is untouched

#107 edited it. That is unnecessary and risky:

- The fuzz job runs `cargo fuzz run` **without `--locked`**, so that lockfile is not enforced. It has been stale for a while, still pinning the irlume crates at 0.5.0.
- Running `cargo update` in `fuzz/` re-resolves tss-esapi from our git fork (7.7.0) to crates.io 7.6.0 and downgrades a dozen transitive crates, after which the workspace does not compile. That is exactly what the warning comment in `fuzz/Cargo.toml` is about. I did this by accident, saw the breakage, and reverted.
- The fuzz workspace builds clean against this change with its existing lockfile.

This also explains #107's red CI: it bumped the root `Cargo.toml` while regenerating only `fuzz/Cargo.lock`, leaving the root lock stale, so every `--locked` job failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>