### PR TITLE
Derive the pcrlock branch digests once, not on every unseal

### DIFF
--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -927,6 +927,7 @@ fn digest_list(digests: &[Digest]) -> Result<DigestList> {
 }
 
 /// A single-value PCR group plus the ordered multi-value PCRs of a super policy.
+#[derive(Clone)]
 struct SuperPcr {
     /// Single-value PCRs, ascending (replayed live as one PolicyPCR at unseal).
     singles: Vec<u32>,
@@ -937,7 +938,58 @@ struct SuperPcr {
 /// Reconstruct systemd's super-PCR policy structure from the prediction, deriving
 /// each multi-value PCR's OR-branch digests via trial replays of the growing
 /// prefix (mirrors `tpm2_calculate_policy_super_pcr`).
+/// Memo for [`build_super_pcr`], keyed on the prediction it was derived from.
+///
+/// Deriving the branch digests costs ONE TRIAL TPM SESSION PER PREDICTED BRANCH,
+/// and the result depends only on the prediction file, never on the request. It
+/// was being recomputed on every unseal: measured 10.88s on a ThinkPad X13
+/// (STMicro discrete TPM, 17 branches) against 0.36s on a Zenbook (firmware TPM,
+/// 4 branches), three runs each within 0.01s. Because `pam_irlume`'s keyring line
+/// runs inside the PAM auth stack, that was 11 seconds of login the user waited
+/// through (#246).
+///
+/// Keyed on the prediction's own content, so `systemd-pcrlock make-policy`
+/// invalidates it by changing the key rather than by anyone remembering to clear
+/// it. In memory only: a persisted cache would need its own argument about what a
+/// tampered entry can do, and this already removes the repeat cost within a
+/// daemon's lifetime.
+static SUPER_PCR_MEMO: std::sync::OnceLock<std::sync::Mutex<Option<(u64, SuperPcr)>>> =
+    std::sync::OnceLock::new();
+
+/// Content key for a prediction: the PCR numbers and their predicted values, in
+/// the order the policy is built from. Hashing the parsed values rather than the
+/// file bytes keeps reformatting from invalidating a still-correct memo.
+fn pcrlock_key(plock: &PcrlockJson) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    let mut entries: Vec<(u32, Vec<String>)> = plock
+        .pcr_values
+        .iter()
+        .map(|e| (e.pcr, e.values.clone()))
+        .collect();
+    entries.sort_by_key(|(pcr, _)| *pcr);
+    entries.hash(&mut h);
+    h.finish()
+}
+
 fn build_super_pcr(ctx: &mut Context, plock: &PcrlockJson) -> Result<SuperPcr> {
+    let key = pcrlock_key(plock);
+    let memo = SUPER_PCR_MEMO.get_or_init(|| std::sync::Mutex::new(None));
+    if let Ok(guard) = memo.lock() {
+        if let Some((cached_key, cached)) = guard.as_ref() {
+            if *cached_key == key {
+                return Ok(cached.clone());
+            }
+        }
+    }
+    let built = build_super_pcr_uncached(ctx, plock)?;
+    if let Ok(mut guard) = memo.lock() {
+        *guard = Some((key, built.clone()));
+    }
+    Ok(built)
+}
+
+fn build_super_pcr_uncached(ctx: &mut Context, plock: &PcrlockJson) -> Result<SuperPcr> {
     let mut entries: Vec<(u32, Vec<[u8; 32]>)> = plock
         .pcr_values
         .iter()

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -953,23 +953,29 @@ struct SuperPcr {
 /// it. In memory only: a persisted cache would need its own argument about what a
 /// tampered entry can do, and this already removes the repeat cost within a
 /// daemon's lifetime.
-static SUPER_PCR_MEMO: std::sync::OnceLock<std::sync::Mutex<Option<(u64, SuperPcr)>>> =
+type PcrlockKey = Vec<(u32, Vec<String>)>;
+
+static SUPER_PCR_MEMO: std::sync::OnceLock<std::sync::Mutex<Option<(PcrlockKey, SuperPcr)>>> =
     std::sync::OnceLock::new();
 
-/// Content key for a prediction: the PCR numbers and their predicted values, in
-/// the order the policy is built from. Hashing the parsed values rather than the
-/// file bytes keeps reformatting from invalidating a still-correct memo.
-fn pcrlock_key(plock: &PcrlockJson) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut h = std::collections::hash_map::DefaultHasher::new();
-    let mut entries: Vec<(u32, Vec<String>)> = plock
+/// Identity of a prediction: its PCR numbers and predicted values, sorted into
+/// the order the policy is built from.
+///
+/// The whole prediction is kept and compared, not a hash of it. A 64-bit digest
+/// would have been smaller and the collision odds absurd, but the failure it
+/// admits is handing back digests derived from a DIFFERENT prediction, and this
+/// sits under credential release. A prediction is a handful of PCRs with a few
+/// hex strings each, so exact comparison costs nothing worth trading for that.
+/// Comparing parsed values rather than file bytes keeps reformatting from
+/// invalidating a still-correct memo.
+fn pcrlock_key(plock: &PcrlockJson) -> PcrlockKey {
+    let mut entries: PcrlockKey = plock
         .pcr_values
         .iter()
         .map(|e| (e.pcr, e.values.clone()))
         .collect();
     entries.sort_by_key(|(pcr, _)| *pcr);
-    entries.hash(&mut h);
-    h.finish()
+    entries
 }
 
 fn build_super_pcr(ctx: &mut Context, plock: &PcrlockJson) -> Result<SuperPcr> {
@@ -977,7 +983,7 @@ fn build_super_pcr(ctx: &mut Context, plock: &PcrlockJson) -> Result<SuperPcr> {
     let memo = SUPER_PCR_MEMO.get_or_init(|| std::sync::Mutex::new(None));
     if let Ok(guard) = memo.lock() {
         if let Some((cached_key, cached)) = guard.as_ref() {
-            if *cached_key == key {
+            if cached_key == &key {
                 return Ok(cached.clone());
             }
         }
@@ -1210,6 +1216,53 @@ pub fn diagnose_pcrs(env: &SealedEnvelope) -> Result<Vec<u32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The memo's identity guard must distinguish predictions that differ in any
+    /// way the policy is built from, and must ignore ordering, which is why it
+    /// sorts. A guard that collided would serve branch digests derived from a
+    /// DIFFERENT prediction, under credential release; that is the reason it
+    /// compares the prediction itself rather than a hash of it.
+    #[test]
+    fn the_memo_key_separates_predictions_that_differ() {
+        let mk = |json: &str| -> PcrlockKey {
+            pcrlock_key(&serde_json::from_str::<PcrlockJson>(json).expect("fixture parses"))
+        };
+        let base = mk(r#"{"pcrBank":"sha256","pcrValues":[
+            {"pcr":7,"values":["aa"]},{"pcr":2,"values":["bb","cc"]}]}"#);
+
+        // Same content, PCRs listed in the other order: the same policy.
+        let reordered = mk(r#"{"pcrBank":"sha256","pcrValues":[
+            {"pcr":2,"values":["bb","cc"]},{"pcr":7,"values":["aa"]}]}"#);
+        assert_eq!(base, reordered, "listing order must not invalidate a memo");
+
+        // A changed predicted value is a different policy.
+        let changed = mk(r#"{"pcrBank":"sha256","pcrValues":[
+            {"pcr":7,"values":["aa"]},{"pcr":2,"values":["bb","dd"]}]}"#);
+        assert_ne!(base, changed, "a changed prediction must miss the memo");
+
+        // An extra branch on the same PCR is a different policy, and it changes
+        // how many trial replays the derivation performs.
+        let extra = mk(r#"{"pcrBank":"sha256","pcrValues":[
+            {"pcr":7,"values":["aa"]},{"pcr":2,"values":["bb","cc","ee"]}]}"#);
+        assert_ne!(base, extra, "an added branch must miss the memo");
+
+        // A different PCR carrying the same values is a different policy.
+        let moved = mk(r#"{"pcrBank":"sha256","pcrValues":[
+            {"pcr":7,"values":["aa"]},{"pcr":3,"values":["bb","cc"]}]}"#);
+        assert_ne!(
+            base, moved,
+            "the same values on another PCR must miss the memo"
+        );
+
+        // Branch ORDER within a PCR is load-bearing: it is the order the OR
+        // branches are derived and replayed in.
+        let swapped = mk(r#"{"pcrBank":"sha256","pcrValues":[
+            {"pcr":7,"values":["aa"]},{"pcr":2,"values":["cc","bb"]}]}"#);
+        assert_ne!(
+            base, swapped,
+            "branch order feeds the derivation, so it counts"
+        );
+    }
 
     #[test]
     fn srk_identity_match_accepts_ours_rejects_foreign() {


### PR DESCRIPTION
Closes #246.

## The bug

`build_super_pcr` derives each predicted PCR branch's policy digest with a trial TPM session, one per branch. The result depends only on `/var/lib/systemd/pcrlock.json`: same prediction, same digests, every time. It was recomputed on every unseal.

`pam_irlume.so keyring` runs inside the PAM auth stack, so that cost is login latency. On a ThinkPad X13 the journal showed 11.5 seconds between `fprintd` starting and the session opening, with the unseal completing 23ms before it. The user's report was "about 9 seconds signing into the DE".

## Why the two machines differ so much

Branch counts read from each machine's own prediction file:

| machine | TPM | PCRs | multi-value branches | per branch |
|---|---|---|---|---|
| ThinkPad X13 Yoga Gen 4 | STMicro, discrete | 8 | **17** | ~0.64s |
| Zenbook S14 | firmware (MSFT0101) | 4 | 4 | ~0.09s |

Four times the branches on a TPM roughly seven times slower per operation accounts for the 30x gap, and it explains the determinism: a fixed number of TPM round-trips rather than variable latency.

## The fix

Memoize the derivation, keyed on the prediction's own content, so `systemd-pcrlock make-policy` invalidates it by changing the key rather than by anyone remembering to clear it.

In memory only. A persisted cache would need its own argument about what a tampered entry can do; my reading is that `policy_authorize_nv` binds the final digest to the NV index, so injected branches would make the unseal FAIL rather than succeed wrongly, but that is reasoning I have not verified and it is not needed to remove the repeat cost.

## Measured

Same-session A/B on the ThinkPad, swapping only the binary, three unseals each:

```
PRE-FIX (packaged 0.8.0):  10.88s  10.89s  10.88s
WITH MEMO:                  2.71s   2.70s   2.72s
```

**8.17 seconds off every unseal on that machine.** Zenbook, same method: 0.36s to 0.20s. On both, every run after the first is identical to the first, because the daemon's own startup work warms the memo, so the first login of a boot benefits too.

## What is left, and it is not this change

2.7 seconds remain on the ThinkPad and are still deterministic, so something else in the unseal path costs a fixed number of TPM round-trips. The candidates are the SRK primary (`with_srk`, and `CreatePrimary` is expensive on slow TPMs) and the live policy replay, which is one `PolicyPCR` plus a `PolicyPCR`/`PolicyOR` pair for each of the seven multi-value PCRs. Worth its own issue and its own measurement rather than a guess folded in here.

## Interaction with #244

These have to ship together. Serving `UnsealKeyring` early fixes the reboot case where the socket does not exist yet, but on this hardware that would have left the login blocked for 11 seconds instead of prompting later. #244 alone trades a locked keyring for a slow one.

## Not tested

- Whether a `systemd-pcrlock make-policy` mid-run correctly invalidates the memo. The key is derived from the prediction content, so it should, but I did not re-run `make-policy` on either machine to watch it happen.
- Machines with a single-value prediction on every PCR, where the loop does no work and the memo is free.
