### PR TITLE
docs: record that a fork pull request is not CodeQL-scanned before merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,16 @@ you certify the DCO. That's it: no forms, no rights assignment.
   `padreport` and
   include the per-species APCER/BPCER numbers. See
   [`docs/PAD_SELFTEST.md`](docs/PAD_SELFTEST.md) for the methodology and protocol.
+- **A pull request from a fork is not CodeQL-scanned before merge.** GitHub's
+  default setup for code scanning does not analyse fork pull requests, so an
+  external contribution reaches review with the ordinary CI behind it (clippy as
+  `-D warnings`, cargo-deny, the fuzz corpus, zizmor and actionlint over
+  workflows) but without CodeQL. Measured on this repo: of the last 30 merged
+  pull requests, the 29 from repo branches each ran CodeQL and the one from a
+  fork ran none. main is analysed straight after the merge, so the code is
+  scanned, later than a maintainer would want. A maintainer who wants CodeQL on
+  a fork contribution first can push the branch into this repository and open
+  the pull request from there, which is the same shape as every scanned PR.
 - Run `cargo fmt`, `cargo clippy`, and `cargo test` before opening a PR; CI
   runs the same checks (`cargo fmt --check`, `cargo clippy -D warnings`, build,
   test on Rust 1.88) on every push and PR, so a green local run means a green CI.


### PR DESCRIPTION
Closes the Scorecard SAST alert (code-scanning alert 13) by recording what it actually found, rather than changing scanning configuration to move a number.

## What the alert says

`score is 9: SAST tool is not run on all commits — 29 commits out of 30 are checked with a SAST tool`.

## What it is

Measured across the last 30 merged pull requests:

| Source | CodeQL check runs |
|---|---|
| 29 PRs from repo branches, dependabot included | present, all `success` |
| #109, the one PR from a fork | none, ever |

The cause is [documented GitHub behaviour](https://docs.github.com/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning): default setup for code scanning does not analyse pull requests from forks. Nothing here is misconfigured, and CodeQL is not among the seven required checks, so nothing was bypassed to merge it.

main is analysed straight after each merge, so #109's code was scanned; later than a reviewer would want it, which is the part worth knowing.

## Why this is a docs change and not a configuration change

Advanced setup would put CodeQL on fork pull requests. It also means hand-maintaining the workflow, SHA-pinned and passing this repo's own zizmor and actionlint jobs, instead of GitHub maintaining it. Whether code scanning results upload cleanly from a fork's read-only token is not something I could settle from the documentation: the official triage page does not mention forks, and community answers conflict.

That change is worth making deliberately, verified against a real fork pull request. Folding it into a docs commit on ambiguous evidence would risk trading a scoring blip for reduced scanning.

The alert itself ages out as the 30-PR window moves.