### PR TITLE
ci: stop the release workflows failing on a release with no assets yet

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -30,7 +30,16 @@ jobs:
       - name: Download release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets
+        # `gh release download` exits 1 on "no assets to download". A release is
+        # always published BEFORE its assets are uploaded (they are built and
+        # GPG-signed off-CI), so at publish time there are zero assets and this
+        # step failed on every release, v0.7.0 included. That red run says
+        # nothing about the release; it only says the maintainer has not
+        # uploaded yet. Tolerate the empty case and let the next step decide.
+        run: |
+          mkdir -p assets
+          gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets \
+            || echo "no assets on the release yet"
       - name: Base64 subjects for the deb + rpm
         id: hash
         working-directory: assets
@@ -51,9 +60,19 @@ jobs:
           # RPM stays listed so it is covered the day it does ship.
           shopt -s nullglob
           packages=(irlume_*.deb irlume-selinux-*.rpm)
+          everything=(*)
           shopt -u nullglob
           if [ "${#packages[@]}" -eq 0 ]; then
-            echo "::error::no release packages found; refusing to request provenance over nothing"
+            # Nothing on the release at all means the assets have not been
+            # uploaded yet, which is the normal state at publish time. Say so
+            # and stop; the maintainer re-runs this once the upload finishes.
+            # Assets present but no package among them is a different thing and
+            # stays an error, because something was uploaded wrong.
+            if [ "${#everything[@]}" -eq 0 ]; then
+              echo "::notice::no assets uploaded yet; nothing to attest, re-run after the upload"
+              exit 0
+            fi
+            echo "::error::assets are present but none is a package; refusing to request provenance over nothing"
             exit 1
           fi
           echo "covering: ${packages[*]}"
@@ -69,6 +88,10 @@ jobs:
   # referenced by tag, not SHA, per its own security model.
   provenance:
     needs: hashes
+    # Skipped when `hashes` found nothing to attest (assets not uploaded yet).
+    # Handing the generator an empty subjects blob fails it with a bare exit 27,
+    # which reads like a signing problem rather than an empty release.
+    if: needs.hashes.outputs.digests != ''
     permissions:
       actions: read # read this run's metadata for the provenance
       id-token: write # Sigstore/Fulcio keyless signing (no stored secret)

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -37,7 +37,16 @@ jobs:
       - name: Download release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets
+        # `gh release download` exits 1 on "no assets to download", which is the
+        # state every release is in at `published`: the assets are built and
+        # GPG-signed off-CI and uploaded afterwards. The steps below already
+        # treat a partial upload as "skip, not fail"; this step used to fail
+        # before they got the chance, so v0.7.0 published with a red check that
+        # meant nothing was uploaded yet. Same handling, one step earlier.
+        run: |
+          mkdir -p assets
+          gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets \
+            || echo "no assets on the release yet"
 
       - name: Skip until the signed checksums are present
         working-directory: assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to irlume are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [0.7.0] - 2026-07-28
 
 ### Added
@@ -1352,6 +1354,7 @@ is always the fallback: no lockout, ever.
   credentials).
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
+[Unreleased]: https://github.com/archledger/irlume/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/archledger/irlume/releases/tag/v0.7.0
 [0.6.1]: https://github.com/archledger/irlume/releases/tag/v0.6.1
 [0.6.0]: https://github.com/archledger/irlume/releases/tag/v0.6.0


### PR DESCRIPTION
Cutting 0.7.0 turned both release workflows red within seconds of publishing, for a reason that has nothing to do with 0.7.0.

Both start with:

```
gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets
```

That exits 1 with `no assets to download`. Every irlume release is published *before* its assets exist, because the `.deb` and the GPG-signed `SHA256SUMS` are built on a maintainer machine and uploaded afterwards. So the failure is structural, not specific to this tag:

```
2026-07-28T05:28:21.5082123Z no assets to download
2026-07-28T05:28:21.5103787Z ##[error]Process completed with exit code 1.
```

`verify-release.yml` already handled this correctly one step later; its "Skip until the signed checksums are present" step exits neutrally on a partial upload. It just never got to run. This moves the same tolerance up to the download.

For `slsa-provenance.yml` the two empty cases are now distinguished:

- no assets at all: the normal state at publish time, exits neutrally with a notice
- assets present, none of them a package: still an error, because an upload went wrong

and the generator job is skipped when there is nothing to attest, instead of receiving an empty subjects blob and failing with a bare exit 27.

Also adds a fresh empty `## [Unreleased]` above the 0.7.0 stamp with its compare link, which is the documented post-release step.

## Validation

- `yaml.safe_load` parses both workflows.
- This does not change the v0.7.0 run: those workflows execute from the tagged commit, and re-running them after the assets are uploaded succeeds because the download finds them. The fix is for every release after this one.