### PR TITLE
ir-setup refuses to write firmware while the privacy shutter is engaged

### DIFF
--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2143,6 +2143,10 @@ pub enum DiscoveryError {
     UnresolvedChange,
     /// The undo record could not be written, so nothing was sent to the camera.
     JournalUnwritable(String),
+    /// The caller's pre-write guard refused the next exploratory write, e.g.
+    /// the privacy shutter engaged after setup began. Anything already changed
+    /// was restored before this was returned.
+    WriteRefused(String),
 }
 
 impl std::fmt::Display for DiscoveryError {
@@ -2217,6 +2221,11 @@ impl std::fmt::Display for DiscoveryError {
                  be written ({why}). Setup writes that record first on purpose, so that a crash \
                  or a power loss part-way through still leaves something that can put the \
                  control back"
+            ),
+            Self::WriteRefused(why) => write!(
+                f,
+                "{why}; setup stopped without sending anything further, and anything it had \
+                 already changed was put back"
             ),
         }
     }
@@ -3055,10 +3064,15 @@ impl RecoveryOutcome {
 /// Preference order is IR Torch first (its whole purpose is the lamp), then Face
 /// Authentication (which drives the illuminator as a side effect of putting a
 /// streaming interface into face-auth mode).
-pub fn discover<F: FnMut() -> Option<f32>>(
+pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     measure: &mut F,
+    // Consulted immediately before each FORWARD write (never before a
+    // restore); an `Err` refuses the write and ends the run with its reason.
+    // The caller supplies the privacy-shutter re-check through this, so the
+    // check-to-write window is one syscall, not the whole discovery pipeline.
+    before_forward_write: &mut G,
 ) -> std::result::Result<Discovered, DiscoveryError> {
     let ms = id
         .microsoft_xu()
@@ -3099,7 +3113,7 @@ pub fn discover<F: FnMut() -> Option<f32>>(
             tried.push(format!("selector {selector:#04x} not advertised"));
             continue;
         }
-        match try_documented_control(fd, id, ms.unit_id, selector, measure) {
+        match try_documented_control(fd, id, ms.unit_id, selector, measure, before_forward_write) {
             // The lock travels with the open record: the camera stays held until
             // the configuration naming the applied control is durable, so nothing
             // else can file a record over this one in between.
@@ -3123,6 +3137,7 @@ pub fn discover<F: FnMut() -> Option<f32>>(
                 })
             }
             Err(TryFailure::Journal(why)) => return Err(DiscoveryError::JournalUnwritable(why)),
+            Err(TryFailure::Guard(why)) => return Err(DiscoveryError::WriteRefused(why)),
             // Any error at all stops everything. Only selectors the descriptor
             // advertises are reached, so a failure here is the camera
             // contradicting its own descriptor, and the errno cannot be relied
@@ -3254,6 +3269,9 @@ enum TryFailure {
     /// as much a sign of trouble as a control request going unanswered, and the
     /// old code turned it into "the picture is dark" and carried on.
     Measurement,
+    /// The caller's pre-write guard (the privacy-shutter re-check) refused the
+    /// next forward write. Nothing was sent; carries the guard's own reason.
+    Guard(String),
 }
 
 impl From<XuError> for TryFailure {
@@ -3264,12 +3282,13 @@ impl From<XuError> for TryFailure {
 
 /// Try one advertised, documented control, leaving it as it was found unless it
 /// worked.
-fn try_documented_control<F: FnMut() -> Option<f32>>(
+fn try_documented_control<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     unit: u8,
     selector: u8,
     measure: &mut F,
+    before_forward_write: &mut G,
 ) -> std::result::Result<Attempt, TryFailure> {
     if !info_allows_set(get_info(fd, unit, selector)?) {
         return Ok(Attempt::NotUsable(
@@ -3360,6 +3379,21 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     if abort_requested() {
         return Err(TryFailure::Measurement);
     }
+    // The guard runs immediately before EACH forward write, not only at the
+    // top of setup: the early sample there left format negotiation, the
+    // settling frames, the journal fsyncs and the baseline burst as a window
+    // in which the operator can engage the shutter, and this write would then
+    // be spent measuring a blanked frame (#193 review). Restores are
+    // deliberately not guarded: refusing to put a control back would leave it
+    // changed, which is the worse outcome by this file's own rules.
+    if let Err(why) = before_forward_write() {
+        // Nothing has been written, so the record describes a change that
+        // never happened; drop it, as the moved-control refusal above does.
+        pending
+            .abandon_before_write()
+            .map_err(TryFailure::Journal)?;
+        return Err(TryFailure::Guard(why));
+    }
     pending.apply_exploratory(&wanted)?;
     let Some(lit) = measure() else {
         // The stream died after the control was changed. Aborting without
@@ -3411,6 +3445,13 @@ fn try_documented_control<F: FnMut() -> Option<f32>>(
     // on disk that could put it back. `Discovered::committed` closes it.
     if abort_requested() {
         return Err(TryFailure::Measurement);
+    }
+    if let Err(why) = before_forward_write() {
+        // The restore above already put the control back and this branch
+        // writes nothing further, so the record resolves the same way the
+        // stayed-bright refusal does.
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
+        return Err(TryFailure::Guard(why));
     }
     pending.apply_exploratory(&wanted)?;
     Ok(Attempt::Lit(
@@ -3891,7 +3932,21 @@ mod tests {
     fn run_discovery(
         camera: fake_camera::Camera,
         tag: &str,
+        measure: impl FnMut() -> Option<f32>,
+    ) -> (
+        std::result::Result<Attempt, TryFailure>,
+        Vec<fake_camera::Request>,
+        Vec<u8>,
+        std::path::PathBuf,
+    ) {
+        run_discovery_guarded(camera, tag, measure, || Ok(()))
+    }
+
+    fn run_discovery_guarded(
+        camera: fake_camera::Camera,
+        tag: &str,
         mut measure: impl FnMut() -> Option<f32>,
+        mut guard: impl FnMut() -> Result<(), String>,
     ) -> (
         std::result::Result<Attempt, TryFailure>,
         Vec<fake_camera::Request>,
@@ -3912,7 +3967,8 @@ mod tests {
         .find(|s| ms.advertises(*s))
         .expect("fixture advertises an emitter selector");
         // fd is never reached: the fake intercepts before the ioctl.
-        let outcome = try_documented_control(-1, &id, ms.unit_id, selector, &mut measure);
+        let outcome =
+            try_documented_control(-1, &id, ms.unit_id, selector, &mut measure, &mut guard);
         (outcome, fake_camera::log(), fake_camera::current(), dir)
     }
 
@@ -6388,6 +6444,84 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// The pre-write guard refusing before the FIRST exploratory write ends the
+    /// run with the guard's reason and zero bytes sent (#193 review: the early
+    /// privacy sample alone left the whole pipeline as a check-to-write window).
+    #[test]
+    fn a_guard_refusal_before_the_first_write_sends_nothing() {
+        let _lock = crate::testenv::env_lock();
+        let (outcome, log, current, dir) = run_discovery_guarded(
+            a_working_camera(),
+            "guard-first",
+            || Some(50.0),
+            || Err("the hardware privacy shutter is engaged".to_string()),
+        );
+        assert!(
+            matches!(&outcome, Err(TryFailure::Guard(why)) if why.contains("engaged")),
+            "the refusal must carry the guard's reason: {outcome:?}"
+        );
+        assert!(
+            !log.iter()
+                .any(|r| matches!(r, fake_camera::Request::Set { .. })),
+            "a refused run may not write: {log:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1], "the control is untouched");
+        let left: Vec<_> = std::fs::read_dir(dir.join("ir-emitter-journal"))
+            .map(|rd| rd.flatten().map(|e| e.file_name()).collect())
+            .unwrap_or_default();
+        assert!(
+            left.is_empty(),
+            "nothing was written, so no undo record may survive: {left:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The guard is consulted before EACH forward write, not once: a refusal
+    /// arriving between the restore and the final re-apply leaves the control
+    /// at its original value, with the record resolved and exactly the two
+    /// writes of the measurement (apply, restore) on the wire.
+    #[test]
+    fn a_guard_refusal_before_the_final_write_leaves_the_control_restored() {
+        let _lock = crate::testenv::env_lock();
+        let mut readings = [10.0, 40.0, 10.0].into_iter();
+        let mut calls = 0;
+        let (outcome, log, current, dir) = run_discovery_guarded(
+            a_working_camera(),
+            "guard-final",
+            || readings.next(),
+            || {
+                calls += 1;
+                if calls == 1 {
+                    Ok(())
+                } else {
+                    Err("the hardware privacy shutter is engaged".to_string())
+                }
+            },
+        );
+        assert!(
+            matches!(&outcome, Err(TryFailure::Guard(why)) if why.contains("engaged")),
+            "the second consultation must be able to refuse: {outcome:?}"
+        );
+        let sets: Vec<_> = log
+            .iter()
+            .filter(|r| matches!(r, fake_camera::Request::Set { .. }))
+            .collect();
+        assert_eq!(
+            sets.len(),
+            2,
+            "exactly the measurement's apply and restore, nothing after the refusal: {log:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1], "the control ends where it began");
+        let left: Vec<_> = std::fs::read_dir(dir.join("ir-emitter-journal"))
+            .map(|rd| rd.flatten().map(|e| e.file_name()).collect())
+            .unwrap_or_default();
+        assert!(
+            left.is_empty(),
+            "the restore was confirmed, so the record must be resolved: {left:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// Recovering a MISFILED record leaves exactly one file behind, and then
     /// none.
     ///
@@ -7028,7 +7162,14 @@ mod tests {
             serial: Some("200901010001".into()),
             usb_devpath: "/devices/pci0000:00/0000:00:14.0/usb3/3-5".into(),
         };
-        let err = discover(std::os::fd::AsRawFd::as_raw_fd(&f), &no_ms, &mut measure).unwrap_err();
+        let mut permit = || Ok(());
+        let err = discover(
+            std::os::fd::AsRawFd::as_raw_fd(&f),
+            &no_ms,
+            &mut measure,
+            &mut permit,
+        )
+        .unwrap_err();
         match err {
             DiscoveryError::NoMicrosoftXu { seen } => assert_eq!(seen, vec![4, 7]),
             other => panic!("expected NoMicrosoftXu, got {other:?}"),

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2351,6 +2351,31 @@ pub fn store_capture_mode(device: &str, mode: CaptureMode) -> irlume_common::Res
 /// anything changed can be undone.
 pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     verify_pinned(device)?;
+    // Refuse before anything touches the camera. An engaged shutter blanks the
+    // sensor to a flat frame (ASUS 3277:0059, eight frames per state: released
+    // mean 37.0 stddev 62.68, engaged a constant 144.0 stddev 0.00 with
+    // `privacy` reading 1 throughout), so every exploratory write would be
+    // spent measuring a constant, and discovery would then report "no usable
+    // emitter control" about a camera whose shutter is merely shut (#186).
+    // Every capture entry point already refuses this way; the one path that
+    // WRITES firmware must too. An undo record pending on this camera loses
+    // nothing: it is durable, `doctor` reports it, and recovery re-runs on the
+    // next capture or setup once the shutter is released — the same stance as
+    // `IRLUME_IR_EMITTER=off`.
+    //
+    // No test can stage this branch: `privacy` is a real V4L2 control, no fake
+    // provides it, and `verify_pinned` above rejects loopback devices before
+    // this line is reached. It is exercised on hardware only, with the
+    // machine's own E-shutter key (the capture-path guards above share this
+    // limit).
+    if privacy_engaged(device) {
+        return Err(Error::Hardware(format!(
+            "{device}: the hardware privacy shutter is engaged (the `privacy` \
+             control reads 1), so the sensor returns a blank frame and \
+             discovery would measure nothing; release the shutter and re-run \
+             ir-setup"
+        )));
+    }
     // Declared first, so it is dropped LAST: the guard that puts the control
     // back lives inside `discover` (or inside `found` on the success path) and
     // has to finish before this re-raises the signal that stops the process.

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -384,19 +384,64 @@ pub fn discover_nodes() -> Vec<(String, Role)> {
         .collect()
 }
 
-/// Best-effort privacy-shutter check. Returns `Ok(true)` if the hardware privacy
-/// switch is engaged. Never panics: reads only the specific CID, not the whole
-/// control set.
+/// Whether a failed privacy-control read means the camera does not HAVE the
+/// control, as opposed to having one that could not be read. The V4L2
+/// specification assigns EINVAL to an unsupported control id, and ENOTTY means
+/// the device does not implement the control ioctls at all; both are absence
+/// of the feature, stable across retries. Everything else (EIO, ENODEV, ...)
+/// is a failure to observe a control that may exist, which must never be
+/// reported as "not engaged" (#193 review). Pure so the classification is
+/// testable without hardware.
+fn control_read_failure_means_absent(e: &std::io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::ENOTTY))
+}
+
+/// Read the privacy control, keeping three outcomes apart: `Ok(Some(engaged))`
+/// when the control answered, `Ok(None)` when the camera does not have one,
+/// and `Err` when the observation itself failed. The old bool-returning check
+/// collapsed the third into the second, which let a transient read failure on
+/// a shuttered camera license a firmware write.
+fn privacy_state(dev: &Device) -> std::io::Result<Option<bool>> {
+    match dev.control(V4L2_CID_PRIVACY) {
+        Ok(ctrl) => Ok(Some(
+            matches!(ctrl.value, v4l::control::Value::Boolean(true))
+                || matches!(ctrl.value, v4l::control::Value::Integer(n) if n != 0),
+        )),
+        Err(e) if control_read_failure_means_absent(&e) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Best-effort privacy-shutter check for the CAPTURE paths. Returns `true` only
+/// when the control answered "engaged"; an unopenable device or a failed read
+/// stays `false`, because the cost of failing open here is a capture of dark
+/// frames and a refused authentication, which the pipeline already handles.
+/// `setup_ir_emitter` deliberately does NOT use this: it writes to firmware,
+/// where an unknown shutter state must refuse — see [`privacy_permits_setup`].
 pub fn privacy_engaged(device: &str) -> bool {
     let Ok(dev) = Device::with_path(device) else {
         return false;
     };
-    match dev.control(V4L2_CID_PRIVACY) {
-        Ok(ctrl) => {
-            matches!(ctrl.value, v4l::control::Value::Boolean(true))
-                || matches!(ctrl.value, v4l::control::Value::Integer(n) if n != 0)
-        }
-        Err(_) => false, // control absent on this camera
+    matches!(privacy_state(&dev), Ok(Some(true)))
+}
+
+/// The decision `setup_ir_emitter` makes about one privacy observation, as a
+/// value: an engaged shutter refuses, and a FAILED observation refuses too,
+/// because "could not read the switch" is not "the switch is released". Only a
+/// control that answered "released", or a camera that has no such control, may
+/// proceed to a firmware write. Pure and used by the production path, so the
+/// fail-closed rule is testable without hardware.
+fn privacy_permits_setup(observed: std::io::Result<Option<bool>>) -> Result<(), String> {
+    match observed {
+        Ok(Some(true)) => Err("the hardware privacy shutter is engaged (the `privacy` \
+             control reads 1), so the sensor returns a blank frame and discovery \
+             would measure nothing; release the shutter and re-run ir-setup"
+            .into()),
+        Ok(Some(false)) | Ok(None) => Ok(()),
+        Err(e) => Err(format!(
+            "could not read the hardware privacy control ({e}); refusing to write \
+             to camera firmware while the shutter state is unknown"
+        )),
     }
 }
 
@@ -2351,36 +2396,29 @@ pub fn store_capture_mode(device: &str, mode: CaptureMode) -> irlume_common::Res
 /// anything changed can be undone.
 pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     verify_pinned(device)?;
-    // Refuse before anything touches the camera. An engaged shutter blanks the
-    // sensor to a flat frame (ASUS 3277:0059, eight frames per state: released
-    // mean 37.0 stddev 62.68, engaged a constant 144.0 stddev 0.00 with
-    // `privacy` reading 1 throughout), so every exploratory write would be
-    // spent measuring a constant, and discovery would then report "no usable
-    // emitter control" about a camera whose shutter is merely shut (#186).
-    // Every capture entry point already refuses this way; the one path that
-    // WRITES firmware must too. An undo record pending on this camera loses
-    // nothing: it is durable, `doctor` reports it, and recovery re-runs on the
-    // next capture or setup once the shutter is released — the same stance as
+    // Open only long enough to read the standard V4L2 privacy control, and
+    // refuse before format negotiation, streaming, or any extension-unit
+    // write. An engaged shutter blanks the sensor to a flat frame (ASUS
+    // 3277:0059, eight frames per state: released mean 37.0 stddev 62.68,
+    // engaged a constant 144.0 stddev 0.00 with `privacy` reading 1
+    // throughout), so every exploratory write would be spent measuring a
+    // constant, and discovery would then report "no usable emitter control"
+    // about a camera whose shutter is merely shut (#186). Every capture entry
+    // point already refuses an engaged shutter; the one path that WRITES
+    // firmware refuses an UNREADABLE one too, and re-checks before each
+    // exploratory write below, because this early sample covers only this
+    // moment. An undo record pending on this camera loses nothing: it is
+    // durable, `doctor` reports it, and recovery re-runs on the next capture
+    // or setup once the shutter is released — the same stance as
     // `IRLUME_IR_EMITTER=off`.
-    //
-    // No test can stage this branch: `privacy` is a real V4L2 control, no fake
-    // provides it, and `verify_pinned` above rejects loopback devices before
-    // this line is reached. It is exercised on hardware only, with the
-    // machine's own E-shutter key (the capture-path guards above share this
-    // limit).
-    if privacy_engaged(device) {
-        return Err(Error::Hardware(format!(
-            "{device}: the hardware privacy shutter is engaged (the `privacy` \
-             control reads 1), so the sensor returns a blank frame and \
-             discovery would measure nothing; release the shutter and re-run \
-             ir-setup"
-        )));
-    }
-    // Declared first, so it is dropped LAST: the guard that puts the control
-    // back lives inside `discover` (or inside `found` on the success path) and
-    // has to finish before this re-raises the signal that stops the process.
-    let _abort_orderly = ir_emitter::AbortOnSignal::install();
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
+    privacy_permits_setup(privacy_state(&dev))
+        .map_err(|why| Error::Hardware(format!("{device}: {why}")))?;
+    // Declared before the stream and the guards below, so it is dropped LAST:
+    // the guard that puts the control back lives inside `discover` (or inside
+    // `found` on the success path) and has to finish before this re-raises the
+    // signal that stops the process.
+    let _abort_orderly = ir_emitter::AbortOnSignal::install();
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix);
     let (w, h) = (fmt.width, fmt.height);
@@ -2439,7 +2477,14 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
 
     let id = crate::uvc_descriptor::identity_from_fd(fd)
         .map_err(|e| Error::Hardware(format!("could not identify the camera: {e}")))?;
-    match ir_emitter::discover(fd, &id, &mut measure) {
+    // Re-read the shutter immediately before each forward write. The early
+    // sample above is one moment; format negotiation, the settling frames, the
+    // journal fsyncs and the baseline burst all sit between it and the first
+    // SET_CUR, and the operator can engage the E-shutter anywhere in that
+    // window (#193 review). The residual race is one syscall wide: V4L2 offers
+    // no transaction spanning the privacy read and the extension-unit write.
+    let mut privacy_allows_write = || privacy_permits_setup(privacy_state(&dev));
+    match ir_emitter::discover(fd, &id, &mut measure, &mut privacy_allows_write) {
         Ok(found) => {
             let encoded = found.control().encode();
             // Confirm, publish, release, in that order. The sequence lives in
@@ -3294,6 +3339,44 @@ mod tests {
         // (the capture path then surfaces the real error).
         assert!(!privacy_engaged("/dev/irlume-test-missing"));
         assert!(!privacy_engaged("/dev/null"));
+    }
+
+    /// The setup decision fails CLOSED: an engaged shutter refuses, and a
+    /// FAILED observation refuses too, because "could not read the switch" is
+    /// not "the switch is released" (#193 review). Only an answered "released"
+    /// or a camera without the control proceeds to a firmware write.
+    #[test]
+    fn privacy_setup_decision_fails_closed() {
+        let engaged =
+            privacy_permits_setup(Ok(Some(true))).expect_err("an engaged shutter must refuse");
+        assert!(engaged.contains("shutter is engaged"), "{engaged}");
+        let unreadable = privacy_permits_setup(Err(std::io::Error::from_raw_os_error(libc::EIO)))
+            .expect_err("an unreadable shutter must refuse, not read as released");
+        assert!(unreadable.contains("could not read"), "{unreadable}");
+        assert!(privacy_permits_setup(Ok(Some(false))).is_ok());
+        assert!(privacy_permits_setup(Ok(None)).is_ok());
+    }
+
+    /// Only the errnos the V4L2 specification assigns to "this control does
+    /// not exist" (EINVAL for an unsupported id, ENOTTY for a device without
+    /// the ioctl) read as absence; an IO failure or a vanished device must not.
+    #[test]
+    fn only_specified_errnos_mean_the_control_is_absent() {
+        assert!(control_read_failure_means_absent(
+            &std::io::Error::from_raw_os_error(libc::EINVAL)
+        ));
+        assert!(control_read_failure_means_absent(
+            &std::io::Error::from_raw_os_error(libc::ENOTTY)
+        ));
+        assert!(!control_read_failure_means_absent(
+            &std::io::Error::from_raw_os_error(libc::EIO)
+        ));
+        assert!(!control_read_failure_means_absent(
+            &std::io::Error::from_raw_os_error(libc::ENODEV)
+        ));
+        assert!(!control_read_failure_means_absent(&std::io::Error::other(
+            "no errno at all"
+        )));
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -417,7 +417,7 @@ fn privacy_state(dev: &Device) -> std::io::Result<Option<bool>> {
 /// stays `false`, because the cost of failing open here is a capture of dark
 /// frames and a refused authentication, which the pipeline already handles.
 /// `setup_ir_emitter` deliberately does NOT use this: it writes to firmware,
-/// where an unknown shutter state must refuse — see [`privacy_permits_setup`].
+/// where an unknown shutter state must refuse — see `privacy_permits_setup`.
 pub fn privacy_engaged(device: &str) -> bool {
     let Ok(dev) = Device::with_path(device) else {
         return false;

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -435,7 +435,8 @@ fn privacy_permits_setup(observed: std::io::Result<Option<bool>>) -> Result<(), 
     match observed {
         Ok(Some(true)) => Err("the hardware privacy shutter is engaged (the `privacy` \
              control reads 1), so the sensor returns a blank frame and discovery \
-             would measure nothing; release the shutter and re-run ir-setup"
+             would measure nothing; release the shutter and re-run \
+             `sudo irlume ir-setup`"
             .into()),
         Ok(Some(false)) | Ok(None) => Ok(()),
         Err(e) => Err(format!(


### PR DESCRIPTION
Closes #186.

`setup_ir_emitter` was the one camera-touching path without a privacy check, and it is the one that writes to firmware. Against a shuttered sensor, discovery measured a constant (the ASUS blanks to 144.0 with a standard deviation of exactly 0.00; released it reads mean 37.0, stddev 62.68, eight frames per state), learned nothing from every exploratory write, and told the user their camera "advertises no usable emitter control".

## What ships

- **A three-valued privacy observation** (`privacy_state`): answered, absent (EINVAL/ENOTTY, the errnos V4L2 assigns to a control that does not exist), or FAILED. The old bool collapsed "failed to read" into "not engaged".
- **A fail-closed setup decision** (`privacy_permits_setup`, pure, used by the production path): engaged refuses; failed-to-read refuses; only an answered "released" or a camera without the control proceeds to a firmware write. The capture paths keep their fail-open bool deliberately: there the cost is dark frames and a refused authentication, and the asymmetry is documented at both sites.
- **A re-check before EACH forward write.** `discover` takes a `before_forward_write` guard, consulted immediately before the two exploratory writes and never before a restore (refusing to put a control back would leave it changed). A refusal before the first write abandons the untouched record; before the final re-apply it resolves the restored record. The residual window is one syscall wide: V4L2 offers no transaction spanning the privacy read and the XU write.

## Review

One Codex round, per the standing one-round policy. It found two merge-blocking Highs, both in the guard as first committed: the fail-open collapse and the check-to-write window described above. Both are fixed in the second commit with the reviewer's prescribed shape. Its one follow-up (a comment claiming the refusal ran "before anything touches the camera" when it opens the device to read one control) is corrected in the same commit.

## Evidence

- irlume-camera: 210 passed, 0 failed (4 new tests); clippy and fmt clean; full workspace suite green (25 result lines, zero failures).
- Four hand-applied mutants, four killed, each by exactly the test written for it, on a committed tree verified clean and green after each: (1) the setup decision made fail-open again; (2) every errno reading as "control absent"; (3) the first guard call deleted; (4) the second guard call deleted.

## Hardware, three camera models, final sha, repeated runs

- **ASUS 3277:0059 (E-shutter, `privacy` control): two interactive runs, 6/6 each.** Engaged: `ir-setup` exits nonzero, the refusal names the shutter, zero `SET_CUR` in the write log. Released: past the gate into real discovery (its normal lit-room outcome, "did not brighten, before 47 after 51", proves the exploratory write and restore ran through the released gate).
- **NexiGo 3443:c803 (no `privacy` control): three runs, 4/4 each.** The absent-control branch proceeds un-refused, and with the control parked at `GET_DEF`, discovery ran the full lit-both-ways verification and enabled the emitter — both forward writes through the new per-write guard on a real camera.
- **BRIO 046d:085e (no control; external mechanical cover): two runs, 4/4 each.** Proceeds un-refused; the cover is invisible to the gate by design (#185's documented territory), and its selector already holds the applied value, so discovery writes nothing (#192, reproduced).

## Not tested

- The per-write guard REFUSING mid-run on hardware: a human keypress cannot reliably land in the sub-second window between the early sample and the first write. Covered by the fake-camera tests and mutants 3 and 4.
- A real failed privacy read (EIO from a camera that has the control) was not provoked; the decision it feeds is covered by the pure-function tests and mutant 1.
- The two `rpm-build` lanes are red on Copr infrastructure trouble (SRPM builds rc 0, chroot workers die in about a minute with empty result directories, twice, both chroots). Nothing of this PR's code runs in that failure; the lanes are non-required and the GitHub Fedora build lanes are green.
