### PR TITLE
feat: add `irlume status --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **`irlume status --json`.** The readiness summary a desktop integration needs,
+  as values instead of prose. It reports the daemon state, auth method,
+  enrollment counts, template protection, keyring arming, recovery passphrase,
+  camera capability and fingerprint presence.
+
+  Two deliberate narrowings against the human command: it reports whether an RGB
+  and an IR camera resolved, never which device nodes, and it does not name the
+  account, since the caller already knows which one it asked about.
+
+  Anything that depends on the daemon carries a `known` flag, and when that is
+  false the counts are absent rather than zero. A consumer must not be able to
+  mistake "we could not find out" for "this account has nothing enrolled".
+
+  This exists because the alternative is what a real consumer is doing today:
+  matching English phrases and column spacing out of the human output, where a
+  reworded line silently degrades its interface.
+
 - **A consumer can state which contract it implements.** `--contract N` on any
   machine command makes the engine agree only to a version it actually speaks,
   and refuse anything else before the daemon is contacted or any side effect

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -27,7 +27,7 @@ pub const CONTRACT_MAX: u32 = 1;
 /// never asked for it. "Newest" is the one thing a default must not mean here.
 pub const CONTRACT_DEFAULT: u32 = 1;
 
-const CAPABILITIES: &[&str] = &["version-json", "profiles-list-json"];
+const CAPABILITIES: &[&str] = &["version-json", "profiles-list-json", "status-json"];
 
 /// The contract the caller asked for, or the failure to report.
 ///
@@ -199,6 +199,140 @@ pub fn version(args: &[String]) -> ExitCode {
         ),
         ExitCode::SUCCESS,
     )
+}
+
+/// `irlume status --json`: the readiness summary a desktop integration needs,
+/// as values rather than prose.
+///
+/// Deliberately narrower than the human `status`. It omits camera device paths
+/// and the account name: a consumer needs to know whether an IR camera is
+/// usable, not which node it is, and it already knows which account it asked
+/// about. Everything here is derived from the same sources the human command
+/// reads, so the two cannot disagree about the machine's state, only about how
+/// it is worded.
+pub fn status(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "status";
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    let args = &without_contract(args);
+    if !valid_status_args(args) {
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
+    }
+    let user = crate::user_arg(args);
+
+    // Reachability is reported, not fatal: a consumer wants to render "the
+    // daemon is not answering" rather than receive an error with no detail, and
+    // the fields that do not need the daemon are still worth having.
+    let daemon = match crate::commands::daemon_reach() {
+        crate::commands::DaemonReach::Running => "running",
+        crate::commands::DaemonReach::AccessDenied => "access-denied",
+        crate::commands::DaemonReach::Down => "unreachable",
+    };
+
+    let method = irlume_core::policy::method();
+    let enrollment = match crate::daemon_request(&Request::ListProfiles {
+        user: user.clone(),
+        structured_errors: true,
+    }) {
+        Ok(Response::Enrollment { profiles, .. }) => {
+            let scans: usize = profiles.iter().map(|p| p.scans.len()).sum();
+            json!({ "known": true, "profiles": profiles.len(), "scans": scans })
+        }
+        // Unknown is not zero. A consumer must be able to tell "this account has
+        // no face enrolled" from "we could not find out".
+        _ => json!({ "known": false }),
+    };
+
+    let keyring = match crate::daemon_request(&Request::KeyringInfo { user: user.clone() }) {
+        Ok(Response::KeyringInfo { armed, policy, .. }) => {
+            json!({ "known": true, "armed": armed, "policy": policy })
+        }
+        _ => json!({ "known": false }),
+    };
+
+    let (templates, recovery) = match crate::daemon_request(&Request::RecoveryStatus { user }) {
+        Ok(Response::RecoveryStatus {
+            encrypted,
+            recovery_set,
+            ..
+        }) => (
+            json!(if encrypted { "encrypted" } else { "plaintext" }),
+            json!({ "known": true, "passphrase_set": recovery_set }),
+        ),
+        _ => (json!("unknown"), json!({ "known": false })),
+    };
+
+    // Camera capability, not camera identity: whether each spectrum resolved to
+    // a device, never which one.
+    let (rgb, ir) = irlume_camera::select_pair();
+    let camera = json!({
+        "rgb": !rgb.is_empty(),
+        "ir": !ir.is_empty(),
+    });
+
+    emit(
+        &success(
+            COMMAND,
+            json!({
+                "daemon": daemon,
+                "auth_method": format!("{method:?}").to_lowercase(),
+                "face_disabled": method.face_disabled(),
+                "enrollment": enrollment,
+                "templates": templates,
+                "keyring": keyring,
+                "recovery": recovery,
+                "camera": camera,
+                "fingerprint": irlume_fingerprint::device_name().is_some(),
+            }),
+            contract,
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
+fn valid_status_args(args: &[String]) -> bool {
+    if args.first().map(String::as_str) != Some("status") {
+        return false;
+    }
+    let mut saw_json = false;
+    let mut saw_user = false;
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" if !saw_json => {
+                saw_json = true;
+                index += 1;
+            }
+            "--user" if !saw_user => {
+                saw_user = true;
+                let Some(user) = args.get(index + 1) else {
+                    return false;
+                };
+                if user.is_empty() || user.starts_with('-') {
+                    return false;
+                }
+                index += 2;
+            }
+            _ => return false,
+        }
+    }
+    saw_json
 }
 
 pub fn profiles_list(args: &[String]) -> ExitCode {
@@ -413,7 +547,7 @@ mod tests {
         assert_eq!(document["ok"], true);
         assert_eq!(
             document["data"]["capabilities"],
-            json!(["version-json", "profiles-list-json"])
+            json!(["version-json", "profiles-list-json", "status-json"])
         );
         assert!(document.get("error").is_none());
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -129,6 +129,7 @@ fn main() -> std::process::ExitCode {
         (Some("set-cameras"), _) => set_cameras(&args),
         (Some("update"), _) => commands::update(&args),
         (Some("uninstall"), _) => uninstall::run(&args),
+        (Some("status"), _) if args.iter().any(|arg| arg == "--json") => machine::status(&args),
         (Some("version"), _) if args.iter().any(|arg| arg == "--json") => machine::version(&args),
         (Some("version"), _) | (Some("--version"), _) | (Some("-V"), _) => {
             println!("irlume {}", env!("CARGO_PKG_VERSION"));

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -23,7 +23,7 @@ fn version_json_is_one_machine_document() {
     assert_eq!(document["ok"], true);
     assert_eq!(
         document["data"]["capabilities"],
-        serde_json::json!(["version-json", "profiles-list-json"])
+        serde_json::json!(["version-json", "profiles-list-json", "status-json"])
     );
 }
 
@@ -84,4 +84,57 @@ fn unknown_machine_flags_are_a_typed_usage_error() {
     assert_eq!(document["ok"], false);
     assert_eq!(document["error"]["code"], "usage-error");
     assert_eq!(document["error"]["retryable"], false);
+}
+
+#[test]
+fn status_json_is_one_machine_document_with_no_device_paths() {
+    // status is the command a desktop integration polls, so it is also the one
+    // most likely to leak. It must carry camera CAPABILITY without camera
+    // IDENTITY, and must not name the account.
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["status", "--json"])
+        .env("IRLUME_SOCKET", "/nonexistent/irlume-status-test.sock")
+        .output()
+        .expect("run irlume");
+
+    assert!(output.stderr.is_empty(), "stdout must stay machine-only");
+    assert_eq!(
+        output.stdout.iter().filter(|&&b| b == b'\n').count(),
+        1,
+        "exactly one document"
+    );
+    let raw = String::from_utf8(output.stdout).expect("utf-8");
+    assert!(
+        !raw.contains("/dev/video"),
+        "device paths must not appear in machine output: {raw}"
+    );
+
+    let document: Value = serde_json::from_str(&raw).expect("valid JSON");
+    assert_eq!(document["command"], "status");
+    assert_eq!(document["contract_version"], 1);
+    let data = &document["data"];
+    // Camera is a capability summary, so both spectra are booleans.
+    assert!(data["camera"]["rgb"].is_boolean());
+    assert!(data["camera"]["ir"].is_boolean());
+    // With no daemon reachable, the daemon-derived facts must say they are
+    // unknown rather than defaulting to a confident zero.
+    assert_eq!(data["daemon"], "unreachable");
+    assert_eq!(data["enrollment"]["known"], false);
+    assert!(
+        data["enrollment"].get("profiles").is_none(),
+        "an unknown enrollment must not report a count"
+    );
+    assert_eq!(data["keyring"]["known"], false);
+}
+
+#[test]
+fn status_json_refuses_an_unsupported_contract_before_reading_anything() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["status", "--contract", "9", "--json"])
+        .env("IRLUME_SOCKET", "/nonexistent/irlume-status-test.sock")
+        .output()
+        .expect("run irlume");
+    assert_eq!(output.status.code(), Some(2));
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["error"]["code"], "unsupported-contract");
 }

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -120,6 +120,40 @@ machine.
 Does not contact the daemon. It returns the engine version, contract version,
 advertised capabilities, and public limits.
 
+### `irlume status --json [--user USER]`
+
+Capability: `status-json`.
+
+The readiness summary, as values rather than prose. Deliberately narrower than
+the human `status`: it reports camera **capability** and never camera identity,
+and it does not name the account, because the caller already knows which one it
+asked about.
+
+```json
+{
+  "daemon": "running",
+  "auth_method": "auto",
+  "face_disabled": false,
+  "enrollment": { "known": true, "profiles": 1, "scans": 10 },
+  "templates": "encrypted",
+  "keyring": { "known": true, "armed": true, "policy": "…" },
+  "recovery": { "known": true, "passphrase_set": true },
+  "camera": { "rgb": true, "ir": true },
+  "fingerprint": false
+}
+```
+
+`daemon` is one of `running`, `access-denied` or `unreachable`. An unreachable
+daemon is reported, not raised as an error, because the fields that do not need
+it are still worth having.
+
+Anything derived from the daemon carries `known`. **Unknown is not zero**: when
+`known` is false the counts are absent entirely rather than reported as `0`, so a
+consumer cannot mistake "we could not find out" for "this account has nothing
+enrolled".
+
+`templates` is `encrypted`, `plaintext`, or `unknown`.
+
 ### `irlume profiles list --json [--user USER]`
 
 Capability: `profiles-list-json`.


### PR DESCRIPTION
Next step in the machine API, after #109, #123 and #124.

## Why

The downstream KDE integration reads readiness by matching English phrases and **column spacing** out of the human `status` (`systemprobe.cpp:352-385`):

```cpp
status.contains(QStringLiteral("daemon        : running"))
status.contains(QRegularExpression(R"(enrollment\s+:\s+\d+ profile\(s\))"))
```

Any rewording on our side silently degrades its interface, and it cannot tell that happened. This replaces guessing with values.

Worth noting a second fragility I confirmed while checking their source: `supportedIrlumeVersion` is `\A0\.6\.\d+\z`, so **the moment 0.7.0 ships, their read-only diagnostics report "This irlume version is not supported"** and show nothing. A hard-coded version regex is precisely what a negotiated contract replaces.

## Shape

```json
{
  "daemon": "running",
  "auth_method": "auto",
  "face_disabled": false,
  "enrollment": { "known": true, "profiles": 1, "scans": 10 },
  "templates": "encrypted",
  "keyring": { "known": true, "armed": true, "policy": "…" },
  "recovery": { "known": true, "passphrase_set": true },
  "camera": { "rgb": true, "ir": true },
  "fingerprint": false
}
```

## Two deliberate narrowings

**Camera capability, never camera identity.** Whether an RGB and an IR device resolved, not which nodes. `MACHINE-API.md` already promises machine output carries no device paths, and a consumer needs to know a spectrum is usable, not which `/dev` entry it is. There is a test asserting `/dev/video` never appears in the output.

**No account name.** The caller already knows which one it asked about.

## Unknown is not zero

Anything derived from the daemon carries `known`, and when false the counts are **absent** rather than `0`. "We could not find out" and "this account has nothing enrolled" must not produce the same document — a consumer that conflated them would tell a user to enroll a face they already have. Tested with no daemon reachable.

An unreachable daemon is a reported value rather than an error, so the facts that do not need it survive.

## Verified

The human `status` is untouched — full output diffed before and after, **byte-identical**. The JSON is derived from the same sources it reads, so the two can differ in wording but not in what they claim.

Checked field by field against the live system: daemon running, 1 profile / 10 scans, templates encrypted, keyring armed with its policy string, recovery set, both cameras present, no fingerprint reader. Also checked unprivileged, and that `--contract 9` is refused with exit 2.

666 workspace tests pass, clippy `-D warnings` clean, fmt clean.

## Next

`doctor --json` with stable check IDs, then `login status --json`. `doctor` is the larger design, since the check IDs become public API the moment they ship.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>