### PR TITLE
A status miss falls through to the worker instead of answering an error

### DIFF
--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3043,6 +3043,19 @@ mod tests {
         assert_eq!(peer.pid, std::process::id() as i32);
     }
 
+    /// Serialize the tests that mutate the process-global enrollment-summary
+    /// cache for the same username. libtest runs tests in parallel, so
+    /// without this one test's `publish` lands inside another's miss window
+    /// and turns a real pass into an intermittent failure (or worse, a false
+    /// pass in a mutation run, which is how a flake becomes a lie about
+    /// coverage).
+    fn enrollment_summary_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     /// A Status request the connection thread CANNOT answer from memory must
     /// reach the worker, not be answered with an error.
     ///
@@ -3054,6 +3067,7 @@ mod tests {
     /// asserting their type: both were the same error.
     #[test]
     fn an_unpublished_listing_reaches_the_worker_instead_of_erroring() {
+        let _summary_guard = enrollment_summary_test_lock();
         let me = users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into());
         invalidate_enrollment_summary(&me);
 
@@ -3247,6 +3261,7 @@ mod tests {
 
     #[test]
     fn a_listing_serves_the_published_summary_and_misses_queue_to_the_worker() {
+        let _summary_guard = enrollment_summary_test_lock();
         let me = users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into());
         let peer = Peer {
             uid: unsafe { libc::getuid() },

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1108,10 +1108,17 @@ fn serve(stream: UnixStream, arbiter: &arbiter::Arbiter<Queued>) -> std::io::Res
             // read-only, engine-free, and possibly slow (ListProfiles is a
             // TPM unseal), so it must neither wait behind the worker nor make
             // an authentication wait behind it (#212).
+            // A Status request is answered here ONLY if dispatch_status can
+            // answer it from memory. `None` means it cannot (an unpublished
+            // enrollment summary), and the request must then take the normal
+            // queue path so the worker does the real load and publishes it.
+            // Answering the None with an error instead made every listing
+            // fail: the miss never reached the worker, so nothing ever
+            // published, so every later listing missed too.
             if class == arbiter::Class::Status {
-                let resp = dispatch_status(&req, &peer)
-                    .unwrap_or_else(|| Response::Error("not a status request".into()));
-                return respond(stream, &resp);
+                if let Some(resp) = dispatch_status(&req, &peer) {
+                    return respond(stream, &resp);
+                }
             }
             let (reply, answer) = std::sync::mpsc::channel();
             let queued = Queued {
@@ -3034,6 +3041,78 @@ mod tests {
         assert_eq!(peer.uid, unsafe { libc::geteuid() });
         assert_eq!(peer.gid, unsafe { libc::getegid() });
         assert_eq!(peer.pid, std::process::id() as i32);
+    }
+
+    /// A Status request the connection thread CANNOT answer from memory must
+    /// reach the worker, not be answered with an error.
+    ///
+    /// Shipped broken once: `serve` turned `dispatch_status`'s `None` (an
+    /// unpublished enrollment summary) into `Error("not a status request")`,
+    /// so the miss never reached the worker, nothing ever published, and
+    /// every listing on the machine failed. The bug survived a hardware
+    /// check that compared two response BODIES for equality without
+    /// asserting their type: both were the same error.
+    #[test]
+    fn an_unpublished_listing_reaches_the_worker_instead_of_erroring() {
+        let me = users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into());
+        invalidate_enrollment_summary(&me);
+
+        let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+        let worker = {
+            let arbiter = std::sync::Arc::clone(&arbiter);
+            std::thread::spawn(move || {
+                while let Some(job) = arbiter.take() {
+                    let Queued { req, reply, .. } = job.payload;
+                    arbiter.finish(job.class, job.uid);
+                    // Stand in for the real load: the worker is what answers
+                    // a miss, and what publishes the summary afterwards.
+                    let resp = match req {
+                        Request::ListProfiles { .. } => Response::Enrollment {
+                            profiles: vec![irlume_common::ProfileSummary {
+                                name: "FromWorker".into(),
+                                scans: vec!["s1".into()],
+                            }],
+                            require_eyes_open: false,
+                            require_challenge: false,
+                            closure_calibrated: false,
+                            ir_ratio_calibrated: false,
+                        },
+                        _ => Response::Pong,
+                    };
+                    let _ = reply.send(resp);
+                }
+            })
+        };
+
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        ours.set_read_timeout(Some(std::time::Duration::from_secs(10)))
+            .unwrap();
+        (&ours)
+            .write_all(
+                format!("{{\"ListProfiles\":{{\"user\":\"{me}\",\"structured_errors\":false}}}}\n")
+                    .as_bytes(),
+            )
+            .unwrap();
+        let a = std::sync::Arc::clone(&arbiter);
+        std::thread::spawn(move || serve(theirs, &a).unwrap());
+
+        let mut line = String::new();
+        BufReader::new(&ours)
+            .read_line(&mut line)
+            .expect("an answer within the deadline");
+        let resp: Response = serde_json::from_str(line.trim()).unwrap();
+        match resp {
+            Response::Enrollment { profiles, .. } => {
+                assert_eq!(
+                    profiles.first().map(|p| p.name.as_str()),
+                    Some("FromWorker")
+                )
+            }
+            other => panic!("a cache miss must be served by the worker, got {other:?}"),
+        }
+
+        arbiter.close();
+        worker.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Regression shipped in #218, caught on archhost within the hour. `serve` turned `dispatch_status`'s `None` (an unpublished enrollment summary) into `Error("not a status request")` and returned it, so the miss never reached the worker, the worker never published a summary, and every subsequent listing missed too. On a machine running that build, `ListProfiles` fails for every client: the TUI's Profiles screen, `irlume profiles list`, anything that lists.

`serve` now answers only what `dispatch_status` can answer and lets a `None` take the normal queue path.

## How it survived the first hardware check

My verification compared two response **bodies for equality** without asserting their type. Both were the same error, and "identical: True" read as success. The regression test asserts the response IS an `Enrollment`, served by a stand-in worker, and fails against the shipped code with the exact message users saw (`a cache miss must be served by the worker, got Error("not a status request")`).

## Measured on archhost (discrete TPM, real enrollment)

| | packaged 0.7.0 daemon | #218 as merged | this fix |
|---|---|---|---|
| listing (cache miss) | 1472 ms, Enrollment | 0 ms, **Error** | 1492 ms, Enrollment |
| listing (repeat) | 1448 ms, Enrollment | 0.1 ms, **Error** | 0.2 ms, Enrollment (identical body) |
| Ping during a listing | **1419 ms** | n/a (no real listing ran) | **0.2 ms** |
| HasSealedPassword during a listing | — | — | 0.2 ms |

The bottom row is #212's invariant, now measured against a real 1469 ms worker listing rather than inferred.

Daemon deployed by drop-in for each measurement and reverted afterwards; the packaged daemon is answering on archhost again.

## The review round

SHIP, no runtime or security defect. Its one finding was a test-isolation race I introduced: both cache tests key on the current username and libtest runs in parallel, so one test's publish could land inside the other's miss window. Applied rather than deferred, because that shape does not just flake, it manufactures false results in a mutation run. Suite run three times clean afterwards.
