### PR TITLE
models: support measured models irlume does not fetch, and document them

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ see [Honest limitations](#-honest-limitations).
 | **Write software that drives irlume** | [`docs/INTEGRATION.md`](docs/INTEGRATION.md) |
 | Look up the versioned **machine API**, field by field | [`docs/MACHINE-API.md`](docs/MACHINE-API.md) |
 | Understand the **architecture** | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
+| Choose a **third-party liveness model** irlume has measured | [`docs/THIRD-PARTY-MODELS.md`](docs/THIRD-PARTY-MODELS.md) |
 | Read the **threat model** and standards mapping | [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) · [`docs/STANDARDS.md`](docs/STANDARDS.md) |
 | **Verify the claims** on my own machine | [`docs/VERIFY.md`](docs/VERIFY.md) |
 | **Debug** a login or trace every stage | [`docs/DEBUGGING.md`](docs/DEBUGGING.md) |

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1449,7 +1449,15 @@ pub fn setup(args: &[String]) -> ExitCode {
         PadOffer::ConfiguredButBroken(name, why) => {
             println!("  '{name}' is configured but the daemon will not load it ({why}),");
             println!("  so this machine has NO trained print defence right now.");
-            println!("  repair with: sudo irlume models enable {name}");
+            // The repair differs by tier: irlume can re-fetch one it fetches,
+            // and can only ask for the file again for one it does not.
+            match irlume_common::thirdparty::by_name(&name).and_then(|m| m.url) {
+                Some(_) => println!("  repair with: sudo irlume models enable {name}"),
+                None => println!(
+                    "  repair with: sudo irlume models add {name} <path>  \
+                     (docs/THIRD-PARTY-MODELS.md)"
+                ),
+            }
         }
         PadOffer::Offer(m) => {
             println!("  A printed photograph of your face passes irlume's built-in liveness");

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1607,7 +1607,14 @@ fn pad_model_offer() -> PadOffer {
             Ok(_) => PadOffer::AlreadyEnabled(name),
         };
     }
-    match irlume_common::thirdparty::CATALOG.first() {
+    // Only a FETCHABLE model can be offered here: setup cannot obtain one whose
+    // licence makes acquiring it the user's decision, and a step that asks a
+    // question it cannot act on is worse than no step. Those are documented in
+    // docs/THIRD-PARTY-MODELS.md and installed with `models add`.
+    match irlume_common::thirdparty::CATALOG
+        .iter()
+        .find(|m| m.url.is_some())
+    {
         Some(m) => PadOffer::Offer(m),
         None => PadOffer::NoCatalog,
     }
@@ -1984,10 +1991,15 @@ mod setup_offer_tests {
         // weights really are present and match their pin, because the daemon
         // silently runs without the cue otherwise (#274 review).
         assert!(
-            !irlume_common::thirdparty::CATALOG.is_empty(),
-            "setup offers CATALOG.first(); an empty catalog makes the step dead"
+            irlume_common::thirdparty::CATALOG
+                .iter()
+                .any(|m| m.url.is_some()),
+            "setup offers the first FETCHABLE entry; with none the step is dead"
         );
-        let first = irlume_common::thirdparty::CATALOG.first().unwrap();
+        let first = irlume_common::thirdparty::CATALOG
+            .iter()
+            .find(|m| m.url.is_some())
+            .unwrap();
         // Everything the step prints before asking for consent must exist, or
         // the user accepts a license and provenance the screen never showed.
         assert!(!first.name.is_empty());
@@ -1998,7 +2010,7 @@ mod setup_offer_tests {
         );
 
         match pad_model_offer() {
-            PadOffer::NoCatalog => panic!("catalog is non-empty but the offer said otherwise"),
+            PadOffer::NoCatalog => panic!("a fetchable entry exists but the offer said otherwise"),
             PadOffer::Offer(m) => assert_eq!(m.name, first.name),
             PadOffer::ConfiguredButBroken(_, why) => {
                 assert!(!why.is_empty(), "a broken state must say why");

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -311,27 +311,7 @@ fn pin_matches(m: &ThirdPartyModel, bytes: &[u8]) -> bool {
 /// first; this re-states that in one place so a future third caller cannot
 /// install unpinned weights by forgetting the check.
 fn install_verified(m: &ThirdPartyModel, bytes: &[u8]) -> ExitCode {
-    if !pin_matches(m, bytes) {
-        eprintln!(
-            "[models] refusing to install unpinned weights for '{}'",
-            m.name
-        );
-        return ExitCode::FAILURE;
-    }
-    let dir = thirdparty::dir();
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        eprintln!("[models] could not create {}: {e}", dir.display());
-        return ExitCode::FAILURE;
-    }
-    let path = thirdparty::model_path(m);
-    if let Err(e) = std::fs::write(&path, bytes) {
-        eprintln!("[models] could not install {}: {e}", path.display());
-        return ExitCode::FAILURE;
-    }
-    if let Err(e) =
-        irlume_common::config::write_kv("settings.conf", thirdparty::SETTINGS_KEY, m.name)
-    {
-        eprintln!("[models] weights installed but settings.conf update failed: {e}");
+    if !place_verified(m, bytes) {
         return ExitCode::FAILURE;
     }
     restart_daemon();
@@ -341,6 +321,43 @@ fn install_verified(m: &ThirdPartyModel, bytes: &[u8]) -> ExitCode {
     );
     println!("[models] check with: irlume doctor · disable with: sudo irlume models disable");
     ExitCode::SUCCESS
+}
+
+/// The disk half of an install: verify the pin, place the weights atomically,
+/// record the choice. Split from the daemon restart so a test can exercise the
+/// pin against a real writable directory without restarting a service, which
+/// is what a test of the refusal needs: refusing because the directory is
+/// unwritable proves nothing about the pin.
+fn place_verified(m: &ThirdPartyModel, bytes: &[u8]) -> bool {
+    if !pin_matches(m, bytes) {
+        eprintln!(
+            "[models] refusing to install unpinned weights for '{}'",
+            m.name
+        );
+        return false;
+    }
+    let dir = thirdparty::dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("[models] could not create {}: {e}", dir.display());
+        return false;
+    }
+    let path = thirdparty::model_path(m);
+    // Atomic replace, never a truncating write. settings.conf keeps naming
+    // this model, so a half-written file is not a failed update: it is a
+    // checksum mismatch the daemon answers by running WITHOUT the cue, and
+    // the built-in gate that remains accepts the print attack. A rename
+    // either publishes the whole artifact or leaves the previous one intact.
+    if let Err(e) = irlume_common::write_atomic_mode(&path, bytes, 0o644) {
+        eprintln!("[models] could not install {}: {e}", path.display());
+        return false;
+    }
+    if let Err(e) =
+        irlume_common::config::write_kv("settings.conf", thirdparty::SETTINGS_KEY, m.name)
+    {
+        eprintln!("[models] weights installed but settings.conf update failed: {e}");
+        return false;
+    }
+    true
 }
 
 fn disable() -> ExitCode {
@@ -461,12 +478,24 @@ pub fn doctor_line() -> String {
 #[cfg(test)]
 mod tests {
 
+    /// A synthetic bring-your-own entry. The catalog has no such model yet, so
+    /// the tier the code must handle would otherwise be untested until one is
+    /// measured, which is exactly when a regression would be discovered.
+    fn byo_fixture() -> ThirdPartyModel {
+        ThirdPartyModel {
+            name: "fixture-byo",
+            file: "fixture-byo.onnx",
+            url: None,
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+            license: "fixture",
+            provenance: "fixture",
+            threshold: 0.9,
+            summary: "fixture",
+        }
+    }
+
     #[test]
-    fn a_bring_your_own_entry_is_never_fetched_and_a_fetchable_one_has_an_origin() {
-        // The tier invariant, asserted over the whole catalog rather than one
-        // entry: irlume must never try to download a model whose licence made
-        // obtaining it the user's decision, and must never leave a fetchable
-        // entry without somewhere to fetch from.
+    fn every_catalog_entry_carries_a_pin_and_only_fetchable_ones_carry_an_origin() {
         for m in thirdparty::CATALOG {
             if let Some(u) = m.url {
                 assert!(
@@ -475,29 +504,87 @@ mod tests {
                     m.name
                 );
             }
-            // Both tiers carry the pin: it is how irlume knows WHICH model is
-            // loaded rather than trusting the file that appeared in the dir.
+            // Both tiers: the pin is how irlume knows WHICH model is loaded
+            // rather than trusting the file that appeared in the directory.
             assert_eq!(m.sha256.len(), 64, "{}: every tier needs a pin", m.name);
         }
+        // And the bring-your-own tier itself, which no catalog entry exercises
+        // today: it must be pinned like any other and must have no origin.
+        let byo = byo_fixture();
+        assert!(byo.url.is_none());
+        assert_eq!(byo.sha256.len(), 64);
     }
 
     #[test]
-    fn install_refuses_bytes_that_do_not_match_the_pin() {
-        // The discriminating case for `models add`: a file that is not the
-        // measured artifact must be refused, because irlume's threshold was
-        // measured on the expected weights and means nothing on others.
-        let m = thirdparty::CATALOG
-            .first()
-            .expect("catalog is non-empty by the invariant above");
-        assert_ne!(
-            thirdparty::sha256_hex(b"not the model"),
-            m.sha256,
-            "the fixture must not collide with the real pin"
+    fn fetching_a_bring_your_own_model_is_refused_before_any_download() {
+        // The tier's whole point: irlume must not download a model whose
+        // licence made obtaining it the user's decision. `fetch_and_enable`
+        // guards this even though the call sites check first, because a
+        // future caller will not.
+        let byo = byo_fixture();
+        assert!(
+            !matches!(fetch_and_enable(&byo), c if format!("{c:?}") == format!("{:?}", ExitCode::SUCCESS)),
+            "a urlless model must never reach the downloader"
+        );
+    }
+
+    #[test]
+    fn the_installer_refuses_bytes_that_do_not_match_the_pin() {
+        // Sandboxed state dir, so the WRITE would genuinely succeed and the
+        // pin is the only thing that can refuse. Without this the test passes
+        // for the wrong reason: an unprivileged process cannot write to the
+        // real state dir, so it returns FAILURE whether the guard exists or
+        // not, and a mutant deleting the guard survives.
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("irlume-pin-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let (cfg, state) = (root.join("cfg"), root.join("state"));
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::fs::create_dir_all(&state).unwrap();
+        let old_cfg = std::env::var_os("IRLUME_CONFIG_DIR");
+        let old_state = std::env::var_os("IRLUME_STATE_DIR");
+        std::env::set_var("IRLUME_CONFIG_DIR", &cfg);
+        std::env::set_var("IRLUME_STATE_DIR", &state);
+
+        let m = byo_fixture();
+        let path = thirdparty::model_path(&m);
+        assert!(!pin_matches(&m, b"not the model"));
+        let refused = place_verified(&m, b"not the model");
+        let nothing_written = !path.exists();
+        // The control: the same call with MATCHING bytes must install, which
+        // is what proves the refusal above came from the pin and not from an
+        // unwritable directory.
+        let good = b"the measured artifact";
+        let mut ok = m;
+        let digest = thirdparty::sha256_hex(good);
+        ok.sha256 = Box::leak(digest.into_boxed_str());
+        let accepted = place_verified(&ok, good);
+        let written = thirdparty::model_path(&ok).exists();
+
+        match (old_cfg, old_state) {
+            (Some(c), Some(st)) => {
+                std::env::set_var("IRLUME_CONFIG_DIR", c);
+                std::env::set_var("IRLUME_STATE_DIR", st);
+            }
+            _ => {
+                std::env::remove_var("IRLUME_CONFIG_DIR");
+                std::env::remove_var("IRLUME_STATE_DIR");
+            }
+        }
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(!refused, "unpinned bytes must not install");
+        assert!(
+            nothing_written,
+            "a refused install must leave nothing behind"
         );
         assert!(
-            !pin_matches(m, b"not the model"),
-            "unpinned bytes must be refused"
+            accepted,
+            "matching bytes must install, or the refusal above proves nothing"
         );
+        assert!(written, "the control install must actually reach disk");
     }
     use super::*;
 

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -556,10 +556,19 @@ mod tests {
         // The control: the same call with MATCHING bytes must install, which
         // is what proves the refusal above came from the pin and not from an
         // unwritable directory.
+        // Precomputed rather than Box::leak'd into a &'static str: leaking to
+        // satisfy a lifetime is a real leak, and LeakSanitizer is right to
+        // report it. The constant is asserted against the hasher below, so a
+        // change to either is caught rather than silently diverging.
         let good = b"the measured artifact";
+        const GOOD_SHA: &str = "b9a5820dd4ae8eb1eb7025b3b9b1351d9ff90e658e0c1d22a027e55be4f6f48e";
+        assert_eq!(
+            thirdparty::sha256_hex(good),
+            GOOD_SHA,
+            "the fixture's precomputed digest no longer matches the hasher"
+        );
         let mut ok = m;
-        let digest = thirdparty::sha256_hex(good);
-        ok.sha256 = Box::leak(digest.into_boxed_str());
+        ok.sha256 = GOOD_SHA;
         let accepted = place_verified(&ok, good);
         let written = thirdparty::model_path(&ok).exists();
 

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -24,6 +24,10 @@ pub fn run(sub: Option<&str>, args: &[String]) -> ExitCode {
     match sub {
         None | Some("list") => list(),
         Some("enable") => enable(args.get(2).map(String::as_str)),
+        Some("add") => add(
+            args.get(2).map(String::as_str),
+            args.get(3).map(String::as_str),
+        ),
         Some("disable") => disable(),
         _ => usage(),
     }
@@ -31,9 +35,78 @@ pub fn run(sub: Option<&str>, args: &[String]) -> ExitCode {
 
 fn usage() -> ExitCode {
     eprintln!("usage: irlume models [list]");
-    eprintln!("       sudo irlume models enable <name>");
+    eprintln!("       sudo irlume models enable <name>          (irlume fetches it)");
+    eprintln!("       sudo irlume models add <name> <path>      (you supply the file)");
     eprintln!("       sudo irlume models disable");
     ExitCode::from(2)
+}
+
+/// Install a model from a file the USER obtained, verified against the pin
+/// irlume measured.
+///
+/// This is the whole point of the two tiers: irlume will not fetch a model
+/// whose licence makes that the user's decision, but it still knows exactly
+/// which artifact it measured. A file that hashes to the catalog's `sha256` is
+/// that artifact and gets its measured threshold; anything else is refused,
+/// because scoring an unknown model against another model's threshold is the
+/// guess this catalog exists to prevent.
+fn add(name: Option<&str>, path: Option<&str>) -> ExitCode {
+    let (Some(name), Some(path)) = (name, path) else {
+        return usage();
+    };
+    let Some(m) = thirdparty::by_name(name) else {
+        eprintln!("[models] '{name}' is not in the catalog; run `irlume models` to list it");
+        return ExitCode::FAILURE;
+    };
+    if !is_root() {
+        eprintln!("[models] needs root: sudo irlume models add {name} {path}");
+        return ExitCode::FAILURE;
+    }
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("[models] cannot read {path}: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let digest = thirdparty::sha256_hex(&bytes);
+    if digest != m.sha256 {
+        eprintln!("[models] this file is NOT the artifact irlume measured.");
+        eprintln!("[models]   got      sha256 {digest}");
+        eprintln!("[models]   expected sha256 {}", m.sha256);
+        eprintln!(
+            "[models] refusing: irlume's threshold for '{}' was measured on the expected\n\
+             [models] artifact, and applying it to different weights would be a guess.",
+            m.name
+        );
+        return ExitCode::FAILURE;
+    }
+    println!("Adding third-party model '{}' from {path}", m.name);
+    println!();
+    println!("  license:    {}", m.license);
+    println!("  provenance: {}", m.provenance);
+    println!("  measured:   {}", m.summary);
+    println!("  effect:     adds a DENY-ONLY liveness cue on the lit IR frame; it can");
+    println!("              reject a presentation, it can never approve one the built-in");
+    println!("              gate rejected. False fires cost a retry or the password.");
+    println!();
+    println!("  sha256 matches the artifact irlume measured. Complying with the license");
+    println!("  above, for your use, is your determination and not irlume's.");
+    println!();
+    if !stdin_is_tty() {
+        eprintln!("[models] enabling needs an interactive terminal to confirm the license");
+        return ExitCode::FAILURE;
+    }
+    print!("Enable '{}'? [y/N] ", m.name);
+    let _ = std::io::stdout().flush();
+    let mut yn = String::new();
+    if std::io::stdin().lock().read_line(&mut yn).is_err()
+        || !matches!(yn.trim(), "y" | "Y" | "yes")
+    {
+        println!("[models] cancelled; nothing was changed.");
+        return ExitCode::FAILURE;
+    }
+    install_verified(m, &bytes)
 }
 
 /// The catalog name currently enabled in settings.conf, if any.
@@ -52,8 +125,9 @@ fn file_state(m: &ThirdPartyModel) -> &'static str {
 
 fn list() -> ExitCode {
     let enabled = enabled_name();
-    println!("Third-party models irlume can fetch but does not ship or warrant.");
-    println!("Each entry was measured on real hardware before listing (docs/pad-results/).");
+    println!("Third-party models irlume has MEASURED but does not ship or warrant.");
+    println!("Nothing is listed here that was not measured on real hardware");
+    println!("(docs/pad-results/, docs/THIRD-PARTY-MODELS.md).");
     println!();
     for m in thirdparty::CATALOG {
         let state = if enabled.as_deref() == Some(m.name) {
@@ -69,11 +143,21 @@ fn list() -> ExitCode {
             m.threshold
         );
         println!("    measured:   {}", m.summary);
+        println!(
+            "    obtain:     {}",
+            match m.url {
+                Some(_) => format!("irlume fetches it: sudo irlume models enable {}", m.name),
+                None => format!(
+                    "you supply the file: sudo irlume models add {} <path>",
+                    m.name
+                ),
+            }
+        );
     }
     println!();
     match enabled {
         Some(n) => println!("enabled: {n} · disable with: sudo irlume models disable"),
-        None => println!("none enabled · enable with: sudo irlume models enable <name>"),
+        None => println!("none enabled · see the 'obtain' line above for each model"),
     }
     ExitCode::SUCCESS
 }
@@ -106,6 +190,15 @@ fn enable(name: Option<&str>) -> ExitCode {
         println!("[models] re-fetching and re-verifying anyway.");
     }
 
+    if m.url.is_none() {
+        println!(
+            "[models] '{}' is measured by irlume but not fetched by it: its license makes\n\
+             [models] obtaining the file your decision. See docs/THIRD-PARTY-MODELS.md, then:\n\
+             [models]   sudo irlume models add {} <path-to-{}>",
+            m.name, m.name, m.file
+        );
+        return ExitCode::FAILURE;
+    }
     println!("Enabling third-party model '{}'", m.name);
     println!();
     println!("  license:    {}", m.license);
@@ -157,12 +250,22 @@ pub(crate) fn fetch_and_enable(m: &thirdparty::ThirdPartyModel) -> ExitCode {
         eprintln!("[models] could not create {}: {e}", dir.display());
         return ExitCode::FAILURE;
     }
+    let Some(url) = m.url else {
+        // Reached only if a caller forgets the check at the call site; the
+        // catalog says this model is not irlume's to fetch.
+        eprintln!(
+            "[models] '{}' is not fetchable by irlume; obtain the file yourself, then:\n\
+             [models]   sudo irlume models add {} <path>",
+            m.name, m.name
+        );
+        return ExitCode::FAILURE;
+    };
     let tmp = dir.join(format!(".{}.part", m.file));
     println!("[models] downloading from the publisher's origin ...");
     let status = Command::new("curl")
         .args(["-fSL", "--max-time", "300", "-o"])
         .arg(&tmp)
-        .arg(m.url)
+        .arg(url)
         .status();
     if !matches!(status, Ok(s) if s.success()) {
         let _ = std::fs::remove_file(&tmp);
@@ -189,9 +292,39 @@ pub(crate) fn fetch_and_enable(m: &thirdparty::ThirdPartyModel) -> ExitCode {
         );
         return ExitCode::FAILURE;
     }
+    let _ = std::fs::remove_file(&tmp);
+    install_verified(m, &bytes)
+}
+
+/// Are these the exact weights irlume measured?
+///
+/// A value rather than an inline comparison so the refusal is testable: this
+/// is the only thing standing between a user and a threshold applied to
+/// weights it was never measured on.
+fn pin_matches(m: &ThirdPartyModel, bytes: &[u8]) -> bool {
+    thirdparty::sha256_hex(bytes) == m.sha256
+}
+
+/// Write already-verified `bytes` into place and enable the cue.
+///
+/// The single installer for both tiers. Callers must have checked the sha256
+/// first; this re-states that in one place so a future third caller cannot
+/// install unpinned weights by forgetting the check.
+fn install_verified(m: &ThirdPartyModel, bytes: &[u8]) -> ExitCode {
+    if !pin_matches(m, bytes) {
+        eprintln!(
+            "[models] refusing to install unpinned weights for '{}'",
+            m.name
+        );
+        return ExitCode::FAILURE;
+    }
+    let dir = thirdparty::dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("[models] could not create {}: {e}", dir.display());
+        return ExitCode::FAILURE;
+    }
     let path = thirdparty::model_path(m);
-    if let Err(e) = std::fs::rename(&tmp, &path) {
-        let _ = std::fs::remove_file(&tmp);
+    if let Err(e) = std::fs::write(&path, bytes) {
         eprintln!("[models] could not install {}: {e}", path.display());
         return ExitCode::FAILURE;
     }
@@ -327,6 +460,45 @@ pub fn doctor_line() -> String {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_bring_your_own_entry_is_never_fetched_and_a_fetchable_one_has_an_origin() {
+        // The tier invariant, asserted over the whole catalog rather than one
+        // entry: irlume must never try to download a model whose licence made
+        // obtaining it the user's decision, and must never leave a fetchable
+        // entry without somewhere to fetch from.
+        for m in thirdparty::CATALOG {
+            if let Some(u) = m.url {
+                assert!(
+                    u.starts_with("https://"),
+                    "{}: origin must be https",
+                    m.name
+                );
+            }
+            // Both tiers carry the pin: it is how irlume knows WHICH model is
+            // loaded rather than trusting the file that appeared in the dir.
+            assert_eq!(m.sha256.len(), 64, "{}: every tier needs a pin", m.name);
+        }
+    }
+
+    #[test]
+    fn install_refuses_bytes_that_do_not_match_the_pin() {
+        // The discriminating case for `models add`: a file that is not the
+        // measured artifact must be refused, because irlume's threshold was
+        // measured on the expected weights and means nothing on others.
+        let m = thirdparty::CATALOG
+            .first()
+            .expect("catalog is non-empty by the invariant above");
+        assert_ne!(
+            thirdparty::sha256_hex(b"not the model"),
+            m.sha256,
+            "the fixture must not collide with the real pin"
+        );
+        assert!(
+            !pin_matches(m, b"not the model"),
+            "unpinned bytes must be refused"
+        );
+    }
     use super::*;
 
     /// doctor_line's classification: enabled name vs catalog membership vs

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -31,8 +31,16 @@ pub struct ThirdPartyModel {
     pub name: &'static str,
     /// On-disk file name under the state subdir.
     pub file: &'static str,
-    /// Direct download URL at the publisher's origin.
-    pub url: &'static str,
+    /// Direct download URL at the publisher's origin, or `None` when irlume
+    /// will not fetch it for you.
+    ///
+    /// `None` is not a lesser tier of evidence: an entry is in this catalog
+    /// only because irlume measured it, and the threshold and pin below carry
+    /// the same weight either way. It means the licence makes fetching the
+    /// user's business rather than irlume's, so the file arrives via
+    /// `irlume models add <name> <path>` and is checked against `sha256`
+    /// exactly as a downloaded one is.
+    pub url: Option<&'static str>,
     /// Pinned sha256 of the artifact; a fetched file that does not match is
     /// deleted, and the daemon refuses to load a file that stops matching.
     pub sha256: &'static str,
@@ -54,7 +62,7 @@ pub struct ThirdPartyModel {
 pub const CATALOG: &[ThirdPartyModel] = &[ThirdPartyModel {
     name: "flir",
     file: "flir.onnx",
-    url: "https://modelscope.cn/api/v1/models/damo/cv_manual_face-liveness_flir/repo?FilePath=model.onnx&Revision=master",
+    url: Some("https://modelscope.cn/api/v1/models/damo/cv_manual_face-liveness_flir/repo?FilePath=model.onnx&Revision=master"),
     sha256: "df80cea7228b92562692e56aac965d35766c77399159798c552fb3c77b410c72",
     license: "MIT (Alibaba DAMO, ModelScope model card)",
     provenance: "training data undocumented by the publisher; not reproducible \
@@ -164,11 +172,17 @@ mod tests {
                 m.name
             );
             assert!(m.sha256.chars().all(|c| c.is_ascii_hexdigit()));
-            assert!(
-                m.url.starts_with("https://"),
-                "{}: origin must be https",
-                m.name
-            );
+            // A fetchable entry must name an https origin; a bring-your-own
+            // entry names none, and both must still carry a pin, because the
+            // pin is how irlume knows WHICH model is loaded rather than
+            // trusting whatever file appeared in the directory.
+            if let Some(url) = m.url {
+                assert!(
+                    url.starts_with("https://"),
+                    "{}: origin must be https",
+                    m.name
+                );
+            }
             assert!(m.threshold > 0.0 && m.threshold < 1.0);
             assert!(m.file.ends_with(".onnx"));
             assert!(

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -65,6 +65,7 @@ Conventions that apply everywhere:
 | `irlume camera-tune [--rounds N]` | yes | measure whether this camera keeps its brightness while both sensors stream, and store the resulting capture mode in `cameras.conf`; some modules starve their own RGB interface (measured: NexiGo HelloCam N930W keeps 56% of its RGB brightness), and this puts those on one-at-a-time capture |
 | `irlume models [list]` | no | show the opt-in third-party liveness models and their checksum state |
 | `irlume models enable <name>` / `models disable` | yes | fetch and enable one (deny-only, checksum-pinned), or turn it off |
+| `irlume models add <name> <path>` | yes | enable a model whose licence means you obtain the file; verified against the pin irlume measured ([THIRD-PARTY-MODELS.md](THIRD-PARTY-MODELS.md)) |
 | `irlume update [--check]` | for install | update via the channel irlume was installed from (Copr/PPA: runs it; .deb/pkg/source: shows the steps); `--check` only reports |
 | `irlume uninstall [--keep-data] [--yes]` | yes | un-wire PAM first (lockout-safe order), stop the daemon, wipe enrolled data unless `--keep-data`, then print the package-removal command |
 

--- a/docs/THIRD-PARTY-MODELS.md
+++ b/docs/THIRD-PARTY-MODELS.md
@@ -1,0 +1,104 @@
+# Third-party liveness models irlume has measured
+
+irlume's built-in liveness gate does not stop a printed photograph of an
+enrolled face. That is measured, not suspected: the gate returned `Live` for all
+24 presentations of a vinyl print in issue #235, and again for an enhanced
+version of the same attack, so a trained cue is currently the only thing that
+refuses it. See [the PAD results](pad-results/) for every number behind that.
+
+This page lists the models irlume can use for that job. **Everything here was
+measured on real hardware by this project before it was listed.** Nothing is
+listed because a publisher claims it works, and a model irlume has not measured
+is not supported, whatever its benchmarks say elsewhere.
+
+Two things follow from that, and they are the reason this page exists:
+
+- irlume knows exactly **which** model is loaded. Every entry carries the sha256
+  of the artifact that was measured, and irlume refuses weights that do not
+  match it. A threshold measured on one set of weights means nothing applied to
+  another, so a near-miss is a refusal rather than a warning.
+- irlume does not have to be the one who **fetches** it. Some models carry
+  licences that make obtaining them the user's decision. Those are still
+  measured, still pinned, still supported; you supply the file.
+
+## How to read an entry
+
+Run `irlume models` for the live version of this table. Each entry states:
+
+| field | what it means |
+|---|---|
+| `license` | the publisher's licence for the weights, as published |
+| `provenance` | whether the training data and pipeline are documented, and so whether the model could ever meet [ADR-0001](adr/0001-liveness-pad-strategy.md) |
+| `threshold` | the decision point irlume **measured**, never the publisher's default |
+| `measured` | the one-line result, pointing at the full document in `pad-results/` |
+| `obtain` | whether irlume fetches it, or you supply the file |
+
+The threshold is the part that matters most and the part a page like this
+usually gets wrong. A deny-only cue firing in a score band where neither genuine
+faces nor attacks were observed is guessing, and it guesses against the user:
+every false fire costs a real login. So irlume sets each threshold from where
+the two populations were actually seen to sit on its own hardware.
+
+## The models
+
+### `flir` — irlume fetches it
+
+An infrared anti-spoof cue from Alibaba DAMO, published on ModelScope under MIT.
+
+- **Measured:** 122 of 123 attack frames flagged across two cameras
+  (2026-07-17); re-measured at the shipped threshold on 2026-07-27, 6 of 6
+  presentations flagged at p_fake 0.941 to 1.000; on 2026-08-04 it refused the
+  same print enhanced with an infrared-absorbing patch, at 0.998 to 0.999, in
+  the same runs where the built-in gate returned `Live`.
+- **Threshold:** 0.9. Highest genuine score observed 0.702, lowest attack score
+  0.941. The publisher's model card states no threshold at all.
+- **Genuine-side failures are mapped, not absent:** dim strobe frames and direct
+  sun, and a blown frame drops the score into an abstain band (#237).
+- **Provenance:** the publisher documents neither the training data nor a
+  reproducible pipeline, so it fails ADR-0001 criteria 2 and 3. irlume does not
+  ship or warrant it.
+
+```sh
+sudo irlume models enable flir
+```
+
+`irlume setup` also offers this one, with the licence and provenance on screen.
+
+### Bring-your-own entries
+
+None yet. When a model whose licence prevents irlume from fetching it has been
+measured, it appears here with its pin, its threshold and its `pad-results`
+document, and is installed with:
+
+```sh
+sudo irlume models add <name> /path/to/weights.onnx
+```
+
+irlume verifies your file against the published sha256 before enabling it. If it
+does not match, it is refused: that file is not the artifact the threshold was
+measured on.
+
+Whether a given licence permits **your** use of a model is your determination.
+irlume prints the licence before enabling anything and distributes no weights.
+
+## What is deliberately not here
+
+- **Models irlume has not measured.** Publishing "this probably works" is how a
+  page like this becomes a recommendation engine for untested weights.
+- **Any model as a default.** These cues are deny-only: they can refuse a
+  presentation the built-in gate accepted, never approve one it rejected. That
+  is what makes them safe to add, and it is also why a broken one degrades
+  quietly rather than loudly, so `irlume doctor` reports which model is active
+  and whether its weights still match their pin.
+
+## Adding a model to this page
+
+The bar is a measurement, not an opinion. `irlume padcapture` and `irlume
+padreport` are the tools; [`PAD_SELFTEST.md`](PAD_SELFTEST.md) describes the
+protocol. A candidate needs genuine and attack presentations on real hardware,
+enough of both to see where the populations sit, and a written result in
+`pad-results/` before a threshold is chosen from it.
+
+Every measurement in this repository so far comes from one subject on one or two
+cameras, which is stated in each document and is the standing limitation on all
+of it.


### PR DESCRIPTION
Builds the two-tier model support and the user-facing page for it.

## The problem

The catalog conflated two different questions: whether irlume has **measured** a model, and whether irlume will **fetch** it. A model whose licence makes obtaining it the user's decision could not be listed at all, so a user had no way to learn which weights irlume actually supports and has tested. The alternative, free-form bring-your-own, fails for a reason this repository already documents: a deny-only cue firing where neither population was observed "guesses against the user", and every false fire costs a real login.

## The design

`url` becomes `Option`. `None` means bring-your-own: measured identically, pinned identically, but installed by the user with

```sh
sudo irlume models add <name> /path/to/weights.onnx
```

which verifies the file against the sha256 irlume measured and refuses anything else. That pin is the point: it is how irlume knows *which* model is loaded rather than trusting whatever file appeared in the directory, and it means a bring-your-own model still gets a measured threshold rather than a guessed one.

- `install_verified` is the single installer for both tiers, so a future caller cannot install unpinned weights by forgetting the check; `pin_matches` is a value so the refusal is testable.
- `setup` only ever offers a fetchable entry, since it cannot act on a model it may not download.
- The listing states per model how to obtain it, and its header no longer claims everything is fetchable.

## The page

`docs/THIRD-PARTY-MODELS.md` lists what irlume has measured, the threshold it measured and why the publisher's default is never used, the mapped genuine-side failures, and what is deliberately absent: any model this project has not measured. The bring-your-own section is empty today and says so, because nothing non-permissive has been measured yet. The page also states that whether a licence permits a given user's use is that user's determination.

## Testing

- Catalog invariant test now covers both tiers: a fetchable entry must name an https origin, a bring-your-own entry names none, and **both** must carry a 64-char pin.
- `pin_matches` test asserts unpinned bytes are refused, with the fixture checked not to collide with the real pin.
- Setup-offer test updated to require a fetchable entry rather than any entry.
- Exercised on the machine: a random file is refused showing both hashes; the genuine artifact passes the pin and stops at the consent prompt, which correctly refuses a non-TTY stdin.
- Full `irlume-cli` and `irlume-common` suites green, workspace clippy clean, fmt clean.

## Not tested

An end-to-end `models add` that actually enables, which needs a TTY; the install path past consent is `install_verified`, shared with the fetch path that is exercised today.
