### PR TITLE
Refuse a blown IR frame instead of judging it

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1152,7 +1152,7 @@ impl Engine {
         // Log the cue values on PASS too; a near-miss on a genuine user is
         // invisible in the outcome line but obvious here.
         irlume_common::dlog!(
-            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} ir_clipped={} (face_frac #174, clipped #221; both gate nothing)",
+            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} ir_clipped={} (face_frac #174, recorded only; clipped #237, refused past the limit)",
             signals.ir_face_brightness, signals.ir_center_edge_ratio, signals.ir_eye_glint,
             signals.ir_ambient, signals.head_yaw_asym, signals.head_pitch_frac,
             signals.face_frac,

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1137,8 +1137,13 @@ impl Engine {
             ir_ambient: ir_stats.ambient_mean,
             // From the IR frame, because the IR cues are measured there.
             face_frac: face_frac_of(ir_top.as_ref().map(|f| &f.bbox), ir.width),
+            // Measured on the RAW gate frame. `ir.data` is the subtracted image
+            // when ambient subtraction is on, and subtraction drops every
+            // ceiling sample below the ceiling, so a 25%-clipped face would
+            // report 0% and the exposure gate would pass a frame carrying
+            // nothing (#238 review).
             ir_saturated_frac: saturated_frac_of(
-                &ir.data,
+                ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
                 ir.width,
                 ir.height,
                 ir_top.as_ref().map(|f| &f.bbox),
@@ -1877,6 +1882,21 @@ impl Engine {
             }
         }
         let a = self.assess()?;
+
+        // An unreadable frame is reported as unreadable BEFORE anything derived
+        // from it is consulted. The eye cue below is computed from the same IR
+        // pixels, so a blown frame that hides the corneal glints would deny with
+        // OtherDeny, which is NOT presence-retryable: the grace window would
+        // stop instead of letting exposure settle, turning a retryable quality
+        // refusal into a terminal one for anybody with require_eyes_open on
+        // (#238 review). Uncertain is the only verdict this promotes; a Spoof
+        // still reaches its own branch below with its own reason.
+        if a.verdict == Verdict::Uncertain {
+            return Ok(Outcome::deny(
+                liveness_deny_kind(a.verdict, &a.reason),
+                format!("liveness {:?}: {}", a.verdict, a.reason),
+            ));
+        }
 
         // Opt-in hard gate: never unlock unless both eyes read open.
         if enr.require_eyes_open && !a.eyes_open {
@@ -3930,6 +3950,35 @@ mod tests {
         assert_eq!(
             saturated_frac_of(&grey, 4, 4, Some(&bbox), Some(255)),
             Some(1.0)
+        );
+    }
+
+    /// Ambient subtraction hides the ceiling it subtracts from, so the exposure
+    /// gate must read the raw gate frame that `IrCaptureStats::saturation_frame`
+    /// preserves. Measuring the returned pixels instead reports a blown face as
+    /// pristine, which is the fail-open the #238 review found: 255 minus an
+    /// ambient 1 is 254, and 254 is not at the ceiling.
+    #[test]
+    fn subtraction_hides_clipping_so_the_gate_reads_the_raw_frame() {
+        let bbox = [0.0f32, 0.0, 4.0, 4.0];
+        // A face region a quarter of which reached the sensor ceiling.
+        let raw: Vec<u8> = [
+            255, 255, 255, 255, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+        ]
+        .into_iter()
+        .collect();
+        let ambient = vec![1u8; 16];
+        let returned = irlume_camera::ir_probe::subtract(&raw, &ambient);
+
+        assert_eq!(
+            saturated_frac_of(&returned, 4, 4, Some(&bbox), Some(255)),
+            Some(0.0),
+            "control: the returned image no longer shows the clipping"
+        );
+        assert_eq!(
+            saturated_frac_of(&raw, 4, 4, Some(&bbox), Some(255)),
+            Some(0.25),
+            "the raw gate frame is where the clipping is still measurable"
         );
     }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -84,6 +84,7 @@ pub(crate) mod testenv {
 
 use irlume_common::Error;
 use v4l::buffer::Type;
+use v4l::format::Quantization;
 use v4l::io::traits::CaptureStream;
 use v4l::video::Capture;
 use v4l::{Device, Format, FourCC};
@@ -1430,10 +1431,24 @@ fn grey16_shift(buf: &[u8]) -> u32 {
 /// The decoded value that means "at or above the sensor's ceiling" for a
 /// negotiated IR format, or `None` when the decode cannot carry that claim.
 /// See [`IrCaptureStats::white_level`] for why only the 8-bit greys qualify.
-pub(crate) fn clipping_white_level(pix: IrPixel) -> Option<u8> {
-    match pix {
-        IrPixel::Grey8 => Some(u8::MAX),
-        IrPixel::Grey16 | IrPixel::Nv12Luma | IrPixel::YuyvLuma => None,
+///
+/// GREY is a luma-only Y' format, so its ceiling depends on the quantization
+/// the driver reports: full range puts white at 255, limited range at 235. A
+/// face entirely at 235 on a limited-range device would otherwise measure as
+/// zero clipping and walk through the exposure gate (#238 review).
+///
+/// `Default` is read as full range, which is what it resolves to on every
+/// module irlume supports: `v4l2-ctl --get-fmt-video` prints
+/// "Quantization: Default (maps to Full Range)" for the ASUS FHD IR pin, the
+/// NexiGo N930W and the Logitech BRIO, all three GREY at sRGB. Answering `None`
+/// there instead would be the cautious-looking choice and would disable the
+/// gate on every camera anyone actually has, which is the failure this exists
+/// to prevent. If a module ever reports limited range, the 235 arm covers it.
+pub(crate) fn clipping_white_level(pix: IrPixel, quantization: Quantization) -> Option<u8> {
+    match (pix, quantization) {
+        (IrPixel::Grey8, Quantization::LimitedRange) => Some(235),
+        (IrPixel::Grey8, Quantization::FullRange | Quantization::Default) => Some(u8::MAX),
+        (IrPixel::Grey16 | IrPixel::Nv12Luma | IrPixel::YuyvLuma, _) => None,
     }
 }
 
@@ -1458,19 +1473,26 @@ fn grey16_to_8_at(buf: &[u8], shift: u32) -> Vec<u8> {
 /// 8-bit formats carry no scale, so they are unaffected.
 pub(crate) struct IrDecoder {
     pix: IrPixel,
+    /// Carried because the GREY ceiling depends on it; see
+    /// [`clipping_white_level`].
+    quantization: Quantization,
     shift: Option<u32>,
 }
 
 impl IrDecoder {
-    pub(crate) fn new(pix: IrPixel) -> Self {
-        Self { pix, shift: None }
+    pub(crate) fn new(pix: IrPixel, quantization: Quantization) -> Self {
+        Self {
+            pix,
+            quantization,
+            shift: None,
+        }
     }
 
     /// See [`clipping_white_level`]: the decoded value that means "at or above
     /// the sensor's ceiling" for this decoder's format, or `None` when the
     /// decode cannot carry that claim.
     pub(crate) fn white_level(&self) -> Option<u8> {
-        clipping_white_level(self.pix)
+        clipping_white_level(self.pix, self.quantization)
     }
 
     pub(crate) fn decode(&mut self, buf: &[u8], w: u32, h: u32) -> Vec<u8> {
@@ -1600,6 +1622,9 @@ pub struct IrCamera {
     device: String,
     dev: Device,
     pix: IrPixel,
+    /// The driver's reported quantization for the negotiated format, which is
+    /// half of what names the clipping ceiling; see [`clipping_white_level`].
+    quantization: Quantization,
     width: u32,
     height: u32,
     card: String,
@@ -1620,6 +1645,7 @@ impl IrCamera {
             device: device.to_string(),
             dev,
             pix,
+            quantization: fmt.quantization,
             width: fmt.width,
             height: fmt.height,
             card,
@@ -1682,7 +1708,7 @@ impl IrCamera {
         Ok(IrSession {
             cam: self,
             stream,
-            dec: IrDecoder::new(self.pix),
+            dec: IrDecoder::new(self.pix, self.quantization),
             lit: mode.lit(),
             _mode: mode,
             meta,
@@ -2119,7 +2145,7 @@ pub mod ir_probe {
         }
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
         let (fmt, pix) = negotiate_ir_format(device, &dev)?;
-        let mut dec = super::IrDecoder::new(pix);
+        let mut dec = super::IrDecoder::new(pix, fmt.quantization);
         let (w, h) = (fmt.width, fmt.height);
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
         // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
@@ -2220,7 +2246,7 @@ pub fn capture_ir_streaming<B>(
     }
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
-    let mut dec = IrDecoder::new(pix);
+    let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
     // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
@@ -2354,7 +2380,7 @@ pub fn capture_ir_sequence(
     let burst = burst.max(1);
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
-    let mut dec = IrDecoder::new(pix);
+    let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
     // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
@@ -2780,7 +2806,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     // signal that stops the process.
     let _abort_orderly = ir_emitter::AbortOnSignal::install();
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
-    let mut dec = IrDecoder::new(pix);
+    let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
     let mut stream = SafeStream::open(device, &dev)?;
     let fd = dev.handle().fd();
@@ -3307,14 +3333,51 @@ mod tests {
     /// Saying None there is what keeps #221's corpus interpretable.
     #[test]
     fn only_native_8bit_grey_can_claim_a_clipping_ceiling() {
-        assert_eq!(clipping_white_level(IrPixel::Grey8), Some(255));
-        assert_eq!(clipping_white_level(IrPixel::Grey16), None);
-        assert_eq!(clipping_white_level(IrPixel::Nv12Luma), None);
-        assert_eq!(clipping_white_level(IrPixel::YuyvLuma), None);
+        for q in [
+            Quantization::Default,
+            Quantization::FullRange,
+            Quantization::LimitedRange,
+        ] {
+            assert_eq!(clipping_white_level(IrPixel::Grey16, q), None);
+            assert_eq!(clipping_white_level(IrPixel::Nv12Luma, q), None);
+            assert_eq!(clipping_white_level(IrPixel::YuyvLuma, q), None);
+        }
         // And the decoder reports its own format's answer, since that is what
         // the capture actually negotiated.
-        assert_eq!(IrDecoder::new(IrPixel::Grey8).white_level(), Some(255));
-        assert_eq!(IrDecoder::new(IrPixel::Grey16).white_level(), None);
+        assert_eq!(
+            IrDecoder::new(IrPixel::Grey8, Quantization::Default).white_level(),
+            Some(255)
+        );
+        assert_eq!(
+            IrDecoder::new(IrPixel::Grey16, Quantization::Default).white_level(),
+            None
+        );
+    }
+
+    /// GREY's ceiling is where the DRIVER says white is. A limited-range device
+    /// puts it at 235, so a face entirely at 235 is fully clipped there and
+    /// would read as pristine against a hardcoded 255, walking straight through
+    /// the exposure gate (#238 review).
+    ///
+    /// `Default` reads as full range because that is what it resolves to on
+    /// every module irlume supports, measured with `v4l2-ctl --get-fmt-video`
+    /// on the ASUS FHD IR pin, the NexiGo N930W and the Logitech BRIO: all
+    /// three print "Default (maps to Full Range)". Answering None there would
+    /// switch the gate off on every camera anyone has.
+    #[test]
+    fn the_grey_ceiling_follows_the_drivers_quantization() {
+        assert_eq!(
+            clipping_white_level(IrPixel::Grey8, Quantization::LimitedRange),
+            Some(235)
+        );
+        assert_eq!(
+            clipping_white_level(IrPixel::Grey8, Quantization::FullRange),
+            Some(255)
+        );
+        assert_eq!(
+            clipping_white_level(IrPixel::Grey8, Quantization::Default),
+            Some(255)
+        );
     }
 
     /// The reason Grey16 cannot: the shift comes from the frame's OWN maximum,
@@ -3710,7 +3773,7 @@ mod tests {
         let first = words(&[0, 256, 512, 1023]); // 10-bit: shift 2
         let with_hot_pixel = words(&[0, 256, 512, 2047]); // one 11-bit sample
 
-        let mut session = IrDecoder::new(IrPixel::Grey16);
+        let mut session = IrDecoder::new(IrPixel::Grey16, Quantization::Default);
         let a = session.decode(&first, 2, 2);
         let b = session.decode(&with_hot_pixel, 2, 2);
         assert_eq!(a, vec![0, 64, 128, 255]);
@@ -3719,11 +3782,11 @@ mod tests {
 
         // A fresh session re-estimates, so a genuinely deeper feed still maps
         // onto the full range instead of clipping forever.
-        let mut next = IrDecoder::new(IrPixel::Grey16);
+        let mut next = IrDecoder::new(IrPixel::Grey16, Quantization::Default);
         assert_eq!(next.decode(&with_hot_pixel, 2, 2), vec![0, 32, 64, 255]);
 
         // 8-bit formats carry no scale and are untouched by the session state.
-        let mut grey8 = IrDecoder::new(IrPixel::Grey8);
+        let mut grey8 = IrDecoder::new(IrPixel::Grey8, Quantization::Default);
         assert_eq!(grey8.decode(&[9, 9], 1, 2), vec![9, 9]);
     }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -158,7 +158,9 @@ pub enum Spectrum {
 /// strobes, `ambient_mean` is the scene's ambient IR level with the emitter off
 /// and `lit_mean - ambient_mean` is the strobe gap; on a steady emitter the two
 /// converge.
-#[derive(Clone, Copy, Debug)]
+// Not Copy: `saturation_frame` owns a frame's worth of pixels, and a silent
+// per-use copy of that is not something a caller should get by accident.
+#[derive(Clone, Debug)]
 pub struct IrCaptureStats {
     pub lit_mean: f32,
     pub ambient_mean: f32,
@@ -183,6 +185,20 @@ pub struct IrCaptureStats {
     /// nominal white at 235, full range at 255) and irlume does not carry that
     /// field, so a clipped face could read as no clipping at all.
     pub white_level: Option<u8>,
+    /// The gate frame's RAW pixels, present only when the returned frame is no
+    /// longer them: ambient subtraction replaces the payload, and a caller
+    /// measuring clipping must not measure the replacement.
+    ///
+    /// Subtraction cannot restore a sample that reached the ceiling, but it
+    /// does move it: a raw 255 minus an ambient 1 is 254, so a face that
+    /// clipped 25% measures 0% afterwards and an exposure guard reading it
+    /// would pass a frame that carries no information (#238 review). The
+    /// camera's own note two screens up already said pixels saturated in the
+    /// lit frame carry no reliable subtracted value; this keeps the evidence
+    /// for the guard that acts on it.
+    ///
+    /// `None` means the returned frame IS the raw gate frame, so measure that.
+    pub saturation_frame: Option<Vec<u8>>,
 }
 
 pub const DEFAULT_RGB_DEVICE: &str = "/dev/video0";
@@ -1845,6 +1861,8 @@ impl IrSession<'_> {
         // Both are moot while the flag is unset (the shipped default).
         let subtract = std::env::var("IRLUME_IR_AMBIENT_SUBTRACT").is_ok_and(|v| v.trim() == "1");
         let debug_ir = std::env::var("IRLUME_DEBUG_IR").is_ok();
+        // Stays None unless the returned pixels stop being the raw gate frame.
+        let mut saturation_frame: Option<Vec<u8>> = None;
         if subtract {
             // An adjacent frame the camera flagged dark, else the darker
             // neighbour as before. Adjacency still bounds auto-exposure drift
@@ -1863,6 +1881,13 @@ impl IrSession<'_> {
                     // face becomes undetectable. Keep the raw lit frame instead of
                     // handing downstream a blank one.
                     if sub_mean >= SUBTRACT_MIN_RESULT {
+                        // Keep the raw gate frame BEFORE handing back the
+                        // subtracted one: saturation is only measurable in the
+                        // pixels that actually hit the ceiling, and subtraction
+                        // moves every one of them below it. Cloned only on this
+                        // branch, the one where the returned pixels stop being
+                        // the raw ones.
+                        saturation_frame = white_level.map(|_| frames[best_i].clone());
                         best = Some(sub);
                         // The result now carries pixels from BOTH frames.
                         ir_window = ir_window.union(CaptureWindow::at(taken[ai]));
@@ -1977,6 +2002,7 @@ impl IrSession<'_> {
                 captured: ir_window,
             },
             IrCaptureStats {
+                saturation_frame,
                 lit_mean: lit_level as f32,
                 ambient_mean: ambient_level as f32,
                 burst_frames: IR_BURST,

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -102,8 +102,12 @@ fn capture_once(
         (None, 0.0, 0.5)
     };
 
-    // IR (brightest-of-burst, matches the auth path).
-    let ir = irlume_camera::capture_ir(ir_dev)?;
+    // IR through the same selection the auth path uses, WITH its statistics.
+    // The stats are not decoration: the exposure gate (#237) reads a clipped
+    // fraction that can only be computed from the frame's own ceiling, and a
+    // harness that left it None would qualify a corpus against a gate
+    // configuration authentication never runs.
+    let (ir, ir_stats) = irlume_camera::capture_ir_with_stats(ir_dev)?;
     let ir_rgb = irlume_camera::grey_to_rgb(&ir.data);
     let iv = irlume_vision::align::RgbView {
         data: &ir_rgb,
@@ -136,6 +140,15 @@ fn capture_once(
         ir_eye_glint,
         head_yaw_asym,
         head_pitch_frac,
+        ir_ambient: ir_stats.ambient_mean,
+        face_frac: irlume_auth::face_frac_of(ir_top.as_ref().map(|f| &f.bbox), ir.width),
+        ir_saturated_frac: irlume_auth::saturated_frac_of(
+            &ir.data,
+            ir.width,
+            ir.height,
+            ir_top.as_ref().map(|f| &f.bbox),
+            ir_stats.white_level,
+        ),
         ..Default::default()
     };
     let gate = LivenessGate::new();
@@ -252,6 +265,17 @@ pub(crate) fn padcapture(args: &[String]) -> std::process::ExitCode {
                 "ir_brightness".into(),
                 crate::json_f32(s.ir_face_brightness),
             );
+            // The exposure gate's input and its answer. A record that reported
+            // the cues without these could not distinguish a frame the gate
+            // judged from one it refused unread (#237).
+            rec.insert(
+                "ir_saturated_frac".into(),
+                match s.ir_saturated_frac {
+                    Some(f) => crate::json_f32(f),
+                    None => serde_json::Value::Null,
+                },
+            );
+            rec.insert("ir_exposure_ok".into(), cues.ir_exposure_ok.into());
             rec.insert(
                 "ir_center_edge_ratio".into(),
                 crate::json_f32(s.ir_center_edge_ratio),

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -142,8 +142,10 @@ fn capture_once(
         head_pitch_frac,
         ir_ambient: ir_stats.ambient_mean,
         face_frac: irlume_auth::face_frac_of(ir_top.as_ref().map(|f| &f.bbox), ir.width),
+        // The raw gate frame, for the reason the auth path states: subtraction
+        // hides the very clipping this measures.
         ir_saturated_frac: irlume_auth::saturated_frac_of(
-            &ir.data,
+            ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
             ir.width,
             ir.height,
             ir_top.as_ref().map(|f| &f.bbox),

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -319,21 +319,8 @@ impl LivenessGate {
             );
         }
 
-        // Exposure sanity, before any cue that reads the pixels. A blown face
-        // region is not evidence of anything: the cues below all degrade
-        // together as it clips, so judging one is reading noise (#237).
-        // Uncertain, not Spoof, because the frame failed to measure a face
-        // rather than showing a fake one, and backing off fixes it.
-        cues.ir_exposure_ok = s
-            .ir_saturated_frac
-            .is_none_or(|f| f <= IR_SATURATED_FRAC_MAX);
-        if !cues.ir_exposure_ok {
-            let clipped = s.ir_saturated_frac.unwrap_or(1.0) * 100.0;
-            return (
-                Verdict::Uncertain,
-                cues,
-                format!("IR frame blown out ({clipped:.0}% of the face at the sensor ceiling); move back or dim the light"),
-            );
+        if let Some((verdict, reason)) = exposure_refusal(s, &mut cues) {
+            return (verdict, cues, reason);
         }
 
         // IR skin reflectance: the face region must be brightly lit.
@@ -444,6 +431,9 @@ impl LivenessGate {
             return (Verdict::Uncertain, cues, "no face in IR".into());
         }
         cues.face_in_ir = true;
+        if let Some((verdict, reason)) = exposure_refusal(s, &mut cues) {
+            return (verdict, cues, reason);
+        }
         cues.ir_reflectance_ok = s.ir_face_brightness >= IR_FACE_MIN_BRIGHTNESS;
         if !cues.ir_reflectance_ok {
             let reason = if s.ir_ambient >= IR_AMBIENT_FLOOD {
@@ -469,6 +459,39 @@ impl LivenessGate {
             "live (dark/IR-only): IR-reflective, 3D".into(),
         )
     }
+}
+
+/// The exposure refusal, shared by every evaluator that can release credentials.
+///
+/// A blown face region measures nothing: the cues below it degrade together as
+/// clipping rises, so judging any one of them is reading noise (#237). Returns
+/// the refusal to propagate, or `None` when the frame is readable, and records
+/// [`Cues::ir_exposure_ok`] either way.
+///
+/// This lives in one function because it guards two entry points,
+/// [`LivenessGate::evaluate`] and [`LivenessGate::evaluate_ir_only`], and the
+/// first version of #237 gated only the first: the dark-room path kept
+/// accepting the frames the cross-spectrum path had just started refusing.
+/// Adding a third evaluator means calling this, not copying it.
+fn exposure_refusal(s: &Signals, cues: &mut Cues) -> Option<(Verdict, String)> {
+    cues.ir_exposure_ok = s
+        .ir_saturated_frac
+        .is_none_or(|f| f <= IR_SATURATED_FRAC_MAX);
+    if cues.ir_exposure_ok {
+        return None;
+    }
+    // Uncertain, not Spoof: the capture failed to measure a face rather than
+    // showing a fake one, and moving back fixes it. That classification is also
+    // what makes the refusal presence-retryable, so a login's grace window can
+    // absorb it while a single-capture probe reports it.
+    let clipped = s.ir_saturated_frac.unwrap_or(1.0) * 100.0;
+    Some((
+        Verdict::Uncertain,
+        format!(
+            "IR frame blown out ({clipped:.0}% of the face at the sensor ceiling); \
+             move back or dim the light"
+        ),
+    ))
 }
 
 // --- Passive blink liveness (opt-in, ADR-0002) ------------------------------
@@ -1515,26 +1538,36 @@ mod tests {
         }
     }
 
-    /// A blown face region is refused before any cue reads it (#237). The
-    /// signals here are otherwise a textbook live face, so the only thing that
-    /// can move the verdict is the clipped fraction.
+    /// A blown face region is refused before any cue reads it (#237), on EVERY
+    /// evaluator that can release credentials. The signals are otherwise a
+    /// textbook live face, so only the clipped fraction can move the verdict.
+    ///
+    /// Both paths are asserted here because the first version of this change
+    /// gated only `evaluate`, and `evaluate_ir_only` (the dark-room path that
+    /// authenticates when RGB finds nothing) kept returning Live for exactly
+    /// the frames the other path had begun refusing. A test that exercised one
+    /// evaluator could not see that.
     #[test]
-    fn a_blown_ir_face_is_refused_however_live_the_other_cues_look() {
+    fn a_blown_ir_face_is_refused_on_every_credential_releasing_path() {
         let gate = LivenessGate::new();
         for frac in [0.11, 0.25, 0.5, 1.0] {
             let mut s = live_signals();
             s.ir_saturated_frac = Some(frac);
-            let (verdict, cues, reason) = gate.evaluate(&s);
-            assert_eq!(
-                verdict,
-                Verdict::Uncertain,
-                "a frame {frac} clipped measures nothing, so it cannot be judged"
-            );
-            assert!(!cues.ir_exposure_ok);
-            assert!(
-                reason.contains("blown out"),
-                "the reason must name the exposure, not a cue read from it: {reason}"
-            );
+            for (path, (verdict, cues, reason)) in [
+                ("cross-spectrum", gate.evaluate(&s)),
+                ("ir-only", gate.evaluate_ir_only(&s)),
+            ] {
+                assert_eq!(
+                    verdict,
+                    Verdict::Uncertain,
+                    "{path} judged a frame {frac} clipped, which measures nothing"
+                );
+                assert!(!cues.ir_exposure_ok, "{path}");
+                assert!(
+                    reason.contains("blown out"),
+                    "{path}: the reason must name the exposure, not a cue read from it: {reason}"
+                );
+            }
         }
     }
 
@@ -1547,19 +1580,32 @@ mod tests {
         for frac in [None, Some(0.0), Some(0.063), Some(IR_SATURATED_FRAC_MAX)] {
             let mut live = live_signals();
             live.ir_saturated_frac = frac;
-            assert_eq!(
-                gate.evaluate(&live).0,
-                Verdict::Live,
-                "a live face must stay Live at ir_saturated_frac {frac:?}"
-            );
             let mut flat = live_signals();
             flat.ir_saturated_frac = frac;
             flat.ir_center_edge_ratio = 1.0; // flat
-            assert_eq!(
-                gate.evaluate(&flat).0,
-                Verdict::Spoof,
-                "a flat target must still be called a spoof at {frac:?}, not merely refused"
-            );
+            for (path, live_verdict, flat_verdict) in [
+                (
+                    "cross-spectrum",
+                    gate.evaluate(&live).0,
+                    gate.evaluate(&flat).0,
+                ),
+                (
+                    "ir-only",
+                    gate.evaluate_ir_only(&live).0,
+                    gate.evaluate_ir_only(&flat).0,
+                ),
+            ] {
+                assert_eq!(
+                    live_verdict,
+                    Verdict::Live,
+                    "{path}: a live face must stay Live at ir_saturated_frac {frac:?}"
+                );
+                assert_eq!(
+                    flat_verdict,
+                    Verdict::Spoof,
+                    "{path}: a flat target must still be called a spoof at {frac:?}, not merely refused"
+                );
+            }
         }
     }
 

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -206,8 +206,10 @@ pub const MIN_CENTER_EDGE_RATIO: f32 = 1.03;
 /// A blown frame does not measure a face, and every cue that reads it degrades
 /// together: the centre/edge ratio compresses toward the floor, and the
 /// third-party PAD model's `p_fake` decays out of its deny range and into the
-/// abstain band it was never qualified in, so a flat print stops being denied
-/// by the one cue that reliably denies it (#237).
+/// abstain band, so a flat print stops being denied by the one cue that
+/// reliably denies it (#237). Whether that band was ever exercised with clipped
+/// frames during the model's qualification is not recorded either way; what is
+/// measured is the decay itself.
 ///
 /// 10% sits between two measured populations on the ASUS module, dark room, one
 /// subject: with clip-aware frame selection (#221) every genuine gate frame

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -86,15 +86,16 @@ pub struct Signals {
     /// is (the Y16 family is rescaled per frame; YUV ceilings depend on a
     /// quantization irlume does not carry). `None` is NOT zero clipping.
     ///
-    /// RECORDED, NEVER GATED, for the same reason as [`face_frac`]. Saturation
-    /// compresses [`ir_center_edge_ratio`] toward 1 the way an ambient pedestal
-    /// does, because a clipped centre cannot read brighter than a clipped rim,
-    /// and the recorded corpora show the case is reachable: in two independent
-    /// sessions the first capture read ~235 mean with a ratio of 1.06 and 1.12
-    /// against a 1.03 floor, while every later capture in the same session
-    /// cleared it by 0.16 or more (#221). irlume guards the ambient end of this
-    /// same starvation and nothing at this end; whether real authentications
-    /// ever run clipped is what this field is for.
+    /// GATED since #237, at [`IR_SATURATED_FRAC_MAX`]. Saturation compresses
+    /// [`ir_center_edge_ratio`] toward 1 the way an ambient pedestal does,
+    /// because a clipped centre cannot read brighter than a clipped rim, and it
+    /// starves the third-party PAD model of the texture it scores: measured
+    /// against a flat vinyl print on one ASUS module, `p_fake` fell 1.000,
+    /// 0.998, 0.963, 0.749 at 0.3%, 5.3%, 8.8% and 24.8% clipped, so past
+    /// roughly 13% the cue drops below its own 0.90 deny threshold, abstains,
+    /// and the print is left facing only cues it already clears (#237).
+    /// Clipping weakens the evidence on both sides at once, which is why this
+    /// end is refused rather than interpreted.
     ///
     /// [`face_frac`]: Self::face_frac
     /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
@@ -176,6 +177,11 @@ pub struct Cues {
     /// Face is frontal enough (≈±15°) to make a decision; Windows-Hello-style
     /// head-orientation gate.
     pub frontal_ok: bool,
+    /// The IR face region is readable rather than blown out: at most
+    /// [`IR_SATURATED_FRAC_MAX`] of it sits at the sensor ceiling, or the format
+    /// cannot say where its ceiling is. False means no cue below it was worth
+    /// reading (#237).
+    pub ir_exposure_ok: bool,
 }
 
 /// IR face region must be at least this bright (0..255). A lit live face ran ~83
@@ -193,6 +199,27 @@ pub const MIN_FACE_SCORE: f32 = 0.6;
 /// 69 of 70 trials (docs/pad-results/2026-06-30-ir-liveness-selftest.md). Treat
 /// it as one weak cue, never as proof of a live face.
 pub const MIN_CENTER_EDGE_RATIO: f32 = 1.03;
+
+/// Fraction of the IR face region at the sensor ceiling above which the frame
+/// is refused as unreadable rather than judged.
+///
+/// A blown frame does not measure a face, and every cue that reads it degrades
+/// together: the centre/edge ratio compresses toward the floor, and the
+/// third-party PAD model's `p_fake` decays out of its deny range and into the
+/// abstain band it was never qualified in, so a flat print stops being denied
+/// by the one cue that reliably denies it (#237).
+///
+/// 10% sits between two measured populations on the ASUS module, dark room, one
+/// subject: with clip-aware frame selection (#221) every genuine gate frame
+/// measured at or below 6.3%, while the print needed roughly 13% before the PAD
+/// cue went quiet (`p_fake` 0.963 at 8.8%, 0.749 at 24.8%). The margin either
+/// side is under 4 points, so this is a floor set from one camera and one room;
+/// widen the corpus before trusting it elsewhere (#101).
+///
+/// Only measurable where the source format names its ceiling
+/// (`clipping_white_level`); an unmeasurable frame is judged as before, since
+/// refusing on a number nobody produced would deny every non-GREY8 module.
+pub const IR_SATURATED_FRAC_MAX: f32 = 0.10;
 
 /// Ambient IR (see [`Signals::ir_ambient`]) above which the brightness and
 /// center/edge cues are physically starved rather than measuring a spoof: the scene's
@@ -289,6 +316,23 @@ impl LivenessGate {
                     "not facing the camera (yaw {:.2}, pitch {:.2}); look directly at it",
                     s.head_yaw_asym, s.head_pitch_frac
                 ),
+            );
+        }
+
+        // Exposure sanity, before any cue that reads the pixels. A blown face
+        // region is not evidence of anything: the cues below all degrade
+        // together as it clips, so judging one is reading noise (#237).
+        // Uncertain, not Spoof, because the frame failed to measure a face
+        // rather than showing a fake one, and backing off fixes it.
+        cues.ir_exposure_ok = s
+            .ir_saturated_frac
+            .is_none_or(|f| f <= IR_SATURATED_FRAC_MAX);
+        if !cues.ir_exposure_ok {
+            let clipped = s.ir_saturated_frac.unwrap_or(1.0) * 100.0;
+            return (
+                Verdict::Uncertain,
+                cues,
+                format!("IR frame blown out ({clipped:.0}% of the face at the sensor ceiling); move back or dim the light"),
             );
         }
 
@@ -1471,26 +1515,36 @@ mod tests {
         }
     }
 
-    /// `face_frac` is RECORDED with the cues and read by nothing: the whole
-    /// point of #174 is to find out whether the existing thresholds move with
-    /// seating distance BEFORE anything is normalised by it. A verdict that
-    /// changed with this field would be exactly the retune-against-
-    /// contaminated-samples the issue warns off.
-    /// The clipped fraction is recorded and read by nothing. #221 exists to
-    /// find out whether authentications ever run clipped BEFORE any threshold
-    /// or warm-up constant changes; a verdict that moved with this field would
-    /// prejudge that.
+    /// A blown face region is refused before any cue reads it (#237). The
+    /// signals here are otherwise a textbook live face, so the only thing that
+    /// can move the verdict is the clipped fraction.
     #[test]
-    fn ir_saturated_frac_changes_no_verdict() {
+    fn a_blown_ir_face_is_refused_however_live_the_other_cues_look() {
         let gate = LivenessGate::new();
-        for frac in [
-            None,
-            Some(0.0),
-            Some(0.01),
-            Some(0.25),
-            Some(0.9),
-            Some(1.0),
-        ] {
+        for frac in [0.11, 0.25, 0.5, 1.0] {
+            let mut s = live_signals();
+            s.ir_saturated_frac = Some(frac);
+            let (verdict, cues, reason) = gate.evaluate(&s);
+            assert_eq!(
+                verdict,
+                Verdict::Uncertain,
+                "a frame {frac} clipped measures nothing, so it cannot be judged"
+            );
+            assert!(!cues.ir_exposure_ok);
+            assert!(
+                reason.contains("blown out"),
+                "the reason must name the exposure, not a cue read from it: {reason}"
+            );
+        }
+    }
+
+    /// The refusal is an exposure ceiling, not a new spoof cue: everything at
+    /// or under the limit is judged exactly as before, and an unmeasurable
+    /// fraction (a format with no known ceiling) must not deny anyone.
+    #[test]
+    fn a_readable_ir_face_is_judged_as_before() {
+        let gate = LivenessGate::new();
+        for frac in [None, Some(0.0), Some(0.063), Some(IR_SATURATED_FRAC_MAX)] {
             let mut live = live_signals();
             live.ir_saturated_frac = frac;
             assert_eq!(
@@ -1501,14 +1555,19 @@ mod tests {
             let mut flat = live_signals();
             flat.ir_saturated_frac = frac;
             flat.ir_center_edge_ratio = 1.0; // flat
-            assert_ne!(
+            assert_eq!(
                 gate.evaluate(&flat).0,
-                Verdict::Live,
-                "a flat target must not pass at ir_saturated_frac {frac:?}"
+                Verdict::Spoof,
+                "a flat target must still be called a spoof at {frac:?}, not merely refused"
             );
         }
     }
 
+    /// `face_frac` is RECORDED with the cues and read by nothing: the whole
+    /// point of #174 is to find out whether the existing thresholds move with
+    /// seating distance BEFORE anything is normalised by it. A verdict that
+    /// changed with this field would be exactly the retune-against-
+    /// contaminated-samples the issue warns off.
     #[test]
     fn face_frac_changes_no_verdict() {
         let gate = LivenessGate::new();


### PR DESCRIPTION
Closes #237.

## Why

A face region at the sensor ceiling measures nothing, and irlume was judging it anyway. Measured against the flat vinyl print from #235 on the ASUS module, the third-party PAD cue decays as clipping rises:

| face region clipped | flir p_fake |
|---|---|
| 0.0 to 2.7% | 1.000 to 0.999 |
| 5.3% | 0.998 |
| 8.8% | 0.963 |
| 24.8% | 0.749, abstains |
| 42.7% | below 0.13, silent |

Past roughly 13% the cue falls under its own 0.90 deny threshold and abstains, so the print is left facing only cues it already clears, and it was declared Live. The centre/edge ratio moves the same way: clipped it reads 1.17 to 1.19, clean it reads 0.97 to 1.20 and twice rejected the print outright against the 1.03 floor. Saturation weakens both sides of the evidence at once, which is why this refuses the frame rather than interpreting it.

The abstain band it lands in is documented as "the band neither class occupied" during qualification, and that qualification never covered clipped frames. An abstention there is not a considered "no objection".

## What changes

`Signals::ir_saturated_frac`, recorded since #224, is now gated at `IR_SATURATED_FRAC_MAX` (10%), before any cue that reads the pixels. Over the limit the gate returns `Uncertain` with the exposure named, never `Live`.

`Uncertain`, not `Spoof`, because the capture failed to measure a face rather than showing a fake one; that also puts it in `presence_retryable`, which is what keeps the cost off real logins. A format that cannot name its ceiling reports `None` and is judged exactly as before, since refusing on a number nobody produced would deny every non-GREY8 module.

10% sits between two measured populations: with clip-aware selection (#221) every genuine gate frame measured at or below 6.3%, and the print needed about 13% before the PAD cue went quiet. Both margins are under 4 points, from one camera in one room, and the constant says so.

## Verification

Container: 2 unit tests (refusal across 0.11 to 1.0; unchanged judgement at `None`, 0.0, 0.063 and exactly the limit, on both the live and flat sides), 5 hand-applied mutants each failing their named test (gate removed, unmeasurable-denies, boundary excluded, Spoof instead of Uncertain, limit loosened to 30% past the PAD cliff), reversed by a self-restoring script with the tree byte-identical after. Full workspace suite green.

Hardware, ASUS module, dark room, one subject, glasses on throughout:

- **Spoof side.** The vinyl print at close range, which reached `Live` on main through a 24.8%-clipped frame, is now refused by the exposure gate before any cue reads it.
- **False rejects, single capture.** 12 `irlume identify` runs: 9 authenticated (normal seating and arm's length, gate frames at or under 1.3%), 3 refused while leaning in close, at 16%, 25% and 50.5% of the face clipped. Those are the captures where the whole burst clipped, so #221's selection had nothing clean to choose.
- **False rejects, real login.** 3 `pam_authenticate` attempts on the sudo stack from that same close position, after a daemon restart each time: all 3 succeeded in 4.0 to 7.8 seconds, gate frames at 6.7 to 8.7%.

The difference between the last two is the point of the `Uncertain` classification. `irlume identify` takes one capture and reports what it got; a login gets a 15 second grace window that retries presence failures, and auto-exposure settles across captures (78.8, 12.7, 5.3, 4.3% over four consecutive captures at one position, measured on #221).

## Not tested

- **I never caught a login whose first capture was over the limit.** The three PAM attempts all drew a gate frame under 10%, so the retry absorbing this specific refusal is an inference, not a measurement: it rests on the refusal mapping to `OutcomeKind::Uncertain`, `presence_retryable` including that kind, and the grace window being measured retrying a different `Uncertain` (an off-angle frame at 21:02, retried and authenticated 4 seconds later). The condition is intermittent, and I could not force it.
- Bright ambient, other modules, other subjects, and the clipping range between 10% and 16% on the genuine side.
- Whether 10% is right for a camera whose face region clips differently from its frame average. On this module the face clipped 50.5% while the whole frame clipped 20.1%, since the face is nearest the emitter; selection can only see the frame-wide number, which is why some bursts have no clean frame to offer.
