### PR TITLE
relief: the occluder that beats every native cue does not move flir

### DIFF
--- a/docs/pad-results/2026-08-04-flir-vs-occluder.jsonl
+++ b/docs/pad-results/2026-08-04-flir-vs-occluder.jsonl
@@ -1,0 +1,6 @@
+{"ce": 1.06, "clip": 0.0, "native": "Live", "p_fake": 0.988}
+{"ce": 1.06, "clip": 0.0, "native": "Live", "p_fake": 1.0}
+{"ce": 1.32, "clip": 0.0, "native": "Live", "p_fake": 0.999}
+{"ce": 1.42, "clip": 0.0, "native": "Live", "p_fake": 0.999}
+{"ce": 1.44, "clip": 0.0, "native": "Live", "p_fake": 0.998}
+{"ce": 1.33, "clip": 0.0, "native": "Live", "p_fake": 0.999}

--- a/docs/pad-results/2026-08-04-occluder.md
+++ b/docs/pad-results/2026-08-04-occluder.md
@@ -100,6 +100,30 @@ experiment that would settle it, and it has not been run.
 against a face minimum of 3.910, so no occluded frame entered its band. That is
 one material at one placement and is not a margin to build on.
 
+## The trained cue is unaffected by the occluder
+
+The measurements above were taken with the third-party PAD model disabled, so
+they describe the native gate alone. Enabling it and repeating both
+presentations through the daemon's real authentication path
+(`2026-08-04-flir-vs-occluder.jsonl`, six runs, all with 0.0% clipping):
+
+| presentation | native verdict | centre/edge | flir p_fake |
+|---|---|---|---|
+| bare print | Live | 1.06, 1.06 | 0.988, 1.000 |
+| print + cotton over the chin | Live | 1.32, 1.42, 1.44, 1.33 | 0.999, 0.999, 0.998, 0.999 |
+
+The occluder does what the earlier sections describe: it carries the native
+centre/edge cue from 1.06 into 1.32-1.44, inside the genuine population of the
+[2026-08-02 corpus](2026-08-02-center-edge-corpus.jsonl) (1.26-1.49), and the
+native gate returns Live on every one. The trained cue is unmoved, denying at
+0.998-0.999 against the bare print's 0.988-1.000.
+
+So the enhancement that defeats every algorithmic cue measured here leaves the
+opt-in model's margin intact. Two limits on reading that as a general result:
+every frame above was unclipped, and the model's known failure mode is exactly
+clipping, where p_fake was measured falling to 0.749 at 24.8% of the face at the
+ceiling (#237); and this is one model, one print instrument and one subject.
+
 ## What this leaves
 
 - The relief cue still separates an **unmodified** print by a wide margin, and


### PR DESCRIPTION
Follow-up measurement prompted by a design question: if the trained model is the only thing that stops this print, is it the better bet than an algorithmic cue?

All the occluder work merged in #272 was measured with the third-party model **disabled**, so it described the native gate alone. This repeats both presentations through the daemon's real authentication path with it enabled.

| presentation | native verdict | centre/edge | flir p_fake |
|---|---|---|---|
| bare print | Live | 1.06, 1.06 | 0.988, 1.000 |
| print + cotton over the chin | Live | 1.32, 1.42, 1.44, 1.33 | 0.999, 0.999, 0.998, 0.999 |

The occluder behaves as #272 documents: it carries the native cue from 1.06 into 1.32-1.44, inside the committed genuine population (1.26-1.49), and the native gate returns Live every time. The trained cue does not move.

That is the enhancement which defeats the shipped centre/edge cue and a floor-style implementation of the relief cue, and it leaves the model's margin intact.

## Scope

Every frame was unclipped (0.0%), and clipping is precisely this model's known failure mode: #237 measured p_fake falling to 0.749 at 24.8% of the face at the sensor ceiling, which auto-exposure can produce unaided after a daemon restart at close range. One model, one print instrument, one subject.

## Testing

Six runs recorded per-run in `2026-08-04-flir-vs-occluder.jsonl` with the native verdict, centre/edge ratio, clipped fraction and p_fake. The occluder report's existing checker still passes.