### PR TITLE
Seal a random keyring token on GNOME, not the login password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,14 @@ name = "irlume-fingerprint"
 version = "0.8.0"
 
 [[package]]
+name = "irlume-gkr-unlock"
+version = "0.8.0"
+dependencies = [
+ "irlume-common",
+ "libc",
+]
+
+[[package]]
 name = "irlume-kwallet-init"
 version = "0.8.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/irlume-liveness",
     "crates/irlume-core",
     "crates/irlume-kwallet-init",
+    "crates/irlume-gkr-unlock",
     "crates/irlume-auth",
     "crates/irlume-fingerprint",
     "crates/irlume-daemon",

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1323,6 +1323,24 @@ pub fn reseal(args: &[String]) -> ExitCode {
             return ExitCode::FAILURE;
         }
     }
+    // A token envelope (#250) heals itself: the session-phase reseal re-seals
+    // it from its password wrap on the next typed-password login. Re-arming it
+    // here would mint a NEW token and hand it back for a keyring re-key this
+    // command does not perform, stranding the keyring on the old one.
+    if matches!(
+        daemon_request(&Request::KeyringInfo { user: user.clone() }),
+        Ok(Response::KeyringInfo {
+            kind: Some(irlume_common::KeyringSecretKind::GnomeKeyringToken),
+            ..
+        })
+    ) {
+        println!(
+            "[reseal] '{user}' is armed with a GNOME keyring token; it re-binds itself on \
+             your next password login. To rebuild it from scratch, run `irlume keyring \
+             forget` then `irlume keyring arm`."
+        );
+        return ExitCode::SUCCESS;
+    }
     println!("[reseal] Re-binding '{user}'s sealed password to the current TPM/PCR state.");
     let Some(pw) = prompt_login_password() else {
         return ExitCode::from(2);
@@ -1428,9 +1446,17 @@ pub fn setup(args: &[String]) -> ExitCode {
             match daemon_request(&Request::SealPassword {
                 kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
-                password: irlume_common::SecretBytes::new(pw.into_bytes()),
+                password: irlume_common::SecretBytes::new(pw.clone().into_bytes()),
             }) {
                 Ok(Response::PasswordSealed) => println!("  armed {OK}"),
+                // GNOME token arm: the wizard runs in the user's session, so
+                // it can finish the re-key exactly like `keyring arm`.
+                Ok(Response::TokenSealed { token, minted }) => {
+                    match crate::finish_token_arm(&user, pw.as_bytes(), token.expose(), minted) {
+                        Ok(()) => println!("  armed with a keyring token {OK}"),
+                        Err(e) => eprintln!("  arm failed: {e}"),
+                    }
+                }
                 r => eprintln!("  arm failed: {r:?}"),
             }
         }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -854,6 +854,101 @@ fn verify(args: &[String]) -> std::process::ExitCode {
     }
 }
 
+/// One CHANGE against the caller's own gnome-keyring control socket. The
+/// control socket authenticates the peer's uid, so this only works for the
+/// invoking user's own keyring, in their own session; arming another user's
+/// token therefore fails here (and rolls back) rather than half-arming.
+fn rekey_login_keyring(current: &[u8], new: &[u8]) -> Result<(), String> {
+    use irlume_common::gkr_wire::{self, ControlResult, Op};
+    let rt = std::env::var_os("XDG_RUNTIME_DIR")
+        .ok_or("no XDG_RUNTIME_DIR; run this inside the user's own session")?;
+    let sock = gkr_wire::control_socket_path(std::path::Path::new(&rt));
+    let mut stream = std::os::unix::net::UnixStream::connect(&sock).map_err(|e| {
+        format!(
+            "connect {}: {e} (is gnome-keyring-daemon running in this session?)",
+            sock.display()
+        )
+    })?;
+    match gkr_wire::call(&mut stream, Op::Change, &[current, new])? {
+        ControlResult::Ok => Ok(()),
+        other => Err(format!("keyring re-key: {}", other.describe())),
+    }
+}
+
+/// Prove `secret` is the login keyring's current credential: a CHANGE from it
+/// to itself succeeds only then, changes nothing, and needs no prompt. This is
+/// the post-re-key verification, so "armed" is never claimed on the strength
+/// of a re-key reply alone.
+fn verify_keyring_credential(secret: &[u8]) -> Result<(), String> {
+    rekey_login_keyring(secret, secret)
+}
+
+/// Second half of a GNOME token arm, shared by `keyring arm`, the setup wizard
+/// and the TUI: re-key the login keyring from `password` to `token` and verify
+/// the token is now the live credential. On a RE-arm the keyring is usually
+/// keyed to the token already, so a denied re-key followed by a passing
+/// verification is success, not failure.
+///
+/// `minted` is the daemon's word on whether this token is fresh: only then is
+/// the envelope inert and safe to roll back with `ForgetPassword` on failure.
+/// A reused token may BE the live keyring credential, and deleting its
+/// envelope on an error path would strand the keyring; that branch only
+/// reports. Returns a human-readable error; success needs no message beyond
+/// the caller's own.
+pub(crate) fn finish_token_arm(
+    user: &str,
+    password: &[u8],
+    token: &[u8],
+    minted: bool,
+) -> Result<(), String> {
+    let keyed = match rekey_login_keyring(password, token) {
+        Ok(()) => verify_keyring_credential(token),
+        // The keyring may already be keyed to this exact token (idempotent
+        // re-arm); verification decides. Keep the original error if not.
+        Err(rekey_err) => verify_keyring_credential(token).map_err(|_| rekey_err),
+    };
+    match keyed {
+        Ok(()) => Ok(()),
+        Err(e) if minted => {
+            let cleanup = match daemon_request(&irlume_common::Request::ForgetPassword {
+                user: user.to_string(),
+            }) {
+                Ok(irlume_common::Response::PasswordForgotten) => {
+                    "rolled back: the sealed token was erased; nothing changed".to_string()
+                }
+                other => format!(
+                    "WARNING: could not erase the unused token envelope ({other:?}); run \
+                     `irlume keyring forget` to clean up. The keyring itself is unchanged"
+                ),
+            };
+            Err(format!(
+                "keyring re-key failed: {e}. {cleanup}. Run the arm as '{user}' inside \
+                 their own graphical session."
+            ))
+        }
+        Err(e) => Err(format!(
+            "keyring re-key failed: {e}. The envelope was left in place (it holds the \
+             keyring's live token); retry as '{user}' inside their own graphical session."
+        )),
+    }
+}
+
+/// Read the user's login password without echo, mirroring the arm prompt's
+/// terminal/pipe split.
+fn read_password(prompt: &str) -> Result<String, String> {
+    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        rpassword::prompt_password(prompt).map_err(|e| format!("could not read password: {e}"))
+    } else {
+        use std::io::BufRead;
+        let mut line = String::new();
+        std::io::stdin()
+            .lock()
+            .read_line(&mut line)
+            .map_err(|e| format!("could not read password: {e}"))?;
+        Ok(line.trim_end_matches(['\n', '\r']).to_string())
+    }
+}
+
 /// `irlume keyring <arm|status|forget>`: manage the TPM-sealed login password
 /// that lets a face login unlock the GNOME-keyring / KWallet. Talks to `irlumed`
 /// over the socket (the daemon owns the TPM + the root-only sealed store).
@@ -905,13 +1000,39 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
             let req = irlume_common::Request::SealPassword {
                 kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
-                password: irlume_common::SecretBytes::new(pw.into_bytes()),
+                password: irlume_common::SecretBytes::new(pw.clone().into_bytes()),
             };
             match daemon_request(&req) {
                 Ok(irlume_common::Response::PasswordSealed) => {
                     println!("[keyring] \u{2705} armed. After a face login, your wallet will unlock automatically.");
                     println!("[keyring] NOTE: if you change your login password, re-run `irlume keyring arm`.");
                     std::process::ExitCode::SUCCESS
+                }
+                // GNOME token arm (#250): the daemon minted and sealed a token;
+                // the login keyring must now be re-keyed to it, which only this
+                // process can do (the control socket is in this session). Until
+                // the re-key lands, the envelope is inert and the keyring still
+                // opens with the password, so a failure here rolls the envelope
+                // back and leaves everything exactly as before the command.
+                Ok(irlume_common::Response::TokenSealed { token, minted }) => {
+                    match finish_token_arm(&user, pw.as_bytes(), token.expose(), minted) {
+                        Ok(()) => {
+                            println!(
+                                "[keyring] \u{2705} armed with a keyring token. Your login keyring \
+                                 is now keyed to a random secret that irlume releases on every \
+                                 login (face, fingerprint, or typed password)."
+                            );
+                            println!(
+                                "[keyring] Your password alone no longer opens the keyring \
+                                 directly; `irlume keyring forget` re-keys it back."
+                            );
+                            std::process::ExitCode::SUCCESS
+                        }
+                        Err(e) => {
+                            eprintln!("[keyring] {e}");
+                            std::process::ExitCode::FAILURE
+                        }
+                    }
                 }
                 Ok(irlume_common::Response::Error(e)) => {
                     eprintln!("[keyring] arm failed: {e}");
@@ -951,26 +1072,90 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
                 }
             }
         }
-        Some("forget") => match daemon_request(&irlume_common::Request::ForgetPassword {
-            user: user.clone(),
-        }) {
-            Ok(irlume_common::Response::PasswordForgotten) => {
-                println!("[keyring] '{user}': sealed password erased; keyring unlock disarmed.");
-                std::process::ExitCode::SUCCESS
+        Some("forget") => {
+            // A token disarm must re-key the login keyring BACK to the
+            // password before the envelope goes away: deleting a token
+            // envelope first would strand the keyring on a secret that no
+            // longer exists anywhere. `--force` skips the re-key for the case
+            // where the keyring is already gone (deleted profile, reinstalled
+            // distro) and the stale envelope is all that is left.
+            let force = args.iter().any(|a| a == "--force");
+            let token_armed = matches!(
+                daemon_request(&irlume_common::Request::KeyringInfo { user: user.clone() }),
+                Ok(irlume_common::Response::KeyringInfo {
+                    armed: true,
+                    kind: Some(irlume_common::KeyringSecretKind::GnomeKeyringToken),
+                    ..
+                })
+            );
+            if token_armed && !force {
+                println!(
+                    "[keyring] '{user}' is armed with a keyring token; re-keying the login \
+                     keyring back to your password first."
+                );
+                let pw = match read_password("Login password: ") {
+                    Ok(p) if !p.is_empty() => p,
+                    Ok(_) => {
+                        eprintln!("[keyring] empty password; aborted (nothing changed).");
+                        return std::process::ExitCode::from(2);
+                    }
+                    Err(e) => {
+                        eprintln!("[keyring] {e}");
+                        return std::process::ExitCode::FAILURE;
+                    }
+                };
+                let token = match daemon_request(&irlume_common::Request::ReleaseTokenForDisarm {
+                    user: user.clone(),
+                    password: irlume_common::SecretBytes::new(pw.clone().into_bytes()),
+                }) {
+                    Ok(irlume_common::Response::PasswordUnsealed { secret, .. }) => secret,
+                    Ok(irlume_common::Response::Error(e)) => {
+                        eprintln!("[keyring] {e}");
+                        return std::process::ExitCode::FAILURE;
+                    }
+                    other => {
+                        eprintln!("[keyring] unexpected response: {other:?}");
+                        return std::process::ExitCode::FAILURE;
+                    }
+                };
+                if let Err(e) = rekey_login_keyring(token.expose(), pw.as_bytes())
+                    .and_then(|()| verify_keyring_credential(pw.as_bytes()))
+                {
+                    eprintln!(
+                        "[keyring] could not re-key the keyring back ({e}); the sealed token \
+                         is UNTOUCHED so nothing is lost. Fix the session (run as '{user}' \
+                         with gnome-keyring running) and retry, or `--force` to delete the \
+                         envelope anyway."
+                    );
+                    return std::process::ExitCode::FAILURE;
+                }
+                println!("[keyring] login keyring re-keyed back to your password.");
+            } else if token_armed && force {
+                eprintln!(
+                    "[keyring] WARNING: --force on a token arm deletes the only copy of the \
+                     keyring token. If the login keyring still exists and is keyed to it, \
+                     its contents become unreachable."
+                );
             }
-            Ok(irlume_common::Response::Error(e)) => {
-                eprintln!("[keyring] forget failed: {e}");
-                std::process::ExitCode::FAILURE
+            match daemon_request(&irlume_common::Request::ForgetPassword { user: user.clone() }) {
+                Ok(irlume_common::Response::PasswordForgotten) => {
+                    println!("[keyring] '{user}': sealed secret erased; keyring unlock disarmed.");
+                    std::process::ExitCode::SUCCESS
+                }
+                Ok(irlume_common::Response::Error(e)) => {
+                    eprintln!("[keyring] forget failed: {e}");
+                    std::process::ExitCode::FAILURE
+                }
+                Ok(other) => {
+                    eprintln!("[keyring] unexpected response: {other:?}");
+                    std::process::ExitCode::FAILURE
+                }
+                Err(e) => {
+                    eprintln!("[keyring] forget failed: {e}");
+                    std::process::ExitCode::FAILURE
+                }
             }
-            Ok(other) => {
-                eprintln!("[keyring] unexpected response: {other:?}");
-                std::process::ExitCode::FAILURE
-            }
-            Err(e) => {
-                eprintln!("[keyring] forget failed: {e}");
-                std::process::ExitCode::FAILURE
-            }
-        },
+        }
         _ => {
             eprintln!("usage: irlume keyring <arm|status|forget> [--user U]");
             std::process::ExitCode::from(2)

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1080,14 +1080,41 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
             // where the keyring is already gone (deleted profile, reinstalled
             // distro) and the stale envelope is all that is left.
             let force = args.iter().any(|a| a == "--force");
-            let token_armed = matches!(
-                daemon_request(&irlume_common::Request::KeyringInfo { user: user.clone() }),
-                Ok(irlume_common::Response::KeyringInfo {
-                    armed: true,
-                    kind: Some(irlume_common::KeyringSecretKind::GnomeKeyringToken),
-                    ..
-                })
-            );
+            // Three outcomes, not two. "Armed with something we could not
+            // identify" must not collapse into "not a token": a daemon from
+            // before #250 answers `kind: None`, an unreadable envelope answers
+            // an error, and deleting a token envelope on either reading leaves
+            // the login keyring encrypted under a secret nothing can
+            // reproduce. Unknown therefore refuses and names `--force`.
+            let (token_armed, unknown) =
+                match daemon_request(&irlume_common::Request::KeyringInfo { user: user.clone() }) {
+                    Ok(irlume_common::Response::KeyringInfo { armed: false, .. }) => (false, false),
+                    Ok(irlume_common::Response::KeyringInfo { kind: Some(k), .. }) => (
+                        k == irlume_common::KeyringSecretKind::GnomeKeyringToken,
+                        false,
+                    ),
+                    // Armed, and the daemon could not say what with: an older
+                    // daemon, or an envelope it failed to parse. This is the
+                    // dangerous reading, so refuse.
+                    Ok(irlume_common::Response::KeyringInfo { kind: None, .. }) => (false, true),
+                    // No usable answer at all (daemon down, refused, older
+                    // protocol). Not "armed with something unknown": fall
+                    // through and let the erase attempt below report the real
+                    // failure, rather than blaming an envelope nobody saw.
+                    _ => (false, false),
+                };
+            if unknown && !force {
+                eprintln!(
+                    "[keyring] cannot tell what '{user}' has armed, so refusing to erase it: \
+                     if it is a GNOME keyring token, deleting it leaves the login keyring \
+                     encrypted under a secret nothing can reproduce."
+                );
+                eprintln!(
+                    "[keyring] Update irlumed (an older one does not report the kind), or \
+                     pass --force if you are certain the keyring no longer matters."
+                );
+                return std::process::ExitCode::FAILURE;
+            }
             if token_armed && !force {
                 println!(
                     "[keyring] '{user}' is armed with a keyring token; re-keying the login \

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -2681,6 +2681,41 @@ session     include       postlogin
         // gnome-keyring installed does not get an error logged.
         assert!(w.contains(KEYRING_TAG));
         assert!(w.contains("-auth") && w.contains("-session"));
+
+        // Our OWN session half. On a GNOME account armed with a keyring token
+        // (#250) the auth line above only releases the token into PAM data;
+        // `open_session` is what delivers it to gnome-keyring's control
+        // socket, because the user's runtime directory need not exist yet at
+        // auth time. Without this line the token is released and dropped, and
+        // the keyring stays locked with nothing naming the reason.
+        let ours = lines
+            .iter()
+            .position(|l| l.contains("pam_irlume.so reseal"))
+            .expect("irlume session line: without it a token is never delivered");
+        let gkr_session = lines
+            .iter()
+            .position(|l| l.contains("pam_gnome_keyring.so") && l.contains("auto_start"))
+            .expect("gnome-keyring session half");
+        assert!(
+            ours > gkr_session,
+            "ours must run after the line that may START the daemon, or the \
+             helper finds nothing listening"
+        );
+    }
+
+    /// A stack that already carries an irlume session line must not get a
+    /// second one: two `reseal` lines mean two reseals and two deliveries per
+    /// login, and a duplicate that `unwire` would leave half of behind.
+    #[test]
+    fn wire_fp_keyring_adds_only_one_irlume_session_line() {
+        let (once, _) = wire_fp_keyring(UPSTREAM_GDM_FINGERPRINT, "gdm-fingerprint");
+        assert_eq!(once.matches("pam_irlume.so reseal").count(), 1);
+        let (twice, _) = wire_fp_keyring(&once, "gdm-fingerprint");
+        assert_eq!(
+            twice.matches("pam_irlume.so reseal").count(),
+            1,
+            "re-wiring an already-wired stack duplicated our session line"
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/pamwire/transform.rs
+++ b/crates/irlume-cli/src/pamwire/transform.rs
@@ -305,6 +305,27 @@ pub(super) fn wire_fp_keyring(content: &str, service: &str) -> (String, bool) {
         // session is otherwise set up.
         out.push(FP_GKR_SESSION.to_string());
     }
+    // Our own session half, and on a token-armed GNOME account it is the only
+    // thing that opens the keyring at all.
+    //
+    // A `keyring` auth line releases a GNOME keyring token into PAM data; the
+    // delivery to gnome-keyring's control socket happens in `open_session`,
+    // because at auth time the user's runtime directory (and so the socket)
+    // need not exist yet. Without this line the token is released and then
+    // dropped when the transaction ends, and the login keyring stays locked
+    // with nothing saying why. GDM runs auth and session for a fingerprint
+    // login on ONE pam handle for THIS service, so the PAM data set above is
+    // readable here and nowhere else.
+    //
+    // After `FP_GKR_SESSION` on purpose: that line may be what starts the
+    // daemon (`auto_start`), and our helper needs something listening.
+    if !lines.iter().any(|l| {
+        let d = directive(l);
+        let phase = d.strip_prefix('-').unwrap_or(d);
+        phase.split_whitespace().next() == Some("session") && d.contains(MODULE)
+    }) {
+        out.push(RESEAL_SESSION.to_string());
+    }
     (format!("{}\n", out.join("\n")), true)
 }
 

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2918,11 +2918,19 @@ impl App {
                 // would delete the keyring's live credential. That flow needs
                 // a password prompt and the control socket, so route it to the
                 // CLI rather than duplicating it in TUI state.
-                if self.keyring_kind == Some(irlume_common::KeyringSecretKind::GnomeKeyringToken) {
+                // Anything other than a confirmed non-token refuses here.
+                // `None` means an older daemon or an envelope it could not
+                // parse, and erasing a token envelope on that reading leaves
+                // the login keyring encrypted under a secret nothing can
+                // reproduce. The CLI has the re-key flow and the --force
+                // escape; this screen has neither, so it defers.
+                if self.keyring_kind != Some(irlume_common::KeyringSecretKind::LoginPassword)
+                    && self.keyring_kind != Some(irlume_common::KeyringSecretKind::KdeWalletKey)
+                {
                     self.log(
                         '!',
-                        "this arm is a keyring token; run `irlume keyring forget` in a \
-                         terminal (it re-keys the keyring back to your password first)",
+                        "cannot confirm this is safe to erase from here; run `irlume keyring \
+                         forget` in a terminal (it re-keys a token back to your password first)",
                     );
                     return;
                 }
@@ -6945,6 +6953,20 @@ mod tests {
             _ => panic!("expected the reseal password prompt"),
         }
         app.input = None;
+
+        // An unidentified arm must NOT offer the plain erase: `None` is what an
+        // older daemon reports and what an unparseable envelope reports, and
+        // erasing a GNOME keyring token on that reading leaves the login
+        // keyring encrypted under a secret nothing can reproduce.
+        app.keyring_kind = None;
+        app.on_key(KeyCode::Char('f'));
+        assert!(
+            app.confirm.is_none(),
+            "an unknown keyring kind must not reach the erase confirm"
+        );
+
+        // A confirmed password arm is safe to erase from here.
+        app.keyring_kind = Some(irlume_common::KeyringSecretKind::LoginPassword);
         app.on_key(KeyCode::Char('f'));
         match &app.confirm {
             Some((q, _, ConfirmAct::Daemon(Request::ForgetPassword { user }))) => {

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -439,6 +439,10 @@ struct App {
     keyring_policy: Option<String>,
     /// Whether the bound PCRs drifted since sealing (`KeyringInfo`).
     keyring_drift: Option<bool>,
+    /// What kind of secret is armed (`KeyringInfo`); `None` from an older
+    /// daemon. Routes the disarm key: a token disarm needs the CLI's re-key
+    /// flow, and a bare `ForgetPassword` on it would strand the keyring.
+    keyring_kind: Option<irlume_common::KeyringSecretKind>,
     nodes: Vec<(String, irlume_camera::Role)>,
     /// Cached camera pairs, refreshed on the slow timer so the Cameras tab and
     /// move_sel don't re-probe the hardware on every keystroke and frame.
@@ -690,6 +694,7 @@ struct LightState {
     keyring_armed: Option<bool>,
     keyring_policy: Option<String>,
     keyring_drift: Option<bool>,
+    keyring_kind: Option<irlume_common::KeyringSecretKind>,
     recovery: Option<RecoveryInfo>,
     nodes: Vec<(String, irlume_camera::Role)>,
     pairs: Vec<irlume_camera::CameraPair>,
@@ -705,6 +710,7 @@ impl LightState {
             keyring_armed: prev_armed,
             keyring_policy: None,
             keyring_drift: None,
+            keyring_kind: None,
             recovery: None,
             nodes: irlume_camera::discover_nodes(),
             pairs: irlume_camera::list_pairs(),
@@ -743,11 +749,13 @@ impl LightState {
                 armed,
                 policy,
                 drifted,
+                kind,
                 ..
             }) => {
                 out.keyring_armed = Some(armed);
                 out.keyring_policy = policy;
                 out.keyring_drift = drifted;
+                out.keyring_kind = kind;
             }
             _ => {
                 out.keyring_armed = match crate::daemon_poll(&Request::HasSealedPassword {
@@ -837,6 +845,7 @@ impl App {
             keyring_armed: None,
             keyring_policy: None,
             keyring_drift: None,
+            keyring_kind: None,
             nodes: irlume_camera::discover_nodes(),
             pairs: irlume_camera::list_pairs(),
             activity: Vec::new(),
@@ -1010,6 +1019,7 @@ impl App {
         if l.daemon_up {
             self.keyring_armed = l.keyring_armed;
             self.keyring_policy = l.keyring_policy;
+            self.keyring_kind = l.keyring_kind;
             self.keyring_drift = l.keyring_drift;
             if l.recovery.is_some() {
                 self.recovery = l.recovery;
@@ -1855,6 +1865,26 @@ impl App {
                 Err(e) => (false, e),
             };
             let _ = tx.send(r);
+        });
+        self.op = Some(Op { label, tag, rx });
+    }
+
+    /// `start_async` for work that is more than one request→map: the whole
+    /// closure runs on the worker thread. Exists for the token arm (#250),
+    /// where a `TokenSealed` reply must be followed by the keyring re-key,
+    /// which needs the password and user the plain fn-pointer mapper cannot
+    /// capture.
+    fn start_async_task(
+        &mut self,
+        label: impl Into<String>,
+        tag: OpTag,
+        task: Box<dyn FnOnce() -> (bool, String) + Send>,
+    ) {
+        let label = label.into();
+        self.log('→', format!("daemon: {label}"));
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(task());
         });
         self.op = Some(Op { label, tag, rx });
     }
@@ -2883,6 +2913,19 @@ impl App {
                 ));
             }
             (SC_KEYRING, KeyCode::Char('f')) => {
+                // A token arm (#250) must re-key the login keyring back to the
+                // password before the envelope is erased; a bare forget here
+                // would delete the keyring's live credential. That flow needs
+                // a password prompt and the control socket, so route it to the
+                // CLI rather than duplicating it in TUI state.
+                if self.keyring_kind == Some(irlume_common::KeyringSecretKind::GnomeKeyringToken) {
+                    self.log(
+                        '!',
+                        "this arm is a keyring token; run `irlume keyring forget` in a \
+                         terminal (it re-keys the keyring back to your password first)",
+                    );
+                    return;
+                }
                 self.confirm = Some((
                     "Erase the TPM-sealed login password?".into(),
                     "Erase",
@@ -3301,13 +3344,38 @@ impl App {
                     self.set_error("passwords don't match; aborted (nothing sealed)");
                     return;
                 }
-                let req = Request::SealPassword {
-                    kind: None, // let the daemon judge from what the user has
-                    user: self.user.clone(),
-                    password: irlume_common::SecretBytes::new(buf.as_bytes().to_vec()),
-                };
-                // Async: the TPM seal is the slowest daemon op; don't freeze the frame.
-                self.start_async("SealPassword", OpTag::Generic, req, map_sealed);
+                let user = self.user.clone();
+                let pw = zeroize::Zeroizing::new(buf.as_bytes().to_vec());
+                // Async: the TPM seal is the slowest daemon op; don't freeze
+                // the frame. A closure task rather than a mapper, because a
+                // TokenSealed reply (GNOME, #250) must be followed by the
+                // keyring re-key, which needs the password and user.
+                self.start_async_task(
+                    "SealPassword",
+                    OpTag::Generic,
+                    Box::new(move || {
+                        let req = Request::SealPassword {
+                            kind: None, // let the daemon judge from what the user has
+                            user: user.clone(),
+                            password: irlume_common::SecretBytes::new(pw.to_vec()),
+                        };
+                        match crate::daemon_request(&req) {
+                            Ok(Response::TokenSealed { token, minted }) => {
+                                match crate::finish_token_arm(&user, &pw, token.expose(), minted) {
+                                    Ok(()) => (
+                                        true,
+                                        "keyring armed with a token; the login keyring was \
+                                         re-keyed to it"
+                                            .into(),
+                                    ),
+                                    Err(e) => (false, e),
+                                }
+                            }
+                            Ok(resp) => map_sealed(resp),
+                            Err(e) => (false, e),
+                        }
+                    }),
+                );
             }
             Pending::RecoveryPw(None) => {
                 if buf.is_empty() {
@@ -5543,6 +5611,7 @@ mod tests {
             keyring_armed: None,
             keyring_policy: None,
             keyring_drift: None,
+            keyring_kind: None,
             nodes: Vec::new(),
             pairs: Vec::new(),
             activity: Vec::new(),
@@ -7675,6 +7744,7 @@ mod tests {
             keyring_armed: None,
             keyring_policy: None,
             keyring_drift: None,
+            keyring_kind: None,
             recovery: None,
             nodes: Vec::new(),
             pairs: Vec::new(),
@@ -8339,6 +8409,7 @@ mod tests {
             keyring_armed: None,
             keyring_policy: None,
             keyring_drift: None,
+            keyring_kind: None,
             recovery: None,
             nodes: Vec::new(),
             pairs: Vec::new(),

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -54,12 +54,28 @@ pub fn run(args: &[String]) -> ExitCode {
     // disarmed from their own session; this is a data-loss guard, so there is
     // deliberately no flag to bypass it (`irlume keyring forget --force` per
     // user is the explicit, per-user override).
-    let token_users: Vec<String> = irlume_core::storage::list_users()
-        .into_iter()
-        .filter(|u| {
-            irlume_core::keyring::sealed_kind(u)
-                == Some(irlume_core::envelope::SecretKind::GnomeKeyringToken)
-        })
+    // Enumerate ENVELOPES, not enrolled users: `keyring arm` needs no
+    // enrollment, so a user can hold a sealed token and never appear in
+    // `storage::list_users()`. And an envelope this cannot READ is not an
+    // envelope that holds no token; the enumerator errors rather than skipping,
+    // because guessing here erases the only copy of the secret a login keyring
+    // is encrypted under.
+    let sealed = match irlume_core::keyring::list_sealed_kinds() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "[uninstall] refusing: could not read the sealed-envelope store ({e}). \
+                 One of these may hold a GNOME keyring token, and deleting it would \
+                 leave that keyring encrypted under a secret nothing can reproduce. \
+                 Fix the store (or move it aside deliberately) and re-run."
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let token_users: Vec<&str> = sealed
+        .iter()
+        .filter(|(_, kind)| *kind == irlume_core::envelope::SecretKind::GnomeKeyringToken)
+        .map(|(u, _)| u.as_str())
         .collect();
     if !token_users.is_empty() {
         eprintln!(

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -46,6 +46,35 @@ pub fn run(args: &[String]) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    // A GNOME keyring token arm (#250) means the user's login keyring is keyed
+    // to a secret that exists ONLY in the sealed envelope. Deleting it here
+    // would make that keyring permanently unreachable, and the re-key back to
+    // the password cannot happen from this root process (the keyring control
+    // socket authenticates the session's uid). Refuse until each such user has
+    // disarmed from their own session; this is a data-loss guard, so there is
+    // deliberately no flag to bypass it (`irlume keyring forget --force` per
+    // user is the explicit, per-user override).
+    let token_users: Vec<String> = irlume_core::storage::list_users()
+        .into_iter()
+        .filter(|u| {
+            irlume_core::keyring::sealed_kind(u)
+                == Some(irlume_core::envelope::SecretKind::GnomeKeyringToken)
+        })
+        .collect();
+    if !token_users.is_empty() {
+        eprintln!(
+            "[uninstall] refusing: the login keyring of {} is keyed to an irlume-held \
+             token, and uninstalling now would lock it permanently.",
+            token_users.join(", ")
+        );
+        eprintln!(
+            "[uninstall] Have each of these users run `irlume keyring forget` in their \
+             own session first (it re-keys the keyring back to their password), then \
+             re-run the uninstall."
+        );
+        return ExitCode::FAILURE;
+    }
+
     println!("irlume uninstall will:");
     println!("  1. remove irlume from every PAM stack (greeters, sudo, lock screen)");
     println!("  2. stop and disable the irlumed service");

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1133,7 +1133,7 @@ fn keyring_success_paths_with_a_live_daemon() {
     let (code, out, _) = run(&mut sb.cmd(&["keyring", "forget", "--user", "tester"]));
     assert_eq!(code, 0);
     assert!(
-        out.contains("sealed password erased; keyring unlock disarmed"),
+        out.contains("sealed secret erased; keyring unlock disarmed"),
         "{out}"
     );
 
@@ -1376,6 +1376,7 @@ fn status_renders_the_full_dashboard_from_daemon_answers() {
             policy: Some("Tier 2 (pcrlock)".into()),
             pcrs: vec![7],
             drifted: Some(true),
+            kind: None,
         },
         Request::RecoveryStatus { .. } => Response::RecoveryStatus {
             encrypted: true,

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1112,6 +1112,17 @@ fn keyring_success_paths_with_a_live_daemon() {
         Request::SealPassword { .. } => Response::PasswordSealed,
         Request::HasSealedPassword { .. } => Response::HasPassword(true),
         Request::ForgetPassword { .. } => Response::PasswordForgotten,
+        // `forget` asks what is armed before erasing it, and refuses when it
+        // cannot tell: erasing a GNOME keyring token leaves the login keyring
+        // encrypted under a secret nothing can reproduce. This user has a
+        // password armed, which is safe to erase directly.
+        Request::KeyringInfo { .. } => Response::KeyringInfo {
+            armed: true,
+            policy: None,
+            pcrs: Vec::new(),
+            drifted: None,
+            kind: Some(irlume_common::KeyringSecretKind::LoginPassword),
+        },
         _ => Response::Error("unexpected request".into()),
     });
 

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -225,6 +225,7 @@ fn status_eyes_open_unarmed_plaintext_and_biopolicy_enforcing() {
             policy: None,
             pcrs: vec![],
             drifted: None,
+            kind: None,
         },
         Request::RecoveryStatus { .. } => Response::RecoveryStatus {
             encrypted: false,

--- a/crates/irlume-common/src/gkr_wire.rs
+++ b/crates/irlume-common/src/gkr_wire.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! gnome-keyring control-socket protocol (the channel `pam_gnome_keyring` uses).
+//!
+//! gnome-keyring-daemon listens on `$XDG_RUNTIME_DIR/keyring/control`, and this
+//! socket, not D-Bus, is how the daemon's own PAM module unlocks the login
+//! keyring at login and re-keys it on a password change. irlume uses the same
+//! channel for the same two operations on a token-armed user ([`Op::Unlock`]
+//! from the session helper, [`Op::Change`] from `keyring arm`/`forget`), because
+//! the alternative, `busctl` with the secret in argv, publishes the secret in
+//! `/proc/<pid>/cmdline`.
+//!
+//! Wire format, from gnome-keyring's `pam/gkr-pam-client.c` and
+//! `egg/egg-buffer.c` (all integers big-endian `u32`):
+//!
+//! ```text
+//! connect  -> 1 credentials byte (value 0; the kernel attaches SO_PASSCRED
+//!             credentials to any byte sent over the socket)
+//! request  -> total_len | op | (arg_len | arg_bytes)*
+//!             where total_len covers itself and op (8 bytes) plus every
+//!             argument's 4-byte length prefix and bytes
+//! response -> total_len (= 8) | result
+//! ```
+//!
+//! The daemon compares the peer's uid against its own, which is why the PAM
+//! module (and irlume's session helper) must be running as the target user
+//! before connecting; `gkr-pam-client.c` does the same seteuid dance.
+
+use std::io::{Read, Write};
+
+/// Control operations, from `daemon/control/gkd-control-codes.h`. Only the two
+/// irlume needs are represented; `INITIALIZE` (0) replies with a variable-length
+/// environment block this client does not parse, and `QUIT` (3) has no business
+/// being reachable from here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Op {
+    /// Unlock the login keyring with the single argument (the master secret).
+    Unlock = 1,
+    /// Re-key the login keyring: arguments are `(current secret, new secret)`,
+    /// in that order (`change_keyring_password` in `gkr-pam-module.c` sends
+    /// `argv[0] = original`). Headless: no prompt is shown, and a wrong
+    /// `current` yields [`ControlResult::Denied`].
+    Change = 2,
+}
+
+/// Result codes, from `gkd-control-codes.h`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlResult {
+    Ok,
+    /// The supplied secret was wrong.
+    Denied,
+    Failed,
+    NoDaemon,
+    /// A value outside the enum: protocol drift or a truncated reply.
+    Unknown(u32),
+}
+
+impl ControlResult {
+    fn from_code(code: u32) -> Self {
+        match code {
+            0 => ControlResult::Ok,
+            1 => ControlResult::Denied,
+            2 => ControlResult::Failed,
+            3 => ControlResult::NoDaemon,
+            other => ControlResult::Unknown(other),
+        }
+    }
+
+    /// Human-readable outcome for logs and CLI messages.
+    pub fn describe(&self) -> String {
+        match self {
+            ControlResult::Ok => "ok".into(),
+            ControlResult::Denied => "denied (wrong secret)".into(),
+            ControlResult::Failed => "failed".into(),
+            ControlResult::NoDaemon => "no daemon".into(),
+            ControlResult::Unknown(c) => format!("unknown result code {c}"),
+        }
+    }
+}
+
+/// Encode one request packet. Pure, so the exact bytes are testable against
+/// the layout in `gkr-pam-client.c` without a socket.
+pub fn encode_request(op: Op, args: &[&[u8]]) -> Vec<u8> {
+    let total: usize = 8 + args.iter().map(|a| 4 + a.len()).sum::<usize>();
+    let mut buf = Vec::with_capacity(total);
+    buf.extend_from_slice(&(total as u32).to_be_bytes());
+    buf.extend_from_slice(&(op as u32).to_be_bytes());
+    for a in args {
+        buf.extend_from_slice(&(a.len() as u32).to_be_bytes());
+        buf.extend_from_slice(a);
+    }
+    buf
+}
+
+/// Decode the fixed 8-byte response. Errors name what was malformed rather than
+/// collapsing into a result code, because a garbled reply and a `Failed` ask
+/// for different reactions (report a bug vs. report the outcome).
+pub fn decode_response(bytes: &[u8]) -> Result<ControlResult, String> {
+    if bytes.len() != 8 {
+        return Err(format!(
+            "control reply was {} bytes, expected 8",
+            bytes.len()
+        ));
+    }
+    let len = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    if len != 8 {
+        return Err(format!("control reply declared length {len}, expected 8"));
+    }
+    Ok(ControlResult::from_code(u32::from_be_bytes([
+        bytes[4], bytes[5], bytes[6], bytes[7],
+    ])))
+}
+
+/// Run one control operation over an already-connected stream.
+///
+/// Generic over the stream so tests can drive it with an in-memory pipe; the
+/// real caller passes a `UnixStream` connected to `control_socket_path`.
+pub fn call<S: Read + Write>(
+    stream: &mut S,
+    op: Op,
+    args: &[&[u8]],
+) -> Result<ControlResult, String> {
+    // The credentials byte. Its value is ignored by the daemon; the kernel
+    // attaches the sender's uid/gid/pid via SO_PASSCRED, which is what the
+    // daemon actually reads.
+    stream
+        .write_all(&[0u8])
+        .map_err(|e| format!("control socket write (credentials): {e}"))?;
+    stream
+        .write_all(&encode_request(op, args))
+        .map_err(|e| format!("control socket write: {e}"))?;
+    let mut reply = [0u8; 8];
+    stream
+        .read_exact(&mut reply)
+        .map_err(|e| format!("control socket read: {e}"))?;
+    decode_response(&reply)
+}
+
+/// The control socket, relative to the user's `XDG_RUNTIME_DIR`
+/// (`get_control_file` in `gkr-pam-module.c` appends `/keyring/control`).
+pub fn control_socket_path(runtime_dir: &std::path::Path) -> std::path::PathBuf {
+    runtime_dir.join("keyring/control")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Golden bytes for a CHANGE, hand-assembled from the layout in
+    /// `gkr-pam-client.c`: total covers the 8-byte header plus 4+len per arg.
+    #[test]
+    fn change_request_matches_the_gkr_client_layout() {
+        let got = encode_request(Op::Change, &[b"old", b"newpw"]);
+        let expect: Vec<u8> = [
+            &(8u32 + 4 + 3 + 4 + 5).to_be_bytes()[..], // total = 24
+            &2u32.to_be_bytes(),                       // GKD_CONTROL_OP_CHANGE
+            &3u32.to_be_bytes(),
+            b"old",
+            &5u32.to_be_bytes(),
+            b"newpw",
+        ]
+        .concat();
+        assert_eq!(got, expect);
+        // Big-endian, not native: the first length byte of a 24-byte packet
+        // must be 0, and the last must be 24.
+        assert_eq!(&got[..4], &[0, 0, 0, 24]);
+    }
+
+    #[test]
+    fn unlock_request_carries_one_argument() {
+        let got = encode_request(Op::Unlock, &[b"s3cret"]);
+        assert_eq!(&got[..4], &(8u32 + 4 + 6).to_be_bytes());
+        assert_eq!(&got[4..8], &1u32.to_be_bytes());
+        assert_eq!(&got[8..12], &6u32.to_be_bytes());
+        assert_eq!(&got[12..], b"s3cret");
+    }
+
+    #[test]
+    fn responses_decode_each_result_code() {
+        for (code, want) in [
+            (0u32, ControlResult::Ok),
+            (1, ControlResult::Denied),
+            (2, ControlResult::Failed),
+            (3, ControlResult::NoDaemon),
+            (9, ControlResult::Unknown(9)),
+        ] {
+            let mut reply = 8u32.to_be_bytes().to_vec();
+            reply.extend_from_slice(&code.to_be_bytes());
+            assert_eq!(decode_response(&reply).unwrap(), want, "code {code}");
+        }
+    }
+
+    #[test]
+    fn malformed_responses_error_instead_of_guessing() {
+        assert!(decode_response(&[0u8; 7]).is_err(), "short reply");
+        assert!(decode_response(&[0u8; 9]).is_err(), "long reply");
+        let mut wrong_len = 12u32.to_be_bytes().to_vec();
+        wrong_len.extend_from_slice(&0u32.to_be_bytes());
+        assert!(
+            decode_response(&wrong_len).is_err(),
+            "declared length must be 8"
+        );
+    }
+
+    /// End-to-end over an in-memory stream: a scripted "daemon" that answers OK
+    /// after asserting the exact request bytes.
+    #[test]
+    fn call_writes_credentials_byte_then_packet() {
+        struct Script {
+            written: Vec<u8>,
+            reply: std::io::Cursor<Vec<u8>>,
+        }
+        impl Write for Script {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.written.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl Read for Script {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                self.reply.read(buf)
+            }
+        }
+        let mut reply = 8u32.to_be_bytes().to_vec();
+        reply.extend_from_slice(&0u32.to_be_bytes());
+        let mut s = Script {
+            written: Vec::new(),
+            reply: std::io::Cursor::new(reply),
+        };
+        let res = call(&mut s, Op::Unlock, &[b"tok"]).unwrap();
+        assert_eq!(res, ControlResult::Ok);
+        assert_eq!(s.written[0], 0, "credentials byte first");
+        assert_eq!(&s.written[1..], &encode_request(Op::Unlock, &[b"tok"])[..]);
+    }
+}

--- a/crates/irlume-common/src/gkr_wire.rs
+++ b/crates/irlume-common/src/gkr_wire.rs
@@ -201,6 +201,20 @@ mod tests {
             decode_response(&wrong_len).is_err(),
             "declared length must be 8"
         );
+
+        // The case that separates the two checks. Both assertions above are
+        // also caught by the declared-length check alone, so without this one a
+        // decoder that quietly truncated to 8 bytes passed the whole test. A
+        // well-formed 8-byte header followed by extra bytes means the daemon
+        // is speaking a protocol this client does not know; reading the first
+        // 8 and discarding the rest would silently misinterpret it.
+        let mut trailing = 8u32.to_be_bytes().to_vec();
+        trailing.extend_from_slice(&0u32.to_be_bytes()); // a valid OK...
+        trailing.extend_from_slice(b"more"); // ...with unexpected payload
+        assert!(
+            decode_response(&trailing).is_err(),
+            "a valid header with trailing bytes is protocol drift, not an OK"
+        );
     }
 
     /// End-to-end over an in-memory stream: a scripted "daemon" that answers OK

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod client;
 pub mod config;
 pub mod dbglog;
+pub mod gkr_wire;
 pub mod memlock;
 pub mod platform;
 pub mod secureboot;
@@ -488,6 +489,17 @@ pub enum Request {
         user: String,
         #[serde(default)]
         service: Option<String>,
+        /// Whether the PAM stack already holds a typed password. For a
+        /// `LoginPassword` envelope that makes the unseal pointless (the keyring
+        /// self-unlocks from the typed password) and the daemon answers
+        /// [`Response::KeyringUnlockNotNeeded`] without touching the TPM. For a
+        /// `GnomeKeyringToken` envelope the typed password does NOT open the
+        /// keyring, so the unseal proceeds regardless. The decision lives in
+        /// the daemon because only it can read the envelope's kind. Defaults to
+        /// `false`, which preserves the old always-unseal behaviour for a PAM
+        /// module from before this field.
+        #[serde(default)]
+        have_password: bool,
     },
     /// Whether `user` has a sealed password armed (for status / CLI / the
     /// delete-erases-it warning). Unprivileged: root or `user`.
@@ -503,6 +515,15 @@ pub enum Request {
     /// Erase `user`'s sealed password (disarms keyring unlock). PRIVILEGED:
     /// root or `user`.
     ForgetPassword { user: String },
+    /// Release `user`'s sealed GNOME keyring token to the caller so `keyring
+    /// forget` can re-key the login keyring BACK to the password before the
+    /// envelope is erased. Without that re-key, deleting a token envelope
+    /// strands the keyring on a secret that no longer exists anywhere.
+    /// `password` must be the user's current login password; the daemon
+    /// verifies it before releasing (the caller proves they could have obtained
+    /// the keyring contents anyway). Refused for envelopes of any other kind.
+    /// PRIVILEGED: root or `user`.
+    ReleaseTokenForDisarm { user: String, password: SecretBytes },
     /// Re-seal `user`'s login password against the *current* PCR policy, but
     /// ONLY if a sealed password is already armed (never auto-arms a fresh user)
     /// and only if it actually changed (the PCRs moved, e.g. a dbx/Secure Boot
@@ -717,6 +738,28 @@ pub enum Response {
     // --- keyring unlock responses -------------------------------------------
     /// The password was sealed (`SealPassword`).
     PasswordSealed,
+    /// A GNOME keyring token was sealed (`SealPassword` that resolved to
+    /// [`KeyringSecretKind::GnomeKeyringToken`]). Carries the token because
+    /// sealing is only half the arm: the caller, which runs in the user's
+    /// session and can reach the keyring control socket, must now re-key the
+    /// login keyring to it. Released only to the requesting peer, which
+    /// `SealPassword` already restricts to root or the user themselves.
+    TokenSealed {
+        token: SecretBytes,
+        /// Whether the token was freshly minted (first arm) or reused from an
+        /// existing envelope (re-arm). Governs the caller's failure handling:
+        /// a minted envelope is inert and safe to roll back with
+        /// `ForgetPassword`; a reused one may hold the LIVE keyring credential
+        /// and must never be deleted on error. Defaults to `false`, the
+        /// never-delete reading, so an older caller cannot inherit the
+        /// destructive branch.
+        #[serde(default)]
+        minted: bool,
+    },
+    /// `UnsealKeyring` with `have_password: true` against a `LoginPassword`
+    /// envelope: the typed password already opens the keyring, so nothing was
+    /// unsealed and nothing needs releasing.
+    KeyringUnlockNotNeeded,
     /// Face matched and the TPM released the secret (`UnsealPassword` /
     /// `UnsealKeyring`).
     PasswordUnsealed {
@@ -739,6 +782,12 @@ pub enum Response {
         pcrs: Vec<u32>,
         #[serde(default)]
         drifted: Option<bool>,
+        /// What kind of secret is armed. `None` from a daemon predating #250's
+        /// GNOME half, or when nothing is armed. `keyring forget` routes on
+        /// this: a token disarm must re-key the keyring back to the password
+        /// first, a password disarm just deletes the envelope.
+        #[serde(default)]
+        kind: Option<KeyringSecretKind>,
     },
     /// The sealed password was erased (`ForgetPassword`).
     PasswordForgotten,
@@ -1251,6 +1300,12 @@ pub enum KeyringSecretKind {
     LoginPassword,
     /// The 56-byte key `ksecretd` opens the KDE wallet with.
     KdeWalletKey,
+    /// A random token the GNOME login keyring has been re-keyed to (#250). Not
+    /// a password: it must never reach `PAM_AUTHTOK`, where `pam_unix` on a
+    /// Debian-style stack would consume it as the Unix password and fail the
+    /// login. It goes to `gnome-keyring-daemon`'s control socket instead, via
+    /// the session helper.
+    GnomeKeyringToken,
 }
 
 /// Wire constants for the KDE wallet handoff.
@@ -1293,3 +1348,8 @@ pub mod kwallet_wire {
 /// `IRLUME_KWALLET_INIT` overrides it for tests and for distributions that
 /// place libexec elsewhere.
 pub const KWALLET_INIT_PATH: &str = "/usr/libexec/irlume/irlume-kwallet-init";
+
+/// Installed path of the GNOME keyring unlock helper (#250). Same reasoning as
+/// [`KWALLET_INIT_PATH`]: takes a secret on stdin, only meaningful inside a PAM
+/// transaction, overridable via `IRLUME_GKR_UNLOCK` for tests.
+pub const GKR_UNLOCK_PATH: &str = "/usr/libexec/irlume/irlume-gkr-unlock";

--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -96,6 +96,12 @@ pub enum SecretKind {
     /// The 56-byte PBKDF2 key `ksecretd` opens the KDE wallet with. See
     /// [`crate::kwallet`].
     KdeWalletKey,
+    /// A random token the GNOME login keyring was re-keyed to at arm time
+    /// (#250). Unlike the other two kinds it is not derivable from the login
+    /// password, so an envelope of this kind also carries a
+    /// [`SealedEnvelope::password_wrap`]: without it, the first PCR drift would
+    /// strand the keyring on a secret nothing can reproduce.
+    GnomeKeyringToken,
 }
 
 impl SecretKind {
@@ -105,6 +111,7 @@ impl SecretKind {
         match self {
             SecretKind::LoginPassword => "login password",
             SecretKind::KdeWalletKey => "KDE wallet key",
+            SecretKind::GnomeKeyringToken => "GNOME keyring token",
         }
     }
 }
@@ -136,6 +143,16 @@ pub struct SealedEnvelope {
     /// SHA-256 values for `pcrs`, same order, captured at seal time (diagnostics).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pcr_values: Vec<PcrValue>,
+    /// The same secret again, wrapped under an Argon2id key derived from the
+    /// user's LOGIN password ([`crate::recovery`]). Present only for
+    /// [`SecretKind::GnomeKeyringToken`], where it is the recovery path the TPM
+    /// seal cannot provide: when the PCRs drift, the next verified-password
+    /// login unwraps the token from this and re-seals it (see
+    /// [`crate::keyring::reseal_password`]). For the other kinds the password
+    /// already reproduces the secret, so wrapping it would only add an offline
+    /// crack surface for no capability.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password_wrap: Option<crate::recovery::RecoveryEnvelope>,
 }
 
 impl SealedEnvelope {
@@ -206,6 +223,7 @@ mod tests {
                 pcr: 7,
                 value: vec![0xab; 32],
             }],
+            password_wrap: None,
         };
         let s = serde_json::to_string(&env).unwrap();
         let back: SealedEnvelope = serde_json::from_str(&s).unwrap();
@@ -263,6 +281,7 @@ mod tests {
             public: vec![1],
             private: vec![2],
             pcr_values: vec![],
+            password_wrap: None,
         };
         let s = serde_json::to_string(&env).unwrap();
         assert!(s.contains(r#""kind":"Authorized""#), "{s}");
@@ -281,6 +300,7 @@ mod tests {
             public: vec![1],
             private: vec![2],
             pcr_values: vec![],
+            password_wrap: None,
         };
         let s2 = serde_json::to_string(&env2).unwrap();
         assert!(!s2.contains("policy_ref"), "{s2}");
@@ -319,6 +339,7 @@ mod tests {
                 pcr: 7,
                 value: vec![0x11; 32],
             }],
+            password_wrap: None,
         };
         env.save(&p).unwrap();
 

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -779,6 +779,70 @@ mod tests {
         std::env::remove_var("IRLUME_KEYRING_DIR");
     }
 
+    /// The tier-climb rewrite must carry BOTH the kind and the password wrap.
+    ///
+    /// Seeded at the weakest tier on purpose: sealing normally lands on this
+    /// machine's best tier, so a reseal returns `Unchanged` and the climb
+    /// never runs, which made a mutant that drops the wrap survive the heal
+    /// test above. Losing the wrap here is silent until the PCRs move, and
+    /// then the token is unrecoverable; losing the kind routes 64 bytes of
+    /// token into `PAM_AUTHTOK` on the next login. This is #253's
+    /// `resealing_preserves_the_secret_kind` trap, one field wider.
+    #[test]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
+    fn a_tier_climb_keeps_both_the_kind_and_the_recovery_wrap() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = "/tmp/irlume-kr-token-climb";
+        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let _ = std::fs::remove_dir_all(dir);
+
+        let pw = b"climb-password";
+        let token = mint_gnome_token();
+        let mut weak = tpm::seal_with_pcrs(token.as_bytes(), &[7]).expect("seal at Tier 3");
+        weak.secret = SecretKind::GnomeKeyringToken;
+        weak.password_wrap = Some(crate::recovery::wrap(pw, token.as_bytes()).unwrap());
+        weak.save(&envelope_path("climb")).expect("arm");
+        assert_eq!(
+            SealedEnvelope::load(&envelope_path("climb"))
+                .unwrap()
+                .policy
+                .strength_rank(),
+            1,
+            "precondition: sealed at Tier 3, or the climb below never runs"
+        );
+
+        assert_eq!(
+            reseal_password("climb", pw, None).unwrap(),
+            Reseal::Upgraded,
+            "expected the tier-climb rewrite; without it this test cannot see whether \
+             that path preserves anything"
+        );
+
+        let env = SealedEnvelope::load(&envelope_path("climb")).unwrap();
+        assert_eq!(
+            env.secret,
+            SecretKind::GnomeKeyringToken,
+            "the climb dropped the secret kind"
+        );
+        let wrap = env
+            .password_wrap
+            .as_ref()
+            .expect("the climb dropped the password wrap: PCR drift would now be fatal");
+        assert_eq!(
+            &*crate::recovery::unwrap(pw, wrap).expect("the carried wrap must still open"),
+            token.as_bytes(),
+            "the carried wrap must hold the same token"
+        );
+        assert_eq!(
+            &*unseal_password("climb").unwrap(),
+            token.as_bytes(),
+            "and the new seal must still hold it too"
+        );
+
+        forget_password("climb").unwrap();
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
     /// A re-arm must hand back the EXISTING token. Minting a fresh one would
     /// overwrite the only copy of the secret the login keyring is currently
     /// keyed to, and the caller's re-key from the password would then be

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -42,6 +42,15 @@ pub fn seal_password(user: &str, password: &[u8]) -> Result<()> {
 /// The kind is stamped here rather than in [`tpm::seal`], which wraps bytes and
 /// has no business knowing what they mean.
 pub fn seal_secret(user: &str, secret: &[u8], kind: SecretKind) -> Result<()> {
+    if kind == SecretKind::GnomeKeyringToken {
+        // Tokens are armed through [`arm_gnome_token`], which mints the bytes
+        // and writes the password wrap in the same envelope. Accepting one here
+        // would write a token envelope with no wrap, and the first PCR drift
+        // would strand the keyring it was re-keyed to.
+        return Err(Error::Protocol(
+            "a GNOME keyring token is armed via arm_gnome_token, not sealed directly".into(),
+        ));
+    }
     if secret.is_empty() {
         // Keep the wording the login path has always used; the wallet key gets
         // its own so the message names what was actually empty.
@@ -49,6 +58,7 @@ pub fn seal_secret(user: &str, secret: &[u8], kind: SecretKind) -> Result<()> {
             match kind {
                 SecretKind::LoginPassword => "refusing to seal an empty password",
                 SecretKind::KdeWalletKey => "refusing to seal an empty KDE wallet key",
+                SecretKind::GnomeKeyringToken => unreachable!("refused above"),
             }
             .to_string(),
         ));
@@ -66,6 +76,92 @@ pub fn seal_secret(user: &str, secret: &[u8], kind: SecretKind) -> Result<()> {
     let mut env = tpm::seal(secret)?;
     env.secret = kind;
     env.save(&envelope_path(user))
+}
+
+/// Length in bytes of entropy behind a GNOME keyring token; the token itself is
+/// its lowercase-hex form (64 ASCII characters), because the keyring credential
+/// is a string and hex survives every string channel it must cross (the control
+/// socket, PAM data, the daemon wire) without escaping.
+pub const GNOME_TOKEN_BYTES: usize = 32;
+
+/// Mint a fresh keyring token: 256 bits from the OS RNG, hex-encoded.
+fn mint_gnome_token() -> Zeroizing<String> {
+    use rand::Rng;
+    let mut raw = Zeroizing::new([0u8; GNOME_TOKEN_BYTES]);
+    rand::rng().fill_bytes(&mut *raw);
+    let mut out = Zeroizing::new(String::with_capacity(GNOME_TOKEN_BYTES * 2));
+    for b in raw.iter() {
+        use std::fmt::Write;
+        // Infallible for String; expect() documents that rather than unwrap.
+        write!(out, "{b:02x}").expect("writing hex to a String cannot fail");
+    }
+    out
+}
+
+/// Arm GNOME-keyring unlock for `user`: mint a token, seal it in the TPM, wrap
+/// it under the VERIFIED login `password` (the recovery path for PCR drift),
+/// save the envelope, and return the token so the caller can re-key the login
+/// keyring to it.
+///
+/// Ordering is load-bearing: the envelope is durable BEFORE the caller re-keys
+/// the keyring. A crash after this returns but before the re-key leaves the
+/// keyring still keyed to the password (the envelope's token merely goes
+/// unused until a re-arm); the other order would re-key the keyring to a token
+/// that no longer exists anywhere, which is unrecoverable.
+pub fn arm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<String>> {
+    if password.is_empty() {
+        return Err(Error::Protocol(
+            "refusing to arm a keyring token for an empty password".into(),
+        ));
+    }
+    let token = mint_gnome_token();
+    let mut env = tpm::seal(token.as_bytes())?;
+    env.secret = SecretKind::GnomeKeyringToken;
+    env.password_wrap = Some(crate::recovery::wrap(password, token.as_bytes())?);
+    env.save(&envelope_path(user))?;
+    Ok(token)
+}
+
+/// Re-arm an EXISTING token envelope, reusing its token.
+///
+/// Minting a fresh token here would be the trap: the login keyring's current
+/// credential is the old token, so the caller's `CHANGE(password -> new)`
+/// would be denied while the only copy of the old token had already been
+/// overwritten, stranding the keyring permanently. Instead the existing token
+/// is recovered (TPM seal first, password wrap second, so this also works
+/// after PCR drift), the envelope is rebuilt against today's policy and
+/// re-wrapped under the possibly-new password, and the SAME token is returned.
+pub fn rearm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
+    let path = envelope_path(user);
+    let env = SealedEnvelope::load(&path)?;
+    if env.secret != SecretKind::GnomeKeyringToken {
+        return Err(Error::Policy(format!(
+            "'{user}' has a {} armed, not a keyring token",
+            env.secret.describe()
+        )));
+    }
+    let token = match tpm::unseal(&env) {
+        Ok(t) => t,
+        Err(unseal_err) => {
+            let Some(wrap) = env.password_wrap.as_ref() else {
+                return Err(Error::Policy(format!(
+                    "keyring token for '{user}': TPM unseal failed ({unseal_err}) and the \
+                     envelope has no password wrap; `irlume keyring forget --force` and re-arm"
+                )));
+            };
+            crate::recovery::unwrap(password, wrap).map_err(|_| {
+                Error::Policy(format!(
+                    "keyring token for '{user}': TPM unseal failed ({unseal_err}) and this \
+                     password does not open the recovery wrap; envelope left untouched"
+                ))
+            })?
+        }
+    };
+    let mut fresh = tpm::seal(&token)?;
+    fresh.secret = SecretKind::GnomeKeyringToken;
+    fresh.password_wrap = Some(crate::recovery::wrap(password, &token)?);
+    fresh.save(&path)?;
+    Ok(token)
 }
 
 /// Derive the secret of `kind` that `user` should have sealed, from their
@@ -94,6 +190,12 @@ pub fn derive_secret(
                     .into(),
             )),
         },
+        // Random by construction. Every caller that wants "the secret this
+        // password implies" must not exist for tokens; the reseal path handles
+        // them through the envelope's password_wrap instead.
+        SecretKind::GnomeKeyringToken => Err(Error::Policy(
+            "a GNOME keyring token is random and cannot be derived from the password".into(),
+        )),
     }
 }
 
@@ -201,8 +303,15 @@ pub fn reseal_password(
     }
     // Reseal whatever kind is already armed. Deriving the wrong kind here would
     // quietly replace a working envelope with one that opens nothing, and the
-    // damage would not show up until the next login.
-    let kind = sealed_kind(user).unwrap_or_default();
+    // damage would not show up until the next login. A LOAD error must
+    // propagate rather than default the kind: defaulting an unreadable token
+    // envelope to `LoginPassword` would overwrite it with a password seal
+    // below, and the keyring it was re-keyed to would be stranded.
+    let env = SealedEnvelope::load(&envelope_path(user))?;
+    let kind = env.secret;
+    if kind == SecretKind::GnomeKeyringToken {
+        return reseal_token(user, password, env);
+    }
     let secret = match derive_secret(kind, password, home) {
         Ok(s) => s,
         // A KDE wallet key cannot be derived without the salt. Leaving the
@@ -248,6 +357,105 @@ pub fn reseal_password(
     }
     seal_secret(user, password, kind)?;
     Ok(Reseal::Resealed)
+}
+
+/// The token half of [`reseal_password`]. A token cannot be re-derived, so the
+/// self-heal runs through the envelope itself: the TPM seal and the password
+/// wrap each recover the other.
+///
+///   * seal unseals, wrap opens under `password`  -> `Unchanged` (or the same
+///     tier climb the password kinds get)
+///   * seal unseals, wrap does not open           -> the user changed their
+///     password; re-wrap under the new one, `Resealed`
+///   * seal fails, wrap opens                     -> PCR drift; re-seal the
+///     recovered token, `Resealed`
+///   * both fail                                  -> error, envelope untouched:
+///     it may still be the only copy of the token, and the caller's password,
+///     though PAM-verified, may simply be newer than the wrap
+fn reseal_token(user: &str, password: &[u8], env: SealedEnvelope) -> Result<Reseal> {
+    match tpm::unseal(&env) {
+        Ok(token) => {
+            let wrap_current = env.password_wrap.as_ref().is_some_and(|w| {
+                crate::recovery::unwrap(password, w).is_ok_and(|t| t.as_slice() == token.as_slice())
+            });
+            if !wrap_current {
+                // Only the wrap is stale (password change, or an envelope
+                // missing its wrap): refresh it and keep the seal as-is.
+                let mut env = env;
+                env.password_wrap = Some(crate::recovery::wrap(password, &token)?);
+                env.save(&envelope_path(user))?;
+                return Ok(Reseal::Resealed);
+            }
+            if tpm::stronger_tier_available_than(&env.policy) {
+                let mut candidate = tpm::seal(&token)?;
+                // tpm::seal knows nothing of kinds or wraps; dropping either
+                // here would downgrade the envelope to a password seal (next
+                // login routes the token into PAM_AUTHTOK) or amputate the
+                // recovery path until the next password change.
+                candidate.secret = SecretKind::GnomeKeyringToken;
+                candidate.password_wrap = env.password_wrap.clone();
+                if candidate.policy.strength_rank() > env.policy.strength_rank() {
+                    candidate.save(&envelope_path(user))?;
+                    return Ok(Reseal::Upgraded);
+                }
+            }
+            Ok(Reseal::Unchanged)
+        }
+        Err(unseal_err) => {
+            let Some(wrap) = env.password_wrap.as_ref() else {
+                return Err(Error::Policy(format!(
+                    "keyring token for '{user}': TPM unseal failed ({unseal_err}) and the \
+                     envelope has no password wrap to recover from; run `irlume keyring arm`"
+                )));
+            };
+            let token = crate::recovery::unwrap(password, wrap).map_err(|_| {
+                Error::Policy(format!(
+                    "keyring token for '{user}': TPM unseal failed ({unseal_err}) and this \
+                     password does not open the recovery wrap (wrapped under an older \
+                     password?); envelope left untouched"
+                ))
+            })?;
+            let mut fresh = tpm::seal(&token)?;
+            fresh.secret = SecretKind::GnomeKeyringToken;
+            fresh.password_wrap = Some(crate::recovery::wrap(password, &token)?);
+            fresh.save(&envelope_path(user))?;
+            Ok(Reseal::Resealed)
+        }
+    }
+}
+
+/// Release `user`'s sealed GNOME keyring token to a caller who proves they
+/// know the login password, for `keyring forget`'s re-key-back step.
+///
+/// The proof is the envelope's own password wrap: only the right password
+/// opens it (AES-GCM authenticates), so no shadow lookup is needed, and it
+/// works with the TPM seal broken, which is exactly when a disarm matters
+/// most. Fails closed: a wrong password, a stale wrap (password changed with
+/// no login since), and a non-token envelope are all refusals, each named.
+pub fn release_token_with_password(user: &str, password: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
+    let path = envelope_path(user);
+    if !path.exists() {
+        return Err(Error::Policy(format!("no sealed secret for '{user}'")));
+    }
+    let env = SealedEnvelope::load(&path)?;
+    if env.secret != SecretKind::GnomeKeyringToken {
+        return Err(Error::Policy(format!(
+            "'{user}' has a {} armed, not a keyring token; nothing to release for a disarm",
+            env.secret.describe()
+        )));
+    }
+    let Some(wrap) = env.password_wrap.as_ref() else {
+        return Err(Error::Policy(format!(
+            "keyring token for '{user}' has no password wrap; cannot verify the password"
+        )));
+    };
+    crate::recovery::unwrap(password, wrap).map_err(|_| {
+        Error::Policy(
+            "that password does not open the token's recovery wrap; if you changed your \
+             password recently and have not logged in since, use the previous one"
+                .into(),
+        )
+    })
 }
 
 /// Whether `user` has a sealed password armed.
@@ -424,6 +632,241 @@ mod tests {
 
         forget_password("kindtest").unwrap();
         let _ = std::fs::remove_dir_all(&home);
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
+    #[test]
+    fn a_minted_token_is_64_hex_characters_and_never_repeats() {
+        let a = mint_gnome_token();
+        let b = mint_gnome_token();
+        assert_eq!(a.len(), GNOME_TOKEN_BYTES * 2, "hex of 32 bytes");
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "the token crosses string channels (control socket, PAM data); it must be \
+             lowercase hex with nothing to escape: {a:?}"
+        );
+        assert_ne!(*a, *b, "two mints must not collide");
+    }
+
+    /// `seal_secret` is the generic path every other kind uses; a token must
+    /// not be reachable through it, because that path writes no password wrap
+    /// and the first PCR drift would then strand the re-keyed keyring with no
+    /// way back.
+    #[test]
+    fn seal_secret_refuses_a_token_so_it_cannot_be_armed_without_a_wrap() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        std::env::set_var("IRLUME_KEYRING_DIR", "/tmp/irlume-kr-notoken");
+        let err = seal_secret("t", b"0123456789abcdef", SecretKind::GnomeKeyringToken)
+            .expect_err("a token must not be sealable through the generic path");
+        assert!(
+            err.to_string().contains("arm_gnome_token"),
+            "the error must name the right path: {err}"
+        );
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
+    /// A token is random, so "the secret this password implies" has no answer.
+    /// Returning the password itself here (the shape `LoginPassword` uses)
+    /// would make `reseal` overwrite a live token envelope with the password,
+    /// and the keyring keyed to that token would be unreachable.
+    #[test]
+    fn a_token_cannot_be_derived_from_a_password() {
+        let err = derive_secret(SecretKind::GnomeKeyringToken, b"hunter2", None)
+            .expect_err("a random token is not derivable");
+        assert!(
+            err.to_string().contains("random"),
+            "the error must say why: {err}"
+        );
+    }
+
+    /// The token self-heal matrix, which is the whole recovery story for a
+    /// secret that cannot be re-derived. Each arm is checked by BREAKING one
+    /// half of the envelope and asserting the other half recovers the SAME
+    /// token: a reseal that produced a different token would be silent data
+    /// loss (the keyring stays keyed to the old one).
+    #[test]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
+    fn a_token_envelope_heals_from_whichever_half_survives() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = "/tmp/irlume-kr-token-heal";
+        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let _ = std::fs::remove_dir_all(dir);
+
+        let pw = b"first-password";
+        let token = arm_gnome_token("tok", pw).expect("arm");
+        assert_eq!(
+            sealed_kind("tok"),
+            Some(SecretKind::GnomeKeyringToken),
+            "arm must stamp the kind"
+        );
+        assert_eq!(
+            &*unseal_password("tok").unwrap(),
+            token.as_bytes(),
+            "the sealed bytes are the token that was returned"
+        );
+
+        // 1. Both halves current -> nothing rewritten.
+        assert_eq!(
+            reseal_password("tok", pw, None).unwrap(),
+            Reseal::Unchanged,
+            "a healthy token envelope must not churn the TPM on every login"
+        );
+
+        // 2. Password changed: the seal still opens, the wrap does not. The
+        //    token must survive and the wrap must be re-made under the new
+        //    password (proved by unwrapping with it below).
+        let newpw = b"second-password";
+        assert_eq!(
+            reseal_password("tok", newpw, None).unwrap(),
+            Reseal::Resealed
+        );
+        assert_eq!(
+            &*unseal_password("tok").unwrap(),
+            token.as_bytes(),
+            "a password change must NOT change the token: the keyring is keyed to it"
+        );
+        let env = SealedEnvelope::load(&envelope_path("tok")).unwrap();
+        let wrap = env.password_wrap.as_ref().expect("wrap kept");
+        assert_eq!(
+            &*crate::recovery::unwrap(newpw, wrap).expect("wrap now opens with the new password"),
+            token.as_bytes()
+        );
+        assert!(
+            crate::recovery::unwrap(pw, wrap).is_err(),
+            "the old password must no longer open the wrap"
+        );
+
+        // 3. PCR drift: replace the seal with one that cannot unseal, leaving
+        //    the wrap intact. Recovery must come from the wrap and produce the
+        //    same token, re-sealed against today's policy.
+        let mut broken = SealedEnvelope::load(&envelope_path("tok")).unwrap();
+        broken.private = vec![0u8; broken.private.len()];
+        broken.save(&envelope_path("tok")).unwrap();
+        assert!(
+            unseal_password("tok").is_err(),
+            "precondition: the seal must really be broken, or this arm proves nothing"
+        );
+        assert_eq!(
+            reseal_password("tok", newpw, None).unwrap(),
+            Reseal::Resealed,
+            "a broken seal with a good wrap must heal"
+        );
+        assert_eq!(
+            &*unseal_password("tok").unwrap(),
+            token.as_bytes(),
+            "healing must restore the SAME token, not mint a new one"
+        );
+
+        // 4. Both halves broken: refuse and leave the envelope alone. It may
+        //    be the only copy of the token, and a wrong-password caller must
+        //    not be able to destroy it.
+        let mut broken = SealedEnvelope::load(&envelope_path("tok")).unwrap();
+        broken.private = vec![0u8; broken.private.len()];
+        broken.save(&envelope_path("tok")).unwrap();
+        let before = std::fs::read(envelope_path("tok")).unwrap();
+        assert!(
+            reseal_password("tok", b"a-third-password", None).is_err(),
+            "no path may claim success when neither half opens"
+        );
+        assert_eq!(
+            std::fs::read(envelope_path("tok")).unwrap(),
+            before,
+            "a failed heal must not rewrite the envelope"
+        );
+
+        forget_password("tok").unwrap();
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
+    /// A re-arm must hand back the EXISTING token. Minting a fresh one would
+    /// overwrite the only copy of the secret the login keyring is currently
+    /// keyed to, and the caller's re-key from the password would then be
+    /// denied, leaving the keyring permanently unreachable.
+    #[test]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
+    fn rearming_reuses_the_existing_token_rather_than_minting() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = "/tmp/irlume-kr-rearm";
+        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let _ = std::fs::remove_dir_all(dir);
+
+        let pw = b"a-password";
+        let first = arm_gnome_token("re", pw).expect("arm");
+        let again = rearm_gnome_token("re", pw).expect("re-arm");
+        assert_eq!(
+            &*again,
+            first.as_bytes(),
+            "a re-arm handed back a DIFFERENT token; the keyring keyed to the first \
+             one would be stranded"
+        );
+
+        // Even with the seal broken, the re-arm recovers via the wrap and
+        // still yields the same token.
+        let mut broken = SealedEnvelope::load(&envelope_path("re")).unwrap();
+        broken.private = vec![0u8; broken.private.len()];
+        broken.save(&envelope_path("re")).unwrap();
+        assert_eq!(
+            &*rearm_gnome_token("re", pw).expect("re-arm after drift"),
+            first.as_bytes()
+        );
+        assert!(
+            unseal_password("re").is_ok(),
+            "the re-arm must leave a working seal behind"
+        );
+
+        // A wrong password cannot re-arm once the seal is broken: that is the
+        // only proof of identity left.
+        let mut broken = SealedEnvelope::load(&envelope_path("re")).unwrap();
+        broken.private = vec![0u8; broken.private.len()];
+        broken.save(&envelope_path("re")).unwrap();
+        assert!(rearm_gnome_token("re", b"wrong-password").is_err());
+
+        forget_password("re").unwrap();
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+    }
+
+    /// The disarm release is the one place a token leaves the daemon on a
+    /// password alone, so its gate has to hold in all three failure shapes.
+    #[test]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
+    fn releasing_a_token_for_disarm_needs_the_right_password() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let dir = "/tmp/irlume-kr-disarm";
+        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert!(
+            release_token_with_password("nobody", b"pw").is_err(),
+            "nothing armed"
+        );
+
+        seal_password("pwuser", b"pw").expect("arm a password envelope");
+        let err = release_token_with_password("pwuser", b"pw")
+            .expect_err("a password envelope has no token to release");
+        assert!(err.to_string().contains("login password"), "{err}");
+
+        let token = arm_gnome_token("tokuser", b"right-pw").expect("arm");
+        assert!(release_token_with_password("tokuser", b"wrong-pw").is_err());
+        assert_eq!(
+            &*release_token_with_password("tokuser", b"right-pw").expect("correct password"),
+            token.as_bytes()
+        );
+
+        // It must work with the TPM seal broken: that is exactly when a user
+        // needs to disarm and get their keyring back.
+        let mut broken = SealedEnvelope::load(&envelope_path("tokuser")).unwrap();
+        broken.private = vec![0u8; broken.private.len()];
+        broken.save(&envelope_path("tokuser")).unwrap();
+        assert!(unseal_password("tokuser").is_err(), "precondition");
+        assert_eq!(
+            &*release_token_with_password("tokuser", b"right-pw")
+                .expect("the wrap must work without the TPM"),
+            token.as_bytes()
+        );
+
+        forget_password("pwuser").unwrap();
+        forget_password("tokuser").unwrap();
         std::env::remove_var("IRLUME_KEYRING_DIR");
     }
 

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -206,6 +206,47 @@ pub fn sealed_kind(user: &str) -> Option<SecretKind> {
         .map(|e| e.secret)
 }
 
+/// Every sealed envelope on this machine, as `(user, kind)`.
+///
+/// Enumerates the ENVELOPE directory, not enrolled users: `keyring arm` does
+/// not require an enrollment, so a user can hold a sealed token and never
+/// appear in `storage::list_users()`.
+///
+/// Any unreadable or malformed envelope is an ERROR, never a skipped entry. A
+/// destructive caller cannot assume the kind of an envelope it could not read,
+/// and the difference between "no token here" and "could not tell" is the
+/// difference between a safe teardown and erasing the only copy of the secret
+/// a login keyring is encrypted under.
+pub fn list_sealed_kinds() -> Result<Vec<(String, SecretKind)>> {
+    let dir = keyring_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        // A machine that never armed anything has no directory, which is a
+        // real answer: nothing is sealed.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(Error::Io(format!("read {}: {e}", dir.display()))),
+    };
+    let mut out = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| Error::Io(format!("read {}: {e}", dir.display())))?;
+        let path = entry.path();
+        if path.extension().and_then(|x| x.to_str()) != Some("json") {
+            continue;
+        }
+        let user = path
+            .file_stem()
+            .and_then(|x| x.to_str())
+            .ok_or_else(|| {
+                Error::Protocol(format!("unreadable envelope name: {}", path.display()))
+            })?
+            .to_string();
+        let env = SealedEnvelope::load(&path)?;
+        out.push((user, env.secret));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
 /// A released secret together with what it is.
 pub struct Unsealed {
     pub secret: Zeroizing<Vec<u8>>,

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -99,22 +99,27 @@ pub fn derive_for_home(password: &[u8], home: &Path) -> Result<Zeroizing<Vec<u8>
 
 /// Which secret to seal for a user, judged by what they actually have.
 ///
-/// A KDE wallet key only makes sense where there is a KDE wallet, and it must
-/// not be chosen on a machine that also runs gnome-keyring: that backend takes
-/// the password string itself, so sealing a wallet key there would leave the
-/// GNOME login keyring locked with nothing to unlock it.
+/// A KDE wallet key only makes sense where there is a KDE wallet. A GNOME
+/// keyring token only makes sense where there is a GNOME login keyring to
+/// re-key to it, and not where a KDE wallet also exists: the wallet key is
+/// derived from the password, so a token arm would leave the KDE wallet with
+/// nothing to open it.
 ///
 /// The conservative direction is [`crate::envelope::SecretKind::LoginPassword`],
-/// the behaviour before #250, so anything ambiguous resolves to it.
+/// the behaviour before #250, so anything ambiguous (both backends, neither)
+/// resolves to it. A home with neither also lands there deliberately: a token
+/// arm on a fresh account would have no keyring to re-key, and the envelope it
+/// wrote would unlock nothing.
 pub fn detect_kind(home: &Path) -> crate::envelope::SecretKind {
     use crate::envelope::SecretKind;
     let has_kde = salt_path(home).exists();
-    // gnome-keyring's login keyring, the thing that would break.
+    // gnome-keyring's login keyring: what a token re-keys, and what a wallet
+    // key arm would break.
     let has_gnome = home.join(".local/share/keyrings/login.keyring").exists();
-    if has_kde && !has_gnome {
-        SecretKind::KdeWalletKey
-    } else {
-        SecretKind::LoginPassword
+    match (has_kde, has_gnome) {
+        (true, false) => SecretKind::KdeWalletKey,
+        (false, true) => SecretKind::GnomeKeyringToken,
+        _ => SecretKind::LoginPassword,
     }
 }
 
@@ -183,9 +188,11 @@ mod tests {
         b.iter().map(|x| format!("{x:02x}")).collect()
     }
 
-    /// Detection has to be conservative in both directions: no KDE wallet means
-    /// there is nothing a wallet key could open, and a machine running both
-    /// backends must keep the password, or its GNOME login keyring is stranded.
+    /// Detection has to be conservative in every ambiguous direction: a home
+    /// with neither backend has nothing to unlock, and a machine running both
+    /// backends must keep the password, or whichever backend the arm did not
+    /// pick is stranded. Only an unambiguous single-backend home gets that
+    /// backend's dedicated secret.
     #[test]
     fn detect_kind_only_picks_the_wallet_key_on_a_kde_only_home() {
         use crate::envelope::SecretKind;
@@ -213,7 +220,7 @@ mod tests {
         );
         assert_eq!(
             detect_kind(&mk("gnome", false, true)),
-            SecretKind::LoginPassword
+            SecretKind::GnomeKeyringToken
         );
         assert_eq!(
             detect_kind(&mk("both", true, true)),

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -478,6 +478,7 @@ pub fn seal_with_pcrs(secret: &[u8], pcrs: &[u32]) -> Result<SealedEnvelope> {
             public: created.out_public.marshall().map_err(tpm_err)?,
             private: created.out_private.to_vec(),
             pcr_values: pcr_values.clone(),
+            password_wrap: None,
         })
     })
 }
@@ -689,6 +690,7 @@ fn seal_authorized(secret: &[u8]) -> Result<SealedEnvelope> {
             public: created.out_public.marshall().map_err(tpm_err)?,
             private: created.out_private.to_vec(),
             pcr_values: pcr_values.clone(),
+            password_wrap: None,
         })
     })
 }
@@ -1249,6 +1251,7 @@ fn seal_pcrlock(secret: &[u8], nv_index: u32) -> Result<SealedEnvelope> {
             public: created.out_public.marshall().map_err(tpm_err)?,
             private: created.out_private.to_vec(),
             pcr_values: pcr_values.clone(),
+            password_wrap: None,
         })
     })
 }

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -451,6 +451,7 @@ mod tests {
             classify(&Request::UnsealKeyring {
                 user: "u".into(),
                 service: None,
+                have_password: false,
             }),
             Class::Auth
         );

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2227,6 +2227,25 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             // live credential is the old token, and overwriting its only copy
             // with a fresh one would strand the keyring permanently.
             if core_kind == irlume_core::envelope::SecretKind::GnomeKeyringToken {
+                // The re-key that completes a token arm CREATES the login
+                // keyring when none exists, keyed to the token, rather than
+                // failing (`change_or_create_login()` in gnome-keyring's
+                // gkd-login.c never checks the old password in that case). The
+                // user would end up with a keyring whose password is 64 random
+                // characters they have never seen. Detection already declines
+                // a home with no login keyring; this catches a client that
+                // asked for the kind explicitly.
+                let keyring_present = home
+                    .as_deref()
+                    .map(|h| h.join(".local/share/keyrings/login.keyring").exists())
+                    .unwrap_or(false);
+                if !keyring_present {
+                    return Response::Error(format!(
+                        "'{user}' has no GNOME login keyring, so there is nothing to re-key; \
+                         arming a token would create one keyed to a random secret. Log into \
+                         GNOME once to create the keyring, or arm without forcing a kind."
+                    ));
+                }
                 let already_token = irlume_core::keyring::sealed_kind(&user)
                     == Some(irlume_core::envelope::SecretKind::GnomeKeyringToken);
                 let armed = if already_token {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1258,7 +1258,7 @@ static SOCKET_ACTIVATED: std::sync::atomic::AtomicBool = std::sync::atomic::Atom
 /// credentials. That is what lets the daemon answer it while the engine is still
 /// loading (#244). Every authorization check below is a property of the REQUEST,
 /// never of startup state, so answering early cannot weaken any of them.
-fn unseal_keyring(user: &str, service: Option<&str>, peer: &Peer) -> Response {
+fn unseal_keyring(user: &str, service: Option<&str>, have_password: bool, peer: &Peer) -> Response {
     let user = user.to_string();
     let service = service.map(str::to_string);
 
@@ -1300,6 +1300,19 @@ fn unseal_keyring(user: &str, service: Option<&str>, peer: &Peer) -> Response {
             return Response::Error(format!("keyring unseal not allowed for {class:?}"));
         }
     }
+    // A typed password already opens a password-keyed keyring, so touching the
+    // TPM would spend an unseal (up to seconds on a discrete TPM) to release a
+    // secret the caller then discards. For a token envelope the typed password
+    // opens nothing, so the release must proceed. The kind read here is a
+    // cheap envelope-file read, not an unseal; the release below re-reads
+    // atomically, so a concurrent re-arm at worst turns this into the old
+    // always-unseal behaviour.
+    if have_password
+        && irlume_core::keyring::sealed_kind(&user)
+            == Some(irlume_core::envelope::SecretKind::LoginPassword)
+    {
+        return Response::KeyringUnlockNotNeeded;
+    }
     // One load yields both the bytes and their kind, so a concurrent re-arm
     // cannot tag one envelope's secret with another's kind.
     match irlume_core::keyring::unseal_secret(&user) {
@@ -1330,7 +1343,11 @@ fn unseal_keyring(user: &str, service: Option<&str>, peer: &Peer) -> Response {
 /// and no early caller occupies a slot for the length of it.
 fn dispatch_before_engine(req: Request, peer: &Peer) -> Response {
     match req {
-        Request::UnsealKeyring { user, service } => unseal_keyring(&user, service.as_deref(), peer),
+        Request::UnsealKeyring {
+            user,
+            service,
+            have_password,
+        } => unseal_keyring(&user, service.as_deref(), have_password, peer),
         Request::Ping => Response::Ok("starting".into()),
         _ => Response::Error(
             "irlumed is still starting (loading models); retry, or use your password".into(),
@@ -1790,6 +1807,7 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                         .ok()
                         .filter(|_| !env.pcr_values.is_empty())
                         .map(|d| !d.is_empty()),
+                    kind: Some(crate::users::core_to_wire_kind(env.secret)),
                 },
                 // Not armed, or the envelope is unreadable/corrupt: report the
                 // armed bit alone rather than failing the whole query.
@@ -1798,6 +1816,7 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     policy: None,
                     pcrs: Vec::new(),
                     drifted: None,
+                    kind: None,
                 },
             }
         }
@@ -2200,11 +2219,47 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     None => irlume_core::envelope::SecretKind::LoginPassword,
                 },
             };
+            // A token arm returns the token: the re-key of the login keyring
+            // can only happen in the user's session (the control socket
+            // authenticates the peer uid), so the caller finishes the job.
+            // Envelope-before-re-key ordering is inside arm_gnome_token. A
+            // RE-arm must reuse the existing token, not mint: the keyring's
+            // live credential is the old token, and overwriting its only copy
+            // with a fresh one would strand the keyring permanently.
+            if core_kind == irlume_core::envelope::SecretKind::GnomeKeyringToken {
+                let already_token = irlume_core::keyring::sealed_kind(&user)
+                    == Some(irlume_core::envelope::SecretKind::GnomeKeyringToken);
+                let armed = if already_token {
+                    irlume_core::keyring::rearm_gnome_token(&user, password.expose())
+                } else {
+                    irlume_core::keyring::arm_gnome_token(&user, password.expose())
+                        .map(|t| zeroize::Zeroizing::new(t.as_bytes().to_vec()))
+                };
+                return match armed {
+                    Ok(token) => {
+                        eprintln!(
+                            "irlumed: SealPassword: sealed a GNOME keyring token for '{user}' \
+                             ({}); caller must now re-key the login keyring",
+                            if already_token {
+                                "reused from the existing envelope"
+                            } else {
+                                "freshly minted"
+                            }
+                        );
+                        Response::TokenSealed {
+                            token: irlume_common::SecretBytes::new(token.to_vec()),
+                            minted: !already_token,
+                        }
+                    }
+                    Err(e) => Response::Error(e.to_string()),
+                };
+            }
             let secret = match core_kind {
                 irlume_core::envelope::SecretKind::LoginPassword => {
                     Ok(zeroize::Zeroizing::new(password.expose().to_vec()))
                 }
-                irlume_core::envelope::SecretKind::KdeWalletKey => {
+                irlume_core::envelope::SecretKind::KdeWalletKey
+                | irlume_core::envelope::SecretKind::GnomeKeyringToken => {
                     irlume_core::keyring::derive_secret(
                         core_kind,
                         password.expose(),
@@ -2323,13 +2378,41 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             }
             do_unseal_password(&user, service.as_deref(), engine)
         }
-        Request::UnsealKeyring { user, service } => unseal_keyring(&user, service.as_deref(), peer),
+        Request::UnsealKeyring {
+            user,
+            service,
+            have_password,
+        } => unseal_keyring(&user, service.as_deref(), have_password, peer),
         Request::ForgetPassword { user } => {
             if !authorized_for(peer, &user) {
                 return Response::Error(format!("not authorized to forget password for '{user}'"));
             }
             match irlume_core::keyring::forget_password(&user) {
                 Ok(()) => Response::PasswordForgotten,
+                Err(e) => Response::Error(e.to_string()),
+            }
+        }
+        Request::ReleaseTokenForDisarm { user, password } => {
+            // Same authz as arming; the password check inside (the token's own
+            // AES-GCM wrap) is what actually gates the release, so a root
+            // caller still has to present the user's password. `password`
+            // zeroizes on drop.
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!(
+                    "not authorized to release the keyring token for '{user}'"
+                ));
+            }
+            match irlume_core::keyring::release_token_with_password(&user, password.expose()) {
+                Ok(token) => {
+                    eprintln!(
+                        "irlumed: ReleaseTokenForDisarm: released '{user}'s keyring token \
+                         (password verified against the recovery wrap)"
+                    );
+                    Response::PasswordUnsealed {
+                        kind: irlume_common::KeyringSecretKind::GnomeKeyringToken,
+                        secret: irlume_common::SecretBytes::new(token.to_vec()),
+                    }
+                }
                 Err(e) => Response::Error(e.to_string()),
             }
         }
@@ -3250,6 +3333,7 @@ mod tests {
             Request::UnsealKeyring {
                 user: u(),
                 service: None,
+                have_password: false,
             },
             Request::HasSealedPassword { user: u() },
             Request::KeyringInfo { user: u() },
@@ -5332,6 +5416,7 @@ mod tests {
             Request::UnsealKeyring {
                 user: "carol".into(),
                 service: Some("kde".into()),
+                have_password: false,
             },
             &peer(NOBODY),
             &mut e,
@@ -5348,6 +5433,7 @@ mod tests {
             Request::UnsealKeyring {
                 user: "carol".into(),
                 service: Some("kde".into()),
+                have_password: false,
             },
             &peer(0),
             &mut e,
@@ -5366,6 +5452,7 @@ mod tests {
             Request::UnsealKeyring {
                 user: "carol".into(),
                 service: Some("sudo".into()),
+                have_password: false,
             },
             &peer(0),
             &mut e,
@@ -5378,6 +5465,7 @@ mod tests {
             Request::UnsealKeyring {
                 user: "carol".into(),
                 service: Some("kde".into()),
+                have_password: false,
             },
             &peer(0),
             &mut e,
@@ -5460,6 +5548,7 @@ mod tests {
                 policy,
                 pcrs,
                 drifted,
+                ..
             } => {
                 assert!(!armed);
                 assert_eq!(policy, None);
@@ -5903,6 +5992,7 @@ mod tests {
             Request::UnsealKeyring {
                 user: "carol".into(),
                 service: Some("kde".into()),
+                have_password: false,
             },
             &peer(NOBODY),
             &mut e,
@@ -5919,6 +6009,7 @@ mod tests {
             Request::UnsealKeyring {
                 user: "carol".into(),
                 service: Some("kde".into()),
+                have_password: false,
             },
             &root,
             &mut e,

--- a/crates/irlume-daemon/src/users.rs
+++ b/crates/irlume-daemon/src/users.rs
@@ -98,6 +98,9 @@ pub fn wire_to_core_kind(k: irlume_common::KeyringSecretKind) -> irlume_core::en
         irlume_common::KeyringSecretKind::KdeWalletKey => {
             irlume_core::envelope::SecretKind::KdeWalletKey
         }
+        irlume_common::KeyringSecretKind::GnomeKeyringToken => {
+            irlume_core::envelope::SecretKind::GnomeKeyringToken
+        }
     }
 }
 
@@ -109,6 +112,9 @@ pub fn core_to_wire_kind(k: irlume_core::envelope::SecretKind) -> irlume_common:
         }
         irlume_core::envelope::SecretKind::KdeWalletKey => {
             irlume_common::KeyringSecretKind::KdeWalletKey
+        }
+        irlume_core::envelope::SecretKind::GnomeKeyringToken => {
+            irlume_common::KeyringSecretKind::GnomeKeyringToken
         }
     }
 }

--- a/crates/irlume-gkr-unlock/Cargo.toml
+++ b/crates/irlume-gkr-unlock/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "irlume-gkr-unlock"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "irlume-gkr-unlock"
+path = "src/main.rs"
+
+# Deliberately minimal, like irlume-kwallet-init: this runs as root in the
+# login path, so it takes no dependency on the TPM, inference or serialization
+# stacks.
+[dependencies]
+irlume-common.workspace = true
+libc.workspace = true

--- a/crates/irlume-gkr-unlock/src/main.rs
+++ b/crates/irlume-gkr-unlock/src/main.rs
@@ -26,6 +26,7 @@
 use irlume_common::gkr_wire::{self, ControlResult, Op};
 use std::ffi::CString;
 use std::io::Read;
+use std::os::unix::ffi::OsStringExt;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 
@@ -33,6 +34,11 @@ use std::path::PathBuf;
 /// the margin tolerates a future longer format without accepting arbitrary
 /// stream lengths from a confused caller.
 const MAX_TOKEN_LEN: usize = 256;
+
+/// Deadline for each control-socket read and write. The daemon imposes none,
+/// and this runs inside the PAM session phase, so an unbounded wait is a hung
+/// login. Generous enough for a socket-activated daemon's cold start.
+const IO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 fn main() -> std::process::ExitCode {
     let mut args = std::env::args_os().skip(1);
@@ -73,13 +79,25 @@ fn run(user: &str) -> Result<(), String> {
     }
 
     let pw = lookup_user(user)?;
-    let runtime_dir = PathBuf::from(format!("/run/user/{}", pw.uid));
-    if !runtime_dir.is_dir() {
+    // Refuse when there is no login keyring to unlock.
+    //
+    // UNLOCK is not read-only: `unlock_or_create_login()` CREATES the login
+    // keyring keyed to whatever secret it was handed when none exists
+    // (gnome-keyring's `daemon/login/gkd-login.c`). Firing blind after the
+    // user deleted their keyring would silently mint a new one whose password
+    // is a 64-character random token they have never seen and no GNOME
+    // interface can tell them. Unlocking an existing keyring is this program's
+    // whole job; creating one is not.
+    let keyring = login_keyring_path(&pw)?;
+    if !keyring.exists() {
         return Err(format!(
-            "{} does not exist; the session is not far enough along for a keyring",
-            runtime_dir.display()
+            "{} does not exist; refusing to UNLOCK, which would CREATE a login keyring \
+             keyed to the sealed token instead of unlocking one. Run `irlume keyring \
+             forget` to disarm, or create the keyring first.",
+            keyring.display()
         ));
     }
+    let runtime_dir = runtime_dir_for(&pw)?;
 
     // EVERYTHING below runs as the target user: the daemon compares the
     // connecting peer's uid against its own, and root pathname work inside a
@@ -95,10 +113,102 @@ fn run(user: &str) -> Result<(), String> {
             sock.display()
         )
     })?;
+    // The daemon applies NO timeout of its own to a control connection
+    // (`gkd-control-server.c` drives the fd from the main loop with no timer),
+    // and the socket may be a systemd listener whose daemon is still starting.
+    // Without deadlines here, a wedged or slow-starting daemon would hang the
+    // PAM session phase, i.e. the login.
+    stream
+        .set_read_timeout(Some(IO_TIMEOUT))
+        .and_then(|()| stream.set_write_timeout(Some(IO_TIMEOUT)))
+        .map_err(|e| format!("setting control socket timeouts: {e}"))?;
     match gkr_wire::call(&mut stream, Op::Unlock, &[&token])? {
         ControlResult::Ok => Ok(()),
+        // A DENIED here is not merely a failed unlock. The daemon remembers
+        // the rejected secret (`gkm_wrap_layer_mark_login_unlock_failure`) and
+        // re-keys the login keyring TO IT the next time the user unlocks that
+        // keyring through a successful prompt. If the token we sent is the one
+        // in the envelope, that self-heal is benign (it converges on the token
+        // irlume holds); if it is stale, the keyring ends up keyed to a secret
+        // nobody has. Say so loudly rather than exiting quietly, because the
+        // journal line is the only place this becomes visible.
+        ControlResult::Denied => Err(format!(
+            "keyring UNLOCK denied: the login keyring is not keyed to the sealed token. \
+             gnome-keyring has cached this rejected secret and may re-key the keyring to \
+             it after the next manual unlock; re-run `irlume keyring arm` (or `irlume \
+             keyring forget`) as {user} to put the keyring and the envelope back in step."
+        )),
         other => Err(format!("keyring UNLOCK: {}", other.describe())),
     }
+}
+
+/// The login keyring file, under the home NSS reports.
+///
+/// `$HOME` is deliberately not consulted: this may run as root with the login
+/// stack's environment, where `$HOME` is root's or unset.
+/// `IRLUME_GKR_HOME` overrides it under the same not-privileged rule as
+/// [`runtime_dir_for`], so the harness can point at a throwaway home.
+fn login_keyring_path(pw: &User) -> Result<PathBuf, String> {
+    let home = match std::env::var_os("IRLUME_GKR_HOME") {
+        Some(over) if !privileged() => PathBuf::from(over),
+        Some(_) => {
+            return Err(
+                "IRLUME_GKR_HOME is set but this process is privileged; refusing to take \
+                 the home directory from the environment"
+                    .into(),
+            )
+        }
+        None => PathBuf::from(&pw.home),
+    };
+    Ok(home.join(".local/share/keyrings/login.keyring"))
+}
+
+/// Whether this process holds privilege that the environment must not steer.
+fn privileged() -> bool {
+    let (euid, uid) = unsafe { (libc::geteuid(), libc::getuid()) };
+    euid == 0 || uid == 0
+}
+
+/// Where the target user's control socket lives.
+///
+/// Derived from the uid, NOT from `XDG_RUNTIME_DIR`. When this runs from the
+/// PAM stack it runs as root, and the environment is the caller's: honouring
+/// an inherited path there would let whoever controls that environment name
+/// the socket this program writes the token to, which is a direct secret leak.
+///
+/// `IRLUME_GKR_RUNTIME_DIR` overrides it for the test harness, and ONLY when
+/// this process is not privileged. An unprivileged process can already reach
+/// everything its own uid can, so the override grants nothing; refusing it
+/// under root keeps the production path environment-independent.
+///
+/// This is a deliberate divergence from `gkr-pam`, which prefers
+/// `$GNOME_KEYRING_CONTROL` and only then falls back to `$XDG_RUNTIME_DIR`
+/// (`get_control_file()` in `gkr-pam-module.c`). That module already runs
+/// inside the user's own environment; this one runs as root with whatever
+/// environment the login stack happened to carry, and honouring a variable
+/// from there would let it name the socket a secret is written to. The
+/// fallback path is what gnome-keyring's own systemd units bind
+/// (`ListenStream=%t/keyring/control`), so the divergence only shows up on a
+/// setup that relocates the socket by hand.
+fn runtime_dir_for(pw: &User) -> Result<PathBuf, String> {
+    let dir = match std::env::var_os("IRLUME_GKR_RUNTIME_DIR") {
+        Some(over) if !privileged() => PathBuf::from(over),
+        Some(_) => {
+            return Err(
+                "IRLUME_GKR_RUNTIME_DIR is set but this process is privileged; refusing to \
+                 take the socket path from the environment"
+                    .into(),
+            )
+        }
+        None => PathBuf::from(format!("/run/user/{}", pw.uid)),
+    };
+    if !dir.is_dir() {
+        return Err(format!(
+            "{} does not exist; the session is not far enough along for a keyring",
+            dir.display()
+        ));
+    }
+    Ok(dir)
 }
 
 /// Become the target user, permanently. Same order and same paranoia as
@@ -107,6 +217,17 @@ fn run(user: &str) -> Result<(), String> {
 /// connection coming from root and everything below running with privilege it
 /// must not have.
 fn drop_privileges(pw: &User) -> Result<(), String> {
+    // Already the target user (the test harness, and any future caller that
+    // runs in-session): there is nothing to drop, and `initgroups` would fail
+    // with EPERM for an unprivileged process. Verified below either way, so
+    // this cannot skip a drop that was actually needed.
+    let already = unsafe { libc::getuid() } == pw.uid
+        && unsafe { libc::geteuid() } == pw.uid
+        && unsafe { libc::getgid() } == pw.gid
+        && unsafe { libc::getegid() } == pw.gid;
+    if already {
+        return Ok(());
+    }
     if unsafe { libc::initgroups(pw.name.as_ptr(), pw.gid) } != 0 {
         return Err(format!("initgroups: {}", std::io::Error::last_os_error()));
     }
@@ -130,6 +251,9 @@ struct User {
     uid: libc::uid_t,
     gid: libc::gid_t,
     name: CString,
+    /// Home directory, read from NSS rather than `$HOME`: this may run as root
+    /// with the login stack's environment, where `$HOME` is not yet the user's.
+    home: std::ffi::OsString,
 }
 
 fn lookup_user(user: &str) -> Result<User, String> {
@@ -144,9 +268,18 @@ fn lookup_user(user: &str) -> Result<User, String> {
     if uid == 0 {
         return Err("refusing to unlock a keyring for uid 0".to_string());
     }
+    // SAFETY: same static buffer as above, still valid; copied out immediately.
+    let home = unsafe {
+        let d = (*pw).pw_dir;
+        if d.is_null() {
+            return Err(format!("no home directory for {user}"));
+        }
+        std::ffi::OsString::from_vec(std::ffi::CStr::from_ptr(d).to_bytes().to_vec())
+    };
     Ok(User {
         uid,
         gid,
         name: cname,
+        home,
     })
 }

--- a/crates/irlume-gkr-unlock/src/main.rs
+++ b/crates/irlume-gkr-unlock/src/main.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Unlock a user's GNOME login keyring with their sealed keyring token (#250).
+//!
+//! On a token-armed account the login keyring is keyed to a random token, not
+//! the login password, so after a face or fingerprint login (and after a typed
+//! password login, whose password no longer opens it) something must hand the
+//! token to `gnome-keyring-daemon`. That channel is the daemon's control
+//! socket, `$XDG_RUNTIME_DIR/keyring/control`, with the `UNLOCK` operation:
+//! the exact channel and operation `pam_gnome_keyring` itself uses.
+//!
+//! This exists as a separate program for the same reason `irlume-kwallet-init`
+//! does: `pam_irlume` is loaded into sshd, login and every greeter, and it has
+//! no privilege dropping. The control socket authenticates the peer's uid
+//! (`gkr-pam-client.c` does its own seteuid dance for the same reason), so the
+//! connection must be made AS the target user, and becoming the user
+//! permanently in a short-lived helper keeps the module's blast radius
+//! unchanged.
+//!
+//! Invoked as `irlume-gkr-unlock <username>` with the token on **stdin**,
+//! never in argv, which is world-readable through `/proc`. Exit status 0 means
+//! the daemon reported the keyring unlocked; anything else is a refusal or an
+//! error, printed to stderr.
+
+use irlume_common::gkr_wire::{self, ControlResult, Op};
+use std::ffi::CString;
+use std::io::Read;
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+
+/// Ceiling on the token read from stdin. The armed token is 64 bytes of hex;
+/// the margin tolerates a future longer format without accepting arbitrary
+/// stream lengths from a confused caller.
+const MAX_TOKEN_LEN: usize = 256;
+
+fn main() -> std::process::ExitCode {
+    let mut args = std::env::args_os().skip(1);
+    let Some(user) = args.next() else {
+        eprintln!("usage: irlume-gkr-unlock <username>  (token on stdin)");
+        return std::process::ExitCode::from(2);
+    };
+    let user = user.to_string_lossy().into_owned();
+
+    match run(&user) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("irlume-gkr-unlock: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(user: &str) -> Result<(), String> {
+    // Read the token first, before any privilege change, so a malformed
+    // invocation fails without side effects.
+    let mut token = Vec::with_capacity(MAX_TOKEN_LEN);
+    std::io::stdin()
+        .take(MAX_TOKEN_LEN as u64 + 1)
+        .read_to_end(&mut token)
+        .map_err(|e| format!("reading the token from stdin: {e}"))?;
+    if token.is_empty() {
+        return Err("empty token on stdin".into());
+    }
+    if token.len() > MAX_TOKEN_LEN {
+        return Err(format!("token longer than {MAX_TOKEN_LEN} bytes; refusing"));
+    }
+    // The keyring credential is a string; a token with a NUL or control bytes
+    // is not one this program ever produced, so refuse it rather than let a
+    // truncated comparison "succeed" somewhere downstream.
+    if token.iter().any(|b| !b.is_ascii_graphic()) {
+        return Err("token contains non-printable bytes; refusing".into());
+    }
+
+    let pw = lookup_user(user)?;
+    let runtime_dir = PathBuf::from(format!("/run/user/{}", pw.uid));
+    if !runtime_dir.is_dir() {
+        return Err(format!(
+            "{} does not exist; the session is not far enough along for a keyring",
+            runtime_dir.display()
+        ));
+    }
+
+    // EVERYTHING below runs as the target user: the daemon compares the
+    // connecting peer's uid against its own, and root pathname work inside a
+    // user-owned directory is the CVE-2018-10380 shape this codebase refuses
+    // to repeat.
+    drop_privileges(&pw)?;
+
+    let sock = gkr_wire::control_socket_path(&runtime_dir);
+    let mut stream = UnixStream::connect(&sock).map_err(|e| {
+        format!(
+            "connect {}: {e} (no gnome-keyring-daemon control socket; is \
+             gnome-keyring installed and socket-activated?)",
+            sock.display()
+        )
+    })?;
+    match gkr_wire::call(&mut stream, Op::Unlock, &[&token])? {
+        ControlResult::Ok => Ok(()),
+        other => Err(format!("keyring UNLOCK: {}", other.describe())),
+    }
+}
+
+/// Become the target user, permanently. Same order and same paranoia as
+/// `irlume-kwallet-init`: groups and gid before uid, then verify the drop
+/// took, because a drop that silently failed would leave the control-socket
+/// connection coming from root and everything below running with privilege it
+/// must not have.
+fn drop_privileges(pw: &User) -> Result<(), String> {
+    if unsafe { libc::initgroups(pw.name.as_ptr(), pw.gid) } != 0 {
+        return Err(format!("initgroups: {}", std::io::Error::last_os_error()));
+    }
+    if unsafe { libc::setgid(pw.gid) } != 0 {
+        return Err(format!("setgid: {}", std::io::Error::last_os_error()));
+    }
+    if unsafe { libc::setuid(pw.uid) } != 0 {
+        return Err(format!("setuid: {}", std::io::Error::last_os_error()));
+    }
+    if unsafe { libc::getuid() } != pw.uid
+        || unsafe { libc::geteuid() } != pw.uid
+        || unsafe { libc::getgid() } != pw.gid
+        || unsafe { libc::getegid() } != pw.gid
+    {
+        return Err("privilege drop did not take effect".into());
+    }
+    Ok(())
+}
+
+struct User {
+    uid: libc::uid_t,
+    gid: libc::gid_t,
+    name: CString,
+}
+
+fn lookup_user(user: &str) -> Result<User, String> {
+    let cname = CString::new(user).map_err(|_| "username contains a NUL".to_string())?;
+    // SAFETY: getpwnam returns a pointer into a static buffer, read before any
+    // further libc call that could overwrite it.
+    let pw = unsafe { libc::getpwnam(cname.as_ptr()) };
+    if pw.is_null() {
+        return Err(format!("no such user: {user}"));
+    }
+    let (uid, gid) = unsafe { ((*pw).pw_uid, (*pw).pw_gid) };
+    if uid == 0 {
+        return Err("refusing to unlock a keyring for uid 0".to_string());
+    }
+    Ok(User {
+        uid,
+        gid,
+        name: cname,
+    })
+}

--- a/crates/irlume-gkr-unlock/src/main.rs
+++ b/crates/irlume-gkr-unlock/src/main.rs
@@ -26,7 +26,7 @@
 use irlume_common::gkr_wire::{self, ControlResult, Op};
 use std::ffi::CString;
 use std::io::Read;
-use std::os::unix::ffi::OsStringExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 
@@ -106,13 +106,7 @@ fn run(user: &str) -> Result<(), String> {
     drop_privileges(&pw)?;
 
     let sock = gkr_wire::control_socket_path(&runtime_dir);
-    let mut stream = UnixStream::connect(&sock).map_err(|e| {
-        format!(
-            "connect {}: {e} (no gnome-keyring-daemon control socket; is \
-             gnome-keyring installed and socket-activated?)",
-            sock.display()
-        )
-    })?;
+    let mut stream = connect_with_deadline(&sock)?;
     // The daemon applies NO timeout of its own to a control connection
     // (`gkd-control-server.c` drives the fd from the main loop with no timer),
     // and the socket may be a systemd listener whose daemon is still starting.
@@ -142,7 +136,106 @@ fn run(user: &str) -> Result<(), String> {
     }
 }
 
-/// The login keyring file, under the home NSS reports.
+/// Connect to the control socket without ever blocking past [`IO_TIMEOUT`].
+///
+/// `UnixStream::connect` creates a BLOCKING socket and completes the connection
+/// before any timeout can be installed, so setting read and write deadlines
+/// afterwards leaves the connect itself unbounded. That matters here: a full
+/// listen backlog, or a socket-activated unit whose service is wedged, blocks
+/// the PAM session phase, which blocks the login.
+fn connect_with_deadline(sock: &std::path::Path) -> Result<UnixStream, String> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    let bytes = sock.as_os_str().as_bytes();
+    if bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
+        return Err(format!("socket path too long: {}", sock.display()));
+    }
+    addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    for (slot, b) in addr.sun_path.iter_mut().zip(bytes) {
+        *slot = *b as libc::c_char;
+    }
+
+    // SAFETY: a fresh socket, wrapped in an owning UnixStream before any
+    // fallible step so it cannot leak.
+    let fd = unsafe {
+        libc::socket(
+            libc::AF_UNIX,
+            libc::SOCK_STREAM | libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
+            0,
+        )
+    };
+    if fd < 0 {
+        return Err(format!("socket: {}", std::io::Error::last_os_error()));
+    }
+    let stream = unsafe { UnixStream::from_raw_fd(fd) };
+
+    // SAFETY: addr is fully initialised above; the length is its real size.
+    let rc = unsafe {
+        libc::connect(
+            fd,
+            &addr as *const _ as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t,
+        )
+    };
+    if rc != 0 {
+        let e = std::io::Error::last_os_error();
+        if e.raw_os_error() != Some(libc::EINPROGRESS) {
+            return Err(format!(
+                "connect {}: {e} (no gnome-keyring-daemon control socket; is \
+                 gnome-keyring installed and socket-activated?)",
+                sock.display()
+            ));
+        }
+        // In progress: wait for writability, bounded.
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        // SAFETY: one descriptor this scope owns.
+        let n = unsafe { libc::poll(&mut pfd, 1, IO_TIMEOUT.as_millis() as libc::c_int) };
+        if n == 0 {
+            return Err(format!(
+                "connect {} timed out after {:?}",
+                sock.display(),
+                IO_TIMEOUT
+            ));
+        }
+        if n < 0 {
+            return Err(format!("poll: {}", std::io::Error::last_os_error()));
+        }
+        // Poll reports readiness, not success; the error is in SO_ERROR.
+        let mut err: libc::c_int = 0;
+        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+        // SAFETY: reading a fixed-size option into a matching local.
+        unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_ERROR,
+                &mut err as *mut _ as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        if err != 0 {
+            return Err(format!(
+                "connect {}: {}",
+                sock.display(),
+                std::io::Error::from_raw_os_error(err)
+            ));
+        }
+    }
+
+    // Back to blocking, now that the read and write deadlines below apply.
+    stream
+        .set_nonblocking(false)
+        .map_err(|e| format!("clearing non-blocking: {e}"))?;
+    let _ = stream.as_raw_fd();
+    Ok(stream)
+}
+
+/// The login keyring file, under the home NSS reports./// The login keyring file, under the home NSS reports.
 ///
 /// `$HOME` is deliberately not consulted: this may run as root with the login
 /// stack's environment, where `$HOME` is root's or unset.

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -44,6 +44,12 @@ const WAIT_RETRY_GAP: Duration = Duration::from_millis(400);
 /// the `reseal` SESSION line to pick up. Namespaced to this module.
 const RESEAL_STASH_KEY: &str = "pam_irlume_reseal_authtok";
 
+/// PAM-data key for a released GNOME keyring token, carried from the auth
+/// phase to `open_session`, which hands it to the unlock helper. A token never
+/// rides `PAM_AUTHTOK`: on a Debian-style `kr` stack `pam_unix` would consume
+/// it as the Unix password and fail the login it was meant to decorate.
+const GKR_TOKEN_STASH_KEY: &str = "pam_irlume_gkr_token";
+
 struct IrlumePam;
 
 /// Panic firewall for the PAM entry points. Unwinding across the C FFI boundary
@@ -165,11 +171,18 @@ impl PamServiceModule for IrlumePam {
             // pam_gnome_keyring/pam_kwallet opens the wallet. ALWAYS IGNORE: keyring
             // unlock is best-effort and must never fail or block the login.
             if keyring {
-                if let Ok(Some(tok)) = pamh.get_cached_authtok() {
-                    if !tok.to_bytes().is_empty() {
-                        return PamError::IGNORE; // password present → keyring self-unlocks
-                    }
-                }
+                // A typed password used to be an early return here. It cannot
+                // be one any more: a token-armed keyring (#250) does not open
+                // with the typed password, so the release must proceed even
+                // then. The daemon makes that call, because only it can read
+                // the envelope's kind: for `have_password: true` against a
+                // password envelope it answers KeyringUnlockNotNeeded without
+                // spending a TPM unseal, which is the old early return, moved
+                // to where the deciding fact lives.
+                let have_password = matches!(
+                    pamh.get_cached_authtok(),
+                    Ok(Some(tok)) if !tok.to_bytes().is_empty()
+                );
                 let service = pamh
                     .get_service()
                     .ok()
@@ -179,11 +192,13 @@ impl PamServiceModule for IrlumePam {
                     request(&Request::UnsealKeyring {
                         user: user.clone(),
                         service,
+                        have_password,
                     })
                 {
                     // Routed by kind, not assumed: on KDE this starts the wallet
-                    // daemon instead of setting an AUTHTOK. Best-effort either
-                    // way; the IGNORE below never becomes a failed login.
+                    // daemon, a GNOME token is stashed for the session helper,
+                    // and only a login password becomes an AUTHTOK. Best-effort
+                    // either way; the IGNORE below never becomes a failed login.
                     let _ = release_secret(&pamh, &user, &secret, kind);
                 }
                 return PamError::IGNORE;
@@ -311,15 +326,11 @@ impl PamServiceModule for IrlumePam {
             // stack always cascades to the password (NIST: a fallback must exist).
             let deadline = Instant::now() + WAIT_BUDGET;
             loop {
-                let mut attempt = if unseal {
+                let (mut attempt, mut delivered) = if unseal {
                     try_unseal(&pamh, &user)
                 } else {
-                    try_verify(&pamh, &user)
+                    (try_verify(&pamh, &user), Released::Failed)
                 };
-                // Did the SUCCESSFUL attempt release the sealed password into
-                // PAM_AUTHTOK? Only `try_unseal` does; the verify fallback below does
-                // not. This drives the `kr` cold-login keyring-continue decision.
-                let mut unsealed = unseal && attempt == PamError::SUCCESS;
                 // GDM and cosmic-greeter each drive BOTH the cold greeter and the
                 // live lock screen through one service. Unsealing is refused on the
                 // convenience tier (and on an un-armed keyring); a warm screen unlock
@@ -329,14 +340,23 @@ impl PamServiceModule for IrlumePam {
                 // fallback only rescues the identity-only warm-unlock case.
                 if (facefirst || ondemand) && unseal && attempt != PamError::SUCCESS {
                     attempt = try_verify(&pamh, &user);
-                    unsealed = false; // the fallback verifies identity, releases no token
+                    delivered = Released::Failed; // identity only, nothing released
                 }
                 if attempt == PamError::SUCCESS {
-                    // `kr` + a COLD login that released the password → IGNORE, so the
-                    // `sufficient` control CONTINUES and pam_gnome_keyring unlocks the
-                    // login keyring (pam_unix accepts the token we set). Every other
-                    // success (warm lock, no token, or no `kr`) short-circuits.
-                    if kr && unsealed && !irlume_common::platform::user_has_live_session(&user) {
+                    // `kr` + a COLD login that put the login PASSWORD in
+                    // `PAM_AUTHTOK` → IGNORE, so the `sufficient` control
+                    // CONTINUES and pam_unix + pam_gnome_keyring authenticate
+                    // and unlock from it. Every other success short-circuits:
+                    // warm lock, nothing released, no `kr`, and every non-
+                    // password delivery. A wallet key or keyring token left
+                    // nothing pam_unix could accept, so continuing would turn a
+                    // verified face into a password prompt; those kinds unlock
+                    // through their own channels (the ksecretd pipe, the
+                    // session helper) after this SUCCESS ends the auth phase.
+                    if kr
+                        && delivered == Released::AuthtokSet
+                        && !irlume_common::platform::user_has_live_session(&user)
+                    {
                         return PamError::IGNORE;
                     }
                     return PamError::SUCCESS;
@@ -364,7 +384,13 @@ impl PamServiceModule for IrlumePam {
         firewall(move || {
             if args.iter().any(|a| a == "reseal") {
                 if let Ok(Some(u)) = pamh.get_user(None) {
-                    try_reseal_session(&pamh, &u.to_string_lossy());
+                    let user = u.to_string_lossy().into_owned();
+                    // Reseal first: on a typed-password login after PCR drift
+                    // it repairs the token envelope from its password wrap, so
+                    // the delivery below can then unseal what a moment ago
+                    // could not be unsealed.
+                    try_reseal_session(&pamh, &user);
+                    deliver_gnome_token(&pamh, &user);
                 }
             }
             PamError::IGNORE
@@ -408,6 +434,83 @@ fn try_reseal_session(pamh: &Pam, user: &str) {
     });
 }
 
+/// SESSION-phase delivery of a GNOME keyring token (#250): the keyring is
+/// keyed to a random token only the TPM (or a password login's reseal) can
+/// produce, so EVERY session open on a token-armed account must send it to the
+/// keyring daemon's control socket; the typed password `pam_gnome_keyring`
+/// stashed, when there is one, no longer opens anything.
+///
+/// The token normally arrives in the auth-phase stash (face or fingerprint
+/// release). Without one — a typed-password login, or a topology where auth
+/// ran in a different PAM transaction — ask the daemon: `have_password: true`
+/// makes that free for password-armed users (no TPM touched), so the extra
+/// round trip costs only token users, only on their stash-less logins.
+/// Best-effort and silent like everything else in the session phase.
+fn deliver_gnome_token(pamh: &Pam, user: &str) {
+    let token = match pamh.retrieve_bytes(GKR_TOKEN_STASH_KEY) {
+        Ok(bytes) if !bytes.is_empty() => SecretBytes::new(bytes),
+        _ => {
+            let service = pamh
+                .get_service()
+                .ok()
+                .flatten()
+                .and_then(|c| c.to_str().ok().map(str::to_string));
+            match request(&Request::UnsealKeyring {
+                user: user.to_string(),
+                service,
+                have_password: true,
+            }) {
+                // Only a token belongs on the control socket. A password or a
+                // wallet key reaching here would mean the user is armed for a
+                // different backend, and this session hook has no business
+                // delivering it.
+                Ok(Response::PasswordUnsealed {
+                    secret,
+                    kind: irlume_common::KeyringSecretKind::GnomeKeyringToken,
+                }) => secret,
+                _ => return,
+            }
+        }
+    };
+    let _ = hand_token_to_keyring_daemon(user, &token);
+}
+
+/// Spawn the unlock helper with the token on stdin. The helper drops to the
+/// target user before touching their runtime directory (the daemon's control
+/// socket authenticates the peer uid, and root pathname work inside a
+/// user-owned directory is the CVE-2018-10380 shape irlume-kwallet-init
+/// already refuses to repeat).
+fn hand_token_to_keyring_daemon(user: &str, token: &irlume_common::SecretBytes) -> bool {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let helper = std::env::var("IRLUME_GKR_UNLOCK")
+        .unwrap_or_else(|_| irlume_common::GKR_UNLOCK_PATH.to_string());
+    if !std::path::Path::new(&helper).is_file() {
+        return false;
+    }
+    let mut child = match Command::new(&helper)
+        .arg(user)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    if let Some(mut sin) = child.stdin.take() {
+        if sin.write_all(token.expose()).is_err() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        // EOF tells the helper the token is complete.
+        drop(sin);
+    }
+    matches!(child.wait(), Ok(status) if status.success())
+}
+
 /// One verify attempt (sudo / in-session unlock): no password released.
 /// Returns `SUCCESS` on a live match, `IGNORE` on anything else. Passes the PAM
 /// service so the daemon can apply tier×operation-class gating (an RGB-only
@@ -432,9 +535,10 @@ fn try_verify(pamh: &Pam, user: &str) -> PamError {
 }
 
 /// One unseal attempt (login / cold-boot lock screen): release the sealed
-/// password and set it as `PAM_AUTHTOK` so the keyring/wallet module unlocks
-/// the wallet. `IGNORE` on decline/error so the password fallback runs.
-fn try_unseal(pamh: &Pam, user: &str) -> PamError {
+/// secret and deliver it by kind. `IGNORE` on decline/error so the password
+/// fallback runs. The second value reports HOW a success delivered, for the
+/// `kr` decision at the call site.
+fn try_unseal(pamh: &Pam, user: &str) -> (PamError, Released) {
     // Pass the PAM service name so the daemon can apply opt-in biopolicy
     // operation-class gating (e.g. refuse credential release to a remote service).
     let service = pamh
@@ -448,27 +552,43 @@ fn try_unseal(pamh: &Pam, user: &str) -> PamError {
     }) {
         Ok(Response::PasswordUnsealed { secret, kind }) => {
             match release_secret(pamh, user, &secret, kind) {
-                true => PamError::SUCCESS,
-                false => PamError::IGNORE,
+                Released::Failed => (PamError::IGNORE, Released::Failed),
+                delivered => (PamError::SUCCESS, delivered),
             }
         }
-        _ => PamError::IGNORE,
+        _ => (PamError::IGNORE, Released::Failed),
     }
+}
+
+/// How a released secret was delivered, which the `kr` cold-login decision
+/// routes on: only [`Released::AuthtokSet`] leaves something `pam_unix` can
+/// authenticate with, so only it may continue the stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Released {
+    /// The login password is in `PAM_AUTHTOK`.
+    AuthtokSet,
+    /// The KDE wallet daemon was started with the wallet key.
+    WalletStarted,
+    /// A GNOME keyring token was stashed for `open_session` to deliver.
+    TokenStashed,
+    Failed,
 }
 
 /// Deliver a released keyring secret to whatever actually consumes it.
 ///
-/// The two kinds are not interchangeable. A login password becomes
-/// `PAM_AUTHTOK`, which `pam_gnome_keyring` reads. A KDE wallet key would be
-/// meaningless as an `AUTHTOK`: `pam_kwallet5` would run PBKDF2 over it a second
-/// time and hand `ksecretd` the wrong bytes. It has to go to `ksecretd` on its
-/// startup pipe instead, which is what the helper does.
+/// The kinds are not interchangeable. A login password becomes `PAM_AUTHTOK`,
+/// which `pam_gnome_keyring` reads. A KDE wallet key would be meaningless as an
+/// `AUTHTOK`: `pam_kwallet5` would run PBKDF2 over it a second time and hand
+/// `ksecretd` the wrong bytes; it goes to `ksecretd` on its startup pipe. A
+/// GNOME keyring token is not the Unix password, so it must never sit where
+/// `pam_unix` might read it; it is stashed in PAM data and `open_session`
+/// sends it to the keyring daemon's control socket via the unlock helper.
 fn release_secret(
     pamh: &Pam,
     user: &str,
     secret: &irlume_common::SecretBytes,
     kind: irlume_common::KeyringSecretKind,
-) -> bool {
+) -> Released {
     use irlume_common::KeyringSecretKind as K;
     match kind {
         K::LoginPassword => {
@@ -480,12 +600,32 @@ fn release_secret(
                 Ok(tok) => {
                     let set = pamh.set_authtok(&tok);
                     zeroize::Zeroize::zeroize(&mut tok.into_bytes_with_nul());
-                    set.is_ok()
+                    if set.is_ok() {
+                        Released::AuthtokSet
+                    } else {
+                        Released::Failed
+                    }
                 }
-                Err(_) => false,
+                Err(_) => Released::Failed,
             }
         }
-        K::KdeWalletKey => hand_key_to_wallet_daemon(pamh, user, secret.expose()),
+        K::KdeWalletKey => {
+            if hand_key_to_wallet_daemon(pamh, user, secret.expose()) {
+                Released::WalletStarted
+            } else {
+                Released::Failed
+            }
+        }
+        K::GnomeKeyringToken => {
+            if pamh
+                .send_bytes(GKR_TOKEN_STASH_KEY, secret.expose().to_vec(), None)
+                .is_ok()
+            {
+                Released::TokenStashed
+            } else {
+                Released::Failed
+            }
+        }
     }
 }
 

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -517,7 +517,39 @@ fn hand_token_to_keyring_daemon(user: &str, token: &irlume_common::SecretBytes) 
         // EOF tells the helper the token is complete.
         drop(sin);
     }
-    matches!(child.wait(), Ok(status) if status.success())
+    // Bounded, because this is the PAM session phase and the login blocks on
+    // it. The helper has its own deadlines on the socket, but a wedged or
+    // stopped child would otherwise hang the login here; the helper's own
+    // ceiling plus a margin is the budget, and a child still running past it
+    // is killed rather than waited on.
+    wait_bounded(&mut child, HELPER_BUDGET)
+}
+
+/// Ceiling on the unlock helper: its own socket deadlines are 10s, so this is
+/// that plus room to start and exit.
+const HELPER_BUDGET: Duration = Duration::from_secs(15);
+
+/// Reap `child`, giving up (and killing it) after `budget`.
+///
+/// `Child::wait` has no timeout, and polling `try_wait` is the only way to put
+/// a ceiling on it without another thread. The poll interval is coarse on
+/// purpose: this runs once per login and the common case exits immediately.
+fn wait_bounded(child: &mut std::process::Child, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(_) => return false,
+        }
+    }
 }
 
 /// One verify attempt (sudo / in-session unlock): no password released.

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -455,6 +455,15 @@ fn deliver_gnome_token(pamh: &Pam, user: &str) {
                 .ok()
                 .flatten()
                 .and_then(|c| c.to_str().ok().map(str::to_string));
+            // `true` is accurate here, not a convenient lie. The flag drives
+            // exactly one decision: whether a PASSWORD-keyed keyring is
+            // already served. By the session phase it always is, either
+            // because the user typed a password or because the auth phase
+            // released the sealed one into `PAM_AUTHTOK`; and if neither
+            // happened, nothing can open that keyring anyway. Passing `false`
+            // instead would make the daemon unseal a login password on every
+            // session open, which this hook then discards, spending a TPM
+            // round trip (seconds on a discrete TPM) per login for nothing.
             match request(&Request::UnsealKeyring {
                 user: user.to_string(),
                 service,

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -849,11 +849,30 @@ fn pamwrap_reseal_stashes_on_auth_and_reseals_on_session() {
     assert!(ok, "auth + session must both pass: {out}");
 
     let reqs = log.lock().unwrap();
+    // The AUTH phase must still contact nobody: acting on a token there is the
+    // bug that let a typo overwrite a good seal. The SESSION phase now makes
+    // two requests, in this order.
     assert_eq!(
         reqs.len(),
-        1,
-        "exactly one reseal, and none during the auth phase: {reqs:?}"
+        2,
+        "reseal, then the token-delivery query, both in the session phase: {reqs:?}"
     );
+    // A typed-password login releases no token in the auth phase, so there is
+    // no stash for open_session to deliver; without asking the daemon here, a
+    // token-armed account's keyring would never be unlocked by a password
+    // login. `have_password: true` lets the daemon answer a password-armed
+    // user without touching the TPM, so the cost lands only on token users.
+    match &reqs[1] {
+        Request::UnsealKeyring {
+            user,
+            have_password,
+            ..
+        } => {
+            assert_eq!(user, "tester");
+            assert!(have_password, "the session phase holds the typed password");
+        }
+        other => panic!("expected the delivery query second, got {other:?}"),
+    }
     match &reqs[0] {
         Request::ResealPassword { user, password } => {
             assert_eq!(user, "tester");
@@ -868,7 +887,9 @@ fn pamwrap_reseal_stashes_on_auth_and_reseals_on_session() {
     drop(reqs);
 
     // A pure face login stashes nothing (blank submit ⇒ empty PAM_AUTHTOK), so
-    // the session half must have nothing to heal with: no daemon contact.
+    // the session half must have nothing to RESEAL. It still asks the daemon
+    // whether a token needs delivering, because a face login that released one
+    // is exactly the case that needs it.
     h.write_service(
         "irlume-reseal-empty",
         &[
@@ -885,9 +906,33 @@ fn pamwrap_reseal_stashes_on_auth_and_reseals_on_session() {
         None,
     );
     assert!(ok, "{out}");
+    let reqs = log.lock().unwrap();
     assert_eq!(
-        log.lock().unwrap().len(),
-        1,
-        "an empty stash must never produce a reseal request"
+        reqs.len(),
+        3,
+        "the two from the run above, plus this run's delivery query and no \
+         reseal: {reqs:?}"
     );
+    assert!(
+        !reqs
+            .iter()
+            .any(|r| matches!(r, Request::ResealPassword { .. })
+                && reqs
+                    .iter()
+                    .filter(|x| matches!(x, Request::ResealPassword { .. }))
+                    .count()
+                    > 1),
+        "an empty stash must never produce a SECOND reseal request: {reqs:?}"
+    );
+    match &reqs[2] {
+        // `true` even though nothing was typed: the flag means "a
+        // password-keyed keyring is already served", which by the session
+        // phase it is, and answering it saves the daemon a TPM unseal this
+        // hook would only discard.
+        Request::UnsealKeyring { have_password, .. } => assert!(
+            *have_password,
+            "the session-phase delivery query always reports a served keyring"
+        ),
+        other => panic!("expected only the delivery query, got {other:?}"),
+    }
 }

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -691,13 +691,16 @@ fn pamwrap_ondemand_unseal_falls_back_to_verify() {
     assert!(matches!(reqs[1], Request::Authenticate { .. }));
 }
 
-/// `keyring` mode (fingerprint path, post-auth landing): with no password in
-/// the transaction the module asks for the sealed password to unlock the
-/// keyring; with one already present it stays silent. Either way it returns
-/// IGNORE (best-effort), so the trailing pam_permit decides the stack.
+/// `keyring` mode (fingerprint path, post-auth landing): the module always
+/// asks the daemon, and REPORTS whether the transaction already holds a
+/// password rather than deciding on it. That decision moved daemon-side with
+/// #250: a token-armed keyring does not open with the typed password, so only
+/// the daemon, which can read the envelope's kind, can tell whether the unseal
+/// is pointless. Either way the module returns IGNORE (best-effort), so the
+/// trailing pam_permit decides the stack.
 #[test]
 #[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
-fn pamwrap_keyring_mode_unseals_only_without_a_password() {
+fn pamwrap_keyring_mode_reports_whether_a_password_is_present() {
     let Some(h) = Harness::try_new("keyring") else {
         return;
     };
@@ -728,23 +731,39 @@ fn pamwrap_keyring_mode_unseals_only_without_a_password() {
         let reqs = log.lock().unwrap();
         assert_eq!(reqs.len(), 1, "{reqs:?}");
         match &reqs[0] {
-            Request::UnsealKeyring { user, service } => {
+            Request::UnsealKeyring {
+                user,
+                service,
+                have_password,
+            } => {
                 assert_eq!(user, "tester");
                 assert_eq!(service.as_deref(), Some("irlume-fp"));
+                assert!(!have_password, "no password was set in this transaction");
             }
             other => panic!("expected UnsealKeyring, daemon saw {other:?}"),
         }
         // (drop the guard before the next run appends)
     }
 
-    // Password already present: the keyring self-unlocks from it; no request.
+    // Password already present: still asked, but flagged, so the daemon can
+    // answer KeyringUnlockNotNeeded for a password envelope without spending a
+    // TPM unseal, and can still release a token for a token envelope.
     let (ok, out) = h.run("irlume-fp-pw", &["authenticate"], "", Some("hunter2"));
     assert!(ok, "{out}");
+    let reqs = log.lock().unwrap();
     assert_eq!(
-        log.lock().unwrap().len(),
-        1,
-        "a present password must mean no daemon contact"
+        reqs.len(),
+        2,
+        "the daemon decides, so it must be asked: {reqs:?}"
     );
+    match &reqs[1] {
+        Request::UnsealKeyring { have_password, .. } => assert!(
+            *have_password,
+            "a password IS present; reporting false would make the daemon spend a \
+             pointless TPM unseal"
+        ),
+        other => panic!("expected UnsealKeyring, daemon saw {other:?}"),
+    }
 }
 
 /// `kr` (Debian `@include` keyring-continue): a COLD face login that released

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -99,7 +99,10 @@ rustPlatform.buildRustPackage {
     substituteInPlace crates/irlume-common/src/lib.rs \
       --replace-fail \
         '"/usr/libexec/irlume/irlume-kwallet-init"' \
-        "\"$out/libexec/irlume/irlume-kwallet-init\""
+        "\"$out/libexec/irlume/irlume-kwallet-init\"" \
+      --replace-fail \
+        '"/usr/libexec/irlume/irlume-gkr-unlock"' \
+        "\"$out/libexec/irlume/irlume-gkr-unlock\""
   '';
 
   # The suite needs a camera, a TPM, and PAM; none exist in the sandbox.
@@ -122,6 +125,13 @@ rustPlatform.buildRustPackage {
     install -Dm0755 "$out/bin/irlume-kwallet-init" \
       "$out/libexec/irlume/irlume-kwallet-init"
     rm "$out/bin/irlume-kwallet-init"
+
+    # GNOME keyring unlock helper (#250), same libexec reasoning and the same
+    # fail-loudly rule as the KDE helper above.
+    test -x "$out/bin/irlume-gkr-unlock"
+    install -Dm0755 "$out/bin/irlume-gkr-unlock" \
+      "$out/libexec/irlume/irlume-gkr-unlock"
+    rm "$out/bin/irlume-gkr-unlock"
 
     install -d "$out/share/irlume/models"
     install -m0644 ${models}/*.onnx "$out/share/irlume/models/"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -55,6 +55,7 @@ package() {
     # runs, it takes a secret on stdin, and it is only meaningful inside a PAM
     # transaction.
     install -Dm0755 target/release/irlume-kwallet-init "$pkgdir/usr/libexec/irlume/irlume-kwallet-init"
+    install -Dm0755 target/release/irlume-gkr-unlock "$pkgdir/usr/libexec/irlume/irlume-gkr-unlock"
     for m in glintr100 face_detection_yunet_2023mar face_landmark blaze_face_short_range; do
         install -Dm0644 "models/$m.onnx" "$pkgdir/usr/share/irlume/models/$m.onnx"
     done

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -48,6 +48,8 @@ contents:
   # transaction.
   - src: ../../target/release/irlume-kwallet-init
     dst: /usr/libexec/irlume/irlume-kwallet-init
+  - src: ../../target/release/irlume-gkr-unlock
+    dst: /usr/libexec/irlume/irlume-gkr-unlock
   # Bundled models (fetched from the models-v1 release by build-deb.sh)
   - src: ../../models/glintr100.onnx
     dst: /usr/share/irlume/models/glintr100.onnx

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -98,6 +98,7 @@ install -Dm0644 target/release/libpam_irlume.so %{buildroot}%{_libdir}/security/
 # user runs, it takes a secret on stdin, and it is only meaningful inside a
 # PAM transaction.
 install -Dm0755 target/release/irlume-kwallet-init %{buildroot}%{_libexecdir}/%{name}/irlume-kwallet-init
+install -Dm0755 target/release/irlume-gkr-unlock %{buildroot}%{_libexecdir}/%{name}/irlume-gkr-unlock
 # Bundled models (release assets, verified in %prep) → /usr/share/irlume/models
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/%{name}/models/glintr100.onnx
 install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/%{name}/models/face_detection_yunet_2023mar.onnx
@@ -196,6 +197,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_libdir}/security/pam_irlume.so
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/irlume-kwallet-init
+%{_libexecdir}/%{name}/irlume-gkr-unlock
 # Own the directories the globs populate (rpmlint: "directory not owned by a
 # package"; also leaves them behind on erase otherwise).
 %dir %{_datadir}/%{name}

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -39,6 +39,8 @@ override_dh_auto_install:
 	# and is only meaningful inside a PAM transaction.
 	install -D -m0755 target/release/irlume-kwallet-init \
 		debian/irlume/usr/libexec/irlume/irlume-kwallet-init
+	install -D -m0755 target/release/irlume-gkr-unlock \
+		debian/irlume/usr/libexec/irlume/irlume-gkr-unlock
 	install -D -m0644 models/glintr100.onnx \
 		debian/irlume/usr/share/irlume/models/glintr100.onnx
 	install -D -m0644 models/face_detection_yunet_2023mar.onnx \

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -33,7 +33,7 @@ fail=0
 # distro logs in and their wallet silently stays locked, which is the same
 # class of miss the units check above exists for.
 echo "== helper programs in every lane =="
-HELPERS=(irlume-kwallet-init)
+HELPERS=(irlume-kwallet-init irlume-gkr-unlock)
 for helper in "${HELPERS[@]}"; do
   for lane in "${LANES[@]}"; do
     if grep -q -- "$helper" "$lane"; then

--- a/scripts/gkr-token-check.sh
+++ b/scripts/gkr-token-check.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Prove the GNOME keyring token handoff (#250) against a REAL
+# gnome-keyring-daemon, without touching the caller's own login keyring.
+#
+#   scripts/gkr-token-check.sh [N]      # N = repeat count for the leak check
+#
+# What it establishes, in order:
+#   1. a token re-key works:      CHANGE(password -> token) is accepted
+#   2. the token IS the credential: CHANGE(token, token) is accepted and
+#                                   CHANGE(password, password) is DENIED
+#   3. it survives a daemon restart: a FRESH daemon (which starts locked) is
+#                                   unlocked by irlume-gkr-unlock with the token
+#                                   and NOT by the password
+#   4. the keyring still works:    a canary secret stored before the re-key is
+#                                   readable after it, through the Secret
+#                                   Service, so "unlocked" is not just a status
+#                                   bit (an earlier KDE measurement was fooled
+#                                   by exactly that)
+#   5. the disarm path works:      CHANGE(token -> password) puts it back
+#   6. N cycles leak no daemons
+#
+# Everything runs as the invoking user inside a throwaway HOME and runtime dir.
+# The Python side implements the control protocol independently of the Rust
+# crate, so agreement between them and a real daemon is a cross-check rather
+# than one implementation agreeing with itself.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="${IRLUME_GKR_UNLOCK:-$REPO/target/release/irlume-gkr-unlock}"
+CYCLES="${1:-3}"
+PASSWORD="orig-pass-4417"
+TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+CANARY="canary-$(python3 -c 'import secrets; print(secrets.token_hex(4))')"
+
+if [[ $EUID -eq 0 ]]; then
+    echo "run this as an ordinary user, not root: it drives a user keyring daemon" >&2
+    exit 2
+fi
+command -v gnome-keyring-daemon >/dev/null || { echo "SKIP: gnome-keyring-daemon not installed"; exit 0; }
+[[ -x "$HELPER" ]] || { echo "missing $HELPER; cargo build --release -p irlume-gkr-unlock" >&2; exit 2; }
+
+BASE="$(mktemp -d "${TMPDIR:-/tmp}/irlume-gkr-check-XXXXXX")"
+export HOME="$BASE/home"
+export XDG_RUNTIME_DIR="$BASE/run"
+export XDG_DATA_HOME="$HOME/.local/share"
+mkdir -p "$HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
+chmod 700 "$XDG_RUNTIME_DIR"
+unset DBUS_SESSION_BUS_ADDRESS GNOME_KEYRING_CONTROL
+
+PASS=0
+FAIL=0
+ok()   { echo "  ok    $*"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL  $*"; FAIL=$((FAIL+1)); }
+note() { echo "  --    $*"; }
+
+cleanup() {
+    pkill -u "$(id -u)" -f "gnome-keyring-daemon.*$BASE" 2>/dev/null
+    [[ -n "${DBUS_PID:-}" ]] && kill "$DBUS_PID" 2>/dev/null
+    rm -rf "$BASE"
+}
+trap cleanup EXIT
+
+# A private session bus: the Secret Service canary needs one, and it must not
+# be the caller's own bus, where a real gnome-keyring is already the provider.
+eval "$(dbus-daemon --session --print-address=1 --print-pid=1 --fork \
+    | { read -r addr; read -r pid; echo "export DBUS_SESSION_BUS_ADDRESS='$addr'; DBUS_PID=$pid"; })"
+
+# ---------------------------------------------------------------- the client
+# Independent implementation of gnome-keyring's control protocol, from
+# pam/gkr-pam-client.c: one credentials byte, then big-endian
+# [total_len][op][(arg_len)(arg)...]; the reply is [8][result].
+ctl() {  # ctl <op-number> <arg>...
+    python3 - "$XDG_RUNTIME_DIR/keyring/control" "$@" <<'PY'
+import socket, struct, sys
+sock, op, *args = sys.argv[1], int(sys.argv[2]), *sys.argv[3:]
+body = b"".join(struct.pack(">I", len(a.encode())) + a.encode() for a in args)
+pkt = struct.pack(">II", 8 + len(body), op) + body
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(10)
+try:
+    s.connect(sock)
+except OSError as e:
+    print(f"connect-error:{e}"); sys.exit(3)
+s.sendall(b"\0"); s.sendall(pkt)
+reply = s.recv(8)
+if len(reply) != 8:
+    print(f"short-reply:{len(reply)}"); sys.exit(4)
+ln, res = struct.unpack(">II", reply)
+print({0: "OK", 1: "DENIED", 2: "FAILED", 3: "NO_DAEMON"}.get(res, f"UNKNOWN{res}"))
+PY
+}
+
+start_daemon() {  # start_daemon; leaves the daemon running, control socket ready
+    gnome-keyring-daemon --start --components=secrets,pkcs11 >"$BASE/env.$$" 2>/dev/null &
+    for _ in $(seq 1 50); do
+        [[ -S "$XDG_RUNTIME_DIR/keyring/control" ]] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+kill_daemon() {
+    pkill -u "$(id -u)" -f "gnome-keyring-daemon" 2>/dev/null
+    # Wait for the socket to actually go: a surviving daemon keeps the
+    # collection unlocked in memory and would report success for a secret it
+    # never accepted.
+    for _ in $(seq 1 50); do
+        pgrep -u "$(id -u)" -f "gnome-keyring-daemon" >/dev/null || break
+        sleep 0.1
+    done
+    rm -f "$XDG_RUNTIME_DIR/keyring/control"
+}
+
+canary_store() {
+    python3 - "$1" <<'PY' 2>/dev/null
+import sys
+try:
+    import secretstorage
+except ImportError:
+    sys.exit(77)
+conn = secretstorage.dbus_init()
+coll = secretstorage.get_default_collection(conn)
+coll.create_item("irlume-check", {"application": "irlume-check"}, sys.argv[1].encode())
+PY
+}
+
+canary_read() {
+    python3 - <<'PY' 2>/dev/null
+import sys
+try:
+    import secretstorage
+except ImportError:
+    sys.exit(77)
+conn = secretstorage.dbus_init()
+coll = secretstorage.get_default_collection(conn)
+for item in coll.search_items({"application": "irlume-check"}):
+    print(item.get_secret().decode()); sys.exit(0)
+sys.exit(1)
+PY
+}
+
+echo "irlume GNOME keyring token check  (HOME=$HOME)"
+
+# ------------------------------------------------------------------- step 1
+echo "[1] create the login keyring with a password"
+start_daemon || { echo "daemon did not start"; exit 1; }
+r="$(ctl 1 "$PASSWORD")"   # UNLOCK on a fresh store creates the login keyring
+[[ "$r" == "OK" ]] && ok "created/unlocked with the password ($r)" || bad "expected OK, got $r"
+
+have_canary=0
+if canary_store "$CANARY"; then
+    have_canary=1
+    ok "stored a canary secret through the Secret Service"
+else
+    rc=$?
+    [[ $rc -eq 77 ]] && note "python3-secretstorage absent: skipping the canary (steps 4 degraded)" \
+                     || note "canary store failed (rc=$rc); skipping the canary"
+fi
+
+# ------------------------------------------------------------------- step 2
+echo "[2] re-key to the token, and prove which secret is now current"
+r="$(ctl 2 "$PASSWORD" "$TOKEN")"
+[[ "$r" == "OK" ]] && ok "CHANGE(password -> token) accepted" || bad "re-key: expected OK, got $r"
+
+r="$(ctl 2 "$TOKEN" "$TOKEN")"
+[[ "$r" == "OK" ]] && ok "CHANGE(token, token) accepted: the token IS the credential" \
+                   || bad "token self-change: expected OK, got $r"
+
+r="$(ctl 2 "$PASSWORD" "$PASSWORD")"
+[[ "$r" == "DENIED" ]] && ok "CHANGE(password, password) DENIED: the password no longer opens it" \
+                       || bad "the old password still works ($r); the re-key did not take"
+
+# ------------------------------------------------------------------- step 3
+echo "[3] restart the daemon, then unlock with irlume-gkr-unlock"
+kill_daemon
+start_daemon || { echo "daemon did not restart"; exit 1; }
+
+if printf '%s' "wrong-token-0000" | env IRLUME_GKR_RUNTIME_DIR="$XDG_RUNTIME_DIR" IRLUME_GKR_HOME="$HOME" \
+        "$HELPER" "$(id -un)" 2>"$BASE/err.wrong"; then
+    bad "the helper reported success for a WRONG token"
+else
+    ok "helper refused a wrong token ($(tr -d '\n' <"$BASE/err.wrong" | tail -c 60))"
+fi
+
+if printf '%s' "$TOKEN" | env IRLUME_GKR_RUNTIME_DIR="$XDG_RUNTIME_DIR" IRLUME_GKR_HOME="$HOME" \
+        "$HELPER" "$(id -un)" 2>"$BASE/err.right"; then
+    ok "helper unlocked a freshly started daemon with the sealed token"
+else
+    bad "helper failed with the correct token: $(cat "$BASE/err.right")"
+fi
+
+# ------------------------------------------------------------------- step 4
+echo "[4] the keyring still holds its contents"
+if [[ $have_canary -eq 1 ]]; then
+    got="$(canary_read)"
+    if [[ "$got" == "$CANARY" ]]; then
+        ok "canary read back through the Secret Service after the re-key + restart"
+    else
+        bad "canary readback was '$got', expected '$CANARY'"
+    fi
+else
+    note "no canary was stored; this step proved nothing"
+fi
+
+# ------------------------------------------------------------------ step 4b
+echo "[4b] the helper refuses to CREATE a keyring that does not exist"
+# UNLOCK mints a login keyring keyed to whatever it is handed when none
+# exists, so a blind unlock after the user deletes theirs would leave a
+# keyring whose password is a random token they have never seen.
+kr="$XDG_DATA_HOME/keyrings/login.keyring"
+if [[ -f "$kr" ]]; then
+    mv "$kr" "$kr.hidden"
+    if printf '%s' "$TOKEN" | env IRLUME_GKR_RUNTIME_DIR="$XDG_RUNTIME_DIR" IRLUME_GKR_HOME="$HOME" \
+            "$HELPER" "$(id -un)" 2>"$BASE/err.nokr"; then
+        bad "the helper unlocked with NO login keyring present (it created one)"
+    else
+        grep -q 'refusing to UNLOCK' "$BASE/err.nokr" \
+            && ok "refused with the reason named" \
+            || bad "refused, but for another reason: $(cat "$BASE/err.nokr")"
+    fi
+    mv "$kr.hidden" "$kr"
+else
+    note "no login.keyring file on disk at $kr; step skipped"
+fi
+
+# ------------------------------------------------------------------- step 5
+echo "[5] disarm: re-key back to the password"
+r="$(ctl 2 "$TOKEN" "$PASSWORD")"
+[[ "$r" == "OK" ]] && ok "CHANGE(token -> password) accepted" || bad "disarm: expected OK, got $r"
+r="$(ctl 2 "$PASSWORD" "$PASSWORD")"
+[[ "$r" == "OK" ]] && ok "the password is the credential again" || bad "after disarm: got $r"
+
+# ------------------------------------------------------------------- step 6
+echo "[6] $CYCLES unlock cycles leak no daemons"
+before="$(pgrep -u "$(id -u)" -cf gnome-keyring-daemon)"
+cycles_run=0
+for _ in $(seq 1 "$CYCLES"); do
+    kill_daemon
+    start_daemon || break
+    printf '%s' "$PASSWORD" | env IRLUME_GKR_RUNTIME_DIR="$XDG_RUNTIME_DIR" IRLUME_GKR_HOME="$HOME" \
+        "$HELPER" "$(id -un)" >/dev/null 2>&1 || bad "cycle unlock failed"
+    cycles_run=$((cycles_run+1))
+done
+after="$(pgrep -u "$(id -u)" -cf gnome-keyring-daemon)"
+if [[ "$cycles_run" -eq "$CYCLES" ]]; then
+    [[ "$after" -le "$before" ]] && ok "$cycles_run cycles, daemon count $before -> $after" \
+                                 || bad "daemon count grew: $before -> $after"
+else
+    bad "only $cycles_run of $CYCLES cycles ran; the count means nothing"
+fi
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/scripts/gkr-token-check.sh
+++ b/scripts/gkr-token-check.sh
@@ -54,7 +54,7 @@ bad()  { echo "  FAIL  $*"; FAIL=$((FAIL+1)); }
 note() { echo "  --    $*"; }
 
 cleanup() {
-    pkill -u "$(id -u)" -f "gnome-keyring-daemon.*$BASE" 2>/dev/null
+    [[ -n "${GKR_PID:-}" ]] && kill "$GKR_PID" 2>/dev/null
     [[ -n "${DBUS_PID:-}" ]] && kill "$DBUS_PID" 2>/dev/null
     rm -rf "$BASE"
 }
@@ -90,24 +90,39 @@ print({0: "OK", 1: "DENIED", 2: "FAILED", 3: "NO_DAEMON"}.get(res, f"UNKNOWN{res
 PY
 }
 
+# --foreground so the PID is OURS, not a daemonised grandchild. The previous
+# version ran the daemon detached and reaped it with
+# `pkill -u <uid> -f gnome-keyring-daemon`, which matches EVERY daemon that
+# user owns, including the one running their actual desktop session. That
+# contradicted this script's own header and did kill real session daemons.
+# Nothing here may select a process by name.
+GKR_PID=""
+
 start_daemon() {  # start_daemon; leaves the daemon running, control socket ready
-    gnome-keyring-daemon --start --components=secrets,pkcs11 >"$BASE/env.$$" 2>/dev/null &
+    gnome-keyring-daemon --foreground --components=secrets,pkcs11 \
+        >"$BASE/gkr.log" 2>&1 &
+    GKR_PID=$!
     for _ in $(seq 1 50); do
         [[ -S "$XDG_RUNTIME_DIR/keyring/control" ]] && return 0
+        # A daemon that died leaves no socket; do not spin the full timeout.
+        kill -0 "$GKR_PID" 2>/dev/null || return 1
         sleep 0.1
     done
     return 1
 }
 
 kill_daemon() {
-    pkill -u "$(id -u)" -f "gnome-keyring-daemon" 2>/dev/null
-    # Wait for the socket to actually go: a surviving daemon keeps the
-    # collection unlocked in memory and would report success for a secret it
-    # never accepted.
+    # Only the PID we started. A surviving daemon keeps the collection
+    # unlocked in memory and would report success for a secret it never
+    # accepted, so wait for it to actually go.
+    [[ -n "$GKR_PID" ]] || return 0
+    kill "$GKR_PID" 2>/dev/null
     for _ in $(seq 1 50); do
-        pgrep -u "$(id -u)" -f "gnome-keyring-daemon" >/dev/null || break
+        kill -0 "$GKR_PID" 2>/dev/null || break
         sleep 0.1
     done
+    wait "$GKR_PID" 2>/dev/null
+    GKR_PID=""
     rm -f "$XDG_RUNTIME_DIR/keyring/control"
 }
 
@@ -232,7 +247,7 @@ r="$(ctl 2 "$PASSWORD" "$PASSWORD")"
 
 # ------------------------------------------------------------------- step 6
 echo "[6] $CYCLES unlock cycles leak no daemons"
-before="$(pgrep -u "$(id -u)" -cf gnome-keyring-daemon)"
+before="$(pgrep -u "$(id -u)" -cf "gnome-keyring-daemon.*--foreground")"
 cycles_run=0
 for _ in $(seq 1 "$CYCLES"); do
     kill_daemon
@@ -241,7 +256,7 @@ for _ in $(seq 1 "$CYCLES"); do
         "$HELPER" "$(id -un)" >/dev/null 2>&1 || bad "cycle unlock failed"
     cycles_run=$((cycles_run+1))
 done
-after="$(pgrep -u "$(id -u)" -cf gnome-keyring-daemon)"
+after="$(pgrep -u "$(id -u)" -cf "gnome-keyring-daemon.*--foreground")"
 if [[ "$cycles_run" -eq "$CYCLES" ]]; then
     [[ "$after" -le "$before" ]] && ok "$cycles_run cycles, daemon count $before -> $after" \
                                  || bad "daemon count grew: $before -> $after"


### PR DESCRIPTION
Closes #250 for GNOME. The KDE half shipped in #253.

The sealed envelope held the user's Unix login password, so a leak of it
was a root escalation. KDE was fixed by sealing the derived wallet key,
which works because `ksecretd` never sees the password. GNOME has no
derived intermediate: gnome-keyring's credential IS the string PAM hands
it, so the only way to stop sealing the password is to change what the
keyring is keyed to.

## The design

`irlume keyring arm` mints a 32-byte random token, seals it, and re-keys
the login keyring to it through gnome-keyring's own control socket, the
channel `pam_gnome_keyring` uses. Not D-Bus: `busctl` would publish the
secret in `/proc/<pid>/cmdline`. A leaked envelope now yields a secret
that opens one keyring and nothing else.

A token cannot be re-derived from the password, so the envelope carries a
second copy wrapped under an Argon2id key from the login password,
reusing the recovery-passphrase machinery. Either half recovers the
other: PCR drift heals from the wrap, a password change re-wraps from the
seal, and losing both refuses rather than overwriting the last copy of a
token the keyring is keyed to. The net offline surface improves, since
`login.keyring` was itself password-derived before.

The token never touches `PAM_AUTHTOK`, where `pam_unix` on a Debian-style
`kr` stack would consume it as the Unix password and fail the login. It
is stashed in PAM data and delivered in the session phase by
`irlume-gkr-unlock`, which drops to the target user before connecting:
the control socket authenticates the peer uid, and root pathname work in
a user-owned directory is the CVE-2018-10380 shape.

Existing armed users are untouched until they re-arm, and detection only
picks a token for an unambiguous GNOME-only home.

## What an upstream source review changed

Reading gnome-keyring, gdm, kwallet and polkit rather than assuming found
three real defects in the first draft:

- **`UNLOCK` and `CHANGE` create the login keyring when it is missing**,
  keyed to whatever secret they were handed, and `CHANGE` does not check
  the old password on that path. A blind unlock after someone deleted
  their keyring would leave them one whose password is 64 random
  characters no GNOME interface can show them. Both the helper and the
  daemon now refuse when `login.keyring` is absent.
- **Fingerprint stacks got no irlume session line**, so the auth line
  released a token into PAM data that was dropped when the transaction
  ended, leaving the keyring locked with nothing naming the reason. KDE
  escapes this because it hands the wallet key over during auth; a token
  cannot, since the user's runtime directory need not exist that early.
- **The control socket has no server-side timeout**, and an unbounded
  wait in the session phase is a hung login, so the helper sets its own.

Two behaviours worth recording for later: a DENIED unlock is cached by
gnome-keyring and can re-key the login keyring to that rejected secret
after the next successful manual unlock, so the helper reports it loudly;
and changing a wallet password in kwalletmanager silently orphans
irlume's sealed KDE key.

## Evidence

`scripts/gkr-token-check.sh` drives the whole cycle against a real
`gnome-keyring-daemon` in a throwaway home, runtime directory and session
bus: re-key, which secret is current, unlock by the helper after a daemon
restart, a canary secret read back through the Secret Service, the
refusal to create a keyring, disarm, and N cycles leaking no daemons. The
Python side implements the control protocol independently of the Rust
crate, so agreement is a cross-check rather than one implementation
agreeing with itself.

| platform | gnome-keyring | result |
|---|---|---|
| Fedora 44 | 50.0 | 12/12 |
| Ubuntu 26.04 | 50.0 | 12/12 |
| Arch | 50.0 | 10/10 |

Arch skipped the canary: its headless session bus would not take the
secret. The other two covered it.

On real hardware, a full `keyring arm` to `keyring forget` cycle against
a throwaway user, a throwaway state directory and a separate `irlumed` on
its own socket, so the system daemon and the invoking user's envelope
were untouched: 8/8. It proved the on-disk envelope is
`secret=GnomeKeyringToken` carrying the Argon2id wrap, that
`CHANGE(password, password)` is then DENIED so the keyring really is
keyed to the token, and that disarm re-keys back and erases the envelope.

Ten mutants confirm the tests discriminate, two of which only after
fixing tests that passed against their own mutant: the malformed-reply
test was fully covered by a neighbouring check, and the tier-climb path
never fired because sealing lands on the machine's best tier, so seeding
at Tier 3 was required to observe it.

## Not covered

**A real face or fingerprint login on a token-armed account.** Arming an
account requires typing its login password, so this was proven with a
throwaway user rather than a live one. The delivery path from a real
greeter is therefore exercised only by the pamwrap tests and the helper
in isolation.

The Arch canary, as above.
