### PR TITLE
relief: what the banner shows about printed tone at 850nm, and what it does not

### DIFF
--- a/docs/pad-results/2026-08-04-landmark-relief.md
+++ b/docs/pad-results/2026-08-04-landmark-relief.md
@@ -123,16 +123,15 @@ by brightness alone on this hardware. This is an extrapolation from faces
 measured to 120 and is offered as a bound, not as evidence about saturated
 frames; saturation clips regions unevenly and is measured separately (#221).
 
-## The printed-shadow attack, measured on this instrument
+## The printed-shadow attack remains untested
 
 The cue reads brightness at the chin and cannot tell an emitter shadow from a
-printed one, so an attacker who darkens the chin region of the print should be
-able to raise the ratio without changing any geometry. That assumes a visibly
-dark print tone also reads dark at 850nm, which is a claim about ink rather
-than about geometry, and the corpus can test it: the banner carries printed
-tones whose real counterparts absorb infrared.
+printed one, so darkening the chin region of the source image should raise the
+ratio without changing the print's geometry.
 
-Each region as a fraction of its own class's forehead (medians):
+What the banner does show is how little contrast its current portrait retains
+at 850nm across the sampled regions. Each value is camera brightness divided by
+the forehead brightness in the same frame (medians):
 
 | region | real face | vinyl print |
 |---|---|---|
@@ -143,48 +142,43 @@ Each region as a fraction of its own class's forehead (medians):
 | socket_deep | 0.424 | 0.721 |
 | chin | 0.192 | 0.625 |
 
-Printed tone barely survives at 850nm on this medium. A real eyebrow reads
-0.728 of forehead because hair absorbs infrared; the printed eyebrow, strongly
-dark to the eye, reads 0.961. The print's entire tonal range compresses into
-0.625-1.137 where the face spans 0.192-1.000.
+A real eyebrow reads 0.728 of forehead; the printed eyebrow, strongly dark to
+the eye, reads 0.961. Across these regions the face spans 0.192 to 1.000 and
+the print 0.625 to 1.137.
 
-The attack arithmetic follows. Print medians are cheek 77.8 and chin 50.8, a
-ratio of 1.532. Reaching the lowest face value measured here, 2.580, needs the
-printed chin at 30.2, which is 0.363 of the print's forehead. The darkest tone
-this ink achieves anywhere on the banner is 0.625, and that is already the
-chin, so the source portrait carried some chin shading and still landed far
-short. **On this instrument the printed-shadow attack is not reachable**: the
-ink would have to absorb roughly 1.7 times more infrared than its whole visible
-tonal range delivers.
+The arithmetic of the attack, holding the measured cheek brightness fixed:
 
-What that does and does not settle. It is one ink set on one medium, and
-infrared absorption is a pigment property rather than a colour one: carbon
-black absorbs 850nm strongly, so laser toner or a carbon-pigment print could
-reach tones this dye set cannot, and the 2026-06-30 self-test already recorded
-matte paper and glossy vinyl behaving differently. It also says nothing about a
-physical occluder, a dark cloth or an infrared-absorbing patch held over the
-chin, which reproduces the same signal without printing anything. Both remain
-open.
+| quantity | value |
+|---|---|
+| print cheek median | 77.8 |
+| print chin median | 50.8 |
+| print cheek/chin | 1.532 |
+| lowest captured face cheek/chin | 2.580 |
+| required print chin | 30.2 |
+| required chin / print forehead | 0.363 |
 
-The strobe suggests a defence and this corpus cannot validate it. Sampling the
-same landmarks on the emitter-off frame gives the emitter-only contribution by
-subtraction; a geometric shadow exists only in the lit frame, while a printed
-one appears in both. Measured on 2026-08-04:
+**This does not rule the attack out, and an earlier revision of this page said
+it did.** The required 0.363 sits below every region sampled here, but these
+are six landmark regions of one portrait, not a tone scale: they differ at once
+in source-image tone, surface orientation, emitter incidence, coating response
+and viewing angle. The lowest of them is not the darkest tone the ink can
+print. Nor is camera brightness over a printed forehead a reflectance
+measurement; reflectance is defined against a reference under stated
+illumination and observation geometry, and no such reference is in frame, so no
+absorption figure can be derived from these numbers either.
 
-| class | chin lit | chin ambient | chin emitter-only | cheek/chin raw | cheek/chin emitter-only |
-|---|---|---|---|---|---|
-| face | 25.0 | 3.3 | 21.8 | 3.122 | 2.792 |
-| print | 44.6 | 0.0 | 44.6 | 1.358 | 1.358 |
-
-Ambient was near zero for both, so the differential barely moves either class
-and demonstrates only that the quantity is computable. Whether it defeats a
-printed shadow is untested and needs a print made to carry one.
+What would settle it: a controlled tone scale printed on the same medium, or
+simply the attack itself, a second print whose chin is filled with the darkest
+printable tone. Neither exists here. A physical occluder, dark cloth or an
+infrared-absorbing patch over the chin of an existing print, produces the same
+signal without printing anything and needs no new instrument at all.
 
 ## What would have to be true before a gate
 
-- **An infrared-absorbing chin**, whether printed with carbon-based ink or
-  physically occluded. This corpus shows the dye set on this banner cannot
-  reach it; it does not show that no medium can.
+- **A deliberately darkened or infrared-absorbing chin**, produced by printing
+  a second attack image or by physical occlusion, captured and refused. The
+  banner carries no controlled tone scale, so nothing here establishes the
+  minimum response its ink and medium can reach.
 - **More than one subject.** Facial relief is the quantity being measured, and
   jaw shape, beard, and chin prominence vary. One subject cannot establish a
   floor.

--- a/docs/pad-results/2026-08-04-landmark-relief.md
+++ b/docs/pad-results/2026-08-04-landmark-relief.md
@@ -123,13 +123,48 @@ by brightness alone on this hardware. This is an extrapolation from faces
 measured to 120 and is offered as a bound, not as evidence about saturated
 frames; saturation clips regions unevenly and is measured separately (#221).
 
-## The attack this corpus cannot rule out
+## The printed-shadow attack, measured on this instrument
 
-The cue reads brightness at the chin, and it cannot tell an emitter shadow from
-a printed one. An attacker who prints a source photograph shot with strong
-top-down lighting, or who simply darkens the chin region of the print, raises
-the ratio without changing the geometry. The banner used here is an evenly lit
-studio portrait, so nothing in this corpus tests that.
+The cue reads brightness at the chin and cannot tell an emitter shadow from a
+printed one, so an attacker who darkens the chin region of the print should be
+able to raise the ratio without changing any geometry. That assumes a visibly
+dark print tone also reads dark at 850nm, which is a claim about ink rather
+than about geometry, and the corpus can test it: the banner carries printed
+tones whose real counterparts absorb infrared.
+
+Each region as a fraction of its own class's forehead (medians):
+
+| region | real face | vinyl print |
+|---|---|---|
+| nose | 0.858 | 1.137 |
+| cheek | 0.645 | 0.974 |
+| brow (eyebrow) | 0.728 | 0.961 |
+| socket | 0.454 | 0.711 |
+| socket_deep | 0.424 | 0.721 |
+| chin | 0.192 | 0.625 |
+
+Printed tone barely survives at 850nm on this medium. A real eyebrow reads
+0.728 of forehead because hair absorbs infrared; the printed eyebrow, strongly
+dark to the eye, reads 0.961. The print's entire tonal range compresses into
+0.625-1.137 where the face spans 0.192-1.000.
+
+The attack arithmetic follows. Print medians are cheek 77.8 and chin 50.8, a
+ratio of 1.532. Reaching the lowest face value measured here, 2.580, needs the
+printed chin at 30.2, which is 0.363 of the print's forehead. The darkest tone
+this ink achieves anywhere on the banner is 0.625, and that is already the
+chin, so the source portrait carried some chin shading and still landed far
+short. **On this instrument the printed-shadow attack is not reachable**: the
+ink would have to absorb roughly 1.7 times more infrared than its whole visible
+tonal range delivers.
+
+What that does and does not settle. It is one ink set on one medium, and
+infrared absorption is a pigment property rather than a colour one: carbon
+black absorbs 850nm strongly, so laser toner or a carbon-pigment print could
+reach tones this dye set cannot, and the 2026-06-30 self-test already recorded
+matte paper and glossy vinyl behaving differently. It also says nothing about a
+physical occluder, a dark cloth or an infrared-absorbing patch held over the
+chin, which reproduces the same signal without printing anything. Both remain
+open.
 
 The strobe suggests a defence and this corpus cannot validate it. Sampling the
 same landmarks on the emitter-off frame gives the emitter-only contribution by
@@ -147,7 +182,9 @@ printed shadow is untested and needs a print made to carry one.
 
 ## What would have to be true before a gate
 
-- **A print with a darkened chin**, the cheap attack above, captured and refused.
+- **An infrared-absorbing chin**, whether printed with carbon-based ink or
+  physically occluded. This corpus shows the dye set on this banner cannot
+  reach it; it does not show that no medium can.
 - **More than one subject.** Facial relief is the quantity being measured, and
   jaw shape, beard, and chin prominence vary. One subject cannot establish a
   floor.

--- a/scripts/analyze-landmark-relief.py
+++ b/scripts/analyze-landmark-relief.py
@@ -89,28 +89,38 @@ def main(argv):
 
     print(f"corpus: {len(rows)} frames ({len(faces)} face, {len(prints_)} print)")
     print("\nexposure (face-region mean) by set")
-    for key in [("2026-08-02", FACE), ("2026-08-04", {"face_dim"}),
-                ("2026-08-02", None), ("2026-08-04", {"banner_curved"})]:
-        sess, conds = key
-        sel = [r for r in rows if r["session"] == sess and
-               ((r["condition"] in conds) if conds else r["condition"] not in FACE)]
+    corpus_rows = [
+        ("face, 2026-08-02", "2026-08-02", FACE - {"face_dim"}, "glasses, no glasses (two sittings)"),
+        ("face, 2026-08-04", "2026-08-04", {"face_dim"}, "room lit, subject dimmer than the print"),
+        ("vinyl banner, 2026-08-02", "2026-08-02", {"banner_flat", "banner_tilted", "banner_close"},
+         "flat, tilted (x2), held closer (x2)"),
+        ("vinyl banner, 2026-08-04", "2026-08-04", {"banner_curved"}, "hand-curved toward the camera"),
+    ]
+    corpus_table = ["| set | n | face-region mean | conditions |", "|---|---|---|---|"]
+    for label, sess, conds, note in corpus_rows:
+        sel = [r for r in rows if r["session"] == sess and r["condition"] in conds]
         lo, hi = rng([r["face_mean"] for r in sel])
-        label = f"{sess} {'face' if conds and 'face' in next(iter(conds)) else 'print'}"
-        print(f"  {label:20} n={len(sel):3}  {lo:.1f}-{hi:.1f}")
-        claims += [f"{lo:.1f}-{hi:.1f}"]
+        corpus_table.append(f"| {label} | {len(sel)} | {lo:.1f}-{hi:.1f} | {note} |")
+        print(f"  {label:26} n={len(sel):3}  {lo:.1f}-{hi:.1f}")
+    blocks.append(("corpus table", "\n".join(corpus_table)))
 
     print("\nratios: face vs print across both sessions")
+    ratio_table = [
+        f"| ratio | face ({len(faces)} frames) | print ({len(prints_)} frames) | verdict |",
+        "|---|---|---|---|",
+    ]
     for name, f in RATIOS.items():
         fa = [f(r) for r in faces]
         pr = [f(r) for r in prints_]
         flo, fhi = rng(fa)
         plo, phi = rng(pr)
         sep = flo - phi if flo > phi else (plo - fhi if plo > fhi else None)
-        verdict = f"separated by {sep:.3f}" if sep else "OVERLAP"
+        verdict = f"separated by {sep:.3f}" if sep else "overlaps"
+        ratio_table.append(
+            f"| {name.replace('/', ' / ')} | {flo:.3f}-{fhi:.3f} | {plo:.3f}-{phi:.3f} | {verdict} |"
+        )
         print(f"  {name:18} face {flo:.3f}-{fhi:.3f}  print {plo:.3f}-{phi:.3f}  {verdict}")
-        claims += [f"{flo:.3f}-{fhi:.3f}", f"{plo:.3f}-{phi:.3f}"]
-        if sep:
-            claims.append(f"{sep:.3f}")
+    blocks.append(("ratio table", "\n".join(ratio_table)))
 
     print("\nregion medians (the mechanism, before any ratio)")
     for label, sel in (("face", faces), ("print", prints_)):
@@ -156,19 +166,30 @@ def main(argv):
         print(f"  {label:16} face {f:.3f}  print {p_:.3f}")
     blocks.append(("ink reflectance table", "\n".join(ink_table)))
 
-    print("\nprinted-shadow attack arithmetic")
+    # Rendered as a block for the same reason the ink table is: the first
+    # version of this check kept the arithmetic as loose substrings, so
+    # editing the prose 0.625 to 0.425 passed (the table still carried 0.625),
+    # and the 1.7 multiplier was never checked at all because it was never
+    # added to `claims`. A figure that appears twice cannot be guarded by
+    # asking whether it appears once.
     pc = st.median([r["cheek"] for r in prints_])
     pch = st.median([r["chin"] for r in prints_])
     pfh = st.median([r["forehead"] for r in prints_])
     face_floor = min(RATIOS["cheek/chin"](r) for r in faces)
     need = pc / face_floor
-    ink_floor = min(st.median([x[r] / x["forehead"] for x in prints_])
-                    for r in ("nose", "cheek", "brow", "socket", "socket_deep", "chin"))
-    print(f"  print cheek {pc:.1f}, chin {pch:.1f}, ratio {pc / pch:.3f}; lowest face ratio {face_floor:.3f}")
-    print(f"  chin must fall to {need:.1f} = {need / pfh:.3f} of forehead; ink floor {ink_floor:.3f} "
-          f"-> {'reachable' if need / pfh >= ink_floor else 'NOT reachable'}")
-    claims += [f"{pc:.1f}", f"{pch:.1f}", f"{pc / pch:.3f}", f"{face_floor:.3f}",
-               f"{need:.1f}", f"{need / pfh:.3f}", f"{ink_floor:.3f}"]
+    arith = [
+        "| quantity | value |",
+        "|---|---|",
+        f"| print cheek median | {pc:.1f} |",
+        f"| print chin median | {pch:.1f} |",
+        f"| print cheek/chin | {pc / pch:.3f} |",
+        f"| lowest captured face cheek/chin | {face_floor:.3f} |",
+        f"| required print chin | {need:.1f} |",
+        f"| required chin / print forehead | {need / pfh:.3f} |",
+    ]
+    print("\nprinted-shadow arithmetic")
+    print("\n".join("  " + r for r in arith))
+    blocks.append(("printed-shadow arithmetic table", "\n".join(arith)))
 
     print("\nexposure correlation within class (why the socket ratios fail)")
     for name in ("brow/socket_deep", "nose/socket"):

--- a/scripts/analyze-landmark-relief.py
+++ b/scripts/analyze-landmark-relief.py
@@ -85,6 +85,7 @@ def main(argv):
     faces = [r for r in rows if r["condition"] in FACE]
     prints_ = [r for r in rows if r["condition"] not in FACE]
     claims = []
+    blocks = []
 
     print(f"corpus: {len(rows)} frames ({len(faces)} face, {len(prints_)} print)")
     print("\nexposure (face-region mean) by set")
@@ -141,11 +142,19 @@ def main(argv):
         claims += [f"{a:.3f}", f"{b:+.4f}", f"{cross:.0f}"]
 
     print("\nink at 850nm: each region as a fraction of its own class's forehead")
-    for label, sel in (("face", faces), ("print", prints_)):
-        fracs = {r: st.median([x[r] / x["forehead"] for x in sel])
-                 for r in ("nose", "cheek", "brow", "socket", "socket_deep", "chin")}
-        print(f"  {label:6} " + "  ".join(f"{k} {v:.3f}" for k, v in fracs.items()))
-        claims += [f"{v:.3f}" for v in fracs.values()]
+    # Rendered verbatim and matched as a BLOCK, not as loose values: a figure
+    # that also appears in the surrounding prose would otherwise mask an edit
+    # to the table cell, which is how the first version of this check passed a
+    # tampered table.
+    ink_rows = {"nose": "nose", "cheek": "cheek", "brow": "brow (eyebrow)",
+                "socket": "socket", "socket_deep": "socket_deep", "chin": "chin"}
+    ink_table = ["| region | real face | vinyl print |", "|---|---|---|"]
+    for key, label in ink_rows.items():
+        f = st.median([x[key] / x["forehead"] for x in faces])
+        p_ = st.median([x[key] / x["forehead"] for x in prints_])
+        ink_table.append(f"| {label} | {f:.3f} | {p_:.3f} |")
+        print(f"  {label:16} face {f:.3f}  print {p_:.3f}")
+    blocks.append(("ink reflectance table", "\n".join(ink_table)))
 
     print("\nprinted-shadow attack arithmetic")
     pc = st.median([r["cheek"] for r in prints_])
@@ -171,12 +180,18 @@ def main(argv):
     if "--check" in argv:
         report = open(argv[argv.index("--check") + 1]).read()
         missing = [c for c in claims if c not in report]
-        if missing:
-            print(f"\nCHECK FAILED: {len(missing)} computed value(s) absent from the report:")
+        bad_blocks = [name for name, text in blocks if text not in report]
+        if missing or bad_blocks:
+            print("\nCHECK FAILED")
             for m in sorted(set(missing)):
-                print(f"  {m}")
+                print(f"  value absent from the report: {m}")
+            for name, text in blocks:
+                if text in report:
+                    continue
+                print(f"  {name} does not match the data; expected:\n{text}")
             return 1
-        print(f"\nCHECK OK: all {len(set(claims))} distinct computed values appear in the report")
+        print(f"\nCHECK OK: {len(set(claims))} distinct values and {len(blocks)} "
+              f"rendered block(s) match the report")
     return 0
 
 

--- a/scripts/analyze-landmark-relief.py
+++ b/scripts/analyze-landmark-relief.py
@@ -140,6 +140,27 @@ def main(argv):
               f"{ceiling:.3f} reached at exposure {cross:.0f}")
         claims += [f"{a:.3f}", f"{b:+.4f}", f"{cross:.0f}"]
 
+    print("\nink at 850nm: each region as a fraction of its own class's forehead")
+    for label, sel in (("face", faces), ("print", prints_)):
+        fracs = {r: st.median([x[r] / x["forehead"] for x in sel])
+                 for r in ("nose", "cheek", "brow", "socket", "socket_deep", "chin")}
+        print(f"  {label:6} " + "  ".join(f"{k} {v:.3f}" for k, v in fracs.items()))
+        claims += [f"{v:.3f}" for v in fracs.values()]
+
+    print("\nprinted-shadow attack arithmetic")
+    pc = st.median([r["cheek"] for r in prints_])
+    pch = st.median([r["chin"] for r in prints_])
+    pfh = st.median([r["forehead"] for r in prints_])
+    face_floor = min(RATIOS["cheek/chin"](r) for r in faces)
+    need = pc / face_floor
+    ink_floor = min(st.median([x[r] / x["forehead"] for x in prints_])
+                    for r in ("nose", "cheek", "brow", "socket", "socket_deep", "chin"))
+    print(f"  print cheek {pc:.1f}, chin {pch:.1f}, ratio {pc / pch:.3f}; lowest face ratio {face_floor:.3f}")
+    print(f"  chin must fall to {need:.1f} = {need / pfh:.3f} of forehead; ink floor {ink_floor:.3f} "
+          f"-> {'reachable' if need / pfh >= ink_floor else 'NOT reachable'}")
+    claims += [f"{pc:.1f}", f"{pch:.1f}", f"{pc / pch:.3f}", f"{face_floor:.3f}",
+               f"{need:.1f}", f"{need / pfh:.3f}", f"{ink_floor:.3f}"]
+
     print("\nexposure correlation within class (why the socket ratios fail)")
     for name in ("brow/socket_deep", "nose/socket"):
         f = RATIOS[name]


### PR DESCRIPTION
Follow-up to #270 on #25. The darkened-chin attack that report called untested needs a second print, and the only instrument available is the original vinyl banner. This measures what the existing corpus can say about it, and after the review round, is explicit that the answer is not "the attack fails".

## Measured

Each region as camera brightness over the forehead brightness in the same frame (medians):

| region | real face | vinyl print |
|---|---|---|
| brow (eyebrow) | 0.728 | 0.961 |
| socket_deep | 0.424 | 0.721 |
| chin | 0.192 | 0.625 |

A real eyebrow reads 0.728 of forehead because hair absorbs 850nm; the printed eyebrow, strongly dark to the eye, reads 0.961. Across the sampled regions the face spans 0.192-1.000 and this print 0.625-1.137.

Defeating cheek/chin needs a printed chin at 0.363 of forehead, below every region sampled here.

## What that does not establish

An earlier revision of this PR concluded the attack was "not reachable on this instrument". That was wrong and is withdrawn. The six values are landmark regions of one portrait, differing simultaneously in source tone, surface orientation, emitter incidence, coating response and viewing angle, so the lowest of them is not the darkest tone the ink can print. Camera brightness over a printed forehead is also not a reflectance measurement, since reflectance is defined against a reference under stated geometry and none is in frame, so no absorption multiple follows from these numbers either.

The report now says what was measured, records that the earlier revision overclaimed, and keeps the requirement as a real test: a deliberately darkened or infrared-absorbing chin, printed or physically occluded, captured and refused. The occluder variant needs no new instrument.

## Testing

Every table in the report is now rendered from the committed corpus and matched verbatim, after the round found the guard incomplete: protecting the ink table had left the prose arithmetic as loose substrings, so editing 0.625 there passed because the table still carried it, and the 1.7 multiplier was never checked because it was never claimed.

Verified by mutating all 30 numeric table rows individually, each caught, plus the four prose figures the round named. My earlier tamper proof tested a single case and generalised; this one does not.