### PR TITLE
fix: make the consent gesture discoverable (name the nod; warn when the greeter hides it)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1681,9 +1681,10 @@ impl Engine {
                 ConsentGesture::Closure => {
                     "close your eyes for about a second, then open, to approve"
                 }
-                ConsentGesture::Either => {
-                    "keep nodding your head to approve (or, if you've calibrated it, close your eyes ~1s then open)"
-                }
+                // Names only the nod, for the reason given on
+                // `ConsentGesture::instruction`: a denial is the worst possible
+                // moment to offer the gesture that needs a calibration to work.
+                ConsentGesture::Either => "keep nodding your head to approve",
             }))
         }
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2430,6 +2430,28 @@ fn report_credential_release(
             "keep nodding your head"
         }
     );
+    // The gate is on AND working; the remaining failure is that the user may never
+    // be TOLD. pam_irlume sends the instruction, but a login manager that drops
+    // PAM_TEXT_INFO turns a required gesture into a silent one, which reads as
+    // "face login worked but my keyring asked for a password anyway". Saying it
+    // here moves the discovery from the login screen, where the greeter can show
+    // nothing, to a command the user runs while set up and unhurried.
+    if let Some(dm) = crate::pamwire::active_dm_hides_pam_instructions() {
+        dout!(
+            report,
+            "[doctor] ⚠ your login manager ({dm}) does not display the gesture \
+             instruction.\n     \
+             It is still REQUIRED at the login screen after a reboot or logout: {}\n     \
+             while your face is being read. Nothing on screen will ask you to. Without \
+             it your\n     \
+             login still succeeds and only the keyring falls back to the typed password.",
+            if gesture_is_closure {
+                "close your eyes ~1s then open"
+            } else {
+                "keep nodding your head"
+            }
+        );
+    }
 }
 
 /// Preflight diagnostics ("preparing"): discover + classify cameras, flag the

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -575,6 +575,38 @@ const DM_PAM_SERVICES: &[(&str, &str, Option<&str>)] = &[
     ("cosmic-greeter", "cosmic-greeter", None),
 ];
 
+/// Login managers MEASURED not to show the user a `PAM_TEXT_INFO` message.
+///
+/// `pam_irlume` sends the consent-gesture instruction as `PAM_TEXT_INFO` before
+/// the capture, because a greeter that just says "Password:" gives the user no
+/// way to know a gesture is required. A login manager that drops that message
+/// leaves the requirement undiscoverable: the user is asked for a gesture nobody
+/// told them about, the watch window expires, and the keyring falls back to the
+/// typed password with no explanation.
+///
+/// Only entries VERIFIED to drop it belong here. An empty warning is better than
+/// a wrong one, so a login manager nobody has checked stays absent and produces
+/// no warning at all; this is not a list of everything that might be broken.
+///
+/// `plasmalogin` (Plasma Login Manager 6.7.3): the helper forwards the message
+/// and `GreeterProxy` emits `informationMessage`, but the greeter QML connects no
+/// handler to that signal, so it is dropped before presentation. Confirmed on
+/// hardware 2026-07-27 across two greeter logins that showed nothing, while the
+/// same code path renders on the KDE lock screen, which is a different codebase.
+const DM_HIDES_PAM_TEXT_INFO: &[&str] = &["plasmalogin"];
+
+/// The active login manager, when it is one known to drop `PAM_TEXT_INFO`.
+///
+/// `None` covers both "no display manager" and "not known to drop it", because
+/// doctor treats them the same: it warns only on a positive finding.
+pub(crate) fn active_dm_hides_pam_instructions() -> Option<String> {
+    let dm = active_display_manager()?;
+    DM_HIDES_PAM_TEXT_INFO
+        .iter()
+        .any(|known| *known == dm)
+        .then_some(dm)
+}
+
 /// The PAM services THIS login manager actually uses, so wiring targets what the
 /// DM will really consult (and, above all, its separate FINGERPRINT service).
 /// Returns `(greeter_label, fingerprint_label_or_none)`.
@@ -2037,6 +2069,26 @@ mod tests {
         assert_eq!(dm_pam_services("cosmic-greeter"), ("cosmic-greeter", None));
         // Anything unrecognised is named "(unknown)" with no fingerprint service.
         assert_eq!(dm_pam_services("mystery-dm"), ("(unknown)", None));
+    }
+
+    /// The warning names a login manager, so every entry must be one irlume
+    /// actually knows; a typo would warn about a DM that never runs, or stay
+    /// silent on the one that does. The list is deliberately short: absence means
+    /// "not measured", never "displays it fine".
+    #[test]
+    fn every_dm_that_hides_pam_text_info_is_a_login_manager_irlume_knows() {
+        for dm in DM_HIDES_PAM_TEXT_INFO {
+            assert!(
+                DM_PAM_SERVICES.iter().any(|(name, _, _)| name == dm),
+                "{dm} is not in DM_PAM_SERVICES, so the warning names a login \
+                 manager irlume cannot otherwise identify"
+            );
+        }
+        // The finding that motivated this: measured on hardware, twice.
+        assert!(DM_HIDES_PAM_TEXT_INFO.contains(&"plasmalogin"));
+        // An unmeasured login manager must not be warned about. sddm is the
+        // near miss: same KDE family, different greeter, never checked here.
+        assert!(!DM_HIDES_PAM_TEXT_INFO.contains(&"sddm"));
     }
 
     #[test]

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -174,9 +174,19 @@ impl ConsentGesture {
             Self::Closure => {
                 format!("close your eyes for about a second, then open, to {what}")
             }
-            Self::Either => {
-                format!("keep nodding your head to {what} (or close your eyes ~1s then open)")
-            }
+            // `Either` accepts both, but the instruction names ONLY the nod. A
+            // one-line prompt at a greeter or a polkit dialog is read once, under
+            // time pressure, and the two gestures are not equally reliable: the nod
+            // needs no calibration at all, while the closure gate depends on a
+            // per-user EAR calibration that can be thin enough to miss. Measured
+            // 2026-07-27 on the maintainer's hardware, 20 self-paced readings:
+            // glasses HALVE the open-eye EAR (0.109-0.120 with, 0.249-0.255
+            // without), so one calibration spanning both conditions left a margin of
+            // 0.0095 EAR. Offering a gesture that thin, in the line someone reads
+            // while trying to log in, costs them the release window and then the
+            // password. Closure stays accepted, and stays documented in `irlume
+            // doctor` where there is room to explain the calibration it needs.
+            Self::Either => format!("keep nodding your head to {what}"),
         }
     }
 }
@@ -434,7 +444,8 @@ mod tests {
         assert_eq!(consent_gesture_mode(), ConsentGesture::Nod);
         std::env::remove_var("IRLUME_CONSENT_GESTURE");
 
-        // The instruction names ONLY gestures that mode actually accepts.
+        // An instruction must never name a gesture its mode would REFUSE; naming
+        // fewer than it accepts is a deliberate choice, not a defect.
         let nod = ConsentGesture::Nod.instruction("unlock your keyring");
         assert!(nod.contains("nod") && !nod.contains("eyes"), "{nod}");
         let closure = ConsentGesture::Closure.instruction("unlock your keyring");
@@ -442,10 +453,14 @@ mod tests {
             closure.contains("eyes") && !closure.contains("nod"),
             "closure-only must not tell the user to nod: {closure}"
         );
+        // `Either` accepts both and names only the nod: it is the gesture that
+        // needs no calibration, and a prompt is read once under time pressure.
+        // Offering the closure here would send an uncalibrated user after the one
+        // gesture that cannot work for them.
         let either = ConsentGesture::Either.instruction("unlock your keyring");
         assert!(
-            either.contains("nod") && either.contains("eyes"),
-            "{either}"
+            either.contains("nod") && !either.contains("eyes"),
+            "the either-mode prompt must name the no-calibration gesture only: {either}"
         );
         // The subject is interpolated, so one wording serves keyring and polkit.
         assert!(nod.ends_with("unlock your keyring"), "{nod}");

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -257,18 +257,25 @@ impl PamServiceModule for IrlumePam {
                 }
             }
 
-            // On a polkit prompt the daemon requires the deliberate eye-closure
-            // consent gesture, which is not discoverable from the dialog, so tell
-            // the user what to do. Best-effort text info (the KDE/GNOME agent
-            // shows it inline); shown once, before the capture, only for the
-            // polkit service so sudo / lock screen are unaffected.
+            // On a polkit prompt the daemon requires a deliberate consent gesture,
+            // which is not discoverable from the dialog, so tell the user what to do.
+            // Best-effort text info (the KDE/GNOME agent shows it inline); shown
+            // once, before the capture, only for the polkit service so sudo / lock
+            // screen are unaffected.
+            //
+            // The text comes from the same `consent_gesture_mode` parse the engine
+            // gates on, exactly as the credential-release probe below does. It used
+            // to be a hardcoded string naming both gestures, which told a
+            // `closure`-only user to nod at a gate that would not accept a nod: the
+            // failure `ConsentGesture` was introduced to prevent.
             let is_polkit = matches!(
                 pamh.get_service().ok().flatten().and_then(|c| c.to_str().ok().map(str::to_string)),
                 Some(ref s) if s == "polkit-1" || s == "polkit"
             );
             if is_polkit && !unseal {
+                let how = irlume_common::config::consent_gesture_mode().instruction("approve");
                 let _ = pamh.conv(
-                    Some("irlume: keep nodding your head to approve (or close your eyes ~1s then open)"),
+                    Some(&format!("irlume: {how}")),
                     pamsm::PamMsgStyle::TEXT_INFO,
                 );
             }

--- a/docs/APP-INTEGRATION.md
+++ b/docs/APP-INTEGRATION.md
@@ -19,15 +19,16 @@ pieces:
    the app and the action being approved, and starts a PAM conversation on the
    `polkit-1` service.
 3. `pam_irlume` in that stack asks `irlumed` to verify your face. For a polkit
-   prompt the daemon also requires a deliberate consent gesture: **nod your
-   head**, or **close your eyes for about a second then open them**, whichever
-   suits your position (see the security section). It then answers yes or no;
-   the app learns only the verdict.
+   prompt the daemon also requires a deliberate consent gesture: **keep nodding
+   your head**, or, if you have calibrated it, **close your eyes for about a
+   second then open them** (see the security section). It then answers yes or
+   no; the app learns only the verdict.
 
 Both the KDE and GNOME agents start the PAM conversation the moment the dialog
-appears, so the camera fires immediately. The dialog shows "irlume: nod your
-head to approve (or close your eyes ~1s then open)"; perform either gesture and
-it approves, no typing or clicking.
+appears, so the camera fires immediately. The dialog shows "irlume: keep
+nodding your head to approve"; do that and it approves, no typing or clicking.
+The eye closure is accepted too when calibrated, but the prompt names only the
+nod, because the nod is the gesture that works with no setup.
 
 ## Enabling
 


### PR DESCRIPTION
Makes the consent-gesture instruction useful: name the gesture that actually
works, and say so somewhere the user will see it when their login screen cannot.

Follows the field diagnosis in #134, where a face login succeeded and KDE Wallet
prompted for a password anyway. The cause was the credential-release gesture
timing out, not a login failure.

## 1. The prompt names only the head nod

The `Either` consent mode accepts a head nod or a calibrated eye closure, and
its one-line instruction offered both. The two are not equally reliable. The nod
is pose-defined and needs no setup. The closure gate depends on a per-user EAR
calibration that can be too thin to fire.

Measured 2026-07-27, 20 self-paced readings, one subject: glasses halve the
open-eye EAR (0.109-0.120 wearing them, 0.249-0.255 without), so a single
calibration spanning both conditions left a margin of 0.0095 EAR. A prompt at a
greeter or a polkit dialog is read once, while the user is trying to get in.
Sending them after the gesture that may not be calibrated for their current
condition costs them the release window and then the password.

Closure stays accepted, and stays documented in `irlume doctor` and SETUP.md
where there is room to explain the calibration it needs. Only the terse prompts
change.

## 2. The polkit prompt was not mode-aware

It was a hardcoded string naming both gestures, so a `consent_gesture=closure`
user was told to nod at a gate that would refuse a nod. That is the exact
failure the `ConsentGesture` type was introduced to prevent, and its own doc
comment names it. The prompt now reads the same `consent_gesture_mode` parse the
engine gates on, as the credential-release probe already did.

## 3. doctor warns when the greeter cannot show the instruction

Plasma Login Manager 6.7.3 never displays it. The helper forwards the
`PAM_TEXT_INFO` and `GreeterProxy` emits `informationMessage`, but the greeter
QML connects no handler to that signal, so the text is dropped before
presentation. Observed on hardware across two greeter logins that showed
nothing, while the same code path renders on the KDE lock screen, a separate
codebase.

irlume cannot fix another project's greeter, so doctor says it instead:

```
[doctor] ⚠ your login manager (plasmalogin) does not display the gesture instruction.
     It is still REQUIRED at the login screen after a reboot or logout: keep nodding your head
     while your face is being read. Nothing on screen will ask you to. Without it your
     login still succeeds and only the keyring falls back to the typed password.
```

`DM_HIDES_PAM_TEXT_INFO` holds only login managers measured to drop the message.
An unmeasured one stays absent and warns about nothing: absence means "not
checked", never "displays it fine". A test requires every entry to be a login
manager `DM_PAM_SERVICES` already knows, so a typo cannot warn about a DM that
never runs.

## Testing

The config test kept the old invariant, asserting that the `Either` instruction
names BOTH gestures, so it failed on this change as it should have. Restated to
the invariant that matters: an instruction must never name a gesture its mode
would refuse, while naming fewer than it accepts is a deliberate choice. The
nod-only and closure-only assertions are unchanged.

688 tests pass; fmt, clippy and `RUSTDOCFLAGS="-D warnings" cargo doc` clean.

Hardware verification of the new warning, both directions:

| Host | Result |
|---|---|
| this machine, plasmalogin | warning prints |
| simulated sddm, private mount namespace | challenge line prints, warning silent |

The namespace kept the real `display-manager.service` symlink untouched;
confirmed unchanged afterwards.

Not addressed here: the greeter still displays nothing, because that is upstream
QML. This makes the requirement discoverable, it does not make the login screen
show it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>
