### PR TITLE
Record #101's candidate discriminator with the consent evidence, gating nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **The consent watch records the #101 candidate discriminator on every run.**
+  `mean_step` — mean absolute pitch change per adjacent frame pair, with
+  face-lost gaps contributing nothing — now rides in the nod evidence, the
+  consent debug line, and `blinkcap replay`'s per-label summary. It gates
+  nothing: #101 measured it separating a still head from a deliberate nod by
+  2.3x where the gating pitch range manages 1.44x, then deliberately declined
+  to set a threshold on one user's single session, because this class of
+  signal is known to drift between sessions. The blocker is cross-session
+  data; recording the metric with the rest of the evidence means every consent
+  watch and every replayed capture accumulates it, instead of only runs where
+  someone remembered the pose-series dump flag.
+
 - **A dark or blinded IR capture reports what its evidence supports.** A dark
   burst used to get one hint ("no active emitter; run `sudo irlume ir-setup`")
   even though shutters, covers, range, exposure and emitter failures all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,22 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
-- **The consent watch records the #101 candidate discriminator on every run.**
-  `mean_step` (mean absolute pitch change per adjacent frame pair, with
-  face-lost gaps contributing nothing) now rides in the nod evidence, the
-  consent debug line, and `blinkcap replay`'s per-label summary. It gates
-  nothing: #101 measured it separating a still head from a deliberate nod by
-  2.3x where the gating pitch range manages 1.44x, then deliberately declined
-  to set a threshold on one user's single session, because this class of
-  signal is known to drift between sessions. The blocker is cross-session
-  data; recording the metric with the rest of the evidence means every consent
-  watch and every replayed capture accumulates it, instead of only runs where
-  someone remembered the pose-series dump flag.
+- **Debug-enabled consent watches report the #101 candidate discriminator.**
+  `mean_step` (mean absolute pitch change per consecutive usable frame pair;
+  a face-lost frame or a missing frame index contributes nothing) now rides
+  in the nod evidence, the opt-in consent debug line (`IRLUME_LOG=debug`, off
+  by default; ordinary authentication runs still emit no diagnostic
+  evidence), and `blinkcap replay`'s per-label summary. It gates nothing:
+  #101 measured it separating a still head from a deliberate nod by 2.3x
+  where the gating pitch range manages 1.44x, then deliberately declined to
+  set a threshold on one user's single session, because this class of signal
+  is known to drift between sessions. The blocker is cross-session data, and
+  replay over recorded corpora is where that accumulates: replay now refuses
+  a damaged or truncated pose recording loudly instead of measuring its
+  fragments as a still head, accepts a single `.jsonl` file as documented
+  rather than only a directory, exits successfully on a pose-only corpus,
+  and captures are staged and renamed into place so a crash cannot leave a
+  valid header over a partial body.
 
 - **A dark or blinded IR capture reports what its evidence supports.** A dark
   burst used to get one hint ("no active emitter; run `sudo irlume ir-setup`")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to irlume are documented here. This project adheres to
 ### Added
 
 - **The consent watch records the #101 candidate discriminator on every run.**
-  `mean_step` — mean absolute pitch change per adjacent frame pair, with
-  face-lost gaps contributing nothing — now rides in the nod evidence, the
+  `mean_step` (mean absolute pitch change per adjacent frame pair, with
+  face-lost gaps contributing nothing) now rides in the nod evidence, the
   consent debug line, and `blinkcap replay`'s per-label summary. It gates
   nothing: #101 measured it separating a still head from a deliberate nod by
   2.3x where the gating pitch range manages 1.44x, then deliberately declined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to irlume are documented here. This project adheres to
 ### Added
 
 - **Debug-enabled consent watches report the #101 candidate discriminator.**
-  `mean_step` (mean absolute pitch change per consecutive usable frame pair;
-  a face-lost frame or a missing frame index contributes nothing) now rides
+  `mean_step` (mean absolute pitch change per frame: |Δpitch|/Δidx over
+  usable pairs at most one strobe apart, since IR modules light alternate
+  frames; a longer, face-lost gap contributes nothing) now rides
   in the nod evidence, the opt-in consent debug line (`IRLUME_LOG=debug`, off
   by default; ordinary authentication runs still emit no diagnostic
   evidence), and `blinkcap replay`'s per-label summary. It gates nothing:

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1561,7 +1561,8 @@ impl Engine {
             // naming a limit the run did not apply is worse than no line.
             irlume_common::dlog!(
                 "consent: {} in {} frames; nod evidence: usable_pitch_frames={} (need {}) \
-                 pitch_range={:.3} (need {:.3}) yaw_range={:.2} (max {:.2}) crossings={} (need {})",
+                 pitch_range={:.3} (need {:.3}) yaw_range={:.2} (max {:.2}) crossings={} (need {}) \
+                 mean_step={:.4} (recorded for #101, gates nothing)",
                 if hit == Some(true) {
                     "GESTURE ACCEPTED"
                 } else {
@@ -1576,6 +1577,7 @@ impl Engine {
                 irlume_liveness::NOD_YAW_MAX,
                 ev.crossings,
                 irlume_liveness::NOD_MIN_CROSSINGS,
+                ev.mean_step,
             );
         }
         Ok(hit == Some(true))

--- a/crates/irlume-cli/src/blinkcap.rs
+++ b/crates/irlume-cli/src/blinkcap.rs
@@ -183,15 +183,31 @@ struct RecordedPose {
     bri: f32,
 }
 
+/// Install a finished capture at `out` through a `.tmp` file in the same
+/// directory, synced before the rename. Writing the destination directly
+/// left a crash window where a valid header sat over a truncated body, and
+/// replay refuses such a file loudly; a capture killed mid-write must leave
+/// either the previous file or nothing. The `.tmp` suffix also keeps a
+/// leftover out of replay's `.jsonl` scan.
+fn install_capture(out: &str, contents: &str) -> irlume_common::Result<()> {
+    use std::io::Write;
+    let io = |e: std::io::Error| irlume_common::Error::Io(e.to_string());
+    let tmp = format!("{out}.tmp");
+    let mut f = std::fs::File::create(&tmp).map_err(io)?;
+    f.write_all(contents.as_bytes()).map_err(io)?;
+    f.sync_all().map_err(io)?;
+    std::fs::rename(&tmp, out).map_err(io)?;
+    Ok(())
+}
+
 fn write_pose_jsonl(
     out: &str,
     label: &str,
     samples: &[irlume_liveness::PoseSample],
 ) -> irlume_common::Result<()> {
-    use std::io::Write;
-    let mut f = std::fs::File::create(out).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+    use std::fmt::Write;
     let header = serde_json::json!({ "posecap": true, "label": label, "frames": samples.len() });
-    writeln!(f, "{header}").map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+    let mut contents = format!("{header}\n");
     for s in samples {
         let rec = RecordedPose {
             idx: s.idx,
@@ -199,15 +215,13 @@ fn write_pose_jsonl(
             yaw_signed: s.yaw_signed,
             bri: s.bri,
         };
-        writeln!(f, "{}", serde_json::to_string(&rec).unwrap())
-            .map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+        let _ = writeln!(contents, "{}", serde_json::to_string(&rec).unwrap());
     }
-    Ok(())
+    install_capture(out, &contents)
 }
 
 fn write_jsonl(out: &str, label: &str, samples: &[EarSample]) -> irlume_common::Result<()> {
-    use std::io::Write;
-    let mut f = std::fs::File::create(out).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+    use std::fmt::Write;
     let header = serde_json::json!({
         "blinkcap": true,
         "label": label,
@@ -215,13 +229,12 @@ fn write_jsonl(out: &str, label: &str, samples: &[EarSample]) -> irlume_common::
         "host": std::fs::read_to_string("/proc/sys/kernel/hostname")
             .unwrap_or_default().trim().to_string(),
     });
-    writeln!(f, "{header}").map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+    let mut contents = format!("{header}\n");
     for s in samples {
         let rec = RecordedSample::from(s);
-        writeln!(f, "{}", serde_json::to_string(&rec).unwrap())
-            .map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+        let _ = writeln!(contents, "{}", serde_json::to_string(&rec).unwrap());
     }
-    Ok(())
+    install_capture(out, &contents)
 }
 
 /// A loaded recording: its label and the samples the detectors consume.
@@ -255,30 +268,42 @@ fn load_recording(path: &Path) -> Option<Recording> {
     })
 }
 
-/// Run the head-nod detector over every pose (`--pose`) recording under `dir`
-/// and tally acceptance per label. Returns false if no pose recordings exist.
-fn replay_pose(dir: &Path) -> bool {
+/// Run the head-nod detector over `path` (one pose recording, or every pose
+/// recording under a directory) and tally acceptance per label.
+///
+/// `Ok(true)` means at least one pose recording replayed; `Ok(false)` means
+/// none of the files were pose recordings, which is not an error because
+/// blink recordings share the same directories and extension. A file whose
+/// header DECLARES it a pose recording and whose body then cannot be read in
+/// full is an `Err`, never a skip: a truncated capture replayed anyway reads
+/// as `mean_step 0.0` and sits in the per-label minimum exactly like a still
+/// head, and the cross-session corpus this output feeds (#101) cannot tell
+/// "observed no motion" from "failed to read the observation".
+fn replay_pose(path: &Path) -> Result<bool, String> {
     use irlume_liveness::{HeadGesture, PoseSample};
     use std::collections::BTreeMap;
-    let files: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
-        .map(|rd| {
-            rd.filter_map(|e| e.ok().map(|e| e.path()))
-                .filter(|p| p.extension().is_some_and(|x| x == "jsonl"))
-                .collect()
-        })
-        .unwrap_or_default();
+    let files: Vec<std::path::PathBuf> = if path.is_dir() {
+        let mut v: Vec<_> = std::fs::read_dir(path)
+            .map_err(|e| format!("{}: {e}", path.display()))?
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x == "jsonl"))
+            .collect();
+        v.sort();
+        v
+    } else {
+        vec![path.to_path_buf()]
+    };
     let mut tally: BTreeMap<String, (usize, usize, f32, f32)> = BTreeMap::new();
     let mut any = false;
     for path in files {
-        let Ok(text) = std::fs::read_to_string(&path) else {
-            continue;
-        };
+        let text =
+            std::fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;
         let mut lines = text.lines();
         let Some(header) = lines
             .next()
             .and_then(|l| serde_json::from_str::<serde_json::Value>(l).ok())
         else {
-            continue;
+            continue; // no parseable header: not a recording of any kind
         };
         if header.get("posecap").and_then(|v| v.as_bool()) != Some(true) {
             continue; // not a pose recording
@@ -289,15 +314,42 @@ fn replay_pose(dir: &Path) -> bool {
             .and_then(|v| v.as_str())
             .unwrap_or("unlabeled")
             .to_string();
-        let samples: Vec<PoseSample> = lines
-            .filter_map(|l| serde_json::from_str::<RecordedPose>(l).ok())
-            .map(|r| PoseSample {
+        // Strict from here down. Every posecap header ever written carries
+        // "frames" (the field predates this check), so a mismatch or an
+        // unparseable record is a damaged file, and damage is reported, not
+        // measured.
+        let expected = header
+            .get("frames")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .ok_or_else(|| {
+                format!(
+                    "{}: posecap header has no valid 'frames' count",
+                    path.display()
+                )
+            })?;
+        let mut samples: Vec<PoseSample> = Vec::new();
+        for (i, line) in lines.enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let r: RecordedPose = serde_json::from_str(line)
+                .map_err(|e| format!("{}:{}: invalid pose record: {e}", path.display(), i + 2))?;
+            samples.push(PoseSample {
                 idx: r.idx,
                 pitch_frac: r.pitch_frac,
                 yaw_signed: r.yaw_signed,
                 bri: r.bri,
-            })
-            .collect();
+            });
+        }
+        if samples.len() != expected {
+            return Err(format!(
+                "{}: header declares {expected} frames but {} were read; refusing to \
+                 measure a partial capture",
+                path.display(),
+                samples.len()
+            ));
+        }
         let e = tally
             .entry(label)
             .or_insert((0usize, 0usize, f32::INFINITY, f32::NEG_INFINITY));
@@ -320,7 +372,7 @@ fn replay_pose(dir: &Path) -> bool {
         }
         println!("\n  A nod should be accepted; still / look-around / reclined-still should not.");
     }
-    any
+    Ok(any)
 }
 
 fn replay(args: &[String]) -> ExitCode {
@@ -330,10 +382,17 @@ fn replay(args: &[String]) -> ExitCode {
         return ExitCode::from(2);
     };
     let path = Path::new(target);
-    // Pose (head-nod) recordings replay through their own detector.
-    if path.is_dir() && replay_pose(path) {
-        // Fall through to the blink/closure replay too if any of those exist.
-    }
+    // Pose (head-nod) recordings replay through their own detector; a single
+    // .jsonl argument can be either kind, so the pose pass sees files too. A
+    // damaged pose recording fails the whole replay rather than shrinking the
+    // corpus silently.
+    let pose_found = match replay_pose(path) {
+        Ok(found) => found,
+        Err(e) => {
+            eprintln!("[blinkcap] {e}");
+            return ExitCode::FAILURE;
+        }
+    };
     let mut files: Vec<std::path::PathBuf> = if path.is_dir() {
         let mut v: Vec<_> = std::fs::read_dir(path)
             .map(|rd| {
@@ -350,7 +409,12 @@ fn replay(args: &[String]) -> ExitCode {
     files.sort();
     let recordings: Vec<Recording> = files.iter().filter_map(|p| load_recording(p)).collect();
     if recordings.is_empty() {
-        eprintln!("[blinkcap] no blinkcap recordings found at {target}");
+        // A pose-only corpus is a successful replay: its summary printed
+        // above, and there was never a blink recording to miss.
+        if pose_found {
+            return ExitCode::SUCCESS;
+        }
+        eprintln!("[blinkcap] no blinkcap or posecap recordings found at {target}");
         return ExitCode::FAILURE;
     }
 

--- a/crates/irlume-cli/src/blinkcap.rs
+++ b/crates/irlume-cli/src/blinkcap.rs
@@ -258,7 +258,7 @@ fn load_recording(path: &Path) -> Option<Recording> {
 /// Run the head-nod detector over every pose (`--pose`) recording under `dir`
 /// and tally acceptance per label. Returns false if no pose recordings exist.
 fn replay_pose(dir: &Path) -> bool {
-    use irlume_liveness::{detect_nod, HeadGesture, PoseSample};
+    use irlume_liveness::{HeadGesture, PoseSample};
     use std::collections::BTreeMap;
     let files: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
         .map(|rd| {
@@ -267,7 +267,7 @@ fn replay_pose(dir: &Path) -> bool {
                 .collect()
         })
         .unwrap_or_default();
-    let mut tally: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    let mut tally: BTreeMap<String, (usize, usize, f32, f32)> = BTreeMap::new();
     let mut any = false;
     for path in files {
         let Ok(text) = std::fs::read_to_string(&path) else {
@@ -298,16 +298,25 @@ fn replay_pose(dir: &Path) -> bool {
                 bri: r.bri,
             })
             .collect();
-        let e = tally.entry(label).or_default();
+        let e = tally
+            .entry(label)
+            .or_insert((0usize, 0usize, f32::INFINITY, f32::NEG_INFINITY));
         e.1 += 1;
-        if detect_nod(&samples) == HeadGesture::Nod {
+        // Verdict and evidence from the same call, so the replayed corpus
+        // accumulates the #101 shadow metric alongside the accept rate: the
+        // per-label mean_step spread is exactly the cross-session data that
+        // issue is blocked on, and old recordings are sessions too.
+        let (verdict, ev) = irlume_liveness::detect_nod_with_evidence(&samples);
+        if verdict == HeadGesture::Nod {
             e.0 += 1;
         }
+        e.2 = e.2.min(ev.mean_step);
+        e.3 = e.3.max(ev.mean_step);
     }
     if any {
         println!("== head-nod acceptance (detect_nod) by label ==");
-        for (label, (acc, total)) in &tally {
-            println!("  {label:<16} {acc}/{total}");
+        for (label, (acc, total, lo, hi)) in &tally {
+            println!("  {label:<16} {acc}/{total}   mean_step {lo:.4}..{hi:.4} (#101, not gating)");
         }
         println!("\n  A nod should be accepted; still / look-around / reclined-still should not.");
     }

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1646,3 +1646,91 @@ esac"#,
         _ => {} // unknown family resolves to Source, covered elsewhere
     }
 }
+
+/// A pose recording exactly as `write_pose_jsonl` lays it out: a posecap
+/// header declaring `frames`, then one record per line with consecutive idx.
+fn write_pose_recording(path: &std::path::Path, label: &str, pitches: &[f32]) {
+    let mut s = format!(
+        "{{\"posecap\":true,\"label\":\"{label}\",\"frames\":{}}}\n",
+        pitches.len()
+    );
+    for (i, p) in pitches.iter().enumerate() {
+        s.push_str(&format!(
+            "{{\"idx\":{i},\"pitch_frac\":{p},\"yaw_signed\":0.0,\"bri\":100.0}}\n"
+        ));
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+#[test]
+fn blinkcap_replay_accepts_a_single_pose_file_and_a_pose_only_dir() {
+    let sb = Sandbox::new("bc-pose-ok");
+    let file = sb.path("work").join("nod-01.jsonl");
+    // Steps 0.02, 0.03, 0.01 over consecutive idx: mean_step 0.0200. The
+    // exact figure in stdout pins the whole path (parse, idx pairing, tally).
+    write_pose_recording(&file, "nod", &[0.50, 0.52, 0.55, 0.54]);
+
+    // One pose FILE: the usage line advertises <file.jsonl | dir>, and a
+    // file used to bypass the pose replay entirely and then exit 1.
+    let (code, out, err) = run(sb
+        .cmd(&["blinkcap", "replay", file.to_str().unwrap()])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(
+        code, 0,
+        "single pose file must replay and exit 0; stderr: {err}"
+    );
+    assert!(out.contains("mean_step 0.0200..0.0200"), "{out}");
+
+    // A pose-only directory: the summary used to print and the exit code
+    // still said FAILURE, so a script could not trust a successful replay.
+    let dir = sb.path("work");
+    let (code, out, err) = run(sb
+        .cmd(&["blinkcap", "replay", dir.to_str().unwrap()])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 0, "pose-only dir must exit 0; stderr: {err}");
+    assert!(out.contains("head-nod acceptance"), "{out}");
+}
+
+#[test]
+fn blinkcap_replay_refuses_damaged_pose_recordings_loudly() {
+    let sb = Sandbox::new("bc-pose-bad");
+    let dir = sb.path("work");
+    write_pose_recording(&dir.join("nod-01.jsonl"), "nod", &[0.50, 0.52, 0.55]);
+
+    // A crash-truncated capture: valid header, no body. Replaying it would
+    // score an unread observation as a perfectly still head (mean_step 0.0)
+    // in the same summary as real sessions, so the whole replay must refuse,
+    // even though a healthy recording sits in the same directory.
+    std::fs::write(
+        dir.join("trunc.jsonl"),
+        "{\"posecap\":true,\"label\":\"nod\",\"frames\":3}\n",
+    )
+    .unwrap();
+    let (code, out, err) = run(sb
+        .cmd(&["blinkcap", "replay", dir.to_str().unwrap()])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1, "a truncated pose recording must fail the replay");
+    assert!(err.contains("declares 3 frames"), "stderr: {err}");
+    assert!(
+        !out.contains("head-nod acceptance"),
+        "no summary may print over a damaged corpus: {out}"
+    );
+
+    // A malformed record inside a file that declares the right count.
+    std::fs::write(
+        dir.join("trunc.jsonl"),
+        "{\"posecap\":true,\"label\":\"nod\",\"frames\":2}\n\
+         {\"idx\":0,\"pitch_frac\":0.5,\"yaw_signed\":0.0,\"bri\":100.0}\n\
+         {\"idx\":1,\"pitch_frac\":BROKEN\n",
+    )
+    .unwrap();
+    let (code, _out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "replay",
+            dir.join("trunc.jsonl").to_str().unwrap(),
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1, "a malformed pose record must fail the replay");
+    assert!(err.contains("invalid pose record"), "stderr: {err}");
+}

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -668,6 +668,23 @@ pub struct NodEvidence {
     pub yaw_range: f32,
     /// Median crossings of sufficient amplitude, against [`NOD_MIN_CROSSINGS`].
     pub crossings: usize,
+    /// Mean absolute pitch change per frame, over ADJACENT frame pairs where
+    /// both readings exist (a face-lost gap contributes nothing, rather than a
+    /// fake jump across it).
+    ///
+    /// RECORDED, NEVER GATING. This is the candidate discriminator #101 left
+    /// on the table: measured there once, it separated a still head from a
+    /// deliberate nod by 2.3x (still at most 0.0064, nods at least 0.0149)
+    /// where the gating `pitch_range` manages 1.44x — but those numbers come
+    /// from one user in one session, and the same thread documents this class
+    /// of signal drifting across sessions (genuine nods at 0.057 in one
+    /// campaign, 0.082 weakest in another). The issue's recorded blocker is
+    /// cross-session data; this field exists so every consent watch and every
+    /// replayed capture accumulates it with the rest of the evidence, instead
+    /// of only the runs where someone remembered IRLUME_DUMP_POSE_SERIES.
+    /// Turning it into a threshold is #101's call to make on that data, not
+    /// this field's.
+    pub mean_step: f32,
 }
 
 /// [`detect_nod`], plus the measurements behind the verdict.
@@ -695,6 +712,15 @@ pub fn detect_nod_with_evidence(samples: &[PoseSample]) -> (HeadGesture, NodEvid
         }
     };
     let pitch_range = range(&pitch);
+    // Adjacent SAMPLES, not adjacent survivors of the filter above: pairing the
+    // filtered vector would read a step across a face-lost gap as one frame's
+    // motion and inflate the very statistic this exists to record faithfully.
+    let (step_sum, step_n) = samples.windows(2).fold((0.0f32, 0usize), |acc, w| {
+        match (w[0].pitch_frac, w[1].pitch_frac) {
+            (Some(a), Some(b)) => (acc.0 + (b - a).abs(), acc.1 + 1),
+            _ => acc,
+        }
+    });
     let evidence = NodEvidence {
         frames: pitch.len(),
         pitch_range,
@@ -704,6 +730,11 @@ pub fn detect_nod_with_evidence(samples: &[PoseSample]) -> (HeadGesture, NodEvid
             0
         } else {
             nod_crossings(&pitch, pitch_range)
+        },
+        mean_step: if step_n == 0 {
+            0.0
+        } else {
+            step_sum / step_n as f32
         },
     };
     let verdict = if evidence.frames < NOD_MIN_FACE_FRAMES {
@@ -1908,6 +1939,49 @@ mod nod_evidence_tests {
         assert!(ev.pitch_range >= ev.pitch_min);
         assert!(ev.yaw_range <= NOD_YAW_MAX);
         assert!(ev.crossings >= NOD_MIN_CROSSINGS);
+    }
+
+    /// `mean_step` is the #101 shadow metric: recorded with the verdict,
+    /// never part of it. Pin the arithmetic — mean |Δpitch| over ADJACENT
+    /// pairs with both readings — and the gap rule that keeps it honest: a
+    /// face-lost frame contributes no pair, rather than a fake jump across
+    /// the gap. The measured populations that motivated it (still ≤0.0064,
+    /// nods ≥0.0149) are provenance in the field's docs, deliberately NOT
+    /// asserted here: one session's numbers are not a contract.
+    #[test]
+    fn mean_step_is_recorded_per_adjacent_pair_and_skips_gaps() {
+        // Known arithmetic: steps 0.02, 0.03, 0.01 → mean 0.02.
+        let (_, ev) = detect_nod_with_evidence(&samples(&[0.50, 0.52, 0.55, 0.54]));
+        assert!((ev.mean_step - 0.02).abs() < 1e-6, "got {}", ev.mean_step);
+
+        // A None gap breaks adjacency: the 0.50→0.60 jump spans the gap and
+        // must NOT count as one frame's motion. Pairs left: none.
+        let mut gappy = samples(&[0.50, 0.60]);
+        gappy.insert(
+            1,
+            PoseSample {
+                idx: 1,
+                pitch_frac: None,
+                yaw_signed: None,
+                bri: 0.0,
+            },
+        );
+        let (_, ev) = detect_nod_with_evidence(&gappy);
+        assert_eq!(ev.mean_step, 0.0, "a gap-spanning jump is not a step");
+
+        // Empty and single-frame windows have no pairs: 0.0, not NaN.
+        assert_eq!(detect_nod_with_evidence(&[]).1.mean_step, 0.0);
+        assert_eq!(detect_nod_with_evidence(&samples(&[0.5])).1.mean_step, 0.0);
+
+        // Directional sanity on the shapes the gate already models: the nod
+        // series moves more per frame than the still series. Relative order
+        // only — no absolute floor, that is #101's threshold call to make.
+        let nod = [
+            0.53, 0.55, 0.60, 0.63, 0.58, 0.52, 0.51, 0.55, 0.62, 0.64, 0.57, 0.52, 0.53, 0.56,
+        ];
+        let nod_step = detect_nod_with_evidence(&samples(&nod)).1.mean_step;
+        let still_step = detect_nod_with_evidence(&samples(&[0.5; 20])).1.mean_step;
+        assert!(nod_step > still_step);
     }
 
     /// The whole value of the evidence is that it describes the gate that

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -668,9 +668,11 @@ pub struct NodEvidence {
     pub yaw_range: f32,
     /// Median crossings of sufficient amplitude, against [`NOD_MIN_CROSSINGS`].
     pub crossings: usize,
-    /// Mean absolute pitch change per frame, over ADJACENT frame pairs where
-    /// both readings exist (a face-lost gap contributes nothing, rather than a
-    /// fake jump across it).
+    /// Mean absolute pitch change per frame, over CONSECUTIVE frame pairs
+    /// (`idx` differing by exactly one) where both readings exist. A face-lost
+    /// gap contributes nothing, and so does a missing frame index: a sample
+    /// dropped before this function sees it must not turn a two-frame move
+    /// into one frame's motion.
     ///
     /// RECORDED, NEVER GATING. This is the candidate discriminator #101 left
     /// on the table: measured there once, it separated a still head from a
@@ -679,11 +681,14 @@ pub struct NodEvidence {
     /// from one user in one session, and the same thread documents this class
     /// of signal drifting across sessions (genuine nods at 0.057 in one
     /// campaign, 0.082 weakest in another). The issue's recorded blocker is
-    /// cross-session data; this field exists so every consent watch and every
-    /// replayed capture accumulates it with the rest of the evidence, instead
-    /// of only the runs where someone remembered IRLUME_DUMP_POSE_SERIES.
-    /// Turning it into a threshold is #101's call to make on that data, not
-    /// this field's.
+    /// cross-session data; this field rides in the evidence so debug-enabled
+    /// consent watches (`IRLUME_LOG=debug`, the same opt-in as every other
+    /// diagnostic line) and validated replay captures report it without
+    /// anyone remembering IRLUME_DUMP_POSE_SERIES. An ordinary authentication
+    /// run computes it and discards it with the rest of the evidence; making
+    /// it durable everywhere would need the storage and access-control design
+    /// the anti-oracle logging policy exists to force. Turning it into a
+    /// threshold is #101's call to make on that data, not this field's.
     pub mean_step: f32,
 }
 
@@ -712,12 +717,19 @@ pub fn detect_nod_with_evidence(samples: &[PoseSample]) -> (HeadGesture, NodEvid
         }
     };
     let pitch_range = range(&pitch);
-    // Adjacent SAMPLES, not adjacent survivors of the filter above: pairing the
-    // filtered vector would read a step across a face-lost gap as one frame's
-    // motion and inflate the very statistic this exists to record faithfully.
+    // Adjacent FRAMES, not adjacent elements of the vector: `windows(2)` pairs
+    // whatever sits next to each other, and a sample dropped upstream (a
+    // record replay could not parse, a frame a caller filtered out) leaves
+    // `idx` 10 beside `idx` 12. Pairing those would read a two-frame move as
+    // one frame's motion and inflate the very statistic this exists to record
+    // faithfully, so a pair only counts when the indices are consecutive AND
+    // both readings exist and are finite.
     let (step_sum, step_n) = samples.windows(2).fold((0.0f32, 0usize), |acc, w| {
-        match (w[0].pitch_frac, w[1].pitch_frac) {
-            (Some(a), Some(b)) => (acc.0 + (b - a).abs(), acc.1 + 1),
+        let consecutive = w[0].idx.checked_add(1) == Some(w[1].idx);
+        match (consecutive, w[0].pitch_frac, w[1].pitch_frac) {
+            (true, Some(a), Some(b)) if a.is_finite() && b.is_finite() => {
+                (acc.0 + (b - a).abs(), acc.1 + 1)
+            }
             _ => acc,
         }
     });
@@ -1956,18 +1968,68 @@ mod nod_evidence_tests {
 
         // A None gap breaks adjacency: the 0.50→0.60 jump spans the gap and
         // must NOT count as one frame's motion. Pairs left: none.
-        let mut gappy = samples(&[0.50, 0.60]);
-        gappy.insert(
-            1,
+        let gappy = vec![
+            PoseSample {
+                idx: 0,
+                pitch_frac: Some(0.50),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
             PoseSample {
                 idx: 1,
                 pitch_frac: None,
                 yaw_signed: None,
                 bri: 0.0,
             },
-        );
+            PoseSample {
+                idx: 2,
+                pitch_frac: Some(0.60),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
+        ];
         let (_, ev) = detect_nod_with_evidence(&gappy);
         assert_eq!(ev.mean_step, 0.0, "a gap-spanning jump is not a step");
+
+        // A missing frame INDEX breaks adjacency the same way: these samples
+        // sit next to each other in the vector but two frames apart in time,
+        // the shape left behind when something upstream drops one frame.
+        let sparse = vec![
+            PoseSample {
+                idx: 10,
+                pitch_frac: Some(0.50),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
+            PoseSample {
+                idx: 12,
+                pitch_frac: Some(0.60),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
+        ];
+        assert_eq!(
+            detect_nod_with_evidence(&sparse).1.mean_step,
+            0.0,
+            "nonconsecutive frame indices must not form a step"
+        );
+
+        // And the adjacency check itself must not overflow on a hostile idx.
+        let wrap = vec![
+            PoseSample {
+                idx: usize::MAX,
+                pitch_frac: Some(0.50),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
+            PoseSample {
+                idx: 0,
+                pitch_frac: Some(0.60),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
+        ];
+        assert_eq!(detect_nod_with_evidence(&wrap).1.mean_step, 0.0);
 
         // Empty and single-frame windows have no pairs: 0.0, not NaN.
         assert_eq!(detect_nod_with_evidence(&[]).1.mean_step, 0.0);

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -675,7 +675,7 @@ pub struct NodEvidence {
     /// RECORDED, NEVER GATING. This is the candidate discriminator #101 left
     /// on the table: measured there once, it separated a still head from a
     /// deliberate nod by 2.3x (still at most 0.0064, nods at least 0.0149)
-    /// where the gating `pitch_range` manages 1.44x — but those numbers come
+    /// where the gating `pitch_range` manages 1.44x. Those numbers come
     /// from one user in one session, and the same thread documents this class
     /// of signal drifting across sessions (genuine nods at 0.057 in one
     /// campaign, 0.082 weakest in another). The issue's recorded blocker is
@@ -1942,8 +1942,8 @@ mod nod_evidence_tests {
     }
 
     /// `mean_step` is the #101 shadow metric: recorded with the verdict,
-    /// never part of it. Pin the arithmetic — mean |Δpitch| over ADJACENT
-    /// pairs with both readings — and the gap rule that keeps it honest: a
+    /// never part of it. Pin the arithmetic (mean |Δpitch| over ADJACENT
+    /// pairs with both readings) and the gap rule that keeps it honest: a
     /// face-lost frame contributes no pair, rather than a fake jump across
     /// the gap. The measured populations that motivated it (still ≤0.0064,
     /// nods ≥0.0149) are provenance in the field's docs, deliberately NOT
@@ -1975,7 +1975,7 @@ mod nod_evidence_tests {
 
         // Directional sanity on the shapes the gate already models: the nod
         // series moves more per frame than the still series. Relative order
-        // only — no absolute floor, that is #101's threshold call to make.
+        // only; no absolute floor, that is #101's threshold call to make.
         let nod = [
             0.53, 0.55, 0.60, 0.63, 0.58, 0.52, 0.51, 0.55, 0.62, 0.64, 0.57, 0.52, 0.53, 0.56,
         ];

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -668,11 +668,13 @@ pub struct NodEvidence {
     pub yaw_range: f32,
     /// Median crossings of sufficient amplitude, against [`NOD_MIN_CROSSINGS`].
     pub crossings: usize,
-    /// Mean absolute pitch change per frame, over CONSECUTIVE frame pairs
-    /// (`idx` differing by exactly one) where both readings exist. A face-lost
-    /// gap contributes nothing, and so does a missing frame index: a sample
-    /// dropped before this function sees it must not turn a two-frame move
-    /// into one frame's motion.
+    /// Mean absolute pitch change PER FRAME: |Δpitch| / Δidx over pairs of
+    /// usable samples whose recorded frame indices differ by 1 (plain
+    /// cadence) or 2 (strobe cadence; the ASUS module lights alternate
+    /// frames, so live captures there have every usable pair at gap 2). The
+    /// division keeps a strobe pair a rate rather than a double step, so a
+    /// gap cannot inflate the metric, and a gap longer than 2 (face lost,
+    /// detection loss) contributes nothing.
     ///
     /// RECORDED, NEVER GATING. This is the candidate discriminator #101 left
     /// on the table: measured there once, it separated a still head from a
@@ -717,20 +719,36 @@ pub fn detect_nod_with_evidence(samples: &[PoseSample]) -> (HeadGesture, NodEvid
         }
     };
     let pitch_range = range(&pitch);
-    // Adjacent FRAMES, not adjacent elements of the vector: `windows(2)` pairs
-    // whatever sits next to each other, and a sample dropped upstream (a
-    // record replay could not parse, a frame a caller filtered out) leaves
-    // `idx` 10 beside `idx` 12. Pairing those would read a two-frame move as
-    // one frame's motion and inflate the very statistic this exists to record
-    // faithfully, so a pair only counts when the indices are consecutive AND
-    // both readings exist and are finite.
-    let (step_sum, step_n) = samples.windows(2).fold((0.0f32, 0usize), |acc, w| {
-        let consecutive = w[0].idx.checked_add(1) == Some(w[1].idx);
-        match (consecutive, w[0].pitch_frac, w[1].pitch_frac) {
-            (true, Some(a), Some(b)) if a.is_finite() && b.is_finite() => {
-                (acc.0 + (b - a).abs(), acc.1 + 1)
-            }
-            _ => acc,
+    // A per-FRAME rate over usable pairs at most one strobe apart, keyed on
+    // the recorded frame index, not vector position. Three constraints shaped
+    // this, each learned the hard way:
+    //
+    //   * position-based pairing let a sample dropped upstream turn a
+    //     two-frame move into one frame's motion (the review round's finding);
+    //   * requiring idx to differ by exactly 1 then zeroed the metric on real
+    //     hardware: the ASUS module strobes alternate frames, so a live 75-
+    //     frame take had 38 usable samples and ALL 37 usable pairs at gap 2
+    //     (measured 2026-08-01, nod and still takes both);
+    //   * dividing |Δpitch| by the gap keeps a strobe pair a per-frame rate
+    //     instead of a double step, so a gap CANNOT inflate the metric.
+    //
+    // Gap 1 is plain cadence, gap 2 is strobe cadence (or one dropped frame,
+    // indistinguishable and equally honest once normalized); anything longer
+    // is a detection loss and contributes nothing, which is the face-lost
+    // rule the field documentation promises. On those live takes this reads
+    // nod 0.0116 against still 0.0018.
+    let usable: Vec<(usize, f32)> = samples
+        .iter()
+        .filter_map(|s| s.pitch_frac.filter(|p| p.is_finite()).map(|p| (s.idx, p)))
+        .collect();
+    let (step_sum, step_n) = usable.windows(2).fold((0.0f32, 0usize), |acc, w| {
+        // saturating_sub: a disordered or duplicate idx yields gap 0 and is
+        // skipped rather than wrapping into a huge divisor.
+        let gap = w[1].0.saturating_sub(w[0].0);
+        if (1..=2).contains(&gap) {
+            (acc.0 + (w[1].1 - w[0].1).abs() / gap as f32, acc.1 + 1)
+        } else {
+            acc
         }
     });
     let evidence = NodEvidence {
@@ -1954,12 +1972,13 @@ mod nod_evidence_tests {
     }
 
     /// `mean_step` is the #101 shadow metric: recorded with the verdict,
-    /// never part of it. Pin the arithmetic (mean |Δpitch| over ADJACENT
-    /// pairs with both readings) and the gap rule that keeps it honest: a
-    /// face-lost frame contributes no pair, rather than a fake jump across
-    /// the gap. The measured populations that motivated it (still ≤0.0064,
-    /// nods ≥0.0149) are provenance in the field's docs, deliberately NOT
-    /// asserted here: one session's numbers are not a contract.
+    /// never part of it. Pin the arithmetic (|Δpitch| / Δidx over usable
+    /// pairs at gap 1 or 2) and the two rules that keep it honest: a strobe
+    /// pair is normalized to a per-frame rate rather than inflated, and a
+    /// longer gap (face lost) contributes nothing. The measured populations
+    /// that motivated it (still ≤0.0064, nods ≥0.0149) are provenance in the
+    /// field's docs, deliberately NOT asserted here: one session's numbers
+    /// are not a contract.
     #[test]
     fn mean_step_is_recorded_per_adjacent_pair_and_skips_gaps() {
         // Known arithmetic: steps 0.02, 0.03, 0.01 → mean 0.02.
@@ -1988,12 +2007,21 @@ mod nod_evidence_tests {
                 bri: 100.0,
             },
         ];
+        // One missing frame is the strobe shape (the ASUS lights alternate
+        // frames; a live 75-frame take had all 37 usable pairs at gap 2), so
+        // this pair COUNTS, normalized: (0.60-0.50)/2, a per-frame rate. The
+        // division is the load-bearing assertion: unnormalized it would read
+        // 0.10 and a gap would inflate the metric.
         let (_, ev) = detect_nod_with_evidence(&gappy);
-        assert_eq!(ev.mean_step, 0.0, "a gap-spanning jump is not a step");
+        assert!(
+            (ev.mean_step - 0.05).abs() < 1e-6,
+            "a strobe pair is one per-frame rate, got {}",
+            ev.mean_step
+        );
 
-        // A missing frame INDEX breaks adjacency the same way: these samples
-        // sit next to each other in the vector but two frames apart in time,
-        // the shape left behind when something upstream drops one frame.
+        // Two samples two frames apart with nothing between them read the
+        // same as the strobe case above: gap alone cannot say whether a frame
+        // was dark or dropped, and normalization makes both readings honest.
         let sparse = vec![
             PoseSample {
                 idx: 10,
@@ -2008,13 +2036,53 @@ mod nod_evidence_tests {
                 bri: 100.0,
             },
         ];
-        assert_eq!(
-            detect_nod_with_evidence(&sparse).1.mean_step,
-            0.0,
-            "nonconsecutive frame indices must not form a step"
+        let sparse_step = detect_nod_with_evidence(&sparse).1.mean_step;
+        assert!(
+            (sparse_step - 0.05).abs() < 1e-6,
+            "a gap-2 pair must be normalized, never a full step, got {sparse_step}"
         );
 
-        // And the adjacency check itself must not overflow on a hostile idx.
+        // A LONGER gap is a detection loss and contributes nothing: the
+        // face-lost rule the field documentation promises.
+        let lost = vec![
+            PoseSample {
+                idx: 0,
+                pitch_frac: Some(0.50),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
+            PoseSample {
+                idx: 4,
+                pitch_frac: Some(0.60),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            },
+        ];
+        assert_eq!(
+            detect_nod_with_evidence(&lost).1.mean_step,
+            0.0,
+            "a face-lost gap must not form a step"
+        );
+
+        // A strobed series end to end: gaps of 2 throughout, steps 0.02,
+        // 0.03, 0.01 across pairs → per-frame mean 0.02 / 2 = 0.01.
+        let strobed: Vec<PoseSample> = [0.50f32, 0.52, 0.55, 0.54]
+            .iter()
+            .enumerate()
+            .map(|(i, &p)| PoseSample {
+                idx: i * 2,
+                pitch_frac: Some(p),
+                yaw_signed: Some(0.0),
+                bri: 100.0,
+            })
+            .collect();
+        let strobed_step = detect_nod_with_evidence(&strobed).1.mean_step;
+        assert!(
+            (strobed_step - 0.01).abs() < 1e-6,
+            "a strobed take must read as per-frame rates, got {strobed_step}"
+        );
+
+        // And the gap arithmetic must not overflow on a hostile idx.
         let wrap = vec![
             PoseSample {
                 idx: usize::MAX,


### PR DESCRIPTION
Advances #101 and deliberately does not close it. Based on `main`, independent of the other open PRs.

## Where #101 stands, per its own thread

The original complaint (no signal for when to nod) is fixed by the pre-match watch, the "keep nodding" wording, #136, and #140. Print resistance moved to #25 after measurement showed a hand-held print physically performs the gesture. What keeps #101 open is consent without intent: the gate fired on a still, non-consenting user 2 times in 18.

The thread measured a candidate discriminator for that case. Mean per-frame pitch step separated still from nod by 2.3x (still at most 0.0064, nods at least 0.0149) where the gating `pitch_range` manages 1.44x. The thread then declined to ship a threshold from one user's single session, citing measured cross-session drift: genuine nods at 0.057 in one campaign against 0.082 weakest in another. The recorded blocker is more subjects and more sessions.

## What this PR is

The collection path for that data, not the threshold.

`NodEvidence` gains `mean_step`, computed over consecutive frame pairs: both pitch readings must exist, be finite, and sit at `idx` values exactly one apart. The review round showed the original adjacency rule was positional, so two samples left neighbouring by an upstream drop (idx 10 beside idx 12) read a two-frame move as one frame's motion; pairing now keys on the recorded frame index and a sparse series measures 0.0. The consent evidence debug line carries the value on accepts and refusals under `IRLUME_LOG=debug`, the same opt-in as every other diagnostic line; ordinary authentication runs compute and discard it, and the docs now say that instead of claiming every watch records it. `blinkcap replay` summarizes it per label, so existing recorded corpora count as sessions too.

Nothing reads the field in a verdict. Its docs quote the one-session populations as provenance, state they are not a contract, and name the threshold decision as #101's to make on the accumulated data.

## What the review round did to replay (`b490002`)

The corpus is only as honest as its reader and writer, and the round found both lying in the tool this PR turns into the collection instrument:

- Replay marked a file as a session the moment its header parsed, silently dropped unparseable record lines, and never checked the header's declared `frames` count. A crash-truncated capture replayed as `mean_step 0.0000` and sat in the per-label minimum exactly like a still head. The body is now parsed strictly, the count is enforced, and any damage fails the whole replay loudly instead of shrinking the corpus.
- `replay <file.jsonl>` is in the usage line but never reached the pose detector (directory-only), and a pose-only directory printed its summary then exited FAILURE. Both forms now work and a pose-only corpus exits 0.
- Captures were written straight to the destination, so a crash mid-write could leave the valid-header-over-partial-body shape the reader now refuses. Captures stage to a `.tmp` file, sync, and rename into place.

## Testing

Liveness unit tests pin the arithmetic (a known series averages to 0.02), the `None` gap rule, the sparse-index rule (idx 10 next to idx 12 yields 0.0), overflow safety at `idx == usize::MAX`, the no-pairs cases (0.0, never NaN), and relative ordering on the gate's own model shapes (nod above still), with no absolute floor asserted. Black-box tests spawn the real binary: a single pose file and a pose-only directory both exit 0 with the exact `mean_step 0.0200..0.0200` figure in the summary; a header-only truncated file and a malformed record both exit 1 naming the damage, with no summary printed over a damaged corpus.

Five hand-applied mutants each made exactly one of those tests fail: positional pairing restored, the count check disabled, the silent record skip restored, the pose-only SUCCESS exit removed, and the single-file arm removed. The existing detector-versus-evidence agreement test is unchanged and green, so verdicts are provably untouched.

- [x] `cargo test`: `irlume-liveness` 37, `irlume-cli` all six targets green on `b490002`
- [x] clippy `-D warnings`, `fmt --check`
- [x] CHANGELOG updated, including the debug-gated recording contract

## What the next hardware session gets

Run consent watches with `IRLUME_LOG=debug`, or `blinkcap replay` over old recordings, and the per-label `mean_step` ranges land in the output beside the accept rates: the cross-session spread #101 needs before `mean_step` can move from recorded to gating.
