### PR TITLE
feat: report authorization failures distinctly in the machine API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **The machine API can tell a consumer why a request failed.** `profiles list
+  --json` previously reported one opaque `operation-failed` whether the caller
+  was not permitted to read that account or the engine genuinely broke, because
+  the daemon reports both to the CLI as prose. It now reports `not-authorized`
+  and `operation-failed` separately, so a desktop integration can show a
+  permission message instead of a generic failure, or retry instead of giving up.
+
+  `not-authorized` still says nothing about whether the named account exists. An
+  ordinary caller is refused before the enrollment store is consulted, so a real
+  account and an invented one give the identical answer, and the command cannot
+  be used to enumerate accounts.
+
+  The socket carries this without breaking an upgrade in either direction. A
+  request opts in with a defaulted `structured_errors` field, and the daemon
+  sends the typed response only to a request that asked for one, because a
+  client that predates the new response variant cannot decode it. An older
+  client omits the field and keeps receiving the prose it understands; a newer
+  client meeting an older daemon has its unknown field ignored and falls back to
+  the same prose. The human CLI and TUI keep the prose deliberately, since it is
+  written to be read.
+
 ### Fixed
 
 - **Face unlock on the KDE lock screen works again, and `irlume detect` stops

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -607,7 +607,11 @@ pub fn status(args: &[String]) -> ExitCode {
     );
 
     // Enrollment.
-    match daemon_request(&Request::ListProfiles { user: user.clone() }) {
+    match daemon_request(&Request::ListProfiles {
+        user: user.clone(),
+        // Human output: keep the daemon's prose, it is written to be read.
+        structured_errors: false,
+    }) {
         Ok(Response::Enrollment {
             profiles,
             require_eyes_open,
@@ -767,7 +771,10 @@ pub fn detect(args: &[String]) -> ExitCode {
     }
     let up = reach == DaemonReach::Running;
     let enrolled = matches!(
-        daemon_request(&Request::ListProfiles { user }),
+        daemon_request(&Request::ListProfiles {
+            user,
+            structured_errors: false,
+        }),
         Ok(Response::Enrollment { ref profiles, .. }) if !profiles.is_empty()
     );
     if up && enrolled {
@@ -1336,7 +1343,11 @@ pub fn setup(args: &[String]) -> ExitCode {
 
     // 2. Enroll (reset if already enrolled and the user wants a clean start).
     println!("\n[2/6] Face enrollment");
-    let enrolled = matches!(daemon_request(&Request::ListProfiles { user: user.clone() }),
+    let enrolled = matches!(
+        daemon_request(&Request::ListProfiles {
+            user: user.clone(),
+            structured_errors: false,
+        }),
         Ok(Response::Enrollment { ref profiles, .. }) if !profiles.is_empty());
     if enrolled {
         println!("  already enrolled.");

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -7,7 +7,7 @@
 //! protocol. A capability is advertised only after its public command, output
 //! shape, and compatibility rules are covered here and in `docs/MACHINE-API.md`.
 
-use irlume_common::{ProfileSummary, Request, Response};
+use irlume_common::{OperationErrorCode, ProfileSummary, Request, Response};
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::process::ExitCode;
@@ -56,6 +56,16 @@ fn failure(command: &'static str, code: &'static str, retryable: bool) -> Docume
     }
 }
 
+/// Map a daemon outcome to a published error code. The mapping is total: an
+/// `Unknown` code from a newer daemon degrades to the generic failure rather
+/// than inventing a meaning for it.
+fn error_code(code: OperationErrorCode) -> &'static str {
+    match code {
+        OperationErrorCode::NotAuthorized => "not-authorized",
+        OperationErrorCode::OperationFailed | OperationErrorCode::Unknown => "operation-failed",
+    }
+}
+
 fn emit(document: &Document, exit: ExitCode) -> ExitCode {
     // Serialization only contains compile-time strings and serde_json values,
     // so failure would be a programming error. Keep stdout machine-only even
@@ -100,7 +110,12 @@ pub fn profiles_list(args: &[String]) -> ExitCode {
         return emit(&failure(COMMAND, "usage-error", false), ExitCode::from(2));
     }
     let user = crate::user_arg(args);
-    match crate::daemon_request(&Request::ListProfiles { user }) {
+    // Ask for typed failures. An older daemon ignores the field and answers
+    // with prose, which the `Response::Error` arm below still maps.
+    match crate::daemon_request(&Request::ListProfiles {
+        user,
+        structured_errors: true,
+    }) {
         Ok(Response::Enrollment {
             profiles,
             require_eyes_open,
@@ -113,6 +128,13 @@ pub fn profiles_list(args: &[String]) -> ExitCode {
             ),
             ExitCode::SUCCESS,
         ),
+        Ok(Response::OperationError { code, retryable }) => emit(
+            &failure(COMMAND, error_code(code), retryable),
+            ExitCode::FAILURE,
+        ),
+        // An older daemon predates the typed variant and answers with prose.
+        // Its text is deliberately not inspected: matching on daemon wording
+        // would make a message change a breaking API change.
         Ok(Response::Error(_)) => emit(
             &failure(COMMAND, "operation-failed", false),
             ExitCode::FAILURE,

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -267,7 +267,10 @@ fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
     use irlume_common::{Request, Response};
     let user = user_arg(args);
     let req = match sub {
-        None | Some("list") => Request::ListProfiles { user },
+        None | Some("list") => Request::ListProfiles {
+            user,
+            structured_errors: false,
+        },
         Some("add-scan") => match flag(args, "--profile") {
             Some(p) => {
                 eprintln!("[profiles] adding a scan to '{p}'; stay in frame…");
@@ -2661,7 +2664,10 @@ fn doctor() -> std::process::ExitCode {
     let gesture_is_closure = irlume_common::config::consent_gesture_mode()
         == irlume_common::config::ConsentGesture::Closure;
     let closure_calibrated = matches!(
-        daemon_request(&irlume_common::Request::ListProfiles { user: user.clone() }),
+        daemon_request(&irlume_common::Request::ListProfiles {
+            user: user.clone(),
+            structured_errors: false,
+        }),
         Ok(irlume_common::Response::Enrollment {
             closure_calibrated: true,
             ..
@@ -2733,7 +2739,10 @@ fn doctor() -> std::process::ExitCode {
     // back to the password, so this is not a lockout, but face login silently
     // stopped working. Surface it with the one-command fix.
     let (enrolled, ir_ratio_calibrated) =
-        match daemon_request(&irlume_common::Request::ListProfiles { user: user.clone() }) {
+        match daemon_request(&irlume_common::Request::ListProfiles {
+            user: user.clone(),
+            structured_errors: false,
+        }) {
             Ok(irlume_common::Response::Enrollment {
                 ref profiles,
                 ir_ratio_calibrated,

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -789,6 +789,7 @@ impl App {
         }
         match crate::daemon_poll(&Request::ListProfiles {
             user: self.user.clone(),
+            structured_errors: false,
         }) {
             Ok(Response::Enrollment {
                 profiles,

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -222,7 +222,7 @@ mod tests {
             assert!(line.ends_with('\n'), "request must be newline-terminated");
             let req: Request = serde_json::from_str(line.trim()).unwrap();
             match req {
-                Request::ListProfiles { user } => assert_eq!(user, "alice"),
+                Request::ListProfiles { user, .. } => assert_eq!(user, "alice"),
                 other => panic!("server expected ListProfiles, got {other:?}"),
             }
             let reply = Response::Profiles(vec!["Face Profile 1".into()]);
@@ -233,6 +233,7 @@ mod tests {
 
         let resp = request(&Request::ListProfiles {
             user: "alice".into(),
+            structured_errors: false,
         })
         .expect("round trip");
         match resp {

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -217,7 +217,23 @@ pub enum Request {
     /// Add one scan to an existing profile ("improve recognition"). PRIVILEGED.
     AddScan { user: String, profile: String },
     /// List enrolled profiles + their scans for `user`.
-    ListProfiles { user: String },
+    ListProfiles {
+        user: String,
+        /// Opt in to [`Response::OperationError`] instead of
+        /// [`Response::Error`].
+        ///
+        /// This exists because the socket has to survive a package upgrade in
+        /// both directions: the old daemon keeps running until it restarts, so
+        /// a new client can meet an old daemon and vice versa. An unknown
+        /// response variant fails to deserialize outright, so the daemon must
+        /// never send a typed error to a client that did not ask for one. An
+        /// old client omits this field, serde defaults it to false, and the
+        /// daemon answers exactly as before. A new client meeting an old daemon
+        /// is equally safe: serde ignores the unknown field and the old daemon
+        /// replies with the prose `Error` the new client still handles.
+        #[serde(default)]
+        structured_errors: bool,
+    },
     /// Delete a whole profile (and its scans). PRIVILEGED, same rule as Enroll.
     DeleteProfile { user: String, profile: String },
     /// Delete one scan from a profile. PRIVILEGED.
@@ -366,6 +382,31 @@ pub enum SelfTestKind {
     Liveness,
 }
 
+/// Why an operation failed, in terms a caller can act on.
+///
+/// Kept deliberately small. Each value has to mean the same thing for the life
+/// of a contract version, because the public machine API maps these straight to
+/// its published error codes, so a new value is cheap to add and a changed
+/// meaning is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OperationErrorCode {
+    /// The peer may not act on the target. Covers "that is not your account"
+    /// and "this needs root": the daemon does not distinguish them to the
+    /// caller, because an unprivileged peer is refused before the store is ever
+    /// consulted, so the answer carries no information about which accounts
+    /// exist or which are enrolled.
+    NotAuthorized,
+    /// The request was well-formed but the engine could not carry it out, for
+    /// example the enrollment store could not be read.
+    OperationFailed,
+    /// A code this build does not know. Present so a client compiled against an
+    /// older contract can still decode a response from a newer daemon rather
+    /// than failing the whole message.
+    #[serde(other)]
+    Unknown,
+}
+
 /// A profile and the names of its scans, for `ListProfiles`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileSummary {
@@ -494,6 +535,21 @@ pub enum Response {
     /// eye was detected in any frame.
     EarMedian(Option<f32>),
     Error(String),
+    /// A failure the caller can act on, sent ONLY to a request that opted in
+    /// (see `ListProfiles::structured_errors`).
+    ///
+    /// `Error(String)` carries prose meant for a human, so the machine API had
+    /// to flatten every failure into one opaque code: a request refused for
+    /// authorization and a storage failure were indistinguishable, and a
+    /// frontend could not tell "you may not do that" from "something broke".
+    /// This variant carries the distinction the daemon already knows.
+    OperationError {
+        code: OperationErrorCode,
+        /// Whether an identical request could plausibly succeed later without
+        /// the caller changing anything.
+        #[serde(default)]
+        retryable: bool,
+    },
 
     // --- keyring unlock responses -------------------------------------------
     /// The password was sealed (`SealPassword`).
@@ -576,6 +632,108 @@ pub(crate) mod testenv {
 
 #[cfg(test)]
 mod tests {
+
+    // --- cross-version wire compatibility for typed operation errors --------
+    //
+    // The package ships client and daemon together, but the old daemon keeps
+    // running until it restarts, so both directions happen during an upgrade.
+    // These pin the behaviour that makes that safe.
+
+    #[test]
+    fn an_old_client_request_defaults_to_prose_errors() {
+        // Exactly what a pre-typed-error client puts on the wire: no
+        // `structured_errors` key at all. The daemon must read it as false and
+        // therefore keep answering with `Error(String)`, which is the only
+        // variant that client can decode.
+        let wire = r#"{"ListProfiles":{"user":"alice"}}"#;
+        let req: Request = serde_json::from_str(wire).expect("old request must still parse");
+        match req {
+            Request::ListProfiles {
+                user,
+                structured_errors,
+            } => {
+                assert_eq!(user, "alice");
+                assert!(!structured_errors, "absent field must default to opted-out");
+            }
+            other => panic!("expected ListProfiles, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_old_daemon_ignores_the_new_request_field() {
+        // The other direction: a new client sends the field to a daemon that
+        // predates it. Serde ignores unknown fields, so the old daemon still
+        // sees a valid request. Simulated with a struct carrying only the old
+        // shape, because the old type no longer exists in this build.
+        #[derive(serde::Deserialize)]
+        struct OldListProfiles {
+            user: String,
+        }
+        #[derive(serde::Deserialize)]
+        enum OldRequest {
+            ListProfiles(OldListProfiles),
+        }
+        let new_wire = serde_json::to_string(&Request::ListProfiles {
+            user: "alice".into(),
+            structured_errors: true,
+        })
+        .unwrap();
+        let parsed: OldRequest =
+            serde_json::from_str(&new_wire).expect("old daemon must still parse a new request");
+        let OldRequest::ListProfiles(p) = parsed;
+        assert_eq!(p.user, "alice");
+    }
+
+    #[test]
+    fn an_unknown_error_code_decodes_instead_of_failing_the_message() {
+        // A newer daemon may name a code this build has never heard of. The
+        // whole response must still decode, degrading to Unknown, rather than
+        // failing to parse and losing the outcome entirely.
+        let wire = r#"{"OperationError":{"code":"some-future-code","retryable":true}}"#;
+        let resp: Response = serde_json::from_str(wire).expect("must decode");
+        match resp {
+            Response::OperationError { code, retryable } => {
+                assert_eq!(code, OperationErrorCode::Unknown);
+                assert!(retryable);
+            }
+            other => panic!("expected OperationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn operation_error_round_trips_and_retryable_defaults_false() {
+        for code in [
+            OperationErrorCode::NotAuthorized,
+            OperationErrorCode::OperationFailed,
+        ] {
+            let wire = serde_json::to_string(&Response::OperationError {
+                code,
+                retryable: false,
+            })
+            .unwrap();
+            match serde_json::from_str::<Response>(&wire).unwrap() {
+                Response::OperationError { code: back, .. } => assert_eq!(back, code),
+                other => panic!("expected OperationError, got {other:?}"),
+            }
+        }
+        // An older peer that omits `retryable` must not fail to decode.
+        let resp: Response =
+            serde_json::from_str(r#"{"OperationError":{"code":"not-authorized"}}"#).unwrap();
+        match resp {
+            Response::OperationError { retryable, .. } => assert!(!retryable),
+            other => panic!("expected OperationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_codes_serialize_as_the_published_kebab_case_names() {
+        // These strings are the public contract's codes; a rename here is a
+        // breaking change for every consumer.
+        let json = serde_json::to_string(&OperationErrorCode::NotAuthorized).unwrap();
+        assert_eq!(json, r#""not-authorized""#);
+        let json = serde_json::to_string(&OperationErrorCode::OperationFailed).unwrap();
+        assert_eq!(json, r#""operation-failed""#);
+    }
     use super::*;
 
     #[cfg(unix)]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -744,7 +744,7 @@ fn request_user(req: &Request) -> Option<&str> {
     match req {
         Authenticate { user, .. }
         | Enroll { user, .. }
-        | ListProfiles { user }
+        | ListProfiles { user, .. }
         | DeleteProfile { user, .. }
         | DeleteScan { user, .. }
         | RenameProfile { user, .. }
@@ -1386,9 +1386,29 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 Err(e) => Response::Error(e.to_string()),
             }
         }
-        Request::ListProfiles { user } => {
+        Request::ListProfiles {
+            user,
+            structured_errors,
+        } => {
+            // Only ever answer with a typed error when the request asked for
+            // one. An older client cannot deserialize an unknown response
+            // variant, so sending one unasked would break it across the upgrade
+            // window, which is the failure class of issue #93.
+            let fail = |code: irlume_common::OperationErrorCode, prose: String| {
+                if structured_errors {
+                    Response::OperationError {
+                        code,
+                        retryable: false,
+                    }
+                } else {
+                    Response::Error(prose)
+                }
+            };
             if !authorized_for(peer, &user) {
-                return Response::Error(format!("not authorized to list '{user}'"));
+                return fail(
+                    irlume_common::OperationErrorCode::NotAuthorized,
+                    format!("not authorized to list '{user}'"),
+                );
             }
             match irlume_core::storage::load(&user) {
                 Ok(Some(enr)) => Response::Enrollment {
@@ -1421,7 +1441,10 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     closure_calibrated: false,
                     ir_ratio_calibrated: false,
                 },
-                Err(e) => Response::Error(e.to_string()),
+                Err(e) => fail(
+                    irlume_common::OperationErrorCode::OperationFailed,
+                    e.to_string(),
+                ),
             }
         }
         Request::DeleteProfile { user, profile } => {
@@ -2204,7 +2227,10 @@ mod tests {
                 scans: None,
                 reset: false,
             },
-            Request::ListProfiles { user: u() },
+            Request::ListProfiles {
+                user: u(),
+                structured_errors: false,
+            },
             Request::DeleteProfile {
                 user: u(),
                 profile: "p".into(),
@@ -2877,6 +2903,7 @@ mod tests {
         for req in [
             Request::ListProfiles {
                 user: "../root".into(),
+                structured_errors: false,
             },
             Request::Authenticate {
                 user: "a/b".into(),
@@ -3113,6 +3140,7 @@ mod tests {
         match dispatch(
             Request::ListProfiles {
                 user: "carol".into(),
+                structured_errors: false,
             },
             &peer(0),
             &mut e,
@@ -3138,6 +3166,7 @@ mod tests {
         match dispatch(
             Request::ListProfiles {
                 user: "ghost".into(),
+                structured_errors: false,
             },
             &peer(0),
             &mut e,
@@ -3149,6 +3178,7 @@ mod tests {
         match dispatch(
             Request::ListProfiles {
                 user: "carol".into(),
+                structured_errors: false,
             },
             &peer(NOBODY),
             &mut e,
@@ -3387,6 +3417,7 @@ mod tests {
         match dispatch(
             Request::ListProfiles {
                 user: "carol".into(),
+                structured_errors: false,
             },
             &root,
             &mut e,

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -108,21 +108,22 @@ identifiers: they may contain anything the user typed.
 |---|---|---|
 | `usage-error` | The command line was not one this contract accepts. Exits 2. | no |
 | `daemon-unavailable` | The daemon could not be reached. | yes |
-| `operation-failed` | The daemon refused or could not complete the request. | no |
+| `not-authorized` | The caller may not act on the named account. | no |
+| `operation-failed` | The engine could not carry out a well-formed request. | no |
 | `protocol-error` | The daemon replied with something this command did not expect. | no |
 
-`operation-failed` is deliberately coarse in contract version 1, and a consumer
-should know what it hides: a request refused because the caller may not act on
-that account, a request naming an account that does not exist, and a genuine
-engine failure all report it identically, because the daemon reports those to the
-CLI as prose rather than as typed outcomes. A consumer therefore cannot yet tell
-"you are not permitted" from "something broke", and should present a neutral
-failure rather than guessing. A distinct authorization code is planned for when
-the daemon reports typed outcomes for this path; it will be additive.
+`not-authorized` and `operation-failed` are distinct so a consumer can tell "you
+may not do that" from "something broke", and act accordingly: the first is worth
+a message about permissions, the second is worth a retry or a support report.
 
-The one thing that identical treatment does buy today is that an unprivileged
-caller cannot use this command to discover which accounts exist or which are
-enrolled.
+`not-authorized` deliberately says nothing about whether the named account
+exists. An ordinary caller is refused before the enrollment store is consulted,
+so a real account and an invented one produce the identical answer, and this
+command cannot be used to discover which accounts exist or which are enrolled.
+
+`retryable` means an identical request could plausibly succeed later without the
+caller changing anything. Only `daemon-unavailable` sets it today. It is not a
+promise that a retry will succeed, and it carries no suggested delay.
 
 ## Security and privacy
 


### PR DESCRIPTION
Follow-up to #109, closing the one gap that PR documented rather than fixed.

## The problem, measured

`profiles list --json` reported a single opaque `operation-failed` whether the caller was not permitted to read that account or the engine genuinely failed, because the daemon reports both as prose inside `Response::Error(String)`. Before this change, all three of these were byte-identical:

```
--user root              {"code":"operation-failed","retryable":false}  exit 1
--user alice             {"code":"operation-failed","retryable":false}  exit 1
--user nosuchuser999     {"code":"operation-failed","retryable":false}  exit 1
```

A desktop integration could not tell "you may not do that" from "something broke", so it could not choose between showing a permission message and retrying. The daemon already knew the difference; it just had nowhere to put it.

## The upgrade-safety problem, which shapes the design

The package ships client and daemon together, but **the old daemon keeps running until it restarts**, so both version pairings occur during an upgrade. An unknown response variant fails to deserialize outright — that is the failure class of issue #93. So a new response variant cannot simply be sent.

It is therefore **opt-in per request**. `ListProfiles` gained a defaulted `structured_errors` field, and the daemon emits `OperationError` **only** when the request set it.

| Pairing | Behaviour |
|---|---|
| old client → new daemon | omits the field, serde defaults false, receives the prose it can decode |
| new client → old daemon | unknown field ignored, falls back to the same prose arm |
| new → new | typed error |
| human CLI and TUI | pass `false` deliberately; that prose is written to be read |

The CLI never inspects the daemon's message text to classify anything, because matching on wording would make a message change a breaking API change.

## No enumeration oracle

`not-authorized` says nothing about whether the account exists. An unprivileged caller is refused by `authorized_for` **before** the enrollment store is consulted, so a real account and an invented one are indistinguishable.

## Verified against a real daemon, with a genuinely unprivileged peer

Not only in unit tests — a root daemon on a private socket, probed from a normal user:

```
old shape, other user       {"Error":"not authorized to list 'root'"}
opted in, other user        {"OperationError":{"code":"not-authorized","retryable":false}}
opted in, nonexistent user  {"OperationError":{"code":"not-authorized","retryable":false}}
opted in, own account       enrollment returned
```

And through the published CLI surface:

```
profiles list --user root --json   ->  {"code":"not-authorized"}  exit 1
profiles list --json               ->  ok, 1 profile
irlume profiles --user root        ->  human path unchanged
```

## Tests

Five wire-compatibility tests pin the contract: an old request without the field parses and defaults to opted-out; a new request still parses against the old request shape; an unrecognised code decodes as `Unknown` rather than failing the whole message; a missing `retryable` defaults to false; and the code strings serialize as the published kebab-case names.

660 workspace tests pass, clippy `-D warnings` clean, fmt clean.

## Docs

`MACHINE-API.md` now lists `not-authorized`, explains what it deliberately does not reveal, and defines what `retryable` promises: that an identical request could plausibly succeed later without the caller changing anything, with no suggested delay and no guarantee.

## Next

Contract negotiation (`--contract N`, engine range advertisement, rejection before side effects) should land before any privileged or mutating machine command exists.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Co-Authored-By: Codex (gpt-5.6-sol) <codex@openai.com>