### PR TITLE
doctor: report the negotiated streams against the Windows Hello minimums

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1315,30 +1315,104 @@ impl StreamSpec {
 }
 
 /// The driver's reported capture rate for `dev`, from VIDIOC_G_PARM. The
-/// interval is time-per-frame, so the rate is its inverse; a zero on either
-/// side of the fraction means the driver reports nothing usable.
+/// interval is time-per-frame, so the rate is its inverse.
 fn driver_fps(dev: &Device) -> Option<f64> {
-    let p = Capture::params(dev).ok()?;
-    let (num, den) = (p.interval.numerator, p.interval.denominator);
-    if num == 0 || den == 0 {
-        return None;
-    }
-    Some(f64::from(den) / f64::from(num))
+    fps_from_params(Capture::params(dev).ok()?)
 }
 
-/// What the capture path would negotiate on `device`, without streaming: the
-/// same verify + privacy + format walk as [`RgbCamera::open`] /
-/// [`IrCamera::open`], no buffers allocated, capture LED off. Reusing the real
-/// open is the point: a parallel reimplementation here could drift from what
-/// capture actually does, and this feeds a report people act on (#223).
-pub fn negotiated_stream(device: &str, role: Role) -> irlume_common::Result<StreamSpec> {
-    match role {
-        Role::Rgb => Ok(RgbCamera::open(device)?.spec()),
-        Role::Ir => Ok(IrCamera::open(device)?.spec()),
-        _ => Err(Error::Hardware(format!(
-            "{device}: no stream to negotiate for this role"
-        ))),
+/// [`driver_fps`]'s conversion, split out so the capability rule is testable
+/// without hardware. V4L2 specifies that `timeperframe` is meaningful only
+/// when the driver sets `V4L2_CAP_TIMEPERFRAME`; without the flag the fields
+/// are whatever the driver left in the struct, and reading a plausible-looking
+/// `1/30` there would let an unestablished rate publish as a pass. A zero on
+/// either side of the fraction is equally unusable.
+fn fps_from_params(p: v4l::video::capture::Parameters) -> Option<f64> {
+    if !p
+        .capabilities
+        .contains(v4l::parameters::Capabilities::TIME_PER_FRAME)
+    {
+        return None;
     }
+    let (num, den) = (p.interval.numerator, p.interval.denominator);
+    (num != 0 && den != 0).then(|| f64::from(den) / f64::from(num))
+}
+
+/// `VIDIOC_TRY_FMT`: what `VIDIOC_S_FMT` would negotiate, without changing
+/// driver state. The kernel specifies TRY_FMT as S_FMT's stateless twin (same
+/// adjustment logic, no hardware preparation), which is what lets the doctor
+/// report read a camera without mutating it. The pinned v4l crate exposes only
+/// `set_format`, so this is the same raw-ioctl shape as the VIDIOC_ENUM_FMT
+/// probe above.
+fn try_format(dev: &Device, fmt: &Format) -> std::io::Result<Format> {
+    let mut wire: v4l::v4l_sys::v4l2_format = unsafe { std::mem::zeroed() };
+    wire.type_ = v4l::buffer::Type::VideoCapture as u32;
+    wire.fmt.pix = (*fmt).into();
+    // SAFETY: `dev` owns the fd for the length of this call, and `wire` is a
+    // correctly sized v4l2_format with the pix union arm initialized, which is
+    // what VIDIOC_TRY_FMT reads and writes.
+    let rc = unsafe {
+        libc::ioctl(
+            dev.handle().fd(),
+            v4l::v4l2::vidioc::VIDIOC_TRY_FMT,
+            &mut wire as *mut _ as *mut libc::c_void,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(Format::from(unsafe { wire.fmt.pix }))
+}
+
+/// What the capture path would negotiate on `device`, observed read-only: the
+/// same verify + privacy checks and the same candidate walks as
+/// [`RgbCamera::open`] / [`IrCamera::open`], applied through `VIDIOC_TRY_FMT`
+/// instead of `VIDIOC_S_FMT`, so nothing on the camera changes. No buffers,
+/// no streaming, LED off. The candidate selection is shared with the real
+/// open paths rather than reimplemented, so this report cannot drift from
+/// what capture actually asks for (#223).
+pub fn negotiated_stream(device: &str, role: Role) -> irlume_common::Result<StreamSpec> {
+    verify_pinned(device)?;
+    if privacy_engaged(device) {
+        return Err(Error::Hardware(format!(
+            "{device}: hardware privacy switch is ON"
+        )));
+    }
+    let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
+    let (fmt, fourcc) = match role {
+        Role::Rgb => {
+            let chosen = negotiate_rgb_format(device, &dev)?;
+            let fmt = try_format(&dev, &Format::new(RGB_W, RGB_H, FourCC::new(&chosen)))
+                .map_err(|e| map_io(device, e))?;
+            // Mirror open()'s echo check: a driver that answers with a
+            // different fourcc would fail capture, so it must not report as a
+            // negotiated stream here.
+            if fmt.fourcc.repr != chosen {
+                return Err(Error::Hardware(format!(
+                    "{device}: driver gave {}, expected {}",
+                    fourcc_str(&fmt.fourcc.repr),
+                    fourcc_str(&chosen)
+                )));
+            }
+            let cc = fourcc_str(&fmt.fourcc.repr);
+            (fmt, cc)
+        }
+        Role::Ir => {
+            let (fmt, _pix) = negotiate_ir_format_via(device, &dev, try_format)?;
+            let cc = fourcc_str(&fmt.fourcc.repr);
+            (fmt, cc)
+        }
+        _ => {
+            return Err(Error::Hardware(format!(
+                "{device}: no stream to negotiate for this role"
+            )))
+        }
+    };
+    Ok(StreamSpec {
+        width: fmt.width,
+        height: fmt.height,
+        fourcc,
+        fps: driver_fps(&dev),
+    })
 }
 
 /// A running RGB stream. Every capture after the first skips the warm-up.
@@ -1585,6 +1659,19 @@ const IR_CANDIDATES: [(&[u8; 4], IrPixel); 8] = [
 /// walk [`IR_CANDIDATES`] against what the driver advertises, accept the first
 /// one the driver echoes back, and fail with a message naming what it offers.
 fn negotiate_ir_format(device: &str, dev: &Device) -> irlume_common::Result<(Format, IrPixel)> {
+    negotiate_ir_format_via(device, dev, Capture::set_format)
+}
+
+/// The IR candidate walk with the format ioctl injected: capture applies it
+/// through `VIDIOC_S_FMT` ([`negotiate_ir_format`]) while the doctor's
+/// read-only probe applies the SAME walk through `VIDIOC_TRY_FMT`
+/// ([`negotiated_stream`]). One walk, two ioctls, so the probe cannot drift
+/// from what capture negotiates.
+fn negotiate_ir_format_via(
+    device: &str,
+    dev: &Device,
+    apply: impl Fn(&Device, &Format) -> std::io::Result<Format>,
+) -> irlume_common::Result<(Format, IrPixel)> {
     let offered: Vec<[u8; 4]> = Capture::enum_formats(dev)
         .map(|v| v.into_iter().map(|d| d.fourcc.repr).collect())
         .unwrap_or_default();
@@ -1595,7 +1682,7 @@ fn negotiate_ir_format(device: &str, dev: &Device) -> irlume_common::Result<(For
             continue;
         }
         let fmt = Format::new(IR_W, IR_H, FourCC::new(cc));
-        let fmt = Capture::set_format(dev, &fmt).map_err(|e| map_io(device, e))?;
+        let fmt = apply(dev, &fmt).map_err(|e| map_io(device, e))?;
         if &fmt.fourcc.repr == cc {
             return Ok((fmt, pix));
         }
@@ -3242,6 +3329,23 @@ fn warm_up_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_rate_without_the_timeperframe_capability_is_unknown() {
+        // V4L2 defines timeperframe as meaningful only under
+        // V4L2_CAP_TIMEPERFRAME; without the flag the fraction is residue, and
+        // a plausible 1/30 there must not publish as an established rate.
+        let mut p = v4l::video::capture::Parameters::with_fps(30);
+        p.capabilities = v4l::parameters::Capabilities::from(0);
+        assert_eq!(fps_from_params(p), None);
+        // With the flag the same fraction is a real 30fps.
+        p.capabilities = v4l::parameters::Capabilities::TIME_PER_FRAME;
+        assert_eq!(fps_from_params(p), Some(30.0));
+        // A zero numerator or denominator is unusable even when capable.
+        let mut z = v4l::video::capture::Parameters::new(v4l::Fraction::new(0, 30));
+        z.capabilities = v4l::parameters::Capabilities::TIME_PER_FRAME;
+        assert_eq!(fps_from_params(z), None);
+    }
 
     #[test]
     fn hello_minimum_verdicts_cover_all_three_outcomes() {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1206,14 +1206,6 @@ impl RgbCamera {
             )));
         }
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
-        // Best-effort backlight/low-light correction: tell auto-exposure to
-        // expose for the face, not a bright window behind it. Harmless if
-        // unsupported (NexiGo N930W needs this; verified mean 49→124 + face
-        // detected).
-        let _ = dev.set_control(v4l::control::Control {
-            id: V4L2_CID_BACKLIGHT_COMPENSATION,
-            value: v4l::control::Value::Integer(2),
-        });
         // Pick an uncompressed format the camera actually offers. Some webcams
         // advertise RGB only as MJPEG (or NV12) and reject YUYV; classify()
         // still labels them usable, so without this negotiation they would
@@ -1242,12 +1234,110 @@ impl RgbCamera {
     /// stream until it is dropped, so keep it exactly as long as the burst of
     /// captures that needs it and no longer.
     pub fn session(&self) -> irlume_common::Result<RgbSession<'_>> {
+        // Best-effort backlight/low-light correction: tell auto-exposure to
+        // expose for the face, not a bright window behind it. Harmless if
+        // unsupported (NexiGo N930W needs this; verified mean 49→124 + face
+        // detected). Written here rather than in `open` so that opening for a
+        // read-only purpose (doctor's stream report) changes nothing on the
+        // camera; AE settles during this session's warm-up either way, and the
+        // write is idempotent across repeated sessions.
+        let _ = self.dev.set_control(v4l::control::Control {
+            id: V4L2_CID_BACKLIGHT_COMPENSATION,
+            value: v4l::control::Value::Integer(2),
+        });
         let stream = SafeStream::open(&self.device, &self.dev)?;
         Ok(RgbSession {
             cam: self,
             stream,
             warmed: false,
         })
+    }
+
+    /// The stream this open camera negotiated. See [`negotiated_stream`].
+    pub fn spec(&self) -> StreamSpec {
+        StreamSpec {
+            width: self.width,
+            height: self.height,
+            fourcc: fourcc_str(&self.chosen),
+            fps: driver_fps(&self.dev),
+        }
+    }
+}
+
+/// The negotiated stream of a camera, for the doctor report (#223).
+#[derive(Clone, Debug)]
+pub struct StreamSpec {
+    pub width: u32,
+    pub height: u32,
+    /// The negotiated pixel format's fourcc, e.g. "GREY" or "YUYV".
+    pub fourcc: String,
+    /// Frames per second from the driver's reported capture interval. `None`
+    /// when the driver does not report one; irlume never sets a rate, so this
+    /// is the default the stream would actually run at.
+    pub fps: Option<f64>,
+}
+
+/// A published stream floor to compare a [`StreamSpec`] against.
+pub struct StreamMinimum {
+    pub width: u32,
+    pub height: u32,
+    pub fps: f64,
+}
+
+/// Windows Hello's published stream minimums, the envelope irlume's cue set
+/// was designed around. Microsoft's UVC camera implementation guide
+/// (learn.microsoft.com, "UVC camera implementation guide"): "Windows Hello
+/// has a minimum requirement of 480x480@7.5fps for the RGB stream and
+/// 340x340@15fps for the IR stream."
+pub const HELLO_IR_MIN: StreamMinimum = StreamMinimum {
+    width: 340,
+    height: 340,
+    fps: 15.0,
+};
+pub const HELLO_RGB_MIN: StreamMinimum = StreamMinimum {
+    width: 480,
+    height: 480,
+    fps: 7.5,
+};
+
+impl StreamSpec {
+    /// Whether this stream meets `min`. `Some(false)` when a dimension or a
+    /// reported rate is below it; `None` when the dimensions meet it but the
+    /// driver reports no rate, which is "cannot say", not "meets": collapsing
+    /// an unobserved rate into a pass would make the one unreadable driver
+    /// look like the one that cleared the bar.
+    pub fn meets(&self, min: &StreamMinimum) -> Option<bool> {
+        if self.width < min.width || self.height < min.height {
+            return Some(false);
+        }
+        self.fps.map(|fps| fps >= min.fps)
+    }
+}
+
+/// The driver's reported capture rate for `dev`, from VIDIOC_G_PARM. The
+/// interval is time-per-frame, so the rate is its inverse; a zero on either
+/// side of the fraction means the driver reports nothing usable.
+fn driver_fps(dev: &Device) -> Option<f64> {
+    let p = Capture::params(dev).ok()?;
+    let (num, den) = (p.interval.numerator, p.interval.denominator);
+    if num == 0 || den == 0 {
+        return None;
+    }
+    Some(f64::from(den) / f64::from(num))
+}
+
+/// What the capture path would negotiate on `device`, without streaming: the
+/// same verify + privacy + format walk as [`RgbCamera::open`] /
+/// [`IrCamera::open`], no buffers allocated, capture LED off. Reusing the real
+/// open is the point: a parallel reimplementation here could drift from what
+/// capture actually does, and this feeds a report people act on (#223).
+pub fn negotiated_stream(device: &str, role: Role) -> irlume_common::Result<StreamSpec> {
+    match role {
+        Role::Rgb => Ok(RgbCamera::open(device)?.spec()),
+        Role::Ir => Ok(IrCamera::open(device)?.spec()),
+        _ => Err(Error::Hardware(format!(
+            "{device}: no stream to negotiate for this role"
+        ))),
     }
 }
 
@@ -1746,6 +1836,9 @@ pub struct IrCamera {
     /// The driver's reported quantization for the negotiated format, which is
     /// half of what names the clipping ceiling; see [`clipping_white_level`].
     quantization: Quantization,
+    /// The negotiated fourcc, kept for [`Self::spec`]: `pix` names how the
+    /// bytes decode, not which of several fourccs mapped to it.
+    fourcc: String,
     width: u32,
     height: u32,
     card: String,
@@ -1767,10 +1860,21 @@ impl IrCamera {
             dev,
             pix,
             quantization: fmt.quantization,
+            fourcc: fourcc_str(&fmt.fourcc.repr),
             width: fmt.width,
             height: fmt.height,
             card,
         })
+    }
+
+    /// The stream this open camera negotiated. See [`negotiated_stream`].
+    pub fn spec(&self) -> StreamSpec {
+        StreamSpec {
+            width: self.width,
+            height: self.height,
+            fourcc: self.fourcc.clone(),
+            fps: driver_fps(&self.dev),
+        }
     }
 
     /// Start streaming and fire the emitter.
@@ -3138,6 +3242,34 @@ fn warm_up_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hello_minimum_verdicts_cover_all_three_outcomes() {
+        let spec = |w, h, fps| StreamSpec {
+            width: w,
+            height: h,
+            fourcc: "GREY".into(),
+            fps,
+        };
+        // The measured ASUS module shape: comfortably above the IR floor.
+        assert_eq!(spec(640, 400, Some(30.0)).meets(&HELLO_IR_MIN), Some(true));
+        // At the floor exactly is meeting it, not below it.
+        assert_eq!(spec(340, 340, Some(15.0)).meets(&HELLO_IR_MIN), Some(true));
+        // ONE dimension below fails, even with plenty of rate; 640x240 has
+        // fewer face pixels than the envelope no matter its width.
+        assert_eq!(spec(640, 240, Some(30.0)).meets(&HELLO_IR_MIN), Some(false));
+        // A reported rate below the floor fails.
+        assert_eq!(spec(640, 400, Some(10.0)).meets(&HELLO_IR_MIN), Some(false));
+        // Dimensions meet, rate unreported: cannot say, which must stay
+        // distinct from a pass (an unobserved rate is not an adequate one).
+        assert_eq!(spec(640, 400, None).meets(&HELLO_IR_MIN), None);
+        // Dimensions below with rate ALSO unreported is still a definite
+        // below, not an unknown: the dimensions alone decide it.
+        assert_eq!(spec(320, 240, None).meets(&HELLO_IR_MIN), Some(false));
+        // The RGB floor has a fractional rate; just below it fails.
+        assert_eq!(spec(640, 480, Some(7.0)).meets(&HELLO_RGB_MIN), Some(false));
+        assert_eq!(spec(640, 480, Some(7.5)).meets(&HELLO_RGB_MIN), Some(true));
+    }
 
     fn unreadable(at: FailedAt, errno: Option<i32>, holder: Option<&str>) -> Unreadable {
         Unreadable {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3153,6 +3153,96 @@ fn doctor(args: &[String]) -> std::process::ExitCode {
     doctor_run(&mut report, args)
 }
 
+/// The negotiated streams against the Windows Hello minimums (#223).
+///
+/// A line, not a gate: an under-spec stream still authenticates, but a smaller
+/// face means fewer pixels behind the centre/edge ratio while a lower rate
+/// means fewer usable frames per burst. Saying so is what the user can act on;
+/// refusing would break cameras that work fine.
+///
+/// Both check ids are ALWAYS emitted, whatever this machine has: the machine
+/// API's contract is that a check never disappears because it had nothing to
+/// say, so an absent node reports Info rather than vanishing. Split from
+/// `doctor_run` so a test can drive it against chosen paths; the camera nodes
+/// come from `select_pair` at the call site.
+fn stream_minimum_checks(report: &mut crate::doctor_report::Report, rgb_node: &str, ir_node: &str) {
+    use crate::doctor_report::State;
+    let checks: [(
+        &str,
+        &str,
+        irlume_camera::Role,
+        &str,
+        &irlume_camera::StreamMinimum,
+    ); 2] = [
+        (
+            "ir-stream-hello-minimum",
+            "IR",
+            irlume_camera::Role::Ir,
+            ir_node,
+            &irlume_camera::HELLO_IR_MIN,
+        ),
+        (
+            "rgb-stream-hello-minimum",
+            "RGB",
+            irlume_camera::Role::Rgb,
+            rgb_node,
+            &irlume_camera::HELLO_RGB_MIN,
+        ),
+    ];
+    for (id, label, role, node, min) in checks {
+        if !std::path::Path::new(node).exists() {
+            dout!(report, "[doctor] {label} stream: no selected node");
+            report.check_detail(id, State::Info, "no selected node");
+            continue;
+        }
+        let floor = format!("{}x{}@{}fps", min.width, min.height, min.fps);
+        match irlume_camera::negotiated_stream(node, role) {
+            Ok(spec) => {
+                // Two decimals, because the floor itself is fractional
+                // (7.5fps) and a 14.9 rounded to 15 would print a value that
+                // contradicts the verdict beside it.
+                let rate = match spec.fps {
+                    Some(fps) => format!("@{fps:.2}fps"),
+                    None => String::new(),
+                };
+                let shown = format!("{}x{}{rate} {}", spec.width, spec.height, spec.fourcc);
+                match spec.meets(min) {
+                    Some(true) => {
+                        dout!(
+                            report,
+                            "[doctor] {label} stream: {shown} ✓ (Windows Hello minimum {floor})"
+                        );
+                        report.check_detail(id, State::Pass, &shown);
+                    }
+                    Some(false) => {
+                        dout!(
+                            report,
+                            "[doctor] {label} stream: {shown} ⚠ below the published Windows \
+                             Hello minimum {floor}; captures work, but expect weaker liveness \
+                             margins on this module"
+                        );
+                        report.check_detail(id, State::Warn, &shown);
+                    }
+                    None => {
+                        dout!(
+                            report,
+                            "[doctor] {label} stream: {shown}; dimensions meet the Windows \
+                             Hello minimum {floor}, the driver reports no frame rate"
+                        );
+                        report.check_detail(id, State::Info, &shown);
+                    }
+                }
+            }
+            // Could not negotiate is "could not look" (the camera may be
+            // mid-capture by the daemon), never silence and never a warn.
+            Err(e) => {
+                dout!(report, "[doctor] {label} stream: not readable now ({e})");
+                report.check_detail(id, State::Unknown, e.to_string());
+            }
+        }
+    }
+}
+
 /// One pass over the machine. Prints the human report or stays silent and
 /// records, depending on `report`.
 /// `args` carries `--user`, which doctor reports on in eight per-user lines.
@@ -3391,84 +3481,9 @@ fn doctor_run(
     }
 
     // --- stream vs the Windows Hello minimums (#223) -----------------------
-    // A line, not a gate: an under-spec stream still authenticates, but the
-    // cue set was designed around the published Hello envelope, and a smaller
-    // face means fewer pixels behind the centre/edge ratio while a lower rate
-    // means fewer usable frames per burst. Saying so is what the user can act
-    // on; refusing would break cameras that work fine.
     {
         let (rgb_node, ir_node) = irlume_camera::select_pair();
-        let checks: [(
-            &str,
-            &str,
-            irlume_camera::Role,
-            &str,
-            &irlume_camera::StreamMinimum,
-        ); 2] = [
-            (
-                "ir-stream-hello-minimum",
-                "IR",
-                irlume_camera::Role::Ir,
-                &ir_node,
-                &irlume_camera::HELLO_IR_MIN,
-            ),
-            (
-                "rgb-stream-hello-minimum",
-                "RGB",
-                irlume_camera::Role::Rgb,
-                &rgb_node,
-                &irlume_camera::HELLO_RGB_MIN,
-            ),
-        ];
-        for (id, label, role, node, min) in checks {
-            // A spectrum with no node is simply not reported on, like a
-            // missing PAM surface in the fingerprint coverage table.
-            if !std::path::Path::new(node).exists() {
-                continue;
-            }
-            let floor = format!("{}x{}@{}fps", min.width, min.height, min.fps);
-            match irlume_camera::negotiated_stream(node, role) {
-                Ok(spec) => {
-                    let rate = match spec.fps {
-                        Some(fps) => format!("@{fps:.0}fps"),
-                        None => String::new(),
-                    };
-                    let shown = format!("{}x{}{rate} {}", spec.width, spec.height, spec.fourcc);
-                    match spec.meets(min) {
-                        Some(true) => {
-                            dout!(
-                                report,
-                                "[doctor] {label} stream: {shown} ✓ (Windows Hello minimum {floor})"
-                            );
-                            report.check_detail(id, State::Pass, &shown);
-                        }
-                        Some(false) => {
-                            dout!(
-                                report,
-                                "[doctor] {label} stream: {shown} ⚠ below the Windows Hello \
-                                 minimum {floor} irlume's cues were designed around; captures \
-                                 work, but expect weaker liveness margins on this module"
-                            );
-                            report.check_detail(id, State::Warn, &shown);
-                        }
-                        None => {
-                            dout!(
-                                report,
-                                "[doctor] {label} stream: {shown}; dimensions meet the Windows \
-                                 Hello minimum {floor}, the driver reports no frame rate"
-                            );
-                            report.check_detail(id, State::Info, &shown);
-                        }
-                    }
-                }
-                // Could not negotiate is "could not look" (the camera may be
-                // mid-capture by the daemon), never silence and never a warn.
-                Err(e) => {
-                    dout!(report, "[doctor] {label} stream: not readable now ({e})");
-                    report.check_detail(id, State::Unknown, e.to_string());
-                }
-            }
-        }
+        stream_minimum_checks(report, &rgb_node, &ir_node);
     }
 
     // --- models / runtime --------------------------------------------------
@@ -4063,6 +4078,28 @@ mod tests {
 
     fn argv(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn stream_minimum_checks_emit_both_ids_even_with_no_nodes() {
+        // The machine API's completeness contract: a check never disappears
+        // because it had nothing to say. A machine with no camera at all must
+        // still carry both stream ids, as Info, or a consumer cannot tell an
+        // older engine from a camera-less machine.
+        let mut report = crate::doctor_report::Report::new(crate::doctor_report::Mode::Collect);
+        stream_minimum_checks(
+            &mut report,
+            "/dev/irlume-test-no-such-rgb",
+            "/dev/irlume-test-no-such-ir",
+        );
+        let checks = report.into_checks();
+        for id in ["ir-stream-hello-minimum", "rgb-stream-hello-minimum"] {
+            assert_eq!(
+                checks.iter().filter(|c| c.id == id).count(),
+                1,
+                "{id} must appear exactly once"
+            );
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3390,6 +3390,87 @@ fn doctor_run(
         dout!(report, "  ⚠ {}: {cause}", paths.join(", "));
     }
 
+    // --- stream vs the Windows Hello minimums (#223) -----------------------
+    // A line, not a gate: an under-spec stream still authenticates, but the
+    // cue set was designed around the published Hello envelope, and a smaller
+    // face means fewer pixels behind the centre/edge ratio while a lower rate
+    // means fewer usable frames per burst. Saying so is what the user can act
+    // on; refusing would break cameras that work fine.
+    {
+        let (rgb_node, ir_node) = irlume_camera::select_pair();
+        let checks: [(
+            &str,
+            &str,
+            irlume_camera::Role,
+            &str,
+            &irlume_camera::StreamMinimum,
+        ); 2] = [
+            (
+                "ir-stream-hello-minimum",
+                "IR",
+                irlume_camera::Role::Ir,
+                &ir_node,
+                &irlume_camera::HELLO_IR_MIN,
+            ),
+            (
+                "rgb-stream-hello-minimum",
+                "RGB",
+                irlume_camera::Role::Rgb,
+                &rgb_node,
+                &irlume_camera::HELLO_RGB_MIN,
+            ),
+        ];
+        for (id, label, role, node, min) in checks {
+            // A spectrum with no node is simply not reported on, like a
+            // missing PAM surface in the fingerprint coverage table.
+            if !std::path::Path::new(node).exists() {
+                continue;
+            }
+            let floor = format!("{}x{}@{}fps", min.width, min.height, min.fps);
+            match irlume_camera::negotiated_stream(node, role) {
+                Ok(spec) => {
+                    let rate = match spec.fps {
+                        Some(fps) => format!("@{fps:.0}fps"),
+                        None => String::new(),
+                    };
+                    let shown = format!("{}x{}{rate} {}", spec.width, spec.height, spec.fourcc);
+                    match spec.meets(min) {
+                        Some(true) => {
+                            dout!(
+                                report,
+                                "[doctor] {label} stream: {shown} ✓ (Windows Hello minimum {floor})"
+                            );
+                            report.check_detail(id, State::Pass, &shown);
+                        }
+                        Some(false) => {
+                            dout!(
+                                report,
+                                "[doctor] {label} stream: {shown} ⚠ below the Windows Hello \
+                                 minimum {floor} irlume's cues were designed around; captures \
+                                 work, but expect weaker liveness margins on this module"
+                            );
+                            report.check_detail(id, State::Warn, &shown);
+                        }
+                        None => {
+                            dout!(
+                                report,
+                                "[doctor] {label} stream: {shown}; dimensions meet the Windows \
+                                 Hello minimum {floor}, the driver reports no frame rate"
+                            );
+                            report.check_detail(id, State::Info, &shown);
+                        }
+                    }
+                }
+                // Could not negotiate is "could not look" (the camera may be
+                // mid-capture by the daemon), never silence and never a warn.
+                Err(e) => {
+                    dout!(report, "[doctor] {label} stream: not readable now ({e})");
+                    report.check_detail(id, State::Unknown, e.to_string());
+                }
+            }
+        }
+    }
+
     // --- models / runtime --------------------------------------------------
     dout!(report, "[doctor] models:");
     if commands::daemon_models_loaded() == Some(true) {

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -206,6 +206,8 @@ reused for a different meaning. The registry as of this contract:
 | `signed-pcr-policy` | the systemd signed-PCR (Tier 1) policy for sealing |
 | `pcrlock` | the systemd-pcrlock (Tier 2) policy and its NV index |
 | `camera-nodes` | whether an RGB and an IR node were classified. Capability only; no device paths |
+| `ir-stream-hello-minimum` | the negotiated IR stream compared with the published Windows Hello IR minimum (340x340@15fps). `info` when no IR node is selected or the dimensions meet it with no reported rate; `unknown` when the node cannot be negotiated right now |
+| `rgb-stream-hello-minimum` | the negotiated RGB stream compared with the published Windows Hello RGB minimum (480x480@7.5fps). Same states as the IR check |
 | `models` | the ONNX weights irlume needs, present and checksummed |
 | `ort-dylib-path` | which ONNX runtime library will be loaded |
 | `third-party-pad-model` | optional third-party presentation-attack weights, if installed |


### PR DESCRIPTION
Closes #223.

Nothing compared what the cameras negotiate against the floors Microsoft publishes for Hello modules ("Windows Hello has a minimum requirement of 480x480@7.5fps for the RGB stream and 340x340@15fps for the IR stream", UVC camera implementation guide on learn.microsoft.com), so a module at 320x240@10fps read exactly like one at 640x480@30fps. The consequences land where #174/#221 are already looking: fewer face pixels behind the centre/edge ratio, fewer usable burst frames.

## What changed

- `StreamSpec` and `negotiated_stream(device, role)` in irlume-camera: doctor opens each selected node through the same `RgbCamera::open` / `IrCamera::open` negotiation capture uses, no streaming, no buffers, so the report cannot drift from what capture does. The rate comes from the driver's VIDIOC_G_PARM interval; irlume never sets one.
- A doctor line per present spectrum, warning only below the floor, per the issue: a gate would break cameras that work fine. `Some(false)` = below; `None` (dims meet, rate unreported) reads as cannot-say, never as a pass. An unnegotiable node (mid-capture daemon, pin mismatch) reads Unknown, never silence.
- New machine-report check ids `ir-stream-hello-minimum` / `rgb-stream-hello-minimum`.
- The backlight-compensation write moved from `RgbCamera::open` to `session()`: doctor must not mutate camera state, and every capture path goes through `session()`, so capture behaviour is unchanged (the write is idempotent and precedes the auto-exposure warm-up either way).

## Testing

- `hello_minimum_verdicts_cover_all_three_outcomes` pins the decision: at-floor passes, one short dimension fails regardless of rate, sub-floor rate fails, unreported rate with passing dims is indeterminate, unreported rate with failing dims is still a definite fail.
- Measured on all three machines with this build: Zenbook ASUS module IR 640x400@15fps GREY ✓ (exactly at the rate floor) and RGB 640x480@30fps YUYV ✓; archhost NexiGo N930W IR 640x360@30fps GREY ✓ (20 rows above the floor) and RGB 640x480@30fps ✓; ThinkPad RGB 640x480@30fps ✓ with no IR line printed, since it has no IR node.
- Full workspace clippy clean; irlume-camera, irlume-cli, irlume-pam suites green.

## Not tested

- A genuinely under-spec module (none on hand); the Warn branch is exercised only by the unit test.
- MJPEG-only or non-UVC nodes; `negotiated_stream` reuses the existing negotiation, which already refuses those with its existing message.