### PR TITLE
Report a camera node irlume cannot read, instead of omitting it

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -378,12 +378,13 @@ pub struct Unreadable {
 }
 
 impl Unreadable {
-    /// The cause in a person's terms, and what resolves it. Pure over the
-    /// struct, so the wording is testable without an unreadable camera to
-    /// hand. Deliberately says what `map_io` says for the same errnos: a user
-    /// who hits this in doctor and then again mid-capture should not get two
+    /// The cause and its remedy, without the path, so a caller can state one
+    /// cause once over the several nodes that share it. Pure over the struct,
+    /// so the wording is testable without an unreadable camera to hand.
+    /// Deliberately says what `map_io` says for the same errnos: a user who
+    /// hits this in doctor and then again mid-capture should not get two
     /// different explanations of one condition.
-    pub fn explain(&self) -> String {
+    pub fn cause(&self) -> String {
         let what = match self.at {
             FailedAt::Open => "could not be opened",
             FailedAt::EnumFormats => "opened but would not list its formats",
@@ -410,7 +411,12 @@ impl Unreadable {
             Some(e) => format!("errno {e}: {}", std::io::Error::from_raw_os_error(e)),
             None => "no OS error reported".to_string(),
         };
-        format!("{} {what} ({code}). {why}", self.path)
+        format!("{what} ({code}). {why}")
+    }
+
+    /// The cause with this node's path in front, for reporting one node alone.
+    pub fn explain(&self) -> String {
+        format!("{} {}", self.path, self.cause())
     }
 }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -3006,6 +3006,25 @@ mod tests {
         std::fs::remove_dir_all(&root).unwrap();
     }
 
+    /// The branch the Codex round on #229 found unreachable: a node that opens
+    /// and then refuses to enumerate must be reported, not silently classified
+    /// as `Other` and dropped. `/dev/null` is exactly that node on any Linux
+    /// machine, since `Device::with_path` only opens (no QUERYCAP) and
+    /// VIDIOC_ENUM_FMT on a non-v4l2 character device returns ENOTTY, so this
+    /// needs no camera, no privilege, and no hardware in CI.
+    #[test]
+    fn a_node_that_opens_then_refuses_to_enumerate_is_reported_not_dropped() {
+        let u = classify_node("/dev/null")
+            .expect_err("a device that cannot enumerate formats must not classify as a role");
+        assert_eq!(u.at, FailedAt::EnumFormats);
+        assert_eq!(u.errno, Some(libc::ENOTTY));
+        assert!(
+            u.explain().contains("would not list its formats"),
+            "{}",
+            u.explain()
+        );
+    }
+
     /// A directory that will not list must not read as a machine with no
     /// cameras. This is the same defect #227 fixes, one level up.
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -467,13 +467,23 @@ fn capture_formats_answered(dev: &Device) -> std::io::Result<()> {
         return Ok(());
     }
     let e = std::io::Error::last_os_error();
-    match e.raw_os_error() {
-        // The node answered: it has no capture format at index 0. A metadata
-        // node reaches here on every machine with a UVC camera, so treating
-        // this as a failure would warn about correctly-ignored nodes.
-        Some(libc::EINVAL) => Ok(()),
-        _ => Err(e),
+    if enum_fmt_failure_means_no_formats(&e) {
+        return Ok(());
     }
+    Err(e)
+}
+
+/// Whether a failed `VIDIOC_ENUM_FMT` at index 0 means the node HAS no capture
+/// format, as opposed to having formats it would not report. The kernel
+/// specifies EINVAL as "no format at this index", which is both the normal end
+/// of enumeration and what a non-capture node answers at index 0; every UVC
+/// camera puts a metadata node on the machine that lands here, and warning
+/// about those would bury the report this fix exists to produce. Every other
+/// errno is a failure to observe. Same shape and the same rule as
+/// `control_read_failure_means_absent`, and pure for the same reason: the
+/// decision is testable without a camera that misbehaves.
+fn enum_fmt_failure_means_no_formats(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EINVAL)
 }
 
 /// `classify_node` for callers that only act on a node they can use. An
@@ -3023,6 +3033,29 @@ mod tests {
             "{}",
             u.explain()
         );
+    }
+
+    /// EINVAL at index 0 is the kernel's "no format here", which every UVC
+    /// metadata node answers. Treating it as a failure would put a warning
+    /// against four correctly-ignored nodes on any machine with two cameras,
+    /// which is how a report that finally says something useful gets ignored.
+    /// Every other errno is a node that would not answer.
+    #[test]
+    fn only_einval_means_a_node_has_no_capture_formats() {
+        let err = |n| std::io::Error::from_raw_os_error(n);
+        assert!(enum_fmt_failure_means_no_formats(&err(libc::EINVAL)));
+        for other in [
+            libc::EBUSY,
+            libc::ENOTTY,
+            libc::EIO,
+            libc::ENODEV,
+            libc::EACCES,
+        ] {
+            assert!(
+                !enum_fmt_failure_means_no_formats(&err(other)),
+                "errno {other} is a failed observation, not an absence"
+            );
+        }
     }
 
     /// A directory that will not list must not read as a machine with no

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -434,9 +434,46 @@ pub fn classify_node(device: &str) -> Result<Role, Unreadable> {
         holder: None,
     };
     let dev = Device::with_path(device).map_err(|e| unreadable(FailedAt::Open, e))?;
+    capture_formats_answered(&dev).map_err(|e| unreadable(FailedAt::EnumFormats, e))?;
     let formats = Capture::enum_formats(&dev).map_err(|e| unreadable(FailedAt::EnumFormats, e))?;
     let fourccs: Vec<[u8; 4]> = formats.iter().map(|f| f.fourcc.repr).collect();
     Ok(role_from_formats(&fourccs))
+}
+
+/// Whether the node ANSWERED the format enumeration, separate from what it
+/// answered. `Capture::enum_formats` in the pinned v4l 0.14.0 returns
+/// `Ok(Vec::new())` for any error at index 0, so a node that refused to answer
+/// is indistinguishable there from one that legitimately offers no capture
+/// format. The kernel gives EINVAL for "no format at this index", which is both
+/// the normal end of enumeration and what a non-capture node (a UVC metadata
+/// node) returns at index 0; every other errno is a failed observation. Asking
+/// index 0 directly is the only way to tell those apart with this crate
+/// version, and telling them apart is the whole of #227.
+fn capture_formats_answered(dev: &Device) -> std::io::Result<()> {
+    let mut desc: v4l::v4l_sys::v4l2_fmtdesc = unsafe { std::mem::zeroed() };
+    desc.index = 0;
+    desc.type_ = v4l::buffer::Type::VideoCapture as u32;
+    // SAFETY: `dev` owns the fd for the length of this call, and `desc` is a
+    // correctly sized, zeroed v4l2_fmtdesc, which is what VIDIOC_ENUM_FMT
+    // reads and writes. Same shape as the ioctl helper in ir_metadata.rs.
+    let rc = unsafe {
+        libc::ioctl(
+            dev.handle().fd(),
+            v4l::v4l2::vidioc::VIDIOC_ENUM_FMT,
+            &mut desc as *mut _ as *mut libc::c_void,
+        )
+    };
+    if rc >= 0 {
+        return Ok(());
+    }
+    let e = std::io::Error::last_os_error();
+    match e.raw_os_error() {
+        // The node answered: it has no capture format at index 0. A metadata
+        // node reaches here on every machine with a UVC camera, so treating
+        // this as a failure would warn about correctly-ignored nodes.
+        Some(libc::EINVAL) => Ok(()),
+        _ => Err(e),
+    }
 }
 
 /// `classify_node` for callers that only act on a node they can use. An
@@ -468,24 +505,66 @@ pub(crate) fn role_from_formats(fourccs: &[[u8; 4]]) -> Role {
     }
 }
 
-/// Every `/dev/video*` node on the machine, in numeric order. Read from the
-/// directory rather than probing a fixed range: the old `0..10` scan never
-/// looked at `/dev/video10`, which a machine with two cameras and a couple of
-/// v4l2loopback nodes reaches without being unusual (#227).
-pub(crate) fn video_node_paths() -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir("/dev") else {
-        return Vec::new();
+/// The video nodes found in a directory, and why the answer may be short.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct NodeListing {
+    pub paths: Vec<String>,
+    /// Set when the directory could not be listed, or an entry in it could
+    /// not be read. An empty `paths` with this set means "could not look",
+    /// which is not the same answer as "nothing there" and must not be
+    /// reported as one.
+    pub error: Option<String>,
+}
+
+/// Every `video*` node in `dir`, in numeric order. Reads the directory rather
+/// than probing a fixed range: the old `/dev/video0..9` scan never looked at
+/// `/dev/video10`, which a machine with two cameras and a couple of
+/// v4l2loopback nodes reaches without being unusual (#227). Takes the
+/// directory so the ordering and filtering are testable against a fake root
+/// instead of whatever this machine happens to have plugged in.
+pub(crate) fn video_node_paths_in(dir: &std::path::Path) -> NodeListing {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            return NodeListing {
+                paths: Vec::new(),
+                error: Some(format!("{} could not be listed: {e}", dir.display())),
+            }
+        }
     };
-    let mut nodes: Vec<(u32, String)> = entries
-        .flatten()
-        .filter_map(|e| {
-            let name = e.file_name().into_string().ok()?;
-            let n: u32 = name.strip_prefix("video")?.parse().ok()?;
-            Some((n, format!("/dev/{name}")))
-        })
-        .collect();
+    let mut nodes: Vec<(u32, String)> = Vec::new();
+    let mut unreadable_entries = 0usize;
+    for entry in entries {
+        let Ok(entry) = entry else {
+            unreadable_entries += 1;
+            continue;
+        };
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let Some(n) = name
+            .strip_prefix("video")
+            .and_then(|d| d.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        nodes.push((n, dir.join(&name).to_string_lossy().into_owned()));
+    }
+    // Numeric, not lexical: a string sort puts video10 before video9.
     nodes.sort_unstable();
-    nodes.into_iter().map(|(_, p)| p).collect()
+    NodeListing {
+        paths: nodes.into_iter().map(|(_, p)| p).collect(),
+        error: (unreadable_entries > 0).then(|| {
+            format!(
+                "{unreadable_entries} entries in {} could not be read",
+                dir.display()
+            )
+        }),
+    }
+}
+
+pub(crate) fn video_node_paths() -> NodeListing {
+    video_node_paths_in(std::path::Path::new("/dev"))
 }
 
 /// Every video node split into the ones that answered and the ones that could
@@ -497,6 +576,9 @@ pub struct NodeScan {
     /// Nodes that answered, excluding `Role::Other`.
     pub classified: Vec<(String, Role)>,
     pub unreadable: Vec<Unreadable>,
+    /// Why this scan may be incomplete. An empty scan with this set means the
+    /// nodes could not be listed, not that there are none.
+    pub listing_error: Option<String>,
 }
 
 /// `with_holders` walks /proc for each busy node to name what holds it. That
@@ -504,7 +586,9 @@ pub struct NodeScan {
 /// callers, which run on the TUI's refresh path.
 fn scan(with_holders: bool) -> NodeScan {
     let mut scan = NodeScan::default();
-    for path in video_node_paths() {
+    let listing = video_node_paths();
+    scan.listing_error = listing.error;
+    for path in listing.paths {
         match classify_node(&path) {
             Ok(Role::Other) => {}
             Ok(role) => scan.classified.push((path, role)),
@@ -2888,25 +2972,50 @@ mod tests {
     }
 
     /// The old scan probed /dev/video0..9 by construction, so a tenth node was
-    /// invisible. archhost has one.
+    /// invisible; archhost has one. Run against a fake root, because a test
+    /// reading the real /dev proves whatever that machine happens to have
+    /// plugged in and would pass on a box with three cameras and no video10.
     #[test]
-    fn the_node_scan_is_not_capped_at_ten() {
-        let paths = video_node_paths();
-        // Ordering is numeric, not lexical: video10 sorts after video9, which
-        // a string sort gets backwards.
-        let numbers: Vec<u32> = paths
-            .iter()
-            .filter_map(|p| p.strip_prefix("/dev/video")?.parse().ok())
-            .collect();
-        assert!(
-            numbers.windows(2).all(|w| w[0] < w[1]),
-            "nodes must be numerically ordered, got {paths:?}"
-        );
-        // Every path this yields is a real entry under /dev, whatever this
-        // machine happens to have.
-        for p in &paths {
-            assert!(std::path::Path::new(p).exists(), "{p} does not exist");
+    fn the_node_scan_reaches_past_nine_and_orders_numerically() {
+        let root = std::env::temp_dir().join(format!("irlume-nodes-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        for name in [
+            "video10", "video2", "video9", "video0", "videoX", "video", "audio3", "video1a",
+        ] {
+            std::fs::write(root.join(name), b"").unwrap();
         }
+
+        let listing = video_node_paths_in(&root);
+        let names: Vec<String> = listing
+            .paths
+            .iter()
+            .map(|p| {
+                std::path::Path::new(p)
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        // video10 present and last: the range cap is gone and the sort is
+        // numeric, which a lexical sort would render video0, video10, video2.
+        assert_eq!(names, ["video0", "video2", "video9", "video10"]);
+        assert!(listing.error.is_none(), "{:?}", listing.error);
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// A directory that will not list must not read as a machine with no
+    /// cameras. This is the same defect #227 fixes, one level up.
+    #[test]
+    fn a_directory_that_cannot_be_listed_is_not_an_empty_machine() {
+        let missing = std::env::temp_dir().join(format!("irlume-absent-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&missing);
+        let listing = video_node_paths_in(&missing);
+        assert!(listing.paths.is_empty());
+        let why = listing.error.expect("a listing failure must be reported");
+        assert!(why.contains("could not be listed"), "{why}");
     }
 
     fn frame(data: &[u8]) -> Frame {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -341,22 +341,103 @@ fn camera_holder(device: &str) -> Option<String> {
 pub enum Role {
     Rgb,
     Ir,
-    /// A capture node advertising neither (metadata node) or unreadable.
+    /// A capture node that answered and advertises neither colour nor grey,
+    /// which is what a UVC metadata node looks like. A node that could not be
+    /// read is NOT this: see `Unreadable`.
     Other,
 }
 
-/// Classify a single `/dev/videoN` node by enumerating its pixel formats.
-/// Defensive: enumerate FORMATS (safe), never `query_controls` (panics on some
-/// UVC drivers; a hard-won linhello lesson).
-pub fn classify(device: &str) -> Role {
-    let Ok(dev) = Device::with_path(device) else {
-        return Role::Other;
+/// Where reading a node failed. A node that could not be read is kept apart
+/// from `Role::Other` all the way to the report, because the two call for
+/// opposite actions: `Other` is a node correctly ignored, while this is a
+/// camera whose kind is still unknown. Collapsing them told a user with a busy
+/// or unreadable camera that the hardware was absent, which is the same
+/// mistake `control_read_failure_means_absent` exists to prevent one function
+/// below (#227).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailedAt {
+    /// `open(2)` on the node itself.
+    Open,
+    /// The node opened, then would not enumerate its formats.
+    EnumFormats,
+}
+
+/// A `/dev/video*` node that exists but could not be classified.
+#[derive(Debug, Clone)]
+pub struct Unreadable {
+    pub path: String,
+    pub at: FailedAt,
+    /// `None` when the failure carried no OS error, which the v4l crate can
+    /// produce for a malformed response rather than a syscall failure.
+    pub errno: Option<i32>,
+    /// The process holding the node, captured at scan time because a holder
+    /// named a minute later may not be the one that caused the failure. Only
+    /// looked up for EBUSY, and best-effort even then: `camera_holder` reads
+    /// /proc and cannot see a holder owned by another uid (#207).
+    pub holder: Option<String>,
+}
+
+impl Unreadable {
+    /// The cause in a person's terms, and what resolves it. Pure over the
+    /// struct, so the wording is testable without an unreadable camera to
+    /// hand. Deliberately says what `map_io` says for the same errnos: a user
+    /// who hits this in doctor and then again mid-capture should not get two
+    /// different explanations of one condition.
+    pub fn explain(&self) -> String {
+        let what = match self.at {
+            FailedAt::Open => "could not be opened",
+            FailedAt::EnumFormats => "opened but would not list its formats",
+        };
+        let why = match self.errno {
+            Some(libc::EACCES) | Some(libc::EPERM) => {
+                "permission denied; add your user to the 'video' group (camera) and re-login"
+                    .to_string()
+            }
+            Some(libc::EBUSY) => match &self.holder {
+                Some(h) => format!("camera busy, in use by {h}. Close that app and retry"),
+                None => {
+                    "camera busy, another app is using it. Close that app and retry".to_string()
+                }
+            },
+            Some(libc::ENODEV) | Some(libc::ENXIO) => {
+                "the node is present but the device behind it is gone, which is what an \
+                 unplugged or reset USB camera leaves behind"
+                    .to_string()
+            }
+            _ => "cause unknown; the errno above is reported as the driver gave it".to_string(),
+        };
+        let code = match self.errno {
+            Some(e) => format!("errno {e}: {}", std::io::Error::from_raw_os_error(e)),
+            None => "no OS error reported".to_string(),
+        };
+        format!("{} {what} ({code}). {why}", self.path)
+    }
+}
+
+/// Classify a single `/dev/videoN` node by enumerating its pixel formats,
+/// keeping a failure to read the node apart from a node that read as neither
+/// kind. Defensive: enumerate FORMATS (safe), never `query_controls` (panics on
+/// some UVC drivers; a hard-won linhello lesson).
+pub fn classify_node(device: &str) -> Result<Role, Unreadable> {
+    let unreadable = |at, e: std::io::Error| Unreadable {
+        path: device.to_string(),
+        at,
+        errno: e.raw_os_error(),
+        // Filled in by `scan_nodes` for a busy node; classifying one node in
+        // isolation does not walk /proc.
+        holder: None,
     };
-    let Ok(formats) = Capture::enum_formats(&dev) else {
-        return Role::Other;
-    };
+    let dev = Device::with_path(device).map_err(|e| unreadable(FailedAt::Open, e))?;
+    let formats = Capture::enum_formats(&dev).map_err(|e| unreadable(FailedAt::EnumFormats, e))?;
     let fourccs: Vec<[u8; 4]> = formats.iter().map(|f| f.fourcc.repr).collect();
-    role_from_formats(&fourccs)
+    Ok(role_from_formats(&fourccs))
+}
+
+/// `classify_node` for callers that only act on a node they can use. An
+/// unreadable node answers `Other` here, so anything reporting to a human
+/// wants `classify_node` or `scan_nodes` instead.
+pub fn classify(device: &str) -> Role {
+    classify_node(device).unwrap_or(Role::Other)
 }
 
 /// Pure classification over a node's advertised fourccs (unit-testable without
@@ -381,17 +462,66 @@ pub(crate) fn role_from_formats(fourccs: &[[u8; 4]]) -> Role {
     }
 }
 
-/// Scan `/dev/video0..9`, returning (path, role) for each readable capture node.
-pub fn discover_nodes() -> Vec<(String, Role)> {
-    (0..10)
-        .map(|n| format!("/dev/video{n}"))
-        .filter(|p| std::path::Path::new(p).exists())
-        .map(|p| {
-            let role = classify(&p);
-            (p, role)
+/// Every `/dev/video*` node on the machine, in numeric order. Read from the
+/// directory rather than probing a fixed range: the old `0..10` scan never
+/// looked at `/dev/video10`, which a machine with two cameras and a couple of
+/// v4l2loopback nodes reaches without being unusual (#227).
+pub(crate) fn video_node_paths() -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir("/dev") else {
+        return Vec::new();
+    };
+    let mut nodes: Vec<(u32, String)> = entries
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().into_string().ok()?;
+            let n: u32 = name.strip_prefix("video")?.parse().ok()?;
+            Some((n, format!("/dev/{name}")))
         })
-        .filter(|(_, r)| *r != Role::Other)
-        .collect()
+        .collect();
+    nodes.sort_unstable();
+    nodes.into_iter().map(|(_, p)| p).collect()
+}
+
+/// Every video node split into the ones that answered and the ones that could
+/// not be read. `discover_nodes` throws the second group away, which is right
+/// for callers picking a camera to open and wrong for anything reporting to a
+/// person.
+#[derive(Debug, Clone, Default)]
+pub struct NodeScan {
+    /// Nodes that answered, excluding `Role::Other`.
+    pub classified: Vec<(String, Role)>,
+    pub unreadable: Vec<Unreadable>,
+}
+
+/// `with_holders` walks /proc for each busy node to name what holds it. That
+/// is worth a report a person reads and not worth it for the camera-picking
+/// callers, which run on the TUI's refresh path.
+fn scan(with_holders: bool) -> NodeScan {
+    let mut scan = NodeScan::default();
+    for path in video_node_paths() {
+        match classify_node(&path) {
+            Ok(Role::Other) => {}
+            Ok(role) => scan.classified.push((path, role)),
+            Err(mut u) => {
+                if with_holders && u.errno == Some(libc::EBUSY) {
+                    u.holder = camera_holder(&u.path);
+                }
+                scan.unreadable.push(u);
+            }
+        }
+    }
+    scan
+}
+
+/// Classify every video node, keeping the failures and naming what holds a
+/// busy one. For reports; use `discover_nodes` to pick a camera.
+pub fn scan_nodes() -> NodeScan {
+    scan(true)
+}
+
+/// Scan for each readable capture node, returning (path, role).
+pub fn discover_nodes() -> Vec<(String, Role)> {
+    scan(false).classified
 }
 
 /// Whether a failed privacy-control read means the camera does not HAVE the
@@ -2707,6 +2837,71 @@ fn warm_up_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn unreadable(at: FailedAt, errno: Option<i32>, holder: Option<&str>) -> Unreadable {
+        Unreadable {
+            path: "/dev/video4".into(),
+            at,
+            errno,
+            holder: holder.map(str::to_string),
+        }
+    }
+
+    /// The whole point of #227: the three conditions a camera node fails under
+    /// must reach the reader as three different sentences, each naming the act
+    /// that clears it. A permission problem that reads as absent hardware sends
+    /// someone after a driver bug they do not have.
+    #[test]
+    fn an_unreadable_node_explains_the_cause_it_actually_hit() {
+        let denied = unreadable(FailedAt::Open, Some(libc::EACCES), None).explain();
+        assert!(denied.contains("/dev/video4"), "{denied}");
+        assert!(denied.contains("could not be opened"), "{denied}");
+        assert!(denied.contains("'video' group"), "{denied}");
+
+        // A named holder is the difference between "something has your camera"
+        // and knowing which app to close.
+        let busy =
+            unreadable(FailedAt::Open, Some(libc::EBUSY), Some("firefox (pid 42)")).explain();
+        assert!(busy.contains("in use by firefox (pid 42)"), "{busy}");
+        assert!(!busy.contains("'video' group"), "{busy}");
+
+        // /proc could not name it (another uid, #207): still busy, no invention.
+        let anon = unreadable(FailedAt::Open, Some(libc::EBUSY), None).explain();
+        assert!(anon.contains("another app is using it"), "{anon}");
+
+        let gone = unreadable(FailedAt::EnumFormats, Some(libc::ENODEV), None).explain();
+        assert!(gone.contains("would not list its formats"), "{gone}");
+        assert!(gone.contains("device behind it is gone"), "{gone}");
+
+        // An errno with no mapping still reports the number rather than
+        // rounding down to silence.
+        let odd = unreadable(FailedAt::Open, Some(libc::EIO), None).explain();
+        assert!(odd.contains("errno 5"), "{odd}");
+        let none = unreadable(FailedAt::Open, None, None).explain();
+        assert!(none.contains("no OS error reported"), "{none}");
+    }
+
+    /// The old scan probed /dev/video0..9 by construction, so a tenth node was
+    /// invisible. archhost has one.
+    #[test]
+    fn the_node_scan_is_not_capped_at_ten() {
+        let paths = video_node_paths();
+        // Ordering is numeric, not lexical: video10 sorts after video9, which
+        // a string sort gets backwards.
+        let numbers: Vec<u32> = paths
+            .iter()
+            .filter_map(|p| p.strip_prefix("/dev/video")?.parse().ok())
+            .collect();
+        assert!(
+            numbers.windows(2).all(|w| w[0] < w[1]),
+            "nodes must be numerically ordered, got {paths:?}"
+        );
+        // Every path this yields is a real entry under /dev, whatever this
+        // machine happens to have.
+        for p in &paths {
+            assert!(std::path::Path::new(p).exists(), "{p} does not exist");
+        }
+    }
 
     fn frame(data: &[u8]) -> Frame {
         Frame {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3039,7 +3039,14 @@ fn doctor_run(
             State::Warn
         },
     );
-    if nodes.is_empty() && scan.unreadable.is_empty() {
+    // "Could not look" is not "nothing there". Reporting a /dev that would not
+    // list as a machine with no cameras is the same mistake at one level up.
+    if let Some(why) = &scan.listing_error {
+        dout!(
+            report,
+            "  ⚠ {why}; whether this machine has camera nodes is unknown"
+        );
+    } else if nodes.is_empty() && scan.unreadable.is_empty() {
         dout!(report, "  (no /dev/video* nodes on this machine)");
     }
     if nodes.is_empty() {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3021,10 +3021,14 @@ fn doctor_run(
         report,
         "[doctor] camera nodes (classified by pixel format):"
     );
-    let nodes = irlume_camera::discover_nodes();
+    let scan = irlume_camera::scan_nodes();
+    let nodes = scan.classified.clone();
     // Capability, not identity: a consumer is told an IR node was classified,
     // never which device it is. The human report below still names them, since
     // a person debugging their own machine needs the path.
+    // The verdict is unchanged by #227: a node irlume cannot read is still a
+    // node it cannot use, so "nodes present, none readable" fails exactly as
+    // "no nodes" does. What changed is that the lines below now say which.
     report.check(
         "camera-nodes",
         if nodes.iter().any(|(_, r)| *r == irlume_camera::Role::Ir) {
@@ -3035,8 +3039,10 @@ fn doctor_run(
             State::Warn
         },
     );
+    if nodes.is_empty() && scan.unreadable.is_empty() {
+        dout!(report, "  (no /dev/video* nodes on this machine)");
+    }
     if nodes.is_empty() {
-        dout!(report, "  (none found under /dev/video0..9)");
         if let Some(gen) = irlume_camera::intel_ipu_present() {
             dout!(report,
                 "  ⚠ this laptop has an Intel {gen} MIPI camera, which irlume cannot use:\n     \
@@ -3096,6 +3102,12 @@ fn doctor_run(
                 );
             }
         }
+    }
+    // A node irlume could not read is named with its errno, never omitted.
+    // Dropping these is what let a permission problem read as absent hardware
+    // and sent the reader after a driver bug they did not have (#227).
+    for u in &scan.unreadable {
+        dout!(report, "  ⚠ {}", u.explain());
     }
 
     // --- models / runtime --------------------------------------------------

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3106,8 +3106,14 @@ fn doctor_run(
     // A node irlume could not read is named with its errno, never omitted.
     // Dropping these is what let a permission problem read as absent hardware
     // and sent the reader after a driver bug they did not have (#227).
+    // Nodes are grouped by cause: one missing 'video' group membership denies
+    // every node on the machine, and that is one fact, not eleven.
+    let mut by_cause: std::collections::BTreeMap<String, Vec<&str>> = Default::default();
     for u in &scan.unreadable {
-        dout!(report, "  ⚠ {}", u.explain());
+        by_cause.entry(u.cause()).or_default().push(&u.path);
+    }
+    for (cause, paths) in &by_cause {
+        dout!(report, "  ⚠ {}: {cause}", paths.join(", "));
     }
 
     // --- models / runtime --------------------------------------------------


### PR DESCRIPTION
Closes #227.

## What was wrong

`classify()` returned `Role::Other` for two unrelated things: a node that answered and advertises neither colour nor grey (a UVC metadata node, correctly ignored) and a node that could not be read. `discover_nodes()` drops every `Other`, so an unreadable camera did not appear at all, and doctor printed `(none found under /dev/video0..9)`.

On archhost, which has eleven video nodes and two the same binary classifies as `Ir`:

```
$ sudo -u nobody irlume doctor        # 0.8.0
[doctor] camera nodes (classified by pixel format):
  (none found under /dev/video0..9)
```

The rule this breaks is already written down in `control_read_failure_means_absent`, one function below, from the #193 review: a failed observation must not be reported as an absence.

## What changed

`classify_node()` returns `Result<Role, Unreadable>` carrying where the read failed and its errno. `scan_nodes()` keeps those alongside the classified nodes; `discover_nodes()` is unchanged for callers picking a camera, and does not pay for the `/proc` holder lookup on the TUI refresh path. Doctor prints each unreadable node with its cause and the act that clears it, grouped by cause so one missing group membership is one line and not eleven, worded to match what `map_io` already says for the same errnos.

```
$ sudo -u nobody ./irlume doctor      # this branch
[doctor] camera nodes (classified by pixel format):
  ⚠ /dev/video0, ... /dev/video10: could not be opened (errno 13: Permission
    denied (os error 13)). permission denied; add your user to the 'video'
    group (camera) and re-login
```

The `camera-nodes` verdict is deliberately unchanged: a node irlume cannot read is a node it cannot use, so "nodes present, none readable" still fails as "no nodes" does. What changed is that the report says which.

The scan enumerated a fixed `/dev/video0..9` range and never examined `/dev/video10`; archhost has one. It now reads the directory and orders numerically, since a string sort puts `video10` before `video9`.

## The Codex round found the central fix unreachable

v4l 0.14.0's `enum_formats` returns `Ok(Vec::new())` for **any** error at index 0, so `map_err(FailedAt::EnumFormats)` could never fire: a node that opened and then refused to enumerate still classified as `Other` and was still dropped. The defect this PR exists to remove survived for every failure occurring after open.

`capture_formats_answered()` now asks index 0 directly through `libc::ioctl`, the same shape as the helper in `ir_metadata.rs`. EINVAL maps to success because that is the kernel's "no format at this index", which is what every UVC metadata node answers and what must stay a quiet `Other`; any other errno is a failed observation and is carried.

Two more from the same round, both taken:

- `video_node_paths_in()` takes its directory and reports why a listing may be short. Returning an empty vec when `/dev` itself will not open reported "could not look" as "nothing there", the same defect one level up. Doctor now says the node list is unknown rather than empty.
- The range test asserted ordering over whatever this machine has plugged in, proving nothing about the ten-node cap on a box without a `video10`. It runs against a fake root holding `video0`, `video2`, `video9`, `video10` and several non-matching names.

## Verification

Four mutants, all killed. The EINVAL mutant survived the first pass, because nothing asserted that a node legitimately reporting no capture format stays quiet; every UVC camera puts a metadata node in that position, so the mutation would have warned about four correctly-ignored nodes on a two-camera machine. The decision is now a pure `enum_fmt_failure_means_no_formats`, mirroring `control_read_failure_means_absent`, with the errno table asserted.

The enumeration branch is covered without hardware: `/dev/null` opens and returns ENOTTY from `VIDIOC_ENUM_FMT`, and `Device::with_path` only opens (no QUERYCAP), so it behaves the same in CI.

On archhost, with the NexiGo IR camera and the BRIO attached:

- Healthy machine unchanged: `video0`/`video4` Rgb, `video2`/`video6` Ir, the four UVC metadata nodes still silent, loopbacks still flagged. This is the regression that mattered for the ioctl change.
- `EACCES` end to end: eleven nodes, previously reported as no cameras, now named with errno 13 and the group membership that fixes it, `/dev/video10` included.
- `EBUSY` and `ENODEV` wordings are unit-tested only. Streaming from `/dev/video2` with `v4l2-ctl --stream-mmap` does **not** make classification fail: UVC permits a second open and format enumeration during streaming, so a busy webcam is not the source of an unreadable node here. That branch covers a driver refusing the second open, which I did not reproduce on this hardware.

This does not explain the 2026-08-01 Hardware suite failure and does not claim to. It makes the next occurrence state which errno it hit instead of reporting plainly present hardware as missing.

`cargo test --workspace` passes on the Zenbook; `irlume-camera` passes on archhost against the real cameras.