### PR TITLE
camera-tune: a concurrent arm that only errors is a Sequential verdict

### DIFF
--- a/crates/irlume-camera/examples/capture_bench.rs
+++ b/crates/irlume-camera/examples/capture_bench.rs
@@ -113,6 +113,18 @@ fn main() {
     // camera-tune` would make from the same measurement, run through the shared
     // implementation so the tool and the example cannot drift apart.
     match irlume_camera::measure_contention(&rgb_dev2, &ir_dev, rounds.min(6)) {
+        Ok(report) if report.concurrent_impossible() => {
+            // Same rule as the daemon: an arm that never streamed has no
+            // retention to print, and "keeps 0%" would read as dimming.
+            println!(
+                "\nRecommendation: {} capture for this camera\n  \
+             it cannot stream RGB and IR at once (all {} concurrent attempts \
+             errored; {} sequential round(s) completed)",
+                report.recommended_mode().as_str(),
+                report.concurrent.failed,
+                report.sequential.rounds,
+            );
+        }
         Ok(report) => {
             println!(
                 "\nRecommendation: {} capture for this camera\n  \

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -3013,37 +3013,62 @@ pub fn measure_contention_with_progress(
 ) -> irlume_common::Result<ContentionReport> {
     verify_pinned(rgb_dev)?;
     verify_pinned(ir_dev)?;
+    measure_contention_impl(
+        || capture_rgb_denoised(rgb_dev),
+        || capture_ir_with_stats(ir_dev),
+        rounds,
+        progress,
+    )
+}
+
+/// [`measure_contention_with_progress`] over injected captures, so the
+/// decisions below are testable without a camera (a panicking capture, an
+/// arm that always errors, a trailing control that fails).
+fn measure_contention_impl<R, I>(
+    rgb_cap: R,
+    ir_cap: I,
+    rounds: usize,
+    progress: &dyn Fn(),
+) -> irlume_common::Result<ContentionReport>
+where
+    R: Fn() -> irlume_common::Result<Frame>,
+    I: Fn() -> irlume_common::Result<(Frame, IrCaptureStats)> + Sync,
+{
     let rounds = rounds.max(1);
     let mut report = ContentionReport::default();
 
     for _ in 0..rounds {
         progress();
         let t0 = std::time::Instant::now();
-        let rgb = capture_rgb_denoised(rgb_dev);
-        let ir = capture_ir_with_stats(ir_dev);
+        let rgb = rgb_cap();
+        let ir = ir_cap();
         accumulate(&mut report.sequential, &rgb, &ir, t0.elapsed());
     }
     for _ in 0..rounds {
         progress();
         let t0 = std::time::Instant::now();
+        // A capture that returns Err is a measured failed round. A capture
+        // that PANICS is not a measurement of anything: counting it as a
+        // failed round would let a software defect that only trips off the
+        // main thread masquerade as "this camera cannot stream both nodes"
+        // and be persisted as durable policy, so a panic aborts the whole
+        // probe instead (#263 review).
         let (rgb, ir) = std::thread::scope(|s| {
-            let ir_t = s.spawn(|| capture_ir_with_stats(ir_dev));
-            let rgb = capture_rgb_denoised(rgb_dev);
-            (
-                rgb,
-                ir_t.join()
-                    .unwrap_or_else(|_| Err(Error::Hardware("IR probe thread panicked".into()))),
-            )
-        });
+            let ir_t = s.spawn(|| ir_cap());
+            let rgb = rgb_cap();
+            match ir_t.join() {
+                Ok(ir) => Ok((rgb, ir)),
+                Err(_) => Err(Error::Hardware(
+                    "capture-mode probe: the IR capture worker panicked; this is \
+                     a software defect, not a camera measurement"
+                        .into(),
+                )),
+            }
+        })?;
         accumulate(&mut report.concurrent, &rgb, &ir, t0.elapsed());
     }
     // Only a dead SEQUENTIAL arm is a failed probe: one capture at a time is
-    // the mode every camera must manage, so nothing was learned. A concurrent
-    // arm that never completes a round IS a measurement, and the strongest one
-    // this probe can make: the camera cannot stream both nodes at once, and
-    // the report's zero concurrent retention answers `recommended_mode` and
-    // `conclusive` with Sequential (#192; the BRIO fails every concurrent
-    // round with EINVAL on the RGB open while its IR sibling streams).
+    // the mode every camera must manage, so nothing was learned.
     if report.sequential.rounds == 0 {
         return Err(Error::Hardware(format!(
             "capture-mode probe: no sequential round completed on this camera \
@@ -3051,6 +3076,34 @@ pub fn measure_contention_with_progress(
              is failing, so nothing was measured",
             report.sequential.failed
         )));
+    }
+    // A concurrent arm that never completes a round IS a measurement, and the
+    // strongest one this probe can make — the camera cannot stream both nodes
+    // at once (#192; the BRIO fails every concurrent round with EINVAL on the
+    // RGB open while its IR sibling streams) — but only if the camera is
+    // still ANSWERING. The baseline ran before the concurrent phase, so on
+    // its own it cannot rule out a camera that was unplugged, reset, or
+    // stopped answering mid-probe; a trailing one-at-a-time control closes
+    // that window (#263 review). One extra capture pair, only in the
+    // all-error case.
+    if report.concurrent.rounds == 0 {
+        progress();
+        if let Err(e) = rgb_cap() {
+            return Err(Error::Hardware(format!(
+                "capture-mode probe: all {rounds} concurrent attempts errored, \
+                 and the trailing sequential RGB control then failed too ({e}); \
+                 the camera stopped answering, so nothing about concurrency was \
+                 measured"
+            )));
+        }
+        if let Err(e) = ir_cap() {
+            return Err(Error::Hardware(format!(
+                "capture-mode probe: all {rounds} concurrent attempts errored, \
+                 and the trailing sequential IR control then failed too ({e}); \
+                 the camera stopped answering, so nothing about concurrency was \
+                 measured"
+            )));
+        }
     }
     Ok(report)
 }
@@ -3663,6 +3716,99 @@ mod tests {
             concurrent: PairSample::default(),
         };
         assert!(!unattempted.concurrent_impossible());
+    }
+
+    fn stats(lit: f32) -> IrCaptureStats {
+        IrCaptureStats {
+            lit_mean: lit,
+            ambient_mean: 1.0,
+            burst_frames: 8,
+            camera_classified_frames: 0,
+            white_level: None,
+            saturation_frame: None,
+        }
+    }
+
+    #[test]
+    fn a_panicking_capture_aborts_the_probe_instead_of_becoming_a_verdict() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        // Sequential IR captures succeed; every concurrent one PANICS. Counting
+        // those as failed rounds would persist "this camera cannot stream both
+        // nodes" over a software defect (#263 review); the probe must abort.
+        let ir_calls = AtomicUsize::new(0);
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // keep the test log clean
+        let got = measure_contention_impl(
+            || Ok(frame(&[100; 4])),
+            || {
+                if ir_calls.fetch_add(1, Ordering::SeqCst) >= 2 {
+                    panic!("injected defect");
+                }
+                Ok((frame(&[10; 4]), stats(50.0)))
+            },
+            2,
+            &|| {},
+        );
+        std::panic::set_hook(prev);
+        let err = got.expect_err("a panic must abort the probe, never report");
+        assert!(err.to_string().contains("panicked"), "{err}");
+    }
+
+    #[test]
+    fn an_all_error_concurrent_arm_needs_the_trailing_control_to_pass() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        // The BRIO shape, injected: sequential rounds fine, every concurrent
+        // RGB open errors, and the trailing control finds the camera still
+        // answering — a real contention verdict.
+        let rgb_calls = AtomicUsize::new(0);
+        let report = measure_contention_impl(
+            || {
+                let n = rgb_calls.fetch_add(1, Ordering::SeqCst);
+                // Calls 0-1: sequential. 2-3: concurrent (error). 4: control.
+                if (2..4).contains(&n) {
+                    Err(Error::Hardware(
+                        "EINVAL while the IR sibling streams".into(),
+                    ))
+                } else {
+                    Ok(frame(&[100; 4]))
+                }
+            },
+            || Ok((frame(&[10; 4]), stats(50.0))),
+            2,
+            &|| {},
+        )
+        .expect("an answering camera with an impossible concurrent arm is a verdict");
+        assert!(report.concurrent_impossible());
+        assert_eq!(report.recommended_mode(), CaptureMode::Sequential);
+        assert_eq!(
+            rgb_calls.load(Ordering::SeqCst),
+            5,
+            "the trailing control must actually run"
+        );
+    }
+
+    #[test]
+    fn a_camera_that_stops_answering_fails_the_probe_not_the_verdict() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        // Sequential rounds fine, then the camera dies: every later capture
+        // errors, including the trailing control. That proves the camera
+        // stopped answering, not that concurrency fails, and must not persist
+        // a capability verdict (#263 review).
+        let rgb_calls = AtomicUsize::new(0);
+        let got = measure_contention_impl(
+            || {
+                if rgb_calls.fetch_add(1, Ordering::SeqCst) >= 2 {
+                    Err(Error::Hardware("ENODEV".into()))
+                } else {
+                    Ok(frame(&[100; 4]))
+                }
+            },
+            || Ok((frame(&[10; 4]), stats(50.0))),
+            2,
+            &|| {},
+        );
+        let err = got.expect_err("a dead camera is a failed probe");
+        assert!(err.to_string().contains("trailing"), "{err}");
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -3054,7 +3054,7 @@ where
         // and be persisted as durable policy, so a panic aborts the whole
         // probe instead (#263 review).
         let (rgb, ir) = std::thread::scope(|s| {
-            let ir_t = s.spawn(|| ir_cap());
+            let ir_t = s.spawn(&ir_cap);
             let rgb = rgb_cap();
             match ir_t.join() {
                 Ok(ir) => Ok((rgb, ir)),

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2850,6 +2850,12 @@ pub struct PairSample {
     pub ir_mean: f32,
     pub total_ms: f32,
     pub rounds: usize,
+    /// Attempted rounds in which a capture ERRORED rather than measured. A
+    /// completed round tells how much brightness survives; a failed one tells
+    /// that the arm cannot run at all, and on some hardware that is the whole
+    /// answer: the BRIO's RGB open returns EINVAL whenever its IR sibling is
+    /// streaming, so its concurrent arm fails every attempt (#192).
+    pub failed: usize,
 }
 
 /// What the probe measured about capturing both sensors at once.
@@ -2907,10 +2913,25 @@ impl ContentionReport {
     /// 122% and 126% across runs, which is not the camera gaining signal from
     /// contention; it is arithmetic on noise.
     pub fn conclusive(&self) -> bool {
+        // A concurrent arm that cannot run at all is definitive in any light:
+        // the failure is an errored open, not a brightness reading, so the
+        // dark-room caveat below does not apply to it.
+        if self.concurrent_impossible() {
+            return true;
+        }
         if self.retained_ir() < CONCURRENT_SIGNAL_FLOOR {
             return true;
         }
         self.sequential.rgb_mean >= CONCLUSIVE_SCENE_BRIGHTNESS
+    }
+
+    /// True when the concurrent arm never completed a round because its
+    /// captures ERRORED: this camera cannot stream both nodes at once, which
+    /// decides the mode by itself. Reported separately so callers do not
+    /// render the arm's empty samples as "retained 0% of brightness", which
+    /// reads as dimming when nothing streamed at all (#192).
+    pub fn concurrent_impossible(&self) -> bool {
+        self.concurrent.rounds == 0 && self.concurrent.failed > 0
     }
 
     /// Share of the sequential RGB brightness the concurrent path kept. 1.0 when
@@ -2927,6 +2948,13 @@ impl ContentionReport {
     /// The mode this camera should use. Pure, so the decision is testable
     /// without hardware.
     pub fn recommended_mode(&self) -> CaptureMode {
+        // Explicit rather than left to the retention arithmetic: with zero
+        // concurrent rounds the retained() guards happen to produce Sequential
+        // today, but "cannot run" deciding the mode must not depend on what a
+        // division does with empty samples.
+        if self.concurrent_impossible() {
+            return CaptureMode::Sequential;
+        }
         if self.retained_rgb() < CONCURRENT_SIGNAL_FLOOR
             || self.retained_ir() < CONCURRENT_SIGNAL_FLOOR
         {
@@ -3009,10 +3037,20 @@ pub fn measure_contention_with_progress(
         });
         accumulate(&mut report.concurrent, &rgb, &ir, t0.elapsed());
     }
-    if report.sequential.rounds == 0 || report.concurrent.rounds == 0 {
-        return Err(Error::Hardware(
-            "capture-mode probe: no round completed on this camera pair".into(),
-        ));
+    // Only a dead SEQUENTIAL arm is a failed probe: one capture at a time is
+    // the mode every camera must manage, so nothing was learned. A concurrent
+    // arm that never completes a round IS a measurement, and the strongest one
+    // this probe can make: the camera cannot stream both nodes at once, and
+    // the report's zero concurrent retention answers `recommended_mode` and
+    // `conclusive` with Sequential (#192; the BRIO fails every concurrent
+    // round with EINVAL on the RGB open while its IR sibling streams).
+    if report.sequential.rounds == 0 {
+        return Err(Error::Hardware(format!(
+            "capture-mode probe: no sequential round completed on this camera \
+             pair ({} of {rounds} attempts errored); even one-at-a-time capture \
+             is failing, so nothing was measured",
+            report.sequential.failed
+        )));
     }
     Ok(report)
 }
@@ -3037,6 +3075,7 @@ fn accumulate(
     elapsed: std::time::Duration,
 ) {
     let (Ok(rgb), Ok((_, ir_stats))) = (rgb, ir) else {
+        into.failed += 1;
         return;
     };
     let n = into.rounds as f32;
@@ -3527,12 +3566,14 @@ mod tests {
                 ir_mean: seq_ir,
                 total_ms: 3595.0,
                 rounds: 20,
+                failed: 0,
             },
             concurrent: PairSample {
                 rgb_mean: con_rgb,
                 ir_mean: con_ir,
                 total_ms: 2194.0,
                 rounds: 20,
+                failed: 0,
             },
         };
 
@@ -3586,6 +3627,42 @@ mod tests {
             CaptureMode::Sequential
         );
         assert!(ir_loss_in_the_dark.conclusive());
+    }
+
+    // The BRIO shape, measured 2026-08-04 on archhost: every concurrent
+    // attempt errors (RGB open returns EINVAL while the IR sibling streams),
+    // sequential rounds measure fine. An arm that cannot run is a definitive
+    // Sequential in any light, and must not read as a failed probe (#192).
+    #[test]
+    fn a_concurrent_arm_that_only_errors_decides_sequential_conclusively() {
+        let brio = ContentionReport {
+            sequential: PairSample {
+                rgb_mean: 16.0, // dark room; the verdict must not need light
+                ir_mean: 58.0,
+                total_ms: 2200.0,
+                rounds: 6,
+                failed: 0,
+            },
+            concurrent: PairSample {
+                rounds: 0,
+                failed: 6,
+                ..Default::default()
+            },
+        };
+        assert!(brio.concurrent_impossible());
+        assert_eq!(brio.recommended_mode(), CaptureMode::Sequential);
+        assert!(
+            brio.conclusive(),
+            "an errored arm is definitive in the dark"
+        );
+
+        // The guard discriminates: zero rounds with zero failures is the
+        // nothing-attempted shape, not the cannot-run shape.
+        let unattempted = ContentionReport {
+            sequential: brio.sequential,
+            concurrent: PairSample::default(),
+        };
+        assert!(!unattempted.concurrent_impossible());
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2113,12 +2113,19 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                             // at all" (#192, the BRIO's EINVAL on concurrent
                             // RGB open).
                             let mut msg = if report.concurrent_impossible() {
+                                // Observed counts, not the requested round
+                                // count: a sequential arm can complete fewer
+                                // rounds than were asked for, and "measured
+                                // fine" must not overstate its evidence.
                                 format!(
                                     "capture mode {} for this camera: it cannot stream RGB and IR \
-                                     at once (all {} concurrent attempts errored; {rounds} \
-                                     sequential rounds measured fine)",
+                                     at once (all {} concurrent attempts errored; {} sequential \
+                                     round(s) completed, {} errored; a trailing one-at-a-time \
+                                     control confirmed the camera still answers)",
                                     mode.as_str(),
                                     report.concurrent.failed,
+                                    report.sequential.rounds,
+                                    report.sequential.failed,
                                 )
                             } else {
                                 format!(

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2107,14 +2107,29 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                     let mode = report.recommended_mode();
                     match irlume_auth::store_capture_mode(&rgb_dev, mode) {
                         Ok(()) => {
-                            let mut msg = format!(
-                                "capture mode {} for this camera: concurrent capture keeps {:.0}% of RGB \
-                                 and {:.0}% of IR brightness and saves {:.0}ms ({rounds} rounds)",
-                                mode.as_str(),
-                                report.retained_rgb() * 100.0,
-                                report.retained_ir() * 100.0,
-                                report.saved_ms(),
-                            );
+                            // An arm that never streamed has no retention to
+                            // report; percentages from its empty samples would
+                            // read as dimming when the finding is "cannot run
+                            // at all" (#192, the BRIO's EINVAL on concurrent
+                            // RGB open).
+                            let mut msg = if report.concurrent_impossible() {
+                                format!(
+                                    "capture mode {} for this camera: it cannot stream RGB and IR \
+                                     at once (all {} concurrent attempts errored; {rounds} \
+                                     sequential rounds measured fine)",
+                                    mode.as_str(),
+                                    report.concurrent.failed,
+                                )
+                            } else {
+                                format!(
+                                    "capture mode {} for this camera: concurrent capture keeps {:.0}% of RGB \
+                                     and {:.0}% of IR brightness and saves {:.0}ms ({rounds} rounds)",
+                                    mode.as_str(),
+                                    report.retained_rgb() * 100.0,
+                                    report.retained_ir() * 100.0,
+                                    report.saved_ms(),
+                                )
+                            };
                             // Say so rather than letting a dark room read as a
                             // clean bill of health.
                             if !report.conclusive() {


### PR DESCRIPTION
Fixes the probe half of #192.

`measure_contention` required both arms to complete a round, so a camera whose concurrent captures always error reported "no round completed" and threw away the strongest evidence the probe can produce. Measured today on the BRIO (046d:085e) on archhost: sequential rounds measure fine (IR lit 58-62 by the camera's own strobe), while concurrent rounds fail with EINVAL on the RGB open while the IR sibling streams — the camera cannot stream both nodes at once, which is precisely the answer camera-tune exists to store.

## What changed

- `PairSample.failed` counts errored rounds.
- Only a dead sequential arm fails the probe now, with a message naming the failure counts. A concurrent arm with zero completed rounds returns a report.
- `concurrent_impossible()` decides Sequential explicitly (not via what division does with empty samples) and makes the verdict conclusive in any light: an errored open is not a brightness reading, so the dark-room caveat does not apply.
- The daemon renders the case as "cannot stream RGB and IR at once (all N concurrent attempts errored)" instead of "retained 0% of brightness", which read as dimming when nothing streamed.

## Testing

- New unit test pins the measured BRIO shape (dark room, zero concurrent rounds, all failed) to Sequential + conclusive, and distinguishes it from the nothing-attempted shape.
- Hardware: ran the fixed probe against the real BRIO pair on archhost. Before: "capture-mode probe: no round completed". After: sequential 3/3, concurrent 1 completed + 2 errored, verdict Sequential, conclusive — the mixed case lands correctly through the retention arithmetic when a round does sneak through.
- Existing contention tests updated for the new field; all 247 camera tests green.

## Not tested

- The daemon's message rendering on hardware (the daemon on archhost is inactive; the report fields it formats are the ones the hardware run produced).
- The remaining #192 question — the "IR is dark ... no active emitter" line on a camera whose emitter demonstrably strobes — is a separate defect in the dark-frame diagnosis (no inter-frame evidence) and gets its own issue.