### PR TITLE
Say that the built-in gate does not stop a printed face

### DIFF
--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -296,7 +296,16 @@ pub fn doctor_line() -> String {
             );
         }
     }
-    "none (default; see `irlume models`)".into()
+    // Named as a gap rather than a neutral default. The built-in gate does not
+    // stop a life-size print: measured 2026-06-30 and again 2026-08-02, an
+    // angled vinyl print of the enrolled face reads a centre/edge ratio above
+    // the genuine range, so no threshold separates them and the gate accepts
+    // it. This cue denied the same print at p_fake 0.999 and above. A user
+    // reading `doctor` should learn that from the line, not from an issue.
+    "none — RECOMMENDED: `sudo irlume models enable flir`. Without it the \
+     built-in gate is the only anti-spoof layer, and it does not stop a \
+     life-size print of your face (docs/PAD_SELFTEST.md)"
+        .into()
 }
 
 #[cfg(test)]
@@ -323,11 +332,15 @@ mod tests {
         std::env::set_var("IRLUME_CONFIG_DIR", &cfg);
         std::env::set_var("IRLUME_STATE_DIR", &state);
 
-        // Nothing enabled, nothing on disk.
+        // Nothing enabled, nothing on disk. The line must name the absence AND
+        // what it costs: reported as a bare default it reads as a setting the
+        // user has already made, which is how a machine ends up with no defence
+        // against a printed face and nothing saying so.
+        let none_line = doctor_line();
+        assert!(none_line.starts_with("none"), "got: {none_line}");
         assert!(
-            doctor_line().starts_with("none (default"),
-            "got: {}",
-            doctor_line()
+            none_line.contains("models enable flir") && none_line.contains("life-size print"),
+            "got: {none_line}"
         );
 
         // Weights on disk but no readable enabled key: report the file without

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -670,8 +670,13 @@ fn doctor_runs_fully_offline_with_a_source_origin() {
     assert!(out.contains("face_detection_yunet_2023mar.onnx"), "{out}");
     assert!(out.contains("ORT_DYLIB_PATH: (unset)"), "{out}");
     assert!(
-        out.contains("third-party PAD model: none (default"),
+        out.contains("third-party PAD model: none"),
         "empty sandbox config/state must report no third-party model: {out}"
+    );
+    assert!(
+        out.contains("models enable flir") && out.contains("life-size print"),
+        "reporting the cue as absent must also say what its absence costs, or the \
+         line reads as a neutral default: {out}"
     );
     assert!(out.contains("unknown (daemon not reachable"), "{out}");
 }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -226,7 +226,14 @@ fn main() {
                 Some(n) => eprintln!(
                     "irlumed: third-party PAD cue '{n}' loaded (deny-only; disable with `sudo irlume models disable`)"
                 ),
-                None => eprintln!("irlumed: third-party PAD cue: none (default)"),
+                // A gap worth naming at every start: the built-in gate accepts
+                // a life-size print of the enrolled face (docs/PAD_SELFTEST.md),
+                // and this cue is the only measured defence against one.
+                None => eprintln!(
+                    "irlumed: third-party PAD cue: none. The built-in gate does NOT stop a \
+                     life-size print of your face; `sudo irlume models enable flir` adds the \
+                     cue that does"
+                ),
             }
             e
         }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -407,7 +407,22 @@ with none of these checks ([#179]).
 [#159]: https://github.com/archledger/irlume/issues/159
 [#179]: https://github.com/archledger/irlume/issues/179
 
-## Optional third-party liveness models
+## Third-party liveness models: optional, and recommended
+
+**Enable one if a printed photograph of you should not unlock your machine.**
+The built-in gate does not stop a life-size print. Measured twice on the same
+hardware, on 2026-06-30 and again on 2026-08-02, an angled vinyl print of the
+enrolled user's face produces the same centre-to-edge infrared falloff a real
+face does, so no threshold separates them and the gate accepts the print. The
+`flir` cue denied the same print at `p_fake` 0.999 and above. It is the only
+defence against this attack that has been measured to work, and it is off until
+you turn it on:
+
+```sh
+sudo irlume models enable flir
+```
+
+The rest of this section is why it is opt-in rather than shipped.
 
 irlume's anti-spoof gate is algorithmic by default. `irlume models` lists
 externally-trained models irlume can fetch onto your machine as an extra,


### PR DESCRIPTION
Part of #235, and the part that helps people running 0.8.0 today.

**The problem is what the absence looks like.** `doctor` said `third-party PAD model: none (default; see `irlume models`)`, the daemon banner said `third-party PAD cue: none (default)`, and SETUP.md filed the whole subject under "Optional third-party liveness models". Nothing there suggests the machine is missing its only working defence against a printed face, so a user reasonably reads it as a choice already made. The reporter on #187 has exactly that line in their `doctor` output.

It is not a neutral default. Measured on 2026-06-30 and again on 2026-08-02, an angled life-size vinyl print of the enrolled user's face produces the same centre-to-edge infrared falloff a real face does. The built-in gate accepts it, and because the print's ratio range extends above the genuine range, no floor value separates them; PR #239 tried and was closed on the measurement. The `flir` cue denied the same print at `p_fake` 0.999 and above.

**What changes:** the three places a user could learn this now say it, with the one command that fixes it. The cue stays opt-in, since the reason it is not shipped is licensing (ADR-0001) rather than any doubt that it works.

Before:

```
[doctor] third-party PAD model: none (default; see `irlume models`)
```

After, rendered against an empty config and state dir:

```
[doctor] third-party PAD model: none — RECOMMENDED: `sudo irlume models enable flir`. Without it the built-in gate is the only anti-spoof layer, and it does not stop a life-size print of your face (docs/PAD_SELFTEST.md)
```

A machine that HAS the cue enabled is unchanged and stays quiet.

**The test asserted the old wording**, which means it was asserting the problem. It now requires the line to carry both the absence and its cost, so a future edit cannot quietly flatten it back to a default.

No behaviour change: nothing is enabled, downloaded or gated differently. This is what the software says about itself.