### PR TITLE
auth: evaluate the completed consent take, not just the in-loop cadence

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -271,6 +271,33 @@ fn consent_gesture_enabled() -> bool {
     !irlume_common::config::read_kv("settings.conf", "polkit_gesture").is_some_and(|v| falsy(&v))
 }
 
+/// The consent verdict once the watch's stream has ended: what the in-loop
+/// cadence already found, or a gesture visible only on the COMPLETE take.
+///
+/// The in-loop check runs every `CHECK_EVERY` poses, so a take whose length is
+/// not a multiple of it ends with unevaluated trailing poses, and a gesture
+/// completing in exactly those frames was refused with whole-take evidence
+/// that passes every gate (measured 2026-08-04, #101: two 20-pose windows at
+/// pitch_range 0.077-0.085 against the 0.075 floor, last in-loop check at
+/// pose 18; one cost a real trial its release). A pure function rather than
+/// inline in `consent_watch`, because this boolean directly satisfies the
+/// consent gate for credential release and a test must be able to fail if the
+/// completed-take evaluation is removed.
+fn completed_consent_take_hit(
+    hit_in_loop: bool,
+    allow_nod: bool,
+    poses: &[irlume_liveness::PoseSample],
+    ears: &[irlume_liveness::EarSample],
+    closure_cal: Option<&irlume_liveness::ClosureCalibration>,
+) -> bool {
+    hit_in_loop
+        || (allow_nod && irlume_liveness::detect_nod(poses) == irlume_liveness::HeadGesture::Nod)
+        || closure_cal.is_some_and(|cal| {
+            irlume_liveness::detect_deliberate_closure(ears, cal)
+                == irlume_liveness::BlinkResult::Blinked
+        })
+}
+
 // The consent-gesture mode is defined in irlume_common::config so the PAM module
 // can name the SAME gesture it tells the user to perform; see `ConsentGesture`.
 use irlume_common::config::{consent_gesture_mode, ConsentGesture};
@@ -1558,13 +1585,8 @@ impl Engine {
         // a real trial its release. One evaluation of the COMPLETE series
         // closes the boundary at zero capture cost.
         let hit_in_loop = hit == Some(true);
-        let hit = hit_in_loop
-            || (allow_nod
-                && irlume_liveness::detect_nod(&poses) == irlume_liveness::HeadGesture::Nod)
-            || closure_cal.as_ref().is_some_and(|cal| {
-                irlume_liveness::detect_deliberate_closure(&ears, cal)
-                    == irlume_liveness::BlinkResult::Blinked
-            });
+        let hit =
+            completed_consent_take_hit(hit_in_loop, allow_nod, &poses, &ears, closure_cal.as_ref());
         if hit && !hit_in_loop {
             // Observable in the journal so a hardware replay can show THIS
             // path fired, not just that a trial released.
@@ -5167,5 +5189,66 @@ mod engine_tests {
         );
 
         teardown_sandbox(&dir);
+    }
+
+    /// A pose series shaped like the measured #101 boundary: flat until the
+    /// last in-loop check point, with the nod completing in the trailing
+    /// frames the cadence never evaluates.
+    fn boundary_poses() -> Vec<irlume_liveness::PoseSample> {
+        [0.5f32; 18]
+            .into_iter()
+            .chain([0.6, 0.4])
+            .enumerate()
+            .map(|(idx, pitch)| irlume_liveness::PoseSample {
+                idx,
+                pitch_frac: Some(pitch),
+                yaw_signed: Some(0.0),
+                bri: 60.0,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn completed_take_catches_a_nod_in_the_trailing_frames() {
+        let poses = boundary_poses();
+        // The premise first: the prefix the last in-loop check saw must NOT
+        // read as a nod, or this test is not about the boundary at all.
+        assert_ne!(
+            irlume_liveness::detect_nod(&poses[..18]),
+            irlume_liveness::HeadGesture::Nod,
+            "the 18-pose prefix must be flat"
+        );
+        // The full take carries the gesture, and the completed-take evaluation
+        // must find it even though no in-loop check fired.
+        assert!(completed_consent_take_hit(false, true, &poses, &[], None));
+        // Removing the completed-take evaluation reduces the decision to
+        // hit_in_loop, which is false here: that is the observation that
+        // fails if the fix is reverted.
+    }
+
+    #[test]
+    fn completed_take_respects_the_gesture_inputs() {
+        let poses = boundary_poses();
+        // With the nod disallowed and no closure calibration, the same series
+        // must NOT satisfy the gate: the final evaluation widens coverage of
+        // the take, never the set of accepted gestures.
+        assert!(!completed_consent_take_hit(false, false, &poses, &[], None));
+        // An in-loop hit stands on its own, whatever the series holds.
+        assert!(completed_consent_take_hit(true, false, &[], &[], None));
+    }
+
+    #[test]
+    fn completed_take_stays_quiet_on_a_still_series() {
+        // A flat take (today's still windows read pitch_range 0.012-0.029
+        // against the 0.075 floor) must not fire through the new path either.
+        let poses: Vec<_> = (0..20)
+            .map(|idx| irlume_liveness::PoseSample {
+                idx,
+                pitch_frac: Some(0.5 + (idx % 2) as f32 * 0.01),
+                yaw_signed: Some(0.0),
+                bri: 60.0,
+            })
+            .collect();
+        assert!(!completed_consent_take_hit(false, true, &poses, &[], None));
     }
 }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1549,6 +1549,32 @@ impl Engine {
         if let Some(e) = err {
             return Err(e);
         }
+        // The in-loop check runs every CHECK_EVERY poses, so a take whose
+        // length is not a multiple of it ends with unevaluated trailing poses,
+        // and a gesture completing in exactly those frames is refused with
+        // whole-take evidence that passes every gate. Measured 2026-08-04
+        // (#101): two 20-pose windows printed pitch_range 0.077-0.085 against
+        // the 0.075 floor after their last check ran at pose 18, and one cost
+        // a real trial its release. One evaluation of the COMPLETE series
+        // closes the boundary at zero capture cost.
+        let hit_in_loop = hit == Some(true);
+        let hit = hit_in_loop
+            || (allow_nod
+                && irlume_liveness::detect_nod(&poses) == irlume_liveness::HeadGesture::Nod)
+            || closure_cal.as_ref().is_some_and(|cal| {
+                irlume_liveness::detect_deliberate_closure(&ears, cal)
+                    == irlume_liveness::BlinkResult::Blinked
+            });
+        if hit && !hit_in_loop {
+            // Observable in the journal so a hardware replay can show THIS
+            // path fired, not just that a trial released.
+            irlume_common::dlog!(
+                "consent: gesture found on the completed take ({} poses; the \
+                 in-loop cadence had last checked at pose {})",
+                poses.len(),
+                (poses.len() / CHECK_EVERY) * CHECK_EVERY,
+            );
+        }
         // A gesture that never arrives is otherwise silent: the caller waits out
         // its deadline and denies, which reads the same whether the user did
         // nothing or nodded in a way the detector did not count. Say which.
@@ -1589,7 +1615,7 @@ impl Engine {
                 "consent: {} in {} frames; nod evidence: usable_pitch_frames={} (need {}) \
                  pitch_range={:.3} (need {:.3}) yaw_range={:.2} (max {:.2}) crossings={} (need {}) \
                  mean_step={:.4} (recorded for #101, gates nothing)",
-                if hit == Some(true) {
+                if hit {
                     "GESTURE ACCEPTED"
                 } else {
                     "no gesture"
@@ -1606,7 +1632,7 @@ impl Engine {
                 ev.mean_step,
             );
         }
-        Ok(hit == Some(true))
+        Ok(hit)
     }
 
     /// Apply whatever gate the purpose and the enrollment ask for on top of the


### PR DESCRIPTION
Part of #101 (the boundary defect found in today's measured session; the issue's larger residual, consent-without-intent, stays open).

consent_watch checks the accumulating pose series every CHECK_EVERY=6 poses, so a take whose length is not a multiple of six ends with unevaluated trailing poses. A gesture completing in exactly those frames is refused while the whole-take evidence passes every gate the log line prints. Measured on hardware today: two 20-pose windows read pitch_range 0.077-0.085 against the 0.075 floor after their last in-loop check ran at pose 18, and one cost a real trial its release (6 of 8 continuous-nod trials; the refused trial 8's post-match window is exactly this shape).

## What changed

One evaluation of the complete pose/EAR series after the stream ends, short-circuited when an in-loop check already accepted. Zero added capture cost. A journal line marks when the final evaluation is the one that decided, so a replay can prove this path fired rather than inferring it from a released trial.

## Trade stated plainly

The final check also evaluates still takes, so any take whose full-series evidence clears the gates now fires where the cadence previously masked it. That is the detector judging the take instead of a scheduling artifact, and today's still windows sat at pitch_range 0.012-0.029 against the 0.075 floor, nowhere near it. The gate's discrimination properties are unchanged; only the evaluation coverage is.

## Testing

- The decision itself (detect_nod / detect_deliberate_closure over a series) is unchanged and keeps its existing tests; irlume-auth suite green, clippy clean.
- The new path cannot be unit-driven without injecting the camera stream into consent_watch; validation is a live replay on the Zenbook: nod trials against the dev daemon, checking the journal for the completed-take marker and that still trials stay at zero accepts. Running next, results will be posted on the PR.