### PR TITLE
fix: bring the TUI and doctor in line with what was measured

### DIFF
--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3135,8 +3135,11 @@ fn doctor_run(report: &mut crate::doctor_report::Report) -> std::process::ExitCo
         },
     );
     match crate::pamwire::polkit_wired() {
+        // "KEEP nodding", matching the prompt the user will actually see: a
+        // single nod released 0 times out of 3 on hardware, because the detector
+        // needs a run of frames showing the motion.
         Some(true) if !gesture_is_closure => dout!(report,
-            "[doctor] polkit app prompts: wired ✓ (NOD your head to approve Bitwarden unlock,\n     \
+            "[doctor] polkit app prompts: wired ✓ (KEEP NODDING to approve Bitwarden unlock,\n     \
              pkexec, …; no calibration needed{})",
             if closure_calibrated {
                 "; closing your eyes ~1s also works"
@@ -3262,14 +3265,23 @@ fn doctor_run(report: &mut crate::doctor_report::Report) -> std::process::ExitCo
     // password no matter how the reconcile self-heal runs. `active_display_manager`
     // still resolves the symlink, so name the DM and point at the tracker; adding
     // one line to dm_pam_services is all support takes.
-    report.check(
-        "display-manager",
-        match crate::pamwire::active_dm_recognized() {
-            Some((_, true)) => State::Pass,
-            Some((_, false)) => State::Warn,
-            None => State::Info,
-        },
-    );
+    // The machine answer carries the instruction-display limitation too, as
+    // DETAIL rather than a new id or a changed state: the check means "irlume can
+    // wire this display manager", which stays true when the greeter cannot show a
+    // PAM message. Without it a desktop integration reading `doctor --json` would
+    // see `pass` while the human output shows a warning, and this file's own rule
+    // is that the two must not disagree.
+    match crate::pamwire::active_dm_recognized() {
+        Some((dm, true)) if crate::pamwire::active_dm_hides_pam_instructions().is_some() => report
+            .check_detail(
+                "display-manager",
+                State::Pass,
+                format!("{dm}; does not display PAM instructions to the user"),
+            ),
+        Some((_, true)) => report.check("display-manager", State::Pass),
+        Some((_, false)) => report.check("display-manager", State::Warn),
+        None => report.check("display-manager", State::Info),
+    }
     if let Some((dm, false)) = crate::pamwire::active_dm_recognized() {
         dout!(
             report,

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3337,20 +3337,28 @@ impl App {
                         Span::styled(label, Style::new().dim()),
                     ])
                 },
+                // Says what this gate was MEASURED to do, not what it was hoped
+                // to do. It read "so a photo or a screen cannot pull the password
+                // out" until 2026-07-27, when the detector was measured firing on
+                // a hand-held print 2 times in 24; liveness and the PAD cue
+                // refused every one of those, so the claim belonged to them and
+                // never to the gesture. THREAT_MODEL.md carries the numbers.
+                // Kept to FOUR lines: this panel does not scroll, so a fifth line
+                // pushes the bottom section off a short terminal.
                 Line::from(Span::styled(
                     "  Releasing your TPM-sealed keyring password needs a NOD (or a calibrated",
                     Style::new().dim(),
                 )),
                 Line::from(Span::styled(
-                    "  eye closure) after the face match, so a photo or a screen cannot pull the",
+                    "  eye closure). It proves INTENT, not liveness: a hand-held print can satisfy",
                     Style::new().dim(),
                 )),
                 Line::from(Span::styled(
-                    "  password out. Login, lock screen and sudo are unaffected, and a missed",
+                    "  it, and the IR liveness check is what stops the print. Login, lock screen",
                     Style::new().dim(),
                 )),
                 Line::from(Span::styled(
-                    "  gesture just falls back to typing the password.",
+                    "  and sudo are unaffected; a missed gesture falls back to typing the password.",
                     Style::new().dim(),
                 )),
                 Line::from(vec![
@@ -4325,10 +4333,13 @@ impl App {
             "Wire app prompts",
             "opt-in; face approves Bitwarden and pkexec",
         ));
+        // Names the nod first, matching the prompts: it needs no calibration and
+        // is unaffected by lighting, while what [c] teaches is stored as absolute
+        // eye measurements that shift as the room changes.
         lines.push(act(
             "[c]",
             "Calibrate gesture",
-            "approve app prompts by closing your eyes ~1s (the nod needs none)",
+            "optional eye-closure alternative; the head nod needs no calibration",
         ));
         // [b] is an ACTION only when Bitwarden is installed without its polkit
         // action; otherwise its state shows as a status line below.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -37,7 +37,7 @@ Conventions that apply everywhere:
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
 | `irlume profiles eyes-open <on\|off>` | require eyes open to unlock |
 | `irlume profiles challenge <on\|off>` | opt-in passive blink liveness |
-| `sudo irlume calibrate-closure` | teach the eye-closure consent gesture for app prompts (captures eyes-open/closed EAR); the head nod is the default and needs no calibration |
+| `sudo irlume calibrate-closure [--rounds N] [--force]` | teach the eye-closure consent gesture for app prompts. Captures eyes-open/closed EAR over N rounds (default 3) and stores the median, because a single capture varies enough to leave the threshold sitting on top of your own closures; it then reports how many of your readings the result would actually accept. Replacing an existing calibration asks first, and `--force` is required to do it with no terminal. The head nod is the default and needs no calibration |
 | `irlume identify` | 1:N "who is this?"; as root it checks all users, otherwise scoped to you |
 
 ## Keyring, TPM, and recovery


### PR DESCRIPTION
This session changed the PAM prompts, the doctor output and the consent
thresholds, and left the TUI saying the old thing. Audit of both surfaces.

## The TUI claimed the gesture stops a photo

It read:

> needs a NOD (or a calibrated eye closure) after the face match, so a photo or
> a screen cannot pull the password out

Measured 2026-07-27: the detector fired on a hand-held print **2 times in 24**.
Liveness and the PAD cue refused every one of those at `p_fake` 0.996-1.000, so
that claim belonged to them and never to the gesture. THREAT_MODEL.md was
corrected in #140 and this surface was missed.

It now says the gate proves INTENT rather than liveness, and names the IR
liveness check as what actually stops a print. Kept to four lines because this
panel does not scroll, so a fifth pushes the bottom section off a short
terminal. Verified by rendering the panel in a pty rather than assuming:

```
  Releasing your TPM-sealed keyring password needs a NOD (or a calibrated
  eye closure). It proves INTENT, not liveness: a hand-held print can satisfy
  it, and the IR liveness check is what stops the print. Login, lock screen
  and sudo are unaffected; a missed gesture falls back to typing the password.
```

with `Match thresholds (read-only)`, the last section, still on screen.

## doctor disagreed with itself

`main.rs` states the rule directly: *"Recorded from the same visibility the block
below prints from, so the machine answer cannot disagree with the human one."*
The login-manager warning added earlier this session broke it. A human saw a
warning that the greeter cannot display PAM instructions; `doctor --json` saw
`display-manager: pass` and nothing else, so a desktop integration reading the
machine surface had no way to know.

The limitation is now carried as `detail` on that check:

```
display-manager | pass | plasmalogin; does not display PAM instructions to the user
```

The id and the state are deliberately unchanged: the check means "irlume can
wire this display manager", which stays true. The array is still exactly the 23
documented ids, so nothing in the contract moves.

## Two wordings drifted from the measurements

The polkit doctor line said "NOD your head". A single nod released 0 times out
of 3 on hardware, which is why every other prompt says to keep nodding; it now
matches. The TUI's `[c]` action led with the eye closure, where the nod is the
default and the one that needs no calibration.

## docs/COMMANDS.md

Did not mention `--rounds` or `--force` from #139.

## Scope

No behaviour changes: no threshold, gate, stored value or check id moves. 696
tests pass; fmt, clippy and `RUSTDOCFLAGS="-D warnings" cargo doc` clean.

Recorded, not acted on: `enroll_runs_end_to_end_against_fake_fprintd` failed once
during this audit and did not reproduce in five subsequent runs. My first
hypothesis, an unserialised process-global, was wrong; `FAKE_LOCK` already
serialises those fixtures. Cause not established, so nothing is changed for it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>
