### PR TITLE
Serialise process spawning with the crate lock (#251)

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -42,6 +42,17 @@ pub mod uvc_descriptor;
 /// `EnvGuard` restores the PREVIOUS value rather than unsetting: unsetting is
 /// not restoring, and a test that leaves `IRLUME_STATE_DIR` cleared changes what
 /// the next one resolves.
+///
+/// It also serialises tests that SPAWN PROCESSES, which is not obvious from the
+/// name and is the cause of #251. `fork` copies the file descriptor table, and
+/// an `flock` belongs to the open file description, so a child briefly holds
+/// every lock its parent held at the moment of the fork. `O_CLOEXEC` closes the
+/// inherited copy at `exec`, not at `fork`, so `Command::spawn` leaves a window
+/// in which an unrelated test's lock is held by a child that knows nothing
+/// about it. A test that then releases its lock and immediately re-takes it
+/// gets `Busy` from a lock nothing appears to hold, which is why `/proc/locks`
+/// looks empty a moment later. `flock_is_inherited_across_fork` pins the
+/// mechanism.
 #[cfg(test)]
 pub(crate) mod testenv {
     pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -3806,6 +3817,13 @@ mod tests {
     /// else is streaming, and the scan then sees two holders.
     #[test]
     fn another_process_outranks_our_own_hold() {
+        // Held for the SPAWN, not for any environment variable: the fork below
+        // copies this process's whole fd table, so between fork and exec the
+        // child holds every flock any concurrently-running test has open. That
+        // made an unrelated stream-lock test see `Busy` from a lock nothing
+        // held (#251). The crate lock is the only serialisation point that
+        // covers process-global state, and the fd table is process-global.
+        let _guard = crate::testenv::env_lock();
         let dir = std::env::temp_dir().join(format!("irlume-cam-two-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -884,6 +884,62 @@ mod tests {
     /// A retirement that fails spends nothing (review round 11): the
     /// increment rolls back with the state, and only the successful
     /// pre-write publication carries it to disk.
+    /// The mechanism behind #251, pinned so the crate lock's spawn duty is
+    /// provable rather than folklore.
+    ///
+    /// `flock` belongs to the open file description, and `fork` copies the fd
+    /// table, so a child holds every lock its parent held at the moment of the
+    /// fork. `O_CLOEXEC` closes that copy at `exec`, NOT at `fork`, so every
+    /// `Command::spawn` anywhere in the process leaves a window in which an
+    /// unrelated lock is held by a child that knows nothing about it. The
+    /// symptom is a `Busy` from a lock that `/proc/locks` shows nobody holding
+    /// a moment later, and it only appears under enough CPU contention to
+    /// stretch fork-to-exec: CI runners, and this laptop only when pinned to
+    /// two cores.
+    ///
+    /// Production is not exposed the same way: `irlumed` holds this lock across
+    /// a control write and does not spawn children inside that window. If it
+    /// ever does, a second irlume would be refused the camera for as long as
+    /// the fork-to-exec gap lasts.
+    #[test]
+    fn flock_is_inherited_across_fork_until_exec() {
+        let _guard = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-fork-flock-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = crate::testenv::EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let id = identity();
+
+        let lock = acquire(&id).expect("the lock is free");
+        // SAFETY: the child only sleeps and _exits, both async-signal-safe,
+        // which is the constraint fork() imposes on a threaded process.
+        let child = unsafe { libc::fork() };
+        assert!(child >= 0, "fork failed");
+        if child == 0 {
+            // Holds the INHERITED descriptor open without exec'ing, which is
+            // the window Command::spawn opens and closes too fast to observe.
+            // The sleep is for DETERMINISM, not correctness: without it the
+            // parent usually still wins the race, so its absence does not
+            // falsify the assertion below.
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            unsafe { libc::_exit(0) };
+        }
+
+        drop(lock); // this process lets go; the child has not.
+        assert!(
+            matches!(acquire(&id), Err(AcquireError::Busy)),
+            "a forked child must still hold the inherited lock; if this ever              stops being true the crate lock no longer needs to cover spawning"
+        );
+
+        let mut status = 0;
+        // SAFETY: reaping the child we just forked.
+        unsafe { libc::waitpid(child, &mut status, 0) };
+        assert!(
+            acquire(&id).is_ok(),
+            "once the last holder of the description is gone the lock is free"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn a_failed_retirement_spends_no_attempt() {
         let _guard = crate::testenv::env_lock();

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -884,25 +884,62 @@ mod tests {
     /// A retirement that fails spends nothing (review round 11): the
     /// increment rolls back with the state, and only the successful
     /// pre-write publication carries it to disk.
-    /// The mechanism behind #251, pinned so the crate lock's spawn duty is
-    /// provable rather than folklore.
+    /// The fact that bounds #251's window to fork-to-exec rather than the
+    /// child's whole lifetime.
+    ///
+    /// `flock` locks survive `execve` when the descriptor stays open, so the
+    /// inherited lock is released at the child's `exec` ONLY because the
+    /// descriptor is close-on-exec. Rust's `OpenOptions` sets that today; if a
+    /// future change opened this file through a path that does not, a spawned
+    /// `sleep 30` would hold the camera lock for thirty seconds and
+    /// `flock_is_inherited_across_fork_until_child_exit` would still pass.
+    /// Asserted on the flag directly rather than through an exec, because the
+    /// flag IS the property and an exec test would only sample it.
+    #[test]
+    fn the_stream_lock_descriptor_is_close_on_exec() {
+        use std::os::unix::io::AsRawFd as _;
+        let _guard = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!("irlume-cloexec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = crate::testenv::EnvGuard::set("IRLUME_STATE_DIR", &dir);
+
+        let lock = acquire(&identity()).expect("the lock is free");
+        // SAFETY: querying flags on a descriptor this scope owns.
+        let flags = unsafe { libc::fcntl(lock._file.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0, "F_GETFD failed");
+        assert!(
+            flags & libc::FD_CLOEXEC != 0,
+            "the stream lock descriptor must be close-on-exec, or a spawned \
+             child keeps this camera's lock for its whole life"
+        );
+        drop(lock);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The mechanism behind #251: a forked child retains the inherited locked
+    /// open file description after the parent releases its own descriptor.
     ///
     /// `flock` belongs to the open file description, and `fork` copies the fd
     /// table, so a child holds every lock its parent held at the moment of the
-    /// fork. `O_CLOEXEC` closes that copy at `exec`, NOT at `fork`, so every
-    /// `Command::spawn` anywhere in the process leaves a window in which an
-    /// unrelated lock is held by a child that knows nothing about it. The
-    /// symptom is a `Busy` from a lock that `/proc/locks` shows nobody holding
-    /// a moment later, and it only appears under enough CPU contention to
-    /// stretch fork-to-exec: CI runners, and this laptop only when pinned to
-    /// two cores.
+    /// fork. That is what let one test's `Command::spawn` hold another test's
+    /// lock: the symptom is a `Busy` from a lock that `/proc/locks` shows
+    /// nobody holding a moment later, and it only appears under enough CPU
+    /// contention to stretch fork-to-exec: CI runners, and this laptop only
+    /// when pinned to two cores.
+    ///
+    /// What bounds that window to fork-to-exec rather than the child's whole
+    /// life is the descriptor being close-on-exec, a SEPARATE fact asserted by
+    /// `the_stream_lock_descriptor_is_close_on_exec`. `flock` locks survive
+    /// `execve` when the descriptor stays open, so without that flag a spawned
+    /// `sleep 30` would hold the camera for thirty seconds and this test would
+    /// still pass.
     ///
     /// Production is not exposed the same way: `irlumed` holds this lock across
     /// a control write and does not spawn children inside that window. If it
     /// ever does, a second irlume would be refused the camera for as long as
     /// the fork-to-exec gap lasts.
     #[test]
-    fn flock_is_inherited_across_fork_until_exec() {
+    fn flock_is_inherited_across_fork_until_child_exit() {
         let _guard = crate::testenv::env_lock();
         let dir = std::env::temp_dir().join(format!("irlume-fork-flock-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -910,8 +947,12 @@ mod tests {
         let id = identity();
 
         let lock = acquire(&id).expect("the lock is free");
-        // SAFETY: the child only sleeps and _exits, both async-signal-safe,
-        // which is the constraint fork() imposes on a threaded process.
+        // SAFETY: after fork in a threaded process the child may call only
+        // async-signal-safe functions until execve. `sleep(3)` and `_exit(2)`
+        // are on that list; Rust's `std::thread::sleep` is NOT and carries no
+        // post-fork contract, so it must not be used here however similar it
+        // looks. It was, until review: the comment claimed a guarantee the
+        // call did not have.
         let child = unsafe { libc::fork() };
         assert!(child >= 0, "fork failed");
         if child == 0 {
@@ -920,8 +961,10 @@ mod tests {
             // The sleep is for DETERMINISM, not correctness: without it the
             // parent usually still wins the race, so its absence does not
             // falsify the assertion below.
-            std::thread::sleep(std::time::Duration::from_millis(300));
-            unsafe { libc::_exit(0) };
+            unsafe {
+                libc::sleep(1);
+                libc::_exit(0);
+            }
         }
 
         drop(lock); // this process lets go; the child has not.


### PR DESCRIPTION
Closes #251.

The flake was a lock that nothing appeared to hold. At the moment
`acquire` returned `Busy`, `/proc/locks` had no entry for the inode and
no process on the machine had the file open. The mechanism is file
descriptor inheritance.

`flock` belongs to the open file description, and `fork` copies the file
descriptor table, so a child briefly holds every lock its parent held at
the moment of the fork. `O_CLOEXEC` closes that copy at `exec`, not at
`fork`, so every `Command::spawn` anywhere in the process opens a window
in which an unrelated test's lock is held by a child that knows nothing
about it. The holder is gone microseconds later, which is why every probe
pointed at nobody, and it only surfaces under enough CPU contention to
stretch fork-to-exec.

## The change

`another_process_outranks_our_own_hold` spawns `sleep 30` and was the one
spawner in the crate not taking the crate-wide lock, so it could fork
while the stream-lock test held its lock. It now takes it. Every other
spawner already did: the `flock` helpers in `emitter_journal` and
`ir_emitter`, and the ffmpeg feeder through its callers.

The lock's documentation now says that serialising spawns is part of its
job. The name says `env`, the duty is process-global state, and the fd
table is process-global.

`flock_is_inherited_across_fork_until_child_exit` pins the mechanism:
fork, release the parent's reference, and the lock is still `Busy` until
the child is reaped.

`the_stream_lock_descriptor_is_close_on_exec` pins the separate fact that
bounds the window. `flock` locks survive `execve` while the descriptor
stays open, so the inherited lock ends at the child's exec only because
the descriptor is close-on-exec; without that flag a spawned `sleep 30`
would hold the camera for thirty seconds and the first test would still
pass. Clearing `FD_CLOEXEC` after the open fails it.

## How it was found

The issue recorded it as not reproducible locally, at 0 failures in 25
isolated runs and 6 whole-crate runs. It reproduces at roughly 1 in 40
with the test binary pinned to two cores and 8 test threads, which is
closer to a CI runner than this laptop's 8 cores:

```
taskset -c 0,1 <test-binary> --test-threads=8
```

Every probe that read `/proc` was too slow to catch the holder, and each
one changed the timing enough to hide the failure. The fork test is what
settled it.

## Limits

**The fix cannot be shown to change the rate here.** It reproduced at 1
in 40 while I was hunting it and then would not reproduce again: 0 in 100
before the change and 0 in 100 after, both pinned to two cores. So the
justification is the proven mechanism and the closing of the only
unserialised window, not a before-and-after measurement.

The fork test asserts an OS property rather than our logic, so it guards
the assumption behind the fix rather than the fix itself. The child's
sleep is for determinism: removing it does not falsify the assertion,
because the parent usually wins the race anyway.

Reviewed once by Codex, which blocked on the child calling Rust's
`std::thread::sleep` after `fork`. Only async-signal-safe functions may
run between `fork` and `execve` in a threaded process; `sleep(3)`
qualifies and `std::thread::sleep` does not, and the SAFETY comment
claimed a guarantee the call did not have. It also caught the test
promising an exec boundary it never exercised, which is why the
close-on-exec fact is now asserted on its own.

Production is not exposed the same way. `irlumed` holds the stream lock
across a control write and does not spawn children inside that window. If
it ever does, a second irlume would be refused the camera for as long as
the fork-to-exec gap lasts.

## Testing

- `cargo test --workspace` green, 26 test binaries.
- `cargo clippy --workspace --all-targets`, `cargo fmt --check`, and
  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean.
- 100 runs pinned to two cores with 8 test threads, no failures.
