### PR TITLE
fix: raise the nod pitch threshold, and measure the print case #101 asked for

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1526,15 +1526,27 @@ impl Engine {
         // A gesture that never arrives is otherwise silent: the caller waits out
         // its deadline and denies, which reads the same whether the user did
         // nothing or nodded in a way the detector did not count. Say which.
-        if hit != Some(true) {
+        // Report the evidence on BOTH outcomes, not just a miss. A refusal
+        // explains itself from the numbers that fell short, but an ACCEPT is the
+        // one that needs auditing: measured 2026-07-27 on real hardware, the gate
+        // fired on a user sitting still 2 times in 8, and on a hand-held printed
+        // face 2 times in 14. Without the numbers behind an accept there is no way
+        // to tell which reading cleared which bar, and thresholds get argued over
+        // instead of measured. Debug-level, numbers only, never frames.
+        {
             let (_, ev) = irlume_liveness::detect_nod_with_evidence(&poses);
             // Every threshold printed here comes from the evidence or a constant
             // the gate itself reads, never a restatement: `pitch_min` is carried
             // because IRLUME_NOD_PITCH_MIN can override the constant, and a line
             // naming a limit the run did not apply is worse than no line.
             irlume_common::dlog!(
-                "consent: no gesture in {} frames; nod evidence: usable_pitch_frames={} (need {}) \
+                "consent: {} in {} frames; nod evidence: usable_pitch_frames={} (need {}) \
                  pitch_range={:.3} (need {:.3}) yaw_range={:.2} (max {:.2}) crossings={} (need {})",
+                if hit == Some(true) {
+                    "GESTURE ACCEPTED"
+                } else {
+                    "no gesture"
+                },
                 poses.len(),
                 ev.frames,
                 irlume_liveness::NOD_MIN_FACE_FRAMES,

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -572,11 +572,33 @@ pub enum HeadGesture {
 
 /// Deliberate head-nod consent gesture ([`detect_nod`]): minimum pitch RANGE
 /// (max-min of `pitch_frac`) over the window. A nod swings the head down and
-/// back; a still head barely moves. Validated on a hardware campaign 2026-07-22
-/// (upright + reclined): still heads ranged ≤0.061, deliberate nods 0.057-0.167,
-/// so 0.07 sits just above every still take with margin. Overridable via
-/// `IRLUME_NOD_PITCH_MIN`.
-pub const NOD_PITCH_MIN: f32 = 0.07;
+/// back; a still head barely moves. This is the gate that actually separates the
+/// two, which is why it carries the threshold.
+///
+/// Raised 0.070 → 0.075 on 2026-07-27 after measuring the live consent watch on
+/// one user, one camera, 28 watches, with the daemon reporting the numbers
+/// behind every verdict:
+///
+/// | population | n | pitch_range |
+/// |---|---|---|
+/// | accepted, deliberate continuous nods | 10 | 0.082 - 0.108 |
+/// | rejected, sitting still + hand-held printed face | 18 | 0.021 - 0.069 |
+///
+/// The populations do not overlap, and 0.070 sat on the very edge of the gap.
+/// 0.075 is its midpoint: 0.006 above the worst non-gesture and 0.007 below the
+/// weakest real nod. An earlier session the same evening, where the numbers were
+/// not captured, DID see the gate fire on a still user and on a print, so treat
+/// this as widening a measured margin rather than as proof the case is closed.
+///
+/// The 2026-07-22 campaign recorded genuine nods as low as 0.057, which this
+/// threshold rejects. Those were single nods; the instruction has since changed
+/// to keep nodding (a single nod released 0 times out of 3), and continuous
+/// nodding measured 0.082 at its weakest. The failure direction is also the safe
+/// one: a rejected gesture falls back to the typed password, while a false
+/// accept releases a credential the user never consented to release.
+///
+/// Overridable via `IRLUME_NOD_PITCH_MIN`.
+pub const NOD_PITCH_MIN: f32 = 0.075;
 /// ...and maximum yaw RANGE, so idle LOOKING-AROUND (which swings yaw a lot) and
 /// a head SHAKE are not read as a nod. Campaign: nods ranged ≤0.46 in yaw while
 /// look-around ranged 0.87-6.95, so 0.6 separates them cleanly.
@@ -588,6 +610,22 @@ pub const NOD_YAW_MAX: f32 = 0.6;
 /// capture window and slowed grants; the campaign data shows 1 crossing accepts
 /// more genuine nods (19/21 vs 17/21) with still ZERO false accepts on
 /// still/look-around (the pitch-range and yaw gates do that work).
+///
+/// DO NOT RAISE THIS TO FIX A FALSE ACCEPT. Measured 2026-07-27 over 28 live
+/// consent watches, crossings does not separate the populations at all, and is
+/// if anything inverted:
+///
+/// | population | crossings observed |
+/// |---|---|
+/// | accepted, deliberate nods | 1, 1, 1, 2, 2, 2, 2, 3, 3, 3 |
+/// | rejected, still + printed face | 0, 0, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 7 |
+///
+/// A still head reached 7 while real nods fired on 1, so requiring 2 would have
+/// rejected three genuine nods and still admitted every still take that produced
+/// 3 or more. The cause is [`NOD_CROSSING_AMP_FRAC`]: the amplitude bar is a
+/// fraction of the take's OWN pitch range, so a nearly-still head gets a tiny
+/// bar and sensor noise oscillates across it repeatedly. [`NOD_PITCH_MIN`] is
+/// the gate that discriminates; raise that instead.
 pub const NOD_MIN_CROSSINGS: usize = 1;
 /// A crossing counts only when the pitch moves past this fraction of the take's
 /// pitch range from the median, so sensor noise on a near-still head is ignored.
@@ -1913,6 +1951,44 @@ mod nod_evidence_tests {
         assert_eq!(ev.crossings, 0);
         assert!(ev.pitch_range.is_finite() && ev.pitch_range == 0.0);
         assert!(ev.yaw_range.is_finite() && ev.yaw_range == 0.0);
+    }
+
+    /// The threshold must keep separating the two populations MEASURED on
+    /// hardware 2026-07-27, or the false-accept this was raised to close comes
+    /// back. Pinned as data, not as a restatement of the constant: if someone
+    /// lowers `NOD_PITCH_MIN` toward the rejected side, this fails and says why.
+    #[test]
+    fn the_pitch_threshold_still_separates_the_measured_populations() {
+        // Deliberate continuous nods, 10 accepted watches.
+        const REAL_NODS: &[f32] = &[
+            0.082, 0.085, 0.088, 0.089, 0.094, 0.095, 0.096, 0.099, 0.107, 0.108,
+        ];
+        // Sitting still and holding a printed face, 18 rejected watches.
+        const NOT_GESTURES: &[f32] = &[
+            0.021, 0.022, 0.023, 0.023, 0.024, 0.024, 0.030, 0.033, 0.035, 0.038, 0.038, 0.042,
+            0.044, 0.052, 0.055, 0.055, 0.059, 0.069,
+        ];
+        let thr = NOD_PITCH_MIN;
+        for v in REAL_NODS {
+            assert!(
+                *v >= thr,
+                "a measured real nod at {v} would now be refused by NOD_PITCH_MIN {thr}"
+            );
+        }
+        for v in NOT_GESTURES {
+            assert!(
+                *v < thr,
+                "a measured still/print take at {v} would now be ACCEPTED by NOD_PITCH_MIN {thr}"
+            );
+        }
+        // And it sits inside the gap rather than on either edge, so neither side
+        // is one noisy capture away from crossing it.
+        let worst_real = REAL_NODS.iter().copied().fold(f32::INFINITY, f32::min);
+        let worst_fake = NOT_GESTURES.iter().copied().fold(0.0f32, f32::max);
+        assert!(
+            thr - worst_fake >= 0.004 && worst_real - thr >= 0.004,
+            "threshold {thr} is not centred in the gap {worst_fake}..{worst_real}"
+        );
     }
 
     /// The reported threshold is the one the gate applied, not the constant.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -215,12 +215,26 @@ with a fabricated print.
   run in a less stable posture released 2 of 5, so incidental body movement
   drives that number.
 
-  **What it has NOT been measured against: a hand-held print.** The detections
-  above show the nod detector responding to incidental motion, and a photo held
-  in the hand produces exactly that. Until that case is measured, treat this gate
-  as raising the cost of the attack rather than closing it, and do not read the
-  9-in-10 refusal above as an anti-spoofing figure. Tracked in
-  [#101](https://github.com/archledger/irlume/issues/101).
+  **Measured against a hand-held print (2026-07-27, same camera, two sessions,
+  38 attempts).** The nod detector fired on a hand-held printed face 2 times in
+  24, and on the same user sitting still with consent withheld 2 times in 18.
+  Incidental motion and hand tremor do satisfy this gate, so it is not evidence
+  of a live person and must not be read as an anti-spoofing figure.
+
+  No printed attempt was ever granted. Every one was refused by cross-spectrum
+  liveness and the third-party PAD cue, at `p_fake` 0.996-1.000; the gesture was
+  never the layer standing between the print and a credential.
+
+  The gate's own separation was then measured directly, with the daemon
+  reporting the numbers behind each verdict: deliberate continuous nods produced
+  a pitch range of 0.082-0.108 (10 accepts), while sitting still and holding a
+  print produced 0.021-0.069 (18 rejects). `NOD_PITCH_MIN` was raised from 0.070
+  to 0.075, the midpoint of that gap. The crossings count did not separate the
+  populations in either direction and was left alone.
+
+  What this gate is for is deliberate INTENT on the credential-release path, and
+  the honest limit is that a present, non-consenting user can still satisfy it by
+  moving. Tracked in [#101](https://github.com/archledger/irlume/issues/101).
 - **Consecutive-failure throttle.** After a run of failed face attempts (5 by
   default, `IRLUME_RATE_LIMIT`), the daemon stops firing the camera on the
   gesture for a cooldown (30s, `IRLUME_RATE_COOLDOWN_SECS`) and PAM falls


### PR DESCRIPTION
Closes the measurement #101 asked for, and fixes the gate the measurement
indicted. The obvious fix turned out to be the wrong one.

## What #101 suspected, now measured

Two sessions on one camera, 38 attempts:

| subject | attempts | gate fired | granted |
|---|---|---|---|
| user sitting still, consent withheld | 18 | 2 | 2 |
| hand-held printed face | 24 | 2 | **0** |

Incidental motion and hand tremor do satisfy this gate. It is not evidence of a
live person.

**No printed attempt was ever granted.** Cross-spectrum liveness and the
third-party PAD cue refused every one at `p_fake` 0.996-1.000. The gesture was
never the layer between a print and a credential; the layered defence did that,
including the threshold change from #135.

## The daemon now reports accepts, not just refusals

A refusal explains itself from the values that fell short. An ACCEPT is the one
that needs auditing, and it was silent. Making it speak is what turned this from
an argument into a measurement.

## What the numbers say, 28 live consent watches

| population | n | pitch_range | crossings |
|---|---|---|---|
| accepted, deliberate nods | 10 | 0.082-0.108 | 1,1,1,2,2,2,2,3,3,3 |
| rejected, still + print | 18 | 0.021-0.069 | 0,0,1,1,1,1,1,2,2,3,3,3,3,4,4,4,5,7 |

`pitch_range` separates the populations completely, with a gap from 0.069 to
0.082. `NOD_PITCH_MIN` moves **0.070 → 0.075**, its midpoint: 0.006 above the
worst non-gesture, 0.007 below the weakest real nod. It had been sitting on the
very edge of that gap.

## Why NOD_MIN_CROSSINGS is deliberately not raised

That was my first instinct and the data killed it. The counts are inverted: a
still head reached **7** crossings while real nods fired on **1**. Requiring 2
would have rejected three genuine nods and still admitted every still take
producing 3 or more.

The cause is structural. `NOD_CROSSING_AMP_FRAC` sets the bar at a fraction of
the take's OWN pitch range, so a nearly-still head gets a tiny bar and sensor
noise oscillates across it repeatedly. The constant's doc now records this so the
next person to see a false accept does not reach for the same wrong knob.

## Cost, stated plainly

The 2026-07-22 campaign recorded genuine nods as low as 0.057, which 0.075
rejects. Those were single nods; the instruction has since changed to keep
nodding (a single nod released 0 times out of 3), and continuous nodding
measured 0.082 at its weakest. The failure direction is the safe one: a refused
gesture falls back to the typed password, while a false accept releases a
credential nobody consented to release.

An earlier session the same evening, where the numbers were not captured, did
see the gate fire on a still user and on a print. This widens a measured margin;
it does not prove the case closed.

## Testing

A test pins both measured populations against the threshold, so lowering it
fails naming the reading that would be wrongly accepted, and raising it fails
naming the real nod that would be wrongly refused. Canaried at 0.070 and 0.085;
both fail as intended.

THREAT_MODEL.md replaces "has NOT been measured against a hand-held print" with
what was found, including the honest remaining limit: a present, non-consenting
user can still satisfy this gate by moving.

696 tests pass; fmt, clippy and `RUSTDOCFLAGS="-D warnings" cargo doc` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>
