### PR TITLE
Record face_frac with the liveness cues, gating nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Seating distance is recorded with the liveness cues.** `face_frac` (face
+  width as a fraction of frame width, the same quantity the framing guide
+  judges distance by) now rides in `Signals` and both liveness debug lines.
+  It gates nothing. Several existing cues are absolute thresholds on
+  quantities that may move across the guide's accepted 0.12 to 0.55 band, and
+  #174 asks which ones actually do before any of them is retuned; recording
+  the distance signal alongside them makes that answerable from ordinary
+  `IRLUME_LOG=debug` output rather than a special capture campaign.
+
 ### Fixed
 
 - **A status read can no longer make a login wait.** Every request used to

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -781,10 +781,7 @@ impl Engine {
             head_yaw_asym: pose.map(|p| p.yaw_asym).unwrap_or(0.0),
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: 0.0, // RGB-only path: no IR burst to measure
-            face_frac: rgb_top
-                .as_ref()
-                .map(|f| bbox_width_frac(&f.bbox, rgb.width))
-                .unwrap_or(0.0),
+            face_frac: face_frac_of(rgb_top.as_ref().map(|f| &f.bbox), rgb.width),
             rgb_face_brightness: rgb_brightness,
             rgb_specular_frac: rgb_specular,
             rgb_moire_score: rgb_moire,
@@ -1137,10 +1134,7 @@ impl Engine {
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: ir_stats.ambient_mean,
             // From the IR frame, because the IR cues are measured there.
-            face_frac: ir_top
-                .as_ref()
-                .map(|f| bbox_width_frac(&f.bbox, ir.width))
-                .unwrap_or(0.0),
+            face_frac: face_frac_of(ir_top.as_ref().map(|f| &f.bbox), ir.width),
             rgb_face_brightness: rgb_brightness,
             rgb_moire_score: 0.0,
             rgb_specular_frac: 0.0,
@@ -2992,14 +2986,6 @@ pub fn mean_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
     }
 }
 
-/// The IR center/edge cue: ratio of the center-box mean to the edge-ring mean
-/// of the IR face crop (grey 0-255). A real 3D face lit by the near-coaxial
-/// emitter is brighter at the center/nose and falls off at the rim (ratio
-/// above 1); a flat matte screen/photo reads ~1. This is a brightness ratio,
-/// not a range measurement: a glossy print with a hot specular center clears
-/// it (docs/pad-results/2026-06-30-ir-liveness-selftest.md), which is why it is
-/// one cue and not a liveness proof. Returns 0.0 on a degenerate bbox or a
-/// near-black edge (no signal, never inf).
 /// Face width as a fraction of frame width: the framing guide's `face_frac`,
 /// computed from a detection box so the liveness path can record the same
 /// quantity the guide judges seating distance by (#174).
@@ -3010,6 +2996,25 @@ pub fn bbox_width_frac(bbox: &[f32; 4], frame_width: u32) -> f32 {
     (bbox[2] - bbox[0]).max(0.0) / frame_width as f32
 }
 
+/// `Signals::face_frac` for a capture: the top detection's width fraction, or
+/// 0.0 when nothing was detected.
+///
+/// Separated from the two call sites so the DECISION (no face means no
+/// distance signal, not a fabricated one) is a value a test can construct.
+/// What remains untestable off hardware is only which frame each caller
+/// hands in, one expression per path.
+pub fn face_frac_of(bbox: Option<&[f32; 4]>, frame_width: u32) -> f32 {
+    bbox.map(|b| bbox_width_frac(b, frame_width)).unwrap_or(0.0)
+}
+
+/// The IR center/edge cue: ratio of the center-box mean to the edge-ring mean
+/// of the IR face crop (grey 0-255). A real 3D face lit by the near-coaxial
+/// emitter is brighter at the center/nose and falls off at the rim (ratio
+/// above 1); a flat matte screen/photo reads ~1. This is a brightness ratio,
+/// not a range measurement: a glossy print with a hot specular center clears
+/// it (docs/pad-results/2026-06-30-ir-liveness-selftest.md), which is why it is
+/// one cue and not a liveness proof. Returns 0.0 on a degenerate bbox or a
+/// near-black edge (no signal, never inf).
 pub fn center_edge_ratio(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
     let (bw, bh) = (bbox[2] - bbox[0], bbox[3] - bbox[1]);
     if bw <= 4.0 || bh <= 4.0 {
@@ -3762,6 +3767,16 @@ mod tests {
         // Degenerate inputs report no face rather than a negative or a NaN.
         assert_eq!(bbox_width_frac(&[300.0, 0.0, 100.0, 50.0], 640), 0.0);
         assert_eq!(bbox_width_frac(&[0.0, 0.0, 100.0, 50.0], 0), 0.0);
+    }
+
+    /// No detection means NO distance signal, and 0.0 is how that is spelled:
+    /// a reader correlating cues against face size must be able to drop those
+    /// rows rather than treat them as "a face filling nothing".
+    #[test]
+    fn face_frac_of_reports_zero_when_nothing_was_detected() {
+        assert_eq!(face_frac_of(None, 640), 0.0);
+        let bbox = [100.0f32, 0.0, 292.0, 200.0];
+        assert!((face_frac_of(Some(&bbox), 640) - 0.3).abs() < 1e-6);
     }
 
     /// The center/edge ratio's GEOMETRY is bbox-relative (the inner box is

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -781,16 +781,21 @@ impl Engine {
             head_yaw_asym: pose.map(|p| p.yaw_asym).unwrap_or(0.0),
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: 0.0, // RGB-only path: no IR burst to measure
+            face_frac: rgb_top
+                .as_ref()
+                .map(|f| bbox_width_frac(&f.bbox, rgb.width))
+                .unwrap_or(0.0),
             rgb_face_brightness: rgb_brightness,
             rgb_specular_frac: rgb_specular,
             rgb_moire_score: rgb_moire,
         };
         let (verdict, _cues, reason) = self.gate.evaluate_rgb_only(&signals);
         irlume_common::dlog!(
-            "liveness(rgb-only): {verdict:?} ({reason}); bright={:.0} specular={:.2} moire={:.0}",
+            "liveness(rgb-only): {verdict:?} ({reason}); bright={:.0} specular={:.2} moire={:.0} face_frac={:.3} (recorded for #174, gates nothing)",
             signals.rgb_face_brightness,
             signals.rgb_specular_frac,
-            signals.rgb_moire_score
+            signals.rgb_moire_score,
+            signals.face_frac
         );
         let embedding = match &rgb_top {
             Some(f) => Some(
@@ -1131,6 +1136,11 @@ impl Engine {
             head_yaw_asym: pose.map(|p| p.yaw_asym).unwrap_or(0.0),
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: ir_stats.ambient_mean,
+            // From the IR frame, because the IR cues are measured there.
+            face_frac: ir_top
+                .as_ref()
+                .map(|f| bbox_width_frac(&f.bbox, ir.width))
+                .unwrap_or(0.0),
             rgb_face_brightness: rgb_brightness,
             rgb_moire_score: 0.0,
             rgb_specular_frac: 0.0,
@@ -1139,9 +1149,10 @@ impl Engine {
         // Log the cue values on PASS too; a near-miss on a genuine user is
         // invisible in the outcome line but obvious here.
         irlume_common::dlog!(
-            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2}",
+            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} (recorded for #174, gates nothing)",
             signals.ir_face_brightness, signals.ir_center_edge_ratio, signals.ir_eye_glint,
-            signals.ir_ambient, signals.head_yaw_asym, signals.head_pitch_frac);
+            signals.ir_ambient, signals.head_yaw_asym, signals.head_pitch_frac,
+            signals.face_frac);
         // Opt-in third-party PAD cue: score whenever an IR face is present (the
         // `ir` frame is the brightest strobe phase, i.e. the LIT frame, which is
         // the regime the cue was measured in), so the dark path can consult the
@@ -2989,6 +3000,16 @@ pub fn mean_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
 /// it (docs/pad-results/2026-06-30-ir-liveness-selftest.md), which is why it is
 /// one cue and not a liveness proof. Returns 0.0 on a degenerate bbox or a
 /// near-black edge (no signal, never inf).
+/// Face width as a fraction of frame width: the framing guide's `face_frac`,
+/// computed from a detection box so the liveness path can record the same
+/// quantity the guide judges seating distance by (#174).
+pub fn bbox_width_frac(bbox: &[f32; 4], frame_width: u32) -> f32 {
+    if frame_width == 0 {
+        return 0.0;
+    }
+    (bbox[2] - bbox[0]).max(0.0) / frame_width as f32
+}
+
 pub fn center_edge_ratio(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
     let (bw, bh) = (bbox[2] - bbox[0], bbox[3] - bbox[1]);
     if bw <= 4.0 || bh <= 4.0 {
@@ -3724,6 +3745,62 @@ mod tests {
         // A frame shorter than w*h (truncated/mismatched capture) must degrade
         // to 0.0, not panic on the out-of-bounds index.
         assert_eq!(mean_in_bbox(&grey[..3], w, h, &[0.0, 0.0, 4.0, 2.0]), 0.0);
+    }
+
+    /// `face_frac` is the seating-distance signal the framing guide already
+    /// judges by, recorded with the liveness cues so the #174 correlation is
+    /// answerable from ordinary debug output. It is a fraction of frame
+    /// width, so it must not depend on the frame's pixel dimensions.
+    #[test]
+    fn bbox_width_frac_is_a_fraction_of_frame_width() {
+        // Same face, same relative size, two sensor resolutions.
+        assert!((bbox_width_frac(&[100.0, 0.0, 292.0, 200.0], 640) - 0.3).abs() < 1e-6);
+        assert!((bbox_width_frac(&[200.0, 0.0, 584.0, 400.0], 1280) - 0.3).abs() < 1e-6);
+        // The guide's accepted band, as ends: 12% and 55% of the frame.
+        assert!((bbox_width_frac(&[0.0, 0.0, 76.8, 50.0], 640) - 0.12).abs() < 1e-6);
+        assert!((bbox_width_frac(&[0.0, 0.0, 352.0, 300.0], 640) - 0.55).abs() < 1e-6);
+        // Degenerate inputs report no face rather than a negative or a NaN.
+        assert_eq!(bbox_width_frac(&[300.0, 0.0, 100.0, 50.0], 640), 0.0);
+        assert_eq!(bbox_width_frac(&[0.0, 0.0, 100.0, 50.0], 0), 0.0);
+    }
+
+    /// The center/edge ratio's GEOMETRY is bbox-relative (the inner box is
+    /// half the bbox per side), so the same face filling more of the frame
+    /// must read the same ratio. This is what makes #174 a question about
+    /// physics and pixel count rather than about the formula: it isolates
+    /// the one part that is scale invariant by construction, so a
+    /// correlation found on hardware cannot be blamed on the sampling
+    /// geometry.
+    #[test]
+    fn center_edge_ratio_is_invariant_to_apparent_face_size() {
+        // One synthetic "face": a bright center square on a dim rim, drawn at
+        // two scales in two frames, each filling its bbox identically.
+        let render = |side: u32| -> Vec<u8> {
+            let mut buf = vec![40u8; (side * side) as usize];
+            let q = side / 4;
+            for y in q..(side - q) {
+                for x in q..(side - q) {
+                    buf[(y * side + x) as usize] = 200;
+                }
+            }
+            buf
+        };
+        let small = render(40);
+        let large = render(160);
+        let r_small = center_edge_ratio(&small, 40, 40, &[0.0, 0.0, 40.0, 40.0]);
+        let r_large = center_edge_ratio(&large, 160, 160, &[0.0, 0.0, 160.0, 160.0]);
+        assert!(r_small > 1.0 && r_large > 1.0, "{r_small} {r_large}");
+        assert!(
+            (r_small - r_large).abs() < 0.05,
+            "the ratio must not move with apparent size on identical content: \
+             {r_small} vs {r_large}"
+        );
+        // The pixel count behind it does move, and the guard against a face
+        // too small to sample is a hard floor, not a gradual one.
+        assert_eq!(
+            center_edge_ratio(&small, 40, 40, &[0.0, 0.0, 4.0, 4.0]),
+            0.0
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1854,12 +1854,15 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
             head_yaw_asym: pose.map(|p| p.yaw_asym).unwrap_or(0.0),
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: 0.0, // dev gate probe: single frame, no burst stats
+            face_frac: ir_top_face
+                .map(|f| irlume_auth::bbox_width_frac(&f.bbox, ir.width))
+                .unwrap_or(0.0),
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
         };
         let (verdict, cues, reason) = irlume_liveness::LivenessGate::new().evaluate(&signals);
-        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {ir_eye_glint:.0}");
+        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {ir_eye_glint:.0}  face_frac {:.3}", signals.face_frac);
         println!(
             "[gate] cues: rgb={} ir={} aligned={} ir_reflective={} center_edge={} glint={}",
             cues.face_in_rgb,

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -63,6 +63,23 @@ pub struct Signals {
     /// not measured (RGB-only path, older callers); the flood rewording below
     /// then never triggers. See [`IR_AMBIENT_FLOOD`].
     pub ir_ambient: f32,
+    /// Face width as a fraction of frame width, from the frame the IR cues
+    /// were measured in (the RGB frame on the RGB-only path). 0.0 when no
+    /// face was found.
+    ///
+    /// RECORDED, NEVER GATED. The framing guide accepts 0.12 to 0.55, a 4.6x
+    /// span, and several cues above are absolute thresholds on quantities
+    /// that may move across it: emitter irradiance falls with distance, and
+    /// the center-to-edge contrast a near-coaxial emitter produces depends on
+    /// how large the face's own depth is relative to its distance. The
+    /// geometry of [`ir_center_edge_ratio`] is bbox-relative and so scale
+    /// invariant by construction, but neither the physics nor the pixel count
+    /// behind it is, and nobody has measured which way that cuts (#174). This
+    /// field exists so the correlation is answerable from ordinary debug
+    /// output instead of a special capture campaign.
+    ///
+    /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
+    pub face_frac: f32,
 }
 
 impl Default for Signals {
@@ -75,6 +92,7 @@ impl Default for Signals {
             ir_eye_glint: 0.0,
             head_yaw_asym: 0.0,   // frontal
             head_pitch_frac: 0.5, // frontal
+            face_frac: 0.0,
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
@@ -1431,6 +1449,41 @@ mod tests {
             ir_eye_glint: 220.0,
             ..Default::default() // frontal pose
         }
+    }
+
+    /// `face_frac` is RECORDED with the cues and read by nothing: the whole
+    /// point of #174 is to find out whether the existing thresholds move with
+    /// seating distance BEFORE anything is normalised by it. A verdict that
+    /// changed with this field would be exactly the retune-against-
+    /// contaminated-samples the issue warns off.
+    #[test]
+    fn face_frac_is_recorded_and_changes_no_verdict() {
+        let gate = LivenessGate::new();
+        // Across the framing guide's whole accepted band and past both ends.
+        for frac in [0.0, 0.05, 0.12, 0.3, 0.55, 0.9] {
+            let mut live = live_signals();
+            live.face_frac = frac;
+            assert_eq!(
+                gate.evaluate(&live).0,
+                Verdict::Live,
+                "a live face must stay Live at face_frac {frac}"
+            );
+            // And the same on the spoof side: a flat target does not become
+            // live by sitting closer, nor a live face a spoof by sitting back.
+            let mut flat = live_signals();
+            flat.face_frac = frac;
+            flat.ir_center_edge_ratio = 1.0; // flat
+            assert_ne!(
+                gate.evaluate(&flat).0,
+                Verdict::Live,
+                "a flat target must not pass at face_frac {frac}"
+            );
+        }
+        // It survives the round trip it exists for: whatever the caller
+        // measured is what the evidence carries.
+        let mut s = live_signals();
+        s.face_frac = 0.3125;
+        assert!((s.face_frac - 0.3125).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1457,7 +1457,7 @@ mod tests {
     /// changed with this field would be exactly the retune-against-
     /// contaminated-samples the issue warns off.
     #[test]
-    fn face_frac_is_recorded_and_changes_no_verdict() {
+    fn face_frac_changes_no_verdict() {
         let gate = LivenessGate::new();
         // Across the framing guide's whole accepted band and past both ends.
         for frac in [0.0, 0.05, 0.12, 0.3, 0.55, 0.9] {
@@ -1479,11 +1479,6 @@ mod tests {
                 "a flat target must not pass at face_frac {frac}"
             );
         }
-        // It survives the round trip it exists for: whatever the caller
-        // measured is what the evidence carries.
-        let mut s = live_signals();
-        s.face_frac = 0.3125;
-        assert!((s.face_frac - 0.3125).abs() < 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
#174's prescribed first step, which is measurement rather than code. Several liveness gates are absolute thresholds on quantities that may move with seating distance, and irlume already computes the distance signal for the framing guide and discards it.

`Signals` gains `face_frac` (face width over frame width, measured in the frame the cues were measured in: IR on the cross-spectrum path, RGB on the RGB-only one), and both liveness debug lines carry it. Nothing reads it.

## What this settles without hardware

The center/edge ratio's geometry is bbox-relative: the inner box is half the bbox per side, so the same content at two apparent sizes reads the same ratio. A test renders one synthetic face at 40px and 160px and requires the ratio to agree within 0.05; the mutant that makes the inset a fixed pixel count reads 5.0 versus 1.2 and fails it. That matters for #174 because it isolates the part that is scale-invariant by construction, so any correlation measured on hardware belongs to the physics (emitter falloff, and the face's own depth relative to its distance) or to pixel count, not to the sampling geometry.

## What still needs the hardware, and what is not proven here

The correlation itself. No existing corpus can answer it: `~/irlume-caldata` records `ir_brightness`, `ir_depth` (the center/edge ratio under its old name) and `ir_glint`, but no face size, so there is nothing to correlate against. That is precisely the gap this PR closes for future runs.

Stated plainly: a mutant that zeroes the IR-path wiring (`face_frac: 0.0`) survives the test suite. No unit test can construct a live capture, so the recording's wiring is checked by reading and by the debug line, not by a test. The line to look for on the next ordinary `IRLUME_LOG=debug` authentication is:

```
liveness(cross-spectrum): Live (...); ir_bright=... face_frac=0.312 (recorded for #174, gates nothing)
```

A non-zero value there is the evidence the wiring works.

## Testing

- `face_frac_is_recorded_and_changes_no_verdict` walks the framing guide's whole accepted band (0.12 to 0.55) and past both ends, requiring a live face to stay Live and a flat target to stay not-Live at every value. The mutant that wires `face_frac` into the center/edge gate fails it. A verdict that moved with this field would be exactly the retune-against-contaminated-samples #174 warns against.
- `bbox_width_frac_is_a_fraction_of_frame_width` pins resolution independence and the degenerate cases.
- Workspace suite green (25 targets), clippy clean.

## Measurement protocol for the next hardware session

Run four ordinary authentications with `IRLUME_LOG=debug`: near and at arm's length, each with and without glasses, then read the `face_frac` and cue values off `irlume logs`. That is enough to see whether `ir_bright` and `ir_center_edge_ratio` track face size at all, which decides whether normalising them is worth designing.

## The review round (`533da92`)

No merge-blocking findings; both follow-ups applied rather than deferred, because both are mine and both are cheap:

- Inserting `bbox_width_frac` between `center_edge_ratio`'s doc comment and its signature handed that documentation to the new function and left the cue undocumented, so rustdoc would have told a caller that a width fraction returns a brightness ratio. This is the same doc-attachment defect the #216 round found earlier in the same session; the helpers now carry their own comments and the cue keeps its glossy-print warning. `cargo doc -D warnings` clean.
- The "round trip" assertion assigned a public field and read it straight back, proving nothing about the recording path while its comment claimed otherwise. Removed, and the test renamed to what it establishes: verdict independence.

The round also confirmed the survivorship I disclosed above, and it is now narrower: `face_frac_of` holds the decision (no detection means no distance signal rather than a fabricated one) as a value a test constructs, so what stays unverifiable off hardware is only which frame each caller hands in, one expression per path.
