### PR TITLE
cli: calibrate-closure --measure-only, EAR readings without storing

### DIFF
--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1569,6 +1569,10 @@ ENROLLMENT & AUTH
   calibrate-closure [--rounds N] [--force]   teach the eye-closure gesture for app
                         prompts; captures N rounds (default 3) and stores the median
                         (sudo; the head nod is the default and needs no calibration)
+  calibrate-closure --measure-only [--rounds N] [--pose LABEL]
+                        print labelled EAR readings and their median WITHOUT
+                        replacing the stored calibration (sudo; for comparing
+                        states such as glasses on/off before re-calibrating)
 
 KEYRING / TPM
   keyring <arm|status|forget>     TPM-sealed secret so a login opens your wallet

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -15,6 +15,7 @@
 //!   irlume keyring <arm|status|forget>           TPM-sealed keyring/wallet unlock
 //!   irlume recovery <status|setup|restore|forget> template-key recovery passphrase
 //!   irlume calibrate-closure [--rounds N]        teach the eye-closure consent gesture
+//!   irlume calibrate-closure --measure-only      labelled EAR readings, nothing stored
 //!   irlume fingerprint <status|add|verify|reset|enable|disable> fprintd companion (face OR fingerprint)
 //!   irlume login <status|enable|disable|reconcile> wire face auth into PAM (+--with-polkit for apps)
 //!   irlume logs [-f] [debug on|off]              face-auth journal view + tracing switch
@@ -506,6 +507,21 @@ fn rounds_that_would_register(
     )
 }
 
+/// The `--pose` label for measure-only runs, refusing a swallowed value:
+/// `flag()` blindly returns the next argument, so `--pose --rounds 5` would
+/// label research data '--rounds' and a trailing `--pose` would silently read
+/// as unlabeled; both mislabel the measurement they exist to identify (#267
+/// review). `Err` means the flag was given without a usable label.
+fn measure_pose_label(args: &[String]) -> Result<&str, ()> {
+    match args.iter().position(|a| a == "--pose") {
+        None => Ok("unlabeled"),
+        Some(i) => match args.get(i + 1).map(String::as_str) {
+            Some(v) if !v.starts_with('-') => Ok(v),
+            _ => Err(()),
+        },
+    }
+}
+
 /// Median of a non-empty slice. Takes `&mut` because selecting the middle
 /// element needs an ordering, and EAR readings are floats (`total_cmp`, so a
 /// stray NaN sorts to one end rather than corrupting the comparison).
@@ -576,10 +592,13 @@ fn calibrate_closure(args: &[String]) -> std::process::ExitCode {
     // with. `--pose` names what the operator is holding; it is recorded in the
     // output only, since the daemon cannot know what the face is doing.
     if args.iter().any(|a| a == "--measure-only") {
-        let pose = flag(args, "--pose").unwrap_or("unlabeled");
+        let Ok(pose) = measure_pose_label(args) else {
+            eprintln!("[calibrate] --pose requires a label (e.g. --pose glasses-on-open)");
+            return std::process::ExitCode::from(2);
+        };
         println!(
             "[calibrate] measure-only: {rounds} capture(s), pose '{pose}', nothing stored.\n\
-             [calibrate] hold the pose now; first capture in ~3s, the rest back-to-back."
+             [calibrate] hold the pose now; each capture starts after a 3s pause."
         );
         let mut vals: Vec<f32> = Vec::new();
         for i in 1..=rounds {
@@ -601,10 +620,12 @@ fn calibrate_closure(args: &[String]) -> std::process::ExitCode {
             eprintln!("[calibrate] no reading succeeded; nothing to report");
             return std::process::ExitCode::FAILURE;
         }
-        vals.sort_by(|a, b| a.total_cmp(b));
+        // The SAME median the calibration path stores (median_ear averages the
+        // two middles of an even sample); a failed round makes the count even,
+        // and an upper-middle pick there is not a median (#267 review).
+        let median = median_ear(&mut vals);
         println!(
-            "[calibrate] pose '{pose}': median EAR {:.4} over {} reading(s) (range {:.4} to {:.4})",
-            vals[vals.len() / 2],
+            "[calibrate] pose '{pose}': median EAR {median:.4} over {} reading(s) (range {:.4} to {:.4})",
             vals.len(),
             vals[0],
             vals[vals.len() - 1]
@@ -4120,6 +4141,30 @@ mod tests {
 
     fn argv(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn measure_pose_label_refuses_swallowed_and_missing_values() {
+        // No flag at all: the honest default.
+        assert_eq!(
+            measure_pose_label(&argv(&["--measure-only"])),
+            Ok("unlabeled")
+        );
+        // A proper label passes through.
+        assert_eq!(
+            measure_pose_label(&argv(&["--measure-only", "--pose", "glasses-on-open"])),
+            Ok("glasses-on-open")
+        );
+        // `--pose --rounds 5` must not label the data '--rounds'.
+        assert_eq!(
+            measure_pose_label(&argv(&["--pose", "--rounds", "5"])),
+            Err(())
+        );
+        // A trailing `--pose` asked for a label and gave none.
+        assert_eq!(
+            measure_pose_label(&argv(&["--measure-only", "--pose"])),
+            Err(())
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -576,7 +576,7 @@ fn calibrate_closure(args: &[String]) -> std::process::ExitCode {
     // with. `--pose` names what the operator is holding; it is recorded in the
     // output only, since the daemon cannot know what the face is doing.
     if args.iter().any(|a| a == "--measure-only") {
-        let pose = flag(args, "--pose").unwrap_or_else(|| "unlabeled".into());
+        let pose = flag(args, "--pose").unwrap_or("unlabeled");
         println!(
             "[calibrate] measure-only: {rounds} capture(s), pose '{pose}', nothing stored.\n\
              [calibrate] hold the pose now; first capture in ~3s, the rest back-to-back."

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -569,6 +569,48 @@ fn calibrate_closure(args: &[String]) -> std::process::ExitCode {
             }
         },
     };
+    // --measure-only: capture and print EAR medians without storing anything.
+    // The #173 measurement mode: the stored calibration stays untouched, so a
+    // second state (glasses on, different seat, different light) can be
+    // measured side by side against the one the user actually authenticates
+    // with. `--pose` names what the operator is holding; it is recorded in the
+    // output only, since the daemon cannot know what the face is doing.
+    if args.iter().any(|a| a == "--measure-only") {
+        let pose = flag(args, "--pose").unwrap_or_else(|| "unlabeled".into());
+        println!(
+            "[calibrate] measure-only: {rounds} capture(s), pose '{pose}', nothing stored.\n\
+             [calibrate] hold the pose now; first capture in ~3s, the rest back-to-back."
+        );
+        let mut vals: Vec<f32> = Vec::new();
+        for i in 1..=rounds {
+            std::thread::sleep(std::time::Duration::from_secs(3));
+            match daemon_request(&Request::CaptureEarMedian { user: user.clone() }) {
+                Ok(Response::EarMedian(Some(v))) => {
+                    println!("    round {i}: EAR = {v:.4}");
+                    vals.push(v);
+                }
+                Ok(Response::EarMedian(None)) => {
+                    println!("    round {i}: no eye detected (face the camera)");
+                }
+                Ok(Response::Error(e)) => println!("    round {i}: {e}"),
+                Ok(other) => println!("    round {i}: unexpected response: {other:?}"),
+                Err(e) => println!("    round {i}: {e}"),
+            }
+        }
+        if vals.is_empty() {
+            eprintln!("[calibrate] no reading succeeded; nothing to report");
+            return std::process::ExitCode::FAILURE;
+        }
+        vals.sort_by(|a, b| a.total_cmp(b));
+        println!(
+            "[calibrate] pose '{pose}': median EAR {:.4} over {} reading(s) (range {:.4} to {:.4})",
+            vals[vals.len() / 2],
+            vals.len(),
+            vals[0],
+            vals[vals.len() - 1]
+        );
+        return std::process::ExitCode::SUCCESS;
+    }
     let interactive = std::io::stdin().is_terminal();
     // Ask BEFORE spending the user's time on captures, not after.
     let already_calibrated = matches!(


### PR DESCRIPTION
Part of #173 (the measurement mode; the multiple-calibrations design stays open).

The #173 question needed EAR distributions from several states (glasses on and off, eyes open and closed) compared against one stored calibration, and the only path that measured EAR also overwrote that calibration. `--measure-only` captures N `CaptureEarMedian` rounds through the daemon, prints each reading and the median under an operator-supplied `--pose` label, and stores nothing. The median goes through `median_ear`, the same even-sample-averaging median the calibration path stores, and `measure_pose_label` refuses a flag-shaped or missing label rather than titling research data '--rounds'.

## Testing

- Produced the measurement posted on #173: four states, five rounds each, Zenbook ASUS FHD IR module, 2026-08-04.
- One instrument fact from that session changes how the tool should be used: the operator has to look at the camera, not the terminal. Reading output mid-capture pointed the gaze down and read open eyes at EAR 0.07-0.16; the same eyes looking at the camera read 0.246-0.254. A self-paced run in the operator's own terminal avoids this; a remotely driven one invites it.
- `measure_pose_label` is pinned by a test over its four argument shapes (absent flag, proper label, `--pose --rounds`, trailing `--pose`). The median arithmetic keeps the existing `median_ear` test.

## Not tested

- Runs against an unreachable daemon: each round prints its own error and the summary counts what succeeded, but every real run had a live daemon behind it.