### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,45 +5,155 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-04
+
+### Security
+
+- **A printed photograph of an enrolled face can pass the built-in liveness
+  gate.** On a default installation the cross-spectrum gate is the only
+  barrier, and it accepted a flat vinyl print of the enrolled face in 22 of 24
+  measured presentations. The falloff cue that is supposed to reject it is a
+  brightness ratio on a 2D infrared sensor, and a life-size print held at an
+  angle produces the same falloff a face does: measured 1.02 to 1.58 over 70
+  varied presentations on 2026-06-30 and 1.02 to 1.51 again on 2026-08-02,
+  against 1.26 to 1.49 for the live user. The print's range extends above the
+  genuine range, so no floor value accepts the user and rejects the print, and
+  the cue cannot be repaired by tuning it. This release fixes the two
+  amplifiers below rather than the attack. The mitigation is
+  `sudo irlume models enable flir`, which denied the same print at `p_fake`
+  0.999 and above. See the advisory for the full measurements and for what to
+  do if a photograph of you should not open your machine.
+
+- **A blown infrared frame is refused rather than judged.** A face region at
+  the sensor ceiling measures nothing, and irlume was reading cues off it
+  anyway. Against the same print, the optional PAD cue's `p_fake` decays with
+  clipping: 1.000 at 0.3% of the face clipped, 0.998 at 5.3%, 0.963 at 8.8%,
+  0.749 at 24.8% where it falls into its abstain band and says nothing, and
+  below 0.13 at 42.7%. Past roughly 13% the print faced only cues it already
+  cleared and was declared Live, so clipping silenced the one cue that denies
+  it. The gate now refuses above 10% clipped, on both credential-releasing
+  evaluators through one shared function, with the verdict Uncertain so a
+  login's grace window retries rather than terminating. Clipping is measured
+  on the raw gate frame, because ambient subtraction hides it. Closes #237.
+
+- **Burst selection prefers a lit frame that is not clipped.** The brightest
+  frame of a warming burst is the most likely to clip, and auto-exposure
+  produced that clipping by itself on the first capture after a daemon restart
+  at close range, which is how ordinary captures reached the regime above.
+  Selection now prefers the brightest camera-flagged-lit frame clipping at
+  most 5%, falling back to the least clipped lit frame; the no-metadata and
+  unknown-ceiling paths keep the old brightest scan. Hardware A/B on the ASUS
+  module: the gate frame clips 0.2 to 2.7% instead of 78.8%, ratios 1.50 to
+  1.64 instead of 1.11, and the same print was denied 6 of 6. Closes #221.
+
+- **The sealed envelope no longer holds the user's login password.** Releasing
+  it for keyring unlock meant a leaked envelope was a root escalation, which
+  is the mode Microsoft names "convenience PIN" and disrecommends. What is
+  sealed now depends on the backend, and both leave the password out of it.
+  On KDE, the 56-byte PBKDF2 key `ksecretd` opens the wallet with, which the
+  wallet is already keyed to, so nothing is re-keyed and a typed password
+  still opens it. On GNOME, whose credential is the string PAM hands it and so
+  has no derived intermediate, a 32-byte random token that `keyring arm`
+  re-keys the login keyring to through gnome-keyring's own control socket. A
+  leaked envelope now yields a secret that opens one keyring and nothing else.
+  Closes #250.
+
+  Existing armed users are untouched until they re-arm. On GNOME, note that
+  after re-arming the password alone no longer opens that keyring, since
+  irlume releases the token on every login; `irlume keyring forget` re-keys it
+  back. Because a random token cannot be re-derived, the envelope carries a
+  second copy wrapped under an Argon2id key from the login password, so a
+  broken TPM seal is recoverable. `irlume uninstall` refuses while any user is
+  token-armed, rather than deleting the only copy.
+
 ### Added
 
-- **The clipped fraction of the IR face is recorded with the liveness cues.**
-  A saturated centre cannot read brighter than a saturated rim, so a blown
-  exposure compresses the centre/edge ratio toward 1 the way strong ambient IR
-  does, and irlume guards only the ambient end. Two recorded corpora show the
-  case is reachable: in both, the session's first capture read about 235 mean
-  with a ratio of 1.06 and 1.12, against a 1.03 spoof floor and 1.19 to 1.42
-  for every later capture. `ir_saturated_frac` now rides in `Signals` and the
-  cross-spectrum debug line so #221 can be answered from ordinary output; it
-  gates nothing, and neither the ratio floor nor the warm-up length changes
-  until there is evidence from real authentications. The reading is absent,
-  not zero, when it cannot be taken: no IR face, or a negotiated format whose
-  decode cannot say where its ceiling is (the Y16 family is rescaled by a
-  shift taken from each frame's own maximum, and the YUV ceilings depend on a
-  quantization irlume does not carry), so the corpus never mixes "no clipping"
-  with "not measurable".
-
-- **Seating distance is recorded with the liveness cues.** `face_frac` (face
-  width as a fraction of frame width, the same quantity the framing guide
-  judges distance by) now rides in `Signals` and both liveness debug lines.
-  It gates nothing. Several existing cues are absolute thresholds on
-  quantities that may move across the guide's accepted 0.12 to 0.55 band, and
-  #174 asks which ones actually do before any of them is retuned; recording
-  the distance signal alongside them makes that answerable from ordinary
-  `IRLUME_LOG=debug` output rather than a special capture campaign.
+- **The clipped fraction and the seating distance are recorded with the
+  liveness cues.** `ir_saturated_frac` and `face_frac` ride in `Signals` and
+  the liveness debug lines. The clipped fraction now also gates, as above;
+  the distance signal gates nothing, and exists because several cues are
+  absolute thresholds on quantities that may move across the framing guide's
+  accepted 0.12 to 0.55 band, which #174 asks about before any of them is
+  retuned. Both readings are absent rather than zero when they cannot be
+  taken, so a corpus never mixes "no clipping" with "not measurable".
 
 ### Fixed
+
+- **A fingerprint login after a reboot could meet a keyring prompt.** irlumed
+  bound its own socket and was ordered after `multi-user.target` while
+  greeters are ordered after `basic.target`: on a ThinkPad X13 the greeter
+  authenticated a fingerprint eight seconds before the socket existed. The
+  keyring line is optional and swallows failures by design, so the login
+  succeeded, nothing was logged, and the prompt arrived later with nothing
+  naming why. systemd now owns the socket, the per-boot enrollment sweep runs
+  once per embedding space rather than every boot (asking whether a user needs
+  a retag costs a TPM unseal, and the TPM serializes, so that work collided
+  with the login it delayed), and the three parts are inseparable. Closes #244
+  and #249.
+
+- **A keyring unseal no longer costs seconds of login latency.** The pcrlock
+  branch digests were derived with one trial TPM session per predicted branch,
+  and this runs inside the PAM auth stack where the login waits on it. They
+  are now computed in software, which TCG Part 3 defines as hash recurrences
+  and which systemd computes the same way. Same-session A/B on a ThinkPad X13,
+  swapping only the binary: 10.88s to 2.71s, and the Zenbook 0.36s to 0.20s.
+  The memo and startup warm-up that existed to pay for the old cost are
+  deleted with it. Closes #246 and #248.
+
+- **A fast login after a reboot could meet a keyring prompt from a retryable
+  TPM error.** `TPM2_PolicyPCR` records the TPM's global PCR update counter in
+  the policy session, and any process extending any PCR invalidates it,
+  whether or not that PCR is one irlume binds. systemd extends PCR 11 at each
+  boot phase and PCR 15 when a user session starts, the second fired by the
+  very login being served, so logging in promptly raced a measurement the
+  login itself caused. The error says nothing about whether the policy is
+  satisfiable, and it was treated as fatal. The unseal now retries, bounded by
+  count and by time so a slow TPM cannot turn retries into a slow login.
+  systemd closed the same gap in systemd/systemd#35657.
+
+- **irlume no longer names itself as the application holding its own camera.**
+  The `/proc` scan returned the first process holding the node, and irlume had
+  just opened the device itself before `S_FMT` failed with EBUSY, so its own
+  pid sorted first and the message read "camera busy, in use by irlumed". The
+  scan now skips its own pid, and when nothing else is found it distinguishes
+  three outcomes: name the application to close, admit the scan was blind
+  without `CAP_SYS_PTRACE` and point at `fuser`, or report an irlume bug.
+
+- **Enrolment no longer opens one camera twice.** The capture loop holds both
+  cameras open, because re-opening per frame costs 1115ms of every attempt.
+  When a session could not be started, the per-frame fallback re-opened both
+  nodes while the held handles were still alive. Modules that permit a second
+  open hide this; one that answers EBUSY makes it fatal. The fallback now runs
+  after the handles are dropped, and the drop moves them, so a regression is a
+  compile error. Both this and the message above are what #187 reported.
 
 - **A status read can no longer make a login wait.** Every request used to
   execute on the single engine worker, so a `ListProfiles` (a TPM unseal of
   the template key, measured at 10.8 seconds on one laptop's TPM) made a
-  concurrently arriving authentication wait behind it: a Ping issued during
-  a listing measured 10.4 seconds. Read-only status requests (Ping, Health,
-  HasSealedPassword, KeyringInfo, RecoveryStatus, ListProfiles) now answer
-  on the connection's own thread, never entering the worker queue; Health
-  reads an engine snapshot published before the socket binds. Mutating
-  requests stay serialized on the worker, and the per-request authorization
-  gates moved with the code unchanged. Closes #212.
+  concurrently arriving authentication wait behind it: a Ping issued during a
+  listing measured 10.4 seconds. Read-only status requests now answer on the
+  connection's own thread, never entering the worker queue. Mutating requests
+  stay serialized on the worker, and the per-request authorization gates moved
+  with the code unchanged. Closes #212.
+
+### Changed
+
+- **The centre/edge floor stays at 1.03, and the corpus says why.** An
+  84-presentation corpus suggested it could rise to 1.25 and separate a flat
+  print from a live face. Every attack presentation in it was held square to
+  the camera; the same banner angled reaches 1.51, four of twenty passed the
+  proposed floor, and a floor blocking those would reject all 58 genuine
+  captures. The corpus now keeps the varied-angle species and a
+  `PAD_SELFTEST` line so the next person does not rediscover it, and `suncal`
+  formats the constant rather than a hardcoded 1.03 that contradicted its own
+  counts. No behaviour change.
+
+- **The absence of the third-party PAD cue is named as a gap, not a default.**
+  `doctor`, the daemon banner and SETUP.md reported it neutrally, which reads
+  as a choice the user already made. All three now say that the built-in gate
+  does not stop a printed face and give the command that closes it. The cue
+  stays opt-in because the reason it is not shipped is licensing (ADR-0001),
+  not doubt about whether it works.
 
 ## [0.8.0] - 2026-08-02
 
@@ -1836,6 +1946,8 @@ is always the fallback: no lockout, ever.
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
 [Unreleased]: https://github.com/archledger/irlume/compare/v0.7.2...HEAD
+[0.8.1]: https://github.com/archledger/irlume/releases/tag/v0.8.1
+[0.8.0]: https://github.com/archledger/irlume/releases/tag/v0.8.0
 [0.7.2]: https://github.com/archledger/irlume/releases/tag/v0.7.2
 [0.7.1]: https://github.com/archledger/irlume/releases/tag/v0.7.1
 [0.7.0]: https://github.com/archledger/irlume/releases/tag/v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "image",
  "irlume-auth",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "libc",
  "serde",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -989,11 +989,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "irlume-gkr-unlock"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-kwallet-init"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-liveness"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-common",
  "pamsm",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "irlume-camera",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1314,7 +1314,7 @@ pub fn reseal(args: &[String]) -> ExitCode {
     // Only meaningful if already armed (we never auto-arm from here).
     match daemon_request(&Request::HasSealedPassword { user: user.clone() }) {
         Ok(Response::HasPassword(false)) => {
-            eprintln!("[reseal] '{user}' has no sealed password; nothing to re-bind. Run `irlume keyring arm` to set one up.");
+            eprintln!("[reseal] '{user}' has no sealed secret; nothing to re-bind. Run `irlume keyring arm` to set one up.");
             return ExitCode::from(2);
         }
         Ok(Response::HasPassword(true)) => {}
@@ -1341,7 +1341,7 @@ pub fn reseal(args: &[String]) -> ExitCode {
         );
         return ExitCode::SUCCESS;
     }
-    println!("[reseal] Re-binding '{user}'s sealed password to the current TPM/PCR state.");
+    println!("[reseal] Re-binding '{user}'s sealed secret to the current TPM/PCR state.");
     let Some(pw) = prompt_login_password() else {
         return ExitCode::from(2);
     };
@@ -1571,8 +1571,9 @@ ENROLLMENT & AUTH
                         (sudo; the head nod is the default and needs no calibration)
 
 KEYRING / TPM
-  keyring <arm|status|forget>     TPM-sealed login password for wallet unlock
-  reseal                re-bind the sealed password to current PCRs (after a
+  keyring <arm|status|forget>     TPM-sealed secret so a login opens your wallet
+                        (forget takes --force to erase without re-keying back)
+  reseal                re-bind the sealed secret to current PCRs (after a
                         firmware/kernel update); safe, re-enters the password
   recovery <status|setup|restore|forget>   recovery passphrase + encryption
   diag                  TPM seal + PCR-drift diagnostics (run with sudo for detail)

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -958,7 +958,10 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
         Some("arm") => {
             println!(
                 "[keyring] Arming face-driven keyring unlock for '{user}'.\n\
-                 Enter this user's LOGIN password (it will be sealed in the TPM, never stored in plaintext)."
+                 Enter this user's LOGIN password. Depending on the wallet you run, what \
+                 gets sealed is the password itself, the key your KDE wallet is already \
+                 opened with, or a fresh random token this re-keys your GNOME keyring to. \
+                 Nothing is stored in plaintext either way."
             );
             // No-echo prompt on a real terminal; fall back to a plain stdin line
             // when piped (scripts / tests), where /dev/tty isn't available.
@@ -1049,8 +1052,50 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
             }
         }
         Some("status") => {
-            match daemon_request(&irlume_common::Request::HasSealedPassword { user: user.clone() })
-            {
+            // Ask for the detail first. WHAT is armed now changes what the
+            // user can expect from their own password: a GNOME token means
+            // their password no longer opens that keyring, which is not
+            // something to leave them to discover.
+            match daemon_request(&irlume_common::Request::KeyringInfo { user: user.clone() }) {
+                Ok(irlume_common::Response::KeyringInfo {
+                    armed: true, kind, ..
+                }) => {
+                    use irlume_common::KeyringSecretKind as K;
+                    match kind {
+                        Some(K::LoginPassword) => println!(
+                            "[keyring] '{user}': ARMED \u{2705} (login password). A face or \
+                             fingerprint login releases it so your wallet unlocks."
+                        ),
+                        Some(K::KdeWalletKey) => println!(
+                            "[keyring] '{user}': ARMED \u{2705} (KDE wallet key). The sealed \
+                             secret is the key ksecretd opens the wallet with, not your \
+                             password; a typed password still opens it too."
+                        ),
+                        Some(K::GnomeKeyringToken) => {
+                            println!(
+                                "[keyring] '{user}': ARMED \u{2705} (GNOME keyring token). Your \
+                                 login keyring is keyed to a random secret irlume releases on \
+                                 every login."
+                            );
+                            println!(
+                                "[keyring] Your password alone no longer opens that keyring; \
+                                 `irlume keyring forget` re-keys it back."
+                            );
+                        }
+                        // An older daemon does not report the kind.
+                        None => println!(
+                            "[keyring] '{user}': ARMED \u{2705} (this irlumed does not report \
+                             what kind)"
+                        ),
+                    }
+                    std::process::ExitCode::SUCCESS
+                }
+                Ok(irlume_common::Response::KeyringInfo { armed: false, .. }) => {
+                    println!("[keyring] '{user}': keyring unlock is not armed");
+                    std::process::ExitCode::SUCCESS
+                }
+                // A daemon predating KeyringInfo answers with an error; the
+                // armed bit is still worth reporting.
                 Ok(irlume_common::Response::HasPassword(armed)) => {
                     println!(
                         "[keyring] '{user}': keyring unlock is {}",
@@ -1184,7 +1229,16 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
             }
         }
         _ => {
-            eprintln!("usage: irlume keyring <arm|status|forget> [--user U]");
+            eprintln!(
+                "usage: irlume keyring <arm|status|forget> [--user U]\n\n\
+                 \x20 arm      seal a secret so a login opens your wallet; what is\n\
+                 \x20          sealed depends on the wallet you run\n\
+                 \x20 status   whether a secret is armed, and which kind\n\
+                 \x20 forget   erase it. A GNOME keyring token is re-keyed back to\n\
+                 \x20          your password first, which needs that password;\n\
+                 \x20          --force skips the re-key and leaves such a keyring\n\
+                 \x20          unreachable"
+            );
             std::process::ExitCode::from(2)
         }
     }

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2935,7 +2935,7 @@ impl App {
                     return;
                 }
                 self.confirm = Some((
-                    "Erase the TPM-sealed login password?".into(),
+                    "Erase the TPM-sealed keyring secret?".into(),
                     "Erase",
                     ConfirmAct::Daemon(Request::ForgetPassword {
                         user: self.user.clone(),
@@ -4272,6 +4272,26 @@ impl App {
             section("TPM keyring unlock"),
             Line::from(vec![Span::raw("  state    "), status]),
         ];
+        // WHAT is sealed, not just whether something is. A GNOME token means
+        // this user's password no longer opens that keyring on its own, which
+        // is not a thing to leave them to discover at a prompt.
+        if armed {
+            use irlume_common::KeyringSecretKind as K;
+            let (what, note) = match self.keyring_kind {
+                Some(K::LoginPassword) => ("login password", ""),
+                Some(K::KdeWalletKey) => ("KDE wallet key", " (a typed password still opens it)"),
+                Some(K::GnomeKeyringToken) => (
+                    "GNOME keyring token",
+                    " (your password alone no longer opens it; [f] re-keys back)",
+                ),
+                None => ("unreported by this daemon", ""),
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  sealed   "),
+                Span::raw(what.to_string()),
+                Span::styled(note.to_string(), Style::new().dim()),
+            ]));
+        }
         if self.keyring_drift == Some(true) {
             lines.push(Line::from(vec![
                 Span::raw("  PCRs     "),
@@ -4306,20 +4326,20 @@ impl App {
         // The unlock trigger depends on this box's hardware.
         if self.caps.ir_pair {
             lines.push(Line::from(Span::styled(
-                "  At a face login the daemon unseals your password and hands it to",
+                "  At a face login the daemon unseals that secret and delivers it,",
                 Style::new().dim(),
             )));
             lines.push(Line::from(Span::styled(
-                "  pam_kwallet/gnome-keyring, so your wallet opens with no prompt.",
+                "  so your wallet opens with no prompt.",
                 Style::new().dim(),
             )));
         } else if self.fp_present {
             lines.push(Line::from(Span::styled(
-                "  At a fingerprint login the daemon unseals your password (ADR-0003)",
+                "  At a fingerprint login the daemon unseals that secret (ADR-0003)",
                 Style::new().dim(),
             )));
             lines.push(Line::from(Span::styled(
-                "  and hands it to gnome-keyring, so your wallet opens with no prompt.",
+                "  and delivers it, so your wallet opens with no prompt.",
                 Style::new().dim(),
             )));
         }
@@ -5381,7 +5401,7 @@ fn map_confirm(resp: Response) -> (bool, String) {
         Response::Ok(m) => (true, m),
         Response::PasswordForgotten => (
             true,
-            "sealed login password erased; keyring unlock disarmed".into(),
+            "sealed keyring secret erased; keyring unlock disarmed".into(),
         ),
         Response::Error(e) => (false, e),
         o => (false, format!("unexpected: {o:?}")),

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -4282,7 +4282,10 @@ impl App {
                 Some(K::KdeWalletKey) => ("KDE wallet key", " (a typed password still opens it)"),
                 Some(K::GnomeKeyringToken) => (
                     "GNOME keyring token",
-                    " (your password alone no longer opens it; [f] re-keys back)",
+                    // NOT "[f] re-keys back": [f] refuses for this kind and
+                    // sends the user to the CLI, which is where the re-key
+                    // and its password prompt live.
+                    " (your password alone no longer opens it; `irlume keyring forget` re-keys back)",
                 ),
                 None => ("unreported by this daemon", ""),
             };

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -98,7 +98,7 @@ pub fn run(args: &[String]) -> ExitCode {
         println!("  3. keep your enrolled faces and sealed secrets (--keep-data)");
     } else {
         println!("  3. disarm the keyring seal, then delete every enrolled face,");
-        println!("     sealed password, third-party model, and config file");
+        println!("     sealed secret, third-party model, and config file");
     }
     println!("  4. remove irlume itself (the package, or the installed files)");
     println!();

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1428,7 +1428,7 @@ fn reseal_rebinds_when_armed_and_refuses_when_not() {
     serve(&sock(&sb2), |_| Response::HasPassword(false));
     let (code, _, err) = run(&mut sb2.cmd(&["reseal", "--user", "tester"]));
     assert_eq!(code, 2, "nothing sealed = usage-class refusal");
-    assert!(err.contains("has no sealed password"), "{err}");
+    assert!(err.contains("has no sealed secret"), "{err}");
     assert!(
         err.contains("keyring arm"),
         "must name the setup command: {err}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -174,7 +174,7 @@ irlume's headline feature is Windows-Hello-style keyring unlock: log in with you
 face and your GNOME-keyring / KWallet is already open. When you submit an empty
 password field, `pam_irlume.so` (in `unseal` mode) asks the daemon to
 `UnsealPassword`. The daemon runs the same pipeline and, **only on a live
-match**, TPM-unseals your login password and hands it back; `pam_irlume` sets it
+match**, TPM-unseals the sealed secret and hands it back; `pam_irlume` sets it
 as `PAM_AUTHTOK`, so a downstream `pam_gnome_keyring` / `pam_kwallet` opens the
 wallet with the same credential a typed password would have supplied. Anything
 short of a live match returns `PAM_IGNORE` and the stack falls through to the

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -44,8 +44,8 @@ Conventions that apply everywhere:
 
 | Command | What it does |
 |---|---|
-| `irlume keyring <arm\|status\|forget>` | TPM-sealed login password so a face login also unlocks the wallet/keyring |
-| `irlume reseal` | re-bind the sealed password to the current PCRs after a firmware or kernel update; prompts for the password, safe to re-run |
+| `irlume keyring <arm\|status\|forget>` | TPM-sealed secret so a login also unlocks the wallet/keyring. What is sealed depends on the backend: the login password, the KDE wallet key, or a random token this re-keys a GNOME keyring to. `status` names which; `forget` re-keys a token back and takes `--force` to skip that |
+| `irlume reseal` | re-bind the sealed secret to the current PCRs after a firmware or kernel update; prompts for the password, safe to re-run. A GNOME keyring token re-binds itself on the next password login, so this reports that and does nothing |
 | `irlume recovery <status\|setup\|restore\|forget>` | recovery passphrase + profile encryption |
 | `irlume diag` | TPM seal + PCR-drift diagnostics; run with `sudo` for full detail |
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -23,11 +23,11 @@ How to read the key lines:
 | Line | Meaning |
 |---|---|
 | `irlumed: UnsealPassword: attempt for 'x'` | a greeter/lock asked for a face login (camera fires now) |
-| `irlumed: UnsealPassword: OK for 'x' (score 0.8800), password unsealed` | face matched AND the TPM released the sealed password |
+| `irlumed: UnsealPassword: OK for 'x' (score 0.8800), login password unsealed` | face matched AND the TPM released the sealed secret; the trailing words name which kind it was (`login password`, `KDE wallet key`, `GNOME keyring token`) |
 | `…face matched … but TPM unseal FAILED` | face was fine; PCR drift kept the keyring locked → `irlume diag`, then `sudo irlume reseal` |
 | `audit … grantors=pam_irlume` | PAM's own record that the grant came from face, not password fallthrough |
 | `pam_unix(<svc>:auth): authentication failure` with **no** irlumed line before it | a typed (wrong) password; correct on-demand behavior: typing never fires the camera |
-| `plasma-kwallet-pam` / `pam_gnome_keyring` lines | the unsealed password reaching your wallet/keyring |
+| `plasma-kwallet-pam` / `pam_gnome_keyring` lines | the unsealed secret reaching your wallet/keyring |
 
 ## Per-stage pipeline tracing
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -216,7 +216,7 @@ stack carries `pam_fprintd.so` (that is what `irlume fingerprint enable` wires,
 via authselect on Fedora or pam-auth-update on Debian), inside the same
 `plasmalogin` transaction. A fingerprint provides no password, so irlume's
 `keyring` line, wired into the greeter whenever a reader is present, releases
-the TPM-sealed login password at the post-auth landing, and `pam_kwallet5.so`
+the TPM-sealed secret at the post-auth landing, and `pam_kwallet5.so`
 below it opens the wallet: a cold-boot fingerprint login unlocks KWallet with
 no prompt, same as face. The lock screen needs none of this: a warm unlock
 meets a wallet the login already opened.
@@ -260,7 +260,7 @@ a consumer to read the released password. `login enable` supplies both:
 
 ```
 auth        substack      fingerprint-auth
-auth       optional       pam_irlume.so keyring          ← releases the sealed password
+auth       optional       pam_irlume.so keyring          ← releases the sealed secret
 -auth      optional       pam_gnome_keyring.so           ← reads and stashes it
 ...
 -session   optional       pam_gnome_keyring.so auto_start  ← unlocks, starts the daemon
@@ -487,7 +487,7 @@ Set these on the service, not in a shell (`sudo systemctl edit irlumed`, then
 | `IRLUME_RGB_MOIRE_MAX` | per-camera ceiling for the screen-replay moiré cue | 28 |
 | `IRLUME_IR_AMBIENT_SUBTRACT` | `1` enables experimental lit-minus-ambient IR subtraction; changes the IR frames the matcher sees, so re-enroll after toggling (see [ARCHITECTURE.md](ARCHITECTURE.md)) | off |
 | `IRLUME_TCTI` | TPM transport | `device:/dev/tpmrm0` |
-| `IRLUME_PCRS` | comma-separated PCR list the sealed password binds to | `7` |
+| `IRLUME_PCRS` | comma-separated PCR list the sealed secret binds to | `7` |
 | `IRLUME_SRK_HANDLE` | persistent SRK handle (hex), if the default collides with another TPM user | `0x81010002` |
 | `IRLUME_METHOD_CONF` | alternate path for the method file | `/etc/irlume/method` |
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -223,7 +223,7 @@ on the current boot by construction. Never store a recoverable face image;
 decrypted template plaintext and keys are zeroized.
 
 **Fingerprint keyring unlock** ([ADR-0003](adr/0003-fingerprint-keyring-unlock.md))
-releases the sealed login password on *root peer + login-service-class*, without
+releases the sealed secret on *root peer + login-service-class*, without
 a daemon-verified biometric: the fingerprint (`pam_fprintd`) authenticated
 first. At-rest protection is preserved (a stolen disk can't unseal). Residual,
 accepted: a **live root attacker** in a login context can obtain the password.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.8.0
+pkgver=0.8.1
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.8.0
+version: 0.8.1
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -1,7 +1,7 @@
 %global ort_ver 1.24.4
 
 Name:           irlume
-Version:        0.8.0
+Version:        0.8.1
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -220,6 +220,17 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Tue Aug 04 2026 archledger <archledger236@gmail.com> - 0.8.1-1
+- A printed photograph of an enrolled face passes the built-in liveness gate; the cue cannot be repaired by tuning it, and the mitigation is `irlume models enable flir` (advisory, #235)
+- A blown infrared frame is refused rather than judged, so clipping no longer silences the PAD cue (#237)
+- Burst selection prefers a lit frame that is not clipped, which is how ordinary captures reached that regime (#221)
+- The sealed envelope no longer holds the login password: the KWallet key on KDE, a random re-keyed token on GNOME (#250)
+- A fingerprint login after a reboot no longer meets a keyring prompt; systemd owns the socket and the per-boot sweep is gone (#244, #249)
+- Keyring unseal latency drops from 10.88s to 2.71s on a discrete TPM; the policy digests are computed in software (#246, #248)
+- A retryable TPM PCR-counter race no longer surfaces as a keyring prompt on a fast login
+- irlume no longer names itself as the application holding its own camera, and enrolment stops opening one camera twice (#187)
+- A status read can no longer make a login wait (#212)
+
 * Sun Aug 02 2026 archledger <archledger236@gmail.com> - 0.8.0-1
 - Emitter write honours the Windows exclusive-control model; consumer scan reports its blind spot (#169, #207)
 - fingerprint enable and status print per-surface coverage; the fingerprint-only gate parses PAM rule fields (#155)


### PR DESCRIPTION
Version bumped in the four places that carry it, `CHANGELOG.md` stamped, and
a `%changelog` entry added for the RPM. `scripts/check-packaging-parity.sh`
agrees across Cargo.toml, irlume.spec, PKGBUILD and nfpm.yaml.

## What the release carries

The advisory-relevant pair (#221, #237): a blown infrared frame is refused
rather than judged, and burst selection prefers a lit frame that is not
clipped. The printed-face weakness itself cannot be repaired by tuning the
cue, and the changelog says so with the measurements; the advisory publishes
with this release, once the fix is installable.

The sealed envelope no longer holds the login password (#250): the KWallet key
on KDE, a random re-keyed token on GNOME. Plus the keyring-prompt fixes
(#244, #249), the unseal latency work (#246, #248), the PCR-counter retry, the
two #187 camera-holder bugs, and #212.

## Walking the surfaces found text the code had made false

Running the binaries, rather than reading them, on both a KDE box and a GNOME
box because the two now print different things:

- `keyring status` reported only that something was armed, never what. With
  three kinds, and a GNOME token meaning the user's own password no longer
  opens that keyring, that is the one thing it has to say. It names the kind
  now, and falls back honestly against a daemon that predates the field.
- The TUI had the same gap and now prints a `sealed` line beside the state.
- The arm prompt said the password would be sealed, false for two of three
  kinds. The TUI's confirm and success lines said "login password". Its body
  text said the daemon "unseals your password and hands it to
  pam_kwallet/gnome-keyring". A hint promised `[f] re-keys back` when `[f]`
  refuses for that kind and defers to the CLI.
- Neither `--help` nor the `keyring` usage mentioned `--force`, the flag that
  can leave a keyring unreachable.
- COMMANDS.md, SETUP.md, ARCHITECTURE.md, THREAT_MODEL.md and DEBUGGING.md
  carried the same assumption.

Two were invisible in the source: the usage block lost its indentation to a
line-continuation backslash, and `status` reported "does not report what kind"
because the installed daemon was older than the field, which also proved the
fallback works.

## Testing

- `cargo test --workspace` green, 27 binaries, 1045 tests.
- clippy, `fmt --check`, and `RUSTDOCFLAGS="-D warnings" cargo doc` clean.
- Every read-only CLI command run twice on both machines, exit codes stable.
- TUI driven under tmux on both, panes read: KDE shows "KDE wallet key",
  GNOME shows "GNOME keyring token" with the consequence spelled out.
- Version identical across `--version`, the machine API's `engine_version`,
  and the TUI header.