### PR TITLE
A dark IR burst gets a diagnosis that names its evidence

### DIFF
--- a/crates/irlume-camera/src/ir_dark.rs
+++ b/crates/irlume-camera/src/ir_dark.rs
@@ -1,0 +1,301 @@
+//! Why an IR burst came back dark, named from evidence instead of guessed.
+//!
+//! `capture_with_stats` used to answer every dark burst with one hint: "no
+//! active emitter; run `sudo irlume ir-setup`". A dark IR frame has at least
+//! six causes and that advice fits exactly one of them; for a covered sensor,
+//! an out-of-range subject or an emitter firing uselessly into a bright room
+//! it sends the user to write to camera firmware for a problem that is not
+//! there (#185). The capture path already holds the evidence to do better:
+//! whether irlume drove the control this stream, the camera's own per-frame
+//! illumination metadata (#167), the privacy control where the camera
+//! publishes one, and the chosen frame's pixel statistics.
+//!
+//! The decision is a pure function over that evidence, so every arm is
+//! testable without a camera, and the renderer returns the full message so
+//! wording and advice stay in one place.
+
+/// The chosen frame's pixel standard deviation below which it is treated as a
+/// firmware-substituted blank rather than a dark scene. Measured on the ASUS
+/// 3277:0059 (#186, eight frames per state): an engaged shutter's blank is a
+/// constant 144.0 with a standard deviation of exactly 0.00, six runs out of
+/// six, while every real scene measured there reads 34 or higher. The floor
+/// only has to sit between "exactly constant" and "carries any signal at all";
+/// 0.5 is an order of magnitude from both measurements.
+const FLAT_STDDEV_MAX: f64 = 0.5;
+
+/// What the capture path observed about a dark burst. Every field is a plain
+/// value so [`diagnose`] stays pure.
+#[derive(Debug, Clone, Copy)]
+pub struct DarkEvidence {
+    /// The emitter control is active for this stream (irlume applied it, or it
+    /// already held the wanted value). `StreamMode::lit`.
+    pub emitter_active: bool,
+    /// `IRLUME_IR_EMITTER=off`: the user told irlume to drive nothing.
+    pub emitter_disabled: bool,
+    /// The V4L2 privacy control read engaged. `false` covers released, absent
+    /// AND unreadable alike: this is a diagnosis, not an authorization, and
+    /// only a positive reading is evidence of a cause (the firmware-write
+    /// paths make the three-way distinction; see `privacy_permits_setup`).
+    pub privacy_engaged: bool,
+    /// Burst frames the camera's illumination metadata flagged LIT (#167).
+    pub frames_lit: usize,
+    /// Burst frames carrying any illumination metadata at all.
+    pub frames_classified: usize,
+    /// Pixel standard deviation of the chosen frame.
+    pub frame_stddev: f64,
+}
+
+/// The named cause of a dark IR burst, most specific evidence first.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum IrDarkCause {
+    /// The privacy control reads engaged: the sensor is blanked by the shutter.
+    PrivacyEngaged,
+    /// The camera says the illuminator FIRED and the image stayed dark: light
+    /// left the emitter and did not reach the sensor (a cover, distance, or
+    /// exposure). `ir-setup` is the wrong advice here.
+    LitButDark {
+        frames_lit: usize,
+        frames_classified: usize,
+    },
+    /// The frame is a near-perfect constant: a covered or firmware-blanked
+    /// sensor, not a dark room (a dark room carries sensor noise; see
+    /// `FLAT_STDDEV_MAX` for the measured gap).
+    FlatFrame { stddev: f64 },
+    /// irlume applied the control and the camera accepted the write, but its
+    /// own metadata never flagged a lit frame: the camera did not act on the
+    /// mode.
+    AppliedNotTaken { frames_classified: usize },
+    /// The user set `IRLUME_IR_EMITTER=off`; a dark frame is the configured
+    /// outcome, and saying anything would be noise they opted out of.
+    EmitterDisabled,
+    /// No emitter was driven and nothing else explains the darkness: the one
+    /// case where `ir-setup` is the right advice. Never
+    /// `linux-enable-ir-emitter`: that tool finds a control by writing
+    /// invented payloads across units and selectors until the picture
+    /// brightens, the exact search irlume removed from its own code after it
+    /// destroyed a reporter's camera (#159). `ir-setup` does the same job
+    /// from the camera's own descriptor and its own `GET_DEF` values.
+    NoEmitterDriven,
+    /// The control is active, the camera supplies no metadata, and the frame
+    /// carries real signal: the evidence cannot separate an emitter the
+    /// camera ignored from a subject out of range or a genuinely dark scene.
+    Undetermined,
+}
+
+/// Name the cause of a dark burst. Pure; the caller decides whether the burst
+/// was dark at all (the `IR_DARK_HINT_MAX` gate, unchanged).
+pub fn diagnose(e: &DarkEvidence) -> IrDarkCause {
+    if e.privacy_engaged {
+        return IrDarkCause::PrivacyEngaged;
+    }
+    if e.frames_lit > 0 {
+        return IrDarkCause::LitButDark {
+            frames_lit: e.frames_lit,
+            frames_classified: e.frames_classified,
+        };
+    }
+    if e.frame_stddev < FLAT_STDDEV_MAX {
+        return IrDarkCause::FlatFrame {
+            stddev: e.frame_stddev,
+        };
+    }
+    if e.emitter_active && e.frames_classified > 0 {
+        return IrDarkCause::AppliedNotTaken {
+            frames_classified: e.frames_classified,
+        };
+    }
+    if e.emitter_disabled {
+        return IrDarkCause::EmitterDisabled;
+    }
+    if !e.emitter_active {
+        return IrDarkCause::NoEmitterDriven;
+    }
+    IrDarkCause::Undetermined
+}
+
+/// The user-facing line for a cause, or `None` where silence is the right
+/// output (`EmitterDisabled`: the hint's own text has always promised that
+/// `off` silences it, and this is where the promise is kept).
+pub fn render(card: &str, mean: f64, cause: &IrDarkCause) -> Option<String> {
+    match cause {
+        IrDarkCause::PrivacyEngaged => Some(format!(
+            "[ir] {card:?}: IR is dark because the privacy shutter is engaged (the \
+             `privacy` control reads 1); release it. No emitter problem is in evidence."
+        )),
+        IrDarkCause::LitButDark {
+            frames_lit,
+            frames_classified,
+        } => Some(format!(
+            "[ir] {card:?}: the camera reports its illuminator fired ({frames_lit}/\
+             {frames_classified} frames) yet the image stayed dark (mean {mean:.0}); \
+             light is leaving the emitter and not reaching the sensor. Check for a \
+             lens cover, move closer, or check exposure; `ir-setup` will not help."
+        )),
+        IrDarkCause::FlatFrame { stddev } => Some(format!(
+            "[ir] {card:?}: the IR frame is flat (mean {mean:.0}, stddev {stddev:.2}): \
+             a covered or blanked sensor, not a dark room (a dark scene still carries \
+             sensor noise). Check for a lens cover or privacy shade."
+        )),
+        IrDarkCause::AppliedNotTaken { frames_classified } => Some(format!(
+            "[ir] {card:?}: irlume applied the emitter control and the camera accepted \
+             the write, but none of {frames_classified} metadata-classified frames was \
+             flagged lit: the camera did not act on the mode. `sudo irlume ir-setup` \
+             re-measures what this control actually does."
+        )),
+        IrDarkCause::EmitterDisabled => None,
+        IrDarkCause::NoEmitterDriven => Some(format!(
+            "[ir] {card:?}: IR is dark (mean {mean:.0}) with no active emitter; run \
+             `sudo irlume ir-setup` to find this camera's emitter control from what it \
+             publishes (IRLUME_IR_EMITTER=off silences this)"
+        )),
+        IrDarkCause::Undetermined => Some(format!(
+            "[ir] {card:?}: IR is dark (mean {mean:.0}) with the emitter control \
+             active; this camera supplies no illumination metadata, so irlume cannot \
+             tell an ignored control from a subject out of range or a dark scene. If \
+             moving closer changes nothing, `sudo irlume ir-setup` re-measures the \
+             control."
+        )),
+    }
+}
+
+/// Pixel standard deviation of one 8-bit frame.
+pub fn frame_stddev(data: &[u8]) -> f64 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let n = data.len() as f64;
+    let mean = data.iter().map(|&p| f64::from(p)).sum::<f64>() / n;
+    let var = data
+        .iter()
+        .map(|&p| {
+            let d = f64::from(p) - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn textured_dark() -> DarkEvidence {
+        DarkEvidence {
+            emitter_active: false,
+            emitter_disabled: false,
+            privacy_engaged: false,
+            frames_lit: 0,
+            frames_classified: 0,
+            frame_stddev: 40.0,
+        }
+    }
+
+    /// Each cause is reachable, and the precedence follows evidence
+    /// specificity: a positive shutter reading beats everything, the camera
+    /// saying "fired" beats inference, a flat frame beats metadata absence.
+    #[test]
+    fn each_cause_is_reachable_and_ordered_by_evidence() {
+        assert_eq!(
+            diagnose(&DarkEvidence {
+                privacy_engaged: true,
+                frames_lit: 3,
+                ..textured_dark()
+            }),
+            IrDarkCause::PrivacyEngaged,
+            "an engaged shutter outranks even a lit flag"
+        );
+        assert_eq!(
+            diagnose(&DarkEvidence {
+                frames_lit: 3,
+                frames_classified: 8,
+                frame_stddev: 0.0,
+                ..textured_dark()
+            }),
+            IrDarkCause::LitButDark {
+                frames_lit: 3,
+                frames_classified: 8
+            },
+            "the camera saying FIRED outranks the flat-frame inference"
+        );
+        assert_eq!(
+            diagnose(&DarkEvidence {
+                frame_stddev: 0.0,
+                emitter_active: true,
+                frames_classified: 8,
+                ..textured_dark()
+            }),
+            IrDarkCause::FlatFrame { stddev: 0.0 },
+            "a flat frame outranks applied-not-taken"
+        );
+        assert_eq!(
+            diagnose(&DarkEvidence {
+                emitter_active: true,
+                frames_classified: 8,
+                ..textured_dark()
+            }),
+            IrDarkCause::AppliedNotTaken {
+                frames_classified: 8
+            },
+        );
+        assert_eq!(
+            diagnose(&DarkEvidence {
+                emitter_disabled: true,
+                ..textured_dark()
+            }),
+            IrDarkCause::EmitterDisabled,
+        );
+        assert_eq!(diagnose(&textured_dark()), IrDarkCause::NoEmitterDriven);
+        assert_eq!(
+            diagnose(&DarkEvidence {
+                emitter_active: true,
+                ..textured_dark()
+            }),
+            IrDarkCause::Undetermined,
+            "active control, no metadata, real signal: the honest answer is no answer"
+        );
+    }
+
+    /// `off` genuinely silences the output. The old hint PROMISED this in its
+    /// own text and did not do it: with the override set to off the emitter is
+    /// inert, `lit` is false, and the hint printed anyway, naming the very
+    /// variable that was already set.
+    #[test]
+    fn disabled_renders_nothing_and_ir_setup_is_advised_only_where_it_helps() {
+        assert!(render("cam", 20.0, &IrDarkCause::EmitterDisabled).is_none());
+        for (cause, wants_setup) in [
+            (IrDarkCause::NoEmitterDriven, true),
+            (
+                IrDarkCause::LitButDark {
+                    frames_lit: 3,
+                    frames_classified: 8,
+                },
+                false,
+            ),
+            (IrDarkCause::PrivacyEngaged, false),
+            (IrDarkCause::FlatFrame { stddev: 0.0 }, false),
+        ] {
+            let msg = render("cam", 20.0, &cause).expect("these causes all speak");
+            assert_eq!(
+                msg.contains("run `sudo irlume ir-setup` to find"),
+                wants_setup,
+                "ir-setup discovery advice on the wrong cause sends a user to write \
+                 firmware for a problem that is not there: {msg}"
+            );
+        }
+    }
+
+    /// The flat floor separates the two measured worlds: a firmware blank
+    /// (stddev exactly 0.00 on the ASUS, #186) and any real scene (34+).
+    #[test]
+    fn frame_stddev_separates_blank_from_scene() {
+        assert_eq!(frame_stddev(&[144; 1000]), 0.0);
+        assert!(frame_stddev(&[144; 1000]) < FLAT_STDDEV_MAX);
+        // Alternating values two apart: stddev 1.0, above the floor.
+        let noisy: Vec<u8> = (0..1000)
+            .map(|i| if i % 2 == 0 { 19 } else { 21 })
+            .collect();
+        assert!(frame_stddev(&noisy) > FLAT_STDDEV_MAX);
+        assert_eq!(frame_stddev(&[]), 0.0);
+    }
+}

--- a/crates/irlume-camera/src/ir_dark.rs
+++ b/crates/irlume-camera/src/ir_dark.rs
@@ -50,21 +50,25 @@ pub struct DarkEvidence {
 pub enum IrDarkCause {
     /// The privacy control reads engaged: the sensor is blanked by the shutter.
     PrivacyEngaged,
-    /// The camera says the illuminator FIRED and the image stayed dark: light
-    /// left the emitter and did not reach the sensor (a cover, distance, or
-    /// exposure). `ir-setup` is the wrong advice here.
+    /// The camera marked frames as captured with illumination ON, yet the
+    /// image stayed dark. The Microsoft metadata reports the illumination
+    /// STATE; it does not measure optical output, so a failed LED and a
+    /// covered lens are both still in play (#196 review).
     LitButDark {
         frames_lit: usize,
         frames_classified: usize,
     },
-    /// The frame is a near-perfect constant: a covered or firmware-blanked
-    /// sensor, not a dark room (a dark room carries sensor noise; see
-    /// `FLAT_STDDEV_MAX` for the measured gap).
+    /// The decoded frame is nearly constant. Evidence of a FLAT OUTPUT, not
+    /// by itself evidence of why: the blank-vs-scene gap behind
+    /// `FLAT_STDDEV_MAX` was measured on one camera, and an ISP may clamp a
+    /// genuinely dark scene to a constant (#196 review).
     FlatFrame { stddev: f64 },
-    /// irlume applied the control and the camera accepted the write, but its
-    /// own metadata never flagged a lit frame: the camera did not act on the
-    /// mode.
-    AppliedNotTaken { frames_classified: usize },
+    /// The requested control value was ACTIVE for the stream (irlume wrote
+    /// it, or it was already held: `StreamMode::lit` does not distinguish),
+    /// but no classified frame was marked illuminated. Whether the camera
+    /// ignored the mode, the emitter failed, or the metadata did not reflect
+    /// the control cannot be told apart from here (#196 review).
+    ActiveButNotReported { frames_classified: usize },
     /// The user set `IRLUME_IR_EMITTER=off`; a dark frame is the configured
     /// outcome, and saying anything would be noise they opted out of.
     EmitterDisabled,
@@ -85,6 +89,12 @@ pub enum IrDarkCause {
 /// Name the cause of a dark burst. Pure; the caller decides whether the burst
 /// was dark at all (the `IR_DARK_HINT_MAX` gate, unchanged).
 pub fn diagnose(e: &DarkEvidence) -> IrDarkCause {
+    // An explicit output policy, not an inferred hardware cause: the user
+    // said "drive nothing", and every line below is chatter they opted out
+    // of, so it precedes every diagnosis that would speak (#196 review).
+    if e.emitter_disabled {
+        return IrDarkCause::EmitterDisabled;
+    }
     if e.privacy_engaged {
         return IrDarkCause::PrivacyEngaged;
     }
@@ -100,12 +110,9 @@ pub fn diagnose(e: &DarkEvidence) -> IrDarkCause {
         };
     }
     if e.emitter_active && e.frames_classified > 0 {
-        return IrDarkCause::AppliedNotTaken {
+        return IrDarkCause::ActiveButNotReported {
             frames_classified: e.frames_classified,
         };
-    }
-    if e.emitter_disabled {
-        return IrDarkCause::EmitterDisabled;
     }
     if !e.emitter_active {
         return IrDarkCause::NoEmitterDriven;
@@ -126,21 +133,26 @@ pub fn render(card: &str, mean: f64, cause: &IrDarkCause) -> Option<String> {
             frames_lit,
             frames_classified,
         } => Some(format!(
-            "[ir] {card:?}: the camera reports its illuminator fired ({frames_lit}/\
-             {frames_classified} frames) yet the image stayed dark (mean {mean:.0}); \
-             light is leaving the emitter and not reaching the sensor. Check for a \
-             lens cover, move closer, or check exposure; `ir-setup` will not help."
+            "[ir] {card:?}: the camera marked {frames_lit}/{frames_classified} frames \
+             as captured with illumination on, yet the image stayed dark (mean \
+             {mean:.0}). That metadata does not measure optical output, so irlume \
+             cannot distinguish a failed or ignored emitter from a lens cover, range, \
+             or exposure problem. Check the cover, distance and exposure; if those do \
+             not explain it, `sudo irlume ir-setup` re-measures the control."
         )),
         IrDarkCause::FlatFrame { stddev } => Some(format!(
-            "[ir] {card:?}: the IR frame is flat (mean {mean:.0}, stddev {stddev:.2}): \
-             a covered or blanked sensor, not a dark room (a dark scene still carries \
-             sensor noise). Check for a lens cover or privacy shade."
+            "[ir] {card:?}: the IR frame is nearly constant (mean {mean:.0}, stddev \
+             {stddev:.2}). On the tested ASUS camera this matched a privacy-blanked \
+             frame, but pixel variance alone cannot distinguish a blanked or covered \
+             sensor from camera processing of a dark scene. Check the privacy shutter \
+             and lens cover; if neither explains it, move closer and re-test."
         )),
-        IrDarkCause::AppliedNotTaken { frames_classified } => Some(format!(
-            "[ir] {card:?}: irlume applied the emitter control and the camera accepted \
-             the write, but none of {frames_classified} metadata-classified frames was \
-             flagged lit: the camera did not act on the mode. `sudo irlume ir-setup` \
-             re-measures what this control actually does."
+        IrDarkCause::ActiveButNotReported { frames_classified } => Some(format!(
+            "[ir] {card:?}: the emitter control held the requested value, but none of \
+             {frames_classified} metadata-classified frames was marked as captured \
+             with illumination on. The evidence cannot tell whether the camera \
+             ignored the mode, the emitter failed, or the metadata does not reflect \
+             the control. `sudo irlume ir-setup` re-measures the control."
         )),
         IrDarkCause::EmitterDisabled => None,
         IrDarkCause::NoEmitterDriven => Some(format!(
@@ -226,7 +238,7 @@ mod tests {
                 ..textured_dark()
             }),
             IrDarkCause::FlatFrame { stddev: 0.0 },
-            "a flat frame outranks applied-not-taken"
+            "a flat frame outranks active-but-not-reported"
         );
         assert_eq!(
             diagnose(&DarkEvidence {
@@ -234,7 +246,7 @@ mod tests {
                 frames_classified: 8,
                 ..textured_dark()
             }),
-            IrDarkCause::AppliedNotTaken {
+            IrDarkCause::ActiveButNotReported {
                 frames_classified: 8
             },
         );
@@ -246,6 +258,20 @@ mod tests {
             IrDarkCause::EmitterDisabled,
         );
         assert_eq!(diagnose(&textured_dark()), IrDarkCause::NoEmitterDriven);
+        // `off` is an output policy, not an inferred cause: it silences every
+        // other observation, through the production precedence, because the
+        // render-only check could not fail when diagnose never picked it
+        // (#196 review).
+        let off = diagnose(&DarkEvidence {
+            emitter_active: false,
+            emitter_disabled: true,
+            privacy_engaged: true,
+            frames_lit: 8,
+            frames_classified: 8,
+            frame_stddev: 0.0,
+        });
+        assert_eq!(off, IrDarkCause::EmitterDisabled);
+        assert!(render("cam", 20.0, &off).is_none());
         assert_eq!(
             diagnose(&DarkEvidence {
                 emitter_active: true,
@@ -285,10 +311,31 @@ mod tests {
         }
     }
 
-    /// The flat floor separates the two measured worlds: a firmware blank
-    /// (stddev exactly 0.00 on the ASUS, #186) and any real scene (34+).
+    /// The metadata flag reports illumination STATE; the message must not
+    /// claim measured optical output, and must not rule the emitter out
+    /// (#196 review: a failed LED sets the flag and emits nothing).
     #[test]
-    fn frame_stddev_separates_blank_from_scene() {
+    fn lit_metadata_does_not_claim_measured_optical_output() {
+        let msg = render(
+            "cam",
+            20.0,
+            &IrDarkCause::LitButDark {
+                frames_lit: 3,
+                frames_classified: 8,
+            },
+        )
+        .unwrap();
+        assert!(msg.contains("captured with illumination on"), "{msg}");
+        assert!(msg.contains("does not measure optical output"), "{msg}");
+        assert!(!msg.contains("light is leaving"), "{msg}");
+        assert!(!msg.contains("will not help"), "{msg}");
+    }
+
+    /// The arithmetic separates a constant sample from a non-constant one.
+    /// That is ALL it establishes: the hardware meaning of a constant frame
+    /// is measured on one camera and worded accordingly in the renderer.
+    #[test]
+    fn frame_stddev_classifies_constant_and_nonconstant_samples() {
         assert_eq!(frame_stddev(&[144; 1000]), 0.0);
         assert!(frame_stddev(&[144; 1000]) < FLAT_STDDEV_MAX);
         // Alternating values two apart: stddev 1.0, above the floor.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -290,6 +290,16 @@ enum OverrideSetting {
     Malformed(String),
 }
 
+/// Whether `IRLUME_IR_EMITTER` is set to `off`/`none`: the user's explicit
+/// "drive nothing". The dark-frame diagnosis silences itself on this (#185);
+/// the old hint printed anyway, naming the very variable that was already set.
+pub(crate) fn emitter_explicitly_disabled() -> bool {
+    matches!(
+        override_setting(std::env::var("IRLUME_IR_EMITTER")),
+        OverrideSetting::Disabled
+    )
+}
+
 fn override_setting(raw: std::result::Result<String, std::env::VarError>) -> OverrideSetting {
     let raw = match raw {
         Err(std::env::VarError::NotPresent) => return OverrideSetting::Absent,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -23,6 +23,7 @@
 //! panic on some drivers. Probe, don't assume.
 
 pub mod emitter_journal;
+pub mod ir_dark;
 pub mod ir_emitter;
 mod ir_metadata;
 mod stream_record;
@@ -1639,24 +1640,36 @@ impl IrSession<'_> {
                 means.len()
             );
         }
-        // Onboarding hint for a new (e.g. external) Hello camera: dark IR with no
-        // emitter fired usually means its 850nm illuminator needs a UVC-XU write we
-        // don't have a table entry for. Guide the user to configure it.
-        //
-        // This used to say "run `linux-enable-ir-emitter configure`, then set
-        // IRLUME_IR_EMITTER=unit:sel:b,b,...". That tool finds a control by
-        // writing invented payloads across units and selectors until the picture
-        // brightens, which is precisely the search irlume removed from its own
-        // code after it destroyed a reporter's camera (#159). Deleting the search
-        // here and then telling the user to go and run it somewhere else is not a
-        // fix. `irlume ir-setup` does the same job from the camera's own
-        // descriptor and its own GET_DEF values.
-        if !lit && (0.0..IR_DARK_HINT_MAX).contains(&best_mean) {
-            eprintln!(
-                "[ir] {card:?}: IR is dark (mean {best_mean:.0}) with no active emitter; \
-             run `sudo irlume ir-setup` to find this camera's emitter control from what it \
-             publishes (IRLUME_IR_EMITTER=off silences this)"
-            );
+        // A dark burst gets a DIAGNOSIS, not the old one-size hint. The single
+        // "run ir-setup" line fit one of a dark frame's six causes and sent
+        // users to write camera firmware for shutters, covers and range
+        // problems (#185); the evidence to do better is already in hand:
+        // whether irlume drove the control, the camera's own per-frame
+        // illumination metadata (#167), the privacy control, and the frame's
+        // variance (a firmware blank is a near-perfect constant, #186). The
+        // gate no longer requires `!lit`: an ACTIVE control with a dark frame
+        // is the broken case most worth explaining, and the causes that only
+        // exist when the control is active (lit-but-dark, applied-not-taken)
+        // were exactly the ones the old silence hid. `ir-setup` discovery
+        // advice survives only on the one cause it fits; the historical note
+        // about why irlume never recommends linux-enable-ir-emitter's blind
+        // search lives with that message's cause in `ir_dark` (#159).
+        if (0.0..IR_DARK_HINT_MAX).contains(&best_mean) {
+            let frames_lit = flags
+                .iter()
+                .filter(|f| matches!(f, Some(ir_metadata::Illumination::Lit)))
+                .count();
+            let evidence = ir_dark::DarkEvidence {
+                emitter_active: lit,
+                emitter_disabled: ir_emitter::emitter_explicitly_disabled(),
+                privacy_engaged: privacy_engaged(device),
+                frames_lit,
+                frames_classified: from_camera,
+                frame_stddev: ir_dark::frame_stddev(&frames[best_i]),
+            };
+            if let Some(line) = ir_dark::render(card, best_mean, &ir_dark::diagnose(&evidence)) {
+                eprintln!("{line}");
+            }
         }
         let grey = best.ok_or_else(|| Error::Hardware("no IR frames captured".into()))?;
         Ok((


### PR DESCRIPTION
Closes #185.

`capture_with_stats` answered every dark burst with one hint ("no active emitter; run `sudo irlume ir-setup`"), which fits one of a dark frame's six causes; for a shutter, a cover, an out-of-range subject or an emitter the camera ignored, it sent users toward camera firmware for a problem that is not there. The evidence to do better was already in hand: whether irlume drove the control this stream, #167's per-frame illumination metadata, the privacy control, and the frame's variance (#186 measured a firmware blank at a constant 144.0 with stddev exactly 0.00, against 34+ for every real scene there).

## What ships

- **`ir_dark`, a new module**: `DarkEvidence` in, `IrDarkCause` out, both pure; the renderer sits alongside so wording and advice stay in one place. Seven causes, precedence ordered by evidence specificity: an engaged shutter outranks a lit flag, the camera saying FIRED outranks the flat-frame inference, flat outranks applied-not-taken.
- **`ir-setup` discovery advice survives only on the cause it fits** (`NoEmitterDriven`). The lit-but-dark, shutter and flat causes name their evidence and say the advice would not help; the no-metadata case says what it cannot tell apart instead of picking the convenient cause.
- **`IRLUME_IR_EMITTER=off` now genuinely silences the output.** The old hint's own text promised this and printed anyway, naming the very variable that was already set.
- **The dark gate no longer requires `!lit`**: an active control with a dark frame is the broken case most worth explaining, and the old code said nothing there.

## Evidence

- irlume-camera: 215 passed (3 new tests: cause reachability and precedence, off-silence plus advice placement, the stddev floor separating a measured blank from a scene).
- Four hand-applied mutants, four killed, each by its own test, on a committed clean tree: the privacy check demoted below the lit flag, `EmitterDisabled` speaking anyway, discovery advice leaking onto lit-but-dark, and the stddev floored above the flat threshold.
- Doc lane clean locally (`RUSTDOCFLAGS="-D warnings"`), clippy and fmt clean.
- Hardware, ASUS 3277:0059, three interactive runs on the final sha:
  - **`LitButDark` fired on real evidence** (run 1, before anyone was in frame): the emitter fired (5/10 frames flagged), nothing in range reflected it (mean 31-34), and the printed diagnosis named exactly that, with range among the listed causes. With a subject in frame (mean 68-70) the same phase stayed silent, twice.
  - **`off` is silent end-to-end, 3/3** - including captures at mean 0.7-1.8, genuinely below the dark gate, so the whole diagnosis path ran and chose `EmitterDisabled` first.
  - **The covered-camera phase found a new fact instead of passing**: an opaque cover under the active emitter SATURATES the sensor (mean 255.0, three runs out of three) rather than darkening it, so the dark-gated diagnosis correctly does not run - the same silence as main, no regression - and the flat-saturated signature is filed as #197. The script's expectation, not the code, was wrong: it predicted cover physics that this camera refutes.

## Not tested

- `AppliedNotTaken` and `Undetermined` end-to-end need a camera that accepts the control without acting on it, or one without metadata; neither is attached here. Both arms are covered by the decision-table tests.
- The flat-frame floor rests on #186's measured blank (stddev exactly 0.00) and measured scenes (34+); a genuinely dark ROOM's noise floor was not separately measured. The floor sits at 0.5, an order of magnitude from both measurements, and the covered-camera phase of the staged hardware run exercises the boundary from the flat side.
