### PR TITLE
fix: stop the anti-spoof cue denying on scores it was never measured at

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -482,6 +482,17 @@ pub fn thirdparty_downgrades(verdict: Verdict, p_fake: Option<f32>, threshold: f
     verdict == Verdict::Live && p_fake.is_some_and(|p| p >= threshold)
 }
 
+/// True when the cue scored in the band where neither genuine faces nor attacks
+/// were measured: above the highest genuine reading, below the deny threshold.
+///
+/// Nothing acts on this. It exists so an out-of-domain score is visible in the
+/// log instead of silently doing nothing, because the frequency of these is what
+/// says whether the cue still suits the hardware it is running on.
+pub fn thirdparty_abstains(p_fake: Option<f32>, threshold: f32) -> bool {
+    p_fake
+        .is_some_and(|p| p >= irlume_common::thirdparty::MEASURED_GENUINE_CEILING && p < threshold)
+}
+
 /// Highest-scoring detection: the face every pipeline stage keys on when a
 /// frame holds more than one.
 fn top_detection(faces: &[Detection]) -> Option<&Detection> {
@@ -1146,6 +1157,13 @@ impl Engine {
             _ => None,
         };
         let (verdict, reason) = if let Some((_, thr, name)) = self.tp_pad.as_ref() {
+            if thirdparty_abstains(thirdparty_fake, *thr) {
+                irlume_common::dlog!(
+                    "thirdparty-pad('{name}'): p_fake {:.3} is between the measured genuine \
+                     ceiling and the deny threshold {thr:.2}; abstaining",
+                    thirdparty_fake.unwrap_or(0.0)
+                );
+            }
             if thirdparty_downgrades(verdict, thirdparty_fake, *thr) {
                 let pf = thirdparty_fake.unwrap_or(1.0);
                 irlume_common::dlog!(
@@ -3749,7 +3767,8 @@ mod tests {
 
 #[cfg(test)]
 mod thirdparty_cue_tests {
-    use super::thirdparty_downgrades;
+    use super::{thirdparty_abstains, thirdparty_downgrades};
+    use irlume_common::thirdparty::{CATALOG, MEASURED_GENUINE_CEILING};
     use irlume_liveness::Verdict;
 
     #[test]
@@ -3758,6 +3777,65 @@ mod thirdparty_cue_tests {
         assert!(thirdparty_downgrades(Verdict::Live, Some(0.5), 0.5)); // at threshold
         assert!(!thirdparty_downgrades(Verdict::Live, Some(0.49), 0.5));
         assert!(!thirdparty_downgrades(Verdict::Live, None, 0.5));
+    }
+
+    #[test]
+    fn the_shipped_threshold_sits_above_every_score_a_genuine_face_produced() {
+        // The 2026-07-17 qualification measured genuine faces at 0.001-0.13 and
+        // the vinyl-print attack at 0.998-1.0000. A threshold inside that empty
+        // band denies on scores neither class was ever observed at, which is how
+        // a live face lost its keyring at 0.702 on 2026-07-27.
+        for m in CATALOG {
+            assert!(
+                m.threshold > MEASURED_GENUINE_CEILING,
+                "{}: threshold {} is at or below the measured genuine ceiling {}",
+                m.name,
+                m.threshold,
+                MEASURED_GENUINE_CEILING
+            );
+            assert!(
+                m.threshold >= 0.9,
+                "{}: threshold {} reaches into the band no attack was measured in",
+                m.name,
+                m.threshold
+            );
+        }
+    }
+
+    #[test]
+    fn the_threshold_stays_below_the_lowest_score_a_real_attack_produced() {
+        // 2026-07-27, same vinyl banner as the qualification, threshold 0.9:
+        // 6/6 flagged at 0.941, 0.956, 0.995, 0.999, 0.999, 1.000. The floor is
+        // 0.941, well under the 0.998-1.0000 medians the qualification reported,
+        // so raising this threshold for a feeling of safety would drop a real
+        // detection. The window is 0.702 (highest genuine) to 0.941.
+        const MEASURED_ATTACK_FLOOR: f32 = 0.941;
+        for m in CATALOG {
+            assert!(
+                m.threshold < MEASURED_ATTACK_FLOOR,
+                "{}: threshold {} is at or above the lowest score a real attack \
+                 produced ({MEASURED_ATTACK_FLOOR}); that loses a detection",
+                m.name,
+                m.threshold
+            );
+        }
+    }
+
+    #[test]
+    fn a_score_in_the_unmeasured_band_abstains_instead_of_denying() {
+        let thr = 0.9;
+        // 0.702 is the real reading that denied a genuine user before this fix.
+        assert!(thirdparty_abstains(Some(0.702), thr));
+        assert!(!thirdparty_downgrades(Verdict::Live, Some(0.702), thr));
+        // Below the genuine ceiling is an ordinary pass, not an abstention.
+        assert!(!thirdparty_abstains(Some(0.05), thr));
+        // At and above the threshold the cue still denies: the attack species
+        // measured 0.998-1.0000, well clear of this line.
+        assert!(!thirdparty_abstains(Some(0.9), thr));
+        assert!(thirdparty_downgrades(Verdict::Live, Some(0.9), thr));
+        assert!(thirdparty_downgrades(Verdict::Live, Some(0.998), thr));
+        // No score at all is neither.
+        assert!(!thirdparty_abstains(None, thr));
     }
 
     #[test]

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -40,6 +40,11 @@ pub struct ThirdPartyModel {
     /// Honest provenance status, shown before the user confirms.
     pub provenance: &'static str,
     /// Decision threshold on the model's P(fake); measured basis in `summary`.
+    ///
+    /// Set from where the two classes were actually MEASURED to sit, not from
+    /// the publisher's default. A deny-only cue that fires in a score band
+    /// neither genuine faces nor attacks were observed in is guessing, and it
+    /// guesses against the user: every such fire costs a real login.
     pub threshold: f32,
     /// One-line measured result, with the repo doc that carries the details.
     pub summary: &'static str,
@@ -54,12 +59,40 @@ pub const CATALOG: &[ThirdPartyModel] = &[ThirdPartyModel {
     license: "MIT (Alibaba DAMO, ModelScope model card)",
     provenance: "training data undocumented by the publisher; not reproducible \
                  (fails ADR-0001 criteria 2-3, which is why it is opt-in)",
-    threshold: 0.5,
+    // 2026-07-17 qualification measured genuine at median 0.0000 (offline
+    // corpus 0.001-0.13) and the vinyl-print attack at medians 0.998-1.0000.
+    // Nothing was observed between 0.13 and 0.99 in either class, so 0.5 sat in
+    // an empty band and turned an out-of-distribution score into a denial. A
+    // genuine face measured 0.702 there on 2026-07-27 and lost its keyring.
+    //
+    // 0.5 was never the publisher's figure: the ModelScope card states no
+    // threshold at all, so it was a conventional binary default rather than an
+    // upstream recommendation being honoured.
+    //
+    // Deliberately conservative rather than calibrated. A deny-only cue has
+    // asymmetric harm (a false fire blocks a real login; a withheld veto only
+    // forgoes an auxiliary check), so the operating point favours the user.
+    // Re-measured at 0.9 on 2026-07-27 against the same vinyl banner: 6/6
+    // presentations flagged, p_fake 0.941 / 0.956 / 0.995 / 0.999 / 0.999 /
+    // 1.000. The attack FLOOR is 0.941, not the 0.998 the medians implied, so
+    // the usable window on this hardware is 0.702 (highest genuine) to 0.941
+    // (lowest attack). DO NOT raise this threshold toward 0.95 "to be safer":
+    // that crosses the measured attack floor and drops a real detection.
+    threshold: 0.9,
     summary: "IR anti-spoof cue; measured 2026-07-17: catches the vinyl-print \
               species the built-in gate misses (122/123 attack frames, 2 \
-              cameras) with 0/35 genuine flagged on the same camera \
+              cameras). Genuine-side failures are mapped, not absent: dim \
+              strobe frames and direct sun \
               (docs/pad-results/2026-07-17-third-party-pad-candidates.md)",
 }];
+
+/// Highest P(fake) a genuine face was measured at during qualification
+/// (offline corpus 0.001-0.13, live medians 0.0000).
+///
+/// A score above this but below the deny threshold is in the band neither class
+/// occupied. The cue abstains there; this constant exists so the abstention can
+/// be logged and counted rather than passing unnoticed.
+pub const MEASURED_GENUINE_CEILING: f32 = 0.13;
 
 pub fn by_name(name: &str) -> Option<&'static ThirdPartyModel> {
     CATALOG.iter().find(|m| m.name == name)

--- a/docs/pad-results/2026-07-17-third-party-pad-candidates.md
+++ b/docs/pad-results/2026-07-17-third-party-pad-candidates.md
@@ -112,3 +112,56 @@ contain the operator's face and are not committed. Model artifacts download
 from their publishers (URLs in the scripts); verify the sha256 values above.
 The live capture harness is `landmark_dump`
 ([DEVELOPMENT.md walkthrough](../DEVELOPMENT.md)) plus ffmpeg for RGB.
+
+## Addendum, 2026-07-27: threshold moved to 0.9 after a genuine-side denial
+
+The 0.5 operating point denied a genuine, present, enrolled user three times on
+the Zenbook (two at real logins, on 2026-07-25 and 2026-07-27, each costing a
+keyring unlock; one reproduced under instrumentation).
+
+**The denial.** Sixteen instrumented credential releases, seated, room ambient
+134. One flagged, and it was the dimmest frame of the session:
+
+```
+liveness(cross-spectrum): Live (...); ir_bright=79 ir_center_edge_ratio=1.45
+   glint=255.00 ambient=22 yaw_asym=0.09 pitch=0.59
+thirdparty-pad('flir'): p_fake 0.702 >= 0.50; downgrading Live to Spoof
+```
+
+Passing frames measured `ir_bright` 89-108 (median 100). `pitch=0.59` is a head
+tilted down: the user was performing the consent nod irlume itself requires
+before releasing a credential. The nod turns the face away from the emitter,
+which dims the lit frame, which is the regime this cue mishandles. The
+lit-phase-only restriction cannot see that, because the frame IS the lit one.
+
+Glasses were the initial hypothesis and the data did not support it: 1 spoof
+denial in 8 with glasses, 0 in 8 without. They do cost about 10 points of IR
+brightness (median 95 against 104), moving the frame toward the cliff without
+being the cause.
+
+**Why 0.5 was wrong.** Qualification measured genuine at 0.001-0.13 and attacks
+at medians 0.998-1.0000. Nothing occupied the space between, so 0.5 turned an
+out-of-distribution score into a denial. The ModelScope card states no
+threshold, so 0.5 was never a publisher recommendation being honoured.
+
+**Re-measured at 0.9, same vinyl banner, 2026-07-27:**
+
+| Presentations | Flagged | p_fake |
+|---|---|---|
+| 8 (varied angle and distance) | 6/6 that reached the cue | 0.941, 0.956, 0.995, 0.999, 0.999, 1.000 |
+
+The remaining 2 were denied by the consecutive-failure throttle before the cue
+ran, which is that throttle working as intended.
+
+**The attack floor is 0.941**, well below the 0.998-1.0000 medians reported
+above. The usable window on this hardware is therefore 0.702 (highest genuine
+observed) to 0.941 (lowest attack observed). A threshold of 0.95, chosen for a
+feeling of extra safety, would have dropped a real detection. A unit test now
+pins the threshold inside that window from both sides.
+
+**Genuine side after the change:** 16 releases, 0 denials, including 8 with
+continuous nodding, the condition that produced the original misfire. Caveat
+worth stating: no frame in that run scored inside the abstain band
+(`ir_bright` floor was 84, against 79 for the misfire), so the run demonstrates
+no regression rather than exercising the new path. The abstain logic is covered
+by unit tests.


### PR DESCRIPTION
Fixes #134.

## The failure

The opt-in `flir` cue denied credential release for a genuine, present, enrolled user three times on one machine. Twice at real logins (2026-07-25, 2026-07-27), each costing a keyring unlock and leaving the user with a wallet password prompt after a successful face login. Once under instrumentation:

```
liveness(cross-spectrum): Live (...); ir_bright=79 ... pitch=0.59
thirdparty-pad('flir'): p_fake 0.702 >= 0.50; downgrading Live to Spoof
```

## Why 0.5 was the wrong line

Qualification measured genuine faces at 0.001-0.13 and the vinyl-print attack at medians 0.998-1.0000. **Nothing was ever observed between.** The 0.5 threshold sat in that empty space, so an out-of-distribution score became a denial.

It was also not a publisher recommendation. The ModelScope card states no threshold at all, so 0.5 was a conventional binary-classifier default rather than an upstream figure being honoured.

## The interaction that triggers it

Credential release requires a consent nod. The nod tilts the face away from the IR emitter, which dims the lit frame, and dim frames are the regime this cue is documented to mishandle. The existing lit-phase-only restriction cannot help, because the frame **is** the lit one; it is dim from head pose, not strobe timing. The feature guarding credential release feeds the cue its worst input.

Glasses were the first hypothesis. The data refuted it: 1 denial in 8 with glasses, 0 in 8 without. They do cost about 10 points of IR brightness (median 95 against 104), moving frames toward the cliff without being the cause.

## Measured, not inferred

I nearly shipped this on the medians. Re-measuring with the same vinyl banner at the new threshold changed what I would have chosen:

| | p_fake |
|---|---|
| genuine, highest observed | 0.702 |
| **attack, lowest observed** | **0.941** |
| attack readings, 6/6 flagged | 0.941, 0.956, 0.995, 0.999, 0.999, 1.000 |

The attack **floor is 0.941**, not the 0.998 the medians implied. A threshold of 0.95, picked for a feeling of extra safety, would have dropped a real detection. The usable window on this hardware is 0.702 to 0.941, and two tests now pin the threshold inside it from both sides, so neither a well-meaning raise nor a revert to 0.5 passes silently.

The other two of the 8 presentations were denied by the consecutive-failure throttle before the cue ran, which is that throttle working.

## Genuine side after the change

16 credential releases, 0 denials, including 8 with continuous nodding, the condition that produced the original misfire.

**Caveat, stated because it matters:** no frame in that run scored inside the abstain band (`ir_bright` floor 84, against 79 for the misfire), so the run demonstrates no regression rather than exercising the new path on hardware. The abstain logic is covered by unit tests only.

## Also

`thirdparty_abstains()` plus a debug line, so a score in the unmeasured band is visible rather than silently inert. The catalog summary advertised "0/35 genuine flagged" while the same document maps dim-frame and harsh-sun failures; it now says so. Addendum added to the PAD results doc.

687 tests pass; fmt, clippy and `cargo doc -D warnings` clean.
