### PR TITLE
Record the clipped fraction of the IR face, gating nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **The clipped fraction of the IR face is recorded with the liveness cues.**
+  A saturated centre cannot read brighter than a saturated rim, so a blown
+  exposure compresses the centre/edge ratio toward 1 the way strong ambient IR
+  does, and irlume guards only the ambient end. Two recorded corpora show the
+  case is reachable: in both, the session's first capture read about 235 mean
+  with a ratio of 1.06 and 1.12, against a 1.03 spoof floor and 1.19 to 1.42
+  for every later capture. `ir_saturated_frac` now rides in `Signals` and the
+  cross-spectrum debug line so #221 can be answered from ordinary output; it
+  gates nothing, and neither the ratio floor nor the warm-up length changes
+  until there is evidence from real authentications.
+
 - **Seating distance is recorded with the liveness cues.** `face_frac` (face
   width as a fraction of frame width, the same quantity the framing guide
   judges distance by) now rides in `Signals` and both liveness debug lines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ All notable changes to irlume are documented here. This project adheres to
   for every later capture. `ir_saturated_frac` now rides in `Signals` and the
   cross-spectrum debug line so #221 can be answered from ordinary output; it
   gates nothing, and neither the ratio floor nor the warm-up length changes
-  until there is evidence from real authentications.
+  until there is evidence from real authentications. The reading is absent,
+  not zero, when it cannot be taken: no IR face, or a negotiated format whose
+  decode cannot say where its ceiling is (the Y16 family is rescaled by a
+  shift taken from each frame's own maximum, and the YUV ceilings depend on a
+  quantization irlume does not carry), so the corpus never mixes "no clipping"
+  with "not measurable".
 
 - **Seating distance is recorded with the liveness cues.** `face_frac` (face
   width as a fraction of frame width, the same quantity the framing guide

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -783,7 +783,7 @@ impl Engine {
             ir_ambient: 0.0, // RGB-only path: no IR burst to measure
             face_frac: face_frac_of(rgb_top.as_ref().map(|f| &f.bbox), rgb.width),
             // RGB-only path: no IR frame exists to clip.
-            ir_saturated_frac: 0.0,
+            ir_saturated_frac: None,
             rgb_face_brightness: rgb_brightness,
             rgb_specular_frac: rgb_specular,
             rgb_moire_score: rgb_moire,
@@ -1142,6 +1142,7 @@ impl Engine {
                 ir.width,
                 ir.height,
                 ir_top.as_ref().map(|f| &f.bbox),
+                ir_stats.white_level,
             ),
             rgb_face_brightness: rgb_brightness,
             rgb_moire_score: 0.0,
@@ -1151,10 +1152,16 @@ impl Engine {
         // Log the cue values on PASS too; a near-miss on a genuine user is
         // invisible in the outcome line but obvious here.
         irlume_common::dlog!(
-            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} ir_clipped={:.1}% (face_frac #174, clipped #221; both gate nothing)",
+            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} ir_clipped={} (face_frac #174, clipped #221; both gate nothing)",
             signals.ir_face_brightness, signals.ir_center_edge_ratio, signals.ir_eye_glint,
             signals.ir_ambient, signals.head_yaw_asym, signals.head_pitch_frac,
-            signals.face_frac, signals.ir_saturated_frac * 100.0);
+            signals.face_frac,
+            // "n/a" is a real answer: this format cannot say where its ceiling
+            // is, so no percentage printed here would mean anything.
+            signals
+                .ir_saturated_frac
+                .map(|f| format!("{:.1}%", f * 100.0))
+                .unwrap_or_else(|| "n/a".into()));
         // Opt-in third-party PAD cue: score whenever an IR face is present (the
         // `ir` frame is the brightest strobe phase, i.e. the LIT frame, which is
         // the regime the cue was measured in), so the dark path can consult the
@@ -2994,8 +3001,15 @@ pub fn mean_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
     }
 }
 
-/// Fraction (0-1) of pixels at full scale (255) inside `bbox`: how much of the
+/// Fraction (0-1) of pixels at or above `white` inside `bbox`: how much of the
 /// face region the sensor clipped.
+///
+/// `white` comes from the capture rather than from here, because what counts
+/// as the ceiling depends on the negotiated format: a native 8-bit grey clips
+/// at 255, limited-range YUV puts nominal white at 235, and the Y16 family is
+/// rescaled by a shift taken from the frame's own maximum, so a decoded 255
+/// there means "the brightest pixel in this frame" and not a clipped sensor.
+/// See `IrCaptureStats::white_level`.
 ///
 /// A clipped centre cannot read brighter than a clipped rim, so saturation
 /// compresses [`center_edge_ratio`] toward 1 exactly as an ambient pedestal
@@ -3005,20 +3019,24 @@ pub fn mean_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
 /// 1.06 and 1.12, against a 1.03 spoof floor and 1.19-1.42 for every later
 /// capture (#221). The whole-frame equivalent already exists in the camera
 /// crate; this is the face region, which is what the cues are measured on.
-pub fn saturated_frac_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
+pub fn saturated_frac_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4], white: u8) -> f32 {
     // Same guard and clamping as mean_in_bbox: a truncated frame degrades to
     // 0.0 rather than panicking the daemon.
     if grey.len() < (w as usize).saturating_mul(h as usize) {
         return 0.0;
     }
-    let x1 = (bbox[0].max(0.0) as u32).min(w.saturating_sub(1));
-    let y1 = (bbox[1].max(0.0) as u32).min(h.saturating_sub(1));
+    // Clamp BOTH corners to the frame, unlike `mean_in_bbox`, whose x1/y1
+    // clamp to w-1/h-1: a box wholly past the right or bottom edge collapses
+    // there to a one-pixel strip of an unrelated edge rather than to an empty
+    // region. Here an off-frame box measures nothing, which is what it saw.
+    let x1 = (bbox[0].max(0.0) as u32).min(w);
+    let y1 = (bbox[1].max(0.0) as u32).min(h);
     let x2 = (bbox[2].max(0.0) as u32).min(w);
     let y2 = (bbox[3].max(0.0) as u32).min(h);
     let (mut clipped, mut n) = (0u64, 0u64);
     for y in y1..y2 {
         for x in x1..x2 {
-            if grey[(y * w + x) as usize] == 255 {
+            if grey[(y * w + x) as usize] >= white {
                 clipped += 1;
             }
             n += 1;
@@ -3031,15 +3049,21 @@ pub fn saturated_frac_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f
     }
 }
 
-/// [`Signals::ir_saturated_frac`] for a capture: the clipped fraction of the
-/// detected face region, or 0.0 when nothing was detected.
+/// [`Signals::ir_saturated_frac`] for a capture, or `None` when the reading
+/// cannot be taken: no face was detected, or the negotiated format cannot say
+/// where its ceiling is (`white` is `None`).
 ///
-/// Separated from the call site for the same reason as [`face_frac_of`]: no
-/// face means no reading, not a fabricated one, and that decision is a value a
-/// test can construct.
-pub fn saturated_frac_of(grey: &[u8], w: u32, h: u32, bbox: Option<&[f32; 4]>) -> f32 {
-    bbox.map(|b| saturated_frac_in_bbox(grey, w, h, b))
-        .unwrap_or(0.0)
+/// Both absences are the same kind of fact, and neither is zero clipping. A
+/// corpus recording 0.0 for "not measured" would answer #221 wrongly on
+/// exactly the cameras where the question is hardest to see.
+pub fn saturated_frac_of(
+    grey: &[u8],
+    w: u32,
+    h: u32,
+    bbox: Option<&[f32; 4]>,
+    white: Option<u8>,
+) -> Option<f32> {
+    Some(saturated_frac_in_bbox(grey, w, h, bbox?, white?))
 }
 
 /// Face width as a fraction of frame width: the framing guide's `face_frac`,
@@ -3826,55 +3850,52 @@ mod tests {
     }
 
     /// The clipped fraction is what #221 needs to know whether a real
-    /// authentication ever measures its cues on a blown exposure. It must
-    /// count only full-scale pixels, and only inside the face region, since
-    /// that is where the cues are measured.
+    /// authentication ever measures its cues on a blown exposure. The ceiling
+    /// is supplied by the caller because it is a property of the negotiated
+    /// format, not of this arithmetic.
     #[test]
-    fn saturated_frac_counts_full_scale_pixels_in_the_region() {
+    fn saturated_frac_counts_pixels_at_or_above_the_supplied_ceiling() {
         let (w, h) = (4u32, 2u32);
-        // Row 0 fully clipped, row 1 not clipped at all.
+        // Row 0 at 255, row 1 below it.
         let grey = [255u8, 255, 255, 255, 200, 254, 0, 128];
-        assert_eq!(
-            saturated_frac_in_bbox(&grey, w, h, &[0.0, 0.0, 4.0, 1.0]),
-            1.0
-        );
-        assert_eq!(
-            saturated_frac_in_bbox(&grey, w, h, &[0.0, 1.0, 4.0, 2.0]),
-            0.0
-        );
-        assert_eq!(
-            saturated_frac_in_bbox(&grey, w, h, &[0.0, 0.0, 4.0, 2.0]),
-            0.5
-        );
-        // 254 is NOT clipped: the compression this measures needs the ceiling.
-        assert_eq!(
-            saturated_frac_in_bbox(&[254u8; 4], 2, 2, &[0.0, 0.0, 2.0, 2.0]),
-            0.0
-        );
+        let f = |bbox: &[f32; 4], white: u8| saturated_frac_in_bbox(&grey, w, h, bbox, white);
+        assert_eq!(f(&[0.0, 0.0, 4.0, 1.0], 255), 1.0);
+        assert_eq!(f(&[0.0, 1.0, 4.0, 2.0], 255), 0.0);
+        assert_eq!(f(&[0.0, 0.0, 4.0, 2.0], 255), 0.5);
+        // A limited-range YUV ceiling counts 254 and 255 alike, which is the
+        // whole reason the ceiling is a parameter: at white=235 the second row
+        // contributes its 254.
+        assert_eq!(f(&[0.0, 1.0, 4.0, 2.0], 235), 0.25);
         // Out-of-frame boxes clamp; a degenerate box reports nothing.
-        assert_eq!(
-            saturated_frac_in_bbox(&grey, w, h, &[-9.0, -9.0, 99.0, 99.0]),
-            0.5
-        );
-        assert_eq!(
-            saturated_frac_in_bbox(&grey, w, h, &[3.0, 1.0, 3.0, 1.0]),
-            0.0
-        );
+        assert_eq!(f(&[-9.0, -9.0, 99.0, 99.0], 255), 0.5);
+        assert_eq!(f(&[3.0, 1.0, 3.0, 1.0], 255), 0.0);
+        // A box wholly past the right or bottom edge measures NOTHING. The
+        // sibling mean_in_bbox clamps its near corner to w-1/h-1 and so
+        // samples a one-pixel strip of an unrelated edge instead.
+        assert_eq!(f(&[10.0, 0.0, 20.0, 2.0], 255), 0.0);
+        assert_eq!(f(&[0.0, 9.0, 4.0, 12.0], 255), 0.0);
         // A truncated frame degrades like mean_in_bbox, never panics.
         assert_eq!(
-            saturated_frac_in_bbox(&grey[..3], w, h, &[0.0, 0.0, 4.0, 2.0]),
+            saturated_frac_in_bbox(&grey[..3], w, h, &[0.0, 0.0, 4.0, 2.0], 255),
             0.0
         );
     }
 
+    /// Two different absences, one meaning: NOT MEASURED. Recording 0.0 for
+    /// either would put "no clipping seen" in the corpus for a capture nobody
+    /// could measure, and #221 would then be answered wrongly on exactly the
+    /// cameras where clipping is hardest to see.
     #[test]
-    fn saturated_frac_of_reports_zero_when_nothing_was_detected() {
+    fn saturated_frac_of_is_absent_without_a_face_or_a_known_ceiling() {
         let grey = [255u8; 16];
-        // No face: no reading. NOT "the whole frame is clipped", which would
-        // be a measurement nobody took.
-        assert_eq!(saturated_frac_of(&grey, 4, 4, None), 0.0);
         let bbox = [0.0f32, 0.0, 4.0, 4.0];
-        assert_eq!(saturated_frac_of(&grey, 4, 4, Some(&bbox)), 1.0);
+        assert_eq!(saturated_frac_of(&grey, 4, 4, None, Some(255)), None);
+        assert_eq!(saturated_frac_of(&grey, 4, 4, Some(&bbox), None), None);
+        assert_eq!(saturated_frac_of(&grey, 4, 4, None, None), None);
+        assert_eq!(
+            saturated_frac_of(&grey, 4, 4, Some(&bbox), Some(255)),
+            Some(1.0)
+        );
     }
 
     /// No detection means NO distance signal, and 0.0 is how that is spelled:

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -782,6 +782,8 @@ impl Engine {
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: 0.0, // RGB-only path: no IR burst to measure
             face_frac: face_frac_of(rgb_top.as_ref().map(|f| &f.bbox), rgb.width),
+            // RGB-only path: no IR frame exists to clip.
+            ir_saturated_frac: 0.0,
             rgb_face_brightness: rgb_brightness,
             rgb_specular_frac: rgb_specular,
             rgb_moire_score: rgb_moire,
@@ -1135,6 +1137,12 @@ impl Engine {
             ir_ambient: ir_stats.ambient_mean,
             // From the IR frame, because the IR cues are measured there.
             face_frac: face_frac_of(ir_top.as_ref().map(|f| &f.bbox), ir.width),
+            ir_saturated_frac: saturated_frac_of(
+                &ir.data,
+                ir.width,
+                ir.height,
+                ir_top.as_ref().map(|f| &f.bbox),
+            ),
             rgb_face_brightness: rgb_brightness,
             rgb_moire_score: 0.0,
             rgb_specular_frac: 0.0,
@@ -1143,10 +1151,10 @@ impl Engine {
         // Log the cue values on PASS too; a near-miss on a genuine user is
         // invisible in the outcome line but obvious here.
         irlume_common::dlog!(
-            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} (recorded for #174, gates nothing)",
+            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} ir_clipped={:.1}% (face_frac #174, clipped #221; both gate nothing)",
             signals.ir_face_brightness, signals.ir_center_edge_ratio, signals.ir_eye_glint,
             signals.ir_ambient, signals.head_yaw_asym, signals.head_pitch_frac,
-            signals.face_frac);
+            signals.face_frac, signals.ir_saturated_frac * 100.0);
         // Opt-in third-party PAD cue: score whenever an IR face is present (the
         // `ir` frame is the brightest strobe phase, i.e. the LIT frame, which is
         // the regime the cue was measured in), so the dark path can consult the
@@ -2986,6 +2994,54 @@ pub fn mean_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
     }
 }
 
+/// Fraction (0-1) of pixels at full scale (255) inside `bbox`: how much of the
+/// face region the sensor clipped.
+///
+/// A clipped centre cannot read brighter than a clipped rim, so saturation
+/// compresses [`center_edge_ratio`] toward 1 exactly as an ambient pedestal
+/// does. irlume guards the ambient end (`IR_AMBIENT_FLOOD`) and has nothing at
+/// this one, and the recorded corpora show the case is reachable: in both
+/// `depth_real_*` sessions the first capture read ~235 mean with a ratio of
+/// 1.06 and 1.12, against a 1.03 spoof floor and 1.19-1.42 for every later
+/// capture (#221). The whole-frame equivalent already exists in the camera
+/// crate; this is the face region, which is what the cues are measured on.
+pub fn saturated_frac_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
+    // Same guard and clamping as mean_in_bbox: a truncated frame degrades to
+    // 0.0 rather than panicking the daemon.
+    if grey.len() < (w as usize).saturating_mul(h as usize) {
+        return 0.0;
+    }
+    let x1 = (bbox[0].max(0.0) as u32).min(w.saturating_sub(1));
+    let y1 = (bbox[1].max(0.0) as u32).min(h.saturating_sub(1));
+    let x2 = (bbox[2].max(0.0) as u32).min(w);
+    let y2 = (bbox[3].max(0.0) as u32).min(h);
+    let (mut clipped, mut n) = (0u64, 0u64);
+    for y in y1..y2 {
+        for x in x1..x2 {
+            if grey[(y * w + x) as usize] == 255 {
+                clipped += 1;
+            }
+            n += 1;
+        }
+    }
+    if n == 0 {
+        0.0
+    } else {
+        clipped as f32 / n as f32
+    }
+}
+
+/// [`Signals::ir_saturated_frac`] for a capture: the clipped fraction of the
+/// detected face region, or 0.0 when nothing was detected.
+///
+/// Separated from the call site for the same reason as [`face_frac_of`]: no
+/// face means no reading, not a fabricated one, and that decision is a value a
+/// test can construct.
+pub fn saturated_frac_of(grey: &[u8], w: u32, h: u32, bbox: Option<&[f32; 4]>) -> f32 {
+    bbox.map(|b| saturated_frac_in_bbox(grey, w, h, b))
+        .unwrap_or(0.0)
+}
+
 /// Face width as a fraction of frame width: the framing guide's `face_frac`,
 /// computed from a detection box so the liveness path can record the same
 /// quantity the guide judges seating distance by (#174).
@@ -3767,6 +3823,58 @@ mod tests {
         // Degenerate inputs report no face rather than a negative or a NaN.
         assert_eq!(bbox_width_frac(&[300.0, 0.0, 100.0, 50.0], 640), 0.0);
         assert_eq!(bbox_width_frac(&[0.0, 0.0, 100.0, 50.0], 0), 0.0);
+    }
+
+    /// The clipped fraction is what #221 needs to know whether a real
+    /// authentication ever measures its cues on a blown exposure. It must
+    /// count only full-scale pixels, and only inside the face region, since
+    /// that is where the cues are measured.
+    #[test]
+    fn saturated_frac_counts_full_scale_pixels_in_the_region() {
+        let (w, h) = (4u32, 2u32);
+        // Row 0 fully clipped, row 1 not clipped at all.
+        let grey = [255u8, 255, 255, 255, 200, 254, 0, 128];
+        assert_eq!(
+            saturated_frac_in_bbox(&grey, w, h, &[0.0, 0.0, 4.0, 1.0]),
+            1.0
+        );
+        assert_eq!(
+            saturated_frac_in_bbox(&grey, w, h, &[0.0, 1.0, 4.0, 2.0]),
+            0.0
+        );
+        assert_eq!(
+            saturated_frac_in_bbox(&grey, w, h, &[0.0, 0.0, 4.0, 2.0]),
+            0.5
+        );
+        // 254 is NOT clipped: the compression this measures needs the ceiling.
+        assert_eq!(
+            saturated_frac_in_bbox(&[254u8; 4], 2, 2, &[0.0, 0.0, 2.0, 2.0]),
+            0.0
+        );
+        // Out-of-frame boxes clamp; a degenerate box reports nothing.
+        assert_eq!(
+            saturated_frac_in_bbox(&grey, w, h, &[-9.0, -9.0, 99.0, 99.0]),
+            0.5
+        );
+        assert_eq!(
+            saturated_frac_in_bbox(&grey, w, h, &[3.0, 1.0, 3.0, 1.0]),
+            0.0
+        );
+        // A truncated frame degrades like mean_in_bbox, never panics.
+        assert_eq!(
+            saturated_frac_in_bbox(&grey[..3], w, h, &[0.0, 0.0, 4.0, 2.0]),
+            0.0
+        );
+    }
+
+    #[test]
+    fn saturated_frac_of_reports_zero_when_nothing_was_detected() {
+        let grey = [255u8; 16];
+        // No face: no reading. NOT "the whole frame is clipped", which would
+        // be a measurement nobody took.
+        assert_eq!(saturated_frac_of(&grey, 4, 4, None), 0.0);
+        let bbox = [0.0f32, 0.0, 4.0, 4.0];
+        assert_eq!(saturated_frac_of(&grey, 4, 4, Some(&bbox)), 1.0);
     }
 
     /// No detection means NO distance signal, and 0.0 is how that is spelled:

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -165,6 +165,20 @@ pub struct IrCaptureStats {
     /// always were. Recorded so "the metadata path ran" is something callers
     /// can check rather than assume.
     pub camera_classified_frames: usize,
+    /// The decoded value that means "this pixel was at or above the sensor's
+    /// ceiling", or `None` when the negotiated format cannot support that
+    /// claim. A caller measuring clipping (#221) must treat `None` as NOT
+    /// MEASURED, never as zero clipping.
+    ///
+    /// Only the native 8-bit greys qualify: there a decoded 255 IS the
+    /// sensor's full-scale sample. The Y16 family does not, because
+    /// `grey16_shift` picks the shift from the frame's OWN maximum, so a
+    /// decoded 255 means "the brightest pixel in this frame" and a dim frame
+    /// full of them is ordinary. NV12 and YUYV do not either, because their
+    /// ceiling depends on the negotiated quantization (limited range puts
+    /// nominal white at 235, full range at 255) and irlume does not carry that
+    /// field, so a clipped face could read as no clipping at all.
+    pub white_level: Option<u8>,
 }
 
 pub const DEFAULT_RGB_DEVICE: &str = "/dev/video0";
@@ -1163,6 +1177,16 @@ fn grey16_shift(buf: &[u8]) -> u32 {
     (16 - max.leading_zeros()).saturating_sub(8)
 }
 
+/// The decoded value that means "at or above the sensor's ceiling" for a
+/// negotiated IR format, or `None` when the decode cannot carry that claim.
+/// See [`IrCaptureStats::white_level`] for why only the 8-bit greys qualify.
+pub(crate) fn clipping_white_level(pix: IrPixel) -> Option<u8> {
+    match pix {
+        IrPixel::Grey8 => Some(u8::MAX),
+        IrPixel::Grey16 | IrPixel::Nv12Luma | IrPixel::YuyvLuma => None,
+    }
+}
+
 /// 16-bit-LE grey (Y16/Y10/Y12) → 8-bit at a given shift.
 fn grey16_to_8_at(buf: &[u8], shift: u32) -> Vec<u8> {
     buf.chunks_exact(2)
@@ -1190,6 +1214,13 @@ pub(crate) struct IrDecoder {
 impl IrDecoder {
     pub(crate) fn new(pix: IrPixel) -> Self {
         Self { pix, shift: None }
+    }
+
+    /// See [`clipping_white_level`]: the decoded value that means "at or above
+    /// the sensor's ceiling" for this decoder's format, or `None` when the
+    /// decode cannot carry that claim.
+    pub(crate) fn white_level(&self) -> Option<u8> {
+        clipping_white_level(self.pix)
     }
 
     pub(crate) fn decode(&mut self, buf: &[u8], w: u32, h: u32) -> Vec<u8> {
@@ -1439,6 +1470,7 @@ impl IrSession<'_> {
         let (w, h) = (self.cam.width, self.cam.height);
         let card = &self.cam.card;
         let lit = self.lit;
+        let white_level = self.dec.white_level();
         let stream = &mut self.stream;
         let dec = &mut self.dec;
         // The emitter may STROBE (pulse), so grab a burst and keep the brightest
@@ -1695,6 +1727,7 @@ impl IrSession<'_> {
                 ambient_mean: ambient_level as f32,
                 burst_frames: IR_BURST,
                 camera_classified_frames: from_camera,
+                white_level,
             },
         ))
     }
@@ -2849,6 +2882,41 @@ mod tests {
         assert_eq!(ir_probe::subtract(&lit, &ambient), vec![150, 0, 0]);
         // Size mismatch falls back to the lit frame unchanged.
         assert_eq!(ir_probe::subtract(&lit, &[1, 2]), lit.to_vec());
+    }
+
+    /// Which formats can support a clipping claim at all. A decoded 255 means
+    /// "the sensor's full-scale sample" ONLY for the native 8-bit greys: the
+    /// Y16 family is rescaled by a shift taken from the frame's own maximum,
+    /// and the YUV ceilings depend on a quantization irlume does not carry.
+    /// Saying None there is what keeps #221's corpus interpretable.
+    #[test]
+    fn only_native_8bit_grey_can_claim_a_clipping_ceiling() {
+        assert_eq!(clipping_white_level(IrPixel::Grey8), Some(255));
+        assert_eq!(clipping_white_level(IrPixel::Grey16), None);
+        assert_eq!(clipping_white_level(IrPixel::Nv12Luma), None);
+        assert_eq!(clipping_white_level(IrPixel::YuyvLuma), None);
+        // And the decoder reports its own format's answer, since that is what
+        // the capture actually negotiated.
+        assert_eq!(IrDecoder::new(IrPixel::Grey8).white_level(), Some(255));
+        assert_eq!(IrDecoder::new(IrPixel::Grey16).white_level(), None);
+    }
+
+    /// The reason Grey16 cannot: the shift comes from the frame's OWN maximum,
+    /// so a frame whose brightest sample is far below the container ceiling
+    /// still decodes that sample to 255.
+    #[test]
+    fn grey16_decoding_maps_a_dim_frames_maximum_to_full_scale() {
+        // 10-bit content in a 16-bit container: max 1023, nowhere near 0xFFFF.
+        let mut buf = Vec::new();
+        for v in [0u16, 256, 512, 1023] {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        let decoded = decode_ir(&buf, IrPixel::Grey16, 4, 1);
+        assert_eq!(
+            decoded.last().copied(),
+            Some(255),
+            "the frame maximum decodes to 255 even though the sensor did not clip"
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1857,12 +1857,18 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
             face_frac: ir_top_face
                 .map(|f| irlume_auth::bbox_width_frac(&f.bbox, ir.width))
                 .unwrap_or(0.0),
+            ir_saturated_frac: irlume_auth::saturated_frac_of(
+                &ir.data,
+                ir.width,
+                ir.height,
+                ir_top_face.map(|f| &f.bbox),
+            ),
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
         };
         let (verdict, cues, reason) = irlume_liveness::LivenessGate::new().evaluate(&signals);
-        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {ir_eye_glint:.0}  face_frac {:.3}", signals.face_frac);
+        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {ir_eye_glint:.0}  face_frac {:.3}  clipped {:.1}%", signals.face_frac, signals.ir_saturated_frac * 100.0);
         println!(
             "[gate] cues: rgb={} ir={} aligned={} ir_reflective={} center_edge={} glint={}",
             cues.face_in_rgb,

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1857,18 +1857,20 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
             face_frac: ir_top_face
                 .map(|f| irlume_auth::bbox_width_frac(&f.bbox, ir.width))
                 .unwrap_or(0.0),
-            ir_saturated_frac: irlume_auth::saturated_frac_of(
-                &ir.data,
-                ir.width,
-                ir.height,
-                ir_top_face.map(|f| &f.bbox),
-            ),
+            // Dev gate probe: a single frame with no burst stats, so the
+            // negotiated format's ceiling is not available here and the
+            // reading is honestly absent rather than guessed at 255.
+            ir_saturated_frac: None,
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
         };
         let (verdict, cues, reason) = irlume_liveness::LivenessGate::new().evaluate(&signals);
-        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {ir_eye_glint:.0}  face_frac {:.3}  clipped {:.1}%", signals.face_frac, signals.ir_saturated_frac * 100.0);
+        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {ir_eye_glint:.0}  face_frac {:.3}  clipped {}", signals.face_frac,
+            signals
+                .ir_saturated_frac
+                .map(|f| format!("{:.1}%", f * 100.0))
+                .unwrap_or_else(|| "n/a".into()));
         println!(
             "[gate] cues: rgb={} ir={} aligned={} ir_reflective={} center_edge={} glint={}",
             cues.face_in_rgb,

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -80,7 +80,11 @@ pub struct Signals {
     ///
     /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
     pub face_frac: f32,
-    /// Fraction (0-1) of the IR face region the sensor clipped at 255.
+    /// Fraction (0-1) of the IR face region at or above the sensor's ceiling,
+    /// or `None` when the reading could not be taken: no IR face, the RGB-only
+    /// path, or a negotiated format whose decode cannot say where its ceiling
+    /// is (the Y16 family is rescaled per frame; YUV ceilings depend on a
+    /// quantization irlume does not carry). `None` is NOT zero clipping.
     ///
     /// RECORDED, NEVER GATED, for the same reason as [`face_frac`]. Saturation
     /// compresses [`ir_center_edge_ratio`] toward 1 the way an ambient pedestal
@@ -94,7 +98,7 @@ pub struct Signals {
     ///
     /// [`face_frac`]: Self::face_frac
     /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
-    pub ir_saturated_frac: f32,
+    pub ir_saturated_frac: Option<f32>,
 }
 
 impl Default for Signals {
@@ -108,7 +112,7 @@ impl Default for Signals {
             head_yaw_asym: 0.0,   // frontal
             head_pitch_frac: 0.5, // frontal
             face_frac: 0.0,
-            ir_saturated_frac: 0.0,
+            ir_saturated_frac: None,
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
@@ -1479,13 +1483,20 @@ mod tests {
     #[test]
     fn ir_saturated_frac_changes_no_verdict() {
         let gate = LivenessGate::new();
-        for frac in [0.0, 0.01, 0.25, 0.9, 1.0] {
+        for frac in [
+            None,
+            Some(0.0),
+            Some(0.01),
+            Some(0.25),
+            Some(0.9),
+            Some(1.0),
+        ] {
             let mut live = live_signals();
             live.ir_saturated_frac = frac;
             assert_eq!(
                 gate.evaluate(&live).0,
                 Verdict::Live,
-                "a live face must stay Live at ir_saturated_frac {frac}"
+                "a live face must stay Live at ir_saturated_frac {frac:?}"
             );
             let mut flat = live_signals();
             flat.ir_saturated_frac = frac;
@@ -1493,7 +1504,7 @@ mod tests {
             assert_ne!(
                 gate.evaluate(&flat).0,
                 Verdict::Live,
-                "a flat target must not pass at ir_saturated_frac {frac}"
+                "a flat target must not pass at ir_saturated_frac {frac:?}"
             );
         }
     }

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -80,6 +80,21 @@ pub struct Signals {
     ///
     /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
     pub face_frac: f32,
+    /// Fraction (0-1) of the IR face region the sensor clipped at 255.
+    ///
+    /// RECORDED, NEVER GATED, for the same reason as [`face_frac`]. Saturation
+    /// compresses [`ir_center_edge_ratio`] toward 1 the way an ambient pedestal
+    /// does, because a clipped centre cannot read brighter than a clipped rim,
+    /// and the recorded corpora show the case is reachable: in two independent
+    /// sessions the first capture read ~235 mean with a ratio of 1.06 and 1.12
+    /// against a 1.03 floor, while every later capture in the same session
+    /// cleared it by 0.16 or more (#221). irlume guards the ambient end of this
+    /// same starvation and nothing at this end; whether real authentications
+    /// ever run clipped is what this field is for.
+    ///
+    /// [`face_frac`]: Self::face_frac
+    /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
+    pub ir_saturated_frac: f32,
 }
 
 impl Default for Signals {
@@ -93,6 +108,7 @@ impl Default for Signals {
             head_yaw_asym: 0.0,   // frontal
             head_pitch_frac: 0.5, // frontal
             face_frac: 0.0,
+            ir_saturated_frac: 0.0,
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
@@ -1456,6 +1472,32 @@ mod tests {
     /// seating distance BEFORE anything is normalised by it. A verdict that
     /// changed with this field would be exactly the retune-against-
     /// contaminated-samples the issue warns off.
+    /// The clipped fraction is recorded and read by nothing. #221 exists to
+    /// find out whether authentications ever run clipped BEFORE any threshold
+    /// or warm-up constant changes; a verdict that moved with this field would
+    /// prejudge that.
+    #[test]
+    fn ir_saturated_frac_changes_no_verdict() {
+        let gate = LivenessGate::new();
+        for frac in [0.0, 0.01, 0.25, 0.9, 1.0] {
+            let mut live = live_signals();
+            live.ir_saturated_frac = frac;
+            assert_eq!(
+                gate.evaluate(&live).0,
+                Verdict::Live,
+                "a live face must stay Live at ir_saturated_frac {frac}"
+            );
+            let mut flat = live_signals();
+            flat.ir_saturated_frac = frac;
+            flat.ir_center_edge_ratio = 1.0; // flat
+            assert_ne!(
+                gate.evaluate(&flat).0,
+                Verdict::Live,
+                "a flat target must not pass at ir_saturated_frac {frac}"
+            );
+        }
+    }
+
     #[test]
     fn face_frac_changes_no_verdict() {
         let gate = LivenessGate::new();


### PR DESCRIPTION
#221's cheapest next step, and it needs to land before the next hardware session or that session's data cannot answer the question.

A clipped centre cannot read brighter than a clipped rim, so saturation compresses the centre/edge ratio toward 1 exactly as an ambient pedestal does. irlume guards the ambient end of that starvation (`IR_AMBIENT_FLOOD`, verdict kept fail-closed with only the reason reworded) and has nothing at this end. The recorded corpora show the case is reachable: in both `depth_real_*` sessions the first capture read about 235 mean with a ratio of **1.06 and 1.12 against a 1.03 spoof floor**, while every later capture in the same session cleared it by 0.16 to 0.39.

`Signals` gains `ir_saturated_frac`, measured on the IR face region because that is where the cues are measured, and the cross-spectrum debug line carries it next to `face_frac`:

```
liveness(cross-spectrum): Live (...); ir_bright=... face_frac=0.312 ir_clipped=0.4% (face_frac #174, clipped #221; both gate nothing)
```

## What this deliberately does not do

Change the ratio floor, change `AE_WARMUP`, or refuse a clipped frame. #221 asks whether real authentications ever run clipped, and no answer exists yet. Recording first is the same sequence #220 used for `face_frac` and #205 used for `mean_step`.

It also does not try to fix the problem by exposure control, because that is not available: `v4l2-ctl --list-ctrls` on three modules shows the IR pin exposing **no exposure or gain controls at all** on both dedicated Hello-style cameras (ASUS FHD, NexiGo HelloCam), and the full set only on the Logitech BRIO. The ASUS RGB pin on the same laptop has the full set, so this is a property of the IR pin. Details in the #221 thread.

## Testing

- `saturated_frac_counts_full_scale_pixels_in_the_region` pins that only 255 counts (254 does not, since the compression this measures needs the ceiling), the region restriction, clamping, the degenerate box and the truncated-frame guard.
- `saturated_frac_of_reports_zero_when_nothing_was_detected` pins the decision that no face means no reading, rather than "the whole frame is clipped", which would be a measurement nobody took.
- `ir_saturated_frac_changes_no_verdict` walks 0 to 100 percent clipped and requires a live face to stay Live and a flat target to stay not-Live at every value.
- Three hand-applied mutants each fail exactly one of those: counting 254 as clipped, falling back to a whole-frame reading with no face, and wiring the fraction into the centre/edge gate.
- Workspace suite green (25 targets), clippy clean.

## The review round (`7cd83d3`)

The round's High finding was correct and the first version of this PR would have produced an uninterpretable corpus: decoded 255 means the sensor's full-scale sample only for the native 8-bit greys. The Y16 family is rescaled by a shift taken from **each frame's own maximum**, so a dim frame's brightest pixel decodes to 255 (there is now a test that pins exactly that), and NV12/YUYV ceilings depend on a negotiated quantization irlume does not carry, where limited range puts nominal white at 235 and a genuinely clipped face would have reported *zero* clipping.

So the reading now names its own ceiling or declines to exist. `IrCaptureStats` carries `white_level`: `Some(255)` for the native greys, `None` for the formats whose decode cannot support the claim. `Signals::ir_saturated_frac` became `Option<f32>`, absent for no IR face, the RGB-only path, or an unknown ceiling, and the debug line prints `n/a` rather than a number that would mean nothing. Absence and zero are different facts, which is the rule the emitter journal learned in #210.

The round's Medium (a box wholly past the right or bottom edge collapsing to a one-pixel strip of an unrelated edge) is fixed here by clamping both corners, with tests for both edges. The same asymmetry is pre-existing in `mean_in_bbox`, which feeds the brightness cue, so it is filed as #225 rather than changed inside an evidence PR.

Three further mutants, each failing exactly one test: claiming a ceiling for Grey16, defaulting an unknown ceiling to 255, and restoring the near-corner clamp.

Practical consequence worth stating: on the reference Zenbook the IR node negotiates GREY, so the reading exists there. A machine whose IR node comes up Y16 will log `n/a`, and that is the honest answer until the decode carries native-scale information.
