### PR TITLE
feat: dump the raw consent pose series for gesture research

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1535,6 +1535,26 @@ impl Engine {
         // instead of measured. Debug-level, numbers only, never frames.
         {
             let (_, ev) = irlume_liveness::detect_nod_with_evidence(&poses);
+            // Raw pitch/yaw series, for developing a better discriminator than
+            // peak-to-peak pitch (#101). Summary statistics cannot show SHAPE:
+            // a deliberate nod and a slow postural drift can reach the same
+            // range, and the difference between them lives in the trajectory.
+            // Behind its own flag rather than IRLUME_LOG, because it is a long
+            // line nobody wants in an ordinary debug capture. Pose angles only,
+            // the same class of number the line above already prints, never
+            // frames or embeddings.
+            if std::env::var("IRLUME_DUMP_POSE_SERIES").is_ok_and(|v| v == "1") {
+                let pitch: Vec<String> = poses
+                    .iter()
+                    .map(|p| p.pitch_frac.map_or("-".into(), |v| format!("{v:.4}")))
+                    .collect();
+                let yaw: Vec<String> = poses
+                    .iter()
+                    .map(|p| p.yaw_signed.map_or("-".into(), |v| format!("{v:.4}")))
+                    .collect();
+                irlume_common::dlog!("consent-series: pitch={}", pitch.join(","));
+                irlume_common::dlog!("consent-series: yaw={}", yaw.join(","));
+            }
             // Every threshold printed here comes from the evidence or a constant
             // the gate itself reads, never a restatement: `pitch_min` is carried
             // because IRLUME_NOD_PITCH_MIN can override the constant, and a line


### PR DESCRIPTION
feat: dump the raw consent pose series for gesture research

The evidence line added in #137 reports summary statistics for a consent watch,
which is what a denial needs. It cannot answer questions about SHAPE, and the
open work on both #101 and #25 is entirely about shape: whether a deliberate nod
and some other motion that reaches the same range can be told apart by their
trajectory.

Behind its own flag rather than IRLUME_LOG, because it is a long line nobody
wants in an ordinary debug capture. Pose angles only, the same class of number
the existing evidence line prints, never frames or embeddings.

This is what produced the #101 measurement. Analysing 29 windows across three
conditions showed every pitch-derived feature separating a still user from a
nodding one and every one of them overlapping a hand-held print, because a print
tilted by hand performs the rotation for real. That result is only visible from
trajectories; the summary statistics had suggested a clean separation.

It also caught a confound worth keeping: the still windows ran 16-38 frames
against the nod windows' 12-20, so total variation and any "count of fast steps"
feature were measuring duration as much as motion. Both were discarded.

#25 needs the same data for the same reason, so this ships rather than living in
a patch.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: archledger <archledger236@gmail.com>
