### PR TITLE
fix(camera): record how to undo an emitter write before making it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,8 @@ version = "0.7.2"
 dependencies = [
  "irlume-common",
  "libc",
+ "serde",
+ "serde_json",
  "thiserror 2.0.19",
  "v4l",
 ]

--- a/crates/irlume-camera/Cargo.toml
+++ b/crates/irlume-camera/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 [dependencies]
 irlume-common.workspace = true
 thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 # V4L2 capture. Chosen over nokhwa: it's the path linhello proved on this exact
 # Hello-class hardware, and builds from cache. nokhwa wraps this crate anyway.
 v4l = "0.14"

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -687,18 +687,37 @@ pub(crate) fn load(id: &CameraIdentity) -> Result<Situation, String> {
     //   * A record could be sitting under this name without describing this
     //     camera at all.
     //
-    // So a hit is checked, a miss falls through, and the scan below decides.
+    // So a MISS falls through and the scan below decides. A hit is still checked,
+    // but a hit that fails the check is an error, not a fall-through: the name is
+    // built from the very fields being compared, so contents that disagree at
+    // this path mean the file was damaged, and continuing to the scan let it drop
+    // out as "nothing pending" while a firmware change was still outstanding.
     let path = record_path(&filing_key(id));
     match std::fs::read_to_string(&path) {
         Ok(body) => {
             let record: PendingWrite = serde_json::from_str(&body)
                 .map_err(|e| format!("parse {}: {e}", path.display()))?;
-            if describes_this_camera(&record, id) {
-                return Ok(Situation::Mine {
-                    path,
-                    record: Box::new(record),
-                });
+            if !describes_this_camera(&record, id) {
+                // Filed under THIS camera's key, yet its contents say otherwise.
+                // The key is built from the fingerprint, serial and device path,
+                // so a record that legitimately belongs to another camera lands
+                // under another name; arriving here means the file was damaged
+                // or edited. Falling through was fail-open: the scan drops it on
+                // the same mismatch, `load` answers `Nothing`, and the capture
+                // path takes that as licence to write to the camera while an
+                // unresolved change may still be outstanding. An existing record
+                // is never absence, which is the rule the unparseable and
+                // unreadable cases already follow.
+                return Err(format!(
+                    "{} is filed under this camera's exact journal key but its contents \
+                     describe a different camera; refusing to treat the store as empty",
+                    path.display()
+                ));
             }
+            return Ok(Situation::Mine {
+                path,
+                record: Box::new(record),
+            });
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(format!("read {}: {e}", path.display())),
@@ -1005,6 +1024,49 @@ mod tests {
 
         clear(&path).expect("clear");
         assert_eq!(load(&id), Ok(Situation::Nothing));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A record sitting at THIS camera's exact key whose contents disagree is an
+    /// error, never "nothing pending".
+    ///
+    /// The key is built from the fingerprint, serial and device path, so a
+    /// record that genuinely belongs to another camera is filed under another
+    /// name. Contents that disagree HERE mean the file was damaged or edited.
+    /// The old code fell through to the scan, which drops it on the same
+    /// mismatch, so `load` answered `Nothing` and the capture path read that as
+    /// licence to write to the camera while an undo record was still outstanding
+    /// — fail-open, in the one module whose entire job is to fail closed.
+    #[test]
+    fn a_damaged_record_at_this_cameras_exact_key_is_not_treated_as_absent() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-damaged-exact");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let id = identity();
+        let mut record = record_for(&id);
+        let path = save(&record).expect("save");
+
+        // Still valid JSON, still at the name this camera computes, but one
+        // identity field no longer matches the camera in front of us.
+        record.descriptor_sha256 = "0".repeat(64);
+        std::fs::write(&path, serde_json::to_string(&record).expect("serialize"))
+            .expect("damage the record");
+
+        let why = load(&id)
+            .expect_err("a record at the exact key that disagrees must not read as an empty store");
+        assert!(
+            why.contains("exact journal key"),
+            "the error must say where the record was found, got: {why}"
+        );
+        // And it is still there: refusing must not destroy the only description
+        // of a change that may still be outstanding.
+        assert!(
+            path.exists(),
+            "the record must be left for a person to look at"
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -516,6 +516,39 @@ pub(crate) struct CameraLock {
     _file: std::fs::File,
 }
 
+/// The lock path, for tests in sibling modules that must hold the same lock the
+/// daemon does rather than rebuild its name.
+#[cfg(test)]
+pub(crate) fn lock_path_for_test(id: &CameraIdentity) -> PathBuf {
+    lock_path(id)
+}
+
+/// One camera at one physical address, for the purpose of EXCLUDING a second
+/// writer. Deliberately not [`filing_key`].
+///
+/// The serial is excluded because `identity_from_fd` maps every failure to read
+/// the sysfs `serial` file to absence. A key that changes when a read
+/// transiently fails is fine for a filename — the lookup falls back to scanning
+/// the store — but it is fatal for a lock: two processes opening the same camera
+/// with different serial-read outcomes would take DIFFERENT lock files, both
+/// `flock` calls would succeed, and both would go on to drive the same control.
+/// `flock` excludes on the open file description, so two names are two locks.
+///
+/// The descriptor pins the model and the device path pins which attached unit of
+/// that model this is. Neither can quietly become unavailable the way the serial
+/// can.
+fn synchronization_key(id: &CameraIdentity) -> String {
+    irlume_common::sha256_hex(
+        format!(
+            "descriptors:{}|devpath:{}:{}",
+            fingerprint(id),
+            id.usb_devpath.len(),
+            id.usb_devpath
+        )
+        .as_bytes(),
+    )
+}
+
 /// Where a camera's lock file lives.
 ///
 /// `/run/lock`, not beside the records, for the same reason `pamwire` puts its
@@ -528,7 +561,7 @@ fn lock_path(id: &CameraIdentity) -> PathBuf {
     std::env::var_os("IRLUME_EMITTER_LOCK_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/run/lock"))
-        .join(format!("irlume-emitter-{}.lock", filing_key(id)))
+        .join(format!("irlume-emitter-{}.lock", synchronization_key(id)))
 }
 
 /// Take this camera's lock, or report that somebody else holds it.
@@ -1173,6 +1206,72 @@ mod tests {
                 "schema {version} must not authorise a firmware write"
             );
         }
+    }
+
+    /// One physical camera must always resolve to ONE lock, whether or not its
+    /// serial happened to read this time.
+    ///
+    /// The filing key deliberately includes the serial and the lookup tolerates
+    /// it changing by scanning the store. A lock cannot do that: two names are
+    /// two locks, so two processes whose serial reads disagreed would each take
+    /// their own and both would proceed to drive the same control. Asserted
+    /// against a SECOND PROCESS, because `flock` is per open file description
+    /// and two calls inside this one would both succeed regardless.
+    #[test]
+    fn serial_availability_does_not_change_the_camera_lock() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-lock-key");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let with_serial = identity();
+        let without_serial = CameraIdentity {
+            serial: None,
+            ..identity()
+        };
+        // The premise: the FILING key really does differ between these two, so
+        // an equal lock path is a property of the lock key and not a
+        // coincidence.
+        assert_ne!(filing_key(&with_serial), filing_key(&without_serial));
+        assert_eq!(
+            lock_path(&with_serial),
+            lock_path(&without_serial),
+            "one camera, one lock"
+        );
+
+        let held = lock_camera(&with_serial)
+            .expect("take the lock")
+            .expect("not busy");
+        let path = lock_path(&without_serial);
+        let ready = dir.join("holder-ready");
+        let mut holder = std::process::Command::new("flock")
+            .args([
+                "-n",
+                path.to_str().expect("path"),
+                "-c",
+                &format!("touch {}", ready.display()),
+            ])
+            .status()
+            .expect("run flock");
+        assert!(
+            !holder.success(),
+            "a second process must not get the lock for the same camera just \
+             because its serial read came back empty"
+        );
+        assert!(!ready.exists(), "the holder should never have run");
+
+        drop(held);
+        holder = std::process::Command::new("flock")
+            .args(["-n", path.to_str().expect("path"), "-c", "true"])
+            .status()
+            .expect("run flock");
+        assert!(
+            holder.success(),
+            "and must get it once released, or the assertion above could pass \
+             for any reason at all"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -326,12 +326,26 @@ impl PendingWrite {
     }
 }
 
-/// Whether this record was written about the camera in front of us.
+/// Whether this record was written about the camera in front of us, to the
+/// standard required to WRITE to that camera.
 ///
-/// The serial is compared only when BOTH sides have one: a record from a build
-/// that did not store it must not be mistaken for a different unit. The devpath
-/// is required on both sides, because it is the only discriminator that holds
-/// when two identical units are attached at once.
+/// This answers the authorisation question, not the "can I find it" question.
+/// The two pull in opposite directions and both matter:
+///
+///   * A record must stay FINDABLE when the serial read fails, or a transient
+///     failure hides the only description of an outstanding change. `load`
+///     handles that by scanning, so the record is still reported and `doctor`
+///     still warns.
+///   * A record must not AUTHORISE a firmware write on evidence weaker than the
+///     evidence it was written with. A record carrying a serial, matched
+///     against a camera whose serial could not be read, is exactly that: the
+///     device path names a port, and the kernel is explicit that it is the
+///     device's key "at that point in time", not a persistent identity. An
+///     identical unit swapped into the same port between the record and the
+///     recovery would satisfy descriptor and path alike.
+///
+/// So a missing current serial fails CLOSED. The record is found, reported and
+/// left alone; when the serial reads again it is acted on.
 pub(crate) fn describes_this_camera(record: &PendingWrite, id: &CameraIdentity) -> bool {
     if record.descriptor_sha256 != fingerprint(id) {
         return false;
@@ -341,7 +355,14 @@ pub(crate) fn describes_this_camera(record: &PendingWrite, id: &CameraIdentity) 
     }
     match (record.serial.as_deref(), id.serial.as_deref()) {
         (Some(recorded), Some(attached)) => recorded == attached,
-        _ => true,
+        // The record was written with a discriminator this observation cannot
+        // reproduce. Throwing that away and writing anyway is the one direction
+        // that cannot be taken back.
+        (Some(_), None) => false,
+        // Nothing to compare: the record was written for a camera that
+        // published no serial, which is the ordinary case on the module this
+        // was developed against.
+        (None, _) => true,
     }
 }
 
@@ -1056,19 +1077,41 @@ mod tests {
     /// The serial narrows a match but never settles one, and it is only compared
     /// when both sides have it: a record from a build that did not store one
     /// must not read as a different unit.
+    /// All four serial combinations, because the asymmetric ones are where the
+    /// safe answer differs and where two review rounds pulled opposite ways.
     #[test]
-    fn a_serial_is_compared_only_when_both_sides_publish_one() {
-        let id = identity();
+    fn a_missing_serial_never_authorises_a_write() {
+        let id = identity(); // publishes 200901010001
+        let no_serial_camera = CameraIdentity {
+            serial: None,
+            ..identity()
+        };
 
-        let mut no_serial_recorded = record_for(&id);
-        no_serial_recorded.serial = None;
-        assert!(describes_this_camera(&no_serial_recorded, &id));
+        // both present and equal -> confirmed
+        assert!(describes_this_camera(&record_for(&id), &id));
 
-        let mut different_serial = record_for(&id);
-        different_serial.serial = Some("some-other-unit".into());
+        // both present and different -> two cameras
+        let mut different = record_for(&id);
+        different.serial = Some("some-other-unit".into());
         assert!(
-            !describes_this_camera(&different_serial, &id),
+            !describes_this_camera(&different, &id),
             "two serials that disagree are two cameras"
+        );
+
+        // record has none -> nothing to compare, and the module this was built
+        // against publishes none at all
+        let mut recorded_without = record_for(&id);
+        recorded_without.serial = None;
+        assert!(describes_this_camera(&recorded_without, &id));
+        assert!(describes_this_camera(&recorded_without, &no_serial_camera));
+
+        // record HAS one and this observation does not -> evidence the record
+        // was written with cannot be reproduced, so it authorises nothing. The
+        // device path names a port, not a unit: an identical camera swapped into
+        // that port satisfies descriptor and path alike.
+        assert!(
+            !describes_this_camera(&record_for(&id), &no_serial_camera),
+            "a missing current serial must fail closed"
         );
     }
 
@@ -1146,10 +1189,19 @@ mod tests {
             filing_key(&no_serial),
             "the premise: the key really does change"
         );
+        // FOUND, but not acted on. Round 7 established that a transient serial
+        // failure must not hide the record; round 12 established that it must
+        // not authorise a write either, because the device path names a port
+        // and an identical unit could have been swapped into it. Both hold:
+        // the record is reported, and left alone until the serial reads again.
         assert_eq!(
             load(&no_serial).expect("load"),
-            Situation::Mine(Box::new(record.clone())),
-            "the record describes this camera and must be found"
+            Situation::SameModelElsewhere(Box::new(record.clone())),
+            "the record must still be found, and must not authorise a write"
+        );
+        assert!(
+            !describes_this_camera(&record, &no_serial),
+            "a serial the record has and this observation lacks is missing evidence"
         );
 
         // And the reverse: written without one, read with one.

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -772,7 +772,7 @@ fn all_records() -> Result<Vec<(PathBuf, PendingWrite)>, String> {
 /// process finds the directory present and inherits a guarantee nobody has made.
 /// `ir-setup` is a person running a command, not a hot path.
 pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
-    save_at(&record_path(&record.filing_key()), record)
+    save_at(&record_path(&record.filing_key()), record).map(|(path, _)| path)
 }
 
 /// Write a record to a PARTICULAR path.
@@ -782,22 +782,36 @@ pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
 /// name its contents produce, so counting an attempt through `save` wrote the
 /// incremented record to a second file and left the first one behind — two
 /// records for one operation, and the clear afterwards removed only one.
-pub(crate) fn save_at(path: &std::path::Path, record: &PendingWrite) -> Result<PathBuf, String> {
+pub(crate) fn save_at(
+    path: &std::path::Path,
+    record: &PendingWrite,
+) -> Result<(PathBuf, irlume_common::AtomicWrite), String> {
     let dir = store_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
     irlume_common::restrict(&dir, 0o700)?;
     irlume_common::fsync_ancestors(&dir)?;
     let path = path.to_path_buf();
     let body = serde_json::to_string(record).map_err(|e| format!("serialize record: {e}"))?;
-    irlume_common::write_0600_atomic(&path, body.as_bytes())
+    // The reporting variant, because an error after the rename does NOT mean the
+    // record is absent. A caller that treats "save failed" as "nothing is on
+    // disk" spends an attempt it never made, or leaves a record it thinks it
+    // never wrote — both have happened here.
+    let durability = irlume_common::write_atomic_reporting(&path, body.as_bytes(), 0o600)
         .map_err(|e| format!("write {}: {e}", path.display()))?;
     // After the fsync, so a line here means the record is durable — which is the
     // property the ordering depends on, not merely that a write was issued.
     trace(&format!(
-        "saved unit{}/sel{} original={} attempts={}",
-        record.unit, record.selector, record.original, record.restore_attempts
+        "saved unit{}/sel{} original={} attempts={} ({})",
+        record.unit,
+        record.selector,
+        record.original,
+        record.restore_attempts,
+        match &durability {
+            irlume_common::AtomicWrite::Durable => "durable",
+            irlume_common::AtomicWrite::VisibleNotDurable(_) => "visible, not durable",
+        }
     ));
-    Ok(path)
+    Ok((path, durability))
 }
 
 /// Remove a record whose control is confirmed back where it was found.

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -771,8 +771,39 @@ fn all_records() -> Result<Vec<(PathBuf, PendingWrite)>, String> {
 /// levels that were missing) is a check-then-act on shared state: a second
 /// process finds the directory present and inherits a guarantee nobody has made.
 /// `ir-setup` is a person running a command, not a hot path.
+/// DURABLE, or this is an error. The initial record's durability IS the
+/// authorization for the first firmware write, so "the rename landed but the
+/// directory fsync failed" must not open discovery: the entry can still be lost,
+/// and losing it after the camera has been written recreates the whole defect
+/// this module exists to prevent. Only the attempt COUNTER may treat a visible
+/// record as good enough, because there the question is whether a later reader
+/// sees the higher number, not whether the machine may be cut.
+///
+/// The visible record is deliberately left where it is. No camera write has
+/// happened, so a later run finds the control already holding `original` and
+/// drops the record without touching anything.
 pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
-    save_at(&record_path(&record.filing_key()), record).map(|(path, _)| path)
+    let (path, durability) = save_at(&record_path(&record.filing_key()), record)?;
+    require_durable(path, durability)
+}
+
+/// The decision itself, separated from the write that produces it.
+///
+/// Nothing available here can make a directory `fsync` fail, so a test that goes
+/// through `save` cannot reach the rejecting arm and a mutant deleting it
+/// survives. `AtomicWrite` is a value, so the decision made ABOUT that value can
+/// be exercised directly even when the condition producing it cannot be staged.
+fn require_durable(
+    path: PathBuf,
+    durability: irlume_common::AtomicWrite,
+) -> Result<PathBuf, String> {
+    match durability {
+        irlume_common::AtomicWrite::Durable => Ok(path),
+        irlume_common::AtomicWrite::VisibleNotDurable(e) => Err(format!(
+            "write {}: the undo record became visible but could not be made durable: {e}",
+            path.display()
+        )),
+    }
 }
 
 /// Write a record to a PARTICULAR path.
@@ -798,8 +829,10 @@ pub(crate) fn save_at(
     // never wrote — both have happened here.
     let durability = irlume_common::write_atomic_reporting(&path, body.as_bytes(), 0o600)
         .map_err(|e| format!("write {}: {e}", path.display()))?;
-    // After the fsync, so a line here means the record is durable — which is the
-    // property the ordering depends on, not merely that a write was issued.
+    // After the fsyncs, and it says which outcome it got rather than asserting
+    // one: the ordering depends on the record being DURABLE before the firmware
+    // write, so a transcript that cannot distinguish "durable" from "published,
+    // might not survive a power cut" cannot establish the thing it is read for.
     trace(&format!(
         "saved unit{}/sel{} original={} attempts={} ({})",
         record.unit,
@@ -1805,6 +1838,39 @@ mod tests {
             ),
             Restore::AlreadyRestored,
             "nothing to write, so writability does not matter"
+        );
+    }
+
+    /// The initial undo record's DURABILITY is what authorizes the first
+    /// firmware write, so a record that is merely visible must be an error.
+    ///
+    /// This is the regression for a fix that went too far: the attempt counter
+    /// genuinely may treat a published-but-not-durable record as counted, and
+    /// relaxing that at the shared helper handed the same licence to `save`,
+    /// where it means "write the camera even though the record can still be
+    /// lost" — the exact defect this module exists to prevent.
+    #[test]
+    fn a_record_that_is_visible_but_not_durable_does_not_authorize_a_write() {
+        let path = std::path::PathBuf::from("/var/lib/irlume/ir-emitter-journal/x.json");
+        assert_eq!(
+            super::require_durable(path.clone(), irlume_common::AtomicWrite::Durable),
+            Ok(path.clone()),
+            "an ordinary durable write is the normal path and must still pass"
+        );
+        let why = super::require_durable(
+            path,
+            irlume_common::AtomicWrite::VisibleNotDurable(std::io::Error::other("disk went away")),
+        )
+        .expect_err("a record that may not survive a power cut must NOT open discovery");
+        // The operator has to be able to tell this apart from an ordinary write
+        // failure: the file IS there, and that is the surprising part.
+        assert!(
+            why.contains("visible") && why.contains("durable"),
+            "the refusal must say the record is visible but not durable, got: {why}"
+        );
+        assert!(
+            why.contains("disk went away"),
+            "the underlying error must survive into the message, got: {why}"
         );
     }
 }

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -1238,10 +1238,18 @@ mod tests {
             writable: true,
             current: vec![1, 3, 2, 0],
         };
-        assert!(matches!(
-            restore_decision(&record, &now),
-            Restore::Refuse(_)
-        ));
+        // The REASON, not merely that it refused. Once the "something else moved
+        // this control" check existed, a build with no width check at all still
+        // refused this input, because a 4-byte current value does not equal a
+        // 3-byte recorded one either. Asserting on the outcome alone stopped
+        // discriminating and the mutant survived.
+        match restore_decision(&record, &now) {
+            Restore::Refuse(why) => assert!(
+                why.contains("4 bytes now") && why.contains("3 when"),
+                "the refusal must be about the control's WIDTH: {why}"
+            ),
+            other => panic!("a control of a different width must be refused: {other:?}"),
+        }
     }
 
     /// Checked AFTER the already-restored case: a camera that refuses writes but

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -474,6 +474,28 @@ pub(crate) fn restore_decision(record: &PendingWrite, now: &ControlNow) -> Resto
     if now.current == original {
         return Restore::AlreadyRestored;
     }
+    // The control must be holding THIS run's exploratory value, or there is no
+    // basis for writing anything.
+    //
+    // `attempted` was recorded from the start and, until review pointed it out,
+    // never read: any value other than the original was taken as proof that
+    // irlume's write was still live. The per-camera lock excludes other irlume
+    // processes and nothing else, so a vendor tool, a driver action or an
+    // operator could have set this control between the interruption and now, and
+    // recovery would have silently overwritten a state it did not create. A
+    // record cannot authorise undoing somebody else's change.
+    let attempted = match from_hex(&record.attempted) {
+        Ok(bytes) => bytes,
+        Err(why) => return Restore::Refuse(format!("attempted: {why}")),
+    };
+    if now.current != attempted {
+        return Restore::Refuse(format!(
+            "the control holds {:02x?}, which is neither the value this run wrote \
+             ({attempted:02x?}) nor the one it recorded ({original:02x?}), so something \
+             else has changed it since",
+            now.current
+        ));
+    }
     if !now.writable {
         return Restore::Refuse(
             "the camera reports it does not accept a write to this control right now".into(),
@@ -1160,6 +1182,47 @@ mod tests {
         };
         assert_eq!(
             restore_decision(&record, &now),
+            Restore::Write(vec![1, 3, 1])
+        );
+    }
+
+    /// A control something ELSE moved is left alone.
+    ///
+    /// The lock excludes other irlume processes and nothing else. A vendor tool
+    /// or an operator can change this control between the interruption and the
+    /// recovery, and "not the original" was being read as "still holding our
+    /// write". `attempted` was recorded from the first commit precisely to tell
+    /// those apart, and until review pointed it out nothing read it.
+    #[test]
+    fn a_control_a_third_party_moved_is_not_overwritten() {
+        let id = identity();
+        let record = record_for(&id); // original 010301, attempted 010302
+        let now = ControlNow {
+            len: 3,
+            writable: true,
+            current: vec![1, 3, 3], // neither
+        };
+        match restore_decision(&record, &now) {
+            Restore::Refuse(why) => {
+                // The operator needs all three values to work out what happened.
+                assert!(why.contains("[01, 03, 03]"), "{why}");
+                assert!(why.contains("[01, 03, 02]"), "{why}");
+                assert!(why.contains("[01, 03, 01]"), "{why}");
+            }
+            other => panic!("a third party's value must not be overwritten: {other:?}"),
+        }
+
+        // And the guard must not swallow the case it exists FOR: the control
+        // still holding this run's write is restored.
+        assert_eq!(
+            restore_decision(
+                &record,
+                &ControlNow {
+                    len: 3,
+                    writable: true,
+                    current: vec![1, 3, 2],
+                }
+            ),
             Restore::Write(vec![1, 3, 1])
         );
     }

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -163,6 +163,24 @@ impl PendingWrite {
     }
 }
 
+/// Trace a journal event onto the same stream `set_cur` traces writes to.
+///
+/// The ordering claims this module makes — record before the first write,
+/// attempt counted before the restore, record dropped only after the read-back —
+/// are sequences of side effects, and a test that inspects the filesystem
+/// afterwards cannot see any of them: the record's whole job is to be gone by
+/// the end. Interleaving these lines with the `SET_CUR` lines makes the order an
+/// observation rather than a reading of the control flow.
+///
+/// `IRLUME_LOG_EMITTER_WRITES` is the same switch, deliberately: someone
+/// debugging what irlume sent their camera wants the undo record in the same
+/// transcript, in order.
+pub(crate) fn trace(event: &str) {
+    if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
+        eprintln!("irlume: journal {event}");
+    }
+}
+
 /// Where journal records live. One file per camera, under the state root.
 ///
 /// A directory rather than a single file because a machine can have more than
@@ -361,12 +379,20 @@ pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
     let body = serde_json::to_string(record).map_err(|e| format!("serialize record: {e}"))?;
     irlume_common::write_0600_atomic(&path, body.as_bytes())
         .map_err(|e| format!("write {}: {e}", path.display()))?;
+    // After the fsync, so a line here means the record is durable — which is the
+    // property the ordering depends on, not merely that a write was issued.
+    trace(&format!(
+        "saved unit{}/sel{} original={} attempts={}",
+        record.unit, record.selector, record.original, record.restore_attempts
+    ));
     Ok(path)
 }
 
 /// Remove a record whose control is confirmed back where it was found.
 pub(crate) fn clear(descriptor_sha256: &str) -> Result<(), String> {
-    irlume_common::remove_durable(&record_path(descriptor_sha256))
+    irlume_common::remove_durable(&record_path(descriptor_sha256))?;
+    trace("cleared");
+    Ok(())
 }
 
 /// Lowercase hex, the encoding the record stores control bytes in.

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -163,6 +163,64 @@ impl PendingWrite {
     }
 }
 
+/// What the store holds right now, for a report that has no camera open.
+///
+/// Deliberately does not open a camera or write anything: `doctor` runs on a
+/// machine whose camera may be detached, may be in use, and whose operator may
+/// have set `IRLUME_IR_EMITTER=off` precisely because they do not want irlume
+/// touching it. It counts files and says so.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingSummary {
+    /// The store has no records: nothing was left changed.
+    None,
+    /// This many cameras have an outstanding change, with the coordinates of
+    /// each so an operator can match them against `lsusb`.
+    Pending(Vec<String>),
+    /// The store could not be listed. Not the same as empty: it is root-only, so
+    /// an ordinary `doctor` run lands here, and reporting that as "nothing
+    /// pending" would be a clean bill of health nobody checked.
+    Unreadable(String),
+}
+
+/// Summarise the store without touching any camera.
+pub fn pending_summary() -> PendingSummary {
+    let dir = store_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return PendingSummary::None,
+        Err(e) => return PendingSummary::Unreadable(format!("{}: {e}", dir.display())),
+    };
+    let mut pending = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => return PendingSummary::Unreadable(format!("{}: {e}", dir.display())),
+        };
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "json") {
+            continue;
+        }
+        // A record that will not parse is still a record: something is pending
+        // and this build cannot read it, which an operator needs told.
+        pending.push(match std::fs::read_to_string(&path) {
+            Ok(body) => match serde_json::from_str::<PendingWrite>(&body) {
+                Ok(record) => format!(
+                    "{} unit {} selector {} (original {})",
+                    record.usb_id, record.unit, record.selector, record.original
+                ),
+                Err(e) => format!("{} (unparseable: {e})", path.display()),
+            },
+            Err(e) => format!("{} (unreadable: {e})", path.display()),
+        });
+    }
+    if pending.is_empty() {
+        PendingSummary::None
+    } else {
+        pending.sort();
+        PendingSummary::Pending(pending)
+    }
+}
+
 /// Trace a journal event onto the same stream `set_cur` traces writes to.
 ///
 /// The ordering claims this module makes — record before the first write,

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -635,7 +635,14 @@ pub(crate) enum Situation {
     Nothing,
     /// A record written about THIS camera: same model, same port, and the same
     /// serial where both sides publish one.
-    Mine(Box<PendingWrite>),
+    ///
+    /// Carries the path it was actually found at, because that is what has to be
+    /// removed when it is resolved. `SameModelElsewhere` needs no path: it is
+    /// reported and never cleared.
+    Mine {
+        path: PathBuf,
+        record: Box<PendingWrite>,
+    },
     /// A record about a camera of the SAME MODEL at a different port, or one
     /// written before records carried a port at all.
     ///
@@ -676,7 +683,10 @@ pub(crate) fn load(id: &CameraIdentity) -> Result<Situation, String> {
             let record: PendingWrite = serde_json::from_str(&body)
                 .map_err(|e| format!("parse {}: {e}", path.display()))?;
             if describes_this_camera(&record, id) {
-                return Ok(Situation::Mine(Box::new(record)));
+                return Ok(Situation::Mine {
+                    path,
+                    record: Box::new(record),
+                });
             }
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -689,12 +699,17 @@ pub(crate) fn load(id: &CameraIdentity) -> Result<Situation, String> {
     // sat further down the list.
     let model = fingerprint(id);
     let mut elsewhere = None;
-    for record in all_records()? {
+    for (found_at, record) in all_records()? {
         if record.descriptor_sha256 != model {
             continue;
         }
         if describes_this_camera(&record, id) {
-            return Ok(Situation::Mine(Box::new(record)));
+            // The path it was FOUND at, not one derived from it: a record is not
+            // necessarily filed under the name its own fields produce.
+            return Ok(Situation::Mine {
+                path: found_at,
+                record: Box::new(record),
+            });
         }
         if elsewhere.is_none() {
             elsewhere = Some(record);
@@ -711,7 +726,7 @@ pub(crate) fn load(id: &CameraIdentity) -> Result<Situation, String> {
 /// A record that will not parse is an error rather than a skip: something is
 /// pending, this build cannot read it, and continuing as though the store were
 /// empty is how an outstanding firmware change gets reported as clean.
-fn all_records() -> Result<Vec<PendingWrite>, String> {
+fn all_records() -> Result<Vec<(PathBuf, PendingWrite)>, String> {
     let dir = store_dir();
     let entries = match std::fs::read_dir(&dir) {
         Ok(entries) => entries,
@@ -728,9 +743,9 @@ fn all_records() -> Result<Vec<PendingWrite>, String> {
         }
         let body =
             std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
-        records.push(
-            serde_json::from_str(&body).map_err(|e| format!("parse {}: {e}", path.display()))?,
-        );
+        let record =
+            serde_json::from_str(&body).map_err(|e| format!("parse {}: {e}", path.display()))?;
+        records.push((path, record));
     }
     Ok(records)
 }
@@ -765,10 +780,15 @@ pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
 
 /// Remove a record whose control is confirmed back where it was found.
 ///
-/// Takes the record rather than a key so the removal cannot target a different
-/// file than the save did.
-pub(crate) fn clear(record: &PendingWrite) -> Result<(), String> {
-    irlume_common::remove_durable(&record_path(&record.filing_key()))?;
+/// Takes the PATH the record was read from or written to, never a path derived
+/// from its contents. Deriving it looked equivalent and was not: a record found
+/// by scanning the store is not necessarily filed under the name its own fields
+/// produce — one written by a build with a different key derivation, or planted
+/// by hand, or left behind by a rename that failed after publication. Removing
+/// the derived name then deletes nothing, and the record warns forever while
+/// looking resolved to the code that "cleared" it.
+pub(crate) fn clear(path: &std::path::Path) -> Result<(), String> {
+    irlume_common::remove_durable(path)?;
     trace("cleared");
     Ok(())
 }
@@ -900,9 +920,21 @@ mod tests {
         let record = record_for(&id);
         let path = save(&record).expect("save");
         assert!(path.starts_with(&dir), "record lands under the state root");
-        assert_eq!(load(&id), Ok(Situation::Mine(Box::new(record.clone()))));
+        match load(&id).expect("load") {
+            Situation::Mine {
+                path: found,
+                record: got,
+            } => {
+                assert_eq!(*got, record);
+                assert_eq!(
+                    found, path,
+                    "the path it was found at is the path it was saved to"
+                );
+            }
+            other => panic!("expected this camera's own record: {other:?}"),
+        }
 
-        clear(&record).expect("clear");
+        clear(&path).expect("clear");
         assert_eq!(load(&id), Ok(Situation::Nothing));
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -944,11 +976,11 @@ mod tests {
 
         assert!(matches!(
             load(&first).expect("load first"),
-            Situation::Mine(_)
+            Situation::Mine { .. }
         ));
         assert!(matches!(
             load(&second).expect("load second"),
-            Situation::Mine(_)
+            Situation::Mine { .. }
         ));
         assert_ne!(
             record_path(&filing_key(&first)),
@@ -1011,8 +1043,59 @@ mod tests {
         save(&record_for(&second)).expect("save the second camera's record");
         assert_eq!(
             load(&first).expect("the first record survived"),
-            Situation::Mine(Box::new(record))
+            Situation::Mine {
+                path: record_path(&record.filing_key()),
+                record: Box::new(record)
+            }
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A record filed under a name its own contents do not produce is still
+    /// cleared, because the path it was FOUND at is what gets removed.
+    ///
+    /// Deriving the path from the record looked equivalent to remembering it and
+    /// was not. A record can sit under a name its fields do not reproduce: one
+    /// written by a build with a different key derivation, one placed by hand, or
+    /// one left by a rename that failed after publication. Removing the derived
+    /// name deletes nothing, and the record then warns forever while the code
+    /// that "cleared" it believes it is gone.
+    #[test]
+    fn a_misfiled_record_is_still_removed_when_it_is_resolved() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-misfiled");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let id = identity();
+        let record = record_for(&id);
+        // Deliberately NOT the name its own fields produce.
+        std::fs::create_dir_all(store_dir()).expect("store");
+        let wrong = store_dir()
+            .join("0000000000000000000000000000000000000000000000000000000000000000.json");
+        std::fs::write(&wrong, serde_json::to_string(&record).expect("serialize")).expect("plant");
+        assert_ne!(
+            wrong,
+            record_path(&record.filing_key()),
+            "the premise: it is filed under a name its contents do not produce"
+        );
+
+        // The scan finds it and reports where it really is.
+        let found_at = match load(&id).expect("load") {
+            Situation::Mine { path, .. } => path,
+            other => panic!("expected this camera's record: {other:?}"),
+        };
+        assert_eq!(
+            found_at, wrong,
+            "the path reported must be the path on disk"
+        );
+
+        clear(&found_at).expect("clear");
+        assert!(
+            !wrong.exists(),
+            "the file that was read must be the file removed"
+        );
+        assert_eq!(load(&id).expect("load"), Situation::Nothing);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1211,7 +1294,10 @@ mod tests {
         save(&no_serial_record).expect("save without a serial");
         assert_eq!(
             load(&with_serial).expect("load"),
-            Situation::Mine(Box::new(no_serial_record)),
+            Situation::Mine {
+                path: record_path(&no_serial_record.filing_key()),
+                record: Box::new(no_serial_record)
+            },
             "a record with no serial still describes a camera that has one"
         );
         let _ = std::fs::remove_dir_all(&dir);
@@ -1235,7 +1321,10 @@ mod tests {
 
         assert_eq!(
             load(&mine).expect("load"),
-            Situation::Mine(Box::new(my_record)),
+            Situation::Mine {
+                path: record_path(&my_record.filing_key()),
+                record: Box::new(my_record)
+            },
             "stopping at the first same-model record found would report the wrong one"
         );
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -482,6 +482,71 @@ pub(crate) fn restore_decision(record: &PendingWrite, now: &ControlNow) -> Resto
     Restore::Write(original)
 }
 
+/// Held for the whole of a recovery pass or a discovery run, so no other
+/// process can act on the same camera's record in between.
+#[derive(Debug)]
+pub(crate) struct CameraLock {
+    _file: std::fs::File,
+}
+
+/// Where a camera's lock file lives.
+///
+/// `/run/lock`, not beside the records, for the same reason `pamwire` puts its
+/// lock there: a lock's lifetime is a boot, not the machine's. Under the store it
+/// would create `/var/lib/irlume/ir-emitter-journal/` on every machine that ever
+/// opens a camera, including the overwhelming majority that never run `ir-setup`
+/// and have nothing to record, and leave a lock file behind for each camera
+/// forever. `IRLUME_EMITTER_LOCK_DIR` moves it for tests and containers.
+fn lock_path(id: &CameraIdentity) -> PathBuf {
+    std::env::var_os("IRLUME_EMITTER_LOCK_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/run/lock"))
+        .join(format!("irlume-emitter-{}.lock", filing_key(id)))
+}
+
+/// Take this camera's lock, or report that somebody else holds it.
+///
+/// Reading a record and acting on it is a check and an act with a long window
+/// between: `GET_LEN`, `GET_INFO`, `GET_CUR`, the attempt counter, `SET_CUR`,
+/// the read-back, and only then the removal. Nothing re-read the record at the
+/// end, so a second process that resolved that record, started its own setup and
+/// saved a NEW record at the same name would have it deleted by the first
+/// process finishing — and its exploratory value would then be live with no undo
+/// data at all. That is the loss this whole module exists to prevent, arriving
+/// through the module itself.
+///
+/// The pid and boot id in a record narrow the window; they do not close it. They
+/// describe the record that happened to be loaded before the window opened.
+/// `flock` is kernel-enforced, covers the whole operation, and is released
+/// however the process exits, so a killed irlume strands nothing.
+///
+/// NON-BLOCKING on purpose. This is taken on the capture path, which runs at
+/// every stream open during authentication; waiting behind a discovery run that
+/// takes tens of seconds would stall a login. A camera whose lock is held is a
+/// camera somebody else is already looking after.
+pub(crate) fn lock_camera(id: &CameraIdentity) -> Result<Option<CameraLock>, String> {
+    use std::os::unix::io::AsRawFd as _;
+    let path = lock_path(id);
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(|e| format!("open {}: {e}", path.display()))?;
+    // SAFETY: `fd` is owned by `file`, which outlives the call and the guard.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let err = std::io::Error::last_os_error();
+        return match err.kind() {
+            std::io::ErrorKind::WouldBlock => Ok(None),
+            _ => Err(format!("lock {}: {err}", path.display())),
+        };
+    }
+    Ok(Some(CameraLock { _file: file }))
+}
+
 /// What the store has to say about the camera in front of us.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Situation {
@@ -877,6 +942,50 @@ mod tests {
             !describes_this_camera(&different_serial, &id),
             "two serials that disagree are two cameras"
         );
+    }
+
+    /// The lock excludes a second PROCESS.
+    ///
+    /// Asserted against one, because `flock` is per open file description: two
+    /// calls in the same process each open the file and each succeed, so a test
+    /// that took the lock twice here would pass no matter what the code did. The
+    /// external `flock -n` is the only thing that answers the question the lock
+    /// exists to answer.
+    #[test]
+    fn the_camera_lock_excludes_another_process() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-camera-lock");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let id = identity();
+        let path = lock_path(&id);
+
+        let held = lock_camera(&id).expect("take the lock").expect("not busy");
+
+        // `flock -n` exits 1 when the lock is held; the shell is a separate
+        // process, which is the whole point.
+        let refused = std::process::Command::new("flock")
+            .args(["-n", path.to_str().expect("path"), "-c", "true"])
+            .status()
+            .expect("run flock");
+        assert!(
+            !refused.success(),
+            "a second process must not get the lock while it is held"
+        );
+
+        drop(held);
+        let granted = std::process::Command::new("flock")
+            .args(["-n", path.to_str().expect("path"), "-c", "true"])
+            .status()
+            .expect("run flock");
+        assert!(
+            granted.success(),
+            "and must get it once released, or the previous assertion could pass \
+             for any reason at all"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -1,0 +1,757 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! A durable record of an exploratory write to camera firmware, so a run that
+//! dies between the write and the restore leaves something that says how to put
+//! the control back.
+//!
+//! # The gap this closes
+//!
+//! `ir_emitter::try_documented_control` reads a control with `GET_CUR`, writes
+//! a different value with `SET_CUR`, measures, and writes the original back. The
+//! original lived only in a stack `Vec<u8>` for the seconds in between, and two
+//! camera measurements sit in that window. A `SIGKILL`, a watchdog, a panic in
+//! the decoder or a power loss there left the control changed with no undo data
+//! anywhere: not in `ir_emitter.conf`, which stores coordinates and deliberately
+//! no payload, and not anywhere else.
+//!
+//! On the cameras this was measured against a control that is set stays set: one
+//! write on a NexiGo N930W held across 120 frames and a stream close. So the
+//! damage does not clear itself.
+//!
+//! # Ordering
+//!
+//! The record is written and fsynced BEFORE the first `SET_CUR`, and removed
+//! only after the control has been read back and found to hold the original
+//! again. Both halves matter. Recording after the write leaves the same gap one
+//! level down, and removing the record on the strength of a `SET_CUR` that
+//! returned success assumes the write landed, which is the assumption that put
+//! the camera in this state to begin with.
+//!
+//! A record that outlives a completed restore is harmless: recovery re-reads the
+//! control, finds it already holding the original, and writes nothing.
+//!
+//! # What this does not prove
+//!
+//! The record is bound to the camera's USB descriptor blob, which two units of
+//! the same model share byte for byte. Swapping one for an identical one between
+//! the interrupted run and the recovery would let the recorded bytes be written
+//! to the second camera. They are that model's own bytes, read from that model's
+//! own control moments earlier, so the exposure is small, but it is not zero and
+//! a serial number would not close it either: not every camera publishes one.
+
+use crate::uvc_descriptor::CameraIdentity;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// The record format this build writes and is willing to act on.
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+/// How many times recovery may write the original back before it stops trying.
+///
+/// Recovery runs on a path that executes at every capture, and it confirms a
+/// restore by reading the control back. A control whose `GET_CUR` does not
+/// report what was just written to it would therefore never satisfy the check,
+/// and irlume would write to camera firmware on every authentication forever.
+/// That is a worse failure than the one being recovered from, so the attempts
+/// are counted, durably, and the record is left for a human once they run out.
+pub(crate) const MAX_RESTORE_ATTEMPTS: u32 = 3;
+
+/// One control left changed by a run that has not finished putting it back.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PendingWrite {
+    /// Which record format this is. A GATE: a build refuses a record from a
+    /// newer schema rather than reading the fields it happens to recognise,
+    /// because serde ignores unknown fields and every field here would still
+    /// deserialize into a plausible-looking older shape.
+    #[serde(default = "schema_version_1")]
+    pub(crate) schema_version: u32,
+    /// Which build wrote the record. Descriptive, not a gate.
+    pub(crate) engine_version: String,
+    /// Hex sha256 of the camera's USB descriptor blob, and this record's
+    /// filename.
+    ///
+    /// The descriptor is what `override_is_published` and `control_is_documented`
+    /// already reason about, so binding the record to it means a record can only
+    /// authorise a write to a camera that publishes the same units and
+    /// selectors it was written against.
+    pub(crate) descriptor_sha256: String,
+    /// `vid:pid`, so the file says which camera it is about without hashing
+    /// anything. Checked as well as the digest: a record whose two identities
+    /// disagree describes no camera that exists.
+    pub(crate) usb_id: String,
+    pub(crate) interface_number: u8,
+    pub(crate) unit: u8,
+    pub(crate) selector: u8,
+    /// `GET_LEN` for this control when the original was read.
+    ///
+    /// A restore that writes a different number of bytes than the control holds
+    /// is not a restore. Re-checked at recovery rather than trusted, because the
+    /// length is a property of the attached camera and this record may have been
+    /// written against a different one.
+    pub(crate) len: usize,
+    /// Hex of what `GET_CUR` answered before the first `SET_CUR`.
+    pub(crate) original: String,
+    /// Hex of the value the interrupted run was about to write.
+    ///
+    /// Not needed to restore. It is here so recovery can tell an operator
+    /// whether the control is still holding irlume's exploratory value or has
+    /// since been moved by something else, which is the difference between "this
+    /// is our mess" and "something else is also writing to this control".
+    pub(crate) attempted: String,
+    /// How many times recovery has written the original back.
+    ///
+    /// Counted BEFORE each write and made durable before the ioctl. Counting
+    /// after would leave the same write-then-record gap the record exists to
+    /// close: a kill during the restore would not increment, and the next boot
+    /// would try again from zero, forever.
+    #[serde(default)]
+    pub(crate) restore_attempts: u32,
+    /// The boot the record was written in, and the process that wrote it.
+    ///
+    /// A record is open for the whole of a discovery run, and the capture path
+    /// recovers records at every stream open. Without this, a capture running
+    /// beside a live `ir-setup` would read that run's open record and restore
+    /// the control out from under it, mid-measurement.
+    ///
+    /// The pair is only ever used to answer "is the writer still running", and
+    /// it fails in the safe direction: a reused pid in the same boot makes
+    /// recovery wait, and the next boot has a different `boot_id` and acts
+    /// unconditionally. Waiting a boot is recoverable; writing to firmware
+    /// underneath a live run is not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) boot_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) pid: Option<u32>,
+}
+
+/// This boot's identifier, or `None` where the kernel does not publish one.
+///
+/// `None` means the owner check cannot be made, and recovery then acts rather
+/// than waiting: a record that is never recovered is the failure this module
+/// exists to prevent, and the alternative risk needs a second irlume writing to
+/// the same camera at the same moment.
+pub(crate) fn current_boot_id() -> Option<String> {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Whether the process that opened this record is still running in this boot.
+pub(crate) fn owner_still_running(record: &PendingWrite) -> bool {
+    let (Some(recorded_boot), Some(pid)) = (record.boot_id.as_deref(), record.pid) else {
+        return false;
+    };
+    if current_boot_id().as_deref() != Some(recorded_boot) {
+        return false;
+    }
+    // `/proc/<pid>` rather than `kill(pid, 0)`: the latter cannot tell a live
+    // process owned by somebody else from a dead one without inspecting errno,
+    // and this runs as root where that distinction disappears anyway.
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
+}
+
+fn schema_version_1() -> u32 {
+    1
+}
+
+impl PendingWrite {
+    /// The original bytes, or an error naming what is wrong with the record.
+    pub(crate) fn original_bytes(&self) -> Result<Vec<u8>, String> {
+        from_hex(&self.original).map_err(|e| format!("original: {e}"))
+    }
+}
+
+/// Where journal records live. One file per camera, under the state root.
+///
+/// A directory rather than a single file because a machine can have more than
+/// one IR camera, and an unresolved record for a camera that is not currently
+/// attached must survive a run against a different one. A single file would let
+/// the second camera's discovery erase the first camera's undo data, which is
+/// the exact loss this module exists to prevent.
+pub(crate) fn store_dir() -> PathBuf {
+    irlume_common::state_dir().join("ir-emitter-journal")
+}
+
+/// This camera's record path.
+///
+/// The filename is the descriptor digest, which `sha256_hex` guarantees is
+/// lowercase hex of a fixed length, so no caller-supplied text ever reaches a
+/// path component.
+pub(crate) fn record_path(descriptor_sha256: &str) -> PathBuf {
+    store_dir().join(format!("{descriptor_sha256}.json"))
+}
+
+/// The digest a record for this camera is filed under.
+pub(crate) fn fingerprint(id: &CameraIdentity) -> String {
+    irlume_common::sha256_hex(&id.descriptors)
+}
+
+/// Why a record cannot be acted on against the camera in front of us.
+///
+/// Separated rather than collapsed to a bool because they call for different
+/// responses: a record for another camera is normal on a machine with two of
+/// them and must be left alone, while a record whose unit is no longer published
+/// means the record and the camera disagree about what exists and nobody should
+/// write anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Mismatch {
+    /// Written for a different camera. Leave it where it is.
+    DifferentCamera,
+    /// Written to a schema this build does not implement.
+    SchemaTooNew { found: u32, supported: u32 },
+    /// The record's own two identities disagree, or a field will not parse.
+    Malformed(String),
+    /// The camera no longer publishes the unit or advertises the selector the
+    /// record names.
+    ControlNotPublished,
+    /// Recovery has already written the original back this many times without
+    /// the control reading back as restored.
+    OutOfAttempts { attempts: u32 },
+    /// The run that opened this record is still going. Its control is supposed
+    /// to be changed right now.
+    OwnerStillRunning { pid: u32 },
+}
+
+/// Whether this record describes the camera in front of us, and may be acted on.
+///
+/// Pure, so the decision can be tested without a camera. Every check that gates
+/// a firmware write lives here rather than in the ioctl wrapper.
+pub(crate) fn record_applies(record: &PendingWrite, id: &CameraIdentity) -> Result<(), Mismatch> {
+    if record.schema_version > SCHEMA_VERSION {
+        return Err(Mismatch::SchemaTooNew {
+            found: record.schema_version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+    if record.descriptor_sha256 != fingerprint(id) {
+        return Err(Mismatch::DifferentCamera);
+    }
+    // The digest already pins the descriptors, and these fields come from the
+    // same sysfs read, so a disagreement means the record was assembled from two
+    // different cameras or edited by hand. Either way it is not a description of
+    // anything, and it must not authorise a write.
+    if record.usb_id != id.usb_id() || record.interface_number != id.interface_number {
+        return Err(Mismatch::Malformed(format!(
+            "record says {} interface {}, camera is {} interface {}",
+            record.usb_id,
+            record.interface_number,
+            id.usb_id(),
+            id.interface_number
+        )));
+    }
+    let original = record.original_bytes().map_err(Mismatch::Malformed)?;
+    if original.len() != record.len {
+        return Err(Mismatch::Malformed(format!(
+            "record holds {} original bytes for a control it says is {} long",
+            original.len(),
+            record.len
+        )));
+    }
+    // The same descriptor gate every other write in this crate passes. A record
+    // cannot be a way around it.
+    match id.microsoft_xu() {
+        Some(ms) if ms.unit_id == record.unit && ms.advertises(record.selector) => {}
+        _ => return Err(Mismatch::ControlNotPublished),
+    }
+    if record.restore_attempts >= MAX_RESTORE_ATTEMPTS {
+        return Err(Mismatch::OutOfAttempts {
+            attempts: record.restore_attempts,
+        });
+    }
+    // Last, so a record that is malformed or names a control this camera does
+    // not publish is reported as that rather than as somebody else's business.
+    if owner_still_running(record) {
+        return Err(Mismatch::OwnerStillRunning {
+            pid: record.pid.unwrap_or_default(),
+        });
+    }
+    Ok(())
+}
+
+/// What the control reports right now, gathered before deciding anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ControlNow {
+    /// `GET_LEN` as the attached camera reports it.
+    pub(crate) len: usize,
+    /// Whether `GET_INFO` still permits a write.
+    pub(crate) writable: bool,
+    /// `GET_CUR`.
+    pub(crate) current: Vec<u8>,
+}
+
+/// What recovery should do about a control.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Restore {
+    /// The control already holds the original. Resolve the record, write
+    /// nothing. This is the expected outcome of a kill that landed after the
+    /// restore but before the record was removed.
+    AlreadyRestored,
+    /// Write these bytes back.
+    Write(Vec<u8>),
+    /// Touch nothing, and say why.
+    Refuse(String),
+}
+
+/// Decide from the record and what the control reports, without touching it.
+///
+/// Pure for the same reason `record_applies` is: this is the decision, and a
+/// decision that only exists inside a sequence of ioctls cannot be tested
+/// anywhere but on hardware.
+pub(crate) fn restore_decision(record: &PendingWrite, now: &ControlNow) -> Restore {
+    let original = match record.original_bytes() {
+        Ok(bytes) => bytes,
+        Err(why) => return Restore::Refuse(why),
+    };
+    // The control's length is the attached camera's answer, not the record's.
+    // A record written against a control of a different width would otherwise
+    // send a short or long payload to firmware.
+    if now.len != record.len {
+        return Restore::Refuse(format!(
+            "the control is {} bytes now and was {} when the value was recorded, \
+             so the recorded bytes are not this control's value",
+            now.len, record.len
+        ));
+    }
+    if now.current == original {
+        return Restore::AlreadyRestored;
+    }
+    if !now.writable {
+        return Restore::Refuse(
+            "the camera reports it does not accept a write to this control right now".into(),
+        );
+    }
+    Restore::Write(original)
+}
+
+/// Read this camera's record, if there is one.
+///
+/// An unreadable record that exists is an error rather than "no record":
+/// treating a permission or IO failure as absence would silently drop the one
+/// description of how to undo a firmware write.
+pub(crate) fn load(id: &CameraIdentity) -> Result<Option<PendingWrite>, String> {
+    let path = record_path(&fingerprint(id));
+    let body = match std::fs::read_to_string(&path) {
+        Ok(body) => body,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    serde_json::from_str(&body)
+        .map(Some)
+        .map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+/// Write a record and make it durable before the caller touches the camera.
+///
+/// The directory chain above the store is fsynced too, unconditionally. On a
+/// fresh install the store's own entry is still only in its parent's page cache,
+/// so a record fsynced into it would be fsynced into a directory that does not
+/// come back, and the firmware write happens seconds later. Every way of
+/// narrowing that (skip it when the directory already exists, sync only the
+/// levels that were missing) is a check-then-act on shared state: a second
+/// process finds the directory present and inherits a guarantee nobody has made.
+/// `ir-setup` is a person running a command, not a hot path.
+pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
+    let dir = store_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    irlume_common::restrict(&dir, 0o700)?;
+    irlume_common::fsync_ancestors(&dir)?;
+    let path = record_path(&record.descriptor_sha256);
+    let body = serde_json::to_string(record).map_err(|e| format!("serialize record: {e}"))?;
+    irlume_common::write_0600_atomic(&path, body.as_bytes())
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+/// Remove a record whose control is confirmed back where it was found.
+pub(crate) fn clear(descriptor_sha256: &str) -> Result<(), String> {
+    irlume_common::remove_durable(&record_path(descriptor_sha256))
+}
+
+/// Lowercase hex, the encoding the record stores control bytes in.
+///
+/// Hex rather than serde's byte array so the file stays readable by a person
+/// recovering a camera by hand, which is the situation the record is for.
+pub(crate) fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Strict inverse of [`to_hex`].
+///
+/// Every failure is an error, never a shorter payload. A lenient decode that
+/// skipped unparseable pairs would turn a corrupted record into a different,
+/// well-formed write to camera firmware, which is the same defect that made
+/// `parse_control` drop bad fields out of an override.
+pub(crate) fn from_hex(text: &str) -> Result<Vec<u8>, String> {
+    if !text.len().is_multiple_of(2) {
+        return Err(format!(
+            "{} hex digits is not a whole number of bytes",
+            text.len()
+        ));
+    }
+    let bytes = text.as_bytes();
+    let mut out = Vec::with_capacity(text.len() / 2);
+    for pair in bytes.chunks(2) {
+        let text = std::str::from_utf8(pair).map_err(|_| "not ascii hex".to_string())?;
+        // `from_str_radix` accepts a leading `+` and unicode digits; the explicit
+        // ascii check keeps the accepted set to exactly what `to_hex` emits.
+        if !text.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(format!("'{text}' is not two hex digits"));
+        }
+        out.push(u8::from_str_radix(text, 16).map_err(|e| format!("'{text}': {e}"))?);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testenv::{env_lock, EnvGuard};
+
+    /// A camera identity backed by the real ASUS descriptor bytes, so these
+    /// exercise the same parsing path production uses.
+    fn identity() -> CameraIdentity {
+        CameraIdentity {
+            descriptors: include_bytes!("../tests/fixtures/asus-3277-0059.descriptors").to_vec(),
+            interface_number: 2,
+            vid: 0x3277,
+            pid: 0x0059,
+        }
+    }
+
+    /// The Microsoft unit and a selector the fixture really advertises, so a
+    /// record built here would pass the descriptor gate for the right reason.
+    fn published_control(id: &CameraIdentity) -> (u8, u8) {
+        let ms = id.microsoft_xu().expect("fixture publishes a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises one of the two emitter selectors");
+        (ms.unit_id, selector)
+    }
+
+    fn record_for(id: &CameraIdentity) -> PendingWrite {
+        let (unit, selector) = published_control(id);
+        PendingWrite {
+            schema_version: SCHEMA_VERSION,
+            engine_version: "test".into(),
+            descriptor_sha256: fingerprint(id),
+            usb_id: id.usb_id(),
+            interface_number: id.interface_number,
+            unit,
+            selector,
+            len: 3,
+            original: to_hex(&[1, 3, 1]),
+            attempted: to_hex(&[1, 3, 2]),
+            restore_attempts: 0,
+            boot_id: None,
+            pid: None,
+        }
+    }
+
+    #[test]
+    fn hex_round_trips_and_refuses_anything_it_did_not_write() {
+        assert_eq!(to_hex(&[0x00, 0x0f, 0xff]), "000fff");
+        assert_eq!(from_hex("000fff"), Ok(vec![0x00, 0x0f, 0xff]));
+        assert_eq!(from_hex(""), Ok(vec![]));
+
+        // A truncated record must not decode to a shorter payload that would
+        // then be written to firmware.
+        assert!(from_hex("01020").is_err(), "odd length");
+        assert!(from_hex("01zz").is_err(), "not hex");
+        assert!(from_hex("01 2").is_err(), "spaces are not hex");
+        // `from_str_radix` accepts these; the record format does not.
+        assert!(from_hex("+1").is_err(), "leading sign");
+    }
+
+    #[test]
+    fn a_record_survives_a_round_trip_through_the_store() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-roundtrip");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let id = identity();
+        let record = record_for(&id);
+        let path = save(&record).expect("save");
+        assert!(path.starts_with(&dir), "record lands under the state root");
+        assert_eq!(load(&id), Ok(Some(record)));
+
+        clear(&fingerprint(&id)).expect("clear");
+        assert_eq!(load(&id), Ok(None));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_store_is_not_readable_by_other_accounts() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-perms");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let id = identity();
+        let path = save(&record_for(&id)).expect("save");
+        let mode =
+            |p: &std::path::Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode(&path), 0o600, "record");
+        assert_eq!(mode(&store_dir()), 0o700, "store directory");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A machine with two IR cameras must not lose one camera's undo data
+    /// because the other one was set up afterwards.
+    #[test]
+    fn a_record_for_one_camera_survives_a_record_for_another() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-two-cameras");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let first = identity();
+        let mut second = identity();
+        // A different descriptor blob is a different camera, which is the whole
+        // basis of the filing.
+        second.descriptors.push(0x00);
+
+        save(&record_for(&first)).expect("save first");
+        save(&record_for(&second)).expect("save second");
+
+        assert!(load(&first).expect("load first").is_some());
+        assert!(load(&second).expect("load second").is_some());
+        assert_ne!(
+            record_path(&fingerprint(&first)),
+            record_path(&fingerprint(&second))
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_record_for_another_camera_is_left_alone() {
+        let id = identity();
+        let mut record = record_for(&id);
+        record.descriptor_sha256 = "0".repeat(64);
+        assert_eq!(record_applies(&record, &id), Err(Mismatch::DifferentCamera));
+    }
+
+    /// serde ignores unknown fields, so a newer record deserializes cleanly into
+    /// this older shape and every field looks reasonable. What this build cannot
+    /// know is whether they still mean the same thing, and the record authorises
+    /// a write to firmware.
+    #[test]
+    fn a_record_from_a_newer_schema_is_refused_rather_than_partly_understood() {
+        let id = identity();
+        let mut record = record_for(&id);
+        record.schema_version = SCHEMA_VERSION + 1;
+        assert_eq!(
+            record_applies(&record, &id),
+            Err(Mismatch::SchemaTooNew {
+                found: SCHEMA_VERSION + 1,
+                supported: SCHEMA_VERSION,
+            })
+        );
+    }
+
+    #[test]
+    fn a_record_whose_two_identities_disagree_authorises_nothing() {
+        let id = identity();
+        let mut record = record_for(&id);
+        record.usb_id = "dead:beef".into();
+        assert!(matches!(
+            record_applies(&record, &id),
+            Err(Mismatch::Malformed(_))
+        ));
+
+        let mut record = record_for(&id);
+        record.interface_number = id.interface_number.wrapping_add(1);
+        assert!(matches!(
+            record_applies(&record, &id),
+            Err(Mismatch::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn a_record_naming_a_control_the_camera_does_not_publish_is_refused() {
+        let id = identity();
+        let (unit, _) = published_control(&id);
+
+        let mut wrong_unit = record_for(&id);
+        wrong_unit.unit = unit.wrapping_add(1);
+        assert_eq!(
+            record_applies(&wrong_unit, &id),
+            Err(Mismatch::ControlNotPublished)
+        );
+
+        // Microsoft's Focus selector: a real selector number, and one discovery
+        // could never have written. Without the check a hand-edited record would
+        // put SET_CUR traffic onto it.
+        let mut wrong_selector = record_for(&id);
+        wrong_selector.selector = 0x01;
+        assert_eq!(
+            record_applies(&wrong_selector, &id),
+            Err(Mismatch::ControlNotPublished)
+        );
+    }
+
+    #[test]
+    fn a_record_whose_original_does_not_match_its_own_length_is_refused() {
+        let id = identity();
+        let mut record = record_for(&id);
+        record.len = 4; // original is three bytes
+        assert!(matches!(
+            record_applies(&record, &id),
+            Err(Mismatch::Malformed(_))
+        ));
+
+        let mut record = record_for(&id);
+        record.original = "not hex".into();
+        assert!(matches!(
+            record_applies(&record, &id),
+            Err(Mismatch::Malformed(_))
+        ));
+    }
+
+    /// Without this the restore runs at every capture forever on a control whose
+    /// GET_CUR does not report what was written to it, which is a worse outcome
+    /// than the one being recovered from.
+    #[test]
+    fn recovery_stops_writing_after_the_attempt_budget() {
+        let id = identity();
+        let mut record = record_for(&id);
+
+        record.restore_attempts = MAX_RESTORE_ATTEMPTS - 1;
+        assert_eq!(record_applies(&record, &id), Ok(()), "one attempt left");
+
+        record.restore_attempts = MAX_RESTORE_ATTEMPTS;
+        assert_eq!(
+            record_applies(&record, &id),
+            Err(Mismatch::OutOfAttempts {
+                attempts: MAX_RESTORE_ATTEMPTS
+            })
+        );
+    }
+
+    /// A capture running beside a live `ir-setup` must leave that run's control
+    /// alone. Its record is open precisely because the control is supposed to be
+    /// changed at that moment.
+    #[test]
+    fn a_record_whose_writer_is_still_running_is_left_alone() {
+        let id = identity();
+        let mut record = record_for(&id);
+        record.boot_id = current_boot_id();
+        record.pid = Some(std::process::id());
+        assert!(
+            record.boot_id.is_some(),
+            "this kernel must publish a boot id for the check to mean anything"
+        );
+        assert_eq!(
+            record_applies(&record, &id),
+            Err(Mismatch::OwnerStillRunning {
+                pid: std::process::id()
+            })
+        );
+
+        // pid 0 is never a live process, so the same record with a dead owner is
+        // recoverable. Without this the test would pass on a build where the
+        // owner check always said "still running".
+        record.pid = Some(0);
+        assert_eq!(record_applies(&record, &id), Ok(()));
+    }
+
+    /// The owner check is scoped to one boot. A record surviving a reboot names
+    /// a pid that means nothing, and the pid space is small enough that some
+    /// live process will eventually wear that number.
+    #[test]
+    fn a_record_from_an_earlier_boot_is_recovered_whatever_pid_it_names() {
+        let id = identity();
+        let mut record = record_for(&id);
+        record.boot_id = Some("00000000-0000-0000-0000-000000000000".into());
+        record.pid = Some(std::process::id());
+        assert_ne!(
+            current_boot_id().as_deref(),
+            Some("00000000-0000-0000-0000-000000000000"),
+            "the nil uuid must not be this boot, or the test proves nothing"
+        );
+        assert_eq!(record_applies(&record, &id), Ok(()));
+    }
+
+    #[test]
+    fn a_control_already_holding_the_original_is_resolved_without_a_write() {
+        let id = identity();
+        let record = record_for(&id);
+        let now = ControlNow {
+            len: 3,
+            writable: true,
+            current: vec![1, 3, 1],
+        };
+        assert_eq!(restore_decision(&record, &now), Restore::AlreadyRestored);
+    }
+
+    #[test]
+    fn a_control_still_holding_the_exploratory_value_is_written_back() {
+        let id = identity();
+        let record = record_for(&id);
+        let now = ControlNow {
+            len: 3,
+            writable: true,
+            current: vec![1, 3, 2],
+        };
+        assert_eq!(
+            restore_decision(&record, &now),
+            Restore::Write(vec![1, 3, 1])
+        );
+    }
+
+    /// The length is the attached camera's answer, not the record's. Trusting
+    /// the record would send a payload of the wrong width to firmware.
+    #[test]
+    fn a_control_of_a_different_width_is_refused_before_anything_is_written() {
+        let id = identity();
+        let record = record_for(&id);
+        let now = ControlNow {
+            len: 4,
+            writable: true,
+            current: vec![1, 3, 2, 0],
+        };
+        assert!(matches!(
+            restore_decision(&record, &now),
+            Restore::Refuse(_)
+        ));
+    }
+
+    /// Checked AFTER the already-restored case: a camera that refuses writes but
+    /// is already holding the original needs its record cleared, not a refusal
+    /// that leaves it pending forever.
+    #[test]
+    fn a_control_the_camera_will_not_accept_a_write_to_is_refused() {
+        let id = identity();
+        let record = record_for(&id);
+        assert!(matches!(
+            restore_decision(
+                &record,
+                &ControlNow {
+                    len: 3,
+                    writable: false,
+                    current: vec![1, 3, 2],
+                }
+            ),
+            Restore::Refuse(_)
+        ));
+        assert_eq!(
+            restore_decision(
+                &record,
+                &ControlNow {
+                    len: 3,
+                    writable: false,
+                    current: vec![1, 3, 1],
+                }
+            ),
+            Restore::AlreadyRestored,
+            "nothing to write, so writability does not matter"
+        );
+    }
+}

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -123,6 +123,24 @@ pub(crate) struct PendingWrite {
     pub(crate) boot_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) pid: Option<u32>,
+    /// The USB serial the camera published, when it published one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) serial: Option<String>,
+    /// The sysfs path of the USB device the change was made to.
+    ///
+    /// The only field that distinguishes two identical units attached at the
+    /// same time. Without it the key was the descriptor blob, which two units of
+    /// one model share byte for byte: a capture on the second camera would load
+    /// the first camera's record, write the first camera's bytes into the
+    /// second, and then delete the record on a successful read-back, leaving the
+    /// camera that was actually changed with no undo data at all. Reported by
+    /// review on #183.
+    ///
+    /// Empty on records written before this field existed. Those cannot be
+    /// confirmed to belong to the camera in front of us, so they are reported
+    /// rather than acted on.
+    #[serde(default)]
+    pub(crate) usb_devpath: String,
 }
 
 /// This boot's identifier, or `None` where the kernel does not publish one.
@@ -259,9 +277,72 @@ pub(crate) fn record_path(descriptor_sha256: &str) -> PathBuf {
     store_dir().join(format!("{descriptor_sha256}.json"))
 }
 
-/// The digest a record for this camera is filed under.
+/// The digest of the camera's PUBLISHED DESCRIPTION: model, not unit.
+///
+/// Two units of one model produce the same value, by construction. That is what
+/// makes it the right key for "is this record about a camera like the one in
+/// front of me" and the wrong key for "is this record about THIS camera", which
+/// is [`filing_key`].
 pub(crate) fn fingerprint(id: &CameraIdentity) -> String {
     irlume_common::sha256_hex(&id.descriptors)
+}
+
+/// The name a record for this exact camera is filed under.
+///
+/// Binds the model description to the port and, where the device publishes one,
+/// the serial. The descriptor blob alone collided across identical units, so one
+/// camera's setup silently replaced another's undo record.
+///
+/// The parts are length-prefixed rather than concatenated, so a serial ending in
+/// what looks like a path cannot produce the same key as a different pairing.
+pub(crate) fn filing_key(id: &CameraIdentity) -> String {
+    key_of(&fingerprint(id), id.serial.as_deref(), &id.usb_devpath)
+}
+
+/// The one place a filing key is built, so a record is always written where a
+/// lookup for the same camera will go looking. Two constructions of this would
+/// be two chances to file a record somewhere it is never found again, which is
+/// the same as not having written it.
+fn key_of(descriptor_sha256: &str, serial: Option<&str>, usb_devpath: &str) -> String {
+    let serial = serial.unwrap_or("");
+    irlume_common::sha256_hex(
+        format!(
+            "descriptors:{descriptor_sha256}|serial:{}:{serial}|devpath:{}:{usb_devpath}",
+            serial.len(),
+            usb_devpath.len(),
+        )
+        .as_bytes(),
+    )
+}
+
+impl PendingWrite {
+    /// Where this record belongs, derived from the record's own fields.
+    pub(crate) fn filing_key(&self) -> String {
+        key_of(
+            &self.descriptor_sha256,
+            self.serial.as_deref(),
+            &self.usb_devpath,
+        )
+    }
+}
+
+/// Whether this record was written about the camera in front of us.
+///
+/// The serial is compared only when BOTH sides have one: a record from a build
+/// that did not store it must not be mistaken for a different unit. The devpath
+/// is required on both sides, because it is the only discriminator that holds
+/// when two identical units are attached at once.
+pub(crate) fn describes_this_camera(record: &PendingWrite, id: &CameraIdentity) -> bool {
+    if record.descriptor_sha256 != fingerprint(id) {
+        return false;
+    }
+    if record.usb_devpath.is_empty() || record.usb_devpath != id.usb_devpath {
+        return false;
+    }
+    match (record.serial.as_deref(), id.serial.as_deref()) {
+        (Some(recorded), Some(attached)) => recorded == attached,
+        _ => true,
+    }
 }
 
 /// Why a record cannot be acted on against the camera in front of us.
@@ -401,21 +482,88 @@ pub(crate) fn restore_decision(record: &PendingWrite, now: &ControlNow) -> Resto
     Restore::Write(original)
 }
 
-/// Read this camera's record, if there is one.
+/// What the store has to say about the camera in front of us.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Situation {
+    /// Nothing about this camera or anything like it.
+    Nothing,
+    /// A record written about THIS camera: same model, same port, and the same
+    /// serial where both sides publish one.
+    Mine(Box<PendingWrite>),
+    /// A record about a camera of the SAME MODEL at a different port, or one
+    /// written before records carried a port at all.
+    ///
+    /// Kept apart from `Mine` because the bytes in it were read from a control
+    /// on some other unit, or on this one at a time we cannot confirm. Writing
+    /// them here would be guessing, and clearing the record afterwards would
+    /// destroy the only description of a change that is still outstanding
+    /// somewhere. Reported, never acted on.
+    SameModelElsewhere(Box<PendingWrite>),
+}
+
+/// Classify the store against this camera.
+///
+/// The exact record is tried first, by name, so the ordinary case costs one
+/// failed open. Only when that misses is the directory scanned, which is what
+/// finds a same-model record filed under a different port.
 ///
 /// An unreadable record that exists is an error rather than "no record":
 /// treating a permission or IO failure as absence would silently drop the one
 /// description of how to undo a firmware write.
-pub(crate) fn load(id: &CameraIdentity) -> Result<Option<PendingWrite>, String> {
-    let path = record_path(&fingerprint(id));
-    let body = match std::fs::read_to_string(&path) {
-        Ok(body) => body,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+pub(crate) fn load(id: &CameraIdentity) -> Result<Situation, String> {
+    let path = record_path(&filing_key(id));
+    match std::fs::read_to_string(&path) {
+        Ok(body) => {
+            let record: PendingWrite = serde_json::from_str(&body)
+                .map_err(|e| format!("parse {}: {e}", path.display()))?;
+            // The filename is a convenience, never the authority. A record that
+            // landed under this name but does not describe this camera is
+            // treated as what it says it is, not as what it is called.
+            if describes_this_camera(&record, id) {
+                return Ok(Situation::Mine(Box::new(record)));
+            }
+            return Ok(Situation::SameModelElsewhere(Box::new(record)));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(format!("read {}: {e}", path.display())),
+    }
+
+    let model = fingerprint(id);
+    for record in all_records()? {
+        if record.descriptor_sha256 == model {
+            return Ok(Situation::SameModelElsewhere(Box::new(record)));
+        }
+    }
+    Ok(Situation::Nothing)
+}
+
+/// Every parseable record in the store.
+///
+/// A record that will not parse is an error rather than a skip: something is
+/// pending, this build cannot read it, and continuing as though the store were
+/// empty is how an outstanding firmware change gets reported as clean.
+fn all_records() -> Result<Vec<PendingWrite>, String> {
+    let dir = store_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(format!("list {}: {e}", dir.display())),
     };
-    serde_json::from_str(&body)
-        .map(Some)
-        .map_err(|e| format!("parse {}: {e}", path.display()))
+    let mut records = Vec::new();
+    for entry in entries {
+        let path = entry
+            .map_err(|e| format!("list {}: {e}", dir.display()))?
+            .path();
+        if path.extension().is_none_or(|e| e != "json") {
+            continue;
+        }
+        let body =
+            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        records.push(
+            serde_json::from_str(&body).map_err(|e| format!("parse {}: {e}", path.display()))?,
+        );
+    }
+    Ok(records)
 }
 
 /// Write a record and make it durable before the caller touches the camera.
@@ -433,7 +581,7 @@ pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
     std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
     irlume_common::restrict(&dir, 0o700)?;
     irlume_common::fsync_ancestors(&dir)?;
-    let path = record_path(&record.descriptor_sha256);
+    let path = record_path(&record.filing_key());
     let body = serde_json::to_string(record).map_err(|e| format!("serialize record: {e}"))?;
     irlume_common::write_0600_atomic(&path, body.as_bytes())
         .map_err(|e| format!("write {}: {e}", path.display()))?;
@@ -447,8 +595,11 @@ pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
 }
 
 /// Remove a record whose control is confirmed back where it was found.
-pub(crate) fn clear(descriptor_sha256: &str) -> Result<(), String> {
-    irlume_common::remove_durable(&record_path(descriptor_sha256))?;
+///
+/// Takes the record rather than a key so the removal cannot target a different
+/// file than the save did.
+pub(crate) fn clear(record: &PendingWrite) -> Result<(), String> {
+    irlume_common::remove_durable(&record_path(&record.filing_key()))?;
     trace("cleared");
     Ok(())
 }
@@ -501,6 +652,21 @@ mod tests {
             interface_number: 2,
             vid: 0x3277,
             pid: 0x0059,
+            // The real values this module was developed against. The serial is
+            // deliberately the batch-looking one the ASUS module actually
+            // reports, so nothing here can quietly assume a serial is unique.
+            serial: Some("200901010001".into()),
+            usb_devpath: "/devices/pci0000:00/0000:00:14.0/usb3/3-5".into(),
+        }
+    }
+
+    /// The same MODEL at a different port: byte-identical descriptors, the same
+    /// serial, a different physical address. This is the pair the descriptor
+    /// digest could not tell apart.
+    fn identical_unit_elsewhere() -> CameraIdentity {
+        CameraIdentity {
+            usb_devpath: "/devices/pci0000:00/0000:00:14.0/usb3/3-2".into(),
+            ..identity()
         }
     }
 
@@ -534,6 +700,8 @@ mod tests {
             restore_attempts: 0,
             boot_id: None,
             pid: None,
+            serial: id.serial.clone(),
+            usb_devpath: id.usb_devpath.clone(),
         }
     }
 
@@ -563,10 +731,10 @@ mod tests {
         let record = record_for(&id);
         let path = save(&record).expect("save");
         assert!(path.starts_with(&dir), "record lands under the state root");
-        assert_eq!(load(&id), Ok(Some(record)));
+        assert_eq!(load(&id), Ok(Situation::Mine(Box::new(record.clone()))));
 
-        clear(&fingerprint(&id)).expect("clear");
-        assert_eq!(load(&id), Ok(None));
+        clear(&record).expect("clear");
+        assert_eq!(load(&id), Ok(Situation::Nothing));
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -605,13 +773,110 @@ mod tests {
         save(&record_for(&first)).expect("save first");
         save(&record_for(&second)).expect("save second");
 
-        assert!(load(&first).expect("load first").is_some());
-        assert!(load(&second).expect("load second").is_some());
+        assert!(matches!(
+            load(&first).expect("load first"),
+            Situation::Mine(_)
+        ));
+        assert!(matches!(
+            load(&second).expect("load second"),
+            Situation::Mine(_)
+        ));
         assert_ne!(
-            record_path(&fingerprint(&first)),
-            record_path(&fingerprint(&second))
+            record_path(&filing_key(&first)),
+            record_path(&filing_key(&second))
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Two units of one model publish byte-identical descriptors, so the model
+    /// digest cannot tell them apart. Filing by it meant a capture on the second
+    /// camera loaded the first camera's record, and a successful read-back then
+    /// DELETED it, leaving the camera that was actually changed with no undo
+    /// data. Setup on the second camera also replaced the first camera's record
+    /// outright, since the atomic write deliberately replaces its destination.
+    #[test]
+    fn two_identical_cameras_do_not_share_one_record() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-identical-units");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let first = identity();
+        let second = identical_unit_elsewhere();
+
+        // The premise: these really are indistinguishable by everything except
+        // the port. Without this the rest of the test proves nothing.
+        assert_eq!(
+            fingerprint(&first),
+            fingerprint(&second),
+            "the fixture must be two units of ONE model"
+        );
+        assert_eq!(first.serial, second.serial, "and the same serial");
+        assert_ne!(first.usb_devpath, second.usb_devpath);
+
+        assert_ne!(
+            filing_key(&first),
+            filing_key(&second),
+            "so they must not be filed under the same name"
+        );
+
+        let record = record_for(&first);
+        save(&record).expect("save the first camera's record");
+
+        // The capture on the second camera: it must not be handed the first
+        // camera's bytes, and it must not delete the record either.
+        match load(&second).expect("load for the second camera") {
+            Situation::SameModelElsewhere(found) => {
+                assert_eq!(found.usb_devpath, first.usb_devpath)
+            }
+            other => panic!("the second camera must not own this record: {other:?}"),
+        }
+        assert!(
+            !describes_this_camera(&record, &second),
+            "the record does not describe the second camera"
+        );
+        assert!(describes_this_camera(&record, &first));
+
+        // And setting up the second camera leaves the first camera's record
+        // where it was, rather than replacing it.
+        save(&record_for(&second)).expect("save the second camera's record");
+        assert_eq!(
+            load(&first).expect("the first record survived"),
+            Situation::Mine(Box::new(record))
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A record written before records carried a port cannot be confirmed to
+    /// belong to anything, so it is reported rather than acted on.
+    #[test]
+    fn a_record_with_no_recorded_port_is_never_acted_on() {
+        let id = identity();
+        let mut legacy = record_for(&id);
+        legacy.usb_devpath = String::new();
+        assert!(
+            !describes_this_camera(&legacy, &id),
+            "an empty port matches nothing, including a camera whose path is also unknown"
+        );
+    }
+
+    /// The serial narrows a match but never settles one, and it is only compared
+    /// when both sides have it: a record from a build that did not store one
+    /// must not read as a different unit.
+    #[test]
+    fn a_serial_is_compared_only_when_both_sides_publish_one() {
+        let id = identity();
+
+        let mut no_serial_recorded = record_for(&id);
+        no_serial_recorded.serial = None;
+        assert!(describes_this_camera(&no_serial_recorded, &id));
+
+        let mut different_serial = record_for(&id);
+        different_serial.serial = Some("some-other-unit".into());
+        assert!(
+            !describes_this_camera(&different_serial, &id),
+            "two serials that disagree are two cameras"
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -962,6 +962,51 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// THE CONSEQUENCE OF TWO IDENTICAL CAMERAS: one camera's pending record
+    /// darkens the other one too.
+    ///
+    /// Two units of one model publish the same descriptors and, on the module
+    /// this was developed against, no serial at all. So when the second camera
+    /// looks for its own record and finds none, the scan turns up the first
+    /// camera's, and nothing can prove it is not about this camera. It is
+    /// reported as `SameModelElsewhere`, which stops the emitter here as well.
+    ///
+    /// That is the conservative answer and it is deliberate — the alternative is
+    /// writing one camera's recorded bytes into another — but the cost is real
+    /// and wider than the camera that was actually changed, so it is pinned by a
+    /// test rather than left as a surprise.
+    #[test]
+    fn an_identical_cameras_pending_record_also_stops_this_one() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-identical-blocks");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let first = identity();
+        let second = identical_unit_elsewhere();
+        // Only the FIRST has an outstanding change.
+        save(&record_for(&first)).expect("save the first unit's record");
+
+        match load(&second).expect("load for the second unit") {
+            Situation::SameModelElsewhere(found) => {
+                assert_eq!(found.usb_devpath, first.usb_devpath)
+            }
+            other => panic!("expected the other unit's record to be visible: {other:?}"),
+        }
+        // A different MODEL is unaffected: its descriptors differ, so the record
+        // is plainly not about it and its emitter keeps working.
+        let mut other_model = identity();
+        other_model
+            .descriptors
+            .extend_from_slice(b"a different model entirely");
+        assert_eq!(
+            load(&other_model).expect("load for a different model"),
+            Situation::Nothing,
+            "only cameras indistinguishable from the recorded one are held back"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// A record written before records carried a port cannot be confirmed to
     /// belong to anything, so it is reported rather than acted on.
     #[test]

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -356,8 +356,8 @@ pub(crate) fn describes_this_camera(record: &PendingWrite, id: &CameraIdentity) 
 pub(crate) enum Mismatch {
     /// Written for a different camera. Leave it where it is.
     DifferentCamera,
-    /// Written to a schema this build does not implement.
-    SchemaTooNew { found: u32, supported: u32 },
+    /// Written to a schema this build does not implement, in either direction.
+    UnsupportedSchema { found: u32, supported: u32 },
     /// The record's own two identities disagree, or a field will not parse.
     Malformed(String),
     /// The camera no longer publishes the unit or advertises the selector the
@@ -376,8 +376,13 @@ pub(crate) enum Mismatch {
 /// Pure, so the decision can be tested without a camera. Every check that gates
 /// a firmware write lives here rather than in the ioctl wrapper.
 pub(crate) fn record_applies(record: &PendingWrite, id: &CameraIdentity) -> Result<(), Mismatch> {
-    if record.schema_version > SCHEMA_VERSION {
-        return Err(Mismatch::SchemaTooNew {
+    // Equality, not an upper bound. `> SCHEMA_VERSION` let schema 0 through, and
+    // there is no schema 0: a corrupted or hand-repaired record carrying one
+    // would have passed every remaining check and authorised a firmware write.
+    // A record this build cannot read is a record this build must not act on,
+    // whichever side of the version it falls.
+    if record.schema_version != SCHEMA_VERSION {
+        return Err(Mismatch::UnsupportedSchema {
             found: record.schema_version,
             supported: SCHEMA_VERSION,
         });
@@ -598,30 +603,53 @@ pub(crate) enum Situation {
 /// treating a permission or IO failure as absence would silently drop the one
 /// description of how to undo a firmware write.
 pub(crate) fn load(id: &CameraIdentity) -> Result<Situation, String> {
+    // The filename is a fast path, never the authority. Two things make it
+    // unreliable on its own, and both were found by review:
+    //
+    //   * It is derived from the serial, and `identity_from_fd` maps EVERY
+    //     failure to read the sysfs `serial` file to `None`. One transient read
+    //     failure changes the key, the exact lookup misses, and a record that
+    //     describes this camera perfectly well by descriptor and device path
+    //     would have been dismissed as another camera's — leaving the camera
+    //     changed and its emitter disabled, which is the opposite of the point.
+    //   * A record could be sitting under this name without describing this
+    //     camera at all.
+    //
+    // So a hit is checked, a miss falls through, and the scan below decides.
     let path = record_path(&filing_key(id));
     match std::fs::read_to_string(&path) {
         Ok(body) => {
             let record: PendingWrite = serde_json::from_str(&body)
                 .map_err(|e| format!("parse {}: {e}", path.display()))?;
-            // The filename is a convenience, never the authority. A record that
-            // landed under this name but does not describe this camera is
-            // treated as what it says it is, not as what it is called.
             if describes_this_camera(&record, id) {
                 return Ok(Situation::Mine(Box::new(record)));
             }
-            return Ok(Situation::SameModelElsewhere(Box::new(record)));
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(format!("read {}: {e}", path.display())),
     }
 
+    // EVERY same-model record is examined, not the first one `read_dir` happens
+    // to hand back. Directory order is unspecified, so stopping at the first
+    // match could report another camera's record while this camera's own record
+    // sat further down the list.
     let model = fingerprint(id);
+    let mut elsewhere = None;
     for record in all_records()? {
-        if record.descriptor_sha256 == model {
-            return Ok(Situation::SameModelElsewhere(Box::new(record)));
+        if record.descriptor_sha256 != model {
+            continue;
+        }
+        if describes_this_camera(&record, id) {
+            return Ok(Situation::Mine(Box::new(record)));
+        }
+        if elsewhere.is_none() {
+            elsewhere = Some(record);
         }
     }
-    Ok(Situation::Nothing)
+    Ok(match elsewhere {
+        Some(record) => Situation::SameModelElsewhere(Box::new(record)),
+        None => Situation::Nothing,
+    })
 }
 
 /// Every parseable record in the store.
@@ -1010,6 +1038,98 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A record must still be found when the serial's AVAILABILITY changes.
+    ///
+    /// `identity_from_fd` maps every failure to read the sysfs `serial` file to
+    /// `None`, and the filename is derived from it. One transient read failure
+    /// therefore changes the key the lookup uses. The record still describes
+    /// this camera by descriptor and device path, and dismissing it as another
+    /// camera's would leave the camera changed with its emitter disabled — the
+    /// exact opposite of what the record is for.
+    #[test]
+    fn a_record_is_found_when_the_serial_becomes_unreadable() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-serial-flip");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let with_serial = identity();
+        let record = record_for(&with_serial);
+        save(&record).expect("save with a serial");
+
+        // Same camera, same port, same descriptors; the serial simply did not
+        // read this time.
+        let no_serial = CameraIdentity {
+            serial: None,
+            ..identity()
+        };
+        assert_ne!(
+            filing_key(&with_serial),
+            filing_key(&no_serial),
+            "the premise: the key really does change"
+        );
+        assert_eq!(
+            load(&no_serial).expect("load"),
+            Situation::Mine(Box::new(record.clone())),
+            "the record describes this camera and must be found"
+        );
+
+        // And the reverse: written without one, read with one.
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut no_serial_record = record_for(&no_serial);
+        no_serial_record.serial = None;
+        save(&no_serial_record).expect("save without a serial");
+        assert_eq!(
+            load(&with_serial).expect("load"),
+            Situation::Mine(Box::new(no_serial_record)),
+            "a record with no serial still describes a camera that has one"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// With several same-model records in the store, this camera's own must be
+    /// found wherever the directory listing happens to put it.
+    #[test]
+    fn this_cameras_record_is_found_whatever_the_directory_order() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-scan-order");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let mine = identity();
+        let other = identical_unit_elsewhere();
+        // A foreign same-model record and this camera's own, both present.
+        save(&record_for(&other)).expect("save the other unit's");
+        let my_record = record_for(&mine);
+        save(&my_record).expect("save mine");
+
+        assert_eq!(
+            load(&mine).expect("load"),
+            Situation::Mine(Box::new(my_record)),
+            "stopping at the first same-model record found would report the wrong one"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// There is no schema 0, so a record claiming one describes nothing this
+    /// build knows how to act on.
+    #[test]
+    fn a_record_from_a_schema_this_build_does_not_implement_is_refused() {
+        let id = identity();
+        for version in [0, SCHEMA_VERSION + 1] {
+            let mut record = record_for(&id);
+            record.schema_version = version;
+            assert_eq!(
+                record_applies(&record, &id),
+                Err(Mismatch::UnsupportedSchema {
+                    found: version,
+                    supported: SCHEMA_VERSION,
+                }),
+                "schema {version} must not authorise a firmware write"
+            );
+        }
+    }
+
     #[test]
     fn a_record_for_another_camera_is_left_alone() {
         let id = identity();
@@ -1029,7 +1149,7 @@ mod tests {
         record.schema_version = SCHEMA_VERSION + 1;
         assert_eq!(
             record_applies(&record, &id),
-            Err(Mismatch::SchemaTooNew {
+            Err(Mismatch::UnsupportedSchema {
                 found: SCHEMA_VERSION + 1,
                 supported: SCHEMA_VERSION,
             })

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -64,7 +64,14 @@ pub(crate) struct PendingWrite {
     /// newer schema rather than reading the fields it happens to recognise,
     /// because serde ignores unknown fields and every field here would still
     /// deserialize into a plausible-looking older shape.
-    #[serde(default = "schema_version_1")]
+    ///
+    /// REQUIRED, with no serde default. A default invented schema 1 whenever the
+    /// field was absent, which handed the gate its own answer: a record with no
+    /// version at all deserialized into a schema-1 record and could authorise a
+    /// firmware write. An absent version is precisely "this build cannot know
+    /// what this record means", so the parse fails, `load` reports it, and
+    /// nothing is acted on. The default existed for records written before the
+    /// field, and this feature has never shipped, so there are none.
     pub(crate) schema_version: u32,
     /// Which build wrote the record. Descriptive, not a gate.
     pub(crate) engine_version: String,
@@ -170,10 +177,6 @@ pub(crate) fn owner_still_running(record: &PendingWrite) -> bool {
     std::path::Path::new(&format!("/proc/{pid}")).exists()
 }
 
-fn schema_version_1() -> u32 {
-    1
-}
-
 impl PendingWrite {
     /// The original bytes, or an error naming what is wrong with the record.
     pub(crate) fn original_bytes(&self) -> Result<Vec<u8>, String> {
@@ -255,6 +258,14 @@ pub(crate) fn trace(event: &str) {
     if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
         eprintln!("irlume: journal {event}");
     }
+}
+
+/// Only referenced by a mutation-test variant that reinstates the serde default
+/// this type deliberately does not have. Never used in production.
+#[cfg(test)]
+#[allow(dead_code)]
+fn schema_version_one() -> u32 {
+    1
 }
 
 /// Where journal records live. One file per camera, under the state root.
@@ -761,11 +772,22 @@ fn all_records() -> Result<Vec<(PathBuf, PendingWrite)>, String> {
 /// process finds the directory present and inherits a guarantee nobody has made.
 /// `ir-setup` is a person running a command, not a hot path.
 pub(crate) fn save(record: &PendingWrite) -> Result<PathBuf, String> {
+    save_at(&record_path(&record.filing_key()), record)
+}
+
+/// Write a record to a PARTICULAR path.
+///
+/// Recovery uses this to rewrite a record it found by scanning. `save` derives
+/// the name from the contents, and a scanned record need not be filed under the
+/// name its contents produce, so counting an attempt through `save` wrote the
+/// incremented record to a second file and left the first one behind — two
+/// records for one operation, and the clear afterwards removed only one.
+pub(crate) fn save_at(path: &std::path::Path, record: &PendingWrite) -> Result<PathBuf, String> {
     let dir = store_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
     irlume_common::restrict(&dir, 0o700)?;
     irlume_common::fsync_ancestors(&dir)?;
-    let path = record_path(&record.filing_key());
+    let path = path.to_path_buf();
     let body = serde_json::to_string(record).map_err(|e| format!("serialize record: {e}"))?;
     irlume_common::write_0600_atomic(&path, body.as_bytes())
         .map_err(|e| format!("write {}: {e}", path.display()))?;
@@ -1099,6 +1121,47 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A record with no schema version at all authorises nothing.
+    ///
+    /// A serde default invented schema 1 whenever the field was missing, which
+    /// handed the gate its own answer. An absent version means this build cannot
+    /// know what the record means, so the parse must fail and the record must be
+    /// reported rather than acted on.
+    #[test]
+    fn a_record_with_no_schema_version_is_refused_rather_than_assumed() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-no-schema");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let id = identity();
+        let mut fields: serde_json::Value =
+            serde_json::to_value(record_for(&id)).expect("serialize");
+        fields
+            .as_object_mut()
+            .expect("object")
+            .remove("schema_version");
+        std::fs::create_dir_all(store_dir()).expect("store");
+        std::fs::write(
+            record_path(&filing_key(&id)),
+            serde_json::to_string(&fields).expect("reserialize"),
+        )
+        .expect("plant");
+
+        // Not silently read as schema 1: the load fails, which the caller turns
+        // into an unresolved outcome rather than an authorisation.
+        assert!(
+            load(&id).is_err(),
+            "a record with no version must not deserialize into one"
+        );
+        // And it is still visible to an operator rather than vanishing.
+        match pending_summary() {
+            PendingSummary::Pending(entries) => assert_eq!(entries.len(), 1),
+            other => panic!("the record must still be reported: {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// THE CONSEQUENCE OF TWO IDENTICAL CAMERAS: one camera's pending record
     /// darkens the other one too.
     ///
@@ -1305,27 +1368,69 @@ mod tests {
 
     /// With several same-model records in the store, this camera's own must be
     /// found wherever the directory listing happens to put it.
+    ///
+    /// MY record is deliberately MISFILED, so the exact-path fast path misses
+    /// and the SCAN is what has to find it. Without that this never reached the
+    /// loop at all: the fast path answered, and a mutant that stopped the scan
+    /// at the first same-model record survived under a test named for
+    /// directory order.
+    ///
+    /// The foreign record is given a name this directory really does hand back
+    /// first, discovered by asking rather than assumed, so the ordering the test
+    /// is named for is the ordering it runs against.
     #[test]
     fn this_cameras_record_is_found_whatever_the_directory_order() {
         let _lock = env_lock();
         let dir = std::env::temp_dir().join("irlume-journal-scan-order");
         let _ = std::fs::remove_dir_all(&dir);
         let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        std::fs::create_dir_all(store_dir()).expect("store");
 
         let mine = identity();
-        let other = identical_unit_elsewhere();
-        // A foreign same-model record and this camera's own, both present.
-        save(&record_for(&other)).expect("save the other unit's");
         let my_record = record_for(&mine);
-        save(&my_record).expect("save mine");
+        let misfiled = store_dir().join(format!("{}.json", "f".repeat(64)));
+        std::fs::write(
+            &misfiled,
+            serde_json::to_string(&my_record).expect("serialize"),
+        )
+        .expect("plant mine misfiled");
+
+        let other = record_for(&identical_unit_elsewhere());
+        let first_entry = || {
+            std::fs::read_dir(store_dir())
+                .expect("read store")
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .next()
+                .expect("an entry")
+        };
+        let mut foreign = None;
+        for n in 0..64u32 {
+            let candidate = store_dir().join(format!("{n:064x}.json"));
+            std::fs::write(
+                &candidate,
+                serde_json::to_string(&other).expect("serialize"),
+            )
+            .expect("plant foreign");
+            if first_entry() == candidate {
+                foreign = Some(candidate);
+                break;
+            }
+            std::fs::remove_file(&candidate).expect("try another name");
+        }
+        assert!(
+            foreign.is_some(),
+            "no name came back before mine in 64 tries, so the ordering this \
+             test is named for was never established"
+        );
 
         assert_eq!(
             load(&mine).expect("load"),
             Situation::Mine {
-                path: record_path(&my_record.filing_key()),
+                path: misfiled,
                 record: Box::new(my_record)
             },
-            "stopping at the first same-model record found would report the wrong one"
+            "stopping at the first same-model record would report the wrong one"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -360,6 +360,22 @@ impl std::fmt::Display for XuError {
 type XuResult<T> = std::result::Result<T, XuError>;
 
 fn xu_query(fd: c_int, unit: u8, selector: u8, query: u8, data: &mut [u8]) -> XuResult<()> {
+    // A test may stand in for the camera here. Every read and every write in
+    // this module funnels through this one call, so a fake installed here can
+    // drive the whole discovery sequence, record the exact order of requests,
+    // and make a chosen one fail.
+    //
+    // That matters more than usual. The guards on this path are ORDERINGS
+    // between ioctls — the record durable before the first write, no second
+    // write after the camera refuses one, the attempt counted before the retry —
+    // and an ordering leaves nothing behind for a test to inspect afterwards.
+    // Four mutants that each reintroduced a hardware-destructive defect survived
+    // the entire suite before this existed, because nothing without a camera
+    // could reach the code at all.
+    #[cfg(test)]
+    if let Some(result) = fake_camera::intercept(unit, selector, query, data) {
+        return result;
+    }
     let mut q = UvcXuControlQuery {
         unit,
         selector,
@@ -375,6 +391,168 @@ fn xu_query(fd: c_int, unit: u8, selector: u8, query: u8, data: &mut [u8]) -> Xu
     Err(XuError::from_errno(
         std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
     ))
+}
+
+/// A stand-in camera for tests, installed in front of [`xu_query`].
+///
+/// Thread-local, so tests that use it need no lock and cannot disturb each
+/// other. Absent by default, in which case every query goes to the real ioctl
+/// exactly as before.
+#[cfg(test)]
+pub(crate) mod fake_camera {
+    use super::{XuError, XuResult, UVC_GET_CUR, UVC_GET_INFO, UVC_GET_LEN, UVC_SET_CUR};
+    use std::cell::RefCell;
+
+    /// One request the code under test made, in order.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) enum Request {
+        Get { query: u8, size: usize },
+        Set(Vec<u8>),
+    }
+
+    #[derive(Default)]
+    pub(crate) struct Camera {
+        /// What `GET_CUR` answers. Updated by an accepted `SET_CUR`, like a real
+        /// control, so a read-back reflects what was written.
+        pub(crate) current: Vec<u8>,
+        pub(crate) len: usize,
+        /// `GET_INFO`: D0 get, D1 set.
+        pub(crate) info: u8,
+        /// `GET_DEF`, `GET_MAX`, `GET_MIN`, `GET_RES`. Separate from `current`
+        /// because the payload discovery intends is DERIVED from them: a fake
+        /// that answered every query with the same bytes would make
+        /// `intended_value` equal the current value and the run would stop
+        /// before writing anything, which is a pass for the wrong reason.
+        pub(crate) def: Vec<u8>,
+        pub(crate) max: Vec<u8>,
+        pub(crate) min: Vec<u8>,
+        pub(crate) res: Vec<u8>,
+        /// Fail the Nth `SET_CUR` (1-based) with this errno, and every one after
+        /// it. Models a camera that stops answering, which is the state this
+        /// module must send nothing further to.
+        pub(crate) fail_set_from: Option<(usize, i32)>,
+        /// `SET_CUR`s seen so far, so `fail_set_from` can count.
+        pub(crate) sets_seen: usize,
+        /// Every request, in order.
+        pub(crate) log: Vec<Request>,
+    }
+
+    thread_local! {
+        static CAMERA: RefCell<Option<Camera>> = const { RefCell::new(None) };
+    }
+
+    /// Install a fake for the rest of this test, and take it back at the end.
+    pub(crate) struct Installed;
+
+    impl Drop for Installed {
+        fn drop(&mut self) {
+            CAMERA.with(|c| *c.borrow_mut() = None);
+        }
+    }
+
+    pub(crate) fn install(camera: Camera) -> Installed {
+        CAMERA.with(|c| *c.borrow_mut() = Some(camera));
+        Installed
+    }
+
+    /// Everything the fake was asked, in order.
+    pub(crate) fn log() -> Vec<Request> {
+        CAMERA.with(|c| {
+            c.borrow()
+                .as_ref()
+                .map(|cam| cam.log.clone())
+                .unwrap_or_default()
+        })
+    }
+
+    /// What the control holds now.
+    pub(crate) fn current() -> Vec<u8> {
+        CAMERA.with(|c| {
+            c.borrow()
+                .as_ref()
+                .map(|cam| cam.current.clone())
+                .unwrap_or_default()
+        })
+    }
+
+    /// `None` when no fake is installed, so the real ioctl runs.
+    pub(crate) fn intercept(
+        _unit: u8,
+        _selector: u8,
+        query: u8,
+        data: &mut [u8],
+    ) -> Option<XuResult<()>> {
+        CAMERA.with(|cell| {
+            let mut borrowed = cell.borrow_mut();
+            let cam = borrowed.as_mut()?;
+            Some(match query {
+                UVC_SET_CUR => {
+                    cam.sets_seen += 1;
+                    cam.log.push(Request::Set(data.to_vec()));
+                    match cam.fail_set_from {
+                        Some((from, errno)) if cam.sets_seen >= from => {
+                            Err(XuError::from_errno(errno))
+                        }
+                        _ => {
+                            // An accepted write changes what the control holds,
+                            // so a read-back sees it. A fake whose GET_CUR never
+                            // moved would make the read-back check pass for the
+                            // wrong reason.
+                            cam.current = data.to_vec();
+                            Ok(())
+                        }
+                    }
+                }
+                UVC_GET_LEN => {
+                    cam.log.push(Request::Get {
+                        query,
+                        size: data.len(),
+                    });
+                    // Little-endian u16, as the UVC specification defines it.
+                    data[0] = (cam.len & 0xff) as u8;
+                    if data.len() > 1 {
+                        data[1] = ((cam.len >> 8) & 0xff) as u8;
+                    }
+                    Ok(())
+                }
+                UVC_GET_INFO => {
+                    cam.log.push(Request::Get {
+                        query,
+                        size: data.len(),
+                    });
+                    data[0] = cam.info;
+                    Ok(())
+                }
+                UVC_GET_CUR => {
+                    cam.log.push(Request::Get {
+                        query,
+                        size: data.len(),
+                    });
+                    for (slot, byte) in data.iter_mut().zip(cam.current.iter()) {
+                        *slot = *byte;
+                    }
+                    Ok(())
+                }
+                other => {
+                    cam.log.push(Request::Get {
+                        query: other,
+                        size: data.len(),
+                    });
+                    let source = match other {
+                        super::UVC_GET_DEF => &cam.def,
+                        super::UVC_GET_MAX => &cam.max,
+                        super::UVC_GET_MIN => &cam.min,
+                        super::UVC_GET_RES => &cam.res,
+                        _ => &cam.current,
+                    };
+                    for (slot, byte) in data.iter_mut().zip(source.iter()) {
+                        *slot = *byte;
+                    }
+                    Ok(())
+                }
+            })
+        })
+    }
 }
 
 /// GET_LEN bounds check: a plausible XU control reports 1..=64 payload bytes;
@@ -1270,9 +1448,17 @@ pub fn abort_requested() -> bool {
 /// but it covers it at the NEXT capture, which is minutes or a reboot away. This
 /// closes it now for every signal that can actually be caught.
 ///
-/// Installed without `SA_RESTART` on purpose: the blocking `VIDIOC_DQBUF` in the
-/// measurement loop then fails with `EINTR` instead of resuming, so the abort is
-/// noticed in milliseconds rather than at the end of a frame burst.
+/// Installed without `SA_RESTART`, which HELPS but cannot be relied on. A
+/// process-directed signal is delivered to an arbitrary thread that has it
+/// unblocked, and only that thread's syscall is interrupted (signal(7)); the
+/// daemon runs a watchdog, a listener and a connection thread besides the camera
+/// worker, so the frame wait may never see `EINTR` at all. An earlier version of
+/// this comment claimed the abort was therefore noticed in milliseconds, which
+/// was not true for any delivery that landed on another thread.
+///
+/// What makes the abort effective is that [`abort_requested`] is polled between
+/// frames and again immediately before each write to the camera, so the delay is
+/// bounded by one frame timeout rather than by which thread the kernel chose.
 ///
 /// `SIGKILL` and a power loss are exactly the cases a handler cannot reach. They
 /// are the record's job.
@@ -1354,6 +1540,21 @@ struct ExploratoryWrite {
     /// value is durably recorded in the configuration. Until then the record
     /// stays on disk and `Drop` still tries.
     resolved: bool,
+    /// Whether the exploratory value is KNOWN to be on the camera and the camera
+    /// is still answering.
+    ///
+    /// `Drop` writes only when this is true. Without it, an explicit restore that
+    /// failed was immediately retried by `Drop` on the way out: an ioctl error
+    /// from this unit is how this crate decides a camera has stopped answering,
+    /// and its own rule is that nothing further may be sent to it. Sending the
+    /// same request again to hardware just classified as unresponsive is the
+    /// #159 hazard, and it bypassed the attempt budget entirely, which only
+    /// governs later recovery passes.
+    ///
+    /// Every ioctl that returns an error clears it, because an error leaves the
+    /// state uncertain. The record stays open in that case, so the next capture
+    /// resolves it through recovery, where each attempt is counted and durable.
+    exploratory_value_is_live: bool,
 }
 
 impl ExploratoryWrite {
@@ -1400,7 +1601,32 @@ impl ExploratoryWrite {
             original: original.to_vec(),
             record,
             resolved: false,
+            // Nothing has been written yet.
+            exploratory_value_is_live: false,
         })
+    }
+
+    /// Put the exploratory value on the camera, arming the guard only if the
+    /// camera accepted it.
+    ///
+    /// Disarmed BEFORE the ioctl, armed after. An error in between leaves the
+    /// state uncertain, and the safe reading of uncertain is "do not send this
+    /// camera anything else".
+    fn apply_exploratory(&mut self, value: &[u8]) -> XuResult<()> {
+        self.exploratory_value_is_live = false;
+        set_cur(self.fd, self.unit, self.selector, value)?;
+        self.exploratory_value_is_live = true;
+        Ok(())
+    }
+
+    /// Put the original back, once.
+    ///
+    /// Disarms first either way: if this succeeds there is nothing left for
+    /// `Drop` to do, and if it fails `Drop` must not repeat it. The record stays
+    /// open until `confirm_restored` proves the control holds the original.
+    fn restore_once(&mut self) -> XuResult<()> {
+        self.exploratory_value_is_live = false;
+        set_cur(self.fd, self.unit, self.selector, &self.original)
     }
 
     /// Read the control back and drop the record only if it holds the original.
@@ -1441,14 +1667,19 @@ impl ExploratoryWrite {
 
 impl Drop for ExploratoryWrite {
     fn drop(&mut self) {
-        if self.resolved {
+        // `exploratory_value_is_live` is the whole difference between putting
+        // back a change this run is known to have made and poking a camera that
+        // has already failed to answer. Only the first is worth a write.
+        if self.resolved || !self.exploratory_value_is_live {
             return;
         }
+        self.exploratory_value_is_live = false;
         // Best effort, and deliberately quiet about its own failure: the record
         // is still on disk, so a failure here is recovered at the next capture
-        // rather than lost. What must not happen is leaving the control changed
-        // AND clearing the record, so the clear only runs behind a confirmed
-        // read-back.
+        // rather than lost — and there, unlike here, every attempt is counted
+        // and made durable before it is made. What must not happen is leaving
+        // the control changed AND clearing the record, so the clear only runs
+        // behind a confirmed read-back.
         if set_cur(self.fd, self.unit, self.selector, &self.original).is_ok() {
             let _ = self.confirm_restored();
         }
@@ -1944,6 +2175,7 @@ impl Discovered {
 /// an operation that already spends seconds on camera I/O, and discovery returns
 /// exactly one of these per run.
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 enum Attempt {
     /// Lit, and still holding the applied value, with its undo record open.
     Lit(EmitterControl, ExploratoryWrite),
@@ -1955,6 +2187,7 @@ enum Attempt {
     NotUsable(String),
 }
 
+#[derive(Debug)]
 enum TryFailure {
     Query(XuError),
     Restore(XuError),
@@ -2029,15 +2262,27 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     // it. `pending` also restores the control from `Drop`, which covers the
     // paths no statement below can — a panic in the decoder, or an ioctl error
     // taken by `?`.
+    // Re-checked here, not only inside `measure`. A process-directed signal is
+    // delivered to an ARBITRARY thread that has it unblocked, and the daemon has
+    // several; the camera worker's frame wait may never see EINTR at all. So the
+    // abort is polled again at each point that is about to change the camera,
+    // rather than relied on to interrupt a syscall.
+    if abort_requested() {
+        return Err(TryFailure::Measurement);
+    }
+
     let mut pending = ExploratoryWrite::open(fd, id, unit, selector, len, &original, &wanted)
         .map_err(TryFailure::Journal)?;
 
-    set_cur(fd, unit, selector, &wanted)?;
+    if abort_requested() {
+        return Err(TryFailure::Measurement);
+    }
+    pending.apply_exploratory(&wanted)?;
     let Some(lit) = measure() else {
         // The stream died after the control was changed. Aborting without
         // putting it back would leave the camera altered by a run that
         // concluded nothing.
-        set_cur(fd, unit, selector, &original).map_err(TryFailure::Restore)?;
+        pending.restore_once().map_err(TryFailure::Restore)?;
         pending.confirm_restored().map_err(TryFailure::Journal)?;
         return Err(TryFailure::Measurement);
     };
@@ -2048,7 +2293,7 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     // lighting, and the same camera here has measured 38 to 168 depending only
     // on what was in front of it.
     if lit < before + AUTOCONF_MIN_LIFT {
-        set_cur(fd, unit, selector, &original).map_err(TryFailure::Restore)?;
+        pending.restore_once().map_err(TryFailure::Restore)?;
         pending.confirm_restored().map_err(TryFailure::Journal)?;
         return Ok(Attempt::NotUsable(format!(
             "the image did not brighten (before {before:.0}, after {lit:.0}, needs +{AUTOCONF_MIN_LIFT:.0})"
@@ -2059,7 +2304,7 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     // or an exposure transition produces the same twenty points as a working
     // illuminator. Put the control back and require the brightness to fall with
     // it: a change that does not follow the control is not caused by it.
-    set_cur(fd, unit, selector, &original).map_err(TryFailure::Restore)?;
+    pending.restore_once().map_err(TryFailure::Restore)?;
     let Some(after_restore) = measure() else {
         return Err(TryFailure::Measurement);
     };
@@ -2081,7 +2326,10 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     // The record stays OPEN. The camera is deliberately changed from here on,
     // and until `save_conf` records which control did it there is still nothing
     // on disk that could put it back. `Discovered::committed` closes it.
-    set_cur(fd, unit, selector, &wanted)?;
+    if abort_requested() {
+        return Err(TryFailure::Measurement);
+    }
+    pending.apply_exploratory(&wanted)?;
     Ok(Attempt::Lit(
         EmitterControl {
             unit,
@@ -2509,6 +2757,272 @@ mod tests {
                 "logging for {outcome:?}"
             );
         }
+    }
+
+    /// Drive one whole `try_documented_control` run against a stand-in camera.
+    ///
+    /// Returns the ordered request log and the value the control ends up
+    /// holding. `IRLUME_STATE_DIR` points at a scratch directory so the undo
+    /// record is real.
+    fn run_discovery(
+        camera: fake_camera::Camera,
+        tag: &str,
+        mut measure: impl FnMut() -> Option<f32>,
+    ) -> (
+        std::result::Result<Attempt, TryFailure>,
+        Vec<fake_camera::Request>,
+        Vec<u8>,
+        std::path::PathBuf,
+    ) {
+        let dir = std::env::temp_dir().join(format!("irlume-discovery-{tag}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _fake = fake_camera::install(camera);
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+        // fd is never reached: the fake intercepts before the ioctl.
+        let outcome = try_documented_control(-1, &id, ms.unit_id, selector, &mut measure);
+        (outcome, fake_camera::log(), fake_camera::current(), dir)
+    }
+
+    /// A camera shaped like the two this module was validated against: they
+    /// report `GET_MAX 01 03 03` and `GET_DEF 01 03 01`, from which
+    /// `face_auth_payload` derives `01 03 02`. Using the real numbers means the
+    /// run reaches a write for the same reason a real one does.
+    fn a_working_camera() -> fake_camera::Camera {
+        fake_camera::Camera {
+            current: vec![1, 3, 1],
+            len: 3,
+            // D0 get + D1 set, and none of the disabled bits.
+            info: 0b0000_0011,
+            def: vec![1, 3, 1],
+            max: vec![1, 3, 3],
+            min: vec![0, 0, 0],
+            res: vec![1, 1, 1],
+            ..Default::default()
+        }
+    }
+
+    /// The undo record reaches disk BEFORE the first byte is written to the
+    /// camera. This is the ordering the whole module exists for, and until a
+    /// stand-in camera existed nothing without hardware could observe it.
+    #[test]
+    fn the_undo_record_is_on_disk_before_the_first_write() {
+        let _lock = crate::testenv::env_lock();
+        let mut brightness = [10.0f32, 90.0, 10.0].into_iter();
+        let (_outcome, log, _current, dir) =
+            run_discovery(a_working_camera(), "record-first", move || {
+                brightness.next()
+            });
+
+        let first_write = log
+            .iter()
+            .position(|r| matches!(r, fake_camera::Request::Set(_)))
+            .expect("discovery must have written something, or this proves nothing");
+        // The record is written inside `ExploratoryWrite::open`, which runs
+        // before that write. Its presence on disk at the moment of the write is
+        // what a crash would depend on, so the store is checked to have been
+        // created rather than the call merely to have been made.
+        assert!(
+            dir.join("ir-emitter-journal").exists(),
+            "the store must exist by the end of a run that wrote to the camera"
+        );
+        assert!(first_write > 0, "reads precede the first write");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A camera that refuses the restoring write must not be written to again.
+    ///
+    /// The guard's `Drop` used to repeat the identical `SET_CUR` on the way out,
+    /// against hardware this crate had just classified as unresponsive, and
+    /// outside the attempt budget entirely. That is the #159 hazard: the rule
+    /// here is that after an error nothing further is sent.
+    #[test]
+    fn a_camera_that_refuses_a_restore_is_not_written_to_again() {
+        let _lock = crate::testenv::env_lock();
+        // Accept the exploratory write, then fail every write after it.
+        let camera = fake_camera::Camera {
+            fail_set_from: Some((2, libc::EIO)),
+            ..a_working_camera()
+        };
+        // Bright, then the stream dies, which is the path that restores.
+        let mut brightness = [10.0f32].into_iter();
+        let (outcome, log, _current, dir) =
+            run_discovery(camera, "restore-refused", move || brightness.next());
+
+        assert!(
+            matches!(outcome, Err(TryFailure::Restore(_))),
+            "the refused restore is what the run reports"
+        );
+        let writes = log
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set(_)))
+            .count();
+        assert_eq!(
+            writes, 2,
+            "one exploratory write and one restore attempt, and nothing after the refusal: {log:?}"
+        );
+        // The record stays, so the next capture resolves it through recovery,
+        // where every attempt is counted and durable before it is made.
+        let store = dir.join("ir-emitter-journal");
+        let remaining = std::fs::read_dir(&store)
+            .map(|d| d.count())
+            .unwrap_or_default();
+        assert_eq!(remaining, 1, "the undo record is left for recovery");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A camera that refuses the FIRST write has not been changed, so there is
+    /// nothing for `Drop` to put back and it must send nothing.
+    #[test]
+    fn a_refused_first_write_produces_no_second_one() {
+        let _lock = crate::testenv::env_lock();
+        let camera = fake_camera::Camera {
+            fail_set_from: Some((1, libc::EIO)),
+            ..a_working_camera()
+        };
+        let mut brightness = [10.0f32].into_iter();
+        let (outcome, log, current, dir) =
+            run_discovery(camera, "first-write-refused", move || brightness.next());
+
+        assert!(matches!(outcome, Err(TryFailure::Query(_))), "{outcome:?}");
+        let writes = log
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set(_)))
+            .count();
+        assert_eq!(
+            writes, 1,
+            "exactly one write, which the camera refused: {log:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1], "the control was never changed");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A run that stops early because the signal flag is set must not have
+    /// written to the camera at all.
+    ///
+    /// The flag is polled directly before each write rather than relied on to
+    /// interrupt a frame wait: a process-directed signal goes to an arbitrary
+    /// thread, so the camera worker may never see EINTR.
+    #[test]
+    fn an_abort_before_the_first_write_sends_the_camera_nothing() {
+        let _lock = crate::testenv::env_lock();
+        // Measurement succeeds; the abort is what stops the run.
+        let guard = AbortOnSignal::install();
+        ABORT_SIGNAL.store(libc::SIGTERM, std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            abort_requested(),
+            "the flag must be set for this to mean anything"
+        );
+
+        let (outcome, log, current, dir) =
+            run_discovery(a_working_camera(), "abort-first", || Some(10.0));
+
+        // Take the flag back before the guard drops, so nothing is re-raised at
+        // the test binary.
+        ABORT_SIGNAL.store(0, std::sync::atomic::Ordering::SeqCst);
+        drop(guard);
+
+        assert!(
+            matches!(outcome, Err(TryFailure::Measurement)),
+            "{outcome:?}"
+        );
+        assert!(
+            !log.iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no write may reach a camera after a stop signal: {log:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Recovery sizes its `GET_CUR` from the length the CAMERA reports, never
+    /// from the record.
+    ///
+    /// The three queries used to sit in one tuple, and a tuple evaluates every
+    /// operand before the match runs: a record claiming 64 bytes against a
+    /// camera reporting 3 sent a 64-byte control request to firmware, and only
+    /// afterwards was the mismatch noticed. This is an ordering between two
+    /// ioctls, so the request log is the only thing that can show it.
+    #[test]
+    fn recovery_asks_the_camera_its_length_before_reading_the_control() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-recovery-length");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        // A record that claims a 64-byte control, against a camera that says 3.
+        let record = crate::emitter_journal::PendingWrite {
+            schema_version: crate::emitter_journal::SCHEMA_VERSION,
+            engine_version: "test".into(),
+            descriptor_sha256: crate::emitter_journal::fingerprint(&id),
+            usb_id: id.usb_id(),
+            interface_number: id.interface_number,
+            unit: ms.unit_id,
+            selector,
+            len: 64,
+            original: crate::emitter_journal::to_hex(&[0u8; 64]),
+            attempted: crate::emitter_journal::to_hex(&[1u8; 64]),
+            restore_attempts: 0,
+            boot_id: None,
+            pid: None,
+            serial: id.serial.clone(),
+            usb_devpath: id.usb_devpath.clone(),
+        };
+        crate::emitter_journal::save(&record).expect("plant the record");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let outcome = recover_pending_write(-1, &id);
+        let log = fake_camera::log();
+
+        assert!(
+            matches!(outcome, RecoveryOutcome::Unresolved(_)),
+            "a length the camera contradicts is unresolved: {outcome:?}"
+        );
+        assert!(
+            !log.iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "nothing is written: {log:?}"
+        );
+        assert!(
+            !log.iter().any(|r| matches!(
+                r,
+                fake_camera::Request::Get {
+                    query: UVC_GET_CUR,
+                    ..
+                }
+            )),
+            "the control is never read once its length is contradicted: {log:?}"
+        );
+        // And the guard has to be reachable: the camera really was asked.
+        assert!(
+            log.iter().any(|r| matches!(
+                r,
+                fake_camera::Request::Get {
+                    query: UVC_GET_LEN,
+                    ..
+                }
+            )),
+            "GET_LEN must have been issued, or this proves nothing: {log:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// An unresolved record stops ALL THREE of the sources a capture can apply

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2942,7 +2942,48 @@ mod tests {
                 true,
                 true,
             ),
+            // Another irlume process holds this camera. Silent, and it stops
+            // both writers: it is being looked after already.
+            (RecoveryOutcome::Busy, false, true, false),
+            // A same-model record this run cannot confirm belongs here.
+            (
+                RecoveryOutcome::Unconfirmed {
+                    unit: 14,
+                    selector: 6,
+                    original: "010301".into(),
+                    recorded_at: "/devices/pci0000:00/0000:00:14.0/usb3/3-5".into(),
+                },
+                false,
+                true,
+                true,
+            ),
         ];
+
+        // The comment above this test used to claim a table made "adding a
+        // variant without deciding its policy impossible to miss", and then two
+        // variants were added and missed exactly that way. A comment cannot
+        // enforce anything. This match can: it is exhaustive, so a new variant
+        // stops the crate compiling until somebody writes down what it means.
+        fn stated_policy(outcome: &RecoveryOutcome) -> (bool, bool) {
+            match outcome {
+                RecoveryOutcome::NothingPending => (true, false),
+                RecoveryOutcome::ForAnotherCamera => (true, false),
+                RecoveryOutcome::AlreadyRestored => (true, false),
+                RecoveryOutcome::Restored { .. } => (true, false),
+                RecoveryOutcome::RestoredRecordKept(_) => (true, true),
+                RecoveryOutcome::OwnerStillRunning { .. } => (false, true),
+                RecoveryOutcome::Busy => (false, true),
+                RecoveryOutcome::Unresolved(_) => (false, true),
+                RecoveryOutcome::Unconfirmed { .. } => (false, true),
+            }
+        }
+        for (outcome, may_write, blocks, _) in &table {
+            assert_eq!(
+                stated_policy(outcome),
+                (*may_write, *blocks),
+                "the table and the exhaustive statement disagree for {outcome:?}"
+            );
+        }
         for (outcome, may_write, blocks, logged) in table {
             assert_eq!(
                 outcome.permits_capture_write(),

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -477,6 +477,11 @@ pub(crate) mod fake_camera {
         /// it. Models a camera that stops answering, which is the state this
         /// module must send nothing further to.
         pub(crate) fail_set_from: Option<(usize, i32)>,
+        /// Fail every `GET_CUR` from now on. A camera can stop answering a READ
+        /// too, and what the code must do about it differs: an ioctl error means
+        /// send nothing further, while a value that merely disagrees means the
+        /// control still needs putting back.
+        pub(crate) fail_get_cur: Option<i32>,
         /// `SET_CUR`s seen so far, so `fail_set_from` can count.
         pub(crate) sets_seen: usize,
         /// Run at the instant the first `SET_CUR` is intercepted, before it is
@@ -520,6 +525,15 @@ pub(crate) mod fake_camera {
                 .map(|cam| cam.log.clone())
                 .unwrap_or_default()
         })
+    }
+
+    /// Make every later `GET_CUR` fail.
+    pub(crate) fn fail_reads(errno: i32) {
+        CAMERA.with(|c| {
+            if let Some(cam) = c.borrow_mut().as_mut() {
+                cam.fail_get_cur = Some(errno);
+            }
+        });
     }
 
     /// Force what the control reports, without a write.
@@ -607,6 +621,9 @@ pub(crate) mod fake_camera {
                         query,
                         size: data.len(),
                     });
+                    if let Some(errno) = cam.fail_get_cur {
+                        return Some(Err(XuError::from_errno(errno)));
+                    }
                     for (slot, byte) in data.iter_mut().zip(cam.current.iter()) {
                         *slot = *byte;
                     }
@@ -1730,17 +1747,34 @@ impl ExploratoryWrite {
     /// this module exists to prevent, so until the configuration lands the
     /// record stays open and the guard would put the control back.
     ///
-    /// The read-back is not optional here either. This used to clear on the
-    /// strength of the final `SET_CUR` returning success, which is exactly the
-    /// assumption the rest of this module refuses to make: a camera that clamps
-    /// the value, applies it partly, or answers success while holding something
-    /// else would have had the only copy of its original bytes deleted, and
-    /// `ir_emitter.conf` stores coordinates and no payload, so nothing else
-    /// holds them. Returning an error leaves the guard armed, so `Discovered`
-    /// dropping puts the original back and confirms THAT.
     fn commit(&mut self) -> Result<(), String> {
-        let now = get_cur(self.fd, self.unit, self.selector, self.attempted.len())
-            .map_err(|e| format!("read the applied control back: {e}"))?;
+        crate::emitter_journal::clear(&self.record)?;
+        self.resolved = true;
+        Ok(())
+    }
+
+    /// Confirm the camera is holding the value this run applied.
+    ///
+    /// Called BEFORE the configuration is written, not after. A `SET_CUR`
+    /// returning success says the ioctl was accepted, not that the control holds
+    /// those bytes, and this is the last chance to find out before anything
+    /// durable is published about it. Ordering the other way round installed the
+    /// configuration first, so a failed verification still left a file naming
+    /// this control for every later capture to apply automatically — which is
+    /// the write the verification exists to prevent.
+    ///
+    /// An ioctl error disarms the guard: the camera has just failed to answer,
+    /// and this module's rule is that nothing further is sent to a camera in
+    /// that state. A value mismatch does NOT disarm it, because there the camera
+    /// is answering fine and the control genuinely needs putting back.
+    fn confirm_applied(&mut self) -> Result<(), String> {
+        let now = match get_cur(self.fd, self.unit, self.selector, self.attempted.len()) {
+            Ok(now) => now,
+            Err(e) => {
+                self.exploratory_value_is_live = false;
+                return Err(format!("read the applied control back: {e}"));
+            }
+        };
         crate::emitter_journal::trace(&format!("read back applied {now:02x?}"));
         if now != self.attempted {
             return Err(format!(
@@ -1748,8 +1782,6 @@ impl ExploratoryWrite {
                 self.attempted
             ));
         }
-        crate::emitter_journal::clear(&self.record)?;
-        self.resolved = true;
         Ok(())
     }
 }
@@ -2300,9 +2332,40 @@ impl Discovered {
         &self.control
     }
 
+    /// Confirm the camera is holding what this run applied.
+    ///
+    /// Call BEFORE writing the configuration. Failing here drops `self`, which
+    /// puts the control back, and nothing durable has been published about it.
+    pub fn confirm_applied(&mut self) -> std::result::Result<(), String> {
+        self.pending.confirm_applied()
+    }
+
     /// Release the undo record. Call only once the configuration naming this
     /// control is durable.
     pub fn committed(mut self) -> std::result::Result<(), String> {
+        self.pending.commit()
+    }
+
+    /// Confirm, publish, release — in that order, as one step.
+    ///
+    /// The order is the whole point and it lived in the caller, where nothing
+    /// without a real camera could reach it: a mutant deleting the confirmation
+    /// survived the entire suite because the test that covers this reproduced
+    /// the sequence itself instead of running the one that ships. As a method it
+    /// is reachable with a stand-in camera, so the ordering is asserted on the
+    /// code the daemon actually executes.
+    ///
+    /// Confirmation first, because publishing a configuration for a control the
+    /// camera did not take leaves a file every later capture applies. The record
+    /// last, because until the configuration is durable the camera is changed
+    /// with nothing saying which control did it, and dropping `self` unresolved
+    /// puts it back.
+    pub fn finish(
+        mut self,
+        id: &crate::uvc_descriptor::CameraIdentity,
+    ) -> std::result::Result<(), String> {
+        self.pending.confirm_applied()?;
+        save_conf(id, &self.control).map_err(|e| format!("save the emitter config: {e}"))?;
         self.pending.commit()
     }
 }
@@ -3044,11 +3107,17 @@ mod tests {
         // accepted SET_CUR, so this is forced directly.
         fake_camera::set_current(vec![1, 3, 3]);
 
-        let err = pending.commit().expect_err("commit must not accept this");
+        let err = pending
+            .confirm_applied()
+            .expect_err("an unconfirmed control must not be accepted");
         assert!(err.contains("[01, 03, 03]"), "{err}");
         assert!(
             !pending.resolved,
             "an unconfirmed control leaves the guard armed so Drop restores it"
+        );
+        assert!(
+            pending.exploratory_value_is_live,
+            "the camera is answering, so the control still needs putting back"
         );
 
         let store = dir.join("ir-emitter-journal");
@@ -3058,6 +3127,195 @@ mod tests {
             "the undo record must survive: nothing else holds the original bytes"
         );
         drop(pending);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A failed verification leaves NO configuration behind.
+    ///
+    /// Drives `Discovered::finish`, the sequence the daemon actually runs, not a
+    /// copy of it: an earlier version of this test reproduced the ordering
+    /// itself, so a mutant deleting the confirmation from the shipped path
+    /// survived the whole suite. `save_conf` used to run first, and a camera that
+    /// did not take the final write still ended up named in a file every later
+    /// capture applies, which is the write the verification exists to prevent.
+    #[test]
+    fn a_failed_verification_publishes_no_configuration() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-verify-order");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let conf = dir.join("ir_emitter.conf");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let _confenv = EnvGuard::set("IRLUME_IR_EMITTER_CONF", &conf);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let mut pending =
+            ExploratoryWrite::open(-1, &id, ms.unit_id, selector, 3, &[1, 3, 1], &[1, 3, 2])
+                .expect("open the record");
+        pending
+            .apply_exploratory(&[1, 3, 2])
+            .expect("write accepted");
+
+        let found = Discovered {
+            control: EmitterControl {
+                unit: ms.unit_id,
+                selector,
+                payload: vec![1, 3, 2],
+            },
+            pending,
+            _lock: crate::emitter_journal::lock_camera(&id)
+                .expect("lock")
+                .expect("not busy"),
+        };
+
+        // The camera quietly holds something else.
+        fake_camera::set_current(vec![1, 3, 3]);
+        let err = found.finish(&id).expect_err("finish must refuse");
+
+        assert!(err.contains("[01, 03, 03]"), "{err}");
+        assert!(
+            !conf.exists(),
+            "a control the camera did not take must not be named in a config \
+             that every later capture applies"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The same sequence, succeeding: the config lands and the record goes.
+    ///
+    /// Without this the assertion above would pass on a `finish` that never
+    /// wrote a config at all.
+    #[test]
+    fn a_confirmed_application_publishes_the_config_and_drops_the_record() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-verify-order-ok");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let conf = dir.join("ir_emitter.conf");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let _confenv = EnvGuard::set("IRLUME_IR_EMITTER_CONF", &conf);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let mut pending =
+            ExploratoryWrite::open(-1, &id, ms.unit_id, selector, 3, &[1, 3, 1], &[1, 3, 2])
+                .expect("open the record");
+        pending
+            .apply_exploratory(&[1, 3, 2])
+            .expect("write accepted");
+
+        let found = Discovered {
+            control: EmitterControl {
+                unit: ms.unit_id,
+                selector,
+                payload: vec![1, 3, 2],
+            },
+            pending,
+            _lock: crate::emitter_journal::lock_camera(&id)
+                .expect("lock")
+                .expect("not busy"),
+        };
+        found.finish(&id).expect("the camera took the write");
+
+        assert_eq!(
+            std::fs::read_to_string(&conf).expect("the config must be written"),
+            format!("{} {}:{selector}", id.usb_id(), ms.unit_id)
+        );
+        assert_eq!(
+            std::fs::read_dir(dir.join("ir-emitter-journal"))
+                .map(|d| d
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+                    .count())
+                .unwrap_or(0),
+            0,
+            "the record is released once the config is durable"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A camera that stops answering a READ during verification is not written
+    /// to again either.
+    ///
+    /// An ioctl error is how this module decides a camera has stopped answering,
+    /// and its rule is that nothing further is sent to one in that state. The
+    /// verification's failure path has to disarm the guard for the same reason
+    /// the write paths do, or `Drop` sends a restore to hardware that has just
+    /// failed to respond.
+    ///
+    /// A mismatched VALUE is the opposite case and must keep the guard armed:
+    /// there the camera is answering and the control genuinely needs putting
+    /// back. Both are asserted here so neither can be traded for the other.
+    #[test]
+    fn a_camera_that_stops_answering_during_verification_is_left_alone() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-verify-read-fails");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let mut pending =
+            ExploratoryWrite::open(-1, &id, ms.unit_id, selector, 3, &[1, 3, 1], &[1, 3, 2])
+                .expect("open the record");
+        pending
+            .apply_exploratory(&[1, 3, 2])
+            .expect("write accepted");
+        let writes_before = fake_camera::log()
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set(_)))
+            .count();
+
+        fake_camera::fail_reads(libc::EIO);
+        pending
+            .confirm_applied()
+            .expect_err("a camera that will not answer cannot confirm anything");
+        assert!(
+            !pending.exploratory_value_is_live,
+            "an ioctl error must disarm the guard"
+        );
+
+        drop(pending);
+        let writes_after = fake_camera::log()
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set(_)))
+            .count();
+        assert_eq!(
+            writes_after, writes_before,
+            "nothing further may be sent to a camera that stopped answering"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -3279,24 +3537,28 @@ mod tests {
         ));
         drop(held);
 
+        // The child signals readiness by creating a marker AFTER `flock` has
+        // granted it the lock. Inferring readiness by racing it for the lock
+        // instead made this test timing-dependent: on a loaded machine the
+        // child had not started yet, our own attempt succeeded, and the test
+        // failed with nothing wrong in the code.
+        let ready = dir.join("holder-has-the-lock");
         let mut holder = std::process::Command::new("flock")
-            .args([path.to_str().expect("path"), "-c", "sleep 30"])
+            .args([
+                path.to_str().expect("path"),
+                "-c",
+                &format!("touch {}; sleep 30", ready.display()),
+            ])
             .spawn()
             .expect("spawn the lock holder");
 
-        // Wait for the child to actually hold it, rather than assuming it does:
-        // asserting against a lock nobody took is the vacuous version of this
-        // test. Bounded so a failure to acquire fails the test instead of
-        // hanging it.
         let mut taken = false;
-        for _ in 0..200 {
-            match crate::emitter_journal::lock_camera(&id) {
-                Ok(None) => {
-                    taken = true;
-                    break;
-                }
-                _ => std::thread::sleep(std::time::Duration::from_millis(25)),
+        for _ in 0..600 {
+            if ready.exists() {
+                taken = true;
+                break;
             }
+            std::thread::sleep(std::time::Duration::from_millis(25));
         }
 
         let (outcome, log) = if taken {
@@ -3476,6 +3738,13 @@ mod tests {
     /// sends someone hunting through the wrong subsystem.
     #[test]
     fn a_refusal_says_the_emitter_will_not_light() {
+        // The message embeds `store_dir()`, which reads `IRLUME_STATE_DIR`. Read
+        // once here and once in the assertion, with other tests flipping that
+        // variable in the same process, the two could disagree and this failed
+        // for reasons having nothing to do with the message. It showed up as a
+        // test that "caught" unrelated mutants.
+        let _lock = crate::testenv::env_lock();
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", "/var/lib/irlume-message-test");
         let msg = RecoveryOutcome::Unresolved("the control reads [1, 3, 2]".into())
             .message()
             .expect("a refusal is always reported");

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2009,22 +2009,46 @@ fn recover_pending_write_locked(
             //
             // A syscall-sized window remains and cannot be closed here: UVC
             // offers no compare-and-set. What is claimed is narrowed to match.
+            // A pass that decides NOT to write must not spend an attempt. The
+            // counter means "times the original was written back", and three
+            // refusals that touched nothing would otherwise exhaust the budget
+            // and leave the emitter off for good over writes that never
+            // happened. The count is put back before returning.
+            //
+            // Rolling back can itself fail, and then the count stays high. That
+            // direction is the safe one: too few retries leaves a reported,
+            // recoverable record, while too many is what the budget exists to
+            // prevent.
+            let give_back = |outcome: RecoveryOutcome| -> RecoveryOutcome {
+                match journal::save_at(&record_path, &record) {
+                    Ok(_) => outcome,
+                    Err(why) => RecoveryOutcome::Unresolved(format!(
+                        "{}; and the unused attempt could not be given back ({why})",
+                        match &outcome {
+                            RecoveryOutcome::Unresolved(w) => w.clone(),
+                            other => format!("{other:?}"),
+                        }
+                    )),
+                }
+            };
             let attempted = match journal::from_hex(&record.attempted) {
                 Ok(bytes) => bytes,
-                Err(why) => return RecoveryOutcome::Unresolved(format!("attempted: {why}")),
+                Err(why) => {
+                    return give_back(RecoveryOutcome::Unresolved(format!("attempted: {why}")))
+                }
             };
             match get_cur(fd, record.unit, record.selector, original.len()) {
                 Ok(now) if now == attempted => {}
                 Ok(now) => {
-                    return RecoveryOutcome::Unresolved(format!(
+                    return give_back(RecoveryOutcome::Unresolved(format!(
                         "the control changed while the attempt was being recorded: it holds \
                          {now:02x?}, not this run's value {attempted:02x?}; nothing was written"
-                    ))
+                    )))
                 }
                 Err(e) => {
-                    return RecoveryOutcome::Unresolved(format!(
+                    return give_back(RecoveryOutcome::Unresolved(format!(
                         "recheck the control before restoring it: {e}"
-                    ))
+                    )))
                 }
             }
 
@@ -4103,6 +4127,81 @@ mod tests {
         assert_eq!(
             left, 0,
             "one operation must not leave a second record behind"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A refusal that writes nothing does not spend an attempt.
+    ///
+    /// The counter is incremented before the write so a kill during the write is
+    /// counted. But the re-read that follows can refuse, and then nothing was
+    /// written: three such passes would exhaust the budget and leave the emitter
+    /// off for good over writes that never happened. The count goes back.
+    #[test]
+    fn a_refusal_that_writes_nothing_gives_the_attempt_back() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-attempt-giveback");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        let record = crate::emitter_journal::PendingWrite {
+            schema_version: crate::emitter_journal::SCHEMA_VERSION,
+            engine_version: "test".into(),
+            descriptor_sha256: crate::emitter_journal::fingerprint(&id),
+            usb_id: id.usb_id(),
+            interface_number: id.interface_number,
+            unit: ms.unit_id,
+            selector,
+            len: 3,
+            original: crate::emitter_journal::to_hex(&[1, 3, 1]),
+            attempted: crate::emitter_journal::to_hex(&[1, 3, 2]),
+            restore_attempts: 0,
+            boot_id: None,
+            pid: None,
+            serial: id.serial.clone(),
+            usb_devpath: id.usb_devpath.clone(),
+        };
+        let path = crate::emitter_journal::save(&record).expect("plant");
+
+        // Authorises on the first read, then something else moves the control
+        // before the re-read.
+        let camera = fake_camera::Camera {
+            current: vec![1, 3, 2],
+            change_after_gets: Some((1, vec![1, 3, 3])),
+            ..a_working_camera()
+        };
+        let _fake = fake_camera::install(camera);
+
+        let outcome = recover_pending_write(-1, &id);
+        assert!(
+            matches!(outcome, RecoveryOutcome::Unresolved(_)),
+            "{outcome:?}"
+        );
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "nothing was written, so nothing should have been spent"
+        );
+
+        let after: crate::emitter_journal::PendingWrite =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read back"))
+                .expect("parse");
+        assert_eq!(
+            after.restore_attempts, 0,
+            "an attempt that wrote nothing must be given back"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1891,6 +1891,34 @@ pub(crate) fn recover_pending_write(
 }
 
 /// The recovery pass proper. The caller holds this camera's lock.
+/// Whether a counted attempt may be followed by a firmware write.
+///
+/// Separated from the write that produces it so the decision can be exercised.
+/// Nothing here can make a directory `fsync` fail, so a test going through
+/// `save_at` cannot reach the middle arm and a mutant deleting it survives; the
+/// outcome is a value, and the decision made about that value is testable even
+/// when the condition producing it is not reachable.
+fn counted_attempt_authorizes_write(
+    saved: Result<(std::path::PathBuf, irlume_common::AtomicWrite), String>,
+) -> Result<(), String> {
+    match saved {
+        Ok((_, irlume_common::AtomicWrite::Durable)) => Ok(()),
+        // The attempt limit exists to bound firmware writes ACROSS CRASHES, so a
+        // count a power loss can revert bounds nothing: the old record comes
+        // back with the lower number and the same restore runs again, past the
+        // limit. The increment IS visible, so refusing may cost an attempt with
+        // no write ever made — at most MAX_RESTORE_ATTEMPTS refusals, against
+        // unbounded writes to somebody's camera.
+        Ok((_, irlume_common::AtomicWrite::VisibleNotDurable(e))) => Err(format!(
+            "count the attempt: the updated record is visible but not durable ({e}); \
+             refusing the write"
+        )),
+        // Nothing became visible, so nothing was spent and nothing may be
+        // written: an uncounted write is the loop the counter exists to stop.
+        Err(why) => Err(format!("count the attempt: {why}")),
+    }
+}
+
 fn recover_pending_write_locked(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
@@ -2006,20 +2034,10 @@ fn recover_pending_write_locked(
             // To the path the record was FOUND at, not the one its contents
             // derive: a scanned record need not be filed under its own name, and
             // deriving here wrote the incremented record to a second file.
-            match journal::save_at(&record_path, &spent) {
-                // Durable, or published-but-not-durable: either way the
-                // incremented count IS what a reader sees, so the write below is
-                // accounted for. An error after the rename does not un-publish
-                // it, and treating that as "nothing was counted" spent an
-                // attempt on a pass that then refused to write — three of those
-                // and the emitter is off for good.
-                Ok(_) => {}
-                Err(why) => {
-                    // Nothing became visible, so nothing was spent and nothing
-                    // may be written: an uncounted write is the loop the counter
-                    // exists to stop.
-                    return RecoveryOutcome::Unresolved(format!("count the attempt: {why}"));
-                }
+            if let Err(why) =
+                counted_attempt_authorizes_write(journal::save_at(&record_path, &spent))
+            {
+                return RecoveryOutcome::Unresolved(why);
             }
 
             // Read the control AGAIN, immediately before writing it.
@@ -4099,6 +4117,47 @@ mod tests {
             "the control must be re-read immediately before the write: {log:?}"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A restoring write needs an attempt counted DURABLY, not merely visibly.
+    ///
+    /// The limit exists to bound firmware writes across crashes. A count that a
+    /// power loss reverts bounds nothing: the old record returns with the lower
+    /// number and the same restore runs again, past the limit. This reverses an
+    /// earlier fix of mine that read "visible" as good enough here — it is good
+    /// enough to say an attempt was SPENT, and not good enough to authorize the
+    /// write that spends it.
+    #[test]
+    fn a_restore_needs_the_attempt_counted_durably_not_just_visibly() {
+        let path = std::path::PathBuf::from("/var/lib/irlume/ir-emitter-journal/x.json");
+        assert_eq!(
+            counted_attempt_authorizes_write(Ok((
+                path.clone(),
+                irlume_common::AtomicWrite::Durable
+            ))),
+            Ok(()),
+            "the ordinary durable path must still authorize the write"
+        );
+
+        let why = counted_attempt_authorizes_write(Ok((
+            path,
+            irlume_common::AtomicWrite::VisibleNotDurable(std::io::Error::other("no space")),
+        )))
+        .expect_err("a count a power loss can revert must NOT authorize a firmware write");
+        assert!(
+            why.contains("visible but not durable") && why.contains("refusing"),
+            "the refusal must say why, got: {why}"
+        );
+        assert!(
+            why.contains("no space"),
+            "the underlying error must survive into the message, got: {why}"
+        );
+
+        // And nothing published at all is also a refusal, but for the other
+        // reason: no attempt was spent, so a write here would be uncounted.
+        let why = counted_attempt_authorizes_write(Err("disk full".into()))
+            .expect_err("an unwritten record must not authorize a write either");
+        assert!(why.contains("disk full"), "got: {why}");
     }
 
     /// Somebody else moves the control while setup is measuring, and setup

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -219,13 +219,24 @@ pub fn save_conf(
     ctrl: &EmitterControl,
 ) -> std::io::Result<()> {
     let path = conf_path();
-    if let Some(dir) = path.parent() {
-        std::fs::create_dir_all(dir)?;
-    }
-    std::fs::write(
+    let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    std::fs::create_dir_all(dir)?;
+    // Atomic and fsynced, because the undo record is dropped on the strength of
+    // this call returning. `std::fs::write` closes the file without syncing
+    // anything, so a successful return only meant the bytes were in the page
+    // cache: a power loss immediately afterwards left the record durably GONE
+    // and the configuration naming the control that is now lit possibly absent.
+    // `commit` says it is called once the configuration is durable, and that was
+    // not true of what it was called after.
+    //
+    // 0644, the mode this file has always had. It names a camera and a control
+    // number, nothing secret, and the diagnostic script reads it as the user.
+    irlume_common::write_atomic_mode(
         &path,
-        format!("{} {}:{}", id.usb_id(), ctrl.unit, ctrl.selector),
-    )
+        format!("{} {}:{}", id.usb_id(), ctrl.unit, ctrl.selector).as_bytes(),
+        0o644,
+    )?;
+    irlume_common::fsync_ancestors(dir).map_err(std::io::Error::other)
 }
 
 /// Parse `unit:selector:b,b,b,...` (decimal or `0x` hex bytes).
@@ -406,10 +417,18 @@ pub(crate) mod fake_camera {
     /// One request the code under test made, in order.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub(crate) enum Request {
-        Get { query: u8, size: usize },
+        Get {
+            query: u8,
+            size: usize,
+        },
         Set(Vec<u8>),
+        /// A check installed as `at_first_write` failed. Recorded rather than
+        /// panicked so the assertion belongs to the test, not to the fake.
+        FailedPrecondition(String),
     }
 
+    // `at_first_write` is a boxed closure, so this cannot derive Debug. Nothing
+    // needs it to.
     #[derive(Default)]
     pub(crate) struct Camera {
         /// What `GET_CUR` answers. Updated by an accepted `SET_CUR`, like a real
@@ -433,6 +452,17 @@ pub(crate) mod fake_camera {
         pub(crate) fail_set_from: Option<(usize, i32)>,
         /// `SET_CUR`s seen so far, so `fail_set_from` can count.
         pub(crate) sets_seen: usize,
+        /// Run at the instant the first `SET_CUR` is intercepted, before it is
+        /// recorded or applied.
+        ///
+        /// The only way to observe "the record was on disk BEFORE the camera was
+        /// written to". Checking after the run cannot tell that apart from a
+        /// record written afterwards, and a test that cannot tell them apart is
+        /// not a test of the ordering: review pointed out that the first version
+        /// of this assertion would have passed with `open` moved below the write,
+        /// which is the crash window the whole module exists to close.
+        #[allow(clippy::type_complexity)]
+        pub(crate) at_first_write: Option<Box<dyn FnMut() -> Result<(), String>>>,
         /// Every request, in order.
         pub(crate) log: Vec<Request>,
     }
@@ -488,6 +518,14 @@ pub(crate) mod fake_camera {
             Some(match query {
                 UVC_SET_CUR => {
                     cam.sets_seen += 1;
+                    if cam.sets_seen == 1 {
+                        if let Some(check) = cam.at_first_write.as_mut() {
+                            if let Err(why) = check() {
+                                cam.log.push(Request::FailedPrecondition(why));
+                                return Some(Err(XuError::from_errno(libc::EIO)));
+                            }
+                        }
+                    }
                     cam.log.push(Request::Set(data.to_vec()));
                     match cam.fail_set_from {
                         Some((from, errno)) if cam.sets_seen >= from => {
@@ -1331,6 +1369,8 @@ pub enum DiscoveryError {
     /// The camera stopped delivering frames, so nothing can be concluded and
     /// nothing further may be sent.
     MeasurementFailed,
+    /// Another irlume process is already working on this camera.
+    CameraBusy,
     /// A control was changed and could not be put back.
     RestoreFailed {
         unit: u8,
@@ -1400,6 +1440,11 @@ impl std::fmt::Display for DiscoveryError {
                 f,
                 "unit {unit} selector {selector} was changed and could not be restored ({err}); \
                  power the camera down fully before using it again"
+            ),
+            Self::CameraBusy => write!(
+                f,
+                "another irlume process is already working on this camera's emitter; \
+                 nothing was sent to it. Wait for that to finish and try again"
             ),
             Self::UnresolvedChange => write!(
                 f,
@@ -1701,6 +1746,26 @@ pub(crate) fn recover_pending_write(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
 ) -> RecoveryOutcome {
+    // The lock covers the WHOLE pass, from the read to the removal. Without it
+    // the record read at the start was removed at the end without being looked
+    // at again, so a second process that resolved it and saved a new one in
+    // between had its live record deleted.
+    match crate::emitter_journal::lock_camera(id) {
+        Ok(Some(lock)) => {
+            let outcome = recover_pending_write_locked(fd, id);
+            drop(lock);
+            outcome
+        }
+        Ok(None) => RecoveryOutcome::Busy,
+        Err(why) => RecoveryOutcome::Unresolved(format!("lock the camera: {why}")),
+    }
+}
+
+/// The recovery pass proper. The caller holds this camera's lock.
+fn recover_pending_write_locked(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+) -> RecoveryOutcome {
     use crate::emitter_journal as journal;
 
     let record = match journal::load(id) {
@@ -1898,6 +1963,11 @@ pub(crate) enum RecoveryOutcome {
     OwnerStillRunning {
         pid: u32,
     },
+    /// Another irlume process holds this camera's lock. Kernel-enforced, unlike
+    /// the pid in a record, and non-blocking so a capture never waits behind a
+    /// setup run. Silent and treated exactly like `OwnerStillRunning`: somebody
+    /// else is already looking after this camera.
+    Busy,
     /// An outstanding change on THIS camera that could not be resolved. Nothing
     /// further may be written to it by any path.
     Unresolved(String),
@@ -1933,7 +2003,7 @@ impl RecoveryOutcome {
         let store = crate::emitter_journal::store_dir();
         match self {
             Self::NothingPending | Self::ForAnotherCamera => None,
-            Self::OwnerStillRunning { .. } => None,
+            Self::OwnerStillRunning { .. } | Self::Busy => None,
             Self::AlreadyRestored => Some(
                 "irlume: an interrupted emitter setup was already undone; \
                  dropped its undo record"
@@ -1984,6 +2054,7 @@ impl RecoveryOutcome {
             Self::Restored { .. } => "restored",
             Self::RestoredRecordKept(_) => "restored-record-kept",
             Self::OwnerStillRunning { .. } => "owner-running",
+            Self::Busy => "busy",
             Self::Unresolved(_) => "unresolved",
             Self::Unconfirmed { .. } => "unconfirmed",
         }
@@ -2017,6 +2088,7 @@ impl RecoveryOutcome {
             // unhappy, and the store does not decide what the camera holds.
             | Self::RestoredRecordKept(_) => true,
             Self::OwnerStillRunning { .. }
+            | Self::Busy
             | Self::Unresolved(_)
             | Self::Unconfirmed { .. } => false,
         }
@@ -2041,6 +2113,7 @@ impl RecoveryOutcome {
             | Self::Restored { .. } => false,
             Self::RestoredRecordKept(_)
             | Self::OwnerStillRunning { .. }
+            | Self::Busy
             | Self::Unresolved(_)
             | Self::Unconfirmed { .. } => true,
         }
@@ -2081,11 +2154,22 @@ pub fn discover<F: FnMut() -> Option<f32>>(
             seen: id.extension_units().iter().map(|u| u.unit_id).collect(),
         })?;
 
+    // ONE lock for the whole run: the recovery pass, every exploratory write,
+    // and the record that describes them. Taking it separately for recovery and
+    // then again for the writes would leave a gap in which another process could
+    // resolve this camera and start its own setup, and the record this run then
+    // wrote would be filed over the top of that one.
+    let lock = match crate::emitter_journal::lock_camera(id) {
+        Ok(Some(lock)) => lock,
+        Ok(None) => return Err(DiscoveryError::CameraBusy),
+        Err(why) => return Err(DiscoveryError::JournalUnwritable(why)),
+    };
+
     // Before the first GET_CUR, not after. Discovery reads the control and calls
     // the answer the original; against a control still holding an earlier run's
     // exploratory value that reading is wrong, and recording it would overwrite
     // the only copy of the real one.
-    let recovery = recover_pending_write(fd, id);
+    let recovery = recover_pending_write_locked(fd, id);
     if let Some(line) = recovery.message() {
         eprintln!("{line}");
     }
@@ -2104,7 +2188,16 @@ pub fn discover<F: FnMut() -> Option<f32>>(
             continue;
         }
         match try_documented_control(fd, id, ms.unit_id, selector, measure) {
-            Ok(Attempt::Lit(control, pending)) => return Ok(Discovered { control, pending }),
+            // The lock travels with the open record: the camera stays held until
+            // the configuration naming the applied control is durable, so nothing
+            // else can file a record over this one in between.
+            Ok(Attempt::Lit(control, pending)) => {
+                return Ok(Discovered {
+                    control,
+                    pending,
+                    _lock: lock,
+                })
+            }
             Ok(Attempt::AlreadyApplied) => tried.push(format!(
                 "selector {selector:#04x} is already set to the value setup would apply"
             )),
@@ -2153,6 +2246,9 @@ pub fn discover<F: FnMut() -> Option<f32>>(
 pub struct Discovered {
     control: EmitterControl,
     pending: ExploratoryWrite,
+    /// Held until this value is dropped or committed, so no other process files
+    /// a record for this camera while its record is still open.
+    _lock: crate::emitter_journal::CameraLock,
 }
 
 impl Discovered {
@@ -2810,31 +2906,59 @@ mod tests {
         }
     }
 
-    /// The undo record reaches disk BEFORE the first byte is written to the
-    /// camera. This is the ordering the whole module exists for, and until a
-    /// stand-in camera existed nothing without hardware could observe it.
+    /// The undo record is on disk, complete and correct, AT THE MOMENT the first
+    /// byte reaches the camera.
+    ///
+    /// Asserted from inside the interception of that write, because no check
+    /// made afterwards can tell "saved before the write" from "saved after it".
+    /// The first version of this test looked at the store when the run was over
+    /// and would have passed with `ExploratoryWrite::open` moved below
+    /// `apply_exploratory`, which is precisely the crash window this module
+    /// exists to close. Review caught that; the mutant is in the harness now.
     #[test]
     fn the_undo_record_is_on_disk_before_the_first_write() {
         let _lock = crate::testenv::env_lock();
-        let mut brightness = [10.0f32, 90.0, 10.0].into_iter();
-        let (_outcome, log, _current, dir) =
-            run_discovery(a_working_camera(), "record-first", move || {
-                brightness.next()
-            });
+        let dir = std::env::temp_dir().join("irlume-discovery-record-first");
+        let _ = std::fs::remove_dir_all(&dir);
 
-        let first_write = log
-            .iter()
-            .position(|r| matches!(r, fake_camera::Request::Set(_)))
-            .expect("discovery must have written something, or this proves nothing");
-        // The record is written inside `ExploratoryWrite::open`, which runs
-        // before that write. Its presence on disk at the moment of the write is
-        // what a crash would depend on, so the store is checked to have been
-        // created rather than the call merely to have been made.
+        let expected = {
+            // Same env the run will use, so the path resolves identically.
+            let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+            let id = identity(0x3277, 0x0059);
+            crate::emitter_journal::record_path(&crate::emitter_journal::filing_key(&id))
+        };
+
+        let mut camera = a_working_camera();
+        camera.at_first_write = Some(Box::new(move || {
+            let body = std::fs::read_to_string(&expected)
+                .map_err(|e| format!("no record at {} yet: {e}", expected.display()))?;
+            let record: crate::emitter_journal::PendingWrite = serde_json::from_str(&body)
+                .map_err(|e| format!("the record is not complete json: {e}"))?;
+            // The bytes that make it an undo record, not just a file.
+            if record.original != "010301" {
+                return Err(format!("original is {}", record.original));
+            }
+            Ok(())
+        }));
+
+        let mut brightness = [10.0f32, 90.0, 10.0].into_iter();
+        let (outcome, log, _current, dir) =
+            run_discovery(camera, "record-first", move || brightness.next());
+
         assert!(
-            dir.join("ir-emitter-journal").exists(),
-            "the store must exist by the end of a run that wrote to the camera"
+            !log.iter()
+                .any(|r| matches!(r, fake_camera::Request::FailedPrecondition(_))),
+            "the record must already be on disk when the camera is first written to: {log:?}"
         );
-        assert!(first_write > 0, "reads precede the first write");
+        assert!(
+            log.iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "a run that never wrote proves nothing about ordering: {log:?}"
+        );
+        assert!(
+            matches!(outcome, Ok(Attempt::Lit(..))),
+            "the fixture must reach a successful discovery: {outcome:?}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -2956,7 +3080,13 @@ mod tests {
         let _lock = crate::testenv::env_lock();
         let dir = std::env::temp_dir().join("irlume-recovery-length");
         let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
         let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        // Recovery takes the camera lock before any ioctl, so a test that cannot
+        // create it never reaches the code under test — and would still see an
+        // `Unresolved` outcome, for entirely the wrong reason. The GET_LEN
+        // assertion below is what caught that.
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
 
         let id = identity(0x3277, 0x0059);
         let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
@@ -3021,6 +3151,134 @@ mod tests {
                 }
             )),
             "GET_LEN must have been issued, or this proves nothing: {log:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A camera another process holds is not touched at all.
+    ///
+    /// Driven against a real second process holding the lock, because `flock` is
+    /// per open file description: taking it twice inside this process would
+    /// succeed no matter what the code did.
+    #[test]
+    fn a_locked_camera_is_not_queried_or_written() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-recovery-locked");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        // Create the store and the lock path the same way production does.
+        let held = crate::emitter_journal::lock_camera(&id)
+            .expect("take the lock")
+            .expect("not busy");
+        let path = dir.join(format!(
+            "irlume-emitter-{}.lock",
+            crate::emitter_journal::filing_key(&id)
+        ));
+        drop(held);
+
+        let mut holder = std::process::Command::new("flock")
+            .args([path.to_str().expect("path"), "-c", "sleep 30"])
+            .spawn()
+            .expect("spawn the lock holder");
+
+        // Wait for the child to actually hold it, rather than assuming it does:
+        // asserting against a lock nobody took is the vacuous version of this
+        // test. Bounded so a failure to acquire fails the test instead of
+        // hanging it.
+        let mut taken = false;
+        for _ in 0..200 {
+            match crate::emitter_journal::lock_camera(&id) {
+                Ok(None) => {
+                    taken = true;
+                    break;
+                }
+                _ => std::thread::sleep(std::time::Duration::from_millis(25)),
+            }
+        }
+
+        let (outcome, log) = if taken {
+            let _fake = fake_camera::install(a_working_camera());
+            let outcome = recover_pending_write(-1, &id);
+            (outcome, fake_camera::log())
+        } else {
+            (RecoveryOutcome::NothingPending, Vec::new())
+        };
+
+        let _ = holder.kill();
+        let _ = holder.wait();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(taken, "the second process never took the lock");
+        assert_eq!(
+            outcome,
+            RecoveryOutcome::Busy,
+            "a camera somebody else holds is busy, not free"
+        );
+        assert!(
+            log.is_empty(),
+            "a busy camera must be sent nothing at all, not even a read: {log:?}"
+        );
+    }
+
+    /// The emitter config is REPLACED, not truncated in place.
+    ///
+    /// The undo record is dropped on the strength of this call returning, so a
+    /// return that only means "the bytes are in the page cache" breaks the
+    /// ordering `commit` documents. An fsync leaves no trace, but the inode does:
+    /// truncate-in-place keeps it and passes through an empty moment, a rename
+    /// gives a new one. A test on the final CONTENT passes either way, which is
+    /// why it is asserted on the inode.
+    #[test]
+    fn the_emitter_config_is_replaced_rather_than_truncated() {
+        use std::os::unix::fs::MetadataExt as _;
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-save-conf-atomic");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let conf = dir.join("ir_emitter.conf");
+        let _env = EnvGuard::set("IRLUME_IR_EMITTER_CONF", &conf);
+
+        let id = identity(0x3277, 0x0059);
+        save_conf(
+            &id,
+            &EmitterControl {
+                unit: 14,
+                selector: 6,
+                payload: vec![],
+            },
+        )
+        .expect("first write");
+        let first = std::fs::metadata(&conf).expect("stat").ino();
+
+        save_conf(
+            &id,
+            &EmitterControl {
+                unit: 14,
+                selector: 10,
+                payload: vec![],
+            },
+        )
+        .expect("second write");
+        let second = std::fs::metadata(&conf).expect("stat").ino();
+
+        assert_ne!(
+            first, second,
+            "a rewrite must land on a fresh inode, not truncate the live file"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&conf).expect("read"),
+            format!("{} 14:10", id.usb_id())
+        );
+        // The mode this file has always had: the diagnostic script reads it as
+        // the user, so making it durable must not quietly make it private.
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            std::fs::metadata(&conf).expect("stat").permissions().mode() & 0o777,
+            0o644
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1990,10 +1990,20 @@ fn recover_pending_write_locked(
             // To the path the record was FOUND at, not the one its contents
             // derive: a scanned record need not be filed under its own name, and
             // deriving here wrote the incremented record to a second file.
-            if let Err(why) = journal::save_at(&record_path, &spent) {
-                // The attempt could not be counted, so making it would be an
-                // uncounted write: exactly the loop the counter exists to stop.
-                return RecoveryOutcome::Unresolved(format!("count the attempt: {why}"));
+            match journal::save_at(&record_path, &spent) {
+                // Durable, or published-but-not-durable: either way the
+                // incremented count IS what a reader sees, so the write below is
+                // accounted for. An error after the rename does not un-publish
+                // it, and treating that as "nothing was counted" spent an
+                // attempt on a pass that then refused to write — three of those
+                // and the emitter is off for good.
+                Ok(_) => {}
+                Err(why) => {
+                    // Nothing became visible, so nothing was spent and nothing
+                    // may be written: an uncounted write is the loop the counter
+                    // exists to stop.
+                    return RecoveryOutcome::Unresolved(format!("count the attempt: {why}"));
+                }
             }
 
             // Read the control AGAIN, immediately before writing it.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -371,6 +371,33 @@ impl std::fmt::Display for XuError {
 type XuResult<T> = std::result::Result<T, XuError>;
 
 fn xu_query(fd: c_int, unit: u8, selector: u8, query: u8, data: &mut [u8]) -> XuResult<()> {
+    // Every read is traced HERE, not in `get_of`, because `get_len` and
+    // `get_info` have fixed widths and call this directly. The trace used to sit
+    // in `get_of` under a comment calling it "the single choke point for every
+    // READ", which was simply untrue: the two queries the ordering claim is
+    // ABOUT were the two it could not see. A hardware run produced a transcript
+    // with no GET_LEN in it at all, which is what caught it. The unit tests
+    // could not: the stand-in camera intercepts at this level and sees
+    // everything either way.
+    //
+    // `SET_CUR` is left to `set_cur`, which prints the payload bytes, so each
+    // ioctl appears exactly once and the order can be read straight off.
+    if query != UVC_SET_CUR && std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
+        let name = match query {
+            UVC_GET_CUR => "GET_CUR",
+            UVC_GET_LEN => "GET_LEN",
+            UVC_GET_INFO => "GET_INFO",
+            UVC_GET_DEF => "GET_DEF",
+            UVC_GET_MIN => "GET_MIN",
+            UVC_GET_MAX => "GET_MAX",
+            UVC_GET_RES => "GET_RES",
+            other => &format!("GET_{other:#04x}"),
+        };
+        eprintln!(
+            "irlume: {name} unit{unit}/sel{selector} size={}",
+            data.len()
+        );
+    }
     // A test may stand in for the camera here. Every read and every write in
     // this module funnels through this one call, so a fake installed here can
     // drive the whole discovery sequence, record the exact order of requests,
@@ -613,29 +640,10 @@ fn get_info(fd: c_int, unit: u8, selector: u8) -> XuResult<u8> {
     Ok(buf[0])
 }
 
-/// The single choke point for every READ of a control.
-///
-/// Traced under the same switch as the writes, and with the transfer SIZE,
-/// because the size is the part that can be wrong. Recovery must size `GET_CUR`
-/// from the length the attached camera just reported and not from the record,
-/// and that is an ordering between two ioctls: it leaves nothing behind for a
-/// test to inspect, and this crate cannot reach any of it without a camera. A
-/// transcript that shows `GET_LEN` answering 3 and then `GET_CUR size=3` is the
-/// evidence. A mutant that removes the check survives the whole unit suite.
+/// Read `size` bytes from a control. Sized reads only; `get_len` and `get_info`
+/// have fixed widths and go straight to [`xu_query`], which is where the tracing
+/// lives precisely because of that.
 fn get_of(fd: c_int, unit: u8, selector: u8, query: u8, size: usize) -> XuResult<Vec<u8>> {
-    if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
-        let name = match query {
-            UVC_GET_CUR => "GET_CUR",
-            UVC_GET_LEN => "GET_LEN",
-            UVC_GET_INFO => "GET_INFO",
-            UVC_GET_DEF => "GET_DEF",
-            UVC_GET_MIN => "GET_MIN",
-            UVC_GET_MAX => "GET_MAX",
-            UVC_GET_RES => "GET_RES",
-            _ => "GET_?",
-        };
-        eprintln!("irlume: {name} unit{unit}/sel{selector} size={size}");
-    }
     let mut buf = vec![0u8; size];
     xu_query(fd, unit, selector, query, &mut buf)?;
     Ok(buf)

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1987,7 +1987,10 @@ fn recover_pending_write_locked(
             // The attempt counter is what limits repeats.
             spent.boot_id = None;
             spent.pid = None;
-            if let Err(why) = journal::save(&spent) {
+            // To the path the record was FOUND at, not the one its contents
+            // derive: a scanned record need not be filed under its own name, and
+            // deriving here wrote the incremented record to a second file.
+            if let Err(why) = journal::save_at(&record_path, &spent) {
                 // The attempt could not be counted, so making it would be an
                 // uncounted write: exactly the loop the counter exists to stop.
                 return RecoveryOutcome::Unresolved(format!("count the attempt: {why}"));
@@ -4017,6 +4020,89 @@ mod tests {
                 .count()
                 >= 2,
             "the control must be re-read immediately before the write: {log:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Recovering a MISFILED record leaves exactly one file behind, and then
+    /// none.
+    ///
+    /// The attempt counter is written before the restoring write. Deriving that
+    /// path from the record's contents put the incremented copy in a SECOND
+    /// file, and the clear afterwards removed only the one that was read — two
+    /// records for one operation, the survivor pending forever. The earlier
+    /// misfiled test only reached the already-restored branch and never took
+    /// this one.
+    #[test]
+    fn recovering_a_misfiled_record_leaves_no_duplicate() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-misfiled-attempt");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        let record = crate::emitter_journal::PendingWrite {
+            schema_version: crate::emitter_journal::SCHEMA_VERSION,
+            engine_version: "test".into(),
+            descriptor_sha256: crate::emitter_journal::fingerprint(&id),
+            usb_id: id.usb_id(),
+            interface_number: id.interface_number,
+            unit: ms.unit_id,
+            selector,
+            len: 3,
+            original: crate::emitter_journal::to_hex(&[1, 3, 1]),
+            attempted: crate::emitter_journal::to_hex(&[1, 3, 2]),
+            restore_attempts: 0,
+            boot_id: None,
+            pid: None,
+            serial: id.serial.clone(),
+            usb_devpath: id.usb_devpath.clone(),
+        };
+        // Deliberately NOT under the name its own fields produce.
+        let store = dir.join("ir-emitter-journal");
+        std::fs::create_dir_all(&store).expect("store");
+        let misfiled =
+            store.join("1111111111111111111111111111111111111111111111111111111111111111.json");
+        std::fs::write(
+            &misfiled,
+            serde_json::to_string(&record).expect("serialize"),
+        )
+        .expect("plant");
+
+        // The control still holds this run's exploratory value, so recovery
+        // takes the counting-and-restoring branch rather than already-restored.
+        let camera = fake_camera::Camera {
+            current: vec![1, 3, 2],
+            ..a_working_camera()
+        };
+        let _fake = fake_camera::install(camera);
+
+        let outcome = recover_pending_write(-1, &id);
+        assert!(
+            matches!(outcome, RecoveryOutcome::Restored { .. }),
+            "the restoring branch must be the one taken: {outcome:?}"
+        );
+        let left = std::fs::read_dir(&store)
+            .map(|d| {
+                d.filter_map(|e| e.ok())
+                    .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+                    .count()
+            })
+            .unwrap_or(0);
+        assert_eq!(
+            left, 0,
+            "one operation must not leave a second record behind"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -3411,8 +3411,15 @@ mod tests {
         let pending =
             ExploratoryWrite::open(-1, &id, ms.unit_id, selector, 3, &[1, 3, 1], &[1, 3, 2])
                 .expect("open the record");
-        std::mem::forget(pending); // leave the record exactly as `open` wrote it
+        // Dropped normally, not forgotten. `open` leaves the guard disarmed —
+        // nothing has been written to the camera yet — so `Drop` returns without
+        // touching the control or the record, which is exactly the state this
+        // test wants and is worth exercising rather than stepping around.
+        // `mem::forget` leaked everything the guard owned, which LeakSanitizer
+        // caught in CI and no ordinary test run would have.
+        drop(pending);
 
+        // Which also proves the disarmed drop left the record alone.
         let record = match crate::emitter_journal::load(&id).expect("load") {
             crate::emitter_journal::Situation::Mine(r) => *r,
             other => panic!("expected this camera's own record: {other:?}"),

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1643,9 +1643,13 @@ struct ExploratoryWrite {
     /// The value this run applies. Kept so `commit` can confirm the camera is
     /// actually holding it before the undo data is thrown away.
     attempted: Vec<u8>,
-    /// The record exactly as it was written, so the removal cannot target a
-    /// different file than the save did.
-    record: crate::emitter_journal::PendingWrite,
+    /// The PATH `save` wrote the record to.
+    ///
+    /// The removal uses this rather than a path derived from the record's
+    /// contents, so it cannot target a different file than the save did. The
+    /// record itself was kept here for that purpose and is no longer needed:
+    /// deriving the name looked equivalent to remembering it and is not.
+    record_path: std::path::PathBuf,
     /// Set once the control is confirmed back at `original`, or once the applied
     /// value is durably recorded in the configuration. Until then the record
     /// stays on disk and `Drop` still tries.
@@ -1713,14 +1717,14 @@ impl ExploratoryWrite {
             serial: id.serial.clone(),
             usb_devpath: id.usb_devpath.clone(),
         };
-        crate::emitter_journal::save(&record)?;
+        let record_path = crate::emitter_journal::save(&record)?;
         Ok(Self {
             fd,
             unit,
             selector,
             original: original.to_vec(),
             attempted: attempted.to_vec(),
-            record,
+            record_path,
             resolved: false,
             // Nothing has been written yet.
             exploratory_value_is_live: false,
@@ -1766,7 +1770,7 @@ impl ExploratoryWrite {
                 now, self.original
             ));
         }
-        crate::emitter_journal::clear(&self.record)?;
+        crate::emitter_journal::clear(&self.record_path)?;
         self.resolved = true;
         Ok(())
     }
@@ -1781,7 +1785,7 @@ impl ExploratoryWrite {
     /// record stays open and the guard would put the control back.
     ///
     fn commit(&mut self) -> Result<(), String> {
-        crate::emitter_journal::clear(&self.record)?;
+        crate::emitter_journal::clear(&self.record_path)?;
         self.resolved = true;
         Ok(())
     }
@@ -1877,9 +1881,9 @@ fn recover_pending_write_locked(
 ) -> RecoveryOutcome {
     use crate::emitter_journal as journal;
 
-    let record = match journal::load(id) {
+    let (record_path, record) = match journal::load(id) {
         Ok(journal::Situation::Nothing) => return RecoveryOutcome::NothingPending,
-        Ok(journal::Situation::Mine(record)) => *record,
+        Ok(journal::Situation::Mine { path, record }) => (path, *record),
         // A record about a camera of the same model at a different port, or one
         // written before records carried a port at all. Its bytes were read from
         // a control this run cannot confirm is the same one, so writing them
@@ -1961,7 +1965,7 @@ fn recover_pending_write_locked(
     };
 
     match journal::restore_decision(&record, &now) {
-        journal::Restore::AlreadyRestored => match journal::clear(&record) {
+        journal::Restore::AlreadyRestored => match journal::clear(&record_path) {
             Ok(()) => RecoveryOutcome::AlreadyRestored,
             // The control holds its original. Only the store is unhappy, and the
             // store does not decide what the camera holds.
@@ -2025,7 +2029,7 @@ fn recover_pending_write_locked(
                 return RecoveryOutcome::Unresolved(format!("restore: {e}"));
             }
             match get_cur(fd, record.unit, record.selector, original.len()) {
-                Ok(back) if back == original => match journal::clear(&record) {
+                Ok(back) if back == original => match journal::clear(&record_path) {
                     Ok(()) => RecoveryOutcome::Restored {
                         unit: record.unit,
                         selector: record.selector,
@@ -3421,7 +3425,7 @@ mod tests {
 
         // Which also proves the disarmed drop left the record alone.
         let record = match crate::emitter_journal::load(&id).expect("load") {
-            crate::emitter_journal::Situation::Mine(r) => *r,
+            crate::emitter_journal::Situation::Mine { record, .. } => *record,
             other => panic!("expected this camera's own record: {other:?}"),
         };
         assert_eq!(record.pid, None, "a live pid would strand this record");

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -229,8 +229,11 @@ pub fn save_conf(
     // `commit` says it is called once the configuration is durable, and that was
     // not true of what it was called after.
     //
-    // 0644, the mode this file has always had. It names a camera and a control
-    // number, nothing secret, and the diagnostic script reads it as the user.
+    // A requested 0644, which the process umask then narrows: under the shipped
+    // `UMask=0027` the file lands at 0640, exactly as `std::fs::write` left it
+    // before this became atomic. The mode is unchanged by this commit, and the
+    // earlier comment here claiming a plain 0644 was simply wrong about the
+    // machine it runs on.
     irlume_common::write_atomic_mode(
         &path,
         format!("{} {}:{}", id.usb_id(), ctrl.unit, ctrl.selector).as_bytes(),
@@ -482,6 +485,14 @@ pub(crate) mod fake_camera {
         /// send nothing further, while a value that merely disagrees means the
         /// control still needs putting back.
         pub(crate) fail_get_cur: Option<i32>,
+        /// After this many `GET_CUR`s, the control quietly becomes this value.
+        ///
+        /// Models something OTHER than irlume writing the control mid-sequence,
+        /// which is the only way to exercise the gap between an authorising read
+        /// and the write it authorises.
+        pub(crate) change_after_gets: Option<(usize, Vec<u8>)>,
+        /// `GET_CUR`s seen so far.
+        pub(crate) gets_seen: usize,
         /// `SET_CUR`s seen so far, so `fail_set_from` can count.
         pub(crate) sets_seen: usize,
         /// Run at the instant the first `SET_CUR` is intercepted, before it is
@@ -617,6 +628,7 @@ pub(crate) mod fake_camera {
                     Ok(())
                 }
                 UVC_GET_CUR => {
+                    cam.gets_seen += 1;
                     cam.log.push(Request::Get {
                         query,
                         size: data.len(),
@@ -624,8 +636,19 @@ pub(crate) mod fake_camera {
                     if let Some(errno) = cam.fail_get_cur {
                         return Some(Err(XuError::from_errno(errno)));
                     }
+                    // Answer THIS read first, then change, so the read that
+                    // triggers the change still sees the old value.
+                    let pending = cam
+                        .change_after_gets
+                        .as_ref()
+                        .filter(|(after, _)| cam.gets_seen >= *after)
+                        .map(|(_, v)| v.clone());
                     for (slot, byte) in data.iter_mut().zip(cam.current.iter()) {
                         *slot = *byte;
+                    }
+                    if let Some(v) = pending {
+                        cam.current = v;
+                        cam.change_after_gets = None;
                     }
                     Ok(())
                 }
@@ -1955,6 +1978,39 @@ fn recover_pending_write_locked(
                 // uncounted write: exactly the loop the counter exists to stop.
                 return RecoveryOutcome::Unresolved(format!("count the attempt: {why}"));
             }
+
+            // Read the control AGAIN, immediately before writing it.
+            //
+            // The authorisation above was made before `journal::save`, which is
+            // a whole durable transaction: create, write, fsync, rename, fsync
+            // the directory, fsync its ancestors. A check made on one side of
+            // that and acted on from the other is a check-then-act with a
+            // filesystem's worth of time in the middle, and the camera lock
+            // excludes other irlume processes, not a vendor tool or another UVC
+            // client. Without this, the refusal to undo somebody else's change
+            // only covered changes made before the first GET_CUR.
+            //
+            // A syscall-sized window remains and cannot be closed here: UVC
+            // offers no compare-and-set. What is claimed is narrowed to match.
+            let attempted = match journal::from_hex(&record.attempted) {
+                Ok(bytes) => bytes,
+                Err(why) => return RecoveryOutcome::Unresolved(format!("attempted: {why}")),
+            };
+            match get_cur(fd, record.unit, record.selector, original.len()) {
+                Ok(now) if now == attempted => {}
+                Ok(now) => {
+                    return RecoveryOutcome::Unresolved(format!(
+                        "the control changed while the attempt was being recorded: it holds \
+                         {now:02x?}, not this run's value {attempted:02x?}; nothing was written"
+                    ))
+                }
+                Err(e) => {
+                    return RecoveryOutcome::Unresolved(format!(
+                        "recheck the control before restoring it: {e}"
+                    ))
+                }
+            }
+
             if let Err(e) = set_cur(fd, record.unit, record.selector, &original) {
                 return RecoveryOutcome::Unresolved(format!("restore: {e}"));
             }
@@ -3676,12 +3732,117 @@ mod tests {
             std::fs::read_to_string(&conf).expect("read"),
             format!("{} 14:10", id.usb_id())
         );
-        // The mode this file has always had: the diagnostic script reads it as
-        // the user, so making it durable must not quietly make it private.
+        // The requested mode NARROWED BY THE PROCESS UMASK, which is what
+        // actually happens. A bare 0644 assertion passed only because the test
+        // binary's umask is 0022; the daemon ships `UMask=0027`, so the real
+        // file is 0640 and this was green here while false on the machine that
+        // matters.
         use std::os::unix::fs::PermissionsExt as _;
+        // SAFETY: umask is process-global, and the env lock held by this test
+        // serialises it against every other test that touches process state.
+        let previous = unsafe { libc::umask(0o027) };
+        let masked = dir.join("masked.conf");
+        irlume_common::write_atomic_mode(&masked, b"x", 0o644).expect("write");
+        let masked_mode = std::fs::metadata(&masked)
+            .expect("stat")
+            .permissions()
+            .mode()
+            & 0o777;
+        unsafe { libc::umask(previous) };
+        assert_eq!(
+            masked_mode, 0o640,
+            "a requested 0644 under UMask=0027 is 0640, which is what the shipped \
+             daemon has always produced"
+        );
         assert_eq!(
             std::fs::metadata(&conf).expect("stat").permissions().mode() & 0o777,
-            0o644
+            0o644 & !previous,
+            "and the config written above follows the same rule"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A control changed AFTER recovery authorised the restore is not
+    /// overwritten.
+    ///
+    /// The authorisation read happens, then the attempt counter is written and
+    /// fsynced — a create, a write, a rename and several directory syncs — and
+    /// only then the restore. Acting on the earlier read across all of that is a
+    /// check-then-act with a filesystem's worth of time in it, and the camera
+    /// lock excludes other irlume processes, not a vendor tool. So the control
+    /// is read again immediately before the write.
+    #[test]
+    fn a_control_changed_while_the_attempt_was_recorded_is_not_overwritten() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-recheck-before-restore");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        crate::emitter_journal::save(&crate::emitter_journal::PendingWrite {
+            schema_version: crate::emitter_journal::SCHEMA_VERSION,
+            engine_version: "test".into(),
+            descriptor_sha256: crate::emitter_journal::fingerprint(&id),
+            usb_id: id.usb_id(),
+            interface_number: id.interface_number,
+            unit: ms.unit_id,
+            selector,
+            len: 3,
+            original: crate::emitter_journal::to_hex(&[1, 3, 1]),
+            attempted: crate::emitter_journal::to_hex(&[1, 3, 2]),
+            restore_attempts: 0,
+            boot_id: None,
+            pid: None,
+            serial: id.serial.clone(),
+            usb_devpath: id.usb_devpath.clone(),
+        })
+        .expect("plant the record");
+
+        // Holding this run's exploratory value at the authorising read, and
+        // something else's by the time the write would happen.
+        let camera = fake_camera::Camera {
+            current: vec![1, 3, 2],
+            change_after_gets: Some((1, vec![1, 3, 3])),
+            ..a_working_camera()
+        };
+        let _fake = fake_camera::install(camera);
+
+        let outcome = recover_pending_write(-1, &id);
+        let log = fake_camera::log();
+
+        assert!(
+            matches!(outcome, RecoveryOutcome::Unresolved(ref why) if why.contains("[01, 03, 03]")),
+            "the second read must be what decides: {outcome:?}"
+        );
+        assert!(
+            !log.iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "nothing may be written over a value irlume did not put there: {log:?}"
+        );
+        // And the read really did happen twice, or the guard was never reached.
+        assert!(
+            log.iter()
+                .filter(|r| matches!(
+                    r,
+                    fake_camera::Request::Get {
+                        query: UVC_GET_CUR,
+                        ..
+                    }
+                ))
+                .count()
+                >= 2,
+            "the control must be re-read immediately before the write: {log:?}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1744,6 +1744,22 @@ impl ExploratoryWrite {
         Ok(())
     }
 
+    /// Drop the record without touching the camera.
+    ///
+    /// For the one case where the record turns out to describe a state irlume
+    /// never got to act on: nothing has been written, so there is nothing to
+    /// undo, and leaving the record behind would make the next run refuse this
+    /// camera over a change that never happened.
+    fn abandon_before_write(&mut self) -> Result<(), String> {
+        debug_assert!(
+            !self.exploratory_value_is_live,
+            "abandoning after the exploratory write would strand the control"
+        );
+        crate::emitter_journal::clear(&self.record_path)?;
+        self.resolved = true;
+        Ok(())
+    }
+
     /// Put the original back, once.
     ///
     /// Disarms first either way: if this succeeds there is nothing left for
@@ -2600,6 +2616,33 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
 
     let mut pending = ExploratoryWrite::open(fd, id, unit, selector, len, &original, &wanted)
         .map_err(TryFailure::Journal)?;
+
+    // Read the control AGAIN, immediately before changing it.
+    //
+    // `original` was read before `intended_value`, before a whole baseline frame
+    // measurement, and before the record's create/write/fsync/rename/fsync. The
+    // per-camera flock excludes other irlume processes and nothing else: a
+    // vendor tool or any other UVC client can move this control inside that
+    // window. Recording a value that is no longer there means the restore later
+    // writes bytes irlume never found, which is precisely the "we do not undo
+    // somebody else's change" promise the rest of this file keeps. Recovery
+    // already re-reads for the same reason; discovery did not.
+    //
+    // The residual race is one syscall wide and cannot be closed here: the UVC
+    // interface offers GET_CUR and SET_CUR and no compare-and-set.
+    let now = get_cur(fd, unit, selector, len)?;
+    if now != original {
+        // Nothing has been written, so the record describes a change that never
+        // happened; drop it rather than leave the camera refused by the next run.
+        pending
+            .abandon_before_write()
+            .map_err(TryFailure::Journal)?;
+        return Ok(Attempt::NotUsable(format!(
+            "the control changed while setup was measuring: it held {original:02x?} \
+             when discovery began and {now:02x?} immediately before the write, so \
+             something else is driving it; nothing was sent"
+        )));
+    }
 
     if abort_requested() {
         return Err(TryFailure::Measurement);
@@ -4054,6 +4097,81 @@ mod tests {
                 .count()
                 >= 2,
             "the control must be re-read immediately before the write: {log:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Somebody else moves the control while setup is measuring, and setup
+    /// notices BEFORE it writes.
+    ///
+    /// `original` is read, then `intended_value` runs, then a whole baseline
+    /// frame measurement, then the record's create/write/fsync/rename/fsync. The
+    /// per-camera flock excludes other irlume processes and nothing else, so a
+    /// vendor tool can move the control anywhere inside that window. Recording a
+    /// value that is no longer there means the eventual restore writes bytes
+    /// irlume never found on this camera, which is the one thing the rest of
+    /// this file promises not to do. Recovery already re-read for exactly this
+    /// reason; discovery did not.
+    #[test]
+    fn discovery_refuses_when_the_control_moved_while_it_was_measuring() {
+        let _lock = crate::testenv::env_lock();
+        let camera = fake_camera::Camera {
+            // The first GET_CUR answers [1,3,1] and THEN the control moves, so
+            // the re-read immediately before the write is what sees it.
+            change_after_gets: Some((1, vec![1, 3, 3])),
+            ..a_working_camera()
+        };
+        let (outcome, log, current, dir) =
+            run_discovery(camera, "moved-while-measuring", || Some(50.0));
+
+        match outcome {
+            Ok(Attempt::NotUsable(why)) => {
+                assert!(
+                    why.contains("changed while setup was measuring"),
+                    "the refusal must name what happened, got: {why}"
+                );
+                assert!(
+                    why.contains("nothing was sent"),
+                    "and must say the camera was left alone, got: {why}"
+                );
+            }
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+        // The whole point: not one byte reached the camera.
+        assert!(
+            !log.iter()
+                .any(|r| matches!(r, fake_camera::Request::Set { .. })),
+            "nothing may be written once the control is known to have moved: {log:?}"
+        );
+        assert_eq!(
+            current,
+            vec![1, 3, 3],
+            "the other writer's value must be left exactly as it was found"
+        );
+        // The re-read has to have actually happened, or this passed for the
+        // wrong reason.
+        assert!(
+            log.iter()
+                .filter(|r| matches!(
+                    r,
+                    fake_camera::Request::Get {
+                        query: UVC_GET_CUR,
+                        ..
+                    }
+                ))
+                .count()
+                >= 2,
+            "the control must be re-read immediately before the write: {log:?}"
+        );
+        // And the record is gone, because nothing was written: leaving it would
+        // make the next run refuse this camera over a change never made.
+        let store = dir.join("ir-emitter-journal");
+        let left: Vec<_> = std::fs::read_dir(&store)
+            .map(|rd| rd.flatten().map(|e| e.file_name()).collect())
+            .unwrap_or_default();
+        assert!(
+            left.is_empty(),
+            "no camera write happened, so no undo record may survive: {left:?}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -397,7 +397,29 @@ fn get_info(fd: c_int, unit: u8, selector: u8) -> XuResult<u8> {
     Ok(buf[0])
 }
 
+/// The single choke point for every READ of a control.
+///
+/// Traced under the same switch as the writes, and with the transfer SIZE,
+/// because the size is the part that can be wrong. Recovery must size `GET_CUR`
+/// from the length the attached camera just reported and not from the record,
+/// and that is an ordering between two ioctls: it leaves nothing behind for a
+/// test to inspect, and this crate cannot reach any of it without a camera. A
+/// transcript that shows `GET_LEN` answering 3 and then `GET_CUR size=3` is the
+/// evidence. A mutant that removes the check survives the whole unit suite.
 fn get_of(fd: c_int, unit: u8, selector: u8, query: u8, size: usize) -> XuResult<Vec<u8>> {
+    if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
+        let name = match query {
+            UVC_GET_CUR => "GET_CUR",
+            UVC_GET_LEN => "GET_LEN",
+            UVC_GET_INFO => "GET_INFO",
+            UVC_GET_DEF => "GET_DEF",
+            UVC_GET_MIN => "GET_MIN",
+            UVC_GET_MAX => "GET_MAX",
+            UVC_GET_RES => "GET_RES",
+            _ => "GET_?",
+        };
+        eprintln!("irlume: {name} unit{unit}/sel{selector} size={size}");
+    }
     let mut buf = vec![0u8; size];
     xu_query(fd, unit, selector, query, &mut buf)?;
     Ok(buf)
@@ -1325,7 +1347,9 @@ struct ExploratoryWrite {
     unit: u8,
     selector: u8,
     original: Vec<u8>,
-    descriptor_sha256: String,
+    /// The record exactly as it was written, so the removal cannot target a
+    /// different file than the save did.
+    record: crate::emitter_journal::PendingWrite,
     /// Set once the control is confirmed back at `original`, or once the applied
     /// value is durably recorded in the configuration. Until then the record
     /// stays on disk and `Drop` still tries.
@@ -1349,7 +1373,7 @@ impl ExploratoryWrite {
         attempted: &[u8],
     ) -> Result<Self, String> {
         let descriptor_sha256 = crate::emitter_journal::fingerprint(id);
-        crate::emitter_journal::save(&crate::emitter_journal::PendingWrite {
+        let record = crate::emitter_journal::PendingWrite {
             schema_version: crate::emitter_journal::SCHEMA_VERSION,
             engine_version: env!("CARGO_PKG_VERSION").to_string(),
             descriptor_sha256: descriptor_sha256.clone(),
@@ -1365,13 +1389,16 @@ impl ExploratoryWrite {
             // while the run that changed it is still going.
             boot_id: crate::emitter_journal::current_boot_id(),
             pid: Some(std::process::id()),
-        })?;
+            serial: id.serial.clone(),
+            usb_devpath: id.usb_devpath.clone(),
+        };
+        crate::emitter_journal::save(&record)?;
         Ok(Self {
             fd,
             unit,
             selector,
             original: original.to_vec(),
-            descriptor_sha256,
+            record,
             resolved: false,
         })
     }
@@ -1392,7 +1419,7 @@ impl ExploratoryWrite {
                 now, self.original
             ));
         }
-        crate::emitter_journal::clear(&self.descriptor_sha256)?;
+        crate::emitter_journal::clear(&self.record)?;
         self.resolved = true;
         Ok(())
     }
@@ -1406,7 +1433,7 @@ impl ExploratoryWrite {
     /// this module exists to prevent, so until the configuration lands the
     /// record stays open and the guard would put the control back.
     fn commit(&mut self) -> Result<(), String> {
-        crate::emitter_journal::clear(&self.descriptor_sha256)?;
+        crate::emitter_journal::clear(&self.record)?;
         self.resolved = true;
         Ok(())
     }
@@ -1446,8 +1473,29 @@ pub(crate) fn recover_pending_write(
     use crate::emitter_journal as journal;
 
     let record = match journal::load(id) {
-        Ok(None) => return RecoveryOutcome::NothingPending,
-        Ok(Some(record)) => record,
+        Ok(journal::Situation::Nothing) => return RecoveryOutcome::NothingPending,
+        Ok(journal::Situation::Mine(record)) => *record,
+        // A record about a camera of the same model at a different port, or one
+        // written before records carried a port at all. Its bytes were read from
+        // a control this run cannot confirm is the same one, so writing them
+        // here would be guessing, and clearing it afterwards would destroy the
+        // only description of a change still outstanding somewhere else.
+        //
+        // Loud rather than silent, and it stops this camera's emitter, because
+        // the alternative reading is that this IS the camera and it is still
+        // holding an exploratory value.
+        Ok(journal::Situation::SameModelElsewhere(record)) => {
+            return RecoveryOutcome::Unconfirmed {
+                unit: record.unit,
+                selector: record.selector,
+                original: record.original.clone(),
+                recorded_at: if record.usb_devpath.is_empty() {
+                    "a build that did not record which port it was on".into()
+                } else {
+                    record.usb_devpath.clone()
+                },
+            }
+        }
         // A store that cannot be read may be hiding a change to THIS camera, so
         // it is unresolved rather than "nothing pending".
         Err(why) => return RecoveryOutcome::Unresolved(why),
@@ -1473,26 +1521,42 @@ pub(crate) fn recover_pending_write(
 
     // Read the control before deciding anything. A restore that is not needed is
     // still a write to firmware.
-    let now = match (
-        get_len(fd, record.unit, record.selector),
-        get_info(fd, record.unit, record.selector),
-        // Length comes from the record here only to size the read; the decision
-        // below compares it against what the camera just reported and refuses if
-        // they differ.
-        get_cur(fd, record.unit, record.selector, record.len),
-    ) {
-        (Ok(len), Ok(info), Ok(current)) => journal::ControlNow {
-            len,
-            writable: info_allows_set(info),
-            current,
-        },
-        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
-            return RecoveryOutcome::Unresolved(format!("query the control: {e}"))
-        }
+    //
+    // Sequenced, not gathered into a tuple. A tuple evaluates every operand
+    // before the match runs, so an earlier version issued `GET_CUR` sized by the
+    // RECORD while `GET_LEN` was being fetched in the same expression: a record
+    // saying 64 against a camera reporting 3 sent a 64-byte control request to
+    // firmware, and only then was the mismatch noticed. The camera's own answer
+    // has to come first and gate the rest.
+    let len = match get_len(fd, record.unit, record.selector) {
+        Ok(len) => len,
+        Err(e) => return RecoveryOutcome::Unresolved(format!("query the control length: {e}")),
+    };
+    if len != record.len {
+        return RecoveryOutcome::Unresolved(format!(
+            "the control is {len} bytes and the record was written when it was {}, \
+             so the recorded bytes are not this control's value",
+            record.len
+        ));
+    }
+    let info = match get_info(fd, record.unit, record.selector) {
+        Ok(info) => info,
+        Err(e) => return RecoveryOutcome::Unresolved(format!("query the control: {e}")),
+    };
+    // Sized by what the camera just reported, which the check above has proved
+    // equal to the record's.
+    let current = match get_cur(fd, record.unit, record.selector, len) {
+        Ok(current) => current,
+        Err(e) => return RecoveryOutcome::Unresolved(format!("read the control: {e}")),
+    };
+    let now = journal::ControlNow {
+        len,
+        writable: info_allows_set(info),
+        current,
     };
 
     match journal::restore_decision(&record, &now) {
-        journal::Restore::AlreadyRestored => match journal::clear(&record.descriptor_sha256) {
+        journal::Restore::AlreadyRestored => match journal::clear(&record) {
             Ok(()) => RecoveryOutcome::AlreadyRestored,
             // The control holds its original. Only the store is unhappy, and the
             // store does not decide what the camera holds.
@@ -1523,7 +1587,7 @@ pub(crate) fn recover_pending_write(
                 return RecoveryOutcome::Unresolved(format!("restore: {e}"));
             }
             match get_cur(fd, record.unit, record.selector, original.len()) {
-                Ok(back) if back == original => match journal::clear(&record.descriptor_sha256) {
+                Ok(back) if back == original => match journal::clear(&record) {
                     Ok(()) => RecoveryOutcome::Restored {
                         unit: record.unit,
                         selector: record.selector,
@@ -1606,6 +1670,23 @@ pub(crate) enum RecoveryOutcome {
     /// An outstanding change on THIS camera that could not be resolved. Nothing
     /// further may be written to it by any path.
     Unresolved(String),
+    /// A record for a camera of the SAME MODEL that this run cannot confirm is
+    /// the camera in front of it: a different port, or a record from a build
+    /// that did not store one.
+    ///
+    /// Two units of one model publish byte-identical descriptors, so the model
+    /// digest alone cannot tell them apart. Acting on the record would write one
+    /// camera's bytes into another and then delete the record on a successful
+    /// read-back, leaving the camera that was actually changed with no undo data
+    /// at all. Reported, never acted on, and it stops writes here because the
+    /// other reading is that this IS that camera, still holding an exploratory
+    /// value.
+    Unconfirmed {
+        unit: u8,
+        selector: u8,
+        original: String,
+        recorded_at: String,
+    },
 }
 
 impl RecoveryOutcome {
@@ -1644,6 +1725,22 @@ impl RecoveryOutcome {
                  light. The recorded original is in {}",
                 store.display()
             )),
+            Self::Unconfirmed {
+                unit,
+                selector,
+                original,
+                recorded_at,
+            } => Some(format!(
+                "irlume: a camera of this model was left with unit {unit} selector {selector} \
+                 changed by an interrupted setup, recorded at {recorded_at}, and this camera is \
+                 not at that address. Two units of one model are indistinguishable from their \
+                 USB descriptors, so irlume will not write those bytes into this one and will \
+                 not write to its emitter at all until the record is resolved: IR face \
+                 authentication will not light. Reconnect the camera to the port it was set up \
+                 on and it will be put back automatically. The original value is {original}, \
+                 recorded in {}",
+                store.display()
+            )),
         }
     }
 
@@ -1657,6 +1754,7 @@ impl RecoveryOutcome {
             Self::RestoredRecordKept(_) => "restored-record-kept",
             Self::OwnerStillRunning { .. } => "owner-running",
             Self::Unresolved(_) => "unresolved",
+            Self::Unconfirmed { .. } => "unconfirmed",
         }
     }
 
@@ -1687,7 +1785,9 @@ impl RecoveryOutcome {
             // The control is confirmed back at its original. Only the store is
             // unhappy, and the store does not decide what the camera holds.
             | Self::RestoredRecordKept(_) => true,
-            Self::OwnerStillRunning { .. } | Self::Unresolved(_) => false,
+            Self::OwnerStillRunning { .. }
+            | Self::Unresolved(_)
+            | Self::Unconfirmed { .. } => false,
         }
     }
 
@@ -1708,9 +1808,10 @@ impl RecoveryOutcome {
             | Self::ForAnotherCamera
             | Self::AlreadyRestored
             | Self::Restored { .. } => false,
-            Self::RestoredRecordKept(_) | Self::OwnerStillRunning { .. } | Self::Unresolved(_) => {
-                true
-            }
+            Self::RestoredRecordKept(_)
+            | Self::OwnerStillRunning { .. }
+            | Self::Unresolved(_)
+            | Self::Unconfirmed { .. } => true,
         }
     }
 }
@@ -1836,6 +1937,13 @@ impl Discovered {
 }
 
 /// What one advertised control turned out to be.
+///
+/// `Lit` is the large variant because it carries the open undo record, which now
+/// holds the whole `PendingWrite` so the removal cannot target a different file
+/// than the save did. Boxing it would move an allocation onto the success path of
+/// an operation that already spends seconds on camera I/O, and discovery returns
+/// exactly one of these per run.
+#[allow(clippy::large_enum_variant)]
 enum Attempt {
     /// Lit, and still holding the applied value, with its undo record open.
     Lit(EmitterControl, ExploratoryWrite),
@@ -2542,6 +2650,8 @@ mod tests {
             interface_number: 2,
             vid,
             pid,
+            serial: Some("200901010001".into()),
+            usb_devpath: "/devices/pci0000:00/0000:00:14.0/usb3/3-5".into(),
         }
     }
 
@@ -2863,6 +2973,8 @@ mod tests {
             interface_number: 0,
             vid: 0x3277,
             pid: 0x0059,
+            serial: Some("200901010001".into()),
+            usb_devpath: "/devices/pci0000:00/0000:00:14.0/usb3/3-5".into(),
         };
         let err = discover(std::os::fd::AsRawFd::as_raw_fd(&f), &no_ms, &mut measure).unwrap_err();
         match err {

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1696,10 +1696,20 @@ impl ExploratoryWrite {
             original: crate::emitter_journal::to_hex(original),
             attempted: crate::emitter_journal::to_hex(attempted),
             restore_attempts: 0,
-            // So a capture running beside this one leaves the control alone
-            // while the run that changed it is still going.
-            boot_id: crate::emitter_journal::current_boot_id(),
-            pid: Some(std::process::id()),
+            // Deliberately NOT recorded any more. The per-camera `flock` is what
+            // excludes a concurrent run, held across the whole of discovery, and
+            // a capture beside it gets `Busy` before it reads anything.
+            //
+            // A pid was worse than redundant. `save` publishes by rename and
+            // fsyncs afterwards, so a failure in those durability steps returns
+            // an error while leaving the record visible — carrying the pid of a
+            // daemon that lives for days. Every later recovery would then see
+            // the owner still running and refuse, turning IR authentication off
+            // until the machine was restarted, over a record whose camera was
+            // never written to. Old records carrying the pair are still read and
+            // still honoured.
+            boot_id: None,
+            pid: None,
             serial: id.serial.clone(),
             usb_devpath: id.usb_devpath.clone(),
         };
@@ -2421,7 +2431,24 @@ impl Discovered {
         id: &crate::uvc_descriptor::CameraIdentity,
     ) -> std::result::Result<(), String> {
         self.pending.confirm_applied()?;
-        save_conf(id, &self.control).map_err(|e| format!("save the emitter config: {e}"))?;
+        if let Err(e) = save_conf(id, &self.control) {
+            // "It returned an error" is not "nothing became visible". The
+            // configuration is published by a rename, which is atomic and
+            // immediate, and the fsyncs that make it DURABLE come afterwards. A
+            // failure in those leaves the file in place, and every later capture
+            // reads it and applies that control automatically.
+            //
+            // So when the configuration is visible, the camera is not put back
+            // and the record is not cleared: the undo data must outlive a
+            // half-published configuration, or a crash that loses the file would
+            // leave a lit emitter with nothing describing it. The next capture
+            // recovers from the record first and then applies the configuration
+            // through the ordinary guarded path.
+            if load_conf(id) == Some((self.control.unit, self.control.selector)) {
+                self.pending.exploratory_value_is_live = false;
+            }
+            return Err(format!("save the emitter config: {e}"));
+        }
         self.pending.commit()
     }
 }
@@ -3352,6 +3379,55 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A record this build writes carries no owner, so a leftover one is always
+    /// recoverable.
+    ///
+    /// `save` publishes by rename and fsyncs afterwards. A failure in those
+    /// durability steps returns an error while leaving the record visible, and a
+    /// record carrying the pid of the long-lived daemon would then be refused by
+    /// every later recovery as "somebody else's" until the machine restarted —
+    /// over a record whose camera was never written to. The per-camera lock is
+    /// what excludes a concurrent run.
+    #[test]
+    fn a_new_record_records_no_owning_process() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-record-no-owner");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let pending =
+            ExploratoryWrite::open(-1, &id, ms.unit_id, selector, 3, &[1, 3, 1], &[1, 3, 2])
+                .expect("open the record");
+        std::mem::forget(pending); // leave the record exactly as `open` wrote it
+
+        let record = match crate::emitter_journal::load(&id).expect("load") {
+            crate::emitter_journal::Situation::Mine(r) => *r,
+            other => panic!("expected this camera's own record: {other:?}"),
+        };
+        assert_eq!(record.pid, None, "a live pid would strand this record");
+        assert_eq!(record.boot_id, None);
+        // And it is recoverable rather than somebody else's business.
+        assert_eq!(
+            crate::emitter_journal::record_applies(&record, &id),
+            Ok(()),
+            "a leftover record must be actionable once the lock is released"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// A camera that stops answering a READ during verification is not written
     /// to again either.
     ///
@@ -3412,6 +3488,93 @@ mod tests {
         assert_eq!(
             writes_after, writes_before,
             "nothing further may be sent to a camera that stopped answering"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A configuration that IS visible after a failed save keeps its undo record
+    /// and leaves the camera alone.
+    ///
+    /// The config is published by a rename and made durable afterwards, so a
+    /// failure in the durability half returns an error while the file stays in
+    /// place, and every later capture reads it and applies that control. Putting
+    /// the camera back and clearing the record there would leave a machine that
+    /// re-lights the emitter from a config with no undo data behind it.
+    #[test]
+    fn a_visible_config_after_a_failed_save_keeps_the_record() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-conf-half-published");
+        let _ = std::fs::remove_dir_all(&dir);
+        let confdir = dir.join("etc");
+        std::fs::create_dir_all(&confdir).expect("scratch dirs");
+        let conf = confdir.join("ir_emitter.conf");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let _confenv = EnvGuard::set("IRLUME_IR_EMITTER_CONF", &conf);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        // The state the finding describes: the configuration naming this control
+        // is READABLE, and the save nevertheless reports failure. Provoked by
+        // taking write permission off the directory, so the temp file cannot be
+        // created, with the published file already there.
+        std::fs::write(&conf, format!("{} {}:{selector}", id.usb_id(), ms.unit_id))
+            .expect("publish a config");
+        std::fs::set_permissions(&confdir, std::fs::Permissions::from_mode(0o500))
+            .expect("make the directory unwritable");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let mut pending =
+            ExploratoryWrite::open(-1, &id, ms.unit_id, selector, 3, &[1, 3, 1], &[1, 3, 2])
+                .expect("open the record");
+        pending
+            .apply_exploratory(&[1, 3, 2])
+            .expect("write accepted");
+        let writes_before = fake_camera::log()
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set(_)))
+            .count();
+
+        let found = Discovered {
+            control: EmitterControl {
+                unit: ms.unit_id,
+                selector,
+                payload: vec![1, 3, 2],
+            },
+            pending,
+            _lock: crate::emitter_journal::lock_camera(&id)
+                .expect("lock")
+                .expect("not busy"),
+        };
+        let err = found.finish(&id).expect_err("the save must fail");
+        assert!(err.contains("save the emitter config"), "{err}");
+
+        std::fs::set_permissions(&confdir, std::fs::Permissions::from_mode(0o700))
+            .expect("restore");
+        assert!(conf.exists(), "the premise: the config is still visible");
+        assert_eq!(
+            std::fs::read_dir(dir.join("ir-emitter-journal"))
+                .map(|d| d.filter_map(|e| e.ok()).count())
+                .unwrap_or(0),
+            1,
+            "the undo record must outlive a half-published configuration"
+        );
+        assert_eq!(
+            fake_camera::log()
+                .iter()
+                .filter(|r| matches!(r, fake_camera::Request::Set(_)))
+                .count(),
+            writes_before,
+            "and the camera must not be put back behind a config that will re-apply it"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1173,6 +1173,92 @@ impl std::fmt::Display for DiscoveryError {
     }
 }
 
+/// Which signal asked the current run to stop, or 0.
+static ABORT_SIGNAL: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
+
+/// The whole signal handler. Storing to a lock-free atomic is one of the very
+/// few things a handler may do; putting the camera back is not, so that happens
+/// on the normal return path where syscalls, locks and allocation are allowed.
+extern "C" fn note_abort_signal(signum: c_int) {
+    ABORT_SIGNAL.store(signum, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Whether a fatal signal arrived during this discovery run.
+///
+/// Polled by the measurement closure, which is the only part of discovery that
+/// blocks for any length of time. Returning `None` from it aborts the run
+/// through the ordinary restore path.
+pub fn abort_requested() -> bool {
+    ABORT_SIGNAL.load(std::sync::atomic::Ordering::SeqCst) != 0
+}
+
+/// Turns a fatal signal arriving mid-discovery into an orderly abort, then lets
+/// it kill the process as it was going to.
+///
+/// Without this, a `systemd` stop or a watchdog SIGTERM during `ir-setup`
+/// terminates the daemon on the default disposition: no unwinding, so no `Drop`
+/// runs, so the control stays changed. The undo record still covers that case,
+/// but it covers it at the NEXT capture, which is minutes or a reboot away. This
+/// closes it now for every signal that can actually be caught.
+///
+/// Installed without `SA_RESTART` on purpose: the blocking `VIDIOC_DQBUF` in the
+/// measurement loop then fails with `EINTR` instead of resuming, so the abort is
+/// noticed in milliseconds rather than at the end of a frame burst.
+///
+/// `SIGKILL` and a power loss are exactly the cases a handler cannot reach. They
+/// are the record's job.
+pub struct AbortOnSignal {
+    saved: Vec<(c_int, libc::sigaction)>,
+}
+
+impl AbortOnSignal {
+    /// Catch the fatal signals for the caller's scope.
+    ///
+    /// Best-effort: a signal whose disposition cannot be changed is skipped
+    /// rather than failing the run, because the record covers it and refusing to
+    /// set up a camera over a `sigaction` failure helps nobody.
+    pub fn install() -> Self {
+        ABORT_SIGNAL.store(0, std::sync::atomic::Ordering::SeqCst);
+        let mut saved = Vec::new();
+        for signum in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+            // SAFETY: `action` is fully initialised below before use, and
+            // `note_abort_signal` touches nothing but one lock-free atomic.
+            unsafe {
+                let mut action: libc::sigaction = std::mem::zeroed();
+                action.sa_sigaction = note_abort_signal as *const () as usize;
+                libc::sigemptyset(&mut action.sa_mask);
+                action.sa_flags = 0; // no SA_RESTART: let the frame dequeue fail with EINTR
+                let mut previous: libc::sigaction = std::mem::zeroed();
+                if libc::sigaction(signum, &action, &mut previous) == 0 {
+                    saved.push((signum, previous));
+                }
+            }
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for AbortOnSignal {
+    fn drop(&mut self) {
+        for (signum, previous) in &self.saved {
+            // SAFETY: `previous` is what sigaction handed back for this signal.
+            unsafe {
+                libc::sigaction(*signum, previous, std::ptr::null_mut());
+            }
+        }
+        // The signal was caught to get the camera put back, not to ignore it.
+        // The original disposition is restored above, so re-raising now does
+        // whatever would have happened had this guard never existed.
+        let pending = ABORT_SIGNAL.swap(0, std::sync::atomic::Ordering::SeqCst);
+        if pending != 0 {
+            // SAFETY: raising a signal at its restored disposition.
+            unsafe {
+                libc::raise(pending);
+            }
+        }
+    }
+}
+
 /// Holds the undo data for an exploratory write for as long as the control is
 /// not known to be back where it was found.
 ///
@@ -1252,6 +1338,7 @@ impl ExploratoryWrite {
     fn confirm_restored(&mut self) -> Result<(), String> {
         let now = get_cur(self.fd, self.unit, self.selector, self.original.len())
             .map_err(|e| format!("read the control back: {e}"))?;
+        crate::emitter_journal::trace(&format!("read back {now:02x?}"));
         if now != self.original {
             return Err(format!(
                 "the control reads {:02x?} after being restored to {:02x?}",
@@ -2085,6 +2172,56 @@ pub fn describe_units(device: &str) -> std::io::Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A caught signal must set the flag the measurement loop polls, and the
+    /// guard must hand the signal back to whatever disposition it displaced.
+    ///
+    /// SIGINT is set to SIG_IGN around the whole test, so the re-raise on drop
+    /// is a no-op instead of killing the test binary. That also makes the
+    /// restore assertion real: SIG_IGN is what must come back.
+    #[test]
+    fn a_caught_signal_is_noted_and_then_handed_back() {
+        // Signal dispositions are process-global, like the environment, so this
+        // contends on the same lock rather than racing the tests that flip env
+        // vars while this one is swapping handlers.
+        let _lock = crate::testenv::env_lock();
+
+        // SAFETY: every sigaction below is fully initialised before use.
+        unsafe {
+            let mut ignore: libc::sigaction = std::mem::zeroed();
+            ignore.sa_sigaction = libc::SIG_IGN;
+            libc::sigemptyset(&mut ignore.sa_mask);
+            let mut before: libc::sigaction = std::mem::zeroed();
+            assert_eq!(libc::sigaction(libc::SIGINT, &ignore, &mut before), 0);
+
+            {
+                let _guard = AbortOnSignal::install();
+                assert!(!abort_requested(), "nothing raised yet");
+                assert_eq!(libc::raise(libc::SIGINT), 0);
+                assert!(
+                    abort_requested(),
+                    "the handler must record the signal for the measurement loop to see"
+                );
+            } // drop restores SIG_IGN, then re-raises into it
+
+            let mut after: libc::sigaction = std::mem::zeroed();
+            assert_eq!(
+                libc::sigaction(libc::SIGINT, std::ptr::null(), &mut after),
+                0
+            );
+            assert_eq!(
+                after.sa_sigaction,
+                libc::SIG_IGN,
+                "the guard must put the previous disposition back"
+            );
+            assert!(
+                !abort_requested(),
+                "the flag must not leak into the next run"
+            );
+
+            libc::sigaction(libc::SIGINT, &before, std::ptr::null_mut());
+        }
+    }
 
     #[test]
     fn encode_parse_roundtrip() {

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -3531,10 +3531,11 @@ mod tests {
         let held = crate::emitter_journal::lock_camera(&id)
             .expect("take the lock")
             .expect("not busy");
-        let path = dir.join(format!(
-            "irlume-emitter-{}.lock",
-            crate::emitter_journal::filing_key(&id)
-        ));
+        // Asked for by the same code the daemon uses, not rebuilt from the
+        // filing key: the lock is deliberately keyed on something narrower, and
+        // a test that constructs the name itself stops holding the lock the
+        // moment that changes. It did, and this caught it.
+        let path = crate::emitter_journal::lock_path_for_test(&id);
         drop(held);
 
         // The child signals readiness by creating a marker AFTER `flock` has

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -522,6 +522,20 @@ pub(crate) mod fake_camera {
         })
     }
 
+    /// Force what the control reports, without a write.
+    ///
+    /// Models a camera that accepted a `SET_CUR` and is nonetheless holding
+    /// something else: a clamp, a partial apply, or a mode it resolved
+    /// differently. The fake normally follows an accepted write, which is right
+    /// for every other test and useless for this one.
+    pub(crate) fn set_current(value: Vec<u8>) {
+        CAMERA.with(|c| {
+            if let Some(cam) = c.borrow_mut().as_mut() {
+                cam.current = value;
+            }
+        });
+    }
+
     /// What the control holds now.
     pub(crate) fn current() -> Vec<u8> {
         CAMERA.with(|c| {
@@ -1586,6 +1600,9 @@ struct ExploratoryWrite {
     unit: u8,
     selector: u8,
     original: Vec<u8>,
+    /// The value this run applies. Kept so `commit` can confirm the camera is
+    /// actually holding it before the undo data is thrown away.
+    attempted: Vec<u8>,
     /// The record exactly as it was written, so the removal cannot target a
     /// different file than the save did.
     record: crate::emitter_journal::PendingWrite,
@@ -1652,6 +1669,7 @@ impl ExploratoryWrite {
             unit,
             selector,
             original: original.to_vec(),
+            attempted: attempted.to_vec(),
             record,
             resolved: false,
             // Nothing has been written yet.
@@ -1704,14 +1722,32 @@ impl ExploratoryWrite {
     }
 
     /// The control is deliberately left at the applied value, and the
-    /// configuration naming it is durable. Drop the record.
+    /// configuration naming it is durable. Confirm it, then drop the record.
     ///
     /// Ordering matters: called only AFTER `save_conf`. A crash between a
     /// successful discovery and that write leaves the camera lit with nothing on
     /// disk saying which control did it, which is the same unrecorded change
     /// this module exists to prevent, so until the configuration lands the
     /// record stays open and the guard would put the control back.
+    ///
+    /// The read-back is not optional here either. This used to clear on the
+    /// strength of the final `SET_CUR` returning success, which is exactly the
+    /// assumption the rest of this module refuses to make: a camera that clamps
+    /// the value, applies it partly, or answers success while holding something
+    /// else would have had the only copy of its original bytes deleted, and
+    /// `ir_emitter.conf` stores coordinates and no payload, so nothing else
+    /// holds them. Returning an error leaves the guard armed, so `Discovered`
+    /// dropping puts the original back and confirms THAT.
     fn commit(&mut self) -> Result<(), String> {
+        let now = get_cur(self.fd, self.unit, self.selector, self.attempted.len())
+            .map_err(|e| format!("read the applied control back: {e}"))?;
+        crate::emitter_journal::trace(&format!("read back applied {now:02x?}"));
+        if now != self.attempted {
+            return Err(format!(
+                "the control reads {now:02x?} after being set to {:02x?}",
+                self.attempted
+            ));
+        }
         crate::emitter_journal::clear(&self.record)?;
         self.resolved = true;
         Ok(())
@@ -2967,6 +3003,61 @@ mod tests {
             matches!(outcome, Ok(Attempt::Lit(..))),
             "the fixture must reach a successful discovery: {outcome:?}"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A camera that says "yes" to the final write but holds something else must
+    /// not have its undo data deleted.
+    ///
+    /// `commit` used to clear on the strength of the `SET_CUR` returning
+    /// success, which is precisely the assumption the rest of this module
+    /// refuses to make. `ir_emitter.conf` stores coordinates and no payload, so
+    /// once the record is gone nothing holds the original bytes at all.
+    #[test]
+    fn a_final_write_the_camera_did_not_take_keeps_the_undo_record() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-commit-readback");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let id = identity(0x3277, 0x0059);
+        let ms = id.microsoft_xu().expect("fixture has a Microsoft XU");
+        let selector = [
+            crate::uvc_descriptor::MSXU_IR_TORCH,
+            crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+        ]
+        .into_iter()
+        .find(|s| ms.advertises(*s))
+        .expect("fixture advertises an emitter selector");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let mut pending =
+            ExploratoryWrite::open(-1, &id, ms.unit_id, selector, 3, &[1, 3, 1], &[1, 3, 2])
+                .expect("open the record");
+        pending
+            .apply_exploratory(&[1, 3, 2])
+            .expect("the fake accepts the write");
+
+        // The camera quietly holds something else. The fake's GET_CUR follows an
+        // accepted SET_CUR, so this is forced directly.
+        fake_camera::set_current(vec![1, 3, 3]);
+
+        let err = pending.commit().expect_err("commit must not accept this");
+        assert!(err.contains("[01, 03, 03]"), "{err}");
+        assert!(
+            !pending.resolved,
+            "an unconfirmed control leaves the guard armed so Drop restores it"
+        );
+
+        let store = dir.join("ir-emitter-journal");
+        assert_eq!(
+            std::fs::read_dir(&store).map(|d| d.count()).unwrap_or(0),
+            1,
+            "the undo record must survive: nothing else holds the original bytes"
+        );
+        drop(pending);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -541,27 +541,74 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> bool {
     // `IRLUME_IR_EMITTER=off` still means irlume sends the camera nothing. A
     // record pending on a machine set that way surfaces through `irlume doctor`
     // instead.
-    report_recovery(&id, recover_pending_write(fd, &id));
+    let recovery = recover_pending_write(fd, &id);
+    let action = planned_action(&recovery, wanted, &id);
+    report_recovery(&id, recovery);
 
-    if let Some(ctrl) = wanted {
-        return apply_override(fd, &id, &ctrl);
+    match action {
+        CaptureAction::Nothing => false,
+        CaptureAction::Override(ctrl) => apply_override(fd, &id, &ctrl),
+        CaptureAction::DeviceDefault { unit, selector } => {
+            apply_device_default(fd, unit, selector).is_ok()
+        }
+        CaptureAction::KnownPayload(ctrl) => apply_known_payload(fd, &ctrl).is_ok(),
+    }
+}
+
+/// Which control, if any, a capture should apply to this camera.
+///
+/// Extracted so the decision is a VALUE. Every input is either pure or a file
+/// read a test can point somewhere else, which `enable` itself is not: it needs
+/// an open camera to reach any of this, so nothing below could be tested at all
+/// while it lived inline. The gap was not theoretical. `enable` used to run the
+/// recovery pass, log that a camera must not be written to, and then apply the
+/// configured control to the very unit and selector the unresolved record named,
+/// at every stream open and every eighth frame of a burst.
+fn planned_action(
+    recovery: &RecoveryOutcome,
+    wanted: Option<EmitterControl>,
+    id: &crate::uvc_descriptor::CameraIdentity,
+) -> CaptureAction {
+    // First, before any of the three sources are consulted: all three write to
+    // the same extension unit an unresolved record is about.
+    //
+    // The cost of refusing is the emitter, so IR authentication does not light
+    // and the user falls back to a password until a human resolves it. #159 is
+    // a camera that never enumerated again after unverified extension-unit
+    // writes, and a control that has already failed to read back what was
+    // written to it is the clearest available sign of that territory.
+    if !recovery.permits_capture_write() {
+        return CaptureAction::Nothing;
     }
 
-    if let Some((unit, selector)) = load_conf(&id) {
+    if let Some(ctrl) = wanted {
+        return CaptureAction::Override(ctrl);
+    }
+
+    if let Some((unit, selector)) = load_conf(id) {
         let recorded = EmitterControl {
             unit,
             selector,
             payload: Vec::new(),
         };
-        if control_is_documented(&id, &recorded) {
-            return apply_device_default(fd, unit, selector).is_ok();
+        if control_is_documented(id, &recorded) {
+            return CaptureAction::DeviceDefault { unit, selector };
         }
     }
 
-    match known_control(id.vid, id.pid).filter(|c| control_is_documented(&id, c)) {
-        Some(ctrl) => apply_known_payload(fd, &ctrl).is_ok(),
-        None => false,
+    match known_control(id.vid, id.pid).filter(|c| control_is_documented(id, c)) {
+        Some(ctrl) => CaptureAction::KnownPayload(ctrl),
+        None => CaptureAction::Nothing,
     }
+}
+
+/// What `enable` decided to send the camera. `Nothing` means no ioctl at all.
+#[derive(Debug, Clone, PartialEq)]
+enum CaptureAction {
+    Nothing,
+    Override(EmitterControl),
+    DeviceDefault { unit: u8, selector: u8 },
+    KnownPayload(EmitterControl),
 }
 
 /// Why an `IRLUME_IR_EMITTER` override was not written to the camera.
@@ -1401,10 +1448,27 @@ pub(crate) fn recover_pending_write(
     let record = match journal::load(id) {
         Ok(None) => return RecoveryOutcome::NothingPending,
         Ok(Some(record)) => record,
-        Err(why) => return RecoveryOutcome::Unreadable(why),
+        // A store that cannot be read may be hiding a change to THIS camera, so
+        // it is unresolved rather than "nothing pending".
+        Err(why) => return RecoveryOutcome::Unresolved(why),
     };
     if let Err(mismatch) = journal::record_applies(&record, id) {
-        return RecoveryOutcome::NotApplicable(mismatch);
+        use journal::Mismatch;
+        return match mismatch {
+            // Not about this camera. Everything else is.
+            Mismatch::DifferentCamera => RecoveryOutcome::ForAnotherCamera,
+            Mismatch::OwnerStillRunning { pid } => RecoveryOutcome::OwnerStillRunning { pid },
+            Mismatch::OutOfAttempts { attempts } => RecoveryOutcome::Unresolved(format!(
+                "{attempts} attempts to put it back did not take, so no more will be made"
+            )),
+            Mismatch::SchemaTooNew { found, supported } => RecoveryOutcome::Unresolved(format!(
+                "the record is schema {found} and this build implements {supported}"
+            )),
+            Mismatch::Malformed(why) => RecoveryOutcome::Unresolved(format!("malformed: {why}")),
+            Mismatch::ControlNotPublished => RecoveryOutcome::Unresolved(
+                "the record names a control this camera does not publish".into(),
+            ),
+        };
     }
 
     // Read the control before deciding anything. A restore that is not needed is
@@ -1423,16 +1487,18 @@ pub(crate) fn recover_pending_write(
             current,
         },
         (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
-            return RecoveryOutcome::Unreadable(format!("query the control: {e}"))
+            return RecoveryOutcome::Unresolved(format!("query the control: {e}"))
         }
     };
 
     match journal::restore_decision(&record, &now) {
         journal::Restore::AlreadyRestored => match journal::clear(&record.descriptor_sha256) {
             Ok(()) => RecoveryOutcome::AlreadyRestored,
-            Err(why) => RecoveryOutcome::Unreadable(why),
+            // The control holds its original. Only the store is unhappy, and the
+            // store does not decide what the camera holds.
+            Err(why) => RecoveryOutcome::RestoredRecordKept(why),
         },
-        journal::Restore::Refuse(why) => RecoveryOutcome::Refused(why),
+        journal::Restore::Refuse(why) => RecoveryOutcome::Unresolved(why),
         journal::Restore::Write(original) => {
             // Count the attempt BEFORE the write and make it durable. Counting
             // after would leave a kill during the restore uncounted, and a
@@ -1449,10 +1515,12 @@ pub(crate) fn recover_pending_write(
             spent.boot_id = None;
             spent.pid = None;
             if let Err(why) = journal::save(&spent) {
-                return RecoveryOutcome::Unreadable(why);
+                // The attempt could not be counted, so making it would be an
+                // uncounted write: exactly the loop the counter exists to stop.
+                return RecoveryOutcome::Unresolved(format!("count the attempt: {why}"));
             }
             if let Err(e) = set_cur(fd, record.unit, record.selector, &original) {
-                return RecoveryOutcome::Refused(format!("restore: {e}"));
+                return RecoveryOutcome::Unresolved(format!("restore: {e}"));
             }
             match get_cur(fd, record.unit, record.selector, original.len()) {
                 Ok(back) if back == original => match journal::clear(&record.descriptor_sha256) {
@@ -1460,12 +1528,12 @@ pub(crate) fn recover_pending_write(
                         unit: record.unit,
                         selector: record.selector,
                     },
-                    Err(why) => RecoveryOutcome::Unreadable(why),
+                    Err(why) => RecoveryOutcome::RestoredRecordKept(why),
                 },
-                Ok(back) => RecoveryOutcome::Refused(format!(
+                Ok(back) => RecoveryOutcome::Unresolved(format!(
                     "the control reads {back:02x?} after being restored to {original:02x?}"
                 )),
-                Err(e) => RecoveryOutcome::Unreadable(format!("read the control back: {e}")),
+                Err(e) => RecoveryOutcome::Unresolved(format!("read the control back: {e}")),
             }
         }
     }
@@ -1499,41 +1567,61 @@ fn report_recovery(id: &crate::uvc_descriptor::CameraIdentity, outcome: Recovery
     }
 }
 
-/// What a recovery pass did. Reported rather than swallowed: this is a write to
-/// camera firmware on a path nobody asked for, so it says so in the journal.
+/// What a recovery pass did.
+///
+/// The variants are split by what the CALLER must do next, not by what went
+/// wrong. Three call sites ask this type two questions — may I write to this
+/// camera, and may discovery start — and both answers live here rather than
+/// being re-derived from a reason string at each site.
+///
+/// "Could not read" used to be one variant covering the store, the control, and
+/// the removal of a record after a confirmed restore. Those call for opposite
+/// actions: a control that will not answer means stop, while a record that will
+/// not delete after the control is provably back means the camera is fine and
+/// the store is not.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RecoveryOutcome {
     NothingPending,
-    /// The control already held the original; the record was dropped and nothing
-    /// was written.
+    /// A record exists for a DIFFERENT camera. Ordinary on a machine with two of
+    /// them, and none of this camera's business: it must not stop the emitter
+    /// here, which is the whole reason this is not folded in with the refusals.
+    ForAnotherCamera,
+    /// The control already held the original and the record was dropped.
     AlreadyRestored,
     Restored {
         unit: u8,
         selector: u8,
     },
-    /// A record exists for a different camera, a newer schema, or a control this
-    /// camera no longer publishes. Left exactly as it is.
-    NotApplicable(crate::emitter_journal::Mismatch),
-    /// The record stands and could not be acted on. It stays on disk.
-    Refused(String),
-    Unreadable(String),
+    /// The control is confirmed back at its original, but the record could not be
+    /// removed. The camera is in the right state, so capture may proceed; the
+    /// store is not, so discovery may not, because it could not record its own
+    /// next write either.
+    RestoredRecordKept(String),
+    /// A run that opened a record on this camera is still going. Silent, and it
+    /// stops both a capture write and a second discovery: the control is
+    /// SUPPOSED to be changed right now.
+    OwnerStillRunning {
+        pid: u32,
+    },
+    /// An outstanding change on THIS camera that could not be resolved. Nothing
+    /// further may be written to it by any path.
+    Unresolved(String),
 }
 
 impl RecoveryOutcome {
     /// One line for the log, or nothing when there was nothing to do.
     ///
-    /// `NotApplicable` is silent for a different camera, which is the ordinary
-    /// case on a machine with two of them and would otherwise print at every
-    /// capture. Everything else is loud: a pending firmware change that cannot
-    /// be undone is the operator's problem, not a debug detail.
+    /// A different camera and a live setup run are silent: both are ordinary and
+    /// both would otherwise print at every capture. Everything else is loud. A
+    /// pending firmware change that cannot be undone is the operator's problem,
+    /// not a debug detail, and each of those messages now also says that the
+    /// emitter is off as a result, because a user whose face login stopped
+    /// working is owed the reason in the same line.
     pub(crate) fn message(&self) -> Option<String> {
-        use crate::emitter_journal::Mismatch;
+        let store = crate::emitter_journal::store_dir();
         match self {
-            Self::NothingPending => None,
-            Self::NotApplicable(Mismatch::DifferentCamera) => None,
-            // A setup run in flight is the normal reason to see this, and it is
-            // about to resolve its own record.
-            Self::NotApplicable(Mismatch::OwnerStillRunning { .. }) => None,
+            Self::NothingPending | Self::ForAnotherCamera => None,
+            Self::OwnerStillRunning { .. } => None,
             Self::AlreadyRestored => Some(
                 "irlume: an interrupted emitter setup was already undone; \
                  dropped its undo record"
@@ -1543,24 +1631,18 @@ impl RecoveryOutcome {
                 "irlume: an interrupted emitter setup had left unit {unit} selector {selector} \
                  changed; put it back to the value the camera reported before that run"
             )),
-            Self::NotApplicable(Mismatch::OutOfAttempts { attempts }) => Some(format!(
-                "irlume: an emitter control was changed by an interrupted setup and {attempts} \
-                 attempts to put it back did not take. Nothing further will be written to it. \
-                 The recorded original is in {}",
-                crate::emitter_journal::store_dir().display()
+            Self::RestoredRecordKept(why) => Some(format!(
+                "irlume: an emitter control was put back and confirmed, but its undo record in \
+                 {} could not be removed ({why}). The camera is in the right state; \
+                 `irlume ir-setup` will refuse until the record can be written",
+                store.display()
             )),
-            Self::NotApplicable(why) => Some(format!(
-                "irlume: an emitter undo record cannot be applied to this camera ({why:?}); \
-                 left in {}",
-                crate::emitter_journal::store_dir().display()
-            )),
-            Self::Refused(why) => Some(format!(
-                "irlume: an emitter control left changed by an interrupted setup was not put \
-                 back ({why}); the undo record stays in {}",
-                crate::emitter_journal::store_dir().display()
-            )),
-            Self::Unreadable(why) => Some(format!(
-                "irlume: could not process the emitter undo record ({why})"
+            Self::Unresolved(why) => Some(format!(
+                "irlume: an emitter control on this camera was left changed by an interrupted \
+                 setup and has not been put back ({why}). irlume will not write to this \
+                 camera's emitter until it is resolved, so IR face authentication will not \
+                 light. The recorded original is in {}",
+                store.display()
             )),
         }
     }
@@ -1569,35 +1651,67 @@ impl RecoveryOutcome {
     fn kind(&self) -> &'static str {
         match self {
             Self::NothingPending => "nothing",
+            Self::ForAnotherCamera => "another-camera",
             Self::AlreadyRestored => "already-restored",
             Self::Restored { .. } => "restored",
-            Self::NotApplicable(_) => "not-applicable",
-            Self::Refused(_) => "refused",
-            Self::Unreadable(_) => "unreadable",
+            Self::RestoredRecordKept(_) => "restored-record-kept",
+            Self::OwnerStillRunning { .. } => "owner-running",
+            Self::Unresolved(_) => "unresolved",
         }
     }
 
-    /// Whether an unresolved change is still outstanding on this camera.
+    /// Whether a capture may go on to apply an emitter control to this camera.
     ///
-    /// Discovery refuses to start when it is. Its first act is to read the
-    /// control and call the answer the original, so running it against a control
-    /// that is still holding a previous run's exploratory value would record the
-    /// wrong bytes as the thing to go back to, and destroy the real ones.
+    /// Reporting that a camera must not be written to and then writing to it is
+    /// worse than never having checked. `enable` used to do exactly that: it
+    /// logged "nothing further will be written to it" and then applied the
+    /// configured control to that same unit and selector on the next line, at
+    /// every stream open and every eighth frame of a burst.
+    ///
+    /// Refusing costs the IR emitter, so face authentication does not light and
+    /// the user falls back to a password until a human resolves it. That is the
+    /// cheaper side of the trade: #159 is a camera that never enumerated again
+    /// after unverified extension-unit writes, and a control that has already
+    /// failed to read back what was written to it is the clearest sign available
+    /// that this camera is in that territory.
+    ///
+    /// A record for ANOTHER camera permits the write. It has nothing to say about
+    /// this one, and treating it as a refusal would put a machine with a detached
+    /// second camera into password-only login for no reason.
+    pub(crate) fn permits_capture_write(&self) -> bool {
+        match self {
+            Self::NothingPending
+            | Self::ForAnotherCamera
+            | Self::AlreadyRestored
+            | Self::Restored { .. }
+            // The control is confirmed back at its original. Only the store is
+            // unhappy, and the store does not decide what the camera holds.
+            | Self::RestoredRecordKept(_) => true,
+            Self::OwnerStillRunning { .. } | Self::Unresolved(_) => false,
+        }
+    }
+
+    /// Whether discovery may start.
+    ///
+    /// Stricter than [`Self::permits_capture_write`] in one place: a record that
+    /// could not be removed also stops discovery, because discovery's first act
+    /// is to write a record of its own, and a store that cannot be written to
+    /// cannot hold one.
+    ///
+    /// Discovery's second act is to read the control and call the answer the
+    /// original, so running it against a control still holding a previous run's
+    /// exploratory value would record the wrong bytes as the thing to go back to
+    /// and destroy the real ones.
     pub(crate) fn blocks_discovery(&self) -> bool {
-        matches!(self, Self::Refused(_) | Self::Unreadable(_))
-            || matches!(
-                self,
-                Self::NotApplicable(
-                    crate::emitter_journal::Mismatch::OutOfAttempts { .. }
-                        | crate::emitter_journal::Mismatch::SchemaTooNew { .. }
-                        | crate::emitter_journal::Mismatch::Malformed(_)
-                        | crate::emitter_journal::Mismatch::ControlNotPublished
-                        // Another setup run holds this camera. Two of them
-                        // interleaving reads and writes on one control would
-                        // each record the other's value as the original.
-                        | crate::emitter_journal::Mismatch::OwnerStillRunning { .. }
-                )
-            )
+        match self {
+            Self::NothingPending
+            | Self::ForAnotherCamera
+            | Self::AlreadyRestored
+            | Self::Restored { .. } => false,
+            Self::RestoredRecordKept(_) | Self::OwnerStillRunning { .. } | Self::Unresolved(_) => {
+                true
+            }
+        }
     }
 }
 
@@ -2223,6 +2337,178 @@ mod tests {
         }
     }
 
+    /// Every outcome, and what each one lets the two callers do.
+    ///
+    /// Written as one exhaustive table rather than a test per variant because
+    /// the defect was not a wrong answer for one case: `enable` did not ask the
+    /// question at all, logged "nothing further will be written to it", and then
+    /// wrote to that same unit and selector on the next line. A table makes
+    /// adding a variant without deciding its policy impossible to miss.
+    #[test]
+    fn each_recovery_outcome_decides_what_the_callers_may_do() {
+        // (outcome, may capture write, blocks discovery, is logged)
+        let table = [
+            (RecoveryOutcome::NothingPending, true, false, false),
+            (RecoveryOutcome::ForAnotherCamera, true, false, false),
+            (RecoveryOutcome::AlreadyRestored, true, false, true),
+            (
+                RecoveryOutcome::Restored {
+                    unit: 14,
+                    selector: 6,
+                },
+                true,
+                false,
+                true,
+            ),
+            // The camera is provably right and only the store is wrong, so a
+            // capture proceeds; discovery cannot, because its first act is to
+            // write a record into that same store.
+            (
+                RecoveryOutcome::RestoredRecordKept("read-only fs".into()),
+                true,
+                true,
+                true,
+            ),
+            // Silent: a setup run in flight is ordinary, and it is about to
+            // resolve its own record. It still stops both writers.
+            (
+                RecoveryOutcome::OwnerStillRunning { pid: 1234 },
+                false,
+                true,
+                false,
+            ),
+            (
+                RecoveryOutcome::Unresolved("3 attempts did not take".into()),
+                false,
+                true,
+                true,
+            ),
+        ];
+        for (outcome, may_write, blocks, logged) in table {
+            assert_eq!(
+                outcome.permits_capture_write(),
+                may_write,
+                "capture policy for {outcome:?}"
+            );
+            assert_eq!(
+                outcome.blocks_discovery(),
+                blocks,
+                "discovery policy for {outcome:?}"
+            );
+            assert_eq!(
+                outcome.message().is_some(),
+                logged,
+                "logging for {outcome:?}"
+            );
+        }
+    }
+
+    /// An unresolved record stops ALL THREE of the sources a capture can apply
+    /// from, not just the recovery write.
+    ///
+    /// This is the finding review caught: the refusal was logged and then the
+    /// configured control was applied to the very unit and selector the record
+    /// named, on the next line, at every stream open and every eighth frame of a
+    /// burst. Each source is checked separately, because a guard placed before
+    /// the override alone would leave the other two writing.
+    #[test]
+    fn an_unresolved_record_stops_every_source_a_capture_could_write_from() {
+        let _lock = crate::testenv::env_lock();
+        let id = identity(0x3277, 0x0059);
+        let blocked = [
+            RecoveryOutcome::Unresolved("3 attempts did not take".into()),
+            RecoveryOutcome::OwnerStillRunning { pid: 4321 },
+        ];
+
+        for recovery in &blocked {
+            // Source 1: the env override, the only path the user asked for.
+            assert_eq!(
+                planned_action(
+                    recovery,
+                    Some(EmitterControl {
+                        unit: 14,
+                        selector: 6,
+                        payload: vec![1, 3, 2],
+                    }),
+                    &id
+                ),
+                CaptureAction::Nothing,
+                "override under {recovery:?}"
+            );
+
+            // Source 2: the control ir-setup recorded. Pointed at a real conf so
+            // the branch is genuinely reachable, otherwise this would pass
+            // because there was nothing to apply.
+            let dir = std::env::temp_dir().join("irlume-planned-action");
+            let _ = std::fs::create_dir_all(&dir);
+            let conf = dir.join("ir_emitter.conf");
+            let (unit, selector) = {
+                let ms = id.microsoft_xu().expect("fixture publishes a Microsoft XU");
+                let selector = [
+                    crate::uvc_descriptor::MSXU_IR_TORCH,
+                    crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+                ]
+                .into_iter()
+                .find(|s| ms.advertises(*s))
+                .expect("fixture advertises an emitter selector");
+                (ms.unit_id, selector)
+            };
+            std::fs::write(&conf, format!("{} {unit}:{selector}", id.usb_id()))
+                .expect("write conf");
+            let _env = EnvGuard::set("IRLUME_IR_EMITTER_CONF", &conf);
+
+            assert_eq!(
+                planned_action(&RecoveryOutcome::NothingPending, None, &id),
+                CaptureAction::DeviceDefault { unit, selector },
+                "the conf branch must be reachable, or the next assertion proves nothing"
+            );
+            assert_eq!(
+                planned_action(recovery, None, &id),
+                CaptureAction::Nothing,
+                "recorded control under {recovery:?}"
+            );
+            drop(_env);
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+
+    /// A record belonging to a DIFFERENT camera must not turn this camera's
+    /// emitter off. A machine with a detached second camera would otherwise drop
+    /// to password-only login for no reason.
+    #[test]
+    fn a_record_for_another_camera_does_not_stop_this_one() {
+        let _lock = crate::testenv::env_lock();
+        let _env = EnvGuard::unset("IRLUME_IR_EMITTER_CONF");
+        let id = identity(0x3277, 0x0059);
+        let ctrl = EmitterControl {
+            unit: 14,
+            selector: 6,
+            payload: vec![1, 3, 2],
+        };
+        assert_eq!(
+            planned_action(&RecoveryOutcome::ForAnotherCamera, Some(ctrl.clone()), &id),
+            CaptureAction::Override(ctrl),
+            "another camera's record is not this camera's business"
+        );
+    }
+
+    /// The message an operator reads has to say why face authentication stopped,
+    /// not only that a record exists. A refusal that does not explain the symptom
+    /// sends someone hunting through the wrong subsystem.
+    #[test]
+    fn a_refusal_says_the_emitter_will_not_light() {
+        let msg = RecoveryOutcome::Unresolved("the control reads [1, 3, 2]".into())
+            .message()
+            .expect("a refusal is always reported");
+        assert!(msg.contains("will not write"), "{msg}");
+        assert!(msg.contains("will not light"), "{msg}");
+        // And where to find the bytes that would put it back.
+        assert!(
+            msg.contains(&crate::emitter_journal::store_dir().display().to_string()),
+            "{msg}"
+        );
+    }
+
     #[test]
     fn encode_parse_roundtrip() {
         let c = EmitterControl {
@@ -2232,6 +2518,8 @@ mod tests {
         };
         assert_eq!(parse_control(&c.encode()), Some(c));
     }
+
+    use crate::testenv::EnvGuard;
 
     /// Serializes access to the process env vars these tests flip
     /// (`IRLUME_IR_EMITTER`, `IRLUME_IR_EMITTER_CONF`).

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -525,6 +525,24 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> bool {
         }
     };
 
+    // Before anything is applied. A control an interrupted setup left changed is
+    // not where its owner left it, and the value applied below would be layered
+    // on top of it.
+    //
+    // This is a write to camera firmware on a path nobody explicitly asked for,
+    // which everything else in this file is written to avoid. It is allowed here
+    // because it is not a new class of write: the bytes are the camera's own,
+    // read from this control moments before an earlier run changed it, the
+    // control is one this camera publishes, and this path is already about to
+    // write to that same control. It is the difference between putting something
+    // back and trying something out.
+    //
+    // The `off` and malformed branches returned above and are not reached, so
+    // `IRLUME_IR_EMITTER=off` still means irlume sends the camera nothing. A
+    // record pending on a machine set that way surfaces through `irlume doctor`
+    // instead.
+    report_recovery(&id, recover_pending_write(fd, &id));
+
     if let Some(ctrl) = wanted {
         return apply_override(fd, &id, &ctrl);
     }
@@ -1072,6 +1090,15 @@ pub enum DiscoveryError {
         selector: u8,
         err: XuError,
     },
+    /// An earlier run left a control changed and this one could not undo it.
+    ///
+    /// Discovery's first act is to read a control and treat the answer as the
+    /// value to go back to. Run against a control still holding a previous run's
+    /// exploratory value, it would record that as the original and the real one
+    /// would be gone for good.
+    UnresolvedChange,
+    /// The undo record could not be written, so nothing was sent to the camera.
+    JournalUnwritable(String),
 }
 
 impl std::fmt::Display for DiscoveryError {
@@ -1127,7 +1154,363 @@ impl std::fmt::Display for DiscoveryError {
                 "unit {unit} selector {selector} was changed and could not be restored ({err}); \
                  power the camera down fully before using it again"
             ),
+            Self::UnresolvedChange => write!(
+                f,
+                "an earlier setup run left a control on this camera changed and it could not be \
+                 put back, so this run stopped before reading anything: it would have recorded \
+                 the changed value as the one to go back to. The original bytes are in {}. \
+                 Unplug and reconnect the camera, or power it down fully, and try again",
+                crate::emitter_journal::store_dir().display()
+            ),
+            Self::JournalUnwritable(why) => write!(
+                f,
+                "nothing was sent to the camera because the record of how to undo it could not \
+                 be written ({why}). Setup writes that record first on purpose, so that a crash \
+                 or a power loss part-way through still leaves something that can put the \
+                 control back"
+            ),
         }
+    }
+}
+
+/// Holds the undo data for an exploratory write for as long as the control is
+/// not known to be back where it was found.
+///
+/// The record reaches disk before the first `SET_CUR` and is removed only after
+/// the control has been read back holding the original again. In between, the
+/// guard's `Drop` puts the control back on any path that leaves the function
+/// early — a panic in the frame decoder, a `?` on an ioctl — which the explicit
+/// restores in `try_documented_control` cannot cover because they are statements
+/// that only run when control reaches them.
+///
+/// `Drop` is best-effort by nature: it cannot report a failure and it does not
+/// run for `SIGKILL` or a power loss. The record is what covers those, and it is
+/// deliberately left in place when the restore cannot be confirmed.
+#[derive(Debug)]
+struct ExploratoryWrite {
+    fd: c_int,
+    unit: u8,
+    selector: u8,
+    original: Vec<u8>,
+    descriptor_sha256: String,
+    /// Set once the control is confirmed back at `original`, or once the applied
+    /// value is durably recorded in the configuration. Until then the record
+    /// stays on disk and `Drop` still tries.
+    resolved: bool,
+}
+
+impl ExploratoryWrite {
+    /// Record the undo data durably. Call BEFORE the first `SET_CUR`.
+    ///
+    /// A failure here is a refusal to write to the camera at all. Discovery
+    /// without a durable record of the original is the behaviour this exists to
+    /// end, so "the journal could not be written" cannot degrade into "write
+    /// anyway and hope".
+    fn open(
+        fd: c_int,
+        id: &crate::uvc_descriptor::CameraIdentity,
+        unit: u8,
+        selector: u8,
+        len: usize,
+        original: &[u8],
+        attempted: &[u8],
+    ) -> Result<Self, String> {
+        let descriptor_sha256 = crate::emitter_journal::fingerprint(id);
+        crate::emitter_journal::save(&crate::emitter_journal::PendingWrite {
+            schema_version: crate::emitter_journal::SCHEMA_VERSION,
+            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+            descriptor_sha256: descriptor_sha256.clone(),
+            usb_id: id.usb_id(),
+            interface_number: id.interface_number,
+            unit,
+            selector,
+            len,
+            original: crate::emitter_journal::to_hex(original),
+            attempted: crate::emitter_journal::to_hex(attempted),
+            restore_attempts: 0,
+            // So a capture running beside this one leaves the control alone
+            // while the run that changed it is still going.
+            boot_id: crate::emitter_journal::current_boot_id(),
+            pid: Some(std::process::id()),
+        })?;
+        Ok(Self {
+            fd,
+            unit,
+            selector,
+            original: original.to_vec(),
+            descriptor_sha256,
+            resolved: false,
+        })
+    }
+
+    /// Read the control back and drop the record only if it holds the original.
+    ///
+    /// The caller has already issued the restoring `SET_CUR`. That call
+    /// returning success says the ioctl was accepted, not that the control now
+    /// holds those bytes, and assuming the two are the same thing is what left
+    /// the camera changed in the first place.
+    fn confirm_restored(&mut self) -> Result<(), String> {
+        let now = get_cur(self.fd, self.unit, self.selector, self.original.len())
+            .map_err(|e| format!("read the control back: {e}"))?;
+        if now != self.original {
+            return Err(format!(
+                "the control reads {:02x?} after being restored to {:02x?}",
+                now, self.original
+            ));
+        }
+        crate::emitter_journal::clear(&self.descriptor_sha256)?;
+        self.resolved = true;
+        Ok(())
+    }
+
+    /// The control is deliberately left at the applied value, and the
+    /// configuration naming it is durable. Drop the record.
+    ///
+    /// Ordering matters: called only AFTER `save_conf`. A crash between a
+    /// successful discovery and that write leaves the camera lit with nothing on
+    /// disk saying which control did it, which is the same unrecorded change
+    /// this module exists to prevent, so until the configuration lands the
+    /// record stays open and the guard would put the control back.
+    fn commit(&mut self) -> Result<(), String> {
+        crate::emitter_journal::clear(&self.descriptor_sha256)?;
+        self.resolved = true;
+        Ok(())
+    }
+}
+
+impl Drop for ExploratoryWrite {
+    fn drop(&mut self) {
+        if self.resolved {
+            return;
+        }
+        // Best effort, and deliberately quiet about its own failure: the record
+        // is still on disk, so a failure here is recovered at the next capture
+        // rather than lost. What must not happen is leaving the control changed
+        // AND clearing the record, so the clear only runs behind a confirmed
+        // read-back.
+        if set_cur(self.fd, self.unit, self.selector, &self.original).is_ok() {
+            let _ = self.confirm_restored();
+        }
+    }
+}
+
+/// Put back anything an interrupted run left changed on this camera.
+///
+/// Runs before discovery and before any capture applies a control, because both
+/// of those would otherwise build on a control that is not where its owner left
+/// it — discovery worst of all, since its first act is to read the current value
+/// and call it the original.
+///
+/// Returns what happened, for the caller to log. Every decision it makes is in
+/// [`crate::emitter_journal::record_applies`] and
+/// [`crate::emitter_journal::restore_decision`], which are pure and tested; this
+/// function is the ioctls and the bookkeeping around them.
+pub(crate) fn recover_pending_write(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+) -> RecoveryOutcome {
+    use crate::emitter_journal as journal;
+
+    let record = match journal::load(id) {
+        Ok(None) => return RecoveryOutcome::NothingPending,
+        Ok(Some(record)) => record,
+        Err(why) => return RecoveryOutcome::Unreadable(why),
+    };
+    if let Err(mismatch) = journal::record_applies(&record, id) {
+        return RecoveryOutcome::NotApplicable(mismatch);
+    }
+
+    // Read the control before deciding anything. A restore that is not needed is
+    // still a write to firmware.
+    let now = match (
+        get_len(fd, record.unit, record.selector),
+        get_info(fd, record.unit, record.selector),
+        // Length comes from the record here only to size the read; the decision
+        // below compares it against what the camera just reported and refuses if
+        // they differ.
+        get_cur(fd, record.unit, record.selector, record.len),
+    ) {
+        (Ok(len), Ok(info), Ok(current)) => journal::ControlNow {
+            len,
+            writable: info_allows_set(info),
+            current,
+        },
+        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
+            return RecoveryOutcome::Unreadable(format!("query the control: {e}"))
+        }
+    };
+
+    match journal::restore_decision(&record, &now) {
+        journal::Restore::AlreadyRestored => match journal::clear(&record.descriptor_sha256) {
+            Ok(()) => RecoveryOutcome::AlreadyRestored,
+            Err(why) => RecoveryOutcome::Unreadable(why),
+        },
+        journal::Restore::Refuse(why) => RecoveryOutcome::Refused(why),
+        journal::Restore::Write(original) => {
+            // Count the attempt BEFORE the write and make it durable. Counting
+            // after would leave a kill during the restore uncounted, and a
+            // control that never reads back as restored would then be written to
+            // at every capture forever.
+            let mut spent = record.clone();
+            spent.restore_attempts += 1;
+            // Drop the owner rather than claiming it. The recorded owner is
+            // already known dead, and writing THIS process in would be worse:
+            // recovery usually runs inside the long-lived daemon, so a refusal
+            // would leave a record owned by a process that stays alive for days
+            // and every later pass would skip it as somebody else's business.
+            // The attempt counter is what limits repeats.
+            spent.boot_id = None;
+            spent.pid = None;
+            if let Err(why) = journal::save(&spent) {
+                return RecoveryOutcome::Unreadable(why);
+            }
+            if let Err(e) = set_cur(fd, record.unit, record.selector, &original) {
+                return RecoveryOutcome::Refused(format!("restore: {e}"));
+            }
+            match get_cur(fd, record.unit, record.selector, original.len()) {
+                Ok(back) if back == original => match journal::clear(&record.descriptor_sha256) {
+                    Ok(()) => RecoveryOutcome::Restored {
+                        unit: record.unit,
+                        selector: record.selector,
+                    },
+                    Err(why) => RecoveryOutcome::Unreadable(why),
+                },
+                Ok(back) => RecoveryOutcome::Refused(format!(
+                    "the control reads {back:02x?} after being restored to {original:02x?}"
+                )),
+                Err(e) => RecoveryOutcome::Unreadable(format!("read the control back: {e}")),
+            }
+        }
+    }
+}
+
+/// Log a recovery outcome once per camera per process.
+///
+/// `enable` runs at every stream open AND every eighth frame of a burst, so an
+/// outcome that repeats — a record that cannot be acted on stays on disk and is
+/// re-read every time — would otherwise put the same line into the journal
+/// several times a second. Keyed by the camera and the kind of outcome, so a
+/// later change of outcome on the same camera still prints.
+fn report_recovery(id: &crate::uvc_descriptor::CameraIdentity, outcome: RecoveryOutcome) {
+    let Some(line) = outcome.message() else {
+        return;
+    };
+    static REPORTED: std::sync::Mutex<Option<std::collections::HashSet<String>>> =
+        std::sync::Mutex::new(None);
+    let key = format!(
+        "{}:{}",
+        crate::emitter_journal::fingerprint(id),
+        outcome.kind()
+    );
+    // A poisoned lock means another thread panicked while holding it. Recovering
+    // the set is right here: the worst case of a wrong answer is a duplicated or
+    // a dropped log line, and taking the panic instead would turn a logging
+    // detail into a failed capture.
+    let mut guard = REPORTED.lock().unwrap_or_else(|e| e.into_inner());
+    if guard.get_or_insert_with(Default::default).insert(key) {
+        eprintln!("{line}");
+    }
+}
+
+/// What a recovery pass did. Reported rather than swallowed: this is a write to
+/// camera firmware on a path nobody asked for, so it says so in the journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryOutcome {
+    NothingPending,
+    /// The control already held the original; the record was dropped and nothing
+    /// was written.
+    AlreadyRestored,
+    Restored {
+        unit: u8,
+        selector: u8,
+    },
+    /// A record exists for a different camera, a newer schema, or a control this
+    /// camera no longer publishes. Left exactly as it is.
+    NotApplicable(crate::emitter_journal::Mismatch),
+    /// The record stands and could not be acted on. It stays on disk.
+    Refused(String),
+    Unreadable(String),
+}
+
+impl RecoveryOutcome {
+    /// One line for the log, or nothing when there was nothing to do.
+    ///
+    /// `NotApplicable` is silent for a different camera, which is the ordinary
+    /// case on a machine with two of them and would otherwise print at every
+    /// capture. Everything else is loud: a pending firmware change that cannot
+    /// be undone is the operator's problem, not a debug detail.
+    pub(crate) fn message(&self) -> Option<String> {
+        use crate::emitter_journal::Mismatch;
+        match self {
+            Self::NothingPending => None,
+            Self::NotApplicable(Mismatch::DifferentCamera) => None,
+            // A setup run in flight is the normal reason to see this, and it is
+            // about to resolve its own record.
+            Self::NotApplicable(Mismatch::OwnerStillRunning { .. }) => None,
+            Self::AlreadyRestored => Some(
+                "irlume: an interrupted emitter setup was already undone; \
+                 dropped its undo record"
+                    .into(),
+            ),
+            Self::Restored { unit, selector } => Some(format!(
+                "irlume: an interrupted emitter setup had left unit {unit} selector {selector} \
+                 changed; put it back to the value the camera reported before that run"
+            )),
+            Self::NotApplicable(Mismatch::OutOfAttempts { attempts }) => Some(format!(
+                "irlume: an emitter control was changed by an interrupted setup and {attempts} \
+                 attempts to put it back did not take. Nothing further will be written to it. \
+                 The recorded original is in {}",
+                crate::emitter_journal::store_dir().display()
+            )),
+            Self::NotApplicable(why) => Some(format!(
+                "irlume: an emitter undo record cannot be applied to this camera ({why:?}); \
+                 left in {}",
+                crate::emitter_journal::store_dir().display()
+            )),
+            Self::Refused(why) => Some(format!(
+                "irlume: an emitter control left changed by an interrupted setup was not put \
+                 back ({why}); the undo record stays in {}",
+                crate::emitter_journal::store_dir().display()
+            )),
+            Self::Unreadable(why) => Some(format!(
+                "irlume: could not process the emitter undo record ({why})"
+            )),
+        }
+    }
+
+    /// A stable tag for the kind of outcome, for de-duplicating log lines.
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::NothingPending => "nothing",
+            Self::AlreadyRestored => "already-restored",
+            Self::Restored { .. } => "restored",
+            Self::NotApplicable(_) => "not-applicable",
+            Self::Refused(_) => "refused",
+            Self::Unreadable(_) => "unreadable",
+        }
+    }
+
+    /// Whether an unresolved change is still outstanding on this camera.
+    ///
+    /// Discovery refuses to start when it is. Its first act is to read the
+    /// control and call the answer the original, so running it against a control
+    /// that is still holding a previous run's exploratory value would record the
+    /// wrong bytes as the thing to go back to, and destroy the real ones.
+    pub(crate) fn blocks_discovery(&self) -> bool {
+        matches!(self, Self::Refused(_) | Self::Unreadable(_))
+            || matches!(
+                self,
+                Self::NotApplicable(
+                    crate::emitter_journal::Mismatch::OutOfAttempts { .. }
+                        | crate::emitter_journal::Mismatch::SchemaTooNew { .. }
+                        | crate::emitter_journal::Mismatch::Malformed(_)
+                        | crate::emitter_journal::Mismatch::ControlNotPublished
+                        // Another setup run holds this camera. Two of them
+                        // interleaving reads and writes on one control would
+                        // each record the other's value as the original.
+                        | crate::emitter_journal::Mismatch::OwnerStillRunning { .. }
+                )
+            )
     }
 }
 
@@ -1158,12 +1541,24 @@ pub fn discover<F: FnMut() -> Option<f32>>(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     measure: &mut F,
-) -> std::result::Result<EmitterControl, DiscoveryError> {
+) -> std::result::Result<Discovered, DiscoveryError> {
     let ms = id
         .microsoft_xu()
         .ok_or_else(|| DiscoveryError::NoMicrosoftXu {
             seen: id.extension_units().iter().map(|u| u.unit_id).collect(),
         })?;
+
+    // Before the first GET_CUR, not after. Discovery reads the control and calls
+    // the answer the original; against a control still holding an earlier run's
+    // exploratory value that reading is wrong, and recording it would overwrite
+    // the only copy of the real one.
+    let recovery = recover_pending_write(fd, id);
+    if let Some(line) = recovery.message() {
+        eprintln!("{line}");
+    }
+    if recovery.blocks_discovery() {
+        return Err(DiscoveryError::UnresolvedChange);
+    }
 
     let mut tried = Vec::new();
 
@@ -1175,8 +1570,8 @@ pub fn discover<F: FnMut() -> Option<f32>>(
             tried.push(format!("selector {selector:#04x} not advertised"));
             continue;
         }
-        match try_documented_control(fd, ms.unit_id, selector, measure) {
-            Ok(Attempt::Lit(ctrl)) => return Ok(ctrl),
+        match try_documented_control(fd, id, ms.unit_id, selector, measure) {
+            Ok(Attempt::Lit(control, pending)) => return Ok(Discovered { control, pending }),
             Ok(Attempt::AlreadyApplied) => tried.push(format!(
                 "selector {selector:#04x} is already set to the value setup would apply"
             )),
@@ -1189,6 +1584,7 @@ pub fn discover<F: FnMut() -> Option<f32>>(
                     err,
                 })
             }
+            Err(TryFailure::Journal(why)) => return Err(DiscoveryError::JournalUnwritable(why)),
             // Any error at all stops everything. Only selectors the descriptor
             // advertises are reached, so a failure here is the camera
             // contradicting its own descriptor, and the errno cannot be relied
@@ -1212,9 +1608,36 @@ pub fn discover<F: FnMut() -> Option<f32>>(
     })
 }
 
+/// A discovery run that has left the camera lit, and the undo record that stays
+/// open until the configuration naming that control is on disk.
+///
+/// The record is deliberately not resolved by a successful discovery. Between
+/// `discover` returning and `save_conf` landing, the camera is changed and
+/// nothing on disk says which control did it; dropping this value without
+/// calling [`Discovered::committed`] puts the control back, which is the right
+/// outcome when the configuration could not be written.
+#[derive(Debug)]
+pub struct Discovered {
+    control: EmitterControl,
+    pending: ExploratoryWrite,
+}
+
+impl Discovered {
+    pub fn control(&self) -> &EmitterControl {
+        &self.control
+    }
+
+    /// Release the undo record. Call only once the configuration naming this
+    /// control is durable.
+    pub fn committed(mut self) -> std::result::Result<(), String> {
+        self.pending.commit()
+    }
+}
+
 /// What one advertised control turned out to be.
 enum Attempt {
-    Lit(EmitterControl),
+    /// Lit, and still holding the applied value, with its undo record open.
+    Lit(EmitterControl, ExploratoryWrite),
     /// The control is already set to the value setup would apply, so writing it
     /// again could not demonstrate anything.
     AlreadyApplied,
@@ -1226,6 +1649,9 @@ enum Attempt {
 enum TryFailure {
     Query(XuError),
     Restore(XuError),
+    /// The undo record could not be written, or could not be confirmed dropped.
+    /// A refusal to touch the camera rather than a reason to write anyway.
+    Journal(String),
     /// The camera stopped delivering frames. The streaming side going quiet is
     /// as much a sign of trouble as a control request going unanswered, and the
     /// old code turned it into "the picture is dark" and carried on.
@@ -1242,6 +1668,7 @@ impl From<XuError> for TryFailure {
 /// worked.
 fn try_documented_control<F: FnMut() -> Option<f32>>(
     fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
     unit: u8,
     selector: u8,
     measure: &mut F,
@@ -1287,12 +1714,22 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
         return Err(TryFailure::Measurement);
     };
 
+    // Durable before the write, not after. Everything from here to the last
+    // restore is the window a kill used to make unrecoverable: the original
+    // existed only in this stack frame, and two camera measurements sit inside
+    // it. `pending` also restores the control from `Drop`, which covers the
+    // paths no statement below can — a panic in the decoder, or an ioctl error
+    // taken by `?`.
+    let mut pending = ExploratoryWrite::open(fd, id, unit, selector, len, &original, &wanted)
+        .map_err(TryFailure::Journal)?;
+
     set_cur(fd, unit, selector, &wanted)?;
     let Some(lit) = measure() else {
         // The stream died after the control was changed. Aborting without
         // putting it back would leave the camera altered by a run that
         // concluded nothing.
         set_cur(fd, unit, selector, &original).map_err(TryFailure::Restore)?;
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
         return Err(TryFailure::Measurement);
     };
 
@@ -1303,6 +1740,7 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     // on what was in front of it.
     if lit < before + AUTOCONF_MIN_LIFT {
         set_cur(fd, unit, selector, &original).map_err(TryFailure::Restore)?;
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
         return Ok(Attempt::NotUsable(format!(
             "the image did not brighten (before {before:.0}, after {lit:.0}, needs +{AUTOCONF_MIN_LIFT:.0})"
         )));
@@ -1317,6 +1755,11 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
         return Err(TryFailure::Measurement);
     };
     if after_restore >= lit - AUTOCONF_MIN_LIFT {
+        // Restored above, and this branch writes nothing further, so the record
+        // is resolvable here. The read-back is what resolves it: the restoring
+        // `set_cur` returning success says the ioctl was accepted, not that the
+        // control holds those bytes.
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
         return Ok(Attempt::NotUsable(format!(
             "the image brightened but stayed bright when the control was put back \
              ({before:.0} before, {lit:.0} with it set, {after_restore:.0} after undoing it), \
@@ -1325,12 +1768,19 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     }
 
     // It followed the control both ways. Apply it and report it.
+    //
+    // The record stays OPEN. The camera is deliberately changed from here on,
+    // and until `save_conf` records which control did it there is still nothing
+    // on disk that could put it back. `Discovered::committed` closes it.
     set_cur(fd, unit, selector, &wanted)?;
-    Ok(Attempt::Lit(EmitterControl {
-        unit,
-        selector,
-        payload: wanted,
-    }))
+    Ok(Attempt::Lit(
+        EmitterControl {
+            unit,
+            selector,
+            payload: wanted,
+        },
+        pending,
+    ))
 }
 
 /// Build a Face Authentication `SET_CUR` payload from what the camera says it
@@ -1647,12 +2097,14 @@ mod tests {
     }
 
     /// Serializes access to the process env vars these tests flip
-    /// (`IRLUME_IR_EMITTER`, `IRLUME_IR_EMITTER_CONF`); cargo runs tests on
-    /// parallel threads sharing one environment.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
+    /// (`IRLUME_IR_EMITTER`, `IRLUME_IR_EMITTER_CONF`).
+    ///
+    /// `crate::testenv::ENV_LOCK`, not a private one. A module-private mutex
+    /// over a process-global serialises the module against itself and nothing
+    /// else, so these raced the capture tests in `lib.rs` that flip their own
+    /// variables in the same process.
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        crate::testenv::env_lock()
     }
 
     /// An fd that is open but is not a UVC device, so every XU ioctl fails

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1881,9 +1881,9 @@ fn recover_pending_write_locked(
             Mismatch::OutOfAttempts { attempts } => RecoveryOutcome::Unresolved(format!(
                 "{attempts} attempts to put it back did not take, so no more will be made"
             )),
-            Mismatch::SchemaTooNew { found, supported } => RecoveryOutcome::Unresolved(format!(
-                "the record is schema {found} and this build implements {supported}"
-            )),
+            Mismatch::UnsupportedSchema { found, supported } => RecoveryOutcome::Unresolved(
+                format!("the record is schema {found} and this build implements {supported}"),
+            ),
             Mismatch::Malformed(why) => RecoveryOutcome::Unresolved(format!("malformed: {why}")),
             Mismatch::ControlNotPublished => RecoveryOutcome::Unresolved(
                 "the record names a control this camera does not publish".into(),

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2195,6 +2195,10 @@ pub fn store_capture_mode(device: &str, mode: CaptureMode) -> irlume_common::Res
 /// anything changed can be undone.
 pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     verify_pinned(device)?;
+    // Declared first, so it is dropped LAST: the guard that puts the control
+    // back lives inside `discover` (or inside `found` on the success path) and
+    // has to finish before this re-raises the signal that stops the process.
+    let _abort_orderly = ir_emitter::AbortOnSignal::install();
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix);
@@ -2216,6 +2220,13 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     // the daemon killed before the control it changed was restored. A fix for a
     // hang is not worth a race with systemd.
     let mut measure = || -> Option<f32> {
+        // A stop signal aborts through the same path a dead stream does, which
+        // is the path that puts the control back. The measurement loop is the
+        // only part of discovery that blocks for any length of time, so this is
+        // where the abort has to be noticed.
+        if ir_emitter::abort_requested() {
+            return None;
+        }
         // Frames already in flight were captured before the control changed, and
         // taking the brightest of the burst makes one stale frame decide the
         // answer. Discard a stream's worth before believing anything.

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2261,13 +2261,9 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     match ir_emitter::discover(fd, &id, &mut measure) {
         Ok(found) => {
             let encoded = found.control().encode();
-            // `save_conf` first, then release the undo record. Until the
-            // configuration naming this control is on disk, the camera is
-            // changed and nothing says which control did it — so if this write
-            // fails, `found` drops unresolved and puts the control back rather
-            // than leaving a lit emitter nobody has a record of.
-            ir_emitter::save_conf(&id, found.control()).map_err(|e| Error::Io(e.to_string()))?;
-            found.committed().map_err(Error::Io)?;
+            // Confirm, publish, release, in that order. The sequence lives in
+            // `finish` rather than here so it is reachable by a test.
+            found.finish(&id).map_err(Error::Hardware)?;
             Ok(format!(
                 "IR emitter enabled: {encoded} on the camera's Microsoft camera-control unit, \
                  using a value built from what the camera reports about that control \

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -22,9 +22,63 @@
 //! to RGB8. FOOTGUN: enumerate V4L2 controls defensively; naive control queries
 //! panic on some drivers. Probe, don't assume.
 
+pub mod emitter_journal;
 pub mod ir_emitter;
 mod ir_metadata;
 pub mod uvc_descriptor;
+
+/// Serializes unit tests that mutate process-global environment variables, and
+/// the RAII guard that restores them.
+///
+/// One lock for the whole crate, deliberately. Three modules here flip env vars
+/// in tests and two of them had grown their OWN private mutex; a second mutex
+/// guarding the same process-global serialises a module against itself and
+/// nothing else, which passes locally and fails under load. Rust's `set_var`
+/// also races any concurrent env READ anywhere in the process, so the lock has
+/// to cover every mutator in the crate to mean anything.
+///
+/// `EnvGuard` restores the PREVIOUS value rather than unsetting: unsetting is
+/// not restoring, and a test that leaves `IRLUME_STATE_DIR` cleared changes what
+/// the next one resolves.
+#[cfg(test)]
+pub(crate) mod testenv {
+    pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        // A panic under the lock (a failed assert) must not cascade into every
+        // later env test; the environment is per-test state, not shared data.
+        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// RAII env-var override: restores the previous value (or absence) on drop,
+    /// so a panicking assertion cannot leak state into later tests.
+    pub(crate) struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        pub(crate) fn set(key: &'static str, val: impl AsRef<std::ffi::OsStr>) -> Self {
+            let prev = std::env::var_os(key);
+            std::env::set_var(key, val);
+            Self { key, prev }
+        }
+        pub(crate) fn unset(key: &'static str) -> Self {
+            let prev = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
 
 use irlume_common::Error;
 use v4l::buffer::Type;
@@ -2181,13 +2235,19 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     let id = crate::uvc_descriptor::identity_from_fd(fd)
         .map_err(|e| Error::Hardware(format!("could not identify the camera: {e}")))?;
     match ir_emitter::discover(fd, &id, &mut measure) {
-        Ok(ctrl) => {
-            ir_emitter::save_conf(&id, &ctrl).map_err(|e| Error::Io(e.to_string()))?;
+        Ok(found) => {
+            let encoded = found.control().encode();
+            // `save_conf` first, then release the undo record. Until the
+            // configuration naming this control is on disk, the camera is
+            // changed and nothing says which control did it — so if this write
+            // fails, `found` drops unresolved and puts the control back rather
+            // than leaving a lit emitter nobody has a record of.
+            ir_emitter::save_conf(&id, found.control()).map_err(|e| Error::Io(e.to_string()))?;
+            found.committed().map_err(Error::Io)?;
             Ok(format!(
-                "IR emitter enabled: {} on the camera's Microsoft camera-control unit, \
+                "IR emitter enabled: {encoded} on the camera's Microsoft camera-control unit, \
                  using a value built from what the camera reports about that control \
-                 (saved; future captures rebuild it the same way)",
-                ctrl.encode()
+                 (saved; future captures rebuild it the same way)"
             ))
         }
         Err(e) => Err(Error::Hardware(e.to_string())),
@@ -3073,41 +3133,11 @@ mod tests {
         std::env::var("IRLUME_TEST_SPARE_DEVICE").ok()
     }
 
-    /// Serializes tests that mutate process-global env vars (cargo runs tests
-    /// on threads, and setters would otherwise race readers in other tests).
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
-    }
-
-    /// RAII env-var override: restores the previous value (or absence) on
-    /// drop, so a panicking assertion cannot leak state into later tests.
-    struct EnvGuard {
-        key: &'static str,
-        prev: Option<std::ffi::OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, val: &str) -> Self {
-            let prev = std::env::var_os(key);
-            std::env::set_var(key, val);
-            Self { key, prev }
-        }
-        fn unset(key: &'static str) -> Self {
-            let prev = std::env::var_os(key);
-            std::env::remove_var(key);
-            Self { key, prev }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.prev.take() {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
+    // The lock and the guard live in `crate::testenv` so every env-mutating
+    // test in this crate contends on ONE mutex. They used to be private here,
+    // which serialised this module against itself and left it racing the
+    // `ir_emitter` tests that flip a different variable in the same process.
+    use crate::testenv::{env_lock, EnvGuard};
 
     /// Extend the exact-path virtual-camera escape with `device` for the
     /// test's lifetime (`verify_pinned` refuses loopback nodes otherwise),

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2221,9 +2221,16 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     // hang is not worth a race with systemd.
     let mut measure = || -> Option<f32> {
         // A stop signal aborts through the same path a dead stream does, which
-        // is the path that puts the control back. The measurement loop is the
-        // only part of discovery that blocks for any length of time, so this is
-        // where the abort has to be noticed.
+        // is the path that puts the control back.
+        //
+        // Polled between frames rather than relied on to interrupt one. A
+        // process-directed signal goes to an ARBITRARY thread that has it
+        // unblocked, and the daemon has a watchdog, a listener and a connection
+        // thread besides this worker; only the syscall in the thread the kernel
+        // picks is interrupted, so dropping SA_RESTART does not guarantee this
+        // frame wait ever returns EINTR (signal(7)). Checking each iteration
+        // bounds the abort by one frame timeout, which this crate sets to five
+        // seconds, instead of by a whole measurement.
         if ir_emitter::abort_requested() {
             return None;
         }
@@ -2231,10 +2238,16 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
         // taking the brightest of the burst makes one stale frame decide the
         // answer. Discard a stream's worth before believing anything.
         for _ in 0..IR_BURST {
+            if ir_emitter::abort_requested() {
+                return None;
+            }
             stream.next().ok()?;
         }
         let mut best: Option<f32> = None;
         for _ in 0..8 {
+            if ir_emitter::abort_requested() {
+                return None;
+            }
             let (buf, _) = stream.next().ok()?;
             let data = dec.decode(buf, w, h);
             let m = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;

--- a/crates/irlume-camera/src/uvc_descriptor.rs
+++ b/crates/irlume-camera/src/uvc_descriptor.rs
@@ -274,11 +274,20 @@ pub fn identity_from_fd(fd: std::os::raw::c_int) -> std::io::Result<CameraIdenti
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty()),
         // `dev_dir` came from `canonicalize`, so it is already the resolved
-        // physical path. Stripping `/sys` keeps the value comparable to the
-        // `DEVPATH` the kernel publishes for the same device.
+        // physical path. Stripping `/sys` makes the value the kernel's own
+        // `DEVPATH` for this device, which is what `udevadm info -q path` prints
+        // and therefore what a person comparing a record against their machine
+        // will have in front of them.
+        //
+        // The leading slash is put back deliberately. `strip_prefix` removes the
+        // component and leaves a RELATIVE path, so this recorded
+        // `devices/pci0000:00/...` while every other source of the same string
+        // says `/devices/pci0000:00/...`. A hardware run is what showed it: the
+        // record on disk did not match the path printed beside it.
         usb_devpath: dev_dir
             .strip_prefix("/sys")
-            .unwrap_or(&dev_dir)
+            .map(|p| std::path::Path::new("/").join(p))
+            .unwrap_or_else(|_| dev_dir.clone())
             .to_string_lossy()
             .into_owned(),
     })
@@ -491,6 +500,32 @@ mod tests {
 
     /// Every descriptor in the real chain must be consumed exactly, with no
     /// trailing slop, or the walk is mis-stepping through the buffer.
+    #[test]
+    /// The recorded device path is the kernel's own `DEVPATH`, leading slash and
+    /// all.
+    ///
+    /// `strip_prefix` leaves a RELATIVE path, so this recorded
+    /// `devices/pci0000:00/...` while `udevadm info -q path` prints
+    /// `/devices/pci0000:00/...` for the same device. Both sides of the match
+    /// computed it the same way, so nothing broke, which is exactly why only a
+    /// transcript from real hardware showed it: the record on disk did not look
+    /// like the path printed next to it.
+    #[test]
+    fn a_recorded_device_path_looks_like_the_kernels_own() {
+        let sys = std::path::Path::new("/sys/devices/pci0000:00/0000:00:14.0/usb3/3-5");
+        let devpath = sys
+            .strip_prefix("/sys")
+            .map(|p| std::path::Path::new("/").join(p))
+            .unwrap_or_else(|_| sys.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(devpath, "/devices/pci0000:00/0000:00:14.0/usb3/3-5");
+        assert!(
+            devpath.starts_with('/'),
+            "a relative path here is not a DEVPATH"
+        );
+    }
+
     #[test]
     fn the_walk_consumes_the_whole_real_descriptor_chain() {
         let mut i = 0usize;

--- a/crates/irlume-camera/src/uvc_descriptor.rs
+++ b/crates/irlume-camera/src/uvc_descriptor.rs
@@ -223,6 +223,22 @@ pub struct CameraIdentity {
     pub interface_number: u8,
     pub vid: u16,
     pub pid: u16,
+    /// The USB serial string, when the device publishes one.
+    ///
+    /// NOT a unique physical identity, and must not be trusted as one: the ASUS
+    /// module this project develops against reports `200901010001`, a batch
+    /// number of the kind webcam vendors repeat across every unit they ship.
+    /// It narrows a match; it does not settle one.
+    pub serial: Option<String>,
+    /// Resolved sysfs path of the USB DEVICE, `/devices/...` with no `/sys`
+    /// prefix and no interface suffix.
+    ///
+    /// The only identifier here that distinguishes two identical units attached
+    /// at the same time, because it names the port rather than the model. It is
+    /// stable across reboots for a fixed port and changes when the device is
+    /// moved to another one, which is the right way round for a record that has
+    /// to survive a power loss.
+    pub usb_devpath: String,
 }
 
 pub fn identity_from_fd(fd: std::os::raw::c_int) -> std::io::Result<CameraIdentity> {
@@ -252,6 +268,19 @@ pub fn identity_from_fd(fd: std::os::raw::c_int) -> std::io::Result<CameraIdenti
             .ok_or_else(|| bad(format!("{} has no idVendor", dev_dir.display())))?,
         pid: read_hex_u16(&dev_dir.join("idProduct"))
             .ok_or_else(|| bad(format!("{} has no idProduct", dev_dir.display())))?,
+        // Absent on plenty of devices, so this is `None` rather than an error.
+        serial: std::fs::read_to_string(dev_dir.join("serial"))
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+        // `dev_dir` came from `canonicalize`, so it is already the resolved
+        // physical path. Stripping `/sys` keeps the value comparable to the
+        // `DEVPATH` the kernel publishes for the same device.
+        usb_devpath: dev_dir
+            .strip_prefix("/sys")
+            .unwrap_or(&dev_dir)
+            .to_string_lossy()
+            .into_owned(),
     })
 }
 

--- a/crates/irlume-camera/src/uvc_descriptor.rs
+++ b/crates/irlume-camera/src/uvc_descriptor.rs
@@ -498,9 +498,6 @@ mod tests {
         assert!(extension_units_for_interface(&buf, 0).is_empty());
     }
 
-    /// Every descriptor in the real chain must be consumed exactly, with no
-    /// trailing slop, or the walk is mis-stepping through the buffer.
-    #[test]
     /// The recorded device path is the kernel's own `DEVPATH`, leading slash and
     /// all.
     ///
@@ -526,6 +523,8 @@ mod tests {
         );
     }
 
+    /// Every descriptor in the real chain must be consumed exactly, with no
+    /// trailing slop, or the walk is mis-stepping through the buffer.
     #[test]
     fn the_walk_consumes_the_whole_real_descriptor_chain() {
         let mut i = 0usize;

--- a/crates/irlume-camera/src/uvc_descriptor.rs
+++ b/crates/irlume-camera/src/uvc_descriptor.rs
@@ -238,6 +238,12 @@ pub struct CameraIdentity {
     /// stable across reboots for a fixed port and changes when the device is
     /// moved to another one, which is the right way round for a record that has
     /// to survive a power loss.
+    ///
+    /// It is NOT a physical-device identity. The kernel calls it the device's
+    /// key "at that point in time": the same path is reused by whatever is
+    /// plugged into that port next. So a path match says "the same place", never
+    /// "the same camera", and anything authorising a write on a path match alone
+    /// is trusting a port.
     pub usb_devpath: String,
 }
 

--- a/crates/irlume-camera/src/uvc_descriptor.rs
+++ b/crates/irlume-camera/src/uvc_descriptor.rs
@@ -274,11 +274,7 @@ pub fn identity_from_fd(fd: std::os::raw::c_int) -> std::io::Result<CameraIdenti
             .ok_or_else(|| bad(format!("{} has no idVendor", dev_dir.display())))?,
         pid: read_hex_u16(&dev_dir.join("idProduct"))
             .ok_or_else(|| bad(format!("{} has no idProduct", dev_dir.display())))?,
-        // Absent on plenty of devices, so this is `None` rather than an error.
-        serial: std::fs::read_to_string(dev_dir.join("serial"))
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty()),
+        serial: read_optional_serial(&dev_dir)?,
         // `dev_dir` came from `canonicalize`, so it is already the resolved
         // physical path. Stripping `/sys` makes the value the kernel's own
         // `DEVPATH` for this device, which is what `udevadm info -q path` prints
@@ -332,6 +328,42 @@ fn device_numbers(fd: std::os::raw::c_int) -> std::io::Result<(u32, u32)> {
     Ok((libc::major(rdev), libc::minor(rdev)))
 }
 
+/// The device's USB serial, distinguishing "publishes none" from "could not read
+/// it".
+///
+/// `.ok()` on the read collapsed those two, and the difference decides whether
+/// one camera's recorded bytes may be written into another. A record created
+/// while the read failed stores `serial: None`, and `None` on the record side is
+/// deliberately permissive — it has to be, because a camera that genuinely
+/// publishes no serial must still be recoverable, and the NexiGo HelloCam this
+/// was validated against publishes none. So an identical unit swapped into the
+/// same USB port would satisfy `(None, Some(_))` and be authorized to receive
+/// the first camera's undo bytes, on matching descriptors and a reused port path
+/// alone. Failing the read closed keeps that authorization from ever being
+/// created.
+///
+/// An ABSENT attribute is `None`, because sysfs simply does not publish `serial`
+/// for a device with no iSerial descriptor, and that is the common case rather
+/// than a fault.
+///
+/// An EMPTY attribute is also `None`, which is where this deliberately diverges
+/// from the review that found the collapse: it proposed treating empty as an
+/// error. Empty carries the same information as absent — the device names no
+/// unit — and no camera here publishes one, so making it fatal would refuse
+/// hardware nobody has tested against on the strength of a guess. The hole being
+/// closed is the failed READ, not the empty value.
+fn read_optional_serial(dev_dir: &Path) -> std::io::Result<Option<String>> {
+    let path = dev_dir.join("serial");
+    match std::fs::read_to_string(&path) {
+        Ok(value) => {
+            let value = value.trim();
+            Ok((!value.is_empty()).then(|| value.to_owned()))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(bad(format!("could not read {}: {e}", path.display()))),
+    }
+}
+
 fn ancestor_with(start: &Path, marker: &str) -> Option<PathBuf> {
     let mut dir = Some(start);
     while let Some(d) = dir {
@@ -379,6 +411,61 @@ fn bad(msg: String) -> std::io::Error {
 
 #[cfg(test)]
 mod tests {
+
+    /// A serial that could not be READ is not the same as a camera that has
+    /// none, and the difference decides whether one camera's undo bytes may be
+    /// written into another.
+    ///
+    /// `.ok()` collapsed the two. A record created during a failed read stored
+    /// `serial: None`, and `None` on the record side is deliberately permissive
+    /// because a camera that publishes no serial must still be recoverable. So
+    /// an identical unit swapped into the same USB port matched on descriptors
+    /// and port alone. A test over `CameraIdentity { serial: None }` cannot see
+    /// this: it has to be exercised at the filesystem boundary.
+    #[test]
+    fn a_serial_that_cannot_be_read_is_an_error_not_an_absent_serial() {
+        let root = std::env::temp_dir().join(format!("irlume-serial-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+
+        // No `serial` attribute at all: the ordinary case for a device with no
+        // iSerial descriptor, and the NexiGo this was validated against.
+        let absent = root.join("absent");
+        std::fs::create_dir_all(&absent).expect("scratch");
+        assert_eq!(
+            super::read_optional_serial(&absent).expect("an absent serial is not an error"),
+            None
+        );
+
+        // Present and readable.
+        let present = root.join("present");
+        std::fs::create_dir_all(&present).expect("scratch");
+        std::fs::write(present.join("serial"), " 200901010001\n").expect("write");
+        assert_eq!(
+            super::read_optional_serial(&present).expect("readable"),
+            Some("200901010001".to_string())
+        );
+
+        // Present and empty carries the same information as absent: the device
+        // names no unit.
+        let empty = root.join("empty");
+        std::fs::create_dir_all(&empty).expect("scratch");
+        std::fs::write(empty.join("serial"), "  \n").expect("write");
+        assert_eq!(super::read_optional_serial(&empty).expect("readable"), None);
+
+        // Present and UNREADABLE. A directory where the attribute belongs makes
+        // the read fail with EISDIR, which is neither NotFound nor success, and
+        // is the shape of every transient sysfs failure this guards against.
+        let broken = root.join("broken");
+        std::fs::create_dir_all(broken.join("serial")).expect("scratch");
+        let e = super::read_optional_serial(&broken)
+            .expect_err("a serial that cannot be read must NOT read as absent");
+        assert!(
+            e.to_string().contains("could not read"),
+            "the error must name what failed, got: {e}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
     use super::*;
 
     /// Captured from the ASUS Hello camera (USB 3277:0059) this was developed

--- a/crates/irlume-cli/src/logintx.rs
+++ b/crates/irlume-cli/src/logintx.rs
@@ -196,14 +196,7 @@ fn schema_version_1() -> u32 {
     1
 }
 
-/// Hex sha256 of a byte slice.
-pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
-    use sha2::{Digest as _, Sha256};
-    Sha256::digest(bytes)
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect()
-}
+pub(crate) use irlume_common::sha256_hex;
 
 /// The digest of a file's current content, or `None` when it does not exist.
 ///
@@ -551,63 +544,12 @@ pub(crate) fn is_valid_id(id: &str) -> bool {
     id.len() == 32 && id.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-/// Make every directory above `dir` durable, so the names leading to it survive
-/// a power loss.
-///
-/// Shallowest first, because a directory's entry lives in its parent: syncing
-/// `/var/lib/irlume` makes `login-transactions` findable, and does nothing for
-/// `irlume` itself, whose entry is in `/var/lib`. A record fsynced into a
-/// directory whose name did not survive is not a record.
-fn fsync_ancestors(dir: &Path) -> Result<(), String> {
-    for parent in ancestor_chain(dir) {
-        fsync_dir(&parent)?;
-    }
-    Ok(())
-}
-
-/// The directories to sync above `dir`, shallowest first.
-///
-/// Separated out because the interesting case cannot be observed from outside:
-/// whether an `fsync` happened is not visible in the filesystem afterwards, so
-/// the list is what a test can actually assert on.
-fn ancestor_chain(dir: &Path) -> Vec<PathBuf> {
-    let mut chain: Vec<PathBuf> = dir
-        .ancestors()
-        .skip(1) // `dir` itself is synced by the atomic write that fills it
-        .map(|p| {
-            // A relative path's last ancestor is "", which opens nothing. The
-            // directory a relative path is anchored in is the working
-            // directory, and that is where the entry actually lives. Filtering
-            // the empty one out instead left `IRLUME_STATE_DIR=state` syncing
-            // `state` while nothing synced the `state` entry itself.
-            if p.as_os_str().is_empty() {
-                PathBuf::from(".")
-            } else {
-                p.to_path_buf()
-            }
-        })
-        .collect();
-    chain.reverse();
-    chain
-}
-
-/// Make a directory's own contents durable, so entries created in it survive a
-/// power loss.
-///
-/// `fsync(2)` is explicit that syncing a file does not necessarily persist the
-/// directory entry naming it; the directory has to be synced too. Opening a
-/// directory read-only and syncing that descriptor is the way to do it.
-fn fsync_dir(dir: &Path) -> Result<(), String> {
-    std::fs::File::open(dir)
-        .and_then(|d| d.sync_all())
-        .map_err(|e| format!("fsync {}: {e}", dir.display()))
-}
-
-fn restrict(path: &Path, mode: u32) -> Result<(), String> {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
-        .map_err(|e| format!("chmod {}: {e}", path.display()))
-}
+// The durability helpers this module was written around now live in
+// `irlume_common`, because `irlume-camera` needs the same guarantees for the IR
+// emitter's undo journal and two copies of an fsync chain drift apart in
+// exactly the way that makes one of them wrong. Behaviour is unchanged; the
+// tests that pin the sync chain moved with them.
+use irlume_common::{fsync_ancestors, fsync_dir, restrict};
 
 /// Why a surface could not be rolled back.
 #[derive(Debug, PartialEq, Eq)]
@@ -1052,49 +994,6 @@ mod tests {
             "1".repeat(32)
         ));
         assert_eq!(Transaction::load(&id).map(|r| r.schema_version), Ok(1));
-    }
-
-    /// Every directory whose entry has to survive is in the chain, shallowest
-    /// first, including the one a RELATIVE state root is anchored in.
-    ///
-    /// A directory's name lives in its parent, so syncing `state` does nothing
-    /// for the `state` entry itself; for a relative path that entry is in the
-    /// working directory. An earlier version dropped the empty last ancestor
-    /// instead of reading it as ".", which left exactly that gap. Asserted on
-    /// the list because an `fsync` leaves no trace in the filesystem to check.
-    #[test]
-    fn the_sync_chain_covers_every_directory_whose_entry_must_survive() {
-        let abs = ancestor_chain(Path::new("/var/lib/irlume/login-transactions"));
-        assert_eq!(
-            abs,
-            vec![
-                PathBuf::from("/"),
-                PathBuf::from("/var"),
-                PathBuf::from("/var/lib"),
-                PathBuf::from("/var/lib/irlume"),
-            ],
-            "shallowest first, and the store itself is left to the atomic write"
-        );
-
-        // The case the filter used to lose: nothing anchored `state`.
-        let rel = ancestor_chain(Path::new("state/login-transactions"));
-        assert_eq!(rel, vec![PathBuf::from("."), PathBuf::from("state")]);
-
-        // A store directly under a relative root still names the anchor.
-        assert_eq!(
-            ancestor_chain(Path::new("login-transactions")),
-            vec![PathBuf::from(".")]
-        );
-        // Nothing in a chain may be empty: an empty path opens nothing, so a
-        // sync of it is a sync that silently did not happen.
-        for dir in ["/a/b", "a/b", "b", "/"] {
-            assert!(
-                ancestor_chain(Path::new(dir))
-                    .iter()
-                    .all(|p| !p.as_os_str().is_empty()),
-                "{dir} produced an empty entry"
-            );
-        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2911,6 +2911,31 @@ fn doctor_run(
         State::Info,
         secureboot::detect_boot_mode().as_str(),
     );
+    // A control an interrupted `ir-setup` left changed on a camera. The capture
+    // path puts it back on its own, but not when the operator has set
+    // IRLUME_IR_EMITTER=off, and not while the camera is detached — which are
+    // exactly the situations someone runs `doctor` in.
+    match irlume_camera::emitter_journal::pending_summary() {
+        irlume_camera::emitter_journal::PendingSummary::None => {
+            report.check("emitter-undo-pending", State::Pass);
+        }
+        irlume_camera::emitter_journal::PendingSummary::Pending(entries) => {
+            dout!(
+                report,
+                "[doctor] IR emitter: {} camera control(s) left changed by an interrupted \
+                 setup ⚠ — {}. Reconnect the camera and authenticate, or run \
+                 `sudo irlume ir-setup`, to put them back",
+                entries.len(),
+                entries.join("; ")
+            );
+            report.check_detail("emitter-undo-pending", State::Warn, entries.join("; "));
+        }
+        irlume_camera::emitter_journal::PendingSummary::Unreadable(why) => {
+            // Root-only by design, so an ordinary run lands here. Unknown, not
+            // Pass: nobody checked.
+            report.check_detail("emitter-undo-pending", State::Unknown, why);
+        }
+    }
     report.check(
         "signed-pcr-policy",
         if irlume_core::pcrsig::signed_policy_available() {

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1870,8 +1870,13 @@ impl App {
     /// Run a privileged sub-step via `sudo` and surface its ACTUAL outcome. A
     /// cancelled or failed sudo (wrong password ×3, subcommand error) must not
     /// look like success: `refresh()` re-probes what it can, but a one-shot like
-    /// `ir-setup` leaves no re-checkable state, so we log ✓ on success and raise
-    /// the error banner on failure.
+    /// `ir-setup` reports its own outcome and is not re-probed here, so we log ✓
+    /// on success and raise the error banner on failure.
+    ///
+    /// It DOES leave re-checkable state now: an interrupted run leaves an undo
+    /// record, which `irlume doctor` reports as `emitter-undo-pending`. This
+    /// step does not read it, because the record is about a camera control and
+    /// this is the sudo wrapper's own success or failure.
     /// Absolute path to the running binary, for re-invoking ourselves as root
     /// instead of whatever `irlume` PATH resolves to (a running TUI must not
     /// shell out to a different, older installed build for its privileged half).

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -233,6 +233,42 @@ pub fn write_0600_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Resul
 /// unaffected: a umask can only remove bits, and every ordinary umask removes
 /// none of those.
 pub fn write_atomic_mode(path: &std::path::Path, bytes: &[u8], mode: u32) -> std::io::Result<()> {
+    match write_atomic_reporting(path, bytes, mode)? {
+        AtomicWrite::Durable => Ok(()),
+        AtomicWrite::VisibleNotDurable(e) => Err(e),
+    }
+}
+
+/// How far an atomic write got.
+///
+/// "It returned an error" and "nothing became visible" are not the same thing,
+/// and three separate defects on #183 came from treating them as one. The rename
+/// publishes the new content immediately and atomically; the fsyncs that make it
+/// survive a power loss come afterwards, and a failure there leaves the new
+/// content exactly where it was put.
+#[derive(Debug)]
+pub enum AtomicWrite {
+    /// Written, published, and both the file and its directory made durable.
+    Durable,
+    /// The rename landed, so the new content IS what a reader sees, but a later
+    /// fsync failed and it may not survive a power loss. A caller that must know
+    /// what is visible now has to treat this as published.
+    ///
+    /// NOT COVERED BY A TEST. Nothing available here can make a directory fsync
+    /// fail; provoking it needs filesystem fault injection, and a mutant that
+    /// reverts this arm to `?` propagation survives the suite. The branch rests
+    /// on `rename(2)` being atomic and immediate and `fsync(2)` being a separate
+    /// step, not on anything observed.
+    VisibleNotDurable(std::io::Error),
+}
+
+/// [`write_atomic_mode`], reporting whether the content became visible when the
+/// durability step failed. `Err` means nothing was published.
+pub fn write_atomic_reporting(
+    path: &std::path::Path,
+    bytes: &[u8],
+    mode: u32,
+) -> std::io::Result<AtomicWrite> {
     #[cfg(unix)]
     {
         use std::io::Write as _;
@@ -275,16 +311,21 @@ pub fn write_atomic_mode(path: &std::path::Path, bytes: &[u8], mode: u32) -> std
         }
         // fsync the directory so the rename (the directory entry that makes the
         // new bytes visible under `path`) is itself durable across a power loss.
-        // A failure here means the update is NOT durably committed, so surface it
-        // as a write failure (the content is live but a crash could revert the
-        // entry); the caller retries the whole atomic write.
-        std::fs::File::open(dir)?.sync_all()?;
-        Ok(())
+        // The rename has ALREADY happened, so a failure here does not un-publish
+        // anything: the new content is what a reader sees, it simply might not
+        // survive a power loss. Reported as such rather than as a plain error,
+        // because a caller that then behaves as though nothing was written is
+        // exactly how a half-published file goes unnoticed.
+        match std::fs::File::open(dir).and_then(|d| d.sync_all()) {
+            Ok(()) => Ok(AtomicWrite::Durable),
+            Err(e) => Ok(AtomicWrite::VisibleNotDurable(e)),
+        }
     }
     #[cfg(not(unix))]
     {
         let _ = mode;
-        std::fs::write(path, bytes)
+        std::fs::write(path, bytes)?;
+        Ok(AtomicWrite::Durable)
     }
 }
 
@@ -791,12 +832,45 @@ mod tests {
         }
     }
 
+    /// A write reports whether it became VISIBLE, separately from whether it
+    /// became durable.
+    ///
+    /// Three defects on #183 came from callers reading "returned an error" as
+    /// "nothing is on disk". The rename publishes; the fsyncs come after. The
+    /// ordinary path must still report `Durable`, or the distinction is a
+    /// distinction nobody can act on.
+    #[test]
+    fn an_atomic_write_reports_that_it_became_durable() {
+        // Per-process, because the ASan lane and the ordinary lane run this same
+        // binary at once and a shared fixed name makes them delete each other's
+        // scratch directory mid-test.
+        let dir =
+            std::env::temp_dir().join(format!("irlume-atomic-reporting-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch");
+        let path = dir.join("f");
+        match super::write_atomic_reporting(&path, b"hello", 0o600).expect("write") {
+            super::AtomicWrite::Durable => {}
+            super::AtomicWrite::VisibleNotDurable(e) => {
+                panic!("an ordinary write must be durable, got {e}")
+            }
+        }
+        assert_eq!(std::fs::read(&path).expect("read"), b"hello");
+        // And a write that cannot be published at all is an error, not a
+        // half-success: nothing is visible under the target name.
+        let missing = dir.join("no-such-dir").join("f");
+        assert!(super::write_atomic_reporting(&missing, b"x", 0o600).is_err());
+        assert!(!missing.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// A removal that is not durable brings the record back after a power loss,
     /// and a record that comes back is acted on again. Absence is the whole
     /// meaning of a resolved journal, so it gets the same treatment as a write.
     #[test]
     fn removing_a_record_that_is_already_gone_is_success() {
-        let dir = std::env::temp_dir().join("irlume-remove-durable-test");
+        let dir =
+            std::env::temp_dir().join(format!("irlume-remove-durable-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("record");
         std::fs::write(&path, b"x").unwrap();

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -221,10 +221,17 @@ pub fn write_0600_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Resul
 /// [`write_0600_atomic`] at a caller-chosen mode.
 ///
 /// Exists because not everything that needs the atomic, fsynced write is secret.
-/// `ir_emitter.conf` names a camera and a control number, is read by the
-/// diagnostic script, and has always been world-readable; it needed durability,
-/// not privacy, and quietly narrowing its mode while fixing that would have been
-/// an unrelated change to something a user-run script depends on.
+/// `ir_emitter.conf` names a camera and a control number; it needed durability,
+/// not privacy.
+///
+/// `mode` is a CEILING, not a guarantee: the kernel applies the process umask to
+/// a newly created file, so the result is `mode & !umask`. `irlumed.service`
+/// sets `UMask=0027`, which turns a requested 0644 into 0640 — and that is
+/// deliberately left alone, because `std::fs::write` behaved identically
+/// (`0666 & !umask` is also 0640 there) and forcing the requested bits would
+/// WIDEN permissions on machines already running. The 0600 callers are
+/// unaffected: a umask can only remove bits, and every ordinary umask removes
+/// none of those.
 pub fn write_atomic_mode(path: &std::path::Path, bytes: &[u8], mode: u32) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -215,6 +215,17 @@ pub fn write_0600(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
 /// torn write. Temp and target must share a directory so the rename stays within
 /// one filesystem (where rename is atomic).
 pub fn write_0600_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    write_atomic_mode(path, bytes, 0o600)
+}
+
+/// [`write_0600_atomic`] at a caller-chosen mode.
+///
+/// Exists because not everything that needs the atomic, fsynced write is secret.
+/// `ir_emitter.conf` names a camera and a control number, is read by the
+/// diagnostic script, and has always been world-readable; it needed durability,
+/// not privacy, and quietly narrowing its mode while fixing that would have been
+/// an unrelated change to something a user-run script depends on.
+pub fn write_atomic_mode(path: &std::path::Path, bytes: &[u8], mode: u32) -> std::io::Result<()> {
     #[cfg(unix)]
     {
         use std::io::Write as _;
@@ -238,7 +249,7 @@ pub fn write_0600_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Resul
             std::fs::OpenOptions::new()
                 .write(true)
                 .create_new(true)
-                .mode(0o600)
+                .mode(mode)
                 .open(&tmp)
         };
         let mut f = match open_tmp() {
@@ -264,7 +275,10 @@ pub fn write_0600_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Resul
         Ok(())
     }
     #[cfg(not(unix))]
-    std::fs::write(path, bytes)
+    {
+        let _ = mode;
+        std::fs::write(path, bytes)
+    }
 }
 
 /// Request from an (untrusted) client to the (privileged) daemon.

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -92,6 +92,91 @@ pub fn state_dir() -> std::path::PathBuf {
         .unwrap_or_else(|| std::path::PathBuf::from(STATE_DIR))
 }
 
+/// Hex sha256 of a byte slice.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Make every directory above `dir` durable, so the names leading to it survive
+/// a power loss.
+///
+/// Shallowest first, because a directory's entry lives in its parent: syncing
+/// `/var/lib/irlume` makes `login-transactions` findable, and does nothing for
+/// `irlume` itself, whose entry is in `/var/lib`. A record fsynced into a
+/// directory whose name did not survive is not a record.
+pub fn fsync_ancestors(dir: &std::path::Path) -> std::result::Result<(), String> {
+    for parent in ancestor_chain(dir) {
+        fsync_dir(&parent)?;
+    }
+    Ok(())
+}
+
+/// The directories to sync above `dir`, shallowest first.
+///
+/// Separated out because the interesting case cannot be observed from outside:
+/// whether an `fsync` happened is not visible in the filesystem afterwards, so
+/// the list is what a test can actually assert on.
+pub fn ancestor_chain(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut chain: Vec<std::path::PathBuf> = dir
+        .ancestors()
+        .skip(1) // `dir` itself is synced by the atomic write that fills it
+        .map(|p| {
+            // A relative path's last ancestor is "", which opens nothing. The
+            // directory a relative path is anchored in is the working
+            // directory, and that is where the entry actually lives. Filtering
+            // the empty one out instead left `IRLUME_STATE_DIR=state` syncing
+            // `state` while nothing synced the `state` entry itself.
+            if p.as_os_str().is_empty() {
+                std::path::PathBuf::from(".")
+            } else {
+                p.to_path_buf()
+            }
+        })
+        .collect();
+    chain.reverse();
+    chain
+}
+
+/// Make a directory's own contents durable, so entries created in it survive a
+/// power loss.
+///
+/// `fsync(2)` is explicit that syncing a file does not necessarily persist the
+/// directory entry naming it; the directory has to be synced too. Opening a
+/// directory read-only and syncing that descriptor is the way to do it.
+pub fn fsync_dir(dir: &std::path::Path) -> std::result::Result<(), String> {
+    std::fs::File::open(dir)
+        .and_then(|d| d.sync_all())
+        .map_err(|e| format!("fsync {}: {e}", dir.display()))
+}
+
+/// Set `path`'s permission bits, naming the path when it fails.
+pub fn restrict(path: &std::path::Path, mode: u32) -> std::result::Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .map_err(|e| format!("chmod {}: {e}", path.display()))
+}
+
+/// Remove `path` and make its absence durable.
+///
+/// The counterpart to [`write_0600_atomic`] for a record whose whole meaning is
+/// "there is unfinished business here": an unlink still sitting in the page
+/// cache when the machine loses power brings the record back, and a record that
+/// comes back is acted on again. Already-gone is success, because the caller's
+/// postcondition is that nothing is there.
+pub fn remove_durable(path: &std::path::Path) -> std::result::Result<(), String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("remove {}: {e}", path.display())),
+    }
+    let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    fsync_dir(dir)
+}
+
 /// Create or truncate `path` with mode 0600 and write `bytes`, then fsync.
 ///
 /// Mode-on-open (not write-then-chmod) so a secret-bearing file is never
@@ -640,6 +725,66 @@ pub(crate) mod testenv {
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
+    /// Every directory whose entry has to survive is in the chain, shallowest
+    /// first, including the one a RELATIVE state root is anchored in.
+    ///
+    /// A directory's name lives in its parent, so syncing `state` does nothing
+    /// for the `state` entry itself; for a relative path that entry is in the
+    /// working directory. An earlier version dropped the empty last ancestor
+    /// instead of reading it as ".", which left exactly that gap. Asserted on
+    /// the list because an `fsync` leaves no trace in the filesystem to check.
+    #[test]
+    fn the_sync_chain_covers_every_directory_whose_entry_must_survive() {
+        let abs = super::ancestor_chain(Path::new("/var/lib/irlume/login-transactions"));
+        assert_eq!(
+            abs,
+            vec![
+                PathBuf::from("/"),
+                PathBuf::from("/var"),
+                PathBuf::from("/var/lib"),
+                PathBuf::from("/var/lib/irlume"),
+            ],
+            "shallowest first, and the store itself is left to the atomic write"
+        );
+
+        // The case the filter used to lose: nothing anchored `state`.
+        let rel = super::ancestor_chain(Path::new("state/login-transactions"));
+        assert_eq!(rel, vec![PathBuf::from("."), PathBuf::from("state")]);
+
+        // A store directly under a relative root still names the anchor.
+        assert_eq!(
+            super::ancestor_chain(Path::new("login-transactions")),
+            vec![PathBuf::from(".")]
+        );
+        // Nothing in a chain may be empty: an empty path opens nothing, so a
+        // sync of it is a sync that silently did not happen.
+        for dir in ["/a/b", "a/b", "b", "/"] {
+            assert!(
+                super::ancestor_chain(Path::new(dir))
+                    .iter()
+                    .all(|p| !p.as_os_str().is_empty()),
+                "{dir} produced an empty entry"
+            );
+        }
+    }
+
+    /// A removal that is not durable brings the record back after a power loss,
+    /// and a record that comes back is acted on again. Absence is the whole
+    /// meaning of a resolved journal, so it gets the same treatment as a write.
+    #[test]
+    fn removing_a_record_that_is_already_gone_is_success() {
+        let dir = std::env::temp_dir().join("irlume-remove-durable-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("record");
+        std::fs::write(&path, b"x").unwrap();
+        assert_eq!(super::remove_durable(&path), Ok(()));
+        assert!(!path.exists());
+        // Idempotent: a caller resuming after a crash must not fail here.
+        assert_eq!(super::remove_durable(&path), Ok(()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     // --- cross-version wire compatibility for typed operation errors --------
     //

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -112,17 +112,14 @@ pub fn model_path(m: &ThirdPartyModel) -> PathBuf {
     dir().join(m.file)
 }
 
-/// Lowercase hex SHA-256 of `bytes`. The one place the checksum is computed, so
-/// the CLI's enable/verify path and the daemon's load guard agree byte for byte.
-pub fn sha256_hex(bytes: &[u8]) -> String {
-    use sha2::Digest;
-    // sha2 0.11's digest output no longer implements LowerHex; hex-encode
-    // the bytes directly.
-    sha2::Sha256::digest(bytes)
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect()
-}
+/// Lowercase hex SHA-256 of `bytes`, re-exported at this path because the
+/// model catalog's callers have always reached it here.
+///
+/// The implementation moved to the crate root once a second and third caller
+/// appeared (login transactions, and the IR emitter's undo journal). Three
+/// copies of a checksum is three chances for one of them to disagree with the
+/// digests already written to disk.
+pub use crate::sha256_hex;
 
 /// Whether a fetched weight file is present and matches its pinned checksum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -202,6 +202,7 @@ reused for a different meaning. The registry as of this contract:
 | `tpm` | a usable TPM 2.0 resource-manager device |
 | `secure-boot` | Secure Boot enabled, disabled, or in setup mode |
 | `boot-mode` | the boot chain, which decides which PCR policy tier applies |
+| `emitter-undo-pending` | camera controls an interrupted `ir-setup` left changed and has not put back. `unknown` when the root-only record store cannot be read, which is any run that is not root |
 | `signed-pcr-policy` | the systemd signed-PCR (Tier 1) policy for sealing |
 | `pcrlock` | the systemd-pcrlock (Tier 2) policy and its NV index |
 | `camera-nodes` | whether an RGB and an IR node were classified. Capability only; no device paths |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -249,7 +249,15 @@ automatically at daemon start and during enrollment. That permanently destroyed 
 reporter's camera ([#159]). It is now only ever run when you ask for it.
 
 To see exactly what irlume sends to the camera, set `IRLUME_LOG_EMITTER_WRITES=1`
-and it prints each emitter write before making it.
+and it prints each emitter write before making it, interleaved with the undo
+record's own events so the order is visible.
+
+Setup writes that undo record before it touches the control and removes it only
+once the control reads back holding its original value again, so a crash, a kill
+or a power loss part-way through leaves the original bytes on disk. The next
+capture on that camera puts them back; `irlume doctor` reports anything still
+outstanding, which is how you find it on a machine running
+`IRLUME_IR_EMITTER=off`.
 
 If your camera's vendor documents a control that irlume cannot discover, set it
 yourself:
@@ -320,6 +328,7 @@ live in them; sealed envelopes are stored separately (see
 | `/etc/irlume/cameras.conf` | `rgb=` / `ir=` device nodes of the active camera pair | TUI camera picker, or `sudo irlume set-cameras <rgb> <ir>` |
 | `/etc/irlume/method` | one line: the active auth method (`auto`, `face`, `fingerprint`, or `both` = face OR fingerprint) | `irlume fingerprint enable/disable` |
 | `/var/lib/irlume/ir_emitter.conf` | the UVC extension-unit control that lights the emitter | `irlume ir-setup` |
+| `/var/lib/irlume/ir-emitter-journal/` | one record per camera, holding the bytes a control held before `ir-setup` changed it. Written before the change and removed once the control reads back as restored, so a crash, a kill or a power loss mid-setup leaves something that can undo it. Root-only | `irlume ir-setup`, cleared by it or by the next capture |
 
 Camera selection precedence: the `IRLUME_RGB_DEVICE`+`IRLUME_IR_DEVICE` env
 pair (both set), then `cameras.conf`, then auto-detection, then the compiled

--- a/scripts/emitter-journal-container-test.sh
+++ b/scripts/emitter-journal-container-test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Exercise the IR emitter's undo record against a throwaway state directory.
+#
+#   podman run --rm -v "$PWD/scripts:/s:z" \
+#     -v "$PWD/target/release/irlume:/work/irlume:z" fedora:44 \
+#     bash -c 'touch /.irlume-throwaway && bash /s/emitter-journal-container-test.sh'
+#
+# WHAT A CONTAINER CAN AND CANNOT SHOW
+#
+# There is no camera here, so nothing below issues a single ioctl. The parts of
+# the record that a container CAN prove are the parts a person can reach without
+# hardware: which records `doctor` reports and how, that the store is root-only,
+# that a record for another camera is not touched, and that an unreadable store
+# is reported as unchecked rather than as clean.
+#
+# The ordering claims — the record durable before the first SET_CUR, the attempt
+# counted before the restore, the record dropped only after the control reads
+# back — need a camera and are proved by the hardware run against the traced
+# output of IRLUME_LOG_EMITTER_WRITES. Nothing in this file demonstrates them,
+# and this file does not pretend to.
+set -uo pipefail
+
+B=/work/irlume
+export IRLUME_STATE_DIR=/var/lib/irlume-journal-test
+STORE="$IRLUME_STATE_DIR/ir-emitter-journal"
+pass=0
+fail=0
+skipped=0
+
+ok() {
+    pass=$((pass + 1))
+    echo "  ok      $1"
+}
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+# `cond && ok || bad` also runs bad when ok fails, which is the SC2015 trap.
+assert() {
+    local desc="$1" detail="$2"
+    shift 2
+    if "$@"; then ok "$desc"; else bad "$desc" "$detail"; fi
+}
+assert_not() {
+    local desc="$1" detail="$2"
+    shift 2
+    if "$@"; then bad "$desc" "$detail"; else ok "$desc"; fi
+}
+
+if [ ! -f /.irlume-throwaway ]; then
+    echo "refusing: no throwaway marker, so this may not be a disposable machine"
+    exit 2
+fi
+if [ "$(id -u)" -ne 0 ]; then
+    echo "refusing: the store is root-only, so a non-root run would prove only that"
+    exit 2
+fi
+
+# The one check id this file is about. Pulled out of the JSON document rather
+# than the human report, because the id is the stable contract and the prose is
+# explicitly not.
+#
+# Matched as a whole object, and the object class is `[^{}]*` on BOTH sides of
+# the id. Two earlier versions of this line were each wrong for one shape: the
+# serializer emits `detail` before `id` when a detail is present and `id` first
+# when there is none, so an id-first pattern missed every warn and a
+# leading-`{"` pattern missed every pass. Either way the empty result read as a
+# failing check rather than as the pattern finding nothing, which is the whole
+# reason the state is compared against an expected value rather than tested for
+# non-emptiness.
+check_object() {
+    "$B" doctor --json 2>/dev/null |
+        grep -o '{[^{}]*"id":"emitter-undo-pending"[^{}]*}' |
+        head -1
+}
+check_state() {
+    check_object | grep -o '"state":"[a-z]*"' | cut -d'"' -f4
+}
+
+plant() {
+    # $1 = filename stem, $2 = usb id, $3 = unit, $4 = selector, $5 = extra json
+    mkdir -p "$STORE"
+    chmod 700 "$STORE"
+    cat >"$STORE/$1.json" <<EOF
+{"schema_version":1,"engine_version":"0.7.2","descriptor_sha256":"$1",
+ "usb_id":"$2","interface_number":2,"unit":$3,"selector":$4,"len":3,
+ "original":"010301","attempted":"010302","restore_attempts":0$5}
+EOF
+}
+
+rm -rf "$IRLUME_STATE_DIR"
+mkdir -p "$IRLUME_STATE_DIR"
+
+echo "=== 1. an absent store is reported clean, not unknown ==="
+# A store that was never created is a machine on which setup never ran. That is
+# a genuine pass, and conflating it with "could not look" would either cry wolf
+# on every fresh install or hide a real pending change behind a shrug.
+assert_not "no store directory exists yet" "left over from a previous run" test -d "$STORE"
+state=$(check_state)
+assert "doctor reports pass with no store: got '${state:-<none>}'" "expected pass" \
+    test "$state" = "pass"
+
+echo "=== 2. an empty store is reported clean ==="
+# Distinct from section 1: the directory exists because a record was written and
+# then resolved, which is the ordinary end state after a successful setup.
+mkdir -p "$STORE"
+chmod 700 "$STORE"
+state=$(check_state)
+assert "doctor reports pass with an empty store: got '${state:-<none>}'" "expected pass" \
+    test "$state" = "pass"
+
+echo "=== 3. a planted record is reported, with its coordinates ==="
+plant 1111 "3277:0059" 14 6 ""
+entry=$(check_object)
+assert "doctor reports warn: got '${entry:-<none>}'" "expected a warn" \
+    grep -q '"state":"warn"' <<<"$entry"
+# The coordinates are the whole point: an operator has to be able to match the
+# record against `lsusb` and against what the camera's descriptor publishes.
+assert "the report names the camera" "$entry" grep -q '3277:0059' <<<"$entry"
+assert "the report names the unit" "$entry" grep -q 'unit 14' <<<"$entry"
+assert "the report names the selector" "$entry" grep -q 'selector 6' <<<"$entry"
+assert "the report names the original bytes" "$entry" grep -q '010301' <<<"$entry"
+
+echo "=== 4. doctor reads the store and writes nothing to it ==="
+# `doctor` runs on machines whose operator has deliberately stopped irlume
+# touching the camera. It must not resolve, rewrite or tidy a record.
+before=$(md5sum "$STORE/1111.json" | cut -d' ' -f1)
+"$B" doctor >/dev/null 2>&1
+"$B" doctor --json >/dev/null 2>&1
+after=$(md5sum "$STORE/1111.json" | cut -d' ' -f1)
+assert "the record is byte-identical after two doctor runs" "$before -> $after" \
+    test "$before" = "$after"
+assert "no stray files appeared in the store" "unexpected entries" \
+    test "$(find "$STORE" -type f | wc -l)" -eq 1
+
+echo "=== 5. every pending camera is reported, not just the first ==="
+# One file per camera exists so that a second camera's setup cannot erase the
+# first camera's undo data. A report that stopped at one would hide exactly the
+# case the layout was chosen for.
+plant 2222 "04f2:b6d9" 12 10 ""
+entry=$(check_object)
+assert "the first camera is still reported" "$entry" grep -q '3277:0059' <<<"$entry"
+assert "the second camera is reported too" "$entry" grep -q '04f2:b6d9' <<<"$entry"
+rm -f "$STORE/2222.json"
+
+echo "=== 6. an unparseable record is reported, never skipped ==="
+# Something is pending and this build cannot read it. Skipping it would report a
+# machine with an outstanding firmware change as clean.
+echo 'not json at all' >"$STORE/3333.json"
+entry=$(check_object)
+assert "a corrupt record still produces a warn: got '${entry:-<none>}'" "expected warn" \
+    grep -q '"state":"warn"' <<<"$entry"
+assert "the corrupt record is named" "$entry" grep -q '3333' <<<"$entry"
+rm -f "$STORE/3333.json"
+
+echo "=== 7. a file that is not a record is ignored ==="
+# The store is a directory irlume owns, but a stray editor swap file or a
+# package's leftover must not be read as a pending firmware change.
+echo 'scratch' >"$STORE/notes.txt"
+entry=$(check_object)
+assert_not "a non-json file is not counted as a record" "$entry" grep -q 'notes.txt' <<<"$entry"
+rm -f "$STORE/notes.txt"
+
+echo "=== 8. a store that cannot be listed is unknown, not clean ==="
+# The failure this guards against is a clean bill of health nobody checked.
+#
+# Exercised by putting a regular file where the store directory belongs, which
+# fails with ENOTDIR for every caller including root. The permission case is the
+# one that actually happens in the field, but it cannot be provoked here: root in
+# a container carries CAP_DAC_OVERRIDE and reads a 000 directory happily. Section
+# 9 makes that explicit instead of leaving a section that silently proved nothing.
+rm -rf "$STORE"
+: >"$STORE"
+state=$(check_state)
+rm -f "$STORE"
+mkdir -p "$STORE"
+chmod 700 "$STORE"
+assert "doctor reports unknown when the store cannot be listed: got '${state:-<none>}'" \
+    "expected unknown" test "$state" = "unknown"
+
+echo "=== 9. the permission case, where this process can be denied ==="
+# Reported as not exercised rather than passing when the process cannot be shut
+# out of its own directory. A guard that never ran is not a guard that passed.
+chmod 000 "$STORE"
+if ls "$STORE" >/dev/null 2>&1; then
+    chmod 700 "$STORE"
+    skipped=$((skipped + 1))
+    echo "  NOT EXERCISED  this process reads a 000 directory (CAP_DAC_OVERRIDE);"
+    echo "                 the permission path is covered by the unit tests instead"
+else
+    state=$(check_state)
+    chmod 700 "$STORE"
+    assert "doctor reports unknown on a 000 store: got '${state:-<none>}'" \
+        "expected unknown" test "$state" = "unknown"
+fi
+
+echo "=== 10. the store keeps its permissions ==="
+assert "the store is root-only" "$(stat -c %a "$STORE")" \
+    test "$(stat -c %a "$STORE")" = "700"
+
+echo "=== 11. resolving the last record returns the report to clean ==="
+# The end state after a recovery: the record is gone and doctor stops warning.
+# Without this the suite would never show the warn clearing, and a check stuck
+# on warn forever would look identical to a working one.
+rm -f "$STORE"/*.json
+state=$(check_state)
+assert "doctor reports pass once the store is emptied: got '${state:-<none>}'" \
+    "expected pass" test "$state" = "pass"
+
+rm -rf "$IRLUME_STATE_DIR"
+
+echo
+echo "$pass passed, $fail failed, $skipped not exercised"
+[ "$fail" -eq 0 ]

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -224,8 +224,15 @@ assert "no record is left after a completed run" "still present" \
 
 echo "=== 3. the emitter config ==="
 if [ -f "$CONF" ]; then
+    # The requested 0644 narrowed by the daemon's umask. The packaged unit sets
+    # UMask=0027, so the real file is 0640; this harness starts the daemon from a
+    # shell and inherits ITS umask, so a bare "644" assertion here would pass
+    # while the shipped service produced something else. Compare against what the
+    # umask in force actually implies.
     mode=$(stat -c %a "$CONF")
-    assert "ir_emitter.conf is 0644" "$mode" test "$mode" = "644"
+    expected=$(printf "%o" $((0644 & ~$(umask))))
+    assert "ir_emitter.conf is $expected, the requested 0644 under umask $(umask)" \
+        "got $mode" test "$mode" = "$expected"
     echo "    conf: $(cat "$CONF")"
     assert "it records the camera and coordinates, not a payload" "old-style entry" \
         grep -qE '^[0-9a-f]{4}:[0-9a-f]{4} [0-9]+:[0-9]+$' "$CONF"

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -54,10 +54,22 @@ STORE="$STATE/ir-emitter-journal"
 CONF="$STATE/ir_emitter.conf"
 LOCKS="$STATE/locks"
 MODELS="${IRLUME_MODEL_DIR:-/usr/share/irlume/models}"
+# Two things a sandboxed daemon needs that only the packaged unit supplies.
+# Without the first it never reaches its socket and sits on a futex, which reads
+# as a hung build; without the second, startup stops on a warning about weights
+# a sandboxed state directory does not have.
+ORT="${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
+    sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)}"
 # The camera's own default for the Microsoft face-authentication control, as both
 # validated modules report it via GET_DEF. Section 1 refuses to draw conclusions
 # if parking to it changed nothing.
 PARK="${PARK_VALUE:-1,3,1,0,0,0,0,0,0}"
+# The Microsoft unit and selector are DERIVED from the camera in section 0, not
+# assumed. They were hardcoded to one module's unit 4, which meant every
+# unit-specific assertion here silently checked nothing on any other camera: the
+# ASUS module in the same drawer publishes its Microsoft XU as unit 14.
+UNIT=""
+SEL=""
 
 pass=0
 fail=0
@@ -111,6 +123,9 @@ trap cleanup EXIT
 
 rm -rf "$OUT"
 mkdir -p "$OUT" "$STATE" "$LOCKS"
+if [ -d /var/lib/irlume/models-thirdparty ]; then
+    ln -sfn /var/lib/irlume/models-thirdparty "$STATE/models-thirdparty"
+fi
 systemctl stop irlumed 2>/dev/null
 sleep 1
 
@@ -119,7 +134,10 @@ sleep 1
 start_daemon() {
     local tag="$1" override="${2:-off}"
     rm -f "$SOCK"
-    IRLUME_SOCKET="$SOCK" \
+    # `env`, not bare assignments: `${ORT:+VAR=val}` expands to a WORD, and a
+    # word in a prefix-assignment list is taken as the command to run, not as an
+    # assignment. Bash duly tried to execute it.
+    env IRLUME_SOCKET="$SOCK" \
         IRLUME_STATE_DIR="$STATE" \
         IRLUME_IR_EMITTER_CONF="$CONF" \
         IRLUME_EMITTER_LOCK_DIR="$LOCKS" \
@@ -131,13 +149,22 @@ start_daemon() {
         IRLUME_MODEL="$MODELS/glintr100.onnx" \
         IRLUME_MESH_MODEL="$MODELS/face_landmark.onnx" \
         IRLUME_BLAZE_MODEL="$MODELS/blaze_face_short_range.onnx" \
+        ${ORT:+ORT_DYLIB_PATH="$ORT"} \
         "$D" >"$OUT/daemon-$tag.log" 2>&1 &
     daemon_pid=$!
-    for _ in $(seq 1 300); do
+    # Four ONNX models load before it listens, which on a laptop takes longer
+    # than the camera work that follows.
+    for _ in $(seq 1 1800); do
         [ -S "$SOCK" ] && return 0
-        kill -0 "$daemon_pid" 2>/dev/null || return 1
+        kill -0 "$daemon_pid" 2>/dev/null || {
+            echo "  the daemon exited during startup:"
+            tail -4 "$OUT/daemon-$tag.log" | sed 's/^/    /'
+            return 1
+        }
         sleep 0.1
     done
+    echo "  the daemon never listened; last lines:"
+    tail -4 "$OUT/daemon-$tag.log" | sed 's/^/    /'
     return 1
 }
 stop_daemon() {
@@ -159,6 +186,17 @@ setup --dry-run >"$OUT/units-before.txt" 2>&1
 sed 's/^/    /' "$OUT/units-before.txt"
 echo "    devpath: $(udevadm info -q path -n "$IR" 2>/dev/null | sed 's,/video4linux.*,,')"
 stop_daemon
+
+# "unit 14 (Microsoft camera control): advertises [0x06, 0x09]"
+UNIT=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$OUT/units-before.txt" | head -1)
+SEL=$(sed -n 's/.*unit '"${UNIT:-x}"' (Microsoft camera control): advertises \[\(0x[0-9a-f]*\).*/\1/p' \
+    "$OUT/units-before.txt" | head -1)
+if [ -z "$UNIT" ] || [ -z "$SEL" ]; then
+    echo "refusing: no Microsoft camera-control unit on this camera; nothing here applies"
+    exit 2
+fi
+SEL=$((SEL))
+echo "    Microsoft XU: unit $UNIT, first advertised selector $SEL"
 if [ -n "$(find "$STORE" -name '*.json' 2>/dev/null)" ]; then
     echo "refusing: $STORE already holds a record; resolve it first"
     find "$STORE" -name '*.json' -exec cat {} \;
@@ -166,15 +204,22 @@ if [ -n "$(find "$STORE" -name '*.json' 2>/dev/null)" ]; then
 fi
 
 echo "=== 1. park the control at the camera's own default ==="
-start_daemon park "4:6:$PARK" || {
+start_daemon park "$UNIT:$SEL:$PARK" || {
     echo "  daemon would not start"
     exit 2
 }
 stop_daemon
-parked=$(grep -ac "SET_CUR unit4/sel6: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null)
-assert "the control was parked at its default" \
-    "no parking write traced; PARK=$PARK may not be this camera's GET_DEF" \
-    test "${parked:-0}" -ge 1
+parked=$(grep -ac "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null)
+if [ "${parked:-0}" -ge 1 ]; then
+    ok "the control was parked at its default"
+else
+    # No write does NOT mean the park failed: the override reads the control
+    # first and writes nothing when it already holds the value, which is the
+    # ordinary state on a camera nothing has driven. What actually matters is
+    # whether discovery then had a difference to measure, and section 2 asserts
+    # that independently by requiring a SET_CUR of its own.
+    skip "the control already held the default, so no parking write was needed"
+fi
 
 echo "=== 2. discovery: record before the write, cleared after a read-back ==="
 start_daemon discover off || {
@@ -241,7 +286,7 @@ else
 fi
 
 echo "=== 4. a SIGKILL mid-run leaves the record ==="
-start_daemon park2 "4:6:$PARK" >/dev/null 2>&1 && stop_daemon
+start_daemon park2 "$UNIT:$SEL:$PARK" >/dev/null 2>&1 && stop_daemon
 start_daemon killed off || {
     echo "  daemon would not start"
     exit 2

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# Hardware validation for the IR emitter undo record (#181, PR #183).
+#
+#   sudo bash hw-validate-emitter-journal.sh <worktree> <ir-node> [rgb-node]
+#
+# WHAT THIS PROVES THAT NOTHING ELSE CAN
+#
+# Every ordering claim in the record is a sequence of ioctls. The record's whole
+# job is to be gone by the end, so nothing is left on disk to inspect, and the
+# unit suite reaches these paths only through a stand-in camera. This reads the
+# order off one transcript from a real device.
+#
+# TWO THINGS THE FIRST VERSION OF THIS SCRIPT GOT WRONG, both of which made it
+# report failures against correct behaviour:
+#
+#   * The daemon writes to the emitter AT STARTUP, from the built-in table,
+#     before any request arrives. Finding a SET_CUR in the log and concluding
+#     discovery had written is how five assertions ran against a run that never
+#     wrote at all. Every section now slices the log from the moment its request
+#     was made.
+#   * `ir-setup` correctly reports "already set to the value setup would apply"
+#     and writes nothing when the control is already there, which is precisely
+#     the state the daemon's own startup write leaves it in. Discovery then has
+#     nothing to explore. The control is parked at the camera's own default
+#     first, so there is a real difference to measure.
+#
+# HOW IT IS ISOLATED
+#
+# A private irlumed from the worktree, on its own socket, state directory,
+# emitter config and lock directory. Nothing here reads or writes the installed
+# irlume's files. The packaged irlumed is stopped because it holds the camera,
+# and an EXIT trap starts it again on every path out.
+#
+# WHAT IT WRITES
+#
+# `ir-setup` writes to the camera's Microsoft extension unit. That is a firmware
+# write; it is the operation under test. Section 4 SIGKILLs the daemon mid-run,
+# which is the state this change exists to recover from. Every value written is
+# one the camera itself reported: the parking value is its own GET_DEF, sent
+# through the documented override. The published descriptor is captured before
+# and after and compared, because a descriptor that changes is what #159 was.
+set -uo pipefail
+
+TREE="${1:?usage: $0 <worktree> <ir-node> [rgb-node]}"
+IR="${2:?usage: $0 <worktree> <ir-node> [rgb-node]}"
+RGB="${3:-/dev/video0}"
+
+B="$TREE/target/release/irlume"
+D="$TREE/target/release/irlumed"
+OUT=/tmp/emitter-journal-hw
+SOCK=/run/irlume-hwtest.sock
+STATE=/var/lib/irlume-hwtest
+STORE="$STATE/ir-emitter-journal"
+CONF="$STATE/ir_emitter.conf"
+LOCKS="$STATE/locks"
+MODELS="${IRLUME_MODEL_DIR:-/usr/share/irlume/models}"
+# The camera's own default for the Microsoft face-authentication control, as both
+# validated modules report it via GET_DEF. Section 1 refuses to draw conclusions
+# if parking to it changed nothing.
+PARK="${PARK_VALUE:-1,3,1,0,0,0,0,0,0}"
+
+pass=0
+fail=0
+skipped=0
+ok() { pass=$((pass + 1)); echo "  ok      $1"; }
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+assert() {
+    local d="$1" x="$2"
+    shift 2
+    if "$@"; then ok "$d"; else bad "$d" "$x"; fi
+}
+skip() {
+    skipped=$((skipped + 1))
+    echo "  NOT EXERCISED  $1"
+}
+
+[ "$(id -u)" -eq 0 ] || {
+    echo "refusing: writes camera firmware, needs root"
+    exit 2
+}
+[ -x "$B" ] && [ -x "$D" ] || {
+    echo "refusing: no irlume/irlumed in $TREE/target/release"
+    exit 2
+}
+[ -e "$IR" ] || {
+    echo "refusing: $IR does not exist"
+    exit 2
+}
+
+# Whether the packaged daemon is ENABLED, not whether it happens to be running.
+#
+# The first version noted "is-active" at startup and restarted only if it had
+# been active. A run that ended without restarting it therefore made the NEXT run
+# see it stopped, decide it was meant to be stopped, and leave it that way: two
+# runs in, the machine's face authentication was off and nothing said so. What
+# the operator wants back is the configured state, so that is what is restored.
+daemon_pid=""
+cleanup() {
+    [ -n "$daemon_pid" ] && kill -KILL "$daemon_pid" 2>/dev/null
+    rm -f "$SOCK"
+    if systemctl is-enabled --quiet irlumed 2>/dev/null; then
+        systemctl start irlumed 2>/dev/null
+        echo "  (packaged irlumed: $(systemctl is-active irlumed))"
+    fi
+}
+trap cleanup EXIT
+
+rm -rf "$OUT"
+mkdir -p "$OUT" "$STATE" "$LOCKS"
+systemctl stop irlumed 2>/dev/null
+sleep 1
+
+# $1 = log tag, $2 = value for IRLUME_IR_EMITTER. "off" makes the daemon write
+# nothing at startup, which is what leaves a parked control alone.
+start_daemon() {
+    local tag="$1" override="${2:-off}"
+    rm -f "$SOCK"
+    IRLUME_SOCKET="$SOCK" \
+        IRLUME_STATE_DIR="$STATE" \
+        IRLUME_IR_EMITTER_CONF="$CONF" \
+        IRLUME_EMITTER_LOCK_DIR="$LOCKS" \
+        IRLUME_RGB_DEVICE="$RGB" \
+        IRLUME_IR_DEVICE="$IR" \
+        IRLUME_IR_EMITTER="$override" \
+        IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$MODELS/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$MODELS/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$MODELS/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$MODELS/blaze_face_short_range.onnx" \
+        "$D" >"$OUT/daemon-$tag.log" 2>&1 &
+    daemon_pid=$!
+    for _ in $(seq 1 300); do
+        [ -S "$SOCK" ] && return 0
+        kill -0 "$daemon_pid" 2>/dev/null || return 1
+        sleep 0.1
+    done
+    return 1
+}
+stop_daemon() {
+    [ -n "$daemon_pid" ] && kill -TERM "$daemon_pid" 2>/dev/null
+    wait "$daemon_pid" 2>/dev/null
+    daemon_pid=""
+}
+setup() { IRLUME_SOCKET="$SOCK" "$B" ir-setup "$@"; }
+mark() { wc -c <"$OUT/daemon-$1.log" 2>/dev/null || echo 0; }
+since() { tail -c "+$2" "$OUT/daemon-$1.log" 2>/dev/null; }
+
+echo "=== 0. the camera before anything ==="
+start_daemon probe off || {
+    echo "refusing: the private daemon would not start"
+    tail -20 "$OUT/daemon-probe.log"
+    exit 2
+}
+setup --dry-run >"$OUT/units-before.txt" 2>&1
+sed 's/^/    /' "$OUT/units-before.txt"
+echo "    devpath: $(udevadm info -q path -n "$IR" 2>/dev/null | sed 's,/video4linux.*,,')"
+stop_daemon
+if [ -n "$(find "$STORE" -name '*.json' 2>/dev/null)" ]; then
+    echo "refusing: $STORE already holds a record; resolve it first"
+    find "$STORE" -name '*.json' -exec cat {} \;
+    exit 2
+fi
+
+echo "=== 1. park the control at the camera's own default ==="
+start_daemon park "4:6:$PARK" || {
+    echo "  daemon would not start"
+    exit 2
+}
+stop_daemon
+parked=$(grep -ac "SET_CUR unit4/sel6: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null)
+assert "the control was parked at its default" \
+    "no parking write traced; PARK=$PARK may not be this camera's GET_DEF" \
+    test "${parked:-0}" -ge 1
+
+echo "=== 2. discovery: record before the write, cleared after a read-back ==="
+start_daemon discover off || {
+    echo "  daemon would not start"
+    exit 2
+}
+at=$(mark discover)
+setup >"$OUT/run-discover.out" 2>&1
+sed 's/^/    /' "$OUT/run-discover.out"
+stop_daemon
+since discover "$at" >"$OUT/discover.seq"
+echo "    --- traced sequence for the request only ---"
+grep -aE "journal|SET_CUR|GET_" "$OUT/discover.seq" | head -40 | sed 's/^/    /'
+
+grep -aE "journal (saved|cleared|read back)|SET_CUR|GET_LEN|GET_CUR" \
+    "$OUT/discover.seq" >"$OUT/discover.filtered"
+first_set=$(grep -n "SET_CUR" "$OUT/discover.filtered" | head -1 | cut -d: -f1)
+first_save=$(grep -n "journal saved" "$OUT/discover.filtered" | head -1 | cut -d: -f1)
+first_len=$(grep -n "GET_LEN" "$OUT/discover.filtered" | head -1 | cut -d: -f1)
+first_cur=$(grep -n "GET_CUR" "$OUT/discover.filtered" | head -1 | cut -d: -f1)
+
+if [ -z "$first_set" ]; then
+    skip "discovery wrote nothing, so the ordering was not exercised"
+    skip "the read-back was not exercised"
+    echo "    reason: $(grep -ao 'already set.*' "$OUT/run-discover.out" | head -1)"
+else
+    assert "the undo record is saved before the first SET_CUR" \
+        "save at ${first_save:-none}, first write at $first_set" \
+        test -n "$first_save" -a "${first_save:-99999}" -lt "$first_set"
+    assert "GET_LEN answers before the control is read" \
+        "len at ${first_len:-none}, cur at ${first_cur:-none}" \
+        test -n "$first_len" -a -n "$first_cur" -a "${first_len:-99999}" -lt "${first_cur:-0}"
+    # NOT a read-back here. A successful discovery deliberately leaves the
+    # control at the applied value and resolves its record through `commit`,
+    # which runs after `save_conf` and has nothing to read back: nothing was
+    # restored. The read-back guards the RESTORE resolution, and section 5 is
+    # where that is observed. Asserting it here read a correct success path as a
+    # failure on the first hardware run.
+    last_set=$(grep -n "SET_CUR" "$OUT/discover.filtered" | tail -1 | cut -d: -f1)
+    cleared=$(grep -n "journal cleared" "$OUT/discover.filtered" | tail -1 | cut -d: -f1)
+    assert "the record is cleared only after the final write" \
+        "last write at ${last_set:-none}, cleared at ${cleared:-none}" \
+        test -n "$cleared" -a "${last_set:-99999}" -lt "${cleared:-0}"
+fi
+assert "no record is left after a completed run" "still present" \
+    test -z "$(find "$STORE" -name '*.json' 2>/dev/null)"
+
+echo "=== 3. the emitter config ==="
+if [ -f "$CONF" ]; then
+    mode=$(stat -c %a "$CONF")
+    assert "ir_emitter.conf is 0644" "$mode" test "$mode" = "644"
+    echo "    conf: $(cat "$CONF")"
+    assert "it records the camera and coordinates, not a payload" "old-style entry" \
+        grep -qE '^[0-9a-f]{4}:[0-9a-f]{4} [0-9]+:[0-9]+$' "$CONF"
+else
+    skip "no ir_emitter.conf was written, so its shape was not checked"
+fi
+
+echo "=== 4. a SIGKILL mid-run leaves the record ==="
+start_daemon park2 "4:6:$PARK" >/dev/null 2>&1 && stop_daemon
+start_daemon killed off || {
+    echo "  daemon would not start"
+    exit 2
+}
+at=$(mark killed)
+setup >"$OUT/run-killed.out" 2>&1 &
+client=$!
+killed=no
+for _ in $(seq 1 900); do
+    if since killed "$at" | grep -aq "journal saved"; then
+        kill -KILL "$daemon_pid" 2>/dev/null && killed=yes
+        break
+    fi
+    kill -0 "$client" 2>/dev/null || break
+    sleep 0.05
+done
+wait "$client" 2>/dev/null
+daemon_pid=""
+
+if [ "$killed" != yes ]; then
+    skip "no exploratory write happened, so the kill had nothing to interrupt"
+    skip "the surviving record was not exercised"
+    skip "the recovery write was not exercised"
+else
+    ok "the daemon was SIGKILLed once its undo record was on disk"
+    record=$(find "$STORE" -name '*.json' 2>/dev/null | head -1)
+    assert "the undo record survived the kill" "nothing in $STORE" test -n "$record"
+    if [ -n "$record" ]; then
+        echo "    --- the surviving record ---"
+        sed 's/^/    /' "$record"
+        # The kernel's own DEVPATH, leading slash and all, so it can be
+        # compared by eye against `udevadm info -q path`.
+        assert "it names the camera's device path as the kernel does" \
+            "usb_devpath is absent or not a DEVPATH" \
+            grep -q '"usb_devpath":"/devices' "$record"
+        # `udevadm` names the INTERFACE directory
+        # (.../3-2.1/3-2.1:1.2); the record holds the USB DEVICE directory one
+        # level up (.../3-2.1), which is where `descriptors` and `idVendor`
+        # live. Strip the last component, not a `:1.N` suffix: the suffix
+        # appears inside the component name too, so removing it left a path
+        # ending in the device id twice and the comparison failed against a
+        # correct record.
+        want=$(udevadm info -q path -n "$IR" 2>/dev/null |
+            sed 's,/video4linux.*,,' | sed 's,/[^/]*$,,')
+        assert "the recorded path is this camera's device directory" \
+            "record does not contain $want" \
+            grep -qF "\"usb_devpath\":\"$want\"" "$record"
+        assert "it holds the original bytes" "no original" \
+            grep -q '"original":"[0-9a-f]' "$record"
+    fi
+
+    echo "=== 5. the next run puts the control back ==="
+    start_daemon recover off || {
+        echo "  daemon would not start"
+        exit 2
+    }
+    at=$(mark recover)
+    setup >"$OUT/run-recover.out" 2>&1
+    sed 's/^/    /' "$OUT/run-recover.out"
+    stop_daemon
+    since recover "$at" >"$OUT/recover.seq"
+    grep -aE "journal|SET_CUR|GET_" "$OUT/recover.seq" | head -30 | sed 's/^/    /'
+    assert "the record is resolved and gone" "still present" \
+        test -z "$(find "$STORE" -name '*.json' 2>/dev/null)"
+    # The sequence the whole change is about, in order, from a real device:
+    # the attempt counted and made durable, then the restoring write, then the
+    # read-back, and only then the record dropped.
+    rec_attempt=$(grep -n "journal saved.*attempts=1" "$OUT/recover.seq" | head -1 | cut -d: -f1)
+    rec_write=$(grep -n "SET_CUR" "$OUT/recover.seq" | head -1 | cut -d: -f1)
+    rec_read=$(grep -n "GET_CUR" "$OUT/recover.seq" | awk -F: -v w="${rec_write:-0}" '$1 > w {print $1; exit}')
+    rec_clear=$(grep -n "journal cleared" "$OUT/recover.seq" | head -1 | cut -d: -f1)
+    assert "the attempt is counted before the restoring write" \
+        "attempt at ${rec_attempt:-none}, write at ${rec_write:-none}" \
+        test -n "$rec_attempt" -a "${rec_attempt:-99999}" -lt "${rec_write:-0}"
+    assert "the control is read back after the restore" \
+        "write at ${rec_write:-none}, read at ${rec_read:-none}" \
+        test -n "$rec_read" -a "${rec_write:-99999}" -lt "${rec_read:-0}"
+    assert "the record is dropped only after that read-back" \
+        "read at ${rec_read:-none}, cleared at ${rec_clear:-none}" \
+        test -n "$rec_clear" -a "${rec_read:-99999}" -lt "${rec_clear:-0}"
+fi
+
+echo "=== 6. the camera after everything ==="
+start_daemon after off || {
+    echo "  daemon would not start"
+    exit 2
+}
+setup --dry-run >"$OUT/units-after.txt" 2>&1
+sed 's/^/    /' "$OUT/units-after.txt"
+stop_daemon
+assert "the camera still publishes the same extension units" \
+    "the descriptor changed, which is what #159 looked like" \
+    diff -q "$OUT/units-before.txt" "$OUT/units-after.txt"
+
+echo
+echo "$pass passed, $fail failed, $skipped not exercised"
+echo "transcripts in $OUT"
+[ "$fail" -eq 0 ]

--- a/scripts/emitter-journal-portmove-1-leave-record.sh
+++ b/scripts/emitter-journal-portmove-1-leave-record.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Stage 1 of the port-move test: leave an UNRESOLVED undo record at this port.
+#
+# What the whole test is for: two units of one camera model publish byte-identical
+# USB descriptors and, on this model, no serial at all. Filing a record by the
+# descriptor digest alone therefore collided, so a capture on the second camera
+# loaded the first camera's record, would have written the first camera's bytes
+# into the second, and on a successful read-back would have DELETED it, leaving
+# the camera that was actually changed with no undo data.
+#
+# One camera moved between two ports reproduces every part of that except
+# simultaneity: same descriptors, same absent serial, different device path.
+set -uo pipefail
+
+# Absolute: `~` expands to /root under sudo, and the worktree is not there.
+B=${IRLUME_TREE:-/home/archledger/irl-emitter-hw}/target/release
+S=/var/lib/irlume-portmove
+M=/usr/share/irlume/models
+IR=/dev/video2
+RGB=/dev/video0
+PARK=1,3,1,0,0,0,0,0,0
+
+rm -rf "$S"
+mkdir -p "$S"
+systemctl stop irlumed 2>/dev/null
+sleep 1
+
+start_daemon() { # $1 tag, $2 override
+    rm -f /run/irlume-portmove.sock
+    env IRLUME_SOCKET=/run/irlume-portmove.sock IRLUME_STATE_DIR="$S" \
+        IRLUME_IR_EMITTER_CONF="$S/ir_emitter.conf" \
+        IRLUME_EMITTER_LOCK_DIR="$S/locks" \
+        IRLUME_RGB_DEVICE="$RGB" IRLUME_IR_DEVICE="$IR" \
+        IRLUME_IR_EMITTER="$2" IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$M/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$M/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$M/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$M/blaze_face_short_range.onnx" \
+        "$B/irlumed" >"$S/daemon-$1.log" 2>&1 &
+    echo $! >"$S/daemon.pid"
+    for _ in $(seq 1 400); do
+        [ -S /run/irlume-portmove.sock ] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+echo "=== the camera, before anything ==="
+dev=$(readlink -f /sys/bus/usb/devices/3-2.1)
+echo "  devpath: ${dev#/sys}"
+echo "  desc:    $(sha256sum "$dev/descriptors" | cut -d' ' -f1)"
+echo "  serial:  $(cat "$dev/serial" 2>/dev/null || echo NONE)"
+
+echo "=== park the control so discovery has something to explore ==="
+start_daemon park "4:6:$PARK" || {
+    echo "daemon would not start"
+    exit 2
+}
+kill -TERM "$(cat "$S/daemon.pid")" 2>/dev/null
+sleep 1
+
+echo "=== run ir-setup and SIGKILL it once its record is on disk ==="
+start_daemon victim off || {
+    echo "daemon would not start"
+    exit 2
+}
+IRLUME_SOCKET=/run/irlume-portmove.sock "$B/irlume" ir-setup >"$S/setup.out" 2>&1 &
+client=$!
+killed=no
+for _ in $(seq 1 900); do
+    if grep -aq "journal saved" "$S/daemon-victim.log" 2>/dev/null; then
+        kill -KILL "$(cat "$S/daemon.pid")" 2>/dev/null && killed=yes
+        break
+    fi
+    kill -0 "$client" 2>/dev/null || break
+    sleep 0.05
+done
+wait "$client" 2>/dev/null
+
+if [ "$killed" != yes ]; then
+    echo "NOT EXERCISED: no record was written, so there is nothing to move away from"
+    cat "$S/setup.out"
+    systemctl start irlumed
+    exit 3
+fi
+
+record=$(find "$S/ir-emitter-journal" -name '*.json' | head -1)
+if [ -z "$record" ]; then
+    echo "FAILED: the kill left no record"
+    systemctl start irlumed
+    exit 1
+fi
+echo "=== the unresolved record now sitting at this port ==="
+echo "  file: $(basename "$record")"
+sed 's/^/  /' "$record"
+echo
+echo "STAGE 1 DONE. The camera is left CHANGED, with this record describing how"
+echo "to undo it. Now move the camera to hub port 2 or 4 (it is on port 1)."
+# The packaged daemon stays stopped on purpose: starting it would drive the
+# emitter and resolve the very record this test needs left alone.
+echo "(the packaged irlumed is deliberately left stopped until the test finishes)"

--- a/scripts/emitter-journal-portmove-2-at-other-port.sh
+++ b/scripts/emitter-journal-portmove-2-at-other-port.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Stage 2: the camera is now at a DIFFERENT device path. Its descriptors and its
+# (absent) serial are unchanged, so this is byte-for-byte what a second unit of
+# the same model looks like to irlume.
+#
+# What must happen, and what used to happen instead:
+#
+#   * The record from the other path must NOT be acted on. Before the fix the key
+#     was the descriptor digest alone, so this record would have been loaded as
+#     "mine", its bytes written to this camera, and then DELETED on a successful
+#     read-back, leaving the camera that was actually changed with no undo data.
+#   * It must NOT be deleted.
+#   * The emitter must stay off, because the other reading of this situation is
+#     that this IS that camera, still holding an exploratory value.
+#   * Discovery must refuse to start, since its first act is to read a control
+#     and call the answer the original.
+set -uo pipefail
+
+B=${IRLUME_TREE:-/home/archledger/irl-emitter-hw}/target/release
+S=/var/lib/irlume-portmove
+M=/usr/share/irlume/models
+IR=/dev/video2
+RGB=/dev/video0
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); echo "  ok      $1"; }
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+assert() {
+    local d="$1" x="$2"
+    shift 2
+    if "$@"; then ok "$d"; else bad "$d" "$x"; fi
+}
+
+record=$(find "$S/ir-emitter-journal" -name '*.json' | head -1)
+[ -n "$record" ] || {
+    echo "refusing: no record from stage 1"
+    exit 2
+}
+before=$(md5sum "$record" | cut -d' ' -f1)
+old_path=$(grep -o '"usb_devpath":"[^"]*"' "$record" | cut -d'"' -f4)
+# Found by product id, not by a hardcoded address: the whole point of this test
+# is that the address changes, so pinning one is how the script stops testing
+# what it claims to.
+cam=""
+for d in /sys/bus/usb/devices/*/; do
+    if [ -f "$d/idProduct" ] && grep -q c803 "$d/idProduct" 2>/dev/null; then
+        cam="${d%/}"
+        break
+    fi
+done
+[ -n "$cam" ] || {
+    echo "refusing: the camera is not attached"
+    exit 2
+}
+new_path=$(readlink -f "$cam" | sed 's,/sys,,')
+
+echo "=== the two addresses ==="
+echo "  record was written at: $old_path"
+echo "  the camera is now at:  $new_path"
+assert "the camera really did move" "same path; nothing was moved" \
+    test "$old_path" != "$new_path"
+assert "its descriptors are unchanged" "a different model would prove nothing" \
+    grep -q "$(sha256sum "$cam/descriptors" | cut -d' ' -f1)" "$record"
+
+rm -f /run/irlume-portmove.sock
+env IRLUME_SOCKET=/run/irlume-portmove.sock IRLUME_STATE_DIR="$S" \
+    IRLUME_IR_EMITTER_CONF="$S/ir_emitter.conf" \
+    IRLUME_EMITTER_LOCK_DIR="$S/locks" \
+    IRLUME_RGB_DEVICE="$RGB" IRLUME_IR_DEVICE="$IR" \
+    IRLUME_LOG_EMITTER_WRITES=1 \
+    IRLUME_DET_MODEL="$M/face_detection_yunet_2023mar.onnx" \
+    IRLUME_MODEL="$M/glintr100.onnx" \
+    IRLUME_MESH_MODEL="$M/face_landmark.onnx" \
+    IRLUME_BLAZE_MODEL="$M/blaze_face_short_range.onnx" \
+    "$B/irlumed" >"$S/daemon-moved.log" 2>&1 &
+pid=$!
+for _ in $(seq 1 400); do
+    [ -S /run/irlume-portmove.sock ] && break
+    sleep 0.1
+done
+[ -S /run/irlume-portmove.sock ] || {
+    echo "daemon would not start"
+    tail -8 "$S/daemon-moved.log"
+    exit 2
+}
+
+echo "=== what the daemon says about the camera in front of it ==="
+grep -a "irlume:" "$S/daemon-moved.log" | grep -viE "loading|loaded|listening" | head -6 | sed 's/^/  /'
+
+echo "=== ir-setup at the new address ==="
+IRLUME_SOCKET=/run/irlume-portmove.sock "$B/irlume" ir-setup >"$S/moved-setup.out" 2>&1
+sed 's/^/  /' "$S/moved-setup.out"
+
+echo "=== doctor ==="
+IRLUME_SOCKET=/run/irlume-portmove.sock IRLUME_STATE_DIR="$S" "$B/irlume" doctor --json 2>/dev/null |
+    grep -o '{[^{}]*"id":"emitter-undo-pending"[^{}]*}' | sed 's/^/  /'
+
+kill -TERM "$pid" 2>/dev/null
+sleep 1
+
+echo "=== the verdict ==="
+assert "the record was NOT deleted" "the other camera's undo data is gone" \
+    test -f "$record"
+assert "the record was not modified either" "it was rewritten" \
+    test "$(md5sum "$record" | cut -d' ' -f1)" = "$before"
+assert "nothing was written to this camera's emitter control" \
+    "a SET_CUR reached a camera whose record could not be confirmed" \
+    test "$(grep -ac 'SET_CUR' "$S/daemon-moved.log")" -eq 0
+assert "discovery refused to start" "it ran against an unconfirmable control" \
+    grep -qiE "not at that address|earlier setup run|unresolved" "$S/moved-setup.out"
+assert "the operator is told where the original is" "no store path in the message" \
+    grep -q "$S" "$S/daemon-moved.log"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/emitter-journal-portmove-3-back-home.sh
+++ b/scripts/emitter-journal-portmove-3-back-home.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Stage 3: the camera is back at the address its record was written at.
+#
+# The refusal in stage 2 is only defensible if the promise attached to it is
+# true. The message told the operator to reconnect the camera to the port it was
+# set up on and it would be put back automatically, so this checks exactly that,
+# and checks the control really does come back to the bytes recorded before
+# anything touched it.
+set -uo pipefail
+
+B=${IRLUME_TREE:-/home/archledger/irl-emitter-hw}/target/release
+S=/var/lib/irlume-portmove
+M=/usr/share/irlume/models
+IR=/dev/video2
+RGB=/dev/video0
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); echo "  ok      $1"; }
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+assert() {
+    local d="$1" x="$2"
+    shift 2
+    if "$@"; then ok "$d"; else bad "$d" "$x"; fi
+}
+
+record=$(find "$S/ir-emitter-journal" -name '*.json' | head -1)
+[ -n "$record" ] || {
+    echo "refusing: no record left to recover"
+    exit 2
+}
+original=$(grep -o '"original":"[^"]*"' "$record" | cut -d'"' -f4)
+attempted=$(grep -o '"attempted":"[^"]*"' "$record" | cut -d'"' -f4)
+recorded_at=$(grep -o '"usb_devpath":"[^"]*"' "$record" | cut -d'"' -f4)
+cam=""
+for d in /sys/bus/usb/devices/*/; do
+    if [ -f "$d/idProduct" ] && grep -q c803 "$d/idProduct" 2>/dev/null; then
+        cam="${d%/}"
+        break
+    fi
+done
+now_at=$(readlink -f "$cam" | sed 's,/sys,,')
+
+echo "=== the addresses agree again ==="
+echo "  recorded at: $recorded_at"
+echo "  camera at:   $now_at"
+assert "the camera is back where the record was written" "still elsewhere" \
+    test "$recorded_at" = "$now_at"
+
+rm -f /run/irlume-portmove.sock
+env IRLUME_SOCKET=/run/irlume-portmove.sock IRLUME_STATE_DIR="$S" \
+    IRLUME_IR_EMITTER_CONF="$S/ir_emitter.conf" \
+    IRLUME_EMITTER_LOCK_DIR="$S/locks" \
+    IRLUME_RGB_DEVICE="$RGB" IRLUME_IR_DEVICE="$IR" \
+    IRLUME_IR_EMITTER=off IRLUME_LOG_EMITTER_WRITES=1 \
+    IRLUME_DET_MODEL="$M/face_detection_yunet_2023mar.onnx" \
+    IRLUME_MODEL="$M/glintr100.onnx" \
+    IRLUME_MESH_MODEL="$M/face_landmark.onnx" \
+    IRLUME_BLAZE_MODEL="$M/blaze_face_short_range.onnx" \
+    "$B/irlumed" >"$S/daemon-home.log" 2>&1 &
+pid=$!
+for _ in $(seq 1 400); do
+    [ -S /run/irlume-portmove.sock ] && break
+    sleep 0.1
+done
+[ -S /run/irlume-portmove.sock ] || {
+    echo "daemon would not start"
+    tail -8 "$S/daemon-home.log"
+    exit 2
+}
+
+# `IRLUME_IR_EMITTER=off` above means the daemon's own startup writes nothing, so
+# whatever reaches the camera below comes from the recovery pass and nothing
+# else. `ir-setup` is the trigger; recovery runs before it reads anything.
+echo "=== recovery, at the address the record names ==="
+IRLUME_SOCKET=/run/irlume-portmove.sock "$B/irlume" ir-setup >"$S/home-setup.out" 2>&1
+sed 's/^/  /' "$S/home-setup.out"
+kill -TERM "$pid" 2>/dev/null
+sleep 1
+
+echo "=== traced ==="
+grep -aE "journal|SET_CUR" "$S/daemon-home.log" | head -12 | sed 's/^/  /'
+
+echo "=== the verdict ==="
+assert "the record was acted on and is gone" "it is still pending" \
+    test -z "$(find "$S/ir-emitter-journal" -name '*.json' 2>/dev/null)"
+# The bytes matter, not just that something was written: a restore that wrote
+# anything else would still empty the store.
+# TWO correct outcomes, and which one happens depends on whether the control is
+# still holding the exploratory value when the record is found again.
+#
+#   * still changed  -> the attempt is counted durably, the original is written
+#                       back, read back, and only then is the record dropped.
+#   * already back   -> nothing is written at all and the record is dropped.
+#
+# Both are right; writing to a control that already holds the recorded value
+# would be a firmware write for no reason. Asserting only the first read a
+# correct run as a failure: a physical unplug removes bus power, and this camera
+# comes back at its default, which IS the recorded original. Re-enumeration
+# without a power cut does NOT clear it, measured separately by driving the
+# control and toggling `authorized`.
+if grep -aq "journal saved.*attempts=1" "$S/daemon-home.log"; then
+    echo "  (the control was still changed: the restoring path ran)"
+    assert "the ORIGINAL bytes were written back" "restored to something else" \
+        grep -aq "SET_CUR unit4/sel6: \[01, 03, 01" "$S/daemon-home.log"
+    assert "the attempt was counted before that write" "no durable attempt recorded" \
+        grep -aq "journal saved.*attempts=1" "$S/daemon-home.log"
+    assert "the control was read back before the record was dropped" "no read-back" \
+        grep -aq "GET_CUR" "$S/daemon-home.log"
+else
+    echo "  (the control was already back at its recorded original)"
+    # The discriminating part: it must have been CHECKED, and not written to.
+    assert "the control was read before anything was decided" "no GET_CUR at all" \
+        grep -aq "GET_CUR" "$S/daemon-home.log"
+    before_clear=$(grep -an "journal cleared" "$S/daemon-home.log" | head -1 | cut -d: -f1)
+    assert "no write was made to undo a change that was not there" \
+        "a SET_CUR preceded the first clear" \
+        test "$(head -n "$((before_clear - 1))" "$S/daemon-home.log" | grep -ac SET_CUR)" -eq 0
+fi
+echo "  (recorded original $original, attempted $attempted)"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/emitter-journal-powerloss-test.sh
+++ b/scripts/emitter-journal-powerloss-test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Does the undo record survive a real power loss?
+#
+# `echo b > /proc/sysrq-trigger` reboots the kernel IMMEDIATELY: no sync, no
+# unmount, no userspace shutdown. Anything sitting in the page cache is gone.
+# That is as close to pulling the plug as a machine can get to itself.
+#
+# THE CANARY. A test that only checks the record is still there afterwards can
+# pass for the wrong reason: ext4 commits its journal every few seconds anyway,
+# so the record might survive because the filesystem happened to flush, not
+# because irlume fsynced it. So a second file is written immediately after,
+# through a plain redirect with no fsync at all, and both are checked after the
+# reboot. The record surviving while the canary does NOT is what makes this
+# evidence about irlume rather than about ext4's timers.
+#
+# Run detached: this script kills the machine it is running on.
+set -uo pipefail
+
+TREE=/tmp/irl-emitter-hw
+IR=/dev/video2
+RGB=/dev/video0
+STATE=/var/lib/irlume-powertest
+OUT=/var/lib/irlume-powertest-out
+MODELS=/usr/share/irlume/models
+PARK=1,3,1,0,0,0,0,0,0
+
+rm -rf "$STATE" "$OUT"
+mkdir -p "$STATE" "$OUT"
+# Make the setup durable BEFORE the dangerous part, so what survives afterwards
+# is only ever about the window under test.
+sync
+
+start_daemon() { # $1 = tag, $2 = override
+    rm -f /run/irlume-power.sock
+    env IRLUME_SOCKET=/run/irlume-power.sock IRLUME_STATE_DIR="$STATE" \
+        IRLUME_IR_EMITTER_CONF="$STATE/ir_emitter.conf" \
+        IRLUME_EMITTER_LOCK_DIR="$STATE/locks" \
+        IRLUME_RGB_DEVICE="$RGB" IRLUME_IR_DEVICE="$IR" \
+        IRLUME_IR_EMITTER="$2" IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$MODELS/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$MODELS/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$MODELS/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$MODELS/blaze_face_short_range.onnx" \
+        "$TREE/target/release/irlumed" >"$OUT/daemon-$1.log" 2>&1 &
+    for _ in $(seq 1 400); do
+        [ -S /run/irlume-power.sock ] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+systemctl stop irlumed
+sleep 1
+
+# Park, so discovery has a real difference to measure and therefore writes.
+start_daemon park "4:6:$PARK" || {
+    echo "park daemon failed" >"$OUT/ABORTED"
+    sync
+    systemctl start irlumed
+    exit 2
+}
+pkill -TERM -f "target/release/irlumed"
+sleep 1
+
+start_daemon victim off || {
+    echo "victim daemon failed" >"$OUT/ABORTED"
+    sync
+    systemctl start irlumed
+    exit 2
+}
+
+# Everything written so far is deliberately made durable, so the only thing the
+# reboot can prove or disprove is the record.
+sync
+
+IRLUME_SOCKET=/run/irlume-power.sock "$TREE/target/release/irlume" ir-setup \
+    >"$OUT/setup.out" 2>&1 &
+
+for _ in $(seq 1 1200); do
+    if grep -aq "journal saved" "$OUT/daemon-victim.log" 2>/dev/null; then
+        # The canary: same directory, same filesystem, written NOW, never
+        # fsynced. If this survives too, the reboot proved nothing.
+        echo "if you can read me, the page cache was flushed by something else" \
+            >"$STATE/canary-not-fsynced"
+        sysctl -w kernel.sysrq=128 >/dev/null
+        echo b >/proc/sysrq-trigger
+        # Not reached.
+        exit 0
+    fi
+    kill -0 %2 2>/dev/null || break
+    sleep 0.05
+done
+
+# Only here if no record was ever written: report and put the machine back.
+echo "no journal record appeared; nothing was interrupted" >"$OUT/ABORTED"
+cat "$OUT/setup.out" >>"$OUT/ABORTED" 2>/dev/null
+sync
+pkill -TERM -f "target/release/irlumed"
+systemctl start irlumed
+exit 3

--- a/scripts/emitter-journal-strace-test.sh
+++ b/scripts/emitter-journal-strace-test.sh
@@ -22,6 +22,11 @@ SOCK=/run/irlume-strace.sock
 STATE=/var/lib/irlume-stracetest
 MODELS=/usr/share/irlume/models
 PARK=1,3,1,0,0,0,0,0,0
+# Taken from the packaged unit rather than assumed: the ONNX runtime ships beside
+# irlume on some installs and sits on the default search path on others, and a
+# daemon that cannot find it never reaches its socket, which reads as a hung build.
+ORT="${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
+    sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)}"
 
 pass=0
 fail=0
@@ -38,6 +43,13 @@ bad() {
 }
 rm -rf "$OUT" "$STATE"
 mkdir -p "$OUT" "$STATE"
+# A sandboxed state directory has no opt-in third-party PAD weights, and on a
+# machine whose settings.conf enables one the daemon stops during startup instead
+# of reaching its socket. Point at the real ones; the subject here is the
+# emitter, not the models.
+if [ -d /var/lib/irlume/models-thirdparty ]; then
+    ln -sfn /var/lib/irlume/models-thirdparty "$STATE/models-thirdparty"
+fi
 
 was_enabled=no
 systemctl is-enabled --quiet irlumed 2>/dev/null && was_enabled=yes
@@ -74,6 +86,7 @@ start_daemon() { # $1 = tag, $2 = override, $3 = "strace" to trace it
         IRLUME_MODEL="$MODELS/glintr100.onnx" \
         IRLUME_MESH_MODEL="$MODELS/face_landmark.onnx" \
         IRLUME_BLAZE_MODEL="$MODELS/blaze_face_short_range.onnx" \
+        ${ORT:+ORT_DYLIB_PATH="$ORT"} \
         "${pre[@]}" "$TREE/target/release/irlumed" >"$OUT/daemon-$1.log" 2>&1 &
     for _ in $(seq 1 400); do
         [ -S "$SOCK" ] && return 0
@@ -82,9 +95,36 @@ start_daemon() { # $1 = tag, $2 = override, $3 = "strace" to trace it
     return 1
 }
 
+# The extension unit is DERIVED, not assumed. This script was written against a
+# NexiGo (unit 4) and hardcoded it; on a camera whose Microsoft XU is unit 14 the
+# override is refused outright and the run dies at the park step with nothing to
+# say why. The same hardcoding in the hardware script was worse, because there it
+# failed silently.
+echo "=== which extension unit does this camera publish ==="
+start_daemon probe off || {
+    echo "daemon would not start for the probe"
+    tail -20 "$OUT/daemon-probe.log"
+    exit 2
+}
+IRLUME_SOCKET="$SOCK" "$TREE/target/release/irlume" ir-setup --dry-run \
+    >"$OUT/units.txt" 2>&1
+pkill -TERM -f "target/release/irlumed" 2>/dev/null
+sleep 1
+sed 's/^/    /' "$OUT/units.txt"
+UNIT=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$OUT/units.txt" | head -1)
+SEL=$(sed -n 's/.*unit '"${UNIT:-x}"' (Microsoft camera control): advertises \[\(0x[0-9a-f]*\).*/\1/p' \
+    "$OUT/units.txt" | head -1)
+if [ -z "$UNIT" ] || [ -z "$SEL" ]; then
+    echo "refusing: no Microsoft camera-control unit on this camera; nothing here applies"
+    exit 2
+fi
+SEL=$((SEL))
+echo "    Microsoft XU: unit $UNIT, first advertised selector $SEL"
+
 echo "=== park the control so discovery has something to explore ==="
-start_daemon park "4:6:$PARK" || {
+start_daemon park "$UNIT:$SEL:$PARK" || {
     echo "daemon would not start"
+    tail -20 "$OUT/daemon-park.log"
     exit 2
 }
 pkill -TERM -f "target/release/irlumed" 2>/dev/null

--- a/scripts/emitter-journal-strace-test.sh
+++ b/scripts/emitter-journal-strace-test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Prove, from syscalls, that the undo record is DURABLE before the camera is
+# written to.
+#
+# An fsync leaves no trace in the filesystem afterwards, so no test can observe
+# it and "the code calls it" is not evidence it reached the right object in the
+# right order. This traces the daemon through one `ir-setup` and reads the
+# ordering off the syscall log:
+#
+#   openat(<record>.tmp) -> fsync(that fd) -> rename -> fsync(<store dir>)
+#   ... and only then ioctl(<camera fd>, UVCIOC_CTRL_QUERY) carrying SET_CUR
+#
+# UVCIOC_CTRL_QUERY is _IOWR('u', 0x21, ...) = 0xc0107521 on 64-bit, which strace
+# prints unrecognised as that number.
+set -uo pipefail
+
+TREE=/tmp/irl-emitter-hw
+IR=/dev/video2
+RGB=/dev/video0
+OUT=/tmp/emitter-strace
+SOCK=/run/irlume-strace.sock
+STATE=/var/lib/irlume-stracetest
+MODELS=/usr/share/irlume/models
+PARK=1,3,1,0,0,0,0,0,0
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); echo "  ok      $1"; }
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+
+[ "$(id -u)" -eq 0 ] || {
+    echo "needs root"
+    exit 2
+}
+rm -rf "$OUT" "$STATE"
+mkdir -p "$OUT" "$STATE"
+
+was_enabled=no
+systemctl is-enabled --quiet irlumed 2>/dev/null && was_enabled=yes
+cleanup() {
+    pkill -KILL -f "irlume-strace" 2>/dev/null
+    rm -f "$SOCK"
+    [ "$was_enabled" = yes ] && systemctl start irlumed 2>/dev/null
+    echo "  (packaged irlumed: $(systemctl is-active irlumed))"
+}
+trap cleanup EXIT
+systemctl stop irlumed 2>/dev/null
+sleep 1
+
+start_daemon() { # $1 = tag, $2 = override, $3 = "strace" to trace it
+    rm -f "$SOCK"
+    local pre=()
+    # `write` is traced too, which is the trick that makes this readable: the
+    # daemon's own `IRLUME_LOG_EMITTER_WRITES` lines go to stderr, so they land
+    # in the SAME syscall stream, in order, and name which XU query each ioctl
+    # is. Every extension-unit request uses one ioctl number, so the trace alone
+    # cannot tell a GET from a SET.
+    if [ "${3:-}" = strace ]; then
+        # One quoted element: the comma list is strace's argument, not shell
+        # array syntax.
+        local syscalls="trace=openat,fsync,fdatasync,rename,unlink,unlinkat,ioctl,write"
+        pre=(strace -f -y -o "$OUT/trace.log" -s 120 -e "$syscalls")
+    fi
+    env IRLUME_SOCKET="$SOCK" IRLUME_STATE_DIR="$STATE" \
+        IRLUME_IR_EMITTER_CONF="$STATE/ir_emitter.conf" \
+        IRLUME_EMITTER_LOCK_DIR="$STATE/locks" \
+        IRLUME_RGB_DEVICE="$RGB" IRLUME_IR_DEVICE="$IR" \
+        IRLUME_IR_EMITTER="$2" IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$MODELS/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$MODELS/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$MODELS/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$MODELS/blaze_face_short_range.onnx" \
+        "${pre[@]}" "$TREE/target/release/irlumed" >"$OUT/daemon-$1.log" 2>&1 &
+    for _ in $(seq 1 400); do
+        [ -S "$SOCK" ] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+echo "=== park the control so discovery has something to explore ==="
+start_daemon park "4:6:$PARK" || {
+    echo "daemon would not start"
+    exit 2
+}
+pkill -TERM -f "target/release/irlumed" 2>/dev/null
+sleep 1
+
+echo "=== trace one ir-setup ==="
+start_daemon traced off strace || {
+    echo "traced daemon would not start"
+    tail -20 "$OUT/daemon-traced.log"
+    exit 2
+}
+IRLUME_SOCKET="$SOCK" "$TREE/target/release/irlume" ir-setup 2>&1 | sed 's/^/    /'
+pkill -TERM -f "target/release/irlumed" 2>/dev/null
+sleep 2
+
+echo "=== the ordering, from syscalls ==="
+# strace -y annotates every fd with its path, so no fd bookkeeping is needed.
+grep -nE 'ir-emitter-journal|UVCIOC|irlume: SET_CUR|irlume: journal' "$OUT/trace.log" |
+    grep -vE 'ENOENT|resumed' >"$OUT/relevant.log"
+sed -n '1,25p' "$OUT/relevant.log" | sed 's/^/    /'
+
+# The record's own fsync, the store directory's fsync, and the first XU ioctl.
+rec_fsync=$(grep -nE 'fsync\([0-9]+<.*ir-emitter-journal/.*tmp' "$OUT/relevant.log" | head -1 | cut -d: -f1)
+dir_fsync=$(grep -nE 'fsync\([0-9]+<.*ir-emitter-journal>' "$OUT/relevant.log" | head -1 | cut -d: -f1)
+# The first WRITE, not the first extension-unit request. The reads that precede
+# it are not merely allowed before the record, they are REQUIRED: the original
+# cannot be recorded until GET_CUR has answered. An earlier version of this
+# script compared against the first ioctl of any kind and reported correct
+# behaviour as a failure, which is the third time an assertion here has been
+# wrong before the product was.
+first_xu=$(grep -n 'irlume: SET_CUR' "$OUT/relevant.log" | head -1 | cut -d: -f1)
+
+if [ -z "$first_xu" ]; then
+    echo "  NOT EXERCISED  no SET_CUR was traced; nothing to order the record against"
+    fail=1
+else
+    # `cond && ok || bad` also runs bad when ok fails, which is the SC2015 trap
+    # the container suite in this directory documents. if/else, every time.
+    if [ -n "$rec_fsync" ]; then
+        ok "the record's own bytes are fsynced (line $rec_fsync)"
+    else
+        bad "the record was never fsynced" "no fsync on a journal temp file"
+    fi
+    if [ -n "$dir_fsync" ]; then
+        ok "the store directory is fsynced (line $dir_fsync)"
+    else
+        bad "the store directory was never fsynced" "the rename could be lost"
+    fi
+    if [ -n "$rec_fsync" ] && [ "$rec_fsync" -lt "$first_xu" ]; then
+        ok "the record is durable BEFORE the first SET_CUR ($rec_fsync < $first_xu)"
+    else
+        bad "the record is not durable before the camera is written to" \
+            "record fsync at ${rec_fsync:-none}, first SET_CUR at $first_xu"
+    fi
+    if [ -n "$dir_fsync" ] && [ "$dir_fsync" -lt "$first_xu" ]; then
+        ok "the directory entry is durable before it too ($dir_fsync < $first_xu)"
+    else
+        bad "the directory entry is not durable before the camera is written to" \
+            "dir fsync at ${dir_fsync:-none}, first SET_CUR at $first_xu"
+    fi
+fi
+
+echo
+echo "$pass passed, $fail failed"
+echo "full trace in $OUT/trace.log"
+[ "$fail" -eq 0 ]

--- a/scripts/emitter-journal-two-cameras-test.sh
+++ b/scripts/emitter-journal-two-cameras-test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Two IR cameras on one machine: does either one's setup destroy the other's
+# undo data?
+#
+#   sudo bash emitter-journal-two-cameras-test.sh <worktree> <ir-A> <rgb-A> <ir-B> <rgb-B>
+#
+# WHY THIS EXISTS
+#
+# Records are filed per camera because a machine can have more than one, and a
+# single shared file would let the second camera's setup replace the first
+# camera's record — the exact loss the module exists to prevent. Until this ran,
+# that was covered only by a unit test with a synthetic second identity.
+#
+# It could not be shown with ONE camera moved between ports, because at an
+# address it cannot confirm, discovery deliberately refuses and therefore never
+# creates a second record. Two DIFFERENT models are what make it reachable: each
+# is plainly not the other, so setup on the second proceeds normally, and the
+# question "did it tread on the first camera's record" gets a real answer.
+#
+# WHAT IT WRITES
+#
+# One `ir-setup` per camera: a documented Microsoft extension-unit control,
+# values the camera itself reported. Everything else is sandboxed under its own
+# state directory, emitter config and lock directory, so the installed irlume's
+# files are never read or written. The packaged daemon is stopped for the
+# duration and restored from its ENABLED state, not from whether it happened to
+# be running.
+set -uo pipefail
+
+TREE="${1:?usage: $0 <worktree> <ir-A> <rgb-A> <ir-B> <rgb-B>}"
+IR_A="${2:?}"
+RGB_A="${3:?}"
+IR_B="${4:?}"
+RGB_B="${5:?}"
+
+B="$TREE/target/release"
+S=/var/lib/irlume-twocam
+M="${IRLUME_MODEL_DIR:-/usr/share/irlume/models}"
+# Taken from the packaged unit rather than assumed. Without it the daemon never
+# reaches its socket and simply sits on a futex, which reads as a hung build:
+# the ONNX runtime is shipped beside irlume on some installs and found on the
+# default search path on others.
+ORT="${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
+    sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)}"
+STORE="$S/ir-emitter-journal"
+PARK=1,3,1,0,0,0,0,0,0
+
+pass=0
+fail=0
+skipped=0
+ok() { pass=$((pass + 1)); echo "  ok      $1"; }
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+assert() {
+    local d="$1" x="$2"
+    shift 2
+    if "$@"; then ok "$d"; else bad "$d" "$x"; fi
+}
+skip() {
+    skipped=$((skipped + 1))
+    echo "  NOT EXERCISED  $1"
+}
+
+[ "$(id -u)" -eq 0 ] || {
+    echo "refusing: writes camera firmware, needs root"
+    exit 2
+}
+for n in "$IR_A" "$RGB_A" "$IR_B" "$RGB_B"; do
+    [ -e "$n" ] || {
+        echo "refusing: $n does not exist"
+        exit 2
+    }
+done
+
+cleanup() {
+    pkill -KILL -f "$B/irlumed" 2>/dev/null
+    rm -f /run/irlume-twocam.sock
+    if systemctl is-enabled --quiet irlumed 2>/dev/null; then
+        systemctl start irlumed 2>/dev/null
+        echo "  (packaged irlumed: $(systemctl is-active irlumed))"
+    fi
+}
+trap cleanup EXIT
+
+rm -rf "$S"
+mkdir -p "$S"
+# A sandboxed state directory does not have the opt-in third-party PAD weights,
+# and on a machine where `settings.conf` enables one the daemon stops during
+# startup rather than reaching its socket. Link the real ones in, read-only as
+# far as this test is concerned: the point here is the emitter, not the models.
+if [ -d /var/lib/irlume/models-thirdparty ]; then
+    ln -sfn /var/lib/irlume/models-thirdparty "$S/models-thirdparty"
+fi
+systemctl stop irlumed 2>/dev/null
+sleep 1
+
+daemon_pid=""
+start_daemon() { # tag, ir, rgb, override
+    rm -f /run/irlume-twocam.sock
+    env IRLUME_SOCKET=/run/irlume-twocam.sock IRLUME_STATE_DIR="$S" \
+        IRLUME_IR_EMITTER_CONF="$S/ir_emitter.conf" \
+        IRLUME_EMITTER_LOCK_DIR="$S/locks" \
+        IRLUME_RGB_DEVICE="$3" IRLUME_IR_DEVICE="$2" \
+        IRLUME_IR_EMITTER="$4" IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$M/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$M/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$M/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$M/blaze_face_short_range.onnx" \
+        ${ORT:+ORT_DYLIB_PATH="$ORT"} \
+        "$B/irlumed" >"$S/daemon-$1.log" 2>&1 &
+    daemon_pid=$!
+    # Generous: this daemon loads four ONNX models before it listens, which on a
+    # laptop takes longer than the camera work that follows it. A short wait here
+    # reads as "the build is broken" when it only means "not finished loading".
+    for _ in $(seq 1 1800); do
+        [ -S /run/irlume-twocam.sock ] && return 0
+        kill -0 "$daemon_pid" 2>/dev/null || {
+            echo "  the daemon exited during startup:"
+            tail -4 "$S/daemon-$1.log" | sed 's/^/    /'
+            return 1
+        }
+        sleep 0.1
+    done
+    echo "  the daemon never listened; last lines:"
+    tail -4 "$S/daemon-$1.log" | sed 's/^/    /'
+    return 1
+}
+stop_daemon() {
+    [ -n "$daemon_pid" ] && kill -TERM "$daemon_pid" 2>/dev/null
+    wait "$daemon_pid" 2>/dev/null
+    daemon_pid=""
+    # The next daemon opens the same camera. Waiting for the node to be free
+    # beats racing it and reporting a busy device as a broken build.
+    for _ in $(seq 1 100); do
+        fuser "$IR_A" "$IR_B" >/dev/null 2>&1 || break
+        sleep 0.1
+    done
+}
+setup() { IRLUME_SOCKET=/run/irlume-twocam.sock "$B/irlume" ir-setup "$@"; }
+
+echo "=== 0. two cameras, and they really are different ==="
+ident() { # ir node -> "vid:pid devpath"
+    local bus
+    bus=$(v4l2-ctl -d "$1" --info 2>/dev/null | grep "Bus info" | head -1 | sed 's/.*usb-//;s/ .*//')
+    for d in /sys/bus/usb/devices/*/; do
+        [ -f "$d/idVendor" ] || continue
+        if find "$d" -maxdepth 3 -name "$(basename "$1")" 2>/dev/null | grep -q .; then
+            echo "$(cat "$d/idVendor"):$(cat "$d/idProduct") $(readlink -f "$d" | sed 's,/sys,,')"
+            return
+        fi
+    done
+    echo "unknown $bus"
+}
+a_id=$(ident "$IR_A")
+b_id=$(ident "$IR_B")
+echo "  A ($IR_A): $a_id"
+echo "  B ($IR_B): $b_id"
+assert "they are two different devices" "the same camera twice proves nothing" \
+    test "${a_id#* }" != "${b_id#* }"
+
+echo "=== 1. leave an UNRESOLVED record on camera A ==="
+# NOT redirected to /dev/null. Hiding this step's diagnostics is how a failed
+# park went unnoticed and left its daemon holding the camera, so the next start
+# failed and the failure looked like it belonged there.
+start_daemon parkA "$IR_A" "$RGB_A" "14:6:$PARK" || {
+    echo "could not park camera A"
+    exit 2
+}
+stop_daemon
+start_daemon killA "$IR_A" "$RGB_A" off || {
+    echo "daemon would not start on A"
+    exit 2
+}
+setup >"$S/a-setup.out" 2>&1 &
+client=$!
+killed=no
+for _ in $(seq 1 900); do
+    if grep -aq "journal saved" "$S/daemon-killA.log" 2>/dev/null; then
+        kill -KILL "$daemon_pid" 2>/dev/null && killed=yes
+        break
+    fi
+    kill -0 "$client" 2>/dev/null || break
+    sleep 0.05
+done
+wait "$client" 2>/dev/null
+daemon_pid=""
+
+if [ "$killed" != yes ]; then
+    skip "camera A was never written to, so there is no record to protect"
+    skip "the second camera's setup was not tested against one"
+    skip "recovery of A was not tested"
+    echo "  reason: $(grep -ao 'already set.*\|hardware:.*' "$S/a-setup.out" | head -1)"
+    echo
+    echo "$pass passed, $fail failed, $skipped not exercised"
+    exit "$fail"
+fi
+
+a_record=$(find "$STORE" -name '*.json' | head -1)
+assert "camera A has an unresolved record" "nothing in $STORE" test -n "$a_record"
+[ -n "$a_record" ] || exit 1
+a_before=$(md5sum "$a_record" | cut -d' ' -f1)
+echo "  A's record: $(basename "$a_record")"
+
+echo "=== 2. now set up camera B, with A's record sitting there ==="
+start_daemon setupB "$IR_B" "$RGB_B" "4:6:$PARK" || {
+    echo "could not park camera B"
+    exit 2
+}
+stop_daemon
+start_daemon runB "$IR_B" "$RGB_B" off || {
+    echo "daemon would not start on B"
+    exit 2
+}
+setup >"$S/b-setup.out" 2>&1
+stop_daemon
+sed 's/^/  /' "$S/b-setup.out" | tail -2
+
+# The whole point. Before records were filed per camera, B's setup would have
+# written its record over A's, and A's original bytes would be gone.
+assert "A's record still exists" "camera B's setup deleted it" test -f "$a_record"
+assert "A's record is byte-identical" "camera B's setup rewrote it" \
+    test "$(md5sum "$a_record" 2>/dev/null | cut -d' ' -f1)" = "$a_before"
+assert "B never wrote to A's extension unit" "a write crossed between cameras" \
+    test "$(grep -ac 'SET_CUR unit14' "$S/daemon-runB.log")" -eq 0
+assert "B's own run did write to its own unit" \
+    "B never wrote anything, so nothing was tested against A's record" \
+    test "$(grep -ac 'SET_CUR unit4/' "$S/daemon-runB.log")" -gt 0
+# The absence of the cross-camera refusal, NOT the presence of success. Whether
+# discovery finds a usable control depends on the room: this camera reported the
+# image rising 114 -> 132 against a +20 threshold and correctly called the
+# control unusable. That is a hardware outcome and has nothing to do with the
+# other camera's record. Asserting "IR emitter enabled" made a legitimate
+# NotUsable read as "B was blocked", which is a different claim entirely.
+assert "B's setup was not refused because of A's record" \
+    "B was blocked by another camera's pending change" \
+    grep -qvE "not at that address|earlier setup run left a control" "$S/b-setup.out"
+if grep -q "IR emitter enabled" "$S/b-setup.out"; then
+    echo "  (B found a usable control)"
+else
+    echo "  (B ran discovery and found no usable control: $(grep -ao 'unit [0-9]* advertises.*' "$S/b-setup.out" | head -1))"
+fi
+
+echo "=== 3. camera A recovers, untouched by any of it ==="
+start_daemon recoverA "$IR_A" "$RGB_A" off || {
+    echo "daemon would not start on A"
+    exit 2
+}
+setup >"$S/a-recover.out" 2>&1
+stop_daemon
+grep -aE "journal|SET_CUR" "$S/daemon-recoverA.log" | head -8 | sed 's/^/  /'
+assert "A's record is resolved and gone" "still pending" \
+    test ! -f "$a_record"
+
+echo
+echo "$pass passed, $fail failed, $skipped not exercised"
+echo "(sandbox left in $S for inspection; remove it when done)"
+[ "$fail" -eq 0 ]

--- a/scripts/emitter-journal-two-cameras-test.sh
+++ b/scripts/emitter-journal-two-cameras-test.sh
@@ -59,6 +59,11 @@ assert() {
     shift 2
     if "$@"; then ok "$d"; else bad "$d" "$x"; fi
 }
+assert_not() {
+    local desc="$1" detail="$2"
+    shift 2
+    if "$@"; then bad "$desc" "$detail"; else ok "$desc"; fi
+}
 skip() {
     skipped=$((skipped + 1))
     echo "  NOT EXERCISED  $1"
@@ -234,9 +239,14 @@ assert "B's own run did write to its own unit" \
 # control unusable. That is a hardware outcome and has nothing to do with the
 # other camera's record. Asserting "IR emitter enabled" made a legitimate
 # NotUsable read as "B was blocked", which is a different claim entirely.
-assert "B's setup was not refused because of A's record" \
+# `grep -qv` is NOT "does not contain": it succeeds as soon as ONE line fails to
+# match, so a file holding the forbidden refusal plus any other line passed. This
+# assertion reported ok while the very thing it forbids was in the output, and
+# the 8/8 it was part of did not establish it. Absence is a POSITIVE grep,
+# negated by the caller.
+assert_not "B's setup was not refused because of A's record" \
     "B was blocked by another camera's pending change" \
-    grep -qvE "not at that address|earlier setup run left a control" "$S/b-setup.out"
+    grep -qE "not at that address|earlier setup run left a control" "$S/b-setup.out"
 if grep -q "IR emitter enabled" "$S/b-setup.out"; then
     echo "  (B found a usable control)"
 else

--- a/scripts/emitter-journal-two-cameras-test.sh
+++ b/scripts/emitter-journal-two-cameras-test.sh
@@ -144,7 +144,9 @@ stop_daemon() {
         sleep 0.1
     done
 }
-setup() { IRLUME_SOCKET=/run/irlume-twocam.sock "$B/irlume" ir-setup "$@"; }
+# No arguments: this script only ever runs a plain `ir-setup`. Forwarding "$@"
+# made shellcheck point out that the parameters could never arrive.
+setup() { IRLUME_SOCKET=/run/irlume-twocam.sock "$B/irlume" ir-setup; }
 
 echo "=== 0. two cameras, and they really are different ==="
 ident() { # ir node -> "vid:pid devpath"


### PR DESCRIPTION
Closes #181.

## What try_documented_control did before this change

It read a control with `GET_CUR`, wrote a different value with `SET_CUR`, measured, and wrote the original back. The original lived only in a stack `Vec<u8>`, and **two camera measurements sit in the window between**. A `SIGKILL`, the daemon watchdog, a panic in the frame decoder or a power loss there left the control changed with nothing anywhere describing how to put it back. `ir_emitter.conf` stores coordinates and deliberately no payload, so recovery from irlume's own files was not possible.

## Hardware transcript, NexiGo HelloCam N930W

`scripts/emitter-journal-hardware-test.sh`: **17 assertions, 0 failed, 0 not exercised.** The sequence read off one transcript from a real device:

```
GET_INFO / GET_LEN / GET_CUR / GET_DEF / GET_MAX
journal saved unit4/sel6 original=010301000000000000 attempts=0
SET_CUR [01,03,02]        <- the exploratory write, AFTER the record
SET_CUR [01,03,01]        <- restored, to measure that the change followed it
SET_CUR [01,03,02]        <- applied
GET_CUR
journal read back applied [01,03,02]
journal cleared           <- only then
```

and after a `SIGKILL` between the record and the end, the next run:

```
journal saved ... attempts=1   <- counted BEFORE the write
SET_CUR [01,03,01]             <- the original, put back
GET_CUR
journal cleared                <- only then
```

The camera published the same extension units before and after. The surviving record named the kernel's own `DEVPATH` for that camera, the unit, the selector and the original bytes.

The same script on the ASUS module: **14 assertions, 0 failed, 2 not exercised**, at its own Microsoft XU, unit 14 rather than unit 4. The two it skipped are the emitter-config checks, which need a run where discovery finds a usable control; on that camera and in that room the image did not brighten enough to qualify.

## The undo record and what it guards

**The record is durable before the first write and dropped only after a read-back**, on both resolutions. A `SET_CUR` returning success says the ioctl was accepted, not that the control holds those bytes.

**Filed per physical camera**: descriptor blob, USB serial where published, and the resolved sysfs device path. The serial is recorded but never trusted as an identity. The ASUS module this was developed against reports `200901010001`, a batch number, and **the NexiGo publishes none at all**, which is why the device path carries the weight.

**Nothing is written to a camera that has just refused a write**, and **nothing is written to undo a change irlume did not make**: a control holding neither the recorded original nor this run's own value is refused, with all three values named.

**An unresolved record stops all three capture sources.** Refusing costs the emitter, so IR authentication does not light and the user falls back to a password; that is the cheaper side of the trade against #159, and the log line says so. A record for a *different* camera permits the write.

Also: a per-camera non-blocking `flock` in `/run/lock`; a `SIGINT`/`SIGTERM`/`SIGHUP` handler polled between frames and before each write; a `doctor` check `emitter-undo-pending`; and `save_conf` made atomic and fsynced, because `commit` drops the undo record on the strength of it returning.

**`IRLUME_IR_EMITTER=off` still sends the camera nothing.**

## Codex review rounds

**Twenty-one rounds. Nineteen found something real; the twenty-first found nothing.** What each turned up:

1. The capture path wrote after recovery refused.
2. The record was keyed on a descriptor blob two units of one model share, and `GET_CUR` was sized from the record before the camera answered.
3. A failed restore was retried by `Drop` against hardware just classified as unresponsive, and the signal handler could not do what its comment claimed, because a process-directed signal goes to an arbitrary thread.
4. A concurrent process could delete a live record; `save_conf` was not durable while `commit` claimed it was; and **the test asserting "record before write" did not observe that ordering**.
5. `commit` cleared without reading the applied value back, and `attempted` was recorded from the first commit and never read.
6. The config was published *before* that read-back, so a failed verification still left a file every later capture applies.
7. The record lookup keyed on the USB serial, whose read failure `identity_from_fd` maps to absence; schema `0` was accepted as authorisation; and **a hardware assertion of mine proved nothing**, because `grep -qv` is not "does not contain".
8. The per-camera lock keyed on that same fallible serial, so two processes could take two different lock files for one camera.
9. The authorisation went stale across `journal::save`'s fsyncs, and a "0644" claim was false under the shipped `UMask=0027`.
10. Two post-`rename` paths confused "returned an error" with "nothing became visible", one of which could strand a record on the daemon's own pid indefinitely.
11. A missing current serial authorised a write on descriptor-plus-port alone, when the kernel is explicit that a device path is a key "at that point in time", not an identity.
12. **A fix of mine reopened the very hole this PR closes**: relaxing "visible" against "durable" at the shared helper let `save` accept a record a power cut can still lose as authorisation for a firmware write.
13. The recorded `original` went stale across `intended_value`, a whole baseline measurement and five filesystem operations before the exploratory write, with nothing re-reading the control.
14. A serial READ FAILURE collapsed into the same `None` a camera that publishes none produces, which would let an identical unit swapped into the same port receive the first camera's undo bytes.
15. **The same visible-against-durable question, decided the other way at the attempt counter.** I had it backwards and the reviewer was right: the limit bounds writes across crashes, so a count a power loss reverts bounds nothing.
16. A record at this camera's exact filing key whose contents disagree fell through the scan and read as an empty store, so capture wrote while a change was still outstanding.

Three of those were defects I introduced while fixing the previous round's.

My own tests were wrong three times. One read `IRLUME_STATE_DIR` twice without the env lock, failed under unrelated mutants, and was recorded as having caught them; with the race fixed, one of those mutants turned out to survive with nothing covering it. One hardware assertion passed while the thing it forbade could have been present.

## Mutation checks, container suite, sanitizers

**55 mutants, 0 survived, 0 broken**, one per guard, including one for each review finding. Two came back BROKEN mid-series when my own refactors moved the code their patterns matched. A pattern that no longer matches is reported as its own outcome and fails the run, because counting it as a kill is how a stale mutant inflates the score.

Getting that honest took four fixes to the harness itself, each described in the commit carrying it: it parsed the wrong `cargo test` output shape; it restored files with `shutil.move`, whose older mtime made cargo skip the rebuild so the suite ran the previous mutant's binary; it counted a pattern it could no longer find as a kill; and it had no crash-safe restore, so four kills mid-run twice left a deliberately broken guard in the working tree.

**A stand-in camera behind `xu_query`.** Four mutants that each reintroduced a hardware-destructive defect survived the whole suite before it existed. The ordering assertions run *inside* the interception of the first write, the only place that can distinguish save-before-write from save-after-write.

**Container suite: 18 assertions, 0 failed, 1 not exercised**, reported rather than hidden: root reads a `000` directory through `CAP_DAC_OVERRIDE`.

**Workspace: 25 test binaries green, 869 tests, clippy clean, shellcheck clean.** The same 869 run under AddressSanitizer and LeakSanitizer with no unsuppressed leak.

## Power loss: sysrq-b on the Arch test bed

`echo b > /proc/sysrq-trigger`, fired the instant the record hit disk: an immediate kernel reboot with no sync, no unmount, no userspace shutdown. The machine came back on a **different boot id** (`b16964dd…` to `6246fc2d…`), so the reboot genuinely happened.

- **The record survived**, complete and valid, with the right original bytes.
- **A canary written moments later through a plain redirect, never fsynced, did NOT survive.**

That second half is what makes it evidence about irlume rather than about ext4's commit timer: if the filesystem had simply flushed, the canary would be there too.

One boot later, recovery acted on it correctly: `attempts=1` counted before the write, `SET_CUR [01,03,01]` restoring the original, then cleared. The record's stored `boot_id` was the previous boot's, which is the case the boot-scoping exists for.

And from `strace` on the same machine, the ordering at syscall level:

```
openat(<record>.tmp, O_CREAT|O_EXCL, 0600)
fsync(<record>.tmp)
rename(<record>.tmp -> <record>.json)
openat(<store dir>) / fsync(<store dir>)
write(2, "irlume: SET_CUR unit")      <- the first firmware write, after all of it
```

## Device identity, measured on three cameras

| Camera | Serial | Microsoft XU | Emitter selectors |
|---|---|---|---|
| ASUS 3277:0059 | `200901010001` (a batch number) | iface 2, unit 14 | `0x06`, `0x09` |
| NexiGo 3443:c803 | **none** | iface 2, unit 4 | `0x06`, `0x09` |
| Chicony 04f2:b7bf | `01.00.00` (a firmware version) | iface 0, unit 5 | neither |

Three cameras, three reasons a serial is not an identity. This is why the record binds to the resolved sysfs device path.

Path stability was measured, not assumed: **identical across a suspend/resume cycle** (ThinkPad, rtcwake) and **identical across a full USB re-enumeration** (NexiGo, authorized toggle). The descriptor digest was byte-identical both times, and matches the `descriptor_sha256` in the record.

## The identical-camera collision, on hardware

One camera moved between ports is what a second unit of the same model looks like to irlume: same descriptors, same absent serial, different device path. Run with the NexiGo at **three addresses on three different PCI controllers**:

```
/devices/.../0d:00.3/usb3/3-2/3-2.1   <- the record was written here
/devices/.../0d:00.4/usb5/5-1/5-1.1
/devices/.../02:00.0/usb1/1-2/1-2.1
```

At both foreign addresses, **7/7**: the record was not acted on, not deleted, not modified; **zero `SET_CUR` reached the camera**; discovery refused to start rather than record a changed value as the original; and `doctor` warned with the coordinates and the original bytes. Before the fix, that record would have been loaded as this camera's, its bytes written here, and deleted on a successful read-back, leaving the camera that was actually changed with no undo data at all.

Back at the recorded address the record resolved and the store emptied.

That run also corrected a claim. **A physical unplug clears the control**: the camera returns at its default, which is the recorded original. **Re-enumeration alone does not.** Driving the control and toggling `authorized` left it set, with zero writes on the next run. So "a control that is set stays set" holds across stream close and re-enumeration, not across a power cut at the port.

## Two IR cameras at once

`scripts/emitter-journal-two-cameras-test.sh`, on a laptop with its built-in ASUS `3277:0059` and an external NexiGo `3443:c803` attached together: **8/8**.

```
A: 3277:0059 at usb3/3-5          Microsoft XU unit 14
B: 3443:c803 at usb3/3-4/3-4.1    Microsoft XU unit 4
```

An unresolved record is left on A, then B is set up with that record sitting in the store. A's record survives **byte for byte**, no write reaches A's extension unit during B's run, B writes to its own, and A recovers afterwards. Different unit numbers make a cross-camera write visible in the trace rather than a matter of inference.

The port-move test could not show this: at an address it cannot confirm, discovery deliberately refuses, so a second record is never created there. Two different models are what make it reachable.

## What this does NOT prove

- **Two physically IDENTICAL cameras have never been attached at once.** One camera at three addresses covers the collision; two different cameras attached together cover the coexistence of two records. The remaining case needs two units of one model and nobody here has them.

  Its consequence is now pinned by a test rather than left implicit: with two indistinguishable cameras attached, **one camera's unresolved record stops the OTHER camera's emitter too**, because nothing can prove the record is not about it. That is the conservative answer, and the blast radius is wider than the camera that was actually changed. A different model is unaffected.
- A camera moved to another port is not recovered automatically, and **`ir-setup` refuses there too**, until the record is resolved or the camera goes back. That is a deliberate trade, and a real cost to anyone who moves a webcam.
- **IR Torch (`0x0A`) was never exercised.** None of the three cameras advertises it on a Microsoft XU, so there is no hardware here that can.
- A camera whose Microsoft XU advertises no emitter selector was not driven end to end: the only such camera available has **no IR node at all** (`MJPG`/`YUYV` only), so the daemon cannot reach the emitter path on it.
- **A directory `fsync` failure has never been observed.** `AtomicWrite::VisibleNotDurable` is reached only when the rename lands and a later fsync fails, and nothing available here can stage that without filesystem fault injection. A mutant reverting that arm to `?` propagation survives the suite, so it was removed from the mutation set rather than left looking like a pass, and the variant's own doc comment says so. What IS covered is the decision made about that value: `require_durable` and `counted_attempt_authorizes_write` are exercised directly on both arms, so "only a durable record authorizes a firmware write" is pinned by a test even though the condition producing it is not reachable.
- **The re-read before the exploratory write does not close the race, it narrows it.** UVC offers `GET_CUR` and `SET_CUR` and no compare-and-set, so a writer that moves the control between that read and the write is still undetectable. What the check removes is the multi-frame, multi-fsync window; what remains is one syscall wide.
- `MAX_RESTORE_ATTEMPTS = 3` is a chosen bound, not a measured one.
- The `Drop` guard is never exercised against a real **panic in the decoder**.
- If `/run/lock` cannot be written, recovery refuses and the emitter stays dark. The daemon runs as root so this should not bite, but it is a new way for IR authentication to stop.
