### PR TITLE
Honour the Windows exclusive-control model at the emitter write; state the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to irlume are documented here. This project adheres to
   settings. irlume wrote the extension-unit control whenever it captured,
   relying on its capture failing busy afterwards anyway. `ir_emitter::enable`
   now stands down from the write when another process already holds the camera
-  node, leaving that application's configuration untouched — the fail-safe
+  node, leaving that application's configuration untouched, the fail-safe
   direction, since an unlit emitter degrades one capture toward the password.
   The threat model gains a sourced section on the whole Windows camera
   contract: the exclusive-control model, the certification tie between IR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **The emitter write honours the Windows exclusive-control model.** Windows
+  permits many camera consumers but only one may modify device configuration;
+  shared consumers are read-only and inherit the controlling application's
+  settings. irlume wrote the extension-unit control whenever it captured,
+  relying on its capture failing busy afterwards anyway. `ir_emitter::enable`
+  now stands down from the write when another process already holds the camera
+  node, leaving that application's configuration untouched — the fail-safe
+  direction, since an unlit emitter degrades one capture toward the password.
+  The threat model gains a sourced section on the whole Windows camera
+  contract: the exclusive-control model, the certification tie between IR
+  capture and visible indication (and irlume's position on it), why
+  re-applying the control every capture is the deliberate answer to D3cold,
+  and what Linux does not reproduce (DeviceMFT, Enhanced Sign-in Security) and
+  irlume does not claim to. Closes #169.
+
 - **A dark or blinded IR capture reports what its evidence supports.** A dark
   burst used to get one hint ("no active emitter; run `sudo irlume ir-setup`")
   even though shutters, covers, range, exposure and emitter failures all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,18 @@ All notable changes to irlume are documented here. This project adheres to
 ### Added
 
 - **The emitter write honours the Windows exclusive-control model.** Windows
-  permits many camera consumers but only one may modify device configuration;
-  shared consumers are read-only and inherit the controlling application's
-  settings. irlume wrote the extension-unit control whenever it captured,
-  relying on its capture failing busy afterwards anyway. `ir_emitter::enable`
-  now stands down from the write when another process already holds the camera
-  node, leaving that application's configuration untouched, the fail-safe
-  direction, since an unlit emitter degrades one capture toward the password.
+  permits many camera consumers but only one controlling instance; sharing
+  consumers cannot change extended camera controls and inherit the controlling
+  application's media type. irlume wrote the extension-unit control whenever
+  it captured, relying on its capture failing busy afterwards anyway.
+  `ir_emitter::enable` now stands down from the write when it sees another
+  process holding the camera node, leaving that application's configuration
+  untouched, the fail-safe direction, since an unlit emitter degrades one
+  capture toward the password. The scan has a stated blind spot: reading
+  another user's `/proc/<pid>/fd` is ptrace-gated and the packaged daemon does
+  not hold `CAP_SYS_PTRACE`, so a cross-uid holder can go unseen. The scan
+  reports that instead of hiding it, the daemon logs the degradation once and
+  proceeds, and #207 tracks closing the blind spot.
   The threat model gains a sourced section on the whole Windows camera
   contract: the exclusive-control model, the certification tie between IR
   capture and visible indication (and irlume's position on it), why

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1056,8 +1056,8 @@ fn write_if_different(
 /// PIDs (with `comm`) of OTHER processes holding `dev` open, read from
 /// `proc_root` (`/proc` in production; a constructed tree in tests).
 ///
-/// The check is definitionally racy — a consumer can arrive one instant after
-/// the scan — and that is acceptable for what it guards: honouring the
+/// The check is definitionally racy (a consumer can arrive one instant after
+/// the scan), and that is acceptable for what it guards: honouring the
 /// read-only-sharer contract for consumers that exist at decision time, not a
 /// mutual-exclusion primitive (the kernel lock does that for irlume's own
 /// processes). Unreadable entries are skipped silently: as root (the daemon)

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1053,8 +1053,51 @@ fn write_if_different(
 /// hardware-target substitution through the API of the type that exists to
 /// prevent it (#189). Holding the `Arc` makes the descriptor outlive the guard
 /// by construction.
+/// PIDs (with `comm`) of OTHER processes holding `dev` open, read from
+/// `proc_root` (`/proc` in production; a constructed tree in tests).
+///
+/// The check is definitionally racy — a consumer can arrive one instant after
+/// the scan — and that is acceptable for what it guards: honouring the
+/// read-only-sharer contract for consumers that exist at decision time, not a
+/// mutual-exclusion primitive (the kernel lock does that for irlume's own
+/// processes). Unreadable entries are skipped silently: as root (the daemon)
+/// everything is readable; as an unprivileged caller the scan degrades toward
+/// empty, which fails OPEN into today's behaviour rather than inventing a
+/// phantom consumer that stands the emitter down.
+fn foreign_consumers(proc_root: &std::path::Path, dev: &str, self_pid: u32) -> Vec<(u32, String)> {
+    let mut out = Vec::new();
+    if dev.is_empty() {
+        return out;
+    }
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let fd_dir = entry.path().join("fd");
+        let Ok(fds) = std::fs::read_dir(&fd_dir) else {
+            continue;
+        };
+        let holds = fds.flatten().any(|fd| {
+            std::fs::read_link(fd.path()).is_ok_and(|t| t.as_os_str() == std::ffi::OsStr::new(dev))
+        });
+        if holds {
+            let comm = std::fs::read_to_string(entry.path().join("comm"))
+                .map(|c| c.trim().to_string())
+                .unwrap_or_else(|_| "?".into());
+            out.push((pid, comm));
+        }
+    }
+    out
+}
+
 pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &str) -> StreamMode {
-    let _ = (card, device);
+    let _ = card;
     let fd = handle.fd();
     let setting = override_setting(std::env::var("IRLUME_IR_EMITTER"));
     let wanted = match setting {
@@ -1071,6 +1114,34 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         OverrideSetting::Absent => None,
         OverrideSetting::Control(ctrl) => Some(ctrl),
     };
+
+    // The Windows contract these modules are certified against permits many
+    // frame consumers but exactly ONE of them to modify device configuration;
+    // shared consumers are read-only and inherit the controlling application's
+    // settings (MediaCaptureSharingMode / MF FrameServer share modes: sharing
+    // instances "cannot change KSPROPERTYSETID_ExtendedCameraControl", the
+    // class the Hello extension unit belongs to). irlume used to write the
+    // control regardless, relying on its capture failing EBUSY later anyway.
+    // Honour the model instead of relying on that (#169): when another PROCESS
+    // already holds this node, stand down from the write and stream-or-fail
+    // with whatever state the controlling application chose. Inert is the
+    // fail-safe direction: an unlit emitter degrades this one capture toward
+    // the password, while a write under a foreign owner mutates a stream that
+    // application is mid-way through using. irlume-vs-irlume exclusion is
+    // handled separately by the kernel lock; this covers everyone else.
+    let foreign = foreign_consumers(std::path::Path::new("/proc"), device, std::process::id());
+    if !foreign.is_empty() {
+        let who: Vec<String> = foreign
+            .iter()
+            .take(3)
+            .map(|(pid, comm)| format!("{comm}({pid})"))
+            .collect();
+        eprintln!(
+            "irlume: not driving the IR emitter on {device}: another application holds              this camera ({}); its configuration is left untouched",
+            who.join(", ")
+        );
+        return StreamMode::inert();
+    }
 
     // Identity comes from the descriptor that will receive the write, not from a
     // path that could point somewhere else by the time the ioctl runs.
@@ -3776,6 +3847,58 @@ pub fn describe_units(device: &str) -> std::io::Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a fake /proc tree: `pids` maps a pid to (comm, fd-targets).
+    fn fake_proc(tag: &str, pids: &[(u32, &str, &[&str])]) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!("irlume-fproc-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        for (pid, comm, targets) in pids {
+            let fd = root.join(pid.to_string()).join("fd");
+            std::fs::create_dir_all(&fd).unwrap();
+            std::fs::write(root.join(pid.to_string()).join("comm"), format!("{comm}\n")).unwrap();
+            for (i, t) in targets.iter().enumerate() {
+                std::os::unix::fs::symlink(t, fd.join(i.to_string())).unwrap();
+            }
+        }
+        // Non-pid entries the scanner must skip, as the real /proc has.
+        std::fs::create_dir_all(root.join("sys")).unwrap();
+        root
+    }
+
+    #[test]
+    fn foreign_consumers_finds_other_processes_holding_the_node() {
+        let root = fake_proc(
+            "basic",
+            &[
+                (1234, "chrome", &["/dev/video2", "/home/user/x.log"]),
+                (5678, "bash", &["/dev/pts/0"]),
+                (9999, "irlumed", &["/dev/video2"]), // self: must be excluded
+            ],
+        );
+        let got = foreign_consumers(&root, "/dev/video2", 9999);
+        assert_eq!(got, vec![(1234, "chrome".to_string())]);
+        // A different node has no foreign consumers here.
+        assert!(foreign_consumers(&root, "/dev/video0", 9999).is_empty());
+        // The self pid holding it is not "foreign".
+        assert!(foreign_consumers(&root, "/dev/video2", 1234).len() == 1);
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn foreign_consumers_fails_open_on_unreadable_or_odd_trees() {
+        // A missing proc root, an empty dev, and a pid dir without fd/ must all
+        // degrade to "no foreign consumers": the guard stands the emitter down
+        // only on positive evidence, never on scan failure.
+        assert!(
+            foreign_consumers(std::path::Path::new("/nonexistent-proc"), "/dev/video2", 1)
+                .is_empty()
+        );
+        let root = fake_proc("odd", &[(4321, "sleep", &[])]);
+        std::fs::remove_dir_all(root.join("4321").join("fd")).unwrap();
+        assert!(foreign_consumers(&root, "/dev/video2", 1).is_empty());
+        assert!(foreign_consumers(&root, "", 1).is_empty());
+        std::fs::remove_dir_all(&root).unwrap();
+    }
 
     /// A caught signal must set the flag the measurement loop polls, and the
     /// guard must hand the signal back to whatever disposition it displaced.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1018,6 +1018,100 @@ fn write_if_different(
     })
 }
 
+/// What one pass over a proc tree could establish about other holders of a
+/// device node. `consumers` is only what the scan positively SAW; a blind spot
+/// is a separate fact, never an empty list.
+#[derive(Debug, Default, PartialEq)]
+struct ConsumerScan {
+    /// PIDs, with `comm`, of OTHER processes seen holding the node.
+    consumers: Vec<(u32, String)>,
+    /// At least one process refused inspection. Reading another process's
+    /// `/proc/<pid>/fd` is gated by PTRACE_MODE_READ_FSCREDS, not by file
+    /// permissions (proc_pid_fd(5), ptrace(2)); the packaged daemon keeps only
+    /// CAP_DAC_OVERRIDE and CAP_FOWNER, and root without CAP_SYS_PTRACE does
+    /// not pass that gate. Every cross-uid consumer in a desktop session
+    /// therefore lands HERE, not in `consumers`. Collapsing this bit into "no
+    /// consumer" is exactly how the scan failed open in production; closing
+    /// the blind spot itself is #207.
+    permission_denied: bool,
+}
+
+impl ConsumerScan {
+    /// Only a consumer the scan actually saw stands the emitter down. A blind
+    /// spot must not: under the packaged capability set the scan is blind to
+    /// every cross-uid process, so treating `permission_denied` as a consumer
+    /// would make every packaged capture inert and the emitter permanently
+    /// dark. The caller reports the blind spot instead (#207 owns removing it).
+    fn stands_down(&self) -> bool {
+        !self.consumers.is_empty()
+    }
+}
+
+/// Scan `proc_root` (`/proc` in production; a constructed tree in tests) for
+/// other processes holding `dev` open.
+///
+/// The check is definitionally racy (a consumer can arrive one instant after
+/// the scan), and that is acceptable for what it guards: honouring the sharing
+/// contract for consumers that exist at decision time, not a mutual-exclusion
+/// primitive (the kernel lock does that for irlume's own processes). Only a
+/// PERMISSION denial marks the scan incomplete: a pid dir that vanished
+/// mid-scan, an fd-less kernel thread, or a missing root are the ordinary
+/// churn of /proc, and counting them as blind spots would put the degradation
+/// warning on every scan on every machine.
+fn foreign_consumers(proc_root: &std::path::Path, dev: &str, self_pid: u32) -> ConsumerScan {
+    let mut scan = ConsumerScan::default();
+    if dev.is_empty() {
+        return scan;
+    }
+    let entries = match std::fs::read_dir(proc_root) {
+        Ok(entries) => entries,
+        Err(err) => {
+            scan.permission_denied = err.kind() == std::io::ErrorKind::PermissionDenied;
+            return scan;
+        }
+    };
+    for entry in entries {
+        let Ok(entry) = entry else { continue };
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let fds = match std::fs::read_dir(entry.path().join("fd")) {
+            Ok(fds) => fds,
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::PermissionDenied {
+                    scan.permission_denied = true;
+                }
+                continue;
+            }
+        };
+        let mut holds = false;
+        for fd in fds {
+            let Ok(fd) = fd else { continue };
+            match std::fs::read_link(fd.path()) {
+                Ok(target) if target.as_os_str() == std::ffi::OsStr::new(dev) => {
+                    holds = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                    scan.permission_denied = true;
+                }
+                Err(_) => {}
+            }
+        }
+        if holds {
+            let comm = std::fs::read_to_string(entry.path().join("comm"))
+                .map(|c| c.trim().to_string())
+                .unwrap_or_else(|_| "?".into());
+            scan.consumers.push((pid, comm));
+        }
+    }
+    scan
+}
+
 /// Light the emitter on the open `fd` for `device`, if a control is configured.
 /// Returns whether a `SET_CUR` succeeded. Best-effort.
 ///
@@ -1053,49 +1147,6 @@ fn write_if_different(
 /// hardware-target substitution through the API of the type that exists to
 /// prevent it (#189). Holding the `Arc` makes the descriptor outlive the guard
 /// by construction.
-/// PIDs (with `comm`) of OTHER processes holding `dev` open, read from
-/// `proc_root` (`/proc` in production; a constructed tree in tests).
-///
-/// The check is definitionally racy (a consumer can arrive one instant after
-/// the scan), and that is acceptable for what it guards: honouring the
-/// read-only-sharer contract for consumers that exist at decision time, not a
-/// mutual-exclusion primitive (the kernel lock does that for irlume's own
-/// processes). Unreadable entries are skipped silently: as root (the daemon)
-/// everything is readable; as an unprivileged caller the scan degrades toward
-/// empty, which fails OPEN into today's behaviour rather than inventing a
-/// phantom consumer that stands the emitter down.
-fn foreign_consumers(proc_root: &std::path::Path, dev: &str, self_pid: u32) -> Vec<(u32, String)> {
-    let mut out = Vec::new();
-    if dev.is_empty() {
-        return out;
-    }
-    let Ok(entries) = std::fs::read_dir(proc_root) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
-            continue;
-        };
-        if pid == self_pid {
-            continue;
-        }
-        let fd_dir = entry.path().join("fd");
-        let Ok(fds) = std::fs::read_dir(&fd_dir) else {
-            continue;
-        };
-        let holds = fds.flatten().any(|fd| {
-            std::fs::read_link(fd.path()).is_ok_and(|t| t.as_os_str() == std::ffi::OsStr::new(dev))
-        });
-        if holds {
-            let comm = std::fs::read_to_string(entry.path().join("comm"))
-                .map(|c| c.trim().to_string())
-                .unwrap_or_else(|_| "?".into());
-            out.push((pid, comm));
-        }
-    }
-    out
-}
-
 pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &str) -> StreamMode {
     let _ = card;
     let fd = handle.fd();
@@ -1116,31 +1167,46 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
     };
 
     // The Windows contract these modules are certified against permits many
-    // frame consumers but exactly ONE of them to modify device configuration;
-    // shared consumers are read-only and inherit the controlling application's
-    // settings (MediaCaptureSharingMode / MF FrameServer share modes: sharing
-    // instances "cannot change KSPROPERTYSETID_ExtendedCameraControl", the
-    // class the Hello extension unit belongs to). irlume used to write the
-    // control regardless, relying on its capture failing EBUSY later anyway.
-    // Honour the model instead of relying on that (#169): when another PROCESS
-    // already holds this node, stand down from the write and stream-or-fail
-    // with whatever state the controlling application chose. Inert is the
-    // fail-safe direction: an unlit emitter degrades this one capture toward
-    // the password, while a write under a foreign owner mutates a stream that
-    // application is mid-way through using. irlume-vs-irlume exclusion is
-    // handled separately by the kernel lock; this covers everyone else.
-    let foreign = foreign_consumers(std::path::Path::new("/proc"), device, std::process::id());
-    if !foreign.is_empty() {
-        let who: Vec<String> = foreign
+    // frame consumers but exactly ONE controlling instance; sharing consumers
+    // "cannot change KSPROPERTYSETID_ExtendedCameraControl controls", the
+    // class the Hello extension unit belongs to, and inherit the controlling
+    // application's media type (MediaCaptureSharingMode / MF FrameServer share
+    // modes). irlume used to write the control regardless, relying on its
+    // capture failing EBUSY later anyway. Honour the model instead of relying
+    // on that (#169): when another PROCESS is seen holding this node, stand
+    // down from the write and stream-or-fail with whatever state the
+    // controlling application chose. Inert is the fail-safe direction: an
+    // unlit emitter degrades this one capture toward the password, while a
+    // write under a foreign owner mutates a stream that application is
+    // mid-way through using. irlume-vs-irlume exclusion is handled separately
+    // by the kernel lock; this covers everyone else.
+    let scan = foreign_consumers(std::path::Path::new("/proc"), device, std::process::id());
+    if scan.stands_down() {
+        let who: Vec<String> = scan
+            .consumers
             .iter()
             .take(3)
             .map(|(pid, comm)| format!("{comm}({pid})"))
             .collect();
         eprintln!(
-            "irlume: not driving the IR emitter on {device}: another application holds              this camera ({}); its configuration is left untouched",
+            "irlume: not driving the IR emitter on {device}: another application holds this \
+             camera ({}); its configuration is left untouched",
             who.join(", ")
         );
         return StreamMode::inert();
+    }
+    if scan.permission_denied {
+        // Once per process, not per capture: under the packaged capability
+        // set this is true on essentially every scan, and repeating it would
+        // bury the journal while saying nothing new.
+        static SCAN_DEGRADED: std::sync::Once = std::sync::Once::new();
+        SCAN_DEGRADED.call_once(|| {
+            eprintln!(
+                "irlume: the camera-consumer scan could not inspect every process \
+                 (permission denied), so a holder of {device} it cannot see goes \
+                 undetected and the emitter write proceeds; see issue #207"
+            );
+        });
     }
 
     // Identity comes from the descriptor that will receive the write, not from a
@@ -3876,28 +3942,108 @@ mod tests {
             ],
         );
         let got = foreign_consumers(&root, "/dev/video2", 9999);
-        assert_eq!(got, vec![(1234, "chrome".to_string())]);
+        assert_eq!(got.consumers, vec![(1234, "chrome".to_string())]);
+        // Everything in this tree was readable, so nothing was a blind spot.
+        assert!(!got.permission_denied);
         // A different node has no foreign consumers here.
-        assert!(foreign_consumers(&root, "/dev/video0", 9999).is_empty());
+        assert!(foreign_consumers(&root, "/dev/video0", 9999)
+            .consumers
+            .is_empty());
         // The self pid holding it is not "foreign".
-        assert!(foreign_consumers(&root, "/dev/video2", 1234).len() == 1);
+        assert!(
+            foreign_consumers(&root, "/dev/video2", 1234)
+                .consumers
+                .len()
+                == 1
+        );
         std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]
-    fn foreign_consumers_fails_open_on_unreadable_or_odd_trees() {
+    fn foreign_consumers_fails_open_on_missing_or_odd_trees() {
         // A missing proc root, an empty dev, and a pid dir without fd/ must all
         // degrade to "no foreign consumers": the guard stands the emitter down
-        // only on positive evidence, never on scan failure.
-        assert!(
-            foreign_consumers(std::path::Path::new("/nonexistent-proc"), "/dev/video2", 1)
-                .is_empty()
-        );
+        // only on positive evidence, never on scan failure. None of these is a
+        // permission DENIAL, so none may mark the scan incomplete either; that
+        // bit carries "a process refused inspection", not "the tree was odd".
+        let missing =
+            foreign_consumers(std::path::Path::new("/nonexistent-proc"), "/dev/video2", 1);
+        assert!(missing.consumers.is_empty());
+        assert!(!missing.permission_denied);
         let root = fake_proc("odd", &[(4321, "sleep", &[])]);
         std::fs::remove_dir_all(root.join("4321").join("fd")).unwrap();
-        assert!(foreign_consumers(&root, "/dev/video2", 1).is_empty());
-        assert!(foreign_consumers(&root, "", 1).is_empty());
+        let fdless = foreign_consumers(&root, "/dev/video2", 1);
+        assert!(fdless.consumers.is_empty());
+        assert!(!fdless.permission_denied);
+        assert_eq!(foreign_consumers(&root, "", 1), ConsumerScan::default());
         std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn an_unlistable_fd_dir_marks_the_scan_incomplete_not_empty() {
+        use std::os::unix::fs::PermissionsExt;
+        // One process holds the node but its fd dir cannot be listed: the
+        // shape a ptrace-gated /proc presents to the packaged daemon (#207).
+        // The observation and its failure must stay distinct: consumers empty
+        // AND permission_denied set, never a bare empty list.
+        let root = fake_proc("denied-list", &[(4321, "chrome", &["/dev/video2"])]);
+        let fd_dir = root.join("4321").join("fd");
+        std::fs::set_permissions(&fd_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read_dir(&fd_dir).is_ok() {
+            // A privileged run bypasses the denial this test constructs, so it
+            // would prove nothing; say so instead of passing vacuously.
+            eprintln!("not exercised: this uid bypasses directory permissions");
+        } else {
+            let scan = foreign_consumers(&root, "/dev/video2", 1);
+            assert!(scan.consumers.is_empty());
+            assert!(
+                scan.permission_denied,
+                "a denied fd listing must mark the scan incomplete"
+            );
+        }
+        std::fs::set_permissions(&fd_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn a_denied_readlink_marks_the_scan_incomplete() {
+        use std::os::unix::fs::PermissionsExt;
+        // r without x on the fd dir: the entry names list, their targets do
+        // not resolve. Exercises the read_link arm, distinct from the
+        // unlistable-dir arm above.
+        let root = fake_proc("denied-link", &[(4321, "chrome", &["/dev/video2"])]);
+        let fd_dir = root.join("4321").join("fd");
+        std::fs::set_permissions(&fd_dir, std::fs::Permissions::from_mode(0o444)).unwrap();
+        match std::fs::read_link(fd_dir.join("0")) {
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                let scan = foreign_consumers(&root, "/dev/video2", 1);
+                assert!(scan.consumers.is_empty());
+                assert!(
+                    scan.permission_denied,
+                    "a denied readlink must mark the scan incomplete"
+                );
+            }
+            _ => eprintln!("not exercised: this uid bypasses directory permissions"),
+        }
+        std::fs::set_permissions(&fd_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn a_blind_spot_alone_does_not_stand_the_emitter_down() {
+        // The packaged daemon sees permission_denied on essentially every
+        // scan; standing down on it would keep the emitter permanently dark.
+        // Only a consumer the scan SAW stands the write down.
+        let blind = ConsumerScan {
+            consumers: vec![],
+            permission_denied: true,
+        };
+        assert!(!blind.stands_down());
+        let seen = ConsumerScan {
+            consumers: vec![(1234, "chrome".to_string())],
+            permission_denied: true,
+        };
+        assert!(seen.stands_down());
     }
 
     /// A caught signal must set the flag the measurement loop polls, and the

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -75,17 +75,21 @@ contract is the closest thing to a specification for the hardware. Where irlume
 diverges, the divergence should be deliberate. Positions, each against the
 primary source:
 
-**Exclusive control.** Windows permits many frame consumers but exactly one of
-them may modify device configuration; shared consumers are read-only and
-inherit the controlling application's settings, and explicitly "cannot change
-KSPROPERTYSETID_ExtendedCameraControl controls", the class the Hello extension
-unit belongs to ([MediaCaptureSharingMode][ms-share],
-[MF FrameServer share modes][ms-frameserver]). irlume honours this: when
-another process already holds the camera node, `ir_emitter::enable` stands
-down from the control write and leaves the controlling application's
-configuration untouched (the capture then proceeds or fails on its own terms;
-an unlit emitter degrades toward the password, which is the fail-safe
-direction). irlume-vs-irlume exclusion is separate and kernel-enforced.
+**Exclusive control.** Windows permits many frame consumers but exactly one
+controlling instance. Sharing-mode consumers must use the controlling
+application's media type and explicitly "cannot change
+KSPROPERTYSETID_ExtendedCameraControl controls", the class Windows routes
+Hello's camera control through; the same page does let them change legacy
+`VIDEOPROCAMP`-style and vendor-specific controls
+([MediaCaptureSharingMode][ms-share],
+[MF FrameServer share modes][ms-frameserver]). irlume takes the strict end of
+that contract: when another process already holds the camera node,
+`ir_emitter::enable` stands down from the control write entirely, even though
+a Windows sharing consumer could touch a vendor extension unit, and leaves the
+controlling application's configuration untouched (the capture then proceeds
+or fails on its own terms; an unlit emitter degrades toward the password,
+which is the fail-safe direction). irlume-vs-irlume exclusion is separate and
+kernel-enforced.
 
 **Privacy indication for IR-only capture.** irlume can illuminate a person
 with 850 nm light during authentication. Windows hardware certification ties
@@ -93,9 +97,10 @@ visible indication to sensor capture, including for IR-only streams: a visible-
 wavelength (850 nm) illuminator may itself serve as the indicator (it glows
 faint red), while designs with an invisible (940 nm) illuminator must light a
 separate visible LED whenever the IR sensor is on
-([camera privacy controls][ms-privacy]). On certified modules that indication
-is wired to sensor power in hardware, which is why it follows irlume's captures
-without irlume's involvement. irlume's position: it never suppresses or
+([camera privacy controls][ms-privacy]). The certification phrases that
+obligation against the module's ISP capturing sensor data, not against any
+host application, which is why on certified modules indication follows
+irlume's captures without irlume's involvement. irlume's position: it never suppresses or
 controls indication, adds no software indicator (software indication is
 exactly what that certification distrusts), and inherits whatever the hardware
 provides. A user of an uncertified or external camera should know its IR

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -78,7 +78,7 @@ primary source:
 **Exclusive control.** Windows permits many frame consumers but exactly one of
 them may modify device configuration; shared consumers are read-only and
 inherit the controlling application's settings, and explicitly "cannot change
-KSPROPERTYSETID_ExtendedCameraControl controls" — the class the Hello extension
+KSPROPERTYSETID_ExtendedCameraControl controls", the class the Hello extension
 unit belongs to ([MediaCaptureSharingMode][ms-share],
 [MF FrameServer share modes][ms-frameserver]). irlume honours this: when
 another process already holds the camera node, `ir_emitter::enable` stands
@@ -90,8 +90,8 @@ direction). irlume-vs-irlume exclusion is separate and kernel-enforced.
 **Privacy indication for IR-only capture.** irlume can illuminate a person
 with 850 nm light during authentication. Windows hardware certification ties
 visible indication to sensor capture, including for IR-only streams: a visible-
-wavelength (850 nm) illuminator may itself serve as the indicator — it glows
-faint red — while designs with an invisible (940 nm) illuminator must light a
+wavelength (850 nm) illuminator may itself serve as the indicator (it glows
+faint red), while designs with an invisible (940 nm) illuminator must light a
 separate visible LED whenever the IR sensor is on
 ([camera privacy controls][ms-privacy]). On certified modules that indication
 is wired to sensor power in hardware, which is why it follows irlume's captures
@@ -106,8 +106,8 @@ camera lines are where irlume already reasons about what the user can see.
 fully off in D3cold and preserves no control context; its optional
 [UVC control cache][ms-cache] restores a fixed list of ordinary
 `VIDEOPROCAMP` controls (brightness, contrast, …) across such transitions, and
-extension-unit state is not on that list. irlume's policy — re-apply the
-emitter control at every capture and restore on stream end — is therefore the
+extension-unit state is not on that list. irlume's policy, re-apply the
+emitter control at every capture and restore on stream end, is therefore the
 deliberate response to the same power behaviour, not an incidental habit:
 nothing below irlume undertakes to preserve this state, on either OS. (#168
 tracks narrowing WHEN within a capture the control is held.)

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -68,6 +68,79 @@ logged. It weakens nothing in production: the daemon's environment comes from
 its root-owned systemd unit, so setting it requires the same root the pin does
 not defend against, and a unit test pins the escape to exact-path matches.
 
+## The Windows camera contract (#169)
+
+These Hello modules are designed and certified against Windows, so the Windows
+contract is the closest thing to a specification for the hardware. Where irlume
+diverges, the divergence should be deliberate. Positions, each against the
+primary source:
+
+**Exclusive control.** Windows permits many frame consumers but exactly one of
+them may modify device configuration; shared consumers are read-only and
+inherit the controlling application's settings, and explicitly "cannot change
+KSPROPERTYSETID_ExtendedCameraControl controls" — the class the Hello extension
+unit belongs to ([MediaCaptureSharingMode][ms-share],
+[MF FrameServer share modes][ms-frameserver]). irlume honours this: when
+another process already holds the camera node, `ir_emitter::enable` stands
+down from the control write and leaves the controlling application's
+configuration untouched (the capture then proceeds or fails on its own terms;
+an unlit emitter degrades toward the password, which is the fail-safe
+direction). irlume-vs-irlume exclusion is separate and kernel-enforced.
+
+**Privacy indication for IR-only capture.** irlume can illuminate a person
+with 850 nm light during authentication. Windows hardware certification ties
+visible indication to sensor capture, including for IR-only streams: a visible-
+wavelength (850 nm) illuminator may itself serve as the indicator — it glows
+faint red — while designs with an invisible (940 nm) illuminator must light a
+separate visible LED whenever the IR sensor is on
+([camera privacy controls][ms-privacy]). On certified modules that indication
+is wired to sensor power in hardware, which is why it follows irlume's captures
+without irlume's involvement. irlume's position: it never suppresses or
+controls indication, adds no software indicator (software indication is
+exactly what that certification distrusts), and inherits whatever the hardware
+provides. A user of an uncertified or external camera should know its IR
+capture may be visually silent; `ir-setup`'s shutter handling and the doctor's
+camera lines are where irlume already reasons about what the user can see.
+
+**Control state across power transitions.** Windows powers camera components
+fully off in D3cold and preserves no control context; its optional
+[UVC control cache][ms-cache] restores a fixed list of ordinary
+`VIDEOPROCAMP` controls (brightness, contrast, …) across such transitions, and
+extension-unit state is not on that list. irlume's policy — re-apply the
+emitter control at every capture and restore on stream end — is therefore the
+deliberate response to the same power behaviour, not an incidental habit:
+nothing below irlume undertakes to preserve this state, on either OS. (#168
+tracks narrowing WHEN within a capture the control is held.)
+
+**What Linux does not reproduce, and irlume does not claim to.** Windows
+routes Hello controls through a vendor DeviceMFT that can translate or refuse
+them; writing the extension unit directly bypasses whatever policy that
+component implements, and no Linux equivalent exists. And Enhanced Sign-in
+Security is not "the same camera with a better application": it requires
+ESS-capable camera firmware under the inbox UVC driver, compatible chipsets,
+VBS with a protected memory pathway from camera to matcher, and an
+OEM-provisioned Secure Devices (SDEV) ACPI table
+([ESS requirements][ms-ess]). Opening the same IR node on Linux does not
+approximate that trust path, and nothing in this document should be read as
+claiming it does.
+
+**Where Windows and irlume agree, since 0.7.1.** Windows' UVC driver probes
+only descriptor-advertised controls and disables a control whose
+initialization queries fail ([extension-unit device requirements][ms-xu]),
+rather than sweeping unit/selector combinations or continuing past a failed
+selector. That is the model irlume's discovery adopted in 0.7.1.
+
+**Not established.** Microsoft does not publish how many frames Hello consumes
+per authentication, its recognition window, or its stopping threshold; nothing
+here is a claim about those.
+
+[ms-share]: https://learn.microsoft.com/uwp/api/windows.media.capture.mediacaptureinitializationsettings.sharingmode
+[ms-frameserver]: https://learn.microsoft.com/windows/win32/medfound/mf-devsource-attribute-frameserver-share-mode
+[ms-privacy]: https://learn.microsoft.com/windows-hardware/drivers/stream/camera-privacy-controls
+[ms-cache]: https://learn.microsoft.com/windows-hardware/drivers/stream/camera-device-uvc-control-cache
+[ms-ess]: https://learn.microsoft.com/windows-hardware/design/device-experiences/windows-hello-enhanced-sign-in-security
+[ms-xu]: https://learn.microsoft.com/windows-hardware/drivers/stream/device-requirements-for-usb-video-class-extension-units
+
 ## Liveness: algorithmic single-frame gate (no trained weights)
 
 The default gate uses no trained weights. (The opt-in passive-blink stage

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -83,13 +83,27 @@ Hello's camera control through; the same page does let them change legacy
 `VIDEOPROCAMP`-style and vendor-specific controls
 ([MediaCaptureSharingMode][ms-share],
 [MF FrameServer share modes][ms-frameserver]). irlume takes the strict end of
-that contract: when another process already holds the camera node,
-`ir_emitter::enable` stands down from the control write entirely, even though
-a Windows sharing consumer could touch a vendor extension unit, and leaves the
-controlling application's configuration untouched (the capture then proceeds
-or fails on its own terms; an unlit emitter degrades toward the password,
-which is the fail-safe direction). irlume-vs-irlume exclusion is separate and
-kernel-enforced.
+that contract: when the `/proc` scan sees another process holding the camera
+node, `ir_emitter::enable` stands down from the control write entirely, even
+though a Windows sharing consumer could touch a vendor extension unit, and
+leaves the controlling application's configuration untouched (the capture
+then proceeds or fails on its own terms; an unlit emitter degrades toward the
+password, which is the fail-safe direction). irlume-vs-irlume exclusion is
+separate and kernel-enforced.
+
+The scan cannot see every holder in production. Reading another process's
+`/proc/<pid>/fd` is gated by `PTRACE_MODE_READ_FSCREDS` (proc_pid_fd(5),
+ptrace(2)), and the packaged unit grants the daemon only `CAP_DAC_OVERRIDE`
+and `CAP_FOWNER`, which do not pass that gate, so a camera holder in the
+user's desktop session (PipeWire, a browser) is invisible to the root daemon.
+The scan reports the blind spot (`ConsumerScan::permission_denied`) rather
+than collapsing it into "no consumer"; the daemon logs the degradation once
+per process and proceeds, which is the pre-#169 behaviour with the honesty
+added. Standing down on a blind spot instead would make every packaged
+capture inert, a permanent self-denial of the emitter. Closing the blind spot
+means granting `CAP_SYS_PTRACE` (a privilege expansion on an authentication
+daemon) or adding a separately confined observer; that decision is #207 and
+is not made here.
 
 **Privacy indication for IR-only capture.** irlume can illuminate a person
 with 850 nm light during authentication. Windows hardware certification ties


### PR DESCRIPTION
Closes #169. Based on `main`, independent of the other open PRs. Each claim in the issue was re-verified against the Microsoft sources before acting; the citations live in the threat model.

## Exclusive control, the one code change

Verified: Windows permits many frame consumers but exactly one controlling instance. Sharing consumers must use the controlling application's media type and "cannot change KSPROPERTYSETID_ExtendedCameraControl controls", the class Windows routes Hello's camera control through. The same page does let sharing consumers change legacy `VIDEOPROCAMP`-style and vendor-specific controls, so the stand-down below is deliberately stricter than the Windows rule ([MediaCaptureSharingMode](https://learn.microsoft.com/uwp/api/windows.media.capture.mediacaptureinitializationsettings.sharingmode), [MF FrameServer share modes](https://learn.microsoft.com/windows/win32/medfound/mf-devsource-attribute-frameserver-share-mode)).

`ir_emitter::enable` now scans `/proc` for other processes holding the target node and stands down from the control write when one exists, returning the existing inert guard. The foreign application's configuration is left untouched and the capture proceeds or fails on its own terms.

Properties, each with its reason in the code:

- Fail-safe direction: an unlit emitter degrades one capture toward the password; a write under a foreign owner mutates a stream that application is using. The previously reachable outcome in this scenario was an EBUSY failure.
- Only positive evidence of a foreign consumer stands the emitter down, and a scan that could not see everything says so. The review round found the original scan silently failing open in production: reading another process's `/proc/<pid>/fd` is gated by `PTRACE_MODE_READ_FSCREDS` (proc_pid_fd(5), ptrace(2)), the packaged unit keeps only `CAP_DAC_OVERRIDE` and `CAP_FOWNER`, so every cross-uid holder (PipeWire, a browser) was invisible and `.is_ok_and` collapsed the denial into "no consumer". The scan now returns `ConsumerScan { consumers, permission_denied }`; a permission denial marks the scan incomplete, the daemon logs that degradation once per process and proceeds, and the threat model states the limit. Standing down on the blind spot instead would make every packaged capture inert. Granting `CAP_SYS_PTRACE` or adding a separately confined observer is #207. A missing `/proc` or an fd-less pid dir is ordinary churn, not a blind spot, and stays silent.
- Racy by nature and documented as such: this honors a sharing contract for consumers that exist at decision time. It is not mutual exclusion; the kernel lock keeps that job for irlume's own processes.
- Self pid excluded, since the daemon holds the node when `enable` runs.

Tested against a constructed proc tree: detection with comm names, self-exclusion, non-pid entries, fd-less dirs, missing root, empty device path. Also probed live against the real `/proc` of the test container: a process holding a file is reported with its comm name, and the report empties when it exits.

## Privacy indication and D3cold, positions in the threat model

The threat model gains a "Windows camera contract" section:

- IR-only privacy indication ([camera privacy controls](https://learn.microsoft.com/windows-hardware/drivers/stream/camera-privacy-controls)): certification ties visible indication to sensor capture including IR-only streams. A visible-wavelength 850 nm illuminator may itself be the indicator (it glows faint red); an invisible 940 nm one requires a separate LED. The obligation is phrased against the module's ISP capturing sensor data, not against any host application, so it follows irlume's captures without irlume's involvement. irlume's stated position: it never suppresses indication, adds no software indicator, and inherits whatever the module provides. Users of uncertified or external cameras should know IR capture may be visually silent.
- D3cold and control state ([UVC control cache](https://learn.microsoft.com/windows-hardware/drivers/stream/camera-device-uvc-control-cache)): the cache protocol restores a fixed `VIDEOPROCAMP` list, and extension-unit state is not on it. Re-applying the control at every capture is recorded as the deliberate answer to the same power behavior; when-within-a-capture stays with #168.
- What Linux does not reproduce: the DeviceMFT policy layer, and Enhanced Sign-in Security ([ESS requirements](https://learn.microsoft.com/windows-hardware/design/device-experiences/windows-hello-enhanced-sign-in-security): ESS camera firmware under the inbox driver, a VBS-protected memory pathway, an SDEV ACPI table). Stated so nothing implies opening the same IR node approximates that trust path.
- The 0.7.1 agreement (descriptor-advertised probing, disable on failed init, per the [extension-unit device requirements](https://learn.microsoft.com/windows-hardware/drivers/stream/device-requirements-for-usb-video-class-extension-units)) and the issue's not-established list (frames per auth, window, threshold) are both carried.

A deep-review pass re-fetched all five Microsoft pages and checked every claim against them. Two overstatements were found and corrected in the threat model and here: "sharing consumers are read-only" (they can change legacy and vendor controls) and "indication is wired to sensor power in hardware" (the requirement binds the ISP, not a wire).

## The review round (`6e5d537`)

The single Codex round found the scan failing open in production, described under the properties bullet above; the fix is in `6e5d537`. Also from the round: `enable`'s doc comment had been captured by the helper sitting between the doc and the function, the changelog called sharing consumers read-only where Windows only forbids extended-control changes, and the stand-down message carried fourteen accidental spaces. All fixed in the same commit.

New tests, each proven by a hand-applied mutant that made exactly that test fail: an unlistable fd dir sets `permission_denied` with `consumers` empty (mutant: restore the silent collapse); a denied readlink does the same through the other arm (mutant: drop that arm's flag); a blind spot alone never stands the emitter down (mutant: the fail-closed variant). Both denial tests construct the denial with directory permissions and skip loudly under a privileged uid instead of passing vacuously.

## Testing

- [x] `cargo test -p irlume-camera`: 224 pass after the round's fixes (up from 220; the runs-as-root failure is pre-existing and identical on `main`)
- [x] `cargo test -p irlume-cli`: all six targets green
- [x] clippy `-D warnings`, `fmt --check`, `doc -D warnings` (re-run on `6e5d537`)
- [x] CHANGELOG and THREAT_MODEL updated, including the production blind spot
- [ ] Hardware: one capture on the reference Zenbook to confirm the happy path (emitter drives as before, degradation line appears once in the journal), a same-uid holder to see the stand-down line, and a cross-uid holder under the packaged capability set to see the incomplete-scan path, the case the round proved the original code could not detect.
