### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-02
+
 ### Fixed
+
+- **The TUI never blocks on the machine.** Every observation (the fprintd and
+  busctl chain, PAM file walks, LSM and TPM probes, V4L2 opens, the daemon
+  polls, and the profile listing, which is a TPM unseal that measured 10.8
+  seconds on one laptop's TPM) now lands as a background snapshot; drawing
+  and the Repair checklist read memory only. On the machine that exposed it,
+  screen entries went from about eight seconds to under twenty milliseconds,
+  first frame in half a second, and the enrolled profile list actually
+  appears, which the old 1.5-second poll budget never allowed there. The
+  daemon-side costs are tracked separately (#211, #212). The TUI's PAM screen
+  now shows the keyring hand-off advisory `login status` prints, and its
+  Fingerprint screen shows the per-surface coverage table from `fingerprint
+  status`.
 
 - **The fingerprint-enable gate could pass on a comment.** `pam_fprintd_wired`
   matched raw lines, so a stack whose only `pam_fprintd.so` sat in a trailing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "image",
  "irlume-auth",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "libc",
  "serde",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -978,11 +978,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.7.2"
+version = "0.8.0"
 
 [[package]]
 name = "irlume-liveness"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "irlume-common",
  "pamsm",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.7.2
+pkgver=0.8.0
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.7.2
+version: 0.8.0
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -1,7 +1,7 @@
 %global ort_ver 1.24.4
 
 Name:           irlume
-Version:        0.7.2
+Version:        0.8.0
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -210,6 +210,16 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Sun Aug 02 2026 archledger <archledger236@gmail.com> - 0.8.0-1
+- Emitter write honours the Windows exclusive-control model; consumer scan reports its blind spot (#169, #207)
+- fingerprint enable and status print per-surface coverage; the fingerprint-only gate parses PAM rule fields (#155)
+- Keyring hand-off check for KWallet and GNOME Keyring; openSUSE and renamed-substack wiring fixes
+- gdm-fingerprint gains the keyring release pair so a fingerprint login opens the wallet
+- camera-tune is reachable from the TUI with an upfront cost explanation (#170)
+- mean_step consent discriminator recorded with the evidence, strobe-aware (#101)
+- TUI: all machine probes moved off the UI thread; slow-TPM machines get a responsive TUI and a visible profile list
+- pamwire split into submodules; origin_tests flake fixed structurally (#194)
+
 * Thu Jul 30 2026 archledger <archledger236@gmail.com> - 0.7.2-1
 - IRLUME_IR_EMITTER is checked against the camera's descriptor before any write
 - Login transactions in the machine API: plan, apply, verify, rollback


### PR DESCRIPTION
Version bump in the four stamped places (Cargo.toml as source of truth; nfpm.yaml, PKGBUILD, spec hand-copies; `scripts/check-packaging-parity.sh` passes), the 0.8.0 changelog stamp dated today, the missing #213 TUI entry, and the spec `%changelog`. No code changes.

The release itself follows the merge: signed tag, GitHub release with the .deb assets and signed SHA256SUMS, AUR sync (both files, built from the tag on the Arch box first), Copr verified by build state, PPA verified by `verify-ppa-publish.py`, and the storefront texts on all four lanes updated in the same sitting.
