### PR TITLE
Let systemd own the socket, and stop sweeping enrollments every boot

### DIFF
--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -493,6 +493,39 @@ pub fn delete(user: &str) -> irlume_common::Result<bool> {
     Ok(existed)
 }
 
+/// Has the one-time IR retag already run for this embedding space?
+///
+/// The retag itself is cheap; ASKING is not. The answer lives inside the
+/// encrypted enrollment, so the daemon used to unseal every user's TPM-sealed
+/// template key at startup just to find nothing to do. On a discrete TPM that
+/// is seconds per user, it happens on every boot, and the TPM serializes, so it
+/// collided with the login it was delaying: a keyring unseal measured 2.70s on a
+/// quiet daemon and 18.97s against that startup (#249).
+///
+/// The marker records the embedding space the sweep completed for. It only ever
+/// SKIPS WORK: a missing, stale or unreadable marker runs the sweep, and no
+/// security decision reads it. Its absence costs a slow startup, never a wrong
+/// answer.
+pub fn retag_done_for(space: &str) -> bool {
+    fs::read_to_string(retag_marker_path())
+        .map(|s| s.trim() == space)
+        .unwrap_or(false)
+}
+
+/// Record that the sweep finished for `space`. Best-effort: failing to write it
+/// costs a repeated sweep next boot, which is the pre-existing behaviour.
+pub fn mark_retag_done(space: &str) {
+    let path = retag_marker_path();
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+    let _ = fs::write(&path, format!("{space}\n"));
+}
+
+fn retag_marker_path() -> PathBuf {
+    state_dir().join(".ir-retag-space")
+}
+
 /// Every OS user with an enrollment on this host (the `<user>.json` stems in the
 /// state dir), sorted. For 1:N identify and status reporting. Returns an empty
 /// list if the state dir doesn't exist yet.
@@ -515,6 +548,50 @@ pub fn list_users() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The retag marker skips work and answers a question about work only.
+    ///
+    /// It exists because ASKING whether a user needs a retag costs a TPM unseal,
+    /// and doing that per user at startup collided with the login it delayed
+    /// (#249). Its whole contract: it matches only the space it recorded, an
+    /// absent or unreadable marker means "sweep", and a different embedding
+    /// space means "sweep again". Nothing security-relevant may ever read it,
+    /// which is why it lives beside the enrollments rather than inside one.
+    #[test]
+    fn the_retag_marker_only_matches_the_space_it_recorded() {
+        let dir = std::env::temp_dir().join(format!("irlume-retag-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+
+        // Nothing recorded yet: the sweep must run.
+        assert!(
+            !retag_done_for("raw"),
+            "an absent marker must not skip the sweep"
+        );
+
+        mark_retag_done("raw");
+        assert!(
+            retag_done_for("raw"),
+            "the recorded space must be recognised"
+        );
+
+        // An adapter change moves the space, so the sweep is owed again.
+        assert!(
+            !retag_done_for("adapter:deadbeef"),
+            "a different embedding space must run the sweep again"
+        );
+
+        // Garbage on disk is not a match, so it fails towards doing the work.
+        fs::write(dir.join(".ir-retag-space"), b"\x00not a space").unwrap();
+        assert!(
+            !retag_done_for("raw"),
+            "an unreadable or unexpected marker must fall back to sweeping"
+        );
+
+        std::env::remove_var("IRLUME_STATE_DIR");
+        let _ = fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn legacy_format_migrates_to_one_profile() {

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -1168,6 +1168,36 @@ pub fn seal_with_pcrlock(secret: &[u8], nv_index: u32) -> Result<SealedEnvelope>
 /// machine has none: `pcrlock.json` absent (the common case), unparseable,
 /// rejected by the empty-policy guard, or carrying no NV index. [`seal`] uses
 /// this to decide whether the Tier 2 rung exists on this machine.
+/// Derive the pcrlock branch digests now, so the first unseal does not.
+///
+/// The derivation costs one trial TPM session per predicted branch, measured at
+/// 8.2s on a ThinkPad X13, and its result depends only on the prediction file
+/// (#246). It is memoized per process, so SOMETHING has to pay for it first.
+/// That used to be the daemon's startup enrollment sweep, by accident: removing
+/// the sweep (#249) moved the cost onto the first login, which measured 10.88s
+/// against 2.71s warm.
+///
+/// Calling this from daemon startup keeps the warm path without unsealing
+/// anyone's enrollment to get it. Best-effort by design: every failure here
+/// means the next real unseal derives them itself, exactly as before.
+///
+/// This is a workaround for computing the digests on the TPM at all. The TCG
+/// spec defines them as plain hash recurrences and systemd computes the same
+/// values in userspace with zero TPM commands (#248); doing that removes this
+/// function's reason to exist.
+pub fn warm_pcrlock_policy_cache() {
+    let Some(_) = pcrlock_provisioned() else {
+        return; // Not sealed under pcrlock; nothing to derive.
+    };
+    let Ok(plock) = read_pcrlock_json() else {
+        return;
+    };
+    let Ok(mut ctx) = open_context() else {
+        return;
+    };
+    let _ = build_super_pcr(&mut ctx, &plock);
+}
+
 pub fn pcrlock_provisioned() -> Option<u32> {
     let plock = read_pcrlock_json().ok()?;
     u32::try_from(plock.nv_index?).ok()

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -314,6 +314,11 @@ fn main() {
             // delaying, taking a keyring unseal from 2.70s to 18.97s on a
             // discrete TPM (#249). The marker only skips work; a missing or
             // stale one just runs the sweep as before.
+            // Derive the pcrlock branch digests before any login needs them.
+            // The sweep below used to warm this by accident; skipping the sweep
+            // moved 8.2s onto the first keyring release (#249, #246).
+            irlume_core::tpm::warm_pcrlock_policy_cache();
+
             let retag_space = engine.ir_space().to_string();
             let sweep_needed = !irlume_core::storage::retag_done_for(&retag_space);
             if !sweep_needed {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -102,31 +102,45 @@ fn main() {
     );
     let socket = std::env::var("IRLUME_SOCKET").unwrap_or_else(|_| SOCKET_PATH.into());
 
-    // BIND BEFORE THE SLOW WORK. Startup loads models and then walks every
-    // enrollment to retag legacy IR scans, which touches the TPM per user;
-    // measured 21 seconds from exec to listening on a ThinkPad X13 (#244).
-    // With the bind at the end of that, the socket does not exist while the
-    // greeter is already authenticating, so `connect()` fails and a fingerprint
-    // login's keyring release never happens: pam_irlume's `keyring` line is
-    // `optional` and swallows the failure by design, so the login proceeds and
-    // the user meets a keyring prompt later, with nothing in any log.
+    // PREFER THE SOCKET SYSTEMD ALREADY BOUND, else bind our own.
     //
-    // Binding here makes the socket exist within milliseconds of exec. A client
-    // that connects during startup is queued by the kernel and served when the
-    // accept loop starts, inside the client's 25s request timeout, instead of
-    // being told nobody is listening.
-    let _ = std::fs::remove_file(&socket);
-    let listener = match UnixListener::bind(&socket) {
-        Ok(l) => l,
-        Err(e) => {
-            eprintln!("irlumed: cannot bind {socket}: {e}");
-            std::process::exit(1);
+    // Startup loads models and walks enrollments before this point could ever be
+    // reached by a self-bind, and greeters are ordered after basic.target, well
+    // before multi-user.target. Measured on a ThinkPad X13: the greeter
+    // authenticated a fingerprint 8 seconds before the socket existed, so
+    // pam_irlume had nothing to connect to and the login proceeded with the
+    // keyring locked and nothing in any log (#244). With irlumed.socket,
+    // systemd owns the socket from sockets.target onward and the request waits
+    // in the backlog instead of being refused.
+    //
+    // Self-binding stays for anyone running the daemon directly (development,
+    // a distro without the socket unit installed, IRLUME_SOCKET pointing
+    // somewhere else in a test).
+    let listener = match inherited_listener() {
+        Some(l) => {
+            eprintln!("irlumed: using the socket systemd bound (socket activation)");
+            l
+        }
+        None => {
+            let _ = std::fs::remove_file(&socket);
+            match UnixListener::bind(&socket) {
+                Ok(l) => l,
+                Err(e) => {
+                    eprintln!("irlumed: cannot bind {socket}: {e}");
+                    std::process::exit(1);
+                }
+            }
         }
     };
     // The mode goes on with the bind, not at the accept loop: a socket that
     // exists but is 0600 refuses exactly the non-root clients this early bind
     // exists to admit. The reasoning for 0666 is at the accept loop below.
-    set_mode(&socket, DAEMON_SOCKET_MODE);
+    // Only ours to set when we bound it; under socket activation the mode came
+    // from SocketMode= in the unit, and chmod'ing systemd's socket behind its
+    // back would drift from what the unit says.
+    if !socket_activated() {
+        set_mode(&socket, DAEMON_SOCKET_MODE);
+    }
     eprintln!("irlumed: socket ready at {socket}; requests queue while startup finishes");
 
     // The engine is built OFF the startup path, so the socket is not merely
@@ -293,7 +307,24 @@ fn main() {
             // embedding space while it is still the space they were captured under.
             // A later adapter swap/removal then degrades to a clear "re-enroll" for
             // dark unlock instead of silently scoring across embedding spaces.
+            // Skip the whole sweep once it has completed for this embedding
+            // space. Asking a user whether they need a retag costs a TPM unseal,
+            // because the answer is inside the encrypted enrollment, and the TPM
+            // serializes: that startup work collided with the very login it was
+            // delaying, taking a keyring unseal from 2.70s to 18.97s on a
+            // discrete TPM (#249). The marker only skips work; a missing or
+            // stale one just runs the sweep as before.
+            let retag_space = engine.ir_space().to_string();
+            let sweep_needed = !irlume_core::storage::retag_done_for(&retag_space);
+            if !sweep_needed {
+                irlume_common::dlog!(
+                    "startup: IR retag already done for '{retag_space}'; skipping the sweep"
+                );
+            }
             for user in irlume_core::storage::list_users() {
+                if !sweep_needed {
+                    break;
+                }
                 if let Ok(Some(mut enr)) = irlume_core::storage::load(&user) {
                     let n = enr.retag_untagged_ir(engine.ir_space(), engine.ir_dim());
                     if n > 0 {
@@ -324,6 +355,11 @@ fn main() {
                         );
                     }
                 }
+            }
+            // Recorded only after a completed sweep, so an interrupted startup
+            // retries next boot rather than skipping users it never reached.
+            if sweep_needed {
+                irlume_core::storage::mark_retag_done(&retag_space);
             }
 
             // SO_PEERCRED is the authorization boundary, and the socket mode must not
@@ -1148,6 +1184,50 @@ fn refusal_throttled(uid: u32) -> bool {
 /// reaches the camera worker is a parsed, authorized-shaped request, which is
 /// what lets an authentication overtake a queue of preview work: before this,
 /// a request nobody had read yet was invisible to the daemon.
+/// The listening socket systemd passed us, if we were socket-activated.
+///
+/// Implements the sd_listen_fds protocol directly rather than pulling in
+/// libsystemd: `LISTEN_PID` must name this process (so an fd inherited by a
+/// child is not mistaken for ours) and `LISTEN_FDS` counts descriptors starting
+/// at 3. We ask for exactly one, because the unit lists exactly one
+/// `ListenStream=`.
+fn inherited_listener() -> Option<UnixListener> {
+    use std::os::fd::FromRawFd;
+    const SD_LISTEN_FDS_START: i32 = 3;
+    if !socket_activated() {
+        return None;
+    }
+    let n: i32 = std::env::var("LISTEN_FDS").ok()?.parse().ok()?;
+    if n != 1 {
+        eprintln!("irlumed: LISTEN_FDS={n}, expected exactly 1; binding our own socket instead");
+        return None;
+    }
+    // The environment must not outlive this: a child that inherits it would
+    // believe the descriptors are its own.
+    SOCKET_ACTIVATED.store(true, std::sync::atomic::Ordering::Relaxed);
+    std::env::remove_var("LISTEN_FDS");
+    std::env::remove_var("LISTEN_PID");
+    // SAFETY: systemd guarantees fd 3 is an open listening socket when
+    // LISTEN_PID names us and LISTEN_FDS is 1, and nothing else in this process
+    // has taken it: this runs before any other socket is opened.
+    Some(unsafe { UnixListener::from_raw_fd(SD_LISTEN_FDS_START) })
+}
+
+/// Whether systemd handed us the socket. Checked separately from taking the fd
+/// because the socket's MODE is systemd's business in that case, and that
+/// question outlives the one call that consumes the descriptor.
+fn socket_activated() -> bool {
+    std::env::var("LISTEN_PID")
+        .ok()
+        .and_then(|p| p.parse::<u32>().ok())
+        == Some(std::process::id())
+        || SOCKET_ACTIVATED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Latched at the moment the descriptor is taken, because `inherited_listener`
+/// clears `LISTEN_PID` and later callers would otherwise see "not activated".
+static SOCKET_ACTIVATED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 /// Release the TPM-sealed login password after another factor has authenticated.
 ///
 /// Free-standing, and deliberately takes no engine: nothing here touches the

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -129,330 +129,357 @@ fn main() {
     set_mode(&socket, DAEMON_SOCKET_MODE);
     eprintln!("irlumed: socket ready at {socket}; requests queue while startup finishes");
 
-    eprintln!("irlumed: loading models (det={det}, model={model})…");
-    verify_models(&models_to_verify([&det, &model, &mesh, &blaze], &adapter));
-    // Auto-select the camera pair: explicit IRLUME_RGB_DEVICE/IR_DEVICE, else a
-    // discovered Hello camera (built-in or external Brio/NexiGo), else defaults.
-    let (rgb_dev, ir_dev) = irlume_auth::select_pair();
-    // Log what is actually usable, not the raw (possibly fallback) selection;
-    // on camera-less or RGB-only hardware the fixed default pair doesn't exist.
-    {
-        let ok = |d: &str| std::path::Path::new(d).exists();
-        match (ok(&rgb_dev), ok(&ir_dev)) {
-            (true, true) => eprintln!("irlumed: cameras rgb={rgb_dev} ir={ir_dev} (secure tier)"),
-            (true, false) => eprintln!(
-                "irlumed: camera rgb={rgb_dev}, no IR node (convenience tier: screen unlock only)"
-            ),
-            (false, _) => eprintln!(
-                "irlumed: no camera found (face auth unavailable; password/fingerprint only)"
-            ),
-        }
-    }
-    // Re-apply the KNOWN emitter control at startup. The emitter is camera
-    // hardware state that resets on a USB/power cycle or a daemon restart, so
-    // without this the first auth after a restart gets a dark IR frame (the
-    // "worked at enroll, failed at the lock screen" case).
+    // The engine is built OFF the startup path, so the socket is not merely
+    // bound early but SERVED early.
     //
-    // This used to fall through to a blind search when IR came back dark, which
-    // is what destroyed a reporter's camera in #159. A daemon start is not
-    // consent to write guessed values to camera firmware, and darkness does not
-    // even imply the emitter is the problem: an unlit room or an empty chair
-    // produces exactly the same measurement. Discovery now happens only when
-    // someone runs `irlume ir-setup` and accepts the warning.
-    if std::path::Path::new(&ir_dev).exists() {
-        match irlume_auth::apply_known_ir_emitter(&ir_dev) {
-            Ok(true) => eprintln!("irlumed: IR emitter ready"),
-            Ok(false) => eprintln!(
-                "irlumed: IR is dark (dark-mode unlock may be unavailable). If this camera needs an \
-                 emitter control irlume does not know, run `sudo irlume ir-setup`."
-            ),
-            Err(e) => eprintln!("irlumed: IR emitter check skipped: {e}"),
-        }
-    }
-    // Opt-in third-party PAD cue (`irlume models`): enabled via settings.conf,
-    // weights fetched by the CLI to the state dir. Unlike the shipped models'
-    // warn-first verification, a third-party file MUST match its catalog pin:
-    // on any mismatch the cue is skipped (the built-in gate alone is the safe
-    // default), never trusted. Env override for sandboxes.
-    let tp_pad: Option<(String, f32, String)> = std::env::var("IRLUME_THIRDPARTY_PAD")
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .or_else(|| {
-            irlume_common::config::read_kv("settings.conf", irlume_common::thirdparty::SETTINGS_KEY)
-        })
-        .and_then(|name| {
-            let Some(entry) = irlume_common::thirdparty::by_name(name.trim()) else {
-                eprintln!("irlumed: WARNING: third_party_pad='{name}' is not in the catalog; ignoring");
-                return None;
-            };
-            let path = irlume_common::thirdparty::model_path(entry);
-            let bytes = match std::fs::read(&path) {
-                Ok(b) => b,
-                Err(e) => {
-                    eprintln!(
-                        "irlumed: WARNING: third-party PAD '{name}' enabled but {} unreadable ({e}); cue disabled (run `sudo irlume models enable {name}` to re-fetch)",
-                        path.display()
-                    );
-                    return None;
-                }
-            };
-            let digest = irlume_common::thirdparty::sha256_hex(&bytes);
-            if digest != entry.sha256 {
-                eprintln!(
-                    "irlumed: WARNING: third-party PAD '{name}' checksum mismatch (sha256 {digest}); cue DISABLED, refusing to load unpinned weights"
-                );
-                return None;
-            }
-            Some((
-                path.to_string_lossy().into_owned(),
-                entry.threshold,
-                entry.name.to_string(),
-            ))
-        });
-    // Engine factory: (re)loads the models and rebinds devices/adapters. Used
-    // once at startup and again by the camera worker to rebuild the engine after
-    // a caught panic, so a fresh request never runs against ONNX sessions left in
-    // an unproven state by an unwind. It owns its inputs so it can move to the
-    // worker thread, and it is Fn, so startup calls it before that move.
-    let build_engine = move || {
-        irlume_auth::Engine::load(&det, &model)
-            .map(|e| e.with_devices(&rgb_dev, &ir_dev))
-            .and_then(|e| e.with_ir_adapter(&adapter))
-            .and_then(|e| e.with_mesh(&mesh))
-            .and_then(|e| e.with_blaze_rescue(&blaze))
-            .and_then(|e| match &tp_pad {
-                Some((path, thr, name)) => e.with_thirdparty_pad(path, *thr, name),
-                None => Ok(e),
-            })
-    };
-    // Bits are published before the socket binds (bind happens after the
-    // models load), so no connection can observe the default EngineBits.
-    let mut engine = match build_engine() {
-        Ok(e) => {
-            eprintln!(
-                "irlumed: IR adapter {}",
-                if e.has_ir_adapter() {
-                    "loaded"
-                } else {
-                    "absent (raw IR)"
-                }
-            );
-            eprintln!(
-                "irlumed: FaceMesh (passive liveness) {}",
-                if e.has_mesh() { "loaded" } else { "absent" }
-            );
-            eprintln!(
-                "irlumed: BlazeFace rescue detector {}",
-                if e.has_blaze_rescue() {
-                    "loaded"
-                } else {
-                    "absent"
-                }
-            );
-            match e.thirdparty_pad_name() {
-                Some(n) => eprintln!(
-                    "irlumed: third-party PAD cue '{n}' loaded (deny-only; disable with `sudo irlume models disable`)"
-                ),
-                // A gap worth naming at every start: the built-in gate accepts
-                // a life-size print of the enrolled face (docs/PAD_SELFTEST.md),
-                // and this cue is the only measured defence against one.
-                None => eprintln!(
-                    "irlumed: third-party PAD cue: none. The built-in gate does NOT stop a \
-                     life-size print of your face; `sudo irlume models enable flir` adds the \
-                     cue that does"
-                ),
-            }
-            e
-        }
-        Err(e) => {
-            eprintln!("irlumed: failed to load models: {e}");
-            std::process::exit(1);
-        }
-    };
-    publish_engine_bits(&engine);
-
-    // One-time inoculation: stamp legacy (untagged) IR scans with the current
-    // embedding space while it is still the space they were captured under.
-    // A later adapter swap/removal then degrades to a clear "re-enroll" for
-    // dark unlock instead of silently scoring across embedding spaces.
-    for user in irlume_core::storage::list_users() {
-        if let Ok(Some(mut enr)) = irlume_core::storage::load(&user) {
-            let n = enr.retag_untagged_ir(engine.ir_space(), engine.ir_dim());
-            if n > 0 {
-                match irlume_core::storage::save(&enr) {
-                    Ok(()) => eprintln!(
-                        "irlumed: tagged {n} legacy IR scan(s) for '{user}' as '{}'",
-                        engine.ir_space()
-                    ),
-                    Err(e) => eprintln!("irlumed: could not retag IR scans for '{user}': {e}"),
-                }
-            }
-            // Upgrade notice: IR scans enrolled under a now-absent adapter (e.g.
-            // 0.1.x -> 0.2.0, where the research-only IR adapter was removed) are
-            // in a foreign embedding space and cannot match. Bright-light RGB
-            // login still works; dark/dim login needs a re-enroll. Surfaced here
-            // (journal, and `irlume logs`) because the daemon restarts on upgrade.
-            // Only an OUTAGE gets the notice: once the user re-enrolls, the fresh
-            // usable scans coexist with the stale ones (whose RGB templates still
-            // help), and nagging them to re-run the remedy they already ran is
-            // noise on every restart.
-            let stale = enr.stale_ir_scans(engine.ir_space());
-            if stale > 0 && enr.usable_ir_scans(engine.ir_space()) == 0 {
-                eprintln!(
-                    "irlumed: NOTE for '{user}': {stale} IR template(s) were enrolled under a \
-                     removed IR adapter and no longer match. Bright-light face login still works; \
-                     run `irlume enroll` to capture fresh scans into your existing profile and \
-                     restore dark/dim login."
-                );
-            }
-        }
-    }
-
-    // SO_PEERCRED is the authorization boundary, and the socket mode must not
-    // pretend to be a second one.
-    //
-    // This was `0660 root:irlume` whenever an `irlume` group existed. That gate
-    // blocked every client it was supposed to admit. The group is created by
-    // packaging with no members, and nothing adds any: the KDE lock screen runs
-    // `kscreenlocker_greet` (not setuid) as the user, so its `pam_irlume.so`
-    // got `connect() = EACCES` and face unlock silently fell through to the
-    // password. `irlume detect` exited 10 (partial) as a user and 0 (ready) as
-    // root on the same healthy box. A gate that stops every intended non-root
-    // client is not defence in depth.
-    //
-    // Membership cannot fix it either: supplementary GIDs are process
-    // credentials set at login, so adding a uid to the group does not reach an
-    // already-running desktop (see newgrp(1)).
-    //
-    // Note what the affected surface actually is, because it is not the login
-    // greeters. SDDM authenticates in `sddm-helper`, GDM in
-    // `gdm-session-worker`, LightDM in `lightdm --session-child`, and greetd in
-    // its session worker; all four keep uid 0 through `pam_authenticate` and
-    // drop privileges only when starting the session, so a dedicated `sddm` or
-    // `gdm` account never reached this socket in the first place. The surfaces
-    // that broke are the ones where the user's own process drives PAM: the KDE
-    // lock screen, and the CLI.
-    //
-    // 0666 plus connect-time peer credentials is the ordinary Linux pattern for
-    // this: it is systemd's own documented default for filesystem sockets
-    // (`SocketMode=` in systemd.socket(5)), pcscd ships the same, and the D-Bus
-    // system bus is world-connectable with authorization done in the service.
-    // `SO_PEERCRED` is supplied by the kernel at connect() time and a client
-    // cannot forge it through protocol input (unix(7)). fprintd, the closest
-    // analogue, likewise keeps its endpoint reachable and authorizes per method.
-    //
-    // What this widens is reachability, not authority: every request still
-    // requires peer uid 0 or `target == peer`, root-only operations stay
-    // root-only, requests are bounded to MAX_REQUEST_BYTES with read/write
-    // deadlines, each connection is isolated behind catch_unwind, and camera
-    // work carries a per-uid throttle. On Fedora the SELinux module remains the
-    // mandatory-access layer.
-    eprintln!("irlumed: serving on {socket} (0666; SO_PEERCRED authorizes every request)");
-    if irlume_common::dbglog::on() {
-        eprintln!("irlumed: diagnostic tracing ON (IRLUME_LOG=debug): per-stage pipeline lines follow; numbers only, never frames/embeddings");
-    }
-
-    // Socket watchdog: if our socket file is deleted/replaced out from under us
-    // (a stale-runtime cleanup, a botched reinstall), the bound fd keeps working
-    // but no client can ever connect again: a silent outage. Detect it and exit
-    // so systemd (Restart=on-failure) re-binds a fresh socket. Self-heals what
-    // the Repair tab otherwise needs a manual restart for.
-    {
-        let socket = socket.clone();
-        std::thread::spawn(move || loop {
-            std::thread::sleep(std::time::Duration::from_secs(3));
-            if !std::path::Path::new(&socket).exists() {
-                eprintln!("irlumed: socket {socket} vanished; exiting for a clean re-bind");
-                std::process::exit(1);
-            }
-        });
-    }
-
-    // One worker owns the engine, and every camera operation happens on it, so
-    // nothing changes about V4L2 and ONNX being driven from a single thread.
-    // What changed is that connections are read elsewhere, which is the only way
-    // an authentication can overtake work already queued: a request nobody has
-    // read yet cannot be prioritised.
+    // Loading models and walking every enrollment costs seconds (21 from exec to
+    // serving on a ThinkPad X13), and a greeter authenticating inside that window
+    // used to find nobody listening at all (#244). Doing it here lets `main` fall
+    // straight through to the accept loop below, so early connections are read
+    // and answered rather than piling up in the kernel backlog: keyring release
+    // needs no engine and is served, everything else is told the daemon is
+    // starting and falls through to the password.
+    let engine_ready = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
-    let worker = {
+    {
         let arbiter = std::sync::Arc::clone(&arbiter);
+        let engine_ready = std::sync::Arc::clone(&engine_ready);
         std::thread::Builder::new()
-            .name("irlume-camera".into())
+            .name("irlume-startup".into())
             .spawn(move || {
-                // The engine asks this between whole captures, so a long
-                // enrolment yields the camera to an authentication instead of
-                // making it wait for ten scans.
-                let token = arbiter.cancel_token();
-                // The engine polls this between whole captures, which makes it
-                // the one place that distinguishes a long-but-healthy job from a
-                // capture stuck inside a driver call. The watchdog (#141) reads
-                // the same signal, so both agree on what "still working" means.
-                engine.set_stop_signal(std::sync::Arc::new(move || {
-                    note_worker_progress();
-                    token.stop_requested()
-                }));
-                while let Some(job) = arbiter.take() {
-                    note_worker_progress();
-                    let Queued { req, peer, reply } = job.payload;
-                    // Isolate each request behind catch_unwind. A panic deep in
-                    // frame decode or inference (e.g. a V4L2 driver echoing back
-                    // a 0-dimension or short-buffered frame) must deny THIS one
-                    // request and let PAM fall back to the password, never
-                    // unwind out of the worker and take down all face auth for
-                    // every user.
-                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        dispatch(req, &peer, &mut engine)
-                    }));
-                    // Release the slot before anything else can fail, so a
-                    // panicking request cannot lock its uid out of the camera
-                    // until the daemon restarts.
-                    arbiter.finish(job.class, job.uid);
-                    let resp = match outcome {
-                        Ok(resp) => resp,
-                        Err(_) => {
+            eprintln!("irlumed: loading models (det={det}, model={model})…");
+            verify_models(&models_to_verify([&det, &model, &mesh, &blaze], &adapter));
+            // Auto-select the camera pair: explicit IRLUME_RGB_DEVICE/IR_DEVICE, else a
+            // discovered Hello camera (built-in or external Brio/NexiGo), else defaults.
+            let (rgb_dev, ir_dev) = irlume_auth::select_pair();
+            // Log what is actually usable, not the raw (possibly fallback) selection;
+            // on camera-less or RGB-only hardware the fixed default pair doesn't exist.
+            {
+                let ok = |d: &str| std::path::Path::new(d).exists();
+                match (ok(&rgb_dev), ok(&ir_dev)) {
+                    (true, true) => eprintln!("irlumed: cameras rgb={rgb_dev} ir={ir_dev} (secure tier)"),
+                    (true, false) => eprintln!(
+                        "irlumed: camera rgb={rgb_dev}, no IR node (convenience tier: screen unlock only)"
+                    ),
+                    (false, _) => eprintln!(
+                        "irlumed: no camera found (face auth unavailable; password/fingerprint only)"
+                    ),
+                }
+            }
+            // Re-apply the KNOWN emitter control at startup. The emitter is camera
+            // hardware state that resets on a USB/power cycle or a daemon restart, so
+            // without this the first auth after a restart gets a dark IR frame (the
+            // "worked at enroll, failed at the lock screen" case).
+            //
+            // This used to fall through to a blind search when IR came back dark, which
+            // is what destroyed a reporter's camera in #159. A daemon start is not
+            // consent to write guessed values to camera firmware, and darkness does not
+            // even imply the emitter is the problem: an unlit room or an empty chair
+            // produces exactly the same measurement. Discovery now happens only when
+            // someone runs `irlume ir-setup` and accepts the warning.
+            if std::path::Path::new(&ir_dev).exists() {
+                match irlume_auth::apply_known_ir_emitter(&ir_dev) {
+                    Ok(true) => eprintln!("irlumed: IR emitter ready"),
+                    Ok(false) => eprintln!(
+                        "irlumed: IR is dark (dark-mode unlock may be unavailable). If this camera needs an \
+                         emitter control irlume does not know, run `sudo irlume ir-setup`."
+                    ),
+                    Err(e) => eprintln!("irlumed: IR emitter check skipped: {e}"),
+                }
+            }
+            // Opt-in third-party PAD cue (`irlume models`): enabled via settings.conf,
+            // weights fetched by the CLI to the state dir. Unlike the shipped models'
+            // warn-first verification, a third-party file MUST match its catalog pin:
+            // on any mismatch the cue is skipped (the built-in gate alone is the safe
+            // default), never trusted. Env override for sandboxes.
+            let tp_pad: Option<(String, f32, String)> = std::env::var("IRLUME_THIRDPARTY_PAD")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| {
+                    irlume_common::config::read_kv("settings.conf", irlume_common::thirdparty::SETTINGS_KEY)
+                })
+                .and_then(|name| {
+                    let Some(entry) = irlume_common::thirdparty::by_name(name.trim()) else {
+                        eprintln!("irlumed: WARNING: third_party_pad='{name}' is not in the catalog; ignoring");
+                        return None;
+                    };
+                    let path = irlume_common::thirdparty::model_path(entry);
+                    let bytes = match std::fs::read(&path) {
+                        Ok(b) => b,
+                        Err(e) => {
                             eprintln!(
-                                "irlumed: request handler PANICKED; this request was denied \
-                                 (PAM falls back to the password). Rebuilding the engine for a \
-                                 clean state; please report this with the backtrace above."
+                                "irlumed: WARNING: third-party PAD '{name}' enabled but {} unreadable ({e}); cue disabled (run `sudo irlume models enable {name}` to re-fetch)",
+                                path.display()
                             );
-                            // AssertUnwindSafe only silences the compiler, it
-                            // does not prove the ONNX sessions are in a
-                            // supported state after an unwind, so a fresh engine
-                            // removes that doubt. Chosen over exiting and
-                            // letting systemd restart because a reproducible
-                            // panic would become a restart loop that takes the
-                            // login path down entirely. If the rebuild fails,
-                            // the old engine is kept: still better than a dead
-                            // daemon.
-                            match build_engine() {
-                                Ok(fresh) => {
-                                    engine = fresh;
-                                    publish_engine_bits(&engine);
-                                    eprintln!("irlumed: engine rebuilt after panic");
-                                }
-                                Err(e) => eprintln!(
-                                    "irlumed: engine rebuild after panic FAILED ({e}); continuing \
-                                     with the existing engine"
-                                ),
-                            }
-                            Response::Error("request failed".into())
+                            return None;
                         }
                     };
-                    // The client may already be gone; its thread owns that.
-                    let _ = reply.send(resp);
-                    // Back to waiting for work: idle is healthy, and leaving the
-                    // last job's timestamp behind would read as a wedge (#141).
-                    note_worker_idle();
+                    let digest = irlume_common::thirdparty::sha256_hex(&bytes);
+                    if digest != entry.sha256 {
+                        eprintln!(
+                            "irlumed: WARNING: third-party PAD '{name}' checksum mismatch (sha256 {digest}); cue DISABLED, refusing to load unpinned weights"
+                        );
+                        return None;
+                    }
+                    Some((
+                        path.to_string_lossy().into_owned(),
+                        entry.threshold,
+                        entry.name.to_string(),
+                    ))
+                });
+            // Engine factory: (re)loads the models and rebinds devices/adapters. Used
+            // once at startup and again by the camera worker to rebuild the engine after
+            // a caught panic, so a fresh request never runs against ONNX sessions left in
+            // an unproven state by an unwind. It owns its inputs so it can move to the
+            // worker thread, and it is Fn, so startup calls it before that move.
+            let build_engine = move || {
+                irlume_auth::Engine::load(&det, &model)
+                    .map(|e| e.with_devices(&rgb_dev, &ir_dev))
+                    .and_then(|e| e.with_ir_adapter(&adapter))
+                    .and_then(|e| e.with_mesh(&mesh))
+                    .and_then(|e| e.with_blaze_rescue(&blaze))
+                    .and_then(|e| match &tp_pad {
+                        Some((path, thr, name)) => e.with_thirdparty_pad(path, *thr, name),
+                        None => Ok(e),
+                    })
+            };
+            // Bits are published before the socket binds (bind happens after the
+            // models load), so no connection can observe the default EngineBits.
+            let mut engine = match build_engine() {
+                Ok(e) => {
+                    eprintln!(
+                        "irlumed: IR adapter {}",
+                        if e.has_ir_adapter() {
+                            "loaded"
+                        } else {
+                            "absent (raw IR)"
+                        }
+                    );
+                    eprintln!(
+                        "irlumed: FaceMesh (passive liveness) {}",
+                        if e.has_mesh() { "loaded" } else { "absent" }
+                    );
+                    eprintln!(
+                        "irlumed: BlazeFace rescue detector {}",
+                        if e.has_blaze_rescue() {
+                            "loaded"
+                        } else {
+                            "absent"
+                        }
+                    );
+                    match e.thirdparty_pad_name() {
+                        Some(n) => eprintln!(
+                            "irlumed: third-party PAD cue '{n}' loaded (deny-only; disable with `sudo irlume models disable`)"
+                        ),
+                        // A gap worth naming at every start: the built-in gate accepts
+                        // a life-size print of the enrolled face (docs/PAD_SELFTEST.md),
+                        // and this cue is the only measured defence against one.
+                        None => eprintln!(
+                            "irlumed: third-party PAD cue: none. The built-in gate does NOT stop a \
+                             life-size print of your face; `sudo irlume models enable flir` adds the \
+                             cue that does"
+                        ),
+                    }
+                    e
                 }
+                Err(e) => {
+                    eprintln!("irlumed: failed to load models: {e}");
+                    std::process::exit(1);
+                }
+            };
+            publish_engine_bits(&engine);
+
+            // One-time inoculation: stamp legacy (untagged) IR scans with the current
+            // embedding space while it is still the space they were captured under.
+            // A later adapter swap/removal then degrades to a clear "re-enroll" for
+            // dark unlock instead of silently scoring across embedding spaces.
+            for user in irlume_core::storage::list_users() {
+                if let Ok(Some(mut enr)) = irlume_core::storage::load(&user) {
+                    let n = enr.retag_untagged_ir(engine.ir_space(), engine.ir_dim());
+                    if n > 0 {
+                        match irlume_core::storage::save(&enr) {
+                            Ok(()) => eprintln!(
+                                "irlumed: tagged {n} legacy IR scan(s) for '{user}' as '{}'",
+                                engine.ir_space()
+                            ),
+                            Err(e) => eprintln!("irlumed: could not retag IR scans for '{user}': {e}"),
+                        }
+                    }
+                    // Upgrade notice: IR scans enrolled under a now-absent adapter (e.g.
+                    // 0.1.x -> 0.2.0, where the research-only IR adapter was removed) are
+                    // in a foreign embedding space and cannot match. Bright-light RGB
+                    // login still works; dark/dim login needs a re-enroll. Surfaced here
+                    // (journal, and `irlume logs`) because the daemon restarts on upgrade.
+                    // Only an OUTAGE gets the notice: once the user re-enrolls, the fresh
+                    // usable scans coexist with the stale ones (whose RGB templates still
+                    // help), and nagging them to re-run the remedy they already ran is
+                    // noise on every restart.
+                    let stale = enr.stale_ir_scans(engine.ir_space());
+                    if stale > 0 && enr.usable_ir_scans(engine.ir_space()) == 0 {
+                        eprintln!(
+                            "irlumed: NOTE for '{user}': {stale} IR template(s) were enrolled under a \
+                             removed IR adapter and no longer match. Bright-light face login still works; \
+                             run `irlume enroll` to capture fresh scans into your existing profile and \
+                             restore dark/dim login."
+                        );
+                    }
+                }
+            }
+
+            // SO_PEERCRED is the authorization boundary, and the socket mode must not
+            // pretend to be a second one.
+            //
+            // This was `0660 root:irlume` whenever an `irlume` group existed. That gate
+            // blocked every client it was supposed to admit. The group is created by
+            // packaging with no members, and nothing adds any: the KDE lock screen runs
+            // `kscreenlocker_greet` (not setuid) as the user, so its `pam_irlume.so`
+            // got `connect() = EACCES` and face unlock silently fell through to the
+            // password. `irlume detect` exited 10 (partial) as a user and 0 (ready) as
+            // root on the same healthy box. A gate that stops every intended non-root
+            // client is not defence in depth.
+            //
+            // Membership cannot fix it either: supplementary GIDs are process
+            // credentials set at login, so adding a uid to the group does not reach an
+            // already-running desktop (see newgrp(1)).
+            //
+            // Note what the affected surface actually is, because it is not the login
+            // greeters. SDDM authenticates in `sddm-helper`, GDM in
+            // `gdm-session-worker`, LightDM in `lightdm --session-child`, and greetd in
+            // its session worker; all four keep uid 0 through `pam_authenticate` and
+            // drop privileges only when starting the session, so a dedicated `sddm` or
+            // `gdm` account never reached this socket in the first place. The surfaces
+            // that broke are the ones where the user's own process drives PAM: the KDE
+            // lock screen, and the CLI.
+            //
+            // 0666 plus connect-time peer credentials is the ordinary Linux pattern for
+            // this: it is systemd's own documented default for filesystem sockets
+            // (`SocketMode=` in systemd.socket(5)), pcscd ships the same, and the D-Bus
+            // system bus is world-connectable with authorization done in the service.
+            // `SO_PEERCRED` is supplied by the kernel at connect() time and a client
+            // cannot forge it through protocol input (unix(7)). fprintd, the closest
+            // analogue, likewise keeps its endpoint reachable and authorizes per method.
+            //
+            // What this widens is reachability, not authority: every request still
+            // requires peer uid 0 or `target == peer`, root-only operations stay
+            // root-only, requests are bounded to MAX_REQUEST_BYTES with read/write
+            // deadlines, each connection is isolated behind catch_unwind, and camera
+            // work carries a per-uid throttle. On Fedora the SELinux module remains the
+            // mandatory-access layer.
+            eprintln!("irlumed: serving on {socket} (0666; SO_PEERCRED authorizes every request)");
+            if irlume_common::dbglog::on() {
+                eprintln!("irlumed: diagnostic tracing ON (IRLUME_LOG=debug): per-stage pipeline lines follow; numbers only, never frames/embeddings");
+            }
+
+            // Socket watchdog: if our socket file is deleted/replaced out from under us
+            // (a stale-runtime cleanup, a botched reinstall), the bound fd keeps working
+            // but no client can ever connect again: a silent outage. Detect it and exit
+            // so systemd (Restart=on-failure) re-binds a fresh socket. Self-heals what
+            // the Repair tab otherwise needs a manual restart for.
+            {
+                let socket = socket.clone();
+                std::thread::spawn(move || loop {
+                    std::thread::sleep(std::time::Duration::from_secs(3));
+                    if !std::path::Path::new(&socket).exists() {
+                        eprintln!("irlumed: socket {socket} vanished; exiting for a clean re-bind");
+                        std::process::exit(1);
+                    }
+                });
+            }
+
+            // One worker owns the engine, and every camera operation happens on it, so
+            // nothing changes about V4L2 and ONNX being driven from a single thread.
+            // What changed is that connections are read elsewhere, which is the only way
+            // an authentication can overtake work already queued: a request nobody has
+            // read yet cannot be prioritised.
+            let _worker = {
+                let arbiter = std::sync::Arc::clone(&arbiter);
+                std::thread::Builder::new()
+                    .name("irlume-camera".into())
+                    .spawn(move || {
+                        // The engine asks this between whole captures, so a long
+                        // enrolment yields the camera to an authentication instead of
+                        // making it wait for ten scans.
+                        let token = arbiter.cancel_token();
+                        // The engine polls this between whole captures, which makes it
+                        // the one place that distinguishes a long-but-healthy job from a
+                        // capture stuck inside a driver call. The watchdog (#141) reads
+                        // the same signal, so both agree on what "still working" means.
+                        engine.set_stop_signal(std::sync::Arc::new(move || {
+                            note_worker_progress();
+                            token.stop_requested()
+                        }));
+                        while let Some(job) = arbiter.take() {
+                            note_worker_progress();
+                            let Queued { req, peer, reply } = job.payload;
+                            // Isolate each request behind catch_unwind. A panic deep in
+                            // frame decode or inference (e.g. a V4L2 driver echoing back
+                            // a 0-dimension or short-buffered frame) must deny THIS one
+                            // request and let PAM fall back to the password, never
+                            // unwind out of the worker and take down all face auth for
+                            // every user.
+                            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                dispatch(req, &peer, &mut engine)
+                            }));
+                            // Release the slot before anything else can fail, so a
+                            // panicking request cannot lock its uid out of the camera
+                            // until the daemon restarts.
+                            arbiter.finish(job.class, job.uid);
+                            let resp = match outcome {
+                                Ok(resp) => resp,
+                                Err(_) => {
+                                    eprintln!(
+                                        "irlumed: request handler PANICKED; this request was denied \
+                                         (PAM falls back to the password). Rebuilding the engine for a \
+                                         clean state; please report this with the backtrace above."
+                                    );
+                                    // AssertUnwindSafe only silences the compiler, it
+                                    // does not prove the ONNX sessions are in a
+                                    // supported state after an unwind, so a fresh engine
+                                    // removes that doubt. Chosen over exiting and
+                                    // letting systemd restart because a reproducible
+                                    // panic would become a restart loop that takes the
+                                    // login path down entirely. If the rebuild fails,
+                                    // the old engine is kept: still better than a dead
+                                    // daemon.
+                                    match build_engine() {
+                                        Ok(fresh) => {
+                                            engine = fresh;
+                                            publish_engine_bits(&engine);
+                                            eprintln!("irlumed: engine rebuilt after panic");
+                                        }
+                                        Err(e) => eprintln!(
+                                            "irlumed: engine rebuild after panic FAILED ({e}); continuing \
+                                             with the existing engine"
+                                        ),
+                                    }
+                                    Response::Error("request failed".into())
+                                }
+                            };
+                            // The client may already be gone; its thread owns that.
+                            let _ = reply.send(resp);
+                            // Back to waiting for work: idle is healthy, and leaving the
+                            // last job's timestamp behind would read as a wedge (#141).
+                            note_worker_idle();
+                        }
+                    })
+                    .unwrap_or_else(|e| {
+                        // Without the worker nothing can be served, and a daemon that
+                        // accepts connections it can never answer is worse than one that
+                        // exits and lets systemd restart it.
+                        eprintln!("irlumed: could not start the camera worker: {e}");
+                        std::process::exit(1);
+                    })
+            };
+                // Published LAST: until this flips, `serve` answers from the
+                // engine-free path. Release pairs with the Acquire load there,
+                // so a thread that sees `true` also sees the worker it needs.
+                engine_ready.store(true, std::sync::atomic::Ordering::Release);
             })
             .unwrap_or_else(|e| {
-                // Without the worker nothing can be served, and a daemon that
-                // accepts connections it can never answer is worse than one that
-                // exits and lets systemd restart it.
-                eprintln!("irlumed: could not start the camera worker: {e}");
+                eprintln!("irlumed: could not start the startup thread: {e}");
                 std::process::exit(1);
-            })
-    };
+            });
+    }
 
     // A cap on connection threads, so a peer that opens sockets faster than it
     // sends requests cannot exhaust memory. Well above any real client: the
@@ -525,6 +552,7 @@ fn main() {
                     continue;
                 }
                 let arbiter = std::sync::Arc::clone(&arbiter);
+                let engine_ready = std::sync::Arc::clone(&engine_ready);
                 // A connection thread reads, parses and writes; it never touches
                 // the engine, so a panic in it is contained by the thread itself
                 // and the queued job (if any) is still completed and released by
@@ -532,7 +560,7 @@ fn main() {
                 if let Err(e) = std::thread::Builder::new()
                     .name("irlume-conn".into())
                     .spawn(move || {
-                        if let Err(e) = serve(stream, &arbiter) {
+                        if let Err(e) = serve(stream, &arbiter, &engine_ready) {
                             eprintln!("irlumed: connection error: {e}");
                         }
                         live.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
@@ -546,7 +574,7 @@ fn main() {
         }
     }
     arbiter.close();
-    let _ = worker.join();
+    // The accept loop above only ends if the listener dies; nothing to join.
 }
 
 // ---------------------------------------------------------------------------
@@ -1120,7 +1148,92 @@ fn refusal_throttled(uid: u32) -> bool {
 /// reaches the camera worker is a parsed, authorized-shaped request, which is
 /// what lets an authentication overtake a queue of preview work: before this,
 /// a request nobody had read yet was invisible to the daemon.
-fn serve(stream: UnixStream, arbiter: &arbiter::Arbiter<Queued>) -> std::io::Result<()> {
+/// Release the TPM-sealed login password after another factor has authenticated.
+///
+/// Free-standing, and deliberately takes no engine: nothing here touches the
+/// camera, the models or the matcher, only `irlume_core::keyring` and the peer's
+/// credentials. That is what lets the daemon answer it while the engine is still
+/// loading (#244). Every authorization check below is a property of the REQUEST,
+/// never of startup state, so answering early cannot weaken any of them.
+fn unseal_keyring(user: &str, service: Option<&str>, peer: &Peer) -> Response {
+    let user = user.to_string();
+    let service = service.map(str::to_string);
+
+    // Fingerprint keyring unlock. pam_fprintd has ALREADY authenticated
+    // the user in this PAM transaction (pam_irlume `keyring` only runs at
+    // the post-auth landing). The daemon can't re-verify a fingerprint
+    // (fprintd owns the sensor), so the trust is: root peer + a login /
+    // unlock service class. Releases the sealed login password so
+    // pam_gnome_keyring can open the wallet, matching Windows Hello's
+    // functional model. SECURITY (ADR-0003 / THREAT_MODEL): preserves
+    // at-rest protection (a stolen disk still can't unseal; it needs the
+    // live TPM), but a live root attacker in a login context can obtain
+    // it; root stays the trust boundary. For daemon-verified biometric
+    // release resistant to live root, use the face/IR path.
+    if peer.uid != 0 {
+        return Response::Error(format!(
+            "unseal_keyring requires root (peer uid {})",
+            peer.uid
+        ));
+    }
+    if !irlume_core::keyring::has_sealed_password(&user) {
+        return Response::Error(format!(
+            "no sealed password for '{user}': run `irlume keyring arm`"
+        ));
+    }
+    // Only a login / greeter / lock-screen context; never sudo,
+    // elevation, remote, or unknown. Defence-in-depth: a direct caller
+    // can forge the service string (root can call us directly), so this
+    // does not stop a root attacker; it does stop the keyring line being
+    // (mis)wired into a non-login stack from releasing the credential.
+    {
+        use irlume_core::biopolicy::{classify, OperationClass, SessionState};
+        let class = classify(service.as_deref().unwrap_or(""), SessionState::Warm);
+        if !matches!(class, OperationClass::ScreenUnlock | OperationClass::Login) {
+            eprintln!(
+                "irlumed: UnsealKeyring refused for service '{}' ({class:?})",
+                service.as_deref().unwrap_or("?")
+            );
+            return Response::Error(format!("keyring unseal not allowed for {class:?}"));
+        }
+    }
+    match irlume_core::keyring::unseal_password(&user) {
+        Ok(secret) => {
+            eprintln!("irlumed: UnsealKeyring: OK for '{user}' (fingerprint-authenticated), password unsealed");
+            Response::PasswordUnsealed {
+                secret: irlume_common::SecretBytes::new(secret.to_vec()),
+            }
+        }
+        Err(e) => {
+            eprintln!("irlumed: UnsealKeyring: TPM unseal FAILED for '{user}': {e}");
+            Response::Error(e.to_string())
+        }
+    }
+}
+
+/// What the daemon can answer before its engine exists.
+///
+/// Keyring release touches `irlume_core::keyring` and the peer's credentials and
+/// nothing else, so it is served here: that is the difference between a
+/// fingerprint login after a reboot unlocking the keyring and meeting a password
+/// prompt (#244). Every other request is REFUSED rather than queued, so a face
+/// attempt falls through to the password at once instead of waiting out startup,
+/// and no early caller occupies a slot for the length of it.
+fn dispatch_before_engine(req: Request, peer: &Peer) -> Response {
+    match req {
+        Request::UnsealKeyring { user, service } => unseal_keyring(&user, service.as_deref(), peer),
+        Request::Ping => Response::Ok("starting".into()),
+        _ => Response::Error(
+            "irlumed is still starting (loading models); retry, or use your password".into(),
+        ),
+    }
+}
+
+fn serve(
+    stream: UnixStream,
+    arbiter: &arbiter::Arbiter<Queued>,
+    engine_ready: &std::sync::atomic::AtomicBool,
+) -> std::io::Result<()> {
     let peer = peer_cred(&stream)?;
     stream.set_read_timeout(Some(std::time::Duration::from_secs(15)))?;
     stream.set_write_timeout(Some(std::time::Duration::from_secs(15)))?;
@@ -1128,6 +1241,10 @@ fn serve(stream: UnixStream, arbiter: &arbiter::Arbiter<Queued>) -> std::io::Res
         ReadOutcome::Closed => Ok(()),
         ReadOutcome::Bad => respond(stream, &Response::Error("bad request".into())),
         ReadOutcome::Req(req) => {
+            // No engine yet means no worker to queue for.
+            if !engine_ready.load(std::sync::atomic::Ordering::Acquire) {
+                return respond(stream, &dispatch_before_engine(req, &peer));
+            }
             let class = arbiter::classify(&req);
             // Status is answered HERE, on the connection's own thread: it is
             // read-only, engine-free, and possibly slow (ListProfiles is a
@@ -2058,58 +2175,7 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             }
             do_unseal_password(&user, service.as_deref(), engine)
         }
-        Request::UnsealKeyring { user, service } => {
-            // Fingerprint keyring unlock. pam_fprintd has ALREADY authenticated
-            // the user in this PAM transaction (pam_irlume `keyring` only runs at
-            // the post-auth landing). The daemon can't re-verify a fingerprint
-            // (fprintd owns the sensor), so the trust is: root peer + a login /
-            // unlock service class. Releases the sealed login password so
-            // pam_gnome_keyring can open the wallet, matching Windows Hello's
-            // functional model. SECURITY (ADR-0003 / THREAT_MODEL): preserves
-            // at-rest protection (a stolen disk still can't unseal; it needs the
-            // live TPM), but a live root attacker in a login context can obtain
-            // it; root stays the trust boundary. For daemon-verified biometric
-            // release resistant to live root, use the face/IR path.
-            if peer.uid != 0 {
-                return Response::Error(format!(
-                    "unseal_keyring requires root (peer uid {})",
-                    peer.uid
-                ));
-            }
-            if !irlume_core::keyring::has_sealed_password(&user) {
-                return Response::Error(format!(
-                    "no sealed password for '{user}': run `irlume keyring arm`"
-                ));
-            }
-            // Only a login / greeter / lock-screen context; never sudo,
-            // elevation, remote, or unknown. Defence-in-depth: a direct caller
-            // can forge the service string (root can call us directly), so this
-            // does not stop a root attacker; it does stop the keyring line being
-            // (mis)wired into a non-login stack from releasing the credential.
-            {
-                use irlume_core::biopolicy::{classify, OperationClass, SessionState};
-                let class = classify(service.as_deref().unwrap_or(""), SessionState::Warm);
-                if !matches!(class, OperationClass::ScreenUnlock | OperationClass::Login) {
-                    eprintln!(
-                        "irlumed: UnsealKeyring refused for service '{}' ({class:?})",
-                        service.as_deref().unwrap_or("?")
-                    );
-                    return Response::Error(format!("keyring unseal not allowed for {class:?}"));
-                }
-            }
-            match irlume_core::keyring::unseal_password(&user) {
-                Ok(secret) => {
-                    eprintln!("irlumed: UnsealKeyring: OK for '{user}' (fingerprint-authenticated), password unsealed");
-                    Response::PasswordUnsealed {
-                        secret: irlume_common::SecretBytes::new(secret.to_vec()),
-                    }
-                }
-                Err(e) => {
-                    eprintln!("irlumed: UnsealKeyring: TPM unseal FAILED for '{user}': {e}");
-                    Response::Error(e.to_string())
-                }
-            }
-        }
+        Request::UnsealKeyring { user, service } => unseal_keyring(&user, service.as_deref(), peer),
         Request::ForgetPassword { user } => {
             if !authorized_for(peer, &user) {
                 return Response::Error(format!("not authorized to forget password for '{user}'"));
@@ -3099,6 +3165,45 @@ mod tests {
         env_lock()
     }
 
+    /// While the engine loads, a request that needs it is REFUSED, not queued.
+    ///
+    /// Queueing would make a greeter's face attempt wait out model loading (14.26s
+    /// measured on a ThinkPad X13) instead of falling through to the password, and
+    /// an early caller would hold a slot for the length of startup. The refusal has
+    /// to name the cause, because it reaches the user through PAM (#244).
+    #[test]
+    fn a_request_needing_the_engine_is_refused_while_it_loads() {
+        use std::io::{BufRead, BufReader, Write};
+        let me = std::env::var("USER").unwrap_or_else(|_| "root".into());
+        let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        ours.set_read_timeout(Some(std::time::Duration::from_secs(10)))
+            .unwrap();
+        (&ours)
+            .write_all(
+                format!("{{\"ListProfiles\":{{\"user\":\"{me}\",\"structured_errors\":false}}}}\n")
+                    .as_bytes(),
+            )
+            .unwrap();
+        let a = std::sync::Arc::clone(&arbiter);
+        // The engine has NOT been published yet: exactly the startup window.
+        let ready = std::sync::atomic::AtomicBool::new(false);
+        std::thread::spawn(move || serve(theirs, &a, &ready).unwrap());
+
+        let mut line = String::new();
+        BufReader::new(&ours)
+            .read_line(&mut line)
+            .expect("a refusal within the deadline, not a wait for the engine");
+        let resp: Response = serde_json::from_str(line.trim()).unwrap();
+        match resp {
+            Response::Error(e) => assert!(
+                e.contains("still starting"),
+                "the refusal must say why, it reaches the user through PAM: {e}"
+            ),
+            other => panic!("a request needing the engine must be refused, got {other:?}"),
+        }
+    }
+
     /// A Status request the connection thread CANNOT answer from memory must
     /// reach the worker, not be answered with an error.
     ///
@@ -3151,7 +3256,9 @@ mod tests {
             )
             .unwrap();
         let a = std::sync::Arc::clone(&arbiter);
-        std::thread::spawn(move || serve(theirs, &a).unwrap());
+        // These cover the SERVING daemon; the not-ready path has its own test.
+        let ready = std::sync::atomic::AtomicBool::new(true);
+        std::thread::spawn(move || serve(theirs, &a, &ready).unwrap());
 
         let mut line = String::new();
         BufReader::new(&ours)
@@ -3192,7 +3299,9 @@ mod tests {
         let (ours, theirs) = UnixStream::pair().unwrap();
         (&ours).write_all(b"\"Ping\"\n").unwrap();
         let a = std::sync::Arc::clone(&arbiter);
-        std::thread::spawn(move || serve(theirs, &a).unwrap());
+        // These cover the SERVING daemon; the not-ready path has its own test.
+        let ready = std::sync::atomic::AtomicBool::new(true);
+        std::thread::spawn(move || serve(theirs, &a, &ready).unwrap());
 
         let mut line = String::new();
         BufReader::new(&ours).read_line(&mut line).unwrap();
@@ -3255,7 +3364,9 @@ mod tests {
                 .unwrap();
             (&ours).write_all(wire.as_bytes()).unwrap();
             let a = std::sync::Arc::clone(&arbiter);
-            std::thread::spawn(move || serve(theirs, &a).unwrap());
+            // These cover the SERVING daemon; the not-ready path has its own test.
+            let ready = std::sync::atomic::AtomicBool::new(true);
+            std::thread::spawn(move || serve(theirs, &a, &ready).unwrap());
             let mut line = String::new();
             BufReader::new(&ours)
                 .read_line(&mut line)
@@ -3501,7 +3612,9 @@ mod tests {
             .write_all(b"{\"PositionSample\":{\"user\":null}}\n")
             .unwrap();
         let a = std::sync::Arc::clone(&arbiter);
-        std::thread::spawn(move || serve(theirs, &a).unwrap());
+        // These cover the SERVING daemon; the not-ready path has its own test.
+        let ready = std::sync::atomic::AtomicBool::new(true);
+        std::thread::spawn(move || serve(theirs, &a, &ready).unwrap());
 
         let mut line = String::new();
         BufReader::new(&ours).read_line(&mut line).unwrap();

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -102,6 +102,33 @@ fn main() {
     );
     let socket = std::env::var("IRLUME_SOCKET").unwrap_or_else(|_| SOCKET_PATH.into());
 
+    // BIND BEFORE THE SLOW WORK. Startup loads models and then walks every
+    // enrollment to retag legacy IR scans, which touches the TPM per user;
+    // measured 21 seconds from exec to listening on a ThinkPad X13 (#244).
+    // With the bind at the end of that, the socket does not exist while the
+    // greeter is already authenticating, so `connect()` fails and a fingerprint
+    // login's keyring release never happens: pam_irlume's `keyring` line is
+    // `optional` and swallows the failure by design, so the login proceeds and
+    // the user meets a keyring prompt later, with nothing in any log.
+    //
+    // Binding here makes the socket exist within milliseconds of exec. A client
+    // that connects during startup is queued by the kernel and served when the
+    // accept loop starts, inside the client's 25s request timeout, instead of
+    // being told nobody is listening.
+    let _ = std::fs::remove_file(&socket);
+    let listener = match UnixListener::bind(&socket) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("irlumed: cannot bind {socket}: {e}");
+            std::process::exit(1);
+        }
+    };
+    // The mode goes on with the bind, not at the accept loop: a socket that
+    // exists but is 0600 refuses exactly the non-root clients this early bind
+    // exists to admit. The reasoning for 0666 is at the accept loop below.
+    set_mode(&socket, DAEMON_SOCKET_MODE);
+    eprintln!("irlumed: socket ready at {socket}; requests queue while startup finishes");
+
     eprintln!("irlumed: loading models (det={det}, model={model})…");
     verify_models(&models_to_verify([&det, &model, &mesh, &blaze], &adapter));
     // Auto-select the camera pair: explicit IRLUME_RGB_DEVICE/IR_DEVICE, else a
@@ -281,14 +308,6 @@ fn main() {
         }
     }
 
-    let _ = std::fs::remove_file(&socket);
-    let listener = match UnixListener::bind(&socket) {
-        Ok(l) => l,
-        Err(e) => {
-            eprintln!("irlumed: cannot bind {socket}: {e}");
-            std::process::exit(1);
-        }
-    };
     // SO_PEERCRED is the authorization boundary, and the socket mode must not
     // pretend to be a second one.
     //
@@ -328,8 +347,7 @@ fn main() {
     // deadlines, each connection is isolated behind catch_unwind, and camera
     // work carries a per-uid throttle. On Fedora the SELinux module remains the
     // mandatory-access layer.
-    set_mode(&socket, DAEMON_SOCKET_MODE);
-    eprintln!("irlumed: listening on {socket} (0666; SO_PEERCRED authorizes every request)");
+    eprintln!("irlumed: serving on {socket} (0666; SO_PEERCRED authorizes every request)");
     if irlume_common::dbglog::on() {
         eprintln!("irlumed: diagnostic tracing ON (IRLUME_LOG=debug): per-stage pipeline lines follow; numbers only, never frames/embeddings");
     }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -326,11 +326,23 @@ fn main() {
                     "startup: IR retag already done for '{retag_space}'; skipping the sweep"
                 );
             }
+            // A user whose load or save failed has NOT been swept, and marking
+            // the space done would retire the migration for them permanently:
+            // the marker is only written when every user was actually handled.
+            let mut all_swept = true;
             for user in irlume_core::storage::list_users() {
                 if !sweep_needed {
                     break;
                 }
-                if let Ok(Some(mut enr)) = irlume_core::storage::load(&user) {
+                let loaded = irlume_core::storage::load(&user);
+                if let Err(ref e) = loaded {
+                    eprintln!(
+                        "irlumed: could not read '{user}' during the IR retag sweep ({e}); \
+                         leaving the sweep owed"
+                    );
+                    all_swept = false;
+                }
+                if let Ok(Some(mut enr)) = loaded {
                     let n = enr.retag_untagged_ir(engine.ir_space(), engine.ir_dim());
                     if n > 0 {
                         match irlume_core::storage::save(&enr) {
@@ -338,7 +350,12 @@ fn main() {
                                 "irlumed: tagged {n} legacy IR scan(s) for '{user}' as '{}'",
                                 engine.ir_space()
                             ),
-                            Err(e) => eprintln!("irlumed: could not retag IR scans for '{user}': {e}"),
+                            Err(e) => {
+                                eprintln!(
+                                    "irlumed: could not retag IR scans for '{user}': {e}"
+                                );
+                                all_swept = false;
+                            }
                         }
                     }
                     // Upgrade notice: IR scans enrolled under a now-absent adapter (e.g.
@@ -361,10 +378,16 @@ fn main() {
                     }
                 }
             }
-            // Recorded only after a completed sweep, so an interrupted startup
-            // retries next boot rather than skipping users it never reached.
-            if sweep_needed {
+            // Recorded only after a sweep that actually reached every user, so a
+            // TPM error or an unwritable enrollment leaves the migration owed
+            // instead of silently retiring it for that user.
+            if sweep_needed && all_swept {
                 irlume_core::storage::mark_retag_done(&retag_space);
+            } else if sweep_needed {
+                eprintln!(
+                    "irlumed: the IR retag sweep did not complete for every user; \
+                     it will run again next start"
+                );
             }
 
             // SO_PEERCRED is the authorization boundary, and the socket mode must not

--- a/crates/irlume-daemon/tests/shutdown.rs
+++ b/crates/irlume-daemon/tests/shutdown.rs
@@ -118,3 +118,81 @@ fn daemon_exits_promptly_on_sigterm() {
     }
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// The socket must exist before the daemon has finished starting up, not after.
+///
+/// Startup loads models and then walks every enrollment, touching the TPM per
+/// user; measured 11 seconds from exec to the old bind on a ThinkPad X13. With
+/// the bind at the end of that, a greeter authenticating during the window gets
+/// `connect()` refused, and a fingerprint login's keyring release never happens.
+/// `pam_irlume`'s `keyring` line is `optional` and swallows the failure by
+/// design, so the user meets a keyring prompt later with nothing in any log
+/// (#244).
+///
+/// The test asserts the ORDER: the socket is connectable well before the daemon
+/// answers its first request. A regression that moves the bind back after the
+/// slow work makes those two times converge, and this fails.
+#[test]
+fn the_socket_is_connectable_before_startup_finishes() {
+    let models = models_dir();
+    let det = models.join("face_detection_yunet_2023mar.onnx");
+    let model = models.join("glintr100.onnx");
+    let Some(ort) = ort_dylib() else {
+        eprintln!("SKIP: no libonnxruntime found");
+        return;
+    };
+    if !det.exists() || !model.exists() {
+        eprintln!("SKIP: models not present (bash scripts/fetch-models.sh)");
+        return;
+    }
+
+    let dir = std::env::temp_dir().join(format!("irlumed-early-bind-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let socket = dir.join("irlumed.sock");
+
+    let started = Instant::now();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_irlumed"))
+        .env("IRLUME_SOCKET", &socket)
+        .env("IRLUME_DET_MODEL", &det)
+        .env("IRLUME_MODEL", &model)
+        .env("IRLUME_MESH_MODEL", models.join("face_landmark.onnx"))
+        .env(
+            "IRLUME_BLAZE_MODEL",
+            models.join("blaze_face_short_range.onnx"),
+        )
+        .env("ORT_DYLIB_PATH", &ort)
+        .env("IRLUME_RGB_DEVICE", "/nonexistent-rgb")
+        .env("IRLUME_IR_DEVICE", "/nonexistent-ir")
+        .spawn()
+        .expect("spawn irlumed");
+
+    // When did a connection first succeed?
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut connectable = None;
+    while Instant::now() < deadline {
+        if let Ok(Some(status)) = child.try_wait() {
+            let _ = std::fs::remove_dir_all(&dir);
+            panic!("daemon exited during startup: {status}");
+        }
+        if std::os::unix::net::UnixStream::connect(&socket).is_ok() {
+            connectable = Some(started.elapsed());
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let verdict = connectable.map(|d| d.as_secs_f32());
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let secs = verdict.expect("daemon never became connectable within 30s");
+    // Model loading alone is over a second on every machine measured, so a bind
+    // that still happens after it cannot land this early. Generous enough not to
+    // flake on a loaded CI runner.
+    assert!(
+        secs < 1.0,
+        "the socket took {secs:.2}s to accept a connection, so it is being bound after \
+         startup work again; clients that connect during startup will be refused (#244)"
+    );
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -195,6 +195,23 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
+    # systemd owns the socket, so it exists from sockets.target onward rather
+    # than only once irlumed has finished loading models. Greeters authenticate
+    # well before that, and a PAM client with nothing to connect to loses the
+    # keyring release silently (#244). The service still starts at boot, so the
+    # first login does not pay for model loading.
+    systemd.sockets.irlumed = {
+      description = "irlume face authentication socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = "/run/irlume.sock";
+        # SO_PEERCRED is the authorization boundary; see the daemon's bind site
+        # for why the mode is not a second one.
+        SocketMode = "0666";
+        Accept = false;
+      };
+    };
+
     systemd.services.irlumed = {
       description = "irlume face authentication daemon";
       documentation = [ "https://github.com/archledger/irlume" ];

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -55,6 +55,7 @@ package() {
         install -Dm0644 "models/$m.onnx" "$pkgdir/usr/share/irlume/models/$m.onnx"
     done
     install -Dm0644 packaging/systemd/irlumed.service "$pkgdir/usr/lib/systemd/system/irlumed.service"
+    install -Dm0644 packaging/systemd/irlumed.socket "$pkgdir/usr/lib/systemd/system/irlumed.socket"
     # Self-heal: re-applies irlume's greeter PAM lines if a distro update strips
     # them. No-op until `irlume login enable` writes its marker.
     install -Dm0644 packaging/systemd/irlume-reconcile.path "$pkgdir/usr/lib/systemd/system/irlume-reconcile.path"

--- a/packaging/arch/irlume.install
+++ b/packaging/arch/irlume.install
@@ -6,7 +6,9 @@ post_install() {
     if command -v apparmor_parser >/dev/null 2>&1; then
         apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
     fi
-    systemctl enable --now irlumed.service 2>/dev/null || true
+    # The socket first: it is what makes /run/irlume.sock exist before the
+    # greeter authenticates (#244).
+    systemctl enable --now irlumed.socket irlumed.service 2>/dev/null || true
     # Watches greeter PAM files and re-applies irlume wiring after a distro
     # update strips it; idle until `irlume login enable` runs. The .service also
     # runs at boot to catch an offline strip and to adopt an existing wiring on
@@ -31,6 +33,11 @@ post_upgrade() {
     systemctl daemon-reload
     if command -v apparmor_parser >/dev/null 2>&1; then
         apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
+    fi
+    # Upgrading from a version without the socket unit: enable it, but only
+    # if the admin has not deliberately disabled the service.
+    if systemctl is-enabled --quiet irlumed.service 2>/dev/null; then
+        systemctl enable --now irlumed.socket 2>/dev/null || true
     fi
     systemctl try-restart irlumed.service 2>/dev/null || true
     # Ensure the self-heal units are enabled and run one reconcile: adopts an
@@ -58,7 +65,7 @@ EOF
 }
 
 pre_remove() {
-    systemctl disable --now irlumed.service 2>/dev/null || true
+    systemctl disable --now irlumed.socket irlumed.service 2>/dev/null || true
     systemctl disable --now irlume-reconcile.path 2>/dev/null || true
     systemctl disable --now irlume-reconcile.timer 2>/dev/null || true
     systemctl disable --now irlume-reconcile.service 2>/dev/null || true

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -58,6 +58,8 @@ contents:
   # systemd unit + an override pointing ORT at the bundled lib
   - src: ../systemd/irlumed.service
     dst: /usr/lib/systemd/system/irlumed.service
+  - src: ../systemd/irlumed.socket
+    dst: /usr/lib/systemd/system/irlumed.socket
   - src: ../../.deb-staging/10-ort.conf
     dst: /usr/lib/systemd/system/irlumed.service.d/10-ort.conf
   # Self-heal: re-applies irlume's greeter PAM lines if a distro update

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -12,7 +12,8 @@ systemctl daemon-reload 2>/dev/null || true
 # would override a unit the user deliberately disabled; try-restart below picks
 # up the new binary/unit for a running daemon and is a no-op for a stopped one.
 if [ -z "${2:-}" ]; then
-    systemctl enable --now irlumed.service 2>/dev/null || true
+    # The socket first: see packaging/systemd/irlumed.socket (#244).
+    systemctl enable --now irlumed.socket irlumed.service 2>/dev/null || true
     # Watches greeter PAM files and re-applies irlume wiring after a distro
     # update strips it. Self-gates on the login.wired marker, so it stays idle
     # until `irlume login enable` runs.
@@ -33,6 +34,10 @@ if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
     mkdir -p /var/lib/irlume
     systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
     : > /var/lib/irlume/.reconcile-timer-armed
+fi
+# Upgrading from a version without the socket unit.
+if systemctl is-enabled --quiet irlumed.service 2>/dev/null; then
+    systemctl enable --now irlumed.socket 2>/dev/null || true
 fi
 systemctl try-restart irlumed.service 2>/dev/null || true
 cat <<'EOF'

--- a/packaging/debian/preremove.sh
+++ b/packaging/debian/preremove.sh
@@ -5,7 +5,7 @@ set -e
 # postinst re-enable it, churns state and would re-enable a unit the user
 # deliberately disabled. On upgrade, postinst's try-restart handles the swap.
 if [ "$1" = remove ]; then
-    systemctl disable --now irlumed.service 2>/dev/null || true
+    systemctl disable --now irlumed.socket irlumed.service 2>/dev/null || true
     systemctl disable --now irlume-reconcile.path 2>/dev/null || true
     systemctl disable --now irlume-reconcile.timer 2>/dev/null || true
     systemctl disable --now irlume-reconcile.service 2>/dev/null || true

--- a/packaging/fedora/90-irlume.preset
+++ b/packaging/fedora/90-irlume.preset
@@ -1,6 +1,11 @@
 # irlumed serves a local Unix socket only; authentication stays opt-in
 # (irlume login enable), so the daemon being up is safe and makes the
 # first-run TUI work immediately after install.
+# Bound at sockets.target so /run/irlume.sock exists before the greeter
+# authenticates. Installing the unit is not enough: [Install] only describes
+# the symlink `systemctl enable` would create, and %systemd_post consults this
+# preset (#244).
+enable irlumed.socket
 enable irlumed.service
 # Watches greeter PAM files and re-applies irlume wiring after a distro update
 # strips it. Self-gates on the login.wired marker, so it stays idle until

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -100,6 +100,7 @@ install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/%{name}/models/face_detection
 install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/%{name}/models/face_landmark.onnx
 install -Dm0644 %{SOURCE5} %{buildroot}%{_datadir}/%{name}/models/blaze_face_short_range.onnx
 install -Dm0644 packaging/systemd/irlumed.service %{buildroot}%{_unitdir}/irlumed.service
+install -Dm0644 packaging/systemd/irlumed.socket %{buildroot}%{_unitdir}/irlumed.socket
 # Self-heal wiring watcher: re-applies irlume's greeter PAM lines if a distro
 # update strips them (no-op unless `login enable` was run and the lines went
 # missing). Enabled by preset; harmless when login was never wired.
@@ -123,7 +124,7 @@ install -Dm0644 schemas/machine-api-v1.schema.json %{buildroot}%{_datadir}/%{nam
 %post
 # %%systemd_post honours our shipped preset → enables irlumed + the PAM-wiring
 # self-heal path unit on first install.
-%systemd_post irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
+%systemd_post irlumed.socket irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
 # Also start it now so `irlume tui` works immediately after `dnf install`
 # (no-op in chroots/containers where systemd isn't running).
 if [ $1 -eq 1 ]; then
@@ -149,7 +150,7 @@ systemctl start irlume-reconcile.service &>/dev/null || :
 # counts installed packages and cannot tell which version is being replaced.
 
 %preun
-%systemd_preun irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
+%systemd_preun irlumed.socket irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
 
 %postun
 %systemd_postun_with_restart irlumed.service
@@ -200,6 +201,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/%{name}/models/*.onnx
 %{_datadir}/%{name}/onnxruntime/lib/*
 %{_unitdir}/irlumed.service
+%{_unitdir}/irlumed.socket
 %{_unitdir}/irlumed.service.d/10-ort.conf
 %{_unitdir}/irlume-reconcile.path
 %{_unitdir}/irlume-reconcile.service

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -52,6 +52,9 @@ override_dh_auto_install:
 	cp -a ort-prebuilt/lib debian/irlume/opt/irlume/onnxruntime/
 	install -D -m0644 packaging/systemd/irlumed.service \
 		debian/irlume/usr/lib/systemd/system/irlumed.service
+	# Makes /run/irlume.sock exist before the greeter authenticates (#244).
+	install -D -m0644 packaging/systemd/irlumed.socket \
+		debian/irlume/usr/lib/systemd/system/irlumed.socket
 	install -D -m0644 debian/10-ort.conf \
 		debian/irlume/usr/lib/systemd/system/irlumed.service.d/10-ort.conf
 	# Self-heal watcher: re-applies irlume's greeter PAM wiring if pam-auth-update

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -4,6 +4,12 @@ Documentation=https://github.com/archledger/irlume
 After=multi-user.target
 
 [Service]
+# Inherit the listening socket from irlumed.socket rather than binding our own,
+# so it exists from sockets.target onward instead of only once models are
+# loaded (#244). Named explicitly rather than relying on the implicit
+# same-name association, because the fallback when the fd does not arrive is to
+# unlink systemd's socket and bind over it, which is silent and wrong.
+Sockets=irlumed.socket
 Type=simple
 ExecStart=/usr/bin/irlumed
 # Packaged FHS layout (all three families install here). onnxruntime is a

--- a/packaging/systemd/irlumed.socket
+++ b/packaging/systemd/irlumed.socket
@@ -1,0 +1,29 @@
+# The socket exists before the daemon does.
+#
+# irlumed spends seconds loading models and walking enrollments before it could
+# bind /run/irlume.sock itself, and greeters are ordered after basic.target,
+# well before multi-user.target. Measured on a ThinkPad X13: boot at 02:21:52,
+# the greeter authenticated a fingerprint at 02:22:05, the socket appeared at
+# 02:22:13. pam_irlume had nothing to connect to, its keyring line is optional
+# and swallows failures by design, so the login succeeded with the keyring still
+# locked and nothing in any log (#244).
+#
+# With systemd owning the socket, connect() succeeds from the moment
+# sockets.target is reached and the request waits in the backlog instead of
+# being refused. The service is still started at boot rather than purely on
+# demand, so model loading is not paid by the first login that arrives.
+[Unit]
+Description=irlume face authentication socket
+Documentation=https://github.com/archledger/irlume
+
+[Socket]
+ListenStream=/run/irlume.sock
+# SO_PEERCRED is the authorization boundary; the mode must not pretend to be a
+# second one. Matches what the daemon sets when it binds the socket itself, and
+# the reasoning is at that call site in irlume-daemon/src/main.rs.
+SocketMode=0666
+# One daemon serving many connections, not one instance per connection.
+Accept=no
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Closes #244 and #249.

## The bug

`irlumed` bound its own socket, and greeters are ordered after `basic.target` while the service was ordered after `multi-user.target`. On a ThinkPad X13 the greeter authenticated a fingerprint **eight seconds before the socket existed**:

```
02:21:52  boot
02:22:02  irlumed: loading models
02:22:05  gdm-fingerprint authenticates; gnome-keyring-daemon starts
02:22:13  irlumed: listening on /run/irlume.sock      <-- too late
02:22:39  irlumed: UnsealKeyring: OK, password unsealed   <-- nobody left to receive it
```

`pam_irlume.so keyring` had nothing to connect to. That line is `optional` and returns IGNORE on any failure by design, so the login succeeded, **nothing was logged**, and the user met a keyring prompt later from whatever first touched the wallet. Every cold boot had this window and the first login was usually inside it.

## What this changes, and why the three parts are inseparable

**1. systemd owns the socket.** `irlumed.socket` binds `/run/irlume.sock` at `sockets.target`, so a PAM `connect()` lands in the backlog instead of failing. The daemon prefers the inherited descriptor (sd_listen_fds protocol: `LISTEN_PID` must name us, `LISTEN_FDS` must be 1, fd 3) and still binds its own when run directly, so development and any distro without the unit are unaffected.

`Sockets=irlumed.socket` is named **explicitly** rather than relying on the implicit same-name association. That association did not deliver the descriptor here: the daemon fell through to self-binding, which unlinks systemd's socket and binds over it, leaving both systemd and irlumed holding the path. It is silent, and `fuser -v /run/irlume.sock` is how it was caught.

**2. The startup sweep runs once, not every boot.** Asking whether a user needs an IR retag costs a TPM unseal, because the answer lives inside the encrypted enrollment (`EncEnvelope` is `{version, enc}` and nothing else). It ran per user, per boot. The TPM serializes, so that work collided with the login it was delaying. A marker records the embedding space the sweep completed for. It only ever skips work: absent, stale or unreadable means sweep, and nothing security-relevant reads it.

**3. The policy-digest cache is warmed deliberately.** Removing the sweep removed what had been warming the pcrlock branch-digest memo **by accident**, and 8.2s moved onto the first login. This is the "first-login benefit" claim a previous review flagged as unproven and I withdrew; it is now proven, in the opposite direction, by measurement.

`warm_pcrlock_policy_cache()` is explicitly a workaround and says so at the definition. The TCG spec defines these digests as hash recurrences and systemd computes the same values in userspace with zero TPM commands (#248); doing that deletes this function and removes the 8.2s rather than relocating it.

## Measured, ThinkPad X13 (STMicro discrete TPM), cold keyring release

| build | result |
|---|---|
| shipped 0.8.0 | **never happened** after a reboot; keyring prompt |
| naive early bind (first attempt) | 14.26s |
| serve-early, no socket unit | 18.97s (TPM contention with startup) |
| **this branch** | **2.72s, 2.73s** |

`connect()` succeeds in **0.000s with the daemon fully stopped**, and the connection starts it.

## Confirmed on hardware: two reboots and two logouts

Every boot: `using the socket systemd bound` → `serving` → `UnsealKeyring: OK`. Keyring reads `Locked: false`, and the user confirms no prompt when opening a browser. Boot 0 timeline:

```
10:03:15.616  Started fprintd.service
10:03:30.574  irlumed: serving on /run/irlume.sock
10:03:36.995  irlumed: UnsealKeyring: OK for 'fimerlwi', password unsealed
10:03:37.018  gdm-fingerprint: session opened          <-- 23ms later
```

Second login on the same boot: unseal at 10:04:13.105, session at 10:04:13.122, 17ms apart. Retag work performed that boot: **zero**.

## Packaging

The socket unit ships in all four lanes (Fedora spec `%install`/`%files`/`%systemd_post`/`%systemd_preun`, Arch PKGBUILD, Debian nfpm) and as `systemd.sockets.irlumed` in the NixOS module.

## Verification

Workspace suite, clippy, fmt and doc lane green. Tests added: the retag marker's contract (recorded space matches, a different space sweeps again, garbage falls back to sweeping), and a request needing the engine is refused rather than queued while it loads. A previous round's insertion silently stole an existing test's `#[test]` attribute; that is repaired and both tests are confirmed to run.

## Not tested

- **A synthetic test that should not be repeated:** stopping the daemon and connecting measures ~19s, because that forces an on-demand start where the login's own connection triggers the warm-up it then waits for. That is not the boot path; the service still starts from `multi-user.target` and warms before any greeter exists.
- Machines with no pcrlock policy, where `warm_pcrlock_policy_cache` returns immediately.
- Whether socket activation behaves the same on a distro whose greeter is ordered differently; the ordering claim is verified on Fedora/KDE and Ubuntu/GNOME only.
