### PR TITLE
Release the held cameras before enrolment falls back to per-frame

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2317,7 +2317,6 @@ impl Engine {
         want: usize,
         pitch_neutral: Option<f32>,
     ) -> irlume_common::Result<Vec<CapturedScan>> {
-        let mut out = Vec::new();
         // Hold the cameras open for the whole loop. This is the heaviest repeated
         // capture in the codebase (the budget below is ten assessments per wanted
         // scan), and every one of them otherwise re-opened, re-negotiated,
@@ -2352,16 +2351,42 @@ impl Engine {
         } else {
             None
         };
-        let mut sessions = match &cams {
-            Some((r, i)) => match (r.session(), i.session()) {
-                (Ok(rs), Ok(is)) => Some((rs, is)),
-                _ => None,
-            },
-            None => None,
-        };
-        if sessions.is_none() {
-            irlume_common::dlog!("enroll: capturing per-frame (no held camera session)");
+        // Fast path: hold both streams for the whole loop.
+        if let Some((r, i)) = &cams {
+            if let (Ok(mut rs), Ok(mut is)) = (r.session(), i.session()) {
+                return self.capture_scan_loop(want, pitch_neutral, Some((&mut rs, &mut is)));
+            }
         }
+        // No held session. RELEASE THE DEVICES FIRST. The per-frame path below
+        // re-opens both nodes itself, and `cams` still holds them: on a module
+        // that permits a second open (both of ours do, measured) that is merely
+        // wasteful, but a module that answers EBUSY turns it into enrolment
+        // failing on its first capture and naming irlumed as the holder of its
+        // own camera (#187). Dropping here also MOVES `cams`, so the fallback
+        // below cannot reach the handles even by mistake.
+        drop(cams);
+        irlume_common::dlog!(
+            "enroll: capturing per-frame (no held camera session; released the devices first)"
+        );
+        self.capture_scan_loop(want, pitch_neutral, None)
+    }
+
+    /// The enrolment capture loop, over held streams when `sessions` is given
+    /// and re-opening per frame when it is not.
+    ///
+    /// Split out from [`Self::capture_scans`] so the per-frame path runs with
+    /// the held cameras already dropped: the two capture strategies must never
+    /// have the devices open at the same time (#187).
+    fn capture_scan_loop(
+        &mut self,
+        want: usize,
+        pitch_neutral: Option<f32>,
+        mut sessions: Option<(
+            &mut irlume_camera::RgbSession<'_>,
+            &mut irlume_camera::IrSession<'_>,
+        )>,
+    ) -> irlume_common::Result<Vec<CapturedScan>> {
+        let mut out = Vec::new();
         // Budget (was ×4) absorbs the added frontality gate (a frame grabbed the
         // instant the user drifts off-angle is rejected, not saved) with enough
         // retries that a brief drift near the capture moment doesn't abort enroll.


### PR DESCRIPTION
Addresses #187, and I want to be precise about how far the evidence goes: the defect is plain in the code, and I could not reproduce it on my hardware.

## The defect

`capture_scans` opens both cameras and holds them for the whole enrolment loop, because re-opening per frame costs 1115ms of every attempt (measured, `examples/session_bench.rs`). If a session cannot be started it falls back to capturing per frame. That fallback calls `capture_rgb_denoised` and `capture_ir_with_stats`, which **open both nodes again**, while `cams` still holds them: two opens of one device from one process.

The reporter's symptom fits exactly. `irlume enroll` never opens a camera; it sends an Enroll request and the daemon captures. So the process that hit EBUSY on `/dev/video0` was `irlumed`, and irlume's holder scan named `irlumed`: it collided with its own handle. That also explains why restarting the daemon never helped and why every retry was identical, and why the node named was RGB, the one the fallback re-opens while `cams` holds it.

## The fix

The loop moves into `capture_scan_loop`, so the fallback runs after `drop(cams)`. The drop also MOVES the handles, so a future edit that reaches for them is a compile error rather than something a runtime test has to catch.

## What I could NOT show

**I could not reproduce the double open.** To reach the branch I need `open` to succeed and `session` to fail. The only lever I have for failing a session is another process streaming the node, and `IrCamera::open` performs `VIDIOC_S_FMT`, which returns EBUSY under exactly that condition:

```
$ v4l2-ctl -d /dev/video2 --set-fmt-video=width=640,height=400,pixelformat=GREY
VIDIOC_S_FMT: failed: Device or resource busy
```

So my forced scenario fails at `open`, giving `cams = None` and a fallback with nothing held. An A/B counting concurrent handles, pre-fix against post-fix, measured 1 on both, because neither run reached the branch. That A/B is inconclusive, not confirming.

On the reporter's machine the sequence would have to be RGB open ok, IR open ok, one session fails, and their RGB then refuses the second open. That is consistent with what they reported but it is their observation, not mine.

The confirmation I asked them for stands: with debug logging on, `capture_scans` prints `enroll: capturing per-frame ...` immediately before falling back. If that line is absent from their failing run, this fix is unrelated to their bug and the second open comes from somewhere else.

## Why merge it anyway

Holding a device open across a re-open of the same device is wrong regardless of who reports it. It is invisible on hardware that permits a second open, which is every module I have, and it is a hard failure on hardware that does not. The change is confined to the fallback branch.

## Verification

- Workspace suite, clippy, fmt, doc lane green.
- **Stress, on the installed daemon:** 20 consecutive authentications (20 granted, latency 3.6 to 4.0s after warm-up), then 15 more with a daemon restart every 5 (13 granted; the 2 denials were the grace window expiring with nobody in frame). No camera-busy in any iteration, daemon fd count flat at 4 throughout, RSS stable.
- **Enrolment capture path, the function actually restructured:** 6 consecutive `enrolldev` cycles against a sandboxed state dir, 6 enrolled, no camera-busy, 5.5 to 5.9s each. These take the fast path, which is what proves no regression there.
- **Fallback branch exercised end to end** by holding the IR stream during enrolment: it logged `enroll: capturing per-frame (no held camera session; released the devices first)` and then named the real external holder, `burst_dump (pid ...)`, rather than itself.
