### PR TITLE
Keyring hand-off check for KWallet + GNOME Keyring, verified against upstream; fix openSUSE and renamed-substack anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **Fingerprint keyring unlock never wired on GNOME, and could not have worked
+  if it had.** Two defects in one stack. The wiring anchored on a literal
+  `pam_fprintd.so` auth line, but GDM's `gdm-fingerprint.pam` never names the
+  module — it delegates to `auth substack fingerprint-auth` — so the anchor
+  search found nothing and the whole step became a silent no-op: `login enable`
+  reported success and wrote nothing. And had it wired, the stack carries no
+  keyring module at all, so the released password would have gone to a stack
+  with no consumer. The anchor now recognizes a fingerprint substack or include
+  as well as the literal module, and when the stack has no keyring consumer of
+  its own the two `pam_gnome_keyring.so` halves it needs are added alongside.
+  Those added lines are tagged so unwiring removes exactly ours and never a
+  distro-shipped keyring line, and carry PAM's leading `-` so a machine without
+  gnome-keyring installed is unaffected. Face login was never involved.
+
 - **A renamed shared PAM stack no longer drops the face block onto the wrong
   line.** The greeter block anchored on a fixed list of stack names
   (`password-auth`, `system-auth`, …) and, failing that, on the first `auth`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **openSUSE greeters anchored face auth on the wrong line, skipping the
+  nologin gate.** openSUSE's `plasmalogin` routes the password through
+  `auth substack common-auth`, a stack name the wiring did not recognize, so it
+  fell back to the first `auth` line and inserted the `success=1` jump above
+  `pam_nologin.so`. A face match then jumped over the nologin gate and landed
+  *before* `substack common-auth`, which ran anyway: face auth that neither
+  honoured nologin nor spared the user the password. The auth and session stack
+  names are now kind-aware and include openSUSE's `common-auth` and
+  `common-session`, so the jump anchors on the password substack (atomic for
+  jump counting, so the jump form stays correct) and `pam_nologin.so` keeps
+  running first. A bare `auth include common-auth` is treated as an include
+  instead, taking the `sufficient` form a jump cannot skip.
+
 ### Added
 
 - **`login status` says when face login releases a password nothing will use.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **The wallet hand-off check was blind to the fingerprint path.** It anchored
+  on the face `unseal` line, but the post-auth `keyring` line releases the same
+  sealed password — and on a fingerprint-only box the greeter carries ONLY that
+  line, so a missing or mis-ordered wallet module after a fingerprint login was
+  never reported: the wallet stayed locked with nothing naming why. The check
+  now anchors on the first credential-releasing line of either mode, and its
+  warning names both methods. Verified against the KDE sources while at it:
+  Plasma's login greeter authenticates through the single `plasmalogin` stack
+  (its PAM backend has no fingerprint service; kscreenlocker's `kde-fingerprint`
+  triple is the lock screen only), so the greeter `keyring` line is exactly
+  where the KDE cold-boot fingerprint→KWallet chain runs — new tests pin that
+  the line lands above `pam_kwallet5.so` on every upstream plasmalogin layout.
+
 - **A stack using backslash line continuations is refused, not corrupted.**
   libpam's line assembler joins a directive ending in `\` with the next
   physical line before tokenizing (whitespace after the backslash does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **A keyring module that stands down for the service was counted as if it
+  worked.** `pam_gnome_keyring.so` takes `only_if=<comma,separated,services>`,
+  and for any service outside that list every one of its entry points returns
+  `PAM_SUCCESS` immediately: it reads no token, stashes nothing, unlocks
+  nothing. The hand-off check matched the module name alone, so such a line
+  counted as a working consumer — reporting a wallet that would open when
+  nothing would, which is the one thing this check exists to prevent. It also
+  suppressed the consumer irlume adds to a fingerprint stack, silently undoing
+  that unlock. The list is now evaluated per service, matching whole
+  comma-separated items the way gkr-pam's own `evaluate_inlist` does, so
+  `only_if=gdm` no longer satisfies `gdm-fingerprint`. `pam_kwallet5.so` has no
+  equivalent option, so only the GNOME case narrows.
+
 - **Fingerprint keyring unlock never wired on GNOME, and could not have worked
   if it had.** Two defects in one stack. The wiring anchored on a literal
   `pam_fprintd.so` auth line, but GDM's `gdm-fingerprint.pam` never names the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **`login status` says when face login releases a password nothing will use.**
+  Wiring the greeter and arming the keyring is only half the KWallet path: the
+  released password still has to be read by `pam_kwallet5.so` (KDE) or
+  `pam_gnome_keyring.so` (GNOME), from an auth line BELOW irlume's, with a
+  matching session line to start the wallet daemon. When that module is absent,
+  or sits above ours where it runs before the token exists, the face login
+  succeeds and the wallet prompts anyway — and every command still reported the
+  greeter as `● wired`, so the one symptom the user could see pointed away from
+  the cause. `login status` and `login enable --apply` now inspect each wired
+  greeter and name which half is missing. Advisory only: it changes no stack and
+  fails no command, because an absent wallet module is a packaging choice rather
+  than a broken wiring.
+
 - **A dark or blinded IR capture reports what its evidence supports.** A dark
   burst used to get one hint ("no active emitter; run `sudo irlume ir-setup`")
   even though shutters, covers, range, exposure and emitter failures all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to irlume are documented here. This project adheres to
 
 - **The wallet hand-off check was blind to the fingerprint path.** It anchored
   on the face `unseal` line, but the post-auth `keyring` line releases the same
-  sealed password — and on a fingerprint-only box the greeter carries ONLY that
+  sealed password. On a fingerprint-only box the greeter carries ONLY that
   line, so a missing or mis-ordered wallet module after a fingerprint login was
   never reported: the wallet stayed locked with nothing naming why. The check
   now anchors on the first credential-releasing line of either mode, and its
@@ -17,19 +17,19 @@ All notable changes to irlume are documented here. This project adheres to
   Plasma's login greeter authenticates through the single `plasmalogin` stack
   (its PAM backend has no fingerprint service; kscreenlocker's `kde-fingerprint`
   triple is the lock screen only), so the greeter `keyring` line is exactly
-  where the KDE cold-boot fingerprint→KWallet chain runs — new tests pin that
+  where the KDE cold-boot fingerprint→KWallet chain runs; new tests pin that
   the line lands above `pam_kwallet5.so` on every upstream plasmalogin layout.
 
 - **A stack using backslash line continuations is refused, not corrupted.**
   libpam's line assembler joins a directive ending in `\` with the next
   physical line before tokenizing (whitespace after the backslash does not
-  defuse it; a backslash ending a comment does not continue — all three pinned
+  defuse it; a backslash ending a comment does not continue; all three pinned
   by experiment against `pam_exec.so`). irlume edits stacks line-by-line, so
   on such a file every matcher reads a different unit than PAM evaluates, and
   inserting a stanza directly after a continued anchor would splice irlume's
-  text into the middle of the neighbouring logical line — corrupting the auth
+  text into the middle of the neighbouring logical line, corrupting the auth
   stack on write. Continuations are now detected up front: the wiring
-  transforms decline the whole file (staged, never written — the same contract
+  transforms decline the whole file (staged, never written, the same contract
   as a missing anchor) and the keyring hand-off advisory stays silent rather
   than judging lines PAM does not see as written. No upstream `plasmalogin` or
   `gdm-password` stack uses continuations, so behaviour on real systems is
@@ -40,8 +40,8 @@ All notable changes to irlume are documented here. This project adheres to
   pam_unix.so  # was pam_irlume.so` loads no irlume module at all. Every
   matcher compared against the raw line instead, and disagreed with the thing
   it configures. The consequences ran from cosmetic to silent: an invented
-  anchor, a keyring consumer that does not exist, and — because
-  `content_has_module` gates the whole wiring path — a stack whose comment
+  anchor, a keyring consumer that does not exist, and, because
+  `content_has_module` gates the whole wiring path, a stack whose comment
   merely mentioned `pam_irlume.so` reported as already wired, so `login
   enable` wrote nothing and said it succeeded. All ten matchers now compare
   against the directive, exactly what PAM tokenizes. The `# irlume-landing`
@@ -53,7 +53,7 @@ All notable changes to irlume are documented here. This project adheres to
   and for any service outside that list every one of its entry points returns
   `PAM_SUCCESS` immediately: it reads no token, stashes nothing, unlocks
   nothing. The hand-off check matched the module name alone, so such a line
-  counted as a working consumer — reporting a wallet that would open when
+  counted as a working consumer, reporting a wallet that would open when
   nothing would, which is the one thing this check exists to prevent. It also
   suppressed the consumer irlume adds to a fingerprint stack, silently undoing
   that unlock. The list is now evaluated per service, matching whole
@@ -64,7 +64,7 @@ All notable changes to irlume are documented here. This project adheres to
 - **Fingerprint keyring unlock never wired on GNOME, and could not have worked
   if it had.** Two defects in one stack. The wiring anchored on a literal
   `pam_fprintd.so` auth line, but GDM's `gdm-fingerprint.pam` never names the
-  module — it delegates to `auth substack fingerprint-auth` — so the anchor
+  module (it delegates to `auth substack fingerprint-auth`), so the anchor
   search found nothing and the whole step became a silent no-op: `login enable`
   reported success and wrote nothing. And had it wired, the stack carries no
   keyring module at all, so the released password would have gone to a stack
@@ -78,15 +78,15 @@ All notable changes to irlume are documented here. This project adheres to
 - **A renamed shared PAM stack no longer drops the face block onto the wrong
   line.** The greeter block anchored on a fixed list of stack names
   (`password-auth`, `system-auth`, …) and, failing that, on the first `auth`
-  line — a guess that puts the `success=1` jump above whatever module happens to
+  line, a guess that puts the `success=1` jump above whatever module happens to
   come first. GDM's development branch renames its shared stack to
   `gdm-password-auth-substack`, which no name matches; the guess would then have
   anchored above `pam_selinux_permit.so` and landed the jump *before* the
   password substack, which still runs. No released GDM ships that rename, so
   this was latent rather than live, but it would have arrived silently with an
   upgrade. Any `auth … substack …` line is now preferred over the guess,
-  whatever the stack is called — a substack is atomic for jump counting, so the
-  jump form stays correct — and the first-auth-line guess is kept strictly last.
+  whatever the stack is called (a substack is atomic for jump counting, so the
+  jump form stays correct), and the first-auth-line guess is kept strictly last.
 
 - **openSUSE greeters anchored face auth on the wrong line, skipping the
   nologin gate.** openSUSE's `plasmalogin` routes the password through
@@ -109,7 +109,7 @@ All notable changes to irlume are documented here. This project adheres to
   `pam_gnome_keyring.so` (GNOME), from an auth line BELOW irlume's, with a
   matching session line to start the wallet daemon. When that module is absent,
   or sits above ours where it runs before the token exists, the face login
-  succeeds and the wallet prompts anyway — and every command still reported the
+  succeeds and the wallet prompts anyway, and every command still reported the
   greeter as `● wired`, so the one symptom the user could see pointed away from
   the cause. `login status` and `login enable --apply` now inspect each wired
   greeter and name which half is missing. Advisory only: it changes no stack and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **A renamed shared PAM stack no longer drops the face block onto the wrong
+  line.** The greeter block anchored on a fixed list of stack names
+  (`password-auth`, `system-auth`, …) and, failing that, on the first `auth`
+  line — a guess that puts the `success=1` jump above whatever module happens to
+  come first. GDM's development branch renames its shared stack to
+  `gdm-password-auth-substack`, which no name matches; the guess would then have
+  anchored above `pam_selinux_permit.so` and landed the jump *before* the
+  password substack, which still runs. No released GDM ships that rename, so
+  this was latent rather than live, but it would have arrived silently with an
+  upgrade. Any `auth … substack …` line is now preferred over the guess,
+  whatever the stack is called — a substack is atomic for jump counting, so the
+  jump form stays correct — and the first-auth-line guess is kept strictly last.
+
 - **openSUSE greeters anchored face auth on the wrong line, skipping the
   nologin gate.** openSUSE's `plasmalogin` routes the password through
   `auth substack common-auth`, a stack name the wiring did not recognize, so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **A module named only in a comment counted as configured.** libpam strips a
+  trailing `#` comment before tokenizing a stack line, so `auth required
+  pam_unix.so  # was pam_irlume.so` loads no irlume module at all. Every
+  matcher compared against the raw line instead, and disagreed with the thing
+  it configures. The consequences ran from cosmetic to silent: an invented
+  anchor, a keyring consumer that does not exist, and — because
+  `content_has_module` gates the whole wiring path — a stack whose comment
+  merely mentioned `pam_irlume.so` reported as already wired, so `login
+  enable` wrote nothing and said it succeeded. All ten matchers now compare
+  against the directive, exactly what PAM tokenizes. The `# irlume-landing`
+  and `# irlume-keyring` tags are still matched on the raw line, since being
+  comments is the whole point of them.
+
 - **A keyring module that stands down for the service was counted as if it
   worked.** `pam_gnome_keyring.so` takes `only_if=<comma,separated,services>`,
   and for any service outside that list every one of its entry points returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **A stack using backslash line continuations is refused, not corrupted.**
+  libpam's line assembler joins a directive ending in `\` with the next
+  physical line before tokenizing (whitespace after the backslash does not
+  defuse it; a backslash ending a comment does not continue — all three pinned
+  by experiment against `pam_exec.so`). irlume edits stacks line-by-line, so
+  on such a file every matcher reads a different unit than PAM evaluates, and
+  inserting a stanza directly after a continued anchor would splice irlume's
+  text into the middle of the neighbouring logical line — corrupting the auth
+  stack on write. Continuations are now detected up front: the wiring
+  transforms decline the whole file (staged, never written — the same contract
+  as a missing anchor) and the keyring hand-off advisory stays silent rather
+  than judging lines PAM does not see as written. No upstream `plasmalogin` or
+  `gdm-password` stack uses continuations, so behaviour on real systems is
+  unchanged; a test now pins that assumption too.
+
 - **A module named only in a comment counted as configured.** libpam strips a
   trailing `#` comment before tokenizing a stack line, so `auth required
   pam_unix.so  # was pam_irlume.so` loads no irlume module at all. Every

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -961,7 +961,8 @@ fn walk_surfaces(enable: bool, with_sudo: bool, with_polkit: bool, visit: &mut S
         visit(s, ROLE_LOGIN, &greeter_wire, face || fp_keyring);
     }
     for s in FP_GREETERS {
-        visit(s, ROLE_LOGIN_FP, &wire_fp_keyring, fp_keyring);
+        let fp_wire = |c: &str| wire_fp_keyring(c, service_name(s.etc));
+        visit(s, ROLE_LOGIN_FP, &fp_wire, fp_keyring);
     }
     visit(&LOCKSCREEN, ROLE_LOCK, &wire_lock, face_lock);
     if sudo_in_scope(enable, with_sudo) {
@@ -1552,7 +1553,8 @@ fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCod
         do_svc(s, &greeter_wire, face || want_fp_keyring);
     }
     for s in FP_GREETERS {
-        do_svc(s, &wire_fp_keyring, want_fp_keyring);
+        let fp_wire = |c: &str| wire_fp_keyring(c, service_name(s.etc));
+        do_svc(s, &fp_wire, want_fp_keyring);
     }
     // A separate lock service (KDE `kde`) is a WARM screen unlock: the module
     // short-circuits (no `kr`), so the keyring (already open) isn't re-touched.
@@ -1963,6 +1965,35 @@ fn find_auth_anchor(lines: &[&str]) -> Option<usize> {
 /// `pam_gnome_keyring.so`.
 const KEYRING_CONSUMERS: &[&str] = &["pam_kwallet5.so", "pam_kwallet.so", "pam_gnome_keyring.so"];
 
+/// The keyring module on this line, if it is one AND it will actually do
+/// something for `service`.
+///
+/// `pam_gnome_keyring.so` accepts `only_if=<comma,separated,services>`, and for
+/// any service outside that list every one of its entry points returns
+/// `PAM_SUCCESS` immediately — it reads no token, stashes nothing, unlocks
+/// nothing. Matching the module name alone would therefore count a line that is
+/// a guaranteed no-op here as a working consumer, and report a hand-off that
+/// cannot happen: the exact false reassurance this check exists to prevent.
+///
+/// The list is matched the way gkr-pam's `evaluate_inlist` matches it — whole
+/// comma-separated items, not substrings, so `only_if=gdm` does not satisfy
+/// `gdm-fingerprint`. Any single excluding `only_if=` disables the module, since
+/// gkr ORs `ARG_IGNORE_SERVICE` in and never clears it. `pam_kwallet5.so` has no
+/// equivalent option (`only_if` appears nowhere in kwallet-pam), so this only
+/// ever narrows the gnome-keyring case.
+fn consumer_active_for(line: &str, service: &str) -> Option<&'static str> {
+    let t = line.trim_start();
+    if t.starts_with('#') {
+        return None;
+    }
+    let module = KEYRING_CONSUMERS.iter().copied().find(|m| t.contains(m))?;
+    let gated_out = t
+        .split_whitespace()
+        .filter_map(|w| w.strip_prefix("only_if="))
+        .any(|list| !list.split(',').any(|item| item == service));
+    (!gated_out).then_some(module)
+}
+
 /// What a wired greeter stack does with the password irlume releases.
 ///
 /// irlume's job ends at setting `PAM_AUTHTOK`. Turning that token into an OPEN
@@ -1996,19 +2027,13 @@ struct KeyringHandoff {
 /// they were never meant to open. The lock screen opts out a level up instead:
 /// `report_keyring_handoff` walks only `GREETERS`, because a warm screen unlock
 /// runs against a wallet the login already opened.
-fn keyring_handoff(content: &str) -> Option<KeyringHandoff> {
+fn keyring_handoff(content: &str, service: &str) -> Option<KeyringHandoff> {
     let lines: Vec<&str> = content.lines().collect();
     let unseal_at = lines.iter().position(|l| {
         let t = l.trim_start();
         !t.starts_with('#') && t.contains(MODULE) && t.contains("unseal")
     })?;
-    let consumer_in = |l: &str| -> Option<&'static str> {
-        let t = l.trim_start();
-        if t.starts_with('#') {
-            return None;
-        }
-        KEYRING_CONSUMERS.iter().copied().find(|m| t.contains(m))
-    };
+    let consumer_in = |l: &str| consumer_active_for(l, service);
     // A given module's session line may sit anywhere in the session phase, so
     // that half is searched across the whole file; only the AUTH half is
     // order-sensitive.
@@ -2019,7 +2044,11 @@ fn keyring_handoff(content: &str) -> Option<KeyringHandoff> {
                 return false;
             }
             let phase = t.strip_prefix('-').unwrap_or(t);
-            phase.split_whitespace().next() == Some("session") && t.contains(module)
+            phase.split_whitespace().next() == Some("session")
+                && t.contains(module)
+                // The session half is gated by `only_if=` exactly as the auth
+                // half is: gkr-pam checks it in `pam_sm_open_session` too.
+                && consumer_active_for(l, service).is_some()
         })
     };
     // Only lines BELOW ours can see the token we set, so the search starts past
@@ -2059,7 +2088,7 @@ fn report_keyring_handoff() {
         if !content_has_module(&content) {
             continue;
         }
-        let Some(handoff) = keyring_handoff(&content) else {
+        let Some(handoff) = keyring_handoff(&content, service_name(s.etc)) else {
             continue;
         };
         // A single complete module is enough: the wallet opens. Only when none
@@ -2220,7 +2249,7 @@ fn wire_lock(content: &str) -> (String, bool) {
 /// Wire the `keyring` unseal line into a fingerprint login service
 /// (`gdm-fingerprint`): insert it right after the `pam_fprintd.so` auth line so
 /// the sealed password is set before pam_gnome_keyring's auth line runs.
-fn wire_fp_keyring(content: &str) -> (String, bool) {
+fn wire_fp_keyring(content: &str, service: &str) -> (String, bool) {
     if content.lines().any(|l| {
         let t = l.trim_start();
         !t.starts_with('#') && t.contains("pam_irlume.so") && t.contains("keyring")
@@ -2234,10 +2263,11 @@ fn wire_fp_keyring(content: &str) -> (String, bool) {
     // Does anything in this stack already read the token we are about to set?
     // GDM's own `gdm-fingerprint` does not, so the unseal line alone would
     // release a password into a stack with no consumer.
-    let has_consumer = lines.iter().any(|l| {
-        let t = l.trim_start();
-        !t.starts_with('#') && KEYRING_CONSUMERS.iter().any(|m| t.contains(m))
-    });
+    // `only_if=` aware: a keyring line that stands down for THIS service is not
+    // a consumer here, however plainly it names the module.
+    let has_consumer = lines
+        .iter()
+        .any(|l| consumer_active_for(l, service).is_some());
     let mut out = Vec::with_capacity(lines.len() + 3);
     for (i, l) in lines.iter().enumerate() {
         out.push((*l).to_string());
@@ -3734,8 +3764,8 @@ session  include        postlogin-session
         ] {
             let (wired, changed) = wire_greeter_impl(vendor, true, false, true);
             assert!(changed, "{os}: upstream stack must be wirable");
-            let h =
-                keyring_handoff(&wired).unwrap_or_else(|| panic!("{os}: releases a credential"));
+            let h = keyring_handoff(&wired, "plasmalogin")
+                .unwrap_or_else(|| panic!("{os}: releases a credential"));
             assert!(
                 h.complete.is_some(),
                 "{os}: expected a complete hand-off, got auth_only={:?}",
@@ -3846,7 +3876,7 @@ session     include       postlogin
         assert!(!UPSTREAM_GDM_FINGERPRINT.contains("pam_fprintd.so"));
         assert!(!UPSTREAM_GDM_FINGERPRINT.contains("pam_gnome_keyring.so"));
 
-        let (w, changed) = wire_fp_keyring(UPSTREAM_GDM_FINGERPRINT);
+        let (w, changed) = wire_fp_keyring(UPSTREAM_GDM_FINGERPRINT, "gdm-fingerprint");
         assert!(changed, "the substack must serve as the anchor");
         let lines: Vec<&str> = w.lines().collect();
         let pos = |n: &str| lines.iter().position(|l| l.contains(n));
@@ -3889,7 +3919,7 @@ session     include       postlogin
         let with_gkr = "#%PAM-1.0\nauth       required      pam_fprintd.so\n\
 auth       optional      pam_gnome_keyring.so\n\
 session    optional      pam_gnome_keyring.so auto_start\n";
-        let (w, changed) = wire_fp_keyring(with_gkr);
+        let (w, changed) = wire_fp_keyring(with_gkr, "gdm-fingerprint");
         assert!(changed);
         assert_eq!(
             w.matches("pam_gnome_keyring.so").count(),
@@ -3902,7 +3932,7 @@ session    optional      pam_gnome_keyring.so auto_start\n";
     #[test]
     fn unwiring_removes_our_keyring_lines_but_keeps_the_distros() {
         // Ours are tagged; a distro-shipped keyring line is not, and must survive.
-        let (wired, _) = wire_fp_keyring(UPSTREAM_GDM_FINGERPRINT);
+        let (wired, _) = wire_fp_keyring(UPSTREAM_GDM_FINGERPRINT, "gdm-fingerprint");
         let (bare, changed) = unwire_lines(&wired);
         assert!(changed);
         assert!(!bare.contains("pam_gnome_keyring.so"), "ours must go");
@@ -3922,8 +3952,8 @@ auth       optional      pam_gnome_keyring.so\n";
         for (os, vendor) in [("redhat", UPSTREAM_GDM_REDHAT), ("arch", UPSTREAM_GDM_ARCH)] {
             let (wired, changed) = wire_greeter_impl(vendor, true, false, false);
             assert!(changed, "{os}: upstream GDM stack must be wirable");
-            let h =
-                keyring_handoff(&wired).unwrap_or_else(|| panic!("{os}: releases a credential"));
+            let h = keyring_handoff(&wired, "plasmalogin")
+                .unwrap_or_else(|| panic!("{os}: releases a credential"));
             assert_eq!(
                 h.complete,
                 Some("pam_gnome_keyring.so"),
@@ -3968,7 +3998,7 @@ auth       optional      pam_gnome_keyring.so\n";
             "the jump must land past the substack"
         );
         // The hand-off still resolves, so a rename costs nothing else.
-        let h = keyring_handoff(&w).expect("releases a credential");
+        let h = keyring_handoff(&w, "gdm-password").expect("releases a credential");
         assert_eq!(h.complete, Some("pam_gnome_keyring.so"));
     }
 
@@ -4076,9 +4106,87 @@ auth       optional      pam_gnome_keyring.so\n";
         assert!(!UPSTREAM_SUSE.contains("pam_gnome_keyring"));
         let (wired, changed) = wire_greeter_impl(UPSTREAM_SUSE, true, false, true);
         assert!(changed);
-        let h = keyring_handoff(&wired).expect("releases a credential");
+        let h = keyring_handoff(&wired, "plasmalogin").expect("releases a credential");
         assert_eq!(h.complete, None);
         assert!(h.auth_only.is_empty());
+    }
+
+    #[test]
+    fn only_if_gating_is_matched_the_way_gkr_pam_matches_it() {
+        // gkr-pam's `evaluate_inlist` matches whole comma-separated items, so a
+        // prefix must NOT satisfy it: `only_if=gdm` leaves gdm-fingerprint out.
+        let line = "-auth optional pam_gnome_keyring.so only_if=gdm,gdm-password";
+        assert_eq!(
+            consumer_active_for(line, "gdm-password"),
+            Some("pam_gnome_keyring.so")
+        );
+        assert_eq!(consumer_active_for(line, "gdm-fingerprint"), None);
+        assert_eq!(
+            consumer_active_for(
+                "-auth optional pam_gnome_keyring.so only_if=gdm",
+                "gdm-fingerprint"
+            ),
+            None,
+            "a prefix must not satisfy a whole-item list"
+        );
+        // No only_if= at all → active everywhere. kwallet has no such option.
+        assert_eq!(
+            consumer_active_for("-auth optional pam_gnome_keyring.so", "anything"),
+            Some("pam_gnome_keyring.so")
+        );
+        assert_eq!(
+            consumer_active_for("-auth optional pam_kwallet5.so", "plasmalogin"),
+            Some("pam_kwallet5.so")
+        );
+        // A commented line is never a consumer.
+        assert_eq!(
+            consumer_active_for("# -auth optional pam_gnome_keyring.so", "plasmalogin"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_keyring_line_gated_off_for_this_service_is_not_a_hand_off() {
+        // The stack names pam_gnome_keyring on both halves, but `only_if=` means
+        // every entry point returns PAM_SUCCESS without reading the token. A
+        // module-name grep would call this complete and reassure the user that a
+        // wallet will open when nothing will.
+        let gated = "#%PAM-1.0\n\
+auth       [success=1 default=ignore]   pam_irlume.so unseal ondemand\n\
+auth       substack      password-auth\n\
+auth       optional                     pam_permit.so   # irlume-landing\n\
+-auth      optional      pam_gnome_keyring.so only_if=gdm-password\n\
+session    include       password-auth\n\
+-session   optional      pam_gnome_keyring.so auto_start only_if=gdm-password\n";
+        assert_eq!(
+            keyring_handoff(gated, "gdm-password").unwrap().complete,
+            Some("pam_gnome_keyring.so"),
+            "on the listed service it really is a hand-off"
+        );
+        let h = keyring_handoff(gated, "gdm-fingerprint").expect("releases a credential");
+        assert_eq!(
+            h.complete, None,
+            "gated off here, so nothing opens the wallet"
+        );
+        assert!(h.auth_only.is_empty());
+    }
+
+    #[test]
+    fn wire_fp_keyring_supplies_a_consumer_when_the_existing_one_is_gated_off() {
+        // Same trap on the fingerprint path: a gated line must not suppress the
+        // consumer we would otherwise add, or the unlock silently does nothing.
+        let gated = "#%PAM-1.0\nauth       required      pam_fprintd.so\n\
+-auth      optional      pam_gnome_keyring.so only_if=gdm-password\n\
+-session   optional      pam_gnome_keyring.so auto_start only_if=gdm-password\n";
+        let (w, changed) = wire_fp_keyring(gated, "gdm-fingerprint");
+        assert!(changed);
+        assert!(
+            w.contains(KEYRING_TAG),
+            "must add our own consumer, the existing one stands down here"
+        );
+        // And on the service the existing line DOES cover, we add nothing.
+        let (w2, _) = wire_fp_keyring(gated, "gdm-password");
+        assert!(!w2.contains(KEYRING_TAG));
     }
 
     #[test]
@@ -4093,7 +4201,7 @@ auth       optional                     pam_permit.so   # irlume-landing\n\
 -auth      optional      pam_kwallet5.so\n\
 session    include       password-auth\n\
 -session   optional      pam_gnome_keyring.so auto_start\n";
-        let h = keyring_handoff(split).expect("releases a credential");
+        let h = keyring_handoff(split, "plasmalogin").expect("releases a credential");
         assert_eq!(h.complete, None);
         assert_eq!(h.auth_only, vec!["pam_kwallet5.so"]);
     }
@@ -4114,7 +4222,7 @@ session    optional                     pam_irlume.so reseal\n";
 
     #[test]
     fn plasmalogin_with_kwallet_has_a_complete_handoff() {
-        let h = keyring_handoff(PLASMA_WIRED).expect("stack releases a credential");
+        let h = keyring_handoff(PLASMA_WIRED, "plasmalogin").expect("stack releases a credential");
         // The jump skips exactly the substack and lands on the permit, so the
         // vendor kwallet auth line below it does observe our PAM_AUTHTOK.
         assert_eq!(h.complete, Some("pam_kwallet5.so"));
@@ -4139,7 +4247,8 @@ session    include       password-auth\n\
         // shipping a stack we wire and then warn about.
         let (wired, changed) = wire_greeter_impl(PLASMA_VENDOR, true, false, true);
         assert!(changed);
-        let h = keyring_handoff(&wired).expect("a wired greeter releases a credential");
+        let h =
+            keyring_handoff(&wired, "plasmalogin").expect("a wired greeter releases a credential");
         assert_eq!(h.complete, Some("pam_kwallet5.so"));
         assert!(h.auth_only.is_empty());
         let face = wired.find("pam_irlume.so unseal").unwrap();
@@ -4157,7 +4266,8 @@ session     include     system-login\n\
 -session    optional    pam_kwallet5.so auto_start\n";
         let (wired, changed) = wire_greeter_impl(ARCH_VENDOR, true, false, true);
         assert!(changed);
-        let h = keyring_handoff(&wired).expect("a wired greeter releases a credential");
+        let h =
+            keyring_handoff(&wired, "plasmalogin").expect("a wired greeter releases a credential");
         assert_eq!(h.complete, Some("pam_kwallet5.so"));
         assert!(h.auth_only.is_empty());
     }
@@ -4169,7 +4279,7 @@ session     include     system-login\n\
             .filter(|l| !l.contains("pam_kwallet5.so"))
             .collect::<Vec<_>>()
             .join("\n");
-        let h = keyring_handoff(&stripped).expect("stack releases a credential");
+        let h = keyring_handoff(&stripped, "plasmalogin").expect("stack releases a credential");
         // Nothing reads the released password: this is the silent case that used
         // to report as "wired ✓" while the wallet kept prompting.
         assert_eq!(h.complete, None);
@@ -4185,7 +4295,7 @@ session     include     system-login\n\
 auth       [success=1 default=ignore]   pam_irlume.so unseal ondemand\n\
 auth       substack      password-auth\n\
 -session   optional      pam_kwallet5.so auto_start\n";
-        let h = keyring_handoff(above).expect("stack releases a credential");
+        let h = keyring_handoff(above, "plasmalogin").expect("stack releases a credential");
         assert_eq!(
             h.complete, None,
             "a consumer above our line cannot see the token"
@@ -4201,7 +4311,7 @@ auth       include     system-login\n\
 auth       optional                     pam_irlume.so reseal\n\
 -auth      optional    pam_kwallet5.so\n\
 -session   optional    pam_kwallet5.so auto_start\n";
-        let h = keyring_handoff(arch).expect("stack releases a credential");
+        let h = keyring_handoff(arch, "plasmalogin").expect("stack releases a credential");
         assert_eq!(h.complete, Some("pam_kwallet5.so"));
         assert!(h.auth_only.is_empty());
     }
@@ -4215,7 +4325,7 @@ auth       optional                     pam_irlume.so reseal\n\
             .filter(|l| !(l.contains("pam_kwallet5.so") && l.contains("session")))
             .collect::<Vec<_>>()
             .join("\n");
-        let h = keyring_handoff(&no_session).expect("stack releases a credential");
+        let h = keyring_handoff(&no_session, "plasmalogin").expect("stack releases a credential");
         assert_eq!(h.complete, None);
         assert_eq!(h.auth_only, vec!["pam_kwallet5.so"]);
     }
@@ -4223,7 +4333,7 @@ auth       optional                     pam_irlume.so reseal\n\
     #[test]
     fn gnome_keyring_counts_as_a_consumer_too() {
         let gnome = PLASMA_WIRED.replace("pam_kwallet5.so", "pam_gnome_keyring.so");
-        let h = keyring_handoff(&gnome).expect("stack releases a credential");
+        let h = keyring_handoff(&gnome, "plasmalogin").expect("stack releases a credential");
         assert_eq!(h.complete, Some("pam_gnome_keyring.so"));
         assert!(h.auth_only.is_empty());
     }
@@ -4234,7 +4344,7 @@ auth       optional                     pam_irlume.so reseal\n\
         // credential is released and there is nothing for a wallet to consume.
         let sudo = "#%PAM-1.0\nauth       sufficient                   pam_irlume.so\n\
 @include common-auth\n";
-        assert!(keyring_handoff(sudo).is_none());
+        assert!(keyring_handoff(sudo, "plasmalogin").is_none());
     }
 
     #[test]
@@ -4243,7 +4353,7 @@ auth       optional                     pam_irlume.so reseal\n\
             "-auth      optional      pam_kwallet5.so",
             "#-auth      optional      pam_kwallet5.so",
         );
-        let h = keyring_handoff(&commented).expect("stack releases a credential");
+        let h = keyring_handoff(&commented, "plasmalogin").expect("stack releases a credential");
         assert_eq!(h.complete, None);
         assert!(h.auth_only.is_empty());
     }
@@ -4447,7 +4557,7 @@ auth       optional                     pam_irlume.so reseal\n\
 
     #[test]
     fn wire_fp_keyring_inserts_between_fprintd_and_the_keyring_auth_line() {
-        let (w, changed) = wire_fp_keyring(GDM_FP);
+        let (w, changed) = wire_fp_keyring(GDM_FP, "gdm-fingerprint");
         assert!(changed);
         let lines: Vec<&str> = w.lines().collect();
         let fp = lines
@@ -4467,18 +4577,22 @@ auth       optional                     pam_irlume.so reseal\n\
             "keyring unseal must sit fprintd→keyring"
         );
         // Idempotent: a second pass is a no-op.
-        let (w2, c2) = wire_fp_keyring(&w);
+        let (w2, c2) = wire_fp_keyring(&w, "gdm-fingerprint");
         assert!(!c2 && w2 == w);
     }
 
     #[test]
     fn wire_fp_keyring_needs_an_fprintd_anchor() {
         // No pam_fprintd line → nothing to anchor to → unchanged.
-        let (w, changed) = wire_fp_keyring("#%PAM-1.0\nauth required pam_unix.so\n");
+        let (w, changed) =
+            wire_fp_keyring("#%PAM-1.0\nauth required pam_unix.so\n", "gdm-fingerprint");
         assert!(!changed);
         assert_eq!(w, "#%PAM-1.0\nauth required pam_unix.so\n");
         // A commented fprintd line is not an anchor either.
-        let (_, c) = wire_fp_keyring("#%PAM-1.0\n# auth required pam_fprintd.so\n");
+        let (_, c) = wire_fp_keyring(
+            "#%PAM-1.0\n# auth required pam_fprintd.so\n",
+            "gdm-fingerprint",
+        );
         assert!(!c);
     }
 

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -3601,11 +3601,19 @@ mod tests {
     // reaches the user as "KWallet asks for its password even though face login
     // worked". These pin the detection of that state.
 
-    // The four `plasmalogin` stacks Plasma Login Manager actually ships, copied
-    // verbatim from upstream `data/pam/<os>/plasmalogin` (KDE/plasma-login-manager).
-    // Its CMake installs them to ${prefix}/lib/pam.d, which is the vendor path
-    // irlume materializes its /etc override from. Held verbatim so a distro
-    // rewrite shows up here as a failing test rather than as a silent wallet.
+    // The four `plasmalogin` stacks Plasma Login Manager actually ships.
+    //
+    // Source: KDE/plasma-login-manager @ master, `data/pam/<os>/plasmalogin`.
+    // Its CMake installs them to `${prefix}/lib/pam.d`, which is the vendor path
+    // irlume materializes its /etc override from.
+    //
+    // BYTE-FOR-BYTE, comments and blank lines included. That is load-bearing, not
+    // tidiness: these pin what irlume's wiring is checked against, so a fixture
+    // that has been "cleaned up" is a fixture that no longer describes any real
+    // machine. An earlier revision of these constants had the comments stripped
+    // and, in the Debian file, had silently lost a `session required pam_env.so`
+    // directive along with them. Re-check with a diff against upstream rather
+    // than by eye.
 
     const UPSTREAM_FEDORA: &str = r#"auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
 auth        substack      password-auth
@@ -3634,6 +3642,9 @@ session     include       postlogin
 
     const UPSTREAM_ARCH: &str = r#"#%PAM-1.0
 
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: none
+
 auth        include     system-login
 -auth       optional    pam_gnome_keyring.so
 -auth       optional    pam_kwallet5.so
@@ -3650,22 +3661,49 @@ session     include     system-login
 "#;
 
     const UPSTREAM_DEBIAN: &str = r#"#%PAM-1.0
+
+# Block login if they are globally disabled
 auth    requisite       pam_nologin.so
 auth    required        pam_succeed_if.so user != root quiet_success
+
+# auth    sufficient      pam_succeed_if.so user ingroup nopasswdlogin
 @include common-auth
+
+# gnome_keyring breaks QProcess
 -auth   optional        pam_gnome_keyring.so
 -auth   optional        pam_kwallet5.so
+
 @include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
 session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Create a new session keyring.
 session optional        pam_keyinit.so force revoke
 session required        pam_limits.so
 session required        pam_loginuid.so
+
 @include common-session
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
 session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
 -session optional       pam_gnome_keyring.so auto_start
 -session optional       pam_kwallet5.so auto_start
+
 @include common-password
+
+# From the pam_env man page
+# Since setting of PAM environment variables can have side effects to other modules, this module should be the last one on the stack.
+
+# Load environment from /etc/environment
 session required        pam_env.so
+
+# Load environment from /etc/default/locale and ~/.pam_environment
+session required        pam_env.so envfile=/etc/default/locale user_readenv=1
 "#;
 
     /// openSUSE's upstream `plasmalogin` carries NO keyring module at all.
@@ -3680,6 +3718,7 @@ session  required       pam_loginuid.so
 session  optional       pam_keyinit.so revoke force
 session  substack       common-session
 session  include        postlogin-session
+
 "#;
 
     #[test]
@@ -3712,8 +3751,10 @@ session  include        postlogin-session
         }
     }
 
-    // GDM's shipped stacks, verbatim from upstream `data/pam-<os>/gdm-password.pam`
-    // (GNOME/gdm). Redhat is the released 50.0 form; Arch is the include layout.
+    // GDM's shipped stacks, byte-for-byte from GNOME/gdm @ tag 50.0 (the latest
+    // release), `data/pam-<os>/gdm-password.pam`. Red Hat is the substack layout,
+    // Arch the include layout.
+    //
     // gnome-keyring's module needs the same two halves kwallet does: its
     // `pam_sm_authenticate` reads PAM_AUTHTOK and stashes it under
     // "gkr_system_authtok", and `pam_sm_open_session` is what acts on it.

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -69,7 +69,7 @@ const KEYRING_UNSEAL: &str = "auth       optional                     pam_irlume
 /// removes exactly ours and never a keyring line the distro shipped. Linux-PAM
 /// strips a trailing `#` comment before tokenizing (verified against
 /// `pam_exec.so`: an argument survives, a trailing comment does not), so this is
-/// invisible to the module — which matters here because gnome-keyring's
+/// invisible to the module, which matters here because gnome-keyring's
 /// `parse_args` syslogs a warning for every option it does not recognize.
 const KEYRING_TAG: &str = "# irlume-keyring";
 /// GDM's `gdm-fingerprint` stack carries NO keyring module at all (verified on
@@ -1858,7 +1858,7 @@ fn wire_service(
 /// Matching the raw line disagrees with libpam, which strips a trailing comment
 /// before tokenizing (verified against `pam_exec.so`: a real argument survives,
 /// a trailing comment does not). Without this, a module named only inside a
-/// comment counts as configured — and because `content_has_module` gates the
+/// comment counts as configured, and because `content_has_module` gates the
 /// whole wiring path, a stack whose comment happens to mention `pam_irlume.so`
 /// would be treated as already wired and silently left alone.
 ///
@@ -1885,16 +1885,16 @@ fn content_has_module(c: &str) -> bool {
 /// evaluates, corrupting the stack on write.
 ///
 /// The semantics are pinned empirically against `pam_exec.so`:
-///   * a trailing `\` on a directive continues — the next physical line's
+///   * a trailing `\` on a directive continues; the next physical line's
 ///     text executed as this line's arguments;
 ///   * whitespace AFTER the backslash does not defuse it (still continues);
-///   * a `\` at the end of a COMMENT does not continue — both lines ran.
+///   * a `\` at the end of a COMMENT does not continue; both lines ran.
 ///
 /// Hence the check runs on `directive()` output with trailing space trimmed.
 ///
 /// No upstream stack irlume pins uses continuations, so the fail-safe answer
 /// is to notice and stand down: the wiring transforms refuse the file
-/// (staged, never written — the same contract as a missing anchor), and the
+/// (staged, never written, the same contract as a missing anchor), and the
 /// hand-off advisory stays silent rather than reporting from an analysis
 /// that cannot see the file the way PAM does.
 fn has_line_continuation(content: &str) -> bool {
@@ -1908,7 +1908,7 @@ fn has_line_continuation(content: &str) -> bool {
 /// `auth include system-login`/`system-local-login`/`system-auth`, or a bare
 /// `auth include common-auth`. These need the `sufficient` (module IGNOREs on
 /// cold login) form, NOT the jump form. A `substack` is atomic for jump
-/// counting, so it deliberately does not match here and keeps the jump stanza —
+/// counting, so it deliberately does not match here and keeps the jump stanza;
 /// which is what openSUSE's `auth substack common-auth` relies on.
 fn is_include_auth_layout(line: &str) -> bool {
     let t = directive(line);
@@ -1936,7 +1936,7 @@ fn is_include_auth_layout(line: &str) -> bool {
 /// `auth substack common-auth`, which matched nothing here: wiring then fell
 /// back to the first auth line and inserted the jump above `pam_nologin.so`, so
 /// a face login skipped the nologin gate and *still* landed on the password
-/// stack underneath — face auth that neither honoured nologin nor logged you in.
+/// stack underneath: face auth that neither honoured nologin nor logged you in.
 fn is_passwd_substack(line: &str, kind: &str) -> bool {
     let d = directive(line);
     let toks: Vec<&str> = d
@@ -1965,7 +1965,7 @@ fn is_auth_directive(line: &str) -> bool {
 ///
 /// This exists because the named list cannot keep up with upstreams. GDM's main
 /// branch renamed its shared stack from `password-auth` to
-/// `gdm-password-auth-substack` (a file GDM does not ship — distros supply it),
+/// `gdm-password-auth-substack` (a file GDM does not ship; distros supply it),
 /// which no name in `is_passwd_substack` matches. Without this tier the anchor
 /// search falls through to "first auth line", which on GDM's stack is
 /// `pam_selinux_permit.so`: the jump would then skip THAT and land above the
@@ -1984,7 +1984,7 @@ fn is_auth_substack_anchor(line: &str) -> bool {
 /// Where the face block anchors, in descending order of confidence: a shared
 /// stack we recognize by name, then any `substack` whatever its name, and only
 /// then the first `auth` line. The last tier is a guess and is kept last
-/// deliberately — it is what produces a jump over an unrelated module.
+/// deliberately: it is what produces a jump over an unrelated module.
 fn find_auth_anchor(lines: &[&str]) -> Option<usize> {
     lines
         .iter()
@@ -2005,12 +2005,12 @@ const KEYRING_CONSUMERS: &[&str] = &["pam_kwallet5.so", "pam_kwallet.so", "pam_g
 ///
 /// `pam_gnome_keyring.so` accepts `only_if=<comma,separated,services>`, and for
 /// any service outside that list every one of its entry points returns
-/// `PAM_SUCCESS` immediately — it reads no token, stashes nothing, unlocks
+/// `PAM_SUCCESS` immediately: it reads no token, stashes nothing, unlocks
 /// nothing. Matching the module name alone would therefore count a line that is
 /// a guaranteed no-op here as a working consumer, and report a hand-off that
 /// cannot happen: the exact false reassurance this check exists to prevent.
 ///
-/// The list is matched the way gkr-pam's `evaluate_inlist` matches it — whole
+/// The list is matched the way gkr-pam's `evaluate_inlist` matches it: whole
 /// comma-separated items, not substrings, so `only_if=gdm` does not satisfy
 /// `gdm-fingerprint`. Any single excluding `only_if=` disables the module, since
 /// gkr ORs `ARG_IGNORE_SERVICE` in and never clears it. `pam_kwallet5.so` has no
@@ -2031,7 +2031,7 @@ fn consumer_active_for(line: &str, service: &str) -> Option<&'static str> {
 /// irlume's job ends at setting `PAM_AUTHTOK`. Turning that token into an OPEN
 /// wallet is another module's work, and if that module is absent (or sits above
 /// our line, where it runs before the token exists) the login succeeds by face
-/// and the wallet stays locked — which surfaces to the user as KWallet
+/// and the wallet stays locked, which surfaces to the user as KWallet
 /// prompting for its password anyway. Nothing checked for this, so the failure
 /// was indistinguishable from "wired ✓".
 struct KeyringHandoff {
@@ -2055,7 +2055,7 @@ struct KeyringHandoff {
 
 /// Locate the keyring hand-off in a wired stack. `None` when this stack
 /// releases no credential at all (no `unseal` line), which is how the plain
-/// verify surfaces — sudo and polkit — opt out of being judged against a wallet
+/// verify surfaces, sudo and polkit, opt out of being judged against a wallet
 /// they were never meant to open. The lock screen opts out a level up instead:
 /// `report_keyring_handoff` walks only `GREETERS`, because a warm screen unlock
 /// runs against a wallet the login already opened.
@@ -2071,7 +2071,7 @@ fn keyring_handoff(content: &str, service: &str) -> Option<KeyringHandoff> {
     // post-auth fingerprint unlock). Anchoring on `unseal` alone left the
     // fingerprint path unchecked: a fingerprint-only box wires the greeter
     // with ONLY the `keyring` line, and a missing or mis-ordered wallet
-    // module there went unreported — the wallet stayed locked after a
+    // module there went unreported: the wallet stayed locked after a
     // fingerprint login with nothing naming why.
     let unseal_at = lines.iter().position(|l| {
         let d = directive(l);
@@ -2405,7 +2405,7 @@ fn unwire_lines(content: &str) -> (String, bool) {
         .filter(|l| {
             // The module is matched on the DIRECTIVE (what PAM tokenizes), so a
             // module named only in a comment is never stripped. The tags are
-            // matched on the RAW line, because that is where they live — they
+            // matched on the RAW line, because that is where they live; they
             // are comments, invisible to PAM by design.
             let d = directive(l);
             let drop = d.contains(MODULE)
@@ -3877,8 +3877,8 @@ session    optional                    pam_gnome_keyring.so auto_start
 
     /// GDM `main`'s `data/pam-redhat/gdm-password.pam`, byte-for-byte: the shared
     /// stack is renamed to `gdm-password-auth-substack`, a file GDM does not itself
-    /// ship. No release carries this — 45.0 through 50.1 and 51.alpha all still say
-    /// `password-auth` — so it is latent, and would arrive with an upgrade.
+    /// ship. No release carries this: 45.0 through 50.1 and 51.alpha all still say
+    /// `password-auth`. It is latent, and would arrive with an upgrade.
     const UPSTREAM_GDM_RENAMED_SUBSTACK: &str = r#"auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
 auth        substack      gdm-password-auth-substack
 auth        optional      pam_gnome_keyring.so
@@ -4022,7 +4022,7 @@ auth       optional      pam_gnome_keyring.so\n";
         // The named list cannot keep up with upstream renames, so an unrecognized
         // `substack` must still be preferred over the first-auth-line guess.
         // Otherwise the jump lands above pam_selinux_permit.so and the password
-        // substack runs anyway — the openSUSE bug, arriving via a GDM upgrade.
+        // substack runs anyway: the openSUSE bug, arriving via a GDM upgrade.
         assert!(!is_passwd_substack(
             "auth        substack      gdm-password-auth-substack",
             "auth"
@@ -4152,7 +4152,7 @@ auth       optional      pam_gnome_keyring.so\n";
     fn plasmalogin_fingerprint_keyring_line_lands_above_the_wallet_module() {
         // The KDE fingerprint→KWallet chain. Plasma's greeter runs ONE stack
         // for user auth (plasma-login-manager's PamBackend selects only
-        // `plasmalogin` / `plasmalogin-greeter` / `plasmalogin-autologin` — no
+        // `plasmalogin` / `plasmalogin-greeter` / `plasmalogin-autologin`, and no
         // fingerprint service, unlike kscreenlocker's kde/kde-fingerprint/
         // kde-smartcard triple). So a greeter fingerprint login happens when
         // the distro's shared stack carries pam_fprintd, provides no password,
@@ -4186,7 +4186,7 @@ auth       optional      pam_gnome_keyring.so\n";
     #[test]
     fn a_keyring_only_greeter_is_still_checked_for_the_wallet_handoff() {
         // A fingerprint-only box (no face login) wires the greeter with ONLY
-        // the `keyring` line — no `unseal`. The hand-off check used to anchor
+        // the `keyring` line and no `unseal` line. The hand-off check used to anchor
         // on `unseal` alone, so this stack was skipped entirely: a missing
         // wallet module after a fingerprint login had no warning at all.
         let (w, changed) = wire_greeter_impl(UPSTREAM_FEDORA, false, true, true);

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1852,11 +1852,27 @@ fn wire_service(
 
 // ---- pure PAM-text mechanics (unit-tested) -----------------------------------
 
+/// The part of a stack line PAM actually tokenizes: everything before the first
+/// `#`, leading whitespace trimmed.
+///
+/// Matching the raw line disagrees with libpam, which strips a trailing comment
+/// before tokenizing (verified against `pam_exec.so`: a real argument survives,
+/// a trailing comment does not). Without this, a module named only inside a
+/// comment counts as configured — and because `content_has_module` gates the
+/// whole wiring path, a stack whose comment happens to mention `pam_irlume.so`
+/// would be treated as already wired and silently left alone.
+///
+/// A full-line comment yields `""`, so callers need no separate `#` check.
+fn directive(line: &str) -> &str {
+    let t = line.trim_start();
+    match t.find('#') {
+        Some(i) => &t[..i],
+        None => t,
+    }
+}
+
 fn content_has_module(c: &str) -> bool {
-    c.lines().any(|l| {
-        let t = l.trim_start();
-        !t.starts_with('#') && t.contains(MODULE)
-    })
+    c.lines().any(|l| directive(l).contains(MODULE))
 }
 
 /// An `auth`-phase line whose password path is an `include` a `success=N` jump
@@ -1867,7 +1883,7 @@ fn content_has_module(c: &str) -> bool {
 /// counting, so it deliberately does not match here and keeps the jump stanza —
 /// which is what openSUSE's `auth substack common-auth` relies on.
 fn is_include_auth_layout(line: &str) -> bool {
-    let t = line.trim_start();
+    let t = directive(line);
     if t.starts_with("@include common-auth") || t.starts_with("@include login") {
         return true;
     }
@@ -1894,13 +1910,10 @@ fn is_include_auth_layout(line: &str) -> bool {
 /// a face login skipped the nologin gate and *still* landed on the password
 /// stack underneath — face auth that neither honoured nologin nor logged you in.
 fn is_passwd_substack(line: &str, kind: &str) -> bool {
-    let t = line.trim_start();
-    if t.starts_with('#') {
-        return false;
-    }
-    let toks: Vec<&str> = t
+    let d = directive(line);
+    let toks: Vec<&str> = d
         .strip_prefix('-')
-        .unwrap_or(t)
+        .unwrap_or(d)
         .split_whitespace()
         .collect();
     let stacks: &[&str] = match kind {
@@ -1914,10 +1927,7 @@ fn is_passwd_substack(line: &str, kind: &str) -> bool {
 }
 
 fn is_auth_directive(line: &str) -> bool {
-    let t = line.trim_start();
-    if t.starts_with('#') {
-        return false;
-    }
+    let t = directive(line);
     t.strip_prefix('-').unwrap_or(t).split_whitespace().next() == Some("auth")
 }
 
@@ -1934,13 +1944,10 @@ fn is_auth_directive(line: &str) -> bool {
 /// password substack, which still runs. That is the openSUSE failure exactly,
 /// and it would arrive silently with a GDM upgrade.
 fn is_auth_substack_anchor(line: &str) -> bool {
-    let t = line.trim_start();
-    if t.starts_with('#') {
-        return false;
-    }
-    let toks: Vec<&str> = t
+    let d = directive(line);
+    let toks: Vec<&str> = d
         .strip_prefix('-')
-        .unwrap_or(t)
+        .unwrap_or(d)
         .split_whitespace()
         .collect();
     toks.first() == Some(&"auth") && toks.get(1) == Some(&"substack")
@@ -1982,10 +1989,7 @@ const KEYRING_CONSUMERS: &[&str] = &["pam_kwallet5.so", "pam_kwallet.so", "pam_g
 /// equivalent option (`only_if` appears nowhere in kwallet-pam), so this only
 /// ever narrows the gnome-keyring case.
 fn consumer_active_for(line: &str, service: &str) -> Option<&'static str> {
-    let t = line.trim_start();
-    if t.starts_with('#') {
-        return None;
-    }
+    let t = directive(line);
     let module = KEYRING_CONSUMERS.iter().copied().find(|m| t.contains(m))?;
     let gated_out = t
         .split_whitespace()
@@ -2030,8 +2034,8 @@ struct KeyringHandoff {
 fn keyring_handoff(content: &str, service: &str) -> Option<KeyringHandoff> {
     let lines: Vec<&str> = content.lines().collect();
     let unseal_at = lines.iter().position(|l| {
-        let t = l.trim_start();
-        !t.starts_with('#') && t.contains(MODULE) && t.contains("unseal")
+        let d = directive(l);
+        d.contains(MODULE) && d.contains("unseal")
     })?;
     let consumer_in = |l: &str| consumer_active_for(l, service);
     // A given module's session line may sit anywhere in the session phase, so
@@ -2039,13 +2043,10 @@ fn keyring_handoff(content: &str, service: &str) -> Option<KeyringHandoff> {
     // order-sensitive.
     let has_session_line = |module: &str| {
         lines.iter().any(|l| {
-            let t = l.trim_start();
-            if t.starts_with('#') {
-                return false;
-            }
-            let phase = t.strip_prefix('-').unwrap_or(t);
+            let d = directive(l);
+            let phase = d.strip_prefix('-').unwrap_or(d);
             phase.split_whitespace().next() == Some("session")
-                && t.contains(module)
+                && d.contains(module)
                 // The session half is gated by `only_if=` exactly as the auth
                 // half is: gkr-pam checks it in `pam_sm_open_session` too.
                 && consumer_active_for(l, service).is_some()
@@ -2251,8 +2252,8 @@ fn wire_lock(content: &str) -> (String, bool) {
 /// the sealed password is set before pam_gnome_keyring's auth line runs.
 fn wire_fp_keyring(content: &str, service: &str) -> (String, bool) {
     if content.lines().any(|l| {
-        let t = l.trim_start();
-        !t.starts_with('#') && t.contains("pam_irlume.so") && t.contains("keyring")
+        let d = directive(l);
+        d.contains(MODULE) && d.contains("keyring")
     }) {
         return (content.to_string(), false); // already wired
     }
@@ -2297,13 +2298,10 @@ fn wire_fp_keyring(content: &str, service: &str) -> (String, bool) {
 /// anchor, `wire_fp_keyring` became a silent no-op, and the fingerprint keyring
 /// unlock never wired on Fedora at all.
 fn is_fingerprint_auth(line: &str) -> bool {
-    let t = line.trim_start();
-    if t.starts_with('#') {
-        return false;
-    }
-    let toks: Vec<&str> = t
+    let d = directive(line);
+    let toks: Vec<&str> = d
         .strip_prefix('-')
-        .unwrap_or(t)
+        .unwrap_or(d)
         .split_whitespace()
         .collect();
     if toks.first() != Some(&"auth") {
@@ -2353,15 +2351,16 @@ fn unwire_lines(content: &str) -> (String, bool) {
     let kept: Vec<&str> = content
         .lines()
         .filter(|l| {
-            let t = l.trim_start();
-            if t.starts_with('#') {
-                return true;
-            }
-            let drop = t.contains(MODULE)
-                || (t.contains("pam_permit.so") && l.contains("# irlume-landing"))
+            // The module is matched on the DIRECTIVE (what PAM tokenizes), so a
+            // module named only in a comment is never stripped. The tags are
+            // matched on the RAW line, because that is where they live — they
+            // are comments, invisible to PAM by design.
+            let d = directive(l);
+            let drop = d.contains(MODULE)
+                || (d.contains("pam_permit.so") && l.contains("# irlume-landing"))
                 // Only the gnome-keyring lines WE tagged; a distro-shipped
                 // keyring line carries no tag and must survive unwiring.
-                || (t.contains("pam_gnome_keyring.so") && l.contains(KEYRING_TAG));
+                || (d.contains("pam_gnome_keyring.so") && l.contains(KEYRING_TAG));
             if drop {
                 changed = true;
             }
@@ -4109,6 +4108,97 @@ auth       optional      pam_gnome_keyring.so\n";
         let h = keyring_handoff(&wired, "plasmalogin").expect("releases a credential");
         assert_eq!(h.complete, None);
         assert!(h.auth_only.is_empty());
+    }
+
+    #[test]
+    fn directive_cuts_at_the_comment_exactly_as_pam_does() {
+        assert_eq!(
+            directive("auth optional pam_unix.so"),
+            "auth optional pam_unix.so"
+        );
+        assert_eq!(
+            directive("  auth optional pam_unix.so  # note"),
+            "auth optional pam_unix.so  "
+        );
+        assert_eq!(directive("# whole line comment"), "");
+        assert_eq!(directive(""), "");
+    }
+
+    #[test]
+    fn a_module_named_only_in_a_comment_is_never_treated_as_configured() {
+        // libpam strips a trailing comment before tokenizing, so none of these
+        // lines load the module they mention. Matching the raw line would make
+        // irlume disagree with the thing it is configuring.
+        //
+        // content_has_module is the dangerous one: it gates the whole wiring
+        // path, so a false positive means `login enable` silently writes
+        // nothing and reports the stack as already wired.
+        assert!(!content_has_module(
+            "auth required pam_unix.so  # was pam_irlume.so\n"
+        ));
+        assert!(content_has_module("auth sufficient pam_irlume.so\n"));
+
+        // Anchors must not be invented out of comment text either.
+        assert!(!is_passwd_substack(
+            "auth required pam_unix.so # substack password-auth",
+            "auth"
+        ));
+        assert!(!is_include_auth_layout(
+            "auth required pam_unix.so # @include common-auth"
+        ));
+        assert!(!is_auth_substack_anchor(
+            "auth required pam_unix.so # substack whatever"
+        ));
+        assert!(!is_fingerprint_auth(
+            "auth required pam_unix.so # substack fingerprint-auth"
+        ));
+        assert!(!is_auth_directive("# auth required pam_unix.so"));
+
+        // Nor a keyring consumer.
+        assert_eq!(
+            consumer_active_for(
+                "auth required pam_unix.so # see pam_gnome_keyring.so",
+                "gdm-password"
+            ),
+            None
+        );
+
+        // A stack whose only mention of a keyring module is a comment has no
+        // hand-off, however complete it looks to a grep.
+        let commented = "#%PAM-1.0\n\
+auth       [success=1 default=ignore]   pam_irlume.so unseal ondemand\n\
+auth       substack      password-auth\n\
+auth       optional                     pam_permit.so   # irlume-landing\n\
+auth       optional      pam_deny.so    # pam_gnome_keyring.so would go here\n\
+session    optional      pam_deny.so    # pam_gnome_keyring.so auto_start\n";
+        let h = keyring_handoff(commented, "gdm-password").expect("releases a credential");
+        assert_eq!(h.complete, None);
+        assert!(h.auth_only.is_empty());
+    }
+
+    #[test]
+    fn unwiring_matches_modules_on_the_directive_but_tags_on_the_raw_line() {
+        // Our tags ARE comments, so they must still be found there; a foreign
+        // line that merely names one of our modules in a comment must survive.
+        let stack = "auth required pam_unix.so  # not pam_irlume.so, just a note\n\
+auth       optional                     pam_permit.so   # irlume-landing\n\
+-auth      optional      pam_gnome_keyring.so   # irlume-keyring\n\
+-auth      optional      pam_gnome_keyring.so\n";
+        let (out, changed) = unwire_lines(stack);
+        assert!(changed);
+        assert!(
+            out.contains("not pam_irlume.so, just a note"),
+            "comment-only mention survives"
+        );
+        assert!(!out.contains("irlume-landing"), "our tagged landing goes");
+        assert!(
+            !out.contains("irlume-keyring"),
+            "our tagged keyring line goes"
+        );
+        assert!(
+            out.contains("-auth      optional      pam_gnome_keyring.so\n"),
+            "the distro's untagged keyring line survives"
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1875,6 +1875,34 @@ fn content_has_module(c: &str) -> bool {
     c.lines().any(|l| directive(l).contains(MODULE))
 }
 
+/// True when any line's DIRECTIVE part ends in a `\` continuation.
+///
+/// libpam's line assembler joins such a line with the next one before
+/// tokenizing, so a two-physical-line entry is ONE line to PAM. Everything
+/// here is line-oriented, and on a continued file the two views disagree.
+/// Worse than mis-reading: inserting a stanza directly after a continued
+/// anchor would splice our text into the MIDDLE of the logical line PAM
+/// evaluates, corrupting the stack on write.
+///
+/// The semantics are pinned empirically against `pam_exec.so`:
+///   * a trailing `\` on a directive continues — the next physical line's
+///     text executed as this line's arguments;
+///   * whitespace AFTER the backslash does not defuse it (still continues);
+///   * a `\` at the end of a COMMENT does not continue — both lines ran.
+///
+/// Hence the check runs on `directive()` output with trailing space trimmed.
+///
+/// No upstream stack irlume pins uses continuations, so the fail-safe answer
+/// is to notice and stand down: the wiring transforms refuse the file
+/// (staged, never written — the same contract as a missing anchor), and the
+/// hand-off advisory stays silent rather than reporting from an analysis
+/// that cannot see the file the way PAM does.
+fn has_line_continuation(content: &str) -> bool {
+    content
+        .lines()
+        .any(|l| directive(l).trim_end().ends_with('\\'))
+}
+
 /// An `auth`-phase line whose password path is an `include` a `success=N` jump
 /// can't skip: Debian's `@include common-auth`/`login`, Arch's
 /// `auth include system-login`/`system-local-login`/`system-auth`, or a bare
@@ -2032,6 +2060,11 @@ struct KeyringHandoff {
 /// `report_keyring_handoff` walks only `GREETERS`, because a warm screen unlock
 /// runs against a wallet the login already opened.
 fn keyring_handoff(content: &str, service: &str) -> Option<KeyringHandoff> {
+    // A continued file cannot be judged line-by-line; silence beats a verdict
+    // reached on lines PAM does not evaluate as written.
+    if has_line_continuation(content) {
+        return None;
+    }
     let lines: Vec<&str> = content.lines().collect();
     let unseal_at = lines.iter().position(|l| {
         let d = directive(l);
@@ -2127,6 +2160,9 @@ fn wire_greeter_impl(content: &str, face: bool, keyring: bool, ondemand: bool) -
     if !face && !keyring {
         return (content.to_string(), false);
     }
+    if has_line_continuation(content) {
+        return (content.to_string(), false);
+    }
     if content_has_module(content) {
         return (content.to_string(), false);
     }
@@ -2211,6 +2247,9 @@ fn wire_greeter_impl(content: &str, face: bool, keyring: bool, ondemand: bool) -
 /// screen unlock releases no credential). Handles both the Debian `@include`
 /// and the Fedora `substack` layouts.
 fn wire_lock(content: &str) -> (String, bool) {
+    if has_line_continuation(content) {
+        return (content.to_string(), false);
+    }
     if content_has_module(content) {
         return (content.to_string(), false);
     }
@@ -2251,6 +2290,9 @@ fn wire_lock(content: &str) -> (String, bool) {
 /// (`gdm-fingerprint`): insert it right after the `pam_fprintd.so` auth line so
 /// the sealed password is set before pam_gnome_keyring's auth line runs.
 fn wire_fp_keyring(content: &str, service: &str) -> (String, bool) {
+    if has_line_continuation(content) {
+        return (content.to_string(), false);
+    }
     if content.lines().any(|l| {
         let d = directive(l);
         d.contains(MODULE) && d.contains("keyring")
@@ -2322,6 +2364,9 @@ fn is_fingerprint_auth(line: &str) -> bool {
 /// on a failed face would then fail the whole prompt instead of falling back to
 /// the password.
 fn wire_verify_service(content: &str) -> (String, bool) {
+    if has_line_continuation(content) {
+        return (content.to_string(), false);
+    }
     if content_has_module(content) {
         return (content.to_string(), false);
     }
@@ -4122,6 +4167,13 @@ auth       optional      pam_gnome_keyring.so\n";
         );
         assert_eq!(directive("# whole line comment"), "");
         assert_eq!(directive(""), "");
+        // libpam truncates at '#' even mid-token (pam_exec received `arg` from
+        // a literal `arg#embedded`), so cutting at the FIRST '#' anywhere is
+        // the faithful reading, not an approximation.
+        assert_eq!(
+            directive("auth optional pam_unix.so arg#embedded"),
+            "auth optional pam_unix.so arg"
+        );
     }
 
     #[test]
@@ -4199,6 +4251,80 @@ auth       optional                     pam_permit.so   # irlume-landing\n\
             out.contains("-auth      optional      pam_gnome_keyring.so\n"),
             "the distro's untagged keyring line survives"
         );
+    }
+
+    #[test]
+    fn line_continuation_semantics_match_the_pam_assembler() {
+        // Each row was executed against libpam via pam_exec.so:
+        // a trailing backslash on a directive joins the NEXT physical line into
+        // this one (the module received the next line's text as its argument);
+        assert!(has_line_continuation(
+            "auth optional pam_exec.so run.sh \\\n  CONT\n"
+        ));
+        // whitespace after the backslash does not defuse it (the follow-up
+        // line was still swallowed);
+        assert!(has_line_continuation(
+            "auth optional pam_exec.so run.sh A \\   \n"
+        ));
+        // a backslash at the end of a COMMENT does not continue (both modules
+        // ran as separate lines);
+        assert!(!has_line_continuation(
+            "auth optional pam_exec.so run.sh FIRST # note \\\nauth optional pam_exec.so run.sh SECOND\n"
+        ));
+        // and a whole-line comment ending in a backslash is still just a comment.
+        assert!(!has_line_continuation("# just a comment \\\n"));
+        // A backslash mid-line is an ordinary character, not a continuation.
+        assert!(!has_line_continuation(
+            "auth optional pam_unix.so arg\\more\n"
+        ));
+    }
+
+    #[test]
+    fn a_stack_using_line_continuations_is_never_rewritten() {
+        // PAM evaluates a continued pair as ONE logical line, so a line-based
+        // insertion after the anchor would splice our stanza into the middle of
+        // it. Every transform must refuse the whole file: staged-never-written,
+        // the same contract as a missing anchor.
+        let cont =
+            "#%PAM-1.0\nauth substack \\\n    password-auth\nsession include password-auth\n";
+        assert!(has_line_continuation(cont));
+        let (g, changed) = wire_greeter_impl(cont, true, true, true);
+        assert!(!changed);
+        assert_eq!(g, cont);
+        let (l, changed) = wire_lock(cont);
+        assert!(!changed);
+        assert_eq!(l, cont);
+        let (v, changed) = wire_verify_service(cont);
+        assert!(!changed);
+        assert_eq!(v, cont);
+        let fp = "auth required pam_fprintd.so \\\n    likeauth\n";
+        let (f, changed) = wire_fp_keyring(fp, "gdm-fingerprint");
+        assert!(!changed);
+        assert_eq!(f, fp);
+        // The advisory stays silent too: a verdict from lines PAM does not
+        // evaluate as written would be worse than no verdict.
+        let wired = "auth sufficient pam_irlume.so unseal ondemand\n\
+-auth optional pam_kwallet5.so \\\n    someopt\n";
+        assert!(keyring_handoff(wired, "plasmalogin").is_none());
+    }
+
+    #[test]
+    fn no_upstream_fixture_uses_line_continuations() {
+        // What makes the refusal gate behaviour-neutral on real stacks. If a
+        // distro starts shipping continuations, this fails and the gate needs
+        // real assembly support instead of refusal.
+        for (name, body) in [
+            ("plasmalogin fedora", UPSTREAM_FEDORA),
+            ("plasmalogin arch", UPSTREAM_ARCH),
+            ("plasmalogin debian", UPSTREAM_DEBIAN),
+            ("plasmalogin suse", UPSTREAM_SUSE),
+            ("gdm redhat", UPSTREAM_GDM_REDHAT),
+            ("gdm arch", UPSTREAM_GDM_ARCH),
+            ("gdm renamed", UPSTREAM_GDM_RENAMED_SUBSTACK),
+            ("gdm fingerprint", UPSTREAM_GDM_FINGERPRINT),
+        ] {
+            assert!(!has_line_continuation(body), "{name}");
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1398,6 +1398,11 @@ fn status() -> ExitCode {
     if any_ondemand {
         println!("  on-demand: {ONDEMAND_HINT}");
     }
+    // A greeter can be correctly wired and still leave the wallet locked, so
+    // this is reported next to the wiring rather than left to `doctor`: it is
+    // the difference between "face logs me in" and "face logs me in AND my
+    // wallet is open", which is what the keyring path exists for.
+    report_keyring_handoff();
     println!(
         "[login] SELinux module: {}",
         match selinux_loaded() {
@@ -1588,6 +1593,12 @@ fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCod
         // (authselect, pam-auth-update, or a package upgrade shipping a fresh
         // vendor copy). On disable we clear the marker so reconcile stays quiet.
         write_wired_marker(enable, with_sudo, with_polkit, want_face_lock);
+        // Say it at the moment the user wired it, not only when they next run
+        // `login status`: a wallet that still prompts after `enable --apply`
+        // otherwise reads as irlume having failed.
+        if enable {
+            report_keyring_handoff();
+        }
         println!("[login] done. Password remains the fallback everywhere.");
     }
     if errs == 0 {
@@ -1874,6 +1885,102 @@ fn is_auth_directive(line: &str) -> bool {
         return false;
     }
     t.strip_prefix('-').unwrap_or(t).split_whitespace().next() == Some("auth")
+}
+
+/// Login-keyring modules that CONSUME the password an `unseal` line releases.
+/// KDE's kwallet-pam still installs `pam_kwallet5.so` under Plasma 6 (the
+/// running provider process is `ksecretd`, but the PAM module kept the 5 in its
+/// name); older Plasma and a few distros ship `pam_kwallet.so`. GNOME ships
+/// `pam_gnome_keyring.so`.
+const KEYRING_CONSUMERS: &[&str] = &["pam_kwallet5.so", "pam_kwallet.so", "pam_gnome_keyring.so"];
+
+/// What a wired greeter stack does with the password irlume releases.
+///
+/// irlume's job ends at setting `PAM_AUTHTOK`. Turning that token into an OPEN
+/// wallet is another module's work, and if that module is absent (or sits above
+/// our line, where it runs before the token exists) the login succeeds by face
+/// and the wallet stays locked — which surfaces to the user as KWallet
+/// prompting for its password anyway. Nothing checked for this, so the failure
+/// was indistinguishable from "wired ✓".
+struct KeyringHandoff {
+    /// Consumer module on an `auth` line positioned AFTER irlume's `unseal`
+    /// line, i.e. one that will actually observe the token. `None` means the
+    /// released password is read by nobody.
+    auth: Option<&'static str>,
+    /// Whether a consumer also has a `session` line. That is the half that
+    /// starts the wallet daemon and hands it the key; an auth line alone
+    /// derives the key and then drops it.
+    session: bool,
+}
+
+/// Locate the keyring hand-off in a wired stack. `None` when this stack
+/// releases no credential at all (no `unseal` line), which is how the plain
+/// verify surfaces — sudo and polkit — opt out of being judged against a wallet
+/// they were never meant to open. The lock screen opts out a level up instead:
+/// `report_keyring_handoff` walks only `GREETERS`, because a warm screen unlock
+/// runs against a wallet the login already opened.
+fn keyring_handoff(content: &str) -> Option<KeyringHandoff> {
+    let lines: Vec<&str> = content.lines().collect();
+    let unseal_at = lines.iter().position(|l| {
+        let t = l.trim_start();
+        !t.starts_with('#') && t.contains(MODULE) && t.contains("unseal")
+    })?;
+    let consumer_in = |l: &str| -> Option<&'static str> {
+        let t = l.trim_start();
+        if t.starts_with('#') {
+            return None;
+        }
+        KEYRING_CONSUMERS.iter().copied().find(|m| t.contains(m))
+    };
+    // Only lines BELOW ours can see the token we set, so the search starts past
+    // the unseal line rather than scanning the whole file.
+    let auth = lines
+        .iter()
+        .skip(unseal_at + 1)
+        .filter(|l| is_auth_directive(l))
+        .find_map(|l| consumer_in(l));
+    let session = lines.iter().any(|l| {
+        let t = l.trim_start();
+        let t = t.strip_prefix('-').unwrap_or(t);
+        t.split_whitespace().next() == Some("session") && consumer_in(l).is_some()
+    });
+    Some(KeyringHandoff { auth, session })
+}
+
+/// Print a warning for every wired greeter that releases the login password
+/// with nothing downstream to open the wallet. Advisory only: it never changes
+/// a stack and never fails a command, because a missing wallet module is the
+/// user's package/desktop choice, not a broken irlume wiring.
+fn report_keyring_handoff() {
+    for s in GREETERS {
+        let Some(path) = service_present(s) else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if !content_has_module(&content) {
+            continue;
+        }
+        let Some(handoff) = keyring_handoff(&content) else {
+            continue;
+        };
+        match (handoff.auth, handoff.session) {
+            (Some(_), true) => {}
+            (Some(m), false) => println!(
+                "  ⚠ {}: {m} has an auth line but no session line, so the wallet\n     \
+                 daemon is never started with the key. Your wallet will still prompt.",
+                s.etc
+            ),
+            (None, _) => println!(
+                "  ⚠ {}: face login releases your login password, but no keyring module\n     \
+                 reads it afterwards, so KWallet/the login keyring will still prompt.\n     \
+                 Install kwallet-pam (KDE) or gnome-keyring (GNOME); if it is already\n     \
+                 installed, its auth line must sit BELOW the pam_irlume unseal line.",
+                s.etc
+            ),
+        }
+    }
 }
 
 /// Insert irlume's greeter block: `unseal` before the password substack, a
@@ -3350,6 +3457,160 @@ mod tests {
         assert!(msg.message.contains("restored from backup"), "{msg}");
         assert_eq!(std::fs::read_to_string(&etc).unwrap(), SUDO_STOCK);
         assert!(!dir.0.join(format!("sudo{BACKUP}")).exists());
+    }
+
+    // ---- keyring hand-off (KWallet / gnome-keyring) --------------------------
+    // A greeter can be wired perfectly and still leave the wallet locked, which
+    // reaches the user as "KWallet asks for its password even though face login
+    // worked". These pin the detection of that state.
+
+    /// Fedora KDE `plasmalogin` (substack layout) AFTER irlume wires it, with
+    /// the vendor kwallet lines in their shipped positions.
+    const PLASMA_WIRED: &str = "#%PAM-1.0\n\
+auth       [success=1 default=ignore]   pam_irlume.so unseal ondemand\n\
+auth       substack      password-auth\n\
+auth       optional                     pam_permit.so   # irlume-landing\n\
+auth       optional                     pam_irlume.so reseal\n\
+-auth      optional      pam_kwallet5.so\n\
+auth       include       postlogin\n\
+account    include       password-auth\n\
+session    include       password-auth\n\
+-session   optional      pam_kwallet5.so auto_start\n\
+session    optional                     pam_irlume.so reseal\n";
+
+    #[test]
+    fn plasmalogin_with_kwallet_has_a_complete_handoff() {
+        let h = keyring_handoff(PLASMA_WIRED).expect("stack releases a credential");
+        // The jump skips exactly the substack and lands on the permit, so the
+        // vendor kwallet auth line below it does observe our PAM_AUTHTOK.
+        assert_eq!(h.auth, Some("pam_kwallet5.so"));
+        assert!(h.session, "session auto_start line must be seen");
+    }
+
+    /// The Fedora KDE vendor `plasmalogin` as shipped: kwallet lines in place,
+    /// irlume not yet wired.
+    const PLASMA_VENDOR: &str = "#%PAM-1.0\n\
+auth       substack      password-auth\n\
+-auth      optional      pam_kwallet5.so\n\
+auth       include       postlogin\n\
+account    include       password-auth\n\
+session    include       password-auth\n\
+-session   optional      pam_kwallet5.so auto_start\n";
+
+    #[test]
+    fn what_we_wire_is_what_the_handoff_check_approves() {
+        // Closes the loop between the two halves: the wiring must insert the
+        // unseal line ABOVE the vendor's kwallet auth line, which is exactly the
+        // order the check demands. If either side moves, this fails rather than
+        // shipping a stack we wire and then warn about.
+        let (wired, changed) = wire_greeter_impl(PLASMA_VENDOR, true, false, true);
+        assert!(changed);
+        let h = keyring_handoff(&wired).expect("a wired greeter releases a credential");
+        assert_eq!(h.auth, Some("pam_kwallet5.so"));
+        assert!(h.session);
+        let face = wired.find("pam_irlume.so unseal").unwrap();
+        let kwallet = wired.find("pam_kwallet5.so").unwrap();
+        assert!(face < kwallet, "our line must precede the wallet's");
+    }
+
+    #[test]
+    fn arch_include_greeter_we_wire_also_passes_the_handoff_check() {
+        const ARCH_VENDOR: &str = "#%PAM-1.0\n\
+auth        include     system-login\n\
+-auth       optional    pam_kwallet5.so\n\
+account     include     system-login\n\
+session     include     system-login\n\
+-session    optional    pam_kwallet5.so auto_start\n";
+        let (wired, changed) = wire_greeter_impl(ARCH_VENDOR, true, false, true);
+        assert!(changed);
+        let h = keyring_handoff(&wired).expect("a wired greeter releases a credential");
+        assert_eq!(h.auth, Some("pam_kwallet5.so"));
+        assert!(h.session);
+    }
+
+    #[test]
+    fn plasmalogin_without_any_keyring_module_is_flagged() {
+        let stripped: String = PLASMA_WIRED
+            .lines()
+            .filter(|l| !l.contains("pam_kwallet5.so"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let h = keyring_handoff(&stripped).expect("stack releases a credential");
+        // Nothing reads the released password: this is the silent case that used
+        // to report as "wired ✓" while the wallet kept prompting.
+        assert_eq!(h.auth, None);
+        assert!(!h.session);
+    }
+
+    #[test]
+    fn kwallet_above_the_irlume_line_does_not_count_as_a_consumer() {
+        // Ordering, not mere presence, is what matters: an auth line ABOVE ours
+        // runs before the token exists, so the wallet stays locked.
+        let above = "#%PAM-1.0\n\
+-auth      optional      pam_kwallet5.so\n\
+auth       [success=1 default=ignore]   pam_irlume.so unseal ondemand\n\
+auth       substack      password-auth\n\
+-session   optional      pam_kwallet5.so auto_start\n";
+        let h = keyring_handoff(above).expect("stack releases a credential");
+        assert_eq!(
+            h.auth, None,
+            "a consumer above our line cannot see the token"
+        );
+        assert!(h.session);
+    }
+
+    #[test]
+    fn arch_include_layout_handoff_is_detected() {
+        let arch = "#%PAM-1.0\n\
+auth       sufficient   pam_irlume.so unseal ondemand kr\n\
+auth       include     system-login\n\
+auth       optional                     pam_irlume.so reseal\n\
+-auth      optional    pam_kwallet5.so\n\
+-session   optional    pam_kwallet5.so auto_start\n";
+        let h = keyring_handoff(arch).expect("stack releases a credential");
+        assert_eq!(h.auth, Some("pam_kwallet5.so"));
+        assert!(h.session);
+    }
+
+    #[test]
+    fn auth_line_without_a_session_line_is_reported_separately() {
+        // pam_kwallet5 derives the key at auth time but it is the SESSION line
+        // that starts the daemon and hands it over; auth alone opens nothing.
+        let no_session: String = PLASMA_WIRED
+            .lines()
+            .filter(|l| !(l.contains("pam_kwallet5.so") && l.contains("session")))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let h = keyring_handoff(&no_session).expect("stack releases a credential");
+        assert_eq!(h.auth, Some("pam_kwallet5.so"));
+        assert!(!h.session);
+    }
+
+    #[test]
+    fn gnome_keyring_counts_as_a_consumer_too() {
+        let gnome = PLASMA_WIRED.replace("pam_kwallet5.so", "pam_gnome_keyring.so");
+        let h = keyring_handoff(&gnome).expect("stack releases a credential");
+        assert_eq!(h.auth, Some("pam_gnome_keyring.so"));
+        assert!(h.session);
+    }
+
+    #[test]
+    fn a_verify_only_stack_is_not_judged_for_a_wallet() {
+        // sudo / polkit carry the plain verify stanza: no `unseal`, so no
+        // credential is released and there is nothing for a wallet to consume.
+        let sudo = "#%PAM-1.0\nauth       sufficient                   pam_irlume.so\n\
+@include common-auth\n";
+        assert!(keyring_handoff(sudo).is_none());
+    }
+
+    #[test]
+    fn a_commented_out_keyring_line_is_not_a_consumer() {
+        let commented = PLASMA_WIRED.replace(
+            "-auth      optional      pam_kwallet5.so",
+            "#-auth      optional      pam_kwallet5.so",
+        );
+        let h = keyring_handoff(&commented).expect("stack releases a credential");
+        assert_eq!(h.auth, None);
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -65,6 +65,23 @@ const RESEAL_AUTH: &str = "auth       optional                     pam_irlume.so
 /// the TPM-sealed password and sets PAM_AUTHTOK so pam_gnome_keyring opens the
 /// wallet. No-op when the keyring isn't armed or a password is already set.
 const KEYRING_UNSEAL: &str = "auth       optional                     pam_irlume.so keyring";
+/// Tag on the gnome-keyring lines irlume ADDS to a fingerprint stack, so unwiring
+/// removes exactly ours and never a keyring line the distro shipped. Linux-PAM
+/// strips a trailing `#` comment before tokenizing (verified against
+/// `pam_exec.so`: an argument survives, a trailing comment does not), so this is
+/// invisible to the module — which matters here because gnome-keyring's
+/// `parse_args` syslogs a warning for every option it does not recognize.
+const KEYRING_TAG: &str = "# irlume-keyring";
+/// GDM's `gdm-fingerprint` stack carries NO keyring module at all (verified on
+/// upstream `data/pam-redhat/gdm-fingerprint.pam` through GDM 50.0), so the
+/// `KEYRING_UNSEAL` line above would set a token nothing reads. These are the
+/// two halves gnome-keyring needs, added only when the stack has no consumer of
+/// its own. The leading `-` is PAM's "do not complain if the module is missing",
+/// so a machine without gnome-keyring installed is unaffected.
+const FP_GKR_AUTH: &str =
+    "-auth      optional                     pam_gnome_keyring.so   # irlume-keyring";
+const FP_GKR_SESSION: &str =
+    "-session   optional                     pam_gnome_keyring.so auto_start   # irlume-keyring";
 const RESEAL_SESSION: &str = "session    optional                     pam_irlume.so reseal";
 /// The plain verify stanza, shared by `sudo` and polkit prompts (Bitwarden vault
 /// unlock, pkexec, systemd unit control): no `unseal` (the daemon refuses
@@ -2211,21 +2228,60 @@ fn wire_fp_keyring(content: &str) -> (String, bool) {
         return (content.to_string(), false); // already wired
     }
     let lines: Vec<&str> = content.lines().collect();
-    let fp_at = lines.iter().position(|l| {
-        let t = l.trim_start();
-        !t.starts_with('#') && t.starts_with("auth") && t.contains("pam_fprintd.so")
-    });
-    let Some(fp_at) = fp_at else {
+    let Some(fp_at) = lines.iter().position(|l| is_fingerprint_auth(l)) else {
         return (content.to_string(), false);
     };
-    let mut out = Vec::with_capacity(lines.len() + 1);
+    // Does anything in this stack already read the token we are about to set?
+    // GDM's own `gdm-fingerprint` does not, so the unseal line alone would
+    // release a password into a stack with no consumer.
+    let has_consumer = lines.iter().any(|l| {
+        let t = l.trim_start();
+        !t.starts_with('#') && KEYRING_CONSUMERS.iter().any(|m| t.contains(m))
+    });
+    let mut out = Vec::with_capacity(lines.len() + 3);
     for (i, l) in lines.iter().enumerate() {
         out.push((*l).to_string());
         if i == fp_at {
             out.push(KEYRING_UNSEAL.to_string());
+            if !has_consumer {
+                out.push(FP_GKR_AUTH.to_string());
+            }
         }
     }
+    if !has_consumer {
+        // Appended last: gnome-keyring's session half wants to run once the
+        // session is otherwise set up, and it is the half that actually starts
+        // the daemon and unlocks with the stashed key.
+        out.push(FP_GKR_SESSION.to_string());
+    }
     (format!("{}\n", out.join("\n")), true)
+}
+
+/// The auth line that performs the fingerprint check, and therefore the line the
+/// keyring unseal must follow.
+///
+/// Matching a literal `pam_fprintd.so` was not enough: GDM's shipped
+/// `gdm-fingerprint.pam` never names the module, delegating instead to
+/// `auth substack fingerprint-auth` (renamed `gdm-fingerprint-auth-substack` on
+/// GDM's development branch). With only the literal match this returned no
+/// anchor, `wire_fp_keyring` became a silent no-op, and the fingerprint keyring
+/// unlock never wired on Fedora at all.
+fn is_fingerprint_auth(line: &str) -> bool {
+    let t = line.trim_start();
+    if t.starts_with('#') {
+        return false;
+    }
+    let toks: Vec<&str> = t
+        .strip_prefix('-')
+        .unwrap_or(t)
+        .split_whitespace()
+        .collect();
+    if toks.first() != Some(&"auth") {
+        return false;
+    }
+    toks.iter().any(|w| w.contains("pam_fprintd.so"))
+        || (toks.iter().any(|w| *w == "substack" || *w == "include")
+            && toks.iter().any(|w| w.contains("fingerprint")))
 }
 /// Wire a single-stanza verify service (`sudo`, `polkit-1`): the stanza goes
 /// ABOVE the first auth-phase line, whether that is Fedora's `auth include
@@ -2272,7 +2328,10 @@ fn unwire_lines(content: &str) -> (String, bool) {
                 return true;
             }
             let drop = t.contains(MODULE)
-                || (t.contains("pam_permit.so") && l.contains("# irlume-landing"));
+                || (t.contains("pam_permit.so") && l.contains("# irlume-landing"))
+                // Only the gnome-keyring lines WE tagged; a distro-shipped
+                // keyring line carries no tag and must survive unwiring.
+                || (t.contains("pam_gnome_keyring.so") && l.contains(KEYRING_TAG));
             if drop {
                 changed = true;
             }
@@ -3703,6 +3762,104 @@ auth        include       postlogin
 session     include       password-auth
 session     optional      pam_gnome_keyring.so auto_start
 "#;
+
+    /// GDM's shipped `gdm-fingerprint.pam` (upstream `data/pam-redhat`, released
+    /// 50.0). It names neither `pam_fprintd.so` nor any keyring module.
+    const UPSTREAM_GDM_FINGERPRINT: &str = r#"auth        substack      fingerprint-auth
+auth        include       postlogin
+
+account     required      pam_nologin.so
+account     include       fingerprint-auth
+
+password    include       fingerprint-auth
+
+session     required      pam_selinux.so close
+session     required      pam_loginuid.so
+session     required      pam_selinux.so open
+session     optional      pam_keyinit.so force revoke
+session     required      pam_namespace.so
+session     include       fingerprint-auth
+session     include       postlogin
+"#;
+
+    #[test]
+    fn gdm_fingerprint_wires_the_unseal_and_supplies_the_missing_consumer() {
+        // Two defects in one stack: no literal pam_fprintd.so to anchor on (so
+        // this used to be a silent no-op), and no keyring module at all (so the
+        // unseal line alone would release a token nothing reads).
+        assert!(!UPSTREAM_GDM_FINGERPRINT.contains("pam_fprintd.so"));
+        assert!(!UPSTREAM_GDM_FINGERPRINT.contains("pam_gnome_keyring.so"));
+
+        let (w, changed) = wire_fp_keyring(UPSTREAM_GDM_FINGERPRINT);
+        assert!(changed, "the substack must serve as the anchor");
+        let lines: Vec<&str> = w.lines().collect();
+        let pos = |n: &str| lines.iter().position(|l| l.contains(n));
+
+        let fp = pos("substack      fingerprint-auth").expect("fingerprint substack");
+        let unseal = pos("pam_irlume.so keyring").expect("keyring unseal");
+        let gkr_auth = lines
+            .iter()
+            .position(|l| l.contains("pam_gnome_keyring.so") && is_auth_directive(l))
+            .expect("gnome-keyring auth line");
+        assert_eq!(
+            fp + 1,
+            unseal,
+            "unseal rides directly after the fingerprint auth"
+        );
+        assert_eq!(
+            unseal + 1,
+            gkr_auth,
+            "the consumer reads it immediately after"
+        );
+
+        // Both halves present and paired, so the hand-off actually completes.
+        let session_gkr = lines
+            .iter()
+            .any(|l| l.contains("pam_gnome_keyring.so") && l.contains("auto_start"));
+        assert!(
+            session_gkr,
+            "gnome-keyring needs its session half to unlock"
+        );
+        // The lines we added are tagged, and use PAM's `-` so a machine without
+        // gnome-keyring installed does not get an error logged.
+        assert!(w.contains(KEYRING_TAG));
+        assert!(w.contains("-auth") && w.contains("-session"));
+    }
+
+    #[test]
+    fn wire_fp_keyring_does_not_duplicate_an_existing_keyring_module() {
+        // gdm-fingerprint stacks that DO ship a keyring module must get the
+        // unseal line only; adding a second consumer would be noise.
+        let with_gkr = "#%PAM-1.0\nauth       required      pam_fprintd.so\n\
+auth       optional      pam_gnome_keyring.so\n\
+session    optional      pam_gnome_keyring.so auto_start\n";
+        let (w, changed) = wire_fp_keyring(with_gkr);
+        assert!(changed);
+        assert_eq!(
+            w.matches("pam_gnome_keyring.so").count(),
+            2,
+            "must not add a third keyring line"
+        );
+        assert!(!w.contains(KEYRING_TAG), "nothing of ours to tag here");
+    }
+
+    #[test]
+    fn unwiring_removes_our_keyring_lines_but_keeps_the_distros() {
+        // Ours are tagged; a distro-shipped keyring line is not, and must survive.
+        let (wired, _) = wire_fp_keyring(UPSTREAM_GDM_FINGERPRINT);
+        let (bare, changed) = unwire_lines(&wired);
+        assert!(changed);
+        assert!(!bare.contains("pam_gnome_keyring.so"), "ours must go");
+        assert!(!bare.contains("pam_irlume.so"));
+        // Round-trips back to the upstream content.
+        assert_eq!(bare.trim_end(), UPSTREAM_GDM_FINGERPRINT.trim_end());
+
+        // A foreign keyring line is untagged and survives.
+        let foreign = "auth       required      pam_fprintd.so\n\
+auth       optional      pam_gnome_keyring.so\n";
+        let (kept, _) = unwire_lines(foreign);
+        assert!(kept.contains("pam_gnome_keyring.so"));
+    }
 
     #[test]
     fn upstream_gdm_stacks_wire_into_a_complete_gnome_keyring_handoff() {

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1903,14 +1903,22 @@ const KEYRING_CONSUMERS: &[&str] = &["pam_kwallet5.so", "pam_kwallet.so", "pam_g
 /// prompting for its password anyway. Nothing checked for this, so the failure
 /// was indistinguishable from "wired ✓".
 struct KeyringHandoff {
-    /// Consumer module on an `auth` line positioned AFTER irlume's `unseal`
-    /// line, i.e. one that will actually observe the token. `None` means the
-    /// released password is read by nobody.
-    auth: Option<&'static str>,
-    /// Whether a consumer also has a `session` line. That is the half that
-    /// starts the wallet daemon and hands it the key; an auth line alone
-    /// derives the key and then drops it.
-    session: bool,
+    /// A module carrying BOTH halves: an `auth` line below ours (so it observes
+    /// the token) and a `session` line of its own. That is a hand-off that
+    /// actually opens a wallet.
+    ///
+    /// The two halves are paired PER MODULE rather than counted separately,
+    /// because upstream stacks list several consumers side by side: Fedora's
+    /// `plasmalogin` ships `pam_gnome_keyring.so`, `pam_kwallet5.so` AND
+    /// `pam_kwallet.so`. Counting "some auth line" and "some session line"
+    /// independently would call a stack complete when one module read the token
+    /// and a different one started a daemon that never received it.
+    complete: Option<&'static str>,
+    /// Modules with an auth line below ours but no session line of their own.
+    /// `pam_kwallet.c` stashes the key with `pam_set_data` in
+    /// `pam_sm_authenticate` and only `pam_sm_open_session` acts on it, so this
+    /// half alone derives a key and then drops it.
+    auth_only: Vec<&'static str>,
 }
 
 /// Locate the keyring hand-off in a wired stack. `None` when this stack
@@ -1932,19 +1940,39 @@ fn keyring_handoff(content: &str) -> Option<KeyringHandoff> {
         }
         KEYRING_CONSUMERS.iter().copied().find(|m| t.contains(m))
     };
+    // A given module's session line may sit anywhere in the session phase, so
+    // that half is searched across the whole file; only the AUTH half is
+    // order-sensitive.
+    let has_session_line = |module: &str| {
+        lines.iter().any(|l| {
+            let t = l.trim_start();
+            if t.starts_with('#') {
+                return false;
+            }
+            let phase = t.strip_prefix('-').unwrap_or(t);
+            phase.split_whitespace().next() == Some("session") && t.contains(module)
+        })
+    };
     // Only lines BELOW ours can see the token we set, so the search starts past
     // the unseal line rather than scanning the whole file.
-    let auth = lines
+    let mut complete = None;
+    let mut auth_only: Vec<&'static str> = Vec::new();
+    for module in lines
         .iter()
         .skip(unseal_at + 1)
         .filter(|l| is_auth_directive(l))
-        .find_map(|l| consumer_in(l));
-    let session = lines.iter().any(|l| {
-        let t = l.trim_start();
-        let t = t.strip_prefix('-').unwrap_or(t);
-        t.split_whitespace().next() == Some("session") && consumer_in(l).is_some()
-    });
-    Some(KeyringHandoff { auth, session })
+        .filter_map(|l| consumer_in(l))
+    {
+        if has_session_line(module) {
+            complete = complete.or(Some(module));
+        } else if !auth_only.contains(&module) {
+            auth_only.push(module);
+        }
+    }
+    Some(KeyringHandoff {
+        complete,
+        auth_only,
+    })
 }
 
 /// Print a warning for every wired greeter that releases the login password
@@ -1965,14 +1993,18 @@ fn report_keyring_handoff() {
         let Some(handoff) = keyring_handoff(&content) else {
             continue;
         };
-        match (handoff.auth, handoff.session) {
-            (Some(_), true) => {}
-            (Some(m), false) => println!(
-                "  ⚠ {}: {m} has an auth line but no session line, so the wallet\n     \
-                 daemon is never started with the key. Your wallet will still prompt.",
+        // A single complete module is enough: the wallet opens. Only when none
+        // is complete does the stack need explaining.
+        if handoff.complete.is_some() {
+            continue;
+        }
+        match handoff.auth_only.first() {
+            Some(m) => println!(
+                "  ⚠ {}: {m} reads the released password but has no session line, so the\n     \
+                 wallet daemon is never started with the key. Your wallet will still prompt.",
                 s.etc
             ),
-            (None, _) => println!(
+            None => println!(
                 "  ⚠ {}: face login releases your login password, but no keyring module\n     \
                  reads it afterwards, so KWallet/the login keyring will still prompt.\n     \
                  Install kwallet-pam (KDE) or gnome-keyring (GNOME); if it is already\n     \
@@ -3464,6 +3496,148 @@ mod tests {
     // reaches the user as "KWallet asks for its password even though face login
     // worked". These pin the detection of that state.
 
+    // The four `plasmalogin` stacks Plasma Login Manager actually ships, copied
+    // verbatim from upstream `data/pam/<os>/plasmalogin` (KDE/plasma-login-manager).
+    // Its CMake installs them to ${prefix}/lib/pam.d, which is the vendor path
+    // irlume materializes its /etc override from. Held verbatim so a distro
+    // rewrite shows up here as a failing test rather than as a silent wallet.
+
+    const UPSTREAM_FEDORA: &str = r#"auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
+auth        substack      password-auth
+-auth        optional      pam_gnome_keyring.so
+-auth        optional      pam_kwallet5.so
+-auth        optional      pam_kwallet.so
+auth        include       postlogin
+
+account     required      pam_nologin.so
+account     include       password-auth
+
+password    include       password-auth
+
+session     required      pam_selinux.so close
+session     required      pam_loginuid.so
+-session    optional    pam_ck_connector.so
+session     required      pam_selinux.so open
+session     optional      pam_keyinit.so force revoke
+session     required      pam_namespace.so
+session     include       password-auth
+-session     optional      pam_gnome_keyring.so auto_start
+-session     optional      pam_kwallet5.so auto_start
+-session     optional      pam_kwallet.so auto_start
+session     include       postlogin
+"#;
+
+    const UPSTREAM_ARCH: &str = r#"#%PAM-1.0
+
+auth        include     system-login
+-auth       optional    pam_gnome_keyring.so
+-auth       optional    pam_kwallet5.so
+
+account     include     system-login
+
+password    include     system-login
+-password   optional    pam_gnome_keyring.so    use_authtok
+
+session     optional    pam_keyinit.so          force revoke
+session     include     system-login
+-session    optional    pam_gnome_keyring.so    auto_start
+-session    optional    pam_kwallet5.so         auto_start
+"#;
+
+    const UPSTREAM_DEBIAN: &str = r#"#%PAM-1.0
+auth    requisite       pam_nologin.so
+auth    required        pam_succeed_if.so user != root quiet_success
+@include common-auth
+-auth   optional        pam_gnome_keyring.so
+-auth   optional        pam_kwallet5.so
+@include common-account
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+session optional        pam_keyinit.so force revoke
+session required        pam_limits.so
+session required        pam_loginuid.so
+@include common-session
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+-session optional       pam_gnome_keyring.so auto_start
+-session optional       pam_kwallet5.so auto_start
+@include common-password
+session required        pam_env.so
+"#;
+
+    /// openSUSE's upstream `plasmalogin` carries NO keyring module at all.
+    const UPSTREAM_SUSE: &str = r#"#%PAM-1.0
+auth     requisite      pam_nologin.so
+auth     substack       common-auth
+account  substack       common-account
+account  include        postlogin-account
+password substack       common-password
+password include        postlogin-password
+session  required       pam_loginuid.so
+session  optional       pam_keyinit.so revoke force
+session  substack       common-session
+session  include        postlogin-session
+"#;
+
+    #[test]
+    fn upstream_plasmalogin_stacks_wire_into_a_complete_handoff() {
+        // Fedora, Arch and Debian each ship a keyring module with both halves,
+        // so wiring them must produce a stack this check passes silently. If
+        // irlume's insertion point ever lands below the vendor's keyring auth
+        // line, `complete` goes None here and the wallet would stop opening.
+        for (os, vendor) in [
+            ("fedora", UPSTREAM_FEDORA),
+            ("arch", UPSTREAM_ARCH),
+            ("debian", UPSTREAM_DEBIAN),
+        ] {
+            let (wired, changed) = wire_greeter_impl(vendor, true, false, true);
+            assert!(changed, "{os}: upstream stack must be wirable");
+            let h =
+                keyring_handoff(&wired).unwrap_or_else(|| panic!("{os}: releases a credential"));
+            assert!(
+                h.complete.is_some(),
+                "{os}: expected a complete hand-off, got auth_only={:?}",
+                h.auth_only
+            );
+            // And our line really does precede the vendor's keyring auth line.
+            let face = wired.find("pam_irlume.so unseal").expect("face line");
+            let consumer = wired
+                .find("pam_gnome_keyring.so")
+                .or_else(|| wired.find("pam_kwallet5.so"))
+                .expect("a keyring module");
+            assert!(face < consumer, "{os}: our line must precede the wallet's");
+        }
+    }
+
+    #[test]
+    fn upstream_suse_plasmalogin_ships_no_keyring_module_and_is_flagged() {
+        // openSUSE's upstream file has neither pam_kwallet5 nor pam_gnome_keyring,
+        // so a face login there releases a password nothing reads. This is the
+        // real-world case the warning exists for, not a synthetic one.
+        assert!(!UPSTREAM_SUSE.contains("pam_kwallet"));
+        assert!(!UPSTREAM_SUSE.contains("pam_gnome_keyring"));
+        let (wired, changed) = wire_greeter_impl(UPSTREAM_SUSE, true, false, true);
+        assert!(changed);
+        let h = keyring_handoff(&wired).expect("releases a credential");
+        assert_eq!(h.complete, None);
+        assert!(h.auth_only.is_empty());
+    }
+
+    #[test]
+    fn a_split_handoff_across_two_modules_is_not_complete() {
+        // The reason the halves are paired per module: kwallet5 reads the token
+        // but has no session line, while gnome-keyring has only a session line.
+        // Counting the halves separately would call this complete; nothing opens.
+        let split = "#%PAM-1.0\n\
+auth       [success=1 default=ignore]   pam_irlume.so unseal ondemand\n\
+auth       substack      password-auth\n\
+auth       optional                     pam_permit.so   # irlume-landing\n\
+-auth      optional      pam_kwallet5.so\n\
+session    include       password-auth\n\
+-session   optional      pam_gnome_keyring.so auto_start\n";
+        let h = keyring_handoff(split).expect("releases a credential");
+        assert_eq!(h.complete, None);
+        assert_eq!(h.auth_only, vec!["pam_kwallet5.so"]);
+    }
+
     /// Fedora KDE `plasmalogin` (substack layout) AFTER irlume wires it, with
     /// the vendor kwallet lines in their shipped positions.
     const PLASMA_WIRED: &str = "#%PAM-1.0\n\
@@ -3483,8 +3657,8 @@ session    optional                     pam_irlume.so reseal\n";
         let h = keyring_handoff(PLASMA_WIRED).expect("stack releases a credential");
         // The jump skips exactly the substack and lands on the permit, so the
         // vendor kwallet auth line below it does observe our PAM_AUTHTOK.
-        assert_eq!(h.auth, Some("pam_kwallet5.so"));
-        assert!(h.session, "session auto_start line must be seen");
+        assert_eq!(h.complete, Some("pam_kwallet5.so"));
+        assert!(h.auth_only.is_empty());
     }
 
     /// The Fedora KDE vendor `plasmalogin` as shipped: kwallet lines in place,
@@ -3506,8 +3680,8 @@ session    include       password-auth\n\
         let (wired, changed) = wire_greeter_impl(PLASMA_VENDOR, true, false, true);
         assert!(changed);
         let h = keyring_handoff(&wired).expect("a wired greeter releases a credential");
-        assert_eq!(h.auth, Some("pam_kwallet5.so"));
-        assert!(h.session);
+        assert_eq!(h.complete, Some("pam_kwallet5.so"));
+        assert!(h.auth_only.is_empty());
         let face = wired.find("pam_irlume.so unseal").unwrap();
         let kwallet = wired.find("pam_kwallet5.so").unwrap();
         assert!(face < kwallet, "our line must precede the wallet's");
@@ -3524,8 +3698,8 @@ session     include     system-login\n\
         let (wired, changed) = wire_greeter_impl(ARCH_VENDOR, true, false, true);
         assert!(changed);
         let h = keyring_handoff(&wired).expect("a wired greeter releases a credential");
-        assert_eq!(h.auth, Some("pam_kwallet5.so"));
-        assert!(h.session);
+        assert_eq!(h.complete, Some("pam_kwallet5.so"));
+        assert!(h.auth_only.is_empty());
     }
 
     #[test]
@@ -3538,8 +3712,8 @@ session     include     system-login\n\
         let h = keyring_handoff(&stripped).expect("stack releases a credential");
         // Nothing reads the released password: this is the silent case that used
         // to report as "wired ✓" while the wallet kept prompting.
-        assert_eq!(h.auth, None);
-        assert!(!h.session);
+        assert_eq!(h.complete, None);
+        assert!(h.auth_only.is_empty());
     }
 
     #[test]
@@ -3553,10 +3727,10 @@ auth       substack      password-auth\n\
 -session   optional      pam_kwallet5.so auto_start\n";
         let h = keyring_handoff(above).expect("stack releases a credential");
         assert_eq!(
-            h.auth, None,
+            h.complete, None,
             "a consumer above our line cannot see the token"
         );
-        assert!(h.session);
+        assert!(h.auth_only.is_empty());
     }
 
     #[test]
@@ -3568,8 +3742,8 @@ auth       optional                     pam_irlume.so reseal\n\
 -auth      optional    pam_kwallet5.so\n\
 -session   optional    pam_kwallet5.so auto_start\n";
         let h = keyring_handoff(arch).expect("stack releases a credential");
-        assert_eq!(h.auth, Some("pam_kwallet5.so"));
-        assert!(h.session);
+        assert_eq!(h.complete, Some("pam_kwallet5.so"));
+        assert!(h.auth_only.is_empty());
     }
 
     #[test]
@@ -3582,16 +3756,16 @@ auth       optional                     pam_irlume.so reseal\n\
             .collect::<Vec<_>>()
             .join("\n");
         let h = keyring_handoff(&no_session).expect("stack releases a credential");
-        assert_eq!(h.auth, Some("pam_kwallet5.so"));
-        assert!(!h.session);
+        assert_eq!(h.complete, None);
+        assert_eq!(h.auth_only, vec!["pam_kwallet5.so"]);
     }
 
     #[test]
     fn gnome_keyring_counts_as_a_consumer_too() {
         let gnome = PLASMA_WIRED.replace("pam_kwallet5.so", "pam_gnome_keyring.so");
         let h = keyring_handoff(&gnome).expect("stack releases a credential");
-        assert_eq!(h.auth, Some("pam_gnome_keyring.so"));
-        assert!(h.session);
+        assert_eq!(h.complete, Some("pam_gnome_keyring.so"));
+        assert!(h.auth_only.is_empty());
     }
 
     #[test]
@@ -3610,7 +3784,8 @@ auth       optional                     pam_irlume.so reseal\n\
             "#-auth      optional      pam_kwallet5.so",
         );
         let h = keyring_handoff(&commented).expect("stack releases a credential");
-        assert_eq!(h.auth, None);
+        assert_eq!(h.complete, None);
+        assert!(h.auth_only.is_empty());
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -2066,9 +2066,16 @@ fn keyring_handoff(content: &str, service: &str) -> Option<KeyringHandoff> {
         return None;
     }
     let lines: Vec<&str> = content.lines().collect();
+    // Anchor on the first line that RELEASES the sealed password into
+    // PAM_AUTHTOK. Two modes do: `unseal` (face login) and `keyring` (the
+    // post-auth fingerprint unlock). Anchoring on `unseal` alone left the
+    // fingerprint path unchecked: a fingerprint-only box wires the greeter
+    // with ONLY the `keyring` line, and a missing or mis-ordered wallet
+    // module there went unreported — the wallet stayed locked after a
+    // fingerprint login with nothing naming why.
     let unseal_at = lines.iter().position(|l| {
         let d = directive(l);
-        d.contains(MODULE) && d.contains("unseal")
+        d.contains(MODULE) && (d.contains("unseal") || d.contains("keyring"))
     })?;
     let consumer_in = |l: &str| consumer_active_for(l, service);
     // A given module's session line may sit anywhere in the session phase, so
@@ -2137,10 +2144,10 @@ fn report_keyring_handoff() {
                 s.etc
             ),
             None => println!(
-                "  ⚠ {}: face login releases your login password, but no keyring module\n     \
-                 reads it afterwards, so KWallet/the login keyring will still prompt.\n     \
-                 Install kwallet-pam (KDE) or gnome-keyring (GNOME); if it is already\n     \
-                 installed, its auth line must sit BELOW the pam_irlume unseal line.",
+                "  ⚠ {}: a face or fingerprint login releases your login password, but no\n     \
+                 keyring module reads it afterwards, so KWallet/the login keyring will\n     \
+                 still prompt. Install kwallet-pam (KDE) or gnome-keyring (GNOME); if it\n     \
+                 is already installed, its auth line must sit BELOW the pam_irlume line.",
                 s.etc
             ),
         }
@@ -4139,6 +4146,61 @@ auth       optional      pam_gnome_keyring.so\n";
         assert!(is_include_auth_layout("auth include common-auth"));
         // Debian's @include form is still caught by the include layout first.
         assert!(is_include_auth_layout("@include common-auth"));
+    }
+
+    #[test]
+    fn plasmalogin_fingerprint_keyring_line_lands_above_the_wallet_module() {
+        // The KDE fingerprint→KWallet chain. Plasma's greeter runs ONE stack
+        // for user auth (plasma-login-manager's PamBackend selects only
+        // `plasmalogin` / `plasmalogin-greeter` / `plasmalogin-autologin` — no
+        // fingerprint service, unlike kscreenlocker's kde/kde-fingerprint/
+        // kde-smartcard triple). So a greeter fingerprint login happens when
+        // the distro's shared stack carries pam_fprintd, provides no password,
+        // and the `keyring` line must then release the sealed one ABOVE the
+        // vendor's pam_kwallet5 auth line for the wallet to open.
+        for (os, vendor, od) in [
+            ("fedora", UPSTREAM_FEDORA, true),
+            ("arch", UPSTREAM_ARCH, true),
+            ("debian", UPSTREAM_DEBIAN, true),
+        ] {
+            let (w, changed) = wire_greeter_impl(vendor, true, true, od);
+            assert!(changed, "{os}");
+            let lines: Vec<&str> = w.lines().collect();
+            let keyring = lines
+                .iter()
+                .position(|l| l.contains("pam_irlume.so keyring"))
+                .unwrap_or_else(|| panic!("{os}: keyring line missing"));
+            let kwallet = lines
+                .iter()
+                .position(|l| is_auth_directive(l) && l.contains("pam_kwallet5.so"))
+                .unwrap_or_else(|| panic!("{os}: kwallet auth line missing"));
+            assert!(
+                keyring < kwallet,
+                "{os}: the released password must be set before pam_kwallet5 reads it"
+            );
+            let h = keyring_handoff(&w, "plasmalogin").expect("releases a credential");
+            assert!(h.complete.is_some(), "{os}");
+        }
+    }
+
+    #[test]
+    fn a_keyring_only_greeter_is_still_checked_for_the_wallet_handoff() {
+        // A fingerprint-only box (no face login) wires the greeter with ONLY
+        // the `keyring` line — no `unseal`. The hand-off check used to anchor
+        // on `unseal` alone, so this stack was skipped entirely: a missing
+        // wallet module after a fingerprint login had no warning at all.
+        let (w, changed) = wire_greeter_impl(UPSTREAM_FEDORA, false, true, true);
+        assert!(changed);
+        assert!(!w.contains("unseal"), "no face line on this box");
+        let h = keyring_handoff(&w, "plasmalogin")
+            .expect("the keyring line releases a credential and must anchor the check");
+        assert!(h.complete.is_some(), "fedora ships the wallet modules");
+        // And on the stack that genuinely lacks a wallet module, the warning
+        // now fires for the fingerprint path too.
+        let (suse, changed) = wire_greeter_impl(UPSTREAM_SUSE, false, true, true);
+        assert!(changed);
+        let h = keyring_handoff(&suse, "plasmalogin").expect("releases a credential");
+        assert_eq!(h.complete, None);
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1902,6 +1902,43 @@ fn is_auth_directive(line: &str) -> bool {
     t.strip_prefix('-').unwrap_or(t).split_whitespace().next() == Some("auth")
 }
 
+/// An `auth` line whose control keyword is `substack`, whatever the shared stack
+/// happens to be NAMED. A substack is atomic for jump counting, so this is a
+/// safe jump anchor even when we do not recognize the target.
+///
+/// This exists because the named list cannot keep up with upstreams. GDM's main
+/// branch renamed its shared stack from `password-auth` to
+/// `gdm-password-auth-substack` (a file GDM does not ship — distros supply it),
+/// which no name in `is_passwd_substack` matches. Without this tier the anchor
+/// search falls through to "first auth line", which on GDM's stack is
+/// `pam_selinux_permit.so`: the jump would then skip THAT and land above the
+/// password substack, which still runs. That is the openSUSE failure exactly,
+/// and it would arrive silently with a GDM upgrade.
+fn is_auth_substack_anchor(line: &str) -> bool {
+    let t = line.trim_start();
+    if t.starts_with('#') {
+        return false;
+    }
+    let toks: Vec<&str> = t
+        .strip_prefix('-')
+        .unwrap_or(t)
+        .split_whitespace()
+        .collect();
+    toks.first() == Some(&"auth") && toks.get(1) == Some(&"substack")
+}
+
+/// Where the face block anchors, in descending order of confidence: a shared
+/// stack we recognize by name, then any `substack` whatever its name, and only
+/// then the first `auth` line. The last tier is a guess and is kept last
+/// deliberately — it is what produces a jump over an unrelated module.
+fn find_auth_anchor(lines: &[&str]) -> Option<usize> {
+    lines
+        .iter()
+        .position(|l| is_passwd_substack(l, "auth"))
+        .or_else(|| lines.iter().position(|l| is_auth_substack_anchor(l)))
+        .or_else(|| lines.iter().position(|l| is_auth_directive(l)))
+}
+
 /// Login-keyring modules that CONSUME the password an `unseal` line releases.
 /// KDE's kwallet-pam still installs `pam_kwallet5.so` under Plasma 6 (the
 /// running provider process is `ksecretd`, but the PAM module kept the 5 in its
@@ -2081,10 +2118,7 @@ fn wire_greeter_impl(content: &str, face: bool, keyring: bool, ondemand: bool) -
         }
         return (format!("{}\n", out.join("\n")), true);
     }
-    let auth_at = lines
-        .iter()
-        .position(|l| is_passwd_substack(l, "auth"))
-        .or_else(|| lines.iter().position(|l| is_auth_directive(l)));
+    let auth_at = find_auth_anchor(&lines);
     let sess_at = lines.iter().position(|l| is_passwd_substack(l, "session"));
     let Some(auth_at) = auth_at else {
         return (content.to_string(), false);
@@ -2149,10 +2183,7 @@ fn wire_lock(content: &str) -> (String, bool) {
         return (format!("{}\n", out.join("\n")), true);
     }
     // Fedora `substack password-auth` layout → jump stanza + permit landing.
-    let auth_at = lines
-        .iter()
-        .position(|l| is_passwd_substack(l, "auth"))
-        .or_else(|| lines.iter().position(|l| is_auth_directive(l)));
+    let auth_at = find_auth_anchor(&lines);
     let Some(auth_at) = auth_at else {
         return (content.to_string(), false);
     };
@@ -3620,6 +3651,133 @@ session  include        postlogin-session
                 .expect("a keyring module");
             assert!(face < consumer, "{os}: our line must precede the wallet's");
         }
+    }
+
+    // GDM's shipped stacks, verbatim from upstream `data/pam-<os>/gdm-password.pam`
+    // (GNOME/gdm). Redhat is the released 50.0 form; Arch is the include layout.
+    // gnome-keyring's module needs the same two halves kwallet does: its
+    // `pam_sm_authenticate` reads PAM_AUTHTOK and stashes it under
+    // "gkr_system_authtok", and `pam_sm_open_session` is what acts on it.
+
+    const UPSTREAM_GDM_REDHAT: &str = r#"auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
+auth        substack      password-auth
+auth        optional      pam_gnome_keyring.so
+auth        include       postlogin
+
+account     required      pam_nologin.so
+account     include       password-auth
+
+password    substack       password-auth
+-password   optional       pam_gnome_keyring.so use_authtok
+
+session     required      pam_selinux.so close
+session     required      pam_loginuid.so
+session     required      pam_selinux.so open
+session     optional      pam_keyinit.so force revoke
+session     required      pam_namespace.so
+session     include       password-auth
+session     optional      pam_gnome_keyring.so auto_start
+session     include       postlogin
+"#;
+
+    const UPSTREAM_GDM_ARCH: &str = r#"#%PAM-1.0
+
+auth       include                     system-local-login
+auth       optional                    pam_gnome_keyring.so
+
+account    include                     system-local-login
+
+password   include                     system-local-login
+password   optional                    pam_gnome_keyring.so use_authtok
+
+session    include                     system-local-login
+session    optional                    pam_gnome_keyring.so auto_start
+"#;
+
+    /// GDM's unreleased `main` renamed the shared stack; no release ships this
+    /// yet, but an upgrade would arrive silently.
+    const UPSTREAM_GDM_RENAMED_SUBSTACK: &str = r#"auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
+auth        substack      gdm-password-auth-substack
+auth        optional      pam_gnome_keyring.so
+auth        include       postlogin
+session     include       password-auth
+session     optional      pam_gnome_keyring.so auto_start
+"#;
+
+    #[test]
+    fn upstream_gdm_stacks_wire_into_a_complete_gnome_keyring_handoff() {
+        for (os, vendor) in [("redhat", UPSTREAM_GDM_REDHAT), ("arch", UPSTREAM_GDM_ARCH)] {
+            let (wired, changed) = wire_greeter_impl(vendor, true, false, false);
+            assert!(changed, "{os}: upstream GDM stack must be wirable");
+            let h =
+                keyring_handoff(&wired).unwrap_or_else(|| panic!("{os}: releases a credential"));
+            assert_eq!(
+                h.complete,
+                Some("pam_gnome_keyring.so"),
+                "{os}: expected a complete hand-off, auth_only={:?}",
+                h.auth_only
+            );
+            let face = wired.find("pam_irlume.so unseal").expect("face line");
+            let gkr = wired.find("pam_gnome_keyring.so").expect("keyring module");
+            assert!(face < gkr, "{os}: our line must precede gnome-keyring's");
+        }
+    }
+
+    #[test]
+    fn a_renamed_gdm_substack_still_anchors_on_the_substack() {
+        // The named list cannot keep up with upstream renames, so an unrecognized
+        // `substack` must still be preferred over the first-auth-line guess.
+        // Otherwise the jump lands above pam_selinux_permit.so and the password
+        // substack runs anyway — the openSUSE bug, arriving via a GDM upgrade.
+        assert!(!is_passwd_substack(
+            "auth        substack      gdm-password-auth-substack",
+            "auth"
+        ));
+        let (w, changed) = wire_greeter_impl(UPSTREAM_GDM_RENAMED_SUBSTACK, true, false, false);
+        assert!(changed);
+        let lines: Vec<&str> = w.lines().collect();
+        let pos = |n: &str| lines.iter().position(|l| l.contains(n));
+        let selinux = pos("pam_selinux_permit.so").expect("selinux line");
+        let face = pos("pam_irlume.so unseal").expect("face line");
+        let substack = pos("gdm-password-auth-substack").expect("substack");
+        let landing = pos("irlume-landing").expect("landing");
+        assert!(
+            selinux < face,
+            "pam_selinux_permit must stay above our line"
+        );
+        assert!(
+            face < substack,
+            "our line must precede the password substack"
+        );
+        assert_eq!(
+            substack + 1,
+            landing,
+            "the jump must land past the substack"
+        );
+        // The hand-off still resolves, so a rename costs nothing else.
+        let h = keyring_handoff(&w).expect("releases a credential");
+        assert_eq!(h.complete, Some("pam_gnome_keyring.so"));
+    }
+
+    #[test]
+    fn the_first_auth_line_guess_stays_the_last_resort() {
+        // Anchor precedence: named stack, then any substack, then the guess.
+        let named = ["auth substack password-auth", "auth substack whatever"];
+        assert_eq!(find_auth_anchor(&named), Some(0));
+        let unnamed = ["auth required pam_env.so", "auth substack whatever"];
+        assert_eq!(
+            find_auth_anchor(&unnamed),
+            Some(1),
+            "substack beats a guess"
+        );
+        let neither = ["auth required pam_env.so", "auth required pam_unix.so"];
+        assert_eq!(
+            find_auth_anchor(&neither),
+            Some(0),
+            "guess is still the floor"
+        );
+        let none: [&str; 0] = [];
+        assert_eq!(find_auth_anchor(&none), None);
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1840,14 +1840,13 @@ fn content_has_module(c: &str) -> bool {
     })
 }
 
-/// `<kind>` is `auth`/`session`; matches a `(substack|include) (password-auth|
-/// system-auth)` line, the shared substack the success=1 jump skips.
 /// An `auth`-phase line whose password path is an `include` a `success=N` jump
-/// can't skip: Debian's `@include common-auth`/`login`, or Arch's
-/// `auth include system-login`/`system-local-login`/`system-auth`. These need
-/// the `sufficient` (module IGNOREs on cold login) form, NOT the jump form. A
-/// Fedora `substack` is atomic for jump counting, so it deliberately does not
-/// match here and keeps the jump stanza.
+/// can't skip: Debian's `@include common-auth`/`login`, Arch's
+/// `auth include system-login`/`system-local-login`/`system-auth`, or a bare
+/// `auth include common-auth`. These need the `sufficient` (module IGNOREs on
+/// cold login) form, NOT the jump form. A `substack` is atomic for jump
+/// counting, so it deliberately does not match here and keeps the jump stanza —
+/// which is what openSUSE's `auth substack common-auth` relies on.
 fn is_include_auth_layout(line: &str) -> bool {
     let t = line.trim_start();
     if t.starts_with("@include common-auth") || t.starts_with("@include login") {
@@ -1858,10 +1857,23 @@ fn is_include_auth_layout(line: &str) -> bool {
         && toks.get(1) == Some(&"include")
         && matches!(
             toks.get(2),
-            Some(&"system-login") | Some(&"system-local-login") | Some(&"system-auth")
+            Some(&"system-login")
+                | Some(&"system-local-login")
+                | Some(&"system-auth")
+                | Some(&"common-auth")
         )
 }
 
+/// `<kind>` is `auth`/`session`; matches the shared password stack that the
+/// `success=1` jump skips: Fedora's `password-auth`/`system-auth`, and
+/// openSUSE's `common-auth`/`common-session`.
+///
+/// The stack names are kind-aware so an `auth` line is only tested against
+/// auth-phase names. openSUSE's `plasmalogin` routes the password through
+/// `auth substack common-auth`, which matched nothing here: wiring then fell
+/// back to the first auth line and inserted the jump above `pam_nologin.so`, so
+/// a face login skipped the nologin gate and *still* landed on the password
+/// stack underneath — face auth that neither honoured nologin nor logged you in.
 fn is_passwd_substack(line: &str, kind: &str) -> bool {
     let t = line.trim_start();
     if t.starts_with('#') {
@@ -1872,11 +1884,14 @@ fn is_passwd_substack(line: &str, kind: &str) -> bool {
         .unwrap_or(t)
         .split_whitespace()
         .collect();
+    let stacks: &[&str] = match kind {
+        "auth" => &["password-auth", "system-auth", "common-auth"],
+        "session" => &["password-auth", "system-auth", "common-session"],
+        _ => &["password-auth", "system-auth"],
+    };
     toks.first() == Some(&kind)
         && toks.iter().any(|w| *w == "substack" || *w == "include")
-        && toks
-            .iter()
-            .any(|w| *w == "password-auth" || *w == "system-auth")
+        && toks.iter().any(|w| stacks.contains(w))
 }
 
 fn is_auth_directive(line: &str) -> bool {
@@ -3605,6 +3620,80 @@ session  include        postlogin-session
                 .expect("a keyring module");
             assert!(face < consumer, "{os}: our line must precede the wallet's");
         }
+    }
+
+    #[test]
+    fn suse_common_auth_substack_is_the_jump_anchor_and_nologin_survives() {
+        let (w, changed) = wire_greeter_impl(UPSTREAM_SUSE, true, false, true);
+        assert!(changed);
+        let lines: Vec<&str> = w.lines().collect();
+        let pos = |needle: &str| lines.iter().position(|l| l.contains(needle));
+        let nologin = pos("pam_nologin.so").expect("nologin line");
+        let face = pos("pam_irlume.so unseal").expect("face line");
+        let substack = pos("substack       common-auth").expect("common-auth substack");
+        let landing = pos("irlume-landing").expect("permit landing");
+
+        // The anchor is the password substack, NOT the first auth line. Before
+        // this, the jump went above pam_nologin.so: a face match skipped the
+        // nologin gate and then met `substack common-auth` anyway, so the user
+        // typed a password regardless.
+        assert!(
+            nologin < face,
+            "pam_nologin must still run before face auth"
+        );
+        assert!(
+            face < substack,
+            "face line must precede the password substack"
+        );
+        assert!(
+            substack + 1 == landing,
+            "success=1 must land on the permit directly after the substack"
+        );
+        // A substack is atomic for jump counting, so the jump form is right here
+        // (an include would need the `sufficient` form instead).
+        assert!(w.contains("[success=1 default=ignore]   pam_irlume.so unseal ondemand"));
+        assert!(!w.contains("sufficient   pam_irlume.so unseal"));
+        // The session reseal now anchors on `substack common-session` rather
+        // than being appended at EOF.
+        let sess = pos("substack       common-session").expect("common-session");
+        let reseal = pos("session    optional                     pam_irlume.so reseal")
+            .expect("session reseal");
+        assert_eq!(
+            sess + 1,
+            reseal,
+            "session reseal follows the session substack"
+        );
+    }
+
+    #[test]
+    fn common_auth_matching_is_kind_aware_and_leaves_other_phases_alone() {
+        assert!(is_passwd_substack(
+            "auth     substack   common-auth",
+            "auth"
+        ));
+        assert!(is_passwd_substack(
+            "session  substack   common-session",
+            "session"
+        ));
+        // An auth line is not matched against a session-phase stack name, and
+        // the account/password phases are never anchors at all.
+        assert!(!is_passwd_substack(
+            "auth     substack   common-session",
+            "auth"
+        ));
+        assert!(!is_passwd_substack(
+            "account  substack   common-account",
+            "auth"
+        ));
+        assert!(!is_passwd_substack(
+            "password substack   common-password",
+            "session"
+        ));
+        // A bare `auth include common-auth` is an include a jump can't skip, so
+        // it takes the `sufficient` path instead of becoming a jump anchor.
+        assert!(is_include_auth_layout("auth include common-auth"));
+        // Debian's @include form is still caught by the include layout first.
+        assert!(is_include_auth_layout("@include common-auth"));
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1740,7 +1740,18 @@ fn wire_service(
                 );
             }
             let (base, _) = unwire_lines(&read(vendor)?);
-            let (wired, _) = wire(&base);
+            let (wired, changed) = wire(&base);
+            // The transform saying "unchanged" means it REFUSED (no anchor, a
+            // continued file): materializing anyway would shadow the vendor
+            // file with a copy carrying no irlume line and report ✓ while face
+            // login stayed off. The in-place branch below already refuses on
+            // this; the override branch must too.
+            if !changed {
+                return out(
+                    PlannedChange::NoAnchor,
+                    format!("· {}: no anchor to wire (skipped)", s.etc),
+                );
+            }
             let body = format!(
                 "{CREATED_PREFIX}{vendor}; delete this file to restore the vendor copy\n{wired}"
             );
@@ -2310,28 +2321,47 @@ fn wire_fp_keyring(content: &str, service: &str) -> (String, bool) {
     let Some(fp_at) = lines.iter().position(|l| is_fingerprint_auth(l)) else {
         return (content.to_string(), false);
     };
-    // Does anything in this stack already read the token we are about to set?
-    // GDM's own `gdm-fingerprint` does not, so the unseal line alone would
-    // release a password into a stack with no consumer.
-    // `only_if=` aware: a keyring line that stands down for THIS service is not
-    // a consumer here, however plainly it names the module.
-    let has_consumer = lines
-        .iter()
-        .any(|l| consumer_active_for(l, service).is_some());
+    // Does this stack already turn the token we are about to set into an open
+    // keyring? That takes ONE module holding BOTH halves in working positions:
+    // an auth line BELOW the fprintd anchor (above it, the module runs before
+    // PAM_AUTHTOK exists) and a session line of its own (the half that starts
+    // the daemon and unlocks with the stashed key), the same per-module rule
+    // `keyring_handoff` reports by. Any weaker test suppressed our lines on
+    // stacks where a lone session line, a lone auth line, a misplaced auth
+    // line, or even a password-phase line named the module, and the
+    // fingerprint login then succeeded with the wallet still locked.
+    // `only_if=` aware in both halves: a keyring line that stands down for
+    // THIS service is not a consumer here, however plainly it names the
+    // module. Supplying our tagged pair beside an incomplete foreign pair is
+    // the safe direction: unwiring removes exactly ours, and an extra pair
+    // risks redundant work where a suppressed pair leaves the wallet locked,
+    // the exact failure this function exists to close.
+    let has_complete_consumer = KEYRING_CONSUMERS.iter().copied().any(|module| {
+        let auth_below_anchor = lines
+            .iter()
+            .skip(fp_at + 1)
+            .any(|l| is_auth_directive(l) && consumer_active_for(l, service) == Some(module));
+        let session_present = lines.iter().any(|l| {
+            let d = directive(l);
+            let phase = d.strip_prefix('-').unwrap_or(d);
+            phase.split_whitespace().next() == Some("session")
+                && consumer_active_for(l, service) == Some(module)
+        });
+        auth_below_anchor && session_present
+    });
     let mut out = Vec::with_capacity(lines.len() + 3);
     for (i, l) in lines.iter().enumerate() {
         out.push((*l).to_string());
         if i == fp_at {
             out.push(KEYRING_UNSEAL.to_string());
-            if !has_consumer {
+            if !has_complete_consumer {
                 out.push(FP_GKR_AUTH.to_string());
             }
         }
     }
-    if !has_consumer {
+    if !has_complete_consumer {
         // Appended last: gnome-keyring's session half wants to run once the
-        // session is otherwise set up, and it is the half that actually starts
-        // the daemon and unlocks with the stashed key.
+        // session is otherwise set up.
         out.push(FP_GKR_SESSION.to_string());
     }
     (format!("{}\n", out.join("\n")), true)
@@ -4872,6 +4902,97 @@ auth       optional                     pam_irlume.so reseal\n\
             "gdm-fingerprint",
         );
         assert!(!c);
+    }
+
+    // A consumer only counts when ONE module holds BOTH halves in working
+    // positions, the same per-module rule `keyring_handoff` reports by. Any
+    // single keyring line used to suppress our pair, and the fingerprint
+    // login then succeeded with the wallet still locked.
+
+    #[test]
+    fn fp_session_only_does_not_suppress_the_auth_consumer() {
+        // Session half alone: nothing reads the token irlume releases.
+        let stack = "auth required pam_fprintd.so\n\
+-session optional pam_gnome_keyring.so auto_start\n";
+        let (wired, changed) = wire_fp_keyring(stack, "gdm-fingerprint");
+        assert!(changed);
+        assert!(wired.contains(FP_GKR_AUTH), "{wired}");
+        assert!(
+            keyring_handoff(&wired, "gdm-fingerprint")
+                .expect("wired stack releases a credential")
+                .complete
+                .is_some(),
+            "the wired stack must form a complete hand-off:\n{wired}"
+        );
+    }
+
+    #[test]
+    fn fp_auth_only_does_not_suppress_the_session_consumer() {
+        // Auth half alone: the key is stashed and dropped, no daemon starts.
+        let stack = "auth required pam_fprintd.so\n\
+-auth optional pam_gnome_keyring.so\n";
+        let (wired, changed) = wire_fp_keyring(stack, "gdm-fingerprint");
+        assert!(changed);
+        assert!(wired.contains(FP_GKR_SESSION), "{wired}");
+        assert!(
+            keyring_handoff(&wired, "gdm-fingerprint")
+                .expect("wired stack releases a credential")
+                .complete
+                .is_some(),
+            "the wired stack must form a complete hand-off:\n{wired}"
+        );
+    }
+
+    #[test]
+    fn fp_consumer_above_the_anchor_does_not_count() {
+        // Both halves present, but the auth half sits ABOVE pam_fprintd.so:
+        // it runs before PAM_AUTHTOK exists, so it consumes nothing, and it
+        // must not suppress a pair that would actually work.
+        let stack = "-auth optional pam_gnome_keyring.so\n\
+auth required pam_fprintd.so\n\
+-session optional pam_gnome_keyring.so auto_start\n";
+        let (wired, changed) = wire_fp_keyring(stack, "gdm-fingerprint");
+        assert!(changed);
+        let release = wired
+            .find("pam_irlume.so keyring")
+            .expect("unseal line present");
+        let tagged_auth = wired.find(FP_GKR_AUTH).expect("tagged auth supplied");
+        assert!(
+            release < tagged_auth,
+            "the supplied consumer must sit below the release:\n{wired}"
+        );
+    }
+
+    // Regression for the vendor-override path: the transform refusing (a
+    // continued vendor file has no judgeable lines) must refuse the
+    // materialization too. This branch used to discard `changed`, write an
+    // override with NO irlume line over the vendor file, and report ✓.
+    #[test]
+    fn wire_service_override_does_not_materialize_a_refused_vendor_stack() {
+        let dir = TestDir::new("override-refused");
+        let vendor = dir.0.join("plasmalogin.vendor");
+        std::fs::write(
+            &vendor,
+            "auth substack \\\n    password-auth\nsession include password-auth\n",
+        )
+        .unwrap();
+        let etc = dir.0.join("plasmalogin");
+        let svc = Svc {
+            etc: leak(&etc),
+            vendor: Some(leak(&vendor)),
+        };
+        let wire = |c: &str| wire_greeter_impl(c, true, false, true);
+        let outcome = wire_service(&svc, true, true, &wire).unwrap();
+        assert_eq!(outcome.change, PlannedChange::NoAnchor);
+        assert!(
+            !etc.exists(),
+            "a refused transform must not create an override"
+        );
+        assert!(
+            !outcome.message.starts_with('✓'),
+            "refusal must not read as successful wiring: {}",
+            outcome.message
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -3794,14 +3794,29 @@ session    include                     system-local-login
 session    optional                    pam_gnome_keyring.so auto_start
 "#;
 
-    /// GDM's unreleased `main` renamed the shared stack; no release ships this
-    /// yet, but an upgrade would arrive silently.
+    /// GDM `main`'s `data/pam-redhat/gdm-password.pam`, byte-for-byte: the shared
+    /// stack is renamed to `gdm-password-auth-substack`, a file GDM does not itself
+    /// ship. No release carries this — 45.0 through 50.1 and 51.alpha all still say
+    /// `password-auth` — so it is latent, and would arrive with an upgrade.
     const UPSTREAM_GDM_RENAMED_SUBSTACK: &str = r#"auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
 auth        substack      gdm-password-auth-substack
 auth        optional      pam_gnome_keyring.so
 auth        include       postlogin
+
+account     required      pam_nologin.so
+account     include       password-auth
+
+password    substack       gdm-password-auth-substack
+-password   optional       pam_gnome_keyring.so use_authtok
+
+session     required      pam_selinux.so close
+session     required      pam_loginuid.so
+session     required      pam_selinux.so open
+session     optional      pam_keyinit.so force revoke
+session     required      pam_namespace.so
 session     include       password-auth
 session     optional      pam_gnome_keyring.so auto_start
+session     include       postlogin
 "#;
 
     /// GDM's shipped `gdm-fingerprint.pam` (upstream `data/pam-redhat`, released

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -206,6 +206,21 @@ password**, since that is the password `keyring arm` seals. A wallet created wit
 a different password cannot be opened on this path — change it under *System
 Settings → KDE Wallet*, or remove and recreate the wallet.
 
+**Fingerprint on KDE.** Plasma's login greeter runs ONE PAM stack for user
+authentication: plasma-login-manager's PAM backend selects only `plasmalogin`
+(plus `plasmalogin-greeter` for the greeter user and `plasmalogin-autologin`) —
+it has no separate fingerprint service, unlike kscreenlocker, which drives the
+*lock screen* through the `kde` / `kde-fingerprint` / `kde-smartcard` triple.
+So a fingerprint login at the KDE greeter happens when your distro's shared
+stack carries `pam_fprintd.so` (that is what `irlume fingerprint enable` wires,
+via authselect on Fedora or pam-auth-update on Debian), inside the same
+`plasmalogin` transaction. A fingerprint provides no password, so irlume's
+`keyring` line — wired into the greeter whenever a reader is present — releases
+the TPM-sealed login password at the post-auth landing, and `pam_kwallet5.so`
+below it opens the wallet: a cold-boot fingerprint login unlocks KWallet with
+no prompt, same as face. The lock screen needs none of this — a warm unlock
+meets a wallet the login already opened.
+
 #### GNOME: what has to be in place for the login keyring
 
 Same shape, different module. `gdm-password` runs irlume's `unseal` line, which

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -231,12 +231,25 @@ GDM's upstream `gdm-password.pam` ships both halves on every OS variant it
 provides (Red Hat, Arch, LFS, Exherbo), so the check stays quiet on a stock
 GNOME system.
 
-**Known gap — fingerprint on GNOME.** Fedora's `gdm-fingerprint.pam` contains no
-`pam_gnome_keyring.so` line at all (and no literal `pam_fprintd.so` line to
-anchor on — it is `auth substack fingerprint-auth`). The fingerprint keyring
-unlock in [ADR-0003](adr/0003-fingerprint-keyring-unlock.md) therefore does not
-wire itself there. Face login is unaffected; this concerns fingerprint logins
-only.
+**Fingerprint on GNOME.** GDM's `gdm-fingerprint.pam` names neither
+`pam_fprintd.so` (it delegates to `auth substack fingerprint-auth`) nor any
+keyring module. So the [ADR-0003](adr/0003-fingerprint-keyring-unlock.md)
+fingerprint keyring unlock needs both an anchor that recognizes the substack and
+a consumer to read the released password. `login enable` supplies both:
+
+```
+auth        substack      fingerprint-auth
+auth       optional       pam_irlume.so keyring          ← releases the sealed password
+-auth      optional       pam_gnome_keyring.so           ← reads and stashes it
+...
+-session   optional       pam_gnome_keyring.so auto_start  ← unlocks, starts the daemon
+```
+
+The two `pam_gnome_keyring.so` lines are added **only** when the stack has no
+keyring module of its own, and are tagged so `login disable` removes exactly
+those and never a line your distro shipped. The leading `-` is PAM's "do not
+complain if the module is missing", so a machine without gnome-keyring installed
+is unaffected.
 
 ### 5. Recovery passphrase: recommended
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -155,24 +155,41 @@ same way (see [ADR-0003](adr/0003-fingerprint-keyring-unlock.md)).
 #### KDE Plasma: what has to be in place for KWallet
 
 On Plasma the chain is: `plasmalogin` runs irlume's `unseal` line, which sets the
-released password as `PAM_AUTHTOK`; `pam_kwallet5.so` reads that token and derives
-the wallet key; its `session` line starts the wallet daemon (`ksecretd` on Plasma
-6, `kwalletd6`/`kwalletd5` before it) and hands the key over. irlume owns only the
-first step, so two things must be true of the rest:
+released password as `PAM_AUTHTOK`; `pam_kwallet5.so`'s **auth** line reads that
+token and stashes the derived key; its **session** line starts the wallet daemon
+(`ksecretd` on Plasma 6, `kwalletd6`/`kwalletd5` before it) and hands the key
+over. Both halves are required — kwallet-pam stashes with `pam_set_data` during
+auth and only acts on it in `pam_sm_open_session`. irlume owns only the first
+step, so two things must be true of the rest:
 
 - **kwallet-pam is installed** — the module is `pam_kwallet5.so`, still that name
-  under Plasma 6.
-- **Its auth line sits BELOW irlume's**, with a matching `session … auto_start`
-  line. Above ours it runs before the token exists, and the wallet stays locked.
+  under Plasma 6 (upstream's CMake sets `library_name "pam_kwallet5"` on the KF6
+  branch). Fedora additionally lists a legacy `pam_kwallet.so`.
+- **Its auth line sits BELOW irlume's**, with a session line for the *same*
+  module. Above ours it runs before the token exists — and kwallet-pam then
+  prompts for the password itself, which is exactly the "it asked me anyway"
+  symptom.
 
-`irlume login status` (and `login enable --apply`) checks both and warns, so a
-wallet that still prompts after a face login names its own cause instead of
-looking like a face-login failure:
+`auto_start` on those lines is a *gnome-keyring* option; kwallet-pam parses only
+`kdehome=`, `kwalletd=`, `socketPath=` and `force_run`, and ignores the rest. Its
+session half also stands down outside a graphical session unless `force_run` is
+given, which is why the greeter is the right place for this and a TTY login is
+not.
+
+`irlume login status` (and `login enable --apply`) checks both halves, paired per
+module, and warns — so a wallet that still prompts after a face login names its
+own cause instead of looking like a face-login failure:
 
 ```
   ⚠ /etc/pam.d/plasmalogin: face login releases your login password, but no keyring module
      reads it afterwards, so KWallet/the login keyring will still prompt.
 ```
+
+Fedora, Arch and Debian all ship a `plasmalogin` with both halves present, so the
+check stays quiet there. **openSUSE's upstream file carries no keyring module at
+all**, so face login on stock openSUSE releases a password nothing reads; the
+warning above is the expected output until `pam_kwallet5.so` is added to that
+stack.
 
 One more requirement is outside PAM: your **wallet password must equal your login
 password**, since that is the password `keyring arm` seals. A wallet created with

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -152,6 +152,33 @@ password is never stored in plaintext. Re-run it after you change your login
 password. On a fingerprint machine a fingerprint login unseals the wallet the
 same way (see [ADR-0003](adr/0003-fingerprint-keyring-unlock.md)).
 
+#### KDE Plasma: what has to be in place for KWallet
+
+On Plasma the chain is: `plasmalogin` runs irlume's `unseal` line, which sets the
+released password as `PAM_AUTHTOK`; `pam_kwallet5.so` reads that token and derives
+the wallet key; its `session` line starts the wallet daemon (`ksecretd` on Plasma
+6, `kwalletd6`/`kwalletd5` before it) and hands the key over. irlume owns only the
+first step, so two things must be true of the rest:
+
+- **kwallet-pam is installed** — the module is `pam_kwallet5.so`, still that name
+  under Plasma 6.
+- **Its auth line sits BELOW irlume's**, with a matching `session … auto_start`
+  line. Above ours it runs before the token exists, and the wallet stays locked.
+
+`irlume login status` (and `login enable --apply`) checks both and warns, so a
+wallet that still prompts after a face login names its own cause instead of
+looking like a face-login failure:
+
+```
+  ⚠ /etc/pam.d/plasmalogin: face login releases your login password, but no keyring module
+     reads it afterwards, so KWallet/the login keyring will still prompt.
+```
+
+One more requirement is outside PAM: your **wallet password must equal your login
+password**, since that is the password `keyring arm` seals. A wallet created with
+a different password cannot be opened on this path — change it under *System
+Settings → KDE Wallet*, or remove and recreate the wallet.
+
 ### 5. Recovery passphrase: recommended
 
 Set this. It's your backstop: without it, a TPM clear or a routine

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -226,6 +226,12 @@ Two differences from KDE are worth knowing:
   nothing visible at the login screen — the keyring simply stays locked, and you
   only find out when an application asks for a secret. That is exactly the case
   `irlume login status` now names.
+- **`only_if=` can switch it off per service.** A line such as
+  `-auth optional pam_gnome_keyring.so only_if=gdm,gdm-password` does nothing at
+  all on any other service — on `gdm-fingerprint`, for instance, it returns
+  success without reading the token. irlume evaluates that list per service, so
+  a line gated off for the stack being checked is not counted as unlocking
+  anything. `pam_kwallet5.so` has no such option.
 
 GDM's upstream `gdm-password.pam` ships both halves on every OS variant it
 provides (Red Hat, Arch, LFS, Exherbo), so the check stays quiet on a stock

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -189,7 +189,17 @@ Fedora, Arch and Debian all ship a `plasmalogin` with both halves present, so th
 check stays quiet there. **openSUSE's upstream file carries no keyring module at
 all**, so face login on stock openSUSE releases a password nothing reads; the
 warning above is the expected output until `pam_kwallet5.so` is added to that
-stack.
+stack. Adding it needs both lines — for example:
+
+```
+-auth    optional    pam_kwallet5.so
+-session optional    pam_kwallet5.so
+```
+
+placed after the `auth substack common-auth` line and in the session phase
+respectively. (openSUSE's greeter is otherwise wired correctly: irlume anchors
+its face line on that `common-auth` substack, leaving `pam_nologin.so` ahead of
+it.)
 
 One more requirement is outside PAM: your **wallet password must equal your login
 password**, since that is the password `keyring arm` seals. A wallet created with

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -206,6 +206,38 @@ password**, since that is the password `keyring arm` seals. A wallet created wit
 a different password cannot be opened on this path — change it under *System
 Settings → KDE Wallet*, or remove and recreate the wallet.
 
+#### GNOME: what has to be in place for the login keyring
+
+Same shape, different module. `gdm-password` runs irlume's `unseal` line, which
+sets `PAM_AUTHTOK`; `pam_gnome_keyring.so`'s **auth** line reads it and stashes it
+under `gkr_system_authtok`; its **session** line unlocks the keyring and starts
+the daemon. Both halves are required, for the same reason as KWallet:
+`pam_sm_authenticate` only stashes, and `pam_sm_open_session` is what acts.
+
+Two differences from KDE are worth knowing:
+
+- **`auto_start` is real here.** gnome-keyring parses it (`ARG_AUTO_START`) and
+  needs it on the session line to start the daemon — the opposite of kwallet,
+  which ignores the option entirely. Upstream GDM already ships
+  `session optional pam_gnome_keyring.so auto_start`.
+- **Failure is silent.** With no `PAM_AUTHTOK`, gnome-keyring's auth phase logs
+  "no password is available for user" and returns success without prompting.
+  kwallet prompts; gnome-keyring does not. So a mis-ordered line costs you
+  nothing visible at the login screen — the keyring simply stays locked, and you
+  only find out when an application asks for a secret. That is exactly the case
+  `irlume login status` now names.
+
+GDM's upstream `gdm-password.pam` ships both halves on every OS variant it
+provides (Red Hat, Arch, LFS, Exherbo), so the check stays quiet on a stock
+GNOME system.
+
+**Known gap — fingerprint on GNOME.** Fedora's `gdm-fingerprint.pam` contains no
+`pam_gnome_keyring.so` line at all (and no literal `pam_fprintd.so` line to
+anchor on — it is `auth substack fingerprint-auth`). The fingerprint keyring
+unlock in [ADR-0003](adr/0003-fingerprint-keyring-unlock.md) therefore does not
+wire itself there. Face login is unaffected; this concerns fingerprint logins
+only.
+
 ### 5. Recovery passphrase: recommended
 
 Set this. It's your backstop: without it, a TPM clear or a routine

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -158,15 +158,15 @@ On Plasma the chain is: `plasmalogin` runs irlume's `unseal` line, which sets th
 released password as `PAM_AUTHTOK`; `pam_kwallet5.so`'s **auth** line reads that
 token and stashes the derived key; its **session** line starts the wallet daemon
 (`ksecretd` on Plasma 6, `kwalletd6`/`kwalletd5` before it) and hands the key
-over. Both halves are required — kwallet-pam stashes with `pam_set_data` during
+over. Both halves are required: kwallet-pam stashes with `pam_set_data` during
 auth and only acts on it in `pam_sm_open_session`. irlume owns only the first
 step, so two things must be true of the rest:
 
-- **kwallet-pam is installed** — the module is `pam_kwallet5.so`, still that name
+- **kwallet-pam is installed**: the module is `pam_kwallet5.so`, still that name
   under Plasma 6 (upstream's CMake sets `library_name "pam_kwallet5"` on the KF6
   branch). Fedora additionally lists a legacy `pam_kwallet.so`.
 - **Its auth line sits BELOW irlume's**, with a session line for the *same*
-  module. Above ours it runs before the token exists — and kwallet-pam then
+  module. Above ours it runs before the token exists, and kwallet-pam then
   prompts for the password itself, which is exactly the "it asked me anyway"
   symptom.
 
@@ -177,7 +177,7 @@ given, which is why the greeter is the right place for this and a TTY login is
 not.
 
 `irlume login status` (and `login enable --apply`) checks both halves, paired per
-module, and warns — so a wallet that still prompts after a face login names its
+module, and warns, so a wallet that still prompts after a face login names its
 own cause instead of looking like a face-login failure:
 
 ```
@@ -189,7 +189,7 @@ Fedora, Arch and Debian all ship a `plasmalogin` with both halves present, so th
 check stays quiet there. **openSUSE's upstream file carries no keyring module at
 all**, so face login on stock openSUSE releases a password nothing reads; the
 warning above is the expected output until `pam_kwallet5.so` is added to that
-stack. Adding it needs both lines — for example:
+stack. Adding it needs both lines, for example:
 
 ```
 -auth    optional    pam_kwallet5.so
@@ -203,22 +203,22 @@ it.)
 
 One more requirement is outside PAM: your **wallet password must equal your login
 password**, since that is the password `keyring arm` seals. A wallet created with
-a different password cannot be opened on this path — change it under *System
+a different password cannot be opened on this path; change it under *System
 Settings → KDE Wallet*, or remove and recreate the wallet.
 
 **Fingerprint on KDE.** Plasma's login greeter runs ONE PAM stack for user
 authentication: plasma-login-manager's PAM backend selects only `plasmalogin`
-(plus `plasmalogin-greeter` for the greeter user and `plasmalogin-autologin`) —
+(plus `plasmalogin-greeter` for the greeter user and `plasmalogin-autologin`);
 it has no separate fingerprint service, unlike kscreenlocker, which drives the
 *lock screen* through the `kde` / `kde-fingerprint` / `kde-smartcard` triple.
 So a fingerprint login at the KDE greeter happens when your distro's shared
 stack carries `pam_fprintd.so` (that is what `irlume fingerprint enable` wires,
 via authselect on Fedora or pam-auth-update on Debian), inside the same
 `plasmalogin` transaction. A fingerprint provides no password, so irlume's
-`keyring` line — wired into the greeter whenever a reader is present — releases
+`keyring` line, wired into the greeter whenever a reader is present, releases
 the TPM-sealed login password at the post-auth landing, and `pam_kwallet5.so`
 below it opens the wallet: a cold-boot fingerprint login unlocks KWallet with
-no prompt, same as face. The lock screen needs none of this — a warm unlock
+no prompt, same as face. The lock screen needs none of this: a warm unlock
 meets a wallet the login already opened.
 
 #### GNOME: what has to be in place for the login keyring
@@ -232,18 +232,18 @@ the daemon. Both halves are required, for the same reason as KWallet:
 Two differences from KDE are worth knowing:
 
 - **`auto_start` is real here.** gnome-keyring parses it (`ARG_AUTO_START`) and
-  needs it on the session line to start the daemon — the opposite of kwallet,
+  needs it on the session line to start the daemon, the opposite of kwallet,
   which ignores the option entirely. Upstream GDM already ships
   `session optional pam_gnome_keyring.so auto_start`.
 - **Failure is silent.** With no `PAM_AUTHTOK`, gnome-keyring's auth phase logs
   "no password is available for user" and returns success without prompting.
   kwallet prompts; gnome-keyring does not. So a mis-ordered line costs you
-  nothing visible at the login screen — the keyring simply stays locked, and you
+  nothing visible at the login screen; the keyring simply stays locked, and you
   only find out when an application asks for a secret. That is exactly the case
   `irlume login status` now names.
 - **`only_if=` can switch it off per service.** A line such as
   `-auth optional pam_gnome_keyring.so only_if=gdm,gdm-password` does nothing at
-  all on any other service — on `gdm-fingerprint`, for instance, it returns
+  all on any other service; on `gdm-fingerprint`, for instance, it returns
   success without reading the token. irlume evaluates that list per service, so
   a line gated off for the stack being checked is not counted as unlocking
   anything. `pam_kwallet5.so` has no such option.


### PR DESCRIPTION
Eleven commits: a diagnostic for the login-keyring hand-off, verification against the KDE, GNOME, and Linux-PAM sources, three PAM-wiring fixes, and four correctness fixes found by re-reading those sources and irlume's own matchers. The last commit removes em dashes from the prose this branch added.

## What the hand-off check does

irlume's job ends at setting `PAM_AUTHTOK`. Opening the wallet belongs to `pam_kwallet5.so` or `pam_gnome_keyring.so`, and that only happens when the module has an auth line below irlume's and a session line of its own. When either half is missing, the face login still succeeds, the wallet prompts anyway, and `login status` still said `● wired`. The check names which half is missing.

## PAM behaviors verified by running them

Each claim the design rests on was executed against libpam in a container, with `pam_exec.so` tracing which modules run and what arguments they receive:

| Experiment | Result |
|---|---|
| `[success=1]` over `auth substack X` | whole substack skipped, so the jump form is correct |
| `[success=1]` over `auth include X` | the jump lands inside the include, so include layouts get `sufficient` instead |
| trailing `# comment` | stripped before tokenizing |
| `#` mid-token (`arg#embedded`) | module received `arg`; truncation happens at the first `#` anywhere |
| directive ending in `\` | joined with the next physical line; two lines executed as one |
| `\` plus trailing spaces | still continues |
| `\` at the end of a comment | does not continue; both lines ran |
| leading `-` with a missing module | rc=0, next module still runs |

## Source claims checked

| Claim | Evidence |
|---|---|
| kwallet-pam builds `pam_kwallet5.so` under Plasma 6 | `CMakeLists.txt` at 6.7.80: `set(library_name "pam_kwallet5")` |
| `auto_start` is not a kwallet option | `parseArguments` takes `kdehome=`, `kwalletd=`, `socketPath=`, `force_run`; the string appears 0 times in the source |
| kwallet prompts when the token is missing | `pam_sm_authenticate` calls `prompt_for_password()` |
| kwallet tolerates duplicate lines | `PAM_KWALLET5_LOGIN` re-entry guard on auth and open_session |
| `auto_start` is a gnome-keyring option | `ARG_AUTO_START` in `parse_args`; unknown options get `syslog("invalid option")` |
| gnome-keyring fails silently without a token | returns `PAM_SUCCESS`, no prompt |
| both modules need auth and session halves | `pam_set_data` in auth; only `open_session` acts on it |
| the GDM substack rename is unreleased | tags 45.0 through 50.1 and 51.alpha all ship `password-auth`; only `main` renames it, and the renamed file 404s there |
| Plasma's greeter has no fingerprint PAM service | `PamBackend.cpp` selects `plasmalogin`, `plasmalogin-greeter`, `plasmalogin-autologin` only |
| kscreenlocker's fingerprint triple is the lock screen | root CMake defines `kde`, `kde-fingerprint`, `kde-smartcard`; `pamauthenticators.cpp` runs them non-interactively |
| the daemon accepts `plasmalogin` for `UnsealKeyring` | `biopolicy::classify` returns Login or ScreenUnlock, both allowed |

## The wiring fixes

openSUSE routes its password through `auth substack common-auth`, a name the matcher did not know. Wiring fell back to the first auth line and put the jump above `pam_nologin.so`, so a face match skipped the nologin gate and still hit the password stack. Stack names are now kind-aware.

GDM's development branch renames its shared stack. Any `auth ... substack ...` line is now preferred over the first-line guess, whatever the stack is named. No released GDM is affected.

The GNOME fingerprint keyring unlock never wired: `wire_fp_keyring` matched a literal `pam_fprintd.so` line that GDM's `gdm-fingerprint.pam` does not contain, so the function silently wrote nothing. That file also carries no keyring module, so fixing the anchor alone would release a password nothing reads. Both halves are now supplied, tagged `# irlume-keyring` so unwiring removes exactly ours, with PAM's leading `-` so a machine without gnome-keyring logs nothing.

## Wrong-answer paths closed in later passes

`pam_gnome_keyring.so` accepts `only_if=<services>`. Outside that list every entry point returns `PAM_SUCCESS` immediately, so a gated line is present in the file and inert. Matching the module name alone counted it as a working consumer. The list is now evaluated per service, whole comma-separated items, the way gkr's `evaluate_inlist` does. authselect's own `fingerprint-auth` ships `only_if=login`, so this occurs on stock Fedora.

libpam strips a trailing `#` before tokenizing, and every matcher compared the raw line. A stack whose comment merely mentioned `pam_irlume.so` was treated as already wired, so `login enable` wrote nothing and reported success. All matchers now compare the directive part. The `# irlume-landing` and `# irlume-keyring` tags stay matched on the raw line; being comments is their purpose.

libpam joins a directive ending in `\` with the next physical line. irlume edits line by line, so inserting a stanza after a continued anchor would splice text into the middle of the logical line PAM evaluates. Continued files are now refused by the wiring transforms (staged, never written, the same contract as a missing anchor) and skipped by the advisory. `unwire` stays ungated because "disable undoes everything" is a documented promise.

The hand-off check anchored on the face `unseal` line only. A fingerprint-only box wires the greeter with just the `keyring` line, so a missing wallet module after a fingerprint login produced no warning. The anchor now matches the first credential-releasing line of either mode. This is also where the KDE cold-boot fingerprint-to-KWallet chain runs, and new tests pin the ordering on every upstream plasmalogin layout.

Fixture fidelity: diffing against freshly fetched upstream files found 4 of 8 had drifted, including a Debian file that had lost the directive `session required pam_env.so envfile=/etc/default/locale user_readenv=1`. All eight are now byte-for-byte upstream, with a sweep test.

## Scope

The hand-off check is read-only. `login status --json` is intercepted before `pamwire::run`, verified empirically. The wiring fixes change generated output only for stacks that previously hit the fallback guess or received nothing; Fedora, Arch, and Debian greeter output is byte-identical, pinned by the fixtures.

## Testing

38 wiring tests, 378 in `irlume-cli` across six targets. Every fix has a negative control: reverting it makes a named guard fail (`pam_nologin must still run before face auth`, `pam_selinux_permit must stay above our line`, `the substack must serve as the anchor`, the three `only_if=` tests, the three comment tests, the two continuation tests). End-to-end through the built binary: plasmalogin fedora/arch/debian 0 warnings, suse 1 (it ships no keyring module), gdm redhat/arch/renamed 0. Workspace failure totals match `main` at 50 (four crates fail for environmental reasons: missing ONNX models, and one test that assumes it is not running as root).

- [x] `cargo test --workspace`, clippy `-D warnings`, `fmt --check`, `doc -D warnings`
- [x] CHANGELOG and docs updated
- [ ] Hardware validation. The openSUSE anchor change and the fingerprint wiring have not run on real openSUSE or a real reader. Every face line stays `[success=1 default=ignore]`, so the password remains the floor.

On hardware:

```sh
irlume login status     # expect no warnings on stock Fedora/Arch/Debian, KDE or GNOME
grep -n 'pam_irlume\|pam_gnome_keyring' /etc/pam.d/gdm-fingerprint   # after enable
```

KDE fingerprint to wallet: enroll, `sudo irlume fingerprint enable`, reboot, touch the sensor at the greeter. KWallet should open without a prompt.

## The review round (`4b9c6b6`)

The single Codex round found two merge-blocking defects, both fixed in `4b9c6b6`:

- The vendor-override branch of `wire_service` discarded the transform's `changed` flag. A vendor stack the transform refused (a continued file, no anchor) was still materialized into `/etc` as an override carrying no irlume line, shadowing the vendor copy and reporting a checkmark while face login stayed off. The branch now refuses exactly as the edit-in-place branch always did, and a caller-level test proves no override file gets created on a refusal.
- `wire_fp_keyring` counted any active keyring line as a consumer of the released token, so a lone session line, a lone auth line, an auth line above the fprintd anchor, or a password-phase line each suppressed the tagged pair, and a fingerprint login could succeed with the wallet still locked. The check now requires one module holding both halves in working positions (auth below the anchor, session anywhere), the same per-module rule `keyring_handoff` reports by.

Three hand-applied mutants each made exactly the new tests fail: the override refusal disabled, the two halves OR-ed instead of AND-ed, and the anchor position ignored. A Copilot thread claimed `keyring_handoff` itself pairs halves across modules; the loop passes the auth line's own module to the session lookup and `a_split_handoff_across_two_modules_is_not_complete` pins the exact scenario, ran green, so the thread was answered and resolved rather than fixed.

Note for the stack: #201 splits `pamwire.rs` into modules from this branch's pre-fix state, so these two fixes must be carried through the split when #201 rebases.
