### PR TITLE
ci: capture forensics when hardware fails, and ratchet unit exposure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,69 @@ jobs:
         with:
           command: check advisories bans licenses sources
 
+  units:
+    name: systemd units (verify + exposure ratchet)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: systemd-analyze verify (unit syntax)
+        run: |
+          set -euo pipefail
+          command -v systemd-analyze >/dev/null || {
+            sudo apt-get update -qq && sudo apt-get install -y -qq systemd; }
+          # verify resolves ExecStart and fails on a binary that is not present,
+          # which on a build runner it never is. Stub the two paths so the check
+          # is about unit syntax, which is what we actually want tested.
+          sudo install -Dm755 /bin/true /usr/bin/irlumed
+          sudo install -Dm755 /bin/true /usr/bin/irlume
+          for u in packaging/systemd/*.service packaging/systemd/*.timer packaging/systemd/*.path; do
+            echo "::group::verify $(basename "$u")"
+            systemd-analyze verify "$u"
+            echo "::endgroup::"
+          done
+
+      - name: systemd-analyze security (exposure must not regress)
+        run: |
+          set -euo pipefail
+          # Ratchet, in the same spirit as the coverage floor. These numbers are
+          # the CURRENT measured exposure, so any change that loosens sandboxing
+          # fails here instead of shipping quietly. --threshold compares on a
+          # 0-100 scale, so 3.7 as displayed is 37 here, and it fails only when
+          # exposure goes OVER the number.
+          #
+          # To re-baseline deliberately: run
+          #   systemd-analyze security --offline=true packaging/systemd/<unit>
+          # and move the number, in the same commit as whatever changed it.
+          #
+          # The score is systemd-version-sensitive. Measured on the ubuntu-24.04
+          # image (systemd 255); a runner image that moves to a systemd with new
+          # checks may need a re-baseline, which is a deliberate act, not a
+          # silent drift.
+          #
+          # irlume-reconcile.service is knowingly high: it is a root oneshot that
+          # rewrites /etc/pam.d, so it holds broad access by design. Locking it
+          # here stops it getting worse. Hardening it is its own change, with its
+          # own validation, because it is the self-heal that repairs broken PAM.
+          fail=0
+          check() {
+            local unit="$1" threshold="$2"
+            echo "::group::security $(basename "$unit") (threshold ${threshold})"
+            if systemd-analyze security --offline=true --threshold="$threshold" "$unit"; then
+              echo "OK: at or below the recorded exposure"
+            else
+              echo "::error::$(basename "$unit") exposure rose above ${threshold} (0-100 scale)"
+              fail=1
+            fi
+            echo "::endgroup::"
+          }
+          check packaging/systemd/irlumed.service 37
+          check packaging/systemd/irlume-reconcile.service 94
+          exit "$fail"
+
   nix:
     name: nix flake check
     runs-on: ubuntu-24.04

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -111,6 +111,72 @@ jobs:
           # capture_ir keys on. A dead emitter shows as a flat, dark burst.
           awk '{print $2}' "$out/means.txt" | sort -n | awk 'NR==1{min=$1} END{max=$1; d=max-min; printf "mean spread: %.1f\n", d; exit (d < 5)}'
 
+      # Forensics on failure only. A hardware-only failure is otherwise
+      # reconstructed by reading raw job logs and guessing at machine state that
+      # has since changed: the first diagnosis of the CARGO_TARGET_DIR breakage
+      # in this very job started from a wrong hypothesis (that the runner was
+      # offline) because none of this was captured.
+      #
+      # Everything is best-effort and must never mask the real failure, so each
+      # command swallows its own error and the step force-succeeds. Scoped
+      # deliberately: the irlumed unit journal and kernel ring rather than the
+      # whole system journal, because this runner is a personal machine.
+      - name: Collect failure forensics
+        if: failure()
+        continue-on-error: true
+        run: |
+          set +e
+          out=hw-forensics
+          mkdir -p "$out"
+
+          {
+            echo "commit:  ${GITHUB_SHA}"
+            echo "run:     ${GITHUB_RUN_ID} attempt ${GITHUB_RUN_ATTEMPT}"
+            echo "runner:  $(uname -a)"
+            echo "rustc:   $(rustc -vV 2>&1 | tr '\n' ' ')"
+            echo "target:  ${CARGO_TARGET_DIR:-target}"
+          } > "$out/context.txt" 2>&1
+
+          # Cameras: which nodes exist, what formats they claim, and whether the
+          # loopback module is loaded. "no IR camera" and "IR camera wedged" look
+          # identical in the job log without this.
+          {
+            ls -l /dev/video* /dev/media* 2>&1
+            echo "--- v4l2 devices ---"; v4l2-ctl --list-devices 2>&1
+            for d in /dev/video*; do
+              echo "--- $d formats ---"; v4l2-ctl -d "$d" --list-formats-ext 2>&1
+            done
+            echo "--- usb ---"; lsusb 2>&1
+            echo "--- v4l2loopback ---"; lsmod 2>&1 | grep -i v4l2 || echo "(module not loaded)"
+          } > "$out/cameras.txt" 2>&1
+
+          # TPM: presence and permissions. A tss-group or device-permission
+          # change is invisible in a "test failed" line.
+          { ls -l /dev/tpm* 2>&1; echo "--- groups ---"; id 2>&1; } > "$out/tpm.txt" 2>&1
+
+          # dmesg is root-only here (kernel.dmesg_restrict=1), but the journal is
+          # readable by the runner user, so take the kernel ring through it.
+          journalctl -k --since "-30 min" --no-pager > "$out/kernel.log" 2>&1
+          journalctl -u irlumed --since "-30 min" --no-pager > "$out/irlumed.log" 2>&1
+          coredumpctl list --no-pager > "$out/coredumps.txt" 2>&1
+
+          # Bound the bundle: a runaway log must not turn a failed run into a
+          # multi-gigabyte upload.
+          find "$out" -type f -size +5M -exec truncate -s 5M {} \;
+          ls -la "$out"
+
+      - name: Upload failure forensics
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hardware-forensics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: hw-forensics/
+          if-no-files-found: warn
+          # Short: this is debugging material from a personal machine, not an
+          # artifact anyone should be able to fetch weeks later.
+          retention-days: 7
+
   # Hardware-inclusive statement coverage: the same measurement the hosted
   # ratchet takes, but with the TPM-gated tests on REAL silicon and the
   # camera/PAM matrices included. Report-only (no floor): the number feeds


### PR DESCRIPTION
The two remaining items from the security-CI review. Both concern the shipped units and the machine that tests them, so they land together.

## Forensics on hardware failure

A failure that only reproduces on the self-hosted runner is currently reconstructed from raw job logs plus guesswork about machine state that has since changed. The recent `CARGO_TARGET_DIR` breakage in that job is the case in point: my first hypothesis was that archhost had been offline, and disproving it took a round trip. The state that would have answered it instantly was never captured.

On failure only, the job now collects:

- camera state: `/dev/video*`, `v4l2-ctl --list-devices`, per-device `--list-formats-ext`, `lsusb`, whether v4l2loopback is loaded
- TPM device presence and the runner's group membership
- the last 30 minutes of the `irlumed` unit journal, and the kernel ring
- `coredumpctl list`

Uploaded as an artifact, 7-day retention.

**What it collects was tested against the runner, not assumed.** As `ghrunner`: the system journal is readable, `coredumpctl` works, `v4l2-ctl`/`lsusb`/`gdb` are present, and the account is in `tss` and `video`. `dmesg` is **not** readable (`kernel.dmesg_restrict=1`), so the kernel ring goes through `journalctl -k` instead.

Every command swallows its own error and both steps are `continue-on-error`, so forensics can never mask or replace the real failure. The journal capture is scoped to the irlumed unit rather than the full system journal, because this is a personal machine, and the bundle is truncated at 5 MB per file so a runaway log cannot turn a failed run into a huge upload.

## Unit exposure ratchet

New `units` job: `systemd-analyze verify` over every shipped unit, plus `systemd-analyze security` with a per-service threshold, in the same spirit as the coverage floor.

Both mechanics were measured rather than read off the manual:

- **`verify` resolves ExecStart** and fails when the binary is absent, which on a build runner it always is. The job stubs `/usr/bin/irlume{,d}` so the check is about unit syntax. All four units then verify clean.
- **`--threshold` does not compare against the displayed score.** It works on a 0-100 scale, so 3.7 is 37. I found this by bisecting: `--threshold=20` fails and `--threshold=37` passes on a unit that displays 3.7. The documented wording alone would have produced a broken check.

Baselines measured **on the ubuntu-24.04 image (systemd 255)**, not on a workstation, since the score is systemd-version-sensitive:

| unit | exposure | threshold |
|---|---|---|
| `irlumed.service` | 3.7 OK | 37 |
| `irlume-reconcile.service` | 9.4 UNSAFE | 94 |

**Proven to catch a regression before committing.** Deleting `ProtectKernelTunables`, `RestrictNamespaces` and `LockPersonality` moves irlumed from 3.7 to 4.6, and the check fails.

`irlume-reconcile.service` is knowingly high: it is a root oneshot that rewrites `/etc/pam.d`, so it holds broad access by design. Locking it here stops it getting worse. Hardening it belongs in its own change with its own validation, because it is the self-heal that repairs broken PAM, and a mistake there is not recoverable by the thing meant to do the repairing.

## Verified locally

```
actionlint (with shellcheck installed) → exit 0
zizmor .                               → No findings (25 suppressed)
ratchet baseline in ubuntu:24.04       → pass at 37 and 94
ratchet against weakened unit          → fails, as intended
```

## Note

One thing this surfaces rather than fixes: `irlumed.service`'s only remaining `systemd-analyze` finding is `UMask=`, since the unit sets `0027` and files are therefore group-readable by default. `0077` would clear it and is likely safe because secrets are explicitly written 0600, but that is a behaviour change to a privileged daemon and wants its own validation rather than riding along here.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Co-Authored-By: Codex (gpt-5.6-sol) <codex@openai.com>
Signed-off-by: archledger <archledger236@gmail.com>