### PR TITLE
docs: say that a closure calibration only describes one lighting condition

### DIFF
--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -506,6 +506,16 @@ fn calibrate_closure(args: &[String]) -> std::process::ExitCode {
         Ok(Response::Ok(msg)) => {
             println!("[calibrate] ✓ {msg}");
             println!("[calibrate] the polkit consent gesture is now calibrated for '{user}'.");
+            // Said HERE, where the user still has the camera up and can redo it,
+            // rather than only in doctor. What was just stored describes the eye
+            // shape under the light in the room right now.
+            println!(
+                "[calibrate] this reading is tied to the light you are in now. Eye shape is \
+                 stored\n            as absolute values and they shift as the room changes, \
+                 so a calibration\n            taken in daylight can stop registering after \
+                 dark. Re-run this in the\n            light you actually use. The head nod \
+                 needs no calibration and is not\n            affected."
+            );
             std::process::ExitCode::SUCCESS
         }
         Ok(Response::Error(e)) => {
@@ -2449,6 +2459,36 @@ fn report_credential_release(
                 "close your eyes ~1s then open"
             } else {
                 "keep nodding your head"
+            }
+        );
+    }
+    // Only for users who actually have a closure calibration: it is stored as
+    // absolute EAR values, and those move with the light. Measured on one user's
+    // hardware the same seated position gave a median open EAR of 0.109 at an
+    // ambient of 22-42 and 0.166 at an ambient of 1, a 52% shift. No single
+    // calibration covers both: registering that session's deepest closure and
+    // its shallowest reopen needs a gap of 0.030, and the code requires 0.05.
+    //
+    // Nothing here can fix that, so doctor says it. Being told once beats
+    // discovering it as a keyring prompt that only happens after dark, and the
+    // nod is right there needing no calibration at all.
+    if closure_calibrated || gesture_is_closure {
+        dout!(
+            report,
+            "[doctor] note: your eye-closure calibration is tied to the LIGHT you \
+             calibrated in.\n     \
+             Eye shape is stored as absolute values, and they shift as the room \
+             changes, so a\n     \
+             calibration taken in daylight can stop registering after dark. \
+             Re-run `sudo irlume\n     \
+             calibrate-closure` in the light you actually use{}",
+            if gesture_is_closure {
+                ". consent_gesture=closure means there\n     \
+                 is no fallback gesture; unset it in settings.conf to also accept the head \
+                 nod,\n     which is pose-defined and needs no calibration."
+            } else {
+                ", or just use the head nod, which is\n     \
+                 pose-defined and unaffected by lighting."
             }
         );
     }

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1091,6 +1091,18 @@ pub fn detect_blink(samples: &[EarSample]) -> BlinkResult {
 /// Modified-EAR method, PeerJ CS-943 / PMC9044337) avoids it, and validated
 /// cleanly on real captures (a deliberate hold reads a 18-35 frame sub-threshold
 /// run; spontaneous blinks and squints read ≤5).
+///
+/// KNOWN COST OF THAT CHOICE, measured 2026-07-27, one user, 20 readings: absolute
+/// values move with the LIGHT. The same seated position gave a median open EAR of
+/// 0.109 at an ambient of 22-42 and 0.166 at an ambient of 1, a 52% shift, with
+/// the closed values rising too. No single calibration spans both sessions:
+/// registering the deepest closure (0.0894) and the shallowest reopen (0.0984)
+/// requires `(CLOSURE_REOPEN_FRACTION - CLOSURE_DEEP_FRACTION) * gap <= 0.0090`,
+/// so `gap <= 0.030`, while [`MIN_CALIBRATION_SEPARATION`] demands 0.05. Each
+/// session calibrates fine alone; the pair cannot. A calibration therefore
+/// describes one lighting condition, which `calibrate-closure` and `doctor` both
+/// now say out loud. [`detect_nod`] is pose-defined and carries none of this,
+/// which is why it is the default and the only gesture the prompts name.
 #[derive(Debug, Clone, Copy)]
 pub struct ClosureCalibration {
     /// Median EAR with the eyes open (the smaller eye, as [`EarSample::ear`]).

--- a/docs/APP-INTEGRATION.md
+++ b/docs/APP-INTEGRATION.md
@@ -51,6 +51,15 @@ that either gesture is accepted. The eye-closure path is 2D and pose-sensitive,
 so it works best sitting square-on to the camera; the nod covers every other
 position. `consent_gesture=nod|closure` in settings.conf restricts to one.
 
+**Calibrate in the light you actually use.** The eye measurements are stored as
+absolute values, and they move with the room. Measured on one user's hardware,
+20 readings: the same seated position gave a median open EAR of 0.109 at an
+ambient of 22-42 and 0.166 at an ambient of 1, and no single calibration covers
+both, so one taken in daylight can stop registering after dark. Re-running
+`calibrate-closure` fixes it for the new condition. The head nod is pose-defined
+and carries none of this, which is why it is the default and the only gesture
+the prompts name.
+
 Check the state any time:
 
 ```console

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -196,8 +196,10 @@ credential to it) and requires a deliberate consent gesture before approving,
 because the prompt starts scanning without any action from you. The default
 gesture is a **head nod** (no calibration; works at any angle or lighting). If
 you prefer to approve by closing your eyes for about a second, run `sudo irlume
-calibrate-closure` once and either gesture is accepted. Full walkthrough,
-Bitwarden setup, and the security stance: [APP-INTEGRATION.md](APP-INTEGRATION.md).
+calibrate-closure` once and either gesture is accepted; calibrate in the light
+you actually use, because the stored eye measurements shift as the room changes.
+Full walkthrough, Bitwarden setup, and the security stance:
+[APP-INTEGRATION.md](APP-INTEGRATION.md).
 
 ## Fingerprint companion (optional)
 


### PR DESCRIPTION
`calibrate-closure` stores absolute open and closed EAR medians, and those move
with the light. Nothing told the user, so a calibration taken in daylight that
stops registering after dark surfaces as a keyring prompt with no explanation.

## The measurement

2026-07-27, one user, 20 readings, same seated position and same glasses. The
second set was taken after dark, with the intent of testing whether an earlier
bimodal set of closed readings was just incomplete closure.

| session | daemon `ambient` | median open EAR | median closed EAR |
|---|---|---|---|
| afternoon | 22-42 | 0.109 | 0.063 |
| after dark | 1 | 0.166 | 0.066 |

Squeezing the eyes firmly shut did not pull the closed floor down. The whole
scale had moved: open EAR rose 52% in the same position.

## Why one calibration cannot cover both

The gate needs every closure below `ear_closed + 0.30 * gap` and every reopen at
or above `ear_closed + 0.60 * gap`. Across both sessions that means

```
(0.60 - 0.30) * gap <= min(open) - max(closed) = 0.0984 - 0.0894 = 0.0090
gap <= 0.030
```

while `MIN_CALIBRATION_SEPARATION` requires 0.05. Each session calibrates fine
alone; the pair cannot. Recalibrating from the evening readings puts the reopen
threshold at 0.1259, above every afternoon open reading, which would kill the
gesture in daylight entirely:

| calibration | closed_thr | reopen_thr | afternoon | after dark |
|---|---|---|---|---|
| from the evening set | 0.0960 | 0.1259 | 5/5 reopens dead | 0/5 fail |
| currently stored | 0.0739 | 0.0889 | 0/5 fail | 1/5 closures fail |
| from the afternoon set | — | — | rejected, gap 0.0473 | — |

The stored calibration is already the best available compromise, so this changes
no value. It only makes the constraint visible.

## What changes

`calibrate-closure` prints the caveat on success, where the user still has the
camera up and can redo it. `doctor` repeats it for anyone with a calibration
stored, with a different second sentence when `consent_gesture=closure` leaves
them no fallback gesture. SETUP.md and APP-INTEGRATION.md carry it, the latter
with the numbers. `ClosureCalibration`'s doc comment records the cost of the
absolute-threshold choice, beside the existing rationale for why a relative
baseline was rejected: a deliberate closure pollutes its own running median, a
failure mode a brief natural blink does not have.

This is also why the nod is the default and the only gesture the prompts name
after #136. That decision was a judgement call at the time; it is now measured.

## Verification

Both wordings checked on hardware, including the `consent_gesture=closure`
variant. The note is gated on `closure_calibrated || gesture_is_closure`, so a
nod-only user never sees it; verified at the source rather than through doctor,
by querying the daemon's `ListProfiles` field directly:

```
wisbfime: closure_calibrated=True     nobody: False     root: False
```

693 tests pass; fmt, clippy and `RUSTDOCFLAGS="-D warnings" cargo doc` clean. No
threshold, gate or stored value moves.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>
