### PR TITLE
The Cameras screen routes camera-tune, saying what it costs first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to irlume are documented here. This project adheres to
 
 - **`camera-tune` is reachable from the TUI.** The Cameras screen gains `[t]`,
   which routes to `sudo irlume camera-tune` like the other privileged
-  one-shots — after saying up front that it holds the camera and fires the IR
+  one-shots, after saying up front that it holds the camera and fires the IR
   emitter for up to a minute and then persists the capture-mode verdict, since
   that materially changes how authentication captures frames afterwards. It
   was the one user-facing operation with no TUI route. Closes #170.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **`camera-tune` is reachable from the TUI.** The Cameras screen gains `[t]`,
+  which routes to `sudo irlume camera-tune` like the other privileged
+  one-shots — after saying up front that it holds the camera and fires the IR
+  emitter for up to a minute and then persists the capture-mode verdict, since
+  that materially changes how authentication captures frames afterwards. It
+  was the one user-facing operation with no TUI route. Closes #170.
+
 - **A dark or blinded IR capture reports what its evidence supports.** A dark
   burst used to get one hint ("no active emitter; run `sudo irlume ir-setup`")
   even though shutters, covers, range, exposure and emitter failures all

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2463,7 +2463,12 @@ impl App {
                 // schedule the suspend, which is the existing shape of every
                 // other consequential route here.
                 self.confirm = Some((
-                    "Tune capture mode? This holds the camera and fires the IR                      emitter for up to a minute, then stores the verdict in                      /etc/irlume/cameras.conf. Your password will be requested."
+                    concat!(
+                        "Tune capture mode? This holds the camera and fires the ",
+                        "IR emitter for up to a minute, then stores the verdict ",
+                        "in /etc/irlume/cameras.conf. Your password will be ",
+                        "requested."
+                    )
                         .into(),
                     "Tune",
                     ConfirmAct::Sus(Suspend::CameraTune),

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2454,8 +2454,20 @@ impl App {
             // path; only a measurement can tell which camera this is. Said
             // up front because it holds the camera for a while (#170).
             (SC_CAMERAS, KeyCode::Char('t')) => {
-                self.log('→', "sudo irlume camera-tune: measure whether RGB and IR can stream at once; holds the camera and fires the IR emitter for up to a minute, then stores the verdict in /etc/irlume/cameras.conf (you'll be asked for your password)");
-                self.suspend = Some(Suspend::CameraTune);
+                // A modal, not an Activity line: the log-then-suspend shape
+                // never RENDERS before the terminal leaves the alt screen (the
+                // frame was drawn before the key was read, and the suspend
+                // runs in the same loop iteration), so the explanation the
+                // route promises would appear only after the run (#204
+                // review). The confirm modal is drawn before any key can
+                // schedule the suspend, which is the existing shape of every
+                // other consequential route here.
+                self.confirm = Some((
+                    "Tune capture mode? This holds the camera and fires the IR                      emitter for up to a minute, then stores the verdict in                      /etc/irlume/cameras.conf. Your password will be requested."
+                        .into(),
+                    "Tune",
+                    ConfirmAct::Sus(Suspend::CameraTune),
+                ));
             }
             (SC_CAMERAS, KeyCode::Char('p')) => self.start_async(
                 "IR emitter units",
@@ -6493,16 +6505,38 @@ mod tests {
         assert!(matches!(app.suspend, Some(Suspend::IrSetup)));
         app.suspend = None;
         // [t] routes capture tuning to sudo (#170: previously no TUI route),
-        // and says what it will do before the suspend happens.
+        // through a confirm modal so the effects are RENDERED before anything
+        // can run: the first version logged an Activity line in the same loop
+        // iteration as the suspend, which never reached the screen (#204
+        // review), and its test read the in-memory vector, which could not
+        // notice.
         app.on_key(KeyCode::Char('t'));
-        assert!(matches!(app.suspend, Some(Suspend::CameraTune)));
         assert!(
-            app.activity
-                .iter()
-                .any(|(_, m)| m.contains("camera-tune") && m.contains("up to a minute")),
-            "the route must say what it does before running"
+            app.suspend.is_none(),
+            "[t] must show the effects before scheduling camera-tune"
         );
+        // The popup wraps its message at the box edge, so reflow the rendered
+        // text before asserting: borders become spaces, runs of whitespace
+        // collapse, and the phrases read as written regardless of wrap point.
+        let text = draw_text(&app);
+        let flat = text
+            .replace(['│', '╭', '╮', '╰', '╯', '─'], " ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            flat.contains("fires the IR emitter for up to a minute")
+                && flat.contains("/etc/irlume/cameras.conf")
+                && flat.contains("password will be requested"),
+            "the pre-run confirmation must render every material effect:\n{text}"
+        );
+        app.on_key(KeyCode::Char('y'));
+        assert!(matches!(app.suspend, Some(Suspend::CameraTune)));
         app.suspend = None;
+        // And [n] declines without scheduling anything.
+        app.on_key(KeyCode::Char('t'));
+        app.on_key(KeyCode::Char('n'));
+        assert!(app.suspend.is_none() && app.confirm.is_none());
         app.on_key(KeyCode::Char('p'));
         assert!(app.op.is_some(), "[p] starts the read-only emitter probe");
         wait_op_done(&mut app);

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -185,6 +185,12 @@ enum Suspend {
     SetCameras(String, String),
     /// Set up the IR emitter; root op, suspends to `sudo irlume ir-setup`.
     IrSetup,
+    /// Measure whether the camera can stream RGB and IR at once and persist
+    /// the verdict (capture policy changes with it). The daemon root-gates the
+    /// write, and the measurement holds the camera and fires the emitter for
+    /// up to a minute, so like the other privileged one-shots it suspends to
+    /// `sudo irlume camera-tune`.
+    CameraTune,
     /// View the face-auth journal (`sudo irlume logs`); the daemon's lines live
     /// in the system journal, so it runs under sudo to guarantee they show.
     Logs,
@@ -1972,6 +1978,10 @@ impl App {
                 &["irlume", "set-cameras", &rgb, &ir],
             ),
             Suspend::IrSetup => self.sudo_step("enable the IR emitter", &["irlume", "ir-setup"]),
+            Suspend::CameraTune => self.sudo_step(
+                "measure simultaneous RGB+IR capture",
+                &["irlume", "camera-tune"],
+            ),
             Suspend::BitwardenSetup => self.sudo_step(
                 "install Bitwarden's polkit action",
                 &["irlume", "bitwarden", "setup", "--apply"],
@@ -2438,6 +2448,14 @@ impl App {
             (SC_CAMERAS, KeyCode::Char('s')) => {
                 self.log('→', "sudo irlume ir-setup: set up the 850nm emitter; this writes to the camera (you'll be asked for your password)");
                 self.suspend = Some(Suspend::IrSetup);
+            }
+            // Capture-mode tuning: some Hello modules starve their own RGB
+            // interface when both stream, others keep the faster concurrent
+            // path; only a measurement can tell which camera this is. Said
+            // up front because it holds the camera for a while (#170).
+            (SC_CAMERAS, KeyCode::Char('t')) => {
+                self.log('→', "sudo irlume camera-tune: measure whether RGB and IR can stream at once; holds the camera and fires the IR emitter for up to a minute, then stores the verdict in /etc/irlume/cameras.conf (you'll be asked for your password)");
+                self.suspend = Some(Suspend::CameraTune);
             }
             (SC_CAMERAS, KeyCode::Char('p')) => self.start_async(
                 "IR emitter units",
@@ -3636,6 +3654,11 @@ impl App {
         lines.push(Line::from(vec![
             Span::styled("  [s]", Style::new().fg(th().accent)),
             Span::styled(" set up emitter   ", Style::new().dim()),
+            Span::styled("[t]", Style::new().fg(th().accent)),
+            Span::styled(
+                " tune capture (holds the camera ~1 min)   ",
+                Style::new().dim(),
+            ),
             Span::styled("[p]", Style::new().fg(th().accent)),
             Span::styled(" list units (writes nothing)", Style::new().dim()),
         ]));
@@ -6468,6 +6491,17 @@ mod tests {
         app.screen = SC_CAMERAS;
         app.on_key(KeyCode::Char('s'));
         assert!(matches!(app.suspend, Some(Suspend::IrSetup)));
+        app.suspend = None;
+        // [t] routes capture tuning to sudo (#170: previously no TUI route),
+        // and says what it will do before the suspend happens.
+        app.on_key(KeyCode::Char('t'));
+        assert!(matches!(app.suspend, Some(Suspend::CameraTune)));
+        assert!(
+            app.activity
+                .iter()
+                .any(|(_, m)| m.contains("camera-tune") && m.contains("up to a minute")),
+            "the route must say what it does before running"
+        );
         app.suspend = None;
         app.on_key(KeyCode::Char('p'));
         assert!(app.op.is_some(), "[p] starts the read-only emitter probe");


### PR DESCRIPTION
Closes #170. Based on `main`, independent of the other open PRs.

## What this does

`camera-tune` measures whether the camera can stream RGB and IR at once without starving its own RGB interface, and persists the verdict that capture policy follows. Per #170's parity audit it was the one user-facing operation with no TUI route.

`[t]` on the Cameras screen now suspends to `sudo irlume camera-tune`, the same shape as the neighbouring `[s]` ir-setup: the daemon root-gates `TuneCaptureMode`, so a direct socket call fails on peer uid, and `sudo_step` re-invokes the running binary rather than whatever `irlume` resolves to on PATH.

The issue's one behavioral requirement is that the route says what it does before running. It does, twice: the pre-suspend activity line states that it holds the camera and fires the IR emitter for up to a minute and then writes `/etc/irlume/cameras.conf`, and the footer hint reads `[t] tune capture (holds the camera ~1 min)`.

The issue's two recorded non-gaps (`credential-release-challenge` via Settings `[g]`, `selinux load` via Repair's conditional fix) were left alone, per its own analysis.

## Testing

The routing test drives `[t]` and asserts both halves: the suspend lands on `Suspend::CameraTune`, and the explanation was logged before the suspend.

- [x] `cargo test -p irlume-cli`: all six targets green (346 tests)
- [x] clippy `-D warnings`, `fmt --check`
- [x] CHANGELOG updated
- [ ] One interactive round-trip on a real terminal: Cameras, `[t]`, password, tune output, return to TUI. The suspend/resume path is the same one every other `sudo_step` route uses.