### PR TITLE
release: 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ Fixes a camera-firmware hazard present in 0.7.1. Please upgrade.
 ### Fixed
 
 - **`IRLUME_IR_EMITTER` wrote to the camera with none of the checks 0.7.1 added.**
-
-- **`IRLUME_IR_EMITTER` wrote to the camera with none of the checks 0.7.1 added.**
   0.7.1 stopped irlume guessing its way around a camera's extension units, but
   left one path exempt: the override applied its bytes before irlume had read the
   camera's descriptor at all, so an arbitrary payload went to an arbitrary unit
@@ -1535,6 +1533,7 @@ is always the fallback: no lockout, ever.
 
 [Unreleased]: https://github.com/archledger/irlume/compare/v0.7.2...HEAD
 [0.7.2]: https://github.com/archledger/irlume/releases/tag/v0.7.2
+[0.7.1]: https://github.com/archledger/irlume/releases/tag/v0.7.1
 [0.7.0]: https://github.com/archledger/irlume/releases/tag/v0.7.0
 [0.6.1]: https://github.com/archledger/irlume/releases/tag/v0.6.1
 [0.6.0]: https://github.com/archledger/irlume/releases/tag/v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,34 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-07-30
+
+Fixes a camera-firmware hazard present in 0.7.1. Please upgrade.
+
+### Added
+
+- **A login transaction the desktop can carry out, confirm and undo.**
+  `irlume login plan|apply|verify|rollback --json` lets an integration make one
+  specific PAM change, check it landed, and put back exactly what was there
+  before. A record is written before the first PAM write and confirmed after, so
+  a crash mid-apply leaves something that says how to get back; rollback restores
+  only while every file is still exactly as apply left it, and refuses rather
+  than reverting an edit the transaction never made. Every irlume path that
+  changes PAM now holds one lock for the whole operation, writes durably, and
+  refuses a PAM path that is a symlink or has more than one hard link. Closes
+  [#108].
+
+- **`auth-test-events`**: `irlume auth test --events=jsonl` streams whether the
+  claimed account's live face matches its own enrolment, as newline-delimited
+  JSON. Verification against one account, never identification, and it releases
+  nothing.
+
+- **`login-plan-json`**: what `login enable` or `login disable` would change,
+  without changing anything.
+
 ### Fixed
+
+- **`IRLUME_IR_EMITTER` wrote to the camera with none of the checks 0.7.1 added.**
 
 - **`IRLUME_IR_EMITTER` wrote to the camera with none of the checks 0.7.1 added.**
   0.7.1 stopped irlume guessing its way around a camera's extension units, but
@@ -48,6 +75,37 @@ All notable changes to irlume are documented here. This project adheres to
   publishes.
 
 [#179]: https://github.com/archledger/irlume/issues/179
+
+- **Infrared frames were called lit by guessing from brightness.** irlume averaged
+  pixels against a fixed threshold of 40 out of 255. Measured on an ASUS Hello
+  module across 2160 stationary frames, exactly one configuration makes that
+  threshold correct: sitting close to the camera without glasses. At arm's length,
+  or simply wearing glasses without moving, every emitter-off frame was
+  misclassified. irlume now reads the camera's own illumination flag, the one
+  Microsoft's UVC extension publishes per frame, instead of inferring it. Closes
+  [#167].
+
+- **Six checks reported success having checked nothing.** One theme in six places:
+  a zero-match, zero-iteration or zero-sample case indistinguishable from a clean
+  pass — a conformance run that attempted nothing and exited 0, a set comparison
+  where no line carried the field, a `zip()` over an empty side. Each was proved
+  by reproducing the failure first. Closes [#161], [#162], [#163], [#164], [#165]
+  and [#166].
+
+- **A CI lane could select tests by name and run none of them.** `cargo test
+  <names>` exits 0 when the filter matches nothing, so a renamed test turned a
+  lane into a green no-op, and the coverage jobs were vulnerable the same way.
+  Closes [#158].
+
+[#108]: https://github.com/archledger/irlume/issues/108
+[#158]: https://github.com/archledger/irlume/issues/158
+[#161]: https://github.com/archledger/irlume/issues/161
+[#162]: https://github.com/archledger/irlume/issues/162
+[#163]: https://github.com/archledger/irlume/issues/163
+[#164]: https://github.com/archledger/irlume/issues/164
+[#165]: https://github.com/archledger/irlume/issues/165
+[#166]: https://github.com/archledger/irlume/issues/166
+[#167]: https://github.com/archledger/irlume/issues/167
 
 ## [0.7.1] - 2026-07-29
 
@@ -1475,7 +1533,8 @@ is always the fallback: no lockout, ever.
   credentials).
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
-[Unreleased]: https://github.com/archledger/irlume/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/archledger/irlume/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/archledger/irlume/releases/tag/v0.7.2
 [0.7.0]: https://github.com/archledger/irlume/releases/tag/v0.7.0
 [0.6.1]: https://github.com/archledger/irlume/releases/tag/v0.6.1
 [0.6.0]: https://github.com/archledger/irlume/releases/tag/v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "irlume-common",
  "libc",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "image",
  "irlume-auth",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "libc",
  "serde",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -976,11 +976,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.7.1"
+version = "0.7.2"
 
 [[package]]
 name = "irlume-liveness"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "irlume-common",
  "pamsm",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "irlume-camera",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.7.1
+pkgver=0.7.2
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.7.1
+version: 0.7.2
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -1,7 +1,7 @@
 %global ort_ver 1.24.4
 
 Name:           irlume
-Version:        0.7.1
+Version:        0.7.2
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -210,6 +210,11 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Thu Jul 30 2026 archledger <archledger236@gmail.com> - 0.7.2-1
+- IRLUME_IR_EMITTER is checked against the camera's descriptor before any write
+- Login transactions in the machine API: plan, apply, verify, rollback
+- IR frames are classified by the camera's illumination flag, not by brightness
+
 * Wed Jul 29 2026 archledger <archledger236@gmail.com> - 0.7.1-1
 - Security: irlume no longer searches for an IR-emitter control by writing
   guessed values to UVC extension units. That search destroyed a reporter's


### PR DESCRIPTION
Cuts 0.7.2. Version bumped in `Cargo.toml` plus the three files that hardcode it (`nfpm.yaml`, `PKGBUILD`, `irlume.spec` with a `%changelog` entry); `scripts/check-packaging-parity.sh` is clean.

## What ships

**A camera-firmware hazard fixed.** `IRLUME_IR_EMITTER` applied its bytes before irlume read the camera's descriptor at all, so an arbitrary payload reached an arbitrary extension unit on whichever device was open — no GUID, no advertised-selector check, no `GET_INFO`, no length bound, no read-back. That is the mechanism which destroyed a reporter's camera in #159, still reachable in 0.7.1, and irlume advertised the variable in the hint that prints when infrared looks dark. ([#179])

**Login transactions in the machine API.** `login plan|apply|verify|rollback`, closing [#108]. One lock across every irlume path that changes PAM, durable writes, symlink and hard-link refusal, a resumable rollback, and a rescue copy before an unconfirmed restore.

**Infrared frames classified by the camera's own illumination flag** rather than a fixed brightness threshold that only held for one seating position without glasses. ([#167])

**Six checks that reported success having checked nothing**, and a CI lane that could select tests by name and run none. ([#161]–[#166], [#158])

## Verified

- 812 tests, 0 failed. clippy `-D warnings`, `fmt --check`, `cargo doc` clean.
- Machine-API conformance 34/34; container transaction suite 51/51.
- Hardware validation on **three distributions** against real `/etc/pam.d` — Fedora 44, Arch, Ubuntu 26.04, up to eleven wired PAM surfaces — with SIGKILL injection and concurrent writers. Every run left the tree byte-identical with the same services wired. That validation found four defects, all fixed before merge.
- The emitter fix verified on a NexiGo HelloCam N930W: unpublished unit, unadvertised selector, wrong payload length and a mistyped byte each write **zero** bytes where the baseline writes 20.

[#108]: https://github.com/archledger/irlume/issues/108
[#158]: https://github.com/archledger/irlume/issues/158
[#161]: https://github.com/archledger/irlume/issues/161
[#166]: https://github.com/archledger/irlume/issues/166
[#167]: https://github.com/archledger/irlume/issues/167
[#179]: https://github.com/archledger/irlume/issues/179
