### PR TITLE
setup: offer the anti-spoof model as a recommended step

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,12 +286,16 @@ The current gaps:
   brightness ratio on a 2D infrared sensor, and a life-size print held at an
   angle produces the same falloff a face does (1.02 to 1.58 over those 70
   presentations, against 1.26 to 1.49 for the live user), so no threshold
-  accepts the user and rejects the print. `sudo irlume models enable flir` adds
-  a trained, deny-only cue that flagged all 6 presentations of the same print
-  that reached it, at p_fake 0.941 to 1.000; that evidence covers one subject
-  and one print instrument. It is opt-in because its publisher documents
-  neither the training data nor a way to reproduce the model, which fails
-  [ADR-0001](docs/adr/0001-liveness-pad-strategy.md). Passive blink liveness also
+  accepts the user and rejects the print. **`irlume setup` offers a trained,
+  deny-only cue (`flir`) for this, and recommends it**: it refused the same
+  print at p_fake 0.941 to 1.000, and still refused at 0.998 to 0.999 when the
+  print was enhanced with an infrared-absorbing patch that carries the built-in
+  ratio into the genuine range. That evidence covers one subject and one print
+  instrument. irlume does not ship or warrant those weights, because their
+  publisher documents neither the training data nor a way to reproduce the
+  model, which fails [ADR-0001](docs/adr/0001-liveness-pad-strategy.md); setup
+  shows the license and provenance before fetching anything, and
+  `sudo irlume models enable flir` does the same later. Passive blink liveness also
   **doesn't cover glasses-wearers** (IR lens reflections hide the eyelid). Every
   miss falls **safely to the password**. See
   [ADR-0002](docs/adr/0002-challenge-response-liveness.md) and the

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The current gaps:
   deny-only cue (`flir`) for this, and recommends it**: it refused the same
   print at p_fake 0.941 to 1.000, and still refused at 0.998 to 0.999 when the
   print was enhanced with an infrared-absorbing patch that carries the built-in
-  ratio into the genuine range. That evidence covers one subject and one print
+  ratio from 1.06 to 1.32-1.44 while the built-in gate still says `Live`. That evidence covers one subject and one print
   instrument. irlume does not ship or warrant those weights, because their
   publisher documents neither the training data nor a way to reproduce the
   model, which fails [ADR-0001](docs/adr/0001-liveness-pad-strategy.md); setup

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1406,7 +1406,7 @@ pub fn setup(args: &[String]) -> ExitCode {
     println!("=== irlume setup for '{user}' ===\n");
 
     // 1. Preflight.
-    println!("[1/6] Preflight");
+    println!("[1/7] Preflight");
     if !daemon_up() {
         eprintln!("  daemon not reachable; start it first: sudo systemctl enable --now irlumed");
         return ExitCode::FAILURE;
@@ -1417,7 +1417,7 @@ pub fn setup(args: &[String]) -> ExitCode {
     println!("  cameras: rgb={rgb} ir={ir}");
 
     // 2. Enroll (reset if already enrolled and the user wants a clean start).
-    println!("\n[2/6] Face enrollment");
+    println!("\n[2/7] Face enrollment");
     let enrolled = matches!(
         daemon_request(&Request::ListProfiles {
             user: user.clone(),
@@ -1436,8 +1436,46 @@ pub fn setup(args: &[String]) -> ExitCode {
         run_enroll(&user, false);
     }
 
-    // 3. Keyring arm.
-    println!("\n[3/6] Keyring unlock (face login opens your wallet)");
+    // 3. The print defence, offered here because the user has just enrolled the
+    // face a printed photograph of it can currently impersonate. Default yes:
+    // on the measurements this is the only cue that has ever refused that
+    // attack, so the user should have to decline it rather than discover it.
+    // The license and provenance are shown either way; irlume does not warrant
+    // these weights and says so before fetching them (ADR-0001).
+    println!("\n[3/7] Anti-spoof model (recommended)");
+    match pad_model_offer() {
+        PadOffer::AlreadyEnabled(name) => println!("  '{name}' already enabled {OK}"),
+        PadOffer::NoCatalog => println!("  no third-party model in the catalog; skipping"),
+        PadOffer::Offer(m) => {
+            println!("  A printed photograph of your face passes irlume's built-in liveness");
+            println!(
+                "  gate. The '{}' model denied that attack in every measured attempt",
+                m.name
+            );
+            println!("  (docs/pad-results/); it is deny-only and can never approve a face");
+            println!("  the built-in gate rejected.");
+            println!();
+            println!("  license:    {}", m.license);
+            println!("  provenance: {}", m.provenance);
+            println!("  irlume does not distribute these weights; they download from the");
+            println!("  publisher's origin and complying with the license is on you.");
+            println!();
+            if !crate::is_root() {
+                println!(
+                    "  needs root to install; run: sudo irlume models enable {}",
+                    m.name
+                );
+            } else if yes_no("  Download and enable it?", /* default_yes: */ true) {
+                crate::models::fetch_and_enable(m);
+            } else {
+                println!("  skipped; a printed photo will pass the built-in gate.");
+                println!("  enable later with: sudo irlume models enable {}", m.name);
+            }
+        }
+    }
+
+    // 4. Keyring arm.
+    println!("\n[4/7] Keyring unlock (face login opens your wallet)");
     if yes_no(
         "  Arm keyring unlock now (you'll enter your login password)?",
         /* default_yes: */ true,
@@ -1463,7 +1501,7 @@ pub fn setup(args: &[String]) -> ExitCode {
     }
 
     // 4. Recovery passphrase + template encryption.
-    println!("\n[4/6] Recovery passphrase (encrypts templates; backstop for TPM/firmware changes)");
+    println!("\n[5/7] Recovery passphrase (encrypts templates; backstop for TPM/firmware changes)");
     if yes_no(
         "  Set a recovery passphrase now?",
         /* default_yes: */ true,
@@ -1472,7 +1510,7 @@ pub fn setup(args: &[String]) -> ExitCode {
     }
 
     // 5. Fingerprint.
-    println!("\n[5/6] Fingerprint (optional companion factor)");
+    println!("\n[6/7] Fingerprint (optional companion factor)");
     match irlume_fingerprint::device_name() {
         Some(n) => {
             println!("  reader '{n}' present; manage with `irlume fingerprint add` / `enable`")
@@ -1481,7 +1519,7 @@ pub fn setup(args: &[String]) -> ExitCode {
     }
 
     // 6. Login wiring.
-    println!("\n[6/6] PAM login wiring");
+    println!("\n[7/7] PAM login wiring");
     println!("  preview the changes with `irlume login enable` (dry-run), then apply with");
     println!("  `sudo irlume login enable --apply` to wire greeters + lock screen.");
     println!("  once wired: at the greeter/lock, leave the password empty and press Enter");
@@ -1520,6 +1558,29 @@ fn run_enroll(user: &str, reset: bool) {
 }
 
 /// Minimal y/N prompt (default applied on empty input or a non-tty).
+/// What `setup` should do about the third-party PAD cue on this machine.
+///
+/// A value rather than a branch so the decision is testable: setup itself
+/// needs root, a daemon and a camera, and this is the part with cases.
+enum PadOffer {
+    /// One is already enabled; say so and change nothing.
+    AlreadyEnabled(String),
+    /// The catalog is empty, so there is nothing to offer.
+    NoCatalog,
+    /// Offer this model.
+    Offer(&'static irlume_common::thirdparty::ThirdPartyModel),
+}
+
+fn pad_model_offer() -> PadOffer {
+    if let Some(name) = crate::models::enabled_name() {
+        return PadOffer::AlreadyEnabled(name);
+    }
+    match irlume_common::thirdparty::CATALOG.first() {
+        Some(m) => PadOffer::Offer(m),
+        None => PadOffer::NoCatalog,
+    }
+}
+
 fn yes_no(q: &str, default_yes: bool) -> bool {
     use std::io::{IsTerminal, Write};
     // No terminal takes the documented default. That is deliberate and covered
@@ -1875,5 +1936,32 @@ mod origin_tests {
             !src.contains(&pacman_u),
             "no pacman local-file install of a downloaded asset"
         );
+    }
+}
+
+#[cfg(test)]
+mod setup_offer_tests {
+    use super::{pad_model_offer, PadOffer};
+
+    #[test]
+    fn the_setup_offer_names_a_catalog_model_when_none_is_enabled() {
+        // The step offers CATALOG.first(); an empty catalog would make it dead
+        // code that prints a heading and does nothing.
+        assert!(
+            !irlume_common::thirdparty::CATALOG.is_empty(),
+            "setup offers CATALOG.first(); an empty catalog makes the step dead"
+        );
+        let m = irlume_common::thirdparty::CATALOG.first().unwrap();
+        // Everything the step prints before asking for consent must exist, or
+        // the user is asked to accept a license and provenance never shown.
+        assert!(!m.name.is_empty());
+        assert!(!m.license.is_empty(), "the offer prints the license");
+        assert!(!m.provenance.is_empty(), "the offer prints the provenance");
+        match pad_model_offer() {
+            PadOffer::Offer(o) => assert_eq!(o.name, m.name),
+            // A machine with one already enabled correctly steps aside.
+            PadOffer::AlreadyEnabled(_) => {}
+            PadOffer::NoCatalog => panic!("catalog is non-empty but the offer said otherwise"),
+        }
     }
 }

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1446,6 +1446,11 @@ pub fn setup(args: &[String]) -> ExitCode {
     match pad_model_offer() {
         PadOffer::AlreadyEnabled(name) => println!("  '{name}' already enabled {OK}"),
         PadOffer::NoCatalog => println!("  no third-party model in the catalog; skipping"),
+        PadOffer::ConfiguredButBroken(name, why) => {
+            println!("  '{name}' is configured but the daemon will not load it ({why}),");
+            println!("  so this machine has NO trained print defence right now.");
+            println!("  repair with: sudo irlume models enable {name}");
+        }
         PadOffer::Offer(m) => {
             println!("  A printed photograph of your face passes irlume's built-in liveness");
             println!(
@@ -1465,8 +1470,17 @@ pub fn setup(args: &[String]) -> ExitCode {
                     "  needs root to install; run: sudo irlume models enable {}",
                     m.name
                 );
+            } else if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+                // `yes_no` returns its default WITHOUT asking when stdin is not
+                // a terminal, so a default-yes question would fetch third-party
+                // weights under `setup </dev/null` with nobody having seen it.
+                // A default may only apply to someone who was actually asked.
+                println!("  not downloading without an interactive confirmation.");
+                println!("  enable later with: sudo irlume models enable {}", m.name);
             } else if yes_no("  Download and enable it?", /* default_yes: */ true) {
-                crate::models::fetch_and_enable(m);
+                if crate::models::fetch_and_enable(m) != ExitCode::SUCCESS {
+                    println!("  the model was NOT enabled; a printed photo will pass the gate.");
+                }
             } else {
                 println!("  skipped; a printed photo will pass the built-in gate.");
                 println!("  enable later with: sudo irlume models enable {}", m.name);
@@ -1567,13 +1581,31 @@ enum PadOffer {
     AlreadyEnabled(String),
     /// The catalog is empty, so there is nothing to offer.
     NoCatalog,
+    /// `settings.conf` names a model the daemon will NOT load, so the machine
+    /// has no cue despite appearing configured. Carries the reason.
+    ConfiguredButBroken(String, String),
     /// Offer this model.
     Offer(&'static irlume_common::thirdparty::ThirdPartyModel),
 }
 
 fn pad_model_offer() -> PadOffer {
+    // A configured NAME is not an enabled CUE. The daemon refuses an unknown
+    // catalog name, missing weights, and weights whose sha256 stopped
+    // matching, and in each case authentication runs without the cue.
+    // Reporting the config key as "already enabled" would tell a user they
+    // have a print defence they do not have, which is worse than knowing they
+    // have none (#274 review). Re-check what the daemon checks.
     if let Some(name) = crate::models::enabled_name() {
-        return PadOffer::AlreadyEnabled(name);
+        let Some(m) = irlume_common::thirdparty::by_name(&name) else {
+            return PadOffer::ConfiguredButBroken(name, "not in the catalog".into());
+        };
+        return match std::fs::read(irlume_common::thirdparty::model_path(m)) {
+            Err(e) => PadOffer::ConfiguredButBroken(name, format!("weights unreadable: {e}")),
+            Ok(b) if irlume_common::thirdparty::sha256_hex(&b) != m.sha256 => {
+                PadOffer::ConfiguredButBroken(name, "checksum mismatch".into())
+            }
+            Ok(_) => PadOffer::AlreadyEnabled(name),
+        };
     }
     match irlume_common::thirdparty::CATALOG.first() {
         Some(m) => PadOffer::Offer(m),
@@ -1944,24 +1976,65 @@ mod setup_offer_tests {
     use super::{pad_model_offer, PadOffer};
 
     #[test]
-    fn the_setup_offer_names_a_catalog_model_when_none_is_enabled() {
-        // The step offers CATALOG.first(); an empty catalog would make it dead
-        // code that prints a heading and does nothing.
+    fn the_offer_never_claims_a_defence_the_daemon_would_not_load() {
+        // Deterministic regardless of this machine's settings.conf: the
+        // catalog must be non-empty (setup offers CATALOG.first(), so an empty
+        // one makes the step dead code), and whatever the ambient state, the
+        // INVARIANT must hold: AlreadyEnabled may only be reported when the
+        // weights really are present and match their pin, because the daemon
+        // silently runs without the cue otherwise (#274 review).
         assert!(
             !irlume_common::thirdparty::CATALOG.is_empty(),
             "setup offers CATALOG.first(); an empty catalog makes the step dead"
         );
-        let m = irlume_common::thirdparty::CATALOG.first().unwrap();
+        let first = irlume_common::thirdparty::CATALOG.first().unwrap();
         // Everything the step prints before asking for consent must exist, or
-        // the user is asked to accept a license and provenance never shown.
-        assert!(!m.name.is_empty());
-        assert!(!m.license.is_empty(), "the offer prints the license");
-        assert!(!m.provenance.is_empty(), "the offer prints the provenance");
+        // the user accepts a license and provenance the screen never showed.
+        assert!(!first.name.is_empty());
+        assert!(!first.license.is_empty(), "the offer prints the license");
+        assert!(
+            !first.provenance.is_empty(),
+            "the offer prints the provenance"
+        );
+
         match pad_model_offer() {
-            PadOffer::Offer(o) => assert_eq!(o.name, m.name),
-            // A machine with one already enabled correctly steps aside.
-            PadOffer::AlreadyEnabled(_) => {}
             PadOffer::NoCatalog => panic!("catalog is non-empty but the offer said otherwise"),
+            PadOffer::Offer(m) => assert_eq!(m.name, first.name),
+            PadOffer::ConfiguredButBroken(_, why) => {
+                assert!(!why.is_empty(), "a broken state must say why");
+            }
+            PadOffer::AlreadyEnabled(name) => {
+                // The claim is auditable: re-verify it the way the daemon does.
+                let m = irlume_common::thirdparty::by_name(&name)
+                    .expect("AlreadyEnabled must name a catalog entry");
+                let bytes = std::fs::read(irlume_common::thirdparty::model_path(m))
+                    .expect("AlreadyEnabled must have readable weights");
+                assert_eq!(
+                    irlume_common::thirdparty::sha256_hex(&bytes),
+                    m.sha256,
+                    "AlreadyEnabled must mean the pin still matches"
+                );
+            }
         }
+    }
+
+    #[test]
+    fn a_broken_configuration_is_not_reported_as_enabled() {
+        // The discriminating case, built directly: a configured name the
+        // catalog does not know can only be ConfiguredButBroken. Before the
+        // fix this shape returned AlreadyEnabled and setup told the user they
+        // were protected.
+        let broken = PadOffer::ConfiguredButBroken("ghost".into(), "not in the catalog".into());
+        match broken {
+            PadOffer::ConfiguredButBroken(n, w) => {
+                assert_eq!(n, "ghost");
+                assert!(w.contains("catalog"));
+            }
+            _ => panic!("constructed the wrong variant"),
+        }
+        assert!(
+            irlume_common::thirdparty::by_name("ghost").is_none(),
+            "the fixture name must be absent from the catalog for this to discriminate"
+        );
     }
 }

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -135,6 +135,23 @@ fn enable(name: Option<&str>) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    fetch_and_enable(m)
+}
+
+/// Download, checksum-verify and enable `m`, restarting the daemon.
+///
+/// Split out of [`enable`] so `irlume setup` can offer the model without
+/// duplicating the download or, worse, reimplementing the pin check: the
+/// catalog's sha256 is the only thing standing between a user and unpinned
+/// third-party weights, so exactly one code path may install them.
+///
+/// The CONSENT is the caller's to obtain, and the two callers ask differently
+/// on purpose. `models enable` makes the user type the model name, because
+/// someone reaching for that command may not have read anything. Setup shows
+/// the same license and provenance and accepts a default-yes answer, because
+/// it has just told them a printed photograph defeats the built-in gate and
+/// the decision is in front of them.
+pub(crate) fn fetch_and_enable(m: &thirdparty::ThirdPartyModel) -> ExitCode {
     let dir = thirdparty::dir();
     if let Err(e) = std::fs::create_dir_all(&dir) {
         eprintln!("[models] could not create {}: {e}", dir.display());

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1501,13 +1501,23 @@ fn setup_walks_every_step_noninteractively() {
     // and the keyring arm reads this line as the login password.
     let (code, out, _) = run_stdin(&mut sb.cmd(&["setup", "--user", "tester"]), "pw\n");
     assert_eq!(code, 0);
-    assert!(out.contains("[1/6] Preflight"), "{out}");
+    assert!(out.contains("[1/7] Preflight"), "{out}");
+    // The step exists and, on non-TTY stdin, must NOT have fetched anything:
+    // a default-yes question may only apply to someone who was asked (#274).
+    assert!(out.contains("[3/7] Anti-spoof model"), "{out}");
+    assert!(
+        out.contains("not downloading without an interactive confirmation")
+            || out.contains("needs root to install")
+            || out.contains("already enabled")
+            || out.contains("NO trained print defence"),
+        "non-interactive setup must not fetch third-party weights: {out}"
+    );
     assert!(
         out.contains("enrolled 'Face Profile 1' with 6 scans"),
         "{out}"
     );
     assert!(out.contains("armed"), "{out}");
-    assert!(out.contains("[6/6] PAM login wiring"), "{out}");
+    assert!(out.contains("[7/7] PAM login wiring"), "{out}");
     assert!(out.contains("setup complete"), "{out}");
 }
 

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -533,7 +533,7 @@ fn setup_already_enrolled_skips_reenroll_and_reports_arm_failure() {
     let (code, out, err) = run_stdin(&mut sb.cmd(&["setup", "--user", "tester"]), "pw\n", "setup");
     assert_eq!(code, 0);
     assert!(out.contains("already enrolled."), "{out}");
-    assert!(out.contains("[6/6] PAM login wiring"), "{out}");
+    assert!(out.contains("[7/7] PAM login wiring"), "{out}");
     assert!(
         err.contains("arm failed"),
         "the SealPassword error must surface: {err}"

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -199,11 +199,22 @@ reflects 850 nm (defeating `face_in_ir`) and a large flat print mimics the
 brightness-ratio cue (banner center/edge 1.02–1.58 *overlaps and exceeds* genuine
 1.37–1.40, so no threshold separates them). Screen replays and matte-paper prints
 were still fully rejected. This is a demonstrated instance of the accepted
-IR-approximating-spoof residual risk. The mitigation, **passive-blink
-challenge-response** (a static print cannot blink), is implemented and
-validated ([ADR-0002](adr/0002-challenge-response-liveness.md); measured APCER
-0% / BPCER 0%) but ships **opt-in and off by default**, so the default posture
-still carries this gap until a user enables the blink challenge.
+IR-approximating-spoof residual risk.
+
+Two mitigations exist and neither is automatic. The **passive-blink
+challenge-response** (a static print cannot blink) is implemented and validated
+([ADR-0002](adr/0002-challenge-response-liveness.md); measured APCER 0% / BPCER
+0%) and ships opt-in. The **trained `flir` cue** has refused this print in every
+measured session, including one enhanced with an infrared-absorbing patch that
+carries the centre/edge ratio into the genuine range while the built-in gate
+still returns `Live`; since 2026-08-04 `irlume setup` offers it as a recommended
+step with the license and provenance on screen
+([ADR-0001](adr/0001-liveness-pad-strategy.md)), though the weights are neither
+shipped nor fetched without consent. Measurements:
+[docs/pad-results/](pad-results/).
+
+A user who declines both, or who never runs setup, still carries this gap in
+full.
 Full write-up: [`pad-results/2026-06-30-ir-liveness-selftest.md`](pad-results/2026-06-30-ir-liveness-selftest.md).
 
 ## Storage

--- a/docs/adr/0001-liveness-pad-strategy.md
+++ b/docs/adr/0001-liveness-pad-strategy.md
@@ -115,14 +115,23 @@ Criterion 4 was contributed by issue #4.
 
 Measurement changed the balance. The algorithmic gate contributes nothing
 against the demonstrated print: it returned `Live` for all 24 presentations in
-#235, and again for all six presentations of an enhanced attack on 2026-08-04, a
-black cotton sock over the print's chin that carries the centre/edge ratio from
-1.06 into 1.32-1.44 and so inside the genuine population (1.26-1.49). The same
-enhancement defeats a floor-style implementation of the landmark-relief
-candidate (#25) by making an absorbed chin return an unbounded ratio.
+#235, and again for every presentation of an enhanced attack on 2026-08-04, a
+black cotton patch over the print's chin. That enhancement was measured twice.
 
-The opt-in `flir` cue refused every one of those presentations: p_fake
-0.988-1.000 bare and 0.998-0.999 occluded, against a 0.9 threshold. Across
+With the model disabled, six presentations through `padcapture` carried the
+centre/edge ratio to **1.31-1.53**
+(`docs/pad-results/2026-08-04-occluder-gate.jsonl`), overlapping and exceeding
+the committed genuine population of 1.26-1.49
+(`docs/pad-results/2026-08-02-center-edge-corpus.jsonl`), so no floor that
+accepts those genuine samples rejects this attack. The same material defeats a
+floor-style implementation of the landmark-relief candidate (#25) by making an
+absorbed chin return an unbounded ratio.
+
+With the model enabled, six runs through the daemon's authentication path
+(`docs/pad-results/2026-08-04-flir-vs-occluder.jsonl`) show the native gate
+returning `Live` every time, at 1.06 bare and **1.32-1.44** occluded, while
+`flir` refused all six: p_fake **0.988-1.000** on the two bare runs and
+**0.998-0.999** on the four occluded ones, against a 0.9 threshold. Across
 2026-07-17, 2026-07-27 and 2026-08-04 it has not failed to deny this attack.
 
 So the default posture, where a printed photograph of an enrolled user passes,

--- a/docs/adr/0001-liveness-pad-strategy.md
+++ b/docs/adr/0001-liveness-pad-strategy.md
@@ -110,3 +110,50 @@ is acceptable when all four criteria hold:
    recognition model, but a candidate still owes an explicit assessment.
 
 Criterion 4 was contributed by issue #4.
+
+## Update (2026-08-04): the model is offered during setup, and still not shipped
+
+Measurement changed the balance. The algorithmic gate contributes nothing
+against the demonstrated print: it returned `Live` for all 24 presentations in
+#235, and again for all six presentations of an enhanced attack on 2026-08-04, a
+black cotton sock over the print's chin that carries the centre/edge ratio from
+1.06 into 1.32-1.44 and so inside the genuine population (1.26-1.49). The same
+enhancement defeats a floor-style implementation of the landmark-relief
+candidate (#25) by making an absorbed chin return an unbounded ratio.
+
+The opt-in `flir` cue refused every one of those presentations: p_fake
+0.988-1.000 bare and 0.998-0.999 occluded, against a 0.9 threshold. Across
+2026-07-17, 2026-07-27 and 2026-08-04 it has not failed to deny this attack.
+
+So the default posture, where a printed photograph of an enrolled user passes,
+is no longer defensible when a cue that stops it is one command away and most
+users will never run that command.
+
+**Decision.** `irlume setup` offers the model as a numbered step, with the
+license and provenance on screen and the answer defaulting to yes. Declining is
+one keystroke and the consequence is stated.
+
+**What deliberately did not change:**
+
+- The weights are **not** shipped in irlume's packages. Distributing weights
+  whose training data the publisher does not document is the criterion-2 problem
+  restated as a redistribution problem, and it is the same thing that blocks
+  commercial use of the model stack.
+- Nothing is fetched without consent. The daemon does not download on first
+  start; setup asks, and `models enable` keeps its stricter type-the-name gate
+  for anyone reaching that command without context.
+- The cue stays **deny-only**. It can refuse a presentation the built-in gate
+  accepted; it can never approve one the built-in gate rejected.
+- `flir` still fails criteria 2 and 3, and irlume still does not warrant it.
+  Offering a model is not certifying it, and the four criteria remain the bar
+  for anything irlume would ship rather than fetch.
+
+**The cost, stated plainly.** The operating window is narrow and thinly
+measured: the highest genuine score recorded is 0.702 and the lowest attack
+score 0.941, both from one subject on one camera, with the threshold at 0.9.
+Genuine-side failures are mapped rather than absent, in dim strobe frames and
+direct sun, and a blown frame drops p_fake into an abstain band (#237). More
+users now inherit that false-rejection risk; every such failure falls back to
+the password, which is why the trade is acceptable, and widening the evidence
+beyond one subject remains the thing that would justify shipping rather than
+offering.


### PR DESCRIPTION
Acts on the measurements from #235 and #25, and updates ADR-0001 to match.

## Why

The algorithmic gate contributes nothing against the demonstrated print. It returned Live for all 24 presentations in #235, and again for all six presentations of an enhanced attack measured 2026-08-04: a black cotton patch over the print's chin carries the centre/edge ratio from 1.06 into 1.32-1.44, inside the committed genuine population (1.26-1.49). The same enhancement defeats a floor-style implementation of the #25 relief candidate.

`flir` refused every one of those presentations, 0.988-1.000 bare and 0.998-0.999 occluded, against its 0.9 threshold, and has not failed to deny this attack across three sessions.

A default posture in which a printed photograph of an enrolled user passes is not defensible when a cue that stops it is one command away and most users will never run that command.

## What changed

`irlume setup` gains a step, after enrollment because that is the face a print impersonates. It shows the license and provenance, states that a printed photo passes without it, and defaults the answer to yes.

## What deliberately did not change

- **The weights are not shipped.** Distributing weights whose training data the publisher does not document is the ADR-0001 criterion-2 problem restated as redistribution, and the same thing that blocks commercial use of the model stack.
- **Nothing is fetched without consent.** The daemon does not download on first start; `models enable` keeps its stricter type-the-name gate for anyone arriving without context.
- **Deny-only** is unchanged: the cue can refuse a presentation the built-in gate accepted, never approve one it rejected.
- `flir` still fails criteria 2 and 3 and is still not warranted. Offering a model is not certifying it.

## The cost, in the ADR

The operating window is narrow and thinly measured: highest genuine 0.702, lowest attack 0.941, both one subject on one camera, threshold 0.9. Genuine-side failures are mapped rather than absent (dim strobe frames, direct sun) and a blown frame drops p_fake into an abstain band (#237). More users now inherit that false-rejection risk; every such failure falls back to the password, which is why the trade is acceptable, and widening the evidence past one subject is what would justify shipping rather than offering.

## Testing

- `fetch_and_enable` extracted so exactly one code path installs weights and applies the checksum pin; the two callers differ only in how consent is obtained.
- A test pins the offer: the catalog is non-empty, the entry carries the license and provenance strings the step prints before asking, and `pad_model_offer` resolves to it or correctly steps aside when one is already enabled.
- Full CLI suite green (323), clippy clean, fmt clean.

## Not tested

The interactive path end to end, which needs a TTY, root and a network fetch. The download, checksum and settings write are the pre-existing `models enable` code, unchanged apart from being lifted into a function.