### PR TITLE
ci: run the test suite under AddressSanitizer

### DIFF
--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -1,0 +1,16 @@
+# LeakSanitizer suppressions for the ASan job. Keep this file short: every entry
+# here is a leak nobody will be told about again.
+#
+# `pamwire`'s wiring tests build a `Svc`, whose `etc` and `vendor` fields are
+# `&'static str` because the real ones are compile-time paths. A test pointing at
+# a temporary directory has to produce a `&'static str` at runtime, which the
+# `leak()` helper does with `Box::leak`. That is a deliberate, bounded leak in
+# test scaffolding: eleven allocations totalling roughly half a kilobyte, all
+# freed when the test process exits.
+#
+# This is scoped to that test module rather than to the crate, so a leak anywhere
+# else in irlume-cli still fails the job. The trade it makes is that a genuine
+# leak inside those specific test functions would also be hidden; they allocate
+# almost nothing else, which is why the trade is acceptable here and would not be
+# at a wider scope.
+leak:irlume::pamwire::tests::

--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -8,6 +8,11 @@
 # test scaffolding: eleven allocations totalling roughly half a kilobyte, all
 # freed when the test process exits.
 #
+# A suppression matches the SYMBOL NAMES in the allocation stack. With no
+# symbolizer the stack is bare addresses, this entry matches nothing, and the
+# deliberate leak reappears as a failure that looks like a real one. The workflow
+# therefore resolves llvm-symbolizer and stops if it cannot find one.
+#
 # This is scoped to that test module rather than to the crate, so a leak anywhere
 # else in irlume-cli still fails the job. The trade it makes is that a genuine
 # leak inside those specific test functions would also be hidden; they allocate

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -79,7 +79,9 @@ jobs:
         run: |
           sym=$(command -v llvm-symbolizer || true)
           if [ -z "$sym" ]; then
-            sym=$(ls -1 /usr/lib/llvm-*/bin/llvm-symbolizer 2>/dev/null | sort -V | tail -1 || true)
+            # Versioned installs land in /usr/lib/llvm-N/bin; take the newest.
+            sym=$(find /usr/lib -maxdepth 3 -path '*/bin/llvm-symbolizer' -type f 2>/dev/null \
+                  | sort -V | tail -1)
           fi
           if [ -z "$sym" ]; then
             echo "no llvm-symbolizer found; ASan reports would be bare addresses" >&2

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,108 @@
+# AddressSanitizer over the test suite.
+#
+# irlume is mostly safe Rust, so this is aimed at the places where it is not:
+# the NSS `getpwnam_r`/`getpwuid_r` buffer handling, the mlock/madvise page
+# arithmetic that protects a decrypted secret, `secure_getenv`, the UVC XU
+# control ioctl, and the SO_PEERCRED socket path the daemon authorizes callers
+# with. Those are a few dozen lines, but they are the lines where a mistake is
+# a memory-safety bug in a program that authenticates people, and clippy cannot
+# see into them.
+#
+# Deliberately NOT a required check, and deliberately not on the fast path: it
+# needs a nightly toolchain (`-Zsanitizer` is unstable), so an unrelated nightly
+# regression must not be able to block a pull request. It runs on pull requests
+# that touch the code, on main, and weekly, so a break is visible without being
+# in the way.
+#
+# Two known interactions, both handled rather than papered over:
+#   * the sanitizer runtime defines its own `mlock`, so the RLIMIT_MEMLOCK
+#     refusal test cannot reach the kernel. That test detects the interception
+#     and reports which assertion it skipped.
+#   * `pamwire`'s wiring tests leak a `&'static str` on purpose; the scope and
+#     the reasoning are in .github/lsan-suppressions.txt.
+name: ASan
+
+on:
+  pull_request:
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/asan.yml"
+      - ".github/lsan-suppressions.txt"
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  schedule:
+    - cron: "40 4 * * 3" # Wednesdays 04:40 UTC, clear of the other scheduled jobs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  asan:
+    name: AddressSanitizer (test suite)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not leave the job token in .git/config for later steps to reach.
+          persist-credentials: false
+
+      - name: Cache model weights
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: models
+          key: models-${{ hashFiles('models/SHA256SUMS') }}
+
+      - name: Fetch model weights (models-v1 release, sha256-verified)
+        run: bash scripts/fetch-models.sh
+
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
+
+      - name: Install nightly Rust (-Zsanitizer is unstable)
+        # @master (declares the `toolchain` input); the version tag branches
+        # have no such input and ignore `with: toolchain:`.
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: nightly
+          # The sanitizer runtimes ship with the standard library for the
+          # explicit target, which is also why --target is passed below: without
+          # it, build scripts and proc macros would be instrumented too.
+          components: rust-src
+          targets: x86_64-unknown-linux-gnu
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Own cache key: an instrumented build shares nothing with the normal
+          # one, and PRs restore without saving (see ci.yml for the quota).
+          key: asan
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
+        run: |
+          ver=1.24.4
+          curl -fsSLO "https://github.com/microsoft/onnxruntime/releases/download/v${ver}/onnxruntime-linux-x64-${ver}.tgz"
+          tar xzf "onnxruntime-linux-x64-${ver}.tgz"
+          echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
+
+      - name: test (instrumented with AddressSanitizer + LeakSanitizer)
+        env:
+          RUSTFLAGS: -Zsanitizer=address
+          # A leak report names the allocation, not the leak's owner, so keep
+          # the whole stack: the deliberate one is only distinguishable by the
+          # test function that allocated it.
+          ASAN_OPTIONS: detect_stack_use_after_return=1
+        run: |
+          LSAN_OPTIONS="suppressions=$PWD/.github/lsan-suppressions.txt" \
+            cargo +nightly test --workspace --locked \
+              --target x86_64-unknown-linux-gnu

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -67,7 +67,26 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
+            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev llvm
+
+      # A leak suppression matches the SYMBOL NAMES in an allocation stack, so
+      # without a symbolizer it matches nothing and the deliberate test leak
+      # comes back as a failure with a stack of bare addresses. That is how this
+      # job failed the first time it ran here, while passing locally where a
+      # symbolizer happened to be installed. Resolve it explicitly and stop if it
+      # is missing, rather than let the job degrade into an unreadable report.
+      - name: Locate llvm-symbolizer (suppressions and reports both need it)
+        run: |
+          sym=$(command -v llvm-symbolizer || true)
+          if [ -z "$sym" ]; then
+            sym=$(ls -1 /usr/lib/llvm-*/bin/llvm-symbolizer 2>/dev/null | sort -V | tail -1 || true)
+          fi
+          if [ -z "$sym" ]; then
+            echo "no llvm-symbolizer found; ASan reports would be bare addresses" >&2
+            exit 1
+          fi
+          "$sym" --version
+          echo "ASAN_SYMBOLIZER_PATH=$sym" >> "$GITHUB_ENV"
 
       - name: Install nightly Rust (-Zsanitizer is unstable)
         # @master (declares the `toolchain` input); the version tag branches
@@ -103,6 +122,8 @@ jobs:
           # test function that allocated it.
           ASAN_OPTIONS: detect_stack_use_after_return=1
         run: |
-          LSAN_OPTIONS="suppressions=$PWD/.github/lsan-suppressions.txt" \
+          # print_suppressions puts "Suppressions used:" in the log, so a reader
+          # can see the deliberate leak was matched rather than assume it.
+          LSAN_OPTIONS="suppressions=$PWD/.github/lsan-suppressions.txt:print_suppressions=1" \
             cargo +nightly test --workspace --locked \
               --target x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **AddressSanitizer over the test suite, weekly and on pull requests that touch
+  the code.** irlume is mostly safe Rust, so this is aimed at the places where it
+  is not: NSS `getpwnam_r` buffer handling, the mlock and madvise page arithmetic
+  that protects a decrypted secret, `secure_getenv`, a UVC control ioctl, and the
+  daemon's `SO_PEERCRED` path. Clippy cannot see into any of them.
+
+  Not a required check, on purpose: `-Zsanitizer` is unstable, and an unrelated
+  nightly regression must not be able to block a pull request.
+
+  Verified by planting a deliberate out-of-bounds read and confirming the job
+  reported it with the right file and line, then removing it. A gate nobody has
+  seen fire is a gate nobody should trust.
+
 - **`docs/INTEGRATION.md`, a guide for people writing software that drives
   irlume.** How to call the machine API, the startup handshake, what contract 1
   offers, what it deliberately does not (no mutation, no event stream, no D-Bus
@@ -138,6 +151,13 @@ All notable changes to irlume are documented here. This project adheres to
   written to be read.
 
 ### Fixed
+
+- **`mlock_refusal_warns_and_continues` failed under a sanitizer instead of
+  saying why.** The sanitizer runtime defines its own `mlock`, so the call never
+  reaches the kernel, `RLIMIT_MEMLOCK` refuses nothing, and the warning the test
+  looks for is never printed. The test now detects that the lock was not enforced
+  and reports which assertion it skipped, rather than reporting a bug that is not
+  there or passing quietly as though it had checked.
 
 - **Two `doctor` checks vanished from the machine document instead of reporting
   that they did not apply.** `polkit-helper-sandbox` was recorded only when

--- a/crates/irlume-common/src/memlock.rs
+++ b/crates/irlume-common/src/memlock.rs
@@ -69,8 +69,23 @@ mod tests {
     #[test]
     fn mlock_refusal_warns_and_continues() {
         if std::env::var("IRLUME_TEST_MEMLOCK_CHILD").is_ok() {
-            lock_slice(&vec![0x5a_u8; 4096]);
+            let secret = vec![0x5a_u8; 4096];
+            lock_slice(&secret);
             println!("survived-without-mlock");
+            // Probe whether mlock reaches the kernel at all here. A sanitizer
+            // runtime defines its own mlock and returns success without making
+            // the syscall, so RLIMIT_MEMLOCK refuses nothing and the warning
+            // this test looks for is never printed. Say so, rather than leaving
+            // the parent to read an intercepted call as a missing warning.
+            let page = match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
+                n if n > 0 => n as usize,
+                _ => 4096,
+            };
+            let aligned = secret.as_ptr() as usize & !(page - 1);
+            // SAFETY: `aligned` is the page containing a live 4 KiB allocation.
+            if unsafe { libc::mlock(aligned as *mut libc::c_void, page) } == 0 {
+                println!("mlock-not-enforced");
+            }
             return;
         }
         use std::os::unix::process::CommandExt;
@@ -103,7 +118,18 @@ mod tests {
             "a refused mlock must not fail the caller; stderr: {}",
             String::from_utf8_lossy(&out.stderr)
         );
-        assert!(String::from_utf8_lossy(&out.stdout).contains("survived-without-mlock"));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("survived-without-mlock"));
+        if stdout.contains("mlock-not-enforced") {
+            // Reported rather than passed silently: under ASan this test proves
+            // only that the caller survived, not that the refusal was warned
+            // about, and a reader of the log should know which.
+            eprintln!(
+                "SKIPPED the refusal-is-warned assertion: mlock is intercepted in this build \
+                 (sanitizer runtime), so RLIMIT_MEMLOCK cannot refuse the lock"
+            );
+            return;
+        }
         let err = String::from_utf8_lossy(&out.stderr);
         assert!(
             err.contains("mlock failed"),

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -184,6 +184,12 @@ LSAN_OPTIONS="suppressions=$PWD/.github/lsan-suppressions.txt" \
 instrumented too and the build fails. The whole suite takes about twenty seconds
 once warm.
 
+A leak suppression matches the symbol names in an allocation stack, so it does
+nothing on a machine with no symbolizer: the suppressed leak comes back looking
+like a real one, with a stack of bare addresses. If that happens, install
+`llvm-symbolizer` and set `ASAN_SYMBOLIZER_PATH` to it. The CI job resolves it
+explicitly and refuses to run without one.
+
 Two interactions are worth knowing before you read a failure. The sanitizer
 runtime defines its own `mlock`, so `RLIMIT_MEMLOCK` cannot refuse anything and
 `mlock_refusal_warns_and_continues` prints which assertion it skipped instead of

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -167,6 +167,30 @@ cargo run -p irlume-cli -- doctor   # platform / TPM / camera / model check
 Developer-only benchmark and capture subcommands are gated behind `IRLUME_DEV=1`
 (e.g. `IRLUME_DEV=1 cargo run -p irlume-cli -- selftest align --model models/glintr100.onnx`).
 
+### AddressSanitizer
+
+The unsafe code in irlume is a few dozen lines: NSS `getpwnam_r` buffers, the
+mlock and madvise page arithmetic around a decrypted secret, `secure_getenv`, a
+UVC control ioctl, and the daemon's `SO_PEERCRED` path. Clippy cannot see into
+them, so a weekly job runs the suite instrumented. To reproduce it:
+
+```sh
+RUSTFLAGS=-Zsanitizer=address \
+LSAN_OPTIONS="suppressions=$PWD/.github/lsan-suppressions.txt" \
+  cargo +nightly test --workspace --target x86_64-unknown-linux-gnu
+```
+
+`--target` is not optional: without it, build scripts and proc macros are
+instrumented too and the build fails. The whole suite takes about twenty seconds
+once warm.
+
+Two interactions are worth knowing before you read a failure. The sanitizer
+runtime defines its own `mlock`, so `RLIMIT_MEMLOCK` cannot refuse anything and
+`mlock_refusal_warns_and_continues` prints which assertion it skipped instead of
+failing. And `pamwire`'s wiring tests leak a `&'static str` deliberately;
+`.github/lsan-suppressions.txt` explains the scope, which is why the suppression
+names those tests rather than the crate.
+
 The TPM-gated tests (marked `#[ignore]`) run against a software TPM, no
 hardware or root needed; CI does exactly this:
 


### PR DESCRIPTION
Closes the last open item from the security-CI research. The `pam_wrapper` item on that list turned out to be already done: `crates/irlume-pam/tests/pamwrap.rs` has 13 tests driving the real module through pamtester, and CI runs them.

## The unsafe surface this instruments

I measured it before building anything:

| Where | What |
|---|---|
| `irlume-common` | NSS `getpwnam_r`/`getpwuid_r` buffers, mlock/madvise page arithmetic, `secure_getenv` |
| `irlume-cli` / `irlume-camera` | a UVC XU control ioctl |
| `irlume-daemon` | the `SO_PEERCRED` path that authorizes callers |

Most of the rest is `geteuid()` and `isatty()`. So the job covers a specific handful of places: the ones where a mistake is a memory-safety bug in a program that authenticates people, and where clippy sees nothing.

**Not a required check, deliberately.** `-Zsanitizer` is unstable, so it needs nightly, and an unrelated nightly regression must not be able to block a PR. Triggers: pull requests touching `crates/**` or the manifests, pushes to main, and weekly.

## Verification

**The gate fires.** I planted a deliberate out-of-bounds read in `irlume-common` and confirmed the report, then removed it:

```
ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1
    #0 ... deliberate_overflow_for_verification_only crates/irlume-common/src/memlock.rs:149:26
```

**Leak detection stays on.** Removing the suppression file still fails the run (`537 byte(s) leaked in 11 allocation(s)`), which is how I checked the suppression is scoped rather than blanket.

**Runtime:** about 20 seconds warm for the whole workspace, 25 test binaries.

## Sanitizer interactions with mlock and the pamwire tests

**The sanitizer defines its own `mlock`.** Confirmed from the shipped runtime's symbol table:

```
$ nm -g --defined-only librustc-nightly_rt.asan.a | grep -E ' (mlock|munlock|mlockall)$'
W mlock    W munlock    W mlockall
```

So the call never reaches the kernel, `RLIMIT_MEMLOCK` refuses nothing, and `mlock_refusal_warns_and_continues` could never observe its warning. The test now probes whether the lock was enforced and prints which assertion it skipped. Checked both ways: on stable the assertion still runs, under ASan it skips with a reason in the log.

**`pamwire`'s wiring tests leak on purpose.** `Svc.etc` is `&'static str` because the real paths are compile-time constants, so a test pointing at a tempdir has to `Box::leak`. The suppression names those test functions rather than the crate, so a leak anywhere else in `irlume-cli` still fails. The trade is stated in the file: a genuine leak inside those eight test functions would be hidden.

## Documentation

`docs/DEVELOPMENT.md` gains the reproduction, including the flag that is not optional. Without `--target`, build scripts and proc macros get instrumented too and the build fails.
