### PR TITLE
An off-frame region measures nothing, not the frame's far edge

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2808,8 +2808,8 @@ fn frontality_hint(pose: &irlume_vision::HeadPose, pitch_neutral: Option<f32>) -
 
 /// Mean BT.601 luma (0–255) of the RGB8 face region.
 fn luma_in_bbox(rgb: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
-    let x1 = (bbox[0].max(0.0) as u32).min(w.saturating_sub(1));
-    let y1 = (bbox[1].max(0.0) as u32).min(h.saturating_sub(1));
+    let x1 = (bbox[0].max(0.0) as u32).min(w);
+    let y1 = (bbox[1].max(0.0) as u32).min(h);
     let x2 = (bbox[2].max(0.0) as u32).min(w);
     let y2 = (bbox[3].max(0.0) as u32).min(h);
     let (mut sum, mut n) = (0f64, 0u64);
@@ -2946,8 +2946,8 @@ fn eye_open_at(grey: &[u8], w: u32, h: u32, (ex, ey): (f32, f32), r: i32) -> boo
 /// and glossy prints blow out highlights, so an unusually high fraction is a
 /// (deterrent-grade) screen/glare signal.
 fn rgb_luma_stats(rgb: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> (f32, f32) {
-    let x1 = (bbox[0].max(0.0) as u32).min(w.saturating_sub(1));
-    let y1 = (bbox[1].max(0.0) as u32).min(h.saturating_sub(1));
+    let x1 = (bbox[0].max(0.0) as u32).min(w);
+    let y1 = (bbox[1].max(0.0) as u32).min(h);
     let x2 = (bbox[2].max(0.0) as u32).min(w);
     let y2 = (bbox[3].max(0.0) as u32).min(h);
     let (mut sum, mut n, mut hot) = (0u64, 0u64, 0u64);
@@ -2983,8 +2983,8 @@ pub fn mean_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4]) -> f32 {
     if grey.len() < (w as usize).saturating_mul(h as usize) {
         return 0.0;
     }
-    let x1 = (bbox[0].max(0.0) as u32).min(w.saturating_sub(1));
-    let y1 = (bbox[1].max(0.0) as u32).min(h.saturating_sub(1));
+    let x1 = (bbox[0].max(0.0) as u32).min(w);
+    let y1 = (bbox[1].max(0.0) as u32).min(h);
     let x2 = (bbox[2].max(0.0) as u32).min(w);
     let y2 = (bbox[3].max(0.0) as u32).min(h);
     let (mut sum, mut n) = (0u64, 0u64);
@@ -3824,12 +3824,47 @@ mod tests {
         let grey = [10u8, 20, 30, 40, 50, 60, 70, 80];
         assert!((mean_in_bbox(&grey, w, h, &[0.0, 0.0, 4.0, 2.0]) - 45.0).abs() < 1e-4);
         assert!((mean_in_bbox(&grey, w, h, &[0.0, 0.0, 2.0, 1.0]) - 15.0).abs() < 1e-4);
-        // Out-of-frame bbox clamps to the frame.
+        // A bbox that straddles the frame clamps to the frame.
         assert!((mean_in_bbox(&grey, w, h, &[-9.0, -9.0, 99.0, 99.0]) - 45.0).abs() < 1e-4);
         assert_eq!(mean_in_bbox(&grey, w, h, &[3.0, 1.0, 3.0, 1.0]), 0.0);
         // A frame shorter than w*h (truncated/mismatched capture) must degrade
         // to 0.0, not panic on the out-of-bounds index.
         assert_eq!(mean_in_bbox(&grey[..3], w, h, &[0.0, 0.0, 4.0, 2.0]), 0.0);
+    }
+
+    /// A region wholly outside the frame contains no pixels, so every
+    /// bbox-sampling helper must measure nothing rather than substitute the
+    /// frame's far edge. The old clamp put the near corner at w-1 and the far
+    /// one at w, leaving a one-pixel strip of the opposite side of the image
+    /// whose mean was returned as the region's (#225). All three helpers had
+    /// the same clamp, so all three are pinned here: fixing one and leaving
+    /// its siblings is how this survived the first time.
+    #[test]
+    fn a_region_off_the_frame_measures_nothing_in_every_helper() {
+        let (w, h) = (4u32, 2u32);
+        let grey = [10u8, 20, 30, 40, 50, 60, 70, 80];
+        // Bright far edge, so an accidental one-column sample is loud.
+        let rgb: Vec<u8> = (0..(w * h)).flat_map(|i| [(i * 30) as u8; 3]).collect();
+
+        for off in [
+            [9.0f32, 0.0, 99.0, 2.0], // wholly right of the frame
+            [0.0, 9.0, 4.0, 99.0],    // wholly below it
+            [9.0, 9.0, 99.0, 99.0],   // past the corner
+            [-99.0, 0.0, -9.0, 2.0],  // wholly left, clamped to zero width
+        ] {
+            assert_eq!(mean_in_bbox(&grey, w, h, &off), 0.0, "mean_in_bbox {off:?}");
+            assert_eq!(luma_in_bbox(&rgb, w, h, &off), 0.0, "luma_in_bbox {off:?}");
+            assert_eq!(
+                rgb_luma_stats(&rgb, w, h, &off),
+                (0.0, 0.0),
+                "rgb_luma_stats {off:?}"
+            );
+        }
+
+        // The on-frame answers are untouched: this changes off-frame boxes
+        // only, and a face detection is always at least partly on-frame.
+        assert!((mean_in_bbox(&grey, w, h, &[0.0, 0.0, 4.0, 2.0]) - 45.0).abs() < 1e-4);
+        assert!((mean_in_bbox(&grey, w, h, &[2.0, 0.0, 4.0, 2.0]) - 55.0).abs() < 1e-4);
     }
 
     /// `face_frac` is the seating-distance signal the framing guide already

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -3025,10 +3025,10 @@ pub fn saturated_frac_in_bbox(grey: &[u8], w: u32, h: u32, bbox: &[f32; 4], whit
     if grey.len() < (w as usize).saturating_mul(h as usize) {
         return 0.0;
     }
-    // Clamp BOTH corners to the frame, unlike `mean_in_bbox`, whose x1/y1
-    // clamp to w-1/h-1: a box wholly past the right or bottom edge collapses
-    // there to a one-pixel strip of an unrelated edge rather than to an empty
-    // region. Here an off-frame box measures nothing, which is what it saw.
+    // Both corners clamp to the frame, so a box wholly past the right or
+    // bottom edge collapses to an empty region and measures nothing, which is
+    // what it saw. `mean_in_bbox` and its siblings clamp the same way since
+    // #225; before that they left a one-pixel strip of an unrelated edge.
     let x1 = (bbox[0].max(0.0) as u32).min(w);
     let y1 = (bbox[1].max(0.0) as u32).min(h);
     let x2 = (bbox[2].max(0.0) as u32).min(w);
@@ -3904,9 +3904,8 @@ mod tests {
         // Out-of-frame boxes clamp; a degenerate box reports nothing.
         assert_eq!(f(&[-9.0, -9.0, 99.0, 99.0], 255), 0.5);
         assert_eq!(f(&[3.0, 1.0, 3.0, 1.0], 255), 0.0);
-        // A box wholly past the right or bottom edge measures NOTHING. The
-        // sibling mean_in_bbox clamps its near corner to w-1/h-1 and so
-        // samples a one-pixel strip of an unrelated edge instead.
+        // A box wholly past the right or bottom edge measures NOTHING, which
+        // every bbox-sampling helper has agreed on since #225.
         assert_eq!(f(&[10.0, 0.0, 20.0, 2.0], 255), 0.0);
         assert_eq!(f(&[0.0, 9.0, 4.0, 12.0], 255), 0.0);
         // A truncated frame degrades like mean_in_bbox, never panics.


### PR DESCRIPTION
Closes #225.

## The defect

`mean_in_bbox` clamped its near corner and its far corner differently:

```rust
let x1 = (bbox[0].max(0.0) as u32).min(w.saturating_sub(1));
let x2 = (bbox[2].max(0.0) as u32).min(w);
```

For a box wholly past the right edge, `x1` clamps to `w-1` and `x2` to `w`, so the loop runs over exactly one column: the frame's last one, which has nothing to do with the requested region. Its mean is then returned as the region's. Same for the bottom edge.

## It was in three functions, not one

The issue named `mean_in_bbox`. `luma_in_bbox` and `rgb_luma_stats` carry the identical clamp, so fixing the named one would have left two live copies of the defect the issue describes. All three now clamp both corners to the frame, which makes an off-frame region run the loop zero times and report through each function's existing `n == 0` path. `saturated_frac_in_bbox` from #224 already clamped this way; the four now agree.

A fourth site, `laplacian_var_bbox` in the CLI, uses a similar-looking clamp and is correct as written: its 3x3 kernel reads `x-1` and `x+1`, so the one-pixel inset is the kernel's requirement, and it already returns 0.0 for a degenerate region. Left alone.

## Latent, not live

Every caller passes a detection measured on the frame being sampled: `mean_in_bbox` from the daemon's IR path, `suncal`, and `pad` all pass `f.bbox` with that frame's own dimensions. `center_edge_ratio`'s inner box is inset 25% per side from the outer box, so it cannot land further off-frame than its parent. I could not construct a path that reaches the bad branch in production, and I am not claiming one exists.

One correction to that reasoning, from the review round: I had written that a detection is always at least partly on-frame. Nothing enforces it. YuNet and Blaze decode model outputs into boxes without an intersection guard, so an entirely off-frame box is a matter of what the model emits rather than an invariant the code holds. That makes the fix worth more than the "latent" label suggests, and it is why the helpers now handle the case instead of relying on the expectation. It is fixed as a correctness defect in helpers that feed `ir_face_brightness` and the centre/edge ratio, where a silently wrong sample would be a bad thing to discover later.

## Verification

`a_region_off_the_frame_measures_nothing_in_every_helper` asserts all three helpers over four off-frame boxes (right, below, past the corner, and wholly left), against an RGB frame whose far edge is bright so an accidental one-column sample would be loud. The on-frame answers are pinned in the same test.

Three mutants, one per site, each reverting that site alone to the old clamp. All three fail the test. `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --workspace` pass.

No hardware run: this changes only the arithmetic for regions no camera path produces, and the on-frame behaviour is asserted unchanged.
