### PR TITLE
feat(machine-api): apply, verify and roll back a login transaction

### DIFF
--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -399,10 +399,22 @@ pub(crate) fn note_rollback_progress(id: &str, done: &[String]) -> Result<(), St
 }
 
 /// Drop the note once every surface is back.
-pub(crate) fn clear_rollback_progress(id: &str) {
-    if let Some(path) = progress_path(id) {
-        let _ = std::fs::remove_file(path);
+///
+/// Durably, and reported. Discarding the outcome meant a note could survive the
+/// success that should have removed it: a power loss after the report resurrects
+/// it, and the NEXT rollback trusts it and skips those files without checking
+/// them. If an administrator changed a restored stack in between, that rollback
+/// would report success having left the change untouched.
+pub(crate) fn clear_rollback_progress(id: &str) -> Result<(), String> {
+    let Some(path) = progress_path(id) else {
+        return Ok(());
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("remove {}: {e}", path.display())),
     }
+    fsync_dir(&store_dir())
 }
 
 /// How a surface's backup is named in the progress note.
@@ -480,6 +492,11 @@ pub(crate) fn snapshot_before_rollback(record: &Transaction) -> Result<PathBuf, 
                         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
                         Err(e) => return Err(format!("write {}: {e}", dest.display())),
                     }
+                    // The link and the temp's removal are directory changes, and
+                    // the rollback that follows destroys what was just copied. A
+                    // snapshot that does not survive the power loss it exists for
+                    // is not a snapshot.
+                    fsync_dir(&dir)?;
                 }
                 // Absent is a state worth knowing about, but there is nothing to
                 // copy and a rollback that recreates the file destroys nothing.
@@ -817,7 +834,7 @@ mod tests {
         assert!(rollback_progress(&id).is_empty());
         note_rollback_progress(&id, &["kde".to_string()]).expect("note");
         assert_eq!(rollback_progress(&id), vec!["kde".to_string()]);
-        clear_rollback_progress(&id);
+        clear_rollback_progress(&id).expect("clear");
         assert!(rollback_progress(&id).is_empty());
 
         // An unreadable note means "no progress", never "all done": redoing a
@@ -830,7 +847,7 @@ mod tests {
         // An id that is not plain hex never becomes a path.
         assert!(note_rollback_progress("../../etc/passwd", &[]).is_err());
         assert!(rollback_progress("../../etc/passwd").is_empty());
-        clear_rollback_progress(&id);
+        clear_rollback_progress(&id).expect("clear");
 
         // A surface is TWO writes, so it is two entries. Noting it only once
         // both landed left a crash between them unresumable at a finer

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -66,6 +66,16 @@ pub(crate) struct SurfaceRecord {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct Transaction {
     pub(crate) id: String,
+    /// How far this transaction got.
+    ///
+    /// A record is written `Prepared` BEFORE the first PAM write and rewritten
+    /// `Applied` afterwards. A record left `Prepared` therefore means the writes
+    /// may have run partially and nothing confirmed them: its before-states are
+    /// still the authority for a rollback, but its after-digests are not, so
+    /// rollback must not gate on them. Defaulted for records written by an
+    /// engine that predates the field.
+    #[serde(default)]
+    pub(crate) status: TransactionStatus,
     /// `enable` or `disable`.
     pub(crate) action: String,
     /// The plan this was applied from, so a consumer can tie the two together.
@@ -74,6 +84,19 @@ pub(crate) struct Transaction {
     /// is still readable, but the difference is worth surfacing.
     pub(crate) engine_version: String,
     pub(crate) surfaces: Vec<SurfaceRecord>,
+}
+
+/// How far a transaction got before the process stopped writing.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum TransactionStatus {
+    /// Before-states captured and persisted; the writes have not been confirmed.
+    /// A record found in this state after the process exited means a crash, a
+    /// full disk, or a kill landed mid-apply.
+    #[default]
+    Prepared,
+    /// Every surface was written and its after-state recorded.
+    Applied,
 }
 
 /// Hex sha256 of a byte slice.
@@ -274,6 +297,7 @@ mod tests {
         unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
         let tx = Transaction {
             id: "0123456789abcdef0123456789abcdef".into(),
+            status: TransactionStatus::Applied,
             action: "enable".into(),
             plan_id: "aaaabbbbccccddddaaaabbbbccccdddd".into(),
             engine_version: "0.0.0".into(),
@@ -299,6 +323,7 @@ mod tests {
         unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
         let tx = Transaction {
             id: "ffffffffffffffffffffffffffffffff".into(),
+            status: TransactionStatus::Applied,
             action: "disable".into(),
             plan_id: "0".repeat(32),
             engine_version: "0.0.0".into(),

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -116,7 +116,23 @@ impl Transaction {
         restrict(&dir, 0o700)?;
         let path = dir.join(format!("{}.json", self.id));
         let body = serde_json::to_string(self).map_err(|e| format!("serialize record: {e}"))?;
-        std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))?;
+        // Created 0600 rather than created-then-chmodded. Between a default-mode
+        // create and a later chmod there is a window, however brief, where the
+        // record is readable by anyone the umask allows, and it describes exactly
+        // how this machine authenticates.
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| format!("create {}: {e}", path.display()))?;
+        file.write_all(body.as_bytes())
+            .map_err(|e| format!("write {}: {e}", path.display()))?;
+        // An existing record from an earlier run keeps its old mode through
+        // OpenOptions, so the mode is asserted either way.
         restrict(&path, 0o600)?;
         Ok(path)
     }
@@ -126,15 +142,38 @@ impl Transaction {
     /// The id is used as a filename, so it is checked to be plain hex first: a
     /// consumer-supplied id containing a separator would otherwise reach
     /// outside the store.
-    pub(crate) fn load(id: &str) -> Result<Self, String> {
+    pub(crate) fn load(id: &str) -> Result<Self, LoadFailure> {
         if !is_valid_id(id) {
-            return Err("transaction id is not a hex identifier".into());
+            return Err(LoadFailure::NotFound);
         }
         let path = store_dir().join(format!("{id}.json"));
-        let body =
-            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
-        serde_json::from_str(&body).map_err(|e| format!("parse {}: {e}", path.display()))
+        let body = match std::fs::read_to_string(&path) {
+            Ok(body) => body,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(LoadFailure::NotFound)
+            }
+            // The store is root-only, so an ordinary caller lands here. Saying
+            // "not found" would tell them their transaction id was wrong when
+            // the truth is that they may not read it.
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                return Err(LoadFailure::NotAuthorized)
+            }
+            Err(error) => return Err(LoadFailure::Unreadable(format!("{error}"))),
+        };
+        serde_json::from_str(&body).map_err(|e| LoadFailure::Unreadable(format!("{e}")))
     }
+}
+
+/// Why a record could not be loaded.
+///
+/// Separated because they mean different things to a caller: a missing record
+/// is a wrong or expired id, while a record that cannot be read is a permission
+/// or storage problem the id has nothing to do with.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum LoadFailure {
+    NotFound,
+    NotAuthorized,
+    Unreadable(String),
 }
 
 /// Whether a transaction id is safe to use as a filename.

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -372,16 +372,50 @@ pub(crate) enum LoadFailure {
 /// Recording what is done, durably, after each surface, turns that into a
 /// resume. A surface named here is skipped and not re-checked, because its
 /// digest is deliberately no longer the one apply left.
-pub(crate) fn rollback_progress(id: &str) -> Vec<String> {
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RollbackProgress {
+    /// Restores that were BEGUN. Each may or may not have landed.
+    ///
+    /// This is the half that was missing, and hardware found it: noting a
+    /// restore only AFTER it succeeded leaves the window between the write and
+    /// the note, and a kill there leaves a surface holding its before-image with
+    /// nothing recording it. The re-run then checks it against the after-digest
+    /// and refuses. Thirty killed rollbacks in a row were unfinishable for
+    /// exactly this reason — write-then-record, the same ordering mistake the
+    /// transaction record itself exists to avoid.
+    ///
+    /// An entry here means "do not trust this file's digest, and just do it
+    /// again": restoring writes the recorded before-content, so doing it twice
+    /// is the same as doing it once.
+    pub(crate) started: Vec<String>,
+    /// Restores known to have completed. Skipped entirely on a re-run.
+    pub(crate) done: Vec<String>,
+}
+
+impl RollbackProgress {
+    /// Whether this item's on-disk digest can still be believed.
+    ///
+    /// Anything begun is untrustworthy whether or not it finished, so both lists
+    /// exempt an item from the drift check.
+    pub(crate) fn touched(&self, key: &str) -> bool {
+        self.started.iter().any(|k| k == key) || self.done.iter().any(|k| k == key)
+    }
+
+    pub(crate) fn finished(&self, key: &str) -> bool {
+        self.done.iter().any(|k| k == key)
+    }
+}
+
+pub(crate) fn rollback_progress(id: &str) -> RollbackProgress {
     let Some(path) = progress_path(id) else {
-        return Vec::new();
+        return RollbackProgress::default();
     };
     // A progress note that cannot be parsed is treated as no progress: redoing a
     // restore is safe, since it writes the same recorded content, while skipping
     // one that never happened is not.
     std::fs::read_to_string(path)
         .ok()
-        .and_then(|body| serde_json::from_str::<Vec<String>>(&body).ok())
+        .and_then(|body| serde_json::from_str::<RollbackProgress>(&body).ok())
         .unwrap_or_default()
 }
 
@@ -389,11 +423,11 @@ pub(crate) fn rollback_progress(id: &str) -> Vec<String> {
 ///
 /// Atomic and fsynced, for the same reason the record itself is: a note that
 /// does not survive the crash it exists to describe is not a note.
-pub(crate) fn note_rollback_progress(id: &str, done: &[String]) -> Result<(), String> {
+pub(crate) fn note_rollback_progress(id: &str, progress: &RollbackProgress) -> Result<(), String> {
     let Some(path) = progress_path(id) else {
         return Err("invalid transaction id".into());
     };
-    let body = serde_json::to_string(done).map_err(|e| format!("serialize progress: {e}"))?;
+    let body = serde_json::to_string(progress).map_err(|e| format!("serialize progress: {e}"))?;
     irlume_common::write_0600_atomic(&path, body.as_bytes())
         .map_err(|e| format!("write {}: {e}", path.display()))
 }
@@ -590,7 +624,7 @@ pub(crate) enum RollbackRefusal {
 /// The check rollback is gated on. Kept separate from the restore itself so it
 /// can be run on its own by `verify`, and so both answer from one rule.
 pub(crate) fn unchanged_since_apply(record: &SurfaceRecord) -> Result<(), RollbackRefusal> {
-    unchanged_since_apply_excluding(record, &[])
+    unchanged_since_apply_excluding(record, &RollbackProgress::default())
 }
 
 /// The same question, minus the halves a stopped rollback already put back.
@@ -601,9 +635,9 @@ pub(crate) fn unchanged_since_apply(record: &SurfaceRecord) -> Result<(), Rollba
 /// unfinishable.
 pub(crate) fn unchanged_since_apply_excluding(
     record: &SurfaceRecord,
-    done: &[String],
+    done: &RollbackProgress,
 ) -> Result<(), RollbackRefusal> {
-    if !done.iter().any(|id| id == &record.id) {
+    if !done.touched(&record.id) {
         let current = match file_sha256(Path::new(&record.path)) {
             Ok(value) => value,
             Err(error) => return Err(RollbackRefusal::Unreadable(error)),
@@ -613,7 +647,7 @@ pub(crate) fn unchanged_since_apply_excluding(
             return Err(RollbackRefusal::ChangedSinceApply);
         }
     }
-    if done.iter().any(|id| id == &sidecar_progress_id(&record.id)) {
+    if done.touched(&sidecar_progress_id(&record.id)) {
         return Ok(());
     }
     // The backup counts as part of the surface. Rollback restores it too, so
@@ -830,23 +864,41 @@ mod tests {
         std::fs::remove_file(&greeter).unwrap();
         assert!(snapshot_before_rollback(&tx).is_ok());
 
-        // Progress: nothing, then something, then cleared.
-        assert!(rollback_progress(&id).is_empty());
-        note_rollback_progress(&id, &["kde".to_string()]).expect("note");
-        assert_eq!(rollback_progress(&id), vec!["kde".to_string()]);
+        // Progress: nothing, then BEGUN, then done, then cleared.
+        assert_eq!(rollback_progress(&id), RollbackProgress::default());
+        let begun = RollbackProgress {
+            started: vec!["kde".to_string()],
+            done: Vec::new(),
+        };
+        note_rollback_progress(&id, &begun).expect("note");
+        // Begun is already enough to stop trusting the file: the write may have
+        // landed before the process died. That is the whole point — a restore
+        // writes the recorded content, so repeating it is safe, while checking
+        // its digest is not.
+        assert!(rollback_progress(&id).touched("kde"));
+        assert!(!rollback_progress(&id).finished("kde"));
+        let done = RollbackProgress {
+            started: vec!["kde".to_string()],
+            done: vec!["kde".to_string()],
+        };
+        note_rollback_progress(&id, &done).expect("note");
+        assert!(rollback_progress(&id).finished("kde"));
         clear_rollback_progress(&id).expect("clear");
-        assert!(rollback_progress(&id).is_empty());
+        assert_eq!(rollback_progress(&id), RollbackProgress::default());
 
         // An unreadable note means "no progress", never "all done": redoing a
         // restore writes the same recorded content, while skipping one that
         // never happened leaves a half-rolled-back stack.
-        note_rollback_progress(&id, &["kde".to_string()]).expect("note");
+        note_rollback_progress(&id, &done).expect("note");
         std::fs::write(store_dir().join(format!("{id}.progress")), "{ not a list").unwrap();
-        assert!(rollback_progress(&id).is_empty());
+        assert_eq!(rollback_progress(&id), RollbackProgress::default());
 
         // An id that is not plain hex never becomes a path.
-        assert!(note_rollback_progress("../../etc/passwd", &[]).is_err());
-        assert!(rollback_progress("../../etc/passwd").is_empty());
+        assert!(note_rollback_progress("../../etc/passwd", &RollbackProgress::default()).is_err());
+        assert_eq!(
+            rollback_progress("../../etc/passwd"),
+            RollbackProgress::default()
+        );
         clear_rollback_progress(&id).expect("clear");
 
         // A surface is TWO writes, so it is two entries. Noting it only once
@@ -854,14 +906,18 @@ mod tests {
         // granularity: the live file held its before-image and nothing said so,
         // and the re-run refused it as drift.
         let surface = &tx.surfaces[0];
+        let started = |ids: &[&str]| RollbackProgress {
+            started: ids.iter().map(|s| (*s).to_string()).collect(),
+            done: Vec::new(),
+        };
         assert!(
-            unchanged_since_apply_excluding(surface, &[]).is_err(),
+            unchanged_since_apply_excluding(surface, &RollbackProgress::default()).is_err(),
             "the live file is not what apply left, so unaided this refuses"
         );
         assert_eq!(
-            unchanged_since_apply_excluding(surface, std::slice::from_ref(&surface.id)),
+            unchanged_since_apply_excluding(surface, &started(&[&surface.id])),
             Ok(()),
-            "with the live half noted, the surface stops being a blocker"
+            "a restore merely BEGUN already exempts the file from the digest check"
         );
 
         // The halves are independent, and each excuses only itself. With a
@@ -878,14 +934,14 @@ mod tests {
             gid: None,
         });
         assert_eq!(
-            unchanged_since_apply_excluding(&with_backup, std::slice::from_ref(&with_backup.id)),
+            unchanged_since_apply_excluding(&with_backup, &started(&[&with_backup.id])),
             Err(RollbackRefusal::ChangedSinceApply),
             "noting the live half excused the backup as well"
         );
         assert_eq!(
             unchanged_since_apply_excluding(
                 &with_backup,
-                &[with_backup.id.clone(), sidecar_progress_id(&with_backup.id)]
+                &started(&[&with_backup.id, &sidecar_progress_id(&with_backup.id)])
             ),
             Ok(()),
             "with both halves noted there is nothing left to check"
@@ -893,7 +949,7 @@ mod tests {
         // And noting the backup does not excuse the live file.
         assert!(unchanged_since_apply_excluding(
             &with_backup,
-            &[sidecar_progress_id(&with_backup.id)]
+            &started(&[&sidecar_progress_id(&with_backup.id)])
         )
         .is_err());
     }

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -125,6 +125,18 @@ pub(crate) struct Transaction {
     /// engine that predates the field.
     #[serde(default)]
     pub(crate) status: TransactionStatus,
+    /// Which record format this is. A GATE, unlike `engine_version`.
+    ///
+    /// Bumped only when the MEANING of a record changes: a new field a rollback
+    /// must act on, or a different interpretation of an existing one. Adding a
+    /// purely descriptive field does not need it. A build refuses anything above
+    /// what it implements rather than reading the parts it recognises.
+    ///
+    /// Defaulted for records written before the field existed. Those predate any
+    /// meaning change, so treating them as version 1 is accurate rather than
+    /// generous.
+    #[serde(default = "schema_version_1")]
+    pub(crate) schema_version: u32,
     /// `enable` or `disable`.
     pub(crate) action: String,
     /// The plan this was applied from, so a consumer can tie the two together.
@@ -159,6 +171,13 @@ pub(crate) enum TransactionStatus {
     /// explicit acknowledgement.
     #[serde(other)]
     Unknown,
+}
+
+/// The record format this build writes and is willing to act on.
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+fn schema_version_1() -> u32 {
+    1
 }
 
 /// Hex sha256 of a byte slice.
@@ -283,7 +302,20 @@ impl Transaction {
             }
             Err(error) => return Err(LoadFailure::Unreadable(format!("{error}"))),
         };
-        serde_json::from_str(&body).map_err(|e| LoadFailure::Unreadable(format!("{e}")))
+        let record: Self =
+            serde_json::from_str(&body).map_err(|e| LoadFailure::Unreadable(format!("{e}")))?;
+        // Before anything reads a field. Deserializing succeeded, which is
+        // exactly the trap: serde ignores unknown fields, so a newer record
+        // parses cleanly into this older shape and every field this build knows
+        // about looks reasonable. What it cannot know is whether they still mean
+        // the same thing.
+        if record.schema_version > SCHEMA_VERSION {
+            return Err(LoadFailure::TooNew {
+                found: record.schema_version,
+                supported: SCHEMA_VERSION,
+            });
+        }
+        Ok(record)
     }
 }
 
@@ -297,6 +329,18 @@ pub(crate) enum LoadFailure {
     NotFound,
     NotAuthorized,
     Unreadable(String),
+    /// Written to a schema this build does not implement.
+    ///
+    /// `engine_version` was recorded but never checked, and serde ignores
+    /// unknown fields, so an older engine happily read a newer record whenever
+    /// the fields it knew about happened to deserialize — then rolled it back
+    /// using its own, older meaning of them. A record is the recovery path for a
+    /// machine's login stack; acting on one whose semantics this build cannot
+    /// know is worse than refusing and naming the version that can.
+    TooNew {
+        found: u32,
+        supported: u32,
+    },
 }
 
 /// Whether a transaction id is safe to use as a filename.
@@ -502,6 +546,7 @@ mod tests {
         let _env = StateDirGuard::new("roundtrip");
         let tx = Transaction {
             id: "0123456789abcdef0123456789abcdef".into(),
+            schema_version: SCHEMA_VERSION,
             status: TransactionStatus::Applied,
             action: "enable".into(),
             plan_id: "aaaabbbbccccddddaaaabbbbccccdddd".into(),
@@ -534,6 +579,64 @@ mod tests {
     /// inode and passes through a moment where the file is empty; replacing by
     /// rename gives a new inode and never does. A test that only checked the
     /// final contents would pass either way.
+    /// A record from a schema this build does not implement is refused, not
+    /// half-read.
+    ///
+    /// `engine_version` was recorded and never checked, and serde ignores
+    /// unknown fields, so a newer record parsed cleanly into the older shape and
+    /// every field this build knew about looked reasonable. What it could not
+    /// know is whether they still MEAN the same thing, and a record is the
+    /// recovery path for a machine's login stack.
+    #[test]
+    fn a_record_from_a_newer_schema_is_refused_rather_than_partly_understood() {
+        let _env = StateDirGuard::new("schema");
+        let dir = store_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = "0".repeat(32);
+        let write = |body: &str| std::fs::write(dir.join(format!("{id}.json")), body).unwrap();
+
+        // A newer engine's record: fields this build knows, plus one it does
+        // not, plus a schema it does not implement.
+        write(&format!(
+            r#"{{"id":"{id}","schema_version":{},"status":"applied","action":"enable",
+                "plan_id":"{}","engine_version":"9.9.9","surfaces":[],
+                "something_this_build_ignores":{{"restore_me_too":"/etc/pam.d/x"}}}}"#,
+            SCHEMA_VERSION + 1,
+            "1".repeat(32)
+        ));
+        assert_eq!(
+            Transaction::load(&id),
+            Err(LoadFailure::TooNew {
+                found: SCHEMA_VERSION + 1,
+                supported: SCHEMA_VERSION
+            }),
+            "a newer record must not be acted on by an older engine"
+        );
+
+        // The same record at a schema this build implements is fine, unknown
+        // field and all: ignoring a descriptive addition is the point of not
+        // bumping the version for one.
+        write(&format!(
+            r#"{{"id":"{id}","schema_version":{SCHEMA_VERSION},"status":"applied","action":"enable",
+                "plan_id":"{}","engine_version":"9.9.9","surfaces":[],
+                "something_this_build_ignores":true}}"#,
+            "1".repeat(32)
+        ));
+        assert_eq!(
+            Transaction::load(&id).map(|r| r.schema_version),
+            Ok(SCHEMA_VERSION)
+        );
+
+        // A record written before the field existed predates any meaning
+        // change, so it reads as version 1 rather than being refused.
+        write(&format!(
+            r#"{{"id":"{id}","status":"applied","action":"enable",
+                "plan_id":"{}","engine_version":"0.7.0","surfaces":[]}}"#,
+            "1".repeat(32)
+        ));
+        assert_eq!(Transaction::load(&id).map(|r| r.schema_version), Ok(1));
+    }
+
     /// Every directory whose entry has to survive is in the chain, shallowest
     /// first, including the one a RELATIVE state root is anchored in.
     ///
@@ -585,6 +688,7 @@ mod tests {
 
         let mut tx = Transaction {
             id: "abcdef0123456789abcdef0123456789".into(),
+            schema_version: SCHEMA_VERSION,
             status: TransactionStatus::Prepared,
             action: "enable".into(),
             plan_id: "1".repeat(32),
@@ -633,6 +737,7 @@ mod tests {
         let _env = StateDirGuard::new("perms");
         let tx = Transaction {
             id: "ffffffffffffffffffffffffffffffff".into(),
+            schema_version: SCHEMA_VERSION,
             status: TransactionStatus::Applied,
             action: "disable".into(),
             plan_id: "0".repeat(32),

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -323,10 +323,19 @@ mod tests {
 
     /// Serialises tests that set IRLUME_STATE_DIR. Cargo runs tests on threads
     /// and the variable is process-global, so two of these racing made one read
-    /// the other's store. Same reason pamwire's tests hold an env lock.
+    /// the other's store.
+    ///
+    /// This is `crate::testenv::ENV_LOCK`, the one every other env-mutating test
+    /// in this crate holds, and it has to be: a second mutex guarding the same
+    /// variable serialises a test against its own module and against nothing
+    /// else. These tests used a private one, so `logintx` and `pamwire` could
+    /// both be inside their own lock, holding different values of
+    /// IRLUME_STATE_DIR, at the same moment. It passed here and failed in CI,
+    /// which is what a lock that guards the wrong scope looks like.
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+        crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
     }
 
     fn temp_state(tag: &str) -> PathBuf {

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Login transactions: a record of what a `login apply` changed, so it can be
+//! verified afterwards and put back.
+//!
+//! # Why a record rather than the backups
+//!
+//! `pamwire` already keeps a `.pre-irlume` backup per file, and its disable path
+//! restores it only when the live file still equals that backup plus irlume's
+//! lines, stripping in place otherwise so an admin's later edit is not reverted.
+//! That mechanism stays exactly as it is. This module does not replace it and
+//! must not become a second opinion about what a PAM file should contain.
+//!
+//! What it adds is the ability to answer two questions the backups cannot:
+//! *did the change I asked for actually land*, and *put back what was there
+//! before THIS operation*, for a consumer that ran one specific apply and holds
+//! its id.
+//!
+//! # The safety rule
+//!
+//! A record stores each file's digest as apply left it. Rollback recomputes
+//! that digest and restores only if it still matches. If anything edited the
+//! file in between, rollback refuses rather than reverting a change nobody
+//! asked it to revert. That is the same principle the disable path already
+//! follows, applied to a narrower question.
+//!
+//! # What is stored
+//!
+//! The pre-change content of each file irlume wrote. PAM stacks under
+//! `/etc/pam.d` are world-readable, so this is not secret material, but the
+//! store is kept root-only anyway: it describes exactly how a machine
+//! authenticates, and there is no reason for an ordinary process to read it.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Where transaction records live, unless `IRLUME_STATE_DIR` overrides the
+/// state root (tests and containers do).
+fn store_dir() -> PathBuf {
+    let root = std::env::var_os("IRLUME_STATE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/var/lib/irlume"));
+    root.join("login-transactions")
+}
+
+/// One file as it stood before and after a transaction.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SurfaceRecord {
+    /// PAM service name. The stable public identifier.
+    pub(crate) id: String,
+    /// The `/etc` path. Needed to restore, and deliberately never published in
+    /// machine output, which names surfaces by service.
+    pub(crate) path: String,
+    /// The planned change this surface was recorded for.
+    pub(crate) change: String,
+    /// The file's content before the change. `None` when it did not exist, so
+    /// rollback removes it rather than writing an empty file.
+    pub(crate) before: Option<String>,
+    /// Digest of the file as apply left it. Rollback requires this to still
+    /// match, which is what stops it reverting somebody else's later edit.
+    pub(crate) after_sha256: String,
+}
+
+/// What one `login apply` did.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct Transaction {
+    pub(crate) id: String,
+    /// `enable` or `disable`.
+    pub(crate) action: String,
+    /// The plan this was applied from, so a consumer can tie the two together.
+    pub(crate) plan_id: String,
+    /// Which engine wrote the record. A record written by a different version
+    /// is still readable, but the difference is worth surfacing.
+    pub(crate) engine_version: String,
+    pub(crate) surfaces: Vec<SurfaceRecord>,
+}
+
+/// Hex sha256 of a byte slice.
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// The digest of a file's current content, or `None` when it does not exist.
+///
+/// An unreadable file that DOES exist is an error rather than `None`: treating
+/// "cannot read" as "absent" would let rollback decide a file was never there
+/// and delete it.
+pub(crate) fn file_sha256(path: &Path) -> Result<Option<String>, String> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Some(sha256_hex(&bytes))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!("read {}: {error}", path.display())),
+    }
+}
+
+/// Digest of an absent file, as recorded. A distinct constant rather than an
+/// empty string, so "the file was absent" cannot be confused with "nobody
+/// recorded a digest".
+pub(crate) const ABSENT: &str = "absent";
+
+impl Transaction {
+    /// Persist the record, root-readable only.
+    ///
+    /// Written before the caller reports success. A transaction that changed
+    /// files but could not be recorded is worse than one that did not run: the
+    /// change is on disk with nothing describing how to undo it, so the write
+    /// failing is an error the caller must surface.
+    pub(crate) fn save(&self) -> Result<PathBuf, String> {
+        let dir = store_dir();
+        std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+        restrict(&dir, 0o700)?;
+        let path = dir.join(format!("{}.json", self.id));
+        let body = serde_json::to_string(self).map_err(|e| format!("serialize record: {e}"))?;
+        std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))?;
+        restrict(&path, 0o600)?;
+        Ok(path)
+    }
+
+    /// Read a record back by id.
+    ///
+    /// The id is used as a filename, so it is checked to be plain hex first: a
+    /// consumer-supplied id containing a separator would otherwise reach
+    /// outside the store.
+    pub(crate) fn load(id: &str) -> Result<Self, String> {
+        if !is_valid_id(id) {
+            return Err("transaction id is not a hex identifier".into());
+        }
+        let path = store_dir().join(format!("{id}.json"));
+        let body =
+            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        serde_json::from_str(&body).map_err(|e| format!("parse {}: {e}", path.display()))
+    }
+}
+
+/// Whether a transaction id is safe to use as a filename.
+///
+/// Hex only, and a fixed length. This is the whole defence against a supplied
+/// id escaping the store directory, so it rejects rather than sanitises: a
+/// `..` or a `/` makes the id invalid, it does not get stripped out.
+pub(crate) fn is_valid_id(id: &str) -> bool {
+    id.len() == 32 && id.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn restrict(path: &Path, mode: u32) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .map_err(|e| format!("chmod {}: {e}", path.display()))
+}
+
+/// Why a surface could not be rolled back.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RollbackRefusal {
+    /// The file no longer matches what apply left, so restoring the recorded
+    /// content would revert an edit this transaction did not make.
+    ChangedSinceApply,
+    /// The file could not be read to check.
+    Unreadable(String),
+}
+
+/// Whether this surface is still exactly as apply left it.
+///
+/// The check rollback is gated on. Kept separate from the restore itself so it
+/// can be run on its own by `verify`, and so both answer from one rule.
+pub(crate) fn unchanged_since_apply(record: &SurfaceRecord) -> Result<(), RollbackRefusal> {
+    let current = match file_sha256(Path::new(&record.path)) {
+        Ok(value) => value,
+        Err(error) => return Err(RollbackRefusal::Unreadable(error)),
+    };
+    let current = current.unwrap_or_else(|| ABSENT.to_string());
+    if current == record.after_sha256 {
+        Ok(())
+    } else {
+        Err(RollbackRefusal::ChangedSinceApply)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialises tests that set IRLUME_STATE_DIR. Cargo runs tests on threads
+    /// and the variable is process-global, so two of these racing made one read
+    /// the other's store. Same reason pamwire's tests hold an env lock.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    fn temp_state(tag: &str) -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("irlume-logintx-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp state dir");
+        root
+    }
+
+    fn record(path: &Path, before: Option<&str>, after_sha: &str) -> SurfaceRecord {
+        SurfaceRecord {
+            id: "plasmalogin".into(),
+            path: path.display().to_string(),
+            change: "wire".into(),
+            before: before.map(str::to_string),
+            after_sha256: after_sha.into(),
+        }
+    }
+
+    #[test]
+    fn an_id_that_is_not_plain_hex_is_refused_rather_than_cleaned() {
+        // The id becomes a filename, so this is the whole defence against one
+        // reaching outside the store. Rejecting beats sanitising: a stripped
+        // separator leaves a plausible-looking id that addresses a different file.
+        assert!(is_valid_id("0123456789abcdef0123456789abcdef"));
+        for bad in [
+            "../../etc/passwd",
+            "0123456789abcdef0123456789abcde/",
+            "0123456789abcdef0123456789abcdeZ",
+            "short",
+            "",
+            "0123456789abcdef0123456789abcdef0",
+        ] {
+            assert!(!is_valid_id(bad), "{bad:?} must be refused");
+        }
+    }
+
+    #[test]
+    fn a_record_survives_a_round_trip() {
+        let _lock = env_lock();
+        let root = temp_state("roundtrip");
+        // SAFETY: single-threaded test, restored below.
+        unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
+        let tx = Transaction {
+            id: "0123456789abcdef0123456789abcdef".into(),
+            action: "enable".into(),
+            plan_id: "aaaabbbbccccddddaaaabbbbccccdddd".into(),
+            engine_version: "0.0.0".into(),
+            surfaces: vec![record(
+                Path::new("/etc/pam.d/plasmalogin"),
+                Some("old\n"),
+                "deadbeef",
+            )],
+        };
+        let path = tx.save().expect("save");
+        assert!(path.exists());
+        assert_eq!(Transaction::load(&tx.id).expect("load"), tx);
+        unsafe { std::env::remove_var("IRLUME_STATE_DIR") };
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_store_is_not_readable_by_other_accounts() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = env_lock();
+        let root = temp_state("perms");
+        // SAFETY: single-threaded test, restored below.
+        unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
+        let tx = Transaction {
+            id: "ffffffffffffffffffffffffffffffff".into(),
+            action: "disable".into(),
+            plan_id: "0".repeat(32),
+            engine_version: "0.0.0".into(),
+            surfaces: vec![],
+        };
+        let path = tx.save().expect("save");
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "a record describes how a machine authenticates"
+        );
+        let dir_mode = std::fs::metadata(path.parent().expect("parent"))
+            .expect("stat dir")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o700);
+        unsafe { std::env::remove_var("IRLUME_STATE_DIR") };
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rollback_is_refused_once_the_file_has_moved_on() {
+        let root = temp_state("changed");
+        let target = root.join("plasmalogin");
+        std::fs::write(&target, "as apply left it\n").expect("write");
+        let after = sha256_hex(b"as apply left it\n");
+        let rec = record(&target, Some("original\n"), &after);
+
+        // Untouched since apply: restoring is safe.
+        assert_eq!(unchanged_since_apply(&rec), Ok(()));
+
+        // Somebody else edited it. Restoring the recorded content now would
+        // revert a change this transaction never made.
+        std::fs::write(&target, "an admin added a line\n").expect("write");
+        assert_eq!(
+            unchanged_since_apply(&rec),
+            Err(RollbackRefusal::ChangedSinceApply)
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_file_apply_created_is_recognised_when_it_is_still_absent() {
+        // `disable` can remove a file. Its recorded after-state is ABSENT, and
+        // an absent file must compare equal to that rather than read as drift.
+        let root = temp_state("absent");
+        let target = root.join("never-existed");
+        let rec = record(&target, Some("was here\n"), ABSENT);
+        assert_eq!(unchanged_since_apply(&rec), Ok(()));
+
+        std::fs::write(&target, "something put it back\n").expect("write");
+        assert_eq!(
+            unchanged_since_apply(&rec),
+            Err(RollbackRefusal::ChangedSinceApply)
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn an_unreadable_file_is_an_error_not_an_absent_one() {
+        // Treating "cannot read" as "absent" would let rollback conclude a file
+        // was never there and delete it.
+        let root = temp_state("unreadable");
+        let dir = root.join("a-directory-where-a-file-is-expected");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let rec = record(&dir, None, "deadbeef");
+        assert!(matches!(
+            unchanged_since_apply(&rec),
+            Err(RollbackRefusal::Unreadable(_))
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -316,17 +316,36 @@ pub(crate) fn is_valid_id(id: &str) -> bool {
 /// `irlume` itself, whose entry is in `/var/lib`. A record fsynced into a
 /// directory whose name did not survive is not a record.
 fn fsync_ancestors(dir: &Path) -> Result<(), String> {
-    let mut chain: Vec<&Path> = dir
-        .ancestors()
-        .skip(1) // `dir` itself is synced by the atomic write that fills it
-        // A relative path's last ancestor is "", which names nothing.
-        .filter(|p| !p.as_os_str().is_empty())
-        .collect();
-    chain.reverse();
-    for parent in chain {
-        fsync_dir(parent)?;
+    for parent in ancestor_chain(dir) {
+        fsync_dir(&parent)?;
     }
     Ok(())
+}
+
+/// The directories to sync above `dir`, shallowest first.
+///
+/// Separated out because the interesting case cannot be observed from outside:
+/// whether an `fsync` happened is not visible in the filesystem afterwards, so
+/// the list is what a test can actually assert on.
+fn ancestor_chain(dir: &Path) -> Vec<PathBuf> {
+    let mut chain: Vec<PathBuf> = dir
+        .ancestors()
+        .skip(1) // `dir` itself is synced by the atomic write that fills it
+        .map(|p| {
+            // A relative path's last ancestor is "", which opens nothing. The
+            // directory a relative path is anchored in is the working
+            // directory, and that is where the entry actually lives. Filtering
+            // the empty one out instead left `IRLUME_STATE_DIR=state` syncing
+            // `state` while nothing synced the `state` entry itself.
+            if p.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                p.to_path_buf()
+            }
+        })
+        .collect();
+    chain.reverse();
+    chain
 }
 
 /// Make a directory's own contents durable, so entries created in it survive a
@@ -515,6 +534,49 @@ mod tests {
     /// inode and passes through a moment where the file is empty; replacing by
     /// rename gives a new inode and never does. A test that only checked the
     /// final contents would pass either way.
+    /// Every directory whose entry has to survive is in the chain, shallowest
+    /// first, including the one a RELATIVE state root is anchored in.
+    ///
+    /// A directory's name lives in its parent, so syncing `state` does nothing
+    /// for the `state` entry itself; for a relative path that entry is in the
+    /// working directory. An earlier version dropped the empty last ancestor
+    /// instead of reading it as ".", which left exactly that gap. Asserted on
+    /// the list because an `fsync` leaves no trace in the filesystem to check.
+    #[test]
+    fn the_sync_chain_covers_every_directory_whose_entry_must_survive() {
+        let abs = ancestor_chain(Path::new("/var/lib/irlume/login-transactions"));
+        assert_eq!(
+            abs,
+            vec![
+                PathBuf::from("/"),
+                PathBuf::from("/var"),
+                PathBuf::from("/var/lib"),
+                PathBuf::from("/var/lib/irlume"),
+            ],
+            "shallowest first, and the store itself is left to the atomic write"
+        );
+
+        // The case the filter used to lose: nothing anchored `state`.
+        let rel = ancestor_chain(Path::new("state/login-transactions"));
+        assert_eq!(rel, vec![PathBuf::from("."), PathBuf::from("state")]);
+
+        // A store directly under a relative root still names the anchor.
+        assert_eq!(
+            ancestor_chain(Path::new("login-transactions")),
+            vec![PathBuf::from(".")]
+        );
+        // Nothing in a chain may be empty: an empty path opens nothing, so a
+        // sync of it is a sync that silently did not happen.
+        for dir in ["/a/b", "a/b", "b", "/"] {
+            assert!(
+                ancestor_chain(Path::new(dir))
+                    .iter()
+                    .all(|p| !p.as_os_str().is_empty()),
+                "{dir} produced an empty entry"
+            );
+        }
+    }
+
     #[test]
     fn confirming_a_transaction_replaces_its_record_instead_of_emptying_it() {
         use std::os::unix::fs::MetadataExt as _;

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -219,11 +219,30 @@ impl Transaction {
     /// returning, which the ordering needs and the old code never did: bytes
     /// still in the page cache when the machine loses power are not a record,
     /// and "written before the first PAM write" only means something if it is
-    /// durable before the first PAM write.
+    /// durable before the first PAM write. The store directory's own entry is
+    /// synced too, on the run that creates it, for the same reason.
     pub(crate) fn save(&self) -> Result<PathBuf, String> {
         let dir = store_dir();
+        let store_is_new = !dir.exists();
         std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
         restrict(&dir, 0o700)?;
+        // Creating the store is itself a directory entry that has to survive a
+        // power loss, and `create_dir_all` does not make one durable.
+        // `write_0600_atomic` fsyncs the record and the directory holding it,
+        // but on the first run of a fresh install the entry for that directory
+        // is still only in its parent's page cache: the record could be fsynced
+        // into a directory that does not come back. PAM is rewritten
+        // immediately afterwards, so the machine would again be left changed
+        // with nothing describing how to undo it — the same defect as the
+        // truncate above, one level up.
+        //
+        // Only on creation: an fsync of the parent on every save would cost two
+        // per apply to re-prove something already durable.
+        if store_is_new {
+            if let Some(parent) = dir.parent() {
+                fsync_dir(parent)?;
+            }
+        }
         let path = dir.join(format!("{}.json", self.id));
         let body = serde_json::to_string(self).map_err(|e| format!("serialize record: {e}"))?;
         // The temp is created 0600 and renamed over the path, so the record is
@@ -282,6 +301,18 @@ pub(crate) enum LoadFailure {
 /// `..` or a `/` makes the id invalid, it does not get stripped out.
 pub(crate) fn is_valid_id(id: &str) -> bool {
     id.len() == 32 && id.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Make a directory's own contents durable, so entries created in it survive a
+/// power loss.
+///
+/// `fsync(2)` is explicit that syncing a file does not necessarily persist the
+/// directory entry naming it; the directory has to be synced too. Opening a
+/// directory read-only and syncing that descriptor is the way to do it.
+fn fsync_dir(dir: &Path) -> Result<(), String> {
+    std::fs::File::open(dir)
+        .and_then(|d| d.sync_all())
+        .map_err(|e| format!("fsync {}: {e}", dir.display()))
 }
 
 fn restrict(path: &Path, mode: u32) -> Result<(), String> {

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -60,6 +60,31 @@ pub(crate) struct SurfaceRecord {
     /// Digest of the file as apply left it. Rollback requires this to still
     /// match, which is what stops it reverting somebody else's later edit.
     pub(crate) after_sha256: String,
+    /// Permission bits before the change.
+    ///
+    /// Content alone does not restore a file. `write_atomic` copies permissions
+    /// from the CURRENT file, which does not exist when apply removed it, so a
+    /// recreated PAM stack would otherwise take the root process's umask
+    /// default. Absent on records written before this field existed, in which
+    /// case the old behaviour is kept rather than guessed at.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) mode: Option<u32>,
+    /// Owner before the change. Restored alongside `mode` for the same reason:
+    /// a stack owned root:some-group and readable by it is not the same file
+    /// once it comes back owned root:root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) uid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) gid: Option<u32>,
+}
+
+/// A file's ownership and permission bits, or `None` when it does not exist.
+pub(crate) fn file_metadata(path: &Path) -> Option<(u32, u32, u32)> {
+    use std::os::unix::fs::MetadataExt;
+    // symlink_metadata, not metadata: a PAM path that is a symlink should be
+    // described as itself rather than as whatever it points at.
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    Some((meta.mode() & 0o7777, meta.uid(), meta.gid()))
 }
 
 /// What one `login apply` did.
@@ -268,6 +293,9 @@ mod tests {
             change: "wire".into(),
             before: before.map(str::to_string),
             after_sha256: after_sha.into(),
+            mode: None,
+            uid: None,
+            gid: None,
         }
     }
 

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -234,17 +234,20 @@ impl Transaction {
         // the machine would again be left changed with nothing describing how
         // to undo it — the same defect as the truncate above, one level up.
         //
-        // Unconditional, and deliberately not skipped when the store already
-        // exists. Testing `exists()` first and syncing only when this process
-        // created it looks like a free optimisation and is not: another process
-        // that finds the directory already there, writes its record and rewrites
-        // PAM has inherited a durability guarantee nobody has made yet, because
-        // the process that created the directory may not have synced its parent
-        // yet, or at all. Two fsyncs per apply is not a price worth an
-        // unrecoverable machine.
-        if let Some(parent) = dir.parent() {
-            fsync_dir(parent)?;
-        }
+        // The WHOLE chain, unconditionally, and not just the immediate parent:
+        // `create_dir_all` can create several levels, and syncing only the
+        // store's parent leaves the parent's own entry in ITS parent unsynced.
+        //
+        // Unconditional because every way of narrowing it is the same
+        // check-then-act split. Skipping the sync when the directory already
+        // exists means a second process finds it there, writes its record and
+        // rewrites PAM having inherited a guarantee nobody has made yet: the
+        // process that created it may not have synced anything yet, or may have
+        // died. Probing which ancestors are missing has the identical hole one
+        // level up. So it is not narrowed. Syncing a directory with nothing
+        // dirty is cheap, this runs twice per `login apply`, and `login apply`
+        // is an administrator rewriting a login stack, not a hot path.
+        fsync_ancestors(&dir)?;
         let path = dir.join(format!("{}.json", self.id));
         let body = serde_json::to_string(self).map_err(|e| format!("serialize record: {e}"))?;
         // The temp is created 0600 and renamed over the path, so the record is
@@ -303,6 +306,27 @@ pub(crate) enum LoadFailure {
 /// `..` or a `/` makes the id invalid, it does not get stripped out.
 pub(crate) fn is_valid_id(id: &str) -> bool {
     id.len() == 32 && id.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Make every directory above `dir` durable, so the names leading to it survive
+/// a power loss.
+///
+/// Shallowest first, because a directory's entry lives in its parent: syncing
+/// `/var/lib/irlume` makes `login-transactions` findable, and does nothing for
+/// `irlume` itself, whose entry is in `/var/lib`. A record fsynced into a
+/// directory whose name did not survive is not a record.
+fn fsync_ancestors(dir: &Path) -> Result<(), String> {
+    let mut chain: Vec<&Path> = dir
+        .ancestors()
+        .skip(1) // `dir` itself is synced by the atomic write that fills it
+        // A relative path's last ancestor is "", which names nothing.
+        .filter(|p| !p.as_os_str().is_empty())
+        .collect();
+    chain.reverse();
+    for parent in chain {
+        fsync_dir(parent)?;
+    }
+    Ok(())
 }
 
 /// Make a directory's own contents durable, so entries created in it survive a
@@ -371,6 +395,49 @@ mod tests {
             .unwrap_or_else(|p| p.into_inner())
     }
 
+    /// Holds the env lock AND puts `IRLUME_STATE_DIR` back to whatever it was.
+    ///
+    /// These tests used to end with `remove_var`, which is not a restore: a
+    /// suite started with `IRLUME_STATE_DIR` pointing at a sandbox came out of
+    /// them with it unset, and a later test would then resolve the store to the
+    /// real `/var/lib/irlume`. The lock stops tests overlapping; it does not
+    /// stop one handing the next a different world than it found. Restoring in
+    /// `Drop` also covers the panicking test, which is when it matters most.
+    struct StateDirGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous: Option<std::ffi::OsString>,
+        root: PathBuf,
+    }
+
+    impl StateDirGuard {
+        fn new(tag: &str) -> Self {
+            let lock = env_lock();
+            let previous = std::env::var_os("IRLUME_STATE_DIR");
+            let root = temp_state(tag);
+            // SAFETY: the env lock is held for this guard's whole lifetime, so
+            // no other test in this process reads or writes the variable here.
+            unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
+            Self {
+                _lock: lock,
+                previous,
+                root,
+            }
+        }
+    }
+
+    impl Drop for StateDirGuard {
+        fn drop(&mut self) {
+            // SAFETY: as above; the lock is released after this runs.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var("IRLUME_STATE_DIR", value),
+                    None => std::env::remove_var("IRLUME_STATE_DIR"),
+                }
+            }
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
     fn temp_state(tag: &str) -> PathBuf {
         let root =
             std::env::temp_dir().join(format!("irlume-logintx-{tag}-{}", std::process::id()));
@@ -413,10 +480,7 @@ mod tests {
 
     #[test]
     fn a_record_survives_a_round_trip() {
-        let _lock = env_lock();
-        let root = temp_state("roundtrip");
-        // SAFETY: single-threaded test, restored below.
-        unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
+        let _env = StateDirGuard::new("roundtrip");
         let tx = Transaction {
             id: "0123456789abcdef0123456789abcdef".into(),
             status: TransactionStatus::Applied,
@@ -432,8 +496,6 @@ mod tests {
         let path = tx.save().expect("save");
         assert!(path.exists());
         assert_eq!(Transaction::load(&tx.id).expect("load"), tx);
-        unsafe { std::env::remove_var("IRLUME_STATE_DIR") };
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Confirming a transaction must never be able to destroy the record that
@@ -457,10 +519,7 @@ mod tests {
     fn confirming_a_transaction_replaces_its_record_instead_of_emptying_it() {
         use std::os::unix::fs::MetadataExt as _;
         use std::os::unix::fs::PermissionsExt as _;
-        let _lock = env_lock();
-        let root = temp_state("atomic");
-        // SAFETY: single-threaded test, restored below.
-        unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
+        let _env = StateDirGuard::new("atomic");
 
         let mut tx = Transaction {
             id: "abcdef0123456789abcdef0123456789".into(),
@@ -504,18 +563,12 @@ mod tests {
             .filter(|n| n != "abcdef0123456789abcdef0123456789.json")
             .collect();
         assert!(strays.is_empty(), "stray files in the store: {strays:?}");
-
-        unsafe { std::env::remove_var("IRLUME_STATE_DIR") };
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
     fn the_store_is_not_readable_by_other_accounts() {
         use std::os::unix::fs::PermissionsExt;
-        let _lock = env_lock();
-        let root = temp_state("perms");
-        // SAFETY: single-threaded test, restored below.
-        unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
+        let _env = StateDirGuard::new("perms");
         let tx = Transaction {
             id: "ffffffffffffffffffffffffffffffff".into(),
             status: TransactionStatus::Applied,
@@ -536,8 +589,6 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(dir_mode, 0o700);
-        unsafe { std::env::remove_var("IRLUME_STATE_DIR") };
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -189,36 +189,50 @@ pub(crate) fn file_sha256(path: &Path) -> Result<Option<String>, String> {
 pub(crate) const ABSENT: &str = "absent";
 
 impl Transaction {
-    /// Persist the record, root-readable only.
+    /// Persist the record, root-readable only, replacing any earlier version of
+    /// it atomically and durably.
     ///
     /// Written before the caller reports success. A transaction that changed
     /// files but could not be recorded is worse than one that did not run: the
     /// change is on disk with nothing describing how to undo it, so the write
     /// failing is an error the caller must surface.
+    ///
+    /// # Why this cannot open the record and truncate it
+    ///
+    /// A transaction is saved twice: `Prepared` before the first PAM write, then
+    /// `Applied` after. The point of that ordering is that the before-states
+    /// reach disk while the files are still untouched, so a crash mid-apply
+    /// leaves something that says how to get back.
+    ///
+    /// This used to open the same path with `truncate(true)`. The second save
+    /// therefore destroyed the prepared record as its FIRST act, and wrote the
+    /// confirmed one into the emptied file. Between those two moments the files
+    /// had already changed and the only description of their previous contents
+    /// was gone; an ENOSPC, an EIO or a kill in that window left a machine whose
+    /// PAM stack had been rewritten with nothing at all to roll back from. The
+    /// write-ahead ordering was defeated by the write that was supposed to
+    /// confirm it.
+    ///
+    /// Writing a temp file in the same directory and renaming means the record
+    /// is only ever the prepared one or the confirmed one, never neither.
+    /// `write_0600_atomic` also `fsync`s the file and its directory before
+    /// returning, which the ordering needs and the old code never did: bytes
+    /// still in the page cache when the machine loses power are not a record,
+    /// and "written before the first PAM write" only means something if it is
+    /// durable before the first PAM write.
     pub(crate) fn save(&self) -> Result<PathBuf, String> {
         let dir = store_dir();
         std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
         restrict(&dir, 0o700)?;
         let path = dir.join(format!("{}.json", self.id));
         let body = serde_json::to_string(self).map_err(|e| format!("serialize record: {e}"))?;
-        // Created 0600 rather than created-then-chmodded. Between a default-mode
-        // create and a later chmod there is a window, however brief, where the
-        // record is readable by anyone the umask allows, and it describes exactly
-        // how this machine authenticates.
-        use std::io::Write as _;
-        use std::os::unix::fs::OpenOptionsExt as _;
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&path)
-            .map_err(|e| format!("create {}: {e}", path.display()))?;
-        file.write_all(body.as_bytes())
+        // The temp is created 0600 and renamed over the path, so the record is
+        // never briefly readable by anyone the umask allows, and it does not
+        // inherit the mode of a record an earlier run left behind: the inode is
+        // a fresh one every time. Same helper as `envelope.rs` and
+        // `template_key.rs`, which store material of the same sensitivity.
+        irlume_common::write_0600_atomic(&path, body.as_bytes())
             .map_err(|e| format!("write {}: {e}", path.display()))?;
-        // An existing record from an earlier run keeps its old mode through
-        // OpenOptions, so the mode is asserted either way.
-        restrict(&path, 0o600)?;
         Ok(path)
     }
 
@@ -376,6 +390,79 @@ mod tests {
         let path = tx.save().expect("save");
         assert!(path.exists());
         assert_eq!(Transaction::load(&tx.id).expect("load"), tx);
+        unsafe { std::env::remove_var("IRLUME_STATE_DIR") };
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Confirming a transaction must never be able to destroy the record that
+    /// says how to undo it.
+    ///
+    /// A transaction is saved twice: `Prepared` before the first PAM write, then
+    /// `Applied` after. `save` used to open the same path with `truncate(true)`,
+    /// so the second save emptied the prepared record as its first act and then
+    /// wrote the confirmed one into it. In that window the PAM files had already
+    /// changed and nothing on disk described their previous contents, so an
+    /// ENOSPC, an EIO or a kill left a rewritten machine with nothing to roll
+    /// back from. The write that was meant to confirm the write-ahead ordering
+    /// was the write that defeated it.
+    ///
+    /// Asserted on the INODE, because that is what distinguishes the two
+    /// mechanisms rather than describing them. Truncating in place keeps the
+    /// inode and passes through a moment where the file is empty; replacing by
+    /// rename gives a new inode and never does. A test that only checked the
+    /// final contents would pass either way.
+    #[test]
+    fn confirming_a_transaction_replaces_its_record_instead_of_emptying_it() {
+        use std::os::unix::fs::MetadataExt as _;
+        use std::os::unix::fs::PermissionsExt as _;
+        let _lock = env_lock();
+        let root = temp_state("atomic");
+        // SAFETY: single-threaded test, restored below.
+        unsafe { std::env::set_var("IRLUME_STATE_DIR", &root) };
+
+        let mut tx = Transaction {
+            id: "abcdef0123456789abcdef0123456789".into(),
+            status: TransactionStatus::Prepared,
+            action: "enable".into(),
+            plan_id: "1".repeat(32),
+            engine_version: "0.0.0".into(),
+            surfaces: vec![record(
+                Path::new("/etc/pam.d/plasmalogin"),
+                Some("the only copy of what was there before\n"),
+                "deadbeef",
+            )],
+        };
+        let path = tx.save().expect("save prepared");
+        let prepared_inode = std::fs::metadata(&path).expect("stat").ino();
+
+        // The second save, the one that happens after PAM has been rewritten.
+        tx.status = TransactionStatus::Applied;
+        tx.save().expect("save applied");
+        let applied_inode = std::fs::metadata(&path).expect("stat").ino();
+
+        assert_ne!(
+            prepared_inode, applied_inode,
+            "the record was rewritten in place, so confirming it passes through a \
+             moment where the before-states are gone"
+        );
+        assert_eq!(
+            Transaction::load(&tx.id).expect("load").status,
+            TransactionStatus::Applied
+        );
+        // The replacement is a fresh inode, so it must carry the mode itself
+        // rather than inheriting the previous record's.
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "the replacement must not widen the record");
+
+        // A temp left behind in the store would be a second, stale description
+        // of how the machine authenticates.
+        let strays: Vec<_> = std::fs::read_dir(store_dir())
+            .expect("read store")
+            .filter_map(|e| e.ok().map(|e| e.file_name()))
+            .filter(|n| n != "abcdef0123456789abcdef0123456789.json")
+            .collect();
+        assert!(strays.is_empty(), "stray files in the store: {strays:?}");
+
         unsafe { std::env::remove_var("IRLUME_STATE_DIR") };
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -76,6 +76,30 @@ pub(crate) struct SurfaceRecord {
     pub(crate) uid: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) gid: Option<u32>,
+    /// The `.pre-irlume` backup, when apply created or consumed one.
+    ///
+    /// Wiring creates a backup and unwiring renames it back over the live file,
+    /// so both change a second path the record would otherwise never mention.
+    /// An undo that does not know about a file cannot undo it, and the leftover
+    /// is not inert: a later enable rebuilds from the backup as its origin, so a
+    /// stale one silently discards whatever an administrator changed in between.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) sidecar: Option<SidecarRecord>,
+}
+
+/// A file changed alongside a surface, restored with it and never published.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SidecarRecord {
+    pub(crate) path: String,
+    /// `None` when it did not exist, so a rollback removes it rather than
+    /// leaving one behind for a later enable to trust.
+    pub(crate) before: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) mode: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) uid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) gid: Option<u32>,
 }
 
 /// A file's ownership and permission bits, or `None` when it does not exist.
@@ -296,6 +320,7 @@ mod tests {
             mode: None,
             uid: None,
             gid: None,
+            sidecar: None,
         }
     }
 

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -405,6 +405,17 @@ pub(crate) fn clear_rollback_progress(id: &str) {
     }
 }
 
+/// How a surface's backup is named in the progress note.
+///
+/// A surface is two writes: the live file and its `.pre-irlume` backup. Noting
+/// the surface only once BOTH were done reproduced the very failure the note
+/// exists to fix, one level down: a crash between them left the live file
+/// holding its before-image and nothing recording that, so the re-run checked it
+/// against the after-digest and refused it as drift.
+pub(crate) fn sidecar_progress_id(surface_id: &str) -> String {
+    format!("{surface_id}\u{0}sidecar")
+}
+
 fn progress_path(id: &str) -> Option<PathBuf> {
     is_valid_id(id).then(|| store_dir().join(format!("{id}.progress")))
 }
@@ -452,8 +463,23 @@ pub(crate) fn snapshot_before_rollback(record: &Transaction) -> Result<PathBuf, 
             match std::fs::read(source) {
                 Ok(bytes) => {
                     let dest = dir.join(name);
-                    irlume_common::write_0600_atomic(&dest, &bytes)
-                        .map_err(|e| format!("write {}: {e}", dest.display()))?;
+                    // The FIRST capture is the one worth keeping. A resumed
+                    // rollback runs this again, and by then the surfaces it
+                    // already restored hold their before-image: re-capturing
+                    // would overwrite the only copy of the administrator's
+                    // change with irlume's own restore. Published by link, which
+                    // fails rather than replaces, so the decision is not a
+                    // separate check that could be raced.
+                    let tmp = dir.join(format!(".{name}.tmp"));
+                    irlume_common::write_0600_atomic(&tmp, &bytes)
+                        .map_err(|e| format!("write {}: {e}", tmp.display()))?;
+                    let linked = std::fs::hard_link(&tmp, &dest);
+                    let _ = std::fs::remove_file(&tmp);
+                    match linked {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                        Err(e) => return Err(format!("write {}: {e}", dest.display())),
+                    }
                 }
                 // Absent is a state worth knowing about, but there is nothing to
                 // copy and a rollback that recreates the file destroys nothing.
@@ -547,13 +573,31 @@ pub(crate) enum RollbackRefusal {
 /// The check rollback is gated on. Kept separate from the restore itself so it
 /// can be run on its own by `verify`, and so both answer from one rule.
 pub(crate) fn unchanged_since_apply(record: &SurfaceRecord) -> Result<(), RollbackRefusal> {
-    let current = match file_sha256(Path::new(&record.path)) {
-        Ok(value) => value,
-        Err(error) => return Err(RollbackRefusal::Unreadable(error)),
-    };
-    let current = current.unwrap_or_else(|| ABSENT.to_string());
-    if current != record.after_sha256 {
-        return Err(RollbackRefusal::ChangedSinceApply);
+    unchanged_since_apply_excluding(record, &[])
+}
+
+/// The same question, minus the halves a stopped rollback already put back.
+///
+/// A surface is two writes, so it is two entries in the progress note. Either
+/// one already restored holds its BEFORE content and therefore no longer matches
+/// the after-digest; checking it would refuse the record and leave the other half
+/// unfinishable.
+pub(crate) fn unchanged_since_apply_excluding(
+    record: &SurfaceRecord,
+    done: &[String],
+) -> Result<(), RollbackRefusal> {
+    if !done.iter().any(|id| id == &record.id) {
+        let current = match file_sha256(Path::new(&record.path)) {
+            Ok(value) => value,
+            Err(error) => return Err(RollbackRefusal::Unreadable(error)),
+        };
+        let current = current.unwrap_or_else(|| ABSENT.to_string());
+        if current != record.after_sha256 {
+            return Err(RollbackRefusal::ChangedSinceApply);
+        }
+    }
+    if done.iter().any(|id| id == &sidecar_progress_id(&record.id)) {
+        return Ok(());
     }
     // The backup counts as part of the surface. Rollback restores it too, so
     // leaving it out of the check meant a backup an administrator or a package
@@ -786,6 +830,97 @@ mod tests {
         // An id that is not plain hex never becomes a path.
         assert!(note_rollback_progress("../../etc/passwd", &[]).is_err());
         assert!(rollback_progress("../../etc/passwd").is_empty());
+        clear_rollback_progress(&id);
+
+        // A surface is TWO writes, so it is two entries. Noting it only once
+        // both landed left a crash between them unresumable at a finer
+        // granularity: the live file held its before-image and nothing said so,
+        // and the re-run refused it as drift.
+        let surface = &tx.surfaces[0];
+        assert!(
+            unchanged_since_apply_excluding(surface, &[]).is_err(),
+            "the live file is not what apply left, so unaided this refuses"
+        );
+        assert_eq!(
+            unchanged_since_apply_excluding(surface, std::slice::from_ref(&surface.id)),
+            Ok(()),
+            "with the live half noted, the surface stops being a blocker"
+        );
+
+        // The halves are independent, and each excuses only itself. With a
+        // DRIFTED backup recorded, noting the live half must not also excuse the
+        // backup: one progress entry standing for both is how a stopped rollback
+        // skipped a write it never made.
+        let mut with_backup = surface.clone();
+        with_backup.sidecar = Some(SidecarRecord {
+            path: sidecar.display().to_string(),
+            after_sha256: Some("a digest the backup does not have".into()),
+            before: None,
+            mode: None,
+            uid: None,
+            gid: None,
+        });
+        assert_eq!(
+            unchanged_since_apply_excluding(&with_backup, std::slice::from_ref(&with_backup.id)),
+            Err(RollbackRefusal::ChangedSinceApply),
+            "noting the live half excused the backup as well"
+        );
+        assert_eq!(
+            unchanged_since_apply_excluding(
+                &with_backup,
+                &[with_backup.id.clone(), sidecar_progress_id(&with_backup.id)]
+            ),
+            Ok(()),
+            "with both halves noted there is nothing left to check"
+        );
+        // And noting the backup does not excuse the live file.
+        assert!(unchanged_since_apply_excluding(
+            &with_backup,
+            &[sidecar_progress_id(&with_backup.id)]
+        )
+        .is_err());
+    }
+
+    /// A resumed unconfirmed rollback must not overwrite its own rescue copies.
+    ///
+    /// Every unconfirmed run snapshots before it looks at the progress note, so
+    /// a second run re-captures surfaces the first already restored — which by
+    /// then hold irlume's own before-image. That would replace the only saved
+    /// copy of the administrator's change with the thing that overwrote it.
+    #[test]
+    fn a_resumed_snapshot_keeps_the_first_capture() {
+        let _env = StateDirGuard::new("resnap");
+        let live = store_dir().parent().unwrap().join("etc");
+        std::fs::create_dir_all(&live).unwrap();
+        let greeter = live.join("kde");
+        std::fs::write(&greeter, "the administrator's change\n").unwrap();
+
+        let tx = Transaction {
+            id: "cd".repeat(16),
+            schema_version: SCHEMA_VERSION,
+            status: TransactionStatus::Prepared,
+            action: "enable".into(),
+            plan_id: "1".repeat(32),
+            engine_version: "0.0.0".into(),
+            surfaces: vec![record(&greeter, Some("the original\n"), "deadbeef")],
+        };
+
+        let dir = snapshot_before_rollback(&tx).expect("first snapshot");
+        // The rollback restored it; a resumed run snapshots again.
+        std::fs::write(&greeter, "the original\n").unwrap();
+        snapshot_before_rollback(&tx).expect("second snapshot");
+
+        assert_eq!(
+            std::fs::read_to_string(dir.join("kde")).unwrap(),
+            "the administrator's change\n",
+            "the resume overwrote the only copy of what the rollback replaced"
+        );
+        let strays: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(strays.is_empty(), "left scratch: {strays:?}");
     }
 
     /// A record from a schema this build does not implement is refused, not

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -91,6 +91,19 @@ pub(crate) struct SurfaceRecord {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct SidecarRecord {
     pub(crate) path: String,
+    /// The backup's digest as apply left it.
+    ///
+    /// Rollback used to restore the backup with no check at all, so a backup an
+    /// administrator or a package replaced afterwards was silently overwritten —
+    /// the same defect the surface's own digest exists to prevent, and worse in
+    /// one way: a later enable rebuilds the live stack FROM the backup, so a
+    /// wrong one propagates into PAM at the next enable.
+    ///
+    /// Absent on records written before this field existed, in which case the
+    /// backup is restored unchecked as it was then; the schema gate is what
+    /// stops an older engine reading a newer record and skipping the check.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) after_sha256: Option<String>,
     /// `None` when it did not exist, so a rollback removes it rather than
     /// leaving one behind for a later enable to trust.
     pub(crate) before: Option<String>,
@@ -174,7 +187,10 @@ pub(crate) enum TransactionStatus {
 }
 
 /// The record format this build writes and is willing to act on.
-pub(crate) const SCHEMA_VERSION: u32 = 1;
+/// 2 since the sidecar carries an after-digest a rollback must honour: an engine
+/// that ignored it would overwrite a backup somebody replaced, which is the
+/// behaviour the field exists to stop.
+pub(crate) const SCHEMA_VERSION: u32 = 2;
 
 fn schema_version_1() -> u32 {
     1
@@ -536,11 +552,30 @@ pub(crate) fn unchanged_since_apply(record: &SurfaceRecord) -> Result<(), Rollba
         Err(error) => return Err(RollbackRefusal::Unreadable(error)),
     };
     let current = current.unwrap_or_else(|| ABSENT.to_string());
-    if current == record.after_sha256 {
-        Ok(())
-    } else {
-        Err(RollbackRefusal::ChangedSinceApply)
+    if current != record.after_sha256 {
+        return Err(RollbackRefusal::ChangedSinceApply);
     }
+    // The backup counts as part of the surface. Rollback restores it too, so
+    // leaving it out of the check meant a backup an administrator or a package
+    // replaced afterwards was silently overwritten — and a later `login enable`
+    // rebuilds the LIVE stack from the backup, so a wrong one reaches PAM at the
+    // next enable rather than sitting inert.
+    //
+    // Asked here rather than in the restore loop so it refuses BEFORE anything
+    // is written: a rollback that stops halfway through is the thing the blanket
+    // precheck exists to prevent.
+    if let Some(sidecar) = &record.sidecar {
+        if let Some(expected) = &sidecar.after_sha256 {
+            let now = match file_sha256(Path::new(&sidecar.path)) {
+                Ok(value) => value.unwrap_or_else(|| ABSENT.to_string()),
+                Err(error) => return Err(RollbackRefusal::Unreadable(error)),
+            };
+            if &now != expected {
+                return Err(RollbackRefusal::ChangedSinceApply);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -709,6 +744,7 @@ mod tests {
         };
         tx.surfaces[0].sidecar = Some(SidecarRecord {
             path: sidecar.display().to_string(),
+            after_sha256: None,
             before: None,
             mode: None,
             uid: None,

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -223,25 +223,27 @@ impl Transaction {
     /// synced too, on the run that creates it, for the same reason.
     pub(crate) fn save(&self) -> Result<PathBuf, String> {
         let dir = store_dir();
-        let store_is_new = !dir.exists();
         std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
         restrict(&dir, 0o700)?;
         // Creating the store is itself a directory entry that has to survive a
         // power loss, and `create_dir_all` does not make one durable.
         // `write_0600_atomic` fsyncs the record and the directory holding it,
-        // but on the first run of a fresh install the entry for that directory
-        // is still only in its parent's page cache: the record could be fsynced
-        // into a directory that does not come back. PAM is rewritten
-        // immediately afterwards, so the machine would again be left changed
-        // with nothing describing how to undo it — the same defect as the
-        // truncate above, one level up.
+        // but on a fresh install the entry FOR that directory is still only in
+        // its parent's page cache: the record would be fsynced into a directory
+        // that does not come back. PAM is rewritten immediately afterwards, so
+        // the machine would again be left changed with nothing describing how
+        // to undo it — the same defect as the truncate above, one level up.
         //
-        // Only on creation: an fsync of the parent on every save would cost two
-        // per apply to re-prove something already durable.
-        if store_is_new {
-            if let Some(parent) = dir.parent() {
-                fsync_dir(parent)?;
-            }
+        // Unconditional, and deliberately not skipped when the store already
+        // exists. Testing `exists()` first and syncing only when this process
+        // created it looks like a free optimisation and is not: another process
+        // that finds the directory already there, writes its record and rewrites
+        // PAM has inherited a durability guarantee nobody has made yet, because
+        // the process that created the directory may not have synced its parent
+        // yet, or at all. Two fsyncs per apply is not a price worth an
+        // unrecoverable machine.
+        if let Some(parent) = dir.parent() {
+            fsync_dir(parent)?;
         }
         let path = dir.join(format!("{}.json", self.id));
         let body = serde_json::to_string(self).map_err(|e| format!("serialize record: {e}"))?;

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -146,6 +146,19 @@ pub(crate) enum TransactionStatus {
     Prepared,
     /// Every surface was written and its after-state recorded.
     Applied,
+    /// A status this build does not know, written by a newer engine.
+    ///
+    /// Present for the same reason `OperationErrorCode::Unknown` is: without it
+    /// serde fails the whole document, and an older engine meeting a newer
+    /// record could not read it AT ALL. That matters more here than elsewhere,
+    /// because the record is the recovery path: refusing to parse it would take
+    /// away the one thing that says how to undo a change.
+    ///
+    /// Treated as conservatively as `Prepared`: this build cannot know what
+    /// guarantees the newer status carries, so a rollback needs the same
+    /// explicit acknowledgement.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Hex sha256 of a byte slice.

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -343,6 +343,112 @@ pub(crate) enum LoadFailure {
     },
 }
 
+/// How far a rollback got, so a stopped one can be finished rather than
+/// restarted.
+///
+/// A rollback restores surfaces one at a time. A write failure, an ENOSPC or a
+/// signal after the second of four leaves a stack that is neither the
+/// transaction's nor the administrator's, and re-running made it worse rather
+/// than better: the surfaces already restored no longer match the recorded
+/// after-digest, so the drift check refused the whole record and the operator
+/// was left reconstructing the rest out of the JSON by hand.
+///
+/// Recording what is done, durably, after each surface, turns that into a
+/// resume. A surface named here is skipped and not re-checked, because its
+/// digest is deliberately no longer the one apply left.
+pub(crate) fn rollback_progress(id: &str) -> Vec<String> {
+    let Some(path) = progress_path(id) else {
+        return Vec::new();
+    };
+    // A progress note that cannot be parsed is treated as no progress: redoing a
+    // restore is safe, since it writes the same recorded content, while skipping
+    // one that never happened is not.
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|body| serde_json::from_str::<Vec<String>>(&body).ok())
+        .unwrap_or_default()
+}
+
+/// Note that a surface is restored, before moving to the next one.
+///
+/// Atomic and fsynced, for the same reason the record itself is: a note that
+/// does not survive the crash it exists to describe is not a note.
+pub(crate) fn note_rollback_progress(id: &str, done: &[String]) -> Result<(), String> {
+    let Some(path) = progress_path(id) else {
+        return Err("invalid transaction id".into());
+    };
+    let body = serde_json::to_string(done).map_err(|e| format!("serialize progress: {e}"))?;
+    irlume_common::write_0600_atomic(&path, body.as_bytes())
+        .map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// Drop the note once every surface is back.
+pub(crate) fn clear_rollback_progress(id: &str) {
+    if let Some(path) = progress_path(id) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+fn progress_path(id: &str) -> Option<PathBuf> {
+    is_valid_id(id).then(|| store_dir().join(format!("{id}.progress")))
+}
+
+/// Copy what is on disk NOW, before an unconfirmed rollback overwrites it.
+///
+/// A `prepared` record has no trustworthy after-digest, so `--accept-unconfirmed`
+/// restores its before-images without checking the current state. That is the
+/// only way to recover a machine whose apply was interrupted, and it is equally
+/// a way to revert a package security update or an administrator's change made
+/// after the crash. Nothing captured what it overwrote.
+///
+/// So it is captured first. This is not a second transaction record and feeds no
+/// automatic path: it is files in a directory whose location the command
+/// reports, for the person who finds their change gone.
+///
+/// Confirmed rollbacks do not need it. Their drift check has already established
+/// that every file is byte-for-byte what apply left, so there is nothing
+/// unrelated to lose.
+pub(crate) fn snapshot_before_rollback(record: &Transaction) -> Result<PathBuf, String> {
+    let dir = store_dir().join(format!("{}.before-rollback", record.id));
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    restrict(&dir, 0o700)?;
+    fsync_ancestors(&dir)?;
+    for surface in &record.surfaces {
+        let paths = [
+            Some(surface.path.clone()),
+            surface.sidecar.as_ref().map(|s| s.path.clone()),
+        ];
+        for path in paths.into_iter().flatten() {
+            let source = Path::new(&path);
+            // Copied under the file's own name, flattened. `sudo` and
+            // `sudo.pre-irlume` therefore do not collide, and a name is checked
+            // rather than trusted so nothing can point outside this directory.
+            let Some(name) = source.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if !name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+                || name.starts_with('.')
+            {
+                return Err(format!("{path} has a name irlume will not copy"));
+            }
+            match std::fs::read(source) {
+                Ok(bytes) => {
+                    let dest = dir.join(name);
+                    irlume_common::write_0600_atomic(&dest, &bytes)
+                        .map_err(|e| format!("write {}: {e}", dest.display()))?;
+                }
+                // Absent is a state worth knowing about, but there is nothing to
+                // copy and a rollback that recreates the file destroys nothing.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(format!("read {path}: {e}")),
+            }
+        }
+    }
+    Ok(dir)
+}
+
 /// Whether a transaction id is safe to use as a filename.
 ///
 /// Hex only, and a fixed length. This is the whole defence against a supplied
@@ -579,6 +685,73 @@ mod tests {
     /// inode and passes through a moment where the file is empty; replacing by
     /// rename gives a new inode and never does. A test that only checked the
     /// final contents would pass either way.
+    /// A stopped rollback can be finished, and an unconfirmed one keeps a copy
+    /// of what it is about to overwrite.
+    #[test]
+    fn a_rollback_records_its_progress_and_snapshots_what_it_overwrites() {
+        let _env = StateDirGuard::new("resume");
+        let live = store_dir().parent().unwrap().join("etc");
+        std::fs::create_dir_all(&live).unwrap();
+        let greeter = live.join("kde");
+        let sidecar = live.join("kde.pre-irlume");
+        std::fs::write(&greeter, "what an administrator put here later\n").unwrap();
+        std::fs::write(&sidecar, "the backup as it stands\n").unwrap();
+
+        let id = "ab".repeat(16);
+        let mut tx = Transaction {
+            id: id.clone(),
+            schema_version: SCHEMA_VERSION,
+            status: TransactionStatus::Prepared,
+            action: "enable".into(),
+            plan_id: "1".repeat(32),
+            engine_version: "0.0.0".into(),
+            surfaces: vec![record(&greeter, Some("the original\n"), "deadbeef")],
+        };
+        tx.surfaces[0].sidecar = Some(SidecarRecord {
+            path: sidecar.display().to_string(),
+            before: None,
+            mode: None,
+            uid: None,
+            gid: None,
+        });
+
+        // The snapshot holds what is on disk NOW, which is precisely what an
+        // unconfirmed rollback would overwrite without checking.
+        let dir = snapshot_before_rollback(&tx).expect("snapshot");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("kde")).unwrap(),
+            "what an administrator put here later\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.join("kde.pre-irlume")).unwrap(),
+            "the backup as it stands\n",
+            "the sidecar is overwritten too, so it is copied too"
+        );
+
+        // A surface that does not exist is not an error: recreating it destroys
+        // nothing.
+        std::fs::remove_file(&greeter).unwrap();
+        assert!(snapshot_before_rollback(&tx).is_ok());
+
+        // Progress: nothing, then something, then cleared.
+        assert!(rollback_progress(&id).is_empty());
+        note_rollback_progress(&id, &["kde".to_string()]).expect("note");
+        assert_eq!(rollback_progress(&id), vec!["kde".to_string()]);
+        clear_rollback_progress(&id);
+        assert!(rollback_progress(&id).is_empty());
+
+        // An unreadable note means "no progress", never "all done": redoing a
+        // restore writes the same recorded content, while skipping one that
+        // never happened leaves a half-rolled-back stack.
+        note_rollback_progress(&id, &["kde".to_string()]).expect("note");
+        std::fs::write(store_dir().join(format!("{id}.progress")), "{ not a list").unwrap();
+        assert!(rollback_progress(&id).is_empty());
+
+        // An id that is not plain hex never becomes a path.
+        assert!(note_rollback_progress("../../etc/passwd", &[]).is_err());
+        assert!(rollback_progress("../../etc/passwd").is_empty());
+    }
+
     /// A record from a schema this build does not implement is refused, not
     /// half-read.
     ///

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -798,6 +798,10 @@ fn emit_load_failure(
         crate::logintx::LoadFailure::NotFound => "not-found",
         crate::logintx::LoadFailure::NotAuthorized => "not-authorized",
         crate::logintx::LoadFailure::Unreadable(_) => "operation-failed",
+        // Distinct from operation-failed: retrying will never help, and the
+        // action a consumer should take is to run the newer irlume, not to
+        // report a storage problem.
+        crate::logintx::LoadFailure::TooNew { .. } => "unsupported-record",
     };
     emit(&failure(command, code, false, contract), ExitCode::FAILURE)
 }
@@ -1107,6 +1111,7 @@ pub fn login_apply(args: &[String]) -> ExitCode {
     };
     let mut record = crate::logintx::Transaction {
         id: transaction_id,
+        schema_version: crate::logintx::SCHEMA_VERSION,
         status: crate::logintx::TransactionStatus::Prepared,
         action: action.to_string(),
         plan_id: current_plan,
@@ -1970,6 +1975,7 @@ mod tests {
     fn record_over(files: &[(&str, &std::path::Path, &str)]) -> crate::logintx::Transaction {
         crate::logintx::Transaction {
             id: "0123456789abcdef0123456789abcdef".into(),
+            schema_version: crate::logintx::SCHEMA_VERSION,
             status: crate::logintx::TransactionStatus::Applied,
             action: "disable".into(),
             plan_id: "f".repeat(32),

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1183,7 +1183,9 @@ pub fn login_verify(args: &[String]) -> ExitCode {
         Ok(record) => record,
         Err(reason) => return emit_load_failure(COMMAND, reason, contract),
     };
-    let unconfirmed = record.status == crate::logintx::TransactionStatus::Prepared;
+    // Unknown is a status a newer engine wrote. This build cannot know what it
+    // guarantees, so it is treated as cautiously as an unconfirmed one.
+    let unconfirmed = !matches!(record.status, crate::logintx::TransactionStatus::Applied);
     let (surfaces, drifted) = verify_surfaces(&record);
     emit(
         &success(
@@ -1196,7 +1198,14 @@ pub fn login_verify(args: &[String]) -> ExitCode {
                 // stopped between persisting the before-states and recording the
                 // result. The before-states are still usable, the after-digests
                 // are not, so drift is not meaningful for such a record.
-                "status": if unconfirmed { "prepared" } else { "applied" },
+                // Reported as it is, not folded into "prepared": a consumer
+                // meeting `unknown` is looking at a record from a newer engine,
+                // which is a different thing to diagnose than an interrupted one.
+                "status": match record.status {
+                    crate::logintx::TransactionStatus::Applied => "applied",
+                    crate::logintx::TransactionStatus::Prepared => "prepared",
+                    crate::logintx::TransactionStatus::Unknown => "unknown",
+                },
                 "surfaces": surfaces,
                 "drifted": drifted,
                 // Whether a rollback would be accepted right now. Stated by the
@@ -1267,7 +1276,7 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
     // still the authority, so a restore IS possible, but it gives up the
     // protection against reverting somebody else's later edit. That trade is the
     // operator's to make, not something to do silently.
-    if record.status == crate::logintx::TransactionStatus::Prepared {
+    if !matches!(record.status, crate::logintx::TransactionStatus::Applied) {
         if !accept_unconfirmed {
             irlume_common::dlog!(
                 "login.rollback: {} is unconfirmed; needs --accept-unconfirmed",

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -877,8 +877,35 @@ fn rollback_restore(
             ExitCode::FAILURE,
         );
     }
-    let mut restored = Vec::new();
+    // An unconfirmed rollback writes over whatever is there without checking,
+    // because its after-digests were never confirmed. That is how a machine
+    // whose apply was interrupted gets recovered, and equally how a package
+    // update or an administrator's later edit gets reverted. Copy it first, and
+    // say where: nothing else captures what this is about to overwrite.
+    let snapshot = if unconfirmed {
+        match crate::logintx::snapshot_before_rollback(record) {
+            Ok(dir) => Some(dir.display().to_string()),
+            Err(message) => {
+                irlume_common::dlog!("{command}: cannot snapshot before restoring: {message}");
+                return emit(
+                    &failure(command, "operation-failed", true, contract),
+                    ExitCode::FAILURE,
+                );
+            }
+        }
+    } else {
+        None
+    };
+    // What a previous run of this rollback already put back. Those surfaces are
+    // skipped: they hold their before-content now, so re-restoring is pointless
+    // and re-checking them against the after-digest would refuse the whole
+    // record — which is what made a stopped rollback unfinishable.
+    let mut restored = crate::logintx::rollback_progress(&record.id);
+    let already: std::collections::HashSet<String> = restored.iter().cloned().collect();
     for surface in &record.surfaces {
+        if already.contains(&surface.id) {
+            continue;
+        }
         // Re-check THIS surface immediately before restoring it. The blanket
         // check above happens before any write, which is what stops a rollback
         // half-completing, but it leaves a window: by the time the loop reaches
@@ -898,6 +925,9 @@ fn rollback_restore(
                         "transaction_id": record.id,
                         "restored": restored,
                         "stopped_at": surface.id,
+                        // Where the pre-rollback copies are, so a caller that
+                        // stopped partway can still find what was overwritten.
+                        "snapshot": snapshot,
                     }),
                     ExitCode::FAILURE,
                 );
@@ -946,6 +976,23 @@ fn rollback_restore(
                     }
                 }
                 restored.push(surface.id.clone());
+                // Durably, before moving to the next surface. A note written
+                // after the whole loop would describe only the runs that did not
+                // need it.
+                if let Err(message) = crate::logintx::note_rollback_progress(&record.id, &restored)
+                {
+                    irlume_common::dlog!("{command}: cannot record progress: {message}");
+                    return emit_with_extra(
+                        &failure(command, "operation-failed", false, contract),
+                        json!({
+                            "transaction_id": record.id,
+                            "restored": restored,
+                            "stopped_at": surface.id,
+                            "snapshot": snapshot,
+                        }),
+                        ExitCode::FAILURE,
+                    );
+                }
             }
             Err(message) => {
                 irlume_common::dlog!("{command}: {} failed: {message}", surface.id);
@@ -958,12 +1005,18 @@ fn rollback_restore(
                         "transaction_id": record.id,
                         "restored": restored,
                         "stopped_at": surface.id,
+                        // Where the pre-rollback copies are, so a caller that
+                        // stopped partway can still find what was overwritten.
+                        "snapshot": snapshot,
                     }),
                     ExitCode::FAILURE,
                 );
             }
         }
     }
+    // Every surface is back, so the resume note has nothing left to describe.
+    // The snapshot stays: it is for a person, not for the next run.
+    crate::logintx::clear_rollback_progress(&record.id);
     emit(
         &success(
             command,
@@ -973,6 +1026,7 @@ fn rollback_restore(
                 "unconfirmed": unconfirmed,
                 "restored": restored,
                 "applied": true,
+                "snapshot": snapshot,
             }),
             contract,
         ),
@@ -999,8 +1053,25 @@ impl RollbackBlockers<'_> {
 }
 
 fn rollback_blockers(record: &crate::logintx::Transaction) -> RollbackBlockers<'_> {
+    rollback_blockers_excluding(record, &crate::logintx::rollback_progress(&record.id))
+}
+
+/// The blanket precheck, minus the surfaces a stopped run already put back.
+///
+/// A restored surface holds its BEFORE content, so it no longer matches the
+/// recorded after-digest and reads as drift. Checking it anyway refused the
+/// whole record, which is precisely what made a stopped rollback unfinishable:
+/// the operator was told their stack had been edited when what had happened is
+/// that irlume itself restored part of it.
+fn rollback_blockers_excluding<'a>(
+    record: &'a crate::logintx::Transaction,
+    done: &[String],
+) -> RollbackBlockers<'a> {
     let mut blockers = RollbackBlockers::default();
     for surface in &record.surfaces {
+        if done.iter().any(|id| id == &surface.id) {
+            continue;
+        }
         match crate::logintx::unchanged_since_apply(surface) {
             Ok(()) => {}
             Err(crate::logintx::RollbackRefusal::ChangedSinceApply) => {
@@ -1228,6 +1299,13 @@ pub fn login_verify(args: &[String]) -> ExitCode {
     // guarantees, so it is treated as cautiously as an unconfirmed one.
     let unconfirmed = !matches!(record.status, crate::logintx::TransactionStatus::Applied);
     let (surfaces, drifted) = verify_surfaces(&record);
+    // A rollback that stopped partway left the surfaces it restored holding
+    // their BEFORE content, which reads as drift here. Counting those would tell
+    // an operator a rollback is unavailable when re-running it is exactly what
+    // finishes the job, so they are excluded from the availability answer and
+    // named instead.
+    let restored = crate::logintx::rollback_progress(&record.id);
+    let blocking = rollback_blockers_excluding(&record, &restored);
     emit(
         &success(
             COMMAND,
@@ -1254,7 +1332,11 @@ pub fn login_verify(args: &[String]) -> ExitCode {
                 // states it may not recognise.
                 // An unconfirmed record can still be rolled back, but only on
                 // request: see login rollback --accept-unconfirmed.
-                "rollback_available": !unconfirmed && drifted == 0,
+                "rollback_available": !unconfirmed && !blocking.any(),
+                // Present only when a previous rollback stopped partway. A
+                // consumer seeing it knows the drift below is irlume's own
+                // work, not somebody's edit.
+                "already_restored": restored,
             }),
             contract,
         ),

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1171,6 +1171,7 @@ pub fn login_apply(args: &[String]) -> ExitCode {
                 sidecar: (surface.sidecar_existed || surface.sidecar_before.is_some()).then(|| {
                     crate::logintx::SidecarRecord {
                         path: format!("{}{}", surface.path, crate::pamwire::BACKUP),
+                        after_sha256: surface.sidecar_after_sha256.clone(),
                         before: surface.sidecar_before.clone(),
                         mode: surface.sidecar_metadata.map(|(mode, _, _)| mode),
                         uid: surface.sidecar_metadata.map(|(_, uid, _)| uid),

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1295,7 +1295,16 @@ pub fn login_apply(args: &[String]) -> ExitCode {
     // The scopes match what `apply` planned: this command wires the greeter and
     // lock screen, and never sudo or polkit, which are their own opt-in.
     if failed.is_empty() {
-        crate::pamwire::write_wired_marker(enable, false, false, enable);
+        // Only the scopes this command is responsible for. `login apply` wires
+        // the greeter and the lock screen and never touches sudo or polkit, so
+        // it must not overwrite their flags: a machine `enable` on a host where
+        // someone had opted into face-polkit would otherwise record
+        // with_polkit=false and reconcile would quietly stop maintaining it.
+        //
+        // On disable the marker goes entirely, because a disable unwires every
+        // surface including those two.
+        let (with_sudo, with_polkit, _) = crate::pamwire::read_wired_marker().unwrap_or_default();
+        crate::pamwire::write_wired_marker(enable, with_sudo, with_polkit, enable);
     }
     let changes: Vec<Value> = applied
         .iter()

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1050,7 +1050,25 @@ fn rollback_restore(
     }
     // Every surface is back, so the resume note has nothing left to describe.
     // The snapshot stays: it is for a person, not for the next run.
-    crate::logintx::clear_rollback_progress(&record.id);
+    //
+    // A note that outlives the success it describes is not harmless: the next
+    // rollback trusts it and skips those files unchecked, so failing to clear it
+    // is reported rather than swallowed.
+    if let Err(message) = crate::logintx::clear_rollback_progress(&record.id) {
+        irlume_common::dlog!(
+            "{command}: restored everything but could not clear progress: {message}"
+        );
+        return emit_with_extra(
+            &failure(command, "operation-failed", true, contract),
+            json!({
+                "transaction_id": record.id,
+                "restored": restored,
+                "applied": true,
+                "snapshot": snapshot,
+            }),
+            ExitCode::FAILURE,
+        );
+    }
     emit(
         &success(
             command,

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -35,6 +35,7 @@ const CAPABILITIES: &[&str] = &[
     "login-status-json",
     "auth-test-events",
     "login-plan-json",
+    "login-transactions",
 ];
 
 /// The contract the caller asked for, or the failure to report.
@@ -731,6 +732,396 @@ fn valid_login_plan_args(args: &[String]) -> Option<&'static str> {
     }
 }
 
+/// Root, or the reason to refuse.
+///
+/// Checked in the command rather than left to the write failing with EACCES:
+/// a mutating command that gets partway before losing permission leaves a PAM
+/// stack half-changed, and `not-authorized` up front is a better answer than a
+/// partial apply.
+fn require_root(command: &'static str, contract: u32) -> Option<ExitCode> {
+    // SAFETY: geteuid cannot fail and touches no memory.
+    if unsafe { libc::geteuid() } == 0 {
+        return None;
+    }
+    Some(emit(
+        &failure(command, "not-authorized", false, contract),
+        ExitCode::FAILURE,
+    ))
+}
+
+/// `irlume login apply --action X --plan-id ID --json`: carry out a plan.
+///
+/// The plan is re-derived from the machine and its id recomputed. A `plan_id`
+/// that no longer matches is refused as `plan-stale`, because the consumer
+/// displayed one set of changes and the machine now calls for another; applying
+/// anyway would change something nobody was shown. The id is never trusted as
+/// input, only compared.
+pub fn login_apply(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "login.apply";
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    let args = &without_contract(args);
+    let Some((action, supplied_plan)) = valid_login_apply_args(args) else {
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
+    };
+    if let Some(refusal) = require_root(COMMAND, contract) {
+        return refusal;
+    }
+    let enable = action == "enable";
+    let planned = crate::pamwire::plan(enable, false, false);
+    let current_plan = plan_id(action, &planned);
+    if current_plan != supplied_plan {
+        return emit(
+            &failure(COMMAND, "plan-stale", false, contract),
+            ExitCode::FAILURE,
+        );
+    }
+
+    let applied = crate::pamwire::apply(enable, false, false);
+    let record = crate::logintx::Transaction {
+        id: random_id(),
+        action: action.to_string(),
+        plan_id: current_plan,
+        engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        surfaces: applied
+            .iter()
+            .map(|surface| crate::logintx::SurfaceRecord {
+                id: surface.id.to_string(),
+                path: surface.path.clone(),
+                change: surface.change.id().to_string(),
+                before: surface.before.clone(),
+                after_sha256: surface.after_sha256.clone(),
+            })
+            .collect(),
+    };
+    // Recorded before the result is reported. Files have already changed; a
+    // record that could not be written would leave them changed with nothing
+    // describing how to undo it, which is worse than not having run.
+    if let Err(message) = record.save() {
+        irlume_common::dlog!("login.apply: recording the transaction failed: {message}");
+        return emit(
+            &failure(COMMAND, "operation-failed", false, contract),
+            ExitCode::FAILURE,
+        );
+    }
+
+    let failed: Vec<&crate::pamwire::AppliedSurface> =
+        applied.iter().filter(|s| s.error.is_some()).collect();
+    let changes: Vec<Value> = applied
+        .iter()
+        .map(|surface| {
+            json!({
+                "surface": surface.id,
+                "role": surface.role,
+                "change": surface.change.id(),
+                "applied": surface.error.is_none(),
+            })
+        })
+        .collect();
+    let data = json!({
+        "transaction_id": record.id,
+        "plan_id": record.plan_id,
+        "action": action,
+        "changes": changes,
+        "applied": applied.len() - failed.len(),
+        "failed": failed.len(),
+    });
+    if failed.is_empty() {
+        emit(&success(COMMAND, data, contract), ExitCode::SUCCESS)
+    } else {
+        // A partial apply is a failure that still has a transaction id, because
+        // the surfaces that DID change are recorded and can be rolled back. The
+        // id is on stderr rather than lost: the error document carries no data.
+        irlume_common::dlog!(
+            "login.apply: {} surface(s) failed; transaction {} can be rolled back",
+            failed.len(),
+            record.id
+        );
+        eprintln!("transaction {} recorded; roll back with: irlume login rollback --transaction-id {} --apply --json", record.id, record.id);
+        emit(
+            &failure(COMMAND, "operation-failed", false, contract),
+            ExitCode::FAILURE,
+        )
+    }
+}
+
+/// `irlume login verify --transaction-id ID --json`: is the machine still as
+/// that transaction left it?
+///
+/// Read-only, and deliberately usable without root: a desktop asking "did my
+/// change stick" should not need privilege to find out. Reading a record does,
+/// though, since the store is root-only, so an unprivileged caller gets
+/// `not-authorized` from the load rather than a wrong answer.
+pub fn login_verify(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "login.verify";
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    let args = &without_contract(args);
+    let Some(id) = valid_transaction_args(args, "verify", false) else {
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
+    };
+    let Ok(record) = crate::logintx::Transaction::load(&id) else {
+        return emit(
+            &failure(COMMAND, "not-found", false, contract),
+            ExitCode::FAILURE,
+        );
+    };
+    let surfaces: Vec<Value> = record
+        .surfaces
+        .iter()
+        .map(|surface| {
+            let state = match crate::logintx::unchanged_since_apply(surface) {
+                Ok(()) => "as-applied",
+                Err(crate::logintx::RollbackRefusal::ChangedSinceApply) => "changed-since-apply",
+                Err(crate::logintx::RollbackRefusal::Unreadable(_)) => "unreadable",
+            };
+            json!({ "surface": surface.id, "state": state })
+        })
+        .collect();
+    let drifted = surfaces
+        .iter()
+        .filter(|s| s["state"] != "as-applied")
+        .count();
+    emit(
+        &success(
+            COMMAND,
+            json!({
+                "transaction_id": record.id,
+                "action": record.action,
+                "plan_id": record.plan_id,
+                "surfaces": surfaces,
+                "drifted": drifted,
+                // Whether a rollback would be accepted right now. Stated by the
+                // engine so a consumer does not have to infer it from per-surface
+                // states it may not recognise.
+                "rollback_available": drifted == 0,
+            }),
+            contract,
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
+/// `irlume login rollback --transaction-id ID --apply --json`: put back what a
+/// transaction changed.
+///
+/// Refuses unless every surface is still exactly as apply left it. Restoring a
+/// file something else has edited since would revert a change this transaction
+/// never made, so drift stops the whole rollback rather than skipping the
+/// drifted surface: a half-rolled-back login stack is its own hazard.
+///
+/// Without `--apply` it reports what it would restore and touches nothing.
+pub fn login_rollback(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "login.rollback";
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    let args = &without_contract(args);
+    let Some(id) = valid_transaction_args(args, "rollback", true) else {
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
+    };
+    let will_apply = args.iter().any(|a| a == "--apply");
+    if will_apply {
+        if let Some(refusal) = require_root(COMMAND, contract) {
+            return refusal;
+        }
+    }
+    let Ok(record) = crate::logintx::Transaction::load(&id) else {
+        return emit(
+            &failure(COMMAND, "not-found", false, contract),
+            ExitCode::FAILURE,
+        );
+    };
+    // Every surface is checked BEFORE any is written. A rollback that restored
+    // three files and then met a fourth it must refuse would leave the stack in
+    // a state neither the transaction nor the admin chose.
+    let drifted: Vec<&str> = record
+        .surfaces
+        .iter()
+        .filter(|s| crate::logintx::unchanged_since_apply(s).is_err())
+        .map(|s| s.id.as_str())
+        .collect();
+    if !drifted.is_empty() {
+        irlume_common::dlog!("login.rollback: refused; changed since apply: {drifted:?}");
+        return emit(
+            &failure(COMMAND, "changed-since-apply", false, contract),
+            ExitCode::FAILURE,
+        );
+    }
+    if !will_apply {
+        return emit(
+            &success(
+                COMMAND,
+                json!({
+                    "transaction_id": record.id,
+                    "action": record.action,
+                    "would_restore": record.surfaces.iter().map(|s| json!(s.id)).collect::<Vec<_>>(),
+                    "applied": false,
+                }),
+                contract,
+            ),
+            ExitCode::SUCCESS,
+        );
+    }
+    let mut restored = Vec::new();
+    for surface in &record.surfaces {
+        match crate::pamwire::restore_surface(
+            std::path::Path::new(&surface.path),
+            surface.before.as_deref(),
+        ) {
+            Ok(()) => restored.push(surface.id.clone()),
+            Err(message) => {
+                irlume_common::dlog!("login.rollback: {} failed: {message}", surface.id);
+                eprintln!(
+                    "rollback stopped after restoring {:?}; {} could not be written",
+                    restored, surface.id
+                );
+                return emit(
+                    &failure(COMMAND, "operation-failed", false, contract),
+                    ExitCode::FAILURE,
+                );
+            }
+        }
+    }
+    emit(
+        &success(
+            COMMAND,
+            json!({
+                "transaction_id": record.id,
+                "action": record.action,
+                "restored": restored,
+                "applied": true,
+            }),
+            contract,
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
+fn valid_login_apply_args(args: &[String]) -> Option<(&'static str, String)> {
+    if args.first().map(String::as_str) != Some("login")
+        || args.get(1).map(String::as_str) != Some("apply")
+    {
+        return None;
+    }
+    let (mut action, mut plan, mut saw_json) = (None, None, false);
+    let mut index = 2;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" if !saw_json => {
+                saw_json = true;
+                index += 1;
+            }
+            "--action" if action.is_none() => {
+                action = match args.get(index + 1).map(String::as_str) {
+                    Some("enable") => Some("enable"),
+                    Some("disable") => Some("disable"),
+                    _ => return None,
+                };
+                index += 2;
+            }
+            "--plan-id" if plan.is_none() => {
+                let value = args.get(index + 1)?;
+                if !crate::logintx::is_valid_id(value) {
+                    return None;
+                }
+                plan = Some(value.clone());
+                index += 2;
+            }
+            _ => return None,
+        }
+    }
+    // The plan id is required. Applying without one would mean acting on
+    // changes the consumer never saw.
+    match (saw_json, action, plan) {
+        (true, Some(action), Some(plan)) => Some((action, plan)),
+        _ => None,
+    }
+}
+
+fn valid_transaction_args(args: &[String], sub: &str, allow_apply: bool) -> Option<String> {
+    if args.first().map(String::as_str) != Some("login")
+        || args.get(1).map(String::as_str) != Some(sub)
+    {
+        return None;
+    }
+    let (mut id, mut saw_json, mut saw_apply) = (None, false, false);
+    let mut index = 2;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" if !saw_json => {
+                saw_json = true;
+                index += 1;
+            }
+            "--apply" if allow_apply && !saw_apply => {
+                saw_apply = true;
+                index += 1;
+            }
+            "--transaction-id" if id.is_none() => {
+                let value = args.get(index + 1)?;
+                if !crate::logintx::is_valid_id(value) {
+                    return None;
+                }
+                id = Some(value.clone());
+                index += 2;
+            }
+            _ => return None,
+        }
+    }
+    if saw_json {
+        id
+    } else {
+        None
+    }
+}
+
 /// An exclusive per-user session, held for as long as the guard lives.
 ///
 /// The contract promises one session per user. That is enforced with an
@@ -1160,7 +1551,8 @@ mod tests {
                 "doctor-json",
                 "login-status-json",
                 "auth-test-events",
-                "login-plan-json"
+                "login-plan-json",
+                "login-transactions"
             ])
         );
         assert!(document.get("error").is_none());

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -856,6 +856,23 @@ fn rollback_restore(
             ExitCode::SUCCESS,
         );
     }
+    // Refuse the whole record if it names anything irlume does not manage,
+    // BEFORE restoring any of it. Checked here rather than at load so a record
+    // can still be read and reported by verify; it is writing that is gated.
+    if let Some(stray) = record
+        .surfaces
+        .iter()
+        .find(|s| !crate::pamwire::is_managed_path(&s.path))
+    {
+        irlume_common::dlog!(
+            "{command}: refusing, record names an unmanaged path: {}",
+            stray.path
+        );
+        return emit(
+            &failure(command, "unmanaged-path", false, contract),
+            ExitCode::FAILURE,
+        );
+    }
     let mut restored = Vec::new();
     for surface in &record.surfaces {
         // Re-check THIS surface immediately before restoring it. The blanket
@@ -898,7 +915,11 @@ fn rollback_restore(
                 // The backup is put back with its surface. Leaving a stale one
                 // behind is not inert: a later enable rebuilds from it as the
                 // origin, so it would silently discard an administrator's edits.
-                if let Some(sidecar) = &surface.sidecar {
+                if let Some(sidecar) = &surface
+                    .sidecar
+                    .as_ref()
+                    .filter(|s| crate::pamwire::is_managed_path(&s.path))
+                {
                     let sidecar_metadata = match (sidecar.mode, sidecar.uid, sidecar.gid) {
                         (Some(mode), Some(uid), Some(gid)) => Some((mode, uid, gid)),
                         _ => None,

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -903,7 +903,12 @@ fn rollback_restore(
     let mut restored = crate::logintx::rollback_progress(&record.id);
     let already: std::collections::HashSet<String> = restored.iter().cloned().collect();
     for surface in &record.surfaces {
-        if already.contains(&surface.id) {
+        let sidecar_key = crate::logintx::sidecar_progress_id(&surface.id);
+        // A surface is two writes. Each is noted as it lands, so a stop between
+        // them resumes at the second rather than refusing the first as drift.
+        let live_done = already.contains(&surface.id);
+        let sidecar_done = already.contains(&sidecar_key);
+        if live_done && sidecar_done {
             continue;
         }
         // Re-check THIS surface immediately before restoring it. The blanket
@@ -914,7 +919,8 @@ fn rollback_restore(
         // check-and-write. Skipped for an unconfirmed record, whose digests were
         // never confirmed and so cannot gate anything.
         if !unconfirmed {
-            if let Err(reason) = crate::logintx::unchanged_since_apply(surface) {
+            if let Err(reason) = crate::logintx::unchanged_since_apply_excluding(surface, &restored)
+            {
                 irlume_common::dlog!(
                     "{command}: {} moved while the rollback was running: {reason:?}",
                     surface.id
@@ -940,18 +946,46 @@ fn rollback_restore(
             (Some(mode), Some(uid), Some(gid)) => Some((mode, uid, gid)),
             _ => None,
         };
-        match crate::pamwire::restore_surface(
-            std::path::Path::new(&surface.path),
-            surface.before.as_deref(),
-            metadata,
-        ) {
+        let live = if live_done {
+            Ok(())
+        } else {
+            crate::pamwire::restore_surface(
+                std::path::Path::new(&surface.path),
+                surface.before.as_deref(),
+                metadata,
+            )
+        };
+        match live {
             Ok(()) => {
+                // Noted BEFORE the backup is touched. Recording the two together
+                // is what left a stop between them unresumable: the live file
+                // held its before-image and nothing said so, so the re-run
+                // checked it against the after-digest and refused it as drift.
+                if !live_done {
+                    restored.push(surface.id.clone());
+                    if let Err(message) =
+                        crate::logintx::note_rollback_progress(&record.id, &restored)
+                    {
+                        irlume_common::dlog!("{command}: cannot record progress: {message}");
+                        return emit_with_extra(
+                            &failure(command, "operation-failed", false, contract),
+                            json!({
+                                "transaction_id": record.id,
+                                "restored": restored,
+                                "stopped_at": surface.id,
+                                "snapshot": snapshot,
+                            }),
+                            ExitCode::FAILURE,
+                        );
+                    }
+                }
                 // The backup is put back with its surface. Leaving a stale one
                 // behind is not inert: a later enable rebuilds from it as the
                 // origin, so it would silently discard an administrator's edits.
                 if let Some(sidecar) = &surface
                     .sidecar
                     .as_ref()
+                    .filter(|_| !sidecar_done)
                     .filter(|s| crate::pamwire::is_managed_path(&s.path))
                 {
                     let sidecar_metadata = match (sidecar.mode, sidecar.uid, sidecar.gid) {
@@ -975,10 +1009,10 @@ fn rollback_restore(
                         );
                     }
                 }
-                restored.push(surface.id.clone());
-                // Durably, before moving to the next surface. A note written
-                // after the whole loop would describe only the runs that did not
-                // need it.
+                // The sidecar half, noted on its own. Durably, before moving
+                // to the next surface: a note written after the whole loop would
+                // describe only the runs that did not need it.
+                restored.push(sidecar_key.clone());
                 if let Err(message) = crate::logintx::note_rollback_progress(&record.id, &restored)
                 {
                     irlume_common::dlog!("{command}: cannot record progress: {message}");
@@ -1069,10 +1103,7 @@ fn rollback_blockers_excluding<'a>(
 ) -> RollbackBlockers<'a> {
     let mut blockers = RollbackBlockers::default();
     for surface in &record.surfaces {
-        if done.iter().any(|id| id == &surface.id) {
-            continue;
-        }
-        match crate::logintx::unchanged_since_apply(surface) {
+        match crate::logintx::unchanged_since_apply_excluding(surface, done) {
             Ok(()) => {}
             Err(crate::logintx::RollbackRefusal::ChangedSinceApply) => {
                 blockers.changed.push(surface.id.as_str());

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -749,6 +749,41 @@ fn require_root(command: &'static str, contract: u32) -> Option<ExitCode> {
     ))
 }
 
+/// Each surface's state, and how many are not as apply left them.
+///
+/// Split out so it can be driven by a test with a record pointing at temporary
+/// files: the command around it needs root and a real PAM tree, but this is the
+/// part that decides the answer.
+fn verify_surfaces(record: &crate::logintx::Transaction) -> (Vec<Value>, usize) {
+    let surfaces: Vec<Value> = record
+        .surfaces
+        .iter()
+        .map(|surface| {
+            let state = match crate::logintx::unchanged_since_apply(surface) {
+                Ok(()) => "as-applied",
+                Err(crate::logintx::RollbackRefusal::ChangedSinceApply) => "changed-since-apply",
+                Err(crate::logintx::RollbackRefusal::Unreadable(_)) => "unreadable",
+            };
+            json!({ "surface": surface.id, "state": state })
+        })
+        .collect();
+    let drifted = surfaces
+        .iter()
+        .filter(|entry| entry["state"] != "as-applied")
+        .count();
+    (surfaces, drifted)
+}
+
+/// The surfaces that block a rollback. Empty means it may proceed.
+fn drifted_surfaces(record: &crate::logintx::Transaction) -> Vec<&str> {
+    record
+        .surfaces
+        .iter()
+        .filter(|surface| crate::logintx::unchanged_since_apply(surface).is_err())
+        .map(|surface| surface.id.as_str())
+        .collect()
+}
+
 /// `irlume login apply --action X --plan-id ID --json`: carry out a plan.
 ///
 /// The plan is re-derived from the machine and its id recomputed. A `plan_id`
@@ -898,22 +933,7 @@ pub fn login_verify(args: &[String]) -> ExitCode {
             ExitCode::FAILURE,
         );
     };
-    let surfaces: Vec<Value> = record
-        .surfaces
-        .iter()
-        .map(|surface| {
-            let state = match crate::logintx::unchanged_since_apply(surface) {
-                Ok(()) => "as-applied",
-                Err(crate::logintx::RollbackRefusal::ChangedSinceApply) => "changed-since-apply",
-                Err(crate::logintx::RollbackRefusal::Unreadable(_)) => "unreadable",
-            };
-            json!({ "surface": surface.id, "state": state })
-        })
-        .collect();
-    let drifted = surfaces
-        .iter()
-        .filter(|s| s["state"] != "as-applied")
-        .count();
+    let (surfaces, drifted) = verify_surfaces(&record);
     emit(
         &success(
             COMMAND,
@@ -982,12 +1002,7 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
     // Every surface is checked BEFORE any is written. A rollback that restored
     // three files and then met a fourth it must refuse would leave the stack in
     // a state neither the transaction nor the admin chose.
-    let drifted: Vec<&str> = record
-        .surfaces
-        .iter()
-        .filter(|s| crate::logintx::unchanged_since_apply(s).is_err())
-        .map(|s| s.id.as_str())
-        .collect();
+    let drifted = drifted_surfaces(&record);
     if !drifted.is_empty() {
         irlume_common::dlog!("login.rollback: refused; changed since apply: {drifted:?}");
         return emit(
@@ -1641,6 +1656,268 @@ mod tests {
         assert_eq!(auth_reason(true, false), "granted");
         assert_eq!(auth_reason(false, false), "not-live");
         assert_eq!(auth_reason(false, true), "no-match");
+    }
+
+    /// A record whose surfaces point at files a test controls, so the verify
+    /// and rollback decisions can be exercised without root or a PAM tree.
+    fn record_over(files: &[(&str, &std::path::Path, &str)]) -> crate::logintx::Transaction {
+        crate::logintx::Transaction {
+            id: "0123456789abcdef0123456789abcdef".into(),
+            action: "disable".into(),
+            plan_id: "f".repeat(32),
+            engine_version: "0.0.0".into(),
+            surfaces: files
+                .iter()
+                .map(|(id, path, after)| crate::logintx::SurfaceRecord {
+                    id: (*id).to_string(),
+                    path: path.display().to_string(),
+                    change: "wire".into(),
+                    before: Some("before\n".into()),
+                    after_sha256: (*after).to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn verify_reports_each_surface_and_counts_the_drift() {
+        let dir = std::env::temp_dir().join(format!("irlume-verify-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let steady = dir.join("steady");
+        let moved = dir.join("moved");
+        std::fs::write(&steady, "as applied\n").expect("write");
+        std::fs::write(&moved, "somebody edited this\n").expect("write");
+
+        let record = record_over(&[
+            (
+                "kde",
+                steady.as_path(),
+                &crate::logintx::sha256_hex(b"as applied\n"),
+            ),
+            (
+                "sudo",
+                moved.as_path(),
+                &crate::logintx::sha256_hex(b"as applied\n"),
+            ),
+        ]);
+        let (surfaces, drifted) = verify_surfaces(&record);
+        assert_eq!(surfaces.len(), 2);
+        assert_eq!(surfaces[0]["surface"], "kde");
+        assert_eq!(surfaces[0]["state"], "as-applied");
+        assert_eq!(surfaces[1]["state"], "changed-since-apply");
+        assert_eq!(drifted, 1);
+
+        // Rollback is gated on the same rule, and names what blocks it.
+        assert_eq!(drifted_surfaces(&record), vec!["sudo"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_rollback_is_allowed_only_when_nothing_drifted() {
+        let dir = std::env::temp_dir().join(format!("irlume-rollback-gate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let file = dir.join("kde");
+        std::fs::write(&file, "as applied\n").expect("write");
+        let record = record_over(&[(
+            "kde",
+            file.as_path(),
+            &crate::logintx::sha256_hex(b"as applied\n"),
+        )]);
+        assert!(
+            drifted_surfaces(&record).is_empty(),
+            "clean stack rolls back"
+        );
+
+        std::fs::write(&file, "changed\n").expect("write");
+        assert_eq!(drifted_surfaces(&record), vec!["kde"]);
+
+        // An unreadable surface blocks a rollback too: it is not evidence the
+        // file is unchanged, so restoring over it would be a guess.
+        std::fs::remove_file(&file).expect("rm");
+        std::fs::create_dir(&file).expect("mkdir in its place");
+        assert_eq!(drifted_surfaces(&record), vec!["kde"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn login_apply_requires_an_action_and_a_plan_id() {
+        let a = |v: &[&str]| -> Vec<String> { v.iter().map(|s| (*s).to_string()).collect() };
+        let good = a(&[
+            "login",
+            "apply",
+            "--action",
+            "enable",
+            "--plan-id",
+            "0123456789abcdef0123456789abcdef",
+            "--json",
+        ]);
+        assert_eq!(
+            valid_login_apply_args(&good),
+            Some(("enable", "0123456789abcdef0123456789abcdef".to_string()))
+        );
+        for bad in [
+            // No plan id: applying without one means acting on changes the
+            // consumer never saw.
+            vec!["login", "apply", "--action", "enable", "--json"],
+            vec![
+                "login",
+                "apply",
+                "--plan-id",
+                "0123456789abcdef0123456789abcdef",
+                "--json",
+            ],
+            // A plan id that is not a hex identifier.
+            vec![
+                "login",
+                "apply",
+                "--action",
+                "enable",
+                "--plan-id",
+                "../etc",
+                "--json",
+            ],
+            vec![
+                "login",
+                "apply",
+                "--action",
+                "enable",
+                "--plan-id",
+                "short",
+                "--json",
+            ],
+            // Unknown action, missing --json, repeats, junk.
+            vec![
+                "login",
+                "apply",
+                "--action",
+                "wat",
+                "--plan-id",
+                "0123456789abcdef0123456789abcdef",
+                "--json",
+            ],
+            vec![
+                "login",
+                "apply",
+                "--action",
+                "enable",
+                "--plan-id",
+                "0123456789abcdef0123456789abcdef",
+            ],
+            vec![
+                "login",
+                "apply",
+                "--action",
+                "enable",
+                "--action",
+                "disable",
+                "--plan-id",
+                "0123456789abcdef0123456789abcdef",
+                "--json",
+            ],
+            vec![
+                "login",
+                "apply",
+                "--action",
+                "enable",
+                "--plan-id",
+                "0123456789abcdef0123456789abcdef",
+                "--json",
+                "--wat",
+            ],
+            vec![
+                "login",
+                "plan",
+                "--action",
+                "enable",
+                "--plan-id",
+                "0123456789abcdef0123456789abcdef",
+                "--json",
+            ],
+        ] {
+            assert_eq!(valid_login_apply_args(&a(&bad)), None, "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn a_transaction_id_shaped_like_a_path_is_refused() {
+        let a = |v: &[&str]| -> Vec<String> { v.iter().map(|s| (*s).to_string()).collect() };
+        let id = "0123456789abcdef0123456789abcdef";
+        assert_eq!(
+            valid_transaction_args(
+                &a(&["login", "verify", "--transaction-id", id, "--json"]),
+                "verify",
+                false
+            ),
+            Some(id.to_string())
+        );
+        // --apply is accepted only where it means something.
+        assert_eq!(
+            valid_transaction_args(
+                &a(&[
+                    "login",
+                    "rollback",
+                    "--transaction-id",
+                    id,
+                    "--apply",
+                    "--json"
+                ]),
+                "rollback",
+                true
+            ),
+            Some(id.to_string())
+        );
+        assert_eq!(
+            valid_transaction_args(
+                &a(&[
+                    "login",
+                    "verify",
+                    "--transaction-id",
+                    id,
+                    "--apply",
+                    "--json"
+                ]),
+                "verify",
+                false
+            ),
+            None,
+            "verify writes nothing, so --apply is meaningless there"
+        );
+        for bad in [
+            vec![
+                "login",
+                "verify",
+                "--transaction-id",
+                "../../etc/passwd",
+                "--json",
+            ],
+            vec![
+                "login",
+                "verify",
+                "--transaction-id",
+                "../../etc/shadow",
+                "--json",
+            ],
+            vec!["login", "verify", "--json"],
+            vec!["login", "verify", "--transaction-id", id],
+            vec![
+                "login",
+                "verify",
+                "--transaction-id",
+                id,
+                "--transaction-id",
+                id,
+                "--json",
+            ],
+            vec!["login", "apply", "--transaction-id", id, "--json"],
+        ] {
+            assert_eq!(
+                valid_transaction_args(&a(&bad), "verify", false),
+                None,
+                "{bad:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -900,14 +900,23 @@ fn rollback_restore(
     // skipped: they hold their before-content now, so re-restoring is pointless
     // and re-checking them against the after-digest would refuse the whole
     // record — which is what made a stopped rollback unfinishable.
-    let mut restored = crate::logintx::rollback_progress(&record.id);
-    let already: std::collections::HashSet<String> = restored.iter().cloned().collect();
+    let mut progress = crate::logintx::rollback_progress(&record.id);
+    // Marking a restore BEGUN before doing it, and finished after, is the same
+    // write-ahead ordering the transaction record itself uses. Noting only
+    // completions left the window between the write and the note: a kill there
+    // leaves a surface holding its before-image with nothing recording it, and
+    // the re-run refuses it as drift. Thirty killed rollbacks in a row were
+    // unfinishable that way on real hardware.
+    let begin = |progress: &mut crate::logintx::RollbackProgress, key: &str| {
+        if !progress.started.iter().any(|k| k == key) {
+            progress.started.push(key.to_string());
+        }
+        crate::logintx::note_rollback_progress(&record.id, progress)
+    };
     for surface in &record.surfaces {
         let sidecar_key = crate::logintx::sidecar_progress_id(&surface.id);
-        // A surface is two writes. Each is noted as it lands, so a stop between
-        // them resumes at the second rather than refusing the first as drift.
-        let live_done = already.contains(&surface.id);
-        let sidecar_done = already.contains(&sidecar_key);
+        let live_done = progress.finished(&surface.id);
+        let sidecar_done = progress.finished(&sidecar_key);
         if live_done && sidecar_done {
             continue;
         }
@@ -919,7 +928,7 @@ fn rollback_restore(
         // check-and-write. Skipped for an unconfirmed record, whose digests were
         // never confirmed and so cannot gate anything.
         if !unconfirmed {
-            if let Err(reason) = crate::logintx::unchanged_since_apply_excluding(surface, &restored)
+            if let Err(reason) = crate::logintx::unchanged_since_apply_excluding(surface, &progress)
             {
                 irlume_common::dlog!(
                     "{command}: {} moved while the rollback was running: {reason:?}",
@@ -929,7 +938,7 @@ fn rollback_restore(
                     &failure(command, "changed-since-apply", false, contract),
                     json!({
                         "transaction_id": record.id,
-                        "restored": restored,
+                        "restored": progress.done,
                         "stopped_at": surface.id,
                         // Where the pre-rollback copies are, so a caller that
                         // stopped partway can still find what was overwritten.
@@ -949,11 +958,16 @@ fn rollback_restore(
         let live = if live_done {
             Ok(())
         } else {
-            crate::pamwire::restore_surface(
-                std::path::Path::new(&surface.path),
-                surface.before.as_deref(),
-                metadata,
-            )
+            // Announced before it happens. Restoring writes the recorded
+            // before-content, so doing it twice is the same as doing it once,
+            // which is what makes an interrupted one safe to repeat.
+            begin(&mut progress, &surface.id).and_then(|()| {
+                crate::pamwire::restore_surface(
+                    std::path::Path::new(&surface.path),
+                    surface.before.as_deref(),
+                    metadata,
+                )
+            })
         };
         match live {
             Ok(()) => {
@@ -962,16 +976,16 @@ fn rollback_restore(
                 // held its before-image and nothing said so, so the re-run
                 // checked it against the after-digest and refused it as drift.
                 if !live_done {
-                    restored.push(surface.id.clone());
+                    progress.done.push(surface.id.clone());
                     if let Err(message) =
-                        crate::logintx::note_rollback_progress(&record.id, &restored)
+                        crate::logintx::note_rollback_progress(&record.id, &progress)
                     {
                         irlume_common::dlog!("{command}: cannot record progress: {message}");
                         return emit_with_extra(
                             &failure(command, "operation-failed", false, contract),
                             json!({
                                 "transaction_id": record.id,
-                                "restored": restored,
+                                "restored": progress.done,
                                 "stopped_at": surface.id,
                                 "snapshot": snapshot,
                             }),
@@ -1002,7 +1016,7 @@ fn rollback_restore(
                             &failure(command, "operation-failed", false, contract),
                             json!({
                                 "transaction_id": record.id,
-                                "restored": restored,
+                                "restored": progress.done,
                                 "stopped_at": surface.id,
                             }),
                             ExitCode::FAILURE,
@@ -1012,15 +1026,15 @@ fn rollback_restore(
                 // The sidecar half, noted on its own. Durably, before moving
                 // to the next surface: a note written after the whole loop would
                 // describe only the runs that did not need it.
-                restored.push(sidecar_key.clone());
-                if let Err(message) = crate::logintx::note_rollback_progress(&record.id, &restored)
+                progress.done.push(sidecar_key.clone());
+                if let Err(message) = crate::logintx::note_rollback_progress(&record.id, &progress)
                 {
                     irlume_common::dlog!("{command}: cannot record progress: {message}");
                     return emit_with_extra(
                         &failure(command, "operation-failed", false, contract),
                         json!({
                             "transaction_id": record.id,
-                            "restored": restored,
+                            "restored": progress.done,
                             "stopped_at": surface.id,
                             "snapshot": snapshot,
                         }),
@@ -1037,7 +1051,7 @@ fn rollback_restore(
                     &failure(command, "operation-failed", false, contract),
                     json!({
                         "transaction_id": record.id,
-                        "restored": restored,
+                        "restored": progress.done,
                         "stopped_at": surface.id,
                         // Where the pre-rollback copies are, so a caller that
                         // stopped partway can still find what was overwritten.
@@ -1062,7 +1076,7 @@ fn rollback_restore(
             &failure(command, "operation-failed", true, contract),
             json!({
                 "transaction_id": record.id,
-                "restored": restored,
+                "restored": progress.done,
                 "applied": true,
                 "snapshot": snapshot,
             }),
@@ -1076,7 +1090,7 @@ fn rollback_restore(
                 "transaction_id": record.id,
                 "action": record.action,
                 "unconfirmed": unconfirmed,
-                "restored": restored,
+                "restored": progress.done,
                 "applied": true,
                 "snapshot": snapshot,
             }),
@@ -1117,7 +1131,7 @@ fn rollback_blockers(record: &crate::logintx::Transaction) -> RollbackBlockers<'
 /// that irlume itself restored part of it.
 fn rollback_blockers_excluding<'a>(
     record: &'a crate::logintx::Transaction,
-    done: &[String],
+    done: &crate::logintx::RollbackProgress,
 ) -> RollbackBlockers<'a> {
     let mut blockers = RollbackBlockers::default();
     for surface in &record.surfaces {

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1281,6 +1281,22 @@ pub fn login_apply(args: &[String]) -> ExitCode {
 
     let failed: Vec<&crate::pamwire::AppliedSurface> =
         applied.iter().filter(|s| s.error.is_some()).collect();
+    // Keep the self-heal marker in step with what was just written, exactly as
+    // the human path does. Without this the machine API unwires the files and
+    // leaves the marker saying "wired", so `irlume-reconcile.path` fires on the
+    // change it just made, re-wires every greeter, and the transaction that
+    // asked for the disable is drifted and no longer rollbackable — irlume
+    // fighting its own writes.
+    //
+    // Found on a machine where login was genuinely wired and the path unit
+    // active. Neither the container suite nor a bed with nothing wired can show
+    // it: there is no reconcile unit in one and nothing to re-wire in the other.
+    //
+    // The scopes match what `apply` planned: this command wires the greeter and
+    // lock screen, and never sudo or polkit, which are their own opt-in.
+    if failed.is_empty() {
+        crate::pamwire::write_wired_marker(enable, false, false, enable);
+    }
     let changes: Vec<Value> = applied
         .iter()
         .map(|surface| {

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -1044,6 +1044,21 @@ pub fn login_apply(args: &[String]) -> ExitCode {
     if let Some(refusal) = require_root(COMMAND, contract) {
         return refusal;
     }
+    // Taken BEFORE the plan is revalidated and held past the confirming record,
+    // so the whole transaction is one unit. Acquiring it later would leave the
+    // staleness check comparing against a stack another irlume process is
+    // partway through rewriting, and the record would then describe a state that
+    // never existed on disk.
+    let _lock = match crate::pamwire::lock_pam() {
+        Ok(lock) => lock,
+        Err(message) => {
+            irlume_common::dlog!("login.apply: refusing, cannot serialise: {message}");
+            return emit(
+                &failure(COMMAND, "operation-failed", true, contract),
+                ExitCode::FAILURE,
+            );
+        }
+    };
     let enable = action == "enable";
     let planned = crate::pamwire::plan(enable, false, false);
     let current_plan = plan_id(action, &planned);
@@ -1279,11 +1294,27 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
     // Restoring an unconfirmed record gives up the protection against reverting
     // somebody else's later edit, so it has to be asked for by name.
     let accept_unconfirmed = args.iter().any(|a| a == "--accept-unconfirmed");
-    if will_apply {
+    // Held across the precheck and every restore, for the same reason apply
+    // holds it: the per-surface drift check and the write it authorises are two
+    // moments, and another irlume process writing between them is exactly what
+    // the check cannot see. A dry run writes nothing and does not take it.
+    let _lock = if will_apply {
         if let Some(refusal) = require_root(COMMAND, contract) {
             return refusal;
         }
-    }
+        match crate::pamwire::lock_pam() {
+            Ok(lock) => Some(lock),
+            Err(message) => {
+                irlume_common::dlog!("login.rollback: refusing, cannot serialise: {message}");
+                return emit(
+                    &failure(COMMAND, "operation-failed", true, contract),
+                    ExitCode::FAILURE,
+                );
+            }
+        }
+    } else {
+        None
+    };
     let record = match crate::logintx::Transaction::load(&id) {
         Ok(record) => record,
         Err(reason) => return emit_load_failure(COMMAND, reason, contract),

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -827,6 +827,75 @@ fn verify_surfaces(record: &crate::logintx::Transaction) -> (Vec<Value>, usize) 
     (surfaces, drifted)
 }
 
+/// Restore every surface of a transaction, or report what it would restore.
+///
+/// Shared by the confirmed and the unconfirmed path so the restore itself has
+/// one implementation. `unconfirmed` only changes what is reported: the writes
+/// are identical, and the decision about whether restoring is safe was already
+/// made by the caller.
+fn rollback_restore(
+    command: &'static str,
+    record: &crate::logintx::Transaction,
+    will_apply: bool,
+    contract: u32,
+    unconfirmed: bool,
+) -> ExitCode {
+    if !will_apply {
+        return emit(
+            &success(
+                command,
+                json!({
+                    "transaction_id": record.id,
+                    "action": record.action,
+                    "unconfirmed": unconfirmed,
+                    "would_restore": record.surfaces.iter().map(|s| json!(s.id)).collect::<Vec<_>>(),
+                    "applied": false,
+                }),
+                contract,
+            ),
+            ExitCode::SUCCESS,
+        );
+    }
+    let mut restored = Vec::new();
+    for surface in &record.surfaces {
+        match crate::pamwire::restore_surface(
+            std::path::Path::new(&surface.path),
+            surface.before.as_deref(),
+        ) {
+            Ok(()) => restored.push(surface.id.clone()),
+            Err(message) => {
+                irlume_common::dlog!("{command}: {} failed: {message}", surface.id);
+                // What was already restored travels in the document, because
+                // machine mode promises an empty stderr and a caller stopped
+                // partway needs to know exactly how far it got.
+                return emit_with_extra(
+                    &failure(command, "operation-failed", false, contract),
+                    json!({
+                        "transaction_id": record.id,
+                        "restored": restored,
+                        "stopped_at": surface.id,
+                    }),
+                    ExitCode::FAILURE,
+                );
+            }
+        }
+    }
+    emit(
+        &success(
+            command,
+            json!({
+                "transaction_id": record.id,
+                "action": record.action,
+                "unconfirmed": unconfirmed,
+                "restored": restored,
+                "applied": true,
+            }),
+            contract,
+        ),
+        ExitCode::SUCCESS,
+    )
+}
+
 /// What blocks a rollback, kept apart by reason.
 ///
 /// A file that CHANGED and one that cannot be READ are different problems: a
@@ -905,15 +974,18 @@ pub fn login_apply(args: &[String]) -> ExitCode {
         );
     }
 
-    // The plan is handed to apply so each surface can be re-checked against the
-    // state it was planned against, immediately before that surface is written.
-    let applied = crate::pamwire::apply(enable, false, false, &planned);
-    let record = crate::logintx::Transaction {
-        id: random_id(),
-        action: action.to_string(),
-        plan_id: current_plan,
-        engine_version: env!("CARGO_PKG_VERSION").to_string(),
-        surfaces: applied
+    // WRITE-AHEAD. The before-states are captured and persisted BEFORE the first
+    // PAM write, because the alternative has no safe ordering: writing the files
+    // first leaves a crash, a kill or a full disk able to strand a changed login
+    // stack with nothing describing how to undo it. A record left `prepared`
+    // says exactly that happened, and its before-states are still the authority
+    // for a rollback.
+    //
+    // Failing to record is therefore a refusal, not a warning: nothing has been
+    // touched yet, so refusing costs the caller a retry rather than a login.
+    let transaction_id = random_id();
+    let to_records = |surfaces: &[crate::pamwire::AppliedSurface]| {
+        surfaces
             .iter()
             .map(|surface| crate::logintx::SurfaceRecord {
                 id: surface.id.to_string(),
@@ -922,15 +994,38 @@ pub fn login_apply(args: &[String]) -> ExitCode {
                 before: surface.before.clone(),
                 after_sha256: surface.after_sha256.clone(),
             })
-            .collect(),
+            .collect::<Vec<_>>()
     };
-    // Recorded before the result is reported. Files have already changed; a
-    // record that could not be written would leave them changed with nothing
-    // describing how to undo it, which is worse than not having run.
+    let mut record = crate::logintx::Transaction {
+        id: transaction_id,
+        status: crate::logintx::TransactionStatus::Prepared,
+        action: action.to_string(),
+        plan_id: current_plan,
+        engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        surfaces: to_records(&crate::pamwire::prepare(enable, false, false)),
+    };
     if let Err(message) = record.save() {
-        irlume_common::dlog!("login.apply: recording the transaction failed: {message}");
+        irlume_common::dlog!("login.apply: refusing, cannot record beforehand: {message}");
         return emit(
+            &failure(COMMAND, "operation-failed", true, contract),
+            ExitCode::FAILURE,
+        );
+    }
+
+    // The plan is handed to apply so each surface can be re-checked against the
+    // state it was planned against, immediately before that surface is written.
+    let applied = crate::pamwire::apply(enable, false, false, &planned);
+    record.surfaces = to_records(&applied);
+    record.status = crate::logintx::TransactionStatus::Applied;
+    // Rewriting this can fail, and by now the files HAVE changed. The prepared
+    // record is already on disk with the before-states, so a rollback remains
+    // possible; what is lost is the confirmed after-state, which is why the
+    // status matters and why this is still reported as a failure.
+    if let Err(message) = record.save() {
+        irlume_common::dlog!("login.apply: applied, but confirming the record failed: {message}");
+        return emit_with_extra(
             &failure(COMMAND, "operation-failed", false, contract),
+            json!({ "transaction_id": record.id, "status": "prepared" }),
             ExitCode::FAILURE,
         );
     }
@@ -1015,6 +1110,7 @@ pub fn login_verify(args: &[String]) -> ExitCode {
         Ok(record) => record,
         Err(reason) => return emit_load_failure(COMMAND, reason, contract),
     };
+    let unconfirmed = record.status == crate::logintx::TransactionStatus::Prepared;
     let (surfaces, drifted) = verify_surfaces(&record);
     emit(
         &success(
@@ -1023,12 +1119,19 @@ pub fn login_verify(args: &[String]) -> ExitCode {
                 "transaction_id": record.id,
                 "action": record.action,
                 "plan_id": record.plan_id,
+                // `prepared` means the writes were never confirmed: the process
+                // stopped between persisting the before-states and recording the
+                // result. The before-states are still usable, the after-digests
+                // are not, so drift is not meaningful for such a record.
+                "status": if unconfirmed { "prepared" } else { "applied" },
                 "surfaces": surfaces,
                 "drifted": drifted,
                 // Whether a rollback would be accepted right now. Stated by the
                 // engine so a consumer does not have to infer it from per-surface
                 // states it may not recognise.
-                "rollback_available": drifted == 0,
+                // An unconfirmed record can still be rolled back, but only on
+                // request: see login rollback --accept-unconfirmed.
+                "rollback_available": !unconfirmed && drifted == 0,
             }),
             contract,
         ),
@@ -1070,6 +1173,9 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
         );
     };
     let will_apply = args.iter().any(|a| a == "--apply");
+    // Restoring an unconfirmed record gives up the protection against reverting
+    // somebody else's later edit, so it has to be asked for by name.
+    let accept_unconfirmed = args.iter().any(|a| a == "--accept-unconfirmed");
     if will_apply {
         if let Some(refusal) = require_root(COMMAND, contract) {
             return refusal;
@@ -1082,6 +1188,25 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
     // Every surface is checked BEFORE any is written. A rollback that restored
     // three files and then met a fourth it must refuse would leave the stack in
     // a state neither the transaction nor the admin chose.
+    // A `prepared` record never confirmed its writes, so its after-digests
+    // cannot gate anything: every existing file would read as drift and rollback
+    // would refuse exactly when recovery is most needed. Its before-states are
+    // still the authority, so a restore IS possible, but it gives up the
+    // protection against reverting somebody else's later edit. That trade is the
+    // operator's to make, not something to do silently.
+    if record.status == crate::logintx::TransactionStatus::Prepared {
+        if !accept_unconfirmed {
+            irlume_common::dlog!(
+                "login.rollback: {} is unconfirmed; needs --accept-unconfirmed",
+                record.id
+            );
+            return emit(
+                &failure(COMMAND, "unconfirmed-transaction", false, contract),
+                ExitCode::FAILURE,
+            );
+        }
+        return rollback_restore(COMMAND, &record, will_apply, contract, true);
+    }
     let blockers = rollback_blockers(&record);
     if blockers.any() {
         irlume_common::dlog!(
@@ -1098,60 +1223,7 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
         };
         return emit(&failure(COMMAND, code, false, contract), ExitCode::FAILURE);
     }
-    if !will_apply {
-        return emit(
-            &success(
-                COMMAND,
-                json!({
-                    "transaction_id": record.id,
-                    "action": record.action,
-                    "would_restore": record.surfaces.iter().map(|s| json!(s.id)).collect::<Vec<_>>(),
-                    "applied": false,
-                }),
-                contract,
-            ),
-            ExitCode::SUCCESS,
-        );
-    }
-    let mut restored = Vec::new();
-    for surface in &record.surfaces {
-        match crate::pamwire::restore_surface(
-            std::path::Path::new(&surface.path),
-            surface.before.as_deref(),
-        ) {
-            Ok(()) => restored.push(surface.id.clone()),
-            Err(message) => {
-                irlume_common::dlog!("login.rollback: {} failed: {message}", surface.id);
-                // What was already restored travels in the document, for the
-                // same reason as in apply: machine mode promises an empty
-                // stderr. A caller stopped partway needs to know exactly how far
-                // it got, and that is not something to lose to a channel the
-                // envelope says is unused.
-                return emit_with_extra(
-                    &failure(COMMAND, "operation-failed", false, contract),
-                    json!({
-                        "transaction_id": record.id,
-                        "restored": restored,
-                        "stopped_at": surface.id,
-                    }),
-                    ExitCode::FAILURE,
-                );
-            }
-        }
-    }
-    emit(
-        &success(
-            COMMAND,
-            json!({
-                "transaction_id": record.id,
-                "action": record.action,
-                "restored": restored,
-                "applied": true,
-            }),
-            contract,
-        ),
-        ExitCode::SUCCESS,
-    )
+    rollback_restore(COMMAND, &record, will_apply, contract, false)
 }
 
 fn valid_login_apply_args(args: &[String]) -> Option<(&'static str, String)> {
@@ -1202,6 +1274,7 @@ fn valid_transaction_args(args: &[String], sub: &str, allow_apply: bool) -> Opti
         return None;
     }
     let (mut id, mut saw_json, mut saw_apply) = (None, false, false);
+    let mut saw_unconfirmed = false;
     let mut index = 2;
     while index < args.len() {
         match args[index].as_str() {
@@ -1211,6 +1284,12 @@ fn valid_transaction_args(args: &[String], sub: &str, allow_apply: bool) -> Opti
             }
             "--apply" if allow_apply && !saw_apply => {
                 saw_apply = true;
+                index += 1;
+            }
+            // Only meaningful where a restore can happen, so it is refused on
+            // verify rather than accepted and ignored.
+            "--accept-unconfirmed" if allow_apply && !saw_unconfirmed => {
+                saw_unconfirmed = true;
                 index += 1;
             }
             "--transaction-id" if id.is_none() => {
@@ -1757,6 +1836,7 @@ mod tests {
     fn record_over(files: &[(&str, &std::path::Path, &str)]) -> crate::logintx::Transaction {
         crate::logintx::Transaction {
             id: "0123456789abcdef0123456789abcdef".into(),
+            status: crate::logintx::TransactionStatus::Applied,
             action: "disable".into(),
             plan_id: "f".repeat(32),
             engine_version: "0.0.0".into(),

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -858,9 +858,41 @@ fn rollback_restore(
     }
     let mut restored = Vec::new();
     for surface in &record.surfaces {
+        // Re-check THIS surface immediately before restoring it. The blanket
+        // check above happens before any write, which is what stops a rollback
+        // half-completing, but it leaves a window: by the time the loop reaches
+        // the last surface, the earlier ones have been written and time has
+        // passed. Checking again here narrows the window to a single
+        // check-and-write. Skipped for an unconfirmed record, whose digests were
+        // never confirmed and so cannot gate anything.
+        if !unconfirmed {
+            if let Err(reason) = crate::logintx::unchanged_since_apply(surface) {
+                irlume_common::dlog!(
+                    "{command}: {} moved while the rollback was running: {reason:?}",
+                    surface.id
+                );
+                return emit_with_extra(
+                    &failure(command, "changed-since-apply", false, contract),
+                    json!({
+                        "transaction_id": record.id,
+                        "restored": restored,
+                        "stopped_at": surface.id,
+                    }),
+                    ExitCode::FAILURE,
+                );
+            }
+        }
+        // Mode and ownership are restored with the content. All three come
+        // from the same record, so a partial record restores what it has rather
+        // than inventing values.
+        let metadata = match (surface.mode, surface.uid, surface.gid) {
+            (Some(mode), Some(uid), Some(gid)) => Some((mode, uid, gid)),
+            _ => None,
+        };
         match crate::pamwire::restore_surface(
             std::path::Path::new(&surface.path),
             surface.before.as_deref(),
+            metadata,
         ) {
             Ok(()) => restored.push(surface.id.clone()),
             Err(message) => {
@@ -993,6 +1025,9 @@ pub fn login_apply(args: &[String]) -> ExitCode {
                 change: surface.change.id().to_string(),
                 before: surface.before.clone(),
                 after_sha256: surface.after_sha256.clone(),
+                mode: surface.before_metadata.map(|(mode, _, _)| mode),
+                uid: surface.before_metadata.map(|(_, uid, _)| uid),
+                gid: surface.before_metadata.map(|(_, _, gid)| gid),
             })
             .collect::<Vec<_>>()
     };
@@ -1848,6 +1883,9 @@ mod tests {
                     change: "wire".into(),
                     before: Some("before\n".into()),
                     after_sha256: (*after).to_string(),
+                    mode: None,
+                    uid: None,
+                    gid: None,
                 })
                 .collect(),
         }

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -688,6 +688,12 @@ fn plan_id(action: &str, planned: &[crate::pamwire::PlannedSurface]) -> String {
         material.push_str(surface.id);
         material.push(' ');
         material.push_str(surface.change.id());
+        material.push(' ');
+        // The observed state, not just the intended outcome. Without this an
+        // admin could rewrite a stack, leave the anchor intact so the outcome
+        // stays `wire`, and an apply carrying the old id would overwrite a stack
+        // the consumer never saw.
+        material.push_str(&surface.state);
     }
     use sha2::{Digest as _, Sha256};
     let digest = Sha256::digest(material.as_bytes());
@@ -899,7 +905,9 @@ pub fn login_apply(args: &[String]) -> ExitCode {
         );
     }
 
-    let applied = crate::pamwire::apply(enable, false, false);
+    // The plan is handed to apply so each surface can be re-checked against the
+    // state it was planned against, immediately before that surface is written.
+    let applied = crate::pamwire::apply(enable, false, false, &planned);
     let record = crate::logintx::Transaction {
         id: random_id(),
         action: action.to_string(),
@@ -2049,6 +2057,37 @@ mod tests {
     }
 
     #[test]
+    fn a_plan_id_changes_when_the_file_changes_but_the_outcome_does_not() {
+        use crate::pamwire::{PlannedChange, PlannedSurface};
+        // Codex found this on #178: the id hashed the outcome LABEL only. An
+        // admin can rewrite a stack and leave a valid anchor in place, so the
+        // outcome stays `wire` while the file is entirely different. An apply
+        // carrying the old id would then overwrite a stack the consumer was
+        // never shown, which is the exact thing plan-stale exists to prevent.
+        let with_state = |state: &str| {
+            vec![PlannedSurface {
+                id: "plasmalogin",
+                role: "login-screen",
+                change: PlannedChange::Wire,
+                state: state.to_string(),
+            }]
+        };
+        let before = plan_id("enable", &with_state("aaaa"));
+        let after = plan_id("enable", &with_state("bbbb"));
+        assert_ne!(
+            before, after,
+            "the same outcome over different file content must not share a plan id"
+        );
+        // And the id is still stable when genuinely nothing moved.
+        assert_eq!(before, plan_id("enable", &with_state("aaaa")));
+        // An unreadable surface is its own state, not folded into absent.
+        assert_ne!(
+            plan_id("enable", &with_state("unreadable")),
+            plan_id("enable", &with_state(crate::logintx::ABSENT))
+        );
+    }
+
+    #[test]
     fn a_plan_id_covers_the_action_and_the_outcomes() {
         use crate::pamwire::{PlannedChange, PlannedSurface};
         let surfaces = |change| {
@@ -2056,6 +2095,7 @@ mod tests {
                 id: "plasmalogin",
                 role: "login-screen",
                 change,
+                state: "same-state".into(),
             }]
         };
         let base = plan_id("enable", &surfaces(PlannedChange::Wire));

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -894,7 +894,34 @@ fn rollback_restore(
             surface.before.as_deref(),
             metadata,
         ) {
-            Ok(()) => restored.push(surface.id.clone()),
+            Ok(()) => {
+                // The backup is put back with its surface. Leaving a stale one
+                // behind is not inert: a later enable rebuilds from it as the
+                // origin, so it would silently discard an administrator's edits.
+                if let Some(sidecar) = &surface.sidecar {
+                    let sidecar_metadata = match (sidecar.mode, sidecar.uid, sidecar.gid) {
+                        (Some(mode), Some(uid), Some(gid)) => Some((mode, uid, gid)),
+                        _ => None,
+                    };
+                    if let Err(message) = crate::pamwire::restore_surface(
+                        std::path::Path::new(&sidecar.path),
+                        sidecar.before.as_deref(),
+                        sidecar_metadata,
+                    ) {
+                        irlume_common::dlog!("{command}: {} backup failed: {message}", surface.id);
+                        return emit_with_extra(
+                            &failure(command, "operation-failed", false, contract),
+                            json!({
+                                "transaction_id": record.id,
+                                "restored": restored,
+                                "stopped_at": surface.id,
+                            }),
+                            ExitCode::FAILURE,
+                        );
+                    }
+                }
+                restored.push(surface.id.clone());
+            }
             Err(message) => {
                 irlume_common::dlog!("{command}: {} failed: {message}", surface.id);
                 // What was already restored travels in the document, because
@@ -1028,6 +1055,17 @@ pub fn login_apply(args: &[String]) -> ExitCode {
                 mode: surface.before_metadata.map(|(mode, _, _)| mode),
                 uid: surface.before_metadata.map(|(_, uid, _)| uid),
                 gid: surface.before_metadata.map(|(_, _, gid)| gid),
+                // Recorded only when there was a backup to speak of, so a
+                // surface irlume never wired carries no sidecar at all.
+                sidecar: (surface.sidecar_existed || surface.sidecar_before.is_some()).then(|| {
+                    crate::logintx::SidecarRecord {
+                        path: format!("{}{}", surface.path, crate::pamwire::BACKUP),
+                        before: surface.sidecar_before.clone(),
+                        mode: surface.sidecar_metadata.map(|(mode, _, _)| mode),
+                        uid: surface.sidecar_metadata.map(|(_, uid, _)| uid),
+                        gid: surface.sidecar_metadata.map(|(_, _, gid)| gid),
+                    }
+                }),
             })
             .collect::<Vec<_>>()
     };
@@ -1886,6 +1924,7 @@ mod tests {
                     mode: None,
                     uid: None,
                     gid: None,
+                    sidecar: None,
                 })
                 .collect(),
         }

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -749,6 +749,53 @@ fn require_root(command: &'static str, contract: u32) -> Option<ExitCode> {
     ))
 }
 
+/// Emit a document with extra top-level fields merged in.
+///
+/// Used where a FAILURE still carries something the caller needs, such as the
+/// transaction id of a partial apply. Contract 1 permits fields to be added, so
+/// this stays inside the contract; putting the value on stderr would not,
+/// because machine mode promises stderr is empty.
+fn emit_with_extra(document: &Document, extra: Value, exit: ExitCode) -> ExitCode {
+    let mut value = match serde_json::to_value(document) {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("irlume machine output serialization failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let (Some(object), Some(fields)) = (value.as_object_mut(), extra.as_object()) {
+        for (key, field) in fields {
+            object.insert(key.clone(), field.clone());
+        }
+    }
+    match serde_json::to_string(&value) {
+        Ok(line) => {
+            println!("{line}");
+            exit
+        }
+        Err(error) => {
+            eprintln!("irlume machine output serialization failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Report why a transaction record could not be loaded, without flattening the
+/// reasons into one code. A caller told "not found" for a permission problem
+/// would go looking for a wrong transaction id.
+fn emit_load_failure(
+    command: &'static str,
+    reason: crate::logintx::LoadFailure,
+    contract: u32,
+) -> ExitCode {
+    let code = match reason {
+        crate::logintx::LoadFailure::NotFound => "not-found",
+        crate::logintx::LoadFailure::NotAuthorized => "not-authorized",
+        crate::logintx::LoadFailure::Unreadable(_) => "operation-failed",
+    };
+    emit(&failure(command, code, false, contract), ExitCode::FAILURE)
+}
+
 /// Each surface's state, and how many are not as apply left them.
 ///
 /// Split out so it can be driven by a test with a record pointing at temporary
@@ -774,14 +821,38 @@ fn verify_surfaces(record: &crate::logintx::Transaction) -> (Vec<Value>, usize) 
     (surfaces, drifted)
 }
 
-/// The surfaces that block a rollback. Empty means it may proceed.
-fn drifted_surfaces(record: &crate::logintx::Transaction) -> Vec<&str> {
-    record
-        .surfaces
-        .iter()
-        .filter(|surface| crate::logintx::unchanged_since_apply(surface).is_err())
-        .map(|surface| surface.id.as_str())
-        .collect()
+/// What blocks a rollback, kept apart by reason.
+///
+/// A file that CHANGED and one that cannot be READ are different problems: a
+/// consumer told "changed-since-apply" goes looking for an edit, when the truth
+/// may be a permission or storage fault the transaction had nothing to do with.
+/// Both still stop the rollback, since neither is safe to restore over.
+#[derive(Default)]
+pub(crate) struct RollbackBlockers<'a> {
+    pub(crate) changed: Vec<&'a str>,
+    pub(crate) unreadable: Vec<&'a str>,
+}
+
+impl RollbackBlockers<'_> {
+    pub(crate) fn any(&self) -> bool {
+        !self.changed.is_empty() || !self.unreadable.is_empty()
+    }
+}
+
+fn rollback_blockers(record: &crate::logintx::Transaction) -> RollbackBlockers<'_> {
+    let mut blockers = RollbackBlockers::default();
+    for surface in &record.surfaces {
+        match crate::logintx::unchanged_since_apply(surface) {
+            Ok(()) => {}
+            Err(crate::logintx::RollbackRefusal::ChangedSinceApply) => {
+                blockers.changed.push(surface.id.as_str());
+            }
+            Err(crate::logintx::RollbackRefusal::Unreadable(_)) => {
+                blockers.unreadable.push(surface.id.as_str());
+            }
+        }
+    }
+    blockers
 }
 
 /// `irlume login apply --action X --plan-id ID --json`: carry out a plan.
@@ -881,16 +952,21 @@ pub fn login_apply(args: &[String]) -> ExitCode {
         emit(&success(COMMAND, data, contract), ExitCode::SUCCESS)
     } else {
         // A partial apply is a failure that still has a transaction id, because
-        // the surfaces that DID change are recorded and can be rolled back. The
-        // id is on stderr rather than lost: the error document carries no data.
+        // the surfaces that DID change are recorded and can be rolled back.
+        //
+        // The id travels IN THE DOCUMENT, not on stderr. Machine mode promises
+        // stdout carries the answer and stderr is empty, and the conformance
+        // suite enforces that, so a hint printed there would break a caller that
+        // trusts the envelope. Contract 1 permits fields to be added, which is
+        // what makes carrying it here possible without a contract bump.
         irlume_common::dlog!(
             "login.apply: {} surface(s) failed; transaction {} can be rolled back",
             failed.len(),
             record.id
         );
-        eprintln!("transaction {} recorded; roll back with: irlume login rollback --transaction-id {} --apply --json", record.id, record.id);
-        emit(
+        emit_with_extra(
             &failure(COMMAND, "operation-failed", false, contract),
+            json!({ "transaction_id": record.id, "failed": failed.len() }),
             ExitCode::FAILURE,
         )
     }
@@ -927,11 +1003,9 @@ pub fn login_verify(args: &[String]) -> ExitCode {
             ExitCode::from(2),
         );
     };
-    let Ok(record) = crate::logintx::Transaction::load(&id) else {
-        return emit(
-            &failure(COMMAND, "not-found", false, contract),
-            ExitCode::FAILURE,
-        );
+    let record = match crate::logintx::Transaction::load(&id) {
+        Ok(record) => record,
+        Err(reason) => return emit_load_failure(COMMAND, reason, contract),
     };
     let (surfaces, drifted) = verify_surfaces(&record);
     emit(
@@ -993,22 +1067,28 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
             return refusal;
         }
     }
-    let Ok(record) = crate::logintx::Transaction::load(&id) else {
-        return emit(
-            &failure(COMMAND, "not-found", false, contract),
-            ExitCode::FAILURE,
-        );
+    let record = match crate::logintx::Transaction::load(&id) {
+        Ok(record) => record,
+        Err(reason) => return emit_load_failure(COMMAND, reason, contract),
     };
     // Every surface is checked BEFORE any is written. A rollback that restored
     // three files and then met a fourth it must refuse would leave the stack in
     // a state neither the transaction nor the admin chose.
-    let drifted = drifted_surfaces(&record);
-    if !drifted.is_empty() {
-        irlume_common::dlog!("login.rollback: refused; changed since apply: {drifted:?}");
-        return emit(
-            &failure(COMMAND, "changed-since-apply", false, contract),
-            ExitCode::FAILURE,
+    let blockers = rollback_blockers(&record);
+    if blockers.any() {
+        irlume_common::dlog!(
+            "login.rollback: refused; changed {:?}, unreadable {:?}",
+            blockers.changed,
+            blockers.unreadable
         );
+        // A surface that cannot be READ is its own failure, not drift. Calling
+        // it drift would send a consumer hunting for an edit nobody made.
+        let code = if blockers.changed.is_empty() {
+            "operation-failed"
+        } else {
+            "changed-since-apply"
+        };
+        return emit(&failure(COMMAND, code, false, contract), ExitCode::FAILURE);
     }
     if !will_apply {
         return emit(
@@ -1034,12 +1114,18 @@ pub fn login_rollback(args: &[String]) -> ExitCode {
             Ok(()) => restored.push(surface.id.clone()),
             Err(message) => {
                 irlume_common::dlog!("login.rollback: {} failed: {message}", surface.id);
-                eprintln!(
-                    "rollback stopped after restoring {:?}; {} could not be written",
-                    restored, surface.id
-                );
-                return emit(
+                // What was already restored travels in the document, for the
+                // same reason as in apply: machine mode promises an empty
+                // stderr. A caller stopped partway needs to know exactly how far
+                // it got, and that is not something to lose to a channel the
+                // envelope says is unused.
+                return emit_with_extra(
                     &failure(COMMAND, "operation-failed", false, contract),
+                    json!({
+                        "transaction_id": record.id,
+                        "restored": restored,
+                        "stopped_at": surface.id,
+                    }),
                     ExitCode::FAILURE,
                 );
             }
@@ -1709,7 +1795,9 @@ mod tests {
         assert_eq!(drifted, 1);
 
         // Rollback is gated on the same rule, and names what blocks it.
-        assert_eq!(drifted_surfaces(&record), vec!["sudo"]);
+        let blockers = rollback_blockers(&record);
+        assert_eq!(blockers.changed, vec!["sudo"]);
+        assert!(blockers.unreadable.is_empty());
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1725,19 +1813,25 @@ mod tests {
             file.as_path(),
             &crate::logintx::sha256_hex(b"as applied\n"),
         )]);
-        assert!(
-            drifted_surfaces(&record).is_empty(),
-            "clean stack rolls back"
-        );
+        assert!(!rollback_blockers(&record).any(), "clean stack rolls back");
 
         std::fs::write(&file, "changed\n").expect("write");
-        assert_eq!(drifted_surfaces(&record), vec!["kde"]);
+        let blockers = rollback_blockers(&record);
+        assert_eq!(blockers.changed, vec!["kde"]);
+        assert!(
+            blockers.unreadable.is_empty(),
+            "an edit is not a read fault"
+        );
 
-        // An unreadable surface blocks a rollback too: it is not evidence the
-        // file is unchanged, so restoring over it would be a guess.
+        // An unreadable surface blocks a rollback too, but as its OWN reason:
+        // it is not evidence the file changed, and reporting it as drift would
+        // send a consumer hunting for an edit nobody made.
         std::fs::remove_file(&file).expect("rm");
         std::fs::create_dir(&file).expect("mkdir in its place");
-        assert_eq!(drifted_surfaces(&record), vec!["kde"]);
+        let blockers = rollback_blockers(&record);
+        assert!(blockers.any(), "unreadable still stops the rollback");
+        assert_eq!(blockers.unreadable, vec!["kde"]);
+        assert!(blockers.changed.is_empty(), "unreadable is not drift");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -25,6 +25,7 @@ mod blinkcap;
 mod commands;
 mod doctor_report;
 mod fingerprint;
+mod logintx;
 mod logs;
 mod machine;
 mod models;
@@ -143,6 +144,13 @@ fn main() -> std::process::ExitCode {
         // phase of a login transaction, and the human equivalent is the dry run
         // `login enable` already prints.
         (Some("login"), _) if args.iter().any(|a| a == "plan") => machine::login_plan(&args),
+        // The mutating half of a login transaction. Machine-only, like `plan`:
+        // the human equivalent is `login enable --apply`.
+        (Some("login"), _) if args.iter().any(|a| a == "apply") => machine::login_apply(&args),
+        (Some("login"), _) if args.iter().any(|a| a == "verify") => machine::login_verify(&args),
+        (Some("login"), _) if args.iter().any(|a| a == "rollback") => {
+            machine::login_rollback(&args)
+        }
         // `auth test` exists only as a machine command, so it routes here
         // whatever flags follow and answers a bad invocation with a JSON
         // usage-error rather than prose. Bare `auth` still falls through to the

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -891,6 +891,16 @@ pub(crate) struct PlannedSurface {
 /// others would let a plan id stay stable across a state it could not actually
 /// observe.
 pub(crate) fn surface_state(path: &Path) -> String {
+    // The backup as well as the live file. Wiring rebuilds from `.pre-irlume`
+    // when one exists, so the content an apply produces depends on it: a backup
+    // that changed between the plan and the apply changes the outcome while the
+    // live file, and therefore the plan id, stayed identical. The consumer would
+    // be shown one result and the machine would get another.
+    let bak = PathBuf::from(format!("{}{BACKUP}", path.display()));
+    format!("{} {}", surface_digest(path), surface_digest(&bak))
+}
+
+pub(crate) fn surface_digest(path: &Path) -> String {
     match crate::logintx::file_sha256(path) {
         Ok(Some(digest)) => digest,
         Ok(None) => crate::logintx::ABSENT.to_string(),
@@ -993,6 +1003,9 @@ pub(crate) struct AppliedSurface {
     /// remove it on rollback" from "was present and empty".
     pub(crate) sidecar_existed: bool,
     pub(crate) after_sha256: String,
+    /// The backup's digest as apply left it, so a rollback can tell whether the
+    /// backup it is about to overwrite is still the one it created.
+    pub(crate) sidecar_after_sha256: Option<String>,
     /// Set when this surface failed. The apply as a whole is reported as failed,
     /// and the surfaces that DID change are still recorded, so a rollback can
     /// undo a partial run.
@@ -1049,6 +1062,7 @@ pub(crate) fn prepare(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<A
                 // Not written yet, so there is no after-state. A record in this
                 // condition is recognisable by its `prepared` status.
                 after_sha256: crate::logintx::ABSENT.to_string(),
+                sidecar_after_sha256: None,
                 error,
             });
         },
@@ -1106,6 +1120,7 @@ pub(crate) fn apply(
                     sidecar_metadata: None,
                     sidecar_existed: false,
                     after_sha256: crate::logintx::ABSENT.to_string(),
+                    sidecar_after_sha256: None,
                     error: Some(message),
                 });
                 return;
@@ -1128,6 +1143,7 @@ pub(crate) fn apply(
                         sidecar_metadata: None,
                         sidecar_existed: false,
                         after_sha256: crate::logintx::ABSENT.to_string(),
+                        sidecar_after_sha256: None,
                         error: Some(format!(
                             "{} changed between the plan and the write; not touched",
                             svc.etc
@@ -1172,6 +1188,7 @@ pub(crate) fn apply(
                     sidecar_metadata: None,
                     sidecar_existed: false,
                     after_sha256: crate::logintx::ABSENT.to_string(),
+                    sidecar_after_sha256: None,
                     error: Some(message),
                 });
                 return;
@@ -1198,6 +1215,11 @@ pub(crate) fn apply(
                 }
             };
             let error = error.or(read_error);
+            // The same question for the backup: what did apply leave there. A
+            // rollback that overwrites a backup somebody replaced afterwards is
+            // the same defect as one that overwrites a stack, and the backup is
+            // the origin a later enable rebuilds from.
+            let sidecar_after_sha256 = Some(surface_digest(&sidecar_path));
             out.push(AppliedSurface {
                 id: service_name(svc.etc),
                 role,
@@ -1209,6 +1231,7 @@ pub(crate) fn apply(
                 sidecar_metadata,
                 sidecar_existed,
                 after_sha256,
+                sidecar_after_sha256,
                 error,
             });
         },

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -2175,7 +2175,35 @@ pub(crate) fn lock_pam() -> Result<PamLock, String> {
             ));
         }
     }
+    sweep_abandoned_scratch();
     Ok(PamLock { _file: file })
+}
+
+/// Remove scratch files a killed irlume left in `/etc/pam.d`.
+///
+/// A `SIGKILL` between creating the scratch file and renaming it skips every
+/// cleanup path, so real hardware runs that interrupt an apply leave
+/// `.sudo.irlume-new.1234.0.tmp` behind. PAM selects a stack by exact filename,
+/// so a dotfile is never read as a service and this is litter rather than a
+/// hazard — but it is irlume's litter, and it accumulates.
+///
+/// Done while holding the lock, which is what makes it safe: the name is one
+/// only this module produces, and no other irlume can be mid-write. Nothing
+/// outside that pattern is ever considered, because a cleanup that reasons about
+/// what "looks unexpected" is how a harness in this project deleted a real
+/// conffile.
+fn sweep_abandoned_scratch() {
+    let dir = std::path::Path::new("/etc/pam.d");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name.starts_with('.') && name.contains(".irlume-") && name.ends_with(".tmp") {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 /// Test-only: replace a target during the window between the first look and the

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -979,6 +979,52 @@ pub(crate) struct AppliedSurface {
     pub(crate) error: Option<String>,
 }
 
+/// Read every surface's pre-change state, writing nothing.
+///
+/// Exists so a record can be persisted BEFORE the first PAM write. Without that
+/// ordering, a crash or a full disk between the writes and the record leaves a
+/// changed login stack with nothing describing how to undo it, which is worse
+/// than not having run at all.
+pub(crate) fn prepare(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<AppliedSurface> {
+    let mut out = Vec::new();
+    walk_surfaces(
+        enable,
+        with_sudo,
+        with_polkit,
+        &mut |svc, role, wire, want| {
+            let path = Path::new(svc.etc);
+            let (before, error) = match std::fs::read_to_string(path) {
+                Ok(content) => (Some(content), None),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => (None, None),
+                Err(error) => (
+                    None,
+                    Some(format!(
+                        "read {} before changing it: {error}",
+                        path.display()
+                    )),
+                ),
+            };
+            // The outcome this surface is expected to reach, so a record written
+            // now already says what was intended. Computed with writing off.
+            let change = wire_service(svc, enable && want, false, wire)
+                .map(|outcome| outcome.change)
+                .unwrap_or(PlannedChange::NotInstalled);
+            out.push(AppliedSurface {
+                id: service_name(svc.etc),
+                role,
+                path: svc.etc.to_string(),
+                change,
+                before,
+                // Not written yet, so there is no after-state. A record in this
+                // condition is recognisable by its `prepared` status.
+                after_sha256: crate::logintx::ABSENT.to_string(),
+                error,
+            });
+        },
+    );
+    out
+}
+
 /// Carry out an enable/disable, recording what each surface looked like first.
 ///
 /// The before-content is read BEFORE `wire_service` runs, because that is the

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1244,23 +1244,23 @@ pub(crate) fn restore_surface(
 ) -> Result<(), String> {
     match before {
         Some(content) => {
-            write_atomic(path, content)?;
-            // Applied AFTER the atomic rename. write_atomic copies permissions
-            // from the file it is replacing, which is the wrong source here and
-            // does not exist at all when apply removed the file, so the recorded
-            // values are reapplied explicitly.
-            if let Some((mode, uid, gid)) = metadata {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
-                    .map_err(|e| format!("chmod {}: {e}", path.display()))?;
-                // Ownership needs privilege irlume has here (rollback --apply is
-                // root-only) but may not on an unusual filesystem, so a failure
-                // is reported rather than silently accepted: a PAM file with the
-                // wrong group is a real access change.
-                std::os::unix::fs::chown(path, Some(uid), Some(gid))
-                    .map_err(|e| format!("chown {}: {e}", path.display()))?;
-            }
-            Ok(())
+            // The recorded mode and owner go on before the rename, not after.
+            // Applying them afterwards published a PAM stack that was briefly
+            // whatever the root umask produced, and on this path in particular
+            // the file may have been REMOVED by apply, so there was nothing to
+            // copy attributes from and the default was all it ever got.
+            //
+            // `None` keeps the old behaviour for records written before those
+            // fields existed: the replacing file inherits the current one's
+            // attributes rather than a guess.
+            let attrs = metadata.or_else(|| {
+                std::fs::symlink_metadata(path).ok().as_ref().map(|m| {
+                    use std::os::unix::fs::MetadataExt as _;
+                    use std::os::unix::fs::PermissionsExt as _;
+                    (m.permissions().mode() & 0o7777, m.uid(), m.gid())
+                })
+            });
+            write_atomic_inner(path, content, attrs)
         }
         None => match std::fs::remove_file(path) {
             Ok(()) => Ok(()),
@@ -2053,25 +2053,162 @@ fn service_present(s: &Svc) -> Option<PathBuf> {
         .filter(|v| Path::new(v).exists())
         .map(|_| PathBuf::from(s.etc))
 }
-fn backup(path: &Path) -> Result<(), String> {
-    let bak = PathBuf::from(format!("{}{BACKUP}", path.display()));
-    if !bak.exists() {
-        std::fs::copy(path, &bak).map_err(|e| format!("backup {}: {e}", path.display()))?;
-    }
-    Ok(())
-}
-fn write_atomic(path: &Path, contents: &str) -> Result<(), String> {
+/// A scratch path in the same directory as `path`, unique to this call.
+///
+/// Every write here used to share one name per service, `.{service}.irlume.tmp`.
+/// Two irlume processes writing the same PAM file would open that one inode and
+/// interleave their bodies, and whichever renamed first published whatever was
+/// in it: an atomic rename makes the NAME change indivisible, it does not make
+/// concurrent production of the source safe. The PAM lock now keeps irlume's own
+/// paths apart, and a unique name means a leftover from a killed run is never
+/// adopted either.
+fn scratch_path(path: &Path, kind: &str) -> PathBuf {
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     let fname = path.file_name().and_then(|s| s.to_str()).unwrap_or("pam");
-    let tmp = dir.join(format!(".{fname}.irlume.tmp"));
-    std::fs::write(&tmp, contents).map_err(|e| format!("write {}: {e}", tmp.display()))?;
-    if let Ok(meta) = std::fs::metadata(path) {
-        let _ = std::fs::set_permissions(&tmp, meta.permissions());
+    dir.join(format!(
+        ".{fname}.irlume-{kind}.{}.{seq}.tmp",
+        std::process::id()
+    ))
+}
+
+/// Create the scratch file, never adopting one that is already there.
+fn create_scratch(tmp: &Path) -> Result<std::fs::File, String> {
+    let open = || {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(tmp)
+    };
+    match open() {
+        // Same pid and counter as a crashed earlier run. Drop it rather than
+        // write into a file whose contents are somebody else's.
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(tmp).map_err(|e| format!("remove {}: {e}", tmp.display()))?;
+            open().map_err(|e| format!("create {}: {e}", tmp.display()))
+        }
+        other => other.map_err(|e| format!("create {}: {e}", tmp.display())),
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
+}
+
+/// Make a directory durable, so an entry created in it survives a power loss.
+fn fsync_dir(dir: &Path) -> Result<(), String> {
+    std::fs::File::open(dir)
+        .and_then(|d| d.sync_all())
+        .map_err(|e| format!("fsync {}: {e}", dir.display()))
+}
+
+/// Copy `path` to its `.pre-irlume` backup, atomically, if there is not one yet.
+///
+/// The copy used to go straight to the final name. A kill or an ENOSPC part way
+/// through left a TRUNCATED file at `.pre-irlume`, and the next enable treats an
+/// existing backup as the pristine origin to rebuild from, so a half-copied
+/// stack became the authority for what the machine's PAM should contain. A
+/// backup that only ever appears complete cannot be believed part way.
+///
+/// The destination is published with `hard_link`, which fails if the name
+/// already exists rather than replacing it. An `exists()` test followed by a
+/// rename would be the same check-then-act split this file has been bitten by
+/// before, and would let a retry overwrite a good backup with the already-wired
+/// content.
+fn backup(path: &Path) -> Result<(), String> {
+    let bak = PathBuf::from(format!("{}{BACKUP}", path.display()));
+    if bak.exists() {
+        return Ok(());
+    }
+    let contents = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let meta =
+        std::fs::symlink_metadata(path).map_err(|e| format!("stat {}: {e}", path.display()))?;
+    let tmp = scratch_path(path, "bak");
+    let written = (|| -> Result<(), String> {
+        use std::io::Write as _;
+        let mut file = create_scratch(&tmp)?;
+        file.write_all(&contents)
+            .map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        apply_metadata(&tmp, &meta)?;
+        // Before the link, so the name never points at bytes that are not there.
+        file.sync_all()
+            .map_err(|e| format!("fsync {}: {e}", tmp.display()))?;
+        // Fails with EEXIST if another run got there first, which is the answer
+        // wanted: that backup is complete and this one is redundant.
+        match std::fs::hard_link(&tmp, &bak) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
+            Err(e) => return Err(format!("backup {}: {e}", path.display())),
+        }
+        fsync_dir(path.parent().unwrap_or_else(|| Path::new(".")))
+    })();
+    let _ = std::fs::remove_file(&tmp);
+    written
+}
+
+/// Copy mode and ownership onto a path.
+fn apply_metadata(path: &Path, meta: &std::fs::Metadata) -> Result<(), String> {
+    use std::os::unix::fs::MetadataExt as _;
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(meta.mode() & 0o7777))
+        .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+    std::os::unix::fs::chown(path, Some(meta.uid()), Some(meta.gid()))
+        .map_err(|e| format!("chown {}: {e}", path.display()))
+}
+
+fn write_atomic(path: &Path, contents: &str) -> Result<(), String> {
+    let existing = std::fs::symlink_metadata(path).ok();
+    write_atomic_inner(path, contents, existing.as_ref().map(mode_uid_gid))
+}
+
+fn mode_uid_gid(meta: &std::fs::Metadata) -> (u32, u32, u32) {
+    use std::os::unix::fs::MetadataExt as _;
+    (meta.mode() & 0o7777, meta.uid(), meta.gid())
+}
+
+/// Replace `path` with `contents`, durably, carrying the given mode and owner.
+///
+/// Attributes are set on the scratch file BEFORE the rename, so the name never
+/// resolves to a PAM file with the wrong mode or owner. Setting them afterwards
+/// leaves a window in which the live stack is whatever the root process's umask
+/// produced, and on the restore path the file did not exist to copy from at all.
+///
+/// `sync_all` before the rename and an fsync of `/etc/pam.d` after it: without
+/// them a successful `close` says nothing about what survives a power loss, and
+/// a PAM stack that comes back as a mixture of two versions is the failure this
+/// whole module exists to avoid.
+pub(crate) fn write_atomic_inner(
+    path: &Path,
+    contents: &str,
+    attrs: Option<(u32, u32, u32)>,
+) -> Result<(), String> {
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let tmp = scratch_path(path, "new");
+    let result = (|| -> Result<(), String> {
+        let mut file = create_scratch(&tmp)?;
+        file.write_all(contents.as_bytes())
+            .map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        if let Some((mode, uid, gid)) = attrs {
+            std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(mode))
+                .map_err(|e| format!("chmod {}: {e}", tmp.display()))?;
+            // Ownership needs privilege, which every caller that writes PAM has,
+            // but an unusual filesystem can still refuse. A PAM file with the
+            // wrong group is a real access change, so it is reported.
+            std::os::unix::fs::chown(&tmp, Some(uid), Some(gid))
+                .map_err(|e| format!("chown {}: {e}", tmp.display()))?;
+        }
+        file.sync_all()
+            .map_err(|e| format!("fsync {}: {e}", tmp.display()))?;
+        drop(file);
+        std::fs::rename(&tmp, path).map_err(|e| format!("rename into {}: {e}", path.display()))?;
+        fsync_dir(&dir)
+    })();
+    if result.is_err() {
         let _ = std::fs::remove_file(&tmp);
-        format!("rename into {}: {e}", path.display())
-    })
+    }
+    result
 }
 
 // ---- SELinux (Fedora) --------------------------------------------------------
@@ -2183,6 +2320,141 @@ mod tests {
 
     // Fedora gdm-password layout (real /etc file, the GDM greeter).
     const GDM: &str = "#%PAM-1.0\nauth     [success=done ...] pam_selinux_permit.so\nauth     substack      password-auth\nauth     optional      pam_gnome_keyring.so\naccount  include       password-auth\nsession  include       password-auth\nsession  optional      pam_gnome_keyring.so auto_start\n";
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("irlume-pamfile-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        dir
+    }
+
+    fn strays(dir: &Path) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect()
+    }
+
+    /// Two writes must never share a scratch name.
+    ///
+    /// Every write used to go through `.{service}.irlume.tmp`. Two irlume
+    /// processes writing one PAM file opened that single inode and interleaved
+    /// their bodies; whichever renamed first published whatever was in it. An
+    /// atomic rename makes the NAME change indivisible, it does not make
+    /// concurrent production of the source safe.
+    #[test]
+    fn each_write_gets_its_own_scratch_file() {
+        let target = Path::new("/etc/pam.d/sudo");
+        let a = scratch_path(target, "new");
+        let b = scratch_path(target, "new");
+        assert_ne!(a, b, "two writes shared one scratch path");
+        assert_eq!(
+            a.parent(),
+            target.parent(),
+            "scratch must be same-directory"
+        );
+        for p in [&a, &b] {
+            let name = p.file_name().unwrap().to_string_lossy().into_owned();
+            assert!(name.starts_with('.'), "{name} is not hidden");
+            assert!(name.contains("sudo"), "{name} does not name its target");
+        }
+        // A scratch file left by a crashed run is dropped, not written into: its
+        // contents are somebody else's.
+        let dir = scratch_dir("scratch");
+        let stale = dir.join(".sudo.irlume-new.stale.tmp");
+        std::fs::write(&stale, "SOMEBODY ELSE'S HALF-WRITTEN BODY").unwrap();
+        create_scratch(&stale).expect("stale scratch must be replaced");
+        assert_eq!(std::fs::read_to_string(&stale).unwrap(), "");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A write carries the mode and owner across, and leaves nothing behind.
+    #[test]
+    fn a_write_preserves_attributes_and_leaves_no_scratch() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = scratch_dir("attrs");
+        let target = dir.join("sudo");
+        std::fs::write(&target, "old\n").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o640)).unwrap();
+        let before_inode = {
+            use std::os::unix::fs::MetadataExt;
+            std::fs::metadata(&target).unwrap().ino()
+        };
+
+        write_atomic(&target, "new\n").expect("write");
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new\n");
+        let meta = std::fs::metadata(&target).unwrap();
+        assert_eq!(
+            meta.permissions().mode() & 0o7777,
+            0o640,
+            "the replacement did not carry the mode across"
+        );
+        use std::os::unix::fs::MetadataExt;
+        assert_ne!(meta.ino(), before_inode, "the file was rewritten in place");
+        assert!(strays(&dir).is_empty(), "left scratch: {:?}", strays(&dir));
+
+        // Restoring a file apply had REMOVED: there is no current file to copy
+        // attributes from, so the recorded ones are the only source. Recorded as
+        // this account rather than root, because the test does not run as root
+        // and a chown to another owner is refused; production rollback --apply
+        // is root-only and the refusal is reported there rather than ignored.
+        let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
+        let gone = dir.join("kde-fingerprint");
+        restore_surface(&gone, Some("restored\n"), Some((0o600, uid, gid))).expect("restore");
+        assert_eq!(
+            std::fs::metadata(&gone).unwrap().permissions().mode() & 0o7777,
+            0o600
+        );
+        assert!(strays(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A backup is complete or absent, and an existing one is never replaced.
+    ///
+    /// `std::fs::copy` straight to `.pre-irlume` could be killed part way, and a
+    /// later enable treats an existing backup as the pristine origin to rebuild
+    /// the live stack from. A truncated backup therefore became the authority
+    /// for what the machine's PAM should contain.
+    #[test]
+    fn a_backup_is_never_published_half_written() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = scratch_dir("backup");
+        let target = dir.join("sudo");
+        std::fs::write(&target, "the original stack\n").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        backup(&target).expect("backup");
+        let bak = dir.join(format!("sudo{BACKUP}"));
+        assert_eq!(
+            std::fs::read_to_string(&bak).unwrap(),
+            "the original stack\n"
+        );
+        assert_eq!(
+            std::fs::metadata(&bak).unwrap().permissions().mode() & 0o7777,
+            0o644,
+            "the backup did not carry the mode across"
+        );
+        assert!(strays(&dir).is_empty(), "left scratch: {:?}", strays(&dir));
+
+        // The live file is now wired. A second backup must NOT overwrite the
+        // pristine one with the already-wired content.
+        std::fs::write(
+            &target,
+            "auth sufficient pam_irlume.so\nthe original stack\n",
+        )
+        .unwrap();
+        backup(&target).expect("second backup");
+        assert_eq!(
+            std::fs::read_to_string(&bak).unwrap(),
+            "the original stack\n",
+            "a retry overwrote the pristine backup with wired content"
+        );
+        assert!(strays(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn path_regressed_flags_only_a_stripped_existing_file() {

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -971,14 +971,57 @@ pub(crate) fn apply(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<App
         with_polkit,
         &mut |svc, role, wire, want| {
             let path = Path::new(svc.etc);
-            let before = std::fs::read_to_string(path).ok();
+            // A file that exists but cannot be read is NOT the same as an
+            // absent one. Collapsing the two with `.ok()` would record
+            // `before: None`, and a later rollback would then DELETE a file it
+            // never captured. Only a genuine NotFound may become None.
+            let (before, mut read_error) = match std::fs::read_to_string(path) {
+                Ok(content) => (Some(content), None),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => (None, None),
+                Err(error) => (
+                    None,
+                    Some(format!(
+                        "read {} before changing it: {error}",
+                        path.display()
+                    )),
+                ),
+            };
+            if let Some(message) = read_error {
+                // Not touched at all: without a usable before-state there is
+                // nothing to roll back to, so writing would be irreversible.
+                out.push(AppliedSurface {
+                    id: service_name(svc.etc),
+                    role,
+                    path: svc.etc.to_string(),
+                    change: PlannedChange::NotInstalled,
+                    before: None,
+                    after_sha256: crate::logintx::ABSENT.to_string(),
+                    error: Some(message),
+                });
+                return;
+            }
             let (change, error) = match wire_service(svc, enable && want, true, wire) {
                 Ok(outcome) => (outcome.change, None),
                 Err(message) => (PlannedChange::NotInstalled, Some(message)),
             };
-            let after_sha256 = std::fs::read(path)
-                .map(|bytes| crate::logintx::sha256_hex(&bytes))
-                .unwrap_or_else(|_| crate::logintx::ABSENT.to_string());
+            // Same rule after the write: only a real NotFound is ABSENT. An
+            // unreadable file would otherwise record a digest
+            // `unchanged_since_apply` can never match, so rollback would report
+            // drift forever instead of the read problem it actually has.
+            let after_sha256 = match std::fs::read(path) {
+                Ok(bytes) => crate::logintx::sha256_hex(&bytes),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    crate::logintx::ABSENT.to_string()
+                }
+                Err(error) => {
+                    read_error = Some(format!(
+                        "read {} after changing it: {error}",
+                        path.display()
+                    ));
+                    crate::logintx::ABSENT.to_string()
+                }
+            };
+            let error = error.or(read_error);
             out.push(AppliedSurface {
                 id: service_name(svc.etc),
                 role,

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -2181,8 +2181,14 @@ fn swap_target_for_test(path: &Path) {
     *armed = None;
     // A different inode under the same name: what an administrator, a package
     // or another writer does in that window.
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::write(path, "SOMEONE ELSE'S FILE\n");
+    //
+    // Written elsewhere and renamed over, NOT removed and recreated. Removing
+    // frees the inode number, and a filesystem is free to hand the same one
+    // straight back: this test passed locally and failed in CI for exactly that
+    // reason. Both files exist at once here, so the numbers cannot coincide.
+    let replacement = path.with_extension("irlume-swap-source");
+    let _ = std::fs::write(&replacement, "SOMEONE ELSE'S FILE\n");
+    let _ = std::fs::rename(&replacement, path);
 }
 
 #[cfg(test)]
@@ -2213,7 +2219,12 @@ type TargetState = Option<(u64, u64)>;
 ///   breaking it silently the wrong default.
 ///
 /// The identity returned is the device and inode, which is what the caller
-/// compares to decide the name still refers to the same file.
+/// compares to decide the name still refers to the same file. That is the usual
+/// answer and not a perfect one: a filesystem may hand the same inode number
+/// back for a file created right after the old one was unlinked, so a
+/// replacement can in principle wear the identity of what it replaced. irlume's
+/// own paths cannot collide here because they hold the PAM lock; against an
+/// external writer this narrows the window rather than closing it.
 fn inspect_target(path: &Path) -> Result<TargetState, String> {
     use std::os::unix::fs::MetadataExt as _;
     let meta = match std::fs::symlink_metadata(path) {

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -268,6 +268,16 @@ fn read_wired_marker() -> Option<(bool, bool, bool)> {
 /// but the PAM stack is no longer wired, re-apply the recorded configuration;
 /// otherwise exit quietly. Always root (the path unit's service runs as root).
 fn reconcile() -> ExitCode {
+    // This unit fires when a PAM file changes, which is exactly what every other
+    // irlume path does, so without the lock reconcile is the most likely thing
+    // to be writing a stack somebody else is halfway through writing.
+    let _lock = match lock_pam() {
+        Ok(lock) => lock,
+        Err(message) => {
+            eprintln!("[login] reconcile cannot serialise: {message}");
+            return ExitCode::FAILURE;
+        }
+    };
     let Some((with_sudo, with_polkit, with_lock)) = read_wired_marker() else {
         // No marker. Two sub-cases:
         //  - Login IS currently wired (an upgrade from a pre-marker version, or
@@ -1370,6 +1380,20 @@ fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCod
         );
         return ExitCode::FAILURE;
     }
+    // Held for the whole run, so a machine transaction or the reconcile unit
+    // cannot be writing the same stacks at the same time. A dry run changes
+    // nothing and does not take it.
+    let _lock = if apply {
+        match lock_pam() {
+            Ok(lock) => Some(lock),
+            Err(message) => {
+                eprintln!("[login] cannot serialise this change: {message}");
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        None
+    };
     if !apply {
         println!("[login] DRY RUN: showing what `--apply` would change (nothing is written):");
     }
@@ -2053,6 +2077,69 @@ fn service_present(s: &Svc) -> Option<PathBuf> {
         .filter(|v| Path::new(v).exists())
         .map(|_| PathBuf::from(s.etc))
 }
+/// Held for as long as a process is changing PAM. Released when dropped.
+pub(crate) struct PamLock {
+    _file: std::fs::File,
+}
+
+/// Where the PAM lock lives. `IRLUME_PAM_LOCK` overrides it for tests and
+/// containers, the same way `IRLUME_STATE_DIR` overrides the state root.
+fn pam_lock_path() -> PathBuf {
+    std::env::var_os("IRLUME_PAM_LOCK")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/run/lock/irlume-pam.lock"))
+}
+
+/// Take the exclusive lock every irlume path that changes PAM must hold.
+///
+/// Nothing serialised these before. `login apply`, `login rollback`, human
+/// `login enable`/`disable`, and `reconcile` could all run at once, and the
+/// combinations are not theoretical: the reconcile path unit fires when a PAM
+/// file changes, which is exactly what the other three do. Two of them
+/// interleaving produced a stack that was a mixture of both, and the record
+/// written by either then described a machine state that never existed.
+///
+/// The lock covers the whole operation, not each write: revalidating a plan,
+/// writing the prepared record, every PAM and sidecar write, and the confirming
+/// record all have to be one indivisible unit, or the record still describes
+/// something other than what is on disk.
+///
+/// `flock` is released by the kernel when the process exits however it exits, so
+/// a killed irlume does not strand it. It does not exclude package managers or
+/// an administrator with an editor: only irlume takes it, which is why every
+/// path still re-checks the file it is about to write.
+pub(crate) fn lock_pam() -> Result<PamLock, String> {
+    use std::os::unix::io::AsRawFd as _;
+    let path = pam_lock_path();
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(|e| format!("open {}: {e}", path.display()))?;
+    let fd = file.as_raw_fd();
+    // SAFETY: `fd` is owned by `file`, which outlives the call and the guard.
+    let busy = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) } != 0;
+    if busy {
+        // Said on stderr, because machine output is JSON on stdout. Then wait:
+        // refusing outright would make the reconcile path unit give up exactly
+        // when an apply is in flight, which is when it most needs to run after.
+        eprintln!("irlume: another irlume PAM operation is in progress, waiting for it…");
+        // SAFETY: as above.
+        if unsafe { libc::flock(fd, libc::LOCK_EX) } != 0 {
+            return Err(format!(
+                "lock {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+    }
+    Ok(PamLock { _file: file })
+}
+
 /// A scratch path in the same directory as `path`, unique to this call.
 ///
 /// Every write here used to share one name per service, `.{service}.irlume.tmp`.
@@ -2335,6 +2422,55 @@ mod tests {
             .map(|e| e.file_name().to_string_lossy().into_owned())
             .filter(|n| n.contains(".tmp"))
             .collect()
+    }
+
+    /// The PAM lock actually excludes, and releases on drop.
+    ///
+    /// Asserted against a SECOND PROCESS, because `flock` is per open file
+    /// description: two locks taken in one process from separate opens do not
+    /// block each other on Linux the way two processes do, so an in-process test
+    /// could report exclusion that does not exist between the commands this is
+    /// meant to serialise.
+    #[test]
+    fn the_pam_lock_excludes_another_process_and_frees_on_drop() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = scratch_dir("pamlock");
+        let lock_path = dir.join("irlume-pam.lock");
+        let previous = std::env::var_os("IRLUME_PAM_LOCK");
+        // SAFETY: the env lock is held for the whole test.
+        unsafe { std::env::set_var("IRLUME_PAM_LOCK", &lock_path) };
+
+        // `flock -n` exits 1 when the lock is held; the shell is a separate
+        // process, which is the case that matters.
+        let contended = || {
+            std::process::Command::new("flock")
+                .arg("-n")
+                .arg(&lock_path)
+                .arg("true")
+                .status()
+                .expect("run flock")
+                .success()
+        };
+
+        assert!(contended(), "nothing held the lock yet");
+        let held = lock_pam().expect("take the lock");
+        assert!(
+            !contended(),
+            "a second process took the PAM lock while irlume held it"
+        );
+        drop(held);
+        assert!(contended(), "the lock was not released when dropped");
+
+        // SAFETY: as above.
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("IRLUME_PAM_LOCK", value),
+                None => std::env::remove_var("IRLUME_PAM_LOCK"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Two writes must never share a scratch name.

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -865,6 +865,27 @@ pub(crate) struct PlannedSurface {
     pub(crate) id: &'static str,
     pub(crate) role: &'static str,
     pub(crate) change: PlannedChange,
+    /// Digest of the file this decision was made against, or `ABSENT`.
+    ///
+    /// The outcome NAME is not enough to identify what was planned. An admin can
+    /// rewrite a stack and leave a valid anchor in place: the outcome stays
+    /// `wire`, so a plan id built from names alone is unchanged, and an apply
+    /// carrying that id would overwrite a stack the consumer was never shown.
+    /// The digest is what makes the id describe a state rather than an intent.
+    pub(crate) state: String,
+}
+
+/// A surface's current content digest, or `ABSENT`, or `unreadable`.
+///
+/// Three distinct answers on purpose. Folding "cannot read" into either of the
+/// others would let a plan id stay stable across a state it could not actually
+/// observe.
+pub(crate) fn surface_state(path: &Path) -> String {
+    match crate::logintx::file_sha256(path) {
+        Ok(Some(digest)) => digest,
+        Ok(None) => crate::logintx::ABSENT.to_string(),
+        Err(_) => "unreadable".to_string(),
+    }
 }
 
 /// What `login enable`/`login disable` would change, computed without writing.
@@ -934,6 +955,7 @@ pub(crate) fn plan(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<Plan
                 id: service_name(svc.etc),
                 role,
                 change,
+                state: surface_state(Path::new(svc.etc)),
             });
         },
     );
@@ -963,7 +985,12 @@ pub(crate) struct AppliedSurface {
 /// only moment it exists to be read; afterwards the file has already changed.
 /// Every surface is recorded even when a later one fails, since a partial apply
 /// is exactly the case a rollback has to be able to undo.
-pub(crate) fn apply(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<AppliedSurface> {
+pub(crate) fn apply(
+    enable: bool,
+    with_sudo: bool,
+    with_polkit: bool,
+    expected: &[PlannedSurface],
+) -> Vec<AppliedSurface> {
     let mut out = Vec::new();
     walk_surfaces(
         enable,
@@ -971,6 +998,35 @@ pub(crate) fn apply(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<App
         with_polkit,
         &mut |svc, role, wire, want| {
             let path = Path::new(svc.etc);
+            // Re-check the state THIS surface was planned against, immediately
+            // before writing it. Comparing plan ids once up front leaves a
+            // window: `plan` and `apply` are separate filesystem walks, so a
+            // change landing between them is never compared to anything. Doing
+            // it per surface narrows that window to the gap between this check
+            // and this write, which is as tight as it gets without holding a
+            // lock nothing else in the system takes.
+            let planned_state = expected
+                .iter()
+                .find(|candidate| candidate.id == service_name(svc.etc))
+                .map(|candidate| candidate.state.as_str());
+            let now = surface_state(path);
+            if let Some(planned_state) = planned_state {
+                if planned_state != now {
+                    out.push(AppliedSurface {
+                        id: service_name(svc.etc),
+                        role,
+                        path: svc.etc.to_string(),
+                        change: PlannedChange::NotInstalled,
+                        before: None,
+                        after_sha256: crate::logintx::ABSENT.to_string(),
+                        error: Some(format!(
+                            "{} changed between the plan and the write; not touched",
+                            svc.etc
+                        )),
+                    });
+                    return;
+                }
+            }
             // A file that exists but cannot be read is NOT the same as an
             // absent one. Collapsing the two with `.ok()` would record
             // `before: None`, and a later rollback would then DELETE a file it

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1072,6 +1072,32 @@ pub(crate) fn apply(
             // it per surface narrows that window to the gap between this check
             // and this write, which is as tight as it gets without holding a
             // lock nothing else in the system takes.
+            // A symlinked surface is refused rather than written. write_atomic
+            // renames over the path, which REPLACES the link with a regular
+            // file, and a rollback restores content rather than the link, so the
+            // conversion is silent and permanent. Writing through the link
+            // instead is no better: on Fedora these point into /etc/authselect
+            // and on Debian into /etc/alternatives, both shared targets that
+            // other tooling owns. Neither choice is irlume's to make quietly.
+            if path.is_symlink() {
+                out.push(AppliedSurface {
+                    id: service_name(svc.etc),
+                    role,
+                    path: svc.etc.to_string(),
+                    change: PlannedChange::NotInstalled,
+                    before: None,
+                    before_metadata: None,
+                    sidecar_before: None,
+                    sidecar_metadata: None,
+                    sidecar_existed: false,
+                    after_sha256: crate::logintx::ABSENT.to_string(),
+                    error: Some(format!(
+                        "{} is a symlink; irlume will not replace it or write through it",
+                        svc.etc
+                    )),
+                });
+                return;
+            }
             let planned_state = expected
                 .iter()
                 .find(|candidate| candidate.id == service_name(svc.etc))

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1297,11 +1297,24 @@ pub(crate) fn restore_surface(
             });
             write_atomic_inner(path, content, attrs)
         }
-        None => match std::fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(format!("remove {}: {error}", path.display())),
-        },
+        None => {
+            // The same refusal the replacing branch gets. Removing was a direct
+            // `remove_file`, so a path recorded as previously absent that is now
+            // a symlink was unlinked despite the claim that every write path
+            // refuses one, and a multiply-linked file lost a name irlume cannot
+            // put back.
+            inspect_target(path)?;
+            match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => return Err(format!("remove {}: {error}", path.display())),
+            }
+            // A deletion is a directory change like any other. Without this the
+            // unlink could be lost to a power cut while the durable progress
+            // note said the surface was done, so a resume would skip a file that
+            // is still there.
+            fsync_dir(path.parent().unwrap_or_else(|| Path::new(".")))
+        }
     }
 }
 
@@ -2722,6 +2735,25 @@ mod tests {
         );
         // Restore refuses on the same terms; it used to have no check at all.
         assert!(restore_surface(&a, Some("restored\n"), None).is_err());
+
+        // REMOVING a surface is a write path too. Rollback removes a file that
+        // was absent before the transaction, and that branch called remove_file
+        // directly: a path now holding a symlink was unlinked despite the claim
+        // that every path refuses one, and a multiply-linked file lost a name
+        // irlume cannot put back.
+        let gone_link = dir.join("was-absent");
+        std::os::unix::fs::symlink(&real, &gone_link).unwrap();
+        let refused = restore_surface(&gone_link, None, None)
+            .expect_err("removing a symlink must be refused too");
+        assert!(refused.contains("symlink"), "{refused}");
+        assert!(gone_link.is_symlink(), "the symlink was unlinked");
+        let peer = dir.join("linked-peer");
+        std::fs::hard_link(&a, &peer).unwrap();
+        assert!(
+            restore_surface(&a, None, None).is_err(),
+            "removing one name of a multiply-linked file must be refused"
+        );
+        std::fs::remove_file(&peer).unwrap();
 
         // Unlinking the peer makes it an ordinary file again, and writable.
         std::fs::remove_file(&b).unwrap();

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1089,7 +1089,12 @@ pub(crate) fn apply(
             // instead is no better: on Fedora these point into /etc/authselect
             // and on Debian into /etc/alternatives, both shared targets that
             // other tooling owns. Neither choice is irlume's to make quietly.
-            if path.is_symlink() {
+            // Asked here as well as inside the write, so the refusal reaches the
+            // consumer as a per-surface state with a reason rather than as one
+            // failed operation. `inspect_target` also covers hard links, which
+            // this check did not: a rename replaces one directory entry and
+            // leaves every other name for the inode on the old content.
+            if let Err(message) = inspect_target(path) {
                 out.push(AppliedSurface {
                     id: service_name(svc.etc),
                     role,
@@ -1101,10 +1106,7 @@ pub(crate) fn apply(
                     sidecar_metadata: None,
                     sidecar_existed: false,
                     after_sha256: crate::logintx::ABSENT.to_string(),
-                    error: Some(format!(
-                        "{} is a symlink; irlume will not replace it or write through it",
-                        svc.etc
-                    )),
+                    error: Some(message),
                 });
                 return;
             }
@@ -2140,6 +2142,85 @@ pub(crate) fn lock_pam() -> Result<PamLock, String> {
     Ok(PamLock { _file: file })
 }
 
+/// Test-only: replace a target during the window between the first look and the
+/// rename, so the recheck has something to catch.
+///
+/// The window cannot be reached from outside — it is entirely inside one
+/// function call — so a test that only sets up a symlink beforehand proves the
+/// FIRST check, never the second. Without this, removing the pre-rename recheck
+/// left every test green.
+#[cfg(test)]
+fn swap_target_for_test(path: &Path) {
+    let mut armed = SWAP_DURING_WRITE.lock().unwrap_or_else(|e| e.into_inner());
+    if armed.as_deref() != Some(path) {
+        return;
+    }
+    *armed = None;
+    // A different inode under the same name: what an administrator, a package
+    // or another writer does in that window.
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::write(path, "SOMEONE ELSE'S FILE\n");
+}
+
+#[cfg(test)]
+static SWAP_DURING_WRITE: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+
+/// What a PAM path is, for deciding whether irlume may replace it.
+///
+/// `None` means it does not exist, which is a legitimate state: apply removes an
+/// override it created, and rollback recreates a file that was absent.
+type TargetState = Option<(u64, u64)>;
+
+/// Establish that a PAM path is something irlume may replace, and identify it.
+///
+/// Two things are refused, and previously each was refused in one place or in
+/// none:
+///
+/// - **A symlink.** Renaming over it REPLACES the link with a regular file, and
+///   a rollback restores content rather than the link, so the conversion is
+///   silent and permanent. Writing through it instead is no better: on Fedora
+///   these point into `/etc/authselect` and on Debian into `/etc/alternatives`,
+///   shared targets other tooling owns. `apply` checked this; human
+///   enable/disable, reconcile and rollback did not, so one command refused a
+///   file another would quietly convert.
+/// - **More than one link to the inode.** A rename replaces one directory entry;
+///   every other name for that inode keeps referring to the OLD content. PAM
+///   then reads one inode while package tooling updates another. The link
+///   topology is recorded nowhere, so irlume could not put it back, which makes
+///   breaking it silently the wrong default.
+///
+/// The identity returned is the device and inode, which is what the caller
+/// compares to decide the name still refers to the same file.
+fn inspect_target(path: &Path) -> Result<TargetState, String> {
+    use std::os::unix::fs::MetadataExt as _;
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("stat {}: {e}", path.display())),
+    };
+    if meta.file_type().is_symlink() {
+        return Err(format!(
+            "{} is a symlink; irlume will not replace it with a regular file, because that \
+             conversion cannot be undone and the target belongs to another tool \
+             (authselect, alternatives)",
+            path.display()
+        ));
+    }
+    if !meta.file_type().is_file() {
+        return Err(format!("{} is not a regular file", path.display()));
+    }
+    if meta.nlink() > 1 {
+        return Err(format!(
+            "{} has {} hard links; replacing it would leave the other names referring to the \
+             old content, and irlume does not record the link topology so it could not put \
+             it back",
+            path.display(),
+            meta.nlink()
+        ));
+    }
+    Ok(Some((meta.dev(), meta.ino())))
+}
+
 /// A scratch path in the same directory as `path`, unique to this call.
 ///
 /// Every write here used to share one name per service, `.{service}.irlume.tmp`.
@@ -2272,6 +2353,10 @@ pub(crate) fn write_atomic_inner(
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .to_path_buf();
+    // What the target is right now. A rename REPLACES whatever the name refers
+    // to, so this has to be settled before anything is written, and confirmed
+    // again before the name is taken over.
+    let before = inspect_target(path)?;
     let tmp = scratch_path(path, "new");
     let result = (|| -> Result<(), String> {
         let mut file = create_scratch(&tmp)?;
@@ -2289,6 +2374,17 @@ pub(crate) fn write_atomic_inner(
         file.sync_all()
             .map_err(|e| format!("fsync {}: {e}", tmp.display()))?;
         drop(file);
+        #[cfg(test)]
+        swap_target_for_test(path);
+        // Immediately before the name is taken over, not once at the start. The
+        // first look and the rename are two moments, and what matters is what
+        // the name refers to at the instant it is replaced.
+        if inspect_target(path)? != before {
+            return Err(format!(
+                "{} changed while irlume was writing it, so it was left alone",
+                path.display()
+            ));
+        }
         std::fs::rename(&tmp, path).map_err(|e| format!("rename into {}: {e}", path.display()))?;
         fsync_dir(&dir)
     })();
@@ -2545,6 +2641,93 @@ mod tests {
             0o600
         );
         assert!(strays(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A symlink and a multiply-linked file are refused by EVERY write path.
+    ///
+    /// The check lived only in the machine `apply` path, so human
+    /// enable/disable, reconcile and rollback would silently replace a symlink
+    /// with a regular file. Nothing anywhere refused a hard link: a rename
+    /// replaces one directory entry, so the other names keep referring to the
+    /// old inode, PAM reads one and package tooling updates the other, and the
+    /// link topology is recorded nowhere so it could not be restored.
+    ///
+    /// Asserted through `write_atomic`, the funnel every path uses, rather than
+    /// on the checker alone: what matters is that a write is refused.
+    #[test]
+    fn a_symlink_or_a_hard_link_is_never_replaced_by_any_write_path() {
+        let dir = scratch_dir("links");
+
+        // A symlink standing in for the authselect/alternatives layout.
+        let real = dir.join("password-auth");
+        std::fs::write(&real, "the shared target\n").unwrap();
+        let link = dir.join("gdm-password");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let refused = write_atomic(&link, "wired\n").expect_err("a symlink must be refused");
+        assert!(refused.contains("symlink"), "{refused}");
+        assert_eq!(
+            std::fs::read_to_string(&real).unwrap(),
+            "the shared target\n",
+            "the symlink's target was written through"
+        );
+        assert!(link.is_symlink(), "the symlink was replaced");
+
+        // Two names for one inode.
+        let a = dir.join("sudo");
+        std::fs::write(&a, "the original stack\n").unwrap();
+        let b = dir.join("sudo-peer");
+        std::fs::hard_link(&a, &b).unwrap();
+        let refused = write_atomic(&a, "wired\n").expect_err("a hard link must be refused");
+        assert!(refused.contains("hard link"), "{refused}");
+        assert_eq!(std::fs::read_to_string(&a).unwrap(), "the original stack\n");
+        assert_eq!(
+            std::fs::read_to_string(&b).unwrap(),
+            "the original stack\n",
+            "the peer name was detached from the content"
+        );
+        // Restore refuses on the same terms; it used to have no check at all.
+        assert!(restore_surface(&a, Some("restored\n"), None).is_err());
+
+        // Unlinking the peer makes it an ordinary file again, and writable.
+        std::fs::remove_file(&b).unwrap();
+        write_atomic(&a, "wired\n").expect("a single-linked regular file is fine");
+        assert_eq!(std::fs::read_to_string(&a).unwrap(), "wired\n");
+        assert!(strays(&dir).is_empty(), "left scratch: {:?}", strays(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A target replaced DURING the write is not overwritten.
+    ///
+    /// The first look at the file and the rename that replaces it are two
+    /// moments. Checking once up front proves what the name meant when the write
+    /// started, and the rename acts on what it means when it finishes; between
+    /// them a package, an administrator or another tool can put a different file
+    /// — or a symlink into /etc/authselect — under that name.
+    ///
+    /// Reachable only from inside the write, hence the test hook. Removing the
+    /// pre-rename recheck left every other test green.
+    #[test]
+    fn a_target_swapped_mid_write_is_left_alone() {
+        let dir = scratch_dir("swap");
+        let target = dir.join("sudo");
+        std::fs::write(&target, "the original stack\n").unwrap();
+
+        *SWAP_DURING_WRITE.lock().unwrap() = Some(target.clone());
+        let refused = write_atomic(&target, "wired\n")
+            .expect_err("a target replaced mid-write must not be overwritten");
+        *SWAP_DURING_WRITE.lock().unwrap() = None;
+
+        assert!(
+            refused.contains("changed while irlume was writing"),
+            "{refused}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "SOMEONE ELSE'S FILE\n",
+            "irlume overwrote the file that replaced its target"
+        );
+        assert!(strays(&dir).is_empty(), "left scratch: {:?}", strays(&dir));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1204,6 +1204,30 @@ pub(crate) fn apply(
     out
 }
 
+/// Whether irlume manages this path at all.
+///
+/// A transaction record names the paths a rollback will write, and nothing
+/// previously checked that those were paths irlume had any business touching. A
+/// record naming /etc/shadow with a correct digest rewrote it: verified, not
+/// theorised. Only root can plant a record, and root can already write that
+/// file, so it was not an escalation, but it made `login rollback` a
+/// general-purpose write-anywhere-as-root primitive whose only gate was a
+/// directory mode. Any future way to plant a record would then be total.
+///
+/// So the paths are checked against the surfaces irlume wires, plus their
+/// `.pre-irlume` sidecars, and nothing else is restorable.
+pub(crate) fn is_managed_path(path: &str) -> bool {
+    let bare = path.strip_suffix(BACKUP).unwrap_or(path);
+    // Built from the same lists the wiring uses, so a surface added there is
+    // restorable without anyone remembering to update a second list.
+    GREETERS
+        .iter()
+        .chain(FP_GREETERS.iter())
+        .map(|s| s.etc)
+        .chain([LOCKSCREEN.etc, POLKIT.etc, SUDO])
+        .any(|managed| managed == bare)
+}
+
 /// Put one surface back to the content recorded before a transaction.
 ///
 /// Reuses the same atomic write the wiring path uses, so a restore lands the
@@ -3041,6 +3065,37 @@ mod tests {
             "the original\n"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn only_paths_irlume_manages_are_restorable() {
+        // Found by attacking, not by review: a record naming /etc/shadow with a
+        // CORRECT digest rewrote it. Only root can plant a record and root can
+        // already write that file, so it was not an escalation, but it made
+        // rollback a write-anywhere-as-root primitive gated on a directory mode.
+        for managed in [
+            "/etc/pam.d/sudo",
+            "/etc/pam.d/kde",
+            "/etc/pam.d/plasmalogin",
+            "/etc/pam.d/polkit-1",
+            "/etc/pam.d/gdm-password",
+            // A sidecar is restorable because its surface is.
+            "/etc/pam.d/sudo.pre-irlume",
+        ] {
+            assert!(is_managed_path(managed), "{managed} must be restorable");
+        }
+        for stray in [
+            "/etc/shadow",
+            "/etc/passwd",
+            "/etc/sudoers",
+            "/root/.ssh/authorized_keys",
+            "/etc/pam.d/../shadow",
+            "/etc/pam.d/sshd",
+            "/etc/pam.d/system-auth",
+            "",
+        ] {
+            assert!(!is_managed_path(stray), "{stray} must NOT be restorable");
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -237,7 +237,7 @@ pub(crate) fn write_wired_marker(
 
 /// Re-read the marker's recorded flags. Returns `None` when login was never
 /// enabled (no marker), so reconcile does nothing on machines that opted out.
-fn read_wired_marker() -> Option<(bool, bool, bool)> {
+pub(crate) fn read_wired_marker() -> Option<(bool, bool, bool)> {
     let path = wired_marker_path();
     // In production (default state dir) the marker must be root-owned: reconcile
     // acts on its with_sudo flag as root, so a marker a non-root user could plant

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -972,6 +972,9 @@ pub(crate) struct AppliedSurface {
     /// Content before the change; `None` when the file did not exist, so a
     /// rollback removes it rather than writing an empty file.
     pub(crate) before: Option<String>,
+    /// Mode, uid and gid before the change. Content alone does not describe a
+    /// file, and these cannot be recovered later once it has been rewritten.
+    pub(crate) before_metadata: Option<(u32, u32, u32)>,
     pub(crate) after_sha256: String,
     /// Set when this surface failed. The apply as a whole is reported as failed,
     /// and the surfaces that DID change are still recorded, so a rollback can
@@ -993,6 +996,7 @@ pub(crate) fn prepare(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<A
         with_polkit,
         &mut |svc, role, wire, want| {
             let path = Path::new(svc.etc);
+            let before_metadata = crate::logintx::file_metadata(path);
             let (before, error) = match std::fs::read_to_string(path) {
                 Ok(content) => (Some(content), None),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => (None, None),
@@ -1015,6 +1019,7 @@ pub(crate) fn prepare(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<A
                 path: svc.etc.to_string(),
                 change,
                 before,
+                before_metadata,
                 // Not written yet, so there is no after-state. A record in this
                 // condition is recognisable by its `prepared` status.
                 after_sha256: crate::logintx::ABSENT.to_string(),
@@ -1064,6 +1069,7 @@ pub(crate) fn apply(
                         path: svc.etc.to_string(),
                         change: PlannedChange::NotInstalled,
                         before: None,
+                        before_metadata: None,
                         after_sha256: crate::logintx::ABSENT.to_string(),
                         error: Some(format!(
                             "{} changed between the plan and the write; not touched",
@@ -1077,6 +1083,7 @@ pub(crate) fn apply(
             // absent one. Collapsing the two with `.ok()` would record
             // `before: None`, and a later rollback would then DELETE a file it
             // never captured. Only a genuine NotFound may become None.
+            let before_metadata = crate::logintx::file_metadata(path);
             let (before, mut read_error) = match std::fs::read_to_string(path) {
                 Ok(content) => (Some(content), None),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => (None, None),
@@ -1097,6 +1104,7 @@ pub(crate) fn apply(
                     path: svc.etc.to_string(),
                     change: PlannedChange::NotInstalled,
                     before: None,
+                    before_metadata: None,
                     after_sha256: crate::logintx::ABSENT.to_string(),
                     error: Some(message),
                 });
@@ -1130,6 +1138,7 @@ pub(crate) fn apply(
                 path: svc.etc.to_string(),
                 change,
                 before,
+                before_metadata,
                 after_sha256,
                 error,
             });
@@ -1147,9 +1156,31 @@ pub(crate) fn apply(
 /// `None` content means the file did not exist before, so it is removed rather
 /// than written empty: an empty PAM file is not the same as an absent one, and
 /// leaving one behind would shadow a vendor copy.
-pub(crate) fn restore_surface(path: &Path, before: Option<&str>) -> Result<(), String> {
+pub(crate) fn restore_surface(
+    path: &Path,
+    before: Option<&str>,
+    metadata: Option<(u32, u32, u32)>,
+) -> Result<(), String> {
     match before {
-        Some(content) => write_atomic(path, content),
+        Some(content) => {
+            write_atomic(path, content)?;
+            // Applied AFTER the atomic rename. write_atomic copies permissions
+            // from the file it is replacing, which is the wrong source here and
+            // does not exist at all when apply removed the file, so the recorded
+            // values are reapplied explicitly.
+            if let Some((mode, uid, gid)) = metadata {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+                    .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+                // Ownership needs privilege irlume has here (rollback --apply is
+                // root-only) but may not on an unusual filesystem, so a failure
+                // is reported rather than silently accepted: a PAM file with the
+                // wrong group is a real access change.
+                std::os::unix::fs::chown(path, Some(uid), Some(gid))
+                    .map_err(|e| format!("chown {}: {e}", path.display()))?;
+            }
+            Ok(())
+        }
         None => match std::fs::remove_file(path) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -2947,10 +2978,41 @@ mod tests {
         let file = dir.join("sudo");
         std::fs::write(&file, "changed by apply\n").expect("write");
 
-        restore_surface(&file, Some("the original\n")).expect("restore");
+        restore_surface(&file, Some("the original\n"), None).expect("restore");
         assert_eq!(
             std::fs::read_to_string(&file).expect("read"),
             "the original\n"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn restoring_puts_back_the_mode_not_just_the_bytes() {
+        use std::os::unix::fs::PermissionsExt;
+        // Codex found this on #178: write_atomic copies permissions from the
+        // file it replaces, which is the wrong source and does not exist at all
+        // when apply removed the file. A PAM stack that was 0640 coming back
+        // 0644 is a real access change, not a cosmetic one.
+        let dir = std::env::temp_dir().join(format!("irlume-restore-mode-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let file = dir.join("greeter");
+        std::fs::write(&file, "rewritten by apply\n").expect("write");
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+
+        // The recorded pre-change state: same bytes, but a tighter mode.
+        let meta = crate::logintx::file_metadata(&file).expect("metadata");
+        restore_surface(&file, Some("the original\n"), Some((0o640, meta.1, meta.2)))
+            .expect("restore");
+
+        assert_eq!(
+            std::fs::read_to_string(&file).expect("read"),
+            "the original\n"
+        );
+        let mode = std::fs::metadata(&file).expect("stat").permissions().mode() & 0o7777;
+        assert_eq!(
+            mode, 0o640,
+            "the recorded mode must come back, not the current one"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -2967,12 +3029,12 @@ mod tests {
         let file = dir.join("materialized-override");
         std::fs::write(&file, "irlume made this\n").expect("write");
 
-        restore_surface(&file, None).expect("restore");
+        restore_surface(&file, None, None).expect("restore");
         assert!(!file.exists(), "the file must be gone, not empty");
 
         // Restoring an already-absent file is not an error: a rollback that
         // partly ran and is run again must be able to finish.
-        restore_surface(&file, None).expect("restoring an absent file is fine");
+        restore_surface(&file, None, None).expect("restoring an absent file is fine");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -872,16 +872,58 @@ pub(crate) struct PlannedSurface {
 /// This runs the identical decision the apply path runs, with `apply` false, so
 /// the plan cannot describe an outcome the apply would not produce. It reads
 /// PAM files and needs no privilege; only applying does.
-pub(crate) fn plan(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<PlannedSurface> {
+/// Called once per surface: the service, its role, the wiring recipe for it,
+/// and whether this configuration wants it wired.
+type SurfaceVisitor<'a> = dyn FnMut(&Svc, &'static str, &dyn Fn(&str) -> (String, bool), bool) + 'a;
+
+/// Walk every surface an enable/disable would touch, calling `visit` for each.
+///
+/// One list, walked by both `plan` and `apply`. Deciding which surfaces are in
+/// scope, and with which wiring recipe, is the part that must not exist twice:
+/// a plan that walked a different set than the apply would describe changes
+/// that never happen, or miss ones that do.
+fn walk_surfaces(enable: bool, with_sudo: bool, with_polkit: bool, visit: &mut SurfaceVisitor<'_>) {
     let Wants {
         face_login,
         face_lock,
         fp_keyring,
     } = wants();
     let gnome = gnome_shell_major();
+    for s in GREETERS {
+        let prof = dm_profile(s.etc, gnome);
+        let unified_login_lock =
+            s.etc.ends_with("/cosmic-greeter") || s.etc.ends_with("/gdm-password");
+        let face = face_login || (unified_login_lock && face_lock);
+        let greeter_wire = |c: &str| wire_greeter_impl(c, face, fp_keyring, prof.ondemand);
+        visit(s, ROLE_LOGIN, &greeter_wire, face || fp_keyring);
+    }
+    for s in FP_GREETERS {
+        visit(s, ROLE_LOGIN_FP, &wire_fp_keyring, fp_keyring);
+    }
+    visit(&LOCKSCREEN, ROLE_LOCK, &wire_lock, face_lock);
+    if sudo_in_scope(enable, with_sudo) {
+        visit(
+            &Svc {
+                etc: SUDO,
+                vendor: None,
+            },
+            ROLE_SUDO,
+            &wire_verify_service,
+            true,
+        );
+    }
+    if polkit_in_scope(enable, with_polkit) {
+        visit(&POLKIT, ROLE_POLKIT, &wire_verify_service, true);
+    }
+}
+
+pub(crate) fn plan(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<PlannedSurface> {
     let mut out = Vec::new();
-    let mut record =
-        |svc: &Svc, role: &'static str, wire: &dyn Fn(&str) -> (String, bool), want: bool| {
+    walk_surfaces(
+        enable,
+        with_sudo,
+        with_polkit,
+        &mut |svc, role, wire, want| {
             // A service whose decision cannot even be computed (an unreadable file)
             // is reported as not-installed rather than omitted: a surface silently
             // missing from a plan is how a consumer comes to believe it was covered.
@@ -893,34 +935,82 @@ pub(crate) fn plan(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<Plan
                 role,
                 change,
             });
-        };
-    for s in GREETERS {
-        let prof = dm_profile(s.etc, gnome);
-        let unified_login_lock =
-            s.etc.ends_with("/cosmic-greeter") || s.etc.ends_with("/gdm-password");
-        let face = face_login || (unified_login_lock && face_lock);
-        let greeter_wire = |c: &str| wire_greeter_impl(c, face, fp_keyring, prof.ondemand);
-        record(s, ROLE_LOGIN, &greeter_wire, face || fp_keyring);
-    }
-    for s in FP_GREETERS {
-        record(s, ROLE_LOGIN_FP, &wire_fp_keyring, fp_keyring);
-    }
-    record(&LOCKSCREEN, ROLE_LOCK, &wire_lock, face_lock);
-    if sudo_in_scope(enable, with_sudo) {
-        record(
-            &Svc {
-                etc: SUDO,
-                vendor: None,
-            },
-            ROLE_SUDO,
-            &wire_verify_service,
-            true,
-        );
-    }
-    if polkit_in_scope(enable, with_polkit) {
-        record(&POLKIT, ROLE_POLKIT, &wire_verify_service, true);
-    }
+        },
+    );
     out
+}
+
+/// One surface after an apply, with what it took to undo it.
+pub(crate) struct AppliedSurface {
+    pub(crate) id: &'static str,
+    pub(crate) role: &'static str,
+    /// The `/etc` path. Needed to restore; never published in machine output.
+    pub(crate) path: String,
+    pub(crate) change: PlannedChange,
+    /// Content before the change; `None` when the file did not exist, so a
+    /// rollback removes it rather than writing an empty file.
+    pub(crate) before: Option<String>,
+    pub(crate) after_sha256: String,
+    /// Set when this surface failed. The apply as a whole is reported as failed,
+    /// and the surfaces that DID change are still recorded, so a rollback can
+    /// undo a partial run.
+    pub(crate) error: Option<String>,
+}
+
+/// Carry out an enable/disable, recording what each surface looked like first.
+///
+/// The before-content is read BEFORE `wire_service` runs, because that is the
+/// only moment it exists to be read; afterwards the file has already changed.
+/// Every surface is recorded even when a later one fails, since a partial apply
+/// is exactly the case a rollback has to be able to undo.
+pub(crate) fn apply(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<AppliedSurface> {
+    let mut out = Vec::new();
+    walk_surfaces(
+        enable,
+        with_sudo,
+        with_polkit,
+        &mut |svc, role, wire, want| {
+            let path = Path::new(svc.etc);
+            let before = std::fs::read_to_string(path).ok();
+            let (change, error) = match wire_service(svc, enable && want, true, wire) {
+                Ok(outcome) => (outcome.change, None),
+                Err(message) => (PlannedChange::NotInstalled, Some(message)),
+            };
+            let after_sha256 = std::fs::read(path)
+                .map(|bytes| crate::logintx::sha256_hex(&bytes))
+                .unwrap_or_else(|_| crate::logintx::ABSENT.to_string());
+            out.push(AppliedSurface {
+                id: service_name(svc.etc),
+                role,
+                path: svc.etc.to_string(),
+                change,
+                before,
+                after_sha256,
+                error,
+            });
+        },
+    );
+    out
+}
+
+/// Put one surface back to the content recorded before a transaction.
+///
+/// Reuses the same atomic write the wiring path uses, so a restore lands the
+/// way every other PAM write here does. The caller must have checked
+/// `unchanged_since_apply` first; this does the write, not the decision.
+///
+/// `None` content means the file did not exist before, so it is removed rather
+/// than written empty: an empty PAM file is not the same as an absent one, and
+/// leaving one behind would shadow a vendor copy.
+pub(crate) fn restore_surface(path: &Path, before: Option<&str>) -> Result<(), String> {
+    match before {
+        Some(content) => write_atomic(path, content),
+        None => match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(format!("remove {}: {error}", path.display())),
+        },
+    }
 }
 
 /// The active login manager and the PAM services it consults.

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -2795,6 +2795,43 @@ mod tests {
     const VENDOR_GREETER: &str = "#%PAM-1.0\nauth       substack      password-auth\nauth       optional      pam_gnome_keyring.so\naccount    include       password-auth\nsession    include       password-auth\n";
 
     #[test]
+    fn restoring_writes_the_recorded_content_back() {
+        let dir = std::env::temp_dir().join(format!("irlume-restore-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let file = dir.join("sudo");
+        std::fs::write(&file, "changed by apply\n").expect("write");
+
+        restore_surface(&file, Some("the original\n")).expect("restore");
+        assert_eq!(
+            std::fs::read_to_string(&file).expect("read"),
+            "the original\n"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn restoring_a_file_that_did_not_exist_removes_it() {
+        // `disable` can remove a file outright. Writing an empty one instead
+        // would leave a stub shadowing the vendor copy, which is not the same
+        // as the file being absent.
+        let dir =
+            std::env::temp_dir().join(format!("irlume-restore-absent-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let file = dir.join("materialized-override");
+        std::fs::write(&file, "irlume made this\n").expect("write");
+
+        restore_surface(&file, None).expect("restore");
+        assert!(!file.exists(), "the file must be gone, not empty");
+
+        // Restoring an already-absent file is not an error: a rollback that
+        // partly ran and is run again must be able to finish.
+        restore_surface(&file, None).expect("restoring an absent file is fine");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn wire_service_override_materialize_idempotent_then_remove() {
         let dir = TestDir::new("wsvc-override");
         let vendor = dir.0.join("plasmalogin.vendor");

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -203,7 +203,12 @@ fn wired_marker_path() -> std::path::PathBuf {
 /// Persist (on enable) or remove (on disable) the wiring marker. The body is a
 /// tiny stable key=value record of the extra scopes so reconcile re-applies the
 /// same `--with-sudo` / `--with-polkit` choice, not a bare login wiring.
-fn write_wired_marker(enable: bool, with_sudo: bool, with_polkit: bool, with_lock: bool) {
+pub(crate) fn write_wired_marker(
+    enable: bool,
+    with_sudo: bool,
+    with_polkit: bool,
+    with_lock: bool,
+) {
     let path = wired_marker_path();
     if !enable {
         let _ = std::fs::remove_file(&path);

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 const MODULE: &str = "pam_irlume.so";
-const BACKUP: &str = ".pre-irlume";
+pub(crate) const BACKUP: &str = ".pre-irlume";
 const CREATED_PREFIX: &str = "# irlume: created from ";
 /// The one sentence that explains the on-demand trigger; shared so the status
 /// line, the plan line, and docs/SETUP.md's mirror never drift apart.
@@ -975,6 +975,13 @@ pub(crate) struct AppliedSurface {
     /// Mode, uid and gid before the change. Content alone does not describe a
     /// file, and these cannot be recovered later once it has been rewritten.
     pub(crate) before_metadata: Option<(u32, u32, u32)>,
+    /// The `.pre-irlume` backup as it stood before the change, since wiring
+    /// creates one and unwiring consumes one.
+    pub(crate) sidecar_before: Option<String>,
+    pub(crate) sidecar_metadata: Option<(u32, u32, u32)>,
+    /// Whether the backup existed at all beforehand. Distinguishes "was absent,
+    /// remove it on rollback" from "was present and empty".
+    pub(crate) sidecar_existed: bool,
     pub(crate) after_sha256: String,
     /// Set when this surface failed. The apply as a whole is reported as failed,
     /// and the surfaces that DID change are still recorded, so a rollback can
@@ -997,6 +1004,12 @@ pub(crate) fn prepare(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<A
         &mut |svc, role, wire, want| {
             let path = Path::new(svc.etc);
             let before_metadata = crate::logintx::file_metadata(path);
+            // Wiring creates this and unwiring renames it away, so it is part of
+            // what the transaction changed.
+            let sidecar_path = PathBuf::from(format!("{}{BACKUP}", svc.etc));
+            let sidecar_before = std::fs::read_to_string(&sidecar_path).ok();
+            let sidecar_metadata = crate::logintx::file_metadata(&sidecar_path);
+            let sidecar_existed = sidecar_path.exists();
             let (before, error) = match std::fs::read_to_string(path) {
                 Ok(content) => (Some(content), None),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => (None, None),
@@ -1020,6 +1033,9 @@ pub(crate) fn prepare(enable: bool, with_sudo: bool, with_polkit: bool) -> Vec<A
                 change,
                 before,
                 before_metadata,
+                sidecar_before,
+                sidecar_metadata,
+                sidecar_existed,
                 // Not written yet, so there is no after-state. A record in this
                 // condition is recognisable by its `prepared` status.
                 after_sha256: crate::logintx::ABSENT.to_string(),
@@ -1070,6 +1086,9 @@ pub(crate) fn apply(
                         change: PlannedChange::NotInstalled,
                         before: None,
                         before_metadata: None,
+                        sidecar_before: None,
+                        sidecar_metadata: None,
+                        sidecar_existed: false,
                         after_sha256: crate::logintx::ABSENT.to_string(),
                         error: Some(format!(
                             "{} changed between the plan and the write; not touched",
@@ -1084,6 +1103,12 @@ pub(crate) fn apply(
             // `before: None`, and a later rollback would then DELETE a file it
             // never captured. Only a genuine NotFound may become None.
             let before_metadata = crate::logintx::file_metadata(path);
+            // Wiring creates this and unwiring renames it away, so it is part of
+            // what the transaction changed.
+            let sidecar_path = PathBuf::from(format!("{}{BACKUP}", svc.etc));
+            let sidecar_before = std::fs::read_to_string(&sidecar_path).ok();
+            let sidecar_metadata = crate::logintx::file_metadata(&sidecar_path);
+            let sidecar_existed = sidecar_path.exists();
             let (before, mut read_error) = match std::fs::read_to_string(path) {
                 Ok(content) => (Some(content), None),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => (None, None),
@@ -1105,6 +1130,9 @@ pub(crate) fn apply(
                     change: PlannedChange::NotInstalled,
                     before: None,
                     before_metadata: None,
+                    sidecar_before: None,
+                    sidecar_metadata: None,
+                    sidecar_existed: false,
                     after_sha256: crate::logintx::ABSENT.to_string(),
                     error: Some(message),
                 });
@@ -1139,6 +1167,9 @@ pub(crate) fn apply(
                 change,
                 before,
                 before_metadata,
+                sidecar_before,
+                sidecar_metadata,
+                sidecar_existed,
                 after_sha256,
                 error,
             });

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -2329,7 +2329,15 @@ fn fsync_dir(dir: &Path) -> Result<(), String> {
 /// content.
 fn backup(path: &Path) -> Result<(), String> {
     let bak = PathBuf::from(format!("{}{BACKUP}", path.display()));
-    if bak.exists() {
+    // The backup is held to the same standard as the stack it came from, and it
+    // was not. `exists()` follows a symlink, so a `.pre-irlume` pointing
+    // somewhere else was accepted and then used as the pristine origin a later
+    // enable rebuilds from. A DANGLING one was worse: `exists()` said no, and the
+    // publishing link then failed with EEXIST against the symlink's own name,
+    // which read as "a backup is already there" when there was none at all.
+    // A complete backup already there is left alone; it must not be replaced
+    // with the now-wired content.
+    if inspect_target(&bak)?.is_some() {
         return Ok(());
     }
     let contents = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
@@ -2838,6 +2846,32 @@ mod tests {
             "a retry overwrote the pristine backup with wired content"
         );
         assert!(strays(&dir).is_empty());
+
+        // An EXISTING backup is held to the same standard as the stack, and was
+        // not. `exists()` follows a symlink, so a `.pre-irlume` pointing
+        // elsewhere was accepted and then used as the pristine origin a later
+        // enable rebuilds from.
+        let linked = dir.join("sddm");
+        std::fs::write(&linked, "the stack\n").unwrap();
+        let elsewhere = dir.join("somewhere-else");
+        std::fs::write(&elsewhere, "not this camera's business\n").unwrap();
+        std::os::unix::fs::symlink(&elsewhere, dir.join(format!("sddm{BACKUP}"))).unwrap();
+        let refused = backup(&linked).expect_err("a symlinked backup must be refused");
+        assert!(refused.contains("symlink"), "{refused}");
+
+        // A DANGLING one was worse: `exists()` said no, and publishing then
+        // failed with EEXIST against the symlink's own name, which read as "a
+        // backup is already there" when there was none at all.
+        let dangling = dir.join("lightdm");
+        std::fs::write(&dangling, "the stack\n").unwrap();
+        std::os::unix::fs::symlink(
+            dir.join("nothing-here"),
+            dir.join(format!("lightdm{BACKUP}")),
+        )
+        .unwrap();
+        let refused = backup(&dangling).expect_err("a dangling backup link must be refused");
+        assert!(refused.contains("symlink"), "{refused}");
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -30,7 +30,8 @@ fn version_json_is_one_machine_document() {
             "doctor-json",
             "login-status-json",
             "auth-test-events",
-            "login-plan-json"
+            "login-plan-json",
+            "login-transactions"
         ])
     );
 }

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -488,3 +488,181 @@ fn doctor_json_reports_every_check_with_a_stable_id() {
     ids.dedup();
     assert_eq!(before, ids.len(), "check ids must be unique");
 }
+
+/// The transaction commands, exercised through the real binary. Their bodies
+/// need root to reach the writing half, but every refusal and the read-only
+/// plan run as an ordinary user, which is also how a desktop first meets them.
+#[test]
+fn login_plan_answers_for_both_actions() {
+    for action in ["enable", "disable"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+            .args(["login", "plan", "--action", action, "--json"])
+            .output()
+            .expect("run irlume");
+        assert!(output.status.success(), "plan {action} should succeed");
+        let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+        assert_eq!(document["command"], "login.plan");
+        assert_eq!(document["data"]["action"], action);
+        // Every wirable surface is listed, present or not, so a consumer that
+        // knows an id can always find it.
+        let changes = document["data"]["changes"]
+            .as_array()
+            .expect("changes is an array");
+        assert!(!changes.is_empty());
+        for change in changes {
+            assert!(change["surface"].is_string());
+            assert!(change["writes"].is_boolean());
+        }
+        // requires_root must agree with the write count rather than being an
+        // independent claim a consumer could act on wrongly.
+        let writes = document["data"]["writes"].as_u64().expect("writes");
+        assert_eq!(document["data"]["requires_root"], writes > 0);
+        let counted = changes
+            .iter()
+            .filter(|c| c["writes"] == serde_json::json!(true))
+            .count() as u64;
+        assert_eq!(writes, counted, "the count must match the entries");
+        // No PAM paths: surfaces are named by service.
+        let text = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !text.contains("/etc/pam.d"),
+            "a plan must not publish paths"
+        );
+    }
+}
+
+#[test]
+fn a_plan_id_is_stable_for_an_unchanged_machine() {
+    let id = |action: &str| -> String {
+        let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+            .args(["login", "plan", "--action", action, "--json"])
+            .output()
+            .expect("run irlume");
+        let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+        document["data"]["plan_id"]
+            .as_str()
+            .expect("plan_id")
+            .to_string()
+    };
+    let first = id("enable");
+    assert_eq!(first.len(), 32);
+    assert_eq!(first, id("enable"), "same machine, same intent, same id");
+    assert_ne!(
+        first,
+        id("disable"),
+        "a different intent is a different plan"
+    );
+}
+
+#[test]
+fn the_transaction_commands_refuse_before_they_write() {
+    let cases: [(&[&str], &str, i32); 6] = [
+        // apply without a plan id would act on changes nobody was shown.
+        (
+            &["login", "apply", "--action", "enable", "--json"],
+            "usage-error",
+            2,
+        ),
+        (
+            &[
+                "login",
+                "apply",
+                "--action",
+                "enable",
+                "--plan-id",
+                "nothex",
+                "--json",
+            ],
+            "usage-error",
+            2,
+        ),
+        // An id shaped like a path is refused, not cleaned: it becomes a filename.
+        (
+            &[
+                "login",
+                "verify",
+                "--transaction-id",
+                "../../etc/passwd",
+                "--json",
+            ],
+            "usage-error",
+            2,
+        ),
+        (
+            &[
+                "login",
+                "rollback",
+                "--transaction-id",
+                "../../etc/shadow",
+                "--apply",
+                "--json",
+            ],
+            "usage-error",
+            2,
+        ),
+        (&["login", "verify", "--json"], "usage-error", 2),
+        // A well-formed id that names no record.
+        (
+            &[
+                "login",
+                "verify",
+                "--transaction-id",
+                "0123456789abcdef0123456789abcdef",
+                "--json",
+            ],
+            "not-found",
+            1,
+        ),
+    ];
+    for (args, expected, exit) in cases {
+        let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+            .args(args)
+            .output()
+            .expect("run irlume");
+        let document: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+            panic!(
+                "{args:?}: {e}, stdout {:?}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        });
+        assert_eq!(document["ok"], false, "{args:?}");
+        assert_eq!(document["error"]["code"], expected, "{args:?}");
+        assert_eq!(output.status.code(), Some(exit), "{args:?}");
+    }
+}
+
+/// Applying needs root, and that is checked BEFORE anything is written: a
+/// mutating command that loses permission partway leaves a stack half-changed.
+/// Skipped when the suite happens to run as root, rather than asserting the
+/// opposite and quietly testing nothing.
+#[test]
+fn applying_without_root_is_refused_up_front() {
+    // SAFETY: geteuid cannot fail and touches no memory.
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("running as root; the unprivileged refusal cannot be exercised here");
+        return;
+    }
+    let plan = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["login", "plan", "--action", "enable", "--json"])
+        .output()
+        .expect("run irlume");
+    let plan: Value = serde_json::from_slice(&plan.stdout).expect("valid JSON");
+    let plan_id = plan["data"]["plan_id"].as_str().expect("plan_id");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args([
+            "login",
+            "apply",
+            "--action",
+            "enable",
+            "--plan-id",
+            plan_id,
+            "--json",
+        ])
+        .output()
+        .expect("run irlume");
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(document["command"], "login.apply");
+    assert_eq!(document["error"]["code"], "not-authorized");
+    assert_eq!(document["error"]["retryable"], false);
+}

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -614,9 +614,17 @@ fn the_transaction_commands_refuse_before_they_write() {
             1,
         ),
     ];
+    // Point the store at an empty directory this test owns. Without it the
+    // answer depends on the machine: a host whose real /var/lib/irlume store
+    // exists but is not readable by this user correctly returns not-authorized
+    // rather than not-found, which is the very distinction this PR added. The
+    // test read the host's state and so passed here and failed on the runner.
+    let store = std::env::temp_dir().join(format!("irlume-tx-empty-{}", std::process::id()));
+    std::fs::create_dir_all(&store).expect("temp store");
     for (args, expected, exit) in cases {
         let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
             .args(args)
+            .env("IRLUME_STATE_DIR", &store)
             .output()
             .expect("run irlume");
         let document: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
@@ -629,6 +637,7 @@ fn the_transaction_commands_refuse_before_they_write() {
         assert_eq!(document["error"]["code"], expected, "{args:?}");
         assert_eq!(output.status.code(), Some(exit), "{args:?}");
     }
+    let _ = std::fs::remove_dir_all(&store);
 }
 
 /// Applying needs root, and that is checked BEFORE anything is written: a

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -675,3 +675,146 @@ fn applying_without_root_is_refused_up_front() {
     assert_eq!(document["error"]["code"], "not-authorized");
     assert_eq!(document["error"]["retryable"], false);
 }
+
+/// Drive verify and rollback against a record this test writes, so the paths
+/// that need root to reach through apply are still exercised. The store is a
+/// temporary directory, so nothing here touches a real transaction or a real
+/// PAM file: rollback runs only as a dry run.
+#[test]
+fn verify_and_rollback_read_a_record_and_report_its_state() {
+    let dir = std::env::temp_dir().join(format!("irlume-hw-rec-{}", std::process::id()));
+    let store = dir.join("login-transactions");
+    std::fs::create_dir_all(&store).expect("store");
+    let subject = dir.join("greeter");
+    std::fs::write(&subject, "as applied\n").expect("write");
+
+    let digest = {
+        use sha2::{Digest as _, Sha256};
+        Sha256::digest(b"as applied\n")
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
+    };
+    let id = "0123456789abcdef0123456789abcdef";
+    let record = serde_json::json!({
+        "id": id,
+        "status": "applied",
+        "action": "disable",
+        "plan_id": "f".repeat(32),
+        "engine_version": "0.0.0",
+        "surfaces": [{
+            "id": "kde",
+            "path": subject.display().to_string(),
+            "change": "wire",
+            "before": "the original\n",
+            "after_sha256": digest,
+        }],
+    });
+    std::fs::write(store.join(format!("{id}.json")), record.to_string()).expect("record");
+
+    let run = |args: &[&str]| -> Value {
+        let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+            .args(args)
+            .env("IRLUME_STATE_DIR", &dir)
+            .output()
+            .expect("run irlume");
+        serde_json::from_slice(&output.stdout).expect("valid JSON")
+    };
+
+    // Untouched since apply: no drift, rollback offered, status reported.
+    let verified = run(&["login", "verify", "--transaction-id", id, "--json"]);
+    assert_eq!(verified["data"]["status"], "applied");
+    assert_eq!(verified["data"]["drifted"], 0);
+    assert_eq!(verified["data"]["rollback_available"], true);
+    assert_eq!(verified["data"]["surfaces"][0]["state"], "as-applied");
+
+    // A dry run reports what it would restore and writes nothing.
+    let dry = run(&["login", "rollback", "--transaction-id", id, "--json"]);
+    assert_eq!(dry["data"]["applied"], false);
+    assert_eq!(dry["data"]["would_restore"][0], "kde");
+    assert_eq!(
+        std::fs::read_to_string(&subject).expect("read"),
+        "as applied\n",
+        "a dry run must not write"
+    );
+
+    // Once something else edits the file, both refuse rather than clobber it.
+    std::fs::write(&subject, "an admin edited this\n").expect("write");
+    let drifted = run(&["login", "verify", "--transaction-id", id, "--json"]);
+    assert_eq!(drifted["data"]["drifted"], 1);
+    assert_eq!(drifted["data"]["rollback_available"], false);
+    assert_eq!(
+        drifted["data"]["surfaces"][0]["state"],
+        "changed-since-apply"
+    );
+
+    let refused = run(&["login", "rollback", "--transaction-id", id, "--json"]);
+    assert_eq!(refused["error"]["code"], "changed-since-apply");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A record whose writes were never confirmed cannot be rolled back silently:
+/// its after-digests mean nothing, so restoring gives up the protection against
+/// reverting an edit the transaction did not make.
+#[test]
+fn an_unconfirmed_record_needs_the_acknowledgement() {
+    let dir = std::env::temp_dir().join(format!("irlume-hw-unconf-{}", std::process::id()));
+    let store = dir.join("login-transactions");
+    std::fs::create_dir_all(&store).expect("store");
+    let subject = dir.join("greeter");
+    std::fs::write(&subject, "half applied\n").expect("write");
+
+    let id = "abcdefabcdefabcdefabcdefabcdef01";
+    let record = serde_json::json!({
+        "id": id,
+        "status": "prepared",
+        "action": "enable",
+        "plan_id": "0".repeat(32),
+        "engine_version": "0.0.0",
+        "surfaces": [{
+            "id": "kde",
+            "path": subject.display().to_string(),
+            "change": "wire",
+            "before": "the original\n",
+            "after_sha256": "absent",
+        }],
+    });
+    std::fs::write(store.join(format!("{id}.json")), record.to_string()).expect("record");
+
+    let run = |args: &[&str]| -> Value {
+        let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+            .args(args)
+            .env("IRLUME_STATE_DIR", &dir)
+            .output()
+            .expect("run irlume");
+        serde_json::from_slice(&output.stdout).expect("valid JSON")
+    };
+
+    let verified = run(&["login", "verify", "--transaction-id", id, "--json"]);
+    assert_eq!(verified["data"]["status"], "prepared");
+    assert_eq!(
+        verified["data"]["rollback_available"], false,
+        "an unconfirmed record is not offered for rollback"
+    );
+
+    let refused = run(&["login", "rollback", "--transaction-id", id, "--json"]);
+    assert_eq!(refused["error"]["code"], "unconfirmed-transaction");
+
+    // With the acknowledgement it is reachable, and a dry run still writes
+    // nothing while reporting that the record is unconfirmed.
+    let dry = run(&[
+        "login",
+        "rollback",
+        "--transaction-id",
+        id,
+        "--accept-unconfirmed",
+        "--json",
+    ]);
+    assert_eq!(dry["data"]["unconfirmed"], true);
+    assert_eq!(dry["data"]["applied"], false);
+    assert_eq!(
+        std::fs::read_to_string(&subject).expect("read"),
+        "half applied\n"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -465,6 +465,52 @@ covers every surface, because turning login off leaves nothing behind.
 `login rollback` are not part of contract 1 and must not be inferred from this
 command or from human output.
 
+### `irlume login apply` / `verify` / `rollback`
+
+Capability: `login-transactions`. The mutating half of a login transaction;
+`login plan` above is the read-only half.
+
+```
+irlume login apply    --action {enable|disable} --plan-id ID --json   # root
+irlume login verify   --transaction-id ID --json
+irlume login rollback --transaction-id ID [--apply] --json            # root to apply
+```
+
+**apply** re-derives the plan from the machine and recomputes its id. A
+`plan_id` that no longer matches is refused as `plan-stale`: the consumer
+displayed one set of changes and the machine now calls for another, so applying
+would change something nobody was shown. The supplied id is never trusted as
+input, only compared. On success it returns a `transaction_id`.
+
+A partial apply is reported as a failure and still records its transaction, so
+the surfaces that did change can be rolled back. The id is written to standard
+error in that case, because an error document carries no `data`.
+
+**verify** answers whether the machine is still as that transaction left it,
+per surface: `as-applied`, `changed-since-apply`, or `unreadable`. It also
+states `rollback_available`, so a consumer does not have to infer it from
+per-surface states it may not recognise. Read-only.
+
+**rollback** restores what the transaction changed, and **refuses unless every
+surface is still exactly as apply left it**. Restoring a file something else has
+edited since would revert a change the transaction never made, so drift stops
+the whole rollback rather than skipping the drifted surface: a half-rolled-back
+login stack is its own hazard. Every surface is checked before any is written.
+Without `--apply` it reports what it would restore and touches nothing.
+
+Transaction records live under the state directory, `0600` in a `0700`
+directory. They contain the pre-change content of each file, which is not secret
+(PAM stacks are world-readable) but does describe exactly how a machine
+authenticates.
+
+A transaction id is a 32-character hex string. Anything else is a `usage-error`,
+rejected rather than sanitised, because the id becomes a filename.
+
+Error codes: `plan-stale`, `changed-since-apply`, `not-found`,
+`not-authorized` (apply and `rollback --apply` need root, checked before
+anything is written rather than left to a write failing partway),
+`operation-failed`.
+
 ## Security and privacy
 
 Ordinary JSON output never includes camera frames, embeddings, templates,
@@ -478,5 +524,4 @@ from human output or the private socket protocol:
 - preview images and cancellation semantics;
 - profile or scan mutation;
 - camera configuration mutation;
-- login apply, verify, or rollback transactions (the read-only plan phase is
-  published above).
+- enrollment preview images and their cancellation semantics.

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -363,7 +363,12 @@ Three properties a consumer may rely on:
 - `sequence` starts at zero and increments by one with no gaps, so a lost line
   is detected by arithmetic rather than by timeout;
 - exactly one event has `terminal` true, and it is the last, so a reader knows
-  when to stop without waiting;
+  when to stop without waiting. **A stream that ends without one means the
+  producer died**: it was killed, lost power, or hit a signal it could not
+  handle. Treat end-of-file as terminal as well, because a reader that waits for
+  the flag alone will wait forever. Verified: killing the command mid-stream
+  leaves the lines already emitted and no terminal event, which is the only
+  honest thing a dead process can do;
 - `operation_id` is identical on every line of one invocation.
 
 `reason` is one of `granted`, `not-live`, or `no-match`, derived from `granted`

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -461,9 +461,8 @@ Sudo and polkit are opt-in on the human command and are not included in a plan,
 so a panel never shows a user surfaces they did not ask for. Disabling still
 covers every surface, because turning login off leaves nothing behind.
 
-**Applying a plan is not implemented yet.** `login apply`, `login verify` and
-`login rollback` are not part of contract 1 and must not be inferred from this
-command or from human output.
+A plan is carried out by `login apply` below, which re-derives it and refuses a
+`plan_id` that no longer matches.
 
 ### `irlume login apply` / `verify` / `rollback`
 

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -513,7 +513,29 @@ rejected rather than sanitised, because the id becomes a filename.
 Error codes: `plan-stale`, `changed-since-apply`, `not-found`,
 `not-authorized` (apply and `rollback --apply` need root, checked before
 anything is written rather than left to a write failing partway),
-`operation-failed`.
+`unconfirmed-transaction`, `unsupported-record`, `operation-failed`.
+
+`unsupported-record` means the record was written to a record schema this engine
+does not implement, and it is not retryable: run the newer irlume. A record
+carries a `schema_version`, which is a gate rather than a description. It is
+raised only when the MEANING of a record changes, so a purely descriptive
+addition does not raise it and an older engine keeps reading such records. What
+an engine will not do is act on the parts of a newer record it recognises: the
+fields would parse and look reasonable while meaning something else, and a
+record is the recovery path for a machine's login stack.
+
+Every irlume path that changes PAM — `login apply`, `login rollback --apply`,
+the human `login enable`/`disable`, and the self-heal reconcile — holds one
+exclusive lock for the whole operation, so a consumer's transaction cannot
+interleave with another irlume process. The lock does not cover package managers
+or an administrator with an editor, which is why each surface is re-checked
+immediately before it is written.
+
+irlume refuses to write a PAM path that is a symlink or that has more than one
+hard link, on every one of those paths. Renaming over a symlink would silently
+convert it to a regular file, and replacing a multiply-linked file would leave
+the other names on the old content; neither is recorded, so neither could be
+undone. Such a surface is reported as not installed with the reason.
 
 ## Security and privacy
 

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -515,6 +515,15 @@ Error codes: `plan-stale`, `changed-since-apply`, `not-found`,
 anything is written rather than left to a write failing partway),
 `unconfirmed-transaction`, `unsupported-record`, `operation-failed`.
 
+A surface's `.pre-irlume` backup is part of the surface. The plan id covers it,
+so a backup that changes between `plan` and `apply` makes the plan stale: wiring
+rebuilds from the backup when one exists, so the content an apply produces
+depends on it, and a consumer would otherwise be shown one outcome while the
+machine got another. Rollback checks it too and refuses the whole record if it
+is not as apply left it. That matters more than it sounds: a later `login
+enable` rebuilds the live stack FROM the backup, so a wrong one reaches PAM at
+the next enable rather than sitting inert.
+
 A rollback that stops partway records which surfaces it put back, durably, as it
 goes. Re-running it resumes: those surfaces are skipped rather than re-checked,
 because a restored file deliberately no longer matches the digest apply left and

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -515,6 +515,23 @@ Error codes: `plan-stale`, `changed-since-apply`, `not-found`,
 anything is written rather than left to a write failing partway),
 `unconfirmed-transaction`, `unsupported-record`, `operation-failed`.
 
+A rollback that stops partway records which surfaces it put back, durably, as it
+goes. Re-running it resumes: those surfaces are skipped rather than re-checked,
+because a restored file deliberately no longer matches the digest apply left and
+checking it would refuse the whole record — which used to leave the operator
+rebuilding the rest from the JSON by hand. `verify` reports them as
+`already_restored` and excludes them from `rollback_available`, so drift caused
+by irlume's own restore is not reported as somebody's edit.
+
+`rollback --accept-unconfirmed --apply` copies every surface and sidecar as it
+currently stands into a root-only directory before restoring anything, and
+returns that path as `snapshot`. An unconfirmed record has no trustworthy
+after-digest, so the restore does not check what it overwrites; that is how an
+interrupted apply is recovered, and equally how a package update made after the
+crash gets reverted. The copies are for a person to find, and feed no automatic
+path. A confirmed rollback has no `snapshot`: its drift check has already
+established every file is byte-for-byte what apply left.
+
 `unsupported-record` means the record was written to a record schema this engine
 does not implement, and it is not retryable: run the newer irlume. A record
 carries a `schema_version`, which is a gate rather than a description. It is

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Exercise login apply / verify / rollback against a throwaway PAM tree.
+#
+#   podman run --rm -v "$PWD/scripts:/s:z" \
+#     -v "$PWD/target/release/irlume:/work/irlume:z" fedora:44 \
+#     bash -c 'touch /.irlume-throwaway && bash /s/login-transaction-container-test.sh'
+#
+# Runs as root INSIDE A CONTAINER and refuses to start without the throwaway
+# marker, so it cannot run against a real stack. Not wired into CI: it needs a
+# machine it may rewrite /etc/pam.d in, and the point is that it can only ever
+# be somewhere disposable.
+#
+# A container has no camera, so `enable` wants nothing and would plan no writes.
+# The disable path exercises the same machinery with real writes: plant a wired
+# stack, then unwire it.
+set -uo pipefail
+
+B=/work/irlume
+export IRLUME_STATE_DIR=/var/lib/irlume
+SUDO_PAM=/etc/pam.d/sudo
+pass=0
+fail=0
+
+ok() {
+    pass=$((pass + 1))
+    echo "  ok      $1"
+}
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+# `cond && ok || bad` also runs bad when ok fails, which is the SC2015 trap.
+# Assert through these instead: the condition is a command, evaluated once.
+assert() {
+    local desc="$1" detail="$2"
+    shift 2
+    if "$@"; then ok "$desc"; else bad "$desc" "$detail"; fi
+}
+assert_not() {
+    local desc="$1" detail="$2"
+    shift 2
+    if "$@"; then bad "$desc" "$detail"; else ok "$desc"; fi
+}
+# No python in the base image; pull one flat scalar with sed.
+field() { sed -n "s/.*\"$1\":\"\?\([^,\"}]*\)\"\?.*/\1/p" | head -1; }
+sum() { md5sum "$SUDO_PAM" | cut -d' ' -f1; }
+
+if [ ! -f /.irlume-throwaway ]; then
+    echo "refusing: no throwaway marker, so this may not be a disposable machine"
+    exit 2
+fi
+
+echo "=== 0. plant a wired stack to unwire ==="
+# sudo exists in the base image. Give it an irlume line plus the backup the
+# disable path expects, which is the shape a real `login enable` leaves behind.
+cp "$SUDO_PAM" "$SUDO_PAM.pre-irlume"
+sed -i '1i auth       sufficient   pam_irlume.so' "$SUDO_PAM"
+assert "planted a wired sudo stack" "no irlume line" grep -q pam_irlume "$SUDO_PAM"
+planted=$(sum)
+
+echo "=== 1. plan the disable (read-only) ==="
+plan=$($B login plan --action disable --json)
+pid=$(echo "$plan" | field plan_id)
+writes=$(echo "$plan" | field writes)
+assert "plan returned an id ($pid, $writes write(s))" "$plan" test -n "$pid"
+assert "the plan includes a write" "$plan" test "$writes" != "0"
+assert "plan wrote nothing" "sudo changed during a read-only plan" test "$(sum)" = "$planted"
+
+echo "=== 2. a stale plan id is refused ==="
+out=$($B login apply --action disable --plan-id 00000000000000000000000000000000 --json)
+assert "stale plan id refused" "$out" test "$(echo "$out" | field code)" = "plan-stale"
+assert "the refused apply wrote nothing" "sudo changed" test "$(sum)" = "$planted"
+
+echo "=== 3. apply ==="
+out=$($B login apply --action disable --plan-id "$pid" --json)
+tx=$(echo "$out" | field transaction_id)
+assert "apply returned transaction $tx" "$out" test -n "$tx"
+assert_not "the irlume line is gone after disable" "still wired" grep -q pam_irlume "$SUDO_PAM"
+
+echo "=== 4. verify reports as-applied ==="
+out=$($B login verify --transaction-id "$tx" --json)
+assert "verify: nothing drifted" "$out" test "$(echo "$out" | field drifted)" = "0"
+assert "verify: rollback available" "$out" test "$(echo "$out" | field rollback_available)" = "true"
+
+echo "=== 5. rollback dry run touches nothing ==="
+mid=$(sum)
+$B login rollback --transaction-id "$tx" --json >/dev/null 2>&1
+assert "dry run changed nothing" "sudo changed" test "$(sum)" = "$mid"
+
+echo "=== 6. rollback restores the planted stack byte for byte ==="
+out=$($B login rollback --transaction-id "$tx" --apply --json)
+assert "rollback reported applied" "$out" test "$(echo "$out" | field applied)" = "true"
+assert "sudo restored byte for byte" "checksum moved" test "$(sum)" = "$planted"
+assert "the irlume line is back" "not restored" grep -q pam_irlume "$SUDO_PAM"
+
+echo "=== 7. drift blocks a rollback, and the admin's edit survives ==="
+pid2=$($B login plan --action disable --json | field plan_id)
+tx2=$($B login apply --action disable --plan-id "$pid2" --json | field transaction_id)
+assert "second apply: transaction $tx2" "no id" test -n "$tx2"
+echo "# an admin added this later" >>"$SUDO_PAM"
+out=$($B login verify --transaction-id "$tx2" --json)
+assert "verify sees the drift" "$out" test "$(echo "$out" | field drifted)" != "0"
+assert "verify says rollback unavailable" "$out" test "$(echo "$out" | field rollback_available)" = "false"
+out=$($B login rollback --transaction-id "$tx2" --apply --json)
+assert "rollback refuses a drifted stack" "$out" test "$(echo "$out" | field code)" = "changed-since-apply"
+assert "the admin's line survived the refusal" "lost" \
+    grep -q "an admin added this later" "$SUDO_PAM"
+
+echo "=== 8. a record is root-only ==="
+perms=$(stat -c %a "$IRLUME_STATE_DIR/login-transactions/$tx.json" 2>/dev/null)
+assert "record is 0600" "got $perms" test "$perms" = "600"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -166,6 +166,72 @@ assert "sudo still has its own auth stack" "lost the original body" \
 # And the lock file itself is left behind for the next run, not deleted.
 assert "the PAM lock exists after the race" "missing" test -e /run/lock/irlume-pam.lock
 
+echo "=== 12. a stopped rollback resumes instead of refusing itself ==="
+# A rollback restores surfaces one at a time. Stopping partway used to be
+# unrecoverable by irlume: the surfaces already restored no longer match the
+# recorded after-digest, so a re-run refused the WHOLE record as drifted and the
+# operator had to reconstruct the rest from JSON by hand. Simulated here by
+# noting one surface as done and checking the re-run skips it rather than
+# refusing.
+grep -q pam_irlume "$SUDO_PAM" || sed -i '1i auth       sufficient   pam_irlume.so' "$SUDO_PAM"
+pid4=$($B login plan --action disable --json | field plan_id)
+tx4=$($B login apply --action disable --plan-id "$pid4" --json | field transaction_id)
+assert "apply for the resume case: $tx4" "no id" test -n "$tx4"
+rec4="$IRLUME_STATE_DIR/login-transactions/$tx4.json"
+# The surface whose path is the one about to drift, not merely the first in the
+# record: the greeters come first and picking one of those would exclude the
+# wrong surface and prove nothing.
+sid=$(grep -o "{\"id\":\"[^\"]*\",\"path\":\"$SUDO_PAM\"" "$rec4" |
+    sed 's/.*"id":"\([^"]*\)".*/\1/')
+assert "found the surface id for $SUDO_PAM" "$rec4" test -n "$sid"
+prog="$IRLUME_STATE_DIR/login-transactions/$tx4.progress"
+
+# A surface already put back no longer matches the recorded after-digest. That
+# is what made a stopped rollback unfinishable: WITHOUT a progress note the
+# re-run refuses the whole record as drifted.
+echo "# this surface was already restored by the run that stopped" >>"$SUDO_PAM"
+rm -f "$prog"
+out=$($B login rollback --transaction-id "$tx4" --apply --json)
+assert "without the note, the re-run refuses the whole record" "$out" \
+    test "$(echo "$out" | field code)" = "changed-since-apply"
+
+# WITH the note, that surface is skipped and the rollback completes.
+printf '["%s"]' "$sid" >"$prog"
+out=$($B login rollback --transaction-id "$tx4" --apply --json)
+assert "with the note, the rollback resumes and completes" "$out" \
+    test "$(echo "$out" | field applied)" = "true"
+assert "the already-restored surface was left as it was" "it was rewritten" \
+    grep -q "already restored by the run that stopped" "$SUDO_PAM"
+assert "the resume note is cleared once everything is back" "left behind" test ! -e "$prog"
+
+echo "=== 13. an unconfirmed rollback keeps what it overwrites ==="
+# --accept-unconfirmed restores before-images without checking current state,
+# which is how an interrupted apply is recovered and equally how a package
+# update made after the crash gets reverted. Nothing used to capture that.
+# A container has no camera, so `enable` plans nothing; the disable path is what
+# exercises real writes here, as in the sections above.
+grep -q pam_irlume "$SUDO_PAM" || sed -i '1i auth       sufficient   pam_irlume.so' "$SUDO_PAM"
+pid5=$($B login plan --action disable --json | field plan_id)
+tx5=$($B login apply --action disable --plan-id "$pid5" --json | field transaction_id)
+rec="$IRLUME_STATE_DIR/login-transactions/$tx5.json"
+assert "apply for the unconfirmed case: $tx5" "no id" test -n "$tx5"
+if [ -f "$rec" ]; then
+    # Exactly what an apply killed between its two record writes leaves behind.
+    sed -i 's/"status":"applied"/"status":"prepared"/' "$rec"
+    echo "# a security update landed after the crash" >>"$SUDO_PAM"
+    out=$($B login rollback --transaction-id "$tx5" --accept-unconfirmed --apply --json)
+    snap=$(echo "$out" | field snapshot)
+    assert "the rollback applied" "$out" test "$(echo "$out" | field applied)" = "true"
+    assert "it reports where the copies are" "$out" test -n "$snap"
+    assert "the snapshot directory exists" "$snap missing" test -d "$snap"
+    assert "the overwritten edit is preserved in the snapshot" "not captured" \
+        grep -rq "a security update landed after the crash" "$snap"
+    assert "the snapshot is root-only" "$(stat -c %a "$snap" 2>/dev/null)" \
+        test "$(stat -c %a "$snap")" = "700"
+else
+    bad "unconfirmed rollback setup" "no record at $rec"
+fi
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -196,7 +196,7 @@ assert "without the note, the re-run refuses the whole record" "$out" \
     test "$(echo "$out" | field code)" = "changed-since-apply"
 
 # WITH the note, that surface is skipped and the rollback completes.
-printf '["%s"]' "$sid" >"$prog"
+printf '{"started":["%s"],"done":["%s"]}' "$sid" "$sid" >"$prog"
 out=$($B login rollback --transaction-id "$tx4" --apply --json)
 assert "with the note, the rollback resumes and completes" "$out" \
     test "$(echo "$out" | field applied)" = "true"

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -256,6 +256,23 @@ assert "the backup survived the refusal" "overwritten" \
     grep -q "somebody put a backup here afterwards" "$SUDO_PAM.pre-irlume"
 rm -f "$SUDO_PAM.pre-irlume"
 
+echo "=== 15. apply keeps the self-heal marker in step ==="
+# The machine API unwired the files and left the marker saying "wired", so
+# irlume-reconcile.path fired on the change apply had just made, re-wired every
+# greeter, and the transaction that asked for the disable was drifted and no
+# longer rollbackable — irlume fighting its own writes. Found on a machine where
+# login was genuinely wired; a container has no path unit, so only the marker
+# itself can be checked here.
+marker="$IRLUME_STATE_DIR/login.wired"
+mkdir -p "$IRLUME_STATE_DIR"
+printf 'with_sudo=false\nwith_polkit=false\nwith_lock=false\n' >"$marker"
+grep -q pam_irlume "$SUDO_PAM" || sed -i '1i auth       sufficient   pam_irlume.so' "$SUDO_PAM"
+pid7=$($B login plan --action disable --json | field plan_id)
+tx7=$($B login apply --action disable --plan-id "$pid7" --json | field transaction_id)
+assert "apply for the marker case: $tx7" "no id" test -n "$tx7"
+assert_not "a machine disable clears the self-heal marker" "reconcile would re-wire" \
+    test -e "$marker"
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -232,6 +232,30 @@ else
     bad "unconfirmed rollback setup" "no record at $rec"
 fi
 
+echo "=== 14. a backup replaced after apply blocks the rollback ==="
+# Rollback restored the .pre-irlume backup with no check at all, so a backup an
+# administrator or a package replaced afterwards was silently overwritten. That
+# is sharper than it sounds: a later `login enable` rebuilds the LIVE stack from
+# the backup, so a wrong one reaches PAM at the next enable.
+# A backup has to EXIST before the apply, or the record carries no sidecar and
+# there is nothing for the check to be about. A branch reporting success when
+# there was nothing to check is how a guard passes without ever running, so this
+# is set up rather than skipped.
+grep -q pam_irlume "$SUDO_PAM" || sed -i '1i auth       sufficient   pam_irlume.so' "$SUDO_PAM"
+cp "$SUDO_PAM" "$SUDO_PAM.pre-irlume"
+pid6=$($B login plan --action disable --json | field plan_id)
+tx6=$($B login apply --action disable --plan-id "$pid6" --json | field transaction_id)
+assert "apply for the backup case: $tx6" "no id" test -n "$tx6"
+assert "the record carries a sidecar for $SUDO_PAM" "no sidecar recorded" \
+    grep -q '"sidecar"' "$IRLUME_STATE_DIR/login-transactions/$tx6.json"
+echo "# somebody put a backup here afterwards" >"$SUDO_PAM.pre-irlume"
+out=$($B login rollback --transaction-id "$tx6" --apply --json)
+assert "the rollback refuses when the backup is not as apply left it" "$out" \
+    test "$(echo "$out" | field code)" = "changed-since-apply"
+assert "the backup survived the refusal" "overwritten" \
+    grep -q "somebody put a backup here afterwards" "$SUDO_PAM.pre-irlume"
+rm -f "$SUDO_PAM.pre-irlume"
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -124,6 +124,23 @@ echo "=== 9. a record is root-only ==="
 perms=$(stat -c %a "$IRLUME_STATE_DIR/login-transactions/$tx.json" 2>/dev/null)
 assert "record is 0600" "got $perms" test "$perms" = "600"
 
+echo "=== 10. confirming a record replaces it rather than emptying it ==="
+# A transaction is saved twice: Prepared before the first PAM write, Applied
+# after. `save` used to truncate the record in place, so the second save emptied
+# the only description of the previous PAM contents and then wrote into it; a
+# failure in that window left a rewritten machine with nothing to roll back
+# from. It now writes a temp beside the record and renames, so what survives on
+# the real store path is checked here: every record is complete, and no temp is
+# left behind for a later read to find.
+store="$IRLUME_STATE_DIR/login-transactions"
+strays=$(find "$store" -type f ! -name '*.json' 2>/dev/null | wc -l)
+assert "no temp files left in the store" "found $strays" test "$strays" -eq 0
+for r in "$store"/*.json; do
+    assert "record $(basename "$r") is not empty" "zero bytes" test -s "$r"
+    assert "record $(basename "$r") ends as complete JSON" "truncated" \
+        grep -q '}$' "$r"
+done
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -141,6 +141,31 @@ for r in "$store"/*.json; do
         grep -q '}$' "$r"
 done
 
+echo "=== 11. concurrent writers cannot interleave into one PAM file ==="
+# Nothing serialised login apply, rollback, human enable/disable and reconcile.
+# write_atomic also shared ONE scratch name per service, so two processes opened
+# the same inode, interleaved their bodies, and whichever renamed first published
+# the mixture. Run several writers at once and require the result to be one of
+# the two whole outcomes, never a blend.
+$B login disable --apply >/dev/null 2>&1
+for _ in 1 2 3 4 5; do
+    $B login enable --with-sudo --apply >/dev/null 2>&1 &
+    $B login disable --apply >/dev/null 2>&1 &
+done
+wait
+assert "no scratch files survive the race" "leftovers in /etc/pam.d" \
+    test -z "$(find /etc/pam.d -name '.*irlume*tmp*' 2>/dev/null)"
+# A blended file is the failure: irlume's own line appearing more than once, or a
+# truncated final line, are both signatures of two bodies in one inode.
+dupes=$(grep -c pam_irlume "$SUDO_PAM" 2>/dev/null || true)
+assert "sudo carries irlume's line at most once" "found $dupes" test "$dupes" -le 1
+assert "sudo ends with a newline" "truncated mid-line" \
+    test -z "$(tail -c 1 "$SUDO_PAM")"
+assert "sudo still has its own auth stack" "lost the original body" \
+    grep -qE 'auth|@include' "$SUDO_PAM"
+# And the lock file itself is left behind for the next run, not deleted.
+assert "the PAM lock exists after the race" "missing" test -e /run/lock/irlume-pam.lock
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/scripts/login-transaction-container-test.sh
+++ b/scripts/login-transaction-container-test.sh
@@ -107,7 +107,20 @@ assert "rollback refuses a drifted stack" "$out" test "$(echo "$out" | field cod
 assert "the admin's line survived the refusal" "lost" \
     grep -q "an admin added this later" "$SUDO_PAM"
 
-echo "=== 8. a record is root-only ==="
+echo "=== 8. an edit between plan and apply is refused ==="
+# The defect this guards: a plan id built from outcome LABELS alone is unchanged
+# when an admin rewrites a stack but leaves the anchor in place, so apply would
+# overwrite a stack the consumer was never shown.
+cp "$SUDO_PAM" "$SUDO_PAM.pre-irlume" 2>/dev/null
+grep -q pam_irlume "$SUDO_PAM" || sed -i '1i auth       sufficient   pam_irlume.so' "$SUDO_PAM"
+pid3=$($B login plan --action disable --json | field plan_id)
+echo "# admin edit after the plan was shown" >>"$SUDO_PAM"
+out=$($B login apply --action disable --plan-id "$pid3" --json)
+assert "an edit after the plan makes it stale" "$out" test "$(echo "$out" | field code)" = "plan-stale"
+assert "the admin's edit survived" "overwritten" grep -q "admin edit after the plan was shown" "$SUDO_PAM"
+assert "the stack was not rewritten" "rewritten" grep -q pam_irlume "$SUDO_PAM"
+
+echo "=== 9. a record is root-only ==="
 perms=$(stat -c %a "$IRLUME_STATE_DIR/login-transactions/$tx.json" 2>/dev/null)
 assert "record is 0600" "got $perms" test "$perms" = "600"
 

--- a/scripts/machine-api-conformance.py
+++ b/scripts/machine-api-conformance.py
@@ -52,6 +52,19 @@ CAPABILITY_COMMANDS = {
 #
 # Capability name -> (argv that must be refused, expected error code).
 STREAMING_CAPABILITY_REFUSALS = {
+    # login-transactions mutates PAM stacks, so this script must never invoke it
+    # for real. Its refusals are checked instead, and they are the ones that
+    # matter: apply without a plan id, an id that is not a hex identifier, and a
+    # transaction id shaped like a path. Same reason streaming capabilities are
+    # listed here rather than left to the unknown-capability skip.
+    "login-transactions": [
+        (["login", "apply", "--json"], "usage-error"),
+        (["login", "apply", "--action", "enable", "--json"], "usage-error"),
+        (["login", "apply", "--action", "enable", "--plan-id", "nothex", "--json"], "usage-error"),
+        (["login", "verify", "--json"], "usage-error"),
+        (["login", "verify", "--transaction-id", "../../etc/passwd", "--json"], "usage-error"),
+        (["login", "rollback", "--transaction-id", "../../etc/shadow", "--apply", "--json"], "usage-error"),
+    ],
     "auth-test-events": [
         (["auth", "test"], "usage-error"),
         (["auth", "test", "--events=jsonl", "--contract", "9"], "unsupported-contract"),


### PR DESCRIPTION
Completes the login transaction surface from #108. `login plan` (#176) published the read-only half; this is the half that writes PAM stacks, which is why it landed separately. Refs #108.

```
irlume login apply    --action {enable|disable} --plan-id ID --json   # root
irlume login verify   --transaction-id ID --json
irlume login rollback --transaction-id ID [--apply] --json            # root to apply
```

## The two rules this rests on

**apply refuses a stale plan.** It re-derives the plan from the machine and recomputes its id. A `plan_id` that no longer matches is `plan-stale`, because the consumer displayed one set of changes and the machine now calls for another — applying anyway would change something nobody was shown. The supplied id is compared, never trusted as input.

**rollback refuses a stack that moved on.** Every surface must still be exactly as apply left it. Restoring a file something else edited since would revert a change this transaction never made, so drift stops the *whole* rollback rather than skipping the drifted surface; a half-rolled-back login stack is its own hazard. Every surface is checked before any is written.

That second rule is what resolves the design hazard I raised when scoping this: irlume already has a restore path in `wire_service`, and a second one that disagreed would land on the login stack. This is the same principle that path already follows — never revert an edit you did not make — applied to a narrower question, not a competing opinion about what a PAM file should contain.

## Structural change

The surface walk is now **one list shared by `plan` and `apply`**. Which surfaces are in scope, and with which wiring recipe, is exactly the thing that must not exist twice: a plan walking a different set than the apply would describe changes that never happen, or miss ones that do.

## Smaller decisions

- **Root is checked before anything is written**, not left to a write failing partway. A mutating command that loses permission mid-run leaves a stack half-changed.
- **A partial apply is a failure that still records its transaction**, so the surfaces that did change can be rolled back. The id goes to stderr, because an error document carries no `data`.
- **Transaction ids are 32-char hex, rejected rather than sanitised.** The id becomes a filename, and a stripped separator leaves a plausible-looking id addressing a different file.
- **An unreadable file is an error, not "absent"** — otherwise rollback could conclude a file was never there and delete it.
- **`ABSENT` is a distinct sentinel**, since `disable` genuinely removes files and "was absent" must not be confusable with "no digest recorded".
- Records are `0600` in a `0700` directory. Not secret (PAM stacks are world-readable) but they describe exactly how a machine authenticates.

## Validation

**Container-first, per the project's protocol.** `scripts/login-transaction-container-test.sh`, 20 assertions, all passing:

```
0. plant a wired stack             1. plan writes nothing
2. a stale id is refused, and writes nothing
3. apply unwires and records       4. verify: 0 drifted, rollback available
5. rollback dry run touches nothing
6. rollback restores byte for byte, the irlume line is back
7. an admin appends a line -> verify reports drift, rollback_available false,
   rollback refuses with changed-since-apply, the admin's line survives
8. the record is 0600
```

The script **refuses to start without a throwaway marker**, verified: without it, exit 2 and nothing runs. Confirmed afterwards that the host has no transaction records and no PAM changes from the run.

Nothing here has touched a real stack, and I would not run apply on hardware without you present.

- 775 workspace tests pass, clippy and `cargo fmt --check` clean
- conformance **34 passed, 0 failed, 0 skipped** — the mutating capability is listed explicitly and checked on its refusals (no plan id, a non-hex id, a transaction id shaped like a path), never invoked for real
- `shellcheck` clean on the new script

## Not included

`enroll --events=jsonl --preview=ir-jpeg` is the last #108 surface. It exports biometric imagery beyond irlume's boundary and wants its own threat-model entry.
