### PR TITLE
ci: fix three workflows that have been failing silently

### DIFF
--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -80,7 +80,17 @@ jobs:
           # fail loudly if it errors, and only skip when it succeeded AND
           # reported no IR node.
           doc="$(mktemp)"
-          if ! ./target/debug/irlume doctor >"$doc" 2>&1; then
+          # The runner sets CARGO_TARGET_DIR in its .env (outside the work dir,
+          # so checkout's clean cannot wipe the incremental build state), which
+          # means cargo never writes ./target here. Hardcoding that path made
+          # every scheduled run fail on a missing binary while the tests above
+          # passed, so resolve the same directory cargo just built into.
+          irlume_bin="${CARGO_TARGET_DIR:-target}/debug/irlume"
+          if [ ! -x "$irlume_bin" ]; then
+            echo "::error::built binary not found at $irlume_bin"
+            exit 1
+          fi
+          if ! "$irlume_bin" doctor >"$doc" 2>&1; then
             echo "::error::irlume doctor failed — not a clean camera-absent skip"
             cat "$doc"; exit 1
           fi

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -16,6 +16,10 @@ jobs:
   # Collect the sha256 of the release's distributable artifacts into the
   # base64 subjects blob the generator signs over.
   hashes:
+    # Version releases only. The model-weights release (`models-v1`) carries
+    # .onnx files and no packages, so it has nothing for this workflow to
+    # attest; it used to run anyway and fail in the generator's final step.
+    if: startsWith(github.ref_name, 'v')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -31,9 +35,20 @@ jobs:
         id: hash
         working-directory: assets
         run: |
+          set -euo pipefail
           # Provenance covers the distributables, not the checksum manifest or
           # its detached signature (those authenticate these same artifacts).
-          echo "digests=$(sha256sum irlume_*.deb irlume-selinux-*.rpm | base64 -w0)" >> "$GITHUB_OUTPUT"
+          #
+          # Compute into a variable first. Writing `echo "digests=$(sha256sum
+          # ...)"` hides the failure, because the exit status belongs to echo:
+          # a release with no packages produced an EMPTY digests output, this
+          # job went green, and the generator failed later with a bare exit 27.
+          digests="$(sha256sum irlume_*.deb irlume-selinux-*.rpm | base64 -w0)"
+          if [ -z "$digests" ]; then
+            echo "::error::no package digests computed; refusing to request provenance over nothing"
+            exit 1
+          fi
+          echo "digests=$digests" >> "$GITHUB_OUTPUT"
 
   # The generic generator runs in an isolated reusable workflow (SLSA L3 for the
   # provenance step) and uploads multiple.intoto.jsonl to the release. It must be

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -50,6 +50,22 @@ jobs:
           if [ ! -f SHA256SUMS ] || [ ! -f SHA256SUMS.asc ]; then
             echo "::notice::SHA256SUMS/.asc not present yet — assets still uploading; skipping this run"
             echo "incomplete=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          # The sums pair can land BEFORE the last package it covers, and then
+          # `sha256sum --check` fails with "listed file could not be read" on a
+          # release that is merely mid-upload. That is the same incomplete state
+          # as a missing sums file, so treat it the same way instead of failing
+          # the release. A genuinely missing asset still fails once uploading
+          # has finished, because the final upload triggers another run.
+          missing=""
+          while read -r _ name; do
+            [ -n "$name" ] || continue
+            [ -f "$name" ] || missing="$missing $name"
+          done < SHA256SUMS
+          if [ -n "$missing" ]; then
+            echo "::notice::assets still uploading, not yet present:$missing — skipping this run"
+            echo "incomplete=1" >> "$GITHUB_ENV"
           fi
 
       - name: Verify signature, checksums, and coverage


### PR DESCRIPTION
Audit of recent runs across all eleven workflows. Three were failing, all diagnosed from logs and the runner itself.

## Hardware suite: red every scheduled night since 2026-07-22

The nightly hardware-in-the-loop gate on archhost has failed five nights running. Every test in the job passed; it died at the doctor step:

```
##[error]irlume doctor failed — not a clean camera-absent skip
./target/debug/irlume: No such file or directory
```

The runner's `.env` sets `CARGO_TARGET_DIR=/home/ghrunner/cargo-target`, deliberately outside the work directory so checkout's clean cannot wipe incremental build state. The workflow's own comment says exactly that, eleven lines above the hardcoded `./target/debug/irlume`. Verified on the runner:

```
/home/ghrunner/cargo-target/debug/irlume        exists
/home/ghrunner/actions-runner/_work/irlume/irlume/target   does not exist
```

Now resolves `${CARGO_TARGET_DIR:-target}/debug/irlume` and fails with a clear message if the binary is missing. My first hypothesis was "archhost was offline"; the log showed the runner online and the job failing in 46 seconds, so that was wrong.

## SLSA provenance: failed on the weights release, and was hiding failures generally

`models-v1` carries four `.onnx` files and no packages, so `sha256sum irlume_*.deb irlume-selinux-*.rpm` matched nothing. The `hashes` job **still reported success**, because in

```bash
echo "digests=$(sha256sum ...)" >> "$GITHUB_OUTPUT"
```

the exit status belongs to `echo`, not the substitution. An empty subjects blob flowed into the generator, which died in `provenance / final` with a bare `exit 27`. That is the worst kind of failure: green where the mistake is, red somewhere unrelated with no message.

Two changes: the job is gated to `v*` tags so a weights release stops requesting provenance over nothing, and the digest is computed into a variable under `set -euo pipefail` with an explicit empty check. The `provenance` job needs `hashes`, so it skips cleanly with no extra guard.

## Verify release assets: failed mid-upload on 0.6.1

```
sha256sum: WARNING: 1 listed file could not be read
```

There is already a guard for a missing `SHA256SUMS`/`.asc`, but the sums pair can land **before** the last package it covers, so a release that was still uploading read as a bad release. The guard now also treats "a file listed in SHA256SUMS is not present yet" as the same incomplete state. A genuinely missing asset still fails, since the final upload triggers another run. The parsing was tested against both the all-present and still-uploading cases.

## Not changed

**Install matrix**: the two 2026-07-21 failures are stale; the two most recent runs of that workflow both pass.

**Hygiene**, confirmed clean during the audit: every action reference is SHA-pinned (`scripts/check-action-pins.sh` passes, SLSA generator excepted by design), and every workflow declares top-level permissions and per-job timeouts.

## Note on merge friction, separate from this PR

`required_status_checks.strict` is on, so every merge puts remaining PRs in `BEHIND` and each needs `gh pr update-branch --rebase` plus a full CI re-run. GitHub's native auto-merge does **not** update branches, so `allow_auto_merge` alone does not fix it. Real options are a merge queue, dropping `strict`, or adding a third-party auto-update action, which I would not do in a repo that SHA-pins everything. Using `--auto` on this PR at least removes the babysitting.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>