### PR TITLE
Push the flake.lock branch instead of opening its PR

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -8,15 +8,23 @@
 # open the pull request. Doing so needs "Allow GitHub Actions to create and
 # approve pull requests", a repository-wide permission that would apply to
 # every workflow here, and this monthly refresh is not worth carrying it for
-# (#228). A maintainer opens the PR from the pushed branch, which also means
-# the required checks run: a PR opened with the workflow token does not
-# trigger them.
+# (#228). A maintainer opens the PR from the pushed branch, so its checks run
+# as an ordinary PR: runs from a workflow-token PR are created but held in an
+# approval-required state, which is one more click on every refresh.
 name: Update flake.lock
 
 on:
   schedule:
     - cron: "15 6 1 * *"
   workflow_dispatch:
+
+# The branch below is force-pushed, and both triggers can otherwise run at
+# once: a slower earlier run would land its older lockfile on top of a newer
+# one that had already finished, leaving the branch disagreeing with the
+# summary that announced it.
+concurrency:
+  group: update-flake-lock
+  cancel-in-progress: true
 
 # Least privilege at the top; the one job that pushes a branch escalates
 # below (Scorecard Token-Permissions best practice). `pull-requests: write`
@@ -63,9 +71,11 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git commit -am "deps: update flake.lock"
-          # --force, not --force-with-lease: this branch is recreated from
-          # main by each run, and the checkout has no remote-tracking ref for
-          # it to lease against. Nothing but this workflow writes it.
+          # --force, not --force-with-lease: the branch is a rolling pointer
+          # to the latest validated lockfile, recreated from main each run,
+          # and the checkout has no remote-tracking ref to lease against. An
+          # open PR from a previous refresh is meant to be updated in place.
+          # The concurrency group above is what stops two runs racing here.
           git push --force \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "$BRANCH"

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -2,10 +2,15 @@
 # has no nix support), so without this the pinned nixpkgs ages silently.
 #
 # The update runs `nix flake check` plus the fixed-output-derivation build
-# BEFORE opening the PR, so the PR arrives pre-validated in this workflow's
-# log. Note: PRs opened with the workflow token do not trigger the CI
-# workflow; close and reopen the PR (one click) to run the required checks
-# before merging.
+# before pushing, so the branch arrives pre-validated in this run's log.
+#
+# This workflow pushes `deps/update-flake-lock` and stops there; it does not
+# open the pull request. Doing so needs "Allow GitHub Actions to create and
+# approve pull requests", a repository-wide permission that would apply to
+# every workflow here, and this monthly refresh is not worth carrying it for
+# (#228). A maintainer opens the PR from the pushed branch, which also means
+# the required checks run: a PR opened with the workflow token does not
+# trigger them.
 name: Update flake.lock
 
 on:
@@ -13,8 +18,9 @@ on:
     - cron: "15 6 1 * *"
   workflow_dispatch:
 
-# Least privilege at the top; the one job that commits and opens a PR
-# escalates below (Scorecard Token-Permissions best practice).
+# Least privilege at the top; the one job that pushes a branch escalates
+# below (Scorecard Token-Permissions best practice). `pull-requests: write`
+# is deliberately absent: nothing here opens a PR.
 permissions:
   contents: read
 
@@ -24,7 +30,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -43,14 +48,33 @@ jobs:
           nix flake check --no-build --show-trace
           nix build --no-link .#default.cargoDeps .#onnxruntime-bin
 
-      - name: Open the update PR
-        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
-        with:
-          pr-title: "deps: update flake.lock"
-          pr-body: |
-            Monthly nix input refresh. `nix flake check` and the
-            fixed-output-derivation builds passed in the generating
-            workflow run before this PR was opened. Close and reopen
-            this PR to trigger the required CI checks.
-          branch: deps/update-flake-lock
-          commit-msg: "deps: update flake.lock"
+      - name: Push the validated update branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: deps/update-flake-lock
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- flake.lock; then
+            echo "flake.lock is already current; nothing to push."
+            echo "flake.lock is already current; nothing to push." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "deps: update flake.lock"
+          # --force, not --force-with-lease: this branch is recreated from
+          # main by each run, and the checkout has no remote-tracking ref for
+          # it to lease against. Nothing but this workflow writes it.
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$BRANCH"
+          {
+            echo "### flake.lock update ready"
+            echo
+            echo "Pushed \`$BRANCH\`. \`nix flake check\` and the"
+            echo "fixed-output-derivation builds passed above."
+            echo
+            echo "Open a PR from it to run the required checks:"
+            echo "<https://github.com/${GITHUB_REPOSITORY}/compare/$BRANCH?expand=1>"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -481,8 +481,9 @@ impl PamSearchPath {
         }
     }
 
-    /// A machine directory with no vendor fallback, for callers and tests that
-    /// mean exactly one directory.
+    /// A machine directory with no vendor fallback, for tests that mean
+    /// exactly one directory. Production always resolves through `live()`.
+    #[cfg(test)]
     pub(crate) fn machine_only(machine: &std::path::Path) -> Self {
         Self {
             machine: machine.to_path_buf(),
@@ -527,11 +528,6 @@ impl PamSearchPath {
             }
         }
         names.into_iter().collect()
-    }
-
-    /// The directories to sweep, machine first.
-    fn dirs(&self) -> impl Iterator<Item = &std::path::Path> {
-        std::iter::once(self.machine.as_path()).chain(self.vendor.as_deref())
     }
 }
 
@@ -780,11 +776,18 @@ fn report_fprintd_coverage(path: &PamSearchPath) {
     if cov.is_empty() {
         return;
     }
-    // The scan reads /etc/pam.d only. Linux-PAM can also load a vendor
-    // service (/usr/lib/pam.d) when no /etc override exists, so a surface
-    // served purely by a vendor stack is absent from this table rather than
-    // shown wrong; saying so beats implying completeness (#208).
-    println!("[fingerprint] coverage: where a finger can answer the prompt (per /etc/pam.d):");
+    // The scan follows libpam's own search path since #208, so name the
+    // directories it actually read. A surface served purely by a vendor stack
+    // now appears; before, it was missing from the table entirely.
+    let where_from = match &path.vendor {
+        Some(v) => format!(
+            "per {} with {} as fallback",
+            path.machine.display(),
+            v.display()
+        ),
+        None => format!("per {}", path.machine.display()),
+    };
+    println!("[fingerprint] coverage: where a finger can answer the prompt ({where_from}):");
     for (svc, label, reaches) in &cov {
         println!("    {} {label}  ({svc})", if *reaches { "✓" } else { "✗" });
     }
@@ -948,6 +951,105 @@ mod tests {
             std::fs::write(dir.join(name), body).unwrap();
         }
         dir
+    }
+
+    /// A machine and a vendor directory, for the precedence tests.
+    fn pam_pair(
+        tag: &str,
+        machine: &[(&str, &str)],
+        vendor: &[(&str, &str)],
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        let m = pam_dir(&format!("{tag}-etc"), machine);
+        let v = pam_dir(&format!("{tag}-vendor"), vendor);
+        (m, v)
+    }
+
+    /// libpam reads a service from the vendor directory when the machine has
+    /// no file for it, and a machine file overrides its vendor namesake
+    /// outright rather than merging (pam.conf(5)). Scanning `/etc/pam.d` alone
+    /// omitted a service whose entire stack is a vendor file, so the coverage
+    /// table understated what a finger answers (#208).
+    #[test]
+    fn a_vendor_service_counts_and_a_machine_file_overrides_it() {
+        let wired = "auth sufficient pam_fprintd.so\n";
+        let bare = "auth required pam_unix.so\n";
+        let (m, v) = pam_pair(
+            "vendor-precedence",
+            // sudo exists in both, and the machine copy has NO fingerprint
+            // line: PAM runs this one, so coverage must follow it.
+            &[("sudo", bare)],
+            // login exists only in the vendor directory, wired.
+            &[("sudo", wired), ("login", wired)],
+        );
+        let path = PamSearchPath::rooted(&m, Some(&v));
+
+        assert_eq!(path.service_path("sudo"), Some(m.join("sudo")));
+        assert_eq!(path.service_path("login"), Some(v.join("login")));
+        assert_eq!(path.service_path("nothing-here"), None);
+
+        let cov = fprintd_coverage(&path);
+        let by = |svc: &str| cov.iter().find(|(s, _, _)| *s == svc).map(|(_, _, r)| *r);
+        // Vendor-only service appears at all, which is the omission #208 names.
+        assert_eq!(by("login"), Some(true), "vendor-only stack must count");
+        // The machine file shadows the wired vendor one, so sudo is NOT covered.
+        assert_eq!(
+            by("sudo"),
+            Some(false),
+            "a machine file overrides its vendor namesake"
+        );
+
+        // Machine-only reading sees neither the vendor service nor the truth
+        // about sudo being the only surface: this is the old behaviour.
+        let old = PamSearchPath::machine_only(&m);
+        assert_eq!(fprintd_coverage(&old).len(), 1);
+
+        for d in [m, v] {
+            let _ = std::fs::remove_dir_all(d);
+        }
+    }
+
+    /// `pam_fprintd_wired` is the GATE that lets `--fingerprint-only` stand
+    /// face down, so it must not be fooled in either direction: a vendor stack
+    /// really does drive a prompt, and a machine file that shadows a wired
+    /// vendor file really does mean nothing drives one.
+    #[test]
+    fn the_wiring_gate_follows_the_same_precedence() {
+        let wired = "auth sufficient pam_fprintd.so\n";
+        let bare = "auth required pam_unix.so\n";
+
+        let (m, v) = pam_pair("gate-vendor-only", &[], &[("login", wired)]);
+        assert!(
+            pam_fprintd_wired(&PamSearchPath::rooted(&m, Some(&v))),
+            "a vendor stack drives a real prompt"
+        );
+        assert!(
+            !pam_fprintd_wired(&PamSearchPath::machine_only(&m)),
+            "and the machine directory alone cannot see it"
+        );
+
+        let (m2, v2) = pam_pair("gate-shadowed", &[("login", bare)], &[("login", wired)]);
+        assert!(
+            !pam_fprintd_wired(&PamSearchPath::rooted(&m2, Some(&v2))),
+            "the shadowed vendor file is never loaded, so nothing is wired"
+        );
+
+        for d in [m, v, m2, v2] {
+            let _ = std::fs::remove_dir_all(d);
+        }
+    }
+
+    /// A vendor directory that is not there is not an empty one: nothing is
+    /// read and nothing is claimed. Ubuntu 26.04 ships no /usr/lib/pam.d even
+    /// though its libpam has the path compiled in.
+    #[test]
+    fn an_absent_vendor_directory_is_carried_as_none() {
+        let m = pam_dir("vendor-absent", &[("login", "auth required pam_unix.so\n")]);
+        let absent = std::env::temp_dir().join(format!("irlume-no-vendor-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&absent);
+        let path = PamSearchPath::rooted(&m, Some(&absent));
+        assert_eq!(path.service_path("login"), Some(m.join("login")));
+        assert_eq!(path.service_path("sudo"), None);
+        let _ = std::fs::remove_dir_all(m);
     }
 
     // The Ubuntu 26.04 box from issue #155, files verbatim from the report:

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -491,6 +491,22 @@ impl PamSearchPath {
         }
     }
 
+    /// The directories this path actually read, for the report to name. A
+    /// vendor directory that is not on this machine is not mentioned: telling
+    /// a user the scan consulted `/usr/lib/pam.d` where no such directory
+    /// exists claims a completeness the scan does not have. Ubuntu 26.04 is
+    /// that case, with the path compiled into libpam and no directory shipped.
+    fn summary(&self) -> String {
+        match &self.vendor {
+            Some(v) => format!(
+                "per {} with {} as fallback",
+                self.machine.display(),
+                v.display()
+            ),
+            None => format!("per {}", self.machine.display()),
+        }
+    }
+
     /// The file PAM would open for `service`, or `None` when neither directory
     /// has one.
     pub(crate) fn service_path(&self, service: &str) -> Option<std::path::PathBuf> {
@@ -779,15 +795,10 @@ fn report_fprintd_coverage(path: &PamSearchPath) {
     // The scan follows libpam's own search path since #208, so name the
     // directories it actually read. A surface served purely by a vendor stack
     // now appears; before, it was missing from the table entirely.
-    let where_from = match &path.vendor {
-        Some(v) => format!(
-            "per {} with {} as fallback",
-            path.machine.display(),
-            v.display()
-        ),
-        None => format!("per {}", path.machine.display()),
-    };
-    println!("[fingerprint] coverage: where a finger can answer the prompt ({where_from}):");
+    println!(
+        "[fingerprint] coverage: where a finger can answer the prompt ({}):",
+        path.summary()
+    );
     for (svc, label, reaches) in &cov {
         println!("    {} {label}  ({svc})", if *reaches { "✓" } else { "✗" });
     }
@@ -1049,7 +1060,22 @@ mod tests {
         let path = PamSearchPath::rooted(&m, Some(&absent));
         assert_eq!(path.service_path("login"), Some(m.join("login")));
         assert_eq!(path.service_path("sudo"), None);
-        let _ = std::fs::remove_dir_all(m);
+        // And the report must not claim it consulted a directory that is not
+        // there, which is the only place the distinction is observable.
+        let summary = path.summary();
+        assert!(!summary.contains("fallback"), "{summary}");
+        assert!(summary.contains(&m.display().to_string()), "{summary}");
+
+        let present = pam_dir("vendor-present", &[("sudo", "auth required pam_unix.so\n")]);
+        let with_vendor = PamSearchPath::rooted(&m, Some(&present));
+        assert!(with_vendor.summary().contains("fallback"));
+        assert!(with_vendor
+            .summary()
+            .contains(&present.display().to_string()));
+
+        for d in [m, present] {
+            let _ = std::fs::remove_dir_all(d);
+        }
     }
 
     // The Ubuntu 26.04 box from issue #155, files verbatim from the report:

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -97,8 +97,8 @@ fn status(user: &str) -> ExitCode {
     // finger answer" is checkable any time, not only in enable's output the
     // one time it scrolled past. Shown only when a line is wired at all: on a
     // face-only box the table would be twelve ✗ rows of noise.
-    if pam_fprintd_wired(std::path::Path::new(PAM_DIR)) {
-        report_fprintd_coverage(std::path::Path::new(PAM_DIR));
+    if pam_fprintd_wired(&PamSearchPath::live()) {
+        report_fprintd_coverage(&PamSearchPath::live());
     }
     // Recommendation. A failed listing means we do NOT know the enrollment
     // state; recommending `add` there sends the user the wrong way (live find:
@@ -354,7 +354,7 @@ fn enable(user: &str, args: &[String]) -> ExitCode {
         // disables face while no biometric drives the prompt, silently leaving
         // the box password-only.
         DistroFamily::Arch | DistroFamily::Other => {
-            let already = pam_fprintd_wired(std::path::Path::new(PAM_DIR));
+            let already = pam_fprintd_wired(&PamSearchPath::live());
             if already {
                 println!(
                     "[fingerprint] found an active pam_fprintd.so line in {PAM_DIR}; using it"
@@ -378,7 +378,7 @@ fn enable(user: &str, args: &[String]) -> ExitCode {
     // Verify the line actually landed before switching the method, even on the
     // tool paths: authselect/pam-auth-update can exit 0 without producing a
     // pam_fprintd line (e.g. a custom authselect profile lacking the feature).
-    if !pam_fprintd_wired(std::path::Path::new(PAM_DIR)) {
+    if !pam_fprintd_wired(&PamSearchPath::live()) {
         eprintln!(
             "[fingerprint] wiring reported success but {PAM_DIR} has no active pam_fprintd.so line"
         );
@@ -400,7 +400,7 @@ fn enable(user: &str, args: &[String]) -> ExitCode {
     // satisfied by one active line anywhere; on a box where only the greeter
     // service carries it (#155), the success message used to promise finger
     // unlock at prompts that have no fingerprint path at all.
-    report_fprintd_coverage(std::path::Path::new(PAM_DIR));
+    report_fprintd_coverage(&PamSearchPath::live());
     if coexist {
         println!("[fingerprint] ✓ enabled alongside face: unlock with EITHER your face or your finger (password is the fallback).");
         println!("[fingerprint] wire the face lines too if you haven't:  sudo irlume login enable --apply");
@@ -441,11 +441,105 @@ fn disable() -> ExitCode {
 /// directory they control.
 const PAM_DIR: &str = "/etc/pam.d";
 
+/// The vendor service directory libpam falls back to when the machine
+/// directory has no file for a service. Measured on the three families irlume
+/// packages for, by reading the path compiled into the installed library:
+/// Fedora 44, Arch, and Ubuntu 26.04 (libpam 1.7.0-5ubuntu3) all carry
+/// `/usr/lib/pam.d`. Fedora and Arch ship files in it; on Ubuntu the directory
+/// does not exist by default, which `PamSearchPath::rooted` handles by
+/// carrying no vendor directory at all rather than probing a path that is not
+/// there.
+const PAM_VENDOR_DIR: &str = "/usr/lib/pam.d";
+
+/// The directories libpam consults for a service, in its order. The machine
+/// directory wins: a file in `/etc/pam.d/sudo` overrides `/usr/lib/pam.d/sudo`
+/// entirely rather than merging with it, and the vendor file is read only when
+/// the machine has none (pam.conf(5)). Scanning the machine directory alone
+/// understated coverage, omitting a service whose whole stack is a vendor file
+/// even though PAM authenticates through it (#208).
+#[derive(Debug, Clone)]
+pub(crate) struct PamSearchPath {
+    machine: std::path::PathBuf,
+    /// `None` when the distro has no vendor directory, which is not the same
+    /// as an empty one: nothing is read, and nothing is claimed about it.
+    vendor: Option<std::path::PathBuf>,
+}
+
+impl PamSearchPath {
+    /// The live path this machine's libpam would use.
+    pub(crate) fn live() -> Self {
+        Self::rooted(
+            std::path::Path::new(PAM_DIR),
+            Some(std::path::Path::new(PAM_VENDOR_DIR)),
+        )
+    }
+
+    pub(crate) fn rooted(machine: &std::path::Path, vendor: Option<&std::path::Path>) -> Self {
+        Self {
+            machine: machine.to_path_buf(),
+            vendor: vendor.filter(|v| v.is_dir()).map(|v| v.to_path_buf()),
+        }
+    }
+
+    /// A machine directory with no vendor fallback, for callers and tests that
+    /// mean exactly one directory.
+    pub(crate) fn machine_only(machine: &std::path::Path) -> Self {
+        Self {
+            machine: machine.to_path_buf(),
+            vendor: None,
+        }
+    }
+
+    /// The file PAM would open for `service`, or `None` when neither directory
+    /// has one.
+    pub(crate) fn service_path(&self, service: &str) -> Option<std::path::PathBuf> {
+        let machine = self.machine.join(service);
+        if machine.is_file() {
+            return Some(machine);
+        }
+        self.vendor
+            .as_ref()
+            .map(|dir| dir.join(service))
+            .filter(|p| p.is_file())
+    }
+
+    /// The service file's contents, following the same precedence.
+    fn read_service(&self, service: &str) -> Option<String> {
+        std::fs::read_to_string(self.service_path(service)?).ok()
+    }
+
+    /// Every service name PAM could load from this path, machine and vendor
+    /// together, deduplicated so a service present in both is considered once
+    /// and read from the machine copy that shadows the other.
+    fn service_names(&self) -> Vec<String> {
+        let mut names: std::collections::BTreeSet<String> = Default::default();
+        for dir in std::iter::once(&self.machine).chain(self.vendor.iter()) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                let name = e.file_name().to_string_lossy().into_owned();
+                // Directory enumeration keys on the dot exactly as before: a
+                // service name carries none, and every backup leftover does.
+                if !name.contains('.') {
+                    names.insert(name);
+                }
+            }
+        }
+        names.into_iter().collect()
+    }
+
+    /// The directories to sweep, machine first.
+    fn dirs(&self) -> impl Iterator<Item = &std::path::Path> {
+        std::iter::once(self.machine.as_path()).chain(self.vendor.as_deref())
+    }
+}
+
 /// [`fprintd_coverage`] over the live `/etc/pam.d`, for surfaces outside this
 /// module (the TUI's Fingerprint screen shows the same table `fingerprint
 /// status` prints, from the same walk).
 pub(crate) fn fprintd_coverage_live() -> Vec<(&'static str, &'static str, bool)> {
-    fprintd_coverage(std::path::Path::new(PAM_DIR))
+    fprintd_coverage(&PamSearchPath::live())
 }
 
 /// Does `text` contain an auth RULE whose module-path names `module`?
@@ -484,14 +578,13 @@ fn has_auth_module(text: &str, module: &str) -> bool {
 /// file by name, and PAM does follow that; [`fprintd_in_sudo`] resolves include
 /// targets by name for exactly that reason. The cost here is a false negative in
 /// that exotic case, which leaves the method unchanged and face active.
-fn live_pam_stacks(pam_dir: &std::path::Path) -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir(pam_dir) else {
-        return Vec::new();
-    };
-    entries
-        .flatten()
-        .filter(|e| !e.file_name().to_string_lossy().contains('.'))
-        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+fn live_pam_stacks(path: &PamSearchPath) -> Vec<String> {
+    // Read each service ONCE, through the same precedence PAM uses. Reading
+    // every file in both directories would let a vendor file that a machine
+    // file shadows answer for a stack PAM never loads.
+    path.service_names()
+        .iter()
+        .filter_map(|svc| path.read_service(svc))
         .collect()
 }
 
@@ -503,8 +596,8 @@ fn live_pam_stacks(pam_dir: &std::path::Path) -> Vec<String> {
 /// a session directive's arguments, executed never. This is the gate before
 /// `--fingerprint-only` disables face; standing down on a file it cannot read
 /// the way PAM does is the safe direction.
-fn pam_fprintd_wired(pam_dir: &std::path::Path) -> bool {
-    live_pam_stacks(pam_dir)
+fn pam_fprintd_wired(path: &PamSearchPath) -> bool {
+    live_pam_stacks(path)
         .iter()
         .any(|s| !crate::pamwire::has_line_continuation(s) && has_auth_module(s, "pam_fprintd.so"))
 }
@@ -514,8 +607,8 @@ fn pam_fprintd_wired(pam_dir: &std::path::Path) -> bool {
 /// all fingerprint retries in under two seconds, each one counting as a
 /// faillock failure (fprintd#209/#215). Doctor surfaces it with the
 /// `faillock --reset` remedy.
-pub(crate) fn faillock_cohabits(pam_dir: &std::path::Path) -> bool {
-    live_pam_stacks(pam_dir)
+pub(crate) fn faillock_cohabits(path: &PamSearchPath) -> bool {
+    live_pam_stacks(path)
         .iter()
         .any(|s| has_auth_module(s, "pam_faillock.so") && has_auth_module(s, "pam_fprintd.so"))
 }
@@ -525,8 +618,8 @@ pub(crate) fn faillock_cohabits(pam_dir: &std::path::Path) -> bool {
 /// is where authselect puts the fingerprint line). Paired with a running sshd
 /// this stalls every `sudo` typed in an SSH session for the full fingerprint
 /// timeout: the prompt waits on a reader the remote user cannot touch.
-pub(crate) fn fprintd_in_sudo(pam_dir: &std::path::Path) -> bool {
-    let Ok(sudo) = std::fs::read_to_string(pam_dir.join("sudo")) else {
+pub(crate) fn fprintd_in_sudo(path: &PamSearchPath) -> bool {
+    let Some(sudo) = path.read_service("sudo") else {
         return false;
     };
     if has_auth_module(&sudo, "pam_fprintd.so") {
@@ -545,8 +638,9 @@ pub(crate) fn fprintd_in_sudo(pam_dir: &std::path::Path) -> bool {
             _ => None,
         };
         if let Some(name) = target {
-            if std::fs::read_to_string(pam_dir.join(name))
-                .is_ok_and(|s| has_auth_module(&s, "pam_fprintd.so"))
+            if path
+                .read_service(name)
+                .is_some_and(|s| has_auth_module(&s, "pam_fprintd.so"))
             {
                 return true;
             }
@@ -603,13 +697,15 @@ const FP_SURFACES: &[(&str, &str)] = &[
 /// before the first `#`), so a commented-out include or module never counts.
 /// Cycles terminate because a file is visited at most once; the depth cap is a
 /// backstop far above any real stack's include chain.
-pub(crate) fn stack_reaches_fprintd(pam_dir: &std::path::Path, service: &str) -> bool {
-    fn walk(pam_dir: &std::path::Path, name: &str, seen: &mut Vec<String>) -> bool {
+pub(crate) fn stack_reaches_fprintd(path: &PamSearchPath, service: &str) -> bool {
+    fn walk(path: &PamSearchPath, name: &str, seen: &mut Vec<String>) -> bool {
         if seen.len() >= 16 || seen.iter().any(|s| s == name) {
             return false;
         }
         seen.push(name.to_string());
-        let Ok(text) = std::fs::read_to_string(pam_dir.join(name)) else {
+        // Each include target resolves through the search path too: a
+        // machine stack may include a service whose only file is the vendor's.
+        let Some(text) = path.read_service(name) else {
             return false;
         };
         // A `\`-continued file defeats line-oriented reading: libpam joins
@@ -631,7 +727,7 @@ pub(crate) fn stack_reaches_fprintd(pam_dir: &std::path::Path, service: &str) ->
             let Some(first) = t1 else { continue };
             if first == "@include" {
                 if let Some(target) = t2 {
-                    if walk(pam_dir, target, seen) {
+                    if walk(path, target, seen) {
                         return true;
                     }
                 }
@@ -644,7 +740,7 @@ pub(crate) fn stack_reaches_fprintd(pam_dir: &std::path::Path, service: &str) ->
             }
             match (t2, t3) {
                 (Some("include" | "substack"), Some(target)) => {
-                    if walk(pam_dir, target, seen) {
+                    if walk(path, target, seen) {
                         return true;
                     }
                 }
@@ -659,7 +755,7 @@ pub(crate) fn stack_reaches_fprintd(pam_dir: &std::path::Path, service: &str) ->
         }
         false
     }
-    walk(pam_dir, service, &mut Vec::new())
+    walk(path, service, &mut Vec::new())
 }
 
 /// Per-surface fingerprint coverage: which of the stacks present on this
@@ -669,20 +765,18 @@ pub(crate) fn stack_reaches_fprintd(pam_dir: &std::path::Path, service: &str) ->
 /// the wrong REPORT: on the observed Ubuntu box the only carrier was
 /// `gdm-fingerprint`, so "you can unlock with a finger" was true at the
 /// greeter and false at sudo and the console.
-pub(crate) fn fprintd_coverage(
-    pam_dir: &std::path::Path,
-) -> Vec<(&'static str, &'static str, bool)> {
+pub(crate) fn fprintd_coverage(path: &PamSearchPath) -> Vec<(&'static str, &'static str, bool)> {
     FP_SURFACES
         .iter()
-        .filter(|(svc, _)| pam_dir.join(svc).is_file())
-        .map(|(svc, label)| (*svc, *label, stack_reaches_fprintd(pam_dir, svc)))
+        .filter(|(svc, _)| path.service_path(svc).is_some())
+        .map(|(svc, label)| (*svc, *label, stack_reaches_fprintd(path, svc)))
         .collect()
 }
 
 /// Print the coverage table. Advisory: it never changes the enable decision,
 /// only what the user is told that decision means.
-fn report_fprintd_coverage(pam_dir: &std::path::Path) {
-    let cov = fprintd_coverage(pam_dir);
+fn report_fprintd_coverage(path: &PamSearchPath) {
+    let cov = fprintd_coverage(path);
     if cov.is_empty() {
         return;
     }
@@ -770,10 +864,10 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("irlume-fpwire-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         // Empty directory: nothing wired.
-        assert!(!pam_fprintd_wired(&dir));
+        assert!(!pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         // A commented-out line does not count.
         std::fs::write(dir.join("sudo"), "#auth sufficient pam_fprintd.so\n").unwrap();
-        assert!(!pam_fprintd_wired(&dir));
+        assert!(!pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         // Nor a TRAILING comment: libpam tokenizes only up to the first '#',
         // so this stack drives no fingerprint prompt. Passing the gate here
         // records a method nothing serves; with --fingerprint-only, face
@@ -783,17 +877,17 @@ mod tests {
             "auth required pam_unix.so   # was pam_fprintd.so\n",
         )
         .unwrap();
-        assert!(!pam_fprintd_wired(&dir));
+        assert!(!pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         // Unrelated modules do not count.
         std::fs::write(dir.join("login"), "auth required pam_unix.so\n").unwrap();
-        assert!(!pam_fprintd_wired(&dir));
+        assert!(!pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         // An active line in any file does.
         std::fs::write(
             dir.join("system-local-login"),
             "auth  sufficient  pam_fprintd.so\nauth required pam_unix.so\n",
         )
         .unwrap();
-        assert!(pam_fprintd_wired(&dir));
+        assert!(pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -811,7 +905,7 @@ mod tests {
                 "session optional pam_exec.so /bin/true \\\nauth optional pam_fprintd.so\n",
             )],
         );
-        assert!(!pam_fprintd_wired(&dir));
+        assert!(!pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(dir).unwrap();
     }
 
@@ -826,7 +920,10 @@ mod tests {
             "auth optional pam_fprintd.so.disabled\n",
         ] {
             let dir = pam_dir("module-field", &[("login", body)]);
-            assert!(!pam_fprintd_wired(&dir), "{body:?}");
+            assert!(
+                !pam_fprintd_wired(&PamSearchPath::machine_only(&dir)),
+                "{body:?}"
+            );
             std::fs::remove_dir_all(dir).unwrap();
         }
         // And the parser recognizes what libpam recognizes: a case-insensitive
@@ -838,7 +935,7 @@ mod tests {
                 "AUTH [success=done default=ignore] /usr/lib64/security/pam_fprintd.so\n",
             )],
         );
-        assert!(pam_fprintd_wired(&dir));
+        assert!(pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(dir).unwrap();
     }
 
@@ -880,9 +977,9 @@ auth\toptional\t\t\tpam_cap.so\n";
             ],
         );
         // The old bool is truthfully "wired somewhere"…
-        assert!(pam_fprintd_wired(&dir));
+        assert!(pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         // …and coverage says where that somewhere is, and is not.
-        let cov = fprintd_coverage(&dir);
+        let cov = fprintd_coverage(&PamSearchPath::machine_only(&dir));
         let get = |svc: &str| cov.iter().find(|(s, _, _)| *s == svc).unwrap().2;
         assert!(get("gdm-fingerprint"), "the greeter really is covered");
         assert!(!get("sudo"), "sudo has no fingerprint path");
@@ -928,7 +1025,7 @@ auth        include       postlogin\n",
                 ),
             ],
         );
-        let cov = fprintd_coverage(&dir);
+        let cov = fprintd_coverage(&PamSearchPath::machine_only(&dir));
         let get = |svc: &str| cov.iter().find(|(s, _, _)| *s == svc).unwrap().2;
         assert!(get("gdm-fingerprint"));
         assert!(
@@ -955,12 +1052,12 @@ auth        include       postlogin\n",
                 ("system-login", "auth      required  pam_unix.so\n"),
             ],
         );
-        let cov = fprintd_coverage(&dir);
+        let cov = fprintd_coverage(&PamSearchPath::machine_only(&dir));
         let get = |svc: &str| cov.iter().find(|(s, _, _)| *s == svc).unwrap().2;
         assert!(get("login"), "the documented flow covers console login");
         assert!(!get("sudo"));
         // The enable gate itself stays satisfied, preserving that flow.
-        assert!(pam_fprintd_wired(&dir));
+        assert!(pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -976,7 +1073,10 @@ auth        include       postlogin\n",
                 ("level-b", "auth sufficient pam_fprintd.so\n"),
             ],
         );
-        assert!(stack_reaches_fprintd(&dir, "login"));
+        assert!(stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
         std::fs::remove_dir_all(&dir).unwrap();
         // 2. A `session include` contributes nothing to authentication (the
         //    session line did NOT run during pam_authenticate).
@@ -990,7 +1090,10 @@ auth        include       postlogin\n",
                 ("sess-target", "auth sufficient pam_fprintd.so\n"),
             ],
         );
-        assert!(!stack_reaches_fprintd(&dir, "login"));
+        assert!(!stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
         std::fs::remove_dir_all(&dir).unwrap();
         // 3. PAM opens include targets by NAME, dotted included (the module in
         //    system-auth.custom ran). The old any-live-file bool misses this
@@ -1004,8 +1107,11 @@ auth        include       postlogin\n",
                 ("system-auth.custom", "auth sufficient pam_fprintd.so\n"),
             ],
         );
-        assert!(stack_reaches_fprintd(&dir, "login"));
-        assert!(!pam_fprintd_wired(&dir));
+        assert!(stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
+        assert!(!pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(&dir).unwrap();
         // 4. Comments are not configuration: a commented include is not
         //    followed and a commented module line is not a hit, while a
@@ -1017,7 +1123,10 @@ auth        include       postlogin\n",
                 ("real", "auth sufficient pam_fprintd.so\n"),
             ],
         );
-        assert!(stack_reaches_fprintd(&dir, "login"));
+        assert!(stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
         let dir2 = pam_dir(
             "comments2",
             &[(
@@ -1025,7 +1134,10 @@ auth        include       postlogin\n",
                 "# auth include real\nauth required pam_unix.so # pam_fprintd.so\n",
             )],
         );
-        assert!(!stack_reaches_fprintd(&dir2, "login"));
+        assert!(!stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir2),
+            "login"
+        ));
         std::fs::remove_dir_all(&dir).unwrap();
         std::fs::remove_dir_all(&dir2).unwrap();
     }
@@ -1045,7 +1157,10 @@ auth        include       postlogin\n",
                 "session optional pam_exec.so /bin/true \\\nauth optional pam_fprintd.so\n",
             )],
         );
-        assert!(!stack_reaches_fprintd(&dir, "login"));
+        assert!(!stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
         std::fs::remove_dir_all(&dir).unwrap();
         // The refusal is per FILE, reached through includes too: a clean
         // service including a continued file gains nothing from it.
@@ -1059,7 +1174,10 @@ auth        include       postlogin\n",
                 ),
             ],
         );
-        assert!(!stack_reaches_fprintd(&dir, "login"));
+        assert!(!stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
         std::fs::remove_dir_all(&dir).unwrap();
         // And a clean sibling path still resolves: only the continued file is
         // opaque, not the whole walk.
@@ -1071,7 +1189,10 @@ auth        include       postlogin\n",
                 ("clean", "auth sufficient pam_fprintd.so\n"),
             ],
         );
-        assert!(stack_reaches_fprintd(&dir, "login"));
+        assert!(stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -1085,7 +1206,10 @@ auth        include       postlogin\n",
                 ("loop-b", "auth include loop-a\nauth include login\n"),
             ],
         );
-        assert!(!stack_reaches_fprintd(&dir, "login"));
+        assert!(!stack_reaches_fprintd(
+            &PamSearchPath::machine_only(&dir),
+            "login"
+        ));
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -1096,14 +1220,14 @@ auth        include       postlogin\n",
         // Modules in separate files: no cohabitation.
         std::fs::write(dir.join("a"), "auth required pam_faillock.so preauth\n").unwrap();
         std::fs::write(dir.join("b"), "auth sufficient pam_fprintd.so\n").unwrap();
-        assert!(!faillock_cohabits(&dir));
+        assert!(!faillock_cohabits(&PamSearchPath::machine_only(&dir)));
         // Both in one stack: the lockout hazard exists.
         std::fs::write(
             dir.join("system-auth"),
             "auth required pam_faillock.so preauth\nauth sufficient pam_fprintd.so\n",
         )
         .unwrap();
-        assert!(faillock_cohabits(&dir));
+        assert!(faillock_cohabits(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -1114,25 +1238,25 @@ auth        include       postlogin\n",
         // Not reachable: sudo includes a stack without fingerprint.
         std::fs::write(dir.join("sudo"), "auth include system-auth\n").unwrap();
         std::fs::write(dir.join("system-auth"), "auth required pam_unix.so\n").unwrap();
-        assert!(!fprintd_in_sudo(&dir));
+        assert!(!fprintd_in_sudo(&PamSearchPath::machine_only(&dir)));
         // Fedora shape: sudo → system-auth → pam_fprintd.
         std::fs::write(
             dir.join("system-auth"),
             "auth sufficient pam_fprintd.so\nauth required pam_unix.so\n",
         )
         .unwrap();
-        assert!(fprintd_in_sudo(&dir));
+        assert!(fprintd_in_sudo(&PamSearchPath::machine_only(&dir)));
         // Debian shape: `@include common-auth`.
         std::fs::write(dir.join("sudo"), "@include common-auth\n").unwrap();
         std::fs::write(dir.join("common-auth"), "auth sufficient pam_fprintd.so\n").unwrap();
-        assert!(fprintd_in_sudo(&dir));
+        assert!(fprintd_in_sudo(&PamSearchPath::machine_only(&dir)));
         // Direct line in sudo itself.
         std::fs::write(dir.join("sudo"), "auth sufficient pam_fprintd.so\n").unwrap();
-        assert!(fprintd_in_sudo(&dir));
+        assert!(fprintd_in_sudo(&PamSearchPath::machine_only(&dir)));
         // Commented lines never count.
         std::fs::write(dir.join("sudo"), "#auth sufficient pam_fprintd.so\n").unwrap();
         std::fs::write(dir.join("common-auth"), "# pam_fprintd.so disabled\n").unwrap();
-        assert!(!fprintd_in_sudo(&dir));
+        assert!(!fprintd_in_sudo(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -1140,8 +1264,8 @@ auth        include       postlogin\n",
     fn pam_fprintd_wired_is_false_for_a_missing_dir() {
         // The enable path must fail closed (method unchanged) when the PAM dir
         // cannot be read at all.
-        assert!(!pam_fprintd_wired(std::path::Path::new(
-            "/nonexistent-irlume-test-pam.d"
+        assert!(!pam_fprintd_wired(&PamSearchPath::machine_only(
+            std::path::Path::new("/nonexistent-irlume-test-pam.d")
         )));
     }
 
@@ -1173,11 +1297,11 @@ auth        include       postlogin\n",
             .unwrap();
         }
         assert!(
-            !pam_fprintd_wired(&dir),
+            !pam_fprintd_wired(&PamSearchPath::machine_only(&dir)),
             "a backup file is not wiring; enable must not record method=fingerprint from one"
         );
         assert!(
-            !faillock_cohabits(&dir),
+            !faillock_cohabits(&PamSearchPath::machine_only(&dir)),
             "a backup file must not raise the doctor lockout warning"
         );
         // The live stack is still read: the skip is about which files count,
@@ -1187,8 +1311,8 @@ auth        include       postlogin\n",
             "auth sufficient pam_fprintd.so\nauth required pam_faillock.so preauth\n",
         )
         .unwrap();
-        assert!(pam_fprintd_wired(&dir));
-        assert!(faillock_cohabits(&dir));
+        assert!(pam_fprintd_wired(&PamSearchPath::machine_only(&dir)));
+        assert!(faillock_cohabits(&PamSearchPath::machine_only(&dir)));
         std::fs::remove_dir_all(&dir).unwrap();
     }
 

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -442,13 +442,26 @@ fn disable() -> ExitCode {
 const PAM_DIR: &str = "/etc/pam.d";
 
 /// The vendor service directory libpam falls back to when the machine
-/// directory has no file for a service. Measured on the three families irlume
-/// packages for, by reading the path compiled into the installed library:
-/// Fedora 44, Arch, and Ubuntu 26.04 (libpam 1.7.0-5ubuntu3) all carry
-/// `/usr/lib/pam.d`. Fedora and Arch ship files in it; on Ubuntu the directory
-/// does not exist by default, which `PamSearchPath::rooted` handles by
-/// carrying no vendor directory at all rather than probing a path that is not
-/// there.
+/// directory has no file for a service.
+///
+/// This is a build-time option, so it is established by measurement, not by
+/// assuming an upstream default. On the two lanes that ship the directory it
+/// was confirmed by BEHAVIOUR rather than by the path appearing in the
+/// library: a `pam_start` + `pam_authenticate` probe against a service placed
+/// only in `/usr/lib/pam.d` returned success, while a service that exists
+/// nowhere fell through to `other` and denied.
+///
+/// - Fedora 44, pam-1.7.2-2.fc44: vendor-only service 0, absent service 7.
+/// - Arch, pam 1.7.2-2: vendor-only service 0, absent service 7.
+/// - Ubuntu 26.04, libpam 1.7.0-5ubuntu3: the path is compiled in, but the
+///   directory does not exist, so `rooted` carries no vendor directory and
+///   nothing is read or claimed.
+///
+/// The Arch measurement matters because that package's changelog records
+/// `-Dvendordir=''`, which reads as removing the search directory; the
+/// installed library disagrees, and KDE ships `kde-fingerprint` there and
+/// nowhere else. Re-run the probe rather than trusting either source if this
+/// ever needs revisiting.
 const PAM_VENDOR_DIR: &str = "/usr/lib/pam.d";
 
 /// The directories libpam consults for a service, in its order. The machine
@@ -511,13 +524,29 @@ impl PamSearchPath {
     /// has one.
     pub(crate) fn service_path(&self, service: &str) -> Option<std::path::PathBuf> {
         let machine = self.machine.join(service);
-        if machine.is_file() {
+        if Self::shadows(&machine) {
             return Some(machine);
         }
         self.vendor
             .as_ref()
             .map(|dir| dir.join(service))
-            .filter(|p| p.is_file())
+            .filter(|p| Self::shadows(p))
+    }
+
+    /// Whether a path is a service file libpam would open, which is not the
+    /// same as `is_file()`. Disabling a service by symlinking it to
+    /// `/dev/null` is standard practice, and libpam opens that happily: the
+    /// stack is empty and it shadows the vendor copy rather than deferring to
+    /// it. `is_file()` follows the symlink to a character device, answers
+    /// false, and would send the scan to a vendor file libpam never reads,
+    /// reporting a fingerprint prompt as wired where PAM in fact denies.
+    /// Verified on archhost (pam 1.7.2-2) with a pam_start probe: a machine
+    /// service symlinked to /dev/null over a vendor copy stacking pam_permit
+    /// authenticated as 7 (failure), not 0.
+    fn shadows(p: &std::path::Path) -> bool {
+        // Follows symlinks, so a dangling link is absent (libpam cannot open
+        // it either) and a directory is not a stack.
+        p.metadata().map(|m| !m.is_dir()).unwrap_or(false)
     }
 
     /// The service file's contents, following the same precedence.
@@ -1045,6 +1074,34 @@ mod tests {
         );
 
         for d in [m, v, m2, v2] {
+            let _ = std::fs::remove_dir_all(d);
+        }
+    }
+
+    /// Symlinking a service to `/dev/null` is how an admin disables it, and
+    /// libpam opens that as an empty stack that shadows the vendor copy. A
+    /// scan that reads it as absent falls through to a vendor file libpam
+    /// never loads and calls a prompt wired that PAM denies, which is the
+    /// fail-open direction in the gate that stands face down. Confirmed on
+    /// archhost (pam 1.7.2-2): the probe returned 7, not 0.
+    #[test]
+    fn a_service_disabled_with_dev_null_still_shadows_the_vendor_copy() {
+        let wired = "auth sufficient pam_fprintd.so\n";
+        let (m, v) = pam_pair("devnull-shadow", &[], &[("sudo", wired)]);
+        std::os::unix::fs::symlink("/dev/null", m.join("sudo")).unwrap();
+        let path = PamSearchPath::rooted(&m, Some(&v));
+
+        assert_eq!(
+            path.service_path("sudo"),
+            Some(m.join("sudo")),
+            "the /dev/null stack is what PAM opens"
+        );
+        assert!(
+            !pam_fprintd_wired(&path),
+            "an emptied stack must not report the shadowed vendor line as wired"
+        );
+
+        for d in [m, v] {
             let _ = std::fs::remove_dir_all(d);
         }
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3214,8 +3214,10 @@ fn doctor_run(
                  appear; common after suspend/resume); fix: sudo systemctl restart fprintd"
             );
         }
-        let pam_dir = std::path::Path::new("/etc/pam.d");
-        if fingerprint::faillock_cohabits(pam_dir) {
+        // The same search path libpam uses, so a vendor-only stack is not
+        // missed by a warning whose whole job is noticing one (#208).
+        let pam_path = fingerprint::PamSearchPath::live();
+        if fingerprint::faillock_cohabits(&pam_path) {
             dout!(
                 report,
                 "  ⚠ pam_faillock and pam_fprintd share a PAM stack: a touch-sensor misread \
@@ -3223,7 +3225,7 @@ fn doctor_run(
                  account lockout. If you get locked out: faillock --user <you> --reset"
             );
         }
-        if fingerprint::fprintd_in_sudo(pam_dir) && fingerprint::sshd_present() {
+        if fingerprint::fprintd_in_sudo(&pam_path) && fingerprint::sshd_present() {
             dout!(
                 report,
                 "  ⚠ pam_fprintd is reachable from the sudo stack and an SSH server is \

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -4085,13 +4085,14 @@ impl App {
                 Style::new().dim(),
             )));
             // Per-surface coverage (#155), the same table `fingerprint status`
-            // prints: which prompts a finger actually answers, per /etc/pam.d.
+            // prints: which prompts a finger actually answers, over the same
+            // search path libpam uses (machine then vendor, #208).
             // Shown only when at least one surface reaches the module; a
             // face-only box would render a column of ✗ noise.
             if self.fp_coverage.iter().any(|(_, _, reaches)| *reaches) {
                 lines.push(Line::raw(""));
                 lines.push(Line::from(Span::styled(
-                    "  Where a finger can answer the prompt (per /etc/pam.d):",
+                    "  Where a finger can answer the prompt (per the PAM service path):",
                     Style::new().dim(),
                 )));
                 for (_, label, reaches) in &self.fp_coverage {


### PR DESCRIPTION
Closes #228.

## The failure

Every run of the monthly refresh has failed, and not at anything to do with Nix. It updates the inputs, passes `nix flake check` and the fixed-output-derivation builds, pushes the branch, and then dies on the last step:

```
* [new branch]      deps/update-flake-lock -> deps/update-flake-lock
Attempting creation of pull request
##[error]GitHub Actions is not permitted to create or approve pull requests.
```

```
$ gh api repos/archledger/irlume/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

That flag is the same toggle that governs PR creation by `GITHUB_TOKEN`. Because the branch is pushed before the failing step, each run has also left `deps/update-flake-lock` sitting on the remote with no PR attached to it.

## The choice

Enabling the toggle applies to every workflow in the repository, not just this one, and a monthly dependency refresh is not worth carrying a repository-wide permission for. A PAT would be narrower but is a credential to store and rotate.

So the workflow now pushes the branch and stops. The job summary carries the compare link, and a maintainer opens the PR. That is not purely a cost: a PR opened with the workflow token does not trigger the required checks, which is why the old PR body had to tell the reader to close and reopen it.

`pull-requests: write` is dropped from the job, and the third-party PR action goes with it, leaving `actions/checkout` and `install-nix-action` as the only actions in the workflow.

## Verification

`scripts/check-action-pins.sh` passes (52 references SHA-pinned), and actionlint reports nothing. The push step no-ops with a job-summary line when `flake.lock` comes back unchanged, so a month with no input movement does not leave a pointless branch.

The existing `deps/update-flake-lock` branch from the 2026-08-01 run is still on the remote; I will open its PR separately so the update it already validated is not lost.