### PR TITLE
feat: let a consumer declare which contract it implements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **A consumer can state which contract it implements.** `--contract N` on any
+  machine command makes the engine agree only to a version it actually speaks,
+  and refuse anything else before the daemon is contacted or any side effect
+  begins. `irlume version --json` advertises the supported range as
+  `contract_versions`, and every response echoes the version in force.
+
+  Omitting the flag always means contract 1 and always will. It deliberately
+  does not mean "newest": a program written against contract 1 must keep getting
+  contract 1 from an engine that has since learned contract 2, rather than
+  having a response change meaning underneath it.
+
+  This exists now, while the surface is read-only, because a capability string
+  alone is a poor gate. A consumer that enables behaviour on seeing a capability
+  name has no way to say which semantics it was built for, and the engine has no
+  way to refuse. Contract negotiation is the part that has to be in place before
+  any privileged or mutating command is added.
+
 - **The machine API can tell a consumer why a request failed.** `profiles list
   --json` previously reported one opaque `operation-failed` whether the caller
   was not permitted to read that account or the engine genuinely broke, because

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -12,9 +12,81 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use std::process::ExitCode;
 
-pub const CONTRACT_VERSION: u32 = 1;
+/// Lowest contract this build can speak.
+pub const CONTRACT_MIN: u32 = 1;
+/// Highest contract this build can speak. Bumping this is a deliberate act: it
+/// means a second set of semantics now exists and both must be served.
+pub const CONTRACT_MAX: u32 = 1;
+
+/// What a caller gets when it does not say which contract it implements.
+///
+/// This is pinned to the FIRST contract and must never track `CONTRACT_MAX`.
+/// A consumer written against contract 1 that omits the flag has to keep
+/// receiving contract 1 on an engine that has since learned contract 2, or the
+/// engine would silently change the meaning of a response under a program that
+/// never asked for it. "Newest" is the one thing a default must not mean here.
+pub const CONTRACT_DEFAULT: u32 = 1;
 
 const CAPABILITIES: &[&str] = &["version-json", "profiles-list-json"];
+
+/// The contract the caller asked for, or the failure to report.
+///
+/// Parsed before anything else happens, so an unsupported request is refused
+/// before the daemon is contacted and before any command with side effects can
+/// begin. There are no mutating machine commands yet; this exists so that when
+/// one arrives it cannot be reached without an agreed contract.
+enum Contract {
+    Agreed(u32),
+    Malformed,
+    Unsupported,
+}
+
+/// Read `--contract N` out of an argument list.
+///
+/// Deliberately tolerant of absence and intolerant of everything else: a
+/// repeated flag, a missing value, a non-numeric value and an out-of-range
+/// version are all refusals rather than guesses.
+fn negotiate(args: &[String]) -> Contract {
+    let mut requested: Option<u32> = None;
+    let mut index = 0;
+    while index < args.len() {
+        if args[index] == "--contract" {
+            if requested.is_some() {
+                return Contract::Malformed;
+            }
+            let Some(raw) = args.get(index + 1) else {
+                return Contract::Malformed;
+            };
+            let Ok(version) = raw.parse::<u32>() else {
+                return Contract::Malformed;
+            };
+            requested = Some(version);
+            index += 2;
+            continue;
+        }
+        index += 1;
+    }
+    match requested {
+        None => Contract::Agreed(CONTRACT_DEFAULT),
+        Some(v) if (CONTRACT_MIN..=CONTRACT_MAX).contains(&v) => Contract::Agreed(v),
+        Some(_) => Contract::Unsupported,
+    }
+}
+
+/// Strip `--contract N` so each command's own validator sees only its flags.
+fn without_contract(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut index = 0;
+    while index < args.len() {
+        if args[index] == "--contract" {
+            index += 2;
+            continue;
+        }
+        out.push(args[index].clone());
+        index += 1;
+    }
+    out
+}
 
 #[derive(Serialize)]
 struct Document {
@@ -34,9 +106,11 @@ struct MachineError {
     retryable: bool,
 }
 
-fn success(command: &'static str, data: Value) -> Document {
+fn success(command: &'static str, data: Value, contract: u32) -> Document {
     Document {
-        contract_version: CONTRACT_VERSION,
+        // Echo the contract actually in force, so a consumer can assert the
+        // engine agreed to the one it implements rather than inferring it.
+        contract_version: contract,
         engine_version: env!("CARGO_PKG_VERSION"),
         command,
         ok: true,
@@ -45,9 +119,9 @@ fn success(command: &'static str, data: Value) -> Document {
     }
 }
 
-fn failure(command: &'static str, code: &'static str, retryable: bool) -> Document {
+fn failure(command: &'static str, code: &'static str, retryable: bool, contract: u32) -> Document {
     Document {
-        contract_version: CONTRACT_VERSION,
+        contract_version: contract,
         engine_version: env!("CARGO_PKG_VERSION"),
         command,
         ok: false,
@@ -83,14 +157,36 @@ fn emit(document: &Document, exit: ExitCode) -> ExitCode {
 }
 
 pub fn version(args: &[String]) -> ExitCode {
-    if args != ["version", "--json"] {
-        return emit(&failure("version", "usage-error", false), ExitCode::from(2));
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure("version", "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure("version", "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    if without_contract(args) != ["version", "--json"] {
+        return emit(
+            &failure("version", "usage-error", false, contract),
+            ExitCode::from(2),
+        );
     }
     emit(
         &success(
             "version",
             json!({
                 "capabilities": CAPABILITIES,
+                // The range this build can speak. A consumer should pick a
+                // version inside it and pass `--contract`, rather than reading
+                // `contract_version` off a response and hoping.
+                "contract_versions": { "min": CONTRACT_MIN, "max": CONTRACT_MAX },
                 "limits": {
                     // Read the engine's own constant rather than repeating the
                     // number. A consumer displays this as the enrollment limit,
@@ -99,6 +195,7 @@ pub fn version(args: &[String]) -> ExitCode {
                     "max_profiles": irlume_core::storage::MAX_PROFILES
                 }
             }),
+            contract,
         ),
         ExitCode::SUCCESS,
     )
@@ -106,8 +203,29 @@ pub fn version(args: &[String]) -> ExitCode {
 
 pub fn profiles_list(args: &[String]) -> ExitCode {
     const COMMAND: &str = "profiles.list";
+    // Negotiate first: an unsupported contract is refused before the daemon is
+    // contacted at all.
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    let args = &without_contract(args);
     if !valid_profiles_list_args(args) {
-        return emit(&failure(COMMAND, "usage-error", false), ExitCode::from(2));
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
     }
     let user = crate::user_arg(args);
     // Ask for typed failures. An older daemon ignores the field and answers
@@ -125,26 +243,27 @@ pub fn profiles_list(args: &[String]) -> ExitCode {
             &success(
                 COMMAND,
                 profiles_data(profiles, require_eyes_open, require_challenge),
+                contract,
             ),
             ExitCode::SUCCESS,
         ),
         Ok(Response::OperationError { code, retryable }) => emit(
-            &failure(COMMAND, error_code(code), retryable),
+            &failure(COMMAND, error_code(code), retryable, contract),
             ExitCode::FAILURE,
         ),
         // An older daemon predates the typed variant and answers with prose.
         // Its text is deliberately not inspected: matching on daemon wording
         // would make a message change a breaking API change.
         Ok(Response::Error(_)) => emit(
-            &failure(COMMAND, "operation-failed", false),
+            &failure(COMMAND, "operation-failed", false, contract),
             ExitCode::FAILURE,
         ),
         Ok(_) => emit(
-            &failure(COMMAND, "protocol-error", false),
+            &failure(COMMAND, "protocol-error", false, contract),
             ExitCode::FAILURE,
         ),
         Err(_) => emit(
-            &failure(COMMAND, "daemon-unavailable", true),
+            &failure(COMMAND, "daemon-unavailable", true, contract),
             ExitCode::FAILURE,
         ),
     }
@@ -212,6 +331,72 @@ mod tests {
     use super::*;
 
     #[test]
+    fn an_absent_contract_flag_always_means_the_first_contract() {
+        // The load-bearing rule. A consumer written against contract 1 that
+        // omits the flag must keep getting contract 1 after the engine learns
+        // contract 2, so this must never be expressed as "the newest".
+        assert_eq!(CONTRACT_DEFAULT, 1);
+        assert_eq!(CONTRACT_DEFAULT, CONTRACT_MIN);
+        let args = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        match negotiate(&args(&["version", "--json"])) {
+            Contract::Agreed(v) => assert_eq!(v, CONTRACT_DEFAULT),
+            _ => panic!("an absent flag must agree, not refuse"),
+        }
+    }
+
+    #[test]
+    fn a_supported_contract_is_agreed_and_an_unsupported_one_is_refused() {
+        let args = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        for v in CONTRACT_MIN..=CONTRACT_MAX {
+            match negotiate(&args(&["version", "--contract", &v.to_string(), "--json"])) {
+                Contract::Agreed(got) => assert_eq!(got, v),
+                _ => panic!("contract {v} is in range and must be agreed"),
+            }
+        }
+        // Above the range: a consumer built for a contract this engine does not
+        // implement must be told so, not served contract 1 semantics silently.
+        assert!(matches!(
+            negotiate(&args(&["version", "--contract", "2", "--json"])),
+            Contract::Unsupported
+        ));
+        // Zero is not a contract.
+        assert!(matches!(
+            negotiate(&args(&["version", "--contract", "0", "--json"])),
+            Contract::Unsupported
+        ));
+    }
+
+    #[test]
+    fn a_malformed_contract_flag_is_refused_rather_than_guessed() {
+        let args = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        for bad in [
+            vec!["version", "--contract"],                  // no value
+            vec!["version", "--contract", "one", "--json"], // not a number
+            vec!["version", "--contract", "-1", "--json"],  // not unsigned
+            vec!["version", "--contract", "1", "--contract", "1", "--json"], // repeated
+        ] {
+            assert!(
+                matches!(negotiate(&args(&bad)), Contract::Malformed),
+                "{bad:?} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn stripping_the_flag_leaves_the_command_its_own_arguments() {
+        let args = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert_eq!(
+            without_contract(&args(&["profiles", "list", "--contract", "1", "--json"])),
+            args(&["profiles", "list", "--json"])
+        );
+        // A command that never saw the flag is untouched.
+        assert_eq!(
+            without_contract(&args(&["profiles", "list", "--json"])),
+            args(&["profiles", "list", "--json"])
+        );
+    }
+
+    #[test]
     fn version_freezes_the_public_envelope_and_capabilities() {
         let document = serde_json::to_value(success(
             "version",
@@ -219,6 +404,7 @@ mod tests {
                 "capabilities": CAPABILITIES,
                 "limits": { "max_profiles": 3 }
             }),
+            CONTRACT_DEFAULT,
         ))
         .unwrap();
 
@@ -253,8 +439,13 @@ mod tests {
 
     #[test]
     fn errors_have_stable_codes_without_daemon_prose() {
-        let document =
-            serde_json::to_value(failure("profiles.list", "daemon-unavailable", true)).unwrap();
+        let document = serde_json::to_value(failure(
+            "profiles.list",
+            "daemon-unavailable",
+            true,
+            CONTRACT_DEFAULT,
+        ))
+        .unwrap();
 
         assert_eq!(document["ok"], false);
         assert_eq!(document["error"]["code"], "daemon-unavailable");

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -41,6 +41,37 @@ meaning requires a new contract version. Consumers must first call
 The machine API is not the daemon socket protocol. The socket remains private,
 and its serialized Rust enums are not a public compatibility promise.
 
+### Declaring which contract you implement
+
+Pass `--contract N` on any machine command. The engine agrees only to a version
+it implements, and refuses anything else **before** contacting the daemon and
+before any command with side effects begins:
+
+```
+$ irlume profiles list --contract 9 --json
+{"contract_version":1,...,"error":{"code":"unsupported-contract","retryable":false}}
+```
+
+Exit code 2. A malformed flag (no value, a non-number, repeated) is a
+`usage-error`.
+
+`irlume version --json` advertises the range this build speaks:
+
+```json
+"contract_versions": { "min": 1, "max": 1 }
+```
+
+Pick a version inside that range and pass it. Every response echoes the contract
+actually in force in `contract_version`, so a consumer can assert the engine
+agreed to the version it implements rather than inferring it.
+
+**Omitting the flag always means contract 1.** It does not mean "whatever is
+newest", and it never will. A program written against contract 1 that omits the
+flag keeps receiving contract 1 on an engine that has since learned contract 2,
+because the alternative is changing the meaning of a response under a program
+that never asked for it. Passing the flag is still better: it makes the refusal
+explicit and immediate when a consumer meets an engine too old for it.
+
 ### A capability is not a compatibility promise
 
 `capabilities` says a command exists and is reachable. It does not say the
@@ -107,6 +138,7 @@ identifiers: they may contain anything the user typed.
 | Code | Meaning | `retryable` |
 |---|---|---|
 | `usage-error` | The command line was not one this contract accepts. Exits 2. | no |
+| `unsupported-contract` | The engine does not implement the requested contract. Refused before any side effect. Exits 2. | no |
 | `daemon-unavailable` | The daemon could not be reached. | yes |
 | `not-authorized` | The caller may not act on the named account. | no |
 | `operation-failed` | The engine could not carry out a well-formed request. | no |


### PR DESCRIPTION
Third in the machine-API sequence, after #109 and #123. This is the one that has to exist **before** any privileged or mutating command, not after.

## Why a capability list is not enough

The only gate was `capabilities`, and a capability name is a poor one: a consumer that enables behaviour on seeing a name cannot say which semantics it was built for, and the engine cannot refuse.

That is not hypothetical. The downstream KDE integration gates its privileged KAuth actions purely on capability presence, and its package requires `irlume >= 0.6.0` with **no upper bound**. So a name published once enables that path in every installed copy, including old ones, with nobody re-reviewing.

## What this adds

`--contract N` on any machine command. The engine agrees only to a version it implements and refuses anything else **before contacting the daemon and before any side effect**.

`version --json` now advertises the range:

```json
"contract_versions": { "min": 1, "max": 1 }
```

Every response echoes the version in force in `contract_version`, so a consumer can assert the engine agreed to the version it implements rather than inferring it from a response it has already acted on.

## The rule that carries the design

**Omitting the flag always means contract 1, and always will.** It deliberately does not mean "newest".

A program written against contract 1 that omits the flag must keep receiving contract 1 on an engine that has since learned contract 2, because the alternative is changing the meaning of a response under a program that never asked for it. `CONTRACT_DEFAULT` is pinned to `CONTRACT_MIN` with a comment saying exactly that, because the tempting future edit is to make it track `CONTRACT_MAX`. There is a test whose only job is to fail if someone does.

## Compatibility was the binding constraint

The downstream sends `version --json` and `profiles list --json` with no flag at all. So the flag is optional and its absence is an agreement, not a refusal. I checked their source rather than assuming.

## Verified by running it

```
no flag                       contract_version 1, range {min:1,max:1}
--contract 1                  agreed, ok
--contract 2                  unsupported-contract, exit 2
--contract | one | repeated   usage-error, exit 2
```

And the property that matters most, with **no daemon reachable at all**:

```
profiles list --contract 9    unsupported-contract   <- refused before contact
profiles list --contract 1    daemon-unavailable     <- reached the daemon step
```

That pair is the proof that refusal precedes side effects, rather than an assertion that it does.

664 workspace tests pass, clippy `-D warnings` clean, fmt clean.

## Next

Read-only JSON for `status`, `doctor` (with stable check IDs) and `login status`. That is what finally kills the downstream's parsing of English prose from those three commands, which today makes any wording change on our side silently degrade its UI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>