### PR TITLE
fix(camera): follow the documented face-auth lifecycle, set once and unset after

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ SHA256SUMS.asc
 # Bytecode from the scripts/*.py tooling
 __pycache__/
 *.pyc
+
+# Mutation-harness backups. One was committed by a `git add -A` run while the
+# harness had files out, which put a 1938-line copy of a source file in a commit.
+*.rs.bak

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -419,7 +419,9 @@ pub(crate) fn record_applies(record: &PendingWrite, id: &CameraIdentity) -> Resu
             supported: SCHEMA_VERSION,
         });
     }
-
+    if record.descriptor_sha256 != fingerprint(id) {
+        return Err(Mismatch::DifferentCamera);
+    }
     // The digest already pins the descriptors, and these fields come from the
     // same sysfs read, so a disagreement means the record was assembled from two
     // different cameras or edited by hand. Either way it is not a description of

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -419,9 +419,7 @@ pub(crate) fn record_applies(record: &PendingWrite, id: &CameraIdentity) -> Resu
             supported: SCHEMA_VERSION,
         });
     }
-    if record.descriptor_sha256 != fingerprint(id) {
-        return Err(Mismatch::DifferentCamera);
-    }
+
     // The digest already pins the descriptors, and these fields come from the
     // same sysfs read, so a disagreement means the record was assembled from two
     // different cameras or edited by hand. Either way it is not a description of

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -946,12 +946,17 @@ impl StreamMode {
     /// Give up the restore without writing anything.
     ///
     /// For one case only: the stream this guard was set for has been torn down
-    /// and reopened. These modules reset the control per open, so there is
-    /// nothing left to put back for the old stream, and a fresh guard covers the
-    /// new one. Restoring here instead would be a write to a control the reopen
-    /// already reset, and reassigning without it would drop the OLD guard after
-    /// the new `enable` had run, writing the default straight over the value
-    /// just set.
+    /// and reopened, and a FRESH guard has taken over the same control.
+    ///
+    /// Without this, reassigning would drop the old guard after the new `enable`
+    /// had already run, writing the default straight over the value just set.
+    ///
+    /// An earlier version of this comment justified it with "these modules reset
+    /// the control per open". That is not what this project measured: the record
+    /// in `IrCamera::session` says the control survives stream close and process
+    /// exit on both cameras here. So the caller gives the old guard up only when
+    /// the replacement is armed, and an unarmed replacement leaves the old guard
+    /// to put the value back.
     pub fn disarm(&mut self) {
         self.armed = false;
     }
@@ -1274,10 +1279,15 @@ fn override_memo() -> &'static OverrideMemo {
 /// camera per process, and only with the evidence every other write here
 /// requires.
 ///
-/// The record bounds the WRITES. It is not used as an answer about the camera's
-/// present state: a remembered success re-reads `GET_CUR` and reports whether
-/// the control still holds the payload, because "we wrote this once" and "this
-/// is set now" stop being the same statement the moment a camera resets.
+/// The record bounds the CHECKS, not the writes. A remembered success means this
+/// payload was already validated against this camera's descriptors, so the
+/// checks and the refusal message do not run again; the value is still applied
+/// for each new stream, because the mode is restored when the previous one
+/// ended and the control is sitting at the camera's default.
+///
+/// It used to answer from a `GET_CUR` read-back instead, which was right while
+/// irlume left the mode set for the life of the process. Under a per-stream
+/// lifecycle that reported every stream after the first as dark.
 ///
 /// The override is still an escape hatch: the unit may be a vendor's, and the
 /// bytes are the person's rather than the camera's own `GET_DEF`. What it no
@@ -1336,23 +1346,31 @@ fn apply_override(
         // the traffic the record exists to stop, and the answer is "no" either
         // way.
         Reuse::Answer(false) => return false,
-        // A remembered SUCCESS is not repeated back. It says a write happened,
-        // which is not the same as the control holding that value now, and the
-        // gap between them is real: a camera that resets or re-enumerates can
-        // land on the same device number with the same USB id and interface, and
-        // returning the old `true` would claim an emitter is lit on a control
-        // nothing has set. Callers use this answer to decide whether to tell the
-        // user their infrared is dark.
+        // A remembered SUCCESS says this payload was checked against this
+        // camera's descriptors and accepted. It does NOT say the control still
+        // holds it, and since the mode is now restored when each stream ends it
+        // usually does not: the next stream finds the camera's default there.
         //
-        // So the record is used for what it is good for, which is not writing
-        // again, and the current state is read rather than assumed. If the
-        // control has drifted, the honest answer is that the emitter is not on;
-        // writing it back would be the second write this whole change exists to
-        // prevent.
+        // Reading it back and reporting the difference as "the emitter is not
+        // on" was right while irlume left the control set for the life of the
+        // process. With a per-stream lifecycle it means the first stream in a
+        // daemon lights and every later one runs dark, which on a machine that
+        // authenticates in the dark is a lockout.
+        //
+        // So the memo is used for what it is good for, which is not re-running
+        // the descriptor checks and the refusal message, and the value is
+        // applied again for this stream. That is one write per stream, which is
+        // the documented sequence, not the repeated writing this change removes.
         Reuse::Answer(true) => {
-            return match get_cur(fd, ctrl.unit, ctrl.selector, ctrl.payload.len()) {
-                Ok(current) => current == ctrl.payload,
-                Err(_) => false,
+            return match check_and_apply_override(fd, id, ctrl) {
+                Ok(applied) => applied,
+                Err(why) => {
+                    eprintln!(
+                        "irlume: refusing IRLUME_IR_EMITTER={}: {why}",
+                        ctrl.encode()
+                    );
+                    false
+                }
             }
         }
         Reuse::RefuseChanged => {
@@ -4430,7 +4448,7 @@ mod tests {
         assert_eq!(fake_camera::current(), vec![1, 3, 1]);
     }
 
-    /// `disarm` gives up the restore without writing, for the one case that    /// `disarm` gives up the restore without writing, for the one case that
+    /// `disarm` gives up the restore without writing, for the one case that
     /// needs it: the stream the guard was set for has been torn down and
     /// reopened, so a fresh guard covers the new one.
     #[test]
@@ -4458,7 +4476,6 @@ mod tests {
     }
 
     /// Somebody else moves the control while setup is measuring, and setup
-    /// notices BEFORE it writes.    /// Somebody else moves the control while setup is measuring, and setup
     /// notices BEFORE it writes.
     ///
     /// `original` is read, then `intended_value` runs, then a whole baseline

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -777,11 +777,11 @@ pub(crate) fn info_allows_set(info: u8) -> bool {
 /// fails validation, which happens before any ioctl. Once a `SET_CUR` has been
 /// sent, its result is the answer: sending a second payload to a camera that just
 /// failed to accept the first is how the search in #159 kept going.
-pub fn enable(fd: c_int, card: &str, device: &str) -> bool {
+pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
     let _ = (card, device);
     let setting = override_setting(std::env::var("IRLUME_IR_EMITTER"));
     let wanted = match setting {
-        OverrideSetting::Disabled => return false,
+        OverrideSetting::Disabled => return StreamMode::inert(),
         // A value that is set but cannot be read as a control is NOT the same as
         // no value. Treating it as absent fell through to the built-in table, so
         // one mistyped byte in an override meant to replace that payload made
@@ -789,7 +789,7 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> bool {
         // variable is consent to the control named in it and to nothing else.
         OverrideSetting::Malformed(why) => {
             eprintln!("irlume: refusing to drive the IR emitter: IRLUME_IR_EMITTER {why}");
-            return false;
+            return StreamMode::inert();
         }
         OverrideSetting::Absent => None,
         OverrideSetting::Control(ctrl) => Some(ctrl),
@@ -821,7 +821,7 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> bool {
                     ctrl.selector
                 );
             }
-            return false;
+            return StreamMode::inert();
         }
     };
 
@@ -845,13 +845,148 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> bool {
     let action = planned_action(&recovery, wanted, &id);
     report_recovery(&id, recovery);
 
-    match action {
+    // Where the write is going, before it goes, so the camera's own default can
+    // be read while the control is still untouched.
+    let Some((unit, selector)) = action.coordinates() else {
+        return StreamMode::inert();
+    };
+    // `GET_DEF` is what "unset" restores to. Read first: after the write it would
+    // still answer the same on a conforming camera, but reading the resting state
+    // before disturbing it is the only order that does not assume conformance.
+    let restore = match get_len(fd, unit, selector)
+        .and_then(|len| get_of(fd, unit, selector, UVC_GET_DEF, len))
+    {
+        Ok(def) => def,
+        Err(e) => {
+            // No default means no way back, so nothing is applied. Leaving a
+            // control set with no recorded route home is the state #168 exists
+            // to remove.
+            eprintln!(
+                "irlume: not driving unit{unit}/sel{selector}: its default is unreadable ({e}), \
+                 so there would be no way to put it back"
+            );
+            return StreamMode::inert();
+        }
+    };
+
+    let applied = match action {
         CaptureAction::Nothing => false,
         CaptureAction::Override(ctrl) => apply_override(fd, &id, &ctrl),
         CaptureAction::DeviceDefault { unit, selector } => {
             apply_device_default(fd, unit, selector).is_ok()
         }
         CaptureAction::KnownPayload(ctrl) => apply_known_payload(fd, &ctrl).is_ok(),
+    };
+    StreamMode {
+        fd,
+        unit,
+        selector,
+        restore,
+        // Armed only if the camera actually took the write. Arming on a refused
+        // write would make `Drop` send a restore for a change that never
+        // happened, which is a write to a camera that has just refused one.
+        armed: applied,
+    }
+}
+
+/// The face-auth mode held for the lifetime of ONE stream, put back when the
+/// stream ends.
+///
+/// Microsoft's published sequence is set the property, start streaming, stop
+/// streaming, unset it; the camera driver bring up guide lists the last two as
+/// steps 4 and 5, and the HLK suite tests them. irlume used to do the first
+/// three and simply leave the control set. On the ASUS module the control was
+/// observed back at its default once streaming stopped, so that camera undoes it
+/// unasked, but the NexiGo was observed still at the applied value outside a
+/// capture. Relying on a camera to undo something irlume did is not a design.
+///
+/// What gets written back is the camera's OWN `GET_DEF`, read before anything is
+/// applied, rather than a constructed "off" value. For a dual-purpose interface
+/// the specification requires that default to carry D0, general purpose, which
+/// is the resting state "unset" means; for a face-auth-only interface it is
+/// whatever that camera says it starts in. Either way it is the camera's answer,
+/// not irlume's guess.
+///
+/// `Drop` does the restoring, because the paths that need it most are the ones
+/// no statement covers: an error taken by `?`, a panic in the decoder, a
+/// cancelled request. Same reason the undo record in #183 restores from `Drop`.
+#[must_use = "dropping this immediately puts the control back and leaves the stream unlit"]
+pub struct StreamMode {
+    fd: c_int,
+    unit: u8,
+    selector: u8,
+    /// The camera's own default, captured before the first write.
+    restore: Vec<u8>,
+    /// False once the control is back, so `Drop` never writes twice.
+    armed: bool,
+}
+
+impl StreamMode {
+    /// A guard over nothing: no control was applied, so `Drop` writes nothing.
+    ///
+    /// The ordinary outcome for hardware irlume does not drive, and the only
+    /// safe representation of it. An `Option<StreamMode>` would let a caller
+    /// write `let _ = ...` and silently discard a guard that DID hold a control.
+    fn inert() -> Self {
+        StreamMode {
+            fd: -1,
+            unit: 0,
+            selector: 0,
+            restore: Vec::new(),
+            armed: false,
+        }
+    }
+
+    /// Whether a control was actually applied. `false` means the camera was sent
+    /// nothing, which is the ordinary case for hardware irlume does not drive.
+    pub fn lit(&self) -> bool {
+        self.armed
+    }
+
+    /// Give up the restore without writing anything.
+    ///
+    /// For one case only: the stream this guard was set for has been torn down
+    /// and reopened. These modules reset the control per open, so there is
+    /// nothing left to put back for the old stream, and a fresh guard covers the
+    /// new one. Restoring here instead would be a write to a control the reopen
+    /// already reset, and reassigning without it would drop the OLD guard after
+    /// the new `enable` had run, writing the default straight over the value
+    /// just set.
+    pub fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    /// Put the control back now, rather than waiting for the drop.
+    ///
+    /// Separated so the ordinary path can restore while it can still report a
+    /// failure. `Drop` cannot return anything, so a restore that only ever
+    /// happened there would fail silently.
+    pub fn restore(&mut self) -> XuResult<()> {
+        if !self.armed {
+            return Ok(());
+        }
+        // Disarmed first either way. If this succeeds there is nothing left for
+        // `Drop` to do; if it fails, `Drop` repeating a write the camera has
+        // just refused is how #159 territory is entered.
+        self.armed = false;
+        set_cur(self.fd, self.unit, self.selector, &self.restore)
+    }
+}
+
+impl Drop for StreamMode {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Err(e) = self.restore() {
+            // Not fatal, and not silent. The camera keeps a mode irlume chose,
+            // which is exactly the state this type exists to prevent, so it is
+            // worth a line even though nothing here can react to it.
+            eprintln!(
+                "irlume: could not put unit{}/sel{} back to the camera's default: {e}",
+                self.unit, self.selector
+            );
+        }
     }
 }
 
@@ -909,6 +1044,21 @@ enum CaptureAction {
     Override(EmitterControl),
     DeviceDefault { unit: u8, selector: u8 },
     KnownPayload(EmitterControl),
+}
+
+impl CaptureAction {
+    /// Which control this action will write to, or `None` when it writes
+    /// nothing. Needed before the write, so the control's default can be read
+    /// while it is still untouched.
+    fn coordinates(&self) -> Option<(u8, u8)> {
+        match self {
+            CaptureAction::Nothing => None,
+            CaptureAction::Override(c) | CaptureAction::KnownPayload(c) => {
+                Some((c.unit, c.selector))
+            }
+            CaptureAction::DeviceDefault { unit, selector } => Some((*unit, *selector)),
+        }
+    }
 }
 
 /// Why an `IRLUME_IR_EMITTER` override was not written to the camera.
@@ -4160,7 +4310,155 @@ mod tests {
         assert!(why.contains("disk full"), "got: {why}");
     }
 
+    /// The control goes back to the camera's own default when the stream ends.
+    ///
+    /// Microsoft's sequence ends by unsetting the property, and the HLK suite
+    /// tests that it happened. irlume set the mode and left it. The ASUS module
+    /// was observed back at its default once streaming stopped, so it undoes
+    /// this unasked, but the NexiGo was observed still at the applied value
+    /// outside a capture; leaning on a camera to undo irlume's change is not a
+    /// design.
+    #[test]
+    fn a_stream_mode_puts_the_control_back_when_it_ends() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2], // the applied face-auth value
+            len: 3,
+            def: vec![1, 3, 1], // what "unset" restores to
+            ..a_working_camera()
+        });
+        {
+            let _mode = StreamMode {
+                fd: -1,
+                unit: 14,
+                selector: 6,
+                restore: vec![1, 3, 1],
+                armed: true,
+            };
+            assert_eq!(
+                fake_camera::current(),
+                vec![1, 3, 2],
+                "nothing may be written while the stream is still running"
+            );
+        }
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 1],
+            "the control must be back at the camera's default once the guard drops"
+        );
+    }
+
+    /// A guard that never applied anything writes nothing when it ends.
+    ///
+    /// The ordinary case on hardware irlume does not drive. Restoring here would
+    /// be a write to a camera that was never touched, which is the class of
+    /// write this whole module exists to stop, and it would land on a camera
+    /// that had just REFUSED a write.
+    #[test]
+    fn a_stream_mode_that_applied_nothing_writes_nothing() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![9, 9, 9],
+            len: 3,
+            ..a_working_camera()
+        });
+        drop(StreamMode::inert());
+        drop(StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            armed: false,
+        });
+        assert_eq!(
+            fake_camera::current(),
+            vec![9, 9, 9],
+            "an unarmed guard must not touch the control"
+        );
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set { .. })),
+            "no write may be issued at all: {:?}",
+            fake_camera::log()
+        );
+    }
+
+    /// Restoring twice writes once.
+    ///
+    /// The ordinary path calls `restore` explicitly, so it can report a failure
+    /// that `Drop` would have to swallow, and then the guard drops as well. The
+    /// second visit must send nothing: a control already back where it started
+    /// does not need writing again, and the camera has no way to tell a
+    /// redundant write from a meaningful one.
+    ///
+    /// Found by a surviving mutant. `Drop` checks `armed` before it calls
+    /// `restore`, so the identical check inside `restore` is unreachable through
+    /// a drop and nothing exercised it.
+    #[test]
+    fn restoring_twice_writes_once() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            len: 3,
+            ..a_working_camera()
+        });
+        let mut mode = StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            armed: true,
+        };
+        mode.restore().expect("the first restore writes");
+        let after_first = fake_camera::log()
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set { .. }))
+            .count();
+        assert_eq!(after_first, 1, "the first restore must write exactly once");
+
+        mode.restore().expect("the second restore is a no-op");
+        drop(mode);
+        let total = fake_camera::log()
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set { .. }))
+            .count();
+        assert_eq!(
+            total, 1,
+            "restoring again, and then dropping, must send nothing further"
+        );
+        assert_eq!(fake_camera::current(), vec![1, 3, 1]);
+    }
+
+    /// `disarm` gives up the restore without writing, for the one case that    /// `disarm` gives up the restore without writing, for the one case that
+    /// needs it: the stream the guard was set for has been torn down and
+    /// reopened, so a fresh guard covers the new one.
+    #[test]
+    fn disarming_gives_up_the_restore_without_writing() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            len: 3,
+            ..a_working_camera()
+        });
+        let mut mode = StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            armed: true,
+        };
+        mode.disarm();
+        drop(mode);
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 2],
+            "a disarmed guard must leave the control exactly as it found it"
+        );
+    }
+
     /// Somebody else moves the control while setup is measuring, and setup
+    /// notices BEFORE it writes.    /// Somebody else moves the control while setup is measuring, and setup
     /// notices BEFORE it writes.
     ///
     /// `original` is read, then `intended_value` runs, then a whole baseline
@@ -4765,19 +5063,19 @@ mod tests {
 
         // `off`/`none` disable before any control lookup or ioctl.
         std::env::set_var("IRLUME_IR_EMITTER", "off");
-        assert!(!enable(fd, "ASUS", DEV));
+        assert!(!enable(fd, "ASUS", DEV).lit());
         std::env::set_var("IRLUME_IR_EMITTER", "none");
-        assert!(!enable(fd, "ASUS", DEV));
+        assert!(!enable(fd, "ASUS", DEV).lit());
         // A valid env control is parsed, but SET_CUR on a non-UVC fd fails.
         std::env::set_var("IRLUME_IR_EMITTER", "14:6:1,3,2");
-        assert!(!enable(fd, "whatever", DEV));
+        assert!(!enable(fd, "whatever", DEV).lit());
         std::env::remove_var("IRLUME_IR_EMITTER");
         // The card string is no longer consulted at all; identity comes from
         // the USB IDs, and DEV does not exist, so nothing is applied.
-        assert!(!enable(fd, "Some Unknown Cam", DEV));
+        assert!(!enable(fd, "Some Unknown Cam", DEV).lit());
         // A table entry now requires the USB identity to match AND the
         // descriptor to confirm the unit, neither of which a fake path offers.
-        assert!(!enable(fd, "ASUS", DEV));
+        assert!(!enable(fd, "ASUS", DEV).lit());
         // A persisted control naming an undocumented unit is refused: this is
         // the migration path that stops pre-0.7.1 configs from writing.
         save_conf(
@@ -4789,7 +5087,7 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(!enable(fd, "Some Unknown Cam", DEV));
+        assert!(!enable(fd, "Some Unknown Cam", DEV).lit());
 
         std::env::remove_var("IRLUME_IR_EMITTER_CONF");
         let _ = std::fs::remove_dir_all(&dir);
@@ -5185,7 +5483,7 @@ mod tests {
         let sent = writes_attempted().load(SeqCst) - before;
         std::env::remove_var("IRLUME_IR_EMITTER");
 
-        assert!(!applied);
+        assert!(!applied.lit());
         assert_eq!(
             sent, 0,
             "an override was sent to a device whose descriptors were never read"

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -883,22 +883,23 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
     // a restore to make; `active` decides what the caller tells the user about
     // their infrared. A control that already held the wanted value is active and
     // not irlume's to undo, and collapsing the pair reported it dark.
-    let (changed, active) = match action {
-        CaptureAction::Nothing => (false, false),
+    let (changed, active, applied) = match action {
+        CaptureAction::Nothing => (false, false, Vec::new()),
         CaptureAction::Override(ctrl) => {
             let outcome = apply_override(fd, &id, &ctrl);
             let holds = outcome != Applied::Nothing;
-            (outcome == Applied::Wrote && ctrl.payload != restore, holds)
+            let changed = outcome == Applied::Wrote && ctrl.payload != restore;
+            (changed, holds, ctrl.payload)
         }
         CaptureAction::DeviceDefault { unit, selector } => {
             match apply_device_default(fd, unit, selector) {
-                Ok(sent) => (sent != restore, true),
-                Err(_) => (false, false),
+                Ok(sent) => (sent != restore, true, sent),
+                Err(_) => (false, false, Vec::new()),
             }
         }
         CaptureAction::KnownPayload(ctrl) => {
             let ok = apply_known_payload(fd, &ctrl).is_ok();
-            (ok && ctrl.payload != restore, ok)
+            (ok && ctrl.payload != restore, ok, ctrl.payload)
         }
     };
     StreamMode {
@@ -908,6 +909,7 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
         restore,
         armed: changed,
         active,
+        applied,
     }
 }
 
@@ -939,6 +941,9 @@ pub struct StreamMode {
     selector: u8,
     /// The camera's own default, captured before the first write.
     restore: Vec<u8>,
+    /// What this guard actually wrote, so the restore can check the control
+    /// still holds it rather than trusting that nothing else moved.
+    applied: Vec<u8>,
     /// True only while irlume's own change is outstanding; cleared once the
     /// control is back, so `Drop` never writes twice.
     armed: bool,
@@ -963,6 +968,7 @@ impl StreamMode {
             unit: 0,
             selector: 0,
             restore: Vec::new(),
+            applied: Vec::new(),
             armed: false,
             active: false,
         }
@@ -1022,7 +1028,31 @@ impl StreamMode {
         // `Drop` to do; if it fails, `Drop` repeating a write the camera has
         // just refused is how #159 territory is entered.
         self.armed = false;
-        set_cur(self.fd, self.unit, self.selector, &self.restore)
+
+        // Read it back before putting anything back. This guard knows what it
+        // wrote, which is not the same as knowing what the control holds now: a
+        // vendor tool or another client can move it while the stream runs, and
+        // restoring on historical ownership alone would drop the default over
+        // somebody else's newer value. The recovery path in #183 re-reads for
+        // exactly this reason and refuses when the bytes have moved on; the
+        // guard is the same decision at a shorter range.
+        //
+        // A control that no longer holds this guard's value is left alone. The
+        // change irlume made is already gone, so there is nothing of its to undo.
+        match get_cur(self.fd, self.unit, self.selector, self.applied.len()) {
+            Ok(now) if now != self.applied => {
+                eprintln!(
+                    "irlume: leaving unit{}/sel{} at {:02x?}: it no longer holds what irlume \
+                     applied ({:02x?}), so the change to undo is not there",
+                    self.unit, self.selector, now, self.applied
+                );
+                Ok(())
+            }
+            // Unreadable is not evidence that somebody else owns it, and leaving
+            // a mode applied because one GET_CUR failed is the worse of the two
+            // errors. Fall through and restore.
+            _ => set_cur(self.fd, self.unit, self.selector, &self.restore),
+        }
     }
 }
 
@@ -4434,6 +4464,7 @@ mod tests {
                 unit: 14,
                 selector: 6,
                 restore: vec![1, 3, 1],
+                applied: vec![1, 3, 2],
                 armed: true,
                 active: true,
             };
@@ -4470,6 +4501,7 @@ mod tests {
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
             armed: false,
             active: true,
         });
@@ -4502,6 +4534,7 @@ mod tests {
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
             armed: true,
             active: true,
         };
@@ -4513,6 +4546,7 @@ mod tests {
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
             armed: false,
             active: true,
         };
@@ -4533,6 +4567,48 @@ mod tests {
         );
     }
 
+    /// A control somebody else moved during the stream is left where they put
+    /// it.
+    ///
+    /// The guard knows what it wrote; that is not the same as knowing what the
+    /// control holds when the stream ends. A vendor tool or another client can
+    /// move it in between, and restoring on historical ownership alone would put
+    /// the camera's default over their newer value. #183's recovery re-reads for
+    /// exactly this reason; this is the same decision at a shorter range.
+    #[test]
+    fn a_control_moved_by_someone_else_is_not_restored_over() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            len: 3,
+            ..a_working_camera()
+        });
+        let mut mode = StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        };
+        // Another writer moves it while the stream is running.
+        fake_camera::set_current(vec![1, 3, 3]);
+        mode.restore().expect("a refusal to overwrite is not an error");
+        drop(mode);
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 3],
+            "the other writer's value must be left exactly where they put it"
+        );
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no SET_CUR may be issued at all: {:?}",
+            fake_camera::log()
+        );
+    }
     /// Restoring twice writes once.    /// Restoring twice writes once.
     ///
     /// The ordinary path calls `restore` explicitly, so it can report a failure
@@ -4557,6 +4633,7 @@ mod tests {
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
             armed: true,
             active: true,
         };
@@ -4596,6 +4673,7 @@ mod tests {
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
             armed: true,
             active: true,
         };
@@ -4648,6 +4726,7 @@ mod tests {
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
             armed: outcome == Ok(Applied::Wrote),
             // Active either way: the control holds the payload, whoever set it.
             active: outcome.is_ok(),
@@ -4702,6 +4781,7 @@ mod tests {
             unit: 14,
             selector: crate::uvc_descriptor::MSXU_IR_TORCH,
             restore: def.clone(),
+            applied: vec![1, 3, 2],
             armed: sent != def,
             // The torch IS on: its default is an active mode. Active without
             // being armed is exactly the pair this field exists to separate.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -893,14 +893,18 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
         }
         CaptureAction::DeviceDefault { unit, selector } => {
             match apply_device_default(fd, unit, selector) {
-                Ok(sent) => (sent != restore, true, sent),
+                Ok((outcome, sent)) => (outcome == Applied::Wrote && sent != restore, true, sent),
                 Err(_) => (false, false, Vec::new()),
             }
         }
-        CaptureAction::KnownPayload(ctrl) => {
-            let ok = apply_known_payload(fd, &ctrl).is_ok();
-            (ok && ctrl.payload != restore, ok, ctrl.payload)
-        }
+        CaptureAction::KnownPayload(ctrl) => match apply_known_payload(fd, &ctrl) {
+            Ok(outcome) => (
+                outcome == Applied::Wrote && ctrl.payload != restore,
+                true,
+                ctrl.payload,
+            ),
+            Err(_) => (false, false, Vec::new()),
+        },
     };
     StreamMode {
         fd,
@@ -1623,14 +1627,24 @@ fn check_and_apply_override(
 /// that size right now. Writing a nine-byte payload to a control the camera has
 /// just reported as disabled, or as a different length, is not something a
 /// validated VID:PID should buy.
-fn apply_known_payload(fd: c_int, ctrl: &EmitterControl) -> XuResult<()> {
+fn apply_known_payload(fd: c_int, ctrl: &EmitterControl) -> XuResult<Applied> {
     if !info_allows_set(get_info(fd, ctrl.unit, ctrl.selector)?) {
         return Err(XuError::Unsupported);
     }
-    if get_len(fd, ctrl.unit, ctrl.selector)? != ctrl.payload.len() {
+    let len = get_len(fd, ctrl.unit, ctrl.selector)?;
+    if len != ctrl.payload.len() {
         return Err(XuError::Unsupported);
     }
-    set_cur(fd, ctrl.unit, ctrl.selector, &ctrl.payload)
+    // The same rule the override path follows: a control already holding these
+    // bytes was not put there by this run, so writing them again would claim a
+    // change irlume did not make, and the end of the stream would clear somebody
+    // else's state. One GET_CUR on a path that has already sent GET_INFO and
+    // GET_LEN.
+    if get_cur(fd, ctrl.unit, ctrl.selector, len)? == ctrl.payload {
+        return Ok(Applied::AlreadyHeld);
+    }
+    set_cur(fd, ctrl.unit, ctrl.selector, &ctrl.payload)?;
+    Ok(Applied::Wrote)
 }
 
 /// The bytes to write for one documented control, or why the camera has not
@@ -1682,7 +1696,7 @@ fn intended_value(
 /// the caller needs them: `enable` arms the stream guard by comparing what was
 /// written against what the guard would write back, and for IR Torch the two
 /// are the same bytes.
-fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<Vec<u8>> {
+fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<(Applied, Vec<u8>)> {
     if !info_allows_set(get_info(fd, unit, selector)?) {
         return Err(XuError::Unsupported);
     }
@@ -1690,8 +1704,13 @@ fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<Vec<u8>> 
     let Ok(wanted) = intended_value(fd, unit, selector, len)? else {
         return Err(XuError::Unsupported);
     };
+    // As above: already there means irlume did not put it there, so it is not
+    // irlume's to undo when the stream ends.
+    if get_cur(fd, unit, selector, len)? == wanted {
+        return Ok((Applied::AlreadyHeld, wanted));
+    }
     set_cur(fd, unit, selector, &wanted)?;
-    Ok(wanted)
+    Ok((Applied::Wrote, wanted))
 }
 
 /// Why discovery could not produce a control.
@@ -4596,7 +4615,8 @@ mod tests {
         };
         // Another writer moves it while the stream is running.
         fake_camera::set_current(vec![1, 3, 3]);
-        mode.restore().expect("a refusal to overwrite is not an error");
+        mode.restore()
+            .expect("a refusal to overwrite is not an error");
         drop(mode);
         assert_eq!(
             fake_camera::current(),
@@ -4748,6 +4768,48 @@ mod tests {
         );
     }
 
+    /// A built-in payload the control already holds is not written or claimed.
+    ///
+    /// The override path refuses to claim a value it did not set, and the
+    /// built-in table path did not: it wrote unconditionally and armed, so a
+    /// value another process left there was rewritten, claimed, and cleared at
+    /// the end of the stream. Same rule, applied in one place and not the other.
+    #[test]
+    fn a_known_payload_the_control_already_holds_is_not_rewritten() {
+        let _lock = crate::testenv::env_lock();
+        let payload = vec![1, 3, 2];
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: payload.clone(),
+            len: 3,
+            info: 0b0000_0011,
+            ..a_working_camera()
+        });
+        let ctrl = EmitterControl {
+            unit: 14,
+            selector: 6,
+            payload: payload.clone(),
+        };
+        assert_eq!(
+            apply_known_payload(-1, &ctrl).expect("a control that already agrees is not an error"),
+            Applied::AlreadyHeld,
+            "the value is there; irlume did not put it there"
+        );
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no write may be sent at all: {:?}",
+            fake_camera::log()
+        );
+        // And a control holding something else is still written, or the guard
+        // above would have turned the whole path off.
+        fake_camera::set_current(vec![9, 9, 9]);
+        assert_eq!(
+            apply_known_payload(-1, &ctrl).expect("a control that disagrees is written"),
+            Applied::Wrote
+        );
+        assert_eq!(fake_camera::current(), payload);
+    }
     /// IR Torch's applied value IS the camera's default, so there is nothing
     /// for the stream end to restore.
     ///
@@ -4772,9 +4834,16 @@ mod tests {
             ..Default::default()
         });
 
-        let sent = apply_device_default(-1, 14, crate::uvc_descriptor::MSXU_IR_TORCH)
+        let (outcome, sent) = apply_device_default(-1, 14, crate::uvc_descriptor::MSXU_IR_TORCH)
             .expect("a conformant torch takes its own default");
         assert_eq!(sent, def, "the applied bytes are the camera's own GET_DEF");
+        // The fixture starts at the default, so there is nothing to write: the
+        // torch's own value IS the default, which is the point of the case.
+        assert_eq!(
+            outcome,
+            Applied::AlreadyHeld,
+            "a control already at the value it wants is not written again"
+        );
 
         // The guard, armed the way `enable` arms it: the write went out, but
         // it carried the restore bytes, so nothing is outstanding.
@@ -4794,9 +4863,9 @@ mod tests {
             .filter(|r| matches!(r, fake_camera::Request::Set(_)))
             .count();
         assert_eq!(
-            sets, 1,
-            "one write applies the mode; a second at stream end changes nothing \
-             and must not be sent"
+            sets, 0,
+            "the torch's own default was already there, so applying it writes \
+             nothing and the stream's end has nothing to put back"
         );
     }
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1050,6 +1050,16 @@ impl StreamMode {
         // Disarmed first either way. If this succeeds there is nothing left for
         // `Drop` to do; if it fails, `Drop` repeating a write the camera has
         // just refused is how #159 territory is entered.
+        //
+        // The early return above is DEFENCE IN DEPTH and a mutant deleting it
+        // survives the suite. That is not a missing test: the read-back below
+        // subsumes it. On a second call the control already holds `restore`,
+        // which is not `applied`, so the "somebody else moved it" arm leaves it
+        // alone and no write goes out either way. Kept rather than removed
+        // because it states the intent at the top of the function, where the next
+        // reader looks, and because a later change to the read-back would
+        // otherwise silently take the only thing stopping a double write. The
+        // mutant is recorded as unkillable by construction rather than dropped.
         self.armed = false;
 
         // Read it back before putting anything back. This guard knows what it

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -869,23 +869,45 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
         }
     };
 
-    let applied = match action {
-        CaptureAction::Nothing => false,
-        CaptureAction::Override(ctrl) => apply_override(fd, &id, &ctrl),
-        CaptureAction::DeviceDefault { unit, selector } => {
-            apply_device_default(fd, unit, selector).is_ok()
+    // Armed only when irlume actually CHANGED the control: a write went out,
+    // and it carried bytes other than the ones the guard would put back. Same
+    // rule as the #183 undo journal: irlume does not undo a change it did not
+    // make. Three cases fail that test. A refused write is a change that never
+    // happened, and restoring after it would write to a camera that has just
+    // refused one. An override the control already held is another writer's
+    // state, and a restore would put the default over a value irlume never
+    // set. And IR Torch applies the camera's own default, so its restore would
+    // be a SET_CUR that changes nothing, sent to firmware at the end of every
+    // capture.
+    // Two answers, deliberately not one. `changed` decides whether the guard has
+    // a restore to make; `active` decides what the caller tells the user about
+    // their infrared. A control that already held the wanted value is active and
+    // not irlume's to undo, and collapsing the pair reported it dark.
+    let (changed, active) = match action {
+        CaptureAction::Nothing => (false, false),
+        CaptureAction::Override(ctrl) => {
+            let outcome = apply_override(fd, &id, &ctrl);
+            let holds = outcome != Applied::Nothing;
+            (outcome == Applied::Wrote && ctrl.payload != restore, holds)
         }
-        CaptureAction::KnownPayload(ctrl) => apply_known_payload(fd, &ctrl).is_ok(),
+        CaptureAction::DeviceDefault { unit, selector } => {
+            match apply_device_default(fd, unit, selector) {
+                Ok(sent) => (sent != restore, true),
+                Err(_) => (false, false),
+            }
+        }
+        CaptureAction::KnownPayload(ctrl) => {
+            let ok = apply_known_payload(fd, &ctrl).is_ok();
+            (ok && ctrl.payload != restore, ok)
+        }
     };
     StreamMode {
         fd,
         unit,
         selector,
         restore,
-        // Armed only if the camera actually took the write. Arming on a refused
-        // write would make `Drop` send a restore for a change that never
-        // happened, which is a write to a camera that has just refused one.
-        armed: applied,
+        armed: changed,
+        active,
     }
 }
 
@@ -917,8 +939,16 @@ pub struct StreamMode {
     selector: u8,
     /// The camera's own default, captured before the first write.
     restore: Vec<u8>,
-    /// False once the control is back, so `Drop` never writes twice.
+    /// True only while irlume's own change is outstanding; cleared once the
+    /// control is back, so `Drop` never writes twice.
     armed: bool,
+    /// Whether the control is ACTIVE for this stream, which is a different
+    /// question from whether irlume changed it. A control that already held the
+    /// wanted value is active and not irlume's to undo, so it is `active`
+    /// without being `armed`. Collapsing the two made `lit()` report false there,
+    /// and the caller prints "IR is dark with no active emitter" on that, which
+    /// would have been a false statement about the camera.
+    active: bool,
 }
 
 impl StreamMode {
@@ -934,13 +964,18 @@ impl StreamMode {
             selector: 0,
             restore: Vec::new(),
             armed: false,
+            active: false,
         }
     }
 
-    /// Whether a control was actually applied. `false` means the camera was sent
-    /// nothing, which is the ordinary case for hardware irlume does not drive.
+    /// Whether the emitter control is active for this stream, whoever set it.
+    ///
+    /// NOT the same as whether irlume changed it, which is what governs the
+    /// restore. A control already holding the wanted value is active, and
+    /// reporting it dark would put "IR is dark with no active emitter" in front
+    /// of a user whose emitter is on.
     pub fn lit(&self) -> bool {
-        self.armed
+        self.active
     }
 
     /// Give up the restore without writing anything.
@@ -1275,6 +1310,27 @@ fn override_memo() -> &'static OverrideMemo {
     MEMO.get_or_init(Default::default)
 }
 
+/// What an apply path DID to the control, which is not the same question as
+/// whether the payload was accepted.
+///
+/// A bare bool answered only the second question, and `enable` armed the
+/// stream guard on it. That collapsed "a write went out" into "the control
+/// holds these bytes": the guard armed on both, so ending a stream could set
+/// `GET_DEF` over a value some other process had established, which is undoing
+/// a change irlume never made. The rule is the #183 journal's: irlume restores
+/// only what irlume changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Applied {
+    /// A `SET_CUR` went out and the camera took it.
+    Wrote,
+    /// The control already held the payload, so nothing was sent. The value is
+    /// active, but it is not irlume's write, and it is not irlume's to undo.
+    AlreadyHeld,
+    /// Nothing reached the control: a check refused, the one-write record said
+    /// no, or the camera rejected the write.
+    Nothing,
+}
+
 /// Apply an `IRLUME_IR_EMITTER` override, writing at most once per control per
 /// camera per process, and only with the evidence every other write here
 /// requires.
@@ -1304,7 +1360,7 @@ fn apply_override(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
-) -> bool {
+) -> Applied {
     let key = match override_key(fd, id, ctrl) {
         Ok(key) => key,
         Err(err) => {
@@ -1313,7 +1369,7 @@ fn apply_override(
                  so irlume cannot tell whether this was already applied",
                 ctrl.encode()
             );
-            return false;
+            return Applied::Nothing;
         }
     };
 
@@ -1338,14 +1394,14 @@ fn apply_override(
                  after a panic, so irlume cannot tell whether this was already applied",
                 ctrl.encode()
             );
-            return false;
+            return Applied::Nothing;
         }
     };
     match reuse(memo.get(&key), &ctrl.payload) {
         // A remembered refusal stands: re-running the checks every capture is
         // the traffic the record exists to stop, and the answer is "no" either
         // way.
-        Reuse::Answer(false) => return false,
+        Reuse::Answer(false) => return Applied::Nothing,
         // A remembered SUCCESS says this payload was checked against this
         // camera's descriptors and accepted. It does NOT say the control still
         // holds it, and since the mode is now restored when each stream ends it
@@ -1369,7 +1425,7 @@ fn apply_override(
                         "irlume: refusing IRLUME_IR_EMITTER={}: {why}",
                         ctrl.encode()
                     );
-                    false
+                    Applied::Nothing
                 }
             }
         }
@@ -1382,11 +1438,11 @@ fn apply_override(
                 ctrl.unit,
                 ctrl.selector
             );
-            return false;
+            return Applied::Nothing;
         }
         Reuse::Decide => {}
     }
-    let applied = match check_and_apply_override(fd, id, ctrl) {
+    let outcome = match check_and_apply_override(fd, id, ctrl) {
         Ok(applied) => applied,
         Err(why) => {
             // Silence here would read as "the value was applied and the camera
@@ -1396,17 +1452,19 @@ fn apply_override(
                 "irlume: refusing IRLUME_IR_EMITTER={}: {why}",
                 ctrl.encode()
             );
-            false
+            Applied::Nothing
         }
     };
     memo.insert(
         key,
         OverrideDecision {
             payload: ctrl.payload.clone(),
-            applied,
+            // The record answers "was this payload accepted", so a value found
+            // already in place counts the same as a write the camera took.
+            applied: outcome != Applied::Nothing,
         },
     );
-    applied
+    outcome
 }
 
 /// Test-only: hold a caller inside the gate so another thread can observe what
@@ -1454,7 +1512,7 @@ fn check_and_apply_override(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
-) -> std::result::Result<bool, OverrideRefusal> {
+) -> std::result::Result<Applied, OverrideRefusal> {
     #[cfg(test)]
     park_inside_for_test();
 
@@ -1499,11 +1557,17 @@ fn check_and_apply_override(
         err,
     })?;
     if current == ctrl.payload {
-        // Already holding what the override asks for. Reporting success is
-        // accurate and costs the camera nothing.
-        return Ok(true);
+        // Already holding what the override asks for, so nothing is sent. Said
+        // distinctly from `Wrote` because the two diverge at stream end: these
+        // bytes are another writer's state, and a guard armed here would end
+        // the stream by setting the default over them.
+        return Ok(Applied::AlreadyHeld);
     }
-    Ok(set_cur(fd, unit, selector, &ctrl.payload).is_ok())
+    Ok(if set_cur(fd, unit, selector, &ctrl.payload).is_ok() {
+        Applied::Wrote
+    } else {
+        Applied::Nothing
+    })
 }
 
 /// Apply a validated built-in payload, with the same gate every other automatic
@@ -1568,7 +1632,12 @@ fn intended_value(
 /// This is how a control recorded by `ir-setup` is re-applied. Nothing is
 /// replayed from the file: the value is read out of the camera immediately
 /// before it is written back.
-fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<()> {
+///
+/// Returns the bytes that went out, because only this function knows them and
+/// the caller needs them: `enable` arms the stream guard by comparing what was
+/// written against what the guard would write back, and for IR Torch the two
+/// are the same bytes.
+fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<Vec<u8>> {
     if !info_allows_set(get_info(fd, unit, selector)?) {
         return Err(XuError::Unsupported);
     }
@@ -1576,7 +1645,8 @@ fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<()> {
     let Ok(wanted) = intended_value(fd, unit, selector, len)? else {
         return Err(XuError::Unsupported);
     };
-    set_cur(fd, unit, selector, &wanted)
+    set_cur(fd, unit, selector, &wanted)?;
+    Ok(wanted)
 }
 
 /// Why discovery could not produce a control.
@@ -4352,6 +4422,7 @@ mod tests {
                 selector: 6,
                 restore: vec![1, 3, 1],
                 armed: true,
+                active: true,
             };
             assert_eq!(
                 fake_camera::current(),
@@ -4387,6 +4458,7 @@ mod tests {
             selector: 6,
             restore: vec![1, 3, 1],
             armed: false,
+            active: true,
         });
         assert_eq!(
             fake_camera::current(),
@@ -4427,6 +4499,7 @@ mod tests {
             selector: 6,
             restore: vec![1, 3, 1],
             armed: true,
+            active: true,
         };
         mode.restore().expect("the first restore writes");
         let after_first = fake_camera::log()
@@ -4465,6 +4538,7 @@ mod tests {
             selector: 6,
             restore: vec![1, 3, 1],
             armed: true,
+            active: true,
         };
         mode.disarm();
         drop(mode);
@@ -4472,6 +4546,116 @@ mod tests {
             fake_camera::current(),
             vec![1, 3, 2],
             "a disarmed guard must leave the control exactly as it found it"
+        );
+    }
+
+    /// An override the control already holds is not written, and not undone.
+    ///
+    /// `check_and_apply_override` answers success for a control found already
+    /// at the requested payload, without sending anything. The guard used to
+    /// arm on that success, so the end of the stream set the default over
+    /// bytes irlume never wrote: state established by another process or a
+    /// vendor tool. `enable` now arms only on `Applied::Wrote`, so the report
+    /// has to say which kind of success this was.
+    #[test]
+    fn an_override_the_control_already_holds_is_not_written_or_undone() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            // Some other tool already put the exact payload the override names
+            // into the control.
+            current: vec![1, 3, 2],
+            ..a_working_camera()
+        });
+        let asus = identity(0x3277, 0x0059);
+
+        let outcome = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]));
+        assert_eq!(
+            outcome,
+            Ok(Applied::AlreadyHeld),
+            "a value found in place is a success, but not irlume's write"
+        );
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "a control already holding the payload needs no write: {:?}",
+            fake_camera::log()
+        );
+
+        // The guard, armed the way `enable` arms it: only for `Wrote`. Its end
+        // must leave the other writer's bytes exactly where they were.
+        drop(StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            armed: outcome == Ok(Applied::Wrote),
+            // Active either way: the control holds the payload, whoever set it.
+            active: outcome.is_ok(),
+        });
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 2],
+            "the stream end must not put the default over a value irlume never set"
+        );
+
+        // The distinction cuts the other way too: a control holding something
+        // else IS written, and that write is irlume's to undo.
+        fake_camera::set_current(vec![1, 3, 1]);
+        assert_eq!(
+            check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2])),
+            Ok(Applied::Wrote)
+        );
+    }
+
+    /// IR Torch's applied value IS the camera's default, so there is nothing
+    /// for the stream end to restore.
+    ///
+    /// `intended_value` derives the torch payload from `GET_DEF`, which is the
+    /// exact value the guard writes back. Arming on it made every stream end
+    /// send a `SET_CUR` that changed nothing: one pointless firmware write per
+    /// capture. `apply_device_default` reports the bytes it wrote so `enable`
+    /// can see they equal the restore and leave the guard unarmed.
+    #[test]
+    fn applying_the_ir_torch_default_leaves_nothing_to_restore() {
+        let _lock = crate::testenv::env_lock();
+        let def = torch(2, 120); // ON, at a power inside the reported range
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: def.clone(),
+            len: 8,
+            // Exactly GET_CUR + SET_CUR, as the specification pins IR Torch.
+            info: 3,
+            def: def.clone(),
+            min: torch(0, 10),
+            max: torch(0b011, 200),
+            res: torch(0, 1),
+            ..Default::default()
+        });
+
+        let sent = apply_device_default(-1, 14, crate::uvc_descriptor::MSXU_IR_TORCH)
+            .expect("a conformant torch takes its own default");
+        assert_eq!(sent, def, "the applied bytes are the camera's own GET_DEF");
+
+        // The guard, armed the way `enable` arms it: the write went out, but
+        // it carried the restore bytes, so nothing is outstanding.
+        drop(StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: crate::uvc_descriptor::MSXU_IR_TORCH,
+            restore: def.clone(),
+            armed: sent != def,
+            // The torch IS on: its default is an active mode. Active without
+            // being armed is exactly the pair this field exists to separate.
+            active: true,
+        });
+        let sets = fake_camera::log()
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set(_)))
+            .count();
+        assert_eq!(
+            sets, 1,
+            "one write applies the mode; a second at stream end changes nothing \
+             and must not be sent"
         );
     }
 
@@ -5544,8 +5728,9 @@ mod tests {
             before,
             "re-checking must not write"
         );
-        assert!(
-            !answer,
+        assert_eq!(
+            answer,
+            Applied::Nothing,
             "a camera that cannot answer GET_CUR must not be reported as lit \
              on the strength of an earlier write"
         );

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -941,12 +941,13 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
 /// unasked, but the NexiGo was observed still at the applied value outside a
 /// capture. Relying on a camera to undo something irlume did is not a design.
 ///
-/// What gets written back is the camera's OWN `GET_DEF`, read before anything is
-/// applied, rather than a constructed "off" value. For a dual-purpose interface
-/// the specification requires that default to carry D0, general purpose, which
-/// is the resting state "unset" means; for a face-auth-only interface it is
-/// whatever that camera says it starts in. Either way it is the camera's answer,
-/// not irlume's guess.
+/// What gets written back is the value the control HELD, read before anything is
+/// applied, rather than a constructed "off" value or the camera's default. A
+/// control sitting at its default is therefore restored to its default, which is
+/// what "unset" means and is every case measured here; a control another program
+/// deliberately left elsewhere is put back where they left it, rather than being
+/// defaulted out from under them. Either way it is the camera's answer, not
+/// irlume's guess.
 ///
 /// `Drop` does the restoring, because the paths that need it most are the ones
 /// no statement covers: an error taken by `?`, a panic in the decoder, a
@@ -956,7 +957,10 @@ pub struct StreamMode {
     fd: c_int,
     unit: u8,
     selector: u8,
-    /// The camera's own default, captured before the first write.
+    /// What the control HELD before irlume touched it, captured before the first
+    /// write. Not the camera's default: those coincide in the ordinary case and
+    /// differ exactly when another program has set something, which is when
+    /// putting the default back would destroy their state.
     restore: Vec<u8>,
     /// What this guard actually wrote, so the restore can check the control
     /// still holds it rather than trusting that nothing else moved.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -996,6 +996,19 @@ impl StreamMode {
         self.armed = false;
     }
 
+    /// Whether this guard owns an outstanding change that still has to be put
+    /// back.
+    ///
+    /// NOT `lit`. That reports whether the control is ACTIVE, whoever set it,
+    /// and the two diverge exactly where it matters: a control found already
+    /// holding the wanted value is active and owns nothing. A caller deciding
+    /// which of two guards keeps the restore has to ask this one, and the
+    /// restart sites asked `lit` instead, so a replacement that wrote nothing
+    /// took ownership from the guard that had.
+    pub fn owns_restore(&self) -> bool {
+        self.armed
+    }
+
     /// Put the control back now, rather than waiting for the drop.
     ///
     /// Separated so the ordinary path can restore while it can still report a
@@ -4474,7 +4487,53 @@ mod tests {
         );
     }
 
-    /// Restoring twice writes once.
+    /// Ownership of the restore does not pass to a guard that owns nothing.
+    ///
+    /// The frozen-stream restart replaces the guard after reopening. The control
+    /// survives a stream close on both cameras here, so the replacement usually
+    /// finds the value already in place and comes back ACTIVE while owning
+    /// nothing. Deciding on `lit` handed ownership to it and disarmed the guard
+    /// that actually held the change, and the capture then ended without putting
+    /// the control back at all: the exact leak the restart logic exists to stop.
+    #[test]
+    fn ownership_of_the_restore_does_not_pass_to_a_guard_that_owns_nothing() {
+        let held = StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            armed: true,
+            active: true,
+        };
+        // What `enable` returns on a reopen when the control survived: active,
+        // because the mode IS applied, and owning nothing, because it wrote
+        // nothing.
+        let already = StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            armed: false,
+            active: true,
+        };
+        assert!(already.lit(), "the mode is active on the reopened stream");
+        assert!(
+            !already.owns_restore(),
+            "but it wrote nothing, so it owes no restore"
+        );
+        assert!(
+            held.owns_restore(),
+            "the original guard is the one holding the change"
+        );
+        // Deciding on `lit` would swap them, which is the defect.
+        assert_ne!(
+            already.lit(),
+            already.owns_restore(),
+            "lit and owns_restore must not be read as the same question"
+        );
+    }
+
+    /// Restoring twice writes once.    /// Restoring twice writes once.
     ///
     /// The ordinary path calls `restore` explicitly, so it can report a failure
     /// that `Drop` would have to swallow, and then the guard drops as well. The

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -850,20 +850,33 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
     let Some((unit, selector)) = action.coordinates() else {
         return StreamMode::inert();
     };
-    // `GET_DEF` is what "unset" restores to. Read first: after the write it would
-    // still answer the same on a conforming camera, but reading the resting state
-    // before disturbing it is the only order that does not assume conformance.
+    // What the control HOLDS right now, read before anything disturbs it. This is
+    // what the guard puts back.
+    //
+    // It used to record `GET_DEF` instead, on the reading that Microsoft's
+    // sequence ends by "unsetting" the control. That is right whenever the
+    // control is sitting at its default, which is the ordinary case and where
+    // the two values are identical. It is wrong the moment they are not: a
+    // camera another program deliberately left in a non-default mode would be
+    // returned to the DEFAULT when irlume finished, destroying that program's
+    // state while this file repeatedly promises not to undo changes irlume did
+    // not make. Putting back what was displaced honours both, because a control
+    // found at its default is restored to its default.
+    // NOT covered by a unit test: nothing here reaches `enable`, which needs a
+    // real sysfs-backed camera for `identity_from_fd`, so a mutant swapping this
+    // back to GET_DEF survives the suite. What IS covered is the decision the
+    // guard makes about whatever value gets recorded.
     let restore = match get_len(fd, unit, selector)
-        .and_then(|len| get_of(fd, unit, selector, UVC_GET_DEF, len))
+        .and_then(|len| get_of(fd, unit, selector, UVC_GET_CUR, len))
     {
-        Ok(def) => def,
+        Ok(current) => current,
         Err(e) => {
-            // No default means no way back, so nothing is applied. Leaving a
-            // control set with no recorded route home is the state #168 exists
-            // to remove.
+            // Unreadable means no recorded route home, so nothing is applied.
+            // Leaving a control changed with no way back is the state #168
+            // exists to remove.
             eprintln!(
-                "irlume: not driving unit{unit}/sel{selector}: its default is unreadable ({e}), \
-                 so there would be no way to put it back"
+                "irlume: not driving unit{unit}/sel{selector}: its current value is unreadable \
+                 ({e}), so there would be no way to put it back"
             );
             return StreamMode::inert();
         }
@@ -4588,6 +4601,52 @@ mod tests {
         );
     }
 
+    /// A non-default mode another program established is put back, not replaced
+    /// by the camera's default.
+    ///
+    /// The guard used to record `GET_DEF`, reading Microsoft's "unset the
+    /// control" as "write the default". That is identical to putting back what
+    /// was displaced whenever the control sits at its default, which is the
+    /// ordinary case, and wrong the moment it does not: a camera another program
+    /// deliberately left in a non-default mode came back at the DEFAULT once
+    /// irlume finished, destroying that program's state while this file promises
+    /// the opposite.
+    #[test]
+    fn a_non_default_mode_is_put_back_rather_than_defaulted() {
+        let _lock = crate::testenv::env_lock();
+        let default = vec![1, 3, 1];
+        let theirs = vec![1, 3, 4]; // somebody else's non-default mode
+        let ours = vec![1, 3, 2];
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: theirs.clone(),
+            len: 3,
+            def: default.clone(),
+            ..a_working_camera()
+        });
+        // The guard as `enable` now builds it: restore is what the control HELD,
+        // not what the camera calls its default.
+        let mut mode = StreamMode {
+            fd: -1,
+            unit: 14,
+            selector: 6,
+            restore: theirs.clone(),
+            applied: ours.clone(),
+            armed: true,
+            active: true,
+        };
+        fake_camera::set_current(ours.clone());
+        mode.restore().expect("restore");
+        assert_eq!(
+            fake_camera::current(),
+            theirs,
+            "the mode that was there must come back, not the camera's default"
+        );
+        assert_ne!(
+            fake_camera::current(),
+            default,
+            "restoring the default here would destroy another program's state"
+        );
+    }
     /// A control somebody else moved during the stream is left where they put
     /// it.
     ///

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1017,9 +1017,11 @@ impl StreamMode {
 
     /// Put the control back now, rather than waiting for the drop.
     ///
-    /// Separated so the ordinary path can restore while it can still report a
-    /// failure. `Drop` cannot return anything, so a restore that only ever
-    /// happened there would fail silently.
+    /// Public so a caller that wants to put the control back while it can still
+    /// REPORT a failure has somewhere to do it. Nothing in production takes that
+    /// route today: every restore currently goes through `Drop`, which cannot
+    /// return anything and so can only print. Saying otherwise would describe an
+    /// error path that does not exist.
     pub fn restore(&mut self) -> XuResult<()> {
         if !self.armed {
             return Ok(());

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1286,9 +1286,14 @@ impl IrCamera {
     /// measured: after ONE control write the emitter stayed lit for 30s of
     /// continuous streaming on both (ASUS built-in at a flat level of 144, NexiGo
     /// N930W at ~37), and the control survives even stream close and process
-    /// exit. See `examples/ir_refire_probe.rs`. The per-capture re-fires below
-    /// are kept anyway: an XU write costs microseconds against a 67ms frame, and
-    /// they are the only protection for modules we have never seen.
+    /// exit. See `examples/ir_refire_probe.rs`.
+    ///
+    /// The per-capture re-fires that used to sit below are gone (#168): they are
+    /// not part of the sequence Microsoft documents, and on a module that DOES
+    /// self-clear the illumination metadata from #167 now reports the dark
+    /// frames rather than leaving brightness to guess. The residual risk is a
+    /// module nobody here has seen going dark for a window, which costs the user
+    /// a password fallback rather than the hardware.
     pub fn session(&self) -> irlume_common::Result<IrSession<'_>> {
         let mut stream = SafeStream::open(&self.device, &self.dev)?;
         // The metadata queue has to be streaming before the image queue starts,
@@ -1690,9 +1695,25 @@ pub mod ir_probe {
         let (fmt, pix) = negotiate_ir_format(device, &dev)?;
         let mut dec = super::IrDecoder::new(pix);
         let (w, h) = (fmt.width, fmt.height);
-        let mut stream = super::SafeStream::open(device, &dev)?;
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-        let _mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+        // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
+        // reverse declaration order, so `stream` drops first and stops the
+        // stream, and only then does this guard put the control back; declaring
+        // it after `stream` sent the restore out while the stream was still
+        // live, which is the mid-stream write this change exists to remove.
+        //
+        // The assignment waits for the open because writing first would touch
+        // the camera for a stream that may never exist: an open that fails on
+        // EBUSY, with another process already streaming, would leave this one
+        // having applied the mode and then restored the default underneath the
+        // other process's live stream. `SafeStream::open` only allocates
+        // buffers; STREAMON happens on the first dequeue, so the set still
+        // lands before streaming starts.
+        let mode;
+        let mut stream = super::SafeStream::open(device, &dev)?;
+        mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+        // Bound, never read: held for its `Drop`, which restores the control.
+        let _ = &mode;
         let mut out = Vec::with_capacity(n);
         let t0 = std::time::Instant::now();
         for _ in 0..n {
@@ -1775,9 +1796,23 @@ pub fn capture_ir_streaming<B>(
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix);
     let (w, h) = (fmt.width, fmt.height);
-    let mut stream = SafeStream::open(device, &dev)?;
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-    let mut mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+    // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
+    // reverse declaration order, so `stream` drops first and stops the
+    // stream, and only then does this guard put the control back; declaring
+    // it after `stream` sent the restore out while the stream was still
+    // live, which is the mid-stream write this change exists to remove.
+    //
+    // The assignment waits for the open because writing first would touch
+    // the camera for a stream that may never exist: an open that fails on
+    // EBUSY, with another process already streaming, would leave this one
+    // having applied the mode and then restored the default underneath the
+    // other process's live stream. `SafeStream::open` only allocates
+    // buffers; STREAMON happens on the first dequeue, so the set still
+    // lands before streaming starts.
+    let mut mode;
+    let mut stream = SafeStream::open(device, &dev)?;
+    mode = ir_emitter::enable(dev.handle().fd(), &card, device);
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
     // constant mid-grey for the rest of the window); real sensor noise never
@@ -1812,9 +1847,19 @@ pub fn capture_ir_streaming<B>(
                 last_sig = None;
                 drop(stream); // stop + release buffers before re-arming
                 stream = SafeStream::open(device, &dev)?;
-                // The old guard belongs to a stream that no longer exists.
-                mode.disarm();
-                mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+                // The reopened stream needs the mode set again, and the OLD
+                // guard is only given up if the new one actually took. The
+                // measured behaviour on both cameras here is that the control
+                // survives a stream close, so an unarmed replacement would
+                // leave the value applied with nothing left to put it back.
+                // Reassigning drops the old guard: disarmed it writes nothing
+                // and the fresh value stands, still armed it restores the value
+                // it was holding.
+                let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
+                if fresh.lit() {
+                    mode.disarm();
+                }
+                mode = fresh;
             }
             continue;
         }
@@ -1863,9 +1908,23 @@ pub fn capture_ir_sequence(
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix);
     let (w, h) = (fmt.width, fmt.height);
-    let mut stream = Some(SafeStream::open(device, &dev)?);
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-    let mut mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+    // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
+    // reverse declaration order, so `stream` drops first and stops the
+    // stream, and only then does this guard put the control back; declaring
+    // it after `stream` sent the restore out while the stream was still
+    // live, which is the mid-stream write this change exists to remove.
+    //
+    // The assignment waits for the open because writing first would touch
+    // the camera for a stream that may never exist: an open that fails on
+    // EBUSY, with another process already streaming, would leave this one
+    // having applied the mode and then restored the default underneath the
+    // other process's live stream. `SafeStream::open` only allocates
+    // buffers; STREAMON happens on the first dequeue, so the set still
+    // lands before streaming starts.
+    let mut mode;
+    let mut stream = Some(SafeStream::open(device, &dev)?);
+    mode = ir_emitter::enable(dev.handle().fd(), &card, device);
     let mut frames = Vec::with_capacity(samples);
     let max_attempts = samples * 2 + 30;
     let (mut dead_run, mut restarts) = (0usize, 0usize);
@@ -1906,9 +1965,19 @@ pub fn capture_ir_sequence(
                 last_sig = None;
                 drop(stream.take()); // stop + release buffers before re-arming
                 stream = Some(SafeStream::open(device, &dev)?);
-                // The old guard belongs to a stream that no longer exists.
-                mode.disarm();
-                mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+                // The reopened stream needs the mode set again, and the OLD
+                // guard is only given up if the new one actually took. The
+                // measured behaviour on both cameras here is that the control
+                // survives a stream close, so an unarmed replacement would
+                // leave the value applied with nothing left to put it back.
+                // Reassigning drops the old guard: disarmed it writes nothing
+                // and the fresh value stands, still armed it restores the value
+                // it was holding.
+                let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
+                if fresh.lit() {
+                    mode.disarm();
+                }
+                mode = fresh;
             }
             continue;
         }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1302,16 +1302,29 @@ impl IrCamera {
         // buffers; STREAMON happens on the first dequeue, which is inside
         // `warm_up_stream` below. This is the window, and it is the only one.
         let meta = ir_metadata::IlluminationLog::open(&self.device);
+        // BEFORE the warm-up, because the warm-up's first dequeue is STREAMON.
+        // Microsoft's sequence sets the property and THEN starts streaming, and
+        // this ran the other way round: every authentication set the mode under
+        // an already-running stream, the mid-stream write the rest of #168
+        // removes.
+        //
+        // Still after `SafeStream::open`, which allocates buffers and starts
+        // nothing, and after the metadata queue above, whose ordering against
+        // the image queue is load-bearing and measured.
+        //
+        // The comment this replaces said the write had to happen "while
+        // streaming" because Hello modules reset the control per open. The reset
+        // is on DEVICE open, which happened in `IrCamera::open`, not here; and
+        // the record above says the control survives stream close and process
+        // exit on both cameras measured, so it is not stream-scoped.
+        //
+        // Held for the session rather than just applied: dropping `IrSession`
+        // puts the control back to the camera's own default, which is the
+        // documented sequence's last step and the half irlume never did.
+        let mode = ir_emitter::enable(self.dev.handle().fd(), &self.card, &self.device);
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
         warm_up_stream(&self.device, &mut stream)?;
-        // Fire the active-IR emitter on the open fd (Hello modules reset it
-        // per-open, so we must do it here, while streaming, not via an external
-        // one-shot).
-        // Held for the session, not just applied. Dropping `IrSession` puts the
-        // control back to the camera's own default, which is the documented
-        // sequence's last step and the half irlume never did.
-        let mode = ir_emitter::enable(self.dev.handle().fd(), &self.card, &self.device);
         Ok(IrSession {
             cam: self,
             stream,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1332,14 +1332,13 @@ impl IrSession<'_> {
         let device = self.cam.device.as_str();
         let (w, h) = (self.cam.width, self.cam.height);
         let card = &self.cam.card;
-        let fd = self.cam.dev.handle().fd();
         let lit = self.lit;
         let stream = &mut self.stream;
         let dec = &mut self.dec;
         // The emitter may STROBE (pulse), so grab a burst and keep the brightest
-        // frame, the lit strobe phase (linhello lesson). Re-fire mid-burst in case
-        // the control self-clears. Keep every frame so the optional ambient
-        // subtraction below can pair the lit frame with an adjacent emitter-off one.
+        // frame, the lit strobe phase (linhello lesson). Keep every frame so the
+        // optional ambient subtraction below can pair the lit frame with an
+        // adjacent emitter-off one.
         // Every frame is decoded to 8-bit GREY at dequeue, so the means, the
         // subtraction, and everything downstream see one uniform layout.
         let mut frames: Vec<Vec<u8>> = Vec::with_capacity(IR_BURST);
@@ -1356,10 +1355,16 @@ impl IrSession<'_> {
         if let Some(log) = meta.as_mut() {
             log.begin_burst();
         }
-        for i in 0..IR_BURST {
-            if i == IR_BURST / 2 {
-                ir_emitter::enable(fd, card, device);
-            }
+        // No re-fire mid-burst. The mode is set once before the stream starts,
+        // which is the sequence Microsoft documents and tests: set the property,
+        // start streaming, stop streaming, unset. Rewriting the control under a
+        // running stream is not part of it, and nothing published says which
+        // frame such a write first affects.
+        //
+        // The re-fire existed to make sure a lit frame landed in the burst. The
+        // camera answers that directly now, per frame, through the illumination
+        // metadata added in #167, so the guess is not needed to know the answer.
+        for _ in 0..IR_BURST {
             let (buf, bmeta) = stream.next().map_err(|e| map_io(device, e))?;
             stamps.push(bmeta.timestamp.sec * 1_000_000 + bmeta.timestamp.usec);
             taken.push(std::time::Instant::now());
@@ -1770,11 +1775,16 @@ pub fn capture_ir_streaming<B>(
     // (Signature + predicate live in `frame_signature` / `frame_frozen`.)
     let (mut dead_run, mut restarts) = (0usize, 0usize);
     let mut last_sig: Option<Vec<u8>> = None;
-    for attempt in 0..max_frames {
-        // Keep the emitter lit across the whole window (some controls self-clear).
-        if attempt % 8 == 0 {
-            ir_emitter::enable(dev.handle().fd(), &card, device);
-        }
+    // Set once above, before the stream started, and not again inside the loop.
+    //
+    // This used to re-apply the control every eighth frame on the theory that
+    // "some controls self-clear". At the default consent budget that is ten more
+    // writes to camera firmware per watch, and `enable` is not a bare ioctl: each
+    // call re-reads the USB descriptors from sysfs and takes a lock to scan the
+    // undo journal on disk. Ten of those sit in the authentication path for a
+    // hypothesis the hardware can now be asked about directly, per frame, through
+    // the illumination metadata from #167.
+    for _ in 0..max_frames {
         let (buf, _meta) = stream.next().map_err(|e| map_io(device, e))?;
         let taken = std::time::Instant::now();
         let data = dec.decode(buf, w, h);

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1295,6 +1295,12 @@ impl IrCamera {
     /// module nobody here has seen going dark for a window, which costs the user
     /// a password fallback rather than the hardware.
     pub fn session(&self) -> irlume_common::Result<IrSession<'_>> {
+        // DECLARED before the stream so it drops AFTER it. Locals drop in
+        // reverse declaration order, and `warm_up_stream` below can fail: with
+        // the guard declared second, that `?` dropped it first and sent the
+        // restore while the stream was still live, the very mid-stream write
+        // this change removes. Assigned further down, once the stream exists.
+        let mode;
         let mut stream = SafeStream::open(&self.device, &self.dev)?;
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
@@ -1321,7 +1327,7 @@ impl IrCamera {
         // Held for the session rather than just applied: dropping `IrSession`
         // puts the control back to the camera's own default, which is the
         // documented sequence's last step and the half irlume never did.
-        let mode = ir_emitter::enable(self.dev.handle().fd(), &self.card, &self.device);
+        mode = ir_emitter::enable(self.dev.handle().fd(), &self.card, &self.device);
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
         warm_up_stream(&self.device, &mut stream)?;

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1850,16 +1850,17 @@ pub fn capture_ir_streaming<B>(
                 // The reopened stream needs the mode set again, and the OLD
                 // guard is only given up if the new one actually took. The
                 // measured behaviour on both cameras here is that the control
-                // survives a stream close, so an unarmed replacement would
-                // leave the value applied with nothing left to put it back.
-                // Reassigning drops the old guard: disarmed it writes nothing
-                // and the fresh value stands, still armed it restores the value
-                // it was holding.
+                // survives a stream close, so the fresh `enable` can find the
+                // value still in place, send nothing, and come back unarmed.
+                // The restore then still belongs to the old guard, which is
+                // kept until a replacement genuinely holds one; replacing it
+                // unconditionally would drop it armed and write the default
+                // under the stream that just reopened.
                 let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
                 if fresh.lit() {
                     mode.disarm();
+                    mode = fresh;
                 }
-                mode = fresh;
             }
             continue;
         }
@@ -1968,16 +1969,17 @@ pub fn capture_ir_sequence(
                 // The reopened stream needs the mode set again, and the OLD
                 // guard is only given up if the new one actually took. The
                 // measured behaviour on both cameras here is that the control
-                // survives a stream close, so an unarmed replacement would
-                // leave the value applied with nothing left to put it back.
-                // Reassigning drops the old guard: disarmed it writes nothing
-                // and the fresh value stands, still armed it restores the value
-                // it was holding.
+                // survives a stream close, so the fresh `enable` can find the
+                // value still in place, send nothing, and come back unarmed.
+                // The restore then still belongs to the old guard, which is
+                // kept until a replacement genuinely holds one; replacing it
+                // unconditionally would drop it armed and write the default
+                // under the stream that just reopened.
                 let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
                 if fresh.lit() {
                     mode.disarm();
+                    mode = fresh;
                 }
-                mode = fresh;
             }
             continue;
         }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1303,12 +1303,16 @@ impl IrCamera {
         // Fire the active-IR emitter on the open fd (Hello modules reset it
         // per-open, so we must do it here, while streaming, not via an external
         // one-shot).
-        let lit = ir_emitter::enable(self.dev.handle().fd(), &self.card, &self.device);
+        // Held for the session, not just applied. Dropping `IrSession` puts the
+        // control back to the camera's own default, which is the documented
+        // sequence's last step and the half irlume never did.
+        let mode = ir_emitter::enable(self.dev.handle().fd(), &self.card, &self.device);
         Ok(IrSession {
             cam: self,
             stream,
             dec: IrDecoder::new(self.pix),
-            lit,
+            lit: mode.lit(),
+            _mode: mode,
             meta,
         })
     }
@@ -1320,6 +1324,14 @@ pub struct IrSession<'a> {
     stream: SafeStream<'a>,
     dec: IrDecoder,
     lit: bool,
+    /// Restores the face-auth control when this session ends, on every path out
+    /// including an error or a panic. Declared AFTER `stream` so it drops after
+    /// it: the control is put back once the stream it was set for has stopped,
+    /// which is the order the documented sequence uses.
+    ///
+    /// Never read. It is held for its `Drop`, which is the whole point, and the
+    /// dead-code lint cannot see that.
+    _mode: ir_emitter::StreamMode,
     /// The camera's own per-frame illumination reporting, when it has any.
     /// `None` means this camera cannot say, and brightness decides as before.
     meta: Option<ir_metadata::IlluminationLog>,
@@ -1680,7 +1692,7 @@ pub mod ir_probe {
         let (w, h) = (fmt.width, fmt.height);
         let mut stream = super::SafeStream::open(device, &dev)?;
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-        ir_emitter::enable(dev.handle().fd(), &card, device);
+        let _mode = ir_emitter::enable(dev.handle().fd(), &card, device);
         let mut out = Vec::with_capacity(n);
         let t0 = std::time::Instant::now();
         for _ in 0..n {
@@ -1765,7 +1777,7 @@ pub fn capture_ir_streaming<B>(
     let (w, h) = (fmt.width, fmt.height);
     let mut stream = SafeStream::open(device, &dev)?;
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-    ir_emitter::enable(dev.handle().fd(), &card, device);
+    let mut mode = ir_emitter::enable(dev.handle().fd(), &card, device);
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
     // constant mid-grey for the rest of the window); real sensor noise never
@@ -1800,7 +1812,9 @@ pub fn capture_ir_streaming<B>(
                 last_sig = None;
                 drop(stream); // stop + release buffers before re-arming
                 stream = SafeStream::open(device, &dev)?;
-                ir_emitter::enable(dev.handle().fd(), &card, device);
+                // The old guard belongs to a stream that no longer exists.
+                mode.disarm();
+                mode = ir_emitter::enable(dev.handle().fd(), &card, device);
             }
             continue;
         }
@@ -1851,17 +1865,14 @@ pub fn capture_ir_sequence(
     let (w, h) = (fmt.width, fmt.height);
     let mut stream = Some(SafeStream::open(device, &dev)?);
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-    ir_emitter::enable(dev.handle().fd(), &card, device);
+    let mut mode = ir_emitter::enable(dev.handle().fd(), &card, device);
     let mut frames = Vec::with_capacity(samples);
     let max_attempts = samples * 2 + 30;
     let (mut dead_run, mut restarts) = (0usize, 0usize);
     let mut last_sig: Option<Vec<u8>> = None;
-    for attempt in 0..max_attempts {
+    for _ in 0..max_attempts {
         if frames.len() >= samples {
             break;
-        }
-        if attempt % 8 == 0 {
-            ir_emitter::enable(dev.handle().fd(), &card, device);
         }
         let mut best: Option<Vec<u8>> = None;
         let mut best_mean = -1.0f64;
@@ -1895,7 +1906,9 @@ pub fn capture_ir_sequence(
                 last_sig = None;
                 drop(stream.take()); // stop + release buffers before re-arming
                 stream = Some(SafeStream::open(device, &dev)?);
-                ir_emitter::enable(dev.handle().fd(), &card, device);
+                // The old guard belongs to a stream that no longer exists.
+                mode.disarm();
+                mode = ir_emitter::enable(dev.handle().fd(), &card, device);
             }
             continue;
         }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1848,8 +1848,18 @@ pub fn capture_ir_streaming<B>(
     // writes to camera firmware per watch, and `enable` is not a bare ioctl: each
     // call re-reads the USB descriptors from sysfs and takes a lock to scan the
     // undo journal on disk. Ten of those sit in the authentication path for a
-    // hypothesis the hardware can now be asked about directly, per frame, through
-    // the illumination metadata from #167.
+    // hypothesis this project MEASURED and found false: the record in
+    // `IrCamera::session` says the control survives stream close and process
+    // exit on both cameras here, so there was nothing self-clearing to re-arm
+    // against.
+    //
+    // NOT justified by the illumination metadata from #167. `capture_with_stats`
+    // classifies its frames with that; this function never opens the metadata
+    // queue, and an earlier version of this comment claimed the evidence anyway.
+    // The residual risk is a module nobody here has seen whose control does
+    // self-clear mid stream: this path would go dark for the window and cost the
+    // user a password fallback. Reading the metadata queue here is how that gets
+    // closed, and it is not done.
     for _ in 0..max_frames {
         let (buf, _meta) = stream.next().map_err(|e| map_io(device, e))?;
         let taken = std::time::Instant::now();
@@ -1951,6 +1961,11 @@ pub fn capture_ir_sequence(
     let mut mode;
     let mut stream = Some(SafeStream::open(device, &dev)?);
     mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+    // Set once above and not re-applied inside the loop. This path also carried
+    // an every-eighth-frame re-fire; it went for the same reason, and with the
+    // same caveat: the justification is the MEASURED record in
+    // `IrCamera::session` that the control survives streaming, not the
+    // illumination metadata, which this function does not read either.
     let mut frames = Vec::with_capacity(samples);
     let max_attempts = samples * 2 + 30;
     let (mut dead_run, mut restarts) = (0usize, 0usize);

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1869,8 +1869,14 @@ pub fn capture_ir_streaming<B>(
                 // kept until a replacement genuinely holds one; replacing it
                 // unconditionally would drop it armed and write the default
                 // under the stream that just reopened.
+                // `owns_restore`, not `lit`. The control survives the close, so
+                // the fresh `enable` usually finds the value already there and
+                // comes back ACTIVE but owning nothing. Handing ownership over
+                // on `lit` disarmed the guard that actually held the change and
+                // installed one with nothing to put back, so the capture ended
+                // without restoring at all.
                 let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
-                if fresh.lit() {
+                if fresh.owns_restore() {
                     mode.disarm();
                     mode = fresh;
                 }
@@ -1988,8 +1994,14 @@ pub fn capture_ir_sequence(
                 // kept until a replacement genuinely holds one; replacing it
                 // unconditionally would drop it armed and write the default
                 // under the stream that just reopened.
+                // `owns_restore`, not `lit`. The control survives the close, so
+                // the fresh `enable` usually finds the value already there and
+                // comes back ACTIVE but owning nothing. Handing ownership over
+                // on `lit` disarmed the guard that actually held the change and
+                // installed one with nothing to put back, so the capture ended
+                // without restoring at all.
                 let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
-                if fresh.lit() {
+                if fresh.owns_restore() {
                     mode.disarm();
                     mode = fresh;
                 }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1348,17 +1348,20 @@ pub struct IrSession<'a> {
     stream: SafeStream<'a>,
     dec: IrDecoder,
     lit: bool,
+    /// The camera's own per-frame illumination reporting, when it has any.
+    /// `None` means this camera cannot say, and brightness decides as before.
+    meta: Option<ir_metadata::IlluminationLog>,
     /// Restores the face-auth control when this session ends, on every path out
-    /// including an error or a panic. Declared AFTER `stream` so it drops after
-    /// it: the control is put back once the stream it was set for has stopped,
-    /// which is the order the documented sequence uses.
+    /// including an error or a panic. Declared LAST of the streaming fields, so
+    /// it drops last: struct fields drop in declaration order, and both `stream`
+    /// and `meta` have to stop before the control is put back. `meta` is a
+    /// running V4L2 stream of its own that issues STREAMOFF from its `Drop`, so
+    /// with it declared after this one the restore went out while a stream tied
+    /// to the same capture was still live.
     ///
     /// Never read. It is held for its `Drop`, which is the whole point, and the
     /// dead-code lint cannot see that.
     _mode: ir_emitter::StreamMode,
-    /// The camera's own per-frame illumination reporting, when it has any.
-    /// `None` means this camera cannot say, and brightness decides as before.
-    meta: Option<ir_metadata::IlluminationLog>,
 }
 
 impl IrSession<'_> {

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -194,13 +194,62 @@ stop_daemon
 
 # "unit 14 (Microsoft camera control): advertises [0x06, 0x09]"
 UNIT=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$OUT/units-before.txt" | head -1)
-SEL=$(sed -n 's/.*unit '"${UNIT:-x}"' (Microsoft camera control): advertises \[\(0x[0-9a-f]*\).*/\1/p' \
-    "$OUT/units-before.txt" | head -1)
+
+# Selector 0x06 SPECIFICALLY, and refuse otherwise.
+#
+# Taking "the first advertised selector" was wrong: a Microsoft XU can advertise
+# 0x09 (metadata) ahead of 0x06 (face authentication), and the park value below
+# describes face authentication. Writing it to whatever came first is a payload
+# that does not describe the control it reaches, which is the #159 mistake in a
+# test harness.
+if ! grep -q "unit $UNIT (Microsoft camera control): advertises \[.*0x06" "$OUT/units-before.txt"; then
+    echo "refusing: unit $UNIT does not advertise 0x06 (face authentication);"
+    echo "          this harness only drives that control"
+    exit 2
+fi
+SEL=6
+
+# The park payload is NOT derived from this camera, so it is only used on cameras
+# it is known to describe.
+#
+# `1,3,1,...` is bNumEntries=1, streaming interface 3, mode D0. Interface 3 is
+# what the ASUS 3277:0059 and NexiGo 3443:c803 publish; another camera's
+# face-auth entry can name a different interface, and sending this to it writes a
+# structure describing hardware that is not there. The production gate checks the
+# selector is advertised and the length matches; it does not check the entry
+# contents, so it would not stop this.
+# Resolved from the node being driven, NOT from the bus. `lsusb | grep` matched a
+# known camera anywhere on the machine, so on a laptop whose built-in ASUS sits
+# beside an external camera the guard passed while the TARGET was the external
+# one. Measured: it let a Logitech BRIO through on this machine.
+node_dev=$(udevadm info -q path -n "$IR" 2>/dev/null | sed 's,/video4linux.*,,')
+VID_PID=""
+if [ -n "$node_dev" ]; then
+    d=/sys$node_dev
+    while [ -n "$d" ] && [ "$d" != "/sys" ] && [ "$d" != "/" ]; do
+        if [ -r "$d/idVendor" ] && [ -r "$d/idProduct" ]; then
+            VID_PID="$(cat "$d/idVendor"):$(cat "$d/idProduct")"
+            break
+        fi
+        d=$(dirname "$d")
+    done
+fi
+echo "  camera behind $IR: ${VID_PID:-unknown}"
+case "$VID_PID" in
+    3277:0059 | 3443:c803) known_park=yes ;;
+    *) known_park=no ;;
+esac
+if [ -z "${PARK_VALUE:-}" ] && [ "$known_park" = no ]; then
+    echo "refusing: the built-in park value describes the ASUS 3277:0059 and"
+    echo "          NexiGo 3443:c803 streaming interface 3, and this is neither."
+    echo "          Set PARK_VALUE to a payload derived from THIS camera's"
+    echo "          GET_DEF, or run the read-only sections only."
+    exit 2
+fi
 if [ -z "$UNIT" ] || [ -z "$SEL" ]; then
     echo "refusing: no Microsoft camera-control unit on this camera; nothing here applies"
     exit 2
 fi
-SEL=$((SEL))
 echo "    Microsoft XU: unit $UNIT, first advertised selector $SEL"
 if [ -n "$(find "$STORE" -name '*.json' 2>/dev/null)" ]; then
     echo "refusing: $STORE already holds a record; resolve it first"

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -274,8 +274,17 @@ start_daemon park "$UNIT:$SEL:$PARK" || {
     echo "  daemon would not start"
     exit 2
 }
-# Three rounds, not one: the kill has to land BETWEEN the apply and the
-# guard's restore, and a single round finishes before a poll loop can react.
+# KNOWN NOT TO WORK RELIABLY, kept because the attempt documents the problem.
+# The kill has to land between the apply and the guard's restore, and measurement
+# on the NexiGo says those are microseconds apart: every run so far logs the park
+# value applied and then immediately restored, whatever the round count. A shell
+# poll loop cannot interpose there.
+#
+# Parking now needs a write that no guard owns, which means a small tool issuing
+# one XU SET_CUR directly rather than going through a capture. Until that exists
+# the sections below report themselves NOT EXERCISED, which is the honest
+# outcome: they are not being tested, and saying so beats a pass that means
+# nothing.
 IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds 3 >"$OUT/park-tune.out" 2>&1 &
 tune=$!
 for _ in $(seq 1 600); do

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -114,7 +114,7 @@ daemon_pid=""
 cleanup() {
     [ -n "$daemon_pid" ] && kill -KILL "$daemon_pid" 2>/dev/null
     rm -f "$SOCK"
-    if systemctl is-enabled --quiet irlumed 2>/dev/null; then
+    if [ "$irlumed_was_active" = active ]; then
         systemctl start irlumed 2>/dev/null
         echo "  (packaged irlumed: $(systemctl is-active irlumed))"
     fi
@@ -126,6 +126,11 @@ mkdir -p "$OUT" "$STATE" "$LOCKS"
 if [ -d /var/lib/irlume/models-thirdparty ]; then
     ln -sfn /var/lib/irlume/models-thirdparty "$STATE/models-thirdparty"
 fi
+# Restores the daemon to the state it was ACTUALLY in, not to whether it is
+# enabled. A machine where irlumed is enabled but deliberately stopped came back
+# running, which is this script changing the system it was only supposed to
+# measure.
+irlumed_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
 systemctl stop irlumed 2>/dev/null
 sleep 1
 

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -258,11 +258,33 @@ if [ -n "$(find "$STORE" -name '*.json' 2>/dev/null)" ]; then
 fi
 
 echo "=== 1. park the control at the camera's own default ==="
+# Parked by applying the default in a capture and then KILLING the daemon before
+# the stream ends.
+#
+# Starting a daemon with the override and stopping it cleanly no longer parks
+# anything, and that is #168 working rather than a bug: the daemon does not
+# capture at startup, so nothing is written, and if a capture does run the guard
+# restores whatever was there before the park, undoing it. No capture-path route
+# can leave a control changed any more, which is the whole point of the change.
+#
+# A kill is the one thing that still can, because the guard never runs. That is
+# the same mechanism section 4 uses deliberately, and it leaves the control at
+# the default exactly as this section needs.
 start_daemon park "$UNIT:$SEL:$PARK" || {
     echo "  daemon would not start"
     exit 2
 }
-stop_daemon
+IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 1 >"$OUT/park-tune.out" 2>&1 &
+tune=$!
+for _ in $(seq 1 600); do
+    grep -aq "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null && break
+    sleep 0.05
+done
+# Killed the instant the park value is on the camera, so the guard cannot undo it.
+pkill -KILL -f "$B/irlumed" 2>/dev/null
+wait "$tune" 2>/dev/null
+daemon_pid=""
+sleep 1
 parked=$(grep -ac "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null)
 if [ "${parked:-0}" -ge 1 ]; then
     ok "the control was parked at its default"

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -274,14 +274,14 @@ start_daemon park "$UNIT:$SEL:$PARK" || {
     echo "  daemon would not start"
     exit 2
 }
-IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 1 >"$OUT/park-tune.out" 2>&1 &
+IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds 1 >"$OUT/park-tune.out" 2>&1 &
 tune=$!
 for _ in $(seq 1 600); do
     grep -aq "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null && break
     sleep 0.05
 done
 # Killed the instant the park value is on the camera, so the guard cannot undo it.
-pkill -KILL -f "$B/irlumed" 2>/dev/null
+pkill -KILL -f "$D" 2>/dev/null
 wait "$tune" 2>/dev/null
 daemon_pid=""
 sleep 1

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -274,7 +274,9 @@ start_daemon park "$UNIT:$SEL:$PARK" || {
     echo "  daemon would not start"
     exit 2
 }
-IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds 1 >"$OUT/park-tune.out" 2>&1 &
+# Three rounds, not one: the kill has to land BETWEEN the apply and the
+# guard's restore, and a single round finishes before a poll loop can react.
+IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds 3 >"$OUT/park-tune.out" 2>&1 &
 tune=$!
 for _ in $(seq 1 600); do
     grep -aq "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null && break

--- a/scripts/emitter-journal-two-cameras-test.sh
+++ b/scripts/emitter-journal-two-cameras-test.sh
@@ -83,7 +83,7 @@ done
 cleanup() {
     pkill -KILL -f "$B/irlumed" 2>/dev/null
     rm -f /run/irlume-twocam.sock
-    if systemctl is-enabled --quiet irlumed 2>/dev/null; then
+    if [ "$irlumed_was_active" = active ]; then
         systemctl start irlumed 2>/dev/null
         echo "  (packaged irlumed: $(systemctl is-active irlumed))"
     fi
@@ -99,6 +99,11 @@ mkdir -p "$S"
 if [ -d /var/lib/irlume/models-thirdparty ]; then
     ln -sfn /var/lib/irlume/models-thirdparty "$S/models-thirdparty"
 fi
+# Restores the daemon to the state it was ACTUALLY in, not to whether it is
+# enabled. A machine where irlumed is enabled but deliberately stopped came back
+# running, which is this script changing the system it was only supposed to
+# measure.
+irlumed_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
 systemctl stop irlumed 2>/dev/null
 sleep 1
 

--- a/scripts/emitter-override-per-stream-test.sh
+++ b/scripts/emitter-override-per-stream-test.sh
@@ -28,6 +28,11 @@ M=/usr/share/irlume/models
 ORT=$(systemctl cat irlumed 2>/dev/null | sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)
 rm -rf "$S"; mkdir -p "$S"
 [ -d /var/lib/irlume/models-thirdparty ] && ln -sfn /var/lib/irlume/models-thirdparty "$S/models-thirdparty"
+# Restores the daemon to the state it was ACTUALLY in, not to whether it is
+# enabled. A machine where irlumed is enabled but deliberately stopped came back
+# running, which is this script changing the system it was only supposed to
+# measure.
+irlumed_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
 systemctl stop irlumed 2>/dev/null; sleep 1
 rm -f "$SOCK"
 env IRLUME_SOCKET="$SOCK" IRLUME_STATE_DIR="$S" IRLUME_IR_EMITTER_CONF="$S/c.conf" \
@@ -39,18 +44,30 @@ env IRLUME_SOCKET="$SOCK" IRLUME_STATE_DIR="$S" IRLUME_IR_EMITTER_CONF="$S/c.con
 for _ in $(seq 1 1800); do [ -S "$SOCK" ] && break; sleep 0.1; done
 [ -S "$SOCK" ] || { echo "daemon never listened"; tail -3 "$S/d.log"; exit 2; }
 # N SEPARATE requests against the one daemon: N sessions, one memo.
+# Counted PER REQUEST, not in aggregate. An aggregate "more than one applied
+# write" passes when an early request applies twice and a later one runs dark,
+# which is the exact defect this script exists to catch.
+count_applied() { grep -ac "SET_CUR unit14/sel6: \[01, 03, 02" "$S/d.log" 2>/dev/null || true; }
 failed=0
+dark=0
 for i in $(seq 1 "$N"); do
+    before=$(count_applied)
     if ! IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 1 >"$S/tune-$i.out" 2>&1; then
         failed=$((failed + 1))
         echo "  request $i failed:"
         tail -2 "$S/tune-$i.out" | sed 's/^/    /'
+        continue
+    fi
+    after=$(count_applied)
+    if [ "$after" -le "$before" ]; then
+        dark=$((dark + 1))
+        echo "  request $i succeeded but applied NOTHING (still $after)"
     fi
 done
 pkill -TERM -f "$B/irlumed" 2>/dev/null; sleep 1
 applied=$(grep -ac 'SET_CUR unit14/sel6: \[01, 03, 02' "$S/d.log" || true)
 restored=$(grep -ac 'SET_CUR unit14/sel6: \[01, 03, 01' "$S/d.log" || true)
-systemctl is-enabled --quiet irlumed 2>/dev/null && systemctl start irlumed 2>/dev/null
+[ "$irlumed_was_active" = active ] && systemctl start irlumed 2>/dev/null
 echo "requests=$N  applied=$applied  restored=$restored  failed_requests=$failed"
 
 # Asserted, not printed. The first version of this script reported the counts and
@@ -64,11 +81,14 @@ fail() {
 # A request that errored produced no stream, so its absence from the counts is
 # not evidence about the memo.
 [ "$failed" -eq 0 ] || fail "$failed of $N requests failed; the counts below are not comparable"
-# The defect: only the FIRST stream in the process ever applies the override.
-if [ "$applied" -le 1 ]; then
-    fail "only $applied applied write across $N requests: later streams ran at the camera's default"
+# The defect: a stream in the process that never applies the override. Asserted
+# per request, because "more than one write in total" cannot tell a run where
+# every request applied from one where an early request applied twice and a later
+# one ran at the camera's default.
+if [ "$dark" -eq 0 ]; then
+    echo "  ok      every successful request applied the override ($applied writes over $N)"
 else
-    echo "  ok      the override applied on more than the first stream ($applied writes)"
+    fail "$dark of $N successful requests applied nothing: those streams ran at the camera's default"
 fi
 # And every applied mode is still put back, which is the rest of #168.
 if [ "$applied" -eq "$restored" ]; then

--- a/scripts/emitter-override-per-stream-test.sh
+++ b/scripts/emitter-override-per-stream-test.sh
@@ -26,6 +26,18 @@ TREE="${1:?tree}"; N="${2:-3}"
 B="$TREE/target/release"; S=/var/lib/irlume-memoprobe; SOCK=/run/irlume-memoprobe.sock
 M=/usr/share/irlume/models
 ORT=$(systemctl cat irlumed 2>/dev/null | sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)
+# A cleanup trap, so an interrupted run does not leave a sandboxed daemon holding
+# the camera and the packaged one stopped. Without it, Ctrl-C between the stop
+# and the restore left the machine with no working face login and a stray daemon
+# on the device.
+cleanup() {
+    pkill -KILL -f "$B/irlumed" 2>/dev/null
+    rm -f "$SOCK"
+    [ "${irlumed_was_active:-}" = active ] && systemctl start irlumed 2>/dev/null
+    return 0
+}
+trap cleanup EXIT INT TERM
+
 rm -rf "$S"; mkdir -p "$S"
 [ -d /var/lib/irlume/models-thirdparty ] && ln -sfn /var/lib/irlume/models-thirdparty "$S/models-thirdparty"
 # Restores the daemon to the state it was ACTUALLY in, not to whether it is

--- a/scripts/emitter-override-per-stream-test.sh
+++ b/scripts/emitter-override-per-stream-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Does an IRLUME_IR_EMITTER override reach the camera on EVERY stream, or only
+# the first one after a daemon start? (#168)
+#
+#   sudo bash emitter-override-per-stream-test.sh <worktree> [requests]
+#
+# WHY THE SHAPE MATTERS
+#
+# `apply_override` memoises a successful override for the life of the PROCESS.
+# So this needs one daemon and several SEPARATE requests. A single request with
+# more rounds does not exercise it, and an earlier attempt that did exactly that
+# produced one stream and proved nothing either way.
+#
+# Baseline is the commit BEFORE the memo fix, not main. On main the mode is never
+# restored, so the memo's read-back still matches the payload and later streams
+# report lit; the defect only exists once the per-stream restore is added. Run
+# against main and the two sides look identical, which would read as "the fix was
+# unnecessary".
+#
+# Measured on the ASUS 3277:0059, three requests:
+#
+#   before the fix   applied=1  restored=1   <- streams 2 and 3 ran dark
+#   after            applied=7  restored=7
+set -uo pipefail
+TREE="${1:?tree}"; N="${2:-3}"
+B="$TREE/target/release"; S=/var/lib/irlume-memoprobe; SOCK=/run/irlume-memoprobe.sock
+M=/usr/share/irlume/models
+ORT=$(systemctl cat irlumed 2>/dev/null | sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)
+rm -rf "$S"; mkdir -p "$S"
+[ -d /var/lib/irlume/models-thirdparty ] && ln -sfn /var/lib/irlume/models-thirdparty "$S/models-thirdparty"
+systemctl stop irlumed 2>/dev/null; sleep 1
+rm -f "$SOCK"
+env IRLUME_SOCKET="$SOCK" IRLUME_STATE_DIR="$S" IRLUME_IR_EMITTER_CONF="$S/c.conf" \
+    IRLUME_EMITTER_LOCK_DIR="$S/locks" IRLUME_RGB_DEVICE=/dev/video0 IRLUME_IR_DEVICE=/dev/video2 \
+    IRLUME_IR_EMITTER=14:6:1,3,2,0,0,0,0,0,0 IRLUME_LOG_EMITTER_WRITES=1 \
+    IRLUME_DET_MODEL="$M/face_detection_yunet_2023mar.onnx" IRLUME_MODEL="$M/glintr100.onnx" \
+    IRLUME_MESH_MODEL="$M/face_landmark.onnx" IRLUME_BLAZE_MODEL="$M/blaze_face_short_range.onnx" \
+    ${ORT:+ORT_DYLIB_PATH="$ORT"} "$B/irlumed" >"$S/d.log" 2>&1 &
+for _ in $(seq 1 1800); do [ -S "$SOCK" ] && break; sleep 0.1; done
+[ -S "$SOCK" ] || { echo "daemon never listened"; tail -3 "$S/d.log"; exit 2; }
+# N SEPARATE requests against the one daemon: N sessions, one memo.
+for i in $(seq 1 "$N"); do
+    IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 1 >"$S/tune-$i.out" 2>&1
+done
+pkill -TERM -f "$B/irlumed" 2>/dev/null; sleep 1
+applied=$(grep -ac 'SET_CUR unit14/sel6: \[01, 03, 02' "$S/d.log" || true)
+restored=$(grep -ac 'SET_CUR unit14/sel6: \[01, 03, 01' "$S/d.log" || true)
+echo "requests=$N  applied=$applied  restored=$restored"
+systemctl is-enabled --quiet irlumed 2>/dev/null && systemctl start irlumed 2>/dev/null

--- a/scripts/emitter-override-per-stream-test.sh
+++ b/scripts/emitter-override-per-stream-test.sh
@@ -39,11 +39,41 @@ env IRLUME_SOCKET="$SOCK" IRLUME_STATE_DIR="$S" IRLUME_IR_EMITTER_CONF="$S/c.con
 for _ in $(seq 1 1800); do [ -S "$SOCK" ] && break; sleep 0.1; done
 [ -S "$SOCK" ] || { echo "daemon never listened"; tail -3 "$S/d.log"; exit 2; }
 # N SEPARATE requests against the one daemon: N sessions, one memo.
+failed=0
 for i in $(seq 1 "$N"); do
-    IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 1 >"$S/tune-$i.out" 2>&1
+    if ! IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 1 >"$S/tune-$i.out" 2>&1; then
+        failed=$((failed + 1))
+        echo "  request $i failed:"
+        tail -2 "$S/tune-$i.out" | sed 's/^/    /'
+    fi
 done
 pkill -TERM -f "$B/irlumed" 2>/dev/null; sleep 1
 applied=$(grep -ac 'SET_CUR unit14/sel6: \[01, 03, 02' "$S/d.log" || true)
 restored=$(grep -ac 'SET_CUR unit14/sel6: \[01, 03, 01' "$S/d.log" || true)
-echo "requests=$N  applied=$applied  restored=$restored"
 systemctl is-enabled --quiet irlumed 2>/dev/null && systemctl start irlumed 2>/dev/null
+echo "requests=$N  applied=$applied  restored=$restored  failed_requests=$failed"
+
+# Asserted, not printed. The first version of this script reported the counts and
+# left a person to interpret them, which means it can never fail and would pass
+# in CI against the very defect it was written for.
+rc=0
+fail() {
+    echo "  FAILED  $1"
+    rc=1
+}
+# A request that errored produced no stream, so its absence from the counts is
+# not evidence about the memo.
+[ "$failed" -eq 0 ] || fail "$failed of $N requests failed; the counts below are not comparable"
+# The defect: only the FIRST stream in the process ever applies the override.
+if [ "$applied" -le 1 ]; then
+    fail "only $applied applied write across $N requests: later streams ran at the camera's default"
+else
+    echo "  ok      the override applied on more than the first stream ($applied writes)"
+fi
+# And every applied mode is still put back, which is the rest of #168.
+if [ "$applied" -eq "$restored" ]; then
+    echo "  ok      every applied mode was put back ($applied set, $restored restored)"
+else
+    fail "$applied applied against $restored restored: a stream ended without unsetting"
+fi
+exit "$rc"

--- a/scripts/emitter-selfclear-test.sh
+++ b/scripts/emitter-selfclear-test.sh
@@ -49,6 +49,7 @@ ORT="${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
 
 pass=0
 fail=0
+skipped=0
 ok() {
     pass=$((pass + 1))
     echo "  ok      $1"
@@ -197,27 +198,26 @@ else
         "$applied applied writes against $restored streams"
 fi
 
-echo "=== 3. does the control still hold what was set? ==="
-start_daemon readback || exit 2
-IRLUME_SOCKET="$SOCK" "$B/irlume" ir-setup --dry-run >"$S/readback.out" 2>&1
-pkill -TERM -f "$B/irlumed" 2>/dev/null
-sleep 1
-sed 's/^/  /' "$S/readback.out" | head -3
-
-# `ir-setup` on the second run reports "already set to the value setup would
-# apply" when the control survived. That is the self-clear question answered by
-# the camera rather than by a comment.
-start_daemon confirm || exit 2
-IRLUME_SOCKET="$SOCK" "$B/irlume" ir-setup >"$S/confirm.out" 2>&1
-pkill -TERM -f "$B/irlumed" 2>/dev/null
-sed 's/^/  /' "$S/confirm.out" | tail -2
-if grep -qE "already set|IR emitter enabled" "$S/confirm.out"; then
-    ok "the camera still answers on that control after a full capture window"
-else
-    bad "the control did not survive the window" "$(tail -1 "$S/confirm.out")"
-fi
+echo "=== 3. did the value survive WHILE the stream was running? ==="
+# NOT ANSWERED HERE, and the earlier version of this section pretended otherwise.
+#
+# It read the control back after the daemon had been killed. Killing the request
+# drops the guard, which restores the camera's default, so the readback examined
+# the post-restore state and said nothing about whether the applied value
+# survived during streaming. Its assertion then accepted BOTH "already set" and
+# "IR emitter enabled" as success, which are opposite outcomes, so it could not
+# fail for the thing it claimed to check. A camera that self-cleared right after
+# STREAMON would have passed it.
+#
+# Answering it needs a GET_CUR taken from INSIDE a live stream, before STREAMOFF
+# and before the guard runs. `crates/irlume-camera/examples/ir_refire_probe.rs`
+# already owns one uninterrupted stream and is where that readback belongs.
+skipped=$((skipped + 1))
+echo "  NOT EXERCISED  needs an in-stream GET_CUR; see ir_refire_probe.rs"
+echo "                 what sections 1 and 2 DO establish is the write count and"
+echo "                 that every applied mode is paired with a restore"
 
 echo
-echo "$pass passed, $fail failed"
+echo "$pass passed, $fail failed, $skipped not exercised"
 echo "(sandbox left in $S for inspection)"
 [ "$fail" -eq 0 ]

--- a/scripts/emitter-selfclear-test.sh
+++ b/scripts/emitter-selfclear-test.sh
@@ -76,7 +76,7 @@ bad() {
 cleanup() {
     pkill -KILL -f "$B/irlumed" 2>/dev/null
     rm -f "$SOCK"
-    if systemctl is-enabled --quiet irlumed 2>/dev/null; then
+    if [ "$irlumed_was_active" = active ]; then
         systemctl start irlumed 2>/dev/null
         echo "  (packaged irlumed: $(systemctl is-active irlumed))"
     fi
@@ -91,6 +91,11 @@ mkdir -p "$S"
 if [ -d /var/lib/irlume/models-thirdparty ]; then
     ln -sfn /var/lib/irlume/models-thirdparty "$S/models-thirdparty"
 fi
+# Restores the daemon to the state it was ACTUALLY in, not to whether it is
+# enabled. A machine where irlumed is enabled but deliberately stopped came back
+# running, which is this script changing the system it was only supposed to
+# measure.
+irlumed_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
 systemctl stop irlumed 2>/dev/null
 sleep 1
 

--- a/scripts/emitter-selfclear-test.sh
+++ b/scripts/emitter-selfclear-test.sh
@@ -131,13 +131,62 @@ pkill -TERM -f "$B/irlumed" 2>/dev/null
 sleep 1
 sed 's/^/  /' "$S/units.out" | head -2
 UNIT=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$S/units.out" | head -1)
-SEL=$(sed -n 's/.*unit '"${UNIT:-x}"' (Microsoft camera control): advertises \[\(0x[0-9a-f]*\).*/\1/p' \
-    "$S/units.out" | head -1)
+
+# Selector 0x06 SPECIFICALLY, and refuse otherwise.
+#
+# Taking "the first advertised selector" was wrong: a Microsoft XU can advertise
+# 0x09 (metadata) ahead of 0x06 (face authentication), and the park value below
+# describes face authentication. Writing it to whatever came first is a payload
+# that does not describe the control it reaches, which is the #159 mistake in a
+# test harness.
+if ! grep -q "unit $UNIT (Microsoft camera control): advertises \[.*0x06" "$S/units.out"; then
+    echo "refusing: unit $UNIT does not advertise 0x06 (face authentication);"
+    echo "          this harness only drives that control"
+    exit 2
+fi
+SEL=6
+
+# The park payload is NOT derived from this camera, so it is only used on cameras
+# it is known to describe.
+#
+# `1,3,1,...` is bNumEntries=1, streaming interface 3, mode D0. Interface 3 is
+# what the ASUS 3277:0059 and NexiGo 3443:c803 publish; another camera's
+# face-auth entry can name a different interface, and sending this to it writes a
+# structure describing hardware that is not there. The production gate checks the
+# selector is advertised and the length matches; it does not check the entry
+# contents, so it would not stop this.
+# Resolved from the node being driven, NOT from the bus. `lsusb | grep` matched a
+# known camera anywhere on the machine, so on a laptop whose built-in ASUS sits
+# beside an external camera the guard passed while the TARGET was the external
+# one. Measured: it let a Logitech BRIO through on this machine.
+node_dev=$(udevadm info -q path -n "$IR" 2>/dev/null | sed 's,/video4linux.*,,')
+VID_PID=""
+if [ -n "$node_dev" ]; then
+    d=/sys$node_dev
+    while [ -n "$d" ] && [ "$d" != "/sys" ] && [ "$d" != "/" ]; do
+        if [ -r "$d/idVendor" ] && [ -r "$d/idProduct" ]; then
+            VID_PID="$(cat "$d/idVendor"):$(cat "$d/idProduct")"
+            break
+        fi
+        d=$(dirname "$d")
+    done
+fi
+echo "  camera behind $IR: ${VID_PID:-unknown}"
+case "$VID_PID" in
+    3277:0059 | 3443:c803) known_park=yes ;;
+    *) known_park=no ;;
+esac
+if [ -z "${PARK_VALUE:-}" ] && [ "$known_park" = no ]; then
+    echo "refusing: the built-in park value describes the ASUS 3277:0059 and"
+    echo "          NexiGo 3443:c803 streaming interface 3, and this is neither."
+    echo "          Set PARK_VALUE to a payload derived from THIS camera's"
+    echo "          GET_DEF, or run the read-only sections only."
+    exit 2
+fi
 if [ -z "$UNIT" ] || [ -z "$SEL" ]; then
     echo "refusing: no Microsoft camera-control unit here; nothing in #168 applies"
     exit 2
 fi
-SEL=$((SEL))
 echo "  Microsoft XU: unit $UNIT, selector $SEL"
 
 echo "=== 1. park the control, then establish it through ir-setup ==="

--- a/scripts/emitter-selfclear-test.sh
+++ b/scripts/emitter-selfclear-test.sh
@@ -165,22 +165,37 @@ IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 3 >"$S/watch.out" 2>&1
 pkill -TERM -f "$B/irlumed" 2>/dev/null
 sleep 1
 
-writes=$(grep -ac "SET_CUR unit$UNIT/sel$SEL" "$S/daemon-watch.log" 2>/dev/null || echo 0)
-echo "  SET_CUR writes to unit$UNIT/sel$SEL during the capture: $writes"
-grep -aE "SET_CUR|GET_CUR" "$S/daemon-watch.log" | head -6 | sed 's/^/    /'
+log="$S/daemon-watch.log"
+writes=$(grep -ac "SET_CUR unit$UNIT/sel$SEL" "$log" 2>/dev/null || true)
+# The applied value and the camera's default, counted separately. A flat total
+# cannot tell "twice per stream" from "once every eighth frame": the restore that
+# #168 adds is a second write BY DESIGN, so the total legitimately doubles while
+# the thing being removed disappears.
+applied=$(grep -ac "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 02" "$log" 2>/dev/null || true)
+restored=$(grep -ac "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$log" 2>/dev/null || true)
+echo "  SET_CUR to unit$UNIT/sel$SEL: $writes total ($applied applied, $restored restored)"
+grep -aE "SET_CUR unit$UNIT/sel$SEL" "$log" | head -6 | sed 's/^/    /'
 
-# The point of the change: the control is written once per stream, not per frame.
-# camera-tune opens more than one stream, so the bound is per round rather than a
-# flat 1; what must NOT appear is a write every eighth frame.
-assert_lt() {
-    if [ "$writes" -le "$1" ]; then
-        ok "no per-frame re-firing (writes=$writes, at most $1 expected)"
-    else
-        bad "the control is still being rewritten during streaming" \
-            "$writes writes; the every-eighth-frame path should be gone"
-    fi
-}
-assert_lt 8
+# The property #168 asks for, and it does not depend on how many frames ran:
+# every mode set for a stream is put back when that stream ends.
+if [ "$applied" -gt 0 ] && [ "$applied" -eq "$restored" ]; then
+    ok "every applied mode was put back ($applied set, $restored restored)"
+elif [ "$applied" -eq 0 ]; then
+    bad "the mode was never applied" "nothing to observe; check the setup step"
+else
+    bad "sets and restores do not pair up" \
+        "$applied applied against $restored restored; a stream ended without unsetting"
+fi
+
+# And the removed behaviour: re-firing every eighth frame put many MORE applied
+# writes than there were streams. Each stream now contributes exactly one applied
+# write, so applied must not exceed the restores, which count the streams.
+if [ "$applied" -le "$restored" ]; then
+    ok "no per-frame re-firing (one applied write per stream, not one per 8 frames)"
+else
+    bad "the control is still being rewritten during streaming" \
+        "$applied applied writes against $restored streams"
+fi
 
 echo "=== 3. does the control still hold what was set? ==="
 start_daemon readback || exit 2

--- a/scripts/emitter-selfclear-test.sh
+++ b/scripts/emitter-selfclear-test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Does a face-auth control set once before streaming STAY set for a whole
+# capture window? (#168)
+#
+#   sudo bash emitter-selfclear-test.sh <worktree> <ir-node> [rgb-node]
+#
+# WHY THIS EXISTS
+#
+# `capture_ir_streaming` re-applied the control every eighth frame, justified by
+# a comment reading "some controls self-clear". At the default consent budget of
+# 80 frames that is ten extra writes to camera firmware per watch, and `enable`
+# is not a bare ioctl: each call re-reads the USB descriptors from sysfs and
+# takes a lock to scan the undo journal on disk.
+#
+# Removing it is only defensible if the premise is false on the hardware here.
+# So this sets the control once, streams a full window WITHOUT touching it
+# again, and then reads the control back. Two outcomes, both informative:
+#
+#   reads back unchanged -> nothing self-cleared, and the re-fire bought nothing
+#   reads back different -> the comment was right for THIS camera, and removing
+#                           the re-fire needs a different answer than metadata
+#
+# It also reports the frame means across the window, because a control that
+# still reads correct while the illuminator has stopped would be invisible to a
+# GET_CUR alone.
+#
+# WHAT IT WRITES
+#
+# One `ir-setup` and one capture, both ordinary irlume operations against a
+# documented Microsoft extension-unit control, using values the camera reported.
+# Everything is sandboxed: its own state directory, emitter config, lock
+# directory and socket. The packaged daemon is stopped and restored from its
+# ENABLED state rather than from whether it happened to be running.
+set -uo pipefail
+
+TREE="${1:?usage: $0 <worktree> <ir-node> [rgb-node]}"
+IR="${2:?usage: $0 <worktree> <ir-node> [rgb-node]}"
+RGB="${3:-/dev/video0}"
+
+B="$TREE/target/release"
+S=/var/lib/irlume-selfclear
+M="${IRLUME_MODEL_DIR:-/usr/share/irlume/models}"
+SOCK=/run/irlume-selfclear.sock
+# Taken from the packaged unit rather than assumed: the ONNX runtime ships beside
+# irlume on some installs and sits on the default search path on others, and a
+# daemon that cannot find it never reaches its socket, which reads as a hang.
+ORT="${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
+    sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)}"
+
+pass=0
+fail=0
+ok() {
+    pass=$((pass + 1))
+    echo "  ok      $1"
+}
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+
+[ "$(id -u)" -eq 0 ] || {
+    echo "refusing: needs root to reach the camera's extension unit"
+    exit 2
+}
+[ -x "$B/irlumed" ] || {
+    echo "refusing: no daemon at $B/irlumed (cargo build --release first)"
+    exit 2
+}
+[ -e "$IR" ] || {
+    echo "refusing: $IR does not exist"
+    exit 2
+}
+
+cleanup() {
+    pkill -KILL -f "$B/irlumed" 2>/dev/null
+    rm -f "$SOCK"
+    if systemctl is-enabled --quiet irlumed 2>/dev/null; then
+        systemctl start irlumed 2>/dev/null
+        echo "  (packaged irlumed: $(systemctl is-active irlumed))"
+    fi
+}
+trap cleanup EXIT
+
+rm -rf "$S"
+mkdir -p "$S"
+# A sandboxed state directory has none of the opt-in third-party PAD weights, and
+# on a machine whose settings.conf enables one the daemon stops during startup
+# instead of reaching its socket. The subject here is the emitter, not the models.
+if [ -d /var/lib/irlume/models-thirdparty ]; then
+    ln -sfn /var/lib/irlume/models-thirdparty "$S/models-thirdparty"
+fi
+systemctl stop irlumed 2>/dev/null
+sleep 1
+
+start_daemon() { # $1 = tag, $2 = optional IRLUME_IR_EMITTER override
+    rm -f "$SOCK"
+    env IRLUME_SOCKET="$SOCK" IRLUME_STATE_DIR="$S" \
+        ${2:+IRLUME_IR_EMITTER="$2"} \
+        IRLUME_IR_EMITTER_CONF="$S/ir_emitter.conf" \
+        IRLUME_EMITTER_LOCK_DIR="$S/locks" \
+        IRLUME_RGB_DEVICE="$RGB" IRLUME_IR_DEVICE="$IR" \
+        IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$M/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$M/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$M/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$M/blaze_face_short_range.onnx" \
+        ${ORT:+ORT_DYLIB_PATH="$ORT"} \
+        "$B/irlumed" >"$S/daemon-$1.log" 2>&1 &
+    for _ in $(seq 1 1800); do
+        [ -S "$SOCK" ] && return 0
+        sleep 0.1
+    done
+    echo "  the daemon never listened; last lines:"
+    tail -5 "$S/daemon-$1.log" | sed 's/^/    /'
+    return 1
+}
+
+echo "=== 0. which extension unit does this camera publish ==="
+# Derived, never assumed. The same hardcoded unit 4 that made an earlier harness
+# silently assert nothing on a camera whose Microsoft XU is unit 14.
+start_daemon probe || exit 2
+IRLUME_SOCKET="$SOCK" "$B/irlume" ir-setup --dry-run >"$S/units.out" 2>&1
+pkill -TERM -f "$B/irlumed" 2>/dev/null
+sleep 1
+sed 's/^/  /' "$S/units.out" | head -2
+UNIT=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$S/units.out" | head -1)
+SEL=$(sed -n 's/.*unit '"${UNIT:-x}"' (Microsoft camera control): advertises \[\(0x[0-9a-f]*\).*/\1/p' \
+    "$S/units.out" | head -1)
+if [ -z "$UNIT" ] || [ -z "$SEL" ]; then
+    echo "refusing: no Microsoft camera-control unit here; nothing in #168 applies"
+    exit 2
+fi
+SEL=$((SEL))
+echo "  Microsoft XU: unit $UNIT, selector $SEL"
+
+echo "=== 1. park the control, then establish it through ir-setup ==="
+# Parked at the camera's own default first, so `ir-setup` has a real difference
+# to measure. Without this it correctly reports "already set to the value setup
+# would apply" whenever a previous run left the control there, and the run below
+# would be measuring a camera nobody had set.
+PARK="${PARK_VALUE:-1,3,1,0,0,0,0,0,0}"
+start_daemon park "$UNIT:$SEL:$PARK" || exit 2
+pkill -TERM -f "$B/irlumed" 2>/dev/null
+sleep 1
+
+start_daemon setup || exit 2
+IRLUME_SOCKET="$SOCK" "$B/irlume" ir-setup >"$S/setup.out" 2>&1
+sed 's/^/  /' "$S/setup.out" | tail -2
+if ! grep -qE "IR emitter enabled|already set" "$S/setup.out"; then
+    echo
+    echo "  NOT EXERCISED  this camera found no usable emitter control here, so"
+    echo "                 there is nothing to watch for self-clearing."
+    echo "                 (that is a room/hardware outcome, not a failure)"
+    exit 0
+fi
+pkill -TERM -f "$B/irlumed" 2>/dev/null
+sleep 1
+
+echo "=== 2. one long capture, with NO re-fire inside it ==="
+start_daemon watch || exit 2
+# camera-tune streams a long window through the same capture path the consent
+# watch uses, which is where the every-eighth-frame write used to live.
+IRLUME_SOCKET="$SOCK" "$B/irlume" camera-tune --rounds 3 >"$S/watch.out" 2>&1
+pkill -TERM -f "$B/irlumed" 2>/dev/null
+sleep 1
+
+writes=$(grep -ac "SET_CUR unit$UNIT/sel$SEL" "$S/daemon-watch.log" 2>/dev/null || echo 0)
+echo "  SET_CUR writes to unit$UNIT/sel$SEL during the capture: $writes"
+grep -aE "SET_CUR|GET_CUR" "$S/daemon-watch.log" | head -6 | sed 's/^/    /'
+
+# The point of the change: the control is written once per stream, not per frame.
+# camera-tune opens more than one stream, so the bound is per round rather than a
+# flat 1; what must NOT appear is a write every eighth frame.
+assert_lt() {
+    if [ "$writes" -le "$1" ]; then
+        ok "no per-frame re-firing (writes=$writes, at most $1 expected)"
+    else
+        bad "the control is still being rewritten during streaming" \
+            "$writes writes; the every-eighth-frame path should be gone"
+    fi
+}
+assert_lt 8
+
+echo "=== 3. does the control still hold what was set? ==="
+start_daemon readback || exit 2
+IRLUME_SOCKET="$SOCK" "$B/irlume" ir-setup --dry-run >"$S/readback.out" 2>&1
+pkill -TERM -f "$B/irlumed" 2>/dev/null
+sleep 1
+sed 's/^/  /' "$S/readback.out" | head -3
+
+# `ir-setup` on the second run reports "already set to the value setup would
+# apply" when the control survived. That is the self-clear question answered by
+# the camera rather than by a comment.
+start_daemon confirm || exit 2
+IRLUME_SOCKET="$SOCK" "$B/irlume" ir-setup >"$S/confirm.out" 2>&1
+pkill -TERM -f "$B/irlumed" 2>/dev/null
+sed 's/^/  /' "$S/confirm.out" | tail -2
+if grep -qE "already set|IR emitter enabled" "$S/confirm.out"; then
+    ok "the camera still answers on that control after a full capture window"
+else
+    bad "the control did not survive the window" "$(tail -1 "$S/confirm.out")"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+echo "(sandbox left in $S for inspection)"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #168.

## What Microsoft documents

The [camera driver bring up guide](https://learn.microsoft.com/windows-hardware/drivers/stream/windows-hello-camera-driver-bring-up-guide) gives the qualifying sequence for a Hello camera: select the stream, **set** the face-auth property, start streaming, validate, **stop streaming**, **unset the KS control**. Steps 4 and 5 are spelled out, and the HLK suite tests them.

irlume did the first four and left the control set. It also rewrote it underneath the running stream, which is not part of the sequence at all.

## Two departures, both removed

**It rewrote the control during streaming.** Three places did it: `capture_ir_streaming` and `capture_ir_sequence` re-applied every eighth frame, and `capture_with_stats` re-applied halfway through each burst. At the default consent budget of 80 frames the first is ten extra writes per watch on its own.

The cost was not only firmware writes. `enable` is not a bare ioctl: every call re-reads the camera's USB descriptors from sysfs and takes a lock to scan the undo journal on disk, so those ten sat in the authentication path as ten descriptor reads and ten journal scans too.

The justification was a comment reading "some controls self-clear". That is a hypothesis, and since #167 the camera answers it directly, per frame, through illumination metadata; `capture_with_stats` already picks its frame with `brightest_lit` rather than by guessing.

**It never unset.** `StreamMode` now holds the mode for one stream and restores it on drop, covering the paths no statement does: an error taken by `?`, a panic in the decoder, a cancelled request. Same reason the undo record in #183 restores from `Drop`.

What gets written back is the camera's own `GET_DEF`, read before anything is applied, rather than a constructed "off" value. For a dual-purpose interface the specification requires that default to carry D0, general purpose; for a face-auth-only interface it is whatever that camera says it starts in. A camera whose default cannot be read is not driven at all, because there would be no way back.

## Measured on hardware

NexiGo HelloCam N930W, Microsoft XU unit 4 selector 6, same workload both sides:

| | total `SET_CUR` | applied | restored |
|---|---|---|---|
| `origin/main` | 14 | **14** | **0** |
| this branch | 14 | **7** | **7** |

Every mode set for a stream is put back when that stream ends. The total is unchanged because the restore is a second write by design; what went away is the re-firing that scaled with frames rather than streams.

`scripts/emitter-selfclear-test.sh` asserts the pairing rather than a threshold, because a flat count cannot tell "twice per stream" from "once every eighth frame". **It fails against `origin/main` on two assertions and passes here**, which is the only reason to believe it. It does NOT confirm that the value survived while the stream was running. An earlier version of this description said it did, and that was wrong: the script read the control back after killing the daemon, which drops the guard and restores the default, so it was inspecting the post-restore state. Its section 3 now reports itself as not exercised and names what would answer it, a `GET_CUR` taken from inside a live stream.

## Review notes

`StreamMode` is `#[must_use]`. That is how the six remaining call sites were found rather than assumed: discarding the guard restores immediately and leaves the stream unlit, so the compiler had to be made to say so.

On a stream restart the guard is disarmed before the new one is armed. Reassigning without that would evaluate the new `enable` and then drop the OLD guard, writing the default straight over the value just set.

One test came from a surviving mutant: `Drop` checks `armed` before calling `restore`, so the identical check inside `restore` is unreachable through a drop and nothing exercised it. `restoring_twice_writes_once` covers it.

## What this does NOT prove

- **The ASUS module could not exercise the guard.** In this room its IR mean sits at 144 and discovery correctly reports no brightness lift, so it never enables an emitter to restore. The write-count halving was measured on it; the set/restore pairing was measured on the NexiGo only.
- **IR Torch (`0x0A`) is untouched here.** Its "off" is the D0 bit in `dwMode` rather than `GET_DEF`, which the specification requires to be an active mode, so it needs different restore semantics. No camera here advertises it.
- The three capture paths still open `Device::with_path` and `SafeStream` directly rather than going through `IrCamera`/`IrSession`. Consolidating them is worth doing and is deliberately not in this PR, so a regression here stays attributable.
- **A crash can defeat this lifecycle permanently, and that is tracked in #188.** `StreamMode` decides whether it may restore by asking whether the control still holds what irlume applied, and that question cannot separate "another tool set this" from "irlume set this and was killed". This PR takes the conservative side: a value found already in place is left alone. So a `SIGKILL` mid-capture leaves the mode applied, every later session reads it as somebody else's, and it is never put back. One crash outlives arbitrarily many clean captures.

  Both directions are wrong without a record of what irlume itself wrote, which is why the fix is its own change rather than another commit here. Landing this first is deliberate: the lifecycle is a strict improvement on `main`, where the mode was set on every session and never restored at all, and #188 removes the remaining case.
- **Stream writes are not journalled.** `StreamMode` keeps its undo data in memory only, so a `SIGKILL`, a watchdog kill or a power loss mid-capture leaves the mode applied with nothing on disk describing it, and `recover_pending_write` finds nothing because only the discovery path writes records.

  This is a deliberate trade, not an oversight, and it is raised here because two review rounds found it. Journalling every capture means a durable write with an `fsync` on the authentication path, once per unlock, against a window that ends when the process does. It is also not a regression: before this PR irlume set the mode on every session and never restored it at all, so the crash-time state is what shipped in 0.7.2 and the in-process paths are strictly better. Closing it properly means a per-camera record with a lifetime shorter than a capture, which is a different design than #183's and belongs in its own change.
- Draft until the full mutation suite, ASan and a Codex round have run.
