### PR TITLE
feat(daemon): arbitrate camera work so an authentication is not queued behind it

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -66,6 +66,14 @@ pub struct Engine {
     /// The gate treats `false` as "not seen yet", which is the fail-closed
     /// reading: the worst a stale `false` can do is ask for another gesture.
     gesture_seen_before_match: bool,
+    /// Asked between whole captures: "should this long operation stop now?".
+    ///
+    /// The daemon points this at its arbiter so an enrolment yields the camera
+    /// to an authentication. `None` (the CLI, tests) never stops. It is polled
+    /// only at a boundary where nothing is half-written, never mid-capture and
+    /// never mid-inference: stopping an operation is a scheduling decision, not
+    /// a way to abandon a device or a session.
+    stop_requested: Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>,
 }
 
 /// Assurance tier of this engine, derived from the available camera hardware.
@@ -495,7 +503,23 @@ impl Engine {
             ir_dev: irlume_camera::DEFAULT_IR_DEVICE.into(),
             ir_available: irlume_camera::capabilities().ir_pair,
             gesture_seen_before_match: false,
+            stop_requested: None,
         })
+    }
+
+    /// Point the engine at a signal asked between whole captures, so a long
+    /// operation can yield the camera to an authentication.
+    ///
+    /// Only the daemon sets this. It is a request, not a kill: the check happens
+    /// at boundaries where nothing is half-written, so a stopped operation
+    /// persists nothing and the caller retries.
+    pub fn set_stop_signal(&mut self, signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>) {
+        self.stop_requested = Some(signal);
+    }
+
+    /// True when something has asked this operation to stop.
+    fn should_stop(&self) -> bool {
+        self.stop_requested.as_ref().is_some_and(|f| f())
     }
 
     /// Assurance tier from the hardware: `Secure` with a real RGB+IR camera,
@@ -2191,6 +2215,14 @@ impl Engine {
         // A camera that cannot be opened is NOT fatal here: fall back to the
         // per-capture path, which is exactly today's behaviour, so enrolment
         // still works on hardware the session path cannot hold.
+        // Asked to yield before the first frame: do not even open the device.
+        // A queued enrolment that already knows an authentication is waiting has
+        // no business claiming the camera for the moment it takes to notice.
+        if self.should_stop() {
+            return Err(irlume_common::Error::Preempted(
+                "an authentication needed the camera; nothing was saved, please retry".into(),
+            ));
+        }
         let (rgb_dev, ir_dev) = (self.rgb_dev.clone(), self.ir_dev.clone());
         let cams = if self.ir_available {
             match (
@@ -2219,6 +2251,14 @@ impl Engine {
         for _ in 0..(want * 10) {
             if out.len() >= want {
                 break;
+            }
+            // The safe boundary: between whole captures, before the next one
+            // opens. Nothing is written until the caller finishes, so returning
+            // here leaves no partial profile behind and no device mid-stream.
+            if self.should_stop() {
+                return Err(irlume_common::Error::Preempted(
+                    "an authentication needed the camera; nothing was saved, please retry".into(),
+                ));
             }
             let a = match &mut sessions {
                 Some((rs, is)) => self.assess_full_with(Some((rs, is)))?,
@@ -4571,6 +4611,69 @@ mod engine_tests {
         );
 
         std::env::remove_var("IRLUME_GRACE_MS");
+        teardown_sandbox(&dir);
+    }
+
+    /// An enrolment asked to stop must yield at a capture boundary and leave
+    /// nothing behind.
+    ///
+    /// Run against the loopback feeders, which hold no face, so the enrolment
+    /// would otherwise spend its whole retry budget looking for one: that is
+    /// precisely the long operation an arriving authentication must not wait
+    /// for. The assertions that matter are the typed `Preempted` outcome and an
+    /// enrollment store that is still empty afterwards, because a half-written
+    /// profile would be worse than the delay this feature removes.
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_enrolment_stops_when_asked_and_saves_nothing() {
+        let (Ok(rgb), Ok(ir)) = (
+            std::env::var("IRLUME_TEST_RGB_DEVICE"),
+            std::env::var("IRLUME_TEST_IR_DEVICE"),
+        ) else {
+            return;
+        };
+        let _g = env_guard();
+        ort_init();
+        let dir = state_sandbox("loopback-preempt");
+
+        let mut e = Engine::load(
+            &model_path("face_detection_yunet_2023mar.onnx"),
+            &model_path("glintr100.onnx"),
+        )
+        .expect("engine load")
+        .with_devices(&rgb, &ir);
+        // Answer "keep going" once so the entry check passes and the camera is
+        // opened, then "stop": that lands the yield on the boundary BETWEEN
+        // captures, which is the case that has to work. A signal that is true
+        // from the start would only prove the cheap entry check.
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let seen = std::sync::Arc::clone(&calls);
+        e.set_stop_signal(std::sync::Arc::new(move || {
+            seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0
+        }));
+
+        let err = e
+            .enroll_profile("preemptuser", None, 10)
+            .expect_err("a stop request must not look like a successful enrolment");
+        assert!(
+            matches!(err, irlume_common::Error::Preempted(_)),
+            "the caller has to tell a yield from a failure, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("retry"),
+            "the message should tell the user what to do: {err}"
+        );
+        assert!(
+            irlume_core::storage::load("preemptuser")
+                .expect("store readable")
+                .is_none(),
+            "a stopped enrolment must persist nothing"
+        );
+        assert!(
+            calls.load(std::sync::atomic::Ordering::SeqCst) >= 2,
+            "the yield must come from the in-loop boundary, not only the entry check"
+        );
+
         teardown_sandbox(&dir);
     }
 }

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -609,6 +609,11 @@ pub enum Error {
     Tpm(String),
     #[error("policy: {0}")]
     Policy(String),
+    /// A long camera operation stopped early because an authentication needed
+    /// the camera. Distinct from a failure: nothing went wrong and nothing was
+    /// written, so the caller should say "retry", not "it broke".
+    #[error("preempted: {0}")]
+    Preempted(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -21,17 +21,18 @@
 //!   back has lost a frame, while one that is queued behind an enrollment holds
 //!   a slot the login path may want.
 //!
-//! What this deliberately does not do is preempt. An operation already running
-//! runs to completion, so an enrollment in flight still delays a login until it
-//! finishes. Stopping one early means checking a signal between whole captures,
-//! inside `irlume_auth`'s enrollment loop rather than here, and that is the
-//! second half of issue #117.
+//! What this deliberately does not do is preempt by force. An operation already
+//! running is ASKED to stop, through [`CancelToken`], and it answers at its own
+//! next safe boundary: between whole captures, where nothing is half-written.
+//! Nothing here unwinds a thread, closes a device out from under a capture, or
+//! interrupts an ONNX session.
 //!
 //! [`Engine`]: irlume_auth::Engine
 
 use irlume_common::Request;
 use std::collections::VecDeque;
-use std::sync::{Condvar, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 
 /// What a request costs and how much it may delay a login.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -91,6 +92,38 @@ impl Refusal {
     }
 }
 
+/// A cooperative stop signal for long camera loops.
+///
+/// Enrolment captures many scans and may retry each one. The boundary between
+/// two whole captures is where stopping is safe, and it is the only place this
+/// is read. The token says "an authentication is waiting"; what it never does is
+/// interrupt a capture already inside V4L2 or an inference session, or fire
+/// while a profile is half-written.
+#[derive(Clone, Default)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ask the running long operation to stop at its next safe boundary.
+    pub fn request_stop(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    /// True once a stop has been asked for.
+    pub fn stop_requested(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    /// Clear the signal before the worker starts its next operation, so the one
+    /// that yielded does not hand its cancellation to the one that follows.
+    pub fn reset(&self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
 /// One queued unit of work: what to run, and who asked.
 pub struct Job<T> {
     pub class: Class,
@@ -120,6 +153,7 @@ impl<T> Inner<T> {
 pub struct Arbiter<T> {
     inner: Mutex<Inner<T>>,
     ready: Condvar,
+    cancel: CancelToken,
 }
 
 impl<T> Default for Arbiter<T> {
@@ -139,7 +173,14 @@ impl<T> Arbiter<T> {
                 closed: false,
             }),
             ready: Condvar::new(),
+            cancel: CancelToken::new(),
         }
+    }
+
+    /// The signal long operations poll. Shared, so an authentication arriving on
+    /// any connection reaches an enrolment already in flight.
+    pub fn cancel_token(&self) -> CancelToken {
+        self.cancel.clone()
     }
 
     /// Offer a request to the queue.
@@ -149,12 +190,18 @@ impl<T> Arbiter<T> {
     pub fn submit(&self, class: Class, uid: u32, payload: T) -> Result<(), Refusal> {
         let mut inner = self.lock();
         match class {
-            // An authentication never waits behind preview work.
-            Class::Auth => inner.auth.push_back(Job {
-                class,
-                uid,
-                payload,
-            }),
+            Class::Auth => {
+                // An authentication never waits behind preview work, and the
+                // request to yield goes out NOW rather than when the worker next
+                // looks: an enrolment should learn it is wanted elsewhere while
+                // it still has boundaries left to stop at.
+                self.cancel.request_stop();
+                inner.auth.push_back(Job {
+                    class,
+                    uid,
+                    payload,
+                });
+            }
             Class::Camera => {
                 if inner.auth_pending() {
                     return Err(Refusal::AuthenticationPending);
@@ -190,9 +237,14 @@ impl<T> Arbiter<T> {
         loop {
             if let Some(job) = inner.auth.pop_front() {
                 inner.auth_running = true;
+                // The stop that was asked for has been honoured by this
+                // authentication reaching the front; clear it so the next long
+                // operation does not start already cancelled.
+                self.cancel.reset();
                 return Some(job);
             }
             if let Some(job) = inner.other.pop_front() {
+                self.cancel.reset();
                 return Some(job);
             }
             if inner.closed {
@@ -303,6 +355,27 @@ mod tests {
         let job = a.take().unwrap();
         a.finish(job.class, job.uid);
         assert!(a.submit(Class::Camera, 1000, "again").is_ok());
+    }
+
+    #[test]
+    fn a_submitted_authentication_asks_a_running_loop_to_stop() {
+        let a = arb();
+        let token = a.cancel_token();
+        a.submit(Class::Camera, 1000, "enrolment").unwrap();
+        let job = a.take().unwrap();
+        assert!(!token.stop_requested(), "nothing is waiting yet");
+        a.submit(Class::Auth, 0, "login").unwrap();
+        assert!(
+            token.stop_requested(),
+            "the enrolment must learn an authentication is waiting"
+        );
+        a.finish(job.class, job.uid);
+        let next = a.take().unwrap();
+        assert_eq!(next.payload, "login");
+        assert!(
+            !token.stop_requested(),
+            "the next operation must not inherit the cancellation"
+        );
     }
 
     #[test]

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Who gets the camera next.
+//!
+//! The daemon serves requests from one worker that owns the [`Engine`], because
+//! two threads driving V4L2 and ONNX over one device is not something to attempt
+//! on an authentication path. That single worker is also the problem: before
+//! this module, a local account running a legitimate self-enrollment held it for
+//! as long as the enrollment took, and a lock-screen unlock arriving meanwhile
+//! waited in the kernel accept backlog where the daemon could not even see it.
+//!
+//! So connections are now read and parsed off the worker, and what they parse
+//! into is queued here. Two rules do the work:
+//!
+//! * **Authentication goes first.** A queued or running authentication is what
+//!   makes every other camera request wait.
+//! * **Non-authentication camera work is refused, not queued,** while
+//!   authentication is pending, and each unprivileged uid may hold at most one
+//!   camera slot. Refusing beats queueing: a preview client that is told to come
+//!   back has lost a frame, while one that is queued behind an enrollment holds
+//!   a slot the login path may want.
+//!
+//! What this deliberately does not do is preempt. An operation already running
+//! runs to completion, so an enrollment in flight still delays a login until it
+//! finishes. Stopping one early means checking a signal between whole captures,
+//! inside `irlume_auth`'s enrollment loop rather than here, and that is the
+//! second half of issue #117.
+//!
+//! [`Engine`]: irlume_auth::Engine
+
+use irlume_common::Request;
+use std::collections::VecDeque;
+use std::sync::{Condvar, Mutex};
+
+/// What a request costs and how much it may delay a login.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Class {
+    /// The login path: face authentication, and the credential release that
+    /// follows it. Never refused, always served before other camera work.
+    Auth,
+    /// Opens the camera without being an authentication: the framing guide,
+    /// 1:N identify, enrollment, emitter probes, self-tests.
+    Camera,
+    /// Touches no camera: listings, keyring metadata, settings. Cheap enough
+    /// that arbitration would cost more than it saves.
+    Plain,
+}
+
+/// Classify a request by what it does to the camera, not by who sent it.
+///
+/// `Authenticate` is the login path. The unseal operations are the credential
+/// release that a successful authentication leads to, and delaying them behind a
+/// preview would leave a user logged in with a locked keyring, so they share the
+/// priority rather than competing with it.
+pub fn classify(req: &Request) -> Class {
+    use Request::*;
+    match req {
+        Authenticate { .. } | UnsealPassword { .. } | UnsealKeyring { .. } => Class::Auth,
+        PositionSample { .. }
+        | Identify
+        | Enroll { .. }
+        | AddScan { .. }
+        | CaptureEarMedian { .. }
+        | SetupIrEmitter { .. }
+        | TuneCaptureMode { .. }
+        | SelfTest { .. } => Class::Camera,
+        _ => Class::Plain,
+    }
+}
+
+/// Why a camera request was turned away, in words a client can show.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Refusal {
+    /// An authentication is queued or running. The camera belongs to it.
+    AuthenticationPending,
+    /// This uid already has a camera operation queued or running.
+    AlreadyHoldsSlot,
+}
+
+impl Refusal {
+    pub fn message(self) -> &'static str {
+        match self {
+            Refusal::AuthenticationPending => {
+                "camera busy: an authentication has priority; retry in a moment"
+            }
+            Refusal::AlreadyHoldsSlot => {
+                "camera busy: this account already has a camera operation in flight"
+            }
+        }
+    }
+}
+
+/// One queued unit of work: what to run, and who asked.
+pub struct Job<T> {
+    pub class: Class,
+    pub uid: u32,
+    pub payload: T,
+}
+
+struct Inner<T> {
+    auth: VecDeque<Job<T>>,
+    other: VecDeque<Job<T>>,
+    /// Uids with a camera job queued or running. Root is never tracked: the
+    /// greeter and PAM run as root, and holding them to one camera operation
+    /// would be a denial of the login path rather than a fairness rule.
+    camera_slots: Vec<u32>,
+    /// An authentication is running (queue length alone would miss it).
+    auth_running: bool,
+    closed: bool,
+}
+
+impl<T> Inner<T> {
+    fn auth_pending(&self) -> bool {
+        self.auth_running || !self.auth.is_empty()
+    }
+}
+
+/// The queue itself: submission decides admission, the worker takes what is next.
+pub struct Arbiter<T> {
+    inner: Mutex<Inner<T>>,
+    ready: Condvar,
+}
+
+impl<T> Default for Arbiter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Arbiter<T> {
+    pub fn new() -> Self {
+        Arbiter {
+            inner: Mutex::new(Inner {
+                auth: VecDeque::new(),
+                other: VecDeque::new(),
+                camera_slots: Vec::new(),
+                auth_running: false,
+                closed: false,
+            }),
+            ready: Condvar::new(),
+        }
+    }
+
+    /// Offer a request to the queue.
+    ///
+    /// `Err(refusal)` means the caller should answer the client immediately; the
+    /// job was not queued and holds nothing.
+    pub fn submit(&self, class: Class, uid: u32, payload: T) -> Result<(), Refusal> {
+        let mut inner = self.lock();
+        match class {
+            // An authentication never waits behind preview work.
+            Class::Auth => inner.auth.push_back(Job {
+                class,
+                uid,
+                payload,
+            }),
+            Class::Camera => {
+                if inner.auth_pending() {
+                    return Err(Refusal::AuthenticationPending);
+                }
+                if uid != 0 && inner.camera_slots.contains(&uid) {
+                    return Err(Refusal::AlreadyHoldsSlot);
+                }
+                if uid != 0 {
+                    inner.camera_slots.push(uid);
+                }
+                inner.other.push_back(Job {
+                    class,
+                    uid,
+                    payload,
+                });
+            }
+            Class::Plain => inner.other.push_back(Job {
+                class,
+                uid,
+                payload,
+            }),
+        }
+        self.ready.notify_one();
+        Ok(())
+    }
+
+    /// Block until there is work, and take the most urgent job.
+    ///
+    /// `None` once the arbiter is closed and drained, which is the worker's
+    /// signal to exit.
+    pub fn take(&self) -> Option<Job<T>> {
+        let mut inner = self.lock();
+        loop {
+            if let Some(job) = inner.auth.pop_front() {
+                inner.auth_running = true;
+                return Some(job);
+            }
+            if let Some(job) = inner.other.pop_front() {
+                return Some(job);
+            }
+            if inner.closed {
+                return None;
+            }
+            inner = self
+                .ready
+                .wait(inner)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+    }
+
+    /// Release what a finished job held. Always call this, including when the
+    /// job panicked: a slot that is never released is a uid locked out of the
+    /// camera until the daemon restarts.
+    pub fn finish(&self, job_class: Class, uid: u32) {
+        let mut inner = self.lock();
+        if job_class == Class::Auth {
+            inner.auth_running = false;
+        }
+        if let Some(i) = inner.camera_slots.iter().position(|&u| u == uid) {
+            inner.camera_slots.swap_remove(i);
+        }
+        // A camera request refused while this one ran can now be retried, and a
+        // waiting worker needs waking if the queue filled while it slept.
+        self.ready.notify_one();
+    }
+
+    /// Stop accepting work and wake the worker so it can drain and exit.
+    pub fn close(&self) {
+        self.lock().closed = true;
+        self.ready.notify_all();
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner<T>> {
+        // A poisoned queue is still a usable queue: the alternative is that one
+        // panicking job takes down every future login.
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arb() -> Arbiter<&'static str> {
+        Arbiter::new()
+    }
+
+    #[test]
+    fn authentication_is_taken_before_camera_work_that_arrived_first() {
+        let a = arb();
+        a.submit(Class::Camera, 1000, "preview").unwrap();
+        a.submit(Class::Plain, 1000, "listing").unwrap();
+        a.submit(Class::Auth, 0, "login").unwrap();
+        // Queued last, served first: that is the whole point.
+        assert_eq!(a.take().unwrap().payload, "login");
+    }
+
+    #[test]
+    fn camera_work_is_refused_while_an_authentication_waits() {
+        let a = arb();
+        a.submit(Class::Auth, 0, "login").unwrap();
+        assert_eq!(
+            a.submit(Class::Camera, 1000, "preview"),
+            Err(Refusal::AuthenticationPending)
+        );
+        // Refusing is not the same as blocking the machine: work that does not
+        // touch the camera still goes through.
+        assert!(a.submit(Class::Plain, 1000, "listing").is_ok());
+    }
+
+    #[test]
+    fn camera_work_is_refused_while_an_authentication_runs() {
+        let a = arb();
+        a.submit(Class::Auth, 0, "login").unwrap();
+        let job = a.take().unwrap();
+        // The queue is empty now, so only `auth_running` can carry the refusal.
+        assert_eq!(
+            a.submit(Class::Camera, 1000, "preview"),
+            Err(Refusal::AuthenticationPending)
+        );
+        a.finish(job.class, job.uid);
+        assert!(a.submit(Class::Camera, 1000, "preview").is_ok());
+    }
+
+    #[test]
+    fn one_camera_slot_per_unprivileged_uid_and_no_cap_on_root() {
+        let a = arb();
+        a.submit(Class::Camera, 1000, "first").unwrap();
+        assert_eq!(
+            a.submit(Class::Camera, 1000, "second"),
+            Err(Refusal::AlreadyHoldsSlot)
+        );
+        // A different account is unaffected by this one's slot.
+        assert!(a.submit(Class::Camera, 1001, "other user").is_ok());
+        // Root is the greeter and PAM; capping it would deny the login path.
+        assert!(a.submit(Class::Camera, 0, "greeter").is_ok());
+        assert!(a.submit(Class::Camera, 0, "greeter again").is_ok());
+    }
+
+    #[test]
+    fn a_finished_job_releases_its_slot() {
+        let a = arb();
+        a.submit(Class::Camera, 1000, "first").unwrap();
+        let job = a.take().unwrap();
+        a.finish(job.class, job.uid);
+        assert!(a.submit(Class::Camera, 1000, "again").is_ok());
+    }
+
+    #[test]
+    fn plain_work_keeps_its_order_behind_earlier_plain_work() {
+        let a = arb();
+        a.submit(Class::Plain, 1000, "first").unwrap();
+        a.submit(Class::Plain, 1001, "second").unwrap();
+        assert_eq!(a.take().unwrap().payload, "first");
+        assert_eq!(a.take().unwrap().payload, "second");
+    }
+
+    #[test]
+    fn a_closed_and_drained_arbiter_tells_the_worker_to_exit() {
+        let a = arb();
+        a.submit(Class::Plain, 0, "last").unwrap();
+        a.close();
+        assert_eq!(a.take().unwrap().payload, "last");
+        assert!(a.take().is_none());
+    }
+
+    #[test]
+    fn the_worker_wakes_when_work_arrives() {
+        use std::sync::Arc;
+        let a = Arc::new(arb());
+        let worker = {
+            let a = Arc::clone(&a);
+            std::thread::spawn(move || a.take().map(|j| j.payload))
+        };
+        // The worker is parked on the condvar; submitting must wake it rather
+        // than leave it asleep with work queued.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        a.submit(Class::Auth, 0, "login").unwrap();
+        assert_eq!(worker.join().unwrap(), Some("login"));
+    }
+
+    #[test]
+    fn classification_follows_what_touches_the_camera() {
+        use irlume_common::SecretBytes;
+        assert_eq!(
+            classify(&Request::Authenticate {
+                user: "u".into(),
+                service: None,
+            }),
+            Class::Auth
+        );
+        assert_eq!(
+            classify(&Request::UnsealKeyring {
+                user: "u".into(),
+                service: None,
+            }),
+            Class::Auth
+        );
+        assert_eq!(
+            classify(&Request::PositionSample { user: None }),
+            Class::Camera
+        );
+        assert_eq!(
+            classify(&Request::ListProfiles {
+                user: "u".into(),
+                structured_errors: true
+            }),
+            Class::Plain
+        );
+        assert_eq!(classify(&Request::Ping), Class::Plain);
+        // A secret-carrying management request is not camera work.
+        assert_eq!(
+            classify(&Request::SealPassword {
+                user: "u".into(),
+                password: SecretBytes::new(vec![1u8]),
+            }),
+            Class::Plain
+        );
+    }
+}

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -807,8 +807,8 @@ enum ReadOutcome {
 }
 
 /// Read one request line (bounded by [`MAX_REQUEST_BYTES`]) and parse it.
-/// Extracted verbatim from [`handle`] (test seam: exercised over a socketpair
-/// without an [`irlume_auth::Engine`]); behavior unchanged.
+/// Called by [`serve`] on the connection's own thread (test seam: exercised
+/// over a socketpair without an [`irlume_auth::Engine`]).
 fn read_request(stream: &UnixStream) -> std::io::Result<ReadOutcome> {
     let mut reader = BufReader::new(stream.try_clone()?).take(MAX_REQUEST_BYTES);
     let mut line = String::new();

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -15,6 +15,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use zeroize::Zeroize;
 
+mod arbiter;
 mod users;
 
 /// Release checksums of the bundled models (models/SHA256SUMS, committed next
@@ -170,11 +171,11 @@ fn main() {
             ))
         });
     // Engine factory: (re)loads the models and rebinds devices/adapters. Used
-    // once at startup and again by the accept loop to rebuild the engine after a
-    // caught connection-handler panic, so a fresh request never runs against ONNX
-    // sessions left in an unproven state by an unwind. It only borrows the load
-    // inputs, so it is Fn and callable repeatedly.
-    let build_engine = || {
+    // once at startup and again by the camera worker to rebuild the engine after
+    // a caught panic, so a fresh request never runs against ONNX sessions left in
+    // an unproven state by an unwind. It owns its inputs so it can move to the
+    // worker thread, and it is Fn, so startup calls it before that move.
+    let build_engine = move || {
         irlume_auth::Engine::load(&det, &model)
             .map(|e| e.with_devices(&rgb_dev, &ir_dev))
             .and_then(|e| e.with_ir_adapter(&adapter))
@@ -327,56 +328,117 @@ fn main() {
         });
     }
 
+    // One worker owns the engine, and every camera operation happens on it, so
+    // nothing changes about V4L2 and ONNX being driven from a single thread.
+    // What changed is that connections are read elsewhere, which is the only way
+    // an authentication can overtake work already queued: a request nobody has
+    // read yet cannot be prioritised.
+    let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+    let worker = {
+        let arbiter = std::sync::Arc::clone(&arbiter);
+        std::thread::Builder::new()
+            .name("irlume-camera".into())
+            .spawn(move || {
+                while let Some(job) = arbiter.take() {
+                    let Queued { req, peer, reply } = job.payload;
+                    // Isolate each request behind catch_unwind. A panic deep in
+                    // frame decode or inference (e.g. a V4L2 driver echoing back
+                    // a 0-dimension or short-buffered frame) must deny THIS one
+                    // request and let PAM fall back to the password, never
+                    // unwind out of the worker and take down all face auth for
+                    // every user.
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        dispatch(req, &peer, &mut engine)
+                    }));
+                    // Release the slot before anything else can fail, so a
+                    // panicking request cannot lock its uid out of the camera
+                    // until the daemon restarts.
+                    arbiter.finish(job.class, job.uid);
+                    let resp = match outcome {
+                        Ok(resp) => resp,
+                        Err(_) => {
+                            eprintln!(
+                                "irlumed: request handler PANICKED; this request was denied \
+                                 (PAM falls back to the password). Rebuilding the engine for a \
+                                 clean state; please report this with the backtrace above."
+                            );
+                            // AssertUnwindSafe only silences the compiler, it
+                            // does not prove the ONNX sessions are in a
+                            // supported state after an unwind, so a fresh engine
+                            // removes that doubt. Chosen over exiting and
+                            // letting systemd restart because a reproducible
+                            // panic would become a restart loop that takes the
+                            // login path down entirely. If the rebuild fails,
+                            // the old engine is kept: still better than a dead
+                            // daemon.
+                            match build_engine() {
+                                Ok(fresh) => {
+                                    engine = fresh;
+                                    eprintln!("irlumed: engine rebuilt after panic");
+                                }
+                                Err(e) => eprintln!(
+                                    "irlumed: engine rebuild after panic FAILED ({e}); continuing \
+                                     with the existing engine"
+                                ),
+                            }
+                            Response::Error("request failed".into())
+                        }
+                    };
+                    // The client may already be gone; its thread owns that.
+                    let _ = reply.send(resp);
+                }
+            })
+            .unwrap_or_else(|e| {
+                // Without the worker nothing can be served, and a daemon that
+                // accepts connections it can never answer is worse than one that
+                // exits and lets systemd restart it.
+                eprintln!("irlumed: could not start the camera worker: {e}");
+                std::process::exit(1);
+            })
+    };
+
+    // A cap on connection threads, so a peer that opens sockets faster than it
+    // sends requests cannot exhaust memory. Well above any real client: the
+    // greeter, the lock screen, a TUI and sudo together are a handful.
+    const MAX_CONNECTION_THREADS: usize = 64;
+    let live_threads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
     for conn in listener.incoming() {
         match conn {
             Ok(stream) => {
-                // Isolate each connection behind catch_unwind. A panic deep in
-                // frame decode or inference (e.g. a V4L2 driver echoing back a
-                // 0-dimension or short-buffered frame) must deny THIS one request
-                // and let PAM fall back to the password, never unwind out of the
-                // single-threaded accept loop and take down all face auth for
-                // every user. The panicking handler dropped the stream, so the
-                // client sees EOF and PAM treats it as a fail-safe decline.
-                //
-                // On a caught panic we REBUILD the engine before serving the next
-                // request rather than reuse it: AssertUnwindSafe only silences the
-                // compiler, it does not prove the ONNX sessions are in a supported
-                // state after an unwind, so a fresh engine removes that doubt. This
-                // is chosen over exiting-and-letting-systemd-restart because a
-                // reproducible panic would otherwise become a restart loop that
-                // takes the login path down entirely; a rebuild keeps the daemon
-                // up. It only runs on a real panic (the known frame-math panic
-                // sources are guarded at their site), so the reload cost is not on
-                // any normal path. If the rebuild itself fails, the old engine is
-                // kept: still better than a dead daemon.
-                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    handle(stream, &mut engine)
-                }));
-                match outcome {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => eprintln!("irlumed: connection error: {e}"),
-                    Err(_) => {
-                        eprintln!(
-                            "irlumed: connection handler PANICKED; this request was denied \
-                             (PAM falls back to the password). Rebuilding the engine for a \
-                             clean state; please report this with the backtrace above."
-                        );
-                        match build_engine() {
-                            Ok(fresh) => {
-                                engine = fresh;
-                                eprintln!("irlumed: engine rebuilt after panic");
-                            }
-                            Err(e) => eprintln!(
-                                "irlumed: engine rebuild after panic FAILED ({e}); continuing \
-                                 with the existing engine"
-                            ),
+                let live = std::sync::Arc::clone(&live_threads);
+                if live.fetch_add(1, std::sync::atomic::Ordering::SeqCst) >= MAX_CONNECTION_THREADS
+                {
+                    live.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                    let _ = respond(
+                        stream,
+                        &Response::Error("daemon busy: too many open connections".into()),
+                    );
+                    continue;
+                }
+                let arbiter = std::sync::Arc::clone(&arbiter);
+                // A connection thread reads, parses and writes; it never touches
+                // the engine, so a panic in it is contained by the thread itself
+                // and the queued job (if any) is still completed and released by
+                // the worker.
+                if let Err(e) = std::thread::Builder::new()
+                    .name("irlume-conn".into())
+                    .spawn(move || {
+                        if let Err(e) = serve(stream, &arbiter) {
+                            eprintln!("irlumed: connection error: {e}");
                         }
-                    }
+                        live.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                    })
+                {
+                    eprintln!("irlumed: could not start a connection thread: {e}");
+                    live_threads.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
                 }
             }
             Err(e) => eprintln!("irlumed: accept error: {e}"),
         }
     }
+    arbiter.close();
+    let _ = worker.join();
 }
 
 // ---------------------------------------------------------------------------
@@ -542,6 +604,7 @@ fn biopolicy_enforced() -> bool {
 }
 
 /// Peer identity from SO_PEERCRED.
+#[derive(Clone)]
 struct Peer {
     uid: u32,
     // gid/pid are unread today; kept for future audit logging, since
@@ -675,20 +738,58 @@ fn uid_of(user: &str) -> Option<u32> {
 /// from a peer that never sends a newline.
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
 
-fn handle(stream: UnixStream, engine: &mut irlume_auth::Engine) -> std::io::Result<()> {
+/// One parsed request waiting for the camera worker, and where to send the
+/// answer. The reply travels back over a channel rather than being written by
+/// the worker, so a client that stops reading stalls its own connection thread
+/// instead of the one thread every login needs.
+struct Queued {
+    req: Request,
+    peer: Peer,
+    reply: std::sync::mpsc::Sender<Response>,
+}
+
+/// How long a connection thread waits for the worker before giving up.
+///
+/// Generous, because it bounds the whole operation: a ten-scan enrollment with
+/// retries is minutes of legitimate work. This is a backstop against a wedged
+/// worker leaving connection threads parked forever, not a latency control.
+const WORKER_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Read and parse one connection, hand the request to the arbiter, write back
+/// what the worker answers.
+///
+/// Everything here runs on the connection's own thread. The only work that
+/// reaches the camera worker is a parsed, authorized-shaped request, which is
+/// what lets an authentication overtake a queue of preview work: before this,
+/// a request nobody had read yet was invisible to the daemon.
+fn serve(stream: UnixStream, arbiter: &arbiter::Arbiter<Queued>) -> std::io::Result<()> {
     let peer = peer_cred(&stream)?;
-    // A read/write deadline stops one wedged peer from blocking the single-
-    // threaded daemon (and thus ALL logins) forever. Propagate a setsockopt
-    // failure (drop this one connection) rather than swallow it: a silently
-    // absent timeout is the exact unbounded-blocking-read this guards against,
-    // and the '?' returns before any read happens.
     stream.set_read_timeout(Some(std::time::Duration::from_secs(15)))?;
     stream.set_write_timeout(Some(std::time::Duration::from_secs(15)))?;
     match read_request(&stream)? {
         ReadOutcome::Closed => Ok(()),
         ReadOutcome::Bad => respond(stream, &Response::Error("bad request".into())),
         ReadOutcome::Req(req) => {
-            let resp = dispatch(req, &peer, engine);
+            let class = arbiter::classify(&req);
+            let (reply, answer) = std::sync::mpsc::channel();
+            let queued = Queued {
+                req,
+                peer: peer.clone(),
+                reply,
+            };
+            if let Err(refusal) = arbiter.submit(class, peer.uid, queued) {
+                // Refused, not queued: answer now so the client can retry rather
+                // than hold a slot the login path may want.
+                return respond(stream, &Response::Error(refusal.message().into()));
+            }
+            let resp = match answer.recv_timeout(WORKER_REPLY_TIMEOUT) {
+                Ok(resp) => resp,
+                // The worker dropped the sender (it panicked and the reply never
+                // came) or took longer than the backstop. Either way this
+                // request has no answer, and a client that gets an error falls
+                // back to the password.
+                Err(_) => Response::Error("request did not complete".into()),
+            };
             respond(stream, &resp)
         }
     }
@@ -2328,6 +2429,79 @@ mod tests {
         assert_eq!(peer.uid, unsafe { libc::geteuid() });
         assert_eq!(peer.gid, unsafe { libc::getegid() });
         assert_eq!(peer.pid, std::process::id() as i32);
+    }
+
+    #[test]
+    fn serve_routes_a_request_through_the_arbiter_and_answers_the_client() {
+        // The whole path a client sees, minus the engine: parse, queue, worker,
+        // reply. A fake worker stands in for the camera so this stays a test of
+        // the wiring rather than of inference.
+        let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+        let worker = {
+            let arbiter = std::sync::Arc::clone(&arbiter);
+            std::thread::spawn(move || {
+                while let Some(job) = arbiter.take() {
+                    let Queued { reply, .. } = job.payload;
+                    arbiter.finish(job.class, job.uid);
+                    let _ = reply.send(Response::Pong);
+                }
+            })
+        };
+
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        (&ours).write_all(b"\"Ping\"\n").unwrap();
+        let a = std::sync::Arc::clone(&arbiter);
+        std::thread::spawn(move || serve(theirs, &a).unwrap());
+
+        let mut line = String::new();
+        BufReader::new(&ours).read_line(&mut line).unwrap();
+        let resp: Response = serde_json::from_str(line.trim()).unwrap();
+        assert!(matches!(resp, Response::Pong), "got {resp:?}");
+
+        arbiter.close();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn a_camera_request_is_refused_while_an_authentication_is_queued() {
+        // No worker: the refusal must be answered by the connection thread
+        // itself, without the request ever reaching the camera. If this only
+        // worked because a worker drained the queue, the test would hang here.
+        let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+        let (_dead_reply, _) = std::sync::mpsc::channel();
+        arbiter
+            .submit(
+                arbiter::Class::Auth,
+                0,
+                Queued {
+                    req: Request::Ping,
+                    peer: Peer {
+                        uid: 0,
+                        gid: 0,
+                        pid: 0,
+                    },
+                    reply: _dead_reply,
+                },
+            )
+            .unwrap();
+
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        (&ours)
+            .write_all(b"{\"PositionSample\":{\"user\":null}}\n")
+            .unwrap();
+        let a = std::sync::Arc::clone(&arbiter);
+        std::thread::spawn(move || serve(theirs, &a).unwrap());
+
+        let mut line = String::new();
+        BufReader::new(&ours).read_line(&mut line).unwrap();
+        let resp: Response = serde_json::from_str(line.trim()).unwrap();
+        match resp {
+            Response::Error(msg) => assert!(
+                msg.contains("authentication has priority"),
+                "the client must be told why: {msg}"
+            ),
+            other => panic!("a queued authentication must refuse preview work, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -339,6 +339,11 @@ fn main() {
         std::thread::Builder::new()
             .name("irlume-camera".into())
             .spawn(move || {
+                // The engine asks this between whole captures, so a long
+                // enrolment yields the camera to an authentication instead of
+                // making it wait for ten scans.
+                let token = arbiter.cancel_token();
+                engine.set_stop_signal(std::sync::Arc::new(move || token.stop_requested()));
                 while let Some(job) = arbiter.take() {
                     let Queued { req, peer, reply } = job.payload;
                     // Isolate each request behind catch_unwind. A panic deep in


### PR DESCRIPTION
Addresses the arbitration half of #117.

## What was wrong

The daemon read one connection at a time and served it synchronously. A request nobody had read yet was invisible to it, so a local account running a legitimate self-enrollment or a preview loop held the only handler, and a lock-screen unlock arriving meanwhile waited in the kernel accept backlog with no way to overtake it.

Connections are now read and parsed on their own threads, and the parsed request is queued in a new arbiter. **One worker still owns the `Engine`**, so nothing changes about V4L2 and ONNX being driven from a single thread. What changed is that the daemon can now see what is waiting and choose.

Two rules do the work:

- An authentication, and the credential release that follows it, are taken before other camera work.
- Non-authentication camera work is **refused rather than queued** while an authentication is pending, and an unprivileged uid may hold at most one camera slot. Root is never capped, because the greeter and PAM are root and capping them would deny the login path.

Refusing beats queueing: a preview client told to retry has lost a frame, while one queued behind an enrollment holds a slot the login path may want.

## Measured on two machines

Eight preview clients from one unprivileged uid, looping `PositionSample`, then one `Authenticate`, timed from submission to answer. Three runs each.

| Machine | Camera | Before | After |
|---|---|---|---|
| Zenbook, Fedora 44 | real RGB+IR pair | 5.25s, 4.77s, 4.80s | 0.16s, 0.14s, 0.20s |
| archhost, Arch | v4l2loopback + ffmpeg | 1.72s, 1.72s, 1.72s | 0.08s, 0.00s, 0.00s |

The after figures are the bound the issue asked for: an authentication waits for at most the one camera operation already in flight. On the real IR pair a `PositionSample` costs about 0.4s, which is where the before figures come from: the authentication sat behind several of them.

Response tally from one arbiter run, which shows the rules working rather than the queue merely draining faster:

```
220421 preview responses: 218836 refused (slot), 1554 refused (auth priority), 31 served
```

## Stage 2: an enrolment in flight yields too

Reordering the queue left the case that started #117: an enrolment already
running held the camera for its whole ten-scan budget while an authentication
waited it out. Measured before this half landed, with an enrolment in flight, the
authentication waited **3.27s**.

The capture loop now asks whether something needs the camera more, at two points:
before the first frame, so an enrolment that already knows it is wanted elsewhere
never opens the device, and between whole captures, where nothing is
half-written. `Error::Preempted` is a distinct variant so a caller can tell a
yield from a failure.

Nothing is preempted by force: no thread unwound, no device closed under a
running capture, no ONNX session interrupted. Enrolment persists only after both
capture phases succeed, so returning early cannot leave a partial profile.

Measured on archhost against loopback feeders, an authentication submitted 1.2s
into an enrolment, three runs:

| | Result |
|---|---|
| Authentication answered | 0.14s, 0.17s, 0.14s |
| Enrolment returned | `preempted: an authentication needed the camera; nothing was saved, please retry` |
| Profiles written | 0 files, every run |

The CI loopback test covers the same path. Its stop signal answers "keep going"
once and "stop" after, so the yield lands on the in-loop boundary rather than the
cheap entry check, and it asserts the signal was consulted at least twice.

## What this still does not do

A capture already inside V4L2 or an inference session finishes; the yield lands
at the next boundary, which on the measured hardware is within a fraction of a
second. There is no wall-clock deadline on a wedged driver, which is a separate
problem from scheduling.

Worth knowing from the measurements: a refusal is cheap for the daemon (no camera) but still costs a connection thread, and a client spinning as hard as the test harness generated about 11k refusals a second. Concurrency is capped at 64 threads, but the rate is not. A refusal-side interval is a candidate follow-up if that ever matters in practice.

## Tests

Nine unit tests over the arbiter cover priority, both refusal reasons, slot release, root exemption, FIFO among plain work, wake-up, and drain-on-close. Two more drive a real `UnixStream` through `serve()`: one round-trips a request through a fake worker, and one asserts a queued authentication makes the connection thread refuse preview work **without a worker running at all**, so the refusal cannot be an artefact of a drained queue.

684 tests pass; fmt, clippy, `cargo doc -D warnings` and the machine-API conformance script are clean.

## Still owed before merge

A face unlock on real hardware. Everything above measures scheduling; none of it proves the authentication it prioritises still grants, because that needs a face in front of the camera.
