### PR TITLE
ci: make release verification fail on real errors, and dispatchable by tag

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -35,11 +35,22 @@ jobs:
         # GPG-signed off-CI), so at publish time there are zero assets and this
         # step failed on every release, v0.7.0 included. That red run says
         # nothing about the release; it only says the maintainer has not
-        # uploaded yet. Tolerate the empty case and let the next step decide.
+        # uploaded yet.
+        #
+        # Tolerating it with `|| echo` was too broad: a bad token, a rate limit,
+        # a network blip and a nonexistent tag were all swallowed into the same
+        # empty directory, and the job went green having attested nothing. Ask
+        # the API for the asset count and accept only a confirmed zero; a failing
+        # count query is an error, not an empty release.
         run: |
+          set -euo pipefail
           mkdir -p assets
-          gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets \
-            || echo "no assets on the release yet"
+          count=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" --jq '.assets | length')
+          if [ "$count" -gt 0 ]; then
+            gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets
+          else
+            echo "::notice::release $GITHUB_REF_NAME has no assets yet"
+          fi
       - name: Base64 subjects for the deb + rpm
         id: hash
         working-directory: assets

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -10,8 +10,15 @@ on:
   release:
     types: [published, edited]
   # Assets are GPG-signed off-CI and uploaded one at a time; a re-verify from
-  # the complete state can always be requested here.
+  # the complete state can always be requested here. The tag is REQUIRED: a
+  # dispatch carries no release context, so without it the download fell back
+  # to the branch name and tried to fetch a release called `main`.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to verify (e.g. v0.7.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -22,7 +29,7 @@ permissions:
 # training them to ignore the check. Cancelling supersedes the intermediate
 # runs (grey, no email); only the final complete state is verified.
 concurrency:
-  group: verify-release-${{ github.event.release.tag_name || github.ref }}
+  group: verify-release-${{ inputs.tag || github.event.release.tag_name || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -37,16 +44,30 @@ jobs:
       - name: Download release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
         # `gh release download` exits 1 on "no assets to download", which is the
         # state every release is in at `published`: the assets are built and
         # GPG-signed off-CI and uploaded afterwards. The steps below already
         # treat a partial upload as "skip, not fail"; this step used to fail
         # before they got the chance, so v0.7.0 published with a red check that
-        # meant nothing was uploaded yet. Same handling, one step earlier.
+        # meant nothing was uploaded yet.
+        #
+        # Tolerating that with `|| echo` was too broad: it also swallowed a bad
+        # token, a rate limit, a network blip and a tag that does not exist,
+        # each of which produced an empty directory and a GREEN no-op run. Ask
+        # the API how many assets the release has instead, and accept only a
+        # confirmed count of zero. Anything else, including the count query
+        # failing, is an error.
         run: |
+          set -euo pipefail
           mkdir -p assets
-          gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets \
-            || echo "no assets on the release yet"
+          count=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq '.assets | length')
+          if [ "$count" -eq 0 ]; then
+            echo "::notice::release $TAG has no assets yet; nothing to verify in this run"
+            echo "incomplete=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets
 
       - name: Skip until the signed checksums are present
         working-directory: assets


### PR DESCRIPTION
Two defects in the release-verification path. Both end the same way: a green run that verified nothing.

## 1. `|| echo` swallowed every error, not just the empty release

```
gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets \
  || echo "no assets on the release yet"
```

Written for the one legitimate case, a release published before its off-CI GPG-signed assets are uploaded. It also catches a bad token, a rate limit, a network blip and a tag that does not exist. Each leaves an empty directory, which the later steps read as "assets still uploading" and skip, and the job reports success.

Proved against a stubbed `gh`:

| condition | old | new |
|---|---|---|
| 0 assets (normal at publish) | exit 0, green | exit 0, skips with a notice |
| 3 assets | exit 0, downloads | exit 0, downloads |
| HTTP 401 bad credentials | **exit 0, green, nothing verified** | exit 1 |
| HTTP 404 no such tag | **exit 0, green, nothing verified** | exit 1 |

Both workflows now ask the API for the asset count and accept only a confirmed zero. A failing count query is an error rather than an empty release.

## 2. The documented manual recovery path could not verify anything

`verify-release`'s `workflow_dispatch` declared no inputs, while the download used `$GITHUB_REF_NAME`. A dispatch carries no release context, so a manual run from `main` tried to download a release named `main`. That failed, the failure was swallowed by the `|| echo` above, no `SHA256SUMS` was found, `incomplete=1` was set, verification was skipped, and the run went green. The comment promising a forced re-verify described something that could not happen.

The tag is now a required input and feeds both the download and the concurrency key.

## Provenance of these findings

Found by a Codex audit of `.github/`. Both were confirmed against the repo before any change.

**A third finding from the same audit was rejected.** It claimed that uploading an asset does not reliably fire `release: edited`, so no run is ever guaranteed to see the complete release. The event log disproves it: v0.7.0 was published at 05:28, and three runs with `event=release` fired at 05:46:11-12 during the upload window. This workflow subscribes only to `published` and `edited`, and `published` had already fired once.

A related suggestion to set `cancel-in-progress: false` was also rejected, mine rather than Codex's. The comment above that block records that it was set to `true` to stop four false failures on v0.5.0 that trained the maintainer to ignore the check, and the run history shows a successful verification starting last on v0.7.0, v0.6.1 and v0.6.0.

## Not addressed

The same audit flagged, plausibly, that several filtered test invocations in `ci.yml`, `preflight.yml` and the `hardware-suite` coverage job lack the zero-test-count assertion that `hardware-suite.yml:63-68` already uses, so a renamed test could vanish while the step still exits 0. That is a real class and a separate change; filed rather than bundled here.