### PR TITLE
ci: audit the workflows themselves, and fix what the audit found

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # Do not adopt a release the day it appears. A compromised push to a
+    # popular action is a real and recent event: Trivy's own action and setup
+    # tags were force-pushed to credential-stealing code in March 2026
+    # (GHSA-69fq-xp46-6x23). A week of aging means a malicious release has time
+    # to be reported and yanked before it is proposed here. This delays version
+    # updates only; Dependabot security updates and the daily cargo-deny
+    # advisory job are unaffected.
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci"
 
@@ -35,6 +44,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Same reasoning as the actions ecosystem above. Cargo supports SemVer-aware
+    # windows, so a major bump (the likeliest place for a hostile rewrite to
+    # hide) ages longer than a patch.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
       cargo-minor:
         update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       # Actions are pinned to a commit SHA (the tag in the comment is what it
       # was) so a moved tag cannot change what runs. Dependabot bumps these.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not leave the job token in .git/config for later steps to reach.
+          persist-credentials: false
 
       # The ONNX weights (~257 MB) are fetched from the models-v1 release, not
       # Git LFS; cache them keyed on models/SHA256SUMS (changes exactly when the
@@ -180,6 +183,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not leave the job token in .git/config for later steps to reach.
+          persist-credentials: false
 
       - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -234,6 +240,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not leave the job token in .git/config for later steps to reach.
+          persist-credentials: false
 
       - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -138,7 +138,10 @@ jobs:
           IRLUME_TEST_SPARE_DEVICE: /dev/video10
           IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
         run: |
-          test -w /dev/video8 && test -w /dev/video9 || { echo "::error::loopback nodes missing — re-provision v4l2loopback"; exit 1; }
+          if [ ! -w /dev/video8 ] || [ ! -w /dev/video9 ]; then
+            echo "::error::loopback nodes missing — re-provision v4l2loopback"
+            exit 1
+          fi
           ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
           ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
           trap 'kill %1 %2 2>/dev/null || true' EXIT

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -22,6 +22,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not leave the job token in .git/config for later steps to reach.
+          persist-credentials: false
 
       # Same model cache as ci.yml (shared key): the ~257 MB weights are
       # fetched from the models-v1 release, cached so warm runs skip the pull.
@@ -82,7 +85,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     container:
-      image: archlinux:latest
+      # Pinned by digest, not `:latest`: a mutable tag means the image can change
+      # under us between runs, and a compromised push would execute here. This
+      # does NOT weaken the "rolling toolchain" purpose of the job, because the
+      # first step runs a full `pacman -Syu`, so the packages under test are
+      # current regardless of how old the base layer is. Refresh the digest when
+      # the base drifts far enough that a full upgrade gets unwieldy.
+      # archlinux:latest as of 2026-07-20.
+      image: archlinux@sha256:592e11bd99ab579f933a0cb77a8f66e2f3ae57f5eafacf13aea44a6e98ef21ae
     steps:
       - name: Install toolchain and system deps
         run: |
@@ -90,6 +100,9 @@ jobs:
             base-devel git rust clang pam tpm2-tss curl ca-certificates
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not leave the job token in .git/config for later steps to reach.
+          persist-credentials: false
 
       - name: Cache model weights
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -95,7 +95,10 @@ jobs:
           IRLUME_TEST_SPARE_DEVICE: /dev/video10
           IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
         run: |
-          test -w /dev/video8 && test -w /dev/video9 || { echo "::error::loopback nodes missing or not writable — re-provision v4l2loopback on the runner"; exit 1; }
+          if [ ! -w /dev/video8 ] || [ ! -w /dev/video9 ]; then
+            echo "::error::loopback nodes missing or not writable — re-provision v4l2loopback on the runner"
+            exit 1
+          fi
           ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video8 >/dev/null 2>&1 &
           ffmpeg -loglevel error -re -f lavfi -i testsrc2=size=640x400:rate=30 -pix_fmt gray -f v4l2 /dev/video9 >/dev/null 2>&1 &
           trap 'kill %1 %2 2>/dev/null || true' EXIT

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -27,6 +27,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not leave the job token in .git/config for later steps to reach.
+          persist-credentials: false
 
       - name: Install Nix with flakes
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0

--- a/.github/workflows/workflow-audit.yml
+++ b/.github/workflows/workflow-audit.yml
@@ -1,0 +1,92 @@
+# Static analysis of the workflows themselves.
+#
+# scripts/check-action-pins.sh already enforces that every `uses:` is SHA-pinned,
+# but that is one property checked by one grep. It structurally cannot see a
+# floating CONTAINER image, a checkout that leaves its token in .git/config for
+# later steps, an expression interpolated into a `run:` block, or a job that
+# quietly gained more permissions than it needs. zizmor covers that class; both
+# findings it produced on its first run against this repo were real (a
+# `container: archlinux:latest`, and six checkouts without
+# `persist-credentials: false`, one of them in the workflow that holds
+# `contents: write`).
+#
+# actionlint is the correctness half: bad `if:` expressions, unknown contexts,
+# shellcheck over `run:` blocks. A workflow typo otherwise surfaces as a failed
+# run on main rather than a failed check on the PR.
+#
+# Deliberately hosted-runner only. Nothing here touches the self-hosted runner.
+name: Workflow audit
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/zizmor.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/zizmor.yml"
+  # Weekly, because the online audits (archived or deleted actions, known-bad
+  # refs) can start failing on a workflow nobody has edited.
+  schedule:
+    - cron: "20 6 * * 2" # Tuesdays 06:20 UTC, clear of the Monday install matrix
+  workflow_dispatch:
+
+# Read-only. Findings are printed in the job log rather than uploaded as SARIF,
+# which keeps this job from needing `security-events: write`.
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor (workflow security)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Config lives at .github/zizmor.yml and is auto-discovered. It carves out
+      # exactly one exception: the SLSA generator must be tag-referenced.
+      - uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          # Pinned rather than `latest`, so a new zizmor release cannot turn a
+          # green PR red without a visible bump.
+          version: 1.28.0
+          # `regular` is the default persona. `auditor` reports 32 findings here,
+          # mostly stylistic (undocumented permissions, unnamed jobs), which
+          # would train everyone to ignore the job. Run auditor by hand when
+          # doing a deliberate hardening pass.
+          persona: regular
+          advanced-security: false
+
+  actionlint:
+    name: actionlint (workflow correctness)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: actionlint
+        env:
+          # Pinned by version and verified by checksum. This downloads a release
+          # binary rather than using an action, so the digest is the only thing
+          # standing between CI and a swapped artifact. Both values come from the
+          # upstream checksums file; update them together.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum -c -
+          tar xzf "$tarball" actionlint
+          # shellcheck is preinstalled on the hosted runner, so `run:` blocks get
+          # linted too rather than silently skipped.
+          ./actionlint -color

--- a/.github/workflows/workflow-audit.yml
+++ b/.github/workflows/workflow-audit.yml
@@ -87,6 +87,8 @@ jobs:
           curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
           echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum -c -
           tar xzf "$tarball" actionlint
-          # shellcheck is preinstalled on the hosted runner, so `run:` blocks get
-          # linted too rather than silently skipped.
+          # The hosted runner preinstalls shellcheck, so actionlint lints `run:`
+          # blocks too rather than silently skipping them. (This comment must not
+          # begin with the tool's name: shellcheck would read it as a directive
+          # and fail to parse it, which is exactly how this job first failed.)
           ./actionlint -color

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+# zizmor configuration (https://docs.zizmor.sh/configuration/).
+#
+# One deliberate exception to hash-pinning. The SLSA generic generator MUST be
+# referenced by an @vX.Y.Z tag rather than a commit SHA: its L3 model embeds the
+# tag in the signed provenance identity and slsa-verifier validates it, so a
+# SHA-pinned reference would produce provenance consumers cannot verify. The same
+# exception is carved out in scripts/check-action-pins.sh, for the same reason.
+#
+# Everything else stays hash-pinned, and the policy is scoped to that one
+# repository rather than the whole slsa-framework org.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        slsa-framework/slsa-github-generator/*: ref-pin
+        "*": hash-pin


### PR DESCRIPTION
`scripts/check-action-pins.sh` checks one property with one grep: that every `uses:` is SHA-pinned. It cannot see a floating container image, a checkout that leaves its token in `.git/config`, an expression interpolated into a `run:` block, or a job that quietly gained permissions. I ran zizmor against this repo before proposing it, and it found real problems in the first run — so this PR is the scanner plus the fixes it produced.

## What it found

**`container: archlinux:latest`** in `install-matrix.yml`. Now pinned by digest (`archlinux@sha256:592e11bd…`, the image built 2026-07-20). This does not weaken the job's "rolling toolchain" purpose: its first step is a full `pacman -Syu`, so the packages under test stay current regardless of the base layer's age. The digest only fixes the starting point.

**Six checkouts leaving the job token in `.git/config`:**

| workflow | checkouts | had the flag |
|---|---|---|
| `ci.yml` | 6 | 3 |
| `install-matrix.yml` | 2 | 0 |
| `update-flake-lock.yml` | 1 | 0 |

The last one is the one that mattered: it holds `contents: write` and `pull-requests: write`, so a **write-scoped** token was persisted for every later step to reach. You clearly set this flag deliberately elsewhere, so it was drift rather than policy.

I verified setting it there is safe rather than assuming: `DeterminateSystems/update-flake-lock` delegates to `peter-evans/create-pull-request`, whose `git-config-helper.ts` calls `configureToken()` to install its own basic credential from the `token` input, and explicitly saves-and-unsets any persisted extraheader first. It never relied on checkout's credentials.

**No Dependabot cooldown**, so a brand-new release could be adopted the day it appeared. That is not hypothetical — Trivy's action and setup tags were force-pushed to credential-stealing code in March 2026 ([GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)). Now 7 days for both ecosystems and 14 for cargo majors. This delays **version** updates only; Dependabot security updates and the daily cargo-deny advisory job are untouched.

## The new workflow

Hosted runners only, nothing touches the self-hosted machine.

- **zizmor pinned to 1.28.0**, not `latest`, so a new release cannot turn a green PR red without a visible bump.
- **`persona: regular`**. The `auditor` persona reports 32 findings here, mostly stylistic (undocumented permissions, unnamed jobs), which would train everyone to ignore the job. Run it by hand for a deliberate hardening pass.
- **`advanced-security: false`** keeps the job at `contents: read` with no `security-events: write`.
- **actionlint** alongside for correctness (bad `if:` expressions, unknown contexts, shellcheck over `run:` blocks), installed from a release tarball verified by sha256 rather than adding another action.
- Triggers on workflow changes, plus weekly, because the online audits can begin failing on a workflow nobody edited.

`.github/zizmor.yml` carves out exactly one exception, scoped to the single repository rather than the whole org: the SLSA generic generator must be tag-referenced, since its L3 model embeds that tag in the signed provenance identity and slsa-verifier validates it. `check-action-pins.sh` excepts the same thing for the same reason.

## Verified locally before pushing

```
zizmor .            → No findings to report. (25 suppressed)
actionlint          → exit 0, all workflows
check-action-pins   → All action references are SHA-pinned (SLSA generator excepted)
```

Both new YAML files parse, and the actionlint checksum was confirmed against the upstream `checksums.txt`.

## Scope note

Two further ideas from the same research are deliberately **not** here: a failure-forensics artifact bundle for the hardware job, and a `systemd-analyze security` ratchet for the shipped units. Both are worth doing and both deserve their own PR.

Explicitly rejected during the research, recorded so it is not revisited: Trivy or Grype (compromised ecosystem this year, and it would miss the bundled onnxruntime without SBOM metadata), ModelScan on the `.onnx` files (it does not support ONNX), cargo-crev (no release since 2019), MSan (the bundled uninstrumented onnxruntime and libc violate its assumptions), cargo-geiger as a gate, and any tmate/SSH-into-runner action.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Co-Authored-By: Codex (gpt-5.6-sol) <codex@openai.com>
Signed-off-by: archledger <archledger236@gmail.com>