### PR TITLE
Gate the brightest lit frame that is not clipped, not the brightest outright

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1163,9 +1163,10 @@ impl Engine {
                 .map(|f| format!("{:.1}%", f * 100.0))
                 .unwrap_or_else(|| "n/a".into()));
         // Opt-in third-party PAD cue: score whenever an IR face is present (the
-        // `ir` frame is the brightest strobe phase, i.e. the LIT frame, which is
-        // the regime the cue was measured in), so the dark path can consult the
-        // result too. DENY-ONLY: it can downgrade Live to Spoof and nothing else.
+        // `ir` frame is a LIT strobe phase, since #221 the brightest one that
+        // is not clipped, which is closer to the regime the cue was measured in
+        // than a blown exposure), so the dark path can consult the result too.
+        // DENY-ONLY: it can downgrade Live to Spoof and nothing else.
         let thirdparty_fake = match (self.tp_pad.as_mut(), ir_top.as_ref()) {
             (Some((pad, _, _)), Some(f)) => match pad.p_fake(&ir_view, &f.bbox) {
                 Ok(p) => Some(p),

--- a/crates/irlume-camera/src/ir_metadata.rs
+++ b/crates/irlume-camera/src/ir_metadata.rs
@@ -320,6 +320,64 @@ pub(crate) fn brightest_lit(means: &[f64], flags: &[Option<Illumination>]) -> Op
     best.map(|(i, _)| i)
 }
 
+/// A gate frame may clip at most this fraction of its pixels before selection
+/// prefers a cleaner frame. 5% is the cutoff the ambient-subtract debug line
+/// has always used for "blown exposure", and it sits under the smallest
+/// clipping measured to move the centre/edge ratio (#221: captures at 0.9-13%
+/// read 1.41-1.54, 20.5% read 1.39, 70%+ read 1.11-1.19 against a 1.03 floor).
+pub(crate) const CLIPPED_FRAC_MAX: f64 = 0.05;
+
+/// Pick the burst frame the liveness gate and matcher read.
+///
+/// The brightest frame of a warming burst is precisely the most likely to
+/// clip: the first capture after a daemon restart at close range gated a frame
+/// with 78.8% of its pixels at the ceiling, the IR detector found no facial
+/// structure in it, and a real user was denied as a spoof; the same position
+/// one capture later read 12.7% (#221). So among the frames the camera itself
+/// flagged lit, take the brightest whose clipped fraction is at most
+/// [`CLIPPED_FRAC_MAX`], and when every lit frame clips harder than that, the
+/// least clipped one (brightest on a tie): the gate reads the best frame that
+/// exists rather than the worst.
+///
+/// `clipped[i]` is the fraction of frame `i`'s pixels at the sensor ceiling,
+/// `None` when the source format cannot say where its ceiling is
+/// ([`super::clipping_white_level`]). A missing per-frame entry is treated as
+/// fully clipped, never as clean: failure to observe must not authorize.
+///
+/// Both fallbacks keep the long-standing brightest scan unchanged: without
+/// camera illumination flags a strobing burst's cleanest frames are the
+/// emitter-OFF ones, so clip-aware selection there would trade a clipped face
+/// for no face at all.
+pub(crate) fn best_gate_frame(
+    means: &[f64],
+    flags: &[Option<Illumination>],
+    clipped: Option<&[f64]>,
+) -> Option<usize> {
+    let lit = |i: usize| matches!(flags.get(i), Some(Some(Illumination::Lit)));
+    let any_lit = (0..means.len()).any(lit);
+    let Some(clipped) = clipped.filter(|_| any_lit) else {
+        return brightest_lit(means, flags);
+    };
+    debug_assert_eq!(clipped.len(), means.len());
+    // Strictly-greater keeps the FIRST frame on a mean tie, matching
+    // `brightest_lit`'s long-standing scan.
+    let mut clean: Option<(usize, f64)> = None;
+    let mut least: Option<(usize, f64, f64)> = None; // (index, clipped, mean)
+    for (i, &m) in means.iter().enumerate() {
+        if !lit(i) {
+            continue;
+        }
+        let c = clipped.get(i).copied().unwrap_or(1.0);
+        if c <= CLIPPED_FRAC_MAX && clean.is_none_or(|(_, best)| m > best) {
+            clean = Some((i, m));
+        }
+        if least.is_none_or(|(_, bc, bm)| c < bc || (c == bc && m > bm)) {
+            least = Some((i, c, m));
+        }
+    }
+    clean.map(|(i, _)| i).or(least.map(|(i, _, _)| i))
+}
+
 /// Pick the ambient partner for `lit_i`: an adjacent frame the camera flagged
 /// dark, else the darker of the two neighbours.
 ///
@@ -936,6 +994,83 @@ mod tests {
         let flags = [None, None, None, None];
         // First frame holding the maximum, as the incremental scan always did.
         assert_eq!(brightest_lit(&means, &flags), Some(1));
+    }
+
+    #[test]
+    fn best_gate_frame_skips_a_clipped_brightest_lit_frame() {
+        // The #221 case: the brightest lit frame is blown, a dimmer lit frame
+        // is clean, and the gate must read the clean one.
+        let means = [200.0, 150.0, 3.0];
+        let flags = [
+            Some(Illumination::Lit),
+            Some(Illumination::Lit),
+            Some(Illumination::Dark),
+        ];
+        let clipped = [0.30, 0.01, 0.0];
+        assert_eq!(best_gate_frame(&means, &flags, Some(&clipped)), Some(1));
+    }
+
+    #[test]
+    fn best_gate_frame_never_trades_a_clipped_face_for_an_emitter_off_frame() {
+        // Every lit frame clips. The dark frame is the cleanest in the burst
+        // and must still lose: least-clipped LIT wins.
+        let means = [2.0, 220.0, 150.0];
+        let flags = [
+            Some(Illumination::Dark),
+            Some(Illumination::Lit),
+            Some(Illumination::Lit),
+        ];
+        let clipped = [0.0, 0.60, 0.30];
+        assert_eq!(best_gate_frame(&means, &flags, Some(&clipped)), Some(2));
+    }
+
+    #[test]
+    fn best_gate_frame_keeps_the_brightest_on_a_clean_burst() {
+        // No frame clips, so selection matches brightest_lit exactly,
+        // including first-on-tie.
+        let means = [50.0, 90.0, 90.0];
+        let flags = [Some(Illumination::Lit); 3];
+        let clipped = [0.0, 0.0, 0.0];
+        assert_eq!(best_gate_frame(&means, &flags, Some(&clipped)), Some(1));
+    }
+
+    #[test]
+    fn best_gate_frame_without_clip_data_matches_brightest_lit() {
+        // A format with no known ceiling reports no clipping; the scan is the
+        // long-standing brightest-lit one.
+        let means = [90.0, 50.0];
+        let flags = [Some(Illumination::Lit), Some(Illumination::Lit)];
+        assert_eq!(best_gate_frame(&means, &flags, None), Some(0));
+    }
+
+    #[test]
+    fn best_gate_frame_without_camera_flags_keeps_the_brightest_scan() {
+        // Unclassified burst: the cleanest frames of a strobing burst are the
+        // emitter-off ones, so clip-aware selection must not run at all, even
+        // when the brightest frame is heavily clipped.
+        let means = [3.0, 220.0, 40.0];
+        let flags = [None, None, None];
+        let clipped = [0.0, 0.80, 0.0];
+        assert_eq!(best_gate_frame(&means, &flags, Some(&clipped)), Some(1));
+    }
+
+    #[test]
+    fn best_gate_frame_counts_the_threshold_itself_as_clean() {
+        // The boundary belongs to the clean side; a frame at exactly
+        // CLIPPED_FRAC_MAX outranks a dimmer spotless one.
+        let means = [200.0, 150.0];
+        let flags = [Some(Illumination::Lit), Some(Illumination::Lit)];
+        let clipped = [CLIPPED_FRAC_MAX, 0.0];
+        assert_eq!(best_gate_frame(&means, &flags, Some(&clipped)), Some(0));
+    }
+
+    #[test]
+    fn best_gate_frame_breaks_a_clipping_tie_toward_the_brighter_frame() {
+        // All-clipped fallback with equal clipping: brightness decides.
+        let means = [90.0, 180.0];
+        let flags = [Some(Illumination::Lit), Some(Illumination::Lit)];
+        let clipped = [0.30, 0.30];
+        assert_eq!(best_gate_frame(&means, &flags, Some(&clipped)), Some(1));
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -104,7 +104,7 @@ pub struct Frame {
 /// The span of time a frame's pixels came from, on the monotonic clock.
 ///
 /// Most frames are one dequeue, so `start == end`. Two are not: the denoised RGB
-/// frame is a per-pixel median over a burst, and the IR frame is the brightest of
+/// frame is a per-pixel median over a burst, and the IR frame is one chosen from
 /// a burst, so their contents belong to a stretch of time rather than an instant.
 /// Keeping the stretch (instead of stamping "now" at return) is what lets
 /// [`CaptureWindow::gap_to`] state a real bound rather than a flattering one.
@@ -1693,8 +1693,9 @@ pub struct IrSession<'a> {
 }
 
 impl IrSession<'_> {
-    /// One IR capture: a burst, the brightest (lit strobe phase) frame, and the
-    /// burst statistics.
+    /// One IR capture: a burst, the brightest clean (lit strobe phase, at most
+    /// [`ir_metadata::CLIPPED_FRAC_MAX`] clipped when measurable) frame, and
+    /// the burst statistics.
     pub fn capture_with_stats(&mut self) -> irlume_common::Result<(Frame, IrCaptureStats)> {
         let device = self.cam.device.as_str();
         let (w, h) = (self.cam.width, self.cam.height);
@@ -1791,10 +1792,22 @@ impl IrSession<'_> {
         }
         let bmin = means.iter().cloned().fold(f64::INFINITY, f64::min);
         let bmax = means.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-        // The brightest frame the CAMERA flagged lit. With no flags this is the
-        // first frame holding the max mean, exactly the original incremental
-        // scan, so the no-metadata path is unchanged.
-        let best_i = ir_metadata::brightest_lit(&means, &flags).unwrap_or(0);
+        // The brightest CLEAN frame the CAMERA flagged lit: a clipped frame
+        // compresses the centre/edge ratio toward the spoof floor and can
+        // defeat IR face detection outright (#221), and the brightest frame of
+        // a warming burst is the most likely to clip. Clipping is only
+        // measurable when the source format names its ceiling, and lit-ness
+        // only when the camera classified frames; on either fallback this is
+        // the first frame holding the max mean, exactly the original
+        // incremental scan.
+        let clipped_fracs: Option<Vec<f64>> = white_level.map(|_| {
+            frames
+                .iter()
+                .map(|f| ir_probe::saturated_fraction(f))
+                .collect()
+        });
+        let best_i =
+            ir_metadata::best_gate_frame(&means, &flags, clipped_fracs.as_deref()).unwrap_or(0);
         let mut best = Some(frames[best_i].clone());
         let mut ir_window = CaptureWindow::at(taken[best_i]);
 
@@ -1857,7 +1870,7 @@ impl IrSession<'_> {
                         eprintln!(
                         "[ir] ambient-subtract {action}: lit {best_i} ({lit_mean:.0}) - ambient {ai} ({amb_mean:.0}) => mean {sub_mean:.0}; lit clipped {:.1}%{}",
                         clipped * 100.0,
-                        if clipped > 0.05 {
+                        if clipped > ir_metadata::CLIPPED_FRAC_MAX {
                             " (blown exposure; subtracted frame unreliable)"
                         } else {
                             ""
@@ -1897,8 +1910,12 @@ impl IrSession<'_> {
             eprintln!("[ir_emitter] card={card:?} SET_CUR ok={lit}; burst {IR_BURST} frames, per-frame mean {bmin:.1}..{bmax:.1}");
             eprintln!(
                 "[ir] illumination: {from_camera}/{} frames classified by the camera; \
-                 chose frame {best_i} (mean {best_mean:.1}), lit {lit_level:.1} / ambient {ambient_level:.1}",
-                means.len()
+                 chose frame {best_i} (mean {best_mean:.1}{}), lit {lit_level:.1} / ambient {ambient_level:.1}",
+                means.len(),
+                match clipped_fracs.as_ref().and_then(|c| c.get(best_i)) {
+                    Some(c) => format!(", clipped {:.1}%", c * 100.0),
+                    None => String::new(),
+                }
             );
         }
         // An unusable burst gets a DIAGNOSIS, not the old one-size hint. The

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -150,10 +150,14 @@ pub enum Spectrum {
     Ir,
 }
 
-/// Burst statistics from an IR capture: the per-frame mean extremes. When the
-/// emitter strobes, `ambient_mean` (the darkest frame of the burst) is the
-/// scene's ambient IR level with the emitter off, and `lit_mean -
-/// ambient_mean` is the strobe gap; on a steady emitter the two converge.
+/// Burst statistics from an IR capture. `lit_mean` is the mean of the frame
+/// capture chose to gate on: with camera illumination metadata and a known
+/// sensor ceiling that is the brightest lit frame clipping at most 5% (#221),
+/// otherwise the brightest eligible frame. `ambient_mean` is the darkest frame
+/// the camera flagged dark, falling back to the burst minimum. When the emitter
+/// strobes, `ambient_mean` is the scene's ambient IR level with the emitter off
+/// and `lit_mean - ambient_mean` is the strobe gap; on a steady emitter the two
+/// converge.
 #[derive(Clone, Copy, Debug)]
 pub struct IrCaptureStats {
     pub lit_mean: f32,
@@ -1693,9 +1697,12 @@ pub struct IrSession<'a> {
 }
 
 impl IrSession<'_> {
-    /// One IR capture: a burst, the brightest clean (lit strobe phase, at most
-    /// [`ir_metadata::CLIPPED_FRAC_MAX`] clipped when measurable) frame, and
-    /// the burst statistics.
+    /// One IR capture: a burst, the gate frame, and the burst statistics.
+    ///
+    /// The gate frame is a lit strobe phase, and on a source whose ceiling is
+    /// known it is the brightest one clipping at most 5% of its pixels, since
+    /// a blown frame both flattens the liveness cues and blinds the PAD model
+    /// (#221).
     pub fn capture_with_stats(&mut self) -> irlume_common::Result<(Frame, IrCaptureStats)> {
         let device = self.cam.device.as_str();
         let (w, h) = (self.cam.width, self.cam.height);
@@ -2649,12 +2656,16 @@ pub fn measure_contention_with_progress(
 /// Fold one probe round into a running mean.
 ///
 /// The IR figure is the burst's `lit_mean`, NOT the returned frame's own mean.
-/// They differ, and the difference was measured: the returned frame is the
-/// brightest of a strobe burst, so which phase of the emitter's pulse happened to
+/// They differ, and the difference was measured: the returned frame is one
+/// phase of a strobe burst, so which phase of the emitter's pulse happened to
 /// land in it swings the frame mean hard. Retention on one unchanged camera read
 /// 94%, 137% and 83% across runs against an 80% floor, i.e. noise big enough to
-/// decide the verdict. `lit_mean` is the burst's own peak, which is the quantity
-/// that is actually stable from round to round.
+/// decide the verdict. `lit_mean` is the mean of the frame capture gated on,
+/// which is stable from round to round because it is drawn from the lit phase
+/// rather than whichever phase the caller happened to receive. Since #221 that
+/// frame is the brightest lit one under the clipping limit rather than the
+/// brightest outright, so a burst that straddles the limit can shift it by a
+/// frame; both are lit-phase means, which is the property this relies on.
 fn accumulate(
     into: &mut PairSample,
     rgb: &irlume_common::Result<Frame>,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,7 +141,9 @@ demographic-fairness measurements are in [FAIRNESS.md](FAIRNESS.md).
 ## IR capture: strobe and ambient subtraction
 
 The 850 nm emitter strobes rather than holding steady, so `irlumed` captures an
-IR burst and keeps the brightest frame (the lit strobe phase). The frames around
+IR burst and keeps a lit strobe phase: the brightest frame that clips at most 5%
+of its pixels, because a blown frame flattens the liveness cues and blinds the
+PAD model (#221). The frames around
 it are emitter-off exposures holding only ambient IR, and they are not simply
 discarded: with `IRLUME_IR_AMBIENT_SUBTRACT=1` the daemon subtracts the
 off-frame adjacent to the lit one, isolating the emitter's own reflected light.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -181,7 +181,7 @@ Physically-grounded cues, hard gate (any failure rejects):
 - **Corneal glint**: *supporting only* (standalone-glint liveness was refuted).
 
 *(Explored but not shipped as gates: bright-pupil retro-reflection and active
-IR-strobe response; the capture path picks the brightest strobe frame but no
+IR-strobe response; the capture path picks an unclipped lit strobe frame but no
 strobe-response check is enforced.)*
 
 **Caveat:** a pure hand-crafted gate is unproven at certification-grade


### PR DESCRIPTION
Closes #221 (the gating half; the floor retune it unblocks is tracked there and on #235).

## What changes

`capture_with_stats` gated the brightest camera-flagged-lit frame of the burst. The brightest frame of a warming burst is exactly the one most likely to clip, and the 2026-08-02 hardware sitting showed what that costs: the first capture after a daemon restart at close range gated a 78.8%-clipped frame, the centre/edge ratio collapsed to 1.11, the IR detector found no facial structure, and a real user was denied as Spoof. The same position one capture later read 12.7% clipped and passed at 1.45.

Selection now runs through `ir_metadata::best_gate_frame`:

- among camera-flagged-lit frames, gate the brightest whose clipped fraction is at most `CLIPPED_FRAC_MAX` (5%, the same cutoff the ambient-subtract debug line has always called a blown exposure; measured captures at 0.9 to 13% read ratios 1.41 to 1.54, 20.5% read 1.39, 70%+ read 1.11 to 1.19);
- when every lit frame clips harder than that, gate the least clipped one (brightest on a tie), so a cover or extreme proximity still gates the best frame that exists;
- with no illumination metadata, or a source format that cannot name its ceiling (`clipping_white_level` answers `None`), the long-standing brightest scan is unchanged. An unclassified strobing burst's cleanest frames are the emitter-off ones, so clip-aware selection there would trade a clipped face for no face.

A missing per-frame clipping entry counts as fully clipped, never clean: failure to observe must not authorize.

## What this deliberately does not change

- The 1.03 centre/edge floor. The flat-vinyl measurements on #235 (print reads 1.12 to 1.17) show the floor should rise, but only after this change stops clipped genuine captures (1.11) from overlapping the print range. Retune is follow-up work with #235 as the attack reference.
- The cover diagnosis (#197 band): a covered sensor clips every frame, so least-clipped is still saturated and the diagnosis still fires on `best_mean`.
- `ambient_mean` and the flood guard: computed as before.
- Ambient subtraction stays opt-in and untouched.

## Verification

- 7 unit tests cover each selection branch: skip-clipped-brightest, never-trade-face-for-emitter-off, clean-burst parity with `brightest_lit` (including first-on-tie), no-clip-data parity, no-flags parity, threshold boundary (exactly 5% is clean), and the clipping-tie brightness tie-break.
- 5 hand-applied mutants (ignore clipping, drop the lit restriction, `<=` to `<`, drop the tie-break, run clip-selection without flags) each fail their named test; applied and reversed by a self-restoring script, tree byte-identical after.
- Full workspace suite and the no-TPM namespace run (`unshare -Umr`, tmpfs `/dev`) green.
- Hardware: [pending, will be edited in before merge]

## Not tested

- The call-site wiring (`clipped_fracs` computed and passed) has no unit test: nothing in the suite can construct a live capture, the same disclosure as #220's `face_frac`. The hardware check is the `clipped N%` field now printed in the `[ir] illumination` debug line, plus the login line's `ir_clipped` dropping under the forced-clipping repro.
- Grey16/NV12/YUYV sources take the unchanged fallback by construction; no such module is on hand to measure.
- Bright ambient. All measurements behind the threshold were dark-room.
