### PR TITLE
doctor names each camera node's backend; docs state the real claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Works with the camera you have: an **IR (Windows Hello) camera** unlocks the ful
 secure tier, a **regular webcam** gives convenient screen unlock, and a
 **fingerprint reader** slots in as a companion factor.
 
-Windows Hello-style security on a fully open, commercially clean stack.
+Windows Hello-style security for Linux, on a fully open, commercially clean stack.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ Works with the camera you have: an **IR (Windows Hello) camera** unlocks the ful
 secure tier, a **regular webcam** gives convenient screen unlock, and a
 **fingerprint reader** slots in as a companion factor.
 
-Built in the Windows Hello mold (IR capture, liveness gates, TPM-sealed
-templates), on a fully open, commercially clean stack. Where the Windows camera
-contract goes further than Linux exposes, [#169] says exactly how.
-
-[#169]: https://github.com/archledger/irlume/issues/169
+Windows Hello-style security on a fully open, commercially clean stack.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Works with the camera you have: an **IR (Windows Hello) camera** unlocks the ful
 secure tier, a **regular webcam** gives convenient screen unlock, and a
 **fingerprint reader** slots in as a companion factor.
 
-Built to match or beat Windows Hello, on a fully open, commercially clean stack.
+Built in the Windows Hello mold (IR capture, liveness gates, TPM-sealed
+templates), on a fully open, commercially clean stack. Where the Windows camera
+contract goes further than Linux exposes, [#169] says exactly how.
+
+[#169]: https://github.com/archledger/irlume/issues/169
 
 <br>
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -446,18 +446,26 @@ fn privacy_permits_setup(observed: std::io::Result<Option<bool>>) -> Result<(), 
     }
 }
 
-/// The kernel driver behind a video node and whether it sits on USB, read from
-/// sysfs. This answers the first question of every camera bug report: is this
-/// the `uvcvideo`-on-USB case irlume is built and tested for, or an IPU/MIPI
-/// or other pipeline that merely looks similar? #187's diagnosis had to ask
-/// for exactly this by shell script; `doctor` now reads it itself.
-pub fn node_backend(device: &str) -> Option<(String, bool)> {
-    let name = device.strip_prefix("/dev/")?;
-    let dev = std::fs::canonicalize(format!("/sys/class/video4linux/{name}/device")).ok()?;
-    let driver = std::fs::read_link(dev.join("driver")).ok()?;
-    let driver = driver.file_name()?.to_str()?.to_string();
-    let on_usb = dev.to_str().is_some_and(|p| p.contains("/usb"));
-    Some((driver, on_usb))
+/// The backend classification from a `VIDIOC_QUERYCAP` answer. The V4L2
+/// specification requires USB devices to report a bus string starting with
+/// `usb-`, so the split is the interface's own, not a sysfs-path heuristic
+/// (the kernel's sysfs rules say not to depend on the `device`/`driver` link
+/// topology). Pure so both halves of the split are testable without a camera.
+fn backend_from_caps(driver: String, bus: &str) -> (String, bool) {
+    (driver, bus.starts_with("usb-"))
+}
+
+/// The kernel driver behind a video node and whether V4L2 reports it on USB.
+/// This answers the first question of every camera bug report: is this the
+/// `uvcvideo`-on-USB case irlume is built and tested for, or an IPU/MIPI or
+/// other pipeline that merely looks similar? #187's diagnosis had to ask for
+/// exactly this by shell script; `doctor` now reads it itself. A failure is an
+/// `Err` the caller must render, never silence: an unobserved backend on a
+/// diagnostic surface has to say "unknown" (#195 review).
+pub fn node_backend(device: &str) -> std::io::Result<(String, bool)> {
+    let dev = Device::with_path(device)?;
+    let caps = dev.query_caps()?;
+    Ok(backend_from_caps(caps.driver, &caps.bus))
 }
 
 /// True iff a sysfs `device` path traces to a real hardware bus (USB/PCI) and
@@ -3349,12 +3357,33 @@ mod tests {
     }
 
     #[test]
-    fn node_backend_is_none_off_the_video_class() {
-        // Missing nodes, non-/dev paths and nodes with no sysfs entry all
-        // answer None rather than inventing a driver name.
-        assert!(node_backend("/dev/irlume-test-missing").is_none());
-        assert!(node_backend("/dev/null").is_none());
-        assert!(node_backend("not-even-a-dev-path").is_none());
+    fn node_backend_errors_off_the_video_class() {
+        // Missing nodes and non-V4L2 paths are observation FAILURES, reported
+        // as Err for the caller to render, never a silent nothing.
+        assert!(node_backend("/dev/irlume-test-missing").is_err());
+        assert!(node_backend("/dev/null").is_err());
+        assert!(node_backend("not-even-a-dev-path").is_err());
+    }
+
+    /// The positive split: the classification comes from the V4L2 bus string's
+    /// specified `usb-` prefix, not from path text (#195 review — the first
+    /// version's only test observed nothing but negatives and passed against
+    /// an implementation that always answered nothing).
+    #[test]
+    fn backend_splits_on_the_specified_bus_prefix() {
+        assert_eq!(
+            backend_from_caps("uvcvideo".into(), "usb-0000:00:14.0-5"),
+            ("uvcvideo".into(), true)
+        );
+        assert_eq!(
+            backend_from_caps("intel-ipu6".into(), "platform:intel-ipu6"),
+            ("intel-ipu6".into(), false)
+        );
+        // A bus merely CONTAINING usb is not the specified prefix.
+        assert_eq!(
+            backend_from_caps("gadget".into(), "platform:dummy_usb"),
+            ("gadget".into(), false)
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -446,6 +446,20 @@ fn privacy_permits_setup(observed: std::io::Result<Option<bool>>) -> Result<(), 
     }
 }
 
+/// The kernel driver behind a video node and whether it sits on USB, read from
+/// sysfs. This answers the first question of every camera bug report: is this
+/// the `uvcvideo`-on-USB case irlume is built and tested for, or an IPU/MIPI
+/// or other pipeline that merely looks similar? #187's diagnosis had to ask
+/// for exactly this by shell script; `doctor` now reads it itself.
+pub fn node_backend(device: &str) -> Option<(String, bool)> {
+    let name = device.strip_prefix("/dev/")?;
+    let dev = std::fs::canonicalize(format!("/sys/class/video4linux/{name}/device")).ok()?;
+    let driver = std::fs::read_link(dev.join("driver")).ok()?;
+    let driver = driver.file_name()?.to_str()?.to_string();
+    let on_usb = dev.to_str().is_some_and(|p| p.contains("/usb"));
+    Some((driver, on_usb))
+}
+
 /// True iff a sysfs `device` path traces to a real hardware bus (USB/PCI) and
 /// not a virtual/loopback origin. Pure so it can be unit-tested without sysfs.
 fn is_physical_camera_path(p: &str) -> bool {
@@ -3332,6 +3346,15 @@ mod tests {
             select_pair(),
             ("/dev/irlume-test-rgb".into(), "/dev/irlume-test-ir".into())
         );
+    }
+
+    #[test]
+    fn node_backend_is_none_off_the_video_class() {
+        // Missing nodes, non-/dev paths and nodes with no sysfs entry all
+        // answer None rather than inventing a driver name.
+        assert!(node_backend("/dev/irlume-test-missing").is_none());
+        assert!(node_backend("/dev/null").is_none());
+        assert!(node_backend("not-even-a-dev-path").is_none());
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3014,7 +3014,19 @@ fn doctor_run(
         } else {
             ""
         };
-        dout!(report, "  {path}: {role:?}{priv_on}");
+        // Name the backend on every node: uvcvideo-on-USB is the case irlume
+        // is built and tested for, and anything else is the first fact a bug
+        // report needs (an IPU/MIPI node classifies by format just as well and
+        // then behaves nothing alike; #187 had to establish this by hand).
+        let backend = match irlume_camera::node_backend(path) {
+            Some((drv, true)) if drv == "uvcvideo" => format!(" ({drv}, USB)"),
+            Some((drv, on_usb)) => {
+                let bus = if on_usb { "USB" } else { "not USB" };
+                format!(" ({drv}, {bus})  ⚠ not the uvcvideo-on-USB case irlume is built for")
+            }
+            None => String::new(),
+        };
+        dout!(report, "  {path}: {role:?}{backend}{priv_on}");
         // An RGB node the capture path can't decode (MJPEG-only) classifies as
         // usable but would fail at capture; warn here instead.
         if *role == irlume_camera::Role::Rgb {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3019,12 +3019,15 @@ fn doctor_run(
         // report needs (an IPU/MIPI node classifies by format just as well and
         // then behaves nothing alike; #187 had to establish this by hand).
         let backend = match irlume_camera::node_backend(path) {
-            Some((drv, true)) if drv == "uvcvideo" => format!(" ({drv}, USB)"),
-            Some((drv, on_usb)) => {
+            Ok((drv, true)) if drv == "uvcvideo" => format!(" ({drv}, USB)"),
+            Ok((drv, on_usb)) => {
                 let bus = if on_usb { "USB" } else { "not USB" };
                 format!(" ({drv}, {bus})  ⚠ not the uvcvideo-on-USB case irlume is built for")
             }
-            None => String::new(),
+            // A failed observation says so; rendering it as the old bare line
+            // would make "could not tell" look like "nothing to tell" on the
+            // one surface whose whole job is telling (#195 review).
+            Err(e) => format!(" (backend unknown: {e})  ⚠ could not identify camera backend"),
         };
         dout!(report, "  {path}: {role:?}{backend}{priv_on}");
         // An RGB node the capture path can't decode (MJPEG-only) classifies as

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ flowchart LR
         cli("irlume CLI / TUI")
     end
     socket{{"/run/irlume.sock<br/>SO_PEERCRED · root-or-self"}}
-    subgraph trust["irlumed: privileged · single-threaded"]
+    subgraph trust["irlumed: privileged · one serialized camera worker"]
         daemon("owns: camera · IR emitter · ONNX models · templates · TPM<br/><i>raw frames never leave here</i>")
     end
     callers -->|invokes| pam
@@ -50,7 +50,12 @@ flowchart LR
   directly by design; they are diagnostics, not auth paths.)
 - **`irlumed`** is the sole owner of the camera/IR/models/templates/TPM. This is
   the Linux analogue of Windows Hello ESS's isolated camera→matcher pathway: the
-  login/display-manager process tree never sees raw image data.
+  login/display-manager process tree never sees raw image data. Connections are
+  handled concurrently, but exactly ONE worker owns and advances the biometric
+  engine and camera state; the arbiter refuses non-auth camera work while an
+  authentication is pending, and long operations yield only at complete capture
+  boundaries. The security invariant is the serialized owner, not the thread
+  count.
 - **Trust boundary:** `irlumed` reads `SO_PEERCRED` on every connection. Only
   root or the target user may enroll/delete that user's profiles, and the sealed
   login password is released only to a root peer. (We use a raw Unix socket +

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,11 @@ flowchart LR
   directly by design; they are diagnostics, not auth paths.)
 - **`irlumed`** is the sole owner of the camera/IR/models/templates/TPM. This is
   the Linux analogue of Windows Hello ESS's isolated camera→matcher pathway: the
-  login/display-manager process tree never sees raw image data. Connections are
+  login/display-manager process tree never sees raw image data. It is an
+  analogue, not an equivalent: Windows adds a Device MFT, secure device
+  enumeration and a VBS-protected pathway that Linux does not expose, and
+  [#169](https://github.com/archledger/irlume/issues/169) tracks each
+  difference. Connections are
   handled concurrently, but exactly ONE worker owns and advances the biometric
   engine and camera state; the arbiter refuses non-auth camera work while an
   authentication is pending, and long operations yield only at complete capture


### PR DESCRIPTION
Three corrections that came out of a repository-wide architecture audit, each verified against the tree before acting.

**`doctor` prints the backend on every camera node, from the V4L2 interface itself.** The driver and bus come from `VIDIOC_QUERYCAP` through the pinned v4l crate; the V4L2 specification requires USB bus strings to carry the `usb-` prefix, so the USB split is the interface's own rather than sysfs path text (which the kernel's sysfs rules say not to depend on). `(uvcvideo, USB)` marks the supported case, anything else gets the driver, bus and a warning, and a FAILED observation renders as "backend unknown" with a warning rather than the old bare line. Measured on this machine:

```
[doctor] camera nodes (classified by pixel format):
  /dev/video0: Rgb (uvcvideo, USB)
  /dev/video2: Ir (uvcvideo, USB)
```

**ARCHITECTURE.md stops saying "single-threaded".** The stated invariant is now the one the arbiter enforces: concurrent connections, exactly one worker owning the biometric engine and camera state. The ESS paragraph also now says "analogue, not equivalent" with the #169 pointer.

**The README landing line stays one sentence** and drops the unsupportable comparative: "Windows Hello-style security on a fully open, commercially clean stack." The detail lives in ARCHITECTURE.md, not on the first screen.

## Review

One Codex round, per policy: two Mediums, both taken. The first version's sysfs walk collapsed every observation failure into `None`, which doctor rendered as the old bare line ("could not tell" indistinguishable from "nothing to tell"), and its only test observed nothing but negatives, so an implementation that always answered `None` passed it. Fixed with the reviewer's prescribed shape: `io::Result` API, `Err` rendered visibly, and a pure `backend_from_caps` with positive tests.

## Evidence

- irlume-camera 212 passed, irlume-cli 254 passed; clippy and fmt clean.
- Two hand-applied mutants killed by the new positive test on a committed clean tree: the USB split forced always-false, and the prefix loosened to a substring match (the `platform:dummy_usb` assertion is what catches that one).
- `doctor` re-run on real hardware after the QUERYCAP rewrite: output above, unchanged from the sysfs version on the supported case.

## Not tested

- The non-uvcvideo and backend-unknown rendering branches have no camera here to produce them; both are rendering arms over the same enum the tests cover.
