### PR TITLE
A lock the process cannot take is a failure to observe, not a pending record

### DIFF
--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2737,7 +2737,7 @@ pub(crate) fn recover_pending_write(
             outcome
         }
         Ok(None) => RecoveryOutcome::Busy,
-        Err(why) => RecoveryOutcome::Unresolved(format!("lock the camera: {why}")),
+        Err(why) => RecoveryOutcome::Unchecked(format!("lock the camera: {why}")),
     }
 }
 
@@ -3010,6 +3010,13 @@ fn report_recovery(id: &crate::uvc_descriptor::CameraIdentity, outcome: Recovery
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RecoveryOutcome {
     NothingPending,
+    /// The journal STATE COULD NOT BE EXAMINED (the per-camera lock was
+    /// unavailable, e.g. an unprivileged process cannot create it under
+    /// /run/lock). Not the same fact as [`Self::Unresolved`]: nothing was
+    /// observed about any record, so the message must not claim one exists.
+    /// The write refusal is identical, because a process that cannot check
+    /// cannot know the camera is safe to write to (#210).
+    Unchecked(String),
     /// A record exists for a DIFFERENT camera. Ordinary on a machine with two of
     /// them, and none of this camera's business: it must not stop the emitter
     /// here, which is the whole reason this is not folded in with the refusals.
@@ -3087,6 +3094,13 @@ impl RecoveryOutcome {
                  `irlume ir-setup` will refuse until the record can be written",
                 store.display()
             )),
+            Self::Unchecked(why) => Some(format!(
+                "irlume: could not check whether an interrupted emitter setup left this \
+                 camera changed ({why}). irlume will not write to this camera's emitter \
+                 from this process until it can check, so IR face authentication will \
+                 not light here. The daemon (root) checks and recovers on its own; an \
+                 unprivileged tool hitting this is expected and harmless."
+            )),
             Self::Unresolved(why) => Some(format!(
                 "irlume: an emitter control on this camera was left changed by an interrupted \
                  setup and has not been put back ({why}). irlume will not write to this \
@@ -3123,6 +3137,7 @@ impl RecoveryOutcome {
             Self::RestoredRecordKept(_) => "restored-record-kept",
             Self::OwnerStillRunning { .. } => "owner-running",
             Self::Busy => "busy",
+            Self::Unchecked(_) => "unchecked",
             Self::Unresolved(_) => "unresolved",
             Self::Unconfirmed { .. } => "unconfirmed",
         }
@@ -3157,6 +3172,7 @@ impl RecoveryOutcome {
             | Self::RestoredRecordKept(_) => true,
             Self::OwnerStillRunning { .. }
             | Self::Busy
+            | Self::Unchecked(_)
             | Self::Unresolved(_)
             | Self::Unconfirmed { .. } => false,
         }
@@ -3182,6 +3198,7 @@ impl RecoveryOutcome {
             Self::RestoredRecordKept(_)
             | Self::OwnerStillRunning { .. }
             | Self::Busy
+            | Self::Unchecked(_)
             | Self::Unresolved(_)
             | Self::Unconfirmed { .. } => true,
         }
@@ -4142,6 +4159,16 @@ mod tests {
                 true,
                 true,
             ),
+            // The journal state was never examined (lock unavailable). Loud,
+            // and it stops both writers: a process that cannot check cannot
+            // know the camera is safe to write to. Distinct from Unresolved
+            // because its message asserts nothing about records (#210).
+            (
+                RecoveryOutcome::Unchecked("lock the camera: permission denied".into()),
+                false,
+                true,
+                true,
+            ),
             // Another irlume process holds this camera. Silent, and it stops
             // both writers: it is being looked after already.
             (RecoveryOutcome::Busy, false, true, false),
@@ -4173,6 +4200,7 @@ mod tests {
                 RecoveryOutcome::RestoredRecordKept(_) => (true, true),
                 RecoveryOutcome::OwnerStillRunning { .. } => (false, true),
                 RecoveryOutcome::Busy => (false, true),
+                RecoveryOutcome::Unchecked(_) => (false, true),
                 RecoveryOutcome::Unresolved(_) => (false, true),
                 RecoveryOutcome::Unconfirmed { .. } => (false, true),
             }
@@ -4330,6 +4358,56 @@ mod tests {
     ///
     /// `commit` used to clear on the strength of the `SET_CUR` returning
     /// success, which is precisely the assumption the rest of this module
+    /// A lock the process cannot take means the journal state was never
+    /// examined; the outcome must SAY that, not fabricate a pending record.
+    /// Every unprivileged dev-tool capture used to print "an emitter control
+    /// ... was left changed by an interrupted setup" on machines whose
+    /// journal directory did not even exist (#210).
+    #[test]
+    fn an_untakeable_lock_reports_unchecked_never_a_phantom_record() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join("irlume-unchecked-lockdir");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555))
+            .expect("read-only lock dir");
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let id = identity(0x3277, 0x0059);
+        let probe = dir.join("probe");
+        if std::fs::write(&probe, b"x").is_ok() {
+            // A privileged run bypasses the permission this test constructs;
+            // say so instead of passing vacuously.
+            let _ = std::fs::remove_file(&probe);
+            eprintln!("not exercised: this uid bypasses directory permissions");
+        } else {
+            let fd = non_uvc_fd();
+            use std::os::unix::io::AsRawFd as _;
+            let outcome = recover_pending_write(fd.as_raw_fd(), &id);
+            assert!(
+                matches!(outcome, RecoveryOutcome::Unchecked(_)),
+                "an untakeable lock is a failure to OBSERVE, got {outcome:?}"
+            );
+            let msg = outcome.message().expect("unchecked is loud");
+            assert!(msg.contains("could not check"), "{msg}");
+            assert!(
+                !msg.contains("was left changed"),
+                "the message must not claim a record was observed: {msg}"
+            );
+            assert!(
+                !msg.contains("recorded original"),
+                "the message must not claim a record exists: {msg}"
+            );
+            assert!(
+                !outcome.permits_capture_write(),
+                "refusing is the safe half"
+            );
+            assert!(outcome.blocks_discovery());
+        }
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).ok();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// refuses to make. `ir_emitter.conf` stores coordinates and no payload, so
     /// once the record is gone nothing holds the original bytes at all.
     #[test]

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -3097,9 +3097,8 @@ impl RecoveryOutcome {
             Self::Unchecked(why) => Some(format!(
                 "irlume: could not check whether an interrupted emitter setup left this \
                  camera changed ({why}). irlume will not write to this camera's emitter \
-                 from this process until it can check, so IR face authentication will \
-                 not light here. The daemon (root) checks and recovers on its own; an \
-                 unprivileged tool hitting this is expected and harmless."
+                 from this process until the lock error is resolved and the journal can \
+                 be checked, so IR face authentication will not light here."
             )),
             Self::Unresolved(why) => Some(format!(
                 "irlume: an emitter control on this camera was left changed by an interrupted \
@@ -4353,61 +4352,61 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A camera that says "yes" to the final write but holds something else must
-    /// not have its undo data deleted.
-    ///
-    /// `commit` used to clear on the strength of the `SET_CUR` returning
-    /// success, which is precisely the assumption the rest of this module
     /// A lock the process cannot take means the journal state was never
     /// examined; the outcome must SAY that, not fabricate a pending record.
     /// Every unprivileged dev-tool capture used to print "an emitter control
     /// ... was left changed by an interrupted setup" on machines whose
     /// journal directory did not even exist (#210).
+    ///
+    /// The blocking fixture is a regular FILE where the lock directory
+    /// belongs: ENOTDIR stops root and CAP_DAC_OVERRIDE exactly like an
+    /// unprivileged uid (the container suite uses the same trick), so this
+    /// test has no privileged skip arm to pass vacuously through.
     #[test]
     fn an_untakeable_lock_reports_unchecked_never_a_phantom_record() {
-        use std::os::unix::fs::PermissionsExt;
         let _lock = crate::testenv::env_lock();
-        let dir = std::env::temp_dir().join("irlume-unchecked-lockdir");
+        let dir =
+            std::env::temp_dir().join(format!("irlume-unchecked-lockdir-{}", std::process::id()));
+        let _ = std::fs::remove_file(&dir);
         let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555))
-            .expect("read-only lock dir");
+        std::fs::write(&dir, b"not a directory").expect("blocking file");
         let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
         let id = identity(0x3277, 0x0059);
-        let probe = dir.join("probe");
-        if std::fs::write(&probe, b"x").is_ok() {
-            // A privileged run bypasses the permission this test constructs;
-            // say so instead of passing vacuously.
-            let _ = std::fs::remove_file(&probe);
-            eprintln!("not exercised: this uid bypasses directory permissions");
-        } else {
-            let fd = non_uvc_fd();
-            use std::os::unix::io::AsRawFd as _;
-            let outcome = recover_pending_write(fd.as_raw_fd(), &id);
-            assert!(
-                matches!(outcome, RecoveryOutcome::Unchecked(_)),
-                "an untakeable lock is a failure to OBSERVE, got {outcome:?}"
-            );
-            let msg = outcome.message().expect("unchecked is loud");
-            assert!(msg.contains("could not check"), "{msg}");
-            assert!(
-                !msg.contains("was left changed"),
-                "the message must not claim a record was observed: {msg}"
-            );
-            assert!(
-                !msg.contains("recorded original"),
-                "the message must not claim a record exists: {msg}"
-            );
-            assert!(
-                !outcome.permits_capture_write(),
-                "refusing is the safe half"
-            );
-            assert!(outcome.blocks_discovery());
-        }
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).ok();
-        let _ = std::fs::remove_dir_all(&dir);
+        let fd = non_uvc_fd();
+        use std::os::unix::io::AsRawFd as _;
+        let outcome = recover_pending_write(fd.as_raw_fd(), &id);
+        assert!(
+            matches!(outcome, RecoveryOutcome::Unchecked(_)),
+            "a lock setup failure is a failure to OBSERVE, got {outcome:?}"
+        );
+        let msg = outcome.message().expect("unchecked is loud");
+        assert!(msg.contains("could not check"), "{msg}");
+        assert!(
+            !msg.contains("was left changed"),
+            "the message must not claim a record was observed: {msg}"
+        );
+        assert!(
+            !msg.contains("recorded original"),
+            "the message must not claim a record exists: {msg}"
+        );
+        // And no unsupported assurance in the other direction: nothing here
+        // knows whether any other process checked or recovered anything, and
+        // the daemon itself can land here (EROFS, ENOSPC, a bad lock path).
+        assert!(!msg.contains("checks and recovers on its own"), "{msg}");
+        assert!(!msg.contains("expected and harmless"), "{msg}");
+        assert!(
+            !outcome.permits_capture_write(),
+            "refusing is the safe half"
+        );
+        assert!(outcome.blocks_discovery());
+        std::fs::remove_file(&dir).expect("remove blocking file");
     }
 
+    /// A camera that says "yes" to the final write but holds something else
+    /// must not have its undo data deleted.
+    ///
+    /// `commit` used to clear on the strength of the `SET_CUR` returning
+    /// success, which is precisely the assumption the rest of this module
     /// refuses to make. `ir_emitter.conf` stores coordinates and no payload, so
     /// once the record is gone nothing holds the original bytes at all.
     #[test]


### PR DESCRIPTION
Closes #210. `recover_pending_write` mapped a lock-acquisition error to `Unresolved` before the journal was ever read, and `Unresolved`'s message asserts a record was found. Every unprivileged dev-tool capture printed "an emitter control on this camera was left changed by an interrupted setup ... The recorded original is in /var/lib/irlume/ir-emitter-journal" on a machine where that directory does not exist.

`RecoveryOutcome` gains `Unchecked`: the identical write refusal (refuses captures, blocks discovery; the exhaustive policy-table test pins both, and it caught the missing arm the moment the variant existed), with a message that asserts only what was observed. The distinction matters because the two facts lead the operator to different actions: investigate an interrupted setup, versus run as root or fix `/run/lock` permissions.

## Testing

- Regression test constructs an untakeable lock directory (0o555), asserts the `Unchecked` outcome, both refusals, and that the message carries neither "was left changed" nor "recorded original"; skips loudly under a privileged uid.
- Two hand-applied mutants each fail their tests: the lock site reverted to `Unresolved`, and `Unchecked` granted capture writes (the policy table catches that one too).
- Live on the Zenbook: the exact `blinkcap capture` invocation from the 0.8.0 release testing now prints the could-not-check message instead of the phantom record, and still refuses the emitter write.
- 225 camera tests, clippy clean.



## The review round (`3280de3`)

Three findings, all applied. The message's tail ("the daemon checks and recovers on its own; expected and harmless") was an unsupported assurance: the daemon itself can land in `Unchecked` through failures privilege does not cure (EROFS, ENOSPC, a lock path that is a regular file), and nothing had checked or recovered anything — the PR's own defect class, reintroduced in its wording. The message now states only the refusal and the remedy, and the test forbids both retired phrases. The regression test's privileged-skip arm could pass vacuously as root; the fixture is now a regular file where the lock directory belongs (ENOTDIR stops every uid, the container suite's own idiom), so no skip arm exists. And the test insertion had split a neighboring doc comment mid-sentence; restored.
