### PR TITLE
fix: six checks that reported success having checked nothing

### DIFF
--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -93,10 +93,25 @@ jobs:
             echo "::error::irlume doctor failed — not a clean camera-absent skip"
             cat "$doc"; exit 1
           fi
+          # An empty result has two very different causes, and reading both as
+          # "no camera" turned a classifier or doctor-format regression into a
+          # clean skip on the ONLY lane with a real camera. Tell them apart by
+          # asking whether doctor classified ANY node: none at all is a genuine
+          # absent-camera skip, while nodes present with no Ir among them is a
+          # regression on a runner that is supposed to have one.
+          if ! grep -q "camera nodes (classified by pixel format)" "$doc"; then
+            echo "::error::doctor produced no camera-nodes section — its output format changed"
+            cat "$doc"; exit 1
+          fi
+          nodes=$(awk '/camera nodes \(classified by pixel format\)/{f=1;next} f&&/^  \/dev\//{n++} f&&!/^  /{f=0} END{print n+0}' "$doc")
           ir=$(awk -F: '/: Ir$/{print $1}' "$doc" | tr -d " " | head -1)
           if [ -z "$ir" ]; then
-            echo "::notice::no IR camera present — camera stage skipped (borrowed for the OS bench?)"
-            exit 0
+            if [ "$nodes" -eq 0 ]; then
+              echo "::notice::no camera nodes at all — camera stage skipped (borrowed for the OS bench?)"
+              exit 0
+            fi
+            echo "::error::doctor classified $nodes camera node(s) but none as Ir on a runner that has one"
+            cat "$doc"; exit 1
           fi
           echo "IR node: $ir"
           out=$(mktemp -d)

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -9,8 +9,27 @@ name: SLSA release provenance
 on:
   release:
     types: [published]
+  # A release is published BEFORE its assets are uploaded: they are built and
+  # GPG-signed off-CI, and GitHub has no asset-upload event. So the automatic
+  # run always fires against a release with nothing on it, goes green having
+  # attested nothing, and there was no way to ask for it again. Provenance for
+  # every release published so far is therefore missing. The tag is REQUIRED,
+  # matching verify-release: a dispatch carries no release context, so
+  # github.ref_name would be the branch and the download would look for a
+  # release called `main`.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to attest (e.g. v0.7.1), after its assets are uploaded"
+        required: true
+        type: string
 
 permissions: read-all
+
+env:
+  # The one place the tag is resolved. Every step reads this rather than
+  # github.ref_name, which is only correct on the release trigger.
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   # Collect the sha256 of the release's distributable artifacts into the
@@ -19,7 +38,7 @@ jobs:
     # Version releases only. The model-weights release (`models-v1`) carries
     # .onnx files and no packages, so it has nothing for this workflow to
     # attest; it used to run anyway and fail in the generator's final step.
-    if: startsWith(github.ref_name, 'v')
+    if: startsWith(inputs.tag || github.ref_name, 'v')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -45,11 +64,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p assets
-          count=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" --jq '.assets | length')
+          count=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.assets | length')
           if [ "$count" -gt 0 ]; then
-            gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir assets
+            gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --dir assets
           else
-            echo "::notice::release $GITHUB_REF_NAME has no assets yet"
+            echo "::notice::release $RELEASE_TAG has no assets yet"
           fi
       - name: Base64 subjects for the deb + rpm
         id: hash

--- a/schemas/fixtures/v1/version.json
+++ b/schemas/fixtures/v1/version.json
@@ -1,1 +1,1 @@
-{"contract_version":1,"engine_version":"0.7.0","command":"version","ok":true,"data":{"capabilities":["version-json","profiles-list-json","status-json","doctor-json","login-status-json"],"contract_versions":{"max":1,"min":1},"limits":{"max_profiles":3}}}
+{"contract_version":1,"engine_version":"0.7.1","command":"version","ok":true,"data":{"capabilities":["version-json","profiles-list-json","status-json","doctor-json","login-status-json","auth-test-events","login-plan-json"],"contract_versions":{"max":1,"min":1},"limits":{"max_profiles":3}}}

--- a/scripts/capture-machine-fixtures.py
+++ b/scripts/capture-machine-fixtures.py
@@ -30,6 +30,33 @@ import sys
 
 UNREACHABLE_SOCKET = "/nonexistent/irlume-fixture-capture.sock"
 
+# What each fixture is supposed to be: "ok", or the error code it must carry.
+# Kept beside the capture list rather than derived from it, so a command that
+# starts failing is caught instead of quietly redefining the fixture.
+# Field values a fixture must carry to be the fixture it claims to be. Without
+# this, status-daemon-unreachable.json and status-daemon-running.json are both
+# just "an ok status document" and a capture run with the daemon up would
+# silently record two identical fixtures.
+REQUIRED_FIELDS = {
+    "status-daemon-running.json": [(("data", "daemon"), "running")],
+    "status-daemon-unreachable.json": [(("data", "daemon"), "unreachable")],
+}
+
+EXPECTED = {
+    "version.json": "ok",
+    "status-daemon-running.json": "ok",
+    # status reports daemon state as data rather than failing, so this is an
+    # ok document. What distinguishes it from status-daemon-running.json is
+    # data.daemon, asserted below.
+    "status-daemon-unreachable.json": "ok",
+    "doctor.json": "ok",
+    "login-status.json": "ok",
+    "profiles-list.json": "ok",
+    "error-daemon-unavailable.json": "daemon-unavailable",
+    "error-unsupported-contract.json": "unsupported-contract",
+    "error-usage-error.json": "usage-error",
+}
+
 
 def run(binary, argv, env_extra=None):
     env = dict(os.environ)
@@ -38,7 +65,11 @@ def run(binary, argv, env_extra=None):
     proc = subprocess.run([binary] + argv, capture_output=True, text=True, env=env, timeout=180)
     if proc.stderr:
         print(f"warning: {' '.join(argv)} wrote to stderr: {proc.stderr.strip()}", file=sys.stderr)
-    return proc.stdout
+    # The exit status is returned, not dropped. A fixture is a claim about what
+    # this engine writes, and a capture that silently recorded a failed command
+    # would make the conformance suite validate against a document the engine
+    # only produces when something is wrong.
+    return proc
 
 
 def redact_profiles(raw):
@@ -82,16 +113,56 @@ def main():
         ("error-usage-error.json", ["version", "--json", "--no-such-flag"], None, None),
     ]
 
+    failures = []
     for name, argv, env_extra, transform in captures:
-        raw = run(args.irlume, argv, env_extra)
+        proc = run(args.irlume, argv, env_extra)
+        raw = proc.stdout
+        expected = EXPECTED[name]
+        try:
+            document = json.loads(raw)
+        except json.JSONDecodeError as error:
+            failures.append(f"{name}: output is not JSON ({error}); fixture NOT written")
+            continue
+        # What the fixture is supposed to be, asserted before it is written.
+        # Valid JSON is not enough: an error document is valid JSON, and
+        # overwriting an ok fixture with one would leave the conformance suite
+        # validating the wrong shape while still reporting success.
+        actual = "ok" if document.get("ok") else document.get("error", {}).get("code")
+        if actual != expected:
+            failures.append(
+                f"{name}: expected {expected!r}, got {actual!r}; fixture NOT written"
+            )
+            continue
+        # An ok document must come from a command that succeeded, and an error
+        # document from one that did not.
+        if (expected == "ok") != (proc.returncode == 0):
+            failures.append(
+                f"{name}: {expected!r} document with exit {proc.returncode}; fixture NOT written"
+            )
+            continue
+        mismatched = None
+        for path_parts, want in REQUIRED_FIELDS.get(name, []):
+            node = document
+            for part in path_parts:
+                node = node.get(part) if isinstance(node, dict) else None
+            if node != want:
+                mismatched = f"{'.'.join(path_parts)} is {node!r}, expected {want!r}"
+                break
+        if mismatched:
+            failures.append(f"{name}: {mismatched}; fixture NOT written")
+            continue
         if transform is not None:
             raw = transform(raw)
         path = os.path.join(args.out, name)
         with open(path, "w", encoding="utf-8") as handle:
             handle.write(raw)
-        document = json.loads(raw)
-        state = "ok" if document.get("ok") else document.get("error", {}).get("code")
-        print(f"{name}: {document.get('command')} ({state})")
+        print(f"{name}: {document.get('command')} ({actual})")
+
+    if failures:
+        print("\nnot captured:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
 
     print(
         "\nCaptured. Read the diff before committing: a fixture is a claim about "

--- a/scripts/deploy-keyring-unlock.sh
+++ b/scripts/deploy-keyring-unlock.sh
@@ -83,6 +83,7 @@ echo "=== 4/5 wire plasmalogin greeter (face → KWallet unlock) ==="
 if [[ -f "$PAM_GREETER" ]] && grep -q "pam_irlume.so unseal" "$PAM_GREETER"; then
     echo "    already wired; skipping"
 else
+    staged=$(mktemp)
     {
         echo "$MARKER"
         awk '
@@ -115,8 +116,26 @@ else
             }
             { print }
         ' "$VENDOR_GREETER"
-    } > "$PAM_GREETER"
-    chmod 644 "$PAM_GREETER"
+    } > "$staged"
+
+    # Both transforms above are anchored to a specific vendor line. If neither
+    # anchor is present, awk copies the file through unchanged and every
+    # variable stays unset, so the result is a PAM file carrying the marker and
+    # NO face line, written over the live stack and reported as success. Staging
+    # first means a stack that could not be wired is never written at all,
+    # rather than written wrong and then detected.
+    missing=()
+    grep -q "pam_irlume.so unseal" "$staged" || missing+=("auth unseal")
+    grep -q "^auth[[:space:]]*optional[[:space:]]*pam_irlume.so reseal" "$staged" || missing+=("auth reseal")
+    grep -q "^session[[:space:]]*optional[[:space:]]*pam_irlume.so reseal" "$staged" || missing+=("session reseal")
+    if (( ${#missing[@]} )); then
+        echo "    ERROR: $VENDOR_GREETER has no anchor for: ${missing[*]}" >&2
+        echo "    $PAM_GREETER left untouched; nothing was written." >&2
+        rm -f "$staged"
+        exit 1
+    fi
+    install -m 644 "$staged" "$PAM_GREETER"
+    rm -f "$staged"
     echo "    wrote $PAM_GREETER:"
     grep -nE "pam_irlume|password-auth|kwallet|gnome_keyring" "$PAM_GREETER" | sed 's/^/      /'
 fi

--- a/scripts/machine-api-conformance.py
+++ b/scripts/machine-api-conformance.py
@@ -513,11 +513,10 @@ def main():
     # result from a check that never ran. An empty capability list produces the
     # same thing by a different route, since the per-capability loop simply has
     # nothing to iterate.
-    if results.passed == 0:
+    if results.passed == 0 and not results.skipped:
         print(
-            "nothing was checked, so nothing passed: this is a failure, not a clean run.\n"
-            "  --no-engine and --no-fixtures cannot both be given, and an engine that\n"
-            "  advertises no capabilities has nothing to verify.",
+            "nothing was attempted, so nothing passed: this is a failure, not a clean run.\n"
+            "  --no-engine and --no-fixtures cannot both be given.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/machine-api-conformance.py
+++ b/scripts/machine-api-conformance.py
@@ -254,6 +254,15 @@ def check_engine(results, binary, validate, validate_note):
 
     data = document.get("data", {})
     capabilities = data.get("capabilities", [])
+    # An engine that advertises nothing gives the per-capability loop below
+    # nothing to iterate, so every capability check silently does not happen and
+    # the run still ends green. Contract 1 requires version-json at minimum, so
+    # an empty list is a broken engine rather than a modest one.
+    if not capabilities:
+        results.fail(
+            "advertised capabilities",
+            "the engine advertises no capabilities, so no capability was checked",
+        )
     versions = data.get("contract_versions", {})
     if versions.get("min", 0) <= CONTRACT <= versions.get("max", 0):
         results.ok(f"engine speaks contract {CONTRACT} (range {versions.get('min')}-{versions.get('max')})")
@@ -497,6 +506,20 @@ def main():
         print("failures:")
         for what, detail in results.failed:
             print(f"  {what}: {detail}")
+        return 1
+    # A run that checked nothing is not a pass. `--no-engine --no-fixtures`
+    # disables both halves and used to print "0 passed, 0 failed" and exit 0,
+    # which is the exact shape this script exists to catch elsewhere: a green
+    # result from a check that never ran. An empty capability list produces the
+    # same thing by a different route, since the per-capability loop simply has
+    # nothing to iterate.
+    if results.passed == 0:
+        print(
+            "nothing was checked, so nothing passed: this is a failure, not a clean run.\n"
+            "  --no-engine and --no-fixtures cannot both be given, and an engine that\n"
+            "  advertises no capabilities has nothing to verify.",
+            file=sys.stderr,
+        )
         return 1
     return 0
 

--- a/scripts/timing-report.py
+++ b/scripts/timing-report.py
@@ -74,7 +74,18 @@ def analyze_log(log_path):
     if overlaps:
         print(f"average overlap:    {sum(overlaps) / len(overlaps):.2f}ms")
         print(f"average sequential: {sum(sequentials) / len(sequentials):.2f}ms")
-    return 0
+        return 0
+    # This report exists to compare RGB against IR, and zip() over an empty
+    # side iterates zero times, so a log with samples from only one spectrum
+    # produced no pair at all and still exited 0. The earlier guard used AND, so
+    # it only caught a log with nothing in it. Producing no pair statistics is
+    # the failure this is asked to detect, whichever side is missing.
+    print(
+        f"no pairs to compare: {len(rgb_times)} rgb and {len(ir_times)} ir samples, "
+        "so no overlap or sequential figure was produced",
+        file=sys.stderr,
+    )
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #161, #162, #163, #164, #165, #166.

One theme in six places: a check whose zero-match, zero-iteration or zero-sample case is indistinguishable from a clean pass. All six were filed and verified earlier; I re-checked each against the current tip before touching it, and every one still reproduced.

**Each fix was proved by reproducing the failure first**, not by inspection.

## The six

**#163 — the verifier could verify nothing.** `machine-api-conformance.py --no-engine --no-fixtures` printed `0 passed, 0 failed, 0 skipped` and exited 0. An engine advertising no capabilities reached the same place by a different route, since the per-capability loop simply had nothing to iterate. A run that checked nothing is now a failure, and an empty capability list is reported.

This is the script whose whole purpose is catching this shape elsewhere.

```
before:  --no-engine --no-fixtures  ->  exit 0
after:   --no-engine --no-fixtures  ->  exit 1
         a real run                 ->  exit 0   (unchanged)
```

**#164 — fixtures could be overwritten with error documents.** `run()` discarded `returncode` and the loop accepted any valid JSON. Each fixture now declares what it must be, and one that does not match is refused rather than written.

That check immediately caught a wrong expectation of my own: `status --json` reports an unreachable daemon as an **ok** document carrying `data.daemon`, not as an error. So the two status fixtures are now distinguished by a required field rather than by `ok` alone — without that they are both just "an ok status document", and a capture run with the daemon up would silently record two identical fixtures.

```
stub engine that errors on everything  ->  exit 1, 0 files written
real engine                            ->  exit 0, 9 files written
```

**#161 — SLSA could never attest a release's assets.** Assets are uploaded after publish and GitHub has no asset-upload event, so the automatic run always fired against an empty release, went green attesting nothing, and could not be re-run. Provenance for every release so far is therefore missing. Adds `workflow_dispatch` with a **required** tag, matching what `verify-release` got in #157, and resolves the tag in one place because `github.ref_name` is the branch on a dispatch.

**#162 — a camera regression read as a clean skip.** An empty classification result meant either "no IR camera" or "the classifier or doctor's output format regressed", on the only lane with real hardware. Now distinguished: no classified nodes at all is a genuine skip; nodes present with none classified `Ir` is an error.

Verified against real `doctor` output: 2 nodes normally, 2 nodes with none `Ir` after simulating a classifier regression (must fail), 0 nodes with the camera absent (must skip).

**#165 — a PAM file written with no face line, reported as success.** Worse than filed: the `>` redirection truncated the live greeter stack *before* anything was verified, so a vendor file without the expected anchor was copied through unchanged and the result carried the marker and no face line. It now stages the output and installs only when all three face lines are present, so a stack that cannot be wired is never written at all.

```
vendor with the anchor    ->  written, face lines present
vendor without it         ->  exit 1, target still untouched
```

**#166 — one-sided samples exited 0.** The guard used AND, so it only caught a log with nothing in it, and `zip()` over an empty side iterates zero times. Producing no pair statistics is now the failure it is asked to detect, whichever side is missing.

```
rgb-only log  ->  exit 1     both  ->  exit 0     empty  ->  exit 1
```

## Also

`schemas/fixtures/v1/version.json` was captured from 0.7.0 and still advertised five capabilities after `auth-test-events` and `login-plan-json` shipped — an oversight in my own earlier PRs, found by the #164 fix. Refreshed. The machine-dependent fixtures are deliberately left alone rather than rewritten with this machine's state.

## Validation

- 769 workspace tests pass; conformance 28 passed, 0 failed, **0 skipped**
- every workflow and Python file parses; `shellcheck` findings on `deploy-keyring-unlock.sh` unchanged at 4, all pre-existing and info-level
- the A/B for each fix is shown above; none rests on reading the code
