### PR TITLE
Status reads answer on the connection thread, so a listing cannot delay a login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **A status read can no longer make a login wait.** Every request used to
+  execute on the single engine worker, so a `ListProfiles` (a TPM unseal of
+  the template key, measured at 10.8 seconds on one laptop's TPM) made a
+  concurrently arriving authentication wait behind it: a Ping issued during
+  a listing measured 10.4 seconds. Read-only status requests (Ping, Health,
+  HasSealedPassword, KeyringInfo, RecoveryStatus, ListProfiles) now answer
+  on the connection's own thread, never entering the worker queue; Health
+  reads an engine snapshot published before the socket binds. Mutating
+  requests stay serialized on the worker, and the per-request authorization
+  gates moved with the code unchanged. Closes #212.
+
 ## [0.8.0] - 2026-08-02
 
 ### Fixed

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -43,9 +43,17 @@ pub enum Class {
     /// Opens the camera without being an authentication: the framing guide,
     /// 1:N identify, enrollment, emitter setup, self-tests.
     Camera,
-    /// Touches no camera: listings, keyring metadata, settings. Cheap enough
-    /// that arbitration would cost more than it saves.
+    /// Touches no camera: settings writes, seals, deletions, renames. These
+    /// stay on the worker so every mutation of shared state stays serialized
+    /// against captures and against each other.
     Plain,
+    /// Read-only status that touches neither the camera nor the engine:
+    /// answered on the CONNECTION THREAD, never queued. This class exists
+    /// because one of its members (`ListProfiles`) is a TPM unseal that
+    /// measured 10.8 seconds on a slow TPM, and queued behind the worker it
+    /// made a concurrently arriving authentication wait that long (#212). A
+    /// status read has no business making a login wait.
+    Status,
 }
 
 /// Classify a request by what it does to the camera, not by who sent it.
@@ -58,6 +66,15 @@ pub fn classify(req: &Request) -> Class {
     use Request::*;
     match req {
         Authenticate { .. } | UnsealPassword { .. } | UnsealKeyring { .. } => Class::Auth,
+        // Read-only, engine-free, and possibly SLOW (ListProfiles pays a TPM
+        // unseal): answered where they arrive so they cannot delay a login
+        // and a login cannot delay them.
+        Ping
+        | Health
+        | HasSealedPassword { .. }
+        | KeyringInfo { .. }
+        | RecoveryStatus { .. }
+        | ListProfiles { .. } => Class::Status,
         PositionSample { .. }
         | Identify
         | Enroll { .. }
@@ -218,7 +235,10 @@ impl<T> Arbiter<T> {
                     payload,
                 });
             }
-            Class::Plain => inner.other.push_back(Job {
+            // Status is answered on the connection thread and never submitted;
+            // if a future caller submits one anyway it queues like Plain, which
+            // is correct (just slower) rather than lost.
+            Class::Plain | Class::Status => inner.other.push_back(Job {
                 class,
                 uid,
                 payload,
@@ -432,14 +452,17 @@ mod tests {
             classify(&Request::PositionSample { user: None }),
             Class::Camera
         );
+        // Read-only status answers on the connection thread (#212): a TPM-
+        // bound listing must not make a login wait, and Ping must answer
+        // while the worker grinds.
         assert_eq!(
             classify(&Request::ListProfiles {
                 user: "u".into(),
                 structured_errors: true
             }),
-            Class::Plain
+            Class::Status
         );
-        assert_eq!(classify(&Request::Ping), Class::Plain);
+        assert_eq!(classify(&Request::Ping), Class::Status);
         // A secret-carrying management request is not camera work.
         assert_eq!(
             classify(&Request::SealPassword {

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -47,12 +47,17 @@ pub enum Class {
     /// stay on the worker so every mutation of shared state stays serialized
     /// against captures and against each other.
     Plain,
-    /// Read-only status that touches neither the camera nor the engine:
-    /// answered on the CONNECTION THREAD, never queued. This class exists
-    /// because one of its members (`ListProfiles`) is a TPM unseal that
-    /// measured 10.8 seconds on a slow TPM, and queued behind the worker it
-    /// made a concurrently arriving authentication wait that long (#212). A
-    /// status read has no business making a login wait.
+    /// Status that can be answered on the CONNECTION THREAD without touching
+    /// the camera, the engine, the TPM, or any shared mutable state: pure
+    /// path checks, the published engine bits, and the worker-published
+    /// enrollment summary. This class exists because `ListProfiles` is a TPM
+    /// unseal that measured 10.8 seconds on a slow TPM, and queued behind
+    /// the worker it made a concurrently arriving authentication wait that
+    /// long (#212). Membership is strict on purpose: the physical TPM
+    /// executes one command at a time (tpmrm queues, it does not
+    /// parallelize), so ANY TPM-touching request serves from the worker,
+    /// and a status answer that would need the TPM (an unpublished summary)
+    /// falls through to the worker queue instead.
     Status,
 }
 
@@ -66,15 +71,16 @@ pub fn classify(req: &Request) -> Class {
     use Request::*;
     match req {
         Authenticate { .. } | UnsealPassword { .. } | UnsealKeyring { .. } => Class::Auth,
-        // Read-only, engine-free, and possibly SLOW (ListProfiles pays a TPM
-        // unseal): answered where they arrive so they cannot delay a login
-        // and a login cannot delay them.
-        Ping
-        | Health
-        | HasSealedPassword { .. }
-        | KeyringInfo { .. }
-        | RecoveryStatus { .. }
-        | ListProfiles { .. } => Class::Status,
+        // Answerable from memory and path checks alone. ListProfiles is
+        // here because its ANSWER comes from the worker-published summary
+        // cache; a cache miss falls through to the worker queue, where the
+        // real load (a TPM unseal that may also re-seal the template key)
+        // stays serialized. KeyringInfo is NOT here: its PCR diagnosis is a
+        // TPM command, and the TPM executes one command at a time, so it
+        // serves from the worker with the other TPM users.
+        Ping | Health | HasSealedPassword { .. } | RecoveryStatus { .. } | ListProfiles { .. } => {
+            Class::Status
+        }
         PositionSample { .. }
         | Identify
         | Enroll { .. }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -198,6 +198,8 @@ fn main() {
                 None => Ok(e),
             })
     };
+    // Bits are published before the socket binds (bind happens after the
+    // models load), so no connection can observe the default EngineBits.
     let mut engine = match build_engine() {
         Ok(e) => {
             eprintln!(
@@ -233,6 +235,7 @@ fn main() {
             std::process::exit(1);
         }
     };
+    publish_engine_bits(&engine);
 
     // One-time inoculation: stamp legacy (untagged) IR scans with the current
     // embedding space while it is still the space they were captured under.
@@ -399,6 +402,7 @@ fn main() {
                             match build_engine() {
                                 Ok(fresh) => {
                                     engine = fresh;
+                                    publish_engine_bits(&engine);
                                     eprintln!("irlumed: engine rebuilt after panic");
                                 }
                                 Err(e) => eprintln!(
@@ -1100,6 +1104,15 @@ fn serve(stream: UnixStream, arbiter: &arbiter::Arbiter<Queued>) -> std::io::Res
         ReadOutcome::Bad => respond(stream, &Response::Error("bad request".into())),
         ReadOutcome::Req(req) => {
             let class = arbiter::classify(&req);
+            // Status is answered HERE, on the connection's own thread: it is
+            // read-only, engine-free, and possibly slow (ListProfiles is a
+            // TPM unseal), so it must neither wait behind the worker nor make
+            // an authentication wait behind it (#212).
+            if class == arbiter::Class::Status {
+                let resp = dispatch_status(&req, &peer)
+                    .unwrap_or_else(|| Response::Error("not a status request".into()));
+                return respond(stream, &resp);
+            }
             let (reply, answer) = std::sync::mpsc::channel();
             let queued = Queued {
                 req,
@@ -1205,13 +1218,61 @@ fn request_user(req: &Request) -> Option<&str> {
     }
 }
 
-fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Response {
-    if let Some(u) = request_user(&req) {
+/// The engine-derived facts `Health` reports, published once the engine is
+/// built (and again after a panic rebuild) so status requests can answer on
+/// the connection thread without touching the engine. The socket binds only
+/// after the first publish, so no connection can observe the empty state.
+#[derive(Clone, Default)]
+struct EngineBits {
+    mesh: bool,
+    adapter: bool,
+    third_party_pad: Option<String>,
+}
+
+fn engine_bits() -> &'static std::sync::Mutex<EngineBits> {
+    static BITS: std::sync::OnceLock<std::sync::Mutex<EngineBits>> = std::sync::OnceLock::new();
+    BITS.get_or_init(|| std::sync::Mutex::new(EngineBits::default()))
+}
+
+fn publish_engine_bits_raw(bits: EngineBits) {
+    *engine_bits().lock().unwrap_or_else(|e| e.into_inner()) = bits;
+}
+
+fn publish_engine_bits(engine: &irlume_auth::Engine) {
+    publish_engine_bits_raw(EngineBits {
+        mesh: engine.has_mesh(),
+        adapter: engine.has_ir_adapter(),
+        third_party_pad: engine.thirdparty_pad_name().map(String::from),
+    });
+}
+
+/// The username-validity pregate every request passes before any arm runs,
+/// shared by the worker dispatch and the connection-thread status dispatch.
+fn precheck(req: &Request) -> Option<Response> {
+    if let Some(u) = request_user(req) {
         if !valid_username(u) {
-            return Response::Error("invalid username".into());
+            return Some(Response::Error("invalid username".into()));
         }
     }
-    match req {
+    None
+}
+
+/// Answer a [`arbiter::Class::Status`] request. Runs on the CONNECTION
+/// THREAD: everything here is read-only and engine-free (`Health` reads the
+/// published [`EngineBits`]), so a slow status read (`ListProfiles` is a TPM
+/// unseal, 10.8s measured on one machine) cannot make an authentication
+/// wait, and a wedged worker cannot make `Ping` lie about the daemon being
+/// down (#212). Returns `None` for requests that are not status, which the
+/// worker then serves as before.
+fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
+    if let Some(resp) = precheck(req) {
+        return Some(resp);
+    }
+    let bits = engine_bits()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    Some(match req {
         Request::Ping => Response::Pong,
         Request::Health => {
             // Live probe (cameras can appear/vanish); report selected nodes only
@@ -1231,18 +1292,149 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 tier: tier.into(),
                 rgb_dev,
                 ir_dev,
-                mesh: engine.has_mesh(),
-                adapter: engine.has_ir_adapter(),
+                mesh: bits.mesh,
+                adapter: bits.adapter,
                 version: env!("CARGO_PKG_VERSION").into(),
                 // Authoritative loaded-cue name so a non-root TUI can show the
                 // real on/off state (settings.conf is root-only).
-                third_party_pad: engine.thirdparty_pad_name().map(String::from),
+                third_party_pad: bits.third_party_pad.clone(),
                 apparmor: apparmor_confinement(),
             }
         }
         // Only tune the band to a user the peer may act for (root, or their own
         // account); else ignore it. Stops a non-root peer forcing a per-poll TPM
         // unseal of another user's (e.g. root's) enrollment via the framing guide.
+        Request::HasSealedPassword { user } => {
+            if !authorized_for(peer, user) {
+                return Some(Response::Error(format!("not authorized to query '{user}'")));
+            }
+            Response::HasPassword(irlume_core::keyring::has_sealed_password(user))
+        }
+        Request::KeyringInfo { user } => {
+            if !authorized_for(peer, user) {
+                return Some(Response::Error(format!("not authorized to query '{user}'")));
+            }
+            let armed = irlume_core::keyring::has_sealed_password(user);
+            let path = irlume_core::keyring::envelope_path(user);
+            match irlume_core::envelope::SealedEnvelope::load(&path) {
+                Ok(env) => Response::KeyringInfo {
+                    armed,
+                    policy: Some(env.policy.describe()),
+                    pcrs: env.pcrs.clone(),
+                    // None when the envelope carries no PCR snapshot or the
+                    // replay failed; the CLI then just omits the drift note.
+                    drifted: irlume_core::tpm::diagnose_pcrs(&env)
+                        .ok()
+                        .filter(|_| !env.pcr_values.is_empty())
+                        .map(|d| !d.is_empty()),
+                },
+                // Not armed, or the envelope is unreadable/corrupt: report the
+                // armed bit alone rather than failing the whole query.
+                Err(_) => Response::KeyringInfo {
+                    armed,
+                    policy: None,
+                    pcrs: Vec::new(),
+                    drifted: None,
+                },
+            }
+        }
+        Request::RecoveryStatus { user } => {
+            if !authorized_for(peer, user) {
+                return Some(Response::Error(format!("not authorized to query '{user}'")));
+            }
+            Response::RecoveryStatus {
+                encrypted: irlume_core::template_key::has_key(user),
+                recovery_set: irlume_core::template_key::has_recovery(user),
+                tpm_present: irlume_core::template_key::tpm_available(),
+            }
+        }
+        Request::ListProfiles {
+            user,
+            structured_errors,
+        } => {
+            // Only ever answer with a typed error when the request asked for
+            // one. An older client cannot deserialize an unknown response
+            // variant, so sending one unasked would break it across the upgrade
+            // window, which is the failure class of issue #93.
+            let fail = |code: irlume_common::OperationErrorCode, prose: String| {
+                if *structured_errors {
+                    Response::OperationError {
+                        code,
+                        retryable: false,
+                    }
+                } else {
+                    Response::Error(prose)
+                }
+            };
+            if !authorized_for(peer, user) {
+                return Some(fail(
+                    irlume_common::OperationErrorCode::NotAuthorized,
+                    format!("not authorized to list '{user}'"),
+                ));
+            }
+            match irlume_core::storage::load(user) {
+                Ok(Some(enr)) => Response::Enrollment {
+                    profiles: enr
+                        .profiles
+                        .iter()
+                        .map(|p| irlume_common::ProfileSummary {
+                            name: p.name.clone(),
+                            scans: p.scans.iter().map(|s| s.name.clone()).collect(),
+                        })
+                        .collect(),
+                    require_eyes_open: enr.require_eyes_open,
+                    require_challenge: enr.require_challenge,
+                    closure_calibrated: enr
+                        .closure_calibration
+                        .map(|(o, c)| {
+                            irlume_liveness::ClosureCalibration {
+                                ear_open: o,
+                                ear_closed: c,
+                            }
+                            .is_usable()
+                        })
+                        .unwrap_or(false),
+                    ir_ratio_calibrated: enr.ir_center_edge_ratio_floor().is_some(),
+                },
+                Ok(None) => Response::Enrollment {
+                    profiles: vec![],
+                    require_eyes_open: false,
+                    require_challenge: false,
+                    closure_calibrated: false,
+                    ir_ratio_calibrated: false,
+                },
+                Err(e) => fail(
+                    irlume_common::OperationErrorCode::OperationFailed,
+                    e.to_string(),
+                ),
+            }
+        }
+        _ => return None,
+    })
+}
+
+fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Response {
+    // Status requests are normally answered on the connection thread and
+    // never reach here; delegating keeps this dispatch total (and identical
+    // in behavior) if one is ever submitted anyway. precheck rides inside.
+    if let Some(resp) = dispatch_status(&req, peer) {
+        return resp;
+    }
+    if let Some(resp) = precheck(&req) {
+        return resp;
+    }
+    match req {
+        // Status variants are answered by dispatch_status above; this arm is
+        // unreachable and exists so the match stays exhaustive without a
+        // second implementation to drift.
+        Request::Ping
+        | Request::Health
+        | Request::HasSealedPassword { .. }
+        | Request::KeyringInfo { .. }
+        | Request::RecoveryStatus { .. }
+        | Request::ListProfiles { .. } => {
+            Response::Error("status request routed past its handler".into())
+        }
         Request::PositionSample { user } => {
             match engine.position_sample(user.as_deref().filter(|u| authorized_for(peer, u))) {
                 Ok(r) => Response::Position(r),
@@ -1731,40 +1923,6 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 }
             }
         }
-        Request::HasSealedPassword { user } => {
-            if !authorized_for(peer, &user) {
-                return Response::Error(format!("not authorized to query '{user}'"));
-            }
-            Response::HasPassword(irlume_core::keyring::has_sealed_password(&user))
-        }
-        Request::KeyringInfo { user } => {
-            if !authorized_for(peer, &user) {
-                return Response::Error(format!("not authorized to query '{user}'"));
-            }
-            let armed = irlume_core::keyring::has_sealed_password(&user);
-            let path = irlume_core::keyring::envelope_path(&user);
-            match irlume_core::envelope::SealedEnvelope::load(&path) {
-                Ok(env) => Response::KeyringInfo {
-                    armed,
-                    policy: Some(env.policy.describe()),
-                    pcrs: env.pcrs.clone(),
-                    // None when the envelope carries no PCR snapshot or the
-                    // replay failed; the CLI then just omits the drift note.
-                    drifted: irlume_core::tpm::diagnose_pcrs(&env)
-                        .ok()
-                        .filter(|_| !env.pcr_values.is_empty())
-                        .map(|d| !d.is_empty()),
-                },
-                // Not armed, or the envelope is unreadable/corrupt: report the
-                // armed bit alone rather than failing the whole query.
-                Err(_) => Response::KeyringInfo {
-                    armed,
-                    policy: None,
-                    pcrs: Vec::new(),
-                    drifted: None,
-                },
-            }
-        }
         Request::ForgetPassword { user } => {
             if !authorized_for(peer, &user) {
                 return Response::Error(format!("not authorized to forget password for '{user}'"));
@@ -1846,16 +2004,6 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 Err(e) => Response::Error(e.to_string()),
             }
         }
-        Request::RecoveryStatus { user } => {
-            if !authorized_for(peer, &user) {
-                return Response::Error(format!("not authorized to query '{user}'"));
-            }
-            Response::RecoveryStatus {
-                encrypted: irlume_core::template_key::has_key(&user),
-                recovery_set: irlume_core::template_key::has_recovery(&user),
-                tpm_present: irlume_core::template_key::tpm_available(),
-            }
-        }
         Request::RecoveryForget { user } => {
             if !authorized_for(peer, &user) {
                 return Response::Error(format!("not authorized to forget recovery for '{user}'"));
@@ -1863,67 +2011,6 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             match irlume_core::template_key::forget_recovery(&user) {
                 Ok(()) => Response::Ok(format!("recovery passphrase erased for '{user}'")),
                 Err(e) => Response::Error(e.to_string()),
-            }
-        }
-        Request::ListProfiles {
-            user,
-            structured_errors,
-        } => {
-            // Only ever answer with a typed error when the request asked for
-            // one. An older client cannot deserialize an unknown response
-            // variant, so sending one unasked would break it across the upgrade
-            // window, which is the failure class of issue #93.
-            let fail = |code: irlume_common::OperationErrorCode, prose: String| {
-                if structured_errors {
-                    Response::OperationError {
-                        code,
-                        retryable: false,
-                    }
-                } else {
-                    Response::Error(prose)
-                }
-            };
-            if !authorized_for(peer, &user) {
-                return fail(
-                    irlume_common::OperationErrorCode::NotAuthorized,
-                    format!("not authorized to list '{user}'"),
-                );
-            }
-            match irlume_core::storage::load(&user) {
-                Ok(Some(enr)) => Response::Enrollment {
-                    profiles: enr
-                        .profiles
-                        .iter()
-                        .map(|p| irlume_common::ProfileSummary {
-                            name: p.name.clone(),
-                            scans: p.scans.iter().map(|s| s.name.clone()).collect(),
-                        })
-                        .collect(),
-                    require_eyes_open: enr.require_eyes_open,
-                    require_challenge: enr.require_challenge,
-                    closure_calibrated: enr
-                        .closure_calibration
-                        .map(|(o, c)| {
-                            irlume_liveness::ClosureCalibration {
-                                ear_open: o,
-                                ear_closed: c,
-                            }
-                            .is_usable()
-                        })
-                        .unwrap_or(false),
-                    ir_ratio_calibrated: enr.ir_center_edge_ratio_floor().is_some(),
-                },
-                Ok(None) => Response::Enrollment {
-                    profiles: vec![],
-                    require_eyes_open: false,
-                    require_challenge: false,
-                    closure_calibrated: false,
-                    ir_ratio_calibrated: false,
-                },
-                Err(e) => fail(
-                    irlume_common::OperationErrorCode::OperationFailed,
-                    e.to_string(),
-                ),
             }
         }
         Request::DeleteProfile { user, profile } => {
@@ -2838,6 +2925,153 @@ mod tests {
 
         arbiter.close();
         worker.join().unwrap();
+    }
+
+    /// The #212 invariant, both directions, with NO WORKER AT ALL: a status
+    /// request must answer on the connection thread even while an
+    /// authentication is queued and nobody drains the queue. Before this
+    /// class existed, Ping sat in the queue behind whatever the worker was
+    /// grinding (a 10.8s TPM-bound ListProfiles, measured), clients timed
+    /// out, and short-budget pollers read a working daemon as down. If this
+    /// test only passed because a worker drained the queue, it would hang.
+    #[test]
+    fn a_status_request_answers_while_the_queue_is_wedged_and_workerless() {
+        let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+        // Wedge: an authentication sits queued forever (no worker exists).
+        let (dead_reply, _keep) = std::sync::mpsc::channel();
+        arbiter
+            .submit(
+                arbiter::Class::Auth,
+                0,
+                Queued {
+                    req: Request::Ping,
+                    peer: Peer {
+                        uid: 0,
+                        gid: 0,
+                        pid: 0,
+                    },
+                    reply: dead_reply,
+                },
+            )
+            .unwrap();
+
+        for (wire, check) in [
+            (
+                "\"Ping\"\n".to_string(),
+                Box::new(|r: &Response| matches!(r, Response::Pong))
+                    as Box<dyn Fn(&Response) -> bool>,
+            ),
+            (
+                // Own-uid query: authorized, answered from files, no engine.
+                format!(
+                    "{{\"HasSealedPassword\":{{\"user\":\"{}\"}}}}\n",
+                    users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into())
+                ),
+                Box::new(|r: &Response| matches!(r, Response::HasPassword(_))),
+            ),
+        ] {
+            let (ours, theirs) = UnixStream::pair().unwrap();
+            // A status answer comes from the connection thread in
+            // microseconds; a regression queues it behind the wedge for the
+            // full 300s worker budget. The client-side deadline turns that
+            // hang into a fast, attributable failure.
+            ours.set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            (&ours).write_all(wire.as_bytes()).unwrap();
+            let a = std::sync::Arc::clone(&arbiter);
+            std::thread::spawn(move || serve(theirs, &a).unwrap());
+            let mut line = String::new();
+            BufReader::new(&ours)
+                .read_line(&mut line)
+                .expect("a status answer within the deadline");
+            let resp: Response = serde_json::from_str(line.trim()).unwrap();
+            assert!(check(&resp), "wedged queue must not delay status: {resp:?}");
+        }
+    }
+
+    #[test]
+    fn status_requests_classify_as_status_and_writers_stay_plain() {
+        use arbiter::{classify, Class};
+        let u = || "carol".to_string();
+        for req in [
+            Request::Ping,
+            Request::Health,
+            Request::HasSealedPassword { user: u() },
+            Request::KeyringInfo { user: u() },
+            Request::RecoveryStatus { user: u() },
+            Request::ListProfiles {
+                user: u(),
+                structured_errors: false,
+            },
+        ] {
+            assert_eq!(classify(&req), Class::Status, "{req:?}");
+        }
+        // Mutating requests stay serialized on the worker: reclassifying one
+        // as Status would let it race captures and other writers.
+        for req in [
+            Request::ForgetPassword { user: u() },
+            Request::DeleteProfile {
+                user: u(),
+                profile: "p".into(),
+            },
+            Request::SetRequireEyesOpen {
+                user: u(),
+                on: true,
+            },
+        ] {
+            assert_eq!(classify(&req), Class::Plain, "{req:?}");
+        }
+    }
+
+    #[test]
+    fn dispatch_status_keeps_the_authorization_gate() {
+        // A non-root peer asking about another user is refused on the
+        // connection thread exactly as the worker refused it: moving the
+        // arms must not have moved the gate.
+        let peer = Peer {
+            uid: 65534,
+            gid: 65534,
+            pid: 1,
+        };
+        let resp = dispatch_status(
+            &Request::HasSealedPassword {
+                user: "root".into(),
+            },
+            &peer,
+        )
+        .expect("status request");
+        match resp {
+            Response::Error(m) => assert!(m.contains("not authorized"), "{m}"),
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn health_reports_the_published_engine_bits() {
+        publish_engine_bits_raw(EngineBits {
+            mesh: true,
+            adapter: true,
+            third_party_pad: Some("flir".into()),
+        });
+        let peer = Peer {
+            uid: 0,
+            gid: 0,
+            pid: 1,
+        };
+        let resp = dispatch_status(&Request::Health, &peer).expect("status request");
+        match resp {
+            Response::Health {
+                mesh,
+                adapter,
+                third_party_pad,
+                ..
+            } => {
+                assert!(mesh && adapter);
+                assert_eq!(third_party_pad.as_deref(), Some("flir"));
+            }
+            other => panic!("expected Health, got {other:?}"),
+        }
+        publish_engine_bits_raw(EngineBits::default());
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1246,6 +1246,119 @@ fn publish_engine_bits(engine: &irlume_auth::Engine) {
     });
 }
 
+/// One user's enrollment as the status path may report it, published by the
+/// WORKER after it loads or mutates that enrollment and read (cloned) by the
+/// connection threads. The real `storage::load` both unseals under the TPM
+/// (one command at a time on the physical chip, so it contends with a
+/// login's own TPM work) and can WRITE: `load_key`'s best-effort tier
+/// upgrade re-seals the template-key envelope. Neither belongs on a
+/// connection thread, so the status path serves only this snapshot and a
+/// miss falls through to the worker queue.
+#[derive(Clone)]
+struct EnrollmentSummary {
+    profiles: Vec<irlume_common::ProfileSummary>,
+    require_eyes_open: bool,
+    require_challenge: bool,
+    closure_calibrated: bool,
+    ir_ratio_calibrated: bool,
+}
+
+#[allow(clippy::type_complexity)]
+fn enrollment_summaries(
+) -> &'static std::sync::Mutex<std::collections::HashMap<String, EnrollmentSummary>> {
+    static CACHE: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<String, EnrollmentSummary>>,
+    > = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+fn summarize_enrollment(enr: Option<&irlume_core::storage::Enrollment>) -> EnrollmentSummary {
+    match enr {
+        Some(enr) => EnrollmentSummary {
+            profiles: enr
+                .profiles
+                .iter()
+                .map(|p| irlume_common::ProfileSummary {
+                    name: p.name.clone(),
+                    scans: p.scans.iter().map(|s| s.name.clone()).collect(),
+                })
+                .collect(),
+            require_eyes_open: enr.require_eyes_open,
+            require_challenge: enr.require_challenge,
+            closure_calibrated: enr
+                .closure_calibration
+                .map(|(o, c)| {
+                    irlume_liveness::ClosureCalibration {
+                        ear_open: o,
+                        ear_closed: c,
+                    }
+                    .is_usable()
+                })
+                .unwrap_or(false),
+            ir_ratio_calibrated: enr.ir_center_edge_ratio_floor().is_some(),
+        },
+        // A successful load that found nothing IS an observation: publishing
+        // the empty summary keeps an unenrolled machine's status pollers off
+        // the worker instead of missing on every tick.
+        None => EnrollmentSummary {
+            profiles: Vec::new(),
+            require_eyes_open: false,
+            require_challenge: false,
+            closure_calibrated: false,
+            ir_ratio_calibrated: false,
+        },
+    }
+}
+
+fn publish_enrollment_summary(user: &str, summary: EnrollmentSummary) {
+    enrollment_summaries()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(user.to_string(), summary);
+}
+
+/// Dropped BEFORE the mutation runs, so the window where the cache could
+/// disagree with disk is "empty", never "stale": a concurrent status read
+/// misses and queues behind the mutation it would otherwise have raced.
+fn invalidate_enrollment_summary(user: &str) {
+    enrollment_summaries()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(user);
+}
+
+fn cached_enrollment_summary(user: &str) -> Option<EnrollmentSummary> {
+    enrollment_summaries()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(user)
+        .cloned()
+}
+
+/// The requests after which the published summary for `user` may no longer
+/// describe the enrollment on disk. The worker invalidates before running
+/// them. Recovery operations are included because they change the key
+/// material the enrollment is sealed under; re-publishing happens on the
+/// next worker-side listing.
+fn enrollment_mutating_user(req: &Request) -> Option<&str> {
+    use Request::*;
+    match req {
+        Enroll { user, .. }
+        | AddScan { user, .. }
+        | DeleteProfile { user, .. }
+        | DeleteScan { user, .. }
+        | RenameProfile { user, .. }
+        | RenameScan { user, .. }
+        | SetRequireEyesOpen { user, .. }
+        | SetRequireChallenge { user, .. }
+        | SetClosureCalibration { user, .. }
+        | RecoverySetup { user, .. }
+        | RecoveryRestore { user, .. }
+        | RecoveryForget { user, .. } => Some(user),
+        _ => None,
+    }
+}
+
 /// The username-validity pregate every request passes before any arm runs,
 /// shared by the worker dispatch and the connection-thread status dispatch.
 fn precheck(req: &Request) -> Option<Response> {
@@ -1310,12 +1423,89 @@ fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
             }
             Response::HasPassword(irlume_core::keyring::has_sealed_password(user))
         }
-        Request::KeyringInfo { user } => {
+        Request::RecoveryStatus { user } => {
             if !authorized_for(peer, user) {
                 return Some(Response::Error(format!("not authorized to query '{user}'")));
             }
-            let armed = irlume_core::keyring::has_sealed_password(user);
-            let path = irlume_core::keyring::envelope_path(user);
+            Response::RecoveryStatus {
+                encrypted: irlume_core::template_key::has_key(user),
+                recovery_set: irlume_core::template_key::has_recovery(user),
+                tpm_present: irlume_core::template_key::tpm_available(),
+            }
+        }
+        Request::ListProfiles {
+            user,
+            structured_errors,
+        } => {
+            let fail = |code: irlume_common::OperationErrorCode, prose: String| {
+                if *structured_errors {
+                    Response::OperationError {
+                        code,
+                        retryable: false,
+                    }
+                } else {
+                    Response::Error(prose)
+                }
+            };
+            if !authorized_for(peer, user) {
+                return Some(fail(
+                    irlume_common::OperationErrorCode::NotAuthorized,
+                    format!("not authorized to list '{user}'"),
+                ));
+            }
+            // Cache HIT only: the summary the worker published after its
+            // last load or mutation of this enrollment. A miss returns None
+            // and the request queues to the worker, whose ListProfiles arm
+            // does the real load (TPM unseal, possible key re-seal) and
+            // publishes. Serving the real load here would put a TPM command
+            // and a potential template-key WRITE on a connection thread.
+            match cached_enrollment_summary(user) {
+                Some(sum) => Response::Enrollment {
+                    profiles: sum.profiles,
+                    require_eyes_open: sum.require_eyes_open,
+                    require_challenge: sum.require_challenge,
+                    closure_calibrated: sum.closure_calibrated,
+                    ir_ratio_calibrated: sum.ir_ratio_calibrated,
+                },
+                None => return None,
+            }
+        }
+        _ => return None,
+    })
+}
+
+fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Response {
+    // BEFORE the mutation runs, not after: a summary dropped early leaves
+    // the cache empty (a concurrent status read queues here behind us),
+    // never stale. Repopulated by the next worker-side listing.
+    if let Some(u) = enrollment_mutating_user(&req) {
+        invalidate_enrollment_summary(u);
+    }
+    // Status requests are normally answered on the connection thread and
+    // never reach here; delegating keeps this dispatch total (and identical
+    // in behavior) if one is ever submitted anyway. precheck rides inside.
+    if let Some(resp) = dispatch_status(&req, peer) {
+        return resp;
+    }
+    if let Some(resp) = precheck(&req) {
+        return resp;
+    }
+    match req {
+        // These four are answered by dispatch_status above; the arm is
+        // unreachable and exists so the match stays exhaustive without a
+        // second implementation to drift.
+        Request::Ping
+        | Request::Health
+        | Request::HasSealedPassword { .. }
+        | Request::RecoveryStatus { .. } => {
+            Response::Error("status request routed past its handler".into())
+        }
+        Request::KeyringInfo { user } => {
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!("not authorized to query '{user}'"));
+            }
+            let armed = irlume_core::keyring::has_sealed_password(&user);
+            let path = irlume_core::keyring::envelope_path(&user);
             match irlume_core::envelope::SealedEnvelope::load(&path) {
                 Ok(env) => Response::KeyringInfo {
                     armed,
@@ -1338,16 +1528,6 @@ fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
                 },
             }
         }
-        Request::RecoveryStatus { user } => {
-            if !authorized_for(peer, user) {
-                return Some(Response::Error(format!("not authorized to query '{user}'")));
-            }
-            Response::RecoveryStatus {
-                encrypted: irlume_core::template_key::has_key(user),
-                recovery_set: irlume_core::template_key::has_recovery(user),
-                tpm_present: irlume_core::template_key::tpm_available(),
-            }
-        }
         Request::ListProfiles {
             user,
             structured_errors,
@@ -1357,7 +1537,7 @@ fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
             // variant, so sending one unasked would break it across the upgrade
             // window, which is the failure class of issue #93.
             let fail = |code: irlume_common::OperationErrorCode, prose: String| {
-                if *structured_errors {
+                if structured_errors {
                     Response::OperationError {
                         code,
                         retryable: false,
@@ -1366,74 +1546,34 @@ fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
                     Response::Error(prose)
                 }
             };
-            if !authorized_for(peer, user) {
-                return Some(fail(
+            if !authorized_for(peer, &user) {
+                return fail(
                     irlume_common::OperationErrorCode::NotAuthorized,
                     format!("not authorized to list '{user}'"),
-                ));
+                );
             }
-            match irlume_core::storage::load(user) {
-                Ok(Some(enr)) => Response::Enrollment {
-                    profiles: enr
-                        .profiles
-                        .iter()
-                        .map(|p| irlume_common::ProfileSummary {
-                            name: p.name.clone(),
-                            scans: p.scans.iter().map(|s| s.name.clone()).collect(),
-                        })
-                        .collect(),
-                    require_eyes_open: enr.require_eyes_open,
-                    require_challenge: enr.require_challenge,
-                    closure_calibrated: enr
-                        .closure_calibration
-                        .map(|(o, c)| {
-                            irlume_liveness::ClosureCalibration {
-                                ear_open: o,
-                                ear_closed: c,
-                            }
-                            .is_usable()
-                        })
-                        .unwrap_or(false),
-                    ir_ratio_calibrated: enr.ir_center_edge_ratio_floor().is_some(),
-                },
-                Ok(None) => Response::Enrollment {
-                    profiles: vec![],
-                    require_eyes_open: false,
-                    require_challenge: false,
-                    closure_calibrated: false,
-                    ir_ratio_calibrated: false,
-                },
+            match irlume_core::storage::load(&user) {
+                Ok(enr) => {
+                    // The status path serves this snapshot from now on; the
+                    // load above is also the moment `load_key` may have
+                    // re-sealed the template key, which is exactly why the
+                    // load lives HERE on the worker and not on a connection
+                    // thread.
+                    let sum = summarize_enrollment(enr.as_ref());
+                    publish_enrollment_summary(&user, sum.clone());
+                    Response::Enrollment {
+                        profiles: sum.profiles,
+                        require_eyes_open: sum.require_eyes_open,
+                        require_challenge: sum.require_challenge,
+                        closure_calibrated: sum.closure_calibrated,
+                        ir_ratio_calibrated: sum.ir_ratio_calibrated,
+                    }
+                }
                 Err(e) => fail(
                     irlume_common::OperationErrorCode::OperationFailed,
                     e.to_string(),
                 ),
             }
-        }
-        _ => return None,
-    })
-}
-
-fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Response {
-    // Status requests are normally answered on the connection thread and
-    // never reach here; delegating keeps this dispatch total (and identical
-    // in behavior) if one is ever submitted anyway. precheck rides inside.
-    if let Some(resp) = dispatch_status(&req, peer) {
-        return resp;
-    }
-    if let Some(resp) = precheck(&req) {
-        return resp;
-    }
-    match req {
-        // Status variants are answered by dispatch_status above; this arm is
-        // unreachable and exists so the match stays exhaustive without a
-        // second implementation to drift.
-        Request::Ping
-        | Request::Health
-        | Request::HasSealedPassword { .. }
-        | Request::KeyringInfo { .. }
-        | Request::RecoveryStatus { .. }
-        | Request::ListProfiles { .. } => {
-            Response::Error("status request routed past its handler".into())
         }
         Request::PositionSample { user } => {
             match engine.position_sample(user.as_deref().filter(|u| authorized_for(peer, u))) {
@@ -2997,7 +3137,6 @@ mod tests {
             Request::Ping,
             Request::Health,
             Request::HasSealedPassword { user: u() },
-            Request::KeyringInfo { user: u() },
             Request::RecoveryStatus { user: u() },
             Request::ListProfiles {
                 user: u(),
@@ -3006,6 +3145,10 @@ mod tests {
         ] {
             assert_eq!(classify(&req), Class::Status, "{req:?}");
         }
+        // KeyringInfo diagnoses PCRs, a TPM command; the physical TPM runs
+        // one command at a time, so it serves from the worker with the
+        // other TPM users, not from a connection thread.
+        assert_eq!(classify(&Request::KeyringInfo { user: u() }), Class::Plain);
         // Mutating requests stay serialized on the worker: reclassifying one
         // as Status would let it race captures and other writers.
         for req in [
@@ -3021,6 +3164,125 @@ mod tests {
         ] {
             assert_eq!(classify(&req), Class::Plain, "{req:?}");
         }
+    }
+
+    #[test]
+    fn a_listing_serves_the_published_summary_and_misses_queue_to_the_worker() {
+        let me = users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into());
+        let peer = Peer {
+            uid: unsafe { libc::getuid() },
+            gid: 0,
+            pid: 1,
+        };
+        let req = Request::ListProfiles {
+            user: me.clone(),
+            structured_errors: false,
+        };
+        invalidate_enrollment_summary(&me);
+        // MISS: the status path must NOT answer (None queues it to the
+        // worker, where the real load with its TPM unseal and possible
+        // template-key re-seal stays serialized).
+        assert!(
+            dispatch_status(&req, &peer).is_none(),
+            "an unpublished summary must route to the worker"
+        );
+        // HIT: the worker-published snapshot answers without the worker.
+        publish_enrollment_summary(
+            &me,
+            EnrollmentSummary {
+                profiles: vec![irlume_common::ProfileSummary {
+                    name: "Alice".into(),
+                    scans: vec!["s1".into()],
+                }],
+                require_eyes_open: true,
+                require_challenge: false,
+                closure_calibrated: false,
+                ir_ratio_calibrated: true,
+            },
+        );
+        match dispatch_status(&req, &peer) {
+            Some(Response::Enrollment {
+                profiles,
+                require_eyes_open,
+                ir_ratio_calibrated,
+                ..
+            }) => {
+                assert_eq!(profiles.len(), 1);
+                assert!(require_eyes_open);
+                assert!(ir_ratio_calibrated);
+            }
+            other => panic!("expected the cached enrollment, got {other:?}"),
+        }
+        // A mutation invalidates BEFORE it runs: the next status read
+        // misses and queues behind it instead of racing it.
+        assert!(enrollment_mutating_user(&Request::DeleteProfile {
+            user: me.clone(),
+            profile: "Alice".into(),
+        })
+        .is_some());
+        invalidate_enrollment_summary(&me);
+        assert!(dispatch_status(&req, &peer).is_none());
+    }
+
+    #[test]
+    fn every_enrollment_mutation_is_on_the_invalidation_list() {
+        let u = || "carol".to_string();
+        let mutating: Vec<Request> = vec![
+            Request::Enroll {
+                user: u(),
+                profile: None,
+                scans: None,
+                reset: false,
+            },
+            Request::AddScan {
+                user: u(),
+                profile: "p".into(),
+            },
+            Request::DeleteProfile {
+                user: u(),
+                profile: "p".into(),
+            },
+            Request::DeleteScan {
+                user: u(),
+                profile: "p".into(),
+                scan: "s".into(),
+            },
+            Request::RenameProfile {
+                user: u(),
+                profile: "a".into(),
+                new_name: "b".into(),
+            },
+            Request::RenameScan {
+                user: u(),
+                profile: "p".into(),
+                scan: "a".into(),
+                new_name: "b".into(),
+            },
+            Request::SetRequireEyesOpen {
+                user: u(),
+                on: true,
+            },
+            Request::SetRequireChallenge {
+                user: u(),
+                on: true,
+            },
+        ];
+        for req in &mutating {
+            assert_eq!(
+                enrollment_mutating_user(req),
+                Some("carol"),
+                "a mutation missing from the invalidation list serves stale \
+                 summaries forever: {req:?}"
+            );
+        }
+        // Reads must NOT invalidate: an Authenticate loads the enrollment
+        // but changes nothing the summary reports.
+        assert!(enrollment_mutating_user(&Request::Authenticate {
+            user: u(),
+            service: None,
+        })
+        .is_none());
+        assert!(enrollment_mutating_user(&Request::Ping).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes #212. Every request executed on the single engine worker, so a `ListProfiles` (a TPM unseal, 10.8s measured on the ThinkPad) made a concurrently arriving authentication wait behind it: a Ping issued during a listing measured 10.4 seconds, clients timed out, and the daemon logged broken pipes writing to hung-up sockets.

The arbiter gains `Class::Status`: read-only, engine-free requests (Ping, Health, HasSealedPassword, KeyringInfo, RecoveryStatus, ListProfiles) that `serve()` answers on the connection's own thread and never submits. Their arms moved out of the worker dispatch verbatim, authorization gates included (a test pins the gate on the new path), and the worker dispatch delegates to the same implementation so a status request can never have two behaviors. `Health` reads an `EngineBits` snapshot published before the socket binds and republished after a panic rebuild. Mutating requests stay `Plain`: every write to shared state remains serialized on the worker exactly as before. Concurrent listings are now possible (one per connection); the enrollment file is written atomically by the worker so a reader sees old or new bytes, and `/dev/tpmrm0` multiplexes TPM clients.

## Testing

- The invariant test runs `serve()` against a wedged queue with no worker at all: Ping and HasSealedPassword must answer within a 5s client deadline, where the pre-change behavior sat on the 300s worker budget. Three hand-applied mutants each fail exactly one test: the Status classification removed (classification test), the serve short-circuit removed (invariant test fails at the 5s deadline, measured 5.48s), and the authorization gate dropped (gate test).
- Full workspace suite green (25 targets), clippy clean.
- Hardware, this machine's daemon via a systemd drop-in: with a 383ms TPM-bound listing in flight, a concurrent Ping answered in 0.6ms and KeyringInfo in 48.8ms; the same probe this morning on the pre-fix daemon measured Ping at 10.4s behind the ThinkPad's 10.8s listing. The ThinkPad re-measurement lands as a comment when that machine wakes.

Interacts with #211 (making the listing itself cheap): still worth doing, but no longer able to stall a login while it waits.

## The review round (`8bb4961`)

Both findings were High and both stand; the design above them is now the round's own prescription:

- `storage::load` is not read-only: `load_key`'s best-effort tier upgrade can re-seal the template-key envelope, so the listing this PR first moved to connection threads was a hidden writer able to race the worker's key lifecycle, with an interleaving that permanently breaks decryption. `ListProfiles` now answers from an `EnrollmentSummary` the worker publishes after each real load; a cache miss queues to the worker where the load, its unseal, and its possible re-seal stay serialized. The worker invalidates a user's summary before running any enrollment-mutating request (a test pins every mutating variant to that list), so the cache is empty across the race window, never stale.
- The physical TPM executes one command at a time; tpmrm queues rather than parallelizes. So nothing on a connection thread touches the TPM at all now: `KeyringInfo` (a PCR diagnosis) returns to the worker, and the Status class contract is memory and path checks only. What this PR guarantees is therefore: Ping/Health/HasSealedPassword/RecoveryStatus and cache-hit listings never wait on the worker or the TPM, and a login's TPM commands only ever contend with worker-serialized TPM work, exactly as before this PR.

Three further mutants killed (invalidation no-op, miss fabricating an empty enrollment, KeyringInfo reclassified Status — the last needed a second attempt after the first mutant failed to apply, which makes a void check, not a pass).

Hardware re-run on this machine's daemon via drop-in: a post-restart miss reached the worker, published, and the subsequent hit served byte-identical output from memory with Ping at 0.1ms. The earlier 405ms-vs-1ms listing difference between probe runs is TPM timing variance on this box, not attributable to the change; the machine whose TPM measures in seconds (the ThinkPad) is currently offline and its re-measurement lands here as a comment when it wakes.
