### PR TITLE
feat: add `irlume login status --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **`irlume login status --json`.** Which PAM surfaces carry face auth, as values
+  instead of the report's glyphs and column spacing. Each surface reports its PAM
+  service name, its role (`login-screen`, `login-screen-fingerprint`,
+  `lock-screen`, `sudo`, `polkit`), whether the service exists here, whether it is
+  wired, and how face fires on it (`face-first`, `on-demand`, `keyring`,
+  `verify`). The active login manager is named alongside the PAM services it
+  consults, so an integration can find the entry describing its own login screen
+  without guessing from service names.
+
+  The surface list is complete: a service absent from the machine still appears,
+  with `present: false`. Service names are published rather than `/etc/pam.d`
+  paths, on the same terms as the camera capability in `status --json`.
+
+  The human `login status` is unchanged, byte for byte. Both outputs are built
+  from one pass over the PAM files, so they can differ in wording but not in what
+  they claim is wired.
+
+  This completes the read-only machine API: `version`, `status`, `doctor`,
+  `profiles list` and `login status` all answer in JSON, and none of the five
+  commands a desktop integration needs requires parsing English.
+
 - **`irlume doctor --json`.** Every readiness check as an identified result with
   a state of `pass`, `warn`, `fail`, `unknown` or `info`, so an integration can
   show a diagnostic list without matching English.

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -32,6 +32,7 @@ const CAPABILITIES: &[&str] = &[
     "profiles-list-json",
     "status-json",
     "doctor-json",
+    "login-status-json",
 ];
 
 /// The contract the caller asked for, or the failure to report.
@@ -380,6 +381,92 @@ pub fn doctor(args: &[String]) -> ExitCode {
     )
 }
 
+/// `irlume login status --json`: which PAM surfaces carry face auth.
+///
+/// Reads the same PAM files the human report reads, in the same pass, so the
+/// two cannot disagree about what is wired. It publishes PAM SERVICE NAMES
+/// rather than `/etc/pam.d` paths, for the same reason `status --json` reports
+/// camera capability rather than camera nodes: a consumer needs to know which
+/// surface is wired, not where the file lives.
+pub fn login_status(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "login.status";
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    if without_contract(args) != ["login", "status", "--json"] {
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
+    }
+
+    let manager = crate::pamwire::login_manager_fact();
+    // Unknown is not "none". A host with no `display-manager.service` may be
+    // headless or may run a greeter that registers none; either way the engine
+    // did not find out, and a consumer must not render that as "no login
+    // manager is installed".
+    let login_manager = match &manager.name {
+        Some(name) => json!({
+            "known": true,
+            "name": name,
+            "recognized": manager.recognized,
+            "services": manager.services,
+        }),
+        None => json!({ "known": false }),
+    };
+
+    let surfaces: Vec<Value> = crate::pamwire::surface_facts()
+        .iter()
+        .map(|s| {
+            let mut entry = json!({
+                "id": s.id,
+                "role": s.role,
+                "present": s.present,
+                "wired": s.wired,
+            });
+            // Absent rather than null when not wired: there is no mode to
+            // report, and an explicit null invites a consumer to render one.
+            if let Some(mode) = s.mode {
+                entry["mode"] = json!(mode);
+            }
+            entry
+        })
+        .collect();
+
+    let selinux_module = match crate::pamwire::selinux_state() {
+        Some(true) => "loaded",
+        Some(false) => "not-loaded",
+        // The policy store needs root to read, so an ordinary caller gets
+        // `unknown` here. It is not a synonym for "not loaded".
+        None => "unknown",
+    };
+
+    emit(
+        &success(
+            COMMAND,
+            json!({
+                "login_manager": login_manager,
+                "surfaces": surfaces,
+                "selinux_module": selinux_module,
+            }),
+            contract,
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
 pub fn profiles_list(args: &[String]) -> ExitCode {
     const COMMAND: &str = "profiles.list";
     // Negotiate first: an unsupported contract is refused before the daemon is
@@ -596,7 +683,8 @@ mod tests {
                 "version-json",
                 "profiles-list-json",
                 "status-json",
-                "doctor-json"
+                "doctor-json",
+                "login-status-json"
             ])
         );
         assert!(document.get("error").is_none());

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -117,6 +117,9 @@ fn main() -> std::process::ExitCode {
         (Some("recovery"), sub) => recovery::run(sub, &args),
         (Some("bitwarden"), sub) => bitwarden::run(sub, &args),
         (Some("fingerprint"), sub) => fingerprint::run(sub, &args),
+        (Some("login"), Some("status")) if args.iter().any(|arg| arg == "--json") => {
+            machine::login_status(&args)
+        }
         (Some("login"), sub) => pamwire::run(sub, &args),
         (Some("logs"), sub) => logs::run(sub, &args),
         (Some("models"), sub) => models::run(sub, &args),

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -449,9 +449,16 @@ pub(crate) fn polkit_wired() -> Option<bool> {
     service_present(&POLKIT).map(|p| file_has_module(&p))
 }
 
+/// The PAM service name in an /etc/pam.d path (e.g. "/etc/pam.d/gdm-password" →
+/// "gdm-password"). Borrows, so a `&'static str` path yields a `&'static str`
+/// name the machine output can publish as a stable id.
+fn service_name(etc: &str) -> &str {
+    etc.rsplit('/').next().unwrap_or(etc)
+}
+
 /// Short label from an /etc/pam.d path (e.g. "/etc/pam.d/gdm-password" → "gdm-password").
 fn label_of(etc: &str) -> String {
-    etc.rsplit('/').next().unwrap_or(etc).to_string()
+    service_name(etc).to_string()
 }
 
 /// The active login manager, from the `display-manager.service` symlink
@@ -615,6 +622,127 @@ pub(crate) fn fp_keyring_wired() -> bool {
     !present.is_empty() && present.iter().all(|&b| b)
 }
 
+// ---- Wiring facts (shared by the human report and `login status --json`) -----
+
+/// What a PAM surface is for. These strings are published by
+/// `login status --json`, so they are public API: a role may be added, never
+/// renamed and never repurposed.
+const ROLE_LOGIN: &str = "login-screen";
+const ROLE_LOGIN_FP: &str = "login-screen-fingerprint";
+const ROLE_LOCK: &str = "lock-screen";
+const ROLE_SUDO: &str = "sudo";
+const ROLE_POLKIT: &str = "polkit";
+
+/// One PAM surface irlume knows how to wire, as facts rather than a rendered
+/// row. The human report prints these and `login status --json` serializes
+/// them, so a single pass feeds both and the two cannot disagree about what is
+/// wired; they can only differ in how they word it.
+pub(crate) struct SurfaceFact {
+    /// The PAM service name (`plasmalogin`, `kde`, `sudo`, …). Stable public id.
+    pub(crate) id: &'static str,
+    pub(crate) role: &'static str,
+    /// The /etc path, for the human report only. Machine output publishes the
+    /// service name instead, in keeping with the no-paths rule.
+    pub(crate) path: &'static str,
+    /// Whether this service exists here at all: a real /etc file, or a vendor
+    /// copy an /etc override would be materialized from.
+    pub(crate) present: bool,
+    pub(crate) wired: bool,
+    /// How face fires here when wired: `face-first`, `on-demand`, `keyring`
+    /// (the fingerprint keyring-unlock line, which is not a face factor) or
+    /// `verify` (the plain sudo/polkit stanza). `None` when not wired.
+    pub(crate) mode: Option<&'static str>,
+}
+
+fn surface_fact(
+    etc: &'static str,
+    vendor: Option<&'static str>,
+    role: &'static str,
+) -> SurfaceFact {
+    let path = service_present(&Svc { etc, vendor });
+    let content = path
+        .as_ref()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_default();
+    let wired = content_has_module(&content);
+    // Name HOW face fires on this service: on-demand (the consent model) is
+    // invisible in the PAM file to a reader, and a keyring-only line is the
+    // fingerprint unlock rather than face at all.
+    let mode = if !wired {
+        None
+    } else if role == ROLE_SUDO || role == ROLE_POLKIT {
+        Some("verify")
+    } else if !content.contains("unseal") {
+        Some("keyring")
+    } else if content.contains("ondemand") {
+        Some("on-demand")
+    } else {
+        Some("face-first")
+    };
+    SurfaceFact {
+        id: service_name(etc),
+        role,
+        path: etc,
+        present: path.is_some(),
+        wired,
+        mode,
+    }
+}
+
+/// Every surface irlume can wire, present or not, in the order the human report
+/// prints them. Absent services are kept in the list with `present: false`: a
+/// consumer must be able to read an id it knows and cannot find as "this engine
+/// does not wire that service" rather than as "not wired here".
+pub(crate) fn surface_facts() -> Vec<SurfaceFact> {
+    let mut out: Vec<SurfaceFact> = GREETERS
+        .iter()
+        .map(|s| surface_fact(s.etc, s.vendor, ROLE_LOGIN))
+        .chain(
+            FP_GREETERS
+                .iter()
+                .map(|s| surface_fact(s.etc, s.vendor, ROLE_LOGIN_FP)),
+        )
+        .collect();
+    out.push(surface_fact(LOCKSCREEN.etc, LOCKSCREEN.vendor, ROLE_LOCK));
+    out.push(surface_fact(SUDO, None, ROLE_SUDO));
+    out.push(surface_fact(POLKIT.etc, POLKIT.vendor, ROLE_POLKIT));
+    out
+}
+
+/// The active login manager and the PAM services it consults.
+pub(crate) struct LoginManagerFact {
+    /// `None` when no `display-manager.service` is set: a headless host, or a
+    /// greeter that does not register one. Not the same as "no face login".
+    pub(crate) name: Option<String>,
+    /// Whether irlume maps this login manager to PAM services at all. An
+    /// unrecognized manager cannot be targeted by `login enable`.
+    pub(crate) recognized: bool,
+    /// The greeter service, plus the separate fingerprint service on the login
+    /// managers that have one (GDM). Empty when unrecognized.
+    pub(crate) services: Vec<&'static str>,
+}
+
+pub(crate) fn login_manager_fact() -> LoginManagerFact {
+    let Some(dm) = active_display_manager() else {
+        return LoginManagerFact {
+            name: None,
+            recognized: false,
+            services: Vec::new(),
+        };
+    };
+    let (greeter, fp) = dm_pam_services(&dm);
+    let recognized = greeter != "(unknown)";
+    LoginManagerFact {
+        name: Some(dm),
+        recognized,
+        services: if recognized {
+            std::iter::once(greeter).chain(fp).collect()
+        } else {
+            Vec::new()
+        },
+    }
+}
+
 fn status() -> ExitCode {
     println!("[login] wiring status (face auth in PAM):");
     if let Some(dm) = active_display_manager() {
@@ -626,55 +754,28 @@ fn status() -> ExitCode {
     }
     let mut any = false;
     let mut any_ondemand = false;
-    for s in GREETERS
-        .iter()
-        .chain(FP_GREETERS.iter())
-        .chain(std::iter::once(&LOCKSCREEN))
-    {
-        if let Some(present) = service_present(s) {
-            let content = std::fs::read_to_string(&present).unwrap_or_default();
-            let wired = content_has_module(&content);
-            any |= wired;
-            // Surface HOW face fires on this service: on-demand (the consent
-            // model) is invisible in the PAM file to a user, so name it here.
-            let label = if !wired {
-                "○ not wired"
-            } else if !content.contains("unseal") {
-                "● wired"
-            }
-            // keyring-only line
-            else if content.contains("ondemand") {
+    for f in surface_facts() {
+        if !f.present {
+            continue;
+        }
+        let label = match (f.role, f.mode) {
+            (ROLE_SUDO, Some(_)) => "● wired (sudo)",
+            (ROLE_SUDO, None) => "○ not wired (sudo)",
+            (ROLE_POLKIT, Some(_)) => "● wired (polkit app prompts)",
+            (ROLE_POLKIT, None) => "○ not wired (polkit app prompts)",
+            (_, None) => "○ not wired",
+            (_, Some("on-demand")) => {
                 any_ondemand = true;
                 "● wired (face on-demand)"
-            } else {
-                "● wired (face-first)"
-            };
-            println!("  {:<34} {}", present.display(), label);
-        }
-    }
-    if Path::new(SUDO).exists() {
-        let wired = file_has_module(Path::new(SUDO));
-        println!(
-            "  {:<34} {}",
-            SUDO,
-            if wired {
-                "● wired (sudo)"
-            } else {
-                "○ not wired (sudo)"
             }
-        );
-    }
-    if let Some(p) = service_present(&POLKIT) {
-        let wired = file_has_module(&p);
-        println!(
-            "  {:<34} {}",
-            p.display(),
-            if wired {
-                "● wired (polkit app prompts)"
-            } else {
-                "○ not wired (polkit app prompts)"
-            }
-        );
+            (_, Some("face-first")) => "● wired (face-first)",
+            // keyring-only line
+            (_, Some(_)) => "● wired",
+        };
+        // face-sudo alone does not make the login screen work, so it does not
+        // silence the "enable with" hint below.
+        any |= f.wired && f.role != ROLE_SUDO && f.role != ROLE_POLKIT;
+        println!("  {:<34} {}", f.path, label);
     }
     if any_ondemand {
         println!("  on-demand: {ONDEMAND_HINT}");
@@ -1898,6 +1999,37 @@ mod tests {
         assert_eq!(dm_pam_services("cosmic-greeter"), ("cosmic-greeter", None));
         // Anything unrecognised is named "(unknown)" with no fingerprint service.
         assert_eq!(dm_pam_services("mystery-dm"), ("(unknown)", None));
+    }
+
+    #[test]
+    fn surface_facts_cover_every_wirable_service_in_report_order() {
+        // The order is the order the human report prints, and the ids are
+        // published by `login status --json`. Both are API: the first would
+        // reshuffle a report people paste into bug threads, the second would
+        // break a consumer keying off an id.
+        let facts = surface_facts();
+        let seen: Vec<(&str, &str)> = facts.iter().map(|f| (f.id, f.role)).collect();
+        assert_eq!(
+            seen,
+            vec![
+                ("gdm-password", ROLE_LOGIN),
+                ("sddm", ROLE_LOGIN),
+                ("lightdm", ROLE_LOGIN),
+                ("plasmalogin", ROLE_LOGIN),
+                ("cosmic-greeter", ROLE_LOGIN),
+                ("greetd", ROLE_LOGIN),
+                ("gdm-fingerprint", ROLE_LOGIN_FP),
+                ("kde", ROLE_LOCK),
+                ("sudo", ROLE_SUDO),
+                ("polkit-1", ROLE_POLKIT),
+            ]
+        );
+        for f in &facts {
+            // A mode describes how face fires here; without wiring nothing fires.
+            assert_eq!(f.mode.is_some(), f.wired, "{} mode vs wired", f.id);
+            // An absent service is still reported, and reports nothing wired.
+            assert!(f.present || !f.wired, "{} wired while absent", f.id);
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -27,7 +27,8 @@ fn version_json_is_one_machine_document() {
             "version-json",
             "profiles-list-json",
             "status-json",
-            "doctor-json"
+            "doctor-json",
+            "login-status-json"
         ])
     );
 }
@@ -141,6 +142,125 @@ fn status_json_refuses_an_unsupported_contract_before_reading_anything() {
         .expect("run irlume");
     assert_eq!(output.status.code(), Some(2));
     let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["error"]["code"], "unsupported-contract");
+}
+
+#[test]
+fn login_status_json_lists_every_surface_by_service_name() {
+    // The surface list is COMPLETE: services that do not exist on this machine
+    // stay in the array with `present: false`, so a consumer reading an id it
+    // knows and cannot find may conclude the engine does not wire that service
+    // rather than that the service is unwired here. That distinction is the
+    // whole reason this command exists, so it is asserted on a machine where
+    // most of these files are certainly absent.
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["login", "status", "--json"])
+        .output()
+        .expect("run irlume");
+
+    assert!(output.stderr.is_empty(), "stdout must stay machine-only");
+    assert_eq!(
+        output.stdout.iter().filter(|&&b| b == b'\n').count(),
+        1,
+        "exactly one document"
+    );
+    let raw = String::from_utf8(output.stdout).expect("utf-8");
+    assert!(
+        !raw.contains("/etc/pam.d"),
+        "machine output publishes service names, never PAM file paths: {raw}"
+    );
+    assert!(
+        !raw.contains("[login]"),
+        "the human report must not leak into machine mode: {raw}"
+    );
+
+    let document: Value = serde_json::from_str(&raw).expect("valid JSON");
+    assert_eq!(document["command"], "login.status");
+    assert_eq!(document["contract_version"], 1);
+    assert_eq!(document["ok"], true);
+
+    let surfaces = document["data"]["surfaces"]
+        .as_array()
+        .expect("surfaces must be an array");
+    // Public API: this list may grow, but an id is never renamed or reused.
+    for required in [
+        "gdm-password",
+        "sddm",
+        "lightdm",
+        "plasmalogin",
+        "cosmic-greeter",
+        "greetd",
+        "gdm-fingerprint",
+        "kde",
+        "sudo",
+        "polkit-1",
+    ] {
+        assert!(
+            surfaces.iter().any(|s| s["id"] == required),
+            "surface `{required}` is missing from the array"
+        );
+    }
+
+    for surface in surfaces {
+        assert!(surface["present"].is_boolean(), "{surface}");
+        assert!(surface["wired"].is_boolean(), "{surface}");
+        let role = surface["role"].as_str().expect("role must be a string");
+        assert!(
+            [
+                "login-screen",
+                "login-screen-fingerprint",
+                "lock-screen",
+                "sudo",
+                "polkit"
+            ]
+            .contains(&role),
+            "unexpected role `{role}`"
+        );
+        match surface["mode"].as_str() {
+            Some(mode) => {
+                assert_eq!(
+                    surface["wired"], true,
+                    "a mode without wiring would describe how nothing fires: {surface}"
+                );
+                assert!(
+                    ["face-first", "on-demand", "keyring", "verify"].contains(&mode),
+                    "unexpected mode `{mode}`"
+                );
+            }
+            // Absent, not null: there is no mode for an unwired surface.
+            None => assert!(surface.get("mode").is_none(), "{surface}"),
+        }
+    }
+
+    let mut ids: Vec<_> = surfaces.iter().map(|s| s["id"].as_str().unwrap()).collect();
+    let before = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(before, ids.len(), "surface ids must be unique");
+
+    // A login manager the engine could not determine says so; it never reports
+    // a name it does not have.
+    let manager = &document["data"]["login_manager"];
+    if manager["known"] == false {
+        assert!(manager.get("name").is_none(), "{manager}");
+    } else {
+        assert!(manager["name"].is_string(), "{manager}");
+        assert!(manager["recognized"].is_boolean(), "{manager}");
+    }
+
+    assert!(["loaded", "not-loaded", "unknown"]
+        .contains(&document["data"]["selinux_module"].as_str().unwrap()));
+}
+
+#[test]
+fn login_status_json_refuses_an_unsupported_contract() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["login", "status", "--contract", "9", "--json"])
+        .output()
+        .expect("run irlume");
+    assert_eq!(output.status.code(), Some(2));
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "login.status");
     assert_eq!(document["error"]["code"], "unsupported-contract");
 }
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -20,9 +20,9 @@ Conventions that apply everywhere:
 |---|---|
 | `irlume tui` | guided setup + live dashboard; enroll and configure here |
 | `irlume setup` | scripted onboarding: enroll, keyring, recovery, PAM wiring, each step prompted y/N |
-| `irlume status` | health dashboard: daemon, enrollment, keyring, cameras |
+| `irlume status` | health dashboard: daemon, enrollment, keyring, cameras; `status --json` uses the read-only public [machine API](MACHINE-API.md) |
 | `irlume detect` | script-friendly probe; exit `0` = ready, `10` = partial, `20` = absent |
-| `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), the authselect/pam-auth-update regeneration guard, and install hygiene (leftover backup files next to the managed binaries, hand-installed builds overlaying the packaged ones) |
+| `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), the authselect/pam-auth-update regeneration guard, and install hygiene (leftover backup files next to the managed binaries, hand-installed builds overlaying the packaged ones); `doctor --json` uses the read-only public [machine API](MACHINE-API.md) |
 | `irlume deps` | verify runtime dependencies (onnxruntime, models, TPM) |
 | `irlume version` | print the installed version (`--version` / `-V` also work); `version --json` uses the public [machine API](MACHINE-API.md) |
 
@@ -53,7 +53,7 @@ Conventions that apply everywhere:
 
 | Command | Sudo | What it does |
 |---|---|---|
-| `irlume login <status\|enable\|disable\|reconcile> [--with-sudo] [--with-polkit] [--apply]` | yes | PAM wiring for the greeter and lock screen; `--with-sudo` adds face-`sudo`, `--with-polkit` adds app prompts (Bitwarden unlock, pkexec; see docs/APP-INTEGRATION.md); `reconcile` re-applies the wiring after a distro PAM regeneration (also run by the `irlume-reconcile.path` unit); without `--apply` it previews |
+| `irlume login <status\|enable\|disable\|reconcile> [--with-sudo] [--with-polkit] [--apply]` | yes | PAM wiring for the greeter and lock screen; `--with-sudo` adds face-`sudo`, `--with-polkit` adds app prompts (Bitwarden unlock, pkexec; see docs/APP-INTEGRATION.md); `reconcile` re-applies the wiring after a distro PAM regeneration (also run by the `irlume-reconcile.path` unit); without `--apply` it previews; `login status --json` uses the read-only public [machine API](MACHINE-API.md) |
 | `irlume logs [-f] [--since T]` | sometimes | the face-auth journal in one view (daemon, PAM, keyring); `-f` follows live, `--since "10 min ago"` widens the window |
 | `irlume logs debug <on\|off>` | yes | per-stage pipeline tracing in the daemon (numbers only, never frames) |
 | `irlume fingerprint <status\|add\|verify\|reset\|enable\|disable> [--fingerprint-only]` | for wiring | fprintd companion; `enable` = unlock with face OR fingerprint (both), `--fingerprint-only` replaces face |

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -187,6 +187,67 @@ and cannot find as "this engine version does not run that check" rather than as
 `id` values are public API. The list may grow; an id is never renamed and never
 reused for a different meaning.
 
+### `irlume login status --json`
+
+Capability: `login-status-json`.
+
+Which PAM surfaces carry face auth, by service name:
+
+```json
+{
+  "login_manager": {
+    "known": true,
+    "name": "plasmalogin",
+    "recognized": true,
+    "services": ["plasmalogin"]
+  },
+  "surfaces": [
+    { "id": "plasmalogin", "role": "login-screen", "present": true, "wired": true, "mode": "on-demand" },
+    { "id": "sddm", "role": "login-screen", "present": false, "wired": false },
+    { "id": "kde", "role": "lock-screen", "present": true, "wired": true, "mode": "on-demand" },
+    { "id": "sudo", "role": "sudo", "present": true, "wired": true, "mode": "verify" }
+  ],
+  "selinux_module": "loaded"
+}
+```
+
+`id` is the PAM service name, and it is public API on the same terms as a doctor
+check id: the list may grow, an id is never renamed and never reused. Paths under
+`/etc/pam.d` are not published, for the reason `status --json` publishes camera
+capability and not camera nodes.
+
+`role` is one of `login-screen`, `login-screen-fingerprint`, `lock-screen`,
+`sudo` or `polkit`.
+
+`present` is whether the service exists on this machine at all, counting a vendor
+copy an override would be materialized from. `wired` is whether it currently
+carries the irlume line.
+
+**The surface array is complete.** A service absent from the machine is still
+reported, with `present: false`, so a consumer that knows an id and cannot find
+it may read that as "this engine version does not wire that service" rather than
+as "it is not wired here".
+
+`mode` says how face fires on a wired surface: `face-first` (the camera verifies
+as soon as the greeter prompts), `on-demand` (the user submits an empty password
+to trigger face), `keyring` (the fingerprint keyring-unlock line, which is not a
+face factor), or `verify` (the plain sudo and polkit stanza). It is absent, never
+null, when the surface is not wired.
+
+`login_manager.known` is false when no `display-manager.service` is set: a
+headless host, or a greeter that registers none. That is not the same as "no
+login manager is installed", and a consumer should not render it that way.
+`recognized` is whether irlume maps this login manager to PAM services at all; an
+unrecognized one cannot be targeted by `login enable`. `services` are the PAM
+services that login manager consults, which is how a consumer decides which
+surface entry describes its own login screen without matching on names. A service
+listed there with no matching entry in `surfaces` is one this engine has no
+wiring recipe for.
+
+`selinux_module` is `loaded`, `not-loaded` or `unknown`. Reading the policy store
+needs root, so an ordinary caller gets `unknown`, which is not a synonym for
+`not-loaded`.
+
 ### `irlume profiles list --json [--user USER]`
 
 Capability: `profiles-list-json`.


### PR DESCRIPTION
Closes the last command a desktop integration has to read as English.

## Why

`plasma-irlume`'s `pamStatusFromOutput()` (`src/backend/systemprobe.cpp:133-180`) splits our human report, keeps lines containing "wired", filters them by service-name substrings (`plasmalogin`, `/kde`, `/sddm`), and counts the literal glyph `● wired` to decide Clean / Drift / NotConfigured / Unknown. `displayManagerMigrationDetected()` regexes the same text for a DM migration. Rewording one status line degrades that UI without either side noticing.

## What ships

`irlume login status --json`, capability `login-status-json`:

```json
{
  "login_manager": { "known": true, "name": "plasmalogin", "recognized": true, "services": ["plasmalogin"] },
  "surfaces": [
    { "id": "plasmalogin", "role": "login-screen", "present": true,  "wired": true,  "mode": "on-demand" },
    { "id": "sddm",        "role": "login-screen", "present": false, "wired": false },
    { "id": "kde",         "role": "lock-screen",  "present": true,  "wired": true,  "mode": "on-demand" },
    { "id": "sudo",        "role": "sudo",         "present": true,  "wired": true,  "mode": "verify" }
  ],
  "selinux_module": "loaded"
}
```

- **Service names, not paths.** `id` is the PAM service name; `/etc/pam.d` never appears, on the same terms as camera capability in `status --json`. A test asserts it.
- **The surface list is complete.** A service absent from this machine still appears with `present: false`, so a consumer that knows an id and cannot find it may read that as "this engine does not wire that service" rather than as "not wired here". That is the property the doctor check array already carries.
- **`login_manager.services`** names the PAM services the active manager consults, so a consumer picks the entry describing its own login screen rather than matching on names.
- **`mode`** says how face fires on a wired surface: `face-first`, `on-demand`, `keyring` (the fingerprint unlock line, not a face factor), `verify` (the sudo/polkit stanza). Absent, never null, when unwired.
- **Unknown is not none.** `selinux_module` is `unknown` when the policy store cannot be read without root, and `login_manager.known` is false when no `display-manager.service` is set.

`role` and `id` values are public API on the same terms as check ids: the list may grow, an entry is never renamed or reused.

## Human output is byte-identical

`status()` prints from the same fact list the JSON serializes, so one pass feeds both and they cannot disagree about what is wired. Verified against golden captures taken twice, as an ordinary user and as root, since SELinux state and file readability differ by privilege.

## Validation

- Full workspace suite: 670 passed, 0 failed. `cargo fmt --check` and `clippy --all-targets` clean.
- Live on this Fedora 44 KDE box, cross-checked field by field against the human report: `plasmalogin` and `kde` wired on-demand, `sudo` and `polkit-1` wired verify, `selinux_module` `unknown` as user and `loaded` under sudo.
- `--contract 9` refused with `unsupported-contract` and exit 2 before any file is read; an unknown flag is a typed `usage-error`.

## Noted, not fixed here

`dm_pam_services()` maps `ly` to a `ly` PAM service that no `Svc` entry covers, so `doctor` calls that display manager recognized while `login enable` cannot wire it. Pre-existing and unrelated to this command; filing separately.
