### PR TITLE
The emitter guard knows what it owns: displaced-value restore, claimable crash leftovers, handle-bound lifetime

### DIFF
--- a/crates/irlume-camera/examples/xu_set.rs
+++ b/crates/irlume-camera/examples/xu_set.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Issue ONE extension-unit `SET_CUR`, owned by no guard.
+//!
+//! Test tooling, not a feature. Two jobs, both impossible from outside the
+//! process otherwise (killing a daemon mid-capture cannot interpose between
+//! apply and restore — they are microseconds apart, measured on the NexiGo):
+//!
+//!   * PARK a control at its device default before a hardware run, so
+//!     discovery and the capture path actually have something to write. The
+//!     daemon's own guard now restores what it displaced, so a previous run
+//!     no longer leaves the control parked for the next one.
+//!   * plant "another writer's" value for the #188 leftover tests: set the
+//!     face-auth value from outside irlume and confirm a capture leaves it
+//!     alone, or leave a value behind and confirm only a stream RECORD makes
+//!     irlume claim it.
+//!
+//! The unit and selector must be published by the camera's descriptors —
+//! the same consent rule as `IRLUME_IR_EMITTER` — but the BYTES are yours,
+//! and nothing validates them. #159 is a camera that never enumerated again
+//! after invented bytes reached its firmware. Send only values the device
+//! itself reported: `def` asks the device and writes its own `GET_DEF`.
+//!
+//! Usage:
+//!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> def
+//!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> <b0,b1,...>
+//!
+//! Bytes are decimal or 0x-hex, comma-separated, and must match GET_LEN.
+
+use irlume_camera::ir_emitter::raw;
+use irlume_camera::uvc_descriptor;
+
+fn parse_byte(s: &str) -> Result<u8, String> {
+    let s = s.trim();
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u8::from_str_radix(hex, 16).map_err(|e| format!("{s}: {e}"))
+    } else {
+        s.parse().map_err(|e| format!("{s}: {e}"))
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let [device, unit, selector, value] = args.as_slice() else {
+        return Err("usage: xu_set <video-dev> <unit> <selector> <def|b0,b1,...>".to_string());
+    };
+    let unit: u8 = unit.parse().map_err(|e| format!("unit {unit}: {e}"))?;
+    let selector: u8 = selector
+        .parse()
+        .map_err(|e| format!("selector {selector}: {e}"))?;
+
+    let dev = v4l::Device::with_path(device).map_err(|e| format!("open {device}: {e}"))?;
+    let handle = dev.handle();
+    let fd = handle.fd();
+
+    // The same gate every irlume write passes: the camera must say the control
+    // exists. Identity comes from the open descriptor, not the path.
+    let id = uvc_descriptor::identity_from_fd(fd)
+        .map_err(|e| format!("read {device}'s USB descriptors: {e}"))?;
+    let published = id
+        .microsoft_xu()
+        .is_some_and(|ms| ms.unit_id == unit && ms.advertises(selector));
+    if !published {
+        return Err(format!(
+            "{} does not publish unit {unit} selector {selector} on its Microsoft XU; \
+             refusing to write to a control the camera never said it has",
+            id.usb_id()
+        ));
+    }
+
+    let len = raw::get_len(fd, unit, selector)?;
+    let before = raw::get_cur(fd, unit, selector, len)?;
+    let payload = if value == "def" {
+        raw::get_def(fd, unit, selector, len)?
+    } else {
+        value
+            .split(',')
+            .map(parse_byte)
+            .collect::<Result<Vec<u8>, String>>()?
+    };
+    if payload.len() != len {
+        return Err(format!(
+            "the control takes {len} bytes, {} given; nothing was sent",
+            payload.len()
+        ));
+    }
+    eprintln!("xu_set: unit{unit}/sel{selector} before: {before:02x?}");
+    raw::set_cur(fd, unit, selector, &payload)?;
+    let after = raw::get_cur(fd, unit, selector, len)?;
+    eprintln!("xu_set: unit{unit}/sel{selector} wrote:  {payload:02x?}");
+    eprintln!("xu_set: unit{unit}/sel{selector} after:  {after:02x?}");
+    if after != payload {
+        eprintln!("xu_set: note: the control did not read back what was written");
+    }
+    Ok(())
+}
+
+fn main() {
+    if let Err(why) = run() {
+        eprintln!("xu_set: {why}");
+        std::process::exit(1);
+    }
+}

--- a/crates/irlume-camera/examples/xu_set.rs
+++ b/crates/irlume-camera/examples/xu_set.rs
@@ -23,10 +23,12 @@
 //! itself reported: `def` asks the device and writes its own `GET_DEF`.
 //!
 //! Usage:
+//!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> get
 //!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> def
 //!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> <b0,b1,...>
 //!
-//! Bytes are decimal or 0x-hex, comma-separated, and must match GET_LEN.
+//! `get` reads GET_CUR and writes nothing at all. Bytes are decimal or 0x-hex,
+//! comma-separated, and must match GET_LEN.
 
 use irlume_camera::ir_emitter::raw;
 use irlume_camera::uvc_descriptor;
@@ -43,7 +45,7 @@ fn parse_byte(s: &str) -> Result<u8, String> {
 fn run() -> Result<(), String> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let [device, unit, selector, value] = args.as_slice() else {
-        return Err("usage: xu_set <video-dev> <unit> <selector> <def|b0,b1,...>".to_string());
+        return Err("usage: xu_set <video-dev> <unit> <selector> <get|def|b0,b1,...>".to_string());
     };
     let unit: u8 = unit.parse().map_err(|e| format!("unit {unit}: {e}"))?;
     let selector: u8 = selector
@@ -71,6 +73,11 @@ fn run() -> Result<(), String> {
 
     let len = raw::get_len(fd, unit, selector)?;
     let before = raw::get_cur(fd, unit, selector, len)?;
+    if value == "get" {
+        // Read-only: the one line a harness parses, and no ioctl but GETs.
+        println!("{}", before.iter().map(|b| format!("{b:02x}")).collect::<String>());
+        return Ok(());
+    }
     let payload = if value == "def" {
         raw::get_def(fd, unit, selector, len)?
     } else {

--- a/crates/irlume-camera/examples/xu_set.rs
+++ b/crates/irlume-camera/examples/xu_set.rs
@@ -104,7 +104,13 @@ fn run() -> Result<(), String> {
     eprintln!("xu_set: unit{unit}/sel{selector} wrote:  {payload:02x?}");
     eprintln!("xu_set: unit{unit}/sel{selector} after:  {after:02x?}");
     if after != payload {
-        eprintln!("xu_set: note: the control did not read back what was written");
+        // An exit status the harnesses can key on: a camera that clamps,
+        // ignores or rewrites the payload has NOT been put into the state
+        // the caller asked for, and a park or plant that silently did not
+        // take makes every assertion built on it vacuous.
+        return Err(format!(
+            "the control did not take the value: wrote {payload:02x?}, reads {after:02x?}"
+        ));
     }
     Ok(())
 }

--- a/crates/irlume-camera/examples/xu_set.rs
+++ b/crates/irlume-camera/examples/xu_set.rs
@@ -75,7 +75,13 @@ fn run() -> Result<(), String> {
     let before = raw::get_cur(fd, unit, selector, len)?;
     if value == "get" {
         // Read-only: the one line a harness parses, and no ioctl but GETs.
-        println!("{}", before.iter().map(|b| format!("{b:02x}")).collect::<String>());
+        println!(
+            "{}",
+            before
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        );
         return Ok(());
     }
     let payload = if value == "def" {

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -358,13 +358,35 @@ impl PendingWrite {
 /// So a missing current serial fails CLOSED. The record is found, reported and
 /// left alone; when the serial reads again it is acted on.
 pub(crate) fn describes_this_camera(record: &PendingWrite, id: &CameraIdentity) -> bool {
-    if record.descriptor_sha256 != fingerprint(id) {
+    identity_authorizes(
+        &record.descriptor_sha256,
+        &record.usb_devpath,
+        record.serial.as_deref(),
+        id,
+    )
+}
+
+/// The authorisation rule itself, over a recorded identity's three parts.
+///
+/// One construction, shared with the per-stream leftover record (#188), so
+/// "which camera may a record act on" cannot drift between the two stores. The
+/// rule is [`describes_this_camera`]'s: descriptor digest and device path must
+/// match outright, and a recorded serial the attached camera cannot currently
+/// reproduce refuses — failing OPEN there would let an identical unit in the
+/// same port receive the first camera's bytes.
+pub(crate) fn identity_authorizes(
+    descriptor_sha256: &str,
+    usb_devpath: &str,
+    serial: Option<&str>,
+    id: &CameraIdentity,
+) -> bool {
+    if descriptor_sha256 != fingerprint(id) {
         return false;
     }
-    if record.usb_devpath.is_empty() || record.usb_devpath != id.usb_devpath {
+    if usb_devpath.is_empty() || usb_devpath != id.usb_devpath {
         return false;
     }
-    match (record.serial.as_deref(), id.serial.as_deref()) {
+    match (serial, id.serial.as_deref()) {
         (Some(recorded), Some(attached)) => recorded == attached,
         // The record was written with a discriminator this observation cannot
         // reproduce. Throwing that away and writing anyway is the one direction

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -777,8 +777,17 @@ pub(crate) fn info_allows_set(info: u8) -> bool {
 /// fails validation, which happens before any ioctl. Once a `SET_CUR` has been
 /// sent, its result is the answer: sending a second payload to a camera that just
 /// failed to accept the first is how the search in #159 kept going.
-pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
+///
+/// Takes the `Arc<Handle>` from `v4l::Device::handle()` rather than the raw fd
+/// it wraps. The guard writes to this descriptor when the stream ends, and a
+/// bare integer permitted the device to be dropped first, the number recycled
+/// by the next `open`, and the restore delivered to whatever now holds it —
+/// hardware-target substitution through the API of the type that exists to
+/// prevent it (#189). Holding the `Arc` makes the descriptor outlive the guard
+/// by construction.
+pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &str) -> StreamMode {
     let _ = (card, device);
+    let fd = handle.fd();
     let setting = override_setting(std::env::var("IRLUME_IR_EMITTER"));
     let wanted = match setting {
         OverrideSetting::Disabled => return StreamMode::inert(),
@@ -920,7 +929,7 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
         },
     };
     StreamMode {
-        fd,
+        handle: Some(handle),
         unit,
         selector,
         restore,
@@ -954,7 +963,12 @@ pub fn enable(fd: c_int, card: &str, device: &str) -> StreamMode {
 /// cancelled request. Same reason the undo record in #183 restores from `Drop`.
 #[must_use = "dropping this immediately puts the control back and leaves the stream unlit"]
 pub struct StreamMode {
-    fd: c_int,
+    /// The open camera the mode was applied through, kept alive for as long as
+    /// this guard can write to it. `None` only for a guard over nothing, which
+    /// never writes. A raw `c_int` here let a caller drop the `v4l::Device`
+    /// first and have the restore land on whatever `open` handed the recycled
+    /// number to next (#189); the `Arc` removes that state from the API.
+    handle: Option<std::sync::Arc<v4l::device::Handle>>,
     unit: u8,
     selector: u8,
     /// What the control HELD before irlume touched it, captured before the first
@@ -985,7 +999,7 @@ impl StreamMode {
     /// write `let _ = ...` and silently discard a guard that DID hold a control.
     fn inert() -> Self {
         StreamMode {
-            fd: -1,
+            handle: None,
             unit: 0,
             selector: 0,
             restore: Vec::new(),
@@ -993,6 +1007,14 @@ impl StreamMode {
             armed: false,
             active: false,
         }
+    }
+
+    /// The descriptor the restore goes to, or -1 for a guard holding no camera.
+    ///
+    /// -1 is unreachable from an armed guard: `enable` is the only place that
+    /// arms one, and it always installs the handle it wrote through.
+    fn fd(&self) -> c_int {
+        self.handle.as_ref().map_or(-1, |h| h.fd())
     }
 
     /// Whether the emitter control is active for this stream, whoever set it.
@@ -1072,7 +1094,7 @@ impl StreamMode {
         //
         // A control that no longer holds this guard's value is left alone. The
         // change irlume made is already gone, so there is nothing of its to undo.
-        match get_cur(self.fd, self.unit, self.selector, self.applied.len()) {
+        match get_cur(self.fd(), self.unit, self.selector, self.applied.len()) {
             Ok(now) if now != self.applied => {
                 eprintln!(
                     "irlume: leaving unit{}/sel{} at {:02x?}: it no longer holds what irlume \
@@ -1084,7 +1106,7 @@ impl StreamMode {
             // Unreadable is not evidence that somebody else owns it, and leaving
             // a mode applied because one GET_CUR failed is the worse of the two
             // errors. Fall through and restore.
-            _ => set_cur(self.fd, self.unit, self.selector, &self.restore),
+            _ => set_cur(self.fd(), self.unit, self.selector, &self.restore),
         }
     }
 }
@@ -4508,7 +4530,7 @@ mod tests {
         });
         {
             let _mode = StreamMode {
-                fd: -1,
+                handle: None,
                 unit: 14,
                 selector: 6,
                 restore: vec![1, 3, 1],
@@ -4545,7 +4567,7 @@ mod tests {
         });
         drop(StreamMode::inert());
         drop(StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4578,7 +4600,7 @@ mod tests {
     #[test]
     fn ownership_of_the_restore_does_not_pass_to_a_guard_that_owns_nothing() {
         let held = StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4590,7 +4612,7 @@ mod tests {
         // because the mode IS applied, and owning nothing, because it wrote
         // nothing.
         let already = StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4640,7 +4662,7 @@ mod tests {
         // The guard as `enable` now builds it: restore is what the control HELD,
         // not what the camera calls its default.
         let mut mode = StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: theirs.clone(),
@@ -4678,7 +4700,7 @@ mod tests {
             ..a_working_camera()
         });
         let mut mode = StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4724,7 +4746,7 @@ mod tests {
             ..a_working_camera()
         });
         let mut mode = StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4764,7 +4786,7 @@ mod tests {
             ..a_working_camera()
         });
         let mut mode = StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4817,7 +4839,7 @@ mod tests {
         // The guard, armed the way `enable` arms it: only for `Wrote`. Its end
         // must leave the other writer's bytes exactly where they were.
         drop(StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4921,7 +4943,7 @@ mod tests {
         // The guard, armed the way `enable` arms it: the write went out, but
         // it carried the restore bytes, so nothing is outstanding.
         drop(StreamMode {
-            fd: -1,
+            handle: None,
             unit: 14,
             selector: crate::uvc_descriptor::MSXU_IR_TORCH,
             restore: def.clone(),
@@ -5330,6 +5352,18 @@ mod tests {
         std::fs::File::open("/dev/null").expect("open /dev/null")
     }
 
+    /// A real `Arc<Handle>` over a node that is not a UVC camera.
+    ///
+    /// `Device::with_path` is a plain `open(2)` with no ioctl, so `/dev/null`
+    /// serves. The point is the TYPE: `enable` no longer accepts a bare
+    /// integer, so a test reaches it the same way production does, through a
+    /// handle that keeps the descriptor alive.
+    fn non_uvc_handle() -> std::sync::Arc<v4l::device::Handle> {
+        v4l::Device::with_path("/dev/null")
+            .expect("open /dev/null")
+            .handle()
+    }
+
     #[test]
     fn parse_control_accepts_decimal_and_hex() {
         assert_eq!(
@@ -5541,25 +5575,23 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         // Point the conf away from any real /var/lib/irlume install.
         std::env::set_var("IRLUME_IR_EMITTER_CONF", dir.join("none.conf"));
-        let f = non_uvc_fd();
-        use std::os::fd::AsRawFd;
-        let fd = f.as_raw_fd();
+        let h = non_uvc_handle();
 
         // `off`/`none` disable before any control lookup or ioctl.
         std::env::set_var("IRLUME_IR_EMITTER", "off");
-        assert!(!enable(fd, "ASUS", DEV).lit());
+        assert!(!enable(h.clone(), "ASUS", DEV).lit());
         std::env::set_var("IRLUME_IR_EMITTER", "none");
-        assert!(!enable(fd, "ASUS", DEV).lit());
+        assert!(!enable(h.clone(), "ASUS", DEV).lit());
         // A valid env control is parsed, but SET_CUR on a non-UVC fd fails.
         std::env::set_var("IRLUME_IR_EMITTER", "14:6:1,3,2");
-        assert!(!enable(fd, "whatever", DEV).lit());
+        assert!(!enable(h.clone(), "whatever", DEV).lit());
         std::env::remove_var("IRLUME_IR_EMITTER");
         // The card string is no longer consulted at all; identity comes from
         // the USB IDs, and DEV does not exist, so nothing is applied.
-        assert!(!enable(fd, "Some Unknown Cam", DEV).lit());
+        assert!(!enable(h.clone(), "Some Unknown Cam", DEV).lit());
         // A table entry now requires the USB identity to match AND the
         // descriptor to confirm the unit, neither of which a fake path offers.
-        assert!(!enable(fd, "ASUS", DEV).lit());
+        assert!(!enable(h.clone(), "ASUS", DEV).lit());
         // A persisted control naming an undocumented unit is refused: this is
         // the migration path that stops pre-0.7.1 configs from writing.
         save_conf(
@@ -5571,7 +5603,7 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(!enable(fd, "Some Unknown Cam", DEV).lit());
+        assert!(!enable(h.clone(), "Some Unknown Cam", DEV).lit());
 
         std::env::remove_var("IRLUME_IR_EMITTER_CONF");
         let _ = std::fs::remove_dir_all(&dir);
@@ -5956,14 +5988,13 @@ mod tests {
     /// other tests that could reach a write, and the assertion is on the delta.
     #[test]
     fn a_set_override_writes_nothing_when_the_descriptor_cannot_be_read() {
-        use std::os::fd::AsRawFd;
         use std::sync::atomic::Ordering::SeqCst;
 
         let _g = env_guard();
-        let f = non_uvc_fd();
+        let h = non_uvc_handle();
         std::env::set_var("IRLUME_IR_EMITTER", "14:6:1,3,2,0,0,0,0,0,0");
         let before = writes_attempted().load(SeqCst);
-        let applied = enable(f.as_raw_fd(), "ASUS FHD webcam", "/dev/irlume-test-missing");
+        let applied = enable(h, "ASUS FHD webcam", "/dev/irlume-test-missing");
         let sent = writes_attempted().load(SeqCst) - before;
         std::env::remove_var("IRLUME_IR_EMITTER");
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -934,9 +934,17 @@ fn write_if_different(
                     eprintln!(
                         "irlume: not driving unit{unit}/sel{selector}: an unresolved record \
                          for unit{old_unit}/sel{old_selector} is outstanding on this camera \
-                         and would be destroyed; resolve it first (a later capture on that \
-                         control claims it automatically)"
+                         and would be destroyed; a capture on that control resolves an \
+                         applied record automatically, an unconfirmed one needs a look at \
+                         the ir-emitter-stream store"
                     );
+                    return Ok(CaptureWrite::refused());
+                }
+                // A record this build must not reason its way past: refuse
+                // the write rather than either destroying it or stacking an
+                // unrecorded change on top of it (review round 7).
+                Err(crate::stream_record::SaveError::Protected { why }) => {
+                    eprintln!("irlume: not driving unit{unit}/sel{selector}: {why}");
                     return Ok(CaptureWrite::refused());
                 }
                 // Machine trouble, nobody contesting. Proceed unrecorded, and
@@ -5831,38 +5839,54 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Plant a record through `save` and hand back its file path.
+    fn plant_record(
+        dir: &std::path::Path,
+        id: &crate::uvc_descriptor::CameraIdentity,
+        unit: u8,
+        selector: u8,
+        applied: &[u8],
+        displaced: &[u8],
+        confirmed: bool,
+    ) -> std::path::PathBuf {
+        let lock = crate::stream_record::acquire(id).expect("the lock is free");
+        let record = crate::stream_record::save(lock, id, unit, selector, applied, displaced)
+            .expect("plant a record");
+        if confirmed {
+            drop(record.mark_applied().expect("confirm the planted record"));
+        } else {
+            drop(record);
+        }
+        std::fs::read_dir(dir.join("ir-emitter-stream"))
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| p.extension().is_some_and(|e| e == "json"))
+            .expect("the planted record file")
+    }
+
     /// Bookkeeping failure must not release the stream lock while the write
     /// it covers is live (#188, review round 5): the lock comes back from a
     /// failed save, rides the guard bare, and a failed confirmation keeps
     /// the record handle rather than dropping it.
     #[test]
     fn a_failed_save_keeps_the_lock_held_for_the_streams_lifetime() {
+        // Staged via an UNREADABLE record file (EACCES), which is machine
+        // trouble rather than a protected record. Meaningless as root, where
+        // mode 000 still reads.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipped: running as root, mode 000 does not refuse reads");
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt as _;
         let _lock = crate::testenv::env_lock();
         let dir = std::env::temp_dir().join(format!("irlume-rec-keeplock-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
         let asus = identity(0x3277, 0x0059);
-        // Make the store unusable for saving without touching the lock: an
-        // unparseable file sits where the record would go.
-        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
-        drop(lock); // the acquire created the store dir
-        let record_file = {
-            // The record path is private; find it by planting through save.
-            let lock = crate::stream_record::acquire(&asus).expect("free again");
-            let planted = crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
-                .expect("plant a record to learn the path");
-            let (_, records) = stream_store_state(&dir);
-            assert_eq!(records.len(), 1);
-            drop(planted); // releases the lock, keeps the file
-            let store = dir.join("ir-emitter-stream");
-            std::fs::read_dir(&store)
-                .unwrap()
-                .flatten()
-                .map(|e| e.path())
-                .find(|p| p.extension().is_some_and(|e| e == "json"))
-                .expect("the planted record file")
-        };
-        std::fs::write(&record_file, b"not json").expect("corrupt the record");
+        let record_file = plant_record(&dir, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1], false);
+        std::fs::set_permissions(&record_file, std::fs::Permissions::from_mode(0o000))
+            .expect("make the record unreadable");
 
         let _fake = fake_camera::install(a_working_camera());
         let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
@@ -5884,15 +5908,84 @@ mod tests {
             ),
             "no second irlume may take the camera while the unrecorded change lives"
         );
-        assert_eq!(
-            std::fs::read(&record_file).expect("still there"),
-            b"not json",
-            "the unreadable file was not written over"
-        );
         drop(write);
         assert!(
             crate::stream_record::acquire(&asus).is_ok(),
             "the lock releases when the guard's write handle drops"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A `prepared` record whose write may have SUCCEEDED is protected from
+    /// replacement (#188, review round 7): a crash between the `SET_CUR` and
+    /// the confirmation leaves `prepared` on disk with the applied bytes in
+    /// the control, and its displaced value is the only route back.
+    /// "Authorises nothing" never meant "may be destroyed".
+    #[test]
+    fn a_prepared_record_whose_bytes_are_live_is_not_written_over() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-gap-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        // The crash-in-the-gap shape: prepared record, applied bytes ON the
+        // camera (the SET_CUR landed, the confirmation did not).
+        let record_file = plant_record(&dir, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1], false);
+        let before = std::fs::read(&record_file).expect("the planted record");
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            ..a_working_camera()
+        });
+        // A later configuration wants different bytes on the same control.
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 3]))
+            .expect("the refusal is not an ioctl error");
+        assert_eq!(write.outcome, Applied::Nothing);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no write may stack on an unresolved change: {:?}",
+            fake_camera::log()
+        );
+        assert_eq!(
+            std::fs::read(&record_file).expect("still there"),
+            before,
+            "the gap record survives byte-for-byte"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A record from a build with another schema is never written over
+    /// (#188, review round 7): this build cannot know what it describes, and
+    /// the claim path already refuses to act on it for the same reason.
+    #[test]
+    fn a_foreign_schema_record_is_not_written_over() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-schema-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        let record_file = plant_record(&dir, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1], true);
+        // A newer build's record: same shape, schema 2.
+        let body = std::fs::read_to_string(&record_file).unwrap();
+        let newer = body.replacen("\"schema_version\":1", "\"schema_version\":2", 1);
+        assert_ne!(body, newer, "the schema field must have been rewritten");
+        std::fs::write(&record_file, &newer).unwrap();
+        let _fake = fake_camera::install(a_working_camera());
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("the refusal is not an ioctl error");
+        assert_eq!(write.outcome, Applied::Nothing);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no write may destroy recovery data this build cannot read: {:?}",
+            fake_camera::log()
+        );
+        assert_eq!(
+            std::fs::read_to_string(&record_file).expect("still there"),
+            newer,
+            "the foreign record survives byte-for-byte"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1422,10 +1422,16 @@ impl StreamMode {
                 );
                 Ok(())
             }
-            // Unreadable is not evidence that somebody else owns it, and leaving
-            // a mode applied because one GET_CUR failed is the worse of the two
-            // errors. Fall through and restore.
-            _ => set_cur(self.fd(), self.unit, self.selector, &self.restore),
+            Ok(_) => set_cur(self.fd(), self.unit, self.selector, &self.restore),
+            // An unreadable control authorises NOTHING: writing blind here
+            // could put the restore value over bytes some other client set
+            // mid-stream, the exact class this file exists to prevent. #184
+            // chose to restore anyway, reasoning that a stranded mode was the
+            // worse error — a calculus the claim machinery has since
+            // inverted: this error path re-promotes the record below, so a
+            // recorded change stays claimable and nothing strands, while an
+            // unrecorded one surfaces through the caller (review round 13).
+            Err(e) => Err(e),
         };
         match outcome {
             // Nothing is outstanding any more: the control is back, or the
@@ -5731,6 +5737,67 @@ mod tests {
         assert!(
             matches!(result, Err(RestoreError::Camera(_))),
             "a rejected unrecorded restore must surface, not vanish: {result:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An unreadable control at restore time authorises no write: the value
+    /// there might be a third party's, set mid-stream, and writing blind
+    /// would put the restore bytes over it (review round 13). The record is
+    /// re-promoted so the change stays claimable.
+    #[test]
+    fn an_unreadable_control_is_not_blindly_restored() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-blind-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        let record = crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+            .expect("the record is on disk")
+            .mark_applied()
+            .expect("the write is confirmed");
+        let _fake = fake_camera::install(fake_camera::Camera {
+            // A third party moved the control mid-stream...
+            current: vec![7, 7, 7],
+            ..a_working_camera()
+        });
+        // ...and the read-back fails transiently.
+        fake_camera::fail_reads(libc::EIO);
+        let mut mode = StreamMode {
+            handle: None,
+            record: Some(record),
+            _lock: None,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        };
+        let result = mode.restore();
+        assert!(
+            matches!(result, Err(RestoreError::Camera(_))),
+            "an unverifiable restore must surface, not succeed: {result:?}"
+        );
+        drop(mode);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no write may go to a control that cannot be read: {:?}",
+            fake_camera::log()
+        );
+        assert_eq!(
+            fake_camera::current(),
+            vec![7, 7, 7],
+            "the third party's value survives"
+        );
+        let (_, records) = stream_store_state(&dir);
+        assert_eq!(
+            records[0].state,
+            crate::stream_record::WriteState::Applied,
+            "the change stays claimable for a session that CAN read the control"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1191,6 +1191,33 @@ pub struct StreamMode {
     record: Option<crate::stream_record::StreamRecord>,
 }
 
+/// Why a restore did not put the control back.
+///
+/// Two causes, and a caller must be able to tell them apart: a camera that
+/// refused or vanished is hardware trouble, while bookkeeping that could not
+/// be written means the restore was deliberately NOT ATTEMPTED and the mode is
+/// still applied (review round 3 — returning `Ok` there made a skipped
+/// restore read as a completed one).
+#[derive(Debug)]
+pub enum RestoreError {
+    /// The camera did not take the read or the write.
+    Camera(XuError),
+    /// The record could not be retired first, so no camera request was made:
+    /// the mode stays applied and the record stays claimable.
+    Bookkeeping(String),
+}
+
+impl std::fmt::Display for RestoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Camera(e) => write!(f, "{e}"),
+            Self::Bookkeeping(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for RestoreError {}
+
 impl StreamMode {
     /// A guard over nothing: no control was applied, so `Drop` writes nothing.
     ///
@@ -1296,9 +1323,9 @@ impl StreamMode {
     /// Public so a caller that wants to put the control back while it can still
     /// REPORT a failure has somewhere to do it. Nothing in production takes that
     /// route today: every restore currently goes through `Drop`, which cannot
-    /// return anything and so can only print. Saying otherwise would describe an
-    /// error path that does not exist.
-    pub fn restore(&mut self) -> XuResult<()> {
+    /// return anything and so can only print. `Err(Bookkeeping)` means no
+    /// camera request was made at all — the mode is still applied, on purpose.
+    pub fn restore(&mut self) -> std::result::Result<(), RestoreError> {
         if !self.armed {
             return Ok(());
         }
@@ -1340,16 +1367,12 @@ impl StreamMode {
             Some(record) => match record.retire() {
                 Ok(record) => Some(record),
                 Err(why) => {
-                    eprintln!(
-                        "irlume: not restoring unit{}/sel{}: its stream record cannot be \
-                         retired ({why}); the mode stays applied and the record stays \
-                         claimable for the next session",
+                    return Err(RestoreError::Bookkeeping(format!(
+                        "not restoring unit{}/sel{}: its stream record cannot be retired \
+                         ({why}); the mode stays applied and the record stays claimable \
+                         for the next session",
                         self.unit, self.selector
-                    );
-                    // Fully reported just above, and returning an error here
-                    // would make `Drop` blame the camera for a filesystem
-                    // problem. The guard restored nothing, on purpose.
-                    return Ok(());
+                    )));
                 }
             },
             None => None,
@@ -1398,7 +1421,7 @@ impl StreamMode {
                         }
                     }
                 }
-                Err(e)
+                Err(RestoreError::Camera(e))
             }
         }
     }
@@ -5571,7 +5594,7 @@ mod tests {
             current: vec![1, 3, 2],
             ..a_working_camera()
         });
-        drop(StreamMode {
+        let mut mode = StreamMode {
             handle: None,
             record: Some(record),
             unit: 14,
@@ -5580,7 +5603,17 @@ mod tests {
             applied: vec![1, 3, 2],
             armed: true,
             active: true,
-        });
+        };
+        let result = mode.restore();
+        assert!(
+            matches!(result, Err(RestoreError::Bookkeeping(_))),
+            "a restore that sends no camera request must not report success: {result:?}"
+        );
+        assert!(
+            !mode.owns_restore(),
+            "the failed attempt must not be repeated by Drop"
+        );
+        drop(mode);
         assert!(
             !fake_camera::log()
                 .iter()

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -879,7 +879,31 @@ fn write_if_different(
     wanted: &[u8],
     id: &crate::uvc_descriptor::CameraIdentity,
 ) -> XuResult<CaptureWrite> {
-    let lock = crate::stream_record::acquire(id);
+    let lock = match crate::stream_record::acquire(id) {
+        Ok(lock) => Some(lock),
+        // A LIVE irlume guard owns this camera. Writing anyway — even
+        // unrecorded — is what review round 4 caught: the owner's restore
+        // would read the newcomer's bytes as "somebody else's", discard the
+        // only record, and the newcomer's own restore would then put the
+        // OWNER'S value back instead of the original. Nothing is sent at
+        // all; the control keeps whatever the live owner is doing with it.
+        Err(crate::stream_record::AcquireError::Busy) => {
+            eprintln!(
+                "irlume: not driving unit{unit}/sel{selector}: another live irlume stream \
+                 owns this camera's emitter"
+            );
+            return Ok(CaptureWrite::refused());
+        }
+        // Machine trouble, nobody contesting: proceed without bookkeeping,
+        // the same degradation as an unwritable record.
+        Err(crate::stream_record::AcquireError::Unavailable(why)) => {
+            eprintln!(
+                "irlume: cannot lock unit{unit}/sel{selector}'s emitter bookkeeping ({why}); \
+                 driving the emitter without crash recovery"
+            );
+            None
+        }
+    };
     let current = get_cur(fd, unit, selector, len)?;
     if current == *wanted {
         // Said distinctly from `Wrote` because the two diverge at stream end:
@@ -907,10 +931,8 @@ fn write_if_different(
                 }
             }
         }
-        // Another live irlume guard owns this camera's bookkeeping. Its lock
-        // is the exclusion that keeps two records from replacing each other;
-        // this write proceeds without one, degraded exactly as a save failure
-        // is. Quiet: the frozen-stream restart lands here at every reopen.
+        // The store is unusable (reported above); nobody contests the
+        // camera, so the write proceeds without bookkeeping.
         None => None,
     };
     if set_cur(fd, unit, selector, wanted).is_ok() {
@@ -1270,39 +1292,13 @@ impl StreamMode {
     /// the replacement is armed, and an unarmed replacement leaves the old guard
     /// to put the value back.
     ///
-    /// The leftover record is NOT resolved here: the change it describes is
-    /// still outstanding, now owned by the replacement. The caller moves the
-    /// record across with `take_record`, because the
-    /// replacement cannot have one of its own — this guard held the
-    /// per-camera stream lock the whole time (#188).
+    /// The leftover record is NOT resolved here: giving up the restore gives
+    /// up the bookkeeping with it, and dropping this guard then releases the
+    /// lock and leaves the file — which no longer matters, because since
+    /// review round 4 no second guard can have WRITTEN while this one lived,
+    /// so a disarmed guard's record describes a change nobody made twice.
     pub fn disarm(&mut self) {
         self.armed = false;
-    }
-
-    /// Take the leftover record (and the stream lock inside it) out of this
-    /// guard, for handing to the replacement that now owns the restore.
-    pub(crate) fn take_record(&mut self) -> Option<crate::stream_record::StreamRecord> {
-        self.record.take()
-    }
-
-    /// Install a record handed over from the guard this one replaces.
-    ///
-    /// Only for the frozen-stream restart: the old guard held the stream lock,
-    /// so this replacement wrote UNRECORDED and its `record` is `None`; the
-    /// old record still describes the outstanding change (same control, same
-    /// applied bytes — the replacement re-derives the same mode). The one
-    /// divergence is the displaced value: this guard restores its own
-    /// in-memory reading, while a claim after a crash restores the record's,
-    /// which is the ORIGINAL pre-irlume value from before the first apply.
-    /// Older truth, device-derived either way.
-    ///
-    /// A replacement that somehow has its own record keeps it: the handed-in
-    /// one is the stale of the two, and dropping it unresolved releases the
-    /// lock while leaving the newer bookkeeping in place.
-    pub(crate) fn adopt_record(&mut self, record: Option<crate::stream_record::StreamRecord>) {
-        if self.record.is_none() {
-            self.record = record;
-        }
     }
 
     /// Whether this guard owns an outstanding change that still has to be put
@@ -5438,8 +5434,11 @@ mod tests {
         // within one process too, which is what the frozen-stream restart
         // leans on.
         assert!(
-            crate::stream_record::acquire(&asus).is_none(),
-            "the stream lock must be refused while its owner lives"
+            matches!(
+                crate::stream_record::acquire(&asus),
+                Err(crate::stream_record::AcquireError::Busy)
+            ),
+            "the stream lock must be refused as BUSY while its owner lives"
         );
 
         // The crash: lock released, file kept, control still holding the mode.
@@ -5668,6 +5667,47 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A write contested by a LIVE irlume guard is refused outright, not made
+    /// unrecorded (#188, review round 4). An unrecorded second write would
+    /// make the owner's restore read the newcomer's bytes as another
+    /// program's, discard the only record, and the newcomer would then
+    /// restore the OWNER'S value instead of the original: the camera ends at
+    /// a value neither stream found, with nothing left to say so.
+    #[test]
+    fn a_contested_write_is_refused_not_made_unrecorded() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-busy-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        // The live owner, holding the camera's stream lock.
+        let owner = crate::stream_record::acquire(&asus).expect("the lock is free");
+        let _fake = fake_camera::install(a_working_camera());
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("a busy refusal is not an ioctl error");
+        assert_eq!(write.outcome, Applied::Nothing);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no write may reach a camera a live guard owns: {:?}",
+            fake_camera::log()
+        );
+        assert!(
+            !fake_camera::log().iter().any(|r| matches!(
+                r,
+                fake_camera::Request::Get {
+                    query: UVC_GET_CUR,
+                    ..
+                }
+            )),
+            "the control is not even read once the lock reports a live owner: {:?}",
+            fake_camera::log()
+        );
+        drop(owner);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// A value somebody else set is left alone: same bytes, no record, no
     /// claim, no write (#188).
     #[test]
@@ -5723,7 +5763,7 @@ mod tests {
             ;
         for attempt in 1..=crate::stream_record::MAX_RESTORE_ATTEMPTS {
             let lock = crate::stream_record::acquire(&asus)
-                .unwrap_or_else(|| panic!("the lock is free before claim {attempt}"));
+                .unwrap_or_else(|_| panic!("the lock is free before claim {attempt}"));
             let (_, record) = crate::stream_record::claim(lock, &asus, 14, 6, &[1, 3, 2])
                 .unwrap_or_else(|| panic!("claim {attempt} is within the limit"));
             // Every restore "fails": the record handle drops unresolved, as

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -798,11 +798,17 @@ struct CaptureWrite {
     outcome: Applied,
     /// What `GET_CUR` answered immediately before the write decision.
     current: Vec<u8>,
-    /// The leftover record covering the write (#188), on disk and locked from
-    /// just before the `SET_CUR`. Present only when the outcome is `Wrote` and
-    /// the store took it; carried to the stream guard, which resolves it when
-    /// the change is no longer outstanding.
+    /// The leftover record covering the write (#188), on disk from just
+    /// before the `SET_CUR` and confirmed after it. Present only when the
+    /// outcome is `Wrote` and the store took both steps; carried to the
+    /// stream guard, which resolves it when the change is no longer
+    /// outstanding.
     record: Option<crate::stream_record::StreamRecord>,
+    /// The per-camera stream lock, still held, when the outcome is
+    /// `AlreadyHeld`: the caller needs it to CLAIM a crash leftover, and
+    /// taking it again would deadlock against ourselves. `None` on every
+    /// other outcome — a write's lock lives inside its record.
+    lock: Option<crate::stream_record::StreamLock>,
 }
 
 impl CaptureWrite {
@@ -813,6 +819,7 @@ impl CaptureWrite {
             outcome: Applied::Nothing,
             current: Vec::new(),
             record: None,
+            lock: None,
         }
     }
 }
@@ -839,18 +846,31 @@ impl CaptureWrite {
 /// as a refusal either way. A `GET_CUR` that cannot be read IS an error — with
 /// no answer there is no restore value, so nothing may be written.
 ///
-/// Between the read and the write, the leftover record goes on disk (#188): a
-/// crash after the `SET_CUR` must leave something saying whose value is in the
-/// control, and recording after the write would leave the same gap one level
-/// down — the ordering the #183 journal establishes for discovery writes,
-/// carried over. Recording is BEST-EFFORT, in the opposite direction from that
-/// journal, and deliberately: a discovery write is exploratory bytes nobody
-/// can re-derive, so an unwritable journal refuses the write; this record is
+/// Around the write sits the leftover record (#188), in two phases. The
+/// PREPARED record goes on disk before the `SET_CUR`, because recording after
+/// the write leaves a crash window with an unrecorded write in it; it is
+/// rewritten as APPLIED once the camera accepts, because a record published
+/// before a write that never happened must not authorise a claim — the value
+/// it matches could be another program's later, deliberate choice. Both steps
+/// happen under the per-camera stream lock, taken here BEFORE the read so the
+/// value recorded as displaced is the one read under the same exclusion that
+/// covers the write.
+///
+/// `current` is the last value THIS PROCESS observed before its `SET_CUR`.
+/// UVC exposes GET_CUR and SET_CUR as separate requests with no
+/// compare-and-swap, so the lock serialises irlume's own writers only; a
+/// non-cooperating client can still move the control inside the window, and
+/// its value would be overwritten and not restored. That window cannot be
+/// closed from software on this interface.
+///
+/// Recording is BEST-EFFORT, in the opposite direction from the #183 journal,
+/// and deliberately: a discovery write is exploratory bytes nobody can
+/// re-derive, so an unwritable journal refuses the write; this record is
 /// crash bookkeeping for a documented mode derived from the camera itself,
-/// and refusing here would turn a full store or read-only state directory
-/// into IR authentication going dark. The cost of proceeding unrecorded is
-/// that a kill mid-stream leaves a leftover no later session can claim, which
-/// is exactly the pre-#188 status quo.
+/// and refusing here would turn a full store, a read-only state directory or
+/// a busy lock into IR authentication going dark. The cost of proceeding
+/// unrecorded is that a kill mid-stream leaves a leftover no later session
+/// can claim, which is exactly the pre-#188 status quo.
 fn write_if_different(
     fd: c_int,
     unit: u8,
@@ -859,39 +879,66 @@ fn write_if_different(
     wanted: &[u8],
     id: &crate::uvc_descriptor::CameraIdentity,
 ) -> XuResult<CaptureWrite> {
+    let lock = crate::stream_record::acquire(id);
     let current = get_cur(fd, unit, selector, len)?;
     if current == *wanted {
         // Said distinctly from `Wrote` because the two diverge at stream end:
         // these bytes are another writer's state, and a guard armed here would
-        // end the stream by writing over them.
+        // end the stream by writing over them. The lock rides along so the
+        // caller can ask whether a stream record marks them as irlume's own.
         return Ok(CaptureWrite {
             outcome: Applied::AlreadyHeld,
             current,
             record: None,
+            lock,
         });
     }
-    let record = match crate::stream_record::save(id, unit, selector, wanted, &current) {
-        Ok(record) => Some(record),
-        Err(why) => {
-            eprintln!(
-                "irlume: cannot record this stream's write to unit{unit}/sel{selector} ({why}); \
-                 driving the emitter anyway — a crash before the restore would leave the mode \
-                 set with nothing marking it as irlume's"
-            );
-            None
+    let record = match lock {
+        Some(lock) => {
+            match crate::stream_record::save(lock, id, unit, selector, wanted, &current) {
+                Ok(record) => Some(record),
+                Err(why) => {
+                    eprintln!(
+                        "irlume: cannot record this stream's write to unit{unit}/sel{selector} \
+                         ({why}); driving the emitter anyway — a crash before the restore would \
+                         leave the mode set with nothing marking it as irlume's"
+                    );
+                    None
+                }
+            }
         }
+        // Another live irlume guard owns this camera's bookkeeping. Its lock
+        // is the exclusion that keeps two records from replacing each other;
+        // this write proceeds without one, degraded exactly as a save failure
+        // is. Quiet: the frozen-stream restart lands here at every reopen.
+        None => None,
     };
     if set_cur(fd, unit, selector, wanted).is_ok() {
+        // Confirm only after the camera accepted. A failure here leaves the
+        // record PREPARED on disk: the write happened, but a crash from this
+        // state leaves a leftover no claim will touch, which is reported by
+        // mark_applied and is the safe direction.
+        let record = record.and_then(|r| match r.mark_applied() {
+            Ok(r) => Some(r),
+            Err(why) => {
+                eprintln!(
+                    "irlume: the emitter write to unit{unit}/sel{selector} succeeded but its \
+                     record could not be confirmed ({why}); a crash before the restore would \
+                     leave a leftover no later session will claim"
+                );
+                None
+            }
+        });
         return Ok(CaptureWrite {
             outcome: Applied::Wrote,
             current,
             record,
+            lock: None,
         });
     }
     // The write never landed, so the record describes a change that does not
-    // exist; a leftover of it would refuse to claim anyway (the control holds
-    // the displaced value, not the applied one), but there is no reason to
-    // leave it lying around.
+    // exist; a leftover of it would refuse to claim anyway (prepared records
+    // never authorise), but there is no reason to leave it lying around.
     if let Some(record) = record {
         record.resolve();
     }
@@ -899,6 +946,7 @@ fn write_if_different(
         outcome: Applied::Nothing,
         current,
         record: None,
+        lock: None,
     })
 }
 
@@ -1060,12 +1108,13 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
     let (restore, record) = match write {
         Some(w) => match w.outcome {
             Applied::Wrote => (Some(w.current), w.record),
-            Applied::AlreadyHeld => {
-                match crate::stream_record::claim(&id, unit, selector, &w.current) {
-                    Some((displaced, record)) => (Some(displaced), Some(record)),
-                    None => (None, None),
-                }
-            }
+            Applied::AlreadyHeld => match w
+                .lock
+                .and_then(|lock| crate::stream_record::claim(lock, &id, unit, selector, &w.current))
+            {
+                Some((displaced, record)) => (Some(displaced), Some(record)),
+                None => (None, None),
+            },
             Applied::Nothing => (None, None),
         },
         None => (None, None),
@@ -1191,12 +1240,39 @@ impl StreamMode {
     /// the replacement is armed, and an unarmed replacement leaves the old guard
     /// to put the value back.
     ///
-    /// The leftover record is NOT resolved here, and must not be: an armed
-    /// replacement has already renamed its own record over this one's name, so
-    /// this guard's inode is nameless and evaporates when the handle drops.
-    /// Resolving would race the replacement for the path (#188).
+    /// The leftover record is NOT resolved here: the change it describes is
+    /// still outstanding, now owned by the replacement. The caller moves the
+    /// record across with [`take_record`](Self::take_record), because the
+    /// replacement cannot have one of its own — this guard held the
+    /// per-camera stream lock the whole time (#188).
     pub fn disarm(&mut self) {
         self.armed = false;
+    }
+
+    /// Take the leftover record (and the stream lock inside it) out of this
+    /// guard, for handing to the replacement that now owns the restore.
+    pub(crate) fn take_record(&mut self) -> Option<crate::stream_record::StreamRecord> {
+        self.record.take()
+    }
+
+    /// Install a record handed over from the guard this one replaces.
+    ///
+    /// Only for the frozen-stream restart: the old guard held the stream lock,
+    /// so this replacement wrote UNRECORDED and its `record` is `None`; the
+    /// old record still describes the outstanding change (same control, same
+    /// applied bytes — the replacement re-derives the same mode). The one
+    /// divergence is the displaced value: this guard restores its own
+    /// in-memory reading, while a claim after a crash restores the record's,
+    /// which is the ORIGINAL pre-irlume value from before the first apply.
+    /// Older truth, device-derived either way.
+    ///
+    /// A replacement that somehow has its own record keeps it: the handed-in
+    /// one is the stale of the two, and dropping it unresolved releases the
+    /// lock while leaving the newer bookkeeping in place.
+    pub(crate) fn adopt_record(&mut self, record: Option<crate::stream_record::StreamRecord>) {
+        if self.record.is_none() {
+            self.record = record;
+        }
     }
 
     /// Whether this guard owns an outstanding change that still has to be put
@@ -5028,6 +5104,11 @@ mod tests {
             "the stream end must not put the default over a value irlume never set"
         );
 
+        // The AlreadyHeld result above still holds the per-camera stream
+        // lock; while it lives, a second apply on this camera runs unrecorded
+        // by design. Release it before staging the write below.
+        drop(outcome);
+
         // The distinction cuts the other way too: a control holding something
         // else IS written, and that write is irlume's to undo.
         fake_camera::set_current(vec![1, 3, 1]);
@@ -5209,6 +5290,13 @@ mod tests {
                         record.applied, record.displaced
                     ));
                 }
+                if record.state != crate::stream_record::WriteState::Prepared {
+                    return Err(format!(
+                        "the record is {:?} at the instant of the write; nothing has \
+                         confirmed yet, so it must be Prepared",
+                        record.state
+                    ));
+                }
                 Ok(())
             })),
             ..a_working_camera()
@@ -5223,6 +5311,12 @@ mod tests {
                 .any(|r| matches!(r, fake_camera::Request::FailedPrecondition(_))),
             "the record was not on disk when the write went out: {:?}",
             fake_camera::log()
+        );
+        let (_, records) = stream_store_state(&dir);
+        assert_eq!(
+            records[0].state,
+            crate::stream_record::WriteState::Applied,
+            "once the camera accepted, the record must be confirmed"
         );
         // The guard, wired the way `enable` wires it, resolves the record when
         // it puts the control back.
@@ -5267,11 +5361,14 @@ mod tests {
         assert_eq!(write.outcome, Applied::Wrote);
         let record = write.record.expect("the write is covered by a record");
 
-        // While the writer lives, the control's value is a RUNNING stream's
-        // business.
+        // While the writer lives, the stream lock cannot be taken, so no
+        // claim can even begin: the control's value is a RUNNING stream's
+        // business. `flock` excludes per open file description, so this holds
+        // within one process too, which is what the frozen-stream restart
+        // leans on.
         assert!(
-            crate::stream_record::claim(&asus, 14, 6, &[1, 3, 2]).is_none(),
-            "a record whose writer holds the lock must not be claimed"
+            crate::stream_record::acquire(&asus).is_none(),
+            "the stream lock must be refused while its owner lives"
         );
 
         // The crash: lock released, file kept, control still holding the mode.
@@ -5283,7 +5380,10 @@ mod tests {
         let next = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
             .expect("the next session reads the control");
         assert_eq!(next.outcome, Applied::AlreadyHeld);
-        let (restore, claimed) = crate::stream_record::claim(&asus, 14, 6, &next.current)
+        let lock = next
+            .lock
+            .expect("the dead stream's lock is free for the next session");
+        let (restore, claimed) = crate::stream_record::claim(lock, &asus, 14, 6, &next.current)
             .expect("the leftover is irlume's and must be claimed");
         assert_eq!(
             restore,
@@ -5309,6 +5409,40 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A kill BETWEEN the record and the write forges no ownership (#188,
+    /// review round 1). The prepared record's bytes can match a value another
+    /// program deliberately sets LATER; restoring over that would be a
+    /// firmware write on the strength of a write that never happened.
+    #[test]
+    fn a_record_without_a_confirmed_write_is_not_claimed() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-prepared-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        // The kill: a prepared record hits the disk and its process dies
+        // before the SET_CUR. No hardware effect exists.
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        drop(
+            crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+                .expect("the prepared record is on disk"),
+        );
+        // Later, another program deliberately sets the exact same bytes.
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            ..a_working_camera()
+        });
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("the control reads");
+        assert_eq!(write.outcome, Applied::AlreadyHeld);
+        let lock = write.lock.expect("the dead process's lock is free");
+        assert!(
+            crate::stream_record::claim(lock, &asus, 14, 6, &write.current).is_none(),
+            "a prepared record matches these bytes and must still authorise nothing"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// A value somebody else set is left alone: same bytes, no record, no
     /// claim, no write (#188).
     #[test]
@@ -5326,8 +5460,9 @@ mod tests {
         let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
             .expect("the control reads");
         assert_eq!(write.outcome, Applied::AlreadyHeld);
+        let lock = write.lock.expect("no other guard lives, the lock is free");
         assert!(
-            crate::stream_record::claim(&asus, 14, 6, &write.current).is_none(),
+            crate::stream_record::claim(lock, &asus, 14, 6, &write.current).is_none(),
             "no record exists, so these bytes are another writer's state"
         );
         assert!(
@@ -5353,12 +5488,18 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
         let asus = identity(0x3277, 0x0059);
-        crate::stream_record::save(&asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+        let seed_lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        crate::stream_record::save(seed_lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
             .expect("seed the leftover")
-            // The seeding "stream" dies without resolving.
+            .mark_applied()
+            .expect("the seed write is confirmed")
+            // The seeding "stream" dies without resolving: the drop releases
+            // the lock and keeps the file.
             ;
         for attempt in 1..=crate::stream_record::MAX_RESTORE_ATTEMPTS {
-            let (_, record) = crate::stream_record::claim(&asus, 14, 6, &[1, 3, 2])
+            let lock = crate::stream_record::acquire(&asus)
+                .unwrap_or_else(|| panic!("the lock is free before claim {attempt}"));
+            let (_, record) = crate::stream_record::claim(lock, &asus, 14, 6, &[1, 3, 2])
                 .unwrap_or_else(|| panic!("claim {attempt} is within the limit"));
             // Every restore "fails": the record handle drops unresolved, as
             // the guard leaves it when its SET_CUR errors.
@@ -5369,8 +5510,9 @@ mod tests {
                 "the attempt is counted on disk before the write it authorises"
             );
         }
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
         assert!(
-            crate::stream_record::claim(&asus, 14, 6, &[1, 3, 2]).is_none(),
+            crate::stream_record::claim(lock, &asus, 14, 6, &[1, 3, 2]).is_none(),
             "the fourth claim is refused: the control never resolves and \
              writing again is the loop the counter stops"
         );

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1340,11 +1340,11 @@ impl StreamMode {
 
     /// Put the control back now, rather than waiting for the drop.
     ///
-    /// Public so a caller that wants to put the control back while it can still
-    /// REPORT a failure has somewhere to do it. Nothing in production takes that
-    /// route today: every restore currently goes through `Drop`, which cannot
-    /// return anything and so can only print. `Err(Bookkeeping)` means no
-    /// camera request was made at all — the mode is still applied, on purpose.
+    /// Used by the frozen-stream restart paths, which must restore the old
+    /// stream's change (and surface a failure) before opening and arming the
+    /// replacement; `Drop` remains the ordinary end-of-session path, and can
+    /// only print. `Err(Bookkeeping)` means no camera request was made at
+    /// all — the mode is still applied, on purpose.
     pub fn restore(&mut self) -> std::result::Result<(), RestoreError> {
         if !self.armed {
             return Ok(());
@@ -5697,6 +5697,42 @@ mod tests {
             "the control is back despite the broken store"
         );
         let _ = std::fs::remove_file(&dir);
+    }
+
+    /// An UNRECORDED guard whose restore write fails surfaces the failure:
+    /// the caller (the frozen-stream restart) must know, because nothing on
+    /// disk marks the leftover and a swallowed error would strand it
+    /// (review round 12).
+    #[test]
+    fn an_unrecorded_guards_failed_restore_reports_the_camera_error() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-unrec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            fail_set_from: Some((1, libc::EIO)),
+            ..a_working_camera()
+        });
+        let mut mode = StreamMode {
+            handle: None,
+            record: None,
+            _lock: Some(lock),
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        };
+        let result = mode.restore();
+        assert!(
+            matches!(result, Err(RestoreError::Camera(_))),
+            "a rejected unrecorded restore must surface, not vanish: {result:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A restore the camera rejects puts the record back into force, so the

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -804,10 +804,11 @@ struct CaptureWrite {
     /// stream guard, which resolves it when the change is no longer
     /// outstanding.
     record: Option<crate::stream_record::StreamRecord>,
-    /// The per-camera stream lock, still held, when the outcome is
-    /// `AlreadyHeld`: the caller needs it to CLAIM a crash leftover, and
-    /// taking it again would deadlock against ourselves. `None` on every
-    /// other outcome — a write's lock lives inside its record.
+    /// The per-camera stream lock, still held, in two cases: `AlreadyHeld`,
+    /// where the caller needs it to CLAIM a crash leftover; and a `Wrote`
+    /// whose record could not be saved, where the lock must outlive the
+    /// bookkeeping trouble or a second irlume takes the camera mid-stream
+    /// (review round 5). A recorded write's lock lives inside its record.
     lock: Option<crate::stream_record::StreamLock>,
 }
 
@@ -917,51 +918,75 @@ fn write_if_different(
             lock,
         });
     }
-    let record = match lock {
+    let (record, bare_lock) = match lock {
         Some(lock) => {
             match crate::stream_record::save(lock, id, unit, selector, wanted, &current) {
-                Ok(record) => Some(record),
-                Err(why) => {
+                Ok(record) => (Some(record), None),
+                // An applied record for a change that may still be live sits
+                // at this camera's path. Writing would either destroy its
+                // only recovery data (rename over it) or make an unrecorded
+                // change on top of an unresolved one. Neither; nothing is
+                // sent (review round 5).
+                Err(crate::stream_record::SaveError::Outstanding {
+                    unit: old_unit,
+                    selector: old_selector,
+                }) => {
+                    eprintln!(
+                        "irlume: not driving unit{unit}/sel{selector}: an unresolved record \
+                         for unit{old_unit}/sel{old_selector} is outstanding on this camera \
+                         and would be destroyed; resolve it first (a later capture on that \
+                         control claims it automatically)"
+                    );
+                    return Ok(CaptureWrite::refused());
+                }
+                // Machine trouble, nobody contesting. Proceed unrecorded, and
+                // KEEP the lock: dropping it here handed the camera to a
+                // second irlume mid-stream (review round 5).
+                Err(crate::stream_record::SaveError::Unavailable { lock, why }) => {
                     eprintln!(
                         "irlume: cannot record this stream's write to unit{unit}/sel{selector} \
                          ({why}); driving the emitter anyway — a crash before the restore would \
                          leave the mode set with nothing marking it as irlume's"
                     );
-                    None
+                    (None, Some(lock))
                 }
             }
         }
-        // The store is unusable (reported above); nobody contests the
-        // camera, so the write proceeds without bookkeeping.
-        None => None,
+        // The lock itself is unavailable (reported at acquire); nobody
+        // demonstrably contests the camera, so the write proceeds without
+        // bookkeeping or exclusion — there is nothing left to hold.
+        None => (None, None),
     };
     if set_cur(fd, unit, selector, wanted).is_ok() {
         // Confirm only after the camera accepted. A failure here leaves the
-        // record PREPARED on disk: the write happened, but a crash from this
-        // state leaves a leftover no claim will touch, which is reported by
-        // mark_applied and is the safe direction.
-        let record = record.and_then(|r| match r.mark_applied() {
-            Ok(r) => Some(r),
-            Err(why) => {
+        // record PREPARED on disk — the write happened, but a crash from this
+        // state leaves a leftover no claim will touch, which is reported and
+        // is the safe direction — and the HANDLE is kept: it holds the stream
+        // lock, which must live as long as the change does.
+        let record = record.map(|r| match r.mark_applied() {
+            Ok(r) => r,
+            Err(e) => {
+                let (r, why) = *e;
                 eprintln!(
                     "irlume: the emitter write to unit{unit}/sel{selector} succeeded but its \
                      record could not be confirmed ({why}); a crash before the restore would \
                      leave a leftover no later session will claim"
                 );
-                None
+                r
             }
         });
         return Ok(CaptureWrite {
             outcome: Applied::Wrote,
             current,
             record,
-            lock: None,
+            lock: bare_lock,
         });
     }
     // The write never landed, so the record describes a change that does not
     // exist; a leftover of it would refuse to claim anyway (prepared records
     // never authorise), but there is no reason to leave it lying around. A
-    // failed removal is inert litter for the same reason.
+    // failed removal is inert litter for the same reason, and no hardware
+    // change exists for the lock to protect.
     if let Some(record) = record {
         if let Err(why) = record.resolve() {
             eprintln!("irlume: {why}");
@@ -1130,19 +1155,19 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
     // refuses while the record's writer is alive, which is also what keeps a
     // frozen-stream restart's fresh guard from taking the restore out from
     // under the old one in this same process.
-    let (restore, record) = match write {
+    let (restore, record, lock) = match write {
         Some(w) => match w.outcome {
-            Applied::Wrote => (Some(w.current), w.record),
+            Applied::Wrote => (Some(w.current), w.record, w.lock),
             Applied::AlreadyHeld => match w
                 .lock
                 .and_then(|lock| crate::stream_record::claim(lock, &id, unit, selector, &w.current))
             {
-                Some((displaced, record)) => (Some(displaced), Some(record)),
-                None => (None, None),
+                Some((displaced, record)) => (Some(displaced), Some(record), None),
+                None => (None, None, None),
             },
-            Applied::Nothing => (None, None),
+            Applied::Nothing => (None, None, None),
         },
-        None => (None, None),
+        None => (None, None, None),
     };
     StreamMode {
         handle: Some(handle),
@@ -1153,6 +1178,7 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         active,
         applied,
         record,
+        _lock: lock,
     }
 }
 
@@ -1211,6 +1237,11 @@ pub struct StreamMode {
     /// concludes there is nothing left to undo; left behind, unlocked, when
     /// the restore write fails, so the next session can claim it.
     record: Option<crate::stream_record::StreamRecord>,
+    /// The bare stream lock, held (never read) when this guard's write could
+    /// not be RECORDED: the exclusion must still outlive the change, or a
+    /// second irlume takes the camera mid-stream (review round 5). `None`
+    /// whenever a record exists — the lock lives inside it then.
+    _lock: Option<crate::stream_record::StreamLock>,
 }
 
 /// Why a restore did not put the control back.
@@ -1250,6 +1281,7 @@ impl StreamMode {
         StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 0,
             selector: 0,
             restore: Vec::new(),
@@ -1362,7 +1394,13 @@ impl StreamMode {
         let record = match self.record.take() {
             Some(record) => match record.retire() {
                 Ok(record) => Some(record),
-                Err(why) => {
+                Err(e) => {
+                    let (record, why) = *e;
+                    // The handle drops HERE, on purpose: this guard will never
+                    // write again, so releasing the lock is what lets the next
+                    // session claim the still-applied record and finish the
+                    // restore this one could not start.
+                    drop(record);
                     return Err(RestoreError::Bookkeeping(format!(
                         "not restoring unit{}/sel{}: its stream record cannot be retired \
                          ({why}); the mode stays applied and the record stays claimable \
@@ -1408,7 +1446,8 @@ impl StreamMode {
                 if let Some(record) = record {
                     match record.mark_applied() {
                         Ok(_kept) => {}
-                        Err(why) => {
+                        Err(e) => {
+                            let why = e.1;
                             eprintln!(
                                 "irlume: the failed restore's record could not be put back \
                                  into force ({why}); the leftover will not be claimed \
@@ -4829,6 +4868,7 @@ mod tests {
             let _mode = StreamMode {
                 handle: None,
                 record: None,
+                _lock: None,
                 unit: 14,
                 selector: 6,
                 restore: vec![1, 3, 1],
@@ -4867,6 +4907,7 @@ mod tests {
         drop(StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4901,6 +4942,7 @@ mod tests {
         let held = StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4914,6 +4956,7 @@ mod tests {
         let already = StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4965,6 +5008,7 @@ mod tests {
         let mut mode = StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: theirs.clone(),
@@ -5004,6 +5048,7 @@ mod tests {
         let mut mode = StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -5051,6 +5096,7 @@ mod tests {
         let mut mode = StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -5092,6 +5138,7 @@ mod tests {
         let mut mode = StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -5157,6 +5204,7 @@ mod tests {
         drop(StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -5390,6 +5438,7 @@ mod tests {
         drop(StreamMode {
             handle: None,
             record: write.record,
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: write.current,
@@ -5463,6 +5512,7 @@ mod tests {
         drop(StreamMode {
             handle: None,
             record: Some(claimed),
+            _lock: None,
             unit: 14,
             selector: 6,
             restore,
@@ -5548,6 +5598,7 @@ mod tests {
         drop(StreamMode {
             handle: None,
             record: Some(record),
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -5596,6 +5647,7 @@ mod tests {
         let mut mode = StreamMode {
             handle: None,
             record: Some(record),
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -5650,6 +5702,7 @@ mod tests {
         drop(StreamMode {
             handle: None,
             record: Some(record),
+            _lock: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -5705,6 +5758,141 @@ mod tests {
             fake_camera::log()
         );
         drop(owner);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A write must not destroy an applied record for a DIFFERENT control
+    /// (#188, review round 5): the record path is per camera, and renaming a
+    /// new record over a live one erases the only recovery data the old
+    /// change has. The write is refused instead.
+    #[test]
+    fn a_write_never_destroys_a_live_record_for_another_control() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-cross-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        // A crash left an applied record for selector 6.
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        drop(
+            crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+                .expect("the record is on disk")
+                .mark_applied()
+                .expect("the write is confirmed"),
+        );
+        // Configuration has moved on: the next capture drives selector 9.
+        let _fake = fake_camera::install(a_working_camera());
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 9, vec![1, 3, 2]))
+            .expect("the refusal is not an ioctl error");
+        assert_eq!(write.outcome, Applied::Nothing);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "no write may land while another control's record is outstanding: {:?}",
+            fake_camera::log()
+        );
+        let (names, records) = stream_store_state(&dir);
+        assert_eq!(names, 1, "the old record survives untouched");
+        assert_eq!(
+            (records[0].unit, records[0].selector, records[0].state),
+            (14, 6, crate::stream_record::WriteState::Applied),
+            "selector 6's recovery data is intact"
+        );
+
+        // The same protection for the SAME control while its leftover is
+        // live: the control still holds the old applied bytes, and a write
+        // of different bytes would orphan them.
+        fake_camera::set_current(vec![1, 3, 2]);
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 3]))
+            .expect("the refusal is not an ioctl error");
+        assert_eq!(write.outcome, Applied::Nothing);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "the live leftover's bytes are still in the control: {:?}",
+            fake_camera::log()
+        );
+
+        // But a SUPERSEDED record (its bytes no longer in the control) is
+        // replaced freely: the leftover it described is already gone.
+        fake_camera::set_current(vec![9, 9, 9]);
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 3]))
+            .expect("a superseded record does not block");
+        assert_eq!(write.outcome, Applied::Wrote);
+        let (_, records) = stream_store_state(&dir);
+        assert_eq!(
+            (records[0].selector, records[0].applied.as_str()),
+            (6, "010303"),
+            "the superseded record is replaced by the new write's"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Bookkeeping failure must not release the stream lock while the write
+    /// it covers is live (#188, review round 5): the lock comes back from a
+    /// failed save, rides the guard bare, and a failed confirmation keeps
+    /// the record handle rather than dropping it.
+    #[test]
+    fn a_failed_save_keeps_the_lock_held_for_the_streams_lifetime() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-keeplock-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        // Make the store unusable for saving without touching the lock: an
+        // unparseable file sits where the record would go.
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        drop(lock); // the acquire created the store dir
+        let record_file = {
+            // The record path is private; find it by planting through save.
+            let lock = crate::stream_record::acquire(&asus).expect("free again");
+            let planted = crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+                .expect("plant a record to learn the path");
+            let (_, records) = stream_store_state(&dir);
+            assert_eq!(records.len(), 1);
+            drop(planted); // releases the lock, keeps the file
+            let store = dir.join("ir-emitter-stream");
+            std::fs::read_dir(&store)
+                .unwrap()
+                .flatten()
+                .map(|e| e.path())
+                .find(|p| p.extension().is_some_and(|e| e == "json"))
+                .expect("the planted record file")
+        };
+        std::fs::write(&record_file, b"not json").expect("corrupt the record");
+
+        let _fake = fake_camera::install(a_working_camera());
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("an unavailable store does not refuse the write");
+        assert_eq!(
+            write.outcome,
+            Applied::Wrote,
+            "machine trouble costs bookkeeping, not authentication"
+        );
+        assert!(write.record.is_none(), "nothing was recorded");
+        assert!(
+            write.lock.is_some(),
+            "the lock must ride the unrecorded write for the stream's lifetime"
+        );
+        assert!(
+            matches!(
+                crate::stream_record::acquire(&asus),
+                Err(crate::stream_record::AcquireError::Busy)
+            ),
+            "no second irlume may take the camera while the unrecorded change lives"
+        );
+        assert_eq!(
+            std::fs::read(&record_file).expect("still there"),
+            b"not json",
+            "the unreadable file was not written over"
+        );
+        drop(write);
+        assert!(
+            crate::stream_record::acquire(&asus).is_ok(),
+            "the lock releases when the guard's write handle drops"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -5856,6 +6044,7 @@ mod tests {
         drop(StreamMode {
             handle: None,
             record: None,
+            _lock: None,
             unit: 14,
             selector: crate::uvc_descriptor::MSXU_IR_TORCH,
             restore: def.clone(),

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -5652,6 +5652,53 @@ mod tests {
         let _ = std::fs::remove_file(&dir);
     }
 
+    /// A record whose confirmation failed must not BLOCK the restore when the
+    /// store stays broken (#188, review round 10): it is already `prepared`
+    /// on disk and in memory, authorises nothing, and retiring it needs no
+    /// rewrite. The hardware cleanup proceeds.
+    #[test]
+    fn a_failed_confirmation_does_not_block_the_restore() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-noblock-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        let record = crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+            .expect("the prepared record is on disk");
+        // The store breaks between the write and its confirmation, and STAYS
+        // broken through the stream's end.
+        std::fs::remove_dir_all(&dir).expect("clear the store");
+        std::fs::write(&dir, b"not a directory").expect("plant a file at the store root");
+        let record = match record.mark_applied() {
+            Ok(_) => panic!("the confirmation must fail on the broken store"),
+            Err(e) => e.0,
+        };
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            ..a_working_camera()
+        });
+        let mut mode = StreamMode {
+            handle: None,
+            record: Some(record),
+            _lock: None,
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        };
+        mode.restore()
+            .expect("an unconfirmed record must not block the hardware cleanup");
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 1],
+            "the control is back despite the broken store"
+        );
+        let _ = std::fs::remove_file(&dir);
+    }
+
     /// A restore the camera rejects puts the record back into force, so the
     /// still-real leftover stays claimable (#188).
     #[test]

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -755,11 +755,16 @@ pub(crate) fn info_allows_set(info: u8) -> bool {
 /// When `outcome` is `Wrote`, `current` is what the write DISPLACED, read on
 /// the same pass that decided to write, and it is the only value a stream
 /// guard may put back.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 struct CaptureWrite {
     outcome: Applied,
     /// What `GET_CUR` answered immediately before the write decision.
     current: Vec<u8>,
+    /// The leftover record covering the write (#188), on disk and locked from
+    /// just before the `SET_CUR`. Present only when the outcome is `Wrote` and
+    /// the store took it; carried to the stream guard, which resolves it when
+    /// the change is no longer outstanding.
+    record: Option<crate::stream_record::StreamRecord>,
 }
 
 impl CaptureWrite {
@@ -769,6 +774,7 @@ impl CaptureWrite {
         CaptureWrite {
             outcome: Applied::Nothing,
             current: Vec::new(),
+            record: None,
         }
     }
 }
@@ -794,12 +800,26 @@ impl CaptureWrite {
 /// used to propagate it discarded the detail, and the override memo records it
 /// as a refusal either way. A `GET_CUR` that cannot be read IS an error — with
 /// no answer there is no restore value, so nothing may be written.
+///
+/// Between the read and the write, the leftover record goes on disk (#188): a
+/// crash after the `SET_CUR` must leave something saying whose value is in the
+/// control, and recording after the write would leave the same gap one level
+/// down — the ordering the #183 journal establishes for discovery writes,
+/// carried over. Recording is BEST-EFFORT, in the opposite direction from that
+/// journal, and deliberately: a discovery write is exploratory bytes nobody
+/// can re-derive, so an unwritable journal refuses the write; this record is
+/// crash bookkeeping for a documented mode derived from the camera itself,
+/// and refusing here would turn a full store or read-only state directory
+/// into IR authentication going dark. The cost of proceeding unrecorded is
+/// that a kill mid-stream leaves a leftover no later session can claim, which
+/// is exactly the pre-#188 status quo.
 fn write_if_different(
     fd: c_int,
     unit: u8,
     selector: u8,
     len: usize,
     wanted: &[u8],
+    id: &crate::uvc_descriptor::CameraIdentity,
 ) -> XuResult<CaptureWrite> {
     let current = get_cur(fd, unit, selector, len)?;
     if current == *wanted {
@@ -809,14 +829,39 @@ fn write_if_different(
         return Ok(CaptureWrite {
             outcome: Applied::AlreadyHeld,
             current,
+            record: None,
         });
     }
-    let outcome = if set_cur(fd, unit, selector, wanted).is_ok() {
-        Applied::Wrote
-    } else {
-        Applied::Nothing
+    let record = match crate::stream_record::save(id, unit, selector, wanted, &current) {
+        Ok(record) => Some(record),
+        Err(why) => {
+            eprintln!(
+                "irlume: cannot record this stream's write to unit{unit}/sel{selector} ({why}); \
+                 driving the emitter anyway — a crash before the restore would leave the mode \
+                 set with nothing marking it as irlume's"
+            );
+            None
+        }
     };
-    Ok(CaptureWrite { outcome, current })
+    if set_cur(fd, unit, selector, wanted).is_ok() {
+        return Ok(CaptureWrite {
+            outcome: Applied::Wrote,
+            current,
+            record,
+        });
+    }
+    // The write never landed, so the record describes a change that does not
+    // exist; a leftover of it would refuse to claim anyway (the control holds
+    // the displaced value, not the applied one), but there is no reason to
+    // leave it lying around.
+    if let Some(record) = record {
+        record.resolve();
+    }
+    Ok(CaptureWrite {
+        outcome: Applied::Nothing,
+        current,
+        record: None,
+    })
 }
 
 /// Light the emitter on the open `fd` for `device`, if a control is configured.
@@ -952,12 +997,12 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
             (Some(apply_override(fd, &id, &ctrl)), payload)
         }
         CaptureAction::DeviceDefault { unit, selector } => {
-            match apply_device_default(fd, unit, selector) {
+            match apply_device_default(fd, &id, unit, selector) {
                 Ok((w, sent)) => (Some(w), sent),
                 Err(_) => (None, Vec::new()),
             }
         }
-        CaptureAction::KnownPayload(ctrl) => match apply_known_payload(fd, &ctrl) {
+        CaptureAction::KnownPayload(ctrl) => match apply_known_payload(fd, &id, &ctrl) {
             Ok(w) => (Some(w), ctrl.payload),
             Err(_) => (None, Vec::new()),
         },
@@ -965,9 +1010,28 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
     let active = write
         .as_ref()
         .is_some_and(|w| w.outcome != Applied::Nothing);
-    let restore = write
-        .filter(|w| w.outcome == Applied::Wrote)
-        .map(|w| w.current);
+    // What the guard owns: a write of its own, with the value it displaced —
+    // or a crash leftover claimed through the stream record (#188). A control
+    // already holding the wanted bytes is another writer's state EXCEPT when a
+    // record for this camera, this control and these bytes marks it as
+    // irlume's own unrestored change; then the guard arms with the recorded
+    // displaced value and finishes what the killed stream could not. The claim
+    // refuses while the record's writer is alive, which is also what keeps a
+    // frozen-stream restart's fresh guard from taking the restore out from
+    // under the old one in this same process.
+    let (restore, record) = match write {
+        Some(w) => match w.outcome {
+            Applied::Wrote => (Some(w.current), w.record),
+            Applied::AlreadyHeld => {
+                match crate::stream_record::claim(&id, unit, selector, &w.current) {
+                    Some((displaced, record)) => (Some(displaced), Some(record)),
+                    None => (None, None),
+                }
+            }
+            Applied::Nothing => (None, None),
+        },
+        None => (None, None),
+    };
     StreamMode {
         handle: Some(handle),
         unit,
@@ -976,6 +1040,7 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         restore: restore.unwrap_or_default(),
         active,
         applied,
+        record,
     }
 }
 
@@ -1029,6 +1094,11 @@ pub struct StreamMode {
     /// and the caller prints "IR is dark with no active emitter" on that, which
     /// would have been a false statement about the camera.
     active: bool,
+    /// The on-disk leftover record for the outstanding change (#188), locked
+    /// for as long as this guard lives. Resolved (removed) when the guard
+    /// concludes there is nothing left to undo; left behind, unlocked, when
+    /// the restore write fails, so the next session can claim it.
+    record: Option<crate::stream_record::StreamRecord>,
 }
 
 impl StreamMode {
@@ -1040,6 +1110,7 @@ impl StreamMode {
     fn inert() -> Self {
         StreamMode {
             handle: None,
+            record: None,
             unit: 0,
             selector: 0,
             restore: Vec::new(),
@@ -1081,6 +1152,11 @@ impl StreamMode {
     /// exit on both cameras here. So the caller gives the old guard up only when
     /// the replacement is armed, and an unarmed replacement leaves the old guard
     /// to put the value back.
+    ///
+    /// The leftover record is NOT resolved here, and must not be: an armed
+    /// replacement has already renamed its own record over this one's name, so
+    /// this guard's inode is nameless and evaporates when the handle drops.
+    /// Resolving would race the replacement for the path (#188).
     pub fn disarm(&mut self) {
         self.armed = false;
     }
@@ -1134,7 +1210,7 @@ impl StreamMode {
         //
         // A control that no longer holds this guard's value is left alone. The
         // change irlume made is already gone, so there is nothing of its to undo.
-        match get_cur(self.fd(), self.unit, self.selector, self.applied.len()) {
+        let outcome = match get_cur(self.fd(), self.unit, self.selector, self.applied.len()) {
             Ok(now) if now != self.applied => {
                 eprintln!(
                     "irlume: leaving unit{}/sel{} at {:02x?}: it no longer holds what irlume \
@@ -1147,6 +1223,21 @@ impl StreamMode {
             // a mode applied because one GET_CUR failed is the worse of the two
             // errors. Fall through and restore.
             _ => set_cur(self.fd(), self.unit, self.selector, &self.restore),
+        };
+        match outcome {
+            // Nothing is outstanding any more: the control is back, or the
+            // change irlume made is already gone. Either way the record must
+            // not outlive the fact it records (#188).
+            Ok(()) => {
+                if let Some(record) = self.record.take() {
+                    record.resolve();
+                }
+                Ok(())
+            }
+            // The restore write failed, so the leftover is REAL. The record
+            // stays on disk for the next session to claim; its lock releases
+            // when this handle drops, and the guard is already disarmed.
+            Err(e) => Err(e),
         }
     }
 }
@@ -1689,7 +1780,7 @@ fn check_and_apply_override(
             given: ctrl.payload.len(),
         });
     }
-    write_if_different(fd, unit, selector, len, &ctrl.payload).map_err(|err| {
+    write_if_different(fd, unit, selector, len, &ctrl.payload, id).map_err(|err| {
         OverrideRefusal::Unreadable {
             unit,
             selector,
@@ -1706,7 +1797,11 @@ fn check_and_apply_override(
 /// that size right now. Writing a nine-byte payload to a control the camera has
 /// just reported as disabled, or as a different length, is not something a
 /// validated VID:PID should buy.
-fn apply_known_payload(fd: c_int, ctrl: &EmitterControl) -> XuResult<CaptureWrite> {
+fn apply_known_payload(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    ctrl: &EmitterControl,
+) -> XuResult<CaptureWrite> {
     if !info_allows_set(get_info(fd, ctrl.unit, ctrl.selector)?) {
         return Err(XuError::Unsupported);
     }
@@ -1714,7 +1809,7 @@ fn apply_known_payload(fd: c_int, ctrl: &EmitterControl) -> XuResult<CaptureWrit
     if len != ctrl.payload.len() {
         return Err(XuError::Unsupported);
     }
-    write_if_different(fd, ctrl.unit, ctrl.selector, len, &ctrl.payload)
+    write_if_different(fd, ctrl.unit, ctrl.selector, len, &ctrl.payload, id)
 }
 
 /// The bytes to write for one documented control, or why the camera has not
@@ -1766,7 +1861,12 @@ fn intended_value(
 /// this function derives them and the caller needs them: `enable` records what
 /// the guard APPLIED, which for IR Torch is the camera's own default rather
 /// than anything the caller named.
-fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<(CaptureWrite, Vec<u8>)> {
+fn apply_device_default(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    unit: u8,
+    selector: u8,
+) -> XuResult<(CaptureWrite, Vec<u8>)> {
     if !info_allows_set(get_info(fd, unit, selector)?) {
         return Err(XuError::Unsupported);
     }
@@ -1774,7 +1874,7 @@ fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<(CaptureW
     let Ok(wanted) = intended_value(fd, unit, selector, len)? else {
         return Err(XuError::Unsupported);
     };
-    let write = write_if_different(fd, unit, selector, len, &wanted)?;
+    let write = write_if_different(fd, unit, selector, len, &wanted, id)?;
     Ok((write, wanted))
 }
 
@@ -4547,6 +4647,7 @@ mod tests {
         {
             let _mode = StreamMode {
                 handle: None,
+                record: None,
                 unit: 14,
                 selector: 6,
                 restore: vec![1, 3, 1],
@@ -4584,6 +4685,7 @@ mod tests {
         drop(StreamMode::inert());
         drop(StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4617,6 +4719,7 @@ mod tests {
     fn ownership_of_the_restore_does_not_pass_to_a_guard_that_owns_nothing() {
         let held = StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4629,6 +4732,7 @@ mod tests {
         // nothing.
         let already = StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4679,6 +4783,7 @@ mod tests {
         // not what the camera calls its default.
         let mut mode = StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: theirs.clone(),
@@ -4717,6 +4822,7 @@ mod tests {
         });
         let mut mode = StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4763,6 +4869,7 @@ mod tests {
         });
         let mut mode = StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4803,6 +4910,7 @@ mod tests {
         });
         let mut mode = StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4830,6 +4938,9 @@ mod tests {
     #[test]
     fn an_override_the_control_already_holds_is_not_written_or_undone() {
         let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-already-held-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
         let _fake = fake_camera::install(fake_camera::Camera {
             // Some other tool already put the exact payload the override names
             // into the control.
@@ -4839,13 +4950,18 @@ mod tests {
         let asus = identity(0x3277, 0x0059);
 
         let outcome = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]));
+        let held = outcome
+            .as_ref()
+            .expect("a value found in place is a success");
         assert_eq!(
-            outcome,
-            Ok(CaptureWrite {
-                outcome: Applied::AlreadyHeld,
-                current: vec![1, 3, 2],
-            }),
+            held.outcome,
+            Applied::AlreadyHeld,
             "a value found in place is a success, but not irlume's write"
+        );
+        assert_eq!(held.current, vec![1, 3, 2]);
+        assert!(
+            held.record.is_none(),
+            "no write went out, so there is no leftover to record"
         );
         assert!(
             !fake_camera::log()
@@ -4859,6 +4975,7 @@ mod tests {
         // must leave the other writer's bytes exactly where they were.
         drop(StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: 6,
             restore: vec![1, 3, 1],
@@ -4876,14 +4993,19 @@ mod tests {
         // The distinction cuts the other way too: a control holding something
         // else IS written, and that write is irlume's to undo.
         fake_camera::set_current(vec![1, 3, 1]);
+        let written = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("a control holding something else is written");
+        assert_eq!(written.outcome, Applied::Wrote);
         assert_eq!(
-            check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2])),
-            Ok(CaptureWrite {
-                outcome: Applied::Wrote,
-                current: vec![1, 3, 1],
-            }),
+            written.current,
+            vec![1, 3, 1],
             "a write reports the value it displaced, read on the same pass"
         );
+        assert!(
+            written.record.is_some(),
+            "a write that went out is covered by a leftover record"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A built-in payload the control already holds is not written or claimed.
@@ -4895,6 +5017,10 @@ mod tests {
     #[test]
     fn a_known_payload_the_control_already_holds_is_not_rewritten() {
         let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-known-held-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
         let payload = vec![1, 3, 2];
         let _fake = fake_camera::install(fake_camera::Camera {
             current: payload.clone(),
@@ -4908,7 +5034,7 @@ mod tests {
             payload: payload.clone(),
         };
         assert_eq!(
-            apply_known_payload(-1, &ctrl)
+            apply_known_payload(-1, &asus, &ctrl)
                 .expect("a control that already agrees is not an error")
                 .outcome,
             Applied::AlreadyHeld,
@@ -4924,15 +5050,16 @@ mod tests {
         // And a control holding something else is still written, or the guard
         // above would have turned the whole path off.
         fake_camera::set_current(vec![9, 9, 9]);
+        let written =
+            apply_known_payload(-1, &asus, &ctrl).expect("a control that disagrees is written");
+        assert_eq!(written.outcome, Applied::Wrote);
         assert_eq!(
-            apply_known_payload(-1, &ctrl).expect("a control that disagrees is written"),
-            CaptureWrite {
-                outcome: Applied::Wrote,
-                current: vec![9, 9, 9],
-            },
+            written.current,
+            vec![9, 9, 9],
             "the write reports the value it displaced"
         );
         assert_eq!(fake_camera::current(), payload);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The apply path reads the control ONCE, and the value it reports as
@@ -4947,6 +5074,9 @@ mod tests {
     #[test]
     fn one_read_decides_and_its_answer_is_what_the_write_displaced() {
         let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-one-read-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
         let _fake = fake_camera::install(fake_camera::Camera {
             current: vec![7, 7, 7],
             len: 3,
@@ -4956,12 +5086,10 @@ mod tests {
         let asus = identity(0x3277, 0x0059);
         let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
             .expect("a published control with a valid payload is applied");
+        assert_eq!(write.outcome, Applied::Wrote);
         assert_eq!(
-            write,
-            CaptureWrite {
-                outcome: Applied::Wrote,
-                current: vec![7, 7, 7],
-            },
+            write.current,
+            vec![7, 7, 7],
             "the displaced value is the one read's answer"
         );
         assert_eq!(
@@ -4983,6 +5111,262 @@ mod tests {
             ],
             "exactly one GET_CUR, immediately before the write it authorises"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Records left in the stream store, as (filename count, parsed records).
+    fn stream_store_state(
+        dir: &std::path::Path,
+    ) -> (usize, Vec<crate::stream_record::StreamWrite>) {
+        let store = dir.join("ir-emitter-stream");
+        let Ok(entries) = std::fs::read_dir(&store) else {
+            return (0, Vec::new());
+        };
+        let mut names = 0;
+        let mut records = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_none_or(|e| e != "json") {
+                continue;
+            }
+            names += 1;
+            if let Ok(body) = std::fs::read_to_string(&path) {
+                if let Ok(record) = serde_json::from_str(&body) {
+                    records.push(record);
+                }
+            }
+        }
+        (names, records)
+    }
+
+    /// The leftover record is on disk BEFORE the `SET_CUR` and gone once the
+    /// guard resolves (#188).
+    ///
+    /// The before half is observed at the instant of the write, the only place
+    /// that distinguishes record-then-write from write-then-record — checking
+    /// afterwards cannot tell them apart, and the gap between them is the
+    /// crash window the record exists to cover. Same construction as the #183
+    /// journal's ordering test, for the same reason.
+    #[test]
+    fn the_record_is_on_disk_before_the_write_and_gone_after_the_restore() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-order-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let probe = dir.clone();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            at_first_write: Some(Box::new(move || {
+                let (names, records) = stream_store_state(&probe);
+                if names != 1 {
+                    return Err(format!(
+                        "{names} records on disk at the first SET_CUR, want 1"
+                    ));
+                }
+                let [record] = records.as_slice() else {
+                    return Err("the record on disk does not parse".to_string());
+                };
+                if record.applied != "010302" || record.displaced != "010301" {
+                    return Err(format!(
+                        "the record says applied={} displaced={}, want 010302/010301",
+                        record.applied, record.displaced
+                    ));
+                }
+                Ok(())
+            })),
+            ..a_working_camera()
+        });
+        let asus = identity(0x3277, 0x0059);
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("a published control with a valid payload is applied");
+        assert_eq!(write.outcome, Applied::Wrote);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::FailedPrecondition(_))),
+            "the record was not on disk when the write went out: {:?}",
+            fake_camera::log()
+        );
+        // The guard, wired the way `enable` wires it, resolves the record when
+        // it puts the control back.
+        drop(StreamMode {
+            handle: None,
+            record: write.record,
+            unit: 14,
+            selector: 6,
+            restore: write.current,
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        });
+        assert_eq!(fake_camera::current(), vec![1, 3, 1], "the control is back");
+        assert_eq!(
+            stream_store_state(&dir).0,
+            0,
+            "a record must not outlive a cleanly ended stream"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A killed stream's leftover is claimed by the next session and restored,
+    /// and a claim while the writer still lives is refused (#188).
+    ///
+    /// The crash is simulated by dropping the record handle without resolving
+    /// it, which is byte-for-byte what `SIGKILL` leaves: the file on disk, the
+    /// lock released. Before that drop, the claim must refuse — the lock is
+    /// the liveness signal, and this is the same-process shape the frozen
+    /// stream restart depends on.
+    #[test]
+    fn a_crash_leftover_is_claimed_and_the_next_session_restores_it() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-claim-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _fake = fake_camera::install(a_working_camera());
+        let asus = identity(0x3277, 0x0059);
+
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("the mode is applied");
+        assert_eq!(write.outcome, Applied::Wrote);
+        let record = write.record.expect("the write is covered by a record");
+
+        // While the writer lives, the control's value is a RUNNING stream's
+        // business.
+        assert!(
+            crate::stream_record::claim(&asus, 14, 6, &[1, 3, 2]).is_none(),
+            "a record whose writer holds the lock must not be claimed"
+        );
+
+        // The crash: lock released, file kept, control still holding the mode.
+        drop(record);
+        assert_eq!(fake_camera::current(), vec![1, 3, 2]);
+
+        // The next session finds the value already in place and the record
+        // marks it as irlume's own.
+        let next = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("the next session reads the control");
+        assert_eq!(next.outcome, Applied::AlreadyHeld);
+        let (restore, claimed) = crate::stream_record::claim(&asus, 14, 6, &next.current)
+            .expect("the leftover is irlume's and must be claimed");
+        assert_eq!(
+            restore,
+            vec![1, 3, 1],
+            "the claim hands back what the killed stream displaced"
+        );
+        drop(StreamMode {
+            handle: None,
+            record: Some(claimed),
+            unit: 14,
+            selector: 6,
+            restore,
+            applied: next.current,
+            armed: true,
+            active: true,
+        });
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 1],
+            "the next session finishes the restore the killed one could not"
+        );
+        assert_eq!(stream_store_state(&dir).0, 0, "the claim is resolved");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A value somebody else set is left alone: same bytes, no record, no
+    /// claim, no write (#188).
+    #[test]
+    fn a_value_someone_else_set_is_not_claimed() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-other-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _fake = fake_camera::install(fake_camera::Camera {
+            // Another tool already established the exact wanted value.
+            current: vec![1, 3, 2],
+            ..a_working_camera()
+        });
+        let asus = identity(0x3277, 0x0059);
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("the control reads");
+        assert_eq!(write.outcome, Applied::AlreadyHeld);
+        assert!(
+            crate::stream_record::claim(&asus, 14, 6, &write.current).is_none(),
+            "no record exists, so these bytes are another writer's state"
+        );
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "nothing may be written to a control irlume never changed: {:?}",
+            fake_camera::log()
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Each claim spends one counted attempt, and the fourth is refused (#188).
+    ///
+    /// Simulates a control that keeps reading back as irlume's leftover no
+    /// matter how many restores land — the pathology the counter exists for:
+    /// without it, every stream open would send one more firmware write,
+    /// forever.
+    #[test]
+    fn a_leftover_that_never_resolves_stops_being_claimed_after_three_attempts() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-cap-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        crate::stream_record::save(&asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+            .expect("seed the leftover")
+            // The seeding "stream" dies without resolving.
+            ;
+        for attempt in 1..=crate::stream_record::MAX_RESTORE_ATTEMPTS {
+            let (_, record) = crate::stream_record::claim(&asus, 14, 6, &[1, 3, 2])
+                .unwrap_or_else(|| panic!("claim {attempt} is within the limit"));
+            // Every restore "fails": the record handle drops unresolved, as
+            // the guard leaves it when its SET_CUR errors.
+            drop(record);
+            let (_, records) = stream_store_state(&dir);
+            assert_eq!(
+                records[0].restore_attempts, attempt,
+                "the attempt is counted on disk before the write it authorises"
+            );
+        }
+        assert!(
+            crate::stream_record::claim(&asus, 14, 6, &[1, 3, 2]).is_none(),
+            "the fourth claim is refused: the control never resolves and \
+             writing again is the loop the counter stops"
+        );
+        assert_eq!(
+            stream_store_state(&dir).0,
+            1,
+            "the spent record stays for a human, like the journal's"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A `SET_CUR` the camera rejects leaves no record behind (#188): the
+    /// record would describe a change that never happened.
+    #[test]
+    fn a_rejected_write_leaves_no_record() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-reject-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _fake = fake_camera::install(fake_camera::Camera {
+            fail_set_from: Some((1, libc::EIO)),
+            ..a_working_camera()
+        });
+        let asus = identity(0x3277, 0x0059);
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("the checks pass; only the write is rejected");
+        assert_eq!(write.outcome, Applied::Nothing);
+        assert!(write.record.is_none());
+        assert_eq!(
+            stream_store_state(&dir).0,
+            0,
+            "a record must not describe a write the camera refused"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// IR Torch's applied value IS the camera's default, so there is nothing
@@ -5009,8 +5393,10 @@ mod tests {
             ..Default::default()
         });
 
-        let (write, sent) = apply_device_default(-1, 14, crate::uvc_descriptor::MSXU_IR_TORCH)
-            .expect("a conformant torch takes its own default");
+        let asus = identity(0x3277, 0x0059);
+        let (write, sent) =
+            apply_device_default(-1, &asus, 14, crate::uvc_descriptor::MSXU_IR_TORCH)
+                .expect("a conformant torch takes its own default");
         assert_eq!(sent, def, "the applied bytes are the camera's own GET_DEF");
         // The fixture starts at the default, so there is nothing to write: the
         // torch's own value IS the default, which is the point of the case.
@@ -5024,6 +5410,7 @@ mod tests {
         // it carried the restore bytes, so nothing is outstanding.
         drop(StreamMode {
             handle: None,
+            record: None,
             unit: 14,
             selector: crate::uvc_descriptor::MSXU_IR_TORCH,
             restore: def.clone(),
@@ -6012,18 +6399,18 @@ mod tests {
         let _g = env_guard();
         let asus = identity(0x3277, 0x0059);
         assert_eq!(
-            check_and_apply_override(-1, &asus, &ctrl(3, 1, vec![255])),
-            Err(OverrideRefusal::NoSuchUnit {
+            check_and_apply_override(-1, &asus, &ctrl(3, 1, vec![255])).unwrap_err(),
+            OverrideRefusal::NoSuchUnit {
                 unit: 3,
                 seen: vec![11, 10, 14]
-            })
+            }
         );
         assert_eq!(
-            check_and_apply_override(-1, &asus, &ctrl(14, 10, vec![0; 4])),
-            Err(OverrideRefusal::NotAdvertised {
+            check_and_apply_override(-1, &asus, &ctrl(14, 10, vec![0; 4])).unwrap_err(),
+            OverrideRefusal::NotAdvertised {
                 unit: 14,
                 selector: 10
-            })
+            }
         );
     }
 
@@ -6123,8 +6510,8 @@ mod tests {
             "re-checking must not write"
         );
         assert_eq!(
-            answer,
-            CaptureWrite::refused(),
+            answer.outcome,
+            Applied::Nothing,
             "a camera that cannot answer GET_CUR must not be reported as lit \
              on the strength of an earlier write"
         );

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -750,6 +750,44 @@ pub(crate) fn info_allows_set(info: u8) -> bool {
         && info & DISABLED_BY_COMMIT_STATE == 0
 }
 
+/// Raw, guard-free extension-unit access, for TEST TOOLING ONLY.
+///
+/// Hidden from the documented API on purpose. Everything else in this module
+/// wraps a write in evidence and an undo path; these wrappers exist so
+/// `examples/xu_set.rs` and the hardware harnesses can put a control INTO a
+/// state — parking it at its device default before a discovery run, or
+/// planting another writer's value for the #188 leftover tests. Killing a
+/// daemon mid-capture cannot do either: apply and restore are microseconds
+/// apart, and a shell cannot interpose (measured on the NexiGo, pt192).
+///
+/// The bytes are the caller's. Nothing here validates a payload, and #159 is
+/// what an invented one can cost; the only safe values are ones the device
+/// itself reported (`GET_DEF`, `GET_CUR`).
+#[doc(hidden)]
+pub mod raw {
+    use super::c_int;
+
+    /// `GET_LEN` for a control, as the device reports it.
+    pub fn get_len(fd: c_int, unit: u8, selector: u8) -> Result<usize, String> {
+        super::get_len(fd, unit, selector).map_err(|e| e.to_string())
+    }
+
+    /// One sized read of `GET_CUR`.
+    pub fn get_cur(fd: c_int, unit: u8, selector: u8, len: usize) -> Result<Vec<u8>, String> {
+        super::get_cur(fd, unit, selector, len).map_err(|e| e.to_string())
+    }
+
+    /// One sized read of `GET_DEF`: the device's own parking value.
+    pub fn get_def(fd: c_int, unit: u8, selector: u8, len: usize) -> Result<Vec<u8>, String> {
+        super::get_of(fd, unit, selector, super::UVC_GET_DEF, len).map_err(|e| e.to_string())
+    }
+
+    /// ONE `SET_CUR`, owned by no guard, recorded in no journal.
+    pub fn set_cur(fd: c_int, unit: u8, selector: u8, payload: &[u8]) -> Result<(), String> {
+        super::set_cur(fd, unit, selector, payload).map_err(|e| e.to_string())
+    }
+}
+
 /// What a capture write did, and what its one read answered.
 ///
 /// When `outcome` is `Wrote`, `current` is what the write DISPLACED, read on

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1353,6 +1353,16 @@ impl StreamMode {
         // `Drop` to do; if it fails, `Drop` repeating a write the camera has
         // just refused is how #159 territory is entered.
         //
+        // The bare lock (an unrecorded write's exclusion) is held THROUGH the
+        // restore below and released when this attempt finishes, success or
+        // not: an explicitly restored guard no longer owns a live change, and
+        // the frozen-stream restart calls restore() and then runs a fresh
+        // enable while this guard still exists — a retained lock made that
+        // enable refuse against its own predecessor and the reopened stream
+        // ran dark (review round 9). A RECORDED write's lock lives in the
+        // record and is released by resolve() on the same schedule.
+        let _bare_lock = self._lock.take();
+
         // The early return above is DEFENCE IN DEPTH and a mutant deleting it
         // survives the suite. That is not a missing test: the read-back below
         // subsumes it. On a second call the control already holds `restore`,
@@ -5861,11 +5871,29 @@ mod tests {
             ),
             "no second irlume may take the camera while the unrecorded change lives"
         );
-        drop(write);
+        // The lock must also release on an EXPLICIT restore, before the guard
+        // itself drops: the frozen-stream restart calls restore() and then
+        // runs a fresh enable while the old guard still exists, and a
+        // retained bare lock made that enable refuse against its own
+        // predecessor (review round 9).
+        let mut mode = StreamMode {
+            handle: None,
+            record: None,
+            _lock: write.lock,
+            unit: 14,
+            selector: 6,
+            restore: write.current,
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        };
+        mode.restore().expect("the unrecorded change restores");
         assert!(
             crate::stream_record::acquire(&asus).is_ok(),
-            "the lock releases when the guard's write handle drops"
+            "an explicitly restored guard must release its bare lock before \
+             the replacement enable runs"
         );
+        drop(mode);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -6074,15 +6074,38 @@ mod tests {
         for attempt in 1..=crate::stream_record::MAX_RESTORE_ATTEMPTS {
             let lock = crate::stream_record::acquire(&asus)
                 .unwrap_or_else(|_| panic!("the lock is free before claim {attempt}"));
-            let (_, record) = crate::stream_record::claim(lock, &asus, 14, 6, &[1, 3, 2])
+            let (restore, record) = crate::stream_record::claim(lock, &asus, 14, 6, &[1, 3, 2])
                 .unwrap_or_else(|| panic!("claim {attempt} is within the limit"));
-            // Every restore "fails": the record handle drops unresolved, as
-            // the guard leaves it when its SET_CUR errors.
-            drop(record);
+            // Every restore is ATTEMPTED and rejected by the camera: the
+            // attempt is spent in retire()'s pre-write publication, the
+            // SET_CUR fails, and the re-promotion puts the record back in
+            // force for the next round. A claim abandoned without a restore
+            // attempt spends nothing (review round 11).
+            let _fake = fake_camera::install(fake_camera::Camera {
+                current: vec![1, 3, 2],
+                fail_set_from: Some((1, libc::EIO)),
+                ..a_working_camera()
+            });
+            drop(StreamMode {
+                handle: None,
+                record: Some(record),
+                _lock: None,
+                unit: 14,
+                selector: 6,
+                restore,
+                applied: vec![1, 3, 2],
+                armed: true,
+                active: true,
+            });
             let (_, records) = stream_store_state(&dir);
             assert_eq!(
                 records[0].restore_attempts, attempt,
-                "the attempt is counted on disk before the write it authorises"
+                "the attempt is counted on disk in the step before the write"
+            );
+            assert_eq!(
+                records[0].state,
+                crate::stream_record::WriteState::Applied,
+                "the failed restore re-promotes the record for the next round"
             );
         }
         let lock = crate::stream_record::acquire(&asus).expect("the lock is free");

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1317,29 +1317,13 @@ impl StreamMode {
         self.active
     }
 
-    /// Give up the restore without writing anything.
-    ///
-    /// For one case only: the stream this guard was set for has been torn down
-    /// and reopened, and a FRESH guard has taken over the same control.
-    ///
-    /// Without this, reassigning would drop the old guard after the new `enable`
-    /// had already run, writing the default straight over the value just set.
-    ///
-    /// An earlier version of this comment justified it with "these modules reset
-    /// the control per open". That is not what this project measured: the record
-    /// in `IrCamera::session` says the control survives stream close and process
-    /// exit on both cameras here. So the caller gives the old guard up only when
-    /// the replacement is armed, and an unarmed replacement leaves the old guard
-    /// to put the value back.
-    ///
-    /// The leftover record is NOT resolved here: giving up the restore gives
-    /// up the bookkeeping with it, and dropping this guard then releases the
-    /// lock and leaves the file — which no longer matters, because since
-    /// review round 4 no second guard can have WRITTEN while this one lived,
-    /// so a disarmed guard's record describes a change nobody made twice.
-    pub fn disarm(&mut self) {
-        self.armed = false;
-    }
+    // There used to be a public `disarm()` here, for the frozen-stream
+    // restart's ownership handover. The restart restores before reopening
+    // since review round 4, which removed the method's one production caller
+    // — and a disarmed guard holding an APPLIED record would abandon it,
+    // unlocked and still authoritative, for a later stream to claim against
+    // a value whose owner meant to keep it (review round 8). Ownership moves
+    // by moving the whole guard, or not at all.
 
     /// Whether this guard owns an outstanding change that still has to be put
     /// back.
@@ -5131,37 +5115,6 @@ mod tests {
             "restoring again, and then dropping, must send nothing further"
         );
         assert_eq!(fake_camera::current(), vec![1, 3, 1]);
-    }
-
-    /// `disarm` gives up the restore without writing, for the one case that
-    /// needs it: the stream the guard was set for has been torn down and
-    /// reopened, so a fresh guard covers the new one.
-    #[test]
-    fn disarming_gives_up_the_restore_without_writing() {
-        let _lock = crate::testenv::env_lock();
-        let _fake = fake_camera::install(fake_camera::Camera {
-            current: vec![1, 3, 2],
-            len: 3,
-            ..a_working_camera()
-        });
-        let mut mode = StreamMode {
-            handle: None,
-            record: None,
-            _lock: None,
-            unit: 14,
-            selector: 6,
-            restore: vec![1, 3, 1],
-            applied: vec![1, 3, 2],
-            armed: true,
-            active: true,
-        };
-        mode.disarm();
-        drop(mode);
-        assert_eq!(
-            fake_camera::current(),
-            vec![1, 3, 2],
-            "a disarmed guard must leave the control exactly as it found it"
-        );
     }
 
     /// An override the control already holds is not written, and not undone.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -938,9 +938,12 @@ fn write_if_different(
     }
     // The write never landed, so the record describes a change that does not
     // exist; a leftover of it would refuse to claim anyway (prepared records
-    // never authorise), but there is no reason to leave it lying around.
+    // never authorise), but there is no reason to leave it lying around. A
+    // failed removal is inert litter for the same reason.
     if let Some(record) = record {
-        record.resolve();
+        if let Err(why) = record.resolve() {
+            eprintln!("irlume: {why}");
+        }
     }
     Ok(CaptureWrite {
         outcome: Applied::Nothing,
@@ -1324,6 +1327,33 @@ impl StreamMode {
         //
         // A control that no longer holds this guard's value is left alone. The
         // change irlume made is already gone, so there is nothing of its to undo.
+        // Before anything touches the camera: make the record incapable of
+        // authorising another restore. The unlink at the end can fail, and an
+        // `applied` record outliving its own resolution would later authorise
+        // a firmware write over whatever unrelated value happened to match it
+        // (review round 2). If even the demotion cannot be written, nothing is
+        // restored at all: the mode stays applied and the record stays
+        // claimable, and the next session finishes the job when the store
+        // recovers. Restoring anyway would recreate the exact hole, since a
+        // store that cannot take a rename is not going to take the unlink.
+        let record = match self.record.take() {
+            Some(record) => match record.retire() {
+                Ok(record) => Some(record),
+                Err(why) => {
+                    eprintln!(
+                        "irlume: not restoring unit{}/sel{}: its stream record cannot be \
+                         retired ({why}); the mode stays applied and the record stays \
+                         claimable for the next session",
+                        self.unit, self.selector
+                    );
+                    // Fully reported just above, and returning an error here
+                    // would make `Drop` blame the camera for a filesystem
+                    // problem. The guard restored nothing, on purpose.
+                    return Ok(());
+                }
+            },
+            None => None,
+        };
         let outcome = match get_cur(self.fd(), self.unit, self.selector, self.applied.len()) {
             Ok(now) if now != self.applied => {
                 eprintln!(
@@ -1341,17 +1371,35 @@ impl StreamMode {
         match outcome {
             // Nothing is outstanding any more: the control is back, or the
             // change irlume made is already gone. Either way the record must
-            // not outlive the fact it records (#188).
+            // not outlive the fact it records (#188). A failed unlink costs
+            // litter, not authority: the record was retired above.
             Ok(()) => {
-                if let Some(record) = self.record.take() {
-                    record.resolve();
+                if let Some(record) = record {
+                    if let Err(why) = record.resolve() {
+                        eprintln!("irlume: {why}");
+                    }
                 }
                 Ok(())
             }
-            // The restore write failed, so the leftover is REAL. The record
-            // stays on disk for the next session to claim; its lock releases
-            // when this handle drops, and the guard is already disarmed.
-            Err(e) => Err(e),
+            // The restore write failed, so the leftover is REAL again and the
+            // record must go back into force for the next session to claim.
+            // If the re-promotion fails too, that is reported and the
+            // leftover goes unclaimed — the safe direction, twice over.
+            Err(e) => {
+                if let Some(record) = record {
+                    match record.mark_applied() {
+                        Ok(_kept) => {}
+                        Err(why) => {
+                            eprintln!(
+                                "irlume: the failed restore's record could not be put back \
+                                 into force ({why}); the leftover will not be claimed \
+                                 automatically"
+                            );
+                        }
+                    }
+                }
+                Err(e)
+            }
         }
     }
 }
@@ -5439,6 +5487,150 @@ mod tests {
         assert!(
             crate::stream_record::claim(lock, &asus, 14, 6, &write.current).is_none(),
             "a prepared record matches these bytes and must still authorise nothing"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The record is demoted BEFORE the restoring write, so a failed unlink
+    /// afterwards leaves litter, never authority (#188, review round 2).
+    #[test]
+    fn the_record_is_demoted_before_the_restoring_write() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-demote-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        let record = crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+            .expect("the record is on disk")
+            .mark_applied()
+            .expect("the write is confirmed");
+        let probe = dir.clone();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            // The restore is the only SET this test issues; at its instant
+            // the record must already be non-authoritative.
+            at_first_write: Some(Box::new(move || {
+                let (_, records) = stream_store_state(&probe);
+                match records.as_slice() {
+                    [r] if r.state == crate::stream_record::WriteState::Prepared => Ok(()),
+                    [r] => Err(format!(
+                        "the record is {:?} at the restoring write",
+                        r.state
+                    )),
+                    other => Err(format!("{} records on disk", other.len())),
+                }
+            })),
+            ..a_working_camera()
+        });
+        drop(StreamMode {
+            handle: None,
+            record: Some(record),
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        });
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::FailedPrecondition(_))),
+            "the record still authorised a restore at the instant of the write: {:?}",
+            fake_camera::log()
+        );
+        assert_eq!(fake_camera::current(), vec![1, 3, 1], "the control is back");
+        assert_eq!(
+            stream_store_state(&dir).0,
+            0,
+            "the record is gone afterwards"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A record that cannot be demoted blocks the restore entirely: restoring
+    /// under an `applied` record reopens the round-2 hole, since a store that
+    /// cannot take a rename will not take the unlink either (#188).
+    #[test]
+    fn a_record_that_cannot_be_retired_blocks_the_restore() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-block-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        let record = crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+            .expect("the record is on disk")
+            .mark_applied()
+            .expect("the write is confirmed");
+        // Break the store: the retire's temp file has nowhere to go.
+        std::fs::remove_dir_all(&dir).expect("clear the store");
+        std::fs::write(&dir, b"not a directory").expect("plant a file at the store root");
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            ..a_working_camera()
+        });
+        drop(StreamMode {
+            handle: None,
+            record: Some(record),
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        });
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|r| matches!(r, fake_camera::Request::Set(_))),
+            "nothing may be restored under a record that cannot be demoted: {:?}",
+            fake_camera::log()
+        );
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 2],
+            "the mode stays applied, for the next session to claim"
+        );
+        let _ = std::fs::remove_file(&dir);
+    }
+
+    /// A restore the camera rejects puts the record back into force, so the
+    /// still-real leftover stays claimable (#188).
+    #[test]
+    fn a_failed_restore_repromotes_the_record() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-rec-repromote-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let asus = identity(0x3277, 0x0059);
+        let lock = crate::stream_record::acquire(&asus).expect("the lock is free");
+        let record = crate::stream_record::save(lock, &asus, 14, 6, &[1, 3, 2], &[1, 3, 1])
+            .expect("the record is on disk")
+            .mark_applied()
+            .expect("the write is confirmed");
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 3, 2],
+            fail_set_from: Some((1, libc::EIO)),
+            ..a_working_camera()
+        });
+        drop(StreamMode {
+            handle: None,
+            record: Some(record),
+            unit: 14,
+            selector: 6,
+            restore: vec![1, 3, 1],
+            applied: vec![1, 3, 2],
+            armed: true,
+            active: true,
+        });
+        let (names, records) = stream_store_state(&dir);
+        assert_eq!(names, 1, "the record survives the failed restore");
+        assert_eq!(
+            records[0].state,
+            crate::stream_record::WriteState::Applied,
+            "the leftover is real again, so the record is back in force"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1242,7 +1242,7 @@ impl StreamMode {
     ///
     /// The leftover record is NOT resolved here: the change it describes is
     /// still outstanding, now owned by the replacement. The caller moves the
-    /// record across with [`take_record`](Self::take_record), because the
+    /// record across with `take_record`, because the
     /// replacement cannot have one of its own — this guard held the
     /// per-camera stream lock the whole time (#188).
     pub fn disarm(&mut self) {

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1472,7 +1472,7 @@ impl Drop for StreamMode {
             // which is exactly the state this type exists to prevent, so it is
             // worth a line even though nothing here can react to it.
             eprintln!(
-                "irlume: could not put unit{}/sel{} back to the camera's default: {e}",
+                "irlume: could not put unit{}/sel{} back to the value irlume displaced: {e}",
                 self.unit, self.selector
             );
         }
@@ -4847,7 +4847,8 @@ mod tests {
         assert!(why.contains("disk full"), "got: {why}");
     }
 
-    /// The control goes back to the camera's own default when the stream ends.
+    /// The control goes back to the value irlume displaced when the stream
+    /// ends — its own default here, because the fixture starts there.
     ///
     /// Microsoft's sequence ends by unsetting the property, and the HLK suite
     /// tests that it happened. irlume set the mode and left it. The ASUS module

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -750,6 +750,75 @@ pub(crate) fn info_allows_set(info: u8) -> bool {
         && info & DISABLED_BY_COMMIT_STATE == 0
 }
 
+/// What a capture write did, and what its one read answered.
+///
+/// When `outcome` is `Wrote`, `current` is what the write DISPLACED, read on
+/// the same pass that decided to write, and it is the only value a stream
+/// guard may put back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CaptureWrite {
+    outcome: Applied,
+    /// What `GET_CUR` answered immediately before the write decision.
+    current: Vec<u8>,
+}
+
+impl CaptureWrite {
+    /// Nothing was read and nothing was sent: a check refused before the
+    /// control was consulted at all.
+    fn refused() -> Self {
+        CaptureWrite {
+            outcome: Applied::Nothing,
+            current: Vec::new(),
+        }
+    }
+}
+
+/// The one tail every capture write goes through: read what the control holds,
+/// and write only when it differs.
+///
+/// The read and the write decision are ONE pass, which is the point. `enable`
+/// used to read `GET_CUR` itself, record that as the guard's restore value, and
+/// then let the apply path read `GET_CUR` a second time to decide whether to
+/// write. Another client landing between the two reads got the FIRST, stale
+/// value restored over its own when the stream ended (#190). Here the value the
+/// guard records is the value the write displaced, because they are the same
+/// read.
+///
+/// The restore value used to be `GET_DEF`, on the reading that Microsoft's
+/// sequence ends by "unsetting" the control. That destroys a non-default mode
+/// another program deliberately established; putting back what was displaced
+/// restores a control found at its default to its default, and a control found
+/// anywhere else to where its owner left it.
+///
+/// A `SET_CUR` the camera rejects is `Nothing`, not an error: the callers that
+/// used to propagate it discarded the detail, and the override memo records it
+/// as a refusal either way. A `GET_CUR` that cannot be read IS an error — with
+/// no answer there is no restore value, so nothing may be written.
+fn write_if_different(
+    fd: c_int,
+    unit: u8,
+    selector: u8,
+    len: usize,
+    wanted: &[u8],
+) -> XuResult<CaptureWrite> {
+    let current = get_cur(fd, unit, selector, len)?;
+    if current == *wanted {
+        // Said distinctly from `Wrote` because the two diverge at stream end:
+        // these bytes are another writer's state, and a guard armed here would
+        // end the stream by writing over them.
+        return Ok(CaptureWrite {
+            outcome: Applied::AlreadyHeld,
+            current,
+        });
+    }
+    let outcome = if set_cur(fd, unit, selector, wanted).is_ok() {
+        Applied::Wrote
+    } else {
+        Applied::Nothing
+    };
+    Ok(CaptureWrite { outcome, current })
+}
+
 /// Light the emitter on the open `fd` for `device`, if a control is configured.
 /// Returns whether a `SET_CUR` succeeded. Best-effort.
 ///
@@ -854,86 +923,57 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
     let action = planned_action(&recovery, wanted, &id);
     report_recovery(&id, recovery);
 
-    // Where the write is going, before it goes, so the camera's own default can
-    // be read while the control is still untouched.
+    // Which control the write is going to. Needed here only to give the guard
+    // its coordinates; every read of the control itself happens inside the
+    // apply path, on the same pass that decides whether to write.
     let Some((unit, selector)) = action.coordinates() else {
         return StreamMode::inert();
     };
-    // What the control HOLDS right now, read before anything disturbs it. This is
-    // what the guard puts back.
-    //
-    // It used to record `GET_DEF` instead, on the reading that Microsoft's
-    // sequence ends by "unsetting" the control. That is right whenever the
-    // control is sitting at its default, which is the ordinary case and where
-    // the two values are identical. It is wrong the moment they are not: a
-    // camera another program deliberately left in a non-default mode would be
-    // returned to the DEFAULT when irlume finished, destroying that program's
-    // state while this file repeatedly promises not to undo changes irlume did
-    // not make. Putting back what was displaced honours both, because a control
-    // found at its default is restored to its default.
-    // NOT covered by a unit test: nothing here reaches `enable`, which needs a
-    // real sysfs-backed camera for `identity_from_fd`, so a mutant swapping this
-    // back to GET_DEF survives the suite. What IS covered is the decision the
-    // guard makes about whatever value gets recorded.
-    let restore = match get_len(fd, unit, selector)
-        .and_then(|len| get_of(fd, unit, selector, UVC_GET_CUR, len))
-    {
-        Ok(current) => current,
-        Err(e) => {
-            // Unreadable means no recorded route home, so nothing is applied.
-            // Leaving a control changed with no way back is the state #168
-            // exists to remove.
-            eprintln!(
-                "irlume: not driving unit{unit}/sel{selector}: its current value is unreadable \
-                 ({e}), so there would be no way to put it back"
-            );
-            return StreamMode::inert();
-        }
-    };
 
-    // Armed only when irlume actually CHANGED the control: a write went out,
-    // and it carried bytes other than the ones the guard would put back. Same
-    // rule as the #183 undo journal: irlume does not undo a change it did not
-    // make. Three cases fail that test. A refused write is a change that never
-    // happened, and restoring after it would write to a camera that has just
-    // refused one. An override the control already held is another writer's
-    // state, and a restore would put the default over a value irlume never
-    // set. And IR Torch applies the camera's own default, so its restore would
-    // be a SET_CUR that changes nothing, sent to firmware at the end of every
-    // capture.
-    // Two answers, deliberately not one. `changed` decides whether the guard has
-    // a restore to make; `active` decides what the caller tells the user about
-    // their infrared. A control that already held the wanted value is active and
-    // not irlume's to undo, and collapsing the pair reported it dark.
-    let (changed, active, applied) = match action {
-        CaptureAction::Nothing => (false, false, Vec::new()),
+    // Armed only when irlume actually CHANGED the control, and the guard's
+    // restore value is what that change DISPLACED — the answer of the one
+    // `GET_CUR` in the apply path, not a separate earlier read. Recording an
+    // earlier read left a window: another client writing between the two reads
+    // got the stale value restored over its own (#190). Same rule as the #183
+    // undo journal either way: irlume does not undo a change it did not make.
+    // A refused write is a change that never happened, and an already-held
+    // value is another writer's state. `Wrote` needs no "did it differ" check:
+    // the tail only writes when the displaced value differs from the payload.
+    //
+    // Two answers, deliberately not one. The restore decides whether the guard
+    // has something to put back; `active` decides what the caller tells the
+    // user about their infrared. A control that already held the wanted value
+    // is active and not irlume's to undo, and collapsing the pair reported it
+    // dark.
+    let (write, applied) = match action {
+        CaptureAction::Nothing => (None, Vec::new()),
         CaptureAction::Override(ctrl) => {
-            let outcome = apply_override(fd, &id, &ctrl);
-            let holds = outcome != Applied::Nothing;
-            let changed = outcome == Applied::Wrote && ctrl.payload != restore;
-            (changed, holds, ctrl.payload)
+            let payload = ctrl.payload.clone();
+            (Some(apply_override(fd, &id, &ctrl)), payload)
         }
         CaptureAction::DeviceDefault { unit, selector } => {
             match apply_device_default(fd, unit, selector) {
-                Ok((outcome, sent)) => (outcome == Applied::Wrote && sent != restore, true, sent),
-                Err(_) => (false, false, Vec::new()),
+                Ok((w, sent)) => (Some(w), sent),
+                Err(_) => (None, Vec::new()),
             }
         }
         CaptureAction::KnownPayload(ctrl) => match apply_known_payload(fd, &ctrl) {
-            Ok(outcome) => (
-                outcome == Applied::Wrote && ctrl.payload != restore,
-                true,
-                ctrl.payload,
-            ),
-            Err(_) => (false, false, Vec::new()),
+            Ok(w) => (Some(w), ctrl.payload),
+            Err(_) => (None, Vec::new()),
         },
     };
+    let active = write
+        .as_ref()
+        .is_some_and(|w| w.outcome != Applied::Nothing);
+    let restore = write
+        .filter(|w| w.outcome == Applied::Wrote)
+        .map(|w| w.current);
     StreamMode {
         handle: Some(handle),
         unit,
         selector,
-        restore,
-        armed: changed,
+        armed: restore.is_some(),
+        restore: restore.unwrap_or_default(),
         active,
         applied,
     }
@@ -1458,7 +1498,7 @@ fn apply_override(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
-) -> Applied {
+) -> CaptureWrite {
     let key = match override_key(fd, id, ctrl) {
         Ok(key) => key,
         Err(err) => {
@@ -1467,7 +1507,7 @@ fn apply_override(
                  so irlume cannot tell whether this was already applied",
                 ctrl.encode()
             );
-            return Applied::Nothing;
+            return CaptureWrite::refused();
         }
     };
 
@@ -1492,14 +1532,14 @@ fn apply_override(
                  after a panic, so irlume cannot tell whether this was already applied",
                 ctrl.encode()
             );
-            return Applied::Nothing;
+            return CaptureWrite::refused();
         }
     };
     match reuse(memo.get(&key), &ctrl.payload) {
         // A remembered refusal stands: re-running the checks every capture is
         // the traffic the record exists to stop, and the answer is "no" either
         // way.
-        Reuse::Answer(false) => return Applied::Nothing,
+        Reuse::Answer(false) => return CaptureWrite::refused(),
         // A remembered SUCCESS says this payload was checked against this
         // camera's descriptors and accepted. It does NOT say the control still
         // holds it, and since the mode is now restored when each stream ends it
@@ -1517,13 +1557,13 @@ fn apply_override(
         // the documented sequence, not the repeated writing this change removes.
         Reuse::Answer(true) => {
             return match check_and_apply_override(fd, id, ctrl) {
-                Ok(applied) => applied,
+                Ok(write) => write,
                 Err(why) => {
                     eprintln!(
                         "irlume: refusing IRLUME_IR_EMITTER={}: {why}",
                         ctrl.encode()
                     );
-                    Applied::Nothing
+                    CaptureWrite::refused()
                 }
             }
         }
@@ -1536,12 +1576,12 @@ fn apply_override(
                 ctrl.unit,
                 ctrl.selector
             );
-            return Applied::Nothing;
+            return CaptureWrite::refused();
         }
         Reuse::Decide => {}
     }
-    let outcome = match check_and_apply_override(fd, id, ctrl) {
-        Ok(applied) => applied,
+    let write = match check_and_apply_override(fd, id, ctrl) {
+        Ok(write) => write,
         Err(why) => {
             // Silence here would read as "the value was applied and the camera
             // is simply dark", which is the reading that sends someone back to
@@ -1550,7 +1590,7 @@ fn apply_override(
                 "irlume: refusing IRLUME_IR_EMITTER={}: {why}",
                 ctrl.encode()
             );
-            Applied::Nothing
+            CaptureWrite::refused()
         }
     };
     memo.insert(
@@ -1559,10 +1599,10 @@ fn apply_override(
             payload: ctrl.payload.clone(),
             // The record answers "was this payload accepted", so a value found
             // already in place counts the same as a write the camera took.
-            applied: outcome != Applied::Nothing,
+            applied: write.outcome != Applied::Nothing,
         },
     );
-    outcome
+    write
 }
 
 /// Test-only: hold a caller inside the gate so another thread can observe what
@@ -1610,7 +1650,7 @@ fn check_and_apply_override(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
-) -> std::result::Result<Applied, OverrideRefusal> {
+) -> std::result::Result<CaptureWrite, OverrideRefusal> {
     #[cfg(test)]
     park_inside_for_test();
 
@@ -1649,22 +1689,12 @@ fn check_and_apply_override(
             given: ctrl.payload.len(),
         });
     }
-    let current = get_cur(fd, unit, selector, len).map_err(|err| OverrideRefusal::Unreadable {
-        unit,
-        selector,
-        err,
-    })?;
-    if current == ctrl.payload {
-        // Already holding what the override asks for, so nothing is sent. Said
-        // distinctly from `Wrote` because the two diverge at stream end: these
-        // bytes are another writer's state, and a guard armed here would end
-        // the stream by setting the default over them.
-        return Ok(Applied::AlreadyHeld);
-    }
-    Ok(if set_cur(fd, unit, selector, &ctrl.payload).is_ok() {
-        Applied::Wrote
-    } else {
-        Applied::Nothing
+    write_if_different(fd, unit, selector, len, &ctrl.payload).map_err(|err| {
+        OverrideRefusal::Unreadable {
+            unit,
+            selector,
+            err,
+        }
     })
 }
 
@@ -1676,7 +1706,7 @@ fn check_and_apply_override(
 /// that size right now. Writing a nine-byte payload to a control the camera has
 /// just reported as disabled, or as a different length, is not something a
 /// validated VID:PID should buy.
-fn apply_known_payload(fd: c_int, ctrl: &EmitterControl) -> XuResult<Applied> {
+fn apply_known_payload(fd: c_int, ctrl: &EmitterControl) -> XuResult<CaptureWrite> {
     if !info_allows_set(get_info(fd, ctrl.unit, ctrl.selector)?) {
         return Err(XuError::Unsupported);
     }
@@ -1684,16 +1714,7 @@ fn apply_known_payload(fd: c_int, ctrl: &EmitterControl) -> XuResult<Applied> {
     if len != ctrl.payload.len() {
         return Err(XuError::Unsupported);
     }
-    // The same rule the override path follows: a control already holding these
-    // bytes was not put there by this run, so writing them again would claim a
-    // change irlume did not make, and the end of the stream would clear somebody
-    // else's state. One GET_CUR on a path that has already sent GET_INFO and
-    // GET_LEN.
-    if get_cur(fd, ctrl.unit, ctrl.selector, len)? == ctrl.payload {
-        return Ok(Applied::AlreadyHeld);
-    }
-    set_cur(fd, ctrl.unit, ctrl.selector, &ctrl.payload)?;
-    Ok(Applied::Wrote)
+    write_if_different(fd, ctrl.unit, ctrl.selector, len, &ctrl.payload)
 }
 
 /// The bytes to write for one documented control, or why the camera has not
@@ -1741,11 +1762,11 @@ fn intended_value(
 /// replayed from the file: the value is read out of the camera immediately
 /// before it is written back.
 ///
-/// Returns the bytes that went out, because only this function knows them and
-/// the caller needs them: `enable` arms the stream guard by comparing what was
-/// written against what the guard would write back, and for IR Torch the two
-/// are the same bytes.
-fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<(Applied, Vec<u8>)> {
+/// Returns the bytes that went out alongside the write's outcome, because only
+/// this function derives them and the caller needs them: `enable` records what
+/// the guard APPLIED, which for IR Torch is the camera's own default rather
+/// than anything the caller named.
+fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<(CaptureWrite, Vec<u8>)> {
     if !info_allows_set(get_info(fd, unit, selector)?) {
         return Err(XuError::Unsupported);
     }
@@ -1753,13 +1774,8 @@ fn apply_device_default(fd: c_int, unit: u8, selector: u8) -> XuResult<(Applied,
     let Ok(wanted) = intended_value(fd, unit, selector, len)? else {
         return Err(XuError::Unsupported);
     };
-    // As above: already there means irlume did not put it there, so it is not
-    // irlume's to undo when the stream ends.
-    if get_cur(fd, unit, selector, len)? == wanted {
-        return Ok((Applied::AlreadyHeld, wanted));
-    }
-    set_cur(fd, unit, selector, &wanted)?;
-    Ok((Applied::Wrote, wanted))
+    let write = write_if_different(fd, unit, selector, len, &wanted)?;
+    Ok((write, wanted))
 }
 
 /// Why discovery could not produce a control.
@@ -4825,7 +4841,10 @@ mod tests {
         let outcome = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]));
         assert_eq!(
             outcome,
-            Ok(Applied::AlreadyHeld),
+            Ok(CaptureWrite {
+                outcome: Applied::AlreadyHeld,
+                current: vec![1, 3, 2],
+            }),
             "a value found in place is a success, but not irlume's write"
         );
         assert!(
@@ -4844,9 +4863,9 @@ mod tests {
             selector: 6,
             restore: vec![1, 3, 1],
             applied: vec![1, 3, 2],
-            armed: outcome == Ok(Applied::Wrote),
+            armed: matches!(&outcome, Ok(w) if w.outcome == Applied::Wrote),
             // Active either way: the control holds the payload, whoever set it.
-            active: outcome.is_ok(),
+            active: matches!(&outcome, Ok(w) if w.outcome != Applied::Nothing),
         });
         assert_eq!(
             fake_camera::current(),
@@ -4859,7 +4878,11 @@ mod tests {
         fake_camera::set_current(vec![1, 3, 1]);
         assert_eq!(
             check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2])),
-            Ok(Applied::Wrote)
+            Ok(CaptureWrite {
+                outcome: Applied::Wrote,
+                current: vec![1, 3, 1],
+            }),
+            "a write reports the value it displaced, read on the same pass"
         );
     }
 
@@ -4885,7 +4908,9 @@ mod tests {
             payload: payload.clone(),
         };
         assert_eq!(
-            apply_known_payload(-1, &ctrl).expect("a control that already agrees is not an error"),
+            apply_known_payload(-1, &ctrl)
+                .expect("a control that already agrees is not an error")
+                .outcome,
             Applied::AlreadyHeld,
             "the value is there; irlume did not put it there"
         );
@@ -4901,10 +4926,65 @@ mod tests {
         fake_camera::set_current(vec![9, 9, 9]);
         assert_eq!(
             apply_known_payload(-1, &ctrl).expect("a control that disagrees is written"),
-            Applied::Wrote
+            CaptureWrite {
+                outcome: Applied::Wrote,
+                current: vec![9, 9, 9],
+            },
+            "the write reports the value it displaced"
         );
         assert_eq!(fake_camera::current(), payload);
     }
+
+    /// The apply path reads the control ONCE, and the value it reports as
+    /// displaced is that read's answer.
+    ///
+    /// Two reads was the defect (#190): `enable` recorded an early `GET_CUR` as
+    /// the guard's restore value while the apply path decided on a later one,
+    /// so a writer landing between them had its value overwritten by the stale
+    /// record when the stream ended. The FULL request order is asserted, so a
+    /// second `GET_CUR` reappearing anywhere in the path fails here rather than
+    /// reopening the window quietly.
+    #[test]
+    fn one_read_decides_and_its_answer_is_what_the_write_displaced() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![7, 7, 7],
+            len: 3,
+            info: 0b0000_0011,
+            ..a_working_camera()
+        });
+        let asus = identity(0x3277, 0x0059);
+        let write = check_and_apply_override(-1, &asus, &ctrl(14, 6, vec![1, 3, 2]))
+            .expect("a published control with a valid payload is applied");
+        assert_eq!(
+            write,
+            CaptureWrite {
+                outcome: Applied::Wrote,
+                current: vec![7, 7, 7],
+            },
+            "the displaced value is the one read's answer"
+        );
+        assert_eq!(
+            fake_camera::log(),
+            vec![
+                fake_camera::Request::Get {
+                    query: UVC_GET_INFO,
+                    size: 1,
+                },
+                fake_camera::Request::Get {
+                    query: UVC_GET_LEN,
+                    size: 2,
+                },
+                fake_camera::Request::Get {
+                    query: UVC_GET_CUR,
+                    size: 3,
+                },
+                fake_camera::Request::Set(vec![1, 3, 2]),
+            ],
+            "exactly one GET_CUR, immediately before the write it authorises"
+        );
+    }
+
     /// IR Torch's applied value IS the camera's default, so there is nothing
     /// for the stream end to restore.
     ///
@@ -4929,13 +5009,13 @@ mod tests {
             ..Default::default()
         });
 
-        let (outcome, sent) = apply_device_default(-1, 14, crate::uvc_descriptor::MSXU_IR_TORCH)
+        let (write, sent) = apply_device_default(-1, 14, crate::uvc_descriptor::MSXU_IR_TORCH)
             .expect("a conformant torch takes its own default");
         assert_eq!(sent, def, "the applied bytes are the camera's own GET_DEF");
         // The fixture starts at the default, so there is nothing to write: the
         // torch's own value IS the default, which is the point of the case.
         assert_eq!(
-            outcome,
+            write.outcome,
             Applied::AlreadyHeld,
             "a control already at the value it wants is not written again"
         );
@@ -4948,7 +5028,7 @@ mod tests {
             selector: crate::uvc_descriptor::MSXU_IR_TORCH,
             restore: def.clone(),
             applied: vec![1, 3, 2],
-            armed: sent != def,
+            armed: write.outcome == Applied::Wrote,
             // The torch IS on: its default is an active mode. Active without
             // being armed is exactly the pair this field exists to separate.
             active: true,
@@ -6044,7 +6124,7 @@ mod tests {
         );
         assert_eq!(
             answer,
-            Applied::Nothing,
+            CaptureWrite::refused(),
             "a camera that cannot answer GET_CUR must not be reported as lit \
              on the strength of an earlier write"
         );

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -25,6 +25,7 @@
 pub mod emitter_journal;
 pub mod ir_emitter;
 mod ir_metadata;
+mod stream_record;
 pub mod uvc_descriptor;
 
 /// Serializes unit tests that mutate process-global environment variables, and
@@ -1893,7 +1894,10 @@ pub fn capture_ir_streaming<B>(
                 // comes back ACTIVE but owning nothing. Handing ownership over
                 // on `lit` disarmed the guard that actually held the change and
                 // installed one with nothing to put back, so the capture ended
-                // without restoring at all.
+                // without restoring at all. The stream record's lock now
+                // enforces the same answer: while the old guard lives, its
+                // leftover record cannot be claimed, so the fresh `enable`
+                // cannot arm off the record either.
                 let fresh = ir_emitter::enable(dev.handle(), &card, device);
                 if fresh.owns_restore() {
                     mode.disarm();
@@ -2023,7 +2027,10 @@ pub fn capture_ir_sequence(
                 // comes back ACTIVE but owning nothing. Handing ownership over
                 // on `lit` disarmed the guard that actually held the change and
                 // installed one with nothing to put back, so the capture ended
-                // without restoring at all.
+                // without restoring at all. The stream record's lock now
+                // enforces the same answer: while the old guard lives, its
+                // leftover record cannot be claimed, so the fresh `enable`
+                // cannot arm off the record either.
                 let fresh = ir_emitter::enable(dev.handle(), &card, device);
                 if fresh.owns_restore() {
                     mode.disarm();

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1879,34 +1879,22 @@ pub fn capture_ir_streaming<B>(
                 dead_run = 0;
                 last_sig = None;
                 drop(stream); // stop + release buffers before re-arming
-                stream = SafeStream::open(device, &dev)?;
-                // The reopened stream needs the mode set again, and the OLD
-                // guard is only given up if the new one actually took. The
-                // measured behaviour on both cameras here is that the control
-                // survives a stream close, so the fresh `enable` can find the
-                // value still in place, send nothing, and come back unarmed.
-                // The restore then still belongs to the old guard, which is
-                // kept until a replacement genuinely holds one; replacing it
-                // unconditionally would drop it armed and write the default
-                // under the stream that just reopened.
-                // `owns_restore`, not `lit`. The control survives the close, so
-                // the fresh `enable` usually finds the value already there and
-                // comes back ACTIVE but owning nothing. Handing ownership over
-                // on `lit` disarmed the guard that actually held the change and
-                // installed one with nothing to put back, so the capture ended
-                // without restoring at all. The stream record's lock now
-                // enforces the same answer: while the old guard lives, its
-                // leftover record cannot be claimed, so the fresh `enable`
-                // cannot arm off the record either.
-                let mut fresh = ir_emitter::enable(dev.handle(), &card, device);
-                if fresh.owns_restore() {
-                    mode.disarm();
-                    // The old guard held the per-camera stream lock, so the
-                    // fresh one wrote unrecorded; the outstanding change and
-                    // its on-disk record move over together (#188).
-                    fresh.adopt_record(mode.take_record());
-                    mode = fresh;
+                              // The OLD guard restores BEFORE the reopen. Its stream is
+                              // already gone, and while the guard lives it holds the
+                              // per-camera stream lock, which would make the fresh `enable`
+                              // refuse to drive the emitter at all — the lock refuses
+                              // contested writes rather than allowing an unrecorded one
+                              // (#188, review round 4). Restoring here cannot write under
+                              // the new stream either, because it happens before the fresh
+                              // apply. Earlier versions kept the old guard armed across the
+                              // reopen and negotiated ownership afterwards; the cost of
+                              // this simpler shape is one restore/apply pair per restart,
+                              // and restarts are the exception, not the path.
+                if let Err(e) = mode.restore() {
+                    eprintln!("irlume: restoring the emitter before a stream restart: {e}");
                 }
+                stream = SafeStream::open(device, &dev)?;
+                mode = ir_emitter::enable(dev.handle(), &card, device);
             }
             continue;
         }
@@ -2016,34 +2004,22 @@ pub fn capture_ir_sequence(
                 dead_run = 0;
                 last_sig = None;
                 drop(stream.take()); // stop + release buffers before re-arming
-                stream = Some(SafeStream::open(device, &dev)?);
-                // The reopened stream needs the mode set again, and the OLD
-                // guard is only given up if the new one actually took. The
-                // measured behaviour on both cameras here is that the control
-                // survives a stream close, so the fresh `enable` can find the
-                // value still in place, send nothing, and come back unarmed.
-                // The restore then still belongs to the old guard, which is
-                // kept until a replacement genuinely holds one; replacing it
-                // unconditionally would drop it armed and write the default
-                // under the stream that just reopened.
-                // `owns_restore`, not `lit`. The control survives the close, so
-                // the fresh `enable` usually finds the value already there and
-                // comes back ACTIVE but owning nothing. Handing ownership over
-                // on `lit` disarmed the guard that actually held the change and
-                // installed one with nothing to put back, so the capture ended
-                // without restoring at all. The stream record's lock now
-                // enforces the same answer: while the old guard lives, its
-                // leftover record cannot be claimed, so the fresh `enable`
-                // cannot arm off the record either.
-                let mut fresh = ir_emitter::enable(dev.handle(), &card, device);
-                if fresh.owns_restore() {
-                    mode.disarm();
-                    // The old guard held the per-camera stream lock, so the
-                    // fresh one wrote unrecorded; the outstanding change and
-                    // its on-disk record move over together (#188).
-                    fresh.adopt_record(mode.take_record());
-                    mode = fresh;
+                                     // The OLD guard restores BEFORE the reopen. Its stream is
+                                     // already gone, and while the guard lives it holds the
+                                     // per-camera stream lock, which would make the fresh `enable`
+                                     // refuse to drive the emitter at all — the lock refuses
+                                     // contested writes rather than allowing an unrecorded one
+                                     // (#188, review round 4). Restoring here cannot write under
+                                     // the new stream either, because it happens before the fresh
+                                     // apply. Earlier versions kept the old guard armed across the
+                                     // reopen and negotiated ownership afterwards; the cost of
+                                     // this simpler shape is one restore/apply pair per restart,
+                                     // and restarts are the exception, not the path.
+                if let Err(e) = mode.restore() {
+                    eprintln!("irlume: restoring the emitter before a stream restart: {e}");
                 }
+                stream = Some(SafeStream::open(device, &dev)?);
+                mode = ir_emitter::enable(dev.handle(), &card, device);
             }
             continue;
         }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1898,9 +1898,13 @@ pub fn capture_ir_streaming<B>(
                 // enforces the same answer: while the old guard lives, its
                 // leftover record cannot be claimed, so the fresh `enable`
                 // cannot arm off the record either.
-                let fresh = ir_emitter::enable(dev.handle(), &card, device);
+                let mut fresh = ir_emitter::enable(dev.handle(), &card, device);
                 if fresh.owns_restore() {
                     mode.disarm();
+                    // The old guard held the per-camera stream lock, so the
+                    // fresh one wrote unrecorded; the outstanding change and
+                    // its on-disk record move over together (#188).
+                    fresh.adopt_record(mode.take_record());
                     mode = fresh;
                 }
             }
@@ -2031,9 +2035,13 @@ pub fn capture_ir_sequence(
                 // enforces the same answer: while the old guard lives, its
                 // leftover record cannot be claimed, so the fresh `enable`
                 // cannot arm off the record either.
-                let fresh = ir_emitter::enable(dev.handle(), &card, device);
+                let mut fresh = ir_emitter::enable(dev.handle(), &card, device);
                 if fresh.owns_restore() {
                     mode.disarm();
+                    // The old guard held the per-camera stream lock, so the
+                    // fresh one wrote unrecorded; the outstanding change and
+                    // its on-disk record move over together (#188).
+                    fresh.adopt_record(mode.take_record());
                     mode = fresh;
                 }
             }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1327,7 +1327,7 @@ impl IrCamera {
         // Held for the session rather than just applied: dropping `IrSession`
         // puts the control back to the camera's own default, which is the
         // documented sequence's last step and the half irlume never did.
-        mode = ir_emitter::enable(self.dev.handle().fd(), &self.card, &self.device);
+        mode = ir_emitter::enable(self.dev.handle(), &self.card, &self.device);
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
         warm_up_stream(&self.device, &mut stream)?;
@@ -1733,7 +1733,7 @@ pub mod ir_probe {
         // lands before streaming starts.
         let mode;
         let mut stream = super::SafeStream::open(device, &dev)?;
-        mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+        mode = ir_emitter::enable(dev.handle(), &card, device);
         // Bound, never read: held for its `Drop`, which restores the control.
         let _ = &mode;
         let mut out = Vec::with_capacity(n);
@@ -1834,7 +1834,7 @@ pub fn capture_ir_streaming<B>(
     // lands before streaming starts.
     let mut mode;
     let mut stream = SafeStream::open(device, &dev)?;
-    mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+    mode = ir_emitter::enable(dev.handle(), &card, device);
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
     // constant mid-grey for the rest of the window); real sensor noise never
@@ -1894,7 +1894,7 @@ pub fn capture_ir_streaming<B>(
                 // on `lit` disarmed the guard that actually held the change and
                 // installed one with nothing to put back, so the capture ended
                 // without restoring at all.
-                let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
+                let fresh = ir_emitter::enable(dev.handle(), &card, device);
                 if fresh.owns_restore() {
                     mode.disarm();
                     mode = fresh;
@@ -1963,7 +1963,7 @@ pub fn capture_ir_sequence(
     // lands before streaming starts.
     let mut mode;
     let mut stream = Some(SafeStream::open(device, &dev)?);
-    mode = ir_emitter::enable(dev.handle().fd(), &card, device);
+    mode = ir_emitter::enable(dev.handle(), &card, device);
     // Set once above and not re-applied inside the loop. This path also carried
     // an every-eighth-frame re-fire; it went for the same reason, and with the
     // same caveat: the justification is the MEASURED record in
@@ -2024,7 +2024,7 @@ pub fn capture_ir_sequence(
                 // on `lit` disarmed the guard that actually held the change and
                 // installed one with nothing to put back, so the capture ended
                 // without restoring at all.
-                let fresh = ir_emitter::enable(dev.handle().fd(), &card, device);
+                let fresh = ir_emitter::enable(dev.handle(), &card, device);
                 if fresh.owns_restore() {
                     mode.disarm();
                     mode = fresh;

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1326,8 +1326,10 @@ impl IrCamera {
         // exit on both cameras measured, so it is not stream-scoped.
         //
         // Held for the session rather than just applied: dropping `IrSession`
-        // puts the control back to the camera's own default, which is the
-        // documented sequence's last step and the half irlume never did.
+        // puts back the value the capture write displaced — the camera's
+        // default in the ordinary case, another program's value where one was
+        // deliberately set — which is the documented sequence's last step and
+        // the half irlume never did.
         mode = ir_emitter::enable(self.dev.handle(), &self.card, &self.device);
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1892,9 +1892,19 @@ pub fn capture_ir_streaming<B>(
                               // reopen and negotiated ownership afterwards; the cost of
                               // this simpler shape is one restore/apply pair per restart,
                               // and restarts are the exception, not the path.
-                if let Err(e) = mode.restore() {
-                    eprintln!("irlume: restoring the emitter before a stream restart: {e}");
-                }
+                              // A restore failure PROPAGATES rather than being logged
+                              // over: the guard is spent after one attempt, and an
+                              // UNRECORDED write whose restore failed here would otherwise
+                              // become permanently unowned — the fresh enable finds the
+                              // wanted bytes with no record to claim and leaves them
+                              // forever (review round 12). Surfacing hardware trouble
+                              // beats continuing to authenticate through it.
+                mode.restore().map_err(|e| {
+                    Error::Hardware(format!(
+                        "{device}: could not restore the emitter before restarting \
+                         a frozen stream: {e}"
+                    ))
+                })?;
                 stream = SafeStream::open(device, &dev)?;
                 mode = ir_emitter::enable(dev.handle(), &card, device);
             }
@@ -2017,9 +2027,19 @@ pub fn capture_ir_sequence(
                                      // reopen and negotiated ownership afterwards; the cost of
                                      // this simpler shape is one restore/apply pair per restart,
                                      // and restarts are the exception, not the path.
-                if let Err(e) = mode.restore() {
-                    eprintln!("irlume: restoring the emitter before a stream restart: {e}");
-                }
+                                     // A restore failure PROPAGATES rather than being logged
+                                     // over: the guard is spent after one attempt, and an
+                                     // UNRECORDED write whose restore failed here would otherwise
+                                     // become permanently unowned — the fresh enable finds the
+                                     // wanted bytes with no record to claim and leaves them
+                                     // forever (review round 12). Surfacing hardware trouble
+                                     // beats continuing to authenticate through it.
+                mode.restore().map_err(|e| {
+                    Error::Hardware(format!(
+                        "{device}: could not restore the emitter before restarting \
+                         a frozen stream: {e}"
+                    ))
+                })?;
                 stream = Some(SafeStream::open(device, &dev)?);
                 mode = ir_emitter::enable(dev.handle(), &card, device);
             }

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -187,48 +187,56 @@ pub(crate) struct StreamLock {
     _file: std::fs::File,
 }
 
-/// Take this camera's stream lock, or report why not.
+/// Why the stream lock was not acquired. The two answers demand OPPOSITE
+/// responses, and collapsing them was review round 4's finding: a busy lock
+/// is a LIVE irlume writer whose restore bookkeeping a second, unrecorded
+/// write would silently invalidate, so the write must be refused; an
+/// unavailable store is machine trouble with nobody contesting the camera,
+/// where refusing would turn a full disk into dark IR at every login.
+#[derive(Debug)]
+pub(crate) enum AcquireError {
+    /// Another live irlume guard holds this camera's lock.
+    Busy,
+    /// The lock could not be created, opened or taken for a reason other
+    /// than contention.
+    Unavailable(String),
+}
+
+/// Take this camera's stream lock, or say why not.
 ///
-/// `None` means another live irlume guard owns this camera's record right now
-/// — another process mid-capture, or this process's own previous guard during
-/// a frozen-stream restart (`flock` excludes per open file description, so a
-/// second open in the same process is refused too). The caller proceeds
-/// without bookkeeping; an error creating or opening the lock is reported and
-/// answered the same way, since a write that cannot be recorded is still a
-/// write worth making (see `write_if_different`).
-pub(crate) fn acquire(id: &CameraIdentity) -> Option<StreamLock> {
+/// `Busy` means another live irlume guard owns this camera right now —
+/// another process mid-capture, or this process's own previous guard
+/// (`flock` excludes per open file description, so a second open in the same
+/// process is refused too).
+pub(crate) fn acquire(id: &CameraIdentity) -> Result<StreamLock, AcquireError> {
     use std::os::unix::fs::OpenOptionsExt as _;
     use std::os::unix::io::AsRawFd as _;
 
     let dir = store_dir();
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        eprintln!("irlume: cannot create {}: {e}", dir.display());
-        return None;
-    }
-    if let Err(e) = irlume_common::restrict(&dir, 0o700) {
-        eprintln!("irlume: {e}");
-        return None;
-    }
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| AcquireError::Unavailable(format!("create {}: {e}", dir.display())))?;
+    irlume_common::restrict(&dir, 0o700).map_err(AcquireError::Unavailable)?;
     let path = lock_path(id);
-    let file = match std::fs::OpenOptions::new()
+    let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(false)
         .mode(0o600)
         .open(&path)
-    {
-        Ok(file) => file,
-        Err(e) => {
-            eprintln!("irlume: cannot open {}: {e}", path.display());
-            return None;
-        }
-    };
+        .map_err(|e| AcquireError::Unavailable(format!("open {}: {e}", path.display())))?;
     // SAFETY: the fd is owned by `file`, which the returned guard keeps open.
     if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-        return None;
+        let e = std::io::Error::last_os_error();
+        return match e.raw_os_error() {
+            Some(libc::EWOULDBLOCK) => Err(AcquireError::Busy),
+            _ => Err(AcquireError::Unavailable(format!(
+                "lock {}: {e}",
+                path.display()
+            ))),
+        };
     }
-    Some(StreamLock { _file: file })
+    Ok(StreamLock { _file: file })
 }
 
 /// A live record: the file on disk, its parsed contents, and the stream lock

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -259,9 +259,17 @@ impl StreamRecord {
     /// leftover is real again, so the record must be claimable again. On
     /// failure the record stays `prepared` on disk: reported, unclaimable,
     /// and the safe direction.
-    pub(crate) fn mark_applied(mut self) -> Result<Self, String> {
+    pub(crate) fn mark_applied(mut self) -> Result<Self, Box<(Self, String)>> {
         self.record.state = WriteState::Applied;
-        publish(&self.path, &self.record)?;
+        if let Err(why) = publish(&self.path, &self.record) {
+            // The handle comes BACK on failure. Consuming it here dropped the
+            // stream lock while the hardware write it covered was still live,
+            // and a second irlume could then interleave exactly the way the
+            // busy-refusal exists to prevent (review round 5). Boxed for the
+            // cold path only.
+            self.record.state = WriteState::Prepared;
+            return Err(Box::new((self, why)));
+        }
         trace("confirmed applied");
         Ok(self)
     }
@@ -275,9 +283,12 @@ impl StreamRecord {
     /// resolution would later authorise a firmware write over whatever
     /// unrelated value happened to match it (review round 2). Demoting first
     /// means the worst a failed cleanup leaves is inert litter.
-    pub(crate) fn retire(mut self) -> Result<Self, String> {
+    pub(crate) fn retire(mut self) -> Result<Self, Box<(Self, String)>> {
         self.record.state = WriteState::Prepared;
-        publish(&self.path, &self.record)?;
+        if let Err(why) = publish(&self.path, &self.record) {
+            self.record.state = WriteState::Applied;
+            return Err(Box::new((self, why)));
+        }
         trace("retired");
         Ok(self)
     }
@@ -354,12 +365,37 @@ fn publish(path: &Path, record: &StreamWrite) -> Result<(), String> {
     Ok(())
 }
 
+/// Why a record was not saved. Both failures return the caller's lock: the
+/// exclusion must outlive the bookkeeping trouble, or a second irlume takes
+/// the camera mid-stream (review round 5).
+#[derive(Debug)]
+pub(crate) enum SaveError {
+    /// An `applied` record for a change that may still be LIVE sits at this
+    /// camera's path, and publishing would rename over the only recovery
+    /// data it has (review round 5). Same control with the record's applied
+    /// bytes still in the control, or a DIFFERENT control whose state this
+    /// write cannot see: either way, nothing is written and nothing is
+    /// destroyed.
+    /// The lock is NOT returned here: the caller refuses the write, so there
+    /// is no change for the exclusion to outlive, and releasing it lets the
+    /// control's own next capture claim the outstanding record.
+    Outstanding { unit: u8, selector: u8 },
+    /// The store could not take the record for a reason other than an
+    /// outstanding one: unreadable existing file, unwritable directory, a
+    /// failed rename. The caller proceeds unrecorded, still holding the lock.
+    Unavailable { lock: StreamLock, why: String },
+}
+
 /// Put the `prepared` record for this stream's write on disk, BEFORE the
 /// write, under the lock the caller acquired.
 ///
-/// Best-effort at the caller: a store that cannot be written costs crash
-/// bookkeeping, not the authentication — see `write_if_different` for why
-/// that direction was chosen.
+/// `displaced` is what the target control holds right now, which doubles as
+/// the liveness probe for an existing SAME-control record: an applied record
+/// whose bytes are still in the control describes irlume's own live leftover,
+/// and renaming over it would destroy the only route back. A record for a
+/// DIFFERENT control cannot be probed from here at all, so it is never
+/// replaced while `applied`. Superseded records (bytes no longer present) and
+/// `prepared` ones authorise nothing and are replaced freely.
 pub(crate) fn save(
     lock: StreamLock,
     id: &CameraIdentity,
@@ -367,7 +403,53 @@ pub(crate) fn save(
     selector: u8,
     applied: &[u8],
     displaced: &[u8],
-) -> Result<StreamRecord, String> {
+) -> Result<StreamRecord, SaveError> {
+    let path = record_path(id);
+    match std::fs::read_to_string(&path) {
+        Ok(body) => match serde_json::from_str::<StreamWrite>(&body) {
+            Ok(existing)
+                if existing.schema_version == SCHEMA_VERSION
+                    && existing.state == WriteState::Applied =>
+            {
+                let live = if (existing.unit, existing.selector) == (unit, selector) {
+                    // Same control: superseded exactly when its bytes are no
+                    // longer what the control holds. An unparseable applied
+                    // field cannot prove that, so it reads as live.
+                    from_hex(&existing.applied)
+                        .map(|bytes| bytes == displaced)
+                        .unwrap_or(true)
+                } else {
+                    true
+                };
+                if live {
+                    drop(lock);
+                    return Err(SaveError::Outstanding {
+                        unit: existing.unit,
+                        selector: existing.selector,
+                    });
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                // A file that will not parse could be hiding an applied
+                // record. Nothing is written over it; a human gets to look.
+                return Err(SaveError::Unavailable {
+                    lock,
+                    why: format!(
+                        "existing record {} does not parse ({e}); not writing over it",
+                        path.display()
+                    ),
+                });
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(SaveError::Unavailable {
+                lock,
+                why: format!("read {}: {e}", path.display()),
+            });
+        }
+    }
     let record = StreamWrite {
         schema_version: SCHEMA_VERSION,
         engine_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -383,8 +465,9 @@ pub(crate) fn save(
         serial: id.serial.clone(),
         usb_devpath: id.usb_devpath.clone(),
     };
-    let path = record_path(id);
-    publish(&path, &record)?;
+    if let Err(why) = publish(&path, &record) {
+        return Err(SaveError::Unavailable { lock, why });
+    }
     trace(&format!(
         "saved unit{unit}/sel{selector} applied={} displaced={} state=prepared",
         record.applied, record.displaced

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -16,9 +16,39 @@
 //! Claiming it always undoes another program's change; never claiming it makes
 //! one `SIGKILL` leave the mode applied forever, because every later session
 //! reads the leftover as somebody else's. This record is the missing fact: it
-//! is written immediately before the `SET_CUR` and removed once the guard
+//! goes on disk immediately before the `SET_CUR` and is removed once the guard
 //! resolves, so a value found already in place is irlume's own leftover
-//! exactly when a record for this camera, this control and these bytes exists.
+//! exactly when a CONFIRMED record for this camera, this control and these
+//! bytes exists.
+//!
+//! # Two phases, because the record precedes the write
+//!
+//! A record written before the `SET_CUR` describes a write that may never
+//! happen: a kill in the gap leaves the file with no hardware effect behind
+//! it. If that file could authorise a claim, a value some other program set
+//! LATER, matching the bytes irlume once intended, would be "restored" over —
+//! a firmware write on the strength of nothing (review of this PR, round 1).
+//! So the record is published as `prepared`, and rewritten as `applied` only
+//! after the camera accepts the write. Claims require `applied`. A crash
+//! between the write and the confirmation leaves an unclaimable leftover,
+//! which is the pre-#188 status quo and the safe direction.
+//!
+//! # One writer at a time, on a lock that never moves
+//!
+//! Every mutation of the record happens holding a per-camera LOCK FILE that is
+//! created once and never renamed or removed. The lock cannot ride the record
+//! itself: `flock` binds to the open file description, and replacing the
+//! pathname by rename leaves the old lock attached to a nameless inode while
+//! a second writer locks a fresh one — two live "exclusive" locks, no
+//! exclusion (same review round). The stable inode gives the lock one
+//! identity for everyone. It is held for the guard's whole lifetime, released
+//! by any death, so it is also the liveness signal: a claim that cannot take
+//! it is looking at a live stream's record and refuses. No pid or boot id is
+//! stored; #183 removed those from the journal after one stranded a record.
+//!
+//! The lock serialises IRLUME's writers only. A non-cooperating process can
+//! still move the control between irlume's `GET_CUR` and `SET_CUR`; UVC has
+//! no compare-and-swap, so that window cannot be closed from here.
 //!
 //! # Durability, deliberately weaker than the discovery journal's
 //!
@@ -31,17 +61,6 @@
 //! control that a physical power cycle was measured to reset anyway (pt190:
 //! a replugged camera returns at its `GET_DEF`). Conflating the two
 //! requirements is what kept this record out of #184 for two review rounds.
-//!
-//! # Liveness
-//!
-//! The file doubles as its own liveness signal: the writer holds a
-//! non-blocking `flock` on it for as long as the guard is armed, and the lock
-//! dies with the process while the file does not. A claim that cannot take
-//! the lock is looking at a LIVE stream's record — a second process, or this
-//! process's own previous guard during a frozen-stream restart — and refuses.
-//! No pid or boot id is stored: #183 removed those from the journal because a
-//! recorded pid strands a record when its long-lived writer outlives the
-//! stream, and a kernel-released lock cannot go stale.
 
 use crate::emitter_journal::{filing_key, fingerprint, from_hex, identity_authorizes, to_hex};
 use crate::uvc_descriptor::CameraIdentity;
@@ -62,14 +81,27 @@ pub(crate) const MAX_RESTORE_ATTEMPTS: u32 = 3;
 /// Trace a stream-record event onto the stream `set_cur` traces writes to.
 ///
 /// Same switch as the journal's, for the same reason: the claims this module
-/// makes are ORDERINGS — record on disk before the `SET_CUR`, resolved only
-/// after the restore — and on hardware the only way to observe them is to put
-/// the events into the same transcript as the writes, in order. An strace of
-/// `write(2)` then shows both interleaved (pt190).
+/// makes are ORDERINGS — record on disk before the `SET_CUR`, confirmed after
+/// it, resolved only after the restore — and on hardware the only way to
+/// observe them is to put the events into the same transcript as the writes,
+/// in order. An strace of `write(2)` then shows both interleaved (pt190).
 fn trace(event: &str) {
     if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
         eprintln!("irlume: stream-record {event}");
     }
+}
+
+/// How far the write this record covers actually got.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WriteState {
+    /// Published before the `SET_CUR`. The write may never have happened, so
+    /// this state authorises NOTHING; it exists so a crash after the write
+    /// cannot be unrecorded, not so a crash before it can forge ownership.
+    Prepared,
+    /// The camera accepted the `SET_CUR`. Only this state makes a leftover
+    /// irlume's to undo.
+    Applied,
 }
 
 /// One stream's applied emitter mode, on disk from just before the `SET_CUR`
@@ -90,6 +122,10 @@ pub(crate) struct StreamWrite {
     pub(crate) interface_number: u8,
     pub(crate) unit: u8,
     pub(crate) selector: u8,
+    /// Whether the write this record covers is known to have reached the
+    /// camera. REQUIRED, no default: a record that cannot say is a record
+    /// that must not authorise.
+    pub(crate) state: WriteState,
     /// Hex of the payload the stream applied. A claim requires the control to
     /// be holding exactly this, or the leftover it describes is already gone.
     pub(crate) applied: String,
@@ -129,8 +165,74 @@ fn record_path(id: &CameraIdentity) -> PathBuf {
     store_dir().join(format!("{}.json", filing_key(id)))
 }
 
-/// A live record: the file on disk plus the `flock` that marks its writer as
-/// alive. Held by the stream guard while armed.
+/// This camera's lock path: the stable inode every writer and claimer locks.
+///
+/// Beside the record, one per camera, created on first use and never renamed
+/// or removed — removing a lock file hands the next opener a different inode
+/// and two "exclusive" locks. The store directory is root-only, so the lock
+/// is too.
+fn lock_path(id: &CameraIdentity) -> PathBuf {
+    store_dir().join(format!("{}.lock", filing_key(id)))
+}
+
+/// The per-camera stream lock, held from before the control is read until the
+/// guard resolves.
+///
+/// Released by ANY process death, which makes it the liveness signal for the
+/// record beside it. Excludes irlume's own writers only; see the module doc.
+#[derive(Debug)]
+pub(crate) struct StreamLock {
+    /// Held, never read: the open file description IS the lock, released
+    /// when this drops however the process ends.
+    _file: std::fs::File,
+}
+
+/// Take this camera's stream lock, or report why not.
+///
+/// `None` means another live irlume guard owns this camera's record right now
+/// — another process mid-capture, or this process's own previous guard during
+/// a frozen-stream restart (`flock` excludes per open file description, so a
+/// second open in the same process is refused too). The caller proceeds
+/// without bookkeeping; an error creating or opening the lock is reported and
+/// answered the same way, since a write that cannot be recorded is still a
+/// write worth making (see `write_if_different`).
+pub(crate) fn acquire(id: &CameraIdentity) -> Option<StreamLock> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+    use std::os::unix::io::AsRawFd as _;
+
+    let dir = store_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("irlume: cannot create {}: {e}", dir.display());
+        return None;
+    }
+    if let Err(e) = irlume_common::restrict(&dir, 0o700) {
+        eprintln!("irlume: {e}");
+        return None;
+    }
+    let path = lock_path(id);
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("irlume: cannot open {}: {e}", path.display());
+            return None;
+        }
+    };
+    // SAFETY: the fd is owned by `file`, which the returned guard keeps open.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return None;
+    }
+    Some(StreamLock { _file: file })
+}
+
+/// A live record: the file on disk, its parsed contents, and the stream lock
+/// that marks its writer as alive. Held by the stream guard while armed.
 ///
 /// Dropping this WITHOUT [`resolve`](StreamRecord::resolve) keeps the file and
 /// releases the lock, which is exactly the crash shape on purpose: a restore
@@ -138,50 +240,44 @@ fn record_path(id: &CameraIdentity) -> PathBuf {
 #[derive(Debug)]
 pub(crate) struct StreamRecord {
     path: PathBuf,
-    file: std::fs::File,
+    record: StreamWrite,
+    _lock: StreamLock,
 }
 
 impl StreamRecord {
+    /// Rewrite the record as `applied`, after the camera accepted the write.
+    ///
+    /// On failure the record stays `prepared` on disk: the write happened but
+    /// a crash from here would leave a leftover no claim will touch, which is
+    /// reported, and is the safe direction.
+    pub(crate) fn mark_applied(mut self) -> Result<Self, String> {
+        self.record.state = WriteState::Applied;
+        publish(&self.path, &self.record)?;
+        trace("confirmed applied");
+        Ok(self)
+    }
+
     /// Remove the record: the change it describes is no longer outstanding,
     /// either because the restore landed or because the control was found no
     /// longer holding irlume's value.
     ///
-    /// Only the inode this handle locked is removed. The path may already
-    /// hold a NEWER record — a replacement guard renames its own over this
-    /// one — and removing by name alone would delete bookkeeping that is not
-    /// ours. A writer renaming over between the check and the unlink loses
-    /// its file's name; the window is a few instructions wide, needs a second
-    /// irlume on the same camera in it, and costs that writer a claimable
-    /// leftover rather than a wrong write, so it is accepted rather than
-    /// closed.
+    /// A plain unlink is enough: every writer of this path holds the stable
+    /// lock, this handle holds it now, so the record at the name is this
+    /// handle's own.
     pub(crate) fn resolve(self) {
-        use std::os::unix::fs::MetadataExt as _;
-        let Ok(ours) = self.file.metadata() else {
-            return;
-        };
-        match std::fs::metadata(&self.path) {
-            Ok(m) if (m.dev(), m.ino()) == (ours.dev(), ours.ino()) => {
-                let _ = std::fs::remove_file(&self.path);
-                trace("resolved");
-            }
-            _ => trace("resolved (already replaced, left in place)"),
-        }
+        let _ = std::fs::remove_file(&self.path);
+        trace("resolved");
     }
 }
 
-/// Serialize, write to a fresh temp file, lock it, and rename it into place.
-///
-/// The lock is taken on the temp fd BEFORE the rename, so from the first
-/// instant the record is visible its writer already reads as alive; there is
-/// no window in which a concurrent claim could adopt a record whose owner is
-/// running. `flock` follows the open file description across the rename.
+/// Serialize and publish a record: temp file, write, rename. The caller holds
+/// the stream lock; nothing here locks.
 ///
 /// No fsync anywhere, see the module doc: process death is the requirement,
 /// and the page cache meets it.
-fn publish(path: &Path, record: &StreamWrite) -> Result<StreamRecord, String> {
+fn publish(path: &Path, record: &StreamWrite) -> Result<(), String> {
     use std::io::Write as _;
     use std::os::unix::fs::OpenOptionsExt as _;
-    use std::os::unix::io::AsRawFd as _;
 
     let dir = store_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
@@ -196,7 +292,6 @@ fn publish(path: &Path, record: &StreamWrite) -> Result<StreamRecord, String> {
     let tmp = dir.join(format!(".{name}.tmp.{}.{seq}", std::process::id()));
     let open_tmp = || {
         std::fs::OpenOptions::new()
-            .read(true)
             .write(true)
             .create_new(true)
             .mode(0o600)
@@ -216,30 +311,22 @@ fn publish(path: &Path, record: &StreamWrite) -> Result<StreamRecord, String> {
         let _ = std::fs::remove_file(&tmp);
         return Err(format!("write {}: {e}", tmp.display()));
     }
-    // SAFETY: the fd is owned by `file`, which the returned guard keeps open.
-    // A fresh 0600 temp file nobody else can have opened: the non-blocking
-    // lock cannot fail with WouldBlock, and any failure is reported.
-    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-        let e = std::io::Error::last_os_error();
-        let _ = std::fs::remove_file(&tmp);
-        return Err(format!("lock {}: {e}", tmp.display()));
-    }
+    drop(file);
     if let Err(e) = std::fs::rename(&tmp, path) {
         let _ = std::fs::remove_file(&tmp);
         return Err(format!("publish {}: {e}", path.display()));
     }
-    Ok(StreamRecord {
-        path: path.to_path_buf(),
-        file,
-    })
+    Ok(())
 }
 
-/// Put the record for this stream's write on disk, locked, BEFORE the write.
+/// Put the `prepared` record for this stream's write on disk, BEFORE the
+/// write, under the lock the caller acquired.
 ///
 /// Best-effort at the caller: a store that cannot be written costs crash
 /// bookkeeping, not the authentication — see `write_if_different` for why
 /// that direction was chosen.
 pub(crate) fn save(
+    lock: StreamLock,
     id: &CameraIdentity,
     unit: u8,
     selector: u8,
@@ -254,18 +341,24 @@ pub(crate) fn save(
         interface_number: id.interface_number,
         unit,
         selector,
+        state: WriteState::Prepared,
         applied: to_hex(applied),
         displaced: to_hex(displaced),
         restore_attempts: 0,
         serial: id.serial.clone(),
         usb_devpath: id.usb_devpath.clone(),
     };
-    let handle = publish(&record_path(id), &record)?;
+    let path = record_path(id);
+    publish(&path, &record)?;
     trace(&format!(
-        "saved unit{unit}/sel{selector} applied={} displaced={}",
+        "saved unit{unit}/sel{selector} applied={} displaced={} state=prepared",
         record.applied, record.displaced
     ));
-    Ok(handle)
+    Ok(StreamRecord {
+        path,
+        record,
+        _lock: lock,
+    })
 }
 
 /// Why a record does not hand this stream a restore.
@@ -283,6 +376,11 @@ pub(crate) enum ClaimRefusal {
     UnsupportedSchema { found: u32 },
     /// The record's own fields disagree with each other or will not parse.
     Malformed(String),
+    /// The record was published before its write and never confirmed after
+    /// it, so the write may not have happened at all. A value matching it can
+    /// be another program's deliberate choice, and restoring over that would
+    /// be a firmware write on the strength of nothing.
+    NotConfirmed,
     /// The record names a different control than this stream is applying.
     /// The leftover may still be real, but it is not THIS write's business:
     /// claiming it here would arm a restore for a control nobody validated
@@ -317,6 +415,11 @@ pub(crate) fn record_claims(
         return Err(ClaimRefusal::UnsupportedSchema {
             found: record.schema_version,
         });
+    }
+    // Before anything else about the camera: a record whose write was never
+    // confirmed authorises nothing, whoever it matches.
+    if record.state != WriteState::Applied {
+        return Err(ClaimRefusal::NotConfirmed);
     }
     if !identity_authorizes(
         &record.descriptor_sha256,
@@ -374,26 +477,24 @@ pub(crate) fn record_claims(
 }
 
 /// Try to claim a control found already holding the wanted value as irlume's
-/// own crash leftover.
+/// own crash leftover. The caller holds the stream lock, which is consumed:
+/// into the returned record on success, dropped on refusal.
 ///
 /// `None` is the ordinary answer and means "not irlume's to undo": no record,
-/// a record whose writer is still alive (its lock is held), or a record the
-/// pure gate refuses. `Some` arms the caller's guard with the displaced value
-/// and hands over the still-locked record, with the attempt already counted
-/// on disk — counted BEFORE the write it authorises, so a crash between claim
-/// and restore cannot uncount it.
+/// or a record the pure gate refuses. `Some` arms the caller's guard with the
+/// displaced value and hands over the record, with the attempt already
+/// counted on disk — counted BEFORE the write it authorises, so a crash
+/// between claim and restore cannot uncount it.
 pub(crate) fn claim(
+    lock: StreamLock,
     id: &CameraIdentity,
     unit: u8,
     selector: u8,
     current: &[u8],
 ) -> Option<(Vec<u8>, StreamRecord)> {
-    use std::os::unix::fs::MetadataExt as _;
-    use std::os::unix::io::AsRawFd as _;
-
     let path = record_path(id);
-    let file = match std::fs::File::open(&path) {
-        Ok(file) => file,
+    let body = match std::fs::read_to_string(&path) {
+        Ok(body) => body,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
         Err(e) => {
             // Not absence: a store that cannot be read may be hiding a real
@@ -402,37 +503,6 @@ pub(crate) fn claim(
             eprintln!(
                 "irlume: cannot read the stream record {}: {e}; treating the control's value \
                  as another writer's",
-                path.display()
-            );
-            return None;
-        }
-    };
-    // A held lock is a live writer: this stream's own predecessor during a
-    // frozen-stream restart, or another process mid-capture. Either way the
-    // value in the control is a RUNNING stream's business. Silent, because
-    // the restart path lands here at every reopen on a camera whose control
-    // survives a stream close.
-    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-        return None;
-    }
-    // The lock arrived after the open; make sure the name still means this
-    // inode. A record replaced in between belongs to whoever replaced it.
-    // NOT covered by a test, and a mutant deleting it survives the suite:
-    // staging the condition needs another process's rename to land inside the
-    // instructions between our open and our flock, which nothing available
-    // here can arrange deterministically. The decision has no extractable
-    // value either — it IS the comparison.
-    let (Ok(ours), Ok(named)) = (file.metadata(), std::fs::metadata(&path)) else {
-        return None;
-    };
-    if (ours.dev(), ours.ino()) != (named.dev(), named.ino()) {
-        return None;
-    }
-    let body = match std::io::read_to_string(&file) {
-        Ok(body) => body,
-        Err(e) => {
-            eprintln!(
-                "irlume: cannot read the stream record {}: {e}",
                 path.display()
             );
             return None;
@@ -452,9 +522,11 @@ pub(crate) fn claim(
     let displaced = match record_claims(&record, id, unit, selector, current) {
         Ok(displaced) => displaced,
         // Ordinary refusals, quiet: a machine where something else also sets
-        // the control lands here at every stream open.
+        // the control lands here at every stream open, and an unconfirmed
+        // record is precisely a value that may be somebody else's choice.
         Err(ClaimRefusal::DifferentCamera)
         | Err(ClaimRefusal::DifferentControl { .. })
+        | Err(ClaimRefusal::NotConfirmed)
         | Err(ClaimRefusal::Superseded) => return None,
         Err(ClaimRefusal::UnsupportedSchema { found }) => {
             eprintln!(
@@ -479,20 +551,26 @@ pub(crate) fn claim(
             return None;
         }
     };
-    // Count the attempt before the write it authorises. The rewrite replaces
-    // the inode, so the lock moves to the new file with the returned handle;
-    // a claim that cannot count durably-enough does not arm.
+    // Count the attempt before the write it authorises. A claim whose count
+    // cannot be recorded does not arm.
     let counted = StreamWrite {
         restore_attempts: record.restore_attempts + 1,
         ..record
     };
     match publish(&path, &counted) {
-        Ok(handle) => {
+        Ok(()) => {
             trace(&format!(
                 "claimed unit{unit}/sel{selector} displaced={} attempt={}",
                 counted.displaced, counted.restore_attempts
             ));
-            Some((displaced, handle))
+            Some((
+                displaced,
+                StreamRecord {
+                    path,
+                    record: counted,
+                    _lock: lock,
+                },
+            ))
         }
         Err(why) => {
             eprintln!(
@@ -532,6 +610,7 @@ mod tests {
             interface_number: id.interface_number,
             unit: 4,
             selector: 6,
+            state: WriteState::Applied,
             applied: "010302".into(),
             displaced: "010301".into(),
             restore_attempts: 0,
@@ -547,6 +626,21 @@ mod tests {
             record_claims(&record_for(&id), &id, 4, 6, &[1, 3, 2]),
             Ok(vec![1, 3, 1]),
             "camera, control and bytes all match: this is irlume's leftover"
+        );
+    }
+
+    /// The finding from review round 1: a record published before a write
+    /// that never happened must not authorise a restore, however well it
+    /// matches. The value it matches may be another program's later choice.
+    #[test]
+    fn a_prepared_record_never_authorizes_a_claim() {
+        let id = identity();
+        let mut unconfirmed = record_for(&id);
+        unconfirmed.state = WriteState::Prepared;
+        assert_eq!(
+            record_claims(&unconfirmed, &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::NotConfirmed),
+            "an unconfirmed write may never have reached the camera"
         );
     }
 

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -284,6 +284,15 @@ impl StreamRecord {
     /// unrelated value happened to match it (review round 2). Demoting first
     /// means the worst a failed cleanup leaves is inert litter.
     pub(crate) fn retire(mut self) -> Result<Self, Box<(Self, String)>> {
+        // Already non-authoritative: a failed post-write confirmation left the
+        // record `prepared` in memory and on disk, and rewriting it buys
+        // nothing — while a store still broken from that failure would turn
+        // the rewrite into a refusal that blocks the RESTORE of a change
+        // whose record never authorised anything (review round 10).
+        if self.record.state == WriteState::Prepared {
+            trace("retired");
+            return Ok(self);
+        }
         self.record.state = WriteState::Prepared;
         if let Err(why) = publish(&self.path, &self.record) {
             self.record.state = WriteState::Applied;

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -380,9 +380,17 @@ pub(crate) enum SaveError {
     /// is no change for the exclusion to outlive, and releasing it lets the
     /// control's own next capture claim the outstanding record.
     Outstanding { unit: u8, selector: u8 },
-    /// The store could not take the record for a reason other than an
-    /// outstanding one: unreadable existing file, unwritable directory, a
-    /// failed rename. The caller proceeds unrecorded, still holding the lock.
+    /// The existing record cannot be REASONED ABOUT — an unsupported schema,
+    /// an unparseable body — or is `prepared` for a change this write cannot
+    /// prove absent. Not authorising a claim does not license destroying it:
+    /// a `prepared` record's write may have SUCCEEDED (a crash between the
+    /// `SET_CUR` and the confirmation), and its displaced value is then the
+    /// only route back (review round 7). The caller refuses the write; the
+    /// lock is dropped, nothing is written, nothing is destroyed.
+    Protected { why: String },
+    /// The store could not take the record for a reason other than the two
+    /// above: an unreadable existing file, an unwritable directory, a failed
+    /// rename. The caller proceeds unrecorded, still holding the lock.
     Unavailable { lock: StreamLock, why: String },
 }
 
@@ -405,23 +413,33 @@ pub(crate) fn save(
     displaced: &[u8],
 ) -> Result<StreamRecord, SaveError> {
     let path = record_path(id);
+    // What already sits at this camera's path decides whether writing is
+    // allowed at all. The ONLY record that may be replaced is one that is
+    // demonstrably superseded: same schema, same control, and its applied
+    // bytes no longer in the control. Everything else is protected —
+    // including `prepared` records, whose write may have succeeded before a
+    // crash stopped the confirmation, and schemas this build cannot read
+    // (review round 7: "authorises nothing" never meant "may be destroyed").
     match std::fs::read_to_string(&path) {
         Ok(body) => match serde_json::from_str::<StreamWrite>(&body) {
-            Ok(existing)
-                if existing.schema_version == SCHEMA_VERSION
-                    && existing.state == WriteState::Applied =>
-            {
-                let live = if (existing.unit, existing.selector) == (unit, selector) {
-                    // Same control: superseded exactly when its bytes are no
-                    // longer what the control holds. An unparseable applied
-                    // field cannot prove that, so it reads as live.
-                    from_hex(&existing.applied)
-                        .map(|bytes| bytes == displaced)
-                        .unwrap_or(true)
-                } else {
-                    true
-                };
-                if live {
+            Ok(existing) => {
+                if existing.schema_version != SCHEMA_VERSION {
+                    drop(lock);
+                    return Err(SaveError::Protected {
+                        why: format!(
+                            "existing record {} uses schema {} and this build reads \
+                             {SCHEMA_VERSION}; not writing over recovery data this build \
+                             cannot interpret",
+                            path.display(),
+                            existing.schema_version
+                        ),
+                    });
+                }
+                let superseded = (existing.unit, existing.selector) == (unit, selector)
+                    && from_hex(&existing.applied)
+                        .map(|bytes| bytes != displaced)
+                        .unwrap_or(false);
+                if !superseded {
                     drop(lock);
                     return Err(SaveError::Outstanding {
                         unit: existing.unit,
@@ -429,12 +447,11 @@ pub(crate) fn save(
                     });
                 }
             }
-            Ok(_) => {}
             Err(e) => {
-                // A file that will not parse could be hiding an applied
-                // record. Nothing is written over it; a human gets to look.
-                return Err(SaveError::Unavailable {
-                    lock,
+                // A file that will not parse could be hiding anything,
+                // including an applied record. Nothing is written over it.
+                drop(lock);
+                return Err(SaveError::Protected {
                     why: format!(
                         "existing record {} does not parse ({e}); not writing over it",
                         path.display()

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -417,6 +417,11 @@ pub(crate) fn claim(
     }
     // The lock arrived after the open; make sure the name still means this
     // inode. A record replaced in between belongs to whoever replaced it.
+    // NOT covered by a test, and a mutant deleting it survives the suite:
+    // staging the condition needs another process's rename to land inside the
+    // instructions between our open and our flock, which nothing available
+    // here can arrange deterministically. The decision has no extractable
+    // value either — it IS the comparison.
     let (Ok(ours), Ok(named)) = (file.metadata(), std::fs::metadata(&path)) else {
         return None;
     };

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -1,0 +1,622 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! A record of the ONE capture write a stream makes, so a later irlume can
+//! tell its own crash leftover from another writer's value.
+//!
+//! # The question this answers
+//!
+//! `StreamMode` restores the emitter control when a stream ends. When a new
+//! stream finds the control already holding the value it wants, that fact
+//! alone cannot separate two cases (#188):
+//!
+//!   * another tool set this value, so it is not irlume's to undo;
+//!   * irlume set it and was killed before it could undo it.
+//!
+//! Claiming it always undoes another program's change; never claiming it makes
+//! one `SIGKILL` leave the mode applied forever, because every later session
+//! reads the leftover as somebody else's. This record is the missing fact: it
+//! is written immediately before the `SET_CUR` and removed once the guard
+//! resolves, so a value found already in place is irlume's own leftover
+//! exactly when a record for this camera, this control and these bytes exists.
+//!
+//! # Durability, deliberately weaker than the discovery journal's
+//!
+//! What this must survive is PROCESS death: a `SIGKILL`, the watchdog, a panic.
+//! The page cache survives all of those, so a plain write and rename is
+//! enough for the next process to read the record, and nothing here calls
+//! `fsync`. The #183 journal fsyncs because a discovery record must survive a
+//! POWER CUT; this record sits on the authentication path, once per unlock,
+//! and a power cut that loses it loses an in-flight stream's bookkeeping on a
+//! control that a physical power cycle was measured to reset anyway (pt190:
+//! a replugged camera returns at its `GET_DEF`). Conflating the two
+//! requirements is what kept this record out of #184 for two review rounds.
+//!
+//! # Liveness
+//!
+//! The file doubles as its own liveness signal: the writer holds a
+//! non-blocking `flock` on it for as long as the guard is armed, and the lock
+//! dies with the process while the file does not. A claim that cannot take
+//! the lock is looking at a LIVE stream's record — a second process, or this
+//! process's own previous guard during a frozen-stream restart — and refuses.
+//! No pid or boot id is stored: #183 removed those from the journal because a
+//! recorded pid strands a record when its long-lived writer outlives the
+//! stream, and a kernel-released lock cannot go stale.
+
+use crate::emitter_journal::{filing_key, fingerprint, from_hex, identity_authorizes, to_hex};
+use crate::uvc_descriptor::CameraIdentity;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// The record format this build writes and is willing to act on.
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+/// How many times a leftover may be claimed before irlume stops trying.
+///
+/// A claim ends in a firmware write at stream end, and a control whose
+/// `GET_CUR` never reflects that write would otherwise be "claimed" again at
+/// every stream open, forever — the unbounded rewrite loop the #183 journal
+/// bounds with the same constant, on the same reasoning.
+pub(crate) const MAX_RESTORE_ATTEMPTS: u32 = 3;
+
+/// One stream's applied emitter mode, on disk from just before the `SET_CUR`
+/// until the guard resolves.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct StreamWrite {
+    /// A GATE, required with no serde default, for the reason the journal's
+    /// is: serde ignores unknown fields, so any future record would otherwise
+    /// deserialize into a plausible-looking older shape and authorise a write
+    /// this build cannot reason about.
+    pub(crate) schema_version: u32,
+    /// Which build wrote the record. Descriptive, not a gate.
+    pub(crate) engine_version: String,
+    /// Hex sha256 of the camera's USB descriptor blob: the model.
+    pub(crate) descriptor_sha256: String,
+    /// `vid:pid`, human-readable, checked against the digest's camera.
+    pub(crate) usb_id: String,
+    pub(crate) interface_number: u8,
+    pub(crate) unit: u8,
+    pub(crate) selector: u8,
+    /// Hex of the payload the stream applied. A claim requires the control to
+    /// be holding exactly this, or the leftover it describes is already gone.
+    pub(crate) applied: String,
+    /// Hex of what the write displaced: the value a claimed restore puts back.
+    pub(crate) displaced: String,
+    /// How many times a claim has armed a restore for this record. Counted at
+    /// claim time, before the write it authorises, like the journal's.
+    #[serde(default)]
+    pub(crate) restore_attempts: u32,
+    /// The USB serial, when the camera published one at write time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) serial: Option<String>,
+    /// The sysfs path of the USB device: the port, which with the digest and
+    /// serial is the same three-part identity the journal files under.
+    pub(crate) usb_devpath: String,
+}
+
+/// Where stream records live. Separate from the discovery journal's store:
+/// the two have different lifetimes, different durability, and a shared
+/// directory would invite a shared reader.
+fn store_dir() -> PathBuf {
+    irlume_common::state_dir().join("ir-emitter-stream")
+}
+
+/// This camera's record path. One file per camera: a stream applies one
+/// control, and a second stream on the same camera replaces rather than
+/// accumulates.
+///
+/// Filed under the journal's [`filing_key`], which includes the serial. A
+/// serial that reads at write time and not at claim time (or the reverse)
+/// makes the claim MISS; that fails toward not restoring, which is the
+/// pre-#188 status quo for a leftover, and the identity check would refuse
+/// such a claim anyway. No scan fallback, deliberately: a stream record is
+/// bookkeeping for the machine's own camera, not undo data for exploratory
+/// bytes, and the cost of a miss is bounded where the journal's was not.
+fn record_path(id: &CameraIdentity) -> PathBuf {
+    store_dir().join(format!("{}.json", filing_key(id)))
+}
+
+/// A live record: the file on disk plus the `flock` that marks its writer as
+/// alive. Held by the stream guard while armed.
+///
+/// Dropping this WITHOUT [`resolve`](StreamRecord::resolve) keeps the file and
+/// releases the lock, which is exactly the crash shape on purpose: a restore
+/// that failed leaves the leftover real, so the record must stay claimable.
+#[derive(Debug)]
+pub(crate) struct StreamRecord {
+    path: PathBuf,
+    file: std::fs::File,
+}
+
+impl StreamRecord {
+    /// Remove the record: the change it describes is no longer outstanding,
+    /// either because the restore landed or because the control was found no
+    /// longer holding irlume's value.
+    ///
+    /// Only the inode this handle locked is removed. The path may already
+    /// hold a NEWER record — a replacement guard renames its own over this
+    /// one — and removing by name alone would delete bookkeeping that is not
+    /// ours. A writer renaming over between the check and the unlink loses
+    /// its file's name; the window is a few instructions wide, needs a second
+    /// irlume on the same camera in it, and costs that writer a claimable
+    /// leftover rather than a wrong write, so it is accepted rather than
+    /// closed.
+    pub(crate) fn resolve(self) {
+        use std::os::unix::fs::MetadataExt as _;
+        let Ok(ours) = self.file.metadata() else {
+            return;
+        };
+        match std::fs::metadata(&self.path) {
+            Ok(m) if (m.dev(), m.ino()) == (ours.dev(), ours.ino()) => {
+                let _ = std::fs::remove_file(&self.path);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Serialize, write to a fresh temp file, lock it, and rename it into place.
+///
+/// The lock is taken on the temp fd BEFORE the rename, so from the first
+/// instant the record is visible its writer already reads as alive; there is
+/// no window in which a concurrent claim could adopt a record whose owner is
+/// running. `flock` follows the open file description across the rename.
+///
+/// No fsync anywhere, see the module doc: process death is the requirement,
+/// and the page cache meets it.
+fn publish(path: &Path, record: &StreamWrite) -> Result<StreamRecord, String> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+    use std::os::unix::io::AsRawFd as _;
+
+    let dir = store_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    irlume_common::restrict(&dir, 0o700)?;
+    let body = serde_json::to_string(record).map_err(|e| format!("serialize: {e}"))?;
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("stream");
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = dir.join(format!(".{name}.tmp.{}.{seq}", std::process::id()));
+    let open_tmp = || {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp)
+    };
+    let mut file = match open_tmp() {
+        // A crashed prior writer with this pid and seq left its temp behind;
+        // it is nobody's record (never renamed), so replace it.
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(&tmp)
+                .map_err(|e| format!("clear stale {}: {e}", tmp.display()))?;
+            open_tmp().map_err(|e| format!("create {}: {e}", tmp.display()))?
+        }
+        other => other.map_err(|e| format!("create {}: {e}", tmp.display()))?,
+    };
+    if let Err(e) = file.write_all(body.as_bytes()) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("write {}: {e}", tmp.display()));
+    }
+    // SAFETY: the fd is owned by `file`, which the returned guard keeps open.
+    // A fresh 0600 temp file nobody else can have opened: the non-blocking
+    // lock cannot fail with WouldBlock, and any failure is reported.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let e = std::io::Error::last_os_error();
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("lock {}: {e}", tmp.display()));
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("publish {}: {e}", path.display()));
+    }
+    Ok(StreamRecord {
+        path: path.to_path_buf(),
+        file,
+    })
+}
+
+/// Put the record for this stream's write on disk, locked, BEFORE the write.
+///
+/// Best-effort at the caller: a store that cannot be written costs crash
+/// bookkeeping, not the authentication — see `write_if_different` for why
+/// that direction was chosen.
+pub(crate) fn save(
+    id: &CameraIdentity,
+    unit: u8,
+    selector: u8,
+    applied: &[u8],
+    displaced: &[u8],
+) -> Result<StreamRecord, String> {
+    let record = StreamWrite {
+        schema_version: SCHEMA_VERSION,
+        engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        descriptor_sha256: fingerprint(id),
+        usb_id: id.usb_id(),
+        interface_number: id.interface_number,
+        unit,
+        selector,
+        applied: to_hex(applied),
+        displaced: to_hex(displaced),
+        restore_attempts: 0,
+        serial: id.serial.clone(),
+        usb_devpath: id.usb_devpath.clone(),
+    };
+    publish(&record_path(id), &record)
+}
+
+/// Why a record does not hand this stream a restore.
+///
+/// Separated because they call for different noise: most are the ordinary
+/// business of a machine where something else also touches the control, and
+/// two mean the store holds something wrong enough to say so.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ClaimRefusal {
+    /// Not written about the camera in front of us, to the standard required
+    /// to write to it. Includes a recorded serial the attached camera cannot
+    /// currently reproduce, which fails CLOSED exactly as the journal does.
+    DifferentCamera,
+    /// A build with a different record format wrote this. Report, never act.
+    UnsupportedSchema { found: u32 },
+    /// The record's own fields disagree with each other or will not parse.
+    Malformed(String),
+    /// The record names a different control than this stream is applying.
+    /// The leftover may still be real, but it is not THIS write's business:
+    /// claiming it here would arm a restore for a control nobody validated
+    /// this pass.
+    DifferentControl { unit: u8, selector: u8 },
+    /// The control is not holding what the record says was applied, so the
+    /// leftover it describes is already gone — somebody moved the control
+    /// after the crash. There is nothing of irlume's to undo.
+    Superseded,
+    /// Claimed and restored [`MAX_RESTORE_ATTEMPTS`] times without the
+    /// control ever reading back different. Writing again is the loop the
+    /// counter exists to stop.
+    OutOfAttempts { attempts: u32 },
+}
+
+/// Whether this record hands the stream that found `current` already in place
+/// a restore value. Pure, so every gate that ends in a firmware write is
+/// testable without a camera (#183's rule).
+///
+/// The caller has already validated that (unit, selector) names a control
+/// this camera's descriptor publishes — every apply path checks that before
+/// reading the control — so equality with the record's coordinates carries
+/// that gate over to the claim without a second descriptor walk.
+pub(crate) fn record_claims(
+    record: &StreamWrite,
+    id: &CameraIdentity,
+    unit: u8,
+    selector: u8,
+    current: &[u8],
+) -> Result<Vec<u8>, ClaimRefusal> {
+    if record.schema_version != SCHEMA_VERSION {
+        return Err(ClaimRefusal::UnsupportedSchema {
+            found: record.schema_version,
+        });
+    }
+    if !identity_authorizes(
+        &record.descriptor_sha256,
+        &record.usb_devpath,
+        record.serial.as_deref(),
+        id,
+    ) {
+        return Err(ClaimRefusal::DifferentCamera);
+    }
+    // The digest already pins the descriptors; these two come from the same
+    // sysfs read, so a disagreement means the record was assembled from two
+    // cameras or edited. Same check, same reasoning as the journal's.
+    if record.usb_id != id.usb_id() || record.interface_number != id.interface_number {
+        return Err(ClaimRefusal::Malformed(format!(
+            "record says {} interface {}, camera is {} interface {}",
+            record.usb_id,
+            record.interface_number,
+            id.usb_id(),
+            id.interface_number
+        )));
+    }
+    if (record.unit, record.selector) != (unit, selector) {
+        return Err(ClaimRefusal::DifferentControl {
+            unit: record.unit,
+            selector: record.selector,
+        });
+    }
+    let applied =
+        from_hex(&record.applied).map_err(|e| ClaimRefusal::Malformed(format!("applied: {e}")))?;
+    let displaced = from_hex(&record.displaced)
+        .map_err(|e| ClaimRefusal::Malformed(format!("displaced: {e}")))?;
+    if displaced.len() != applied.len() {
+        return Err(ClaimRefusal::Malformed(format!(
+            "{} displaced bytes recorded for a control whose applied value is {} long",
+            displaced.len(),
+            applied.len()
+        )));
+    }
+    if applied == displaced {
+        // A write that displaced nothing is a write the tail never makes, so
+        // this record did not come from it.
+        return Err(ClaimRefusal::Malformed(
+            "applied and displaced are identical".to_string(),
+        ));
+    }
+    if applied != current {
+        return Err(ClaimRefusal::Superseded);
+    }
+    if record.restore_attempts >= MAX_RESTORE_ATTEMPTS {
+        return Err(ClaimRefusal::OutOfAttempts {
+            attempts: record.restore_attempts,
+        });
+    }
+    Ok(displaced)
+}
+
+/// Try to claim a control found already holding the wanted value as irlume's
+/// own crash leftover.
+///
+/// `None` is the ordinary answer and means "not irlume's to undo": no record,
+/// a record whose writer is still alive (its lock is held), or a record the
+/// pure gate refuses. `Some` arms the caller's guard with the displaced value
+/// and hands over the still-locked record, with the attempt already counted
+/// on disk — counted BEFORE the write it authorises, so a crash between claim
+/// and restore cannot uncount it.
+pub(crate) fn claim(
+    id: &CameraIdentity,
+    unit: u8,
+    selector: u8,
+    current: &[u8],
+) -> Option<(Vec<u8>, StreamRecord)> {
+    use std::os::unix::fs::MetadataExt as _;
+    use std::os::unix::io::AsRawFd as _;
+
+    let path = record_path(id);
+    let file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            // Not absence: a store that cannot be read may be hiding a real
+            // leftover, and silence here would wear the "somebody else's
+            // value" answer without the evidence for it.
+            eprintln!(
+                "irlume: cannot read the stream record {}: {e}; treating the control's value \
+                 as another writer's",
+                path.display()
+            );
+            return None;
+        }
+    };
+    // A held lock is a live writer: this stream's own predecessor during a
+    // frozen-stream restart, or another process mid-capture. Either way the
+    // value in the control is a RUNNING stream's business. Silent, because
+    // the restart path lands here at every reopen on a camera whose control
+    // survives a stream close.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return None;
+    }
+    // The lock arrived after the open; make sure the name still means this
+    // inode. A record replaced in between belongs to whoever replaced it.
+    let (Ok(ours), Ok(named)) = (file.metadata(), std::fs::metadata(&path)) else {
+        return None;
+    };
+    if (ours.dev(), ours.ino()) != (named.dev(), named.ino()) {
+        return None;
+    }
+    let body = match std::io::read_to_string(&file) {
+        Ok(body) => body,
+        Err(e) => {
+            eprintln!(
+                "irlume: cannot read the stream record {}: {e}",
+                path.display()
+            );
+            return None;
+        }
+    };
+    let record: StreamWrite = match serde_json::from_str(&body) {
+        Ok(record) => record,
+        Err(e) => {
+            eprintln!(
+                "irlume: stream record {} does not parse ({e}); a leftover may be \
+                 unresolved and this build cannot claim it",
+                path.display()
+            );
+            return None;
+        }
+    };
+    let displaced = match record_claims(&record, id, unit, selector, current) {
+        Ok(displaced) => displaced,
+        // Ordinary refusals, quiet: a machine where something else also sets
+        // the control lands here at every stream open.
+        Err(ClaimRefusal::DifferentCamera)
+        | Err(ClaimRefusal::DifferentControl { .. })
+        | Err(ClaimRefusal::Superseded) => return None,
+        Err(ClaimRefusal::UnsupportedSchema { found }) => {
+            eprintln!(
+                "irlume: stream record {} has schema {found}, this build reads {SCHEMA_VERSION}; \
+                 a leftover may be unresolved and this build cannot claim it",
+                path.display()
+            );
+            return None;
+        }
+        Err(ClaimRefusal::Malformed(why)) => {
+            eprintln!(
+                "irlume: stream record {} is malformed ({why}); not acting on it",
+                path.display()
+            );
+            return None;
+        }
+        Err(ClaimRefusal::OutOfAttempts { attempts }) => {
+            eprintln!(
+                "irlume: unit{unit}/sel{selector} was restored {attempts} times and still \
+                 reads as irlume's leftover; leaving it and its record alone"
+            );
+            return None;
+        }
+    };
+    // Count the attempt before the write it authorises. The rewrite replaces
+    // the inode, so the lock moves to the new file with the returned handle;
+    // a claim that cannot count durably-enough does not arm.
+    let counted = StreamWrite {
+        restore_attempts: record.restore_attempts + 1,
+        ..record
+    };
+    match publish(&path, &counted) {
+        Ok(handle) => Some((displaced, handle)),
+        Err(why) => {
+            eprintln!(
+                "irlume: cannot count a claim on {} ({why}); not restoring",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity_with(descriptors: Vec<u8>) -> CameraIdentity {
+        CameraIdentity {
+            descriptors,
+            interface_number: 0,
+            vid: 0x3443,
+            pid: 0xc803,
+            serial: None,
+            usb_devpath: "/devices/pci0000:00/usb1/1-2/1-2.1".to_string(),
+        }
+    }
+
+    fn identity() -> CameraIdentity {
+        identity_with(vec![0x0a, 0x24, 0x03, 0x0e])
+    }
+
+    fn record_for(id: &CameraIdentity) -> StreamWrite {
+        StreamWrite {
+            schema_version: SCHEMA_VERSION,
+            engine_version: "test".into(),
+            descriptor_sha256: fingerprint(id),
+            usb_id: id.usb_id(),
+            interface_number: id.interface_number,
+            unit: 4,
+            selector: 6,
+            applied: "010302".into(),
+            displaced: "010301".into(),
+            restore_attempts: 0,
+            serial: None,
+            usb_devpath: id.usb_devpath.clone(),
+        }
+    }
+
+    #[test]
+    fn a_matching_record_hands_over_the_displaced_value() {
+        let id = identity();
+        assert_eq!(
+            record_claims(&record_for(&id), &id, 4, 6, &[1, 3, 2]),
+            Ok(vec![1, 3, 1]),
+            "camera, control and bytes all match: this is irlume's leftover"
+        );
+    }
+
+    #[test]
+    fn a_record_for_another_camera_is_refused() {
+        let id = identity();
+        let other = identity_with(vec![0xff]);
+        assert_eq!(
+            record_claims(&record_for(&other), &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::DifferentCamera)
+        );
+        let mut moved = record_for(&id);
+        moved.usb_devpath = "/devices/pci0000:00/usb1/1-3/1-3.1".to_string();
+        assert_eq!(
+            record_claims(&moved, &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::DifferentCamera),
+            "a devpath names a port; a record from another port is not this camera's"
+        );
+    }
+
+    #[test]
+    fn a_recorded_serial_the_camera_cannot_reproduce_fails_closed() {
+        let id = identity();
+        let mut with_serial = record_for(&id);
+        with_serial.serial = Some("200901010001".to_string());
+        assert_eq!(
+            record_claims(&with_serial, &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::DifferentCamera),
+            "the record was written with a discriminator this camera cannot currently show"
+        );
+    }
+
+    #[test]
+    fn schema_and_malformed_records_never_authorize() {
+        let id = identity();
+        let mut newer = record_for(&id);
+        newer.schema_version = 2;
+        assert_eq!(
+            record_claims(&newer, &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::UnsupportedSchema { found: 2 })
+        );
+        let mut zero = record_for(&id);
+        zero.schema_version = 0;
+        assert!(
+            matches!(
+                record_claims(&zero, &id, 4, 6, &[1, 3, 2]),
+                Err(ClaimRefusal::UnsupportedSchema { found: 0 })
+            ),
+            "equality, not an upper bound: schema 0 is not a schema this build wrote"
+        );
+        let mut badhex = record_for(&id);
+        badhex.displaced = "01030".into();
+        assert!(matches!(
+            record_claims(&badhex, &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::Malformed(_))
+        ));
+        let mut wrong_usb = record_for(&id);
+        wrong_usb.usb_id = "ffff:0000".into();
+        assert!(matches!(
+            record_claims(&wrong_usb, &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::Malformed(_))
+        ));
+        let mut same = record_for(&id);
+        same.displaced = same.applied.clone();
+        assert!(
+            matches!(
+                record_claims(&same, &id, 4, 6, &[1, 3, 2]),
+                Err(ClaimRefusal::Malformed(_))
+            ),
+            "the tail never writes a value over itself, so this record is not the tail's"
+        );
+    }
+
+    #[test]
+    fn another_control_or_moved_bytes_are_not_this_streams_business() {
+        let id = identity();
+        assert_eq!(
+            record_claims(&record_for(&id), &id, 14, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::DifferentControl {
+                unit: 4,
+                selector: 6
+            })
+        );
+        assert_eq!(
+            record_claims(&record_for(&id), &id, 4, 6, &[9, 9, 9]),
+            Err(ClaimRefusal::Superseded),
+            "the control is not holding what was applied, so the leftover is already gone"
+        );
+    }
+
+    #[test]
+    fn the_attempt_limit_refuses_the_fourth_claim() {
+        let id = identity();
+        let mut spent = record_for(&id);
+        spent.restore_attempts = MAX_RESTORE_ATTEMPTS;
+        assert_eq!(
+            record_claims(&spent, &id, 4, 6, &[1, 3, 2]),
+            Err(ClaimRefusal::OutOfAttempts {
+                attempts: MAX_RESTORE_ATTEMPTS
+            })
+        );
+    }
+}

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -247,9 +247,10 @@ pub(crate) struct StreamRecord {
 impl StreamRecord {
     /// Rewrite the record as `applied`, after the camera accepted the write.
     ///
-    /// On failure the record stays `prepared` on disk: the write happened but
-    /// a crash from here would leave a leftover no claim will touch, which is
-    /// reported, and is the safe direction.
+    /// Also how a record whose RESTORE failed is put back into force: the
+    /// leftover is real again, so the record must be claimable again. On
+    /// failure the record stays `prepared` on disk: reported, unclaimable,
+    /// and the safe direction.
     pub(crate) fn mark_applied(mut self) -> Result<Self, String> {
         self.record.state = WriteState::Applied;
         publish(&self.path, &self.record)?;
@@ -257,16 +258,42 @@ impl StreamRecord {
         Ok(self)
     }
 
-    /// Remove the record: the change it describes is no longer outstanding,
-    /// either because the restore landed or because the control was found no
-    /// longer holding irlume's value.
+    /// Rewrite the record as `prepared`, BEFORE the effect it covers is
+    /// undone, so it can no longer authorise a restore.
+    ///
+    /// The unlink in [`resolve`](Self::resolve) can fail — a store gone
+    /// read-only is exactly the kind of machine trouble that arrives between
+    /// a write and its cleanup — and an `applied` record surviving its own
+    /// resolution would later authorise a firmware write over whatever
+    /// unrelated value happened to match it (review round 2). Demoting first
+    /// means the worst a failed cleanup leaves is inert litter.
+    pub(crate) fn retire(mut self) -> Result<Self, String> {
+        self.record.state = WriteState::Prepared;
+        publish(&self.path, &self.record)?;
+        trace("retired");
+        Ok(self)
+    }
+
+    /// Remove a record that [`retire`](Self::retire) has already made
+    /// non-authoritative.
     ///
     /// A plain unlink is enough: every writer of this path holds the stable
     /// lock, this handle holds it now, so the record at the name is this
-    /// handle's own.
-    pub(crate) fn resolve(self) {
-        let _ = std::fs::remove_file(&self.path);
-        trace("resolved");
+    /// handle's own. A failure is the caller's to report, and costs litter
+    /// rather than authority: the record on disk is `prepared`, and a later
+    /// write replaces it.
+    pub(crate) fn resolve(self) -> Result<(), String> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {
+                trace("resolved");
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                trace("resolved");
+                Ok(())
+            }
+            Err(e) => Err(format!("remove {}: {e}", self.path.display())),
+        }
     }
 }
 

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -59,6 +59,19 @@ pub(crate) const SCHEMA_VERSION: u32 = 1;
 /// bounds with the same constant, on the same reasoning.
 pub(crate) const MAX_RESTORE_ATTEMPTS: u32 = 3;
 
+/// Trace a stream-record event onto the stream `set_cur` traces writes to.
+///
+/// Same switch as the journal's, for the same reason: the claims this module
+/// makes are ORDERINGS — record on disk before the `SET_CUR`, resolved only
+/// after the restore — and on hardware the only way to observe them is to put
+/// the events into the same transcript as the writes, in order. An strace of
+/// `write(2)` then shows both interleaved (pt190).
+fn trace(event: &str) {
+    if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
+        eprintln!("irlume: stream-record {event}");
+    }
+}
+
 /// One stream's applied emitter mode, on disk from just before the `SET_CUR`
 /// until the guard resolves.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -149,8 +162,9 @@ impl StreamRecord {
         match std::fs::metadata(&self.path) {
             Ok(m) if (m.dev(), m.ino()) == (ours.dev(), ours.ino()) => {
                 let _ = std::fs::remove_file(&self.path);
+                trace("resolved");
             }
-            _ => {}
+            _ => trace("resolved (already replaced, left in place)"),
         }
     }
 }
@@ -246,7 +260,12 @@ pub(crate) fn save(
         serial: id.serial.clone(),
         usb_devpath: id.usb_devpath.clone(),
     };
-    publish(&record_path(id), &record)
+    let handle = publish(&record_path(id), &record)?;
+    trace(&format!(
+        "saved unit{unit}/sel{selector} applied={} displaced={}",
+        record.applied, record.displaced
+    ));
+    Ok(handle)
 }
 
 /// Why a record does not hand this stream a restore.
@@ -463,7 +482,13 @@ pub(crate) fn claim(
         ..record
     };
     match publish(&path, &counted) {
-        Ok(handle) => Some((displaced, handle)),
+        Ok(handle) => {
+            trace(&format!(
+                "claimed unit{unit}/sel{selector} displaced={} attempt={}",
+                counted.displaced, counted.restore_attempts
+            ));
+            Some((displaced, handle))
+        }
         Err(why) => {
             eprintln!(
                 "irlume: cannot count a claim on {} ({why}); not restoring",

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -249,6 +249,12 @@ pub(crate) fn acquire(id: &CameraIdentity) -> Result<StreamLock, AcquireError> {
 pub(crate) struct StreamRecord {
     path: PathBuf,
     record: StreamWrite,
+    /// Whether this handle came from [`claim`] rather than [`save`]. A
+    /// claimed restore spends one counted attempt — persisted inside
+    /// [`retire`](Self::retire)'s pre-write publication, not at claim time,
+    /// so a bookkeeping failure that prevents the restore from even being
+    /// attempted spends nothing (review round 11).
+    claimed: bool,
     _lock: StreamLock,
 }
 
@@ -293,9 +299,20 @@ impl StreamRecord {
             trace("retired");
             return Ok(self);
         }
+        let previous_attempts = self.record.restore_attempts;
         self.record.state = WriteState::Prepared;
+        if self.claimed {
+            // The claimed attempt is counted HERE, in the same durable step
+            // that precedes the restoring write, and not at claim time: a
+            // retirement that fails makes no camera request, and spending the
+            // budget on bookkeeping failures could exhaust it with zero
+            // restores ever attempted (review round 11). Plain add: a claim
+            // only arms below MAX_RESTORE_ATTEMPTS, far from overflow.
+            self.record.restore_attempts += 1;
+        }
         if let Err(why) = publish(&self.path, &self.record) {
             self.record.state = WriteState::Applied;
+            self.record.restore_attempts = previous_attempts;
             return Err(Box::new((self, why)));
         }
         trace("retired");
@@ -411,8 +428,10 @@ pub(crate) enum SaveError {
 /// whose bytes are still in the control describes irlume's own live leftover,
 /// and renaming over it would destroy the only route back. A record for a
 /// DIFFERENT control cannot be probed from here at all, so it is never
-/// replaced while `applied`. Superseded records (bytes no longer present) and
-/// `prepared` ones authorise nothing and are replaced freely.
+/// replaced. The ONLY record replaced is one demonstrably superseded on this
+/// same control: its applied bytes are no longer what the control holds. A
+/// `prepared` record authorises no claim, and is still protected wherever
+/// its write may have landed — see the gate below and review rounds 7 and 11.
 pub(crate) fn save(
     lock: StreamLock,
     id: &CameraIdentity,
@@ -501,6 +520,7 @@ pub(crate) fn save(
     Ok(StreamRecord {
         path,
         record,
+        claimed: false,
         _lock: lock,
     })
 }
@@ -626,9 +646,10 @@ pub(crate) fn record_claims(
 ///
 /// `None` is the ordinary answer and means "not irlume's to undo": no record,
 /// or a record the pure gate refuses. `Some` arms the caller's guard with the
-/// displaced value and hands over the record, with the attempt already
-/// counted on disk — counted BEFORE the write it authorises, so a crash
-/// between claim and restore cannot uncount it.
+/// displaced value and hands over the record. The attempt it spends is
+/// persisted by `retire`, in the durable step immediately before the write it
+/// authorises — not here, where a later bookkeeping failure could leave it
+/// spent with no restore ever attempted (review round 11).
 pub(crate) fn claim(
     lock: StreamLock,
     id: &CameraIdentity,
@@ -695,35 +716,20 @@ pub(crate) fn claim(
             return None;
         }
     };
-    // Count the attempt before the write it authorises. A claim whose count
-    // cannot be recorded does not arm.
-    let counted = StreamWrite {
-        restore_attempts: record.restore_attempts + 1,
-        ..record
-    };
-    match publish(&path, &counted) {
-        Ok(()) => {
-            trace(&format!(
-                "claimed unit{unit}/sel{selector} displaced={} attempt={}",
-                counted.displaced, counted.restore_attempts
-            ));
-            Some((
-                displaced,
-                StreamRecord {
-                    path,
-                    record: counted,
-                    _lock: lock,
-                },
-            ))
-        }
-        Err(why) => {
-            eprintln!(
-                "irlume: cannot count a claim on {} ({why}); not restoring",
-                path.display()
-            );
-            None
-        }
-    }
+    trace(&format!(
+        "claimed unit{unit}/sel{selector} displaced={} attempt={}",
+        record.displaced,
+        record.restore_attempts + 1
+    ));
+    Some((
+        displaced,
+        StreamRecord {
+            path,
+            record,
+            claimed: true,
+            _lock: lock,
+        },
+    ))
 }
 
 #[cfg(test)]
@@ -873,6 +879,61 @@ mod tests {
             Err(ClaimRefusal::Superseded),
             "the control is not holding what was applied, so the leftover is already gone"
         );
+    }
+
+    /// A retirement that fails spends nothing (review round 11): the
+    /// increment rolls back with the state, and only the successful
+    /// pre-write publication carries it to disk.
+    #[test]
+    fn a_failed_retirement_spends_no_attempt() {
+        let _guard = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-sr-rollback-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = crate::testenv::EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let id = identity();
+        let lock = acquire(&id).expect("the lock is free");
+        drop(
+            save(lock, &id, 4, 6, &[1, 3, 2], &[1, 3, 1])
+                .expect("seed")
+                .mark_applied()
+                .expect("confirm"),
+        );
+        let lock = acquire(&id).expect("free again");
+        let (_, record) = claim(lock, &id, 4, 6, &[1, 3, 2]).expect("claimable");
+        // Break the retirement: the record's own path becomes a directory,
+        // so the publishing rename fails while everything else works.
+        let store = dir.join("ir-emitter-stream");
+        let path = std::fs::read_dir(&store)
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| p.extension().is_some_and(|e| e == "json"))
+            .expect("the record file");
+        let bytes = std::fs::read(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        let record = match record.retire() {
+            Ok(_) => panic!("the broken store must fail the retirement"),
+            Err(e) => e.0,
+        };
+        // Repair, and retire for real: exactly ONE attempt lands, in the
+        // successful publication.
+        std::fs::remove_dir(&path).unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+        record
+            .retire()
+            .expect("the repaired store retires")
+            .resolve()
+            .expect("resolve");
+        // Nothing left: resolve removed the record, and the one attempt it
+        // carried went with it — the failed try left no counter behind.
+        let survivors = std::fs::read_dir(&store)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+            .count();
+        assert_eq!(survivors, 0, "the retired record resolved cleanly");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/scripts/emitter-journal-hardware-test.sh
+++ b/scripts/emitter-journal-hardware-test.sh
@@ -36,9 +36,10 @@
 # `ir-setup` writes to the camera's Microsoft extension unit. That is a firmware
 # write; it is the operation under test. Section 4 SIGKILLs the daemon mid-run,
 # which is the state this change exists to recover from. Every value written is
-# one the camera itself reported: the parking value is its own GET_DEF, sent
-# through the documented override. The published descriptor is captured before
-# and after and compared, because a descriptor that changes is what #159 was.
+# one the camera itself reported: the parking value is its own GET_DEF, read
+# from the device and sent by examples/xu_set. The published descriptor is
+# captured before and after and compared, because a descriptor that changes is
+# what #159 was.
 set -uo pipefail
 
 TREE="${1:?usage: $0 <worktree> <ir-node> [rgb-node]}"
@@ -47,6 +48,11 @@ RGB="${3:-/dev/video0}"
 
 B="$TREE/target/release/irlume"
 D="$TREE/target/release/irlumed"
+# One guard-free SET_CUR (crates/irlume-camera/examples/xu_set.rs). Parking by
+# killing a daemon mid-capture does not work: apply and restore are microseconds
+# apart on the NexiGo and a shell poll loop cannot interpose. This writes the
+# camera's OWN GET_DEF, read from the device at run time.
+XU_SET="$TREE/target/release/examples/xu_set"
 OUT=/tmp/emitter-journal-hw
 SOCK=/run/irlume-hwtest.sock
 STATE=/var/lib/irlume-hwtest
@@ -60,10 +66,6 @@ MODELS="${IRLUME_MODEL_DIR:-/usr/share/irlume/models}"
 # a sandboxed state directory does not have.
 ORT="${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
     sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)}"
-# The camera's own default for the Microsoft face-authentication control, as both
-# validated modules report it via GET_DEF. Section 1 refuses to draw conclusions
-# if parking to it changed nothing.
-PARK="${PARK_VALUE:-1,3,1,0,0,0,0,0,0}"
 # The Microsoft unit and selector are DERIVED from the camera in section 0, not
 # assumed. They were hardcoded to one module's unit 4, which meant every
 # unit-specific assertion here silently checked nothing on any other camera: the
@@ -236,15 +238,14 @@ if [ -n "$node_dev" ]; then
 fi
 echo "  camera behind $IR: ${VID_PID:-unknown}"
 case "$VID_PID" in
-    3277:0059 | 3443:c803) known_park=yes ;;
-    *) known_park=no ;;
+    3277:0059 | 3443:c803) known_camera=yes ;;
+    *) known_camera=no ;;
 esac
-if [ -z "${PARK_VALUE:-}" ] && [ "$known_park" = no ]; then
-    echo "refusing: the built-in park value describes the ASUS 3277:0059 and"
-    echo "          NexiGo 3443:c803 streaming interface 3, and this is neither."
-    echo "          Set PARK_VALUE to a payload derived from THIS camera's"
-    echo "          GET_DEF, or run the read-only sections only."
-    exit 2
+if [ "$known_camera" = no ]; then
+    echo "note: this camera is neither of the two this harness was validated"
+    echo "      against (ASUS 3277:0059, NexiGo 3443:c803). The park value is"
+    echo "      read from THIS camera's GET_DEF, so it is still the device's"
+    echo "      own; the assertions below may still be module-specific."
 fi
 if [ -z "$UNIT" ] || [ -z "$SEL" ]; then
     echo "refusing: no Microsoft camera-control unit on this camera; nothing here applies"
@@ -258,54 +259,25 @@ if [ -n "$(find "$STORE" -name '*.json' 2>/dev/null)" ]; then
 fi
 
 echo "=== 1. park the control at the camera's own default ==="
-# Parked by applying the default in a capture and then KILLING the daemon before
-# the stream ends.
+# One guard-free SET_CUR of this camera's own GET_DEF, via examples/xu_set.
 #
-# Starting a daemon with the override and stopping it cleanly no longer parks
-# anything, and that is #168 working rather than a bug: the daemon does not
-# capture at startup, so nothing is written, and if a capture does run the guard
-# restores whatever was there before the park, undoing it. No capture-path route
-# can leave a control changed any more, which is the whole point of the change.
-#
-# A kill is the one thing that still can, because the guard never runs. That is
-# the same mechanism section 4 uses deliberately, and it leaves the control at
-# the default exactly as this section needs.
-start_daemon park "$UNIT:$SEL:$PARK" || {
-    echo "  daemon would not start"
+# No daemon-based route can park any more, and that is #168 working rather than
+# a bug: a clean stop writes nothing, and a captured write is restored by the
+# stream guard. Killing the daemon between apply and restore was tried and does
+# not work — they are microseconds apart on the NexiGo and a shell poll loop
+# cannot interpose. The tool exists for exactly this job.
+if [ ! -x "$XU_SET" ]; then
+    echo "  $XU_SET is missing; build it first:"
+    echo "  cargo build --release -p irlume-camera --example xu_set"
     exit 2
-}
-# KNOWN NOT TO WORK RELIABLY, kept because the attempt documents the problem.
-# The kill has to land between the apply and the guard's restore, and measurement
-# on the NexiGo says those are microseconds apart: every run so far logs the park
-# value applied and then immediately restored, whatever the round count. A shell
-# poll loop cannot interpose there.
-#
-# Parking now needs a write that no guard owns, which means a small tool issuing
-# one XU SET_CUR directly rather than going through a capture. Until that exists
-# the sections below report themselves NOT EXERCISED, which is the honest
-# outcome: they are not being tested, and saying so beats a pass that means
-# nothing.
-IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds 3 >"$OUT/park-tune.out" 2>&1 &
-tune=$!
-for _ in $(seq 1 600); do
-    grep -aq "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null && break
-    sleep 0.05
-done
-# Killed the instant the park value is on the camera, so the guard cannot undo it.
-pkill -KILL -f "$D" 2>/dev/null
-wait "$tune" 2>/dev/null
-daemon_pid=""
-sleep 1
-parked=$(grep -ac "SET_CUR unit$UNIT/sel$SEL: \[01, 03, 01" "$OUT/daemon-park.log" 2>/dev/null)
-if [ "${parked:-0}" -ge 1 ]; then
-    ok "the control was parked at its default"
+fi
+if "$XU_SET" "$IR" "$UNIT" "$SEL" def >"$OUT/park.out" 2>&1; then
+    sed 's/^/    /' "$OUT/park.out"
+    ok "the control is parked at its own GET_DEF"
 else
-    # No write does NOT mean the park failed: the override reads the control
-    # first and writes nothing when it already holds the value, which is the
-    # ordinary state on a camera nothing has driven. What actually matters is
-    # whether discovery then had a difference to measure, and section 2 asserts
-    # that independently by requiring a SET_CUR of its own.
-    skip "the control already held the default, so no parking write was needed"
+    sed 's/^/    /' "$OUT/park.out"
+    echo "refusing: the control could not be parked, so nothing below would be exercised"
+    exit 2
 fi
 
 echo "=== 2. discovery: record before the write, cleared after a read-back ==="
@@ -373,7 +345,11 @@ else
 fi
 
 echo "=== 4. a SIGKILL mid-run leaves the record ==="
-start_daemon park2 "$UNIT:$SEL:$PARK" >/dev/null 2>&1 && stop_daemon
+"$XU_SET" "$IR" "$UNIT" "$SEL" def >"$OUT/park2.out" 2>&1 || {
+    sed 's/^/    /' "$OUT/park2.out"
+    echo "refusing: could not re-park before the kill section"
+    exit 2
+}
 start_daemon killed off || {
     echo "  daemon would not start"
     exit 2

--- a/scripts/emitter-journal-strace-test.sh
+++ b/scripts/emitter-journal-strace-test.sh
@@ -14,9 +14,9 @@
 # prints unrecognised as that number.
 set -uo pipefail
 
-TREE=/tmp/irl-emitter-hw
-IR=/dev/video2
-RGB=/dev/video0
+TREE="${1:-/tmp/irl-emitter-hw}"
+IR="${2:-/dev/video2}"
+RGB="${3:-/dev/video0}"
 OUT=/tmp/emitter-strace
 SOCK=/run/irlume-strace.sock
 STATE=/var/lib/irlume-stracetest

--- a/scripts/emitter-journal-strace-test.sh
+++ b/scripts/emitter-journal-strace-test.sh
@@ -21,7 +21,11 @@ OUT=/tmp/emitter-strace
 SOCK=/run/irlume-strace.sock
 STATE=/var/lib/irlume-stracetest
 MODELS=/usr/share/irlume/models
-PARK=1,3,1,0,0,0,0,0,0
+# Guard-free SET_CUR tool; the park value is read from THIS camera's GET_DEF.
+# A daemon-based park no longer works: the stream guard restores what a capture
+# applies, and a kill cannot land inside the microseconds between apply and
+# restore (pt192).
+XU_SET="$TREE/target/release/examples/xu_set"
 # Taken from the packaged unit rather than assumed: the ONNX runtime ships beside
 # irlume on some installs and sits on the default search path on others, and a
 # daemon that cannot find it never reaches its socket, which reads as a hung build.
@@ -122,13 +126,15 @@ SEL=$((SEL))
 echo "    Microsoft XU: unit $UNIT, first advertised selector $SEL"
 
 echo "=== park the control so discovery has something to explore ==="
-start_daemon park "$UNIT:$SEL:$PARK" || {
-    echo "daemon would not start"
-    tail -20 "$OUT/daemon-park.log"
+if [ ! -x "$XU_SET" ]; then
+    echo "$XU_SET is missing; build it first:"
+    echo "  cargo build --release -p irlume-camera --example xu_set"
+    exit 2
+fi
+"$XU_SET" "$IR" "$UNIT" "$SEL" def 2>&1 | sed 's/^/    /' || {
+    echo "refusing: the control could not be parked"
     exit 2
 }
-pkill -TERM -f "target/release/irlumed" 2>/dev/null
-sleep 1
 
 echo "=== trace one ir-setup ==="
 start_daemon traced off strace || {

--- a/scripts/emitter-stream-record-hardware-test.sh
+++ b/scripts/emitter-stream-record-hardware-test.sh
@@ -141,6 +141,14 @@ stop_daemon() {
 }
 capture() { IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds "${1:-1}"; }
 records() { find "$STORE" -name '*.json' 2>/dev/null | wc -l; }
+# A record whose write is CONFIRMED on disk. The kill trigger keys on this,
+# not on the file existing: the file appears before the SET_CUR, and a kill
+# landing in the microseconds between the save and the confirmation leaves a
+# prepared record — a real, deliberate outcome (unclaimable and protected,
+# unit-covered), but not the branch this section stages. Keying on applied
+# makes the staged branch deterministic; the applied state lasts the whole
+# capture, so the window is wide.
+applied_records() { grep -al '"state":"applied"' "$STORE"/*.json 2>/dev/null | wc -l; }
 control() { "$XU_SET" "$IR" "$UNIT" "$SEL" get 2>/dev/null; }
 
 echo "=== 0. which control does this camera publish ==="
@@ -207,14 +215,16 @@ else
     capture 3 >"$OUT/capture-killed.out" 2>&1 &
     client=$!
     killed=no
-    # The trigger is the record FILE, not the log line. The log stays true
-    # forever once round 1 has run, so a grep-based kill can land between
-    # rounds, after the guard has already resolved — which is exactly how the
-    # first version of this section reported a false failure. The file is
-    # momentary state: present exactly while a guard is armed, and a SIGKILL
-    # cannot unlink it.
+    # The trigger is the CONFIRMED record on disk, not the log line and not
+    # the file's existence. The log stays true forever once round 1 has run,
+    # so a grep-based kill landed between rounds; the bare file appears
+    # before the SET_CUR, so a file-based kill sometimes landed in the
+    # save-to-confirmation gap and staged the prepared-leftover outcome
+    # instead of the claim this section is about (measured: roughly one run
+    # in three on the NexiGo). Both are momentary state a SIGKILL cannot
+    # unlink; only the applied state means the claim branch is staged.
     for _ in $(seq 1 900); do
-        if [ "$(records)" -ge 1 ]; then
+        if [ "$(applied_records)" -ge 1 ]; then
             kill -KILL "$daemon_pid" 2>/dev/null && killed=yes
             break
         fi

--- a/scripts/emitter-stream-record-hardware-test.sh
+++ b/scripts/emitter-stream-record-hardware-test.sh
@@ -140,6 +140,23 @@ stop_daemon() {
     daemon_pid=""
 }
 capture() { IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds "${1:-1}"; }
+# A synchronous capture that fails (missing model, dead socket, daemon error)
+# must fail the RUN, not soften into a skip: sections 2 and 3 assert that
+# things did NOT happen, which is trivially true of a capture that never ran,
+# so an ignored capture status turns four absence checks into vacuous passes
+# (review round 14). The killed capture stays on bare capture(): its daemon
+# dies under it by design, so its client MAY fail, and its success condition
+# is the confirmed record plus a successful kill.
+capture_checked() {
+    local tag="$1" rounds="${2:-1}"
+    if capture "$rounds" >"$OUT/capture-$tag.out" 2>&1; then
+        return 0
+    fi
+    echo "  FAILED  capture '$tag' did not complete"
+    sed 's/^/    /' "$OUT/capture-$tag.out"
+    stop_daemon
+    exit 1
+}
 records() { find "$STORE" -name '*.json' 2>/dev/null | wc -l; }
 # A record whose write is CONFIRMED on disk. The kill trigger keys on this,
 # not on the file existing: the file appears before the SET_CUR, and a kill
@@ -178,7 +195,7 @@ echo "=== 1. a clean capture: record before the write, resolved after ==="
 PARKED=$(control)
 echo "    parked at: $PARKED"
 start_daemon clean || exit 2
-capture 1 >"$OUT/capture-clean.out" 2>&1
+capture_checked clean 1
 stop_daemon
 grep -aE "stream-record|SET_CUR|leaving unit" "$OUT/daemon-clean.log" >"$OUT/clean.seq"
 sed 's/^/    /' "$OUT/clean.seq"
@@ -247,7 +264,7 @@ else
             # leftover the record describes is already gone. The next run must
             # supersede the record rather than claim it.
             start_daemon after || exit 2
-            capture 1 >"$OUT/capture-after.out" 2>&1
+            capture_checked after 1
             stop_daemon
             assert "the stale record is superseded, not claimed" \
                 "a claim appeared in the log" \
@@ -258,7 +275,7 @@ else
 close, so a leftover cannot survive here (use the NexiGo 3443:c803)"
         else
             start_daemon claim || exit 2
-            capture 1 >"$OUT/capture-claim.out" 2>&1
+            capture_checked claim 1
             stop_daemon
             grep -aE "stream-record|SET_CUR|leaving unit" "$OUT/daemon-claim.log" \
                 >"$OUT/claim.seq"
@@ -289,7 +306,7 @@ else
     fi
     if [ "$planted" = yes ]; then
         start_daemon outside || exit 2
-        capture 1 >"$OUT/capture-outside.out" 2>&1
+        capture_checked outside 1
         stop_daemon
         assert "irlume writes nothing over a value it did not set" \
             "a SET_CUR appeared" \

--- a/scripts/emitter-stream-record-hardware-test.sh
+++ b/scripts/emitter-stream-record-hardware-test.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# The per-stream leftover record (#188), against a real camera.
+#
+#   sudo bash scripts/emitter-stream-record-hardware-test.sh <worktree> <ir-node> [rgb-node]
+#
+# WHAT THIS PROVES
+#
+#   1. A capture's emitter write is covered: the record is on disk BEFORE the
+#      SET_CUR, and resolved once the guard concludes nothing is outstanding.
+#      The order is read from IRLUME_LOG_EMITTER_WRITES, where the record's
+#      trace lines and the write log share one stderr stream.
+#   2. A SIGKILL mid-capture leaves the record on disk, and the NEXT daemon
+#      claims it and finishes the restore. Whether the control survives the
+#      kill is the module's business: the ASUS 3277:0059 clears its control at
+#      a clean STREAMOFF yet was measured still holding it after a SIGKILL, so
+#      both branches are handled and the one taken is reported — a cleared
+#      control must supersede the stale record, a surviving one must be
+#      claimed.
+#   3. A value planted from OUTSIDE irlume — the exact bytes irlume itself
+#      would apply — is not claimed, not restored, and not recorded: same
+#      bytes, no record, not irlume's.
+#
+# WHAT IT WRITES
+#
+# Emitter-control writes to this camera's Microsoft extension unit, all values
+# the device itself reported: parking is its own GET_DEF via examples/xu_set,
+# the capture write is irlume's ordinary derived mode, and the planted value in
+# section 3 is read out of irlume's own earlier write, not typed in.
+set -uo pipefail
+
+TREE="${1:?usage: $0 <worktree> <ir-node> [rgb-node]}"
+IR="${2:?usage: $0 <worktree> <ir-node> [rgb-node]}"
+RGB="${3:-/dev/video0}"
+
+B="$TREE/target/release/irlume"
+D="$TREE/target/release/irlumed"
+XU_SET="$TREE/target/release/examples/xu_set"
+OUT=/tmp/emitter-stream-record-hw
+SOCK=/run/irlume-srtest.sock
+STATE=/var/lib/irlume-srtest
+STORE="$STATE/ir-emitter-stream"
+LOCKS="$STATE/locks"
+MODELS="${IRLUME_MODEL_DIR:-/usr/share/irlume/models}"
+ORT="${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
+    sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)}"
+
+pass=0
+fail=0
+skipped=0
+ok() { pass=$((pass + 1)); echo "  ok      $1"; }
+bad() {
+    fail=$((fail + 1))
+    echo "  FAILED  $1"
+    echo "            $2"
+}
+assert() {
+    local d="$1" x="$2"
+    shift 2
+    if "$@"; then ok "$d"; else bad "$d" "$x"; fi
+}
+skip() {
+    skipped=$((skipped + 1))
+    echo "  NOT EXERCISED  $1"
+}
+
+[ "$(id -u)" -eq 0 ] || {
+    echo "refusing: writes camera firmware, needs root"
+    exit 2
+}
+[ -x "$B" ] && [ -x "$D" ] || {
+    echo "refusing: no irlume/irlumed in $TREE/target/release"
+    exit 2
+}
+[ -x "$XU_SET" ] || {
+    echo "refusing: $XU_SET is missing; build it first:"
+    echo "  cargo build --release -p irlume-camera --example xu_set"
+    exit 2
+}
+[ -e "$IR" ] || {
+    echo "refusing: $IR does not exist"
+    exit 2
+}
+
+daemon_pid=""
+cleanup() {
+    [ -n "$daemon_pid" ] && kill -KILL "$daemon_pid" 2>/dev/null
+    rm -f "$SOCK"
+    if [ "$irlumed_was_active" = active ]; then
+        systemctl start irlumed 2>/dev/null
+        echo "  (packaged irlumed: $(systemctl is-active irlumed))"
+    fi
+}
+trap cleanup EXIT
+
+rm -rf "$OUT" "$STATE"
+mkdir -p "$OUT" "$STATE" "$LOCKS"
+if [ -d /var/lib/irlume/models-thirdparty ]; then
+    ln -sfn /var/lib/irlume/models-thirdparty "$STATE/models-thirdparty"
+fi
+irlumed_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
+systemctl stop irlumed 2>/dev/null
+sleep 1
+
+# $1 = log tag. The capture path under test is the BUILT-IN table one, so
+# IRLUME_IR_EMITTER is left unset: "off" would write nothing and an empty
+# value is a refused malformed override, not an absent one.
+start_daemon() {
+    local tag="$1"
+    rm -f "$SOCK"
+    env IRLUME_SOCKET="$SOCK" \
+        IRLUME_STATE_DIR="$STATE" \
+        IRLUME_IR_EMITTER_CONF="$STATE/ir_emitter.conf" \
+        IRLUME_EMITTER_LOCK_DIR="$LOCKS" \
+        IRLUME_RGB_DEVICE="$RGB" \
+        IRLUME_IR_DEVICE="$IR" \
+        IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$MODELS/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$MODELS/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$MODELS/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$MODELS/blaze_face_short_range.onnx" \
+        ${ORT:+ORT_DYLIB_PATH="$ORT"} \
+        "$D" >"$OUT/daemon-$tag.log" 2>&1 &
+    daemon_pid=$!
+    for _ in $(seq 1 1800); do
+        [ -S "$SOCK" ] && return 0
+        kill -0 "$daemon_pid" 2>/dev/null || {
+            echo "  the daemon exited during startup:"
+            tail -4 "$OUT/daemon-$tag.log" | sed 's/^/    /'
+            return 1
+        }
+        sleep 0.1
+    done
+    echo "  the daemon never listened; last lines:"
+    tail -4 "$OUT/daemon-$tag.log" | sed 's/^/    /'
+    return 1
+}
+stop_daemon() {
+    [ -n "$daemon_pid" ] && kill -TERM "$daemon_pid" 2>/dev/null
+    wait "$daemon_pid" 2>/dev/null
+    daemon_pid=""
+}
+capture() { IRLUME_SOCKET="$SOCK" "$B" camera-tune --rounds "${1:-1}"; }
+records() { find "$STORE" -name '*.json' 2>/dev/null | wc -l; }
+control() { "$XU_SET" "$IR" "$UNIT" "$SEL" get 2>/dev/null; }
+
+echo "=== 0. which control does this camera publish ==="
+start_daemon probe || {
+    echo "refusing: the private daemon would not start"
+    exit 2
+}
+IRLUME_SOCKET="$SOCK" "$B" ir-setup --dry-run >"$OUT/units.txt" 2>&1
+stop_daemon
+sed 's/^/    /' "$OUT/units.txt"
+UNIT=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$OUT/units.txt" | head -1)
+SEL=$(sed -n 's/.*unit '"${UNIT:-x}"' (Microsoft camera control): advertises \[\(0x[0-9a-f]*\).*/\1/p' \
+    "$OUT/units.txt" | head -1)
+if [ -z "$UNIT" ] || [ -z "$SEL" ]; then
+    echo "refusing: no Microsoft camera-control unit on this camera"
+    exit 2
+fi
+SEL=$((SEL))
+echo "    Microsoft XU: unit $UNIT, selector $SEL"
+
+echo "=== 1. a clean capture: record before the write, resolved after ==="
+"$XU_SET" "$IR" "$UNIT" "$SEL" def >"$OUT/park1.out" 2>&1 || {
+    sed 's/^/    /' "$OUT/park1.out"
+    echo "refusing: could not park the control"
+    exit 2
+}
+PARKED=$(control)
+echo "    parked at: $PARKED"
+start_daemon clean || exit 2
+capture 1 >"$OUT/capture-clean.out" 2>&1
+stop_daemon
+grep -aE "stream-record|SET_CUR|leaving unit" "$OUT/daemon-clean.log" >"$OUT/clean.seq"
+sed 's/^/    /' "$OUT/clean.seq"
+
+first_set=$(grep -an "SET_CUR unit$UNIT/sel$SEL" "$OUT/clean.seq" | head -1 | cut -d: -f1)
+saved=$(grep -an "stream-record saved" "$OUT/clean.seq" | head -1 | cut -d: -f1)
+resolved=$(grep -an "stream-record resolved" "$OUT/clean.seq" | head -1 | cut -d: -f1)
+if [ -z "$first_set" ]; then
+    skip "no emitter write happened (no built-in control for this camera?), nothing to cover"
+    skip "the resolve was not exercised"
+else
+    assert "the stream record is saved before the first SET_CUR" \
+        "saved=$saved set=$first_set" \
+        test -n "$saved" -a -n "$first_set" -a "$saved" -lt "$first_set"
+    assert "the record is resolved by the time the daemon stops" \
+        "no 'stream-record resolved' in the log" test -n "$resolved"
+    assert "no record outlives the clean capture" "$(records) left in $STORE" \
+        test "$(records)" -eq 0
+    NOW=$(control)
+    assert "the control is back at the parked value" "parked $PARKED, now $NOW" \
+        test "$NOW" = "$PARKED"
+fi
+# What irlume applied, from its own log, for section 3's plant.
+APPLIED=$(grep -a "SET_CUR unit$UNIT/sel$SEL" "$OUT/clean.seq" | head -1 |
+    sed 's/.*\[//;s/\].*//;s/ //g' | tr ',' '\n' | sed 's/^/0x/' | paste -sd,)
+echo "    irlume applied: ${APPLIED:-nothing}"
+
+echo "=== 2. a SIGKILL mid-capture leaves the record, the next daemon claims it ==="
+if [ -z "${APPLIED:-}" ]; then
+    skip "no capture write in section 1, so there is nothing to kill or claim"
+else
+    "$XU_SET" "$IR" "$UNIT" "$SEL" def >/dev/null 2>&1
+    start_daemon killed || exit 2
+    capture 3 >"$OUT/capture-killed.out" 2>&1 &
+    client=$!
+    killed=no
+    # The trigger is the record FILE, not the log line. The log stays true
+    # forever once round 1 has run, so a grep-based kill can land between
+    # rounds, after the guard has already resolved — which is exactly how the
+    # first version of this section reported a false failure. The file is
+    # momentary state: present exactly while a guard is armed, and a SIGKILL
+    # cannot unlink it.
+    for _ in $(seq 1 900); do
+        if [ "$(records)" -ge 1 ]; then
+            kill -KILL "$daemon_pid" 2>/dev/null && killed=yes
+            break
+        fi
+        kill -0 "$client" 2>/dev/null || break
+        sleep 0.02
+    done
+    wait "$client" 2>/dev/null
+    daemon_pid=""
+    if [ "$killed" != yes ]; then
+        skip "the capture ended before a kill could land, so nothing was left behind"
+        skip "the claim was not exercised"
+    else
+        ok "the daemon was SIGKILLed after its stream record hit the disk"
+        assert "the record survived the kill" "nothing in $STORE" \
+            test "$(records)" -eq 1
+        LEFT=$(control)
+        echo "    control after the kill: $LEFT (parked $PARKED)"
+        if [ "$LEFT" = "$PARKED" ]; then
+            # The module undoes its own control at stream close, so the
+            # leftover the record describes is already gone. The next run must
+            # supersede the record rather than claim it.
+            start_daemon after || exit 2
+            capture 1 >"$OUT/capture-after.out" 2>&1
+            stop_daemon
+            assert "the stale record is superseded, not claimed" \
+                "a claim appeared in the log" \
+                bash -c '! grep -aq "stream-record claimed" "$1"' _ "$OUT/daemon-after.log"
+            assert "no record outlives the next clean capture" "$(records) left" \
+                test "$(records)" -eq 0
+            skip "the claim itself: this module clears its own control at stream \
+close, so a leftover cannot survive here (use the NexiGo 3443:c803)"
+        else
+            start_daemon claim || exit 2
+            capture 1 >"$OUT/capture-claim.out" 2>&1
+            stop_daemon
+            grep -aE "stream-record|SET_CUR|leaving unit" "$OUT/daemon-claim.log" \
+                >"$OUT/claim.seq"
+            sed 's/^/    /' "$OUT/claim.seq"
+            assert "the next daemon claims the leftover" \
+                "no 'stream-record claimed' in the log" \
+                grep -aq "stream-record claimed.*attempt=1" "$OUT/claim.seq"
+            assert "the claim is resolved" "no resolve in the log" \
+                grep -aq "stream-record resolved" "$OUT/claim.seq"
+            assert "no record is left" "$(records) left" test "$(records)" -eq 0
+            NOW=$(control)
+            assert "the control is back where the killed stream found it" \
+                "parked $PARKED, now $NOW" test "$NOW" = "$PARKED"
+        fi
+    fi
+fi
+
+echo "=== 3. the same bytes planted from outside irlume are not claimed ==="
+if [ -z "${APPLIED:-}" ]; then
+    skip "no applied value is known, so nothing can be planted"
+else
+    "$XU_SET" "$IR" "$UNIT" "$SEL" "$APPLIED" >"$OUT/plant.out" 2>&1 || {
+        sed 's/^/    /' "$OUT/plant.out"
+        skip "the plant write was refused, so the outside-writer case was not staged"
+    }
+    if grep -aq "after:" "$OUT/plant.out"; then
+        start_daemon outside || exit 2
+        capture 1 >"$OUT/capture-outside.out" 2>&1
+        stop_daemon
+        assert "irlume writes nothing over a value it did not set" \
+            "a SET_CUR appeared" \
+            bash -c '! grep -aq "SET_CUR unit'"$UNIT"'/sel'"$SEL"'" "$1"' _ "$OUT/daemon-outside.log"
+        assert "and records nothing" "a stream-record line appeared" \
+            bash -c '! grep -aq "stream-record saved" "$1"' _ "$OUT/daemon-outside.log"
+        assert "and claims nothing" "a claim appeared" \
+            bash -c '! grep -aq "stream-record claimed" "$1"' _ "$OUT/daemon-outside.log"
+        assert "the store stays empty" "$(records) records" test "$(records)" -eq 0
+    fi
+    # Unpark: put the camera's own default back so nothing is left planted.
+    "$XU_SET" "$IR" "$UNIT" "$SEL" def >/dev/null 2>&1
+fi
+
+echo
+echo "$pass passed, $fail failed, $skipped not exercised"
+[ "$fail" -eq 0 ]

--- a/scripts/emitter-stream-record-hardware-test.sh
+++ b/scripts/emitter-stream-record-hardware-test.sh
@@ -270,11 +270,14 @@ echo "=== 3. the same bytes planted from outside irlume are not claimed ==="
 if [ -z "${APPLIED:-}" ]; then
     skip "no applied value is known, so nothing can be planted"
 else
-    "$XU_SET" "$IR" "$UNIT" "$SEL" "$APPLIED" >"$OUT/plant.out" 2>&1 || {
+    planted=no
+    if "$XU_SET" "$IR" "$UNIT" "$SEL" "$APPLIED" >"$OUT/plant.out" 2>&1; then
+        planted=yes
+    else
         sed 's/^/    /' "$OUT/plant.out"
-        skip "the plant write was refused, so the outside-writer case was not staged"
-    }
-    if grep -aq "after:" "$OUT/plant.out"; then
+        skip "the plant write did not take, so the outside-writer case was not staged"
+    fi
+    if [ "$planted" = yes ]; then
         start_daemon outside || exit 2
         capture 1 >"$OUT/capture-outside.out" 2>&1
         stop_daemon


### PR DESCRIPTION
Closes #188, closes #189, closes #190. The three were split out of #184 as one problem in three parts: the stream guard acting without knowing what it actually owns.

## What each fix does

**#190, one read instead of two.** `enable` recorded a `GET_CUR` of its own while each apply path read `GET_CUR` again to decide whether to write. A client writing between the two reads had its value overwritten by the stale record at stream end. All three apply paths now end in one shared tail, `write_if_different`, whose single read both decides the write and reports what it displaced; the guard arms with that value. A new test pins the full request order (`GET_INFO`, `GET_LEN`, `GET_CUR`, `SET_CUR`), so a second read reappearing anywhere in the path fails it.

**#189, the guard holds the camera, not an integer.** `StreamMode` kept a raw `c_int` and its `Drop` wrote to it; nothing tied that number to the open `v4l::Device`, so a caller could drop the device, let the kernel recycle the number, and have the restore land on whatever `open(2)` produced next. `enable` now takes the `Arc<Handle>` from `Device::handle()` and the guard keeps it. The inert guard holds `None`.

**#188, a crash leftover is now claimable.** (Design as hardened across six review rounds; the review section below lists what each round changed.) `current == wanted` cannot distinguish another writer's value from irlume's own kill leftover, and #184 chose never to claim, so one SIGKILL left the mode applied permanently. A new store, `/var/lib/irlume/ir-emitter-stream`, holds one record per camera: identity, control coordinates, bytes applied, bytes displaced. The record is TWO-PHASE (added in review round 1): published as `prepared` between the one `GET_CUR` and the `SET_CUR`, rewritten as `applied` once the camera accepts, and removed when the guard resolves. A stream that finds the wanted value already in place claims it only when an `applied` record for this camera, this control, and these bytes exists, then arms with the recorded displaced value and finishes the interrupted restore. A `prepared` record authorises nothing: the write it describes may never have happened, and the matching value could be another program's later, deliberate choice.

## Design decisions that want review

- **No fsync.** The record must survive process death, not power loss: the page cache survives SIGKILL, so it is a plain write and rename. The #183 journal fsyncs because discovery writes exploratory bytes nobody can re-derive; this store covers a mode derived from the camera itself, once per unlock. Getting this distinction wrong twice is what kept the record out of #184.
- **Liveness and exclusion by one stable lock, not pid.** Every record mutation happens under a per-camera `.lock` file beside the record, created once and never renamed, taken before the control is read and held for the guard's lifetime. It cannot ride the record inode itself: `flock` binds to the open file description and rename replaces the pathname without touching it, so record-inode locking let two publishers hold two live "exclusive" locks (review round 1). The lock dies with the process, the file does not, so a claim that cannot take it is looking at a live stream's record and refuses; `flock` excludes per open file description, so the same process's previous guard blocks it too, and the frozen-stream restart hands record and lock from the old guard to its replacement. A writer that cannot take the lock proceeds unrecorded, the same degradation as an unwritable store. No pid or boot id is stored; #183 removed those from the journal after one stranded a record. The lock serialises irlume's writers only: UVC has no compare-and-swap, so a non-cooperating client can still move the control between `GET_CUR` and `SET_CUR`, and that window has no software fix on this interface.
- **Best-effort save, in the opposite direction from #183.** An unwritable store costs crash bookkeeping, never the authentication. Refusing would turn a full disk or read-only `/var/lib` into IR going dark at every login; proceeding unrecorded reproduces the pre-#188 status quo for a kill that lands in that window. Documented at the save site.
- **Claims are counted and capped at 3**, on the record, before the write they authorize; a control whose `GET_CUR` never reflects a restore would otherwise buy one firmware write per stream open forever. Same constant and reasoning as the journal's `MAX_RESTORE_ATTEMPTS`.
- **The identity gate is shared, not copied.** `identity_authorizes` is extracted from the journal's `describes_this_camera` and both stores use it: digest and port must match, and a recorded serial the attached camera cannot currently reproduce fails closed.

## Tooling

`examples/xu_set.rs` issues one guard-free XU `SET_CUR` (plus a read-only `get` mode). Parking by killing a daemon mid-capture does not work; apply and restore are microseconds apart. It refuses units and selectors the descriptor does not publish, and its `def` mode writes the device's own `GET_DEF`. The hardware and strace harnesses now park through it; `PARK_VALUE` and its hardcoded payload are gone.

## Review rounds

Fourteen adversarial Codex rounds; every round but one found something real, every code fix carries a regression test plus a hand-applied mutant proving that test fires (round 14's harness fix is proven by a forced-failure run instead), and the reviewer's own round-6 SHIP verdict was re-earned after each later fix. Review is capped at three rounds per PR from here on, by standing policy set on this PR:

1. Two High. A record published before a `SET_CUR` could authorise a claim for a write that never happened; records are now two-phase (`prepared` to `applied`, confirmed only after the camera accepts). And the flock rode the replaceable record inode, so two publishers could hold two live "exclusive" locks; the lock is now a stable per-camera `.lock` file held for the guard's lifetime.
2. One High. A failed unlink after a successful restore left an `applied` record for a change that no longer existed; the record is now retired (demoted) before the restoring write and unlinked after, re-promoted if the restore write fails, and a record that cannot even be demoted blocks the restore.
3. One Medium. `restore()` returned `Ok` when retire failure made it skip the camera; the result is now typed (`RestoreError::Camera` vs `Bookkeeping`).
4. One High. On lock contention a second irlume wrote unrecorded, and the interleaving could strand the camera at neither writer's original value; `Busy` now refuses the write before the control is even read, `Unavailable` (store trouble, nobody contesting) still proceeds unrecorded. This also simplified the frozen-stream restart: the old guard restores before the reopen, and the ownership-handover machinery is gone.
5. Two High. `save` renamed its record over an applied record for a different control, destroying that change's only recovery data; it now refuses (`Outstanding`) whenever the existing record's change may still be live, and replaces only superseded or unconfirmed ones. And `save`/`mark_applied` dropped the stream lock on failure while the hardware write stayed live; failures now hand the lock back, and an unrecorded write carries it in the guard.
6. One Low. Two stale texts still called the restore value "the camera's default"; corrected. Verdict: SHIP after the correction.
7. Two High. `save` replaced a `prepared` record whose write may have landed (a crash between `SET_CUR` and confirmation), destroying the only displaced value; and it replaced records with schemas this build cannot read. The gate is inverted: only a demonstrably superseded same-control record is ever replaced (`Protected` refusal otherwise).
8. One High, one Medium. `disarm()` had lost its last production caller and could abandon an authoritative record; deleted. `xu_set` exited zero when the camera did not take the value; now an error, and the harness keys on it.
9. One Medium. `restore()` retained the bare stream lock after success, so the restart's fresh `enable` refused against its own predecessor; the lock now releases with the restore attempt.
10. One Medium. `retire()` republished an already-`prepared` record, so a persistently broken store blocked the restore of a change whose record never authorised anything; it short-circuits.
11. One High. A claim published its spent attempt before any camera request, so three bookkeeping failures exhausted the cap with zero restores attempted; the attempt now persists inside `retire()`'s pre-write publication and rolls back with it.
12. One Medium. The restart sites logged over a failed restore, which with an unrecorded write stranded the value in-process; the failure now propagates as hardware trouble.
13. One High. The read-back arm restored blind when `GET_CUR` failed, writing over a value it could not see — #184's deliberate choice, whose justification the claim machinery had inverted; an unreadable control now authorises nothing and the record is re-promoted.
14. One Medium, in the evidence rather than the product: the hardware harness ignored the exit status of its four synchronous captures, so a capture that never ran softened into NOT EXERCISED — and in the outside-writer section, whose assertions all check absence, could yield four passes with no capture behind them. A failed synchronous capture now prints the client output and fails the run; the killed capture keeps its bare call because its daemon dies under it by design. Proven by a stubbed run: with capture() forced to fail, the script exits nonzero before recording any pass or skip. The round listed the round-13 fix and the claim design under already-correct and found no production-code defect.

## Evidence

- 206 unit tests in irlume-camera (was 181), plus 10 gate tests in the new module; workspace suite green on all three machines (Fedora, Arch, Ubuntu); clippy, fmt and the doc lane clean.
- ASan/LSan lane run locally on irlume-camera: 193 passed, no leaks.
- 31 hand-applied mutants, 31 killed, each by the test written for it. The original fourteen covered the displaced-value, ordering, identity, schema, attempts and lock gates; the review rounds added seventeen more, one per fix, ending with the recombined read-back wildcard. The tree was verified clean and green after each.
- Container journal suite: 18 passed, 0 failed (unchanged surface, run because `emitter_journal` was touched).
- Hardware, ASUS 3277:0059 unit 14: the #183 journal harness passes 15/0 with the new xu_set park (previously 5 of its sections were not exercised on a camera whose control the daemon had already lit). The new `emitter-stream-record-hardware-test.sh` passes 14/0 including the full loop: record on disk before the `SET_CUR`, SIGKILL mid-capture leaving it, the next daemon claiming at attempt 1, the control restored to the parked value, and a value planted from outside irlume left unwritten, unrecorded, and unclaimed.
- Hardware, NexiGo 3443:c803 unit 4 on archhost: the stream-record harness passes 14/0 with the claim path fully exercised, and the journal harness passes 17/0 with 0 not exercised, the first NexiGo run with nothing skipped since the guard began undoing parks.
- strace harness, ASUS: 4 passed, 0 failed; the journal ordering holds in the syscall stream with the xu_set park.

Both hardware harnesses were re-run on both cameras after every behavioral review-round fix, most recently on the final sha: ASUS 14/0/0 (stream record) and 15/0/1 (journal), NexiGo 14/0/0 and 17/0/0. Stress: 20 consecutive unit-suite runs with zero failures, five consecutive NexiGo harness runs and three ASUS runs at 14/0/0 each, and a container-suite repeat. One intermittent NexiGo failure during this (roughly one run in three) was traced to the HARNESS: its SIGKILL trigger fired on the record file existing, which is true before the write confirms, so the kill sometimes staged the prepared-leftover outcome instead of the claim branch and read the designed fail-closed behavior as five failures. The trigger now keys on the confirmed state and the intermittency is gone.

After the round-14 harness fix (the final sha), both cameras were re-run on the corrected harness: one run each, then three consecutive stress runs each, all eight at 14 passed / 0 failed / 0 not exercised, with per-run summaries asserted against that exact line. Zero not-exercised means the SIGKILL-claim branch staged in every run. The independent round-13 check was also re-proven by hand: the new regression test passes on the fix and fails against a mutant recombining the wildcard read-back arm.

A third camera model was attempted on archhost: the Logitech BRIO (046d:085e, Microsoft XU unit 12, selectors 0x06/0x09, derived from the dry run). Its power-on default already holds the value irlume would apply, so `write_if_different` never writes and the stream record is inert on it by design; its capture also completes no rounds because the IR stays dark, reproduced identically on main at `4db2d53` in a control run with zero emitter writes. Filed as #192. The corrected harness reported this as a hard failure; the pre-fix harness would have called the same runs green or skipped, which is the round-14 defect demonstrating itself on real hardware.

One measured surprise recorded in the harness: the ASUS clears its control at a clean STREAMOFF but was still holding it after a SIGKILL, so the claim path is reachable on both modules here.

## Not tested

- `enable`'s claim wiring has no unit test; `enable` needs a real sysfs-backed camera for `identity_from_fd`. The hardware harness covers it end to end (the "claimed attempt=1" line comes from that wiring).
- A cross-process lock contention test (two daemons, one camera) was not staged; the in-process shape is covered because `flock` excludes per open file description, and the kernel semantics for the cross-process case are the same documented mechanism.
- The ThinkPad's Chicony has no emitter control on its Microsoft XU, so it cannot exercise the emitter paths; it ran the full workspace suite on Ubuntu 26.04 and the `xu_set` consent gate (both unpublished-control probes refused, the published selector read cleanly).
- A crash between the record's demotion and the restoring `SET_CUR` leaves an unclaimable `prepared` record with the mode still applied. Fail-closed by design; round 6 reviewed it and agreed no safe alternative exists without an atomic camera compare-and-swap.
- Two identical cameras attached simultaneously, IR Torch (no camera here advertises 0x0A), and directory-fsync failure remain open from #183/#184, unchanged by this PR.
- `doctor` does not yet report a leftover stream record. It is short-lived by design; say the word and I will wire it into `pending_summary` as a follow-up.

The four remaining park-by-daemon harnesses (portmove 1 to 3, powerloss, two-cameras, selfclear) still carry the pre-#184 park and need the same xu_set conversion before their next run; converting them is mechanical and I left it out to keep this diff reviewable.
