### PR TITLE
deps: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783488441,
-        "narHash": "sha256-jmWf+H3iC/0z7/mmvTovaJx1E/LME1QyHkyk+AFfJPk=",
+        "lastModified": 1785562362,
+        "narHash": "sha256-J15aBa3d6B1SUUAQydQ06wFjPzrrcVceb6jkdfwfGls=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7dc3a177a239ed879c5581a80f6dc246c7e102f1",
+        "rev": "5f29c219a7655519f8a9f8c6968064b82c17cc93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The nix input refresh from the 2026-08-01 scheduled run. The workflow pushed this branch, then failed opening its own PR, so the update has been sitting on the remote unattached since. #232 stops that happening again; this is the update that was already produced.

`nix flake update` plus `nix flake check --no-build` and the fixed-output-derivation builds (`.#default.cargoDeps`, `.#onnxruntime-bin`) all passed in the generating run before the branch was pushed.

Two inputs move, six lines of `flake.lock`. It merges into today's main without conflict, which I checked with `git merge-tree` rather than assuming, since the branch was cut from `460c633` and main has moved a good deal since.

Opened by hand rather than merged: dependency updates are yours to review.