### PR TITLE
fix: ship the self-heal units in the prebuilt Arch package

### DIFF
--- a/packaging/arch/build-pkg.sh
+++ b/packaging/arch/build-pkg.sh
@@ -44,6 +44,15 @@ package() {
     install -Dm0644 "\$startdir/models/\$m.onnx" "\$pkgdir/usr/share/irlume/models/\$m.onnx"
   done
   install -Dm0644 "\$startdir/systemd/irlumed.service" "\$pkgdir/usr/lib/systemd/system/irlumed.service"
+  # The PAM self-heal units. This package omitted them while shipping an
+  # irlume.install that runs \`systemctl enable --now irlume-reconcile.*\`, and
+  # those calls end in \`|| true\`, so every install of this package silently
+  # reported success while leaving the machine with no self-heal at all. Found on
+  # a box installed this way: all three units \`not-found\`, zero owned by the
+  # package. The AUR PKGBUILD has always shipped them; only this one did not.
+  install -Dm0644 "\$startdir/systemd/irlume-reconcile.path" "\$pkgdir/usr/lib/systemd/system/irlume-reconcile.path"
+  install -Dm0644 "\$startdir/systemd/irlume-reconcile.service" "\$pkgdir/usr/lib/systemd/system/irlume-reconcile.service"
+  install -Dm0644 "\$startdir/systemd/irlume-reconcile.timer" "\$pkgdir/usr/lib/systemd/system/irlume-reconcile.timer"
   install -Dm0644 "\$startdir/LICENSE" "\$pkgdir/usr/share/licenses/irlume/LICENSE"
   install -Dm0644 "\$startdir/README.md" "\$pkgdir/usr/share/doc/irlume/README.md"
 }


### PR DESCRIPTION
The prebuilt Arch package installed `irlumed.service` and nothing else, while shipping an `irlume.install` that runs, on both install and upgrade:

```
systemctl enable --now irlume-reconcile.path
systemctl enable --now irlume-reconcile.timer
systemctl enable --now irlume-reconcile.service
```

on units the package never placed on disk. Every call ends in `|| true`, so the install reported success while leaving the machine with **no PAM self-heal at all**, silently.

## Confirmed on the Arch box, which was installed this way

```
irlume-reconcile.path      not-found / inactive
irlume-reconcile.timer     not-found / inactive
irlume-reconcile.service   not-found / inactive
pacman -Ql irlume | grep -c reconcile   ->  0
ls /usr/lib/systemd/system/irlume-reconcile*  ->  No such file or directory
```

The AUR PKGBUILD has always installed all three, so only this build path was affected, and `irlume update` on Arch points at the AUR — which is why it stayed hidden. The prebuilt package serves the GitHub-release channel.

This is the same class as the Fedora `%files` omission fixed in #119: a unit installed into the buildroot but never packaged, plus a hook that appears to enable it. Both were invisible because the failure path was silent.

**Side effect worth noting:** any Arch-lane self-heal validation done on that box was invalid, because the units were never there.

## Hardware validation

Built the fixed package on Arch and checked the archive before installing:

```
usr/lib/systemd/system/irlume-reconcile.path
usr/lib/systemd/system/irlume-reconcile.service
usr/lib/systemd/system/irlume-reconcile.timer
sysusers files: 0
CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER
```

Then upgraded the box 0.7.0-1 → 0.7.0-2:

| Check | Before | After |
|---|---|---|
| `irlume-reconcile.path` | not-found | **enabled / active** |
| `irlume-reconcile.timer` | not-found | **enabled / active** |
| socket | `666 root:root` | `666 root:root` |
| daemon startup line | old, with group warning | `listening on /run/irlume.sock (0666; SO_PEERCRED authorizes every request)` |
| `irlume detect` as user | exit 0 | exit 0, "ready" |
| `irlume status` as user | running | running |

No group warning and no chown attempt in the new daemon's log, confirming the #116 socket work behaves on Arch as it does on Fedora.

## Not fixed

The script's closing message derives a package name without `pkgrel`, so it announced `0.7.0-1` after building `0.7.0-2`. Cosmetic, left alone.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>