### PR TITLE
feat(machine-api): publish the read-only plan phase of a login transaction

### DIFF
--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -34,6 +34,7 @@ const CAPABILITIES: &[&str] = &[
     "doctor-json",
     "login-status-json",
     "auth-test-events",
+    "login-plan-json",
 ];
 
 /// The contract the caller asked for, or the failure to report.
@@ -598,6 +599,138 @@ pub fn login_status(args: &[String]) -> ExitCode {
     )
 }
 
+/// `irlume login plan --json`: what `login enable` or `login disable` would
+/// change, without changing anything.
+///
+/// The plan phase of a login transaction. It runs the identical decision the
+/// apply path runs, with writing switched off, so a plan cannot describe an
+/// outcome the apply would not produce. Reading PAM files needs no privilege;
+/// `requires_root` says that applying does.
+///
+/// `plan_id` is a digest of the intended action and the state the plan was
+/// computed against. It exists so that a later apply can refuse a plan that no
+/// longer matches the machine, rather than silently doing something the
+/// consumer never displayed. Apply is not implemented yet, so nothing consumes
+/// the id; publishing it now means the identifier a consumer stores today is
+/// the one apply will check tomorrow.
+pub fn login_plan(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "login.plan";
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    let args = &without_contract(args);
+    let Some(action) = valid_login_plan_args(args) else {
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
+    };
+    let enable = action == "enable";
+    // Sudo and polkit are opt-in on the human command and stay opt-in here, so
+    // a plan a panel shows never quietly includes surfaces the user did not ask
+    // for. Both default off.
+    let planned = crate::pamwire::plan(enable, false, false);
+    let changes: Vec<Value> = planned
+        .iter()
+        .map(|surface| {
+            json!({
+                "surface": surface.id,
+                "role": surface.role,
+                "change": surface.change.id(),
+                "writes": surface.change.writes(),
+            })
+        })
+        .collect();
+    let writes = planned.iter().filter(|s| s.change.writes()).count();
+    emit(
+        &success(
+            COMMAND,
+            json!({
+                "plan_id": plan_id(action, &planned),
+                "action": action,
+                "changes": changes,
+                // Counted here rather than left to the consumer, so "nothing to
+                // do" is a fact the engine states instead of one a panel infers
+                // from change names it may not recognise.
+                "writes": writes,
+                "requires_root": writes > 0,
+            }),
+            contract,
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
+/// A digest of the action and the exact per-surface outcomes it was computed
+/// against.
+///
+/// Deliberately covers the outcomes rather than a timestamp or a counter: two
+/// plans over an unchanged machine share an id, and any change to what would
+/// happen produces a different one. That is the property an apply needs to
+/// decide whether the plan it was handed still describes this machine.
+fn plan_id(action: &str, planned: &[crate::pamwire::PlannedSurface]) -> String {
+    let mut material = String::from(action);
+    for surface in planned {
+        material.push('\n');
+        material.push_str(surface.id);
+        material.push(' ');
+        material.push_str(surface.change.id());
+    }
+    use sha2::{Digest as _, Sha256};
+    let digest = Sha256::digest(material.as_bytes());
+    // Half the digest. This identifies a plan for a consumer to hand back; it
+    // is not a security boundary, and apply re-derives the plan from the
+    // machine rather than trusting anything the id encodes.
+    digest.iter().take(16).map(|b| format!("{b:02x}")).collect()
+}
+
+fn valid_login_plan_args(args: &[String]) -> Option<&'static str> {
+    if args.first().map(String::as_str) != Some("login")
+        || args.get(1).map(String::as_str) != Some("plan")
+    {
+        return None;
+    }
+    let mut action: Option<&'static str> = None;
+    let mut saw_json = false;
+    let mut index = 2;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" if !saw_json => {
+                saw_json = true;
+                index += 1;
+            }
+            "--action" if action.is_none() => {
+                action = match args.get(index + 1).map(String::as_str) {
+                    Some("enable") => Some("enable"),
+                    Some("disable") => Some("disable"),
+                    _ => return None,
+                };
+                index += 2;
+            }
+            _ => return None,
+        }
+    }
+    // Both required: a plan with no stated action would have to guess whether
+    // the consumer meant to turn login on or off.
+    if saw_json {
+        action
+    } else {
+        None
+    }
+}
+
 /// An exclusive per-user session, held for as long as the guard lives.
 ///
 /// The contract promises one session per user. That is enforced with an
@@ -1026,7 +1159,8 @@ mod tests {
                 "status-json",
                 "doctor-json",
                 "login-status-json",
-                "auth-test-events"
+                "auth-test-events",
+                "login-plan-json"
             ])
         );
         assert!(document.get("error").is_none());
@@ -1115,6 +1249,110 @@ mod tests {
         assert_eq!(auth_reason(true, false), "granted");
         assert_eq!(auth_reason(false, false), "not-live");
         assert_eq!(auth_reason(false, true), "no-match");
+    }
+
+    #[test]
+    fn login_plan_requires_both_json_and_a_known_action() {
+        let a = |v: &[&str]| -> Vec<String> { v.iter().map(|s| (*s).to_string()).collect() };
+        assert_eq!(
+            valid_login_plan_args(&a(&["login", "plan", "--action", "enable", "--json"])),
+            Some("enable")
+        );
+        assert_eq!(
+            valid_login_plan_args(&a(&["login", "plan", "--json", "--action", "disable"])),
+            Some("disable")
+        );
+        // An action is mandatory: guessing whether the consumer meant on or off
+        // is the one thing a plan must never do.
+        assert_eq!(
+            valid_login_plan_args(&a(&["login", "plan", "--json"])),
+            None
+        );
+        assert_eq!(
+            valid_login_plan_args(&a(&["login", "plan", "--action", "enable"])),
+            None
+        );
+        for bad in [
+            vec!["login", "plan", "--action", "wat", "--json"],
+            vec!["login", "plan", "--action", "--json"],
+            vec!["login", "plan", "--action", "enable", "--json", "--json"],
+            vec![
+                "login", "plan", "--action", "enable", "--action", "disable", "--json",
+            ],
+            vec!["login", "plan", "--action", "enable", "--json", "--wat"],
+        ] {
+            assert_eq!(valid_login_plan_args(&a(&bad)), None, "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn a_plan_id_covers_the_action_and_the_outcomes() {
+        use crate::pamwire::{PlannedChange, PlannedSurface};
+        let surfaces = |change| {
+            vec![PlannedSurface {
+                id: "plasmalogin",
+                role: "login-screen",
+                change,
+            }]
+        };
+        let base = plan_id("enable", &surfaces(PlannedChange::Wire));
+        // Same machine, same intent: the same id, so a consumer can tell that
+        // nothing moved between showing a plan and acting on it.
+        assert_eq!(base, plan_id("enable", &surfaces(PlannedChange::Wire)));
+        // A different intent over identical state is a different plan.
+        assert_ne!(base, plan_id("disable", &surfaces(PlannedChange::Wire)));
+        // The same intent over changed state is a different plan. This is the
+        // property that lets a later apply refuse a stale one.
+        assert_ne!(
+            base,
+            plan_id("enable", &surfaces(PlannedChange::AlreadyCorrect))
+        );
+        assert_eq!(base.len(), 32);
+    }
+
+    #[test]
+    fn a_change_that_writes_is_named_as_one() {
+        use crate::pamwire::PlannedChange;
+        // requires_root is derived from these, so a new outcome landing on the
+        // wrong side would tell a panel it needs no privilege when it does.
+        for change in [
+            PlannedChange::MaterializeOverride,
+            PlannedChange::Wire,
+            PlannedChange::RemoveOverride,
+            PlannedChange::RestoreBackup,
+            PlannedChange::StripInPlace,
+        ] {
+            assert!(change.writes(), "{change:?} writes to disk");
+        }
+        for change in [
+            PlannedChange::AlreadyCorrect,
+            PlannedChange::NotInstalled,
+            PlannedChange::NoAnchor,
+            PlannedChange::NotWired,
+        ] {
+            assert!(!change.writes(), "{change:?} does not write");
+        }
+    }
+
+    #[test]
+    fn every_planned_change_has_a_distinct_stable_id() {
+        use crate::pamwire::PlannedChange;
+        let all = [
+            PlannedChange::MaterializeOverride,
+            PlannedChange::Wire,
+            PlannedChange::RemoveOverride,
+            PlannedChange::RestoreBackup,
+            PlannedChange::StripInPlace,
+            PlannedChange::AlreadyCorrect,
+            PlannedChange::NotInstalled,
+            PlannedChange::NoAnchor,
+            PlannedChange::NotWired,
+        ];
+        let ids: std::collections::BTreeSet<&str> = all.iter().map(|c| c.id()).collect();
+        assert_eq!(ids.len(), all.len(), "two outcomes share a published id");
+        for id in ids {
+            assert!(!id.is_empty() && id.chars().all(|c| c.is_ascii_lowercase() || c == '-'));
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -139,6 +139,10 @@ fn main() -> std::process::ExitCode {
         {
             machine::login_status(&args)
         }
+        // `login plan` exists only as a machine command: it is the read-only
+        // phase of a login transaction, and the human equivalent is the dry run
+        // `login enable` already prints.
+        (Some("login"), _) if args.iter().any(|a| a == "plan") => machine::login_plan(&args),
         // `auth test` exists only as a machine command, so it routes here
         // whatever flags follow and answers a bad invocation with a JSON
         // usage-error rather than prose. Bare `auth` still falls through to the

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -833,6 +833,96 @@ pub(crate) fn surface_facts() -> Vec<SurfaceFact> {
     out
 }
 
+/// Which factors this machine's hardware and configured method call for.
+///
+/// Extracted so the human `login enable` report and the machine plan derive
+/// their intent from one place. Two copies of this rule drifting apart would
+/// have the plan promise one thing and the apply do another.
+pub(crate) struct Wants {
+    /// Face releases the login credential only on the Secure (IR) tier.
+    pub(crate) face_login: bool,
+    /// Face verifies the lock screen on any camera.
+    pub(crate) face_lock: bool,
+    /// Fingerprint drives the keyring unlock.
+    pub(crate) fp_keyring: bool,
+}
+
+/// `Auto` follows the hardware; an explicit method overrides it.
+pub(crate) fn wants() -> Wants {
+    let caps = irlume_camera::capabilities();
+    let method = irlume_core::policy::method();
+    let is_fp_method = method.face_disabled(); // Method::Fingerprint
+    let is_face_method = matches!(method, irlume_core::policy::Method::Face);
+    Wants {
+        face_login: caps.ir_pair && !is_fp_method,
+        face_lock: caps.rgb && !is_fp_method,
+        fp_keyring: irlume_fingerprint::available() && !is_face_method,
+    }
+}
+
+/// One surface's planned change, for machine output.
+pub(crate) struct PlannedSurface {
+    pub(crate) id: &'static str,
+    pub(crate) role: &'static str,
+    pub(crate) change: PlannedChange,
+}
+
+/// What `login enable`/`login disable` would change, computed without writing.
+///
+/// This runs the identical decision the apply path runs, with `apply` false, so
+/// the plan cannot describe an outcome the apply would not produce. It reads
+/// PAM files and needs no privilege; only applying does.
+pub(crate) fn plan(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<PlannedSurface> {
+    let Wants {
+        face_login,
+        face_lock,
+        fp_keyring,
+    } = wants();
+    let gnome = gnome_shell_major();
+    let mut out = Vec::new();
+    let mut record =
+        |svc: &Svc, role: &'static str, wire: &dyn Fn(&str) -> (String, bool), want: bool| {
+            // A service whose decision cannot even be computed (an unreadable file)
+            // is reported as not-installed rather than omitted: a surface silently
+            // missing from a plan is how a consumer comes to believe it was covered.
+            let change = wire_service(svc, enable && want, false, wire)
+                .map(|outcome| outcome.change)
+                .unwrap_or(PlannedChange::NotInstalled);
+            out.push(PlannedSurface {
+                id: service_name(svc.etc),
+                role,
+                change,
+            });
+        };
+    for s in GREETERS {
+        let prof = dm_profile(s.etc, gnome);
+        let unified_login_lock =
+            s.etc.ends_with("/cosmic-greeter") || s.etc.ends_with("/gdm-password");
+        let face = face_login || (unified_login_lock && face_lock);
+        let greeter_wire = |c: &str| wire_greeter_impl(c, face, fp_keyring, prof.ondemand);
+        record(s, ROLE_LOGIN, &greeter_wire, face || fp_keyring);
+    }
+    for s in FP_GREETERS {
+        record(s, ROLE_LOGIN_FP, &wire_fp_keyring, fp_keyring);
+    }
+    record(&LOCKSCREEN, ROLE_LOCK, &wire_lock, face_lock);
+    if sudo_in_scope(enable, with_sudo) {
+        record(
+            &Svc {
+                etc: SUDO,
+                vendor: None,
+            },
+            ROLE_SUDO,
+            &wire_verify_service,
+            true,
+        );
+    }
+    if polkit_in_scope(enable, with_polkit) {
+        record(&POLKIT, ROLE_POLKIT, &wire_verify_service, true);
+    }
+    out
+}
+
 /// The active login manager and the PAM services it consults.
 pub(crate) struct LoginManagerFact {
     /// `None` when no login manager could be found at all: a headless host. A
@@ -942,15 +1032,11 @@ fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCod
     // factor; on disable everything is unwired.
     let caps = irlume_camera::capabilities();
     let method = irlume_core::policy::method();
-    let is_fp_method = method.face_disabled(); // Method::Fingerprint
-    let is_face_method = matches!(method, irlume_core::policy::Method::Face);
-    let fp_ready = irlume_fingerprint::available();
-    // Face releases the login credential only on the Secure (IR) tier; face
-    // verifies the lock screen on any camera; fingerprint drives the keyring
-    // unlock. `Auto` follows the hardware; an explicit method overrides.
-    let want_face_login = caps.ir_pair && !is_fp_method;
-    let want_face_lock = caps.rgb && !is_fp_method;
-    let want_fp_keyring = fp_ready && !is_face_method;
+    let Wants {
+        face_login: want_face_login,
+        face_lock: want_face_lock,
+        fp_keyring: want_fp_keyring,
+    } = wants();
     if enable {
         match active_display_manager() {
             Some(dm) => println!(
@@ -976,7 +1062,7 @@ fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCod
             onoff(want_face_lock),
             onoff(want_fp_keyring)
         );
-        if caps.rgb && !caps.ir_pair && !is_fp_method {
+        if caps.rgb && !caps.ir_pair && want_face_lock {
             println!(
                 "  (RGB-only: face satisfies the LOCK SCREEN only; login/sudo keep the password)"
             );
@@ -1113,12 +1199,86 @@ fn polkit_in_scope(enable: bool, with_polkit: bool) -> bool {
 }
 
 /// Wire (or unwire) one service, choosing override-materialize vs edit-in-place.
+/// What wiring a service would do, decided before anything is written.
+///
+/// Named outcomes rather than a rendered sentence, so the human report, the
+/// machine plan and the decision that actually writes all come from one pass.
+/// The alternative is a second implementation of the same rules for machine
+/// callers, and two copies of this logic disagreeing is how a PAM stack ends up
+/// in a state nobody chose.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum PlannedChange {
+    /// Create an irlume-owned /etc override from the vendor copy.
+    MaterializeOverride,
+    /// Write irlume lines into the admin's file, taking a backup first.
+    Wire,
+    /// Remove the irlume-owned override, restoring the vendor copy.
+    RemoveOverride,
+    /// Rename the backup back over the live file.
+    RestoreBackup,
+    /// Strip irlume lines in place, preserving edits made since wiring.
+    StripInPlace,
+    /// The file is already exactly as wiring would leave it.
+    AlreadyCorrect,
+    /// This service is not installed on this machine.
+    NotInstalled,
+    /// The file has no anchor line to wire against.
+    NoAnchor,
+    /// Not wired, and unwiring was asked for.
+    NotWired,
+}
+
+impl PlannedChange {
+    /// Whether applying this outcome would write to disk. The plan reports it
+    /// so a consumer can say "3 files change" without interpreting outcome
+    /// names it may not know.
+    pub(crate) fn writes(self) -> bool {
+        matches!(
+            self,
+            Self::MaterializeOverride
+                | Self::Wire
+                | Self::RemoveOverride
+                | Self::RestoreBackup
+                | Self::StripInPlace
+        )
+    }
+
+    /// A stable identifier for machine output. Kebab-case, never derived from
+    /// the human sentence.
+    pub(crate) fn id(self) -> &'static str {
+        match self {
+            Self::MaterializeOverride => "materialize-override",
+            Self::Wire => "wire",
+            Self::RemoveOverride => "remove-override",
+            Self::RestoreBackup => "restore-backup",
+            Self::StripInPlace => "strip-in-place",
+            Self::AlreadyCorrect => "already-correct",
+            Self::NotInstalled => "not-installed",
+            Self::NoAnchor => "no-anchor",
+            Self::NotWired => "not-wired",
+        }
+    }
+}
+
+/// The decision plus the sentence the human report prints for it.
+pub(crate) struct WireOutcome {
+    pub(crate) change: PlannedChange,
+    pub(crate) message: String,
+}
+
+impl std::fmt::Display for WireOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 fn wire_service(
     s: &Svc,
     enable: bool,
     apply: bool,
     wire: &dyn Fn(&str) -> (String, bool),
-) -> Result<String, String> {
+) -> Result<WireOutcome, String> {
+    let out = |change: PlannedChange, message: String| Ok(WireOutcome { change, message });
     let etc = Path::new(s.etc);
     // vendor-only service with no admin /etc copy → override strategy.
     let use_override = s.vendor.is_some() && (!etc.exists() || file_is_created_override(etc));
@@ -1130,7 +1290,10 @@ fn wire_service(
         if use_override {
             let vendor = s.vendor.unwrap();
             if !Path::new(vendor).exists() {
-                return Ok(format!("· {}: not installed (skipped)", s.etc));
+                return out(
+                    PlannedChange::NotInstalled,
+                    format!("· {}: not installed (skipped)", s.etc),
+                );
             }
             let (base, _) = unwire_lines(&read(vendor)?);
             let (wired, _) = wire(&base);
@@ -1138,15 +1301,24 @@ fn wire_service(
                 "{CREATED_PREFIX}{vendor}; delete this file to restore the vendor copy\n{wired}"
             );
             if etc.exists() && read(s.etc).ok().as_deref() == Some(body.as_str()) {
-                return Ok(format!("· {}: already correctly wired", s.etc));
+                return out(
+                    PlannedChange::AlreadyCorrect,
+                    format!("· {}: already correctly wired", s.etc),
+                );
             }
             if apply {
                 write_atomic(etc, &body)?;
             }
-            Ok(format!("✓ {}: materialized override from {vendor}", s.etc))
+            out(
+                PlannedChange::MaterializeOverride,
+                format!("✓ {}: materialized override from {vendor}", s.etc),
+            )
         } else {
             if !etc.exists() {
-                return Ok(format!("· {}: not installed (skipped)", s.etc));
+                return out(
+                    PlannedChange::NotInstalled,
+                    format!("· {}: not installed (skipped)", s.etc),
+                );
             }
             let current = read(s.etc)?;
             // Rebuild from the pristine stock: the backup if we've wired before,
@@ -1160,16 +1332,25 @@ fn wire_service(
             let (base, _) = unwire_lines(&origin);
             let (wired, changed) = wire(&base);
             if !changed {
-                return Ok(format!("· {}: no anchor to wire (skipped)", s.etc));
+                return out(
+                    PlannedChange::NoAnchor,
+                    format!("· {}: no anchor to wire (skipped)", s.etc),
+                );
             }
             if wired == current {
-                return Ok(format!("· {}: already correctly wired", s.etc));
+                return out(
+                    PlannedChange::AlreadyCorrect,
+                    format!("· {}: already correctly wired", s.etc),
+                );
             }
             if apply {
                 backup(etc)?;
                 write_atomic(etc, &wired)?;
             }
-            Ok(format!("✓ {}: wired (backup {}{})", s.etc, s.etc, BACKUP))
+            out(
+                PlannedChange::Wire,
+                format!("✓ {}: wired (backup {}{})", s.etc, s.etc, BACKUP),
+            )
         }
     } else {
         // disable / unwire
@@ -1177,7 +1358,10 @@ fn wire_service(
             if apply {
                 std::fs::remove_file(etc).map_err(|e| format!("rm {}: {e}", s.etc))?;
             }
-            Ok(format!("✓ {}: removed override (vendor restored)", s.etc))
+            out(
+                PlannedChange::RemoveOverride,
+                format!("✓ {}: removed override (vendor restored)", s.etc),
+            )
         } else if !use_override && etc.exists() {
             let bak = PathBuf::from(format!("{}{BACKUP}", s.etc));
             if bak.exists() {
@@ -1194,24 +1378,30 @@ fn wire_service(
                         std::fs::rename(&bak, etc)
                             .map_err(|e| format!("restore {}: {e}", s.etc))?;
                     }
-                    Ok(format!("✓ {}: restored from backup", s.etc))
+                    out(
+                        PlannedChange::RestoreBackup,
+                        format!("✓ {}: restored from backup", s.etc),
+                    )
                 } else {
                     if apply {
                         write_atomic(etc, &stripped)?;
                     }
-                    Ok(format!("✓ {}: stripped irlume lines (file changed since wiring; backup kept at {}{})", s.etc, s.etc, BACKUP))
+                    out(PlannedChange::StripInPlace, format!("✓ {}: stripped irlume lines (file changed since wiring; backup kept at {}{})", s.etc, s.etc, BACKUP))
                 }
             } else if file_has_module(etc) {
                 let (clean, _) = unwire_lines(&read(s.etc)?);
                 if apply {
                     write_atomic(etc, &clean)?;
                 }
-                Ok(format!("✓ {}: stripped irlume lines", s.etc))
+                out(
+                    PlannedChange::StripInPlace,
+                    format!("✓ {}: stripped irlume lines", s.etc),
+                )
             } else {
-                Ok(format!("· {}: not wired", s.etc))
+                out(PlannedChange::NotWired, format!("· {}: not wired", s.etc))
             }
         } else {
-            Ok(format!("· {}: not wired", s.etc))
+            out(PlannedChange::NotWired, format!("· {}: not wired", s.etc))
         }
     }
 }
@@ -2058,7 +2248,7 @@ mod tests {
             vendor: None,
         };
         let msg = wire_service(&svc, false, true, &wire_verify_service).unwrap();
-        assert!(msg.contains("stripped irlume lines"), "{msg}");
+        assert!(msg.message.contains("stripped irlume lines"), "{msg}");
         let after = std::fs::read_to_string(&etc).unwrap();
         assert!(
             after.contains(admin_line),
@@ -2086,7 +2276,7 @@ mod tests {
             vendor: None,
         };
         let msg = wire_service(&svc, false, true, &wire_verify_service).unwrap();
-        assert!(msg.contains("restored from backup"), "{msg}");
+        assert!(msg.message.contains("restored from backup"), "{msg}");
         assert_eq!(std::fs::read_to_string(&etc).unwrap(), SUDO_STOCK);
         assert!(!dir.0.join(format!("sudo{BACKUP}")).exists());
     }
@@ -2528,7 +2718,7 @@ mod tests {
 
         // First enable → materialize the override from the vendor copy.
         let msg = wire_service(&svc, true, true, &wire).unwrap();
-        assert!(msg.contains("materialized override from"), "{msg}");
+        assert!(msg.message.contains("materialized override from"), "{msg}");
         assert!(etc.exists());
         let body = std::fs::read_to_string(&etc).unwrap();
         assert!(body.starts_with(CREATED_PREFIX));
@@ -2537,11 +2727,11 @@ mod tests {
 
         // Re-enable with the same inputs → recognised as already correct.
         let msg2 = wire_service(&svc, true, true, &wire).unwrap();
-        assert!(msg2.contains("already correctly wired"), "{msg2}");
+        assert!(msg2.message.contains("already correctly wired"), "{msg2}");
 
         // Disable → the created override is removed and the vendor copy restored.
         let msg3 = wire_service(&svc, false, true, &wire).unwrap();
-        assert!(msg3.contains("removed override"), "{msg3}");
+        assert!(msg3.message.contains("removed override"), "{msg3}");
         assert!(!etc.exists());
     }
 
@@ -2556,7 +2746,7 @@ mod tests {
         };
         let wire = |c: &str| wire_greeter_impl(c, true, false, true);
         let msg = wire_service(&svc, true, true, &wire).unwrap();
-        assert!(msg.contains("not installed (skipped)"), "{msg}");
+        assert!(msg.message.contains("not installed (skipped)"), "{msg}");
         assert!(!etc.exists());
     }
 
@@ -2572,7 +2762,7 @@ mod tests {
             vendor: None,
         };
         let msg = wire_service(&svc, true, true, &wire).unwrap();
-        assert!(msg.contains("not installed (skipped)"), "{msg}");
+        assert!(msg.message.contains("not installed (skipped)"), "{msg}");
 
         // Present but nothing to anchor to → skipped, no backup left behind.
         let dir2 = TestDir::new("wsvc-noanchor");
@@ -2583,7 +2773,7 @@ mod tests {
             vendor: None,
         };
         let msg2 = wire_service(&svc2, true, true, &wire).unwrap();
-        assert!(msg2.contains("no anchor to wire"), "{msg2}");
+        assert!(msg2.message.contains("no anchor to wire"), "{msg2}");
         assert!(!dir2.0.join(format!("greeter{BACKUP}")).exists());
     }
 
@@ -2599,14 +2789,14 @@ mod tests {
         let wire = |c: &str| wire_greeter_impl(c, true, true, false);
 
         let msg = wire_service(&svc, true, true, &wire).unwrap();
-        assert!(msg.contains("wired (backup"), "{msg}");
+        assert!(msg.message.contains("wired (backup"), "{msg}");
         assert!(dir.0.join(format!("gdm-password{BACKUP}")).exists());
         let after = std::fs::read_to_string(&etc).unwrap();
         assert!(content_has_module(&after));
 
         // Second identical enable is a recognised no-op (rebuilt from backup).
         let msg2 = wire_service(&svc, true, true, &wire).unwrap();
-        assert!(msg2.contains("already correctly wired"), "{msg2}");
+        assert!(msg2.message.contains("already correctly wired"), "{msg2}");
     }
 
     #[test]
@@ -2622,8 +2812,8 @@ mod tests {
         };
         let wire = |c: &str| wire_greeter_impl(c, true, true, false);
         let msg = wire_service(&svc, false, true, &wire).unwrap();
-        assert!(msg.contains("stripped irlume lines"), "{msg}");
-        assert!(!msg.contains("backup kept")); // the no-backup phrasing
+        assert!(msg.message.contains("stripped irlume lines"), "{msg}");
+        assert!(!msg.message.contains("backup kept")); // the no-backup phrasing
         let after = std::fs::read_to_string(&etc).unwrap();
         assert!(!content_has_module(&after));
     }
@@ -2639,6 +2829,6 @@ mod tests {
         };
         let wire = |c: &str| wire_greeter_impl(c, true, true, false);
         let msg = wire_service(&svc, false, true, &wire).unwrap();
-        assert!(msg.contains("not wired"), "{msg}");
+        assert!(msg.message.contains("not wired"), "{msg}");
     }
 }

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -29,7 +29,8 @@ fn version_json_is_one_machine_document() {
             "status-json",
             "doctor-json",
             "login-status-json",
-            "auth-test-events"
+            "auth-test-events",
+            "login-plan-json"
         ])
     );
 }

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -406,6 +406,59 @@ Stream lines validate against `$defs/event` in the schema, not against the
 document root. `schemas/fixtures/v1/auth-test-events.ndjson` is a capture from a
 real engine.
 
+### `irlume login plan --action {enable|disable} --json`
+
+Capability: `login-plan-json`.
+
+The plan phase of a login transaction: what `login enable` or `login disable`
+would change, without changing anything.
+
+```json
+{
+  "plan_id": "c574f96dba23c06bbb2e2f395a74f074",
+  "action": "disable",
+  "changes": [
+    { "surface": "plasmalogin", "role": "login-screen", "change": "restore-backup", "writes": true },
+    { "surface": "kde", "role": "lock-screen", "change": "restore-backup", "writes": true },
+    { "surface": "gdm-password", "role": "login-screen", "change": "not-installed", "writes": false }
+  ],
+  "writes": 4,
+  "requires_root": true
+}
+```
+
+This runs the identical decision the apply path runs, with writing switched off,
+so a plan cannot describe an outcome the apply would not produce. Reading the PAM
+stack needs no privilege; `requires_root` says whether applying would.
+
+Every surface irlume can wire appears, including absent ones, so a consumer
+reading an id it knows and cannot find learns "this engine does not wire that
+service" rather than "not wired here". Surfaces are named by PAM service, never
+by path, in keeping with the no-paths rule.
+
+`change` is one of `wire`, `materialize-override`, `restore-backup`,
+`remove-override`, `strip-in-place`, `already-correct`, `not-installed`,
+`no-anchor`, `not-wired`. `writes` on a change says whether applying it would
+touch disk, and the top-level `writes` counts them, so "nothing to do" is a fact
+the engine states rather than one a consumer infers from outcome names it may
+not recognise.
+
+`plan_id` is a digest of the action and the exact per-surface outcomes it was
+computed against. Two plans over an unchanged machine share an id; any change to
+what would happen produces a different one. It exists so that a later apply can
+refuse a plan that no longer matches the machine rather than silently doing
+something the consumer never displayed. It is an identifier, not a security
+boundary: apply will re-derive the plan from the machine rather than trusting
+anything the id encodes.
+
+Sudo and polkit are opt-in on the human command and are not included in a plan,
+so a panel never shows a user surfaces they did not ask for. Disabling still
+covers every surface, because turning login off leaves nothing behind.
+
+**Applying a plan is not implemented yet.** `login apply`, `login verify` and
+`login rollback` are not part of contract 1 and must not be inferred from this
+command or from human output.
+
 ## Security and privacy
 
 Ordinary JSON output never includes camera frames, embeddings, templates,
@@ -419,4 +472,5 @@ from human output or the private socket protocol:
 - preview images and cancellation semantics;
 - profile or scan mutation;
 - camera configuration mutation;
-- login plan, apply, verify, or rollback transactions.
+- login apply, verify, or rollback transactions (the read-only plan phase is
+  published above).

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -418,14 +418,20 @@ would change, without changing anything.
   "plan_id": "c574f96dba23c06bbb2e2f395a74f074",
   "action": "disable",
   "changes": [
+    { "surface": "gdm-password", "role": "login-screen", "change": "not-installed", "writes": false },
     { "surface": "plasmalogin", "role": "login-screen", "change": "restore-backup", "writes": true },
     { "surface": "kde", "role": "lock-screen", "change": "restore-backup", "writes": true },
-    { "surface": "gdm-password", "role": "login-screen", "change": "not-installed", "writes": false }
+    { "surface": "sudo", "role": "sudo", "change": "restore-backup", "writes": true },
+    { "surface": "polkit-1", "role": "polkit", "change": "remove-override", "writes": true }
   ],
   "writes": 4,
   "requires_root": true
 }
 ```
+
+Absent surfaces are trimmed from this example for length; a real document lists
+every one. The top-level `writes` always equals the number of entries whose own
+`writes` is true.
 
 This runs the identical decision the apply path runs, with writing switched off,
 so a plan cannot describe an outcome the apply would not produce. Reading the PAM

--- a/scripts/machine-api-conformance.py
+++ b/scripts/machine-api-conformance.py
@@ -39,6 +39,7 @@ CAPABILITY_COMMANDS = {
     "doctor-json": ["doctor", "--json"],
     "profiles-list-json": ["profiles", "list", "--json"],
     "login-status-json": ["login", "status", "--json"],
+    "login-plan-json": ["login", "plan", "--action", "enable", "--json"],
 }
 
 # Streaming capabilities operate the camera, so invoking them here would need


### PR DESCRIPTION
Stacked on #175 — review that first; this diff shows only its own commit once #175 merges. Refs #108.

Second of the three surfaces left in #108. The login transaction has four phases: plan, apply, verify, rollback. **This PR is the read-only half.** Apply and rollback write PAM stacks, where #154 and #165 were both real defects, so they arrive in a diff where they are the only thing to review.

## What this adds

`irlume login plan --action {enable|disable} --json`, under `login-plan-json`:

```json
{
  "plan_id": "c574f96dba23c06bbb2e2f395a74f074",
  "action": "disable",
  "changes": [
    { "surface": "plasmalogin", "role": "login-screen", "change": "restore-backup", "writes": true },
    { "surface": "gdm-password", "role": "login-screen", "change": "not-installed", "writes": false }
  ],
  "writes": 4,
  "requires_root": true
}
```

## The design decision worth reviewing

`wire_service` now returns **what it decided** alongside the sentence it prints, rather than a sentence alone. The plan calls that same function with writing switched off, so a plan cannot describe an outcome the apply would not produce.

The alternative was a second implementation of the same rules for machine callers. Two copies of that logic disagreeing is how a PAM stack ends up in a state nobody chose — and it is the shape of the bugs this file has already had. The want computation moved into `wants()` for the same reason, so the human report and the plan read their intent from one place.

**The refactor is behaviour-preserving.** The human dry run prints identical lines, verified against the same machine, and the 765 existing tests pass unchanged.

## plan_id

A digest of the action and the exact per-surface outcomes it was computed against. Two plans over an unchanged machine share an id; any change to what would happen produces a different one. That is the property a later apply needs to refuse a plan that no longer matches the machine, rather than silently doing something the consumer never displayed.

Apply does not exist yet. Publishing the id now means the identifier a consumer stores today is the one apply will check tomorrow. It is an identifier, not a security boundary: apply will re-derive the plan from the machine rather than trust anything the id encodes.

## Smaller decisions

- Every wirable surface appears, including absent ones, so a consumer reading an id it knows and cannot find learns "this engine does not wire that service" rather than "not wired here".
- Surfaces are named by PAM service, never by path, keeping the no-paths rule. Verified against the conformance script's forbidden-substring check.
- Sudo and polkit stay opt-in and are excluded from a plan, so a panel never shows a user surfaces they did not ask for. Disable still covers everything, because turning login off leaves nothing behind.
- `writes` is counted by the engine so "nothing to do" is a fact it states, not one a consumer infers from outcome names it may not recognise.
- A surface whose decision cannot be computed is reported as `not-installed` rather than omitted: a surface silently missing from a plan is how a consumer comes to believe it was covered.

## Validation

- 769 workspace tests pass, clippy and `cargo fmt --check` clean
- conformance 28 passed, 0 failed, **0 skipped** — the capability is mapped, so it is not silently skipped
- exercised on real hardware: `enable` reports 0 writes and `requires_root: false` on an already-wired machine, `disable` reports 4 writes and `requires_root: true`, `plan_id` is stable across runs and differs per action, and **nothing was written**
- the human dry run and the machine plan agree surface by surface

## Not included

`login apply`, `login verify` and `login rollback`. `docs/MACHINE-API.md` still lists them as outside contract 1 so nothing can be inferred from this command.
