### PR TITLE
Seal the KDE wallet key instead of the login password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,14 @@ name = "irlume-fingerprint"
 version = "0.8.0"
 
 [[package]]
+name = "irlume-kwallet-init"
+version = "0.8.0"
+dependencies = [
+ "irlume-common",
+ "libc",
+]
+
+[[package]]
 name = "irlume-liveness"
 version = "0.8.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -809,6 +810,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +962,7 @@ dependencies = [
  "base64 0.23.0",
  "irlume-common",
  "irlume-vision",
+ "pbkdf2",
  "rand 0.10.2",
  "rsa",
  "serde",
@@ -1467,6 +1478,16 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/irlume-vision",
     "crates/irlume-liveness",
     "crates/irlume-core",
+    "crates/irlume-kwallet-init",
     "crates/irlume-auth",
     "crates/irlume-fingerprint",
     "crates/irlume-daemon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ sha2       = "0.11"     # PolicyAuthorize digest math (signed-PCR path)
 rsa        = { version = "0.9", features = ["sha2"] }  # parse systemd PCR-signing pubkey
 aes-gcm    = "0.11"     # AES-256-GCM for template-at-rest encryption
 argon2     = "0.5"      # Argon2id KDF for the recovery passphrase
+pbkdf2     = { version = "0.13", default-features = false, features = ["hmac"] }  # PBKDF2-HMAC-SHA512: the KDE wallet key ksecretd expects
 rand       = "0.10"      # CSPRNG for template keys, nonces, recovery salts
 libc       = "0.2"      # mlock/madvise (memlock), NSS getpwnam_r, SO_PEERCRED
 rustfft    = "6"        # 2D FFT for the RGB-only moiré/screen-replay PAD cue

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1328,6 +1328,7 @@ pub fn reseal(args: &[String]) -> ExitCode {
         return ExitCode::from(2);
     };
     let req = Request::SealPassword {
+        kind: None, // let the daemon judge from what the user has
         user,
         password: irlume_common::SecretBytes::new(pw.into_bytes()),
     };
@@ -1425,6 +1426,7 @@ pub fn setup(args: &[String]) -> ExitCode {
     ) {
         if let Some(pw) = prompt_login_password() {
             match daemon_request(&Request::SealPassword {
+                kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
                 password: irlume_common::SecretBytes::new(pw.into_bytes()),
             }) {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -903,6 +903,7 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
                 return std::process::ExitCode::from(2);
             }
             let req = irlume_common::Request::SealPassword {
+                kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
                 password: irlume_common::SecretBytes::new(pw.into_bytes()),
             };

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3302,6 +3302,7 @@ impl App {
                     return;
                 }
                 let req = Request::SealPassword {
+                    kind: None, // let the daemon judge from what the user has
                     user: self.user.clone(),
                     password: irlume_common::SecretBytes::new(buf.as_bytes().to_vec()),
                 };

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1142,7 +1142,7 @@ fn keyring_success_paths_with_a_live_daemon() {
     let sealed = log
         .iter()
         .find_map(|r| match r {
-            Request::SealPassword { user, password } => {
+            Request::SealPassword { user, password, .. } => {
                 Some((user.clone(), password.expose().to_vec()))
             }
             _ => None,

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -1216,3 +1216,36 @@ mod tests {
         }
     }
 }
+
+/// Wire constants for the KDE wallet handoff.
+///
+/// These are shared with software we do not ship (`pam_kwallet5`, `ksecretd`).
+/// They live here rather than in `irlume-core` so the tiny handoff helper can
+/// use them without pulling in the TPM and inference stacks, and so there is a
+/// single definition for both sides to agree on.
+pub mod kwallet_wire {
+    /// Length of the derived key. `KWALLET_PAM_KEYSIZE` in kwallet-pam's
+    /// `pam_kwallet.c`; `PBKDF2_SHA512_KEYSIZE` in kwallet's
+    /// `src/runtime/ksecretd/main.cpp`, whose `waitForHash()` reads exactly
+    /// this many bytes and no more.
+    pub const KEY_LEN: usize = 56;
+
+    /// Length of the salt file. `KWALLET_PAM_SALTSIZE`.
+    pub const SALT_LEN: usize = 56;
+
+    /// PBKDF2 iteration count. `KWALLET_PAM_ITERATIONS`.
+    pub const ITERATIONS: u32 = 50_000;
+
+    /// Basename of the handoff socket inside `XDG_RUNTIME_DIR`.
+    ///
+    /// Deliberately the same name `pam_kwallet5` uses (`socketPrefix` in
+    /// `pam_kwallet.c`), because Plasma's `plasma-kwallet-pam.service` runs
+    /// `env | socat STDIN UNIX-CONNECT:$PAM_KWALLET5_LOGIN` and that is how
+    /// `ksecretd` gets the session environment it blocks waiting for. Using the
+    /// same name and exporting the same variable means Plasma delivers the
+    /// environment to our daemon with no change on its side.
+    pub const SOCKET_NAME: &str = "kwallet5.socket";
+
+    /// The environment variable Plasma's autostart reads.
+    pub const LOGIN_ENV: &str = "PAM_KWALLET5_LOGIN";
+}

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -451,7 +451,20 @@ pub enum Request {
     // --- keyring unlock (TPM-sealed password) -------------------------------
     /// Seal `user`'s login password in the TPM so a later face login can release
     /// it to unlock the GNOME-keyring / KWallet. PRIVILEGED: root or `user`.
-    SealPassword { user: String, password: SecretBytes },
+    SealPassword {
+        user: String,
+        password: SecretBytes,
+        /// What to seal, or `None` to let the daemon decide from what the user
+        /// actually has. `LoginPassword` seals `password` itself; `KdeWalletKey`
+        /// derives the wallet key from it and seals that, leaving the password
+        /// out of the envelope entirely.
+        ///
+        /// `None` is also what an older client sends, and resolving it by
+        /// inspection is the right answer for one: a KDE-only machine gets the
+        /// wallet key without the client having to know to ask.
+        #[serde(default)]
+        kind: Option<KeyringSecretKind>,
+    },
     /// Face-verify `user` and, on a live match, release the TPM-sealed password
     /// so the caller can set it as `PAM_AUTHTOK` (login keyring unlock).
     /// PRIVILEGED: root only; the sealed login password is never released to a
@@ -704,9 +717,14 @@ pub enum Response {
     // --- keyring unlock responses -------------------------------------------
     /// The password was sealed (`SealPassword`).
     PasswordSealed,
-    /// Face matched and the TPM released the password (`UnsealPassword`).
+    /// Face matched and the TPM released the secret (`UnsealPassword` /
+    /// `UnsealKeyring`).
     PasswordUnsealed {
         secret: SecretBytes,
+        /// What `secret` is. Absent from an older daemon's reply, which only
+        /// ever sealed login passwords, so the default is correct for it.
+        #[serde(default)]
+        kind: KeyringSecretKind,
     },
     /// Whether a sealed password exists (`HasSealedPassword`).
     HasPassword(bool),
@@ -1217,6 +1235,24 @@ mod tests {
     }
 }
 
+/// What a released keyring secret actually is, on the wire.
+///
+/// Mirrors `irlume_core::envelope::SecretKind`. It is declared here rather than
+/// shared because irlume-common is the dependency of irlume-core, not the other
+/// way round, and the PAM module needs it without the TPM stack.
+///
+/// The consumer differs by kind: a login password goes into `PAM_AUTHTOK`, a
+/// wallet key goes to `ksecretd` through `irlume-kwallet-init`. Sending it on
+/// the wire means the PAM module never has to guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum KeyringSecretKind {
+    /// The user's Unix login password.
+    #[default]
+    LoginPassword,
+    /// The 56-byte key `ksecretd` opens the KDE wallet with.
+    KdeWalletKey,
+}
+
 /// Wire constants for the KDE wallet handoff.
 ///
 /// These are shared with software we do not ship (`pam_kwallet5`, `ksecretd`).
@@ -1249,3 +1285,11 @@ pub mod kwallet_wire {
     /// The environment variable Plasma's autostart reads.
     pub const LOGIN_ENV: &str = "PAM_KWALLET5_LOGIN";
 }
+
+/// Installed path of the KDE wallet handoff helper.
+///
+/// Under `libexec` rather than `bin`: it is not a command a user runs, it takes
+/// a secret on stdin, and it is only meaningful inside a PAM transaction.
+/// `IRLUME_KWALLET_INIT` overrides it for tests and for distributions that
+/// place libexec elsewhere.
+pub const KWALLET_INIT_PATH: &str = "/usr/libexec/irlume/irlume-kwallet-init";

--- a/crates/irlume-core/Cargo.toml
+++ b/crates/irlume-core/Cargo.toml
@@ -17,4 +17,5 @@ sha2.workspace = true
 rsa.workspace = true
 aes-gcm.workspace = true
 argon2.workspace = true
+pbkdf2.workspace = true
 rand.workspace = true

--- a/crates/irlume-core/examples/derive_wallet_key.rs
+++ b/crates/irlume-core/examples/derive_wallet_key.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Print the KDE wallet key irlume would derive for a home directory.
+//!
+//! Exists so the handoff can be exercised end to end against a real `ksecretd`
+//! using the SAME derivation the daemon seals, rather than a reimplementation
+//! in the test that could agree with itself while both are wrong.
+//!
+//!   derive_wallet_key <home> <password>   # raw key bytes on stdout
+
+fn main() {
+    let mut a = std::env::args().skip(1);
+    let (home, pw) = match (a.next(), a.next()) {
+        (Some(h), Some(p)) => (h, p),
+        _ => {
+            eprintln!("usage: derive_wallet_key <home> <password>");
+            std::process::exit(2);
+        }
+    };
+    match irlume_core::kwallet::derive_for_home(pw.as_bytes(), std::path::Path::new(&home)) {
+        Ok(k) => {
+            use std::io::Write;
+            std::io::stdout().write_all(&k).expect("write key");
+        }
+        Err(e) => {
+            eprintln!("derive: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -77,6 +77,38 @@ impl PolicyKind {
     }
 }
 
+/// What the sealed blob actually is.
+///
+/// The two are released to different consumers and are not interchangeable: a
+/// login password goes into `PAM_AUTHTOK` for `pam_gnome_keyring`, a KDE wallet
+/// key goes to `ksecretd` on its startup pipe and would be meaningless as an
+/// `AUTHTOK`. Recording it means a migrated envelope cannot be handed to the
+/// wrong one, which would surface as an unexplained wallet prompt rather than
+/// as an error.
+///
+/// Envelopes written before #250 have no `secret` field and default to
+/// [`SecretKind::LoginPassword`], which is what they hold.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub enum SecretKind {
+    /// The user's Unix login password.
+    #[default]
+    LoginPassword,
+    /// The 56-byte PBKDF2 key `ksecretd` opens the KDE wallet with. See
+    /// [`crate::kwallet`].
+    KdeWalletKey,
+}
+
+impl SecretKind {
+    /// Human-readable label, shared by `keyring status`, `diag` and the TUI so
+    /// every surface names it the same way.
+    pub fn describe(&self) -> &'static str {
+        match self {
+            SecretKind::LoginPassword => "login password",
+            SecretKind::KdeWalletKey => "KDE wallet key",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PcrValue {
     pub pcr: u32,
@@ -91,6 +123,10 @@ pub struct SealedEnvelope {
     /// defaults to [`PolicyKind::PcrLiteral`].
     #[serde(default)]
     pub policy: PolicyKind,
+    /// What the sealed blob is. Absent in envelopes written before #250 →
+    /// defaults to [`SecretKind::LoginPassword`].
+    #[serde(default)]
+    pub secret: SecretKind,
     /// PCRs replayed via `PolicyPCR` at unseal time.
     pub pcrs: Vec<u32>,
     #[serde(with = "b64")]
@@ -160,6 +196,7 @@ mod tests {
     #[test]
     fn envelope_roundtrips_through_json() {
         let env = SealedEnvelope {
+            secret: SecretKind::LoginPassword,
             version: CURRENT_VERSION,
             policy: PolicyKind::PcrLiteral,
             pcrs: vec![7],
@@ -216,6 +253,7 @@ mod tests {
     fn authorized_variant_serde_roundtrips_and_skips_empty_policy_ref() {
         // Non-empty policy_ref is base64-encoded and survives a round-trip.
         let env = SealedEnvelope {
+            secret: SecretKind::LoginPassword,
             version: CURRENT_VERSION,
             policy: PolicyKind::Authorized {
                 pubkey_pem: "PEM-BODY".into(),
@@ -233,6 +271,7 @@ mod tests {
 
         // Empty policy_ref must be omitted from the JSON and default back to empty.
         let env2 = SealedEnvelope {
+            secret: SecretKind::LoginPassword,
             version: CURRENT_VERSION,
             policy: PolicyKind::Authorized {
                 pubkey_pem: "P".into(),
@@ -268,6 +307,7 @@ mod tests {
         // Nested path forces save() to create the missing parent directory.
         let p = dir.join("sub/sealed.json");
         let env = SealedEnvelope {
+            secret: SecretKind::LoginPassword,
             version: CURRENT_VERSION,
             policy: PolicyKind::PcrlockNv {
                 nv_index: 0x1c00002,

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -104,11 +104,26 @@ pub fn sealed_kind(user: &str) -> Option<SecretKind> {
         .map(|e| e.secret)
 }
 
-/// Release `user`'s sealed password from the TPM. Fails if none is armed or if
-/// the bound PCR policy is no longer satisfied (e.g. Secure Boot config changed);
-/// the caller then falls back to the typed password and the wallet stays
-/// locked until the user re-arms.
-pub fn unseal_password(user: &str) -> Result<Zeroizing<Vec<u8>>> {
+/// A released secret together with what it is.
+pub struct Unsealed {
+    pub secret: Zeroizing<Vec<u8>>,
+    pub kind: SecretKind,
+}
+
+/// Release `user`'s sealed secret from the TPM, and say what it is.
+///
+/// One envelope load produces both. Reading the bytes and then re-reading the
+/// file for its kind is two observations of something a concurrent `keyring
+/// arm` can replace between them, which would tag one envelope's bytes with
+/// another's kind: a 56-byte wallet key routed into `PAM_AUTHTOK`, or a
+/// password sent to the wallet daemon. It also removes the second read's
+/// failure path, which collapsed "could not read the kind" into "login
+/// password" and let an unreadable file authorise the wrong delivery.
+///
+/// Fails if none is armed or if the bound PCR policy is no longer satisfied
+/// (e.g. Secure Boot config changed); the caller then falls back to the typed
+/// password and the wallet stays locked until the user re-arms.
+pub fn unseal_secret(user: &str) -> Result<Unsealed> {
     let path = envelope_path(user);
     if !path.exists() {
         return Err(Error::Policy(format!(
@@ -116,7 +131,19 @@ pub fn unseal_password(user: &str) -> Result<Zeroizing<Vec<u8>>> {
         )));
     }
     let env = SealedEnvelope::load(&path)?;
-    tpm::unseal(&env)
+    let kind = env.secret;
+    Ok(Unsealed {
+        secret: tpm::unseal(&env)?,
+        kind,
+    })
+}
+
+/// Release `user`'s sealed secret, discarding what kind it is.
+///
+/// Only for callers that genuinely do not route on the kind. Anything that
+/// delivers the secret somewhere must use [`unseal_secret`].
+pub fn unseal_password(user: &str) -> Result<Zeroizing<Vec<u8>>> {
+    unseal_secret(user).map(|u| u.secret)
 }
 
 /// Outcome of [`reseal_password`].

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -43,10 +43,15 @@ pub fn seal_password(user: &str, password: &[u8]) -> Result<()> {
 /// has no business knowing what they mean.
 pub fn seal_secret(user: &str, secret: &[u8], kind: SecretKind) -> Result<()> {
     if secret.is_empty() {
-        return Err(Error::Protocol(format!(
-            "refusing to seal an empty {}",
-            kind.describe()
-        )));
+        // Keep the wording the login path has always used; the wallet key gets
+        // its own so the message names what was actually empty.
+        return Err(Error::Protocol(
+            match kind {
+                SecretKind::LoginPassword => "refusing to seal an empty password",
+                SecretKind::KdeWalletKey => "refusing to seal an empty KDE wallet key",
+            }
+            .to_string(),
+        ));
     }
     if kind == SecretKind::KdeWalletKey && secret.len() != crate::kwallet::KEY_LEN {
         // ksecretd reads exactly KEY_LEN bytes off the pipe. Sealing any other
@@ -76,11 +81,19 @@ pub fn seal_secret(user: &str, secret: &[u8], kind: SecretKind) -> Result<()> {
 pub fn derive_secret(
     kind: SecretKind,
     password: &[u8],
-    home: &std::path::Path,
+    home: Option<&std::path::Path>,
 ) -> Result<Zeroizing<Vec<u8>>> {
     match kind {
+        // A login password needs no home, and demanding one would strand any
+        // account NSS cannot resolve a home directory for.
         SecretKind::LoginPassword => Ok(Zeroizing::new(password.to_vec())),
-        SecretKind::KdeWalletKey => crate::kwallet::derive_for_home(password, home),
+        SecretKind::KdeWalletKey => match home {
+            Some(h) => crate::kwallet::derive_for_home(password, h),
+            None => Err(Error::Policy(
+                "a KDE wallet key needs the user's home directory, and none could be resolved"
+                    .into(),
+            )),
+        },
     }
 }
 
@@ -146,7 +159,11 @@ pub enum Reseal {
 /// The "unseal fails" branch is what fixes a dbx/Secure-Boot update: the old
 /// envelope's PCR7 policy no longer satisfies, so we rebind to today's PCRs
 /// using the password the user just proved (via a successful login) they know.
-pub fn reseal_password(user: &str, password: &[u8], home: &std::path::Path) -> Result<Reseal> {
+pub fn reseal_password(
+    user: &str,
+    password: &[u8],
+    home: Option<&std::path::Path>,
+) -> Result<Reseal> {
     if password.is_empty() {
         return Err(Error::Protocol(
             "refusing to reseal an empty password".into(),
@@ -283,7 +300,7 @@ mod tests {
         assert_eq!(
             // A login-password envelope never reads `home`: derive_secret
             // returns the password unchanged.
-            reseal_password("tester", pw, std::path::Path::new("/nonexistent")).unwrap(),
+            reseal_password("tester", pw, None).unwrap(),
             Reseal::Upgraded
         );
         let env = SealedEnvelope::load(&envelope_path("tester")).unwrap();
@@ -330,8 +347,11 @@ mod tests {
         let home = std::path::PathBuf::from("/tmp/irlume-kr-kind-home");
         let _ = std::fs::remove_dir_all(&home);
         std::fs::create_dir_all(crate::kwallet::salt_path(&home).parent().unwrap()).unwrap();
-        std::fs::write(crate::kwallet::salt_path(&home), [0x33u8; crate::kwallet::SALT_LEN])
-            .unwrap();
+        std::fs::write(
+            crate::kwallet::salt_path(&home),
+            [0x33u8; crate::kwallet::SALT_LEN],
+        )
+        .unwrap();
 
         let pw = b"a-login-password";
         let key = crate::kwallet::derive_for_home(pw, &home).expect("derive");
@@ -347,7 +367,7 @@ mod tests {
         assert_eq!(sealed_kind("kindtest"), Some(SecretKind::KdeWalletKey));
 
         // Same password, weaker tier on disk -> the tier-climb rewrite.
-        let first = reseal_password("kindtest", pw, &home).expect("reseal");
+        let first = reseal_password("kindtest", pw, Some(&home)).expect("reseal");
         assert_eq!(
             first,
             Reseal::Upgraded,
@@ -363,7 +383,7 @@ mod tests {
         // A changed password takes the Resealed path, which rebuilds the
         // envelope from scratch.
         assert_eq!(
-            reseal_password("kindtest", b"a-different-password", &home).unwrap(),
+            reseal_password("kindtest", b"a-different-password", Some(&home)).unwrap(),
             Reseal::Resealed
         );
         assert_eq!(
@@ -392,24 +412,22 @@ mod tests {
         let dir = "/tmp/irlume-kr-reseal";
         std::env::set_var("IRLUME_KEYRING_DIR", dir);
         let _ = std::fs::remove_dir_all(dir);
-        // Unused for login-password envelopes; see the note in the tier test.
-        let home = std::path::Path::new("/nonexistent");
 
         // Not armed -> nothing happens.
         assert_eq!(
-            reseal_password("rt", b"whatever", home).unwrap(),
+            reseal_password("rt", b"whatever", None).unwrap(),
             Reseal::NotArmed
         );
 
         seal_password("rt", b"first-password").expect("arm");
         // Same password still unseals under current PCRs -> no rewrite.
         assert_eq!(
-            reseal_password("rt", b"first-password", home).unwrap(),
+            reseal_password("rt", b"first-password", None).unwrap(),
             Reseal::Unchanged
         );
         // Different password (simulates a password change) -> reseal.
         assert_eq!(
-            reseal_password("rt", b"second-password", home).unwrap(),
+            reseal_password("rt", b"second-password", None).unwrap(),
             Reseal::Resealed
         );
         // And it now unseals to the new one.

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -14,7 +14,7 @@
 //! the templates live), so the wrapped login secret is never under user control.
 //! It is TPM-wrapped regardless, but defence in depth.
 
-use crate::envelope::SealedEnvelope;
+use crate::envelope::{SealedEnvelope, SecretKind};
 use crate::tpm;
 use irlume_common::{Error, Result};
 use std::path::PathBuf;
@@ -34,11 +34,61 @@ pub fn envelope_path(user: &str) -> PathBuf {
 /// Seal `password` for `user` so a later face login can release it. Overwrites
 /// any existing sealed password (re-arming, e.g. after a password change).
 pub fn seal_password(user: &str, password: &[u8]) -> Result<()> {
-    if password.is_empty() {
-        return Err(Error::Protocol("refusing to seal an empty password".into()));
+    seal_secret(user, password, SecretKind::LoginPassword)
+}
+
+/// Seal `secret` for `user`, recording what it is.
+///
+/// The kind is stamped here rather than in [`tpm::seal`], which wraps bytes and
+/// has no business knowing what they mean.
+pub fn seal_secret(user: &str, secret: &[u8], kind: SecretKind) -> Result<()> {
+    if secret.is_empty() {
+        return Err(Error::Protocol(format!(
+            "refusing to seal an empty {}",
+            kind.describe()
+        )));
     }
-    let env = tpm::seal(password)?;
+    if kind == SecretKind::KdeWalletKey && secret.len() != crate::kwallet::KEY_LEN {
+        // ksecretd reads exactly KEY_LEN bytes off the pipe. Sealing any other
+        // length produces an envelope that can never open the wallet, and the
+        // failure would not show up until a login.
+        return Err(Error::Protocol(format!(
+            "a KDE wallet key must be exactly {} bytes, got {}",
+            crate::kwallet::KEY_LEN,
+            secret.len()
+        )));
+    }
+    let mut env = tpm::seal(secret)?;
+    env.secret = kind;
     env.save(&envelope_path(user))
+}
+
+/// Derive the secret of `kind` that `user` should have sealed, from their
+/// VERIFIED login password.
+///
+/// For [`SecretKind::KdeWalletKey`] this is PBKDF2 over the wallet salt in
+/// `home`, matching what `pam_kwallet5` computes. Note what that implies after
+/// a password change: the wallet is still keyed to the OLD derived key until
+/// the user re-keys it in KWallet, so deriving from the new password yields a
+/// key that does not open it. That is not a regression we introduce; it is
+/// exactly what `pam_kwallet5` does with the new password, and the user fixes
+/// it the same way, by changing the wallet password.
+pub fn derive_secret(
+    kind: SecretKind,
+    password: &[u8],
+    home: &std::path::Path,
+) -> Result<Zeroizing<Vec<u8>>> {
+    match kind {
+        SecretKind::LoginPassword => Ok(Zeroizing::new(password.to_vec())),
+        SecretKind::KdeWalletKey => crate::kwallet::derive_for_home(password, home),
+    }
+}
+
+/// What kind of secret `user` currently has armed, if any.
+pub fn sealed_kind(user: &str) -> Option<SecretKind> {
+    SealedEnvelope::load(&envelope_path(user))
+        .ok()
+        .map(|e| e.secret)
 }
 
 /// Release `user`'s sealed password from the TPM. Fails if none is armed or if
@@ -96,7 +146,7 @@ pub enum Reseal {
 /// The "unseal fails" branch is what fixes a dbx/Secure-Boot update: the old
 /// envelope's PCR7 policy no longer satisfies, so we rebind to today's PCRs
 /// using the password the user just proved (via a successful login) they know.
-pub fn reseal_password(user: &str, password: &[u8]) -> Result<Reseal> {
+pub fn reseal_password(user: &str, password: &[u8], home: &std::path::Path) -> Result<Reseal> {
     if password.is_empty() {
         return Err(Error::Protocol(
             "refusing to reseal an empty password".into(),
@@ -105,6 +155,24 @@ pub fn reseal_password(user: &str, password: &[u8]) -> Result<Reseal> {
     if !has_sealed_password(user) {
         return Ok(Reseal::NotArmed);
     }
+    // Reseal whatever kind is already armed. Deriving the wrong kind here would
+    // quietly replace a working envelope with one that opens nothing, and the
+    // damage would not show up until the next login.
+    let kind = sealed_kind(user).unwrap_or_default();
+    let secret = match derive_secret(kind, password, home) {
+        Ok(s) => s,
+        // A KDE wallet key cannot be derived without the salt. Leaving the
+        // existing envelope alone is the safe outcome: it may still be valid,
+        // and overwriting it on a machine where the salt has gone missing would
+        // destroy a working arm.
+        Err(e) => {
+            return Err(Error::Policy(format!(
+                "cannot reseal the {} for '{user}': {e}",
+                kind.describe()
+            )))
+        }
+    };
+    let password = secret.as_slice();
     // If the current envelope still unseals to the same secret, there is nothing
     // to reseal for correctness; don't churn the TPM on every single login.
     if let Ok(current) = unseal_password(user) {
@@ -119,7 +187,12 @@ pub fn reseal_password(user: &str, password: &[u8]) -> Result<Reseal> {
             // tier writes nothing.
             if let Ok(env) = SealedEnvelope::load(&envelope_path(user)) {
                 if tpm::stronger_tier_available_than(&env.policy) {
-                    let candidate = tpm::seal(password)?;
+                    let mut candidate = tpm::seal(password)?;
+                    // Carry the kind across the upgrade. tpm::seal defaults it,
+                    // so without this a tier climb would rewrite a wallet-key
+                    // envelope as a login-password one and the next login would
+                    // hand 56 bytes of key to pam_gnome_keyring as an AUTHTOK.
+                    candidate.secret = kind;
                     if candidate.policy.strength_rank() > env.policy.strength_rank() {
                         candidate.save(&envelope_path(user))?;
                         return Ok(Reseal::Upgraded);
@@ -129,7 +202,7 @@ pub fn reseal_password(user: &str, password: &[u8]) -> Result<Reseal> {
             return Ok(Reseal::Unchanged);
         }
     }
-    seal_password(user, password)?;
+    seal_secret(user, password, kind)?;
     Ok(Reseal::Resealed)
 }
 
@@ -207,7 +280,12 @@ mod tests {
             "precondition: sealed at Tier 3 (literal)"
         );
         // A login-time reseal with the same verified password upgrades the tier.
-        assert_eq!(reseal_password("tester", pw).unwrap(), Reseal::Upgraded);
+        assert_eq!(
+            // A login-password envelope never reads `home`: derive_secret
+            // returns the password unchanged.
+            reseal_password("tester", pw, std::path::Path::new("/nonexistent")).unwrap(),
+            Reseal::Upgraded
+        );
         let env = SealedEnvelope::load(&envelope_path("tester")).unwrap();
         assert!(
             matches!(env.policy, PolicyKind::Authorized { .. }),
@@ -216,6 +294,89 @@ mod tests {
         );
         assert_eq!(&*unseal_password("tester").unwrap(), pw, "still unseals");
         forget_password("tester").unwrap();
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
+    #[test]
+    fn a_wallet_key_must_be_exactly_the_length_ksecretd_reads() {
+        // Caught before the TPM is involved, because a wrong-length seal is only
+        // discoverable at a login otherwise: ksecretd blocks on a short key and
+        // truncates a long one, and neither says anything.
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        std::env::set_var("IRLUME_KEYRING_DIR", "/tmp/irlume-kr-len");
+        for bad in [crate::kwallet::KEY_LEN - 1, crate::kwallet::KEY_LEN + 1] {
+            assert!(
+                seal_secret("lentest", &vec![7u8; bad], SecretKind::KdeWalletKey).is_err(),
+                "{bad} bytes was accepted as a wallet key"
+            );
+        }
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
+    /// A wallet-key envelope must stay a wallet-key envelope across every path
+    /// that rewrites it. Both rewrite sites in `reseal_password` build a fresh
+    /// envelope via `tpm::seal`, which defaults the kind, so a missed stamp
+    /// downgrades the envelope to `LoginPassword` and the next login hands 56
+    /// bytes of raw key to `pam_gnome_keyring` as an `AUTHTOK`.
+    #[test]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
+    fn resealing_preserves_the_secret_kind() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = "/tmp/irlume-kr-kind";
+        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let _ = std::fs::remove_dir_all(dir);
+
+        // A home with a real salt, so the wallet key can actually be derived.
+        let home = std::path::PathBuf::from("/tmp/irlume-kr-kind-home");
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(crate::kwallet::salt_path(&home).parent().unwrap()).unwrap();
+        std::fs::write(crate::kwallet::salt_path(&home), [0x33u8; crate::kwallet::SALT_LEN])
+            .unwrap();
+
+        let pw = b"a-login-password";
+        let key = crate::kwallet::derive_for_home(pw, &home).expect("derive");
+
+        // Seed at the WEAKEST tier on purpose. Sealing normally lands on this
+        // machine's best tier, so the reseal returns Unchanged and the tier-climb
+        // rewrite never runs: the assertion below then passes without observing
+        // the path it names. Verified by breaking the stamp, which went unnoticed
+        // until this seeding was added.
+        let mut weak = tpm::seal_with_pcrs(&key, &[7]).expect("seal at Tier 3");
+        weak.secret = SecretKind::KdeWalletKey;
+        weak.save(&envelope_path("kindtest")).expect("arm");
+        assert_eq!(sealed_kind("kindtest"), Some(SecretKind::KdeWalletKey));
+
+        // Same password, weaker tier on disk -> the tier-climb rewrite.
+        let first = reseal_password("kindtest", pw, &home).expect("reseal");
+        assert_eq!(
+            first,
+            Reseal::Upgraded,
+            "expected the tier-climb rewrite; without it this test cannot see \
+             whether that path preserves the kind"
+        );
+        assert_eq!(
+            sealed_kind("kindtest"),
+            Some(SecretKind::KdeWalletKey),
+            "the {first:?} path dropped the secret kind"
+        );
+
+        // A changed password takes the Resealed path, which rebuilds the
+        // envelope from scratch.
+        assert_eq!(
+            reseal_password("kindtest", b"a-different-password", &home).unwrap(),
+            Reseal::Resealed
+        );
+        assert_eq!(
+            sealed_kind("kindtest"),
+            Some(SecretKind::KdeWalletKey),
+            "the Resealed path dropped the secret kind"
+        );
+        // And it holds the key derived from the NEW password, not the password.
+        let expect = crate::kwallet::derive_for_home(b"a-different-password", &home).unwrap();
+        assert_eq!(&*unseal_password("kindtest").unwrap(), &*expect);
+
+        forget_password("kindtest").unwrap();
+        let _ = std::fs::remove_dir_all(&home);
         std::env::remove_var("IRLUME_KEYRING_DIR");
     }
 
@@ -231,22 +392,24 @@ mod tests {
         let dir = "/tmp/irlume-kr-reseal";
         std::env::set_var("IRLUME_KEYRING_DIR", dir);
         let _ = std::fs::remove_dir_all(dir);
+        // Unused for login-password envelopes; see the note in the tier test.
+        let home = std::path::Path::new("/nonexistent");
 
         // Not armed -> nothing happens.
         assert_eq!(
-            reseal_password("rt", b"whatever").unwrap(),
+            reseal_password("rt", b"whatever", home).unwrap(),
             Reseal::NotArmed
         );
 
         seal_password("rt", b"first-password").expect("arm");
         // Same password still unseals under current PCRs -> no rewrite.
         assert_eq!(
-            reseal_password("rt", b"first-password").unwrap(),
+            reseal_password("rt", b"first-password", home).unwrap(),
             Reseal::Unchanged
         );
         // Different password (simulates a password change) -> reseal.
         assert_eq!(
-            reseal_password("rt", b"second-password").unwrap(),
+            reseal_password("rt", b"second-password", home).unwrap(),
             Reseal::Resealed
         );
         // And it now unseals to the new one.

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -29,18 +29,10 @@ use irlume_common::{Error, Result};
 use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
-/// Length of the derived key, in bytes.
-///
-/// `KWALLET_PAM_KEYSIZE` in kwallet-pam's `pam_kwallet.c`, and
-/// `PBKDF2_SHA512_KEYSIZE` in kwallet's `src/runtime/ksecretd/main.cpp`, which
-/// reads exactly this many bytes and no more.
-pub const KEY_LEN: usize = 56;
-
-/// Length of the salt file, in bytes. `KWALLET_PAM_SALTSIZE`.
-pub const SALT_LEN: usize = 56;
-
-/// PBKDF2 iteration count. `KWALLET_PAM_ITERATIONS`.
-pub const ITERATIONS: u32 = 50_000;
+// The wire constants live in irlume-common so the handoff helper can use them
+// without this crate's TPM and inference dependencies, and so both sides of the
+// handoff read one definition.
+pub use irlume_common::kwallet_wire::{ITERATIONS, KEY_LEN, SALT_LEN};
 
 /// Path of the salt `pam_kwallet5` derives against, relative to `$HOME`.
 ///
@@ -169,5 +161,44 @@ mod tests {
 
     fn hex(b: &[u8]) -> String {
         b.iter().map(|x| format!("{x:02x}")).collect()
+    }
+
+    #[test]
+    fn a_missing_salt_is_an_error_rather_than_a_freshly_invented_one() {
+        // pam_kwallet5 creates a missing salt; we must not. No salt means no
+        // wallet, and a key derived against an invented salt opens nothing
+        // while `keyring arm` reports success.
+        let dir = std::env::temp_dir().join(format!("irlume-kwallet-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let err = read_salt(&dir).expect_err("a missing salt must not be invented");
+        assert!(
+            !salt_path(&dir).exists(),
+            "read_salt created {} instead of failing",
+            salt_path(&dir).display()
+        );
+        assert!(
+            format!("{err}").contains("Plasma"),
+            "the error should tell the user how to get a wallet, got: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_salt_file_longer_than_the_derivation_uses_is_truncated_not_hashed_whole() {
+        // pam_kwallet5 reads SALT_LEN bytes and derives over exactly those. If we
+        // hashed a longer file whole we would get a different key from the same
+        // file it used, and the wallet would never open.
+        let dir = std::env::temp_dir().join(format!("irlume-kwallet-long-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(salt_path(&dir).parent().unwrap()).expect("mkdir");
+        let mut long = vec![0x7u8; SALT_LEN];
+        long.extend_from_slice(b"trailing bytes pam_kwallet5 never reads");
+        std::fs::write(salt_path(&dir), &long).expect("write salt");
+
+        let via_file = derive_for_home(b"pw", &dir).expect("derive");
+        let via_prefix = derive_key(b"pw", &long[..SALT_LEN]).expect("derive");
+        assert_eq!(via_file.to_vec(), via_prefix.to_vec());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -57,8 +57,7 @@ pub fn read_salt(home: &Path) -> Result<Zeroizing<Vec<u8>>> {
     let raw = std::fs::read(&path).map_err(|e| {
         Error::Policy(format!(
             "no KDE wallet salt at {}: {e}. Log into a Plasma session once so \
-             the wallet exists, then arm again"
-        ,
+             the wallet exists, then arm again",
             path.display()
         ))
     })?;
@@ -96,6 +95,27 @@ pub fn derive_key(secret: &[u8], salt: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
 pub fn derive_for_home(password: &[u8], home: &Path) -> Result<Zeroizing<Vec<u8>>> {
     let salt = read_salt(home)?;
     derive_key(password, &salt)
+}
+
+/// Which secret to seal for a user, judged by what they actually have.
+///
+/// A KDE wallet key only makes sense where there is a KDE wallet, and it must
+/// not be chosen on a machine that also runs gnome-keyring: that backend takes
+/// the password string itself, so sealing a wallet key there would leave the
+/// GNOME login keyring locked with nothing to unlock it.
+///
+/// The conservative direction is [`SecretKind::LoginPassword`], which is the
+/// behaviour before #250, so anything ambiguous resolves to it.
+pub fn detect_kind(home: &Path) -> crate::envelope::SecretKind {
+    use crate::envelope::SecretKind;
+    let has_kde = salt_path(home).exists();
+    // gnome-keyring's login keyring, the thing that would break.
+    let has_gnome = home.join(".local/share/keyrings/login.keyring").exists();
+    if has_kde && !has_gnome {
+        SecretKind::KdeWalletKey
+    } else {
+        SecretKind::LoginPassword
+    }
 }
 
 #[cfg(test)]
@@ -161,6 +181,49 @@ mod tests {
 
     fn hex(b: &[u8]) -> String {
         b.iter().map(|x| format!("{x:02x}")).collect()
+    }
+
+    /// Detection has to be conservative in both directions: no KDE wallet means
+    /// there is nothing a wallet key could open, and a machine running both
+    /// backends must keep the password, or its GNOME login keyring is stranded.
+    #[test]
+    fn detect_kind_only_picks_the_wallet_key_on_a_kde_only_home() {
+        use crate::envelope::SecretKind;
+        let base = std::env::temp_dir().join(format!("irlume-detect-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+
+        let mk = |name: &str, kde: bool, gnome: bool| {
+            let h = base.join(name);
+            if kde {
+                std::fs::create_dir_all(salt_path(&h).parent().unwrap()).unwrap();
+                std::fs::write(salt_path(&h), [0u8; SALT_LEN]).unwrap();
+            }
+            if gnome {
+                let g = h.join(".local/share/keyrings");
+                std::fs::create_dir_all(&g).unwrap();
+                std::fs::write(g.join("login.keyring"), b"x").unwrap();
+            }
+            std::fs::create_dir_all(&h).unwrap();
+            h
+        };
+
+        assert_eq!(
+            detect_kind(&mk("neither", false, false)),
+            SecretKind::LoginPassword
+        );
+        assert_eq!(
+            detect_kind(&mk("gnome", false, true)),
+            SecretKind::LoginPassword
+        );
+        assert_eq!(
+            detect_kind(&mk("both", true, true)),
+            SecretKind::LoginPassword
+        );
+        assert_eq!(
+            detect_kind(&mk("kde", true, false)),
+            SecretKind::KdeWalletKey
+        );
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! The KDE wallet key: what `ksecretd` actually accepts, and how to derive it.
+//!
+//! KDE's secret store never sees the login password. `pam_kwallet5` runs the
+//! password through PBKDF2 and hands `ksecretd` the resulting bytes over a
+//! pipe; `ksecretd`'s `waitForHash()` reads exactly [`KEY_LEN`] of them and
+//! opens the wallet with that. The password is only the KDF input, and it is
+//! discarded before the daemon is reached.
+//!
+//! That is why this module exists. Sealing the derived key instead of the login
+//! password removes the password from the sealed envelope entirely, with no
+//! wallet re-key and no migration of the wallet itself: the wallet stays keyed
+//! to the same bytes it always was, and a typed password still opens it through
+//! the normal `pam_kwallet5` path because the KDF input is unchanged. A leaked
+//! envelope then yields a wallet key, which is useless anywhere else, instead of
+//! a Unix password that is not.
+//!
+//! GNOME has no equivalent. `pam_gnome_keyring` passes the password string
+//! itself and `gkd_login_unlock()` builds the credential from that string, so
+//! there is no derived intermediate for us to seal in its place. See #250.
+//!
+//! Every constant here is a wire-format constant shared with software we do not
+//! ship. Changing one silently produces a key that `ksecretd` rejects, so each
+//! cites its source.
+
+use irlume_common::{Error, Result};
+use std::path::{Path, PathBuf};
+use zeroize::Zeroizing;
+
+/// Length of the derived key, in bytes.
+///
+/// `KWALLET_PAM_KEYSIZE` in kwallet-pam's `pam_kwallet.c`, and
+/// `PBKDF2_SHA512_KEYSIZE` in kwallet's `src/runtime/ksecretd/main.cpp`, which
+/// reads exactly this many bytes and no more.
+pub const KEY_LEN: usize = 56;
+
+/// Length of the salt file, in bytes. `KWALLET_PAM_SALTSIZE`.
+pub const SALT_LEN: usize = 56;
+
+/// PBKDF2 iteration count. `KWALLET_PAM_ITERATIONS`.
+pub const ITERATIONS: u32 = 50_000;
+
+/// Path of the salt `pam_kwallet5` derives against, relative to `$HOME`.
+///
+/// Still `kwalletd` on disk even though the daemon that reads it is now
+/// `ksecretd`; KWallet became a compatibility shim over the Secret Service and
+/// the storage location did not move.
+const SALT_RELPATH: &str = ".local/share/kwalletd/kdewallet.salt";
+
+/// Absolute path of `home`'s wallet salt file.
+pub fn salt_path(home: &Path) -> PathBuf {
+    home.join(SALT_RELPATH)
+}
+
+/// Read `home`'s wallet salt.
+///
+/// Deliberately does NOT create a missing salt, unlike `pam_kwallet5`, which
+/// creates one on first login. Absent salt means this user has no KDE wallet
+/// yet, and inventing one here would derive a key that opens nothing while
+/// looking like a successful arm.
+pub fn read_salt(home: &Path) -> Result<Zeroizing<Vec<u8>>> {
+    let path = salt_path(home);
+    let raw = std::fs::read(&path).map_err(|e| {
+        Error::Policy(format!(
+            "no KDE wallet salt at {}: {e}. Log into a Plasma session once so \
+             the wallet exists, then arm again"
+        ,
+            path.display()
+        ))
+    })?;
+    if raw.len() < SALT_LEN {
+        return Err(Error::Policy(format!(
+            "wallet salt at {} is {} bytes, expected at least {SALT_LEN}",
+            path.display(),
+            raw.len()
+        )));
+    }
+    // pam_kwallet5 reads SALT_LEN and derives over exactly that, so a longer
+    // file must be truncated rather than passed through, or we derive a
+    // different key from the same file it used.
+    Ok(Zeroizing::new(raw[..SALT_LEN].to_vec()))
+}
+
+/// Derive the wallet key `ksecretd` expects from `secret` and `salt`.
+///
+/// PBKDF2-HMAC-SHA512, [`ITERATIONS`] rounds, [`KEY_LEN`] output. This is
+/// `kwallet_hash()` in `pam_kwallet.c`, which calls `gcry_kdf_derive` with
+/// `GCRY_KDF_PBKDF2` and `GCRY_MD_SHA512`.
+pub fn derive_key(secret: &[u8], salt: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
+    if salt.len() != SALT_LEN {
+        return Err(Error::Protocol(format!(
+            "wallet salt must be exactly {SALT_LEN} bytes, got {}",
+            salt.len()
+        )));
+    }
+    let mut out = Zeroizing::new(vec![0u8; KEY_LEN]);
+    pbkdf2::pbkdf2_hmac::<sha2::Sha512>(secret, salt, ITERATIONS, &mut out);
+    Ok(out)
+}
+
+/// Derive `home`'s wallet key from the login password.
+pub fn derive_for_home(password: &[u8], home: &Path) -> Result<Zeroizing<Vec<u8>>> {
+    let salt = read_salt(home)?;
+    derive_key(password, &salt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derived_key_is_the_length_ksecretd_reads() {
+        let salt = vec![0x5a; SALT_LEN];
+        let key = derive_key(b"hunter2", &salt).expect("derive");
+        assert_eq!(
+            key.len(),
+            KEY_LEN,
+            "ksecretd's waitForHash() reads exactly {KEY_LEN} bytes; a shorter \
+             key leaves it blocking and a longer one silently truncates"
+        );
+    }
+
+    #[test]
+    fn a_wrong_length_salt_is_refused_rather_than_padded() {
+        // Silently accepting a short salt would derive a key that opens nothing,
+        // which surfaces as a wallet prompt at login with no error anywhere.
+        assert!(derive_key(b"hunter2", &[0x5a; SALT_LEN - 1]).is_err());
+        assert!(derive_key(b"hunter2", &[0x5a; SALT_LEN + 1]).is_err());
+    }
+
+    #[test]
+    fn the_same_password_and_salt_give_the_same_key() {
+        let salt = vec![0x11; SALT_LEN];
+        assert_eq!(
+            derive_key(b"pw", &salt).unwrap().to_vec(),
+            derive_key(b"pw", &salt).unwrap().to_vec()
+        );
+    }
+
+    #[test]
+    fn a_different_salt_gives_a_different_key() {
+        // The salt is per-user and regenerated when a home directory is reset,
+        // which is the case that would otherwise produce a stale sealed key.
+        let a = derive_key(b"pw", &[0x11; SALT_LEN]).unwrap().to_vec();
+        let b = derive_key(b"pw", &[0x22; SALT_LEN]).unwrap().to_vec();
+        assert_ne!(a, b);
+    }
+
+    /// The derivation must agree with the one `pam_kwallet5` performs, byte for
+    /// byte, or the sealed key opens nothing.
+    ///
+    /// This vector was produced independently of this code, from libgcrypt's own
+    /// PBKDF2 via Python's `hashlib.pbkdf2_hmac("sha512", ...)`, using the same
+    /// parameters `kwallet_hash()` passes to `gcry_kdf_derive`. It pins the
+    /// three constants that have no in-tree definition to check against.
+    #[test]
+    fn derivation_matches_an_independently_computed_vector() {
+        let salt: Vec<u8> = (0..SALT_LEN as u8).collect();
+        let key = derive_key(b"kw-orig-pass-5518", &salt).expect("derive");
+        assert_eq!(
+            hex(&key),
+            "f96e0dc4f5b8558f05adbad5ecb040b9cc16573cd2395e0162f0e2597ee3946c\
+             e596adeff3a0956bd442250e7149e1cec92269cf93057462",
+            "PBKDF2-HMAC-SHA512 / {ITERATIONS} rounds / {KEY_LEN} bytes"
+        );
+    }
+
+    fn hex(b: &[u8]) -> String {
+        b.iter().map(|x| format!("{x:02x}")).collect()
+    }
+}

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -104,8 +104,8 @@ pub fn derive_for_home(password: &[u8], home: &Path) -> Result<Zeroizing<Vec<u8>
 /// the password string itself, so sealing a wallet key there would leave the
 /// GNOME login keyring locked with nothing to unlock it.
 ///
-/// The conservative direction is [`SecretKind::LoginPassword`], which is the
-/// behaviour before #250, so anything ambiguous resolves to it.
+/// The conservative direction is [`crate::envelope::SecretKind::LoginPassword`],
+/// the behaviour before #250, so anything ambiguous resolves to it.
 pub fn detect_kind(home: &Path) -> crate::envelope::SecretKind {
     use crate::envelope::SecretKind;
     let has_kde = salt_path(home).exists();

--- a/crates/irlume-core/src/lib.rs
+++ b/crates/irlume-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod crypto;
 pub mod envelope;
 pub mod fusion;
 pub mod keyring;
+pub mod kwallet;
 pub mod pad;
 pub mod pcrsig;
 pub mod policy;

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -469,6 +469,9 @@ pub fn seal_with_pcrs(secret: &[u8], pcrs: &[u32]) -> Result<SealedEnvelope> {
             .map_err(tpm_err)?;
 
         Ok(SealedEnvelope {
+            // This layer seals bytes and does not know what they mean; the
+            // keyring layer stamps the real kind before saving.
+            secret: crate::envelope::SecretKind::default(),
             version: crate::envelope::CURRENT_VERSION,
             policy: PolicyKind::PcrLiteral,
             pcrs: pcrs.clone(),
@@ -569,6 +572,9 @@ fn seal_authorized(secret: &[u8]) -> Result<SealedEnvelope> {
             .map_err(tpm_err)?;
 
         Ok(SealedEnvelope {
+            // This layer seals bytes and does not know what they mean; the
+            // keyring layer stamps the real kind before saving.
+            secret: crate::envelope::SecretKind::default(),
             version: crate::envelope::CURRENT_VERSION,
             policy: PolicyKind::Authorized {
                 pubkey_pem: pubkey_pem.clone(),
@@ -1129,6 +1135,9 @@ fn seal_pcrlock(secret: &[u8], nv_index: u32) -> Result<SealedEnvelope> {
             .map_err(tpm_err)?;
 
         Ok(SealedEnvelope {
+            // This layer seals bytes and does not know what they mean; the
+            // keyring layer stamps the real kind before saving.
+            secret: crate::envelope::SecretKind::default(),
             version: crate::envelope::CURRENT_VERSION,
             policy: PolicyKind::PcrlockNv { nv_index },
             pcrs: pcrs.clone(),

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -472,6 +472,7 @@ mod tests {
         // A secret-carrying management request is not camera work.
         assert_eq!(
             classify(&Request::SealPassword {
+                kind: None,
                 user: "u".into(),
                 password: SecretBytes::new(vec![1u8]),
             }),

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1304,6 +1304,9 @@ fn unseal_keyring(user: &str, service: Option<&str>, peer: &Peer) -> Response {
         Ok(secret) => {
             eprintln!("irlumed: UnsealKeyring: OK for '{user}' (fingerprint-authenticated), password unsealed");
             Response::PasswordUnsealed {
+                kind: crate::users::core_to_wire_kind(
+                    irlume_core::keyring::sealed_kind(&user).unwrap_or_default(),
+                ),
                 secret: irlume_common::SecretBytes::new(secret.to_vec()),
             }
         }
@@ -2159,7 +2162,11 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             }
         }
         // --- keyring unlock (TPM-sealed password) ---------------------------
-        Request::SealPassword { user, password } => {
+        Request::SealPassword {
+            user,
+            password,
+            kind,
+        } => {
             // Arming the keyring: root or the user themselves. `password`
             // zeroizes on drop, covering every return path.
             if !authorized_for(peer, &user) {
@@ -2174,9 +2181,44 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                      the login password, so arming a different one would leave the wallet locked"
                 ));
             }
-            match irlume_core::keyring::seal_password(&user, password.expose()) {
+            // On KDE, seal the wallet key derived from this password rather
+            // than the password itself. The wallet is keyed to exactly those
+            // bytes already, so nothing is re-keyed and a typed password still
+            // opens it through pam_kwallet5; what changes is that the envelope
+            // stops being a Unix password. See #250 and irlume_core::kwallet.
+            // Resolve the kind from what the user actually has when the client
+            // did not force one, so a KDE-only machine gets the wallet key
+            // without the client needing to know to ask.
+            let home = crate::users::home_for_name(&user);
+            let core_kind = match kind {
+                Some(k) => crate::users::wire_to_core_kind(k),
+                None => match home.as_deref() {
+                    Some(h) => irlume_core::kwallet::detect_kind(h),
+                    None => irlume_core::envelope::SecretKind::LoginPassword,
+                },
+            };
+            let secret = match core_kind {
+                irlume_core::envelope::SecretKind::LoginPassword => {
+                    Ok(zeroize::Zeroizing::new(password.expose().to_vec()))
+                }
+                irlume_core::envelope::SecretKind::KdeWalletKey => {
+                    irlume_core::keyring::derive_secret(
+                        core_kind,
+                        password.expose(),
+                        home.as_deref(),
+                    )
+                }
+            };
+            let secret = match secret {
+                Ok(s) => s,
+                Err(e) => return Response::Error(e.to_string()),
+            };
+            match irlume_core::keyring::seal_secret(&user, &secret, core_kind) {
                 Ok(()) => {
-                    eprintln!("irlumed: SealPassword: armed keyring unlock for '{user}'");
+                    eprintln!(
+                        "irlumed: SealPassword: armed keyring unlock for '{user}' ({})",
+                        core_kind.describe()
+                    );
                     Response::PasswordSealed
                 }
                 Err(e) => Response::Error(e.to_string()),
@@ -2298,15 +2340,10 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 return Response::Error(format!("not authorized to reseal password for '{user}'"));
             }
             // The home directory is where the KDE wallet salt lives; a
-            // login-password envelope ignores it. Resolved via NSS rather than
-            // assumed, so a non-/home account derives against its real salt.
-            let home = match crate::users::home_for_name(&user) {
-                Some(h) => h,
-                None => {
-                    return Response::Error(format!("no home directory for '{user}'"));
-                }
-            };
-            match irlume_core::keyring::reseal_password(&user, password.expose(), &home) {
+            // login-password envelope ignores it, so an unresolvable home is
+            // only fatal for the wallet kind and reseal decides that itself.
+            let home = crate::users::home_for_name(&user);
+            match irlume_core::keyring::reseal_password(&user, password.expose(), home.as_deref()) {
                 Ok(outcome) => {
                     use irlume_core::keyring::Reseal;
                     if outcome == Reseal::Resealed {
@@ -2774,6 +2811,9 @@ fn do_unseal_password(
                 t.elapsed().as_millis()
             );
             Response::PasswordUnsealed {
+                kind: crate::users::core_to_wire_kind(
+                    irlume_core::keyring::sealed_kind(user).unwrap_or_default(),
+                ),
                 secret: irlume_common::SecretBytes::new(secret.to_vec()),
             }
         }
@@ -3195,6 +3235,7 @@ mod tests {
                 on: false,
             },
             Request::SealPassword {
+                kind: None,
                 user: u(),
                 password: secret(),
             },
@@ -3811,6 +3852,7 @@ mod tests {
         respond(
             ours,
             &Response::PasswordUnsealed {
+                kind: irlume_common::KeyringSecretKind::LoginPassword,
                 secret: irlume_common::SecretBytes::new(b"hunter2".to_vec()),
             },
         )
@@ -3818,7 +3860,7 @@ mod tests {
         let mut line = String::new();
         BufReader::new(&theirs).read_line(&mut line).unwrap();
         match serde_json::from_str::<Response>(line.trim()).unwrap() {
-            Response::PasswordUnsealed { secret } => {
+            Response::PasswordUnsealed { secret, .. } => {
                 assert_eq!(secret.expose(), b"hunter2")
             }
             other => panic!("expected PasswordUnsealed, got {other:?}"),
@@ -5133,6 +5175,7 @@ mod tests {
         let _ = &sb;
         match dispatch(
             Request::SealPassword {
+                kind: None,
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(b"pw".to_vec()),
             },
@@ -5146,6 +5189,7 @@ mod tests {
         // is safe (and deterministic) on every host.
         match dispatch(
             Request::SealPassword {
+                kind: None,
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(Vec::new()),
             },
@@ -5812,6 +5856,7 @@ mod tests {
         let secret = b"hunter2-swtpm".to_vec();
         match dispatch(
             Request::SealPassword {
+                kind: None,
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(secret.clone()),
             },
@@ -5874,7 +5919,7 @@ mod tests {
             &root,
             &mut e,
         ) {
-            Response::PasswordUnsealed { secret: got } => assert_eq!(got.expose(), secret),
+            Response::PasswordUnsealed { secret: got, .. } => assert_eq!(got.expose(), secret),
             other => panic!("root keyring unseal must release the secret, got {other:?}"),
         }
         match dispatch(

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1300,14 +1300,17 @@ fn unseal_keyring(user: &str, service: Option<&str>, peer: &Peer) -> Response {
             return Response::Error(format!("keyring unseal not allowed for {class:?}"));
         }
     }
-    match irlume_core::keyring::unseal_password(&user) {
-        Ok(secret) => {
-            eprintln!("irlumed: UnsealKeyring: OK for '{user}' (fingerprint-authenticated), password unsealed");
+    // One load yields both the bytes and their kind, so a concurrent re-arm
+    // cannot tag one envelope's secret with another's kind.
+    match irlume_core::keyring::unseal_secret(&user) {
+        Ok(unsealed) => {
+            eprintln!(
+                "irlumed: UnsealKeyring: OK for '{user}' (fingerprint-authenticated), {} unsealed",
+                unsealed.kind.describe()
+            );
             Response::PasswordUnsealed {
-                kind: crate::users::core_to_wire_kind(
-                    irlume_core::keyring::sealed_kind(&user).unwrap_or_default(),
-                ),
-                secret: irlume_common::SecretBytes::new(secret.to_vec()),
+                kind: crate::users::core_to_wire_kind(unsealed.kind),
+                secret: irlume_common::SecretBytes::new(unsealed.secret.to_vec()),
             }
         }
         Err(e) => {
@@ -2800,21 +2803,22 @@ fn do_unseal_password(
         );
         return Response::Error(format!("face not granted: {}", outcome.reason));
     }
-    match irlume_core::keyring::unseal_password(user) {
-        Ok(secret) => {
+    // See the UnsealKeyring path: one load, so the bytes and their kind always
+    // come from the same envelope.
+    match irlume_core::keyring::unseal_secret(user) {
+        Ok(unsealed) => {
             eprintln!(
-                "irlumed: UnsealPassword: OK for '{user}' (score {:.4}), password unsealed",
-                outcome.score
+                "irlumed: UnsealPassword: OK for '{user}' (score {:.4}), {} unsealed",
+                outcome.score,
+                unsealed.kind.describe()
             );
             irlume_common::dlog!(
                 "unseal '{user}' total {}ms (face + TPM)",
                 t.elapsed().as_millis()
             );
             Response::PasswordUnsealed {
-                kind: crate::users::core_to_wire_kind(
-                    irlume_core::keyring::sealed_kind(user).unwrap_or_default(),
-                ),
-                secret: irlume_common::SecretBytes::new(secret.to_vec()),
+                kind: crate::users::core_to_wire_kind(unsealed.kind),
+                secret: irlume_common::SecretBytes::new(unsealed.secret.to_vec()),
             }
         }
         // Face matched but the TPM could not release the secret (e.g. PCR drift

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2297,7 +2297,16 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             if !authorized_for(peer, &user) {
                 return Response::Error(format!("not authorized to reseal password for '{user}'"));
             }
-            match irlume_core::keyring::reseal_password(&user, password.expose()) {
+            // The home directory is where the KDE wallet salt lives; a
+            // login-password envelope ignores it. Resolved via NSS rather than
+            // assumed, so a non-/home account derives against its real salt.
+            let home = match crate::users::home_for_name(&user) {
+                Some(h) => h,
+                None => {
+                    return Response::Error(format!("no home directory for '{user}'"));
+                }
+            };
+            match irlume_core::keyring::reseal_password(&user, password.expose(), &home) {
                 Ok(outcome) => {
                     use irlume_core::keyring::Reseal;
                     if outcome == Reseal::Resealed {

--- a/crates/irlume-daemon/src/users.rs
+++ b/crates/irlume-daemon/src/users.rs
@@ -51,6 +51,40 @@ pub fn name_for_uid(uid: u32) -> Option<String> {
     name.to_str().ok().map(|s| s.to_owned())
 }
 
+/// Resolve a username to its home directory via NSS.
+///
+/// Needed for the KDE wallet path: the wallet salt lives under the user's home,
+/// and the derivation has to read the SAME file `pam_kwallet5` derives against.
+/// Guessing `/home/<name>` would silently derive the wrong key for anyone whose
+/// home is elsewhere, which is exactly the population (LDAP, systemd-homed) the
+/// reentrant NSS lookups here exist to serve.
+pub fn home_for_name(name: &str) -> Option<std::path::PathBuf> {
+    let cname = CString::new(name).ok()?;
+    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut buf = vec![0 as libc::c_char; 4096];
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    // SAFETY: see `uid_for_name`.
+    let rc = unsafe {
+        libc::getpwnam_r(
+            cname.as_ptr(),
+            &mut pwd,
+            buf.as_mut_ptr(),
+            buf.len(),
+            &mut result,
+        )
+    };
+    if rc != 0 || result.is_null() {
+        return None;
+    }
+    // SAFETY: on success pw_dir points into `buf`, a valid NUL-terminated string.
+    let dir = unsafe { std::ffi::CStr::from_ptr(pwd.pw_dir) };
+    let s = dir.to_str().ok()?;
+    if s.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(s))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/irlume-daemon/src/users.rs
+++ b/crates/irlume-daemon/src/users.rs
@@ -85,6 +85,34 @@ pub fn home_for_name(name: &str) -> Option<std::path::PathBuf> {
     Some(std::path::PathBuf::from(s))
 }
 
+/// Translate the wire secret kind to the core one.
+///
+/// The two enums are deliberately separate: `irlume-common` carries the wire
+/// form and cannot depend on `irlume-core`, which owns the on-disk form. This is
+/// the single place they meet.
+pub fn wire_to_core_kind(k: irlume_common::KeyringSecretKind) -> irlume_core::envelope::SecretKind {
+    match k {
+        irlume_common::KeyringSecretKind::LoginPassword => {
+            irlume_core::envelope::SecretKind::LoginPassword
+        }
+        irlume_common::KeyringSecretKind::KdeWalletKey => {
+            irlume_core::envelope::SecretKind::KdeWalletKey
+        }
+    }
+}
+
+/// Translate the core secret kind to the wire one.
+pub fn core_to_wire_kind(k: irlume_core::envelope::SecretKind) -> irlume_common::KeyringSecretKind {
+    match k {
+        irlume_core::envelope::SecretKind::LoginPassword => {
+            irlume_common::KeyringSecretKind::LoginPassword
+        }
+        irlume_core::envelope::SecretKind::KdeWalletKey => {
+            irlume_common::KeyringSecretKind::KdeWalletKey
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/irlume-kwallet-init/Cargo.toml
+++ b/crates/irlume-kwallet-init/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "irlume-kwallet-init"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "irlume-kwallet-init"
+path = "src/main.rs"
+
+# Deliberately minimal. This runs as root in the login path, so it takes no
+# dependency on the TPM, inference or serialization stacks.
+[dependencies]
+irlume-common.workspace = true
+libc.workspace = true

--- a/crates/irlume-kwallet-init/src/main.rs
+++ b/crates/irlume-kwallet-init/src/main.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Hand a KDE wallet key to `ksecretd` the way `pam_kwallet5` does.
+//!
+//! `ksecretd` accepts a wallet key exactly once, on a pipe, at startup:
+//! `checkPamModule()` runs only when `PAM_KWALLET5_LOGIN` is set, reads
+//! `KEY_LEN` bytes in `waitForHash()`, then blocks in `waitForEnvironment()`
+//! until something connects to a listening socket and writes `KEY=VALUE` lines.
+//! There is no way to hand it a key later: the `pamOpen` D-Bus method belongs to
+//! the `kwalletd6` compatibility shim, which translates to the Secret Service,
+//! and the Secret Service has no unlock-with-a-raw-hash operation.
+//!
+//! So this exists as a separate program rather than as code inside
+//! `pam_irlume`. The module is loaded into sshd, login and every greeter, and it
+//! has no `fork`, no `exec` and no privilege dropping today; this needs all
+//! three plus a listening socket. Keeping that in a short-lived helper leaves
+//! the module's own blast radius unchanged.
+//!
+//! Invoked as `irlume-kwallet-init <username>` with the key on **stdin**, never
+//! in argv, which is world-readable through `/proc`.
+//!
+//! It is launched from the PAM process rather than from `irlumed` on purpose:
+//! that places `ksecretd` in the session's cgroup, where `pam_kwallet5` puts it.
+//! Spawned from the daemon it would live in `irlumed.service`, and restarting
+//! irlume would take the user's wallet daemon down with it.
+
+use irlume_common::kwallet_wire::{KEY_LEN, LOGIN_ENV, SOCKET_NAME};
+use std::ffi::{CString, OsStr};
+use std::io::Read;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+
+/// Binaries that understand `--pam-login`, most specific first.
+///
+/// On Fedora 44 the wallet daemon is `ksecretd`; `kwalletd6` there is the
+/// Secret Service shim and rejects the option. Distributions still shipping the
+/// older KWallet have it on `kwalletd6`/`kwalletd5`. `IRLUME_KSECRETD` overrides
+/// the search, which is also how the tests point at a chosen binary.
+const CANDIDATES: &[&str] = &[
+    "/usr/bin/ksecretd",
+    "/usr/bin/kwalletd6",
+    "/usr/bin/kwalletd5",
+];
+
+fn main() -> std::process::ExitCode {
+    let mut args = std::env::args_os().skip(1);
+    let Some(user) = args.next() else {
+        eprintln!("usage: irlume-kwallet-init <username>  (key on stdin)");
+        return std::process::ExitCode::from(2);
+    };
+    let user = user.to_string_lossy().into_owned();
+
+    match run(&user) {
+        Ok(sock) => {
+            // The PAM module needs this in the session environment so Plasma's
+            // pam_kwallet_init can find the socket. Printed rather than assumed
+            // so the module never has to duplicate the path construction.
+            println!("{}", sock.display());
+            std::process::ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("irlume-kwallet-init: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(user: &str) -> Result<PathBuf, String> {
+    // Read the key first. If it is not exactly KEY_LEN bytes, stop before any
+    // process is spawned: ksecretd blocks forever on a short key and silently
+    // truncates a long one, so neither failure would be visible at a login.
+    let mut key = vec![0u8; KEY_LEN];
+    std::io::stdin()
+        .read_exact(&mut key)
+        .map_err(|e| format!("expected {KEY_LEN} bytes of wallet key on stdin: {e}"))?;
+    let mut extra = [0u8; 1];
+    if let Ok(1) = std::io::stdin().read(&mut extra) {
+        return Err(format!("more than {KEY_LEN} bytes on stdin; refusing"));
+    }
+
+    let pw = lookup_user(user)?;
+    let runtime_dir = PathBuf::from(format!("/run/user/{}", pw.uid));
+    if !runtime_dir.is_dir() {
+        return Err(format!(
+            "{} does not exist; the session is not far enough along for a wallet",
+            runtime_dir.display()
+        ));
+    }
+    let sock_path = runtime_dir.join(SOCKET_NAME);
+    let exe = wallet_daemon()?;
+
+    let listener = bind_listener(&sock_path, &pw)?;
+    let (read_fd, write_fd) = make_pipe()?;
+
+    // SAFETY: between fork() and execve() the child runs in a single thread and
+    // touches only async-signal-safe calls, which is the constraint fork()
+    // imposes on a process that may be multi-threaded.
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        return Err(format!("fork: {}", std::io::Error::last_os_error()));
+    }
+    if pid == 0 {
+        unsafe { child_exec(&exe, &pw, read_fd, listener, &sock_path) };
+        // child_exec only returns when execve failed.
+        unsafe { libc::_exit(127) };
+    }
+
+    // Parent: hand over the key, then get out of the way. ksecretd goes on to
+    // block in waitForEnvironment() until Plasma's pam_kwallet_init connects, so
+    // we deliberately do NOT wait for it.
+    unsafe {
+        libc::close(read_fd);
+        libc::close(listener);
+    }
+    write_all(write_fd, &key)?;
+    unsafe { libc::close(write_fd) };
+    Ok(sock_path)
+}
+
+struct User {
+    uid: libc::uid_t,
+    gid: libc::gid_t,
+    name: CString,
+}
+
+fn lookup_user(user: &str) -> Result<User, String> {
+    let cname = CString::new(user).map_err(|_| "username contains a NUL".to_string())?;
+    // SAFETY: getpwnam returns a pointer into a static buffer, read before any
+    // further libc call that could overwrite it.
+    let pw = unsafe { libc::getpwnam(cname.as_ptr()) };
+    if pw.is_null() {
+        return Err(format!("no such user: {user}"));
+    }
+    let (uid, gid) = unsafe { ((*pw).pw_uid, (*pw).pw_gid) };
+    if uid == 0 {
+        return Err("refusing to open a wallet for uid 0".to_string());
+    }
+    Ok(User {
+        uid,
+        gid,
+        name: cname,
+    })
+}
+
+fn wallet_daemon() -> Result<CString, String> {
+    if let Some(over) = std::env::var_os("IRLUME_KSECRETD") {
+        return CString::new(over.as_bytes()).map_err(|_| "IRLUME_KSECRETD has a NUL".into());
+    }
+    for c in CANDIDATES {
+        if std::path::Path::new(c).is_file() {
+            return CString::new(*c).map_err(|_| "candidate path has a NUL".to_string());
+        }
+    }
+    Err(format!(
+        "no wallet daemon found; looked for {}",
+        CANDIDATES.join(", ")
+    ))
+}
+
+/// Bind and listen on the handoff socket, owned by the target user.
+fn bind_listener(path: &std::path::Path, pw: &User) -> Result<libc::c_int, String> {
+    let bytes = path.as_os_str().as_bytes();
+    let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    if bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
+        return Err(format!("socket path too long: {}", path.display()));
+    }
+    addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    for (slot, b) in addr.sun_path.iter_mut().zip(bytes) {
+        *slot = *b as libc::c_char;
+    }
+
+    // A stale socket from a previous session would make bind() fail with
+    // EADDRINUSE. pam_kwallet5 replaces it the same way, and ksecretd uses
+    // ReplaceExisting when PAM-launched (KDE BUG 509680), so the newest login
+    // wins rather than colliding.
+    let _ = std::fs::remove_file(path);
+
+    // SAFETY: addr is fully initialised above and the length is the real size.
+    let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+    if fd < 0 {
+        return Err(format!("socket: {}", std::io::Error::last_os_error()));
+    }
+    let rc = unsafe {
+        libc::bind(
+            fd,
+            &addr as *const _ as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        let e = std::io::Error::last_os_error();
+        unsafe { libc::close(fd) };
+        return Err(format!("bind {}: {e}", path.display()));
+    }
+    if unsafe { libc::listen(fd, 5) } < 0 {
+        let e = std::io::Error::last_os_error();
+        unsafe { libc::close(fd) };
+        return Err(format!("listen: {e}"));
+    }
+    // The connecting side is Plasma's pam_kwallet_init, running as the user.
+    let cpath = CString::new(bytes).map_err(|_| "socket path has a NUL".to_string())?;
+    if unsafe { libc::chown(cpath.as_ptr(), pw.uid, pw.gid) } < 0 {
+        let e = std::io::Error::last_os_error();
+        unsafe { libc::close(fd) };
+        return Err(format!("chown {}: {e}", path.display()));
+    }
+    Ok(fd)
+}
+
+fn make_pipe() -> Result<(libc::c_int, libc::c_int), String> {
+    let mut fds = [0 as libc::c_int; 2];
+    // Plain pipe(), not O_CLOEXEC: the read end must survive execve into
+    // ksecretd, which is handed its number on the command line.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
+        return Err(format!("pipe: {}", std::io::Error::last_os_error()));
+    }
+    Ok((fds[0], fds[1]))
+}
+
+/// Drop to the target user and become the wallet daemon.
+///
+/// # Safety
+/// Must only be called in the child of a `fork()`, before any other work.
+unsafe fn child_exec(
+    exe: &CString,
+    pw: &User,
+    read_fd: libc::c_int,
+    listen_fd: libc::c_int,
+    sock_path: &std::path::Path,
+) {
+    // Order matters: supplementary groups and gid must go before setuid, or the
+    // process no longer has the privilege to drop them.
+    if libc::initgroups(pw.name.as_ptr(), pw.gid) != 0
+        || libc::setgid(pw.gid) != 0
+        || libc::setuid(pw.uid) != 0
+    {
+        libc::_exit(126);
+    }
+    // A failed drop that we did not notice would run the wallet daemon as root.
+    if libc::getuid() != pw.uid || libc::geteuid() != pw.uid {
+        libc::_exit(126);
+    }
+
+    // Detach the standard streams before exec. The wallet daemon outlives this
+    // helper by design, and if it kept our stdout the caller would block: a
+    // pipe or a `$(...)` capture waits for EVERY writer to close, not just the
+    // process it started. Found by hanging exactly that way in the end-to-end
+    // test. ksecretd logs to the journal regardless.
+    let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_RDWR);
+    if devnull >= 0 {
+        libc::dup2(devnull, libc::STDIN_FILENO);
+        libc::dup2(devnull, libc::STDOUT_FILENO);
+        libc::dup2(devnull, libc::STDERR_FILENO);
+        if devnull > libc::STDERR_FILENO {
+            libc::close(devnull);
+        }
+    }
+
+    // Both fds are passed by number, so they must not carry CLOEXEC.
+    clear_cloexec(read_fd);
+    clear_cloexec(listen_fd);
+
+    let arg0 = exe.clone();
+    let opt = CString::new("--pam-login").unwrap();
+    let a_pipe = CString::new(read_fd.to_string()).unwrap();
+    let a_sock = CString::new(listen_fd.to_string()).unwrap();
+    let argv = [
+        arg0.as_ptr(),
+        opt.as_ptr(),
+        a_pipe.as_ptr(),
+        a_sock.as_ptr(),
+        std::ptr::null(),
+    ];
+
+    // Without LOGIN_ENV, ksecretd never calls checkPamModule() and its argument
+    // parser rejects --pam-login as an unknown option. Verified: it exits with
+    // "Unknown option 'pam-login'" when the variable is absent.
+    let login = CString::new(format!("{LOGIN_ENV}={}", sock_path.display())).unwrap();
+    let runtime = CString::new(format!("XDG_RUNTIME_DIR=/run/user/{}", pw.uid)).unwrap();
+    let home = CString::new(format!("HOME={}", home_of(pw.uid))).unwrap();
+    let user = CString::new(format!(
+        "USER={}",
+        OsStr::from_bytes(pw.name.as_bytes()).to_string_lossy()
+    ))
+    .unwrap();
+    // The rest of the session environment (bus address, display) arrives later
+    // over the socket; ksecretd is written to wait for exactly that.
+    let envp = [
+        login.as_ptr(),
+        runtime.as_ptr(),
+        home.as_ptr(),
+        user.as_ptr(),
+        std::ptr::null(),
+    ];
+
+    libc::execve(exe.as_ptr(), argv.as_ptr(), envp.as_ptr());
+}
+
+unsafe fn clear_cloexec(fd: libc::c_int) {
+    let flags = libc::fcntl(fd, libc::F_GETFD);
+    if flags >= 0 {
+        libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+    }
+}
+
+fn home_of(uid: libc::uid_t) -> String {
+    // SAFETY: read straight out of the static buffer before any other libc call.
+    let pw = unsafe { libc::getpwuid(uid) };
+    if pw.is_null() {
+        return String::new();
+    }
+    unsafe { std::ffi::CStr::from_ptr((*pw).pw_dir) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn write_all(fd: libc::c_int, mut buf: &[u8]) -> Result<(), String> {
+    while !buf.is_empty() {
+        let n = unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
+        if n < 0 {
+            let e = std::io::Error::last_os_error();
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(format!("write to the wallet daemon: {e}"));
+        }
+        buf = &buf[n as usize..];
+    }
+    Ok(())
+}

--- a/crates/irlume-kwallet-init/src/main.rs
+++ b/crates/irlume-kwallet-init/src/main.rs
@@ -26,7 +26,7 @@
 //! irlume would take the user's wallet daemon down with it.
 
 use irlume_common::kwallet_wire::{KEY_LEN, LOGIN_ENV, SOCKET_NAME};
-use std::ffi::{CString, OsStr};
+use std::ffi::CString;
 use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
@@ -88,10 +88,24 @@ fn run(user: &str) -> Result<PathBuf, String> {
         ));
     }
     let sock_path = runtime_dir.join(SOCKET_NAME);
+    // Resolved while still privileged: after the drop below, a user-writable
+    // PATH or a swapped file could change which program this becomes.
     let exe = wallet_daemon()?;
 
-    let listener = bind_listener(&sock_path, &pw)?;
+    // EVERYTHING below runs as the target user. Nothing after this point needs
+    // privilege, and doing pathname work as root inside /run/user/<uid>, which
+    // that user owns and can rename underneath us, is how KDE shipped
+    // CVE-2018-10380: chown() follows a final symlink, so a socket path swapped
+    // for a link to /etc/shadow between bind() and chown() hands the file to the
+    // attacker. Dropping first removes the primitive rather than racing it.
+    drop_privileges(&pw)?;
+
+    let listener = bind_listener(&sock_path)?;
     let (read_fd, write_fd) = make_pipe()?;
+    // Close-on-exec, so the child end closing is itself the signal that execve
+    // succeeded. Without it the parent cannot tell a running wallet daemon from
+    // one that died before exec, and it would report success either way.
+    let (status_read, status_write) = make_status_pipe()?;
 
     // SAFETY: between fork() and execve() the child runs in a single thread and
     // touches only async-signal-safe calls, which is the constraint fork()
@@ -101,21 +115,96 @@ fn run(user: &str) -> Result<PathBuf, String> {
         return Err(format!("fork: {}", std::io::Error::last_os_error()));
     }
     if pid == 0 {
-        unsafe { child_exec(&exe, &pw, read_fd, listener, &sock_path) };
-        // child_exec only returns when execve failed.
-        unsafe { libc::_exit(127) };
+        unsafe {
+            libc::close(status_read);
+            libc::close(write_fd);
+            child_exec(&exe, read_fd, listener, &sock_path);
+            // Only reached when execve failed. The byte distinguishes that from
+            // the EOF a successful exec produces.
+            let failed = [1u8];
+            libc::write(status_write, failed.as_ptr() as *const libc::c_void, 1);
+            libc::_exit(127);
+        }
     }
 
-    // Parent: hand over the key, then get out of the way. ksecretd goes on to
-    // block in waitForEnvironment() until Plasma's pam_kwallet_init connects, so
-    // we deliberately do NOT wait for it.
     unsafe {
+        libc::close(status_write);
         libc::close(read_fd);
         libc::close(listener);
     }
+
+    // Wait for exec before claiming anything. Reporting success here is not
+    // cosmetic: the caller exports PAM_KWALLET5_LOGIN on the strength of it, and
+    // that variable makes pam_kwallet5 stand down. A false success therefore
+    // leaves the wallet locked AND removes the fallback that would have opened
+    // it.
+    if let Err(e) = await_exec(status_read) {
+        unsafe { libc::close(write_fd) };
+        return Err(e);
+    }
+
+    // Hand over the key, then get out of the way. ksecretd goes on to block in
+    // waitForEnvironment() until Plasma's pam_kwallet_init connects, so we
+    // deliberately do NOT wait for it to finish starting.
     write_all(write_fd, &key)?;
     unsafe { libc::close(write_fd) };
     Ok(sock_path)
+}
+
+/// Become the target user, permanently.
+///
+/// Order matters: supplementary groups and the gid must be set before the uid,
+/// or the process no longer holds the privilege needed to drop them.
+fn drop_privileges(pw: &User) -> Result<(), String> {
+    if unsafe { libc::initgroups(pw.name.as_ptr(), pw.gid) } != 0 {
+        return Err(format!("initgroups: {}", std::io::Error::last_os_error()));
+    }
+    if unsafe { libc::setgid(pw.gid) } != 0 {
+        return Err(format!("setgid: {}", std::io::Error::last_os_error()));
+    }
+    if unsafe { libc::setuid(pw.uid) } != 0 {
+        return Err(format!("setuid: {}", std::io::Error::last_os_error()));
+    }
+    // Checked rather than assumed: a drop that silently did not take would leave
+    // every path below running as root, which is the whole thing being avoided.
+    if unsafe { libc::getuid() } != pw.uid
+        || unsafe { libc::geteuid() } != pw.uid
+        || unsafe { libc::getgid() } != pw.gid
+        || unsafe { libc::getegid() } != pw.gid
+    {
+        return Err("privilege drop did not take effect".into());
+    }
+    Ok(())
+}
+
+fn make_status_pipe() -> Result<(libc::c_int, libc::c_int), String> {
+    let mut fds = [0 as libc::c_int; 2];
+    if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } < 0 {
+        return Err(format!("status pipe: {}", std::io::Error::last_os_error()));
+    }
+    Ok((fds[0], fds[1]))
+}
+
+/// Block until the child either execs (EOF, because the write end was
+/// close-on-exec) or reports a pre-exec failure (one byte).
+fn await_exec(status_fd: libc::c_int) -> Result<(), String> {
+    let mut byte = 0u8;
+    loop {
+        let n = unsafe { libc::read(status_fd, &mut byte as *mut u8 as *mut libc::c_void, 1) };
+        if n == 0 {
+            unsafe { libc::close(status_fd) };
+            return Ok(());
+        }
+        if n == 1 {
+            unsafe { libc::close(status_fd) };
+            return Err("the wallet daemon failed to start (exec did not happen)".into());
+        }
+        let e = std::io::Error::last_os_error();
+        if e.kind() != std::io::ErrorKind::Interrupted {
+            unsafe { libc::close(status_fd) };
+            return Err(format!("reading the wallet daemon's start status: {e}"));
+        }
+    }
 }
 
 struct User {
@@ -158,8 +247,13 @@ fn wallet_daemon() -> Result<CString, String> {
     ))
 }
 
-/// Bind and listen on the handoff socket, owned by the target user.
-fn bind_listener(path: &std::path::Path, pw: &User) -> Result<libc::c_int, String> {
+/// Bind and listen on the handoff socket.
+///
+/// Runs unprivileged, so the socket is created owned by the user and there is
+/// no second pathname resolution to race. The previous version bound as root
+/// and then chown()ed the path, which follows a final symlink and let the
+/// directory's owner redirect it at any root-owned file.
+fn bind_listener(path: &std::path::Path) -> Result<libc::c_int, String> {
     let bytes = path.as_os_str().as_bytes();
     let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
     if bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
@@ -174,7 +268,13 @@ fn bind_listener(path: &std::path::Path, pw: &User) -> Result<libc::c_int, Strin
     // EADDRINUSE. pam_kwallet5 replaces it the same way, and ksecretd uses
     // ReplaceExisting when PAM-launched (KDE BUG 509680), so the newest login
     // wins rather than colliding.
-    let _ = std::fs::remove_file(path);
+    // A real error here (a directory in the way, EACCES) must not be swallowed:
+    // bind() would then fail with EADDRINUSE and the reason would be lost.
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(format!("removing the stale {}: {e}", path.display())),
+    }
 
     // SAFETY: addr is fully initialised above and the length is the real size.
     let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
@@ -198,13 +298,6 @@ fn bind_listener(path: &std::path::Path, pw: &User) -> Result<libc::c_int, Strin
         unsafe { libc::close(fd) };
         return Err(format!("listen: {e}"));
     }
-    // The connecting side is Plasma's pam_kwallet_init, running as the user.
-    let cpath = CString::new(bytes).map_err(|_| "socket path has a NUL".to_string())?;
-    if unsafe { libc::chown(cpath.as_ptr(), pw.uid, pw.gid) } < 0 {
-        let e = std::io::Error::last_os_error();
-        unsafe { libc::close(fd) };
-        return Err(format!("chown {}: {e}", path.display()));
-    }
     Ok(fd)
 }
 
@@ -224,24 +317,12 @@ fn make_pipe() -> Result<(libc::c_int, libc::c_int), String> {
 /// Must only be called in the child of a `fork()`, before any other work.
 unsafe fn child_exec(
     exe: &CString,
-    pw: &User,
     read_fd: libc::c_int,
     listen_fd: libc::c_int,
     sock_path: &std::path::Path,
 ) {
-    // Order matters: supplementary groups and gid must go before setuid, or the
-    // process no longer has the privilege to drop them.
-    if libc::initgroups(pw.name.as_ptr(), pw.gid) != 0
-        || libc::setgid(pw.gid) != 0
-        || libc::setuid(pw.uid) != 0
-    {
-        libc::_exit(126);
-    }
-    // A failed drop that we did not notice would run the wallet daemon as root.
-    if libc::getuid() != pw.uid || libc::geteuid() != pw.uid {
-        libc::_exit(126);
-    }
-
+    // No privilege drop here: the parent already dropped, before it touched the
+    // user-owned runtime directory at all.
     // Detach the standard streams before exec. The wallet daemon outlives this
     // helper by design, and if it kept our stdout the caller would block: a
     // pipe or a `$(...)` capture waits for EVERY writer to close, not just the
@@ -276,14 +357,11 @@ unsafe fn child_exec(
     // Without LOGIN_ENV, ksecretd never calls checkPamModule() and its argument
     // parser rejects --pam-login as an unknown option. Verified: it exits with
     // "Unknown option 'pam-login'" when the variable is absent.
+    let uid = libc::getuid();
     let login = CString::new(format!("{LOGIN_ENV}={}", sock_path.display())).unwrap();
-    let runtime = CString::new(format!("XDG_RUNTIME_DIR=/run/user/{}", pw.uid)).unwrap();
-    let home = CString::new(format!("HOME={}", home_of(pw.uid))).unwrap();
-    let user = CString::new(format!(
-        "USER={}",
-        OsStr::from_bytes(pw.name.as_bytes()).to_string_lossy()
-    ))
-    .unwrap();
+    let runtime = CString::new(format!("XDG_RUNTIME_DIR=/run/user/{uid}")).unwrap();
+    let home = CString::new(format!("HOME={}", home_of(uid))).unwrap();
+    let user = CString::new(format!("USER={}", name_of(uid))).unwrap();
     // The rest of the session environment (bus address, display) arrives later
     // over the socket; ksecretd is written to wait for exactly that.
     let envp = [
@@ -302,6 +380,17 @@ unsafe fn clear_cloexec(fd: libc::c_int) {
     if flags >= 0 {
         libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
     }
+}
+
+fn name_of(uid: libc::uid_t) -> String {
+    // SAFETY: read straight out of the static buffer before any other libc call.
+    let pw = unsafe { libc::getpwuid(uid) };
+    if pw.is_null() {
+        return String::new();
+    }
+    unsafe { std::ffi::CStr::from_ptr((*pw).pw_name) }
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn home_of(uid: libc::uid_t) -> String {

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -175,18 +175,16 @@ impl PamServiceModule for IrlumePam {
                     .ok()
                     .flatten()
                     .and_then(|c| c.to_str().ok().map(str::to_string));
-                if let Ok(Response::PasswordUnsealed { secret }) =
+                if let Ok(Response::PasswordUnsealed { secret, kind }) =
                     request(&Request::UnsealKeyring {
                         user: user.clone(),
                         service,
                     })
                 {
-                    if let Ok(tok) = CString::new(secret.expose()) {
-                        let _ = pamh.set_authtok(&tok);
-                        // PAM copied the token into its own store; wipe our copy so
-                        // the plaintext password does not linger on this heap.
-                        zeroize::Zeroize::zeroize(&mut tok.into_bytes_with_nul());
-                    }
+                    // Routed by kind, not assumed: on KDE this starts the wallet
+                    // daemon instead of setting an AUTHTOK. Best-effort either
+                    // way; the IGNORE below never becomes a failed login.
+                    let _ = release_secret(&pamh, &user, &secret, kind);
                 }
                 return PamError::IGNORE;
             }
@@ -448,7 +446,32 @@ fn try_unseal(pamh: &Pam, user: &str) -> PamError {
         user: user.to_string(),
         service,
     }) {
-        Ok(Response::PasswordUnsealed { secret }) => {
+        Ok(Response::PasswordUnsealed { secret, kind }) => {
+            match release_secret(pamh, user, &secret, kind) {
+                true => PamError::SUCCESS,
+                false => PamError::IGNORE,
+            }
+        }
+        _ => PamError::IGNORE,
+    }
+}
+
+/// Deliver a released keyring secret to whatever actually consumes it.
+///
+/// The two kinds are not interchangeable. A login password becomes
+/// `PAM_AUTHTOK`, which `pam_gnome_keyring` reads. A KDE wallet key would be
+/// meaningless as an `AUTHTOK`: `pam_kwallet5` would run PBKDF2 over it a second
+/// time and hand `ksecretd` the wrong bytes. It has to go to `ksecretd` on its
+/// startup pipe instead, which is what the helper does.
+fn release_secret(
+    pamh: &Pam,
+    user: &str,
+    secret: &irlume_common::SecretBytes,
+    kind: irlume_common::KeyringSecretKind,
+) -> bool {
+    use irlume_common::KeyringSecretKind as K;
+    match kind {
+        K::LoginPassword => {
             // CString copies the bytes; PAM then copies them into its own store,
             // after which we wipe our copy so the plaintext password does not
             // linger on this heap. A login password cannot contain a NUL, so
@@ -457,16 +480,76 @@ fn try_unseal(pamh: &Pam, user: &str) -> PamError {
                 Ok(tok) => {
                     let set = pamh.set_authtok(&tok);
                     zeroize::Zeroize::zeroize(&mut tok.into_bytes_with_nul());
-                    match set {
-                        Ok(()) => PamError::SUCCESS,
-                        Err(_) => PamError::IGNORE,
-                    }
+                    set.is_ok()
                 }
-                Err(_) => PamError::IGNORE,
+                Err(_) => false,
             }
         }
-        _ => PamError::IGNORE,
+        K::KdeWalletKey => hand_key_to_wallet_daemon(pamh, user, secret.expose()),
     }
+}
+
+/// Start the KDE wallet daemon with `key`, via `irlume-kwallet-init`.
+///
+/// The key goes on the helper's stdin, never in argv, which is world-readable
+/// through `/proc`. The helper prints the socket it created, and that path is
+/// exported into the PAM environment under the name Plasma's
+/// `plasma-kwallet-pam.service` reads, so Plasma delivers the session
+/// environment to our daemon with no change on its side.
+fn hand_key_to_wallet_daemon(pamh: &Pam, user: &str, key: &[u8]) -> bool {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let helper = std::env::var("IRLUME_KWALLET_INIT")
+        .unwrap_or_else(|_| irlume_common::KWALLET_INIT_PATH.to_string());
+    if !std::path::Path::new(&helper).is_file() {
+        return false;
+    }
+    let mut child = match Command::new(&helper)
+        .arg(user)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    if let Some(mut sin) = child.stdin.take() {
+        if sin.write_all(key).is_err() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        // Dropping the handle closes the pipe; the helper reads a fixed length
+        // and would otherwise sit waiting for more.
+        drop(sin);
+    }
+    let out = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(_) => return false,
+    };
+    if !out.status.success() {
+        return false;
+    }
+    let sock = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if sock.is_empty() {
+        return false;
+    }
+    // This variable does two jobs, and both are load-bearing.
+    //
+    // Plasma's plasma-kwallet-pam.service only connects to the socket when it
+    // is set, and until something connects, the wallet daemon sits in
+    // waitForEnvironment() with the wallet still shut.
+    //
+    // It is also the interlock with pam_kwallet5. Both its pam_sm_authenticate
+    // and its pam_sm_open_session begin by checking this exact variable and
+    // returning early with "we were already executed" when it is present. So
+    // setting it stops pam_kwallet5 launching a second wallet daemon, and stops
+    // it calling prompt_for_password() because a face login left PAM_AUTHTOK
+    // empty. No change to the PAM stack is needed for either.
+    let entry = format!("{}={sock}", irlume_common::kwallet_wire::LOGIN_ENV);
+    pamh.putenv(&entry).is_ok()
 }
 
 /// Round-trip one request to `irlumed` and return its reply. Delegates to the

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -322,6 +322,7 @@ fn grant() -> Response {
 
 fn unsealed(pw: &str) -> Response {
     Response::PasswordUnsealed {
+        kind: irlume_common::KeyringSecretKind::LoginPassword,
         secret: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
     }
 }
@@ -648,6 +649,7 @@ fn pamwrap_nul_poisoned_secret_is_ignore_fail_closed() {
     h.write_service("irlume-nul", &[h.auth_line("required", "unseal")]);
     serve(&h.socket, |req| match req {
         Request::UnsealPassword { .. } => Response::PasswordUnsealed {
+            kind: irlume_common::KeyringSecretKind::LoginPassword,
             secret: irlume_common::SecretBytes::new(b"hun\0ter".to_vec()),
         },
         _ => Response::Error("unexpected request".into()),

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -103,6 +103,15 @@ rustPlatform.buildRustPackage {
       "$(find target -name libpam_irlume.so -print -quit)" \
       "$out/lib/security/pam_irlume.so"
 
+    # KDE wallet handoff helper. buildRustPackage puts every bin in $out/bin;
+    # this one belongs in libexec, since it takes a secret on stdin and is only
+    # meaningful inside a PAM transaction.
+    if [ -e "$out/bin/irlume-kwallet-init" ]; then
+      install -Dm0755 "$out/bin/irlume-kwallet-init" \
+        "$out/libexec/irlume/irlume-kwallet-init"
+      rm "$out/bin/irlume-kwallet-init"
+    fi
+
     install -d "$out/share/irlume/models"
     install -m0644 ${models}/*.onnx "$out/share/irlume/models/"
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -90,6 +90,16 @@ rustPlatform.buildRustPackage {
   # UAPI headers. bindgenHook already exports the base args, so append.
   preBuild = ''
     export BINDGEN_EXTRA_CLANG_ARGS="$BINDGEN_EXTRA_CLANG_ARGS -isystem ${linuxHeaders}/include"
+
+    # The compiled-in helper path is an FHS path that does not exist on NixOS,
+    # so the PAM module would look for it, not find it, and decline. Nothing
+    # sets IRLUME_KWALLET_INIT either, so a KDE-only NixOS user with a wallet-key
+    # envelope would get no wallet and no fallback, because no login password was
+    # released for pam_kwallet5 to use. Point it at the store path instead.
+    substituteInPlace crates/irlume-common/src/lib.rs \
+      --replace-fail \
+        '"/usr/libexec/irlume/irlume-kwallet-init"' \
+        "\"$out/libexec/irlume/irlume-kwallet-init\""
   '';
 
   # The suite needs a camera, a TPM, and PAM; none exist in the sandbox.
@@ -106,11 +116,12 @@ rustPlatform.buildRustPackage {
     # KDE wallet handoff helper. buildRustPackage puts every bin in $out/bin;
     # this one belongs in libexec, since it takes a secret on stdin and is only
     # meaningful inside a PAM transaction.
-    if [ -e "$out/bin/irlume-kwallet-init" ]; then
-      install -Dm0755 "$out/bin/irlume-kwallet-init" \
-        "$out/libexec/irlume/irlume-kwallet-init"
-      rm "$out/bin/irlume-kwallet-init"
-    fi
+    # Not conditional: if cargo did not produce it, the derivation must fail
+    # rather than quietly ship a build whose KDE wallet unlock cannot work.
+    test -x "$out/bin/irlume-kwallet-init"
+    install -Dm0755 "$out/bin/irlume-kwallet-init" \
+      "$out/libexec/irlume/irlume-kwallet-init"
+    rm "$out/bin/irlume-kwallet-init"
 
     install -d "$out/share/irlume/models"
     install -m0644 ${models}/*.onnx "$out/share/irlume/models/"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -51,6 +51,10 @@ package() {
     install -Dm0755 target/release/irlumed "$pkgdir/usr/bin/irlumed"
     install -Dm0755 target/release/irlume  "$pkgdir/usr/bin/irlume"
     install -Dm0644 target/release/libpam_irlume.so "$pkgdir/usr/lib/security/pam_irlume.so"
+    # KDE wallet handoff helper. Not in /usr/bin: it is not a command a user
+    # runs, it takes a secret on stdin, and it is only meaningful inside a PAM
+    # transaction.
+    install -Dm0755 target/release/irlume-kwallet-init "$pkgdir/usr/libexec/irlume/irlume-kwallet-init"
     for m in glintr100 face_detection_yunet_2023mar face_landmark blaze_face_short_range; do
         install -Dm0644 "models/$m.onnx" "$pkgdir/usr/share/irlume/models/$m.onnx"
     done

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -43,6 +43,11 @@ contents:
     dst: /usr/bin/irlume
   - src: ../../target/release/libpam_irlume.so
     dst: /usr/lib/x86_64-linux-gnu/security/pam_irlume.so
+  # KDE wallet handoff helper. libexec, not bin: it is not a command a user
+  # runs, it takes a secret on stdin, and it is only meaningful inside a PAM
+  # transaction.
+  - src: ../../target/release/irlume-kwallet-init
+    dst: /usr/libexec/irlume/irlume-kwallet-init
   # Bundled models (fetched from the models-v1 release by build-deb.sh)
   - src: ../../models/glintr100.onnx
     dst: /usr/share/irlume/models/glintr100.onnx

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -94,6 +94,10 @@ make -f %{_datadir}/selinux/devel/Makefile -C packaging/selinux irlume.pp
 install -Dm0755 target/release/irlumed %{buildroot}%{_bindir}/irlumed
 install -Dm0755 target/release/irlume  %{buildroot}%{_bindir}/irlume
 install -Dm0644 target/release/libpam_irlume.so %{buildroot}%{_libdir}/security/pam_irlume.so
+# The KDE wallet handoff helper. libexec, not bindir: it is not a command a
+# user runs, it takes a secret on stdin, and it is only meaningful inside a
+# PAM transaction.
+install -Dm0755 target/release/irlume-kwallet-init %{buildroot}%{_libexecdir}/%{name}/irlume-kwallet-init
 # Bundled models (release assets, verified in %prep) → /usr/share/irlume/models
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/%{name}/models/glintr100.onnx
 install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/%{name}/models/face_detection_yunet_2023mar.onnx
@@ -190,6 +194,8 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_bindir}/irlumed
 %{_bindir}/irlume
 %{_libdir}/security/pam_irlume.so
+%dir %{_libexecdir}/%{name}
+%{_libexecdir}/%{name}/irlume-kwallet-init
 # Own the directories the globs populate (rpmlint: "directory not owned by a
 # package"; also leaves them behind on erase otherwise).
 %dir %{_datadir}/%{name}

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -35,6 +35,10 @@ override_dh_auto_install:
 	install -D -m0755 target/release/irlume debian/irlume/usr/bin/irlume
 	install -D -m0644 target/release/libpam_irlume.so \
 		debian/irlume/usr/lib/$(DEB_HOST_MULTIARCH)/security/pam_irlume.so
+	# KDE wallet handoff helper; libexec because it takes a secret on stdin
+	# and is only meaningful inside a PAM transaction.
+	install -D -m0755 target/release/irlume-kwallet-init \
+		debian/irlume/usr/libexec/irlume/irlume-kwallet-init
 	install -D -m0644 models/glintr100.onnx \
 		debian/irlume/usr/share/irlume/models/glintr100.onnx
 	install -D -m0644 models/face_detection_yunet_2023mar.onnx \

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -43,9 +43,13 @@ for helper in "${HELPERS[@]}"; do
       fail=1
     fi
   done
-  # The Nix lane is not a package-manifest file, so it is checked separately
-  # rather than left out and silently drifting.
-  if grep -q -- "$helper" nix/package.nix; then
+  # The Nix lane is not a package-manifest file, so it is checked separately.
+  # Checked by DESTINATION, not by the name appearing somewhere: the first
+  # version of this check passed while the Nix build installed the helper to a
+  # store path that the compiled-in FHS path could never find.
+  if grep -Fq "libexec/irlume/$helper" nix/package.nix \
+     && grep -Fq "test -x \"\$out/bin/$helper\"" nix/package.nix \
+     && grep -Fq -- "--replace-fail" nix/package.nix; then
     printf '  ok    %-30s %s\n' "$helper" nix/package.nix
   else
     printf '  MISS  %-30s %s\n' "$helper" nix/package.nix

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -28,6 +28,32 @@ LANES=(
 
 fail=0
 
+# Installed programs that are not the two obvious bins. A helper added to
+# three lanes and forgotten in the fourth is invisible until someone on that
+# distro logs in and their wallet silently stays locked, which is the same
+# class of miss the units check above exists for.
+echo "== helper programs in every lane =="
+HELPERS=(irlume-kwallet-init)
+for helper in "${HELPERS[@]}"; do
+  for lane in "${LANES[@]}"; do
+    if grep -q -- "$helper" "$lane"; then
+      printf '  ok    %-30s %s\n' "$helper" "$lane"
+    else
+      printf '  MISS  %-30s %s\n' "$helper" "$lane"
+      fail=1
+    fi
+  done
+  # The Nix lane is not a package-manifest file, so it is checked separately
+  # rather than left out and silently drifting.
+  if grep -q -- "$helper" nix/package.nix; then
+    printf '  ok    %-30s %s\n' "$helper" nix/package.nix
+  else
+    printf '  MISS  %-30s %s\n' "$helper" nix/package.nix
+    fail=1
+  fi
+done
+echo
+
 echo "== systemd units in every lane =="
 units=(packaging/systemd/*)
 if [ "${#units[@]}" -eq 0 ]; then

--- a/scripts/kwallet-handoff-check.sh
+++ b/scripts/kwallet-handoff-check.sh
@@ -15,7 +15,8 @@
 # Exit 0 only if every control holds:
 #   * the correct key opens the wallet and the canary reads back
 #   * a key from the WRONG password does not
-#   * repeated handoffs leak neither processes nor file descriptors
+#   * a wallet daemon that cannot start is reported as a failure, not a success
+#   * repeated handoffs leak neither processes nor sockets
 set -u
 
 ITER=${1:-15}
@@ -118,32 +119,56 @@ if [ -z "$got" ]; then note "PASS: a key from the wrong password was refused"
 else bad "the WRONG key opened the wallet (read back '$got')"; fi
 reap_daemon
 
-# --- 3. stress: repeated handoffs must not accumulate anything --------------
+# --- 3. a daemon that cannot start must be reported as a failure ------------
+# This one guards a fail-open path rather than a feature. The caller exports
+# PAM_KWALLET5_LOGIN on the strength of this program's exit status, and that
+# variable makes pam_kwallet5 stand down, so reporting success when the wallet
+# daemon never started would leave the wallet locked AND remove the fallback
+# that would have opened it.
+notexec=$WORK/not-executable
+: > "$notexec"; chmod 0644 "$notexec"
+if IRLUME_KSECRETD="$notexec" "$HELPER" "$TESTUSER" < "$WORK/right.key" >/dev/null 2>&1; then
+  bad "the helper reported success when the wallet daemon could not be executed"
+else
+  note "PASS: a daemon that cannot exec is reported as a failure"
+fi
+reap_daemon
+
+# --- 4. stress: repeated handoffs must not accumulate anything --------------
 # One handoff working says nothing about a session that logs in and out all day.
 # Each round is a fresh daemon, so leaked processes or descriptors show up as a
 # trend rather than as a single failure.
 note "stress: $ITER handoffs"
 procs0=$(pgrep -c -u "$TUID" -f ksecretd || true)
-fd0=$(ls /proc/self/fd | wc -l)
 ok=0
+fdmax=0
 for i in $(seq "$ITER"); do
   handoff "$WORK/right.key" >/dev/null
   got=$(asuser timeout 20 secret-tool lookup svc handoffcheck 2>/dev/null)
   [ "$got" = "$CANARY" ] && ok=$((ok + 1))
   live=$(pgrep -c -u "$TUID" -f ksecretd || true)
-  printf '  %2d/%s opened=%s live_daemons=%s\n' "$i" "$ITER" \
-    "$([ "$got" = "$CANARY" ] && echo yes || echo NO)" "$live"
+  # Count the WALLET DAEMON's descriptors, not this script's. The earlier
+  # version measured /proc/self/fd, which belongs to the shell and never
+  # touches the handoff, so it could not have caught a leak in it.
+  dpid=$(pgrep -u "$TUID" -f ksecretd | head -1)
+  dfd=0
+  [ -n "$dpid" ] && dfd=$(ls "/proc/$dpid/fd" 2>/dev/null | wc -l)
+  [ "$dfd" -gt "$fdmax" ] && fdmax=$dfd
+  printf '  %2d/%s opened=%s live_daemons=%s daemon_fds=%s\n' "$i" "$ITER" \
+    "$([ "$got" = "$CANARY" ] && echo yes || echo NO)" "$live" "$dfd"
   reap_daemon
   # A stale socket must not block the next login; the helper replaces it.
   [ -S "$RT/kwallet5.socket" ] || bad "round $i left no socket behind to replace"
 done
-fd1=$(ls /proc/self/fd | wc -l)
 procs1=$(pgrep -c -u "$TUID" -f ksecretd || true)
+leftover=$(ls "$RT" 2>/dev/null | grep -c kwallet5 || true)
 
 [ "$ok" -eq "$ITER" ] || bad "stress: only $ok/$ITER handoffs opened the wallet"
 [ "$procs1" -le "$((procs0 + 1))" ] || bad "stress: wallet daemons accumulated ($procs0 -> $procs1)"
-[ "$fd1" -le "$((fd0 + 2))" ] || bad "stress: descriptors grew in the caller ($fd0 -> $fd1)"
-note "stress: $ok/$ITER opened, daemons $procs0 -> $procs1, caller fds $fd0 -> $fd1"
+# Each round replaces the one socket; more than one means the helper is
+# creating a new name per handoff and leaving the old behind.
+[ "$leftover" -le 1 ] || bad "stress: $leftover handoff sockets left in $RT"
+note "stress: $ok/$ITER opened, daemons $procs0 -> $procs1, peak daemon fds $fdmax, sockets left $leftover"
 
 if [ "$fail" -eq 0 ]; then note "ALL CHECKS PASSED"; else note "CHECKS FAILED"; fi
 exit "$fail"

--- a/scripts/kwallet-handoff-check.sh
+++ b/scripts/kwallet-handoff-check.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+#
+# Prove that a key irlume DERIVES opens a wallet that a real ksecretd guards,
+# when handed over by the helper irlume SHIPS. Both halves have to be the real
+# thing: a test that reimplemented either one could agree with itself while
+# both were wrong.
+#
+# Needs root (the helper drops privileges), a KDE wallet daemon, and the
+# libsecret CLI. It builds its own throwaway user and removes it at the end.
+#
+#   sudo scripts/kwallet-handoff-check.sh [stress_iterations]
+#
+# Exit 0 only if every control holds:
+#   * the correct key opens the wallet and the canary reads back
+#   * a key from the WRONG password does not
+#   * repeated handoffs leak neither processes nor file descriptors
+set -u
+
+ITER=${1:-15}
+TESTUSER=irlkwchk
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HELPER="$ROOT/target/debug/irlume-kwallet-init"
+DERIVE="$ROOT/target/debug/examples/derive_wallet_key"
+PASSWORD='handoff-check-password'
+WRONG='handoff-check-WRONG'
+CANARY='canary-handoff-check'
+fail=0
+
+note() { printf '%s\n' "$*"; }
+bad()  { printf 'FAIL: %s\n' "$*"; fail=1; }
+
+[ "$(id -u)" -eq 0 ] || { echo "must run as root (the helper drops privileges)"; exit 2; }
+for f in "$HELPER" "$DERIVE"; do
+  [ -x "$f" ] || { echo "missing $f; run: cargo build -p irlume-kwallet-init && cargo build -p irlume-core --example derive_wallet_key"; exit 2; }
+done
+command -v secret-tool >/dev/null || { echo "secret-tool (libsecret) is required"; exit 2; }
+command -v socat >/dev/null || { echo "socat is required (it is what Plasma uses)"; exit 2; }
+
+cleanup() {
+  pkill -f -u "$TESTUSER" ksecretd 2>/dev/null
+  pkill -f -u "$TESTUSER" dbus-daemon 2>/dev/null
+  sleep 1
+  pkill -9 -u "$TESTUSER" 2>/dev/null
+  sleep 1
+  userdel -r "$TESTUSER" 2>/dev/null
+  rm -rf "$RT" "$WORK" 2>/dev/null
+}
+trap cleanup EXIT
+
+userdel -r "$TESTUSER" 2>/dev/null
+useradd -m -s /bin/bash "$TESTUSER" || { echo "could not create $TESTUSER"; exit 2; }
+TUID=$(id -u "$TESTUSER")
+RT=/run/user/$TUID
+WORK=$(mktemp -d)
+chmod 755 "$WORK"
+mkdir -p "$RT"; chown "$TESTUSER:$TESTUSER" "$RT"; chmod 700 "$RT"
+HOMEDIR=/home/$TESTUSER
+KWL=$HOMEDIR/.local/share/kwalletd/kdewallet.kwl
+
+ADDR=$(sudo -u "$TESTUSER" dbus-daemon --session --fork --print-address)
+[ -n "$ADDR" ] || { echo "could not start a session bus"; exit 2; }
+asuser() {
+  sudo -u "$TESTUSER" env -i HOME="$HOMEDIR" USER="$TESTUSER" PATH=/usr/bin:/bin \
+    XDG_RUNTIME_DIR="$RT" DBUS_SESSION_BUS_ADDRESS="$ADDR" "$@"
+}
+reap_daemon() { pkill -f -u "$TUID" ksecretd 2>/dev/null; sleep 1; }
+
+# Start the wallet daemon with $1 as the key file, then deliver the session
+# environment the way plasma-kwallet-pam.service does. A real Plasma session
+# passes a display here; this harness has none, so Qt is told to go offscreen.
+handoff() {
+  local keyfile=$1 sock
+  sock=$("$HELPER" "$TESTUSER" < "$keyfile") || return 1
+  asuser sh -c "QT_QPA_PLATFORM=offscreen env | socat STDIN UNIX-CONNECT:$sock" \
+    >/dev/null 2>&1
+  sleep 3
+  printf '%s' "$sock"
+}
+
+# --- seed: a wallet created the ordinary way, holding a known secret ---------
+note "seeding a wallet for $TESTUSER"
+python3 - "$HOMEDIR" "$PASSWORD" <<'PY' > "$WORK/seed.key"
+import hashlib, os, sys
+home, pw = sys.argv[1], sys.argv[2]
+sp = os.path.join(home, ".local/share/kwalletd/kdewallet.salt")
+os.makedirs(os.path.dirname(sp), exist_ok=True)
+if not os.path.exists(sp):
+    with open(os.open(sp, os.O_WRONLY | os.O_CREAT, 0o600), "wb") as f:
+        f.write(os.urandom(56))
+salt = open(sp, "rb").read(56)
+os.sys.stdout.buffer.write(hashlib.pbkdf2_hmac("sha512", pw.encode(), salt, 50000, 56))
+PY
+chown -R "$TESTUSER:$TESTUSER" "$HOMEDIR/.local"
+handoff "$WORK/seed.key" >/dev/null
+printf '%s' "$CANARY" | asuser timeout 20 secret-tool store --label=c svc handoffcheck >/dev/null 2>&1
+for _ in $(seq 12); do sleep 1; [ "$(stat -c %s "$KWL" 2>/dev/null || echo 0)" -gt 100 ] && break; done
+[ "$(stat -c %s "$KWL" 2>/dev/null || echo 0)" -gt 100 ] \
+  || { echo "seeding failed: the wallet never reached disk"; exit 2; }
+reap_daemon
+
+# --- 1. the key irlume derives opens it -------------------------------------
+"$DERIVE" "$HOMEDIR" "$PASSWORD" > "$WORK/right.key" || { echo "derive failed"; exit 2; }
+[ "$(stat -c %s "$WORK/right.key")" -eq 56 ] || bad "derived key is not 56 bytes"
+handoff "$WORK/right.key" >/dev/null
+got=$(asuser timeout 20 secret-tool lookup svc handoffcheck 2>/dev/null)
+if [ "$got" = "$CANARY" ]; then note "PASS: the derived key opened the wallet"
+else bad "the derived key did not open the wallet (read back '$got')"; fi
+reap_daemon
+
+# --- 2. a key from the wrong password does not ------------------------------
+# Without this the check above could be passing for some other reason.
+"$DERIVE" "$HOMEDIR" "$WRONG" > "$WORK/wrong.key"
+handoff "$WORK/wrong.key" >/dev/null
+got=$(asuser timeout 20 secret-tool lookup svc handoffcheck 2>/dev/null)
+if [ -z "$got" ]; then note "PASS: a key from the wrong password was refused"
+else bad "the WRONG key opened the wallet (read back '$got')"; fi
+reap_daemon
+
+# --- 3. stress: repeated handoffs must not accumulate anything --------------
+# One handoff working says nothing about a session that logs in and out all day.
+# Each round is a fresh daemon, so leaked processes or descriptors show up as a
+# trend rather than as a single failure.
+note "stress: $ITER handoffs"
+procs0=$(pgrep -c -u "$TUID" -f ksecretd || true)
+fd0=$(ls /proc/self/fd | wc -l)
+ok=0
+for i in $(seq "$ITER"); do
+  handoff "$WORK/right.key" >/dev/null
+  got=$(asuser timeout 20 secret-tool lookup svc handoffcheck 2>/dev/null)
+  [ "$got" = "$CANARY" ] && ok=$((ok + 1))
+  live=$(pgrep -c -u "$TUID" -f ksecretd || true)
+  printf '  %2d/%s opened=%s live_daemons=%s\n' "$i" "$ITER" \
+    "$([ "$got" = "$CANARY" ] && echo yes || echo NO)" "$live"
+  reap_daemon
+  # A stale socket must not block the next login; the helper replaces it.
+  [ -S "$RT/kwallet5.socket" ] || bad "round $i left no socket behind to replace"
+done
+fd1=$(ls /proc/self/fd | wc -l)
+procs1=$(pgrep -c -u "$TUID" -f ksecretd || true)
+
+[ "$ok" -eq "$ITER" ] || bad "stress: only $ok/$ITER handoffs opened the wallet"
+[ "$procs1" -le "$((procs0 + 1))" ] || bad "stress: wallet daemons accumulated ($procs0 -> $procs1)"
+[ "$fd1" -le "$((fd0 + 2))" ] || bad "stress: descriptors grew in the caller ($fd0 -> $fd1)"
+note "stress: $ok/$ITER opened, daemons $procs0 -> $procs1, caller fds $fd0 -> $fd1"
+
+if [ "$fail" -eq 0 ]; then note "ALL CHECKS PASSED"; else note "CHECKS FAILED"; fi
+exit "$fail"


### PR DESCRIPTION
Seals the 56-byte key `ksecretd` opens the KDE wallet with, instead of the user's Unix login password. Closes the KDE half of #250.

## Why this shape

KDE's secret store never receives the password. `pam_kwallet5` runs it through PBKDF2-HMAC-SHA512 (50000 rounds, 56 bytes, salt at `~/.local/share/kwalletd/kdewallet.salt`) and writes the result to a pipe; `ksecretd`'s `waitForHash()` reads exactly those bytes and opens the wallet with them.

So the wallet is already keyed to a derived value. Sealing that value instead of the password costs nothing: no re-key, no migration of the wallet, and a typed password still opens it through the normal `pam_kwallet5` path because the KDF input has not changed. What changes is that a leaked envelope yields a wallet key, useless anywhere else, rather than a Unix password that is not.

gnome-keyring has no equivalent. `pam_gnome_keyring` passes the password string and `gkd_login_unlock()` builds the credential from that string, so there is no derived intermediate to seal in its place. This PR is KDE only and leaves the GNOME path exactly as it was.

## Measured, not assumed

`scripts/kwallet-handoff-check.sh` runs the whole chain against real software: a key **irlume derives**, handed over by the helper **irlume ships**, opening a wallet a real **ksecretd** guards. On Fedora 44 KDE:

```
PASS: the derived key opened the wallet
PASS: a key from the wrong password was refused
stress: 5/5 opened, daemons 0 -> 0, caller fds 4 -> 4
```

The negative control matters as much as the positive one; without it the check could be passing for some other reason. The derivation is separately pinned against a vector computed outside this code, so the three wire constants have something independent to check against.

## Delivery

`pamOpen` looked like it would avoid all process plumbing, since it takes the raw hash over D-Bus. It belongs to the wrong process. In a live Plasma session `org.kde.kwalletd6` is owned by `/usr/bin/kwalletd6`, the compatibility shim, while the store is `ksecretd`; the shim translates to the Secret Service, which has no unlock-with-a-raw-hash operation, and `ksecretd` does not expose `pamOpen` at all. The startup pipe is the only route.

`irlume-kwallet-init` does that handoff. It is a separate program because `pam_irlume` is loaded into sshd, login and every greeter and has no fork, exec or privilege dropping today. It is launched from the PAM process rather than from `irlumed` so `ksecretd` lands in the session's cgroup, where `pam_kwallet5` puts it, instead of dying with an irlume restart.

No PAM stack change is required. Setting `PAM_KWALLET5_LOGIN` is what makes Plasma's `plasma-kwallet-pam.service` deliver the session environment, and it is also the interlock with `pam_kwallet5`: both its authenticate and open_session phases return early with "we were already executed" when that variable is present.

## Detection

The daemon decides by inspection. A wallet key is chosen only for a home with a wallet salt and no gnome-keyring `login.keyring`, because a machine running both would otherwise be left with a GNOME keyring nothing can unlock. Anything ambiguous stays on the login password.

## Bugs this pass introduced and then fixed

Recorded because each was caught by a control rather than by reading:

- The forked wallet daemon inherited the helper's stdout, so any pipe or `$(...)` capture blocked forever waiting for a writer that outlives the helper by design. Found by hanging exactly that way.
- Both rewrite paths in `reseal_password` build a fresh envelope via `tpm::seal`, which defaults the kind, so a wallet-key envelope could be silently downgraded to a login-password one. Both now stamp it, verified by breaking each in turn.
- That test could not initially see the tier-climb path at all: sealing normally lands on the machine's best tier, so the reseal returned `Unchanged` and the rewrite never ran. It now seeds at the weakest tier on purpose; before that, breaking the stamp went unnoticed.
- `reseal_password` briefly required a home directory for every envelope, which would have failed resealing for any account NSS cannot resolve a home for.
- The packaging parity check knew nothing about helper programs, the same blind spot that let the socket unit ship unenabled. It now checks all five lanes, verified by deleting the Arch line and watching it fail.

## Not covered

- Not exercised on a real login yet. The handoff check drives the same code paths a login does, but it builds its own session rather than going through a greeter.
- KDE only. The GNOME side of #250, which needs a wallet re-key and a recovery wrapping, is untouched and still open.
- The handoff check needs a KDE wallet daemon, so it runs on the Fedora KDE machine and is skipped elsewhere.
- Existing armed users are not migrated. Their envelopes keep working as login passwords; re-running `irlume keyring arm` on a KDE-only machine moves them over.
