### PR TITLE
Drop published enrollment summaries when a test enters a sandbox

### DIFF
--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3064,11 +3064,14 @@ mod tests {
     /// and turns a real pass into an intermittent failure (or worse, a false
     /// pass in a mutation run, which is how a flake becomes a lie about
     /// coverage).
+    ///
+    /// This is `env_lock()` and not a lock of its own: `sandbox()` clears the
+    /// whole cache, so a sandbox test would otherwise be free to wipe the map
+    /// between a cache test's `publish` and its read, turning the hit these
+    /// tests assert into a miss. One lock covers both kinds of shared state.
+    /// No test acquires both helpers, so this cannot recurse.
     fn enrollment_summary_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+        env_lock()
     }
 
     /// A Status request the connection thread CANNOT answer from memory must

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1334,6 +1334,21 @@ fn invalidate_enrollment_summary(user: &str) {
         .remove(user);
 }
 
+/// Drops every published summary. The cache is keyed by user alone, but a
+/// test sandbox swaps `IRLUME_STATE_DIR` underneath it, so a summary another
+/// test published describes an enrollment that no longer exists on disk.
+/// `dispatch` answers a listing from that cache before it ever reads storage
+/// (see `dispatch_status`), so without this a listing can report a profile
+/// from a dead sandbox. Production never moves its state dir, so this has no
+/// caller outside tests.
+#[cfg(test)]
+fn clear_enrollment_summaries() {
+    enrollment_summaries()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
 fn cached_enrollment_summary(user: &str) -> Option<EnrollmentSummary> {
     enrollment_summaries()
         .lock()
@@ -4075,6 +4090,9 @@ mod tests {
         std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", dir.join("template-keys"));
         std::env::set_var("IRLUME_RECOVERY_DIR", dir.join("recovery"));
         std::env::set_var("IRLUME_METHOD_CONF", dir.join("no-method-conf"));
+        // The new state dir makes every published summary stale, and a
+        // listing is served from that cache before storage is read.
+        clear_enrollment_summaries();
         Sandbox { dir }
     }
 
@@ -4444,6 +4462,51 @@ mod tests {
         ) {
             Response::Error(msg) => assert_eq!(msg, "not authorized to list 'carol'"),
             other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+    }
+
+    /// `dispatch` answers a listing from the published summary before it
+    /// reads storage, and that cache is keyed by user with no notion of which
+    /// state dir the summary came from. Entering a sandbox must therefore
+    /// drop it: otherwise a test inherits whatever an earlier test's
+    /// enrollment happened to be called. This ran as a 15%-of-runs failure in
+    /// `list_profiles_reports_the_enrollment_and_gates_on_authorization`,
+    /// which reported the renamed profile from the mutation test's sandbox.
+    #[test]
+    fn a_sandbox_drops_the_summaries_an_earlier_one_published() {
+        let _g = env_lock();
+        let mut e = engine();
+        publish_enrollment_summary(
+            "carol",
+            EnrollmentSummary {
+                profiles: vec![irlume_common::ProfileSummary {
+                    name: "Profile From A Dead Sandbox".into(),
+                    scans: vec!["Face Scan 9".into()],
+                }],
+                require_eyes_open: false,
+                require_challenge: false,
+                closure_calibrated: false,
+                ir_ratio_calibrated: false,
+            },
+        );
+        let sb = sandbox("summary-carryover");
+        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
+        match dispatch(
+            Request::ListProfiles {
+                user: "carol".into(),
+                structured_errors: false,
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Enrollment { profiles, .. } => {
+                assert_eq!(profiles.len(), 1);
+                assert_eq!(
+                    profiles[0].name, "Face Profile 1",
+                    "the listing must come from this sandbox, not the cache"
+                );
+            }
+            other => panic!("expected Response::Enrollment, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## What breaks

`dispatch` answers `ListProfiles` from the enrollment summary cache added in #218 before it reads storage, and that cache is keyed by user with no record of which state dir the summary was built from. Every test sandbox swaps `IRLUME_STATE_DIR` underneath it, so a listing could be served out of a sandbox that had already been deleted.

CI caught it on #224 as `list_profiles_reports_the_enrollment_and_gates_on_authorization` reporting a profile named `Work`, which is what `mutations_that_rewrite_the_enrollment_roundtrip_through_dispatch` renames carol's profile to inside its own sandbox. The branch under test had not touched the daemon.

## Why it never showed up locally

The mutation test that publishes the poisoned summary skips itself when `/dev/tpmrm0` or `/dev/tpm0` exists, because its arms end in `storage::save` and would seal a real key. Every development machine here has a TPM, so that test never ran and the flake could not appear. Running the test binary inside a mount namespace with an empty `/dev` reproduces the CI condition: 3 failures in 20 runs on `main`.

## Fix

`sandbox()` clears the cache on entry. A new state dir makes every published summary describe a world that no longer exists. Production never moves its state dir, so the clear is `#[cfg(test)]` and has no caller outside tests.

`a_sandbox_drops_the_summaries_an_earlier_one_published` seeds a summary for carol, enters a sandbox, writes a different enrollment, and asserts the listing reports the one on disk. It does not depend on the thread race.

## Verification

- Mutant: with the `clear_enrollment_summaries()` call removed, the new test fails; restored, it passes.
- 60 runs of the daemon suite under the no-TPM namespace: 0 failures, against a 3-in-20 baseline on `main`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --workspace` all pass.

The invalidation list was audited while diagnosing this: every `storage::save` call site reachable from a request is covered. The startup retag at daemon boot runs before anything can publish, `RecoverySetup` is already listed, and all seven `mutate_enrollment` callers map to requests already in `enrollment_mutating_user`. No production gap.