### PR TITLE
core+auth: tag templates with the recognizer that produced them

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -35,6 +35,10 @@ pub struct Engine {
     /// Stored on every new scan and matched against at verify, so an adapter
     /// swap/removal degrades to "re-enroll" instead of scoring across spaces.
     ir_space: String,
+    /// The recognizer's own embedding space, `"embed:<sha256 prefix>"` of its
+    /// weights. Stamped onto every scan enrolled and required to match at
+    /// verification: cosine scores are only meaningful inside one space.
+    embed_space: String,
     /// Optional MediaPipe FaceMesh: dense landmarks for the passive EAR blink
     /// liveness (ADR-0002). Loaded iff the model file is present; `None` disables
     /// the opt-in passive-liveness gate (it can't run without landmarks).
@@ -528,11 +532,22 @@ fn top_detection(faces: &[Detection]) -> Option<&Detection> {
 
 impl Engine {
     pub fn load(det_path: &str, model_path: &str) -> irlume_common::Result<Self> {
+        // Identify the recognizer by its weights, not its path: a file swapped
+        // in place under the same name is a different embedding space and must
+        // not silently score against templates from the old one.
+        let embed_space = match std::fs::read(model_path) {
+            Ok(b) => format!("embed:{}", &irlume_common::thirdparty::sha256_hex(&b)[..12]),
+            // Unreadable here means Embedder::load_from_file below will fail
+            // too; keep a value that can never equal a real tag rather than
+            // one that compares equal to everything.
+            Err(_) => "embed:unknown".into(),
+        };
         Ok(Self {
             det: Detector::load_from_file(det_path)?,
             emb: Embedder::load_from_file(model_path)?,
             ir_adapter: None,
             ir_space: "raw".into(),
+            embed_space,
             mesh: None,
             blaze: None,
             tp_pad: None,
@@ -618,6 +633,24 @@ impl Engine {
     /// The IR embedding space this engine produces and matches in.
     pub fn ir_space(&self) -> &str {
         &self.ir_space
+    }
+
+    /// The recognizer embedding space this engine produces and matches in.
+    pub fn embed_space(&self) -> &str {
+        &self.embed_space
+    }
+
+    /// Is this scan comparable with embeddings this engine produces?
+    ///
+    /// A scan tagged with a different recognizer is not: its vector lives in
+    /// another space and a cosine against it means nothing. `None` is
+    /// grandfathered, the same concession `ir_space` makes for scans enrolled
+    /// before tagging existed.
+    pub fn scan_is_comparable(&self, s: &irlume_core::storage::FaceScan) -> bool {
+        match &s.embed_space {
+            Some(sp) => sp == &self.embed_space,
+            None => true,
+        }
     }
 
     /// Dimensionality of the IR embeddings this engine emits. The recognizer
@@ -2005,7 +2038,7 @@ impl Engine {
                     ));
                 }
             }
-            let scans = enr.rgb_scans();
+            let scans = enr.rgb_scans_in(Some(&self.embed_space));
             let thr = irlume_core::scaled_threshold(irlume_core::RGB_MATCH_THRESHOLD, scans.len());
             let (score, who) = best(&probe, &scans);
             irlume_common::dlog!(
@@ -2273,7 +2306,7 @@ impl Engine {
             let Some(enr) = irlume_core::storage::load(&user)? else {
                 continue;
             };
-            let scans = enr.rgb_scans();
+            let scans = enr.rgb_scans_in(Some(&self.embed_space));
             if scans.is_empty() {
                 continue;
             }
@@ -2573,6 +2606,7 @@ impl Engine {
                     rgb: s.rgb,
                     ir: s.ir,
                     ir_space,
+                    embed_space: Some(self.embed_space.clone()),
                     ir_center_edge_ratio: s.center_edge_ratio,
                     ir_brightness: s.brightness,
                     pitch: s.pitch,
@@ -2607,6 +2641,7 @@ impl Engine {
                 rgb: s.rgb,
                 ir: s.ir,
                 ir_space,
+                embed_space: Some(self.embed_space.clone()),
                 ir_center_edge_ratio: s.center_edge_ratio,
                 ir_brightness: s.brightness,
                 pitch: s.pitch,
@@ -2705,6 +2740,7 @@ impl Engine {
             rgb: captured.rgb,
             ir: captured.ir,
             ir_space,
+            embed_space: Some(self.embed_space.clone()),
             ir_center_edge_ratio: captured.center_edge_ratio,
             ir_brightness: captured.brightness,
             pitch: captured.pitch,
@@ -3334,6 +3370,7 @@ mod tests {
                 rgb: rgb.clone(),
                 ir: Some(ir.clone()),
                 ir_space: Some("raw".into()),
+                embed_space: None,
                 ir_center_edge_ratio: 0.0,
                 ir_brightness: 0.0,
                 pitch: 0.0,
@@ -3526,6 +3563,7 @@ mod tests {
             rgb: v,
             ir: None,
             ir_space: None,
+            embed_space: None,
             ir_center_edge_ratio: 0.0,
             ir_brightness: 0.0,
             pitch: 0.0,
@@ -3665,6 +3703,7 @@ mod tests {
         let ir_scan = |v: Vec<f32>, space: Option<&str>| FaceScan {
             ir: Some(vec![0.5; 3]),
             ir_space: space.map(String::from),
+            embed_space: None,
             ..scan(v)
         };
         let enr_with = |scans: Vec<FaceScan>| {
@@ -3851,6 +3890,7 @@ mod tests {
                 rgb: vec![0.0; 4],
                 ir: Some(v.to_vec()),
                 ir_space: Some("raw".into()),
+                embed_space: None,
                 ir_center_edge_ratio: 0.0,
                 ir_brightness: 0.0,
                 pitch: 0.0,
@@ -4437,6 +4477,7 @@ mod engine_tests {
             rgb: unit512(seed),
             ir: ir.then(|| unit512(seed + 100)),
             ir_space: space.map(String::from),
+            embed_space: None,
             ir_center_edge_ratio: 1.3,
             ir_brightness: 90.0,
             pitch: 0.5,

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -431,6 +431,7 @@ struct IrMatch {
 /// template carries no best-of-N FAR inflation).
 fn ir_match_in(
     space: &str,
+    embed_space: &str,
     adapter_loaded: bool,
     enr: &irlume_core::storage::Enrollment,
     probe: &[f32],
@@ -446,6 +447,17 @@ fn ir_match_in(
             .scans
             .iter()
             .filter_map(|s| {
+                // The RECOGNIZER produces the raw IR embedding, so a template
+                // from another recognizer is in a foreign space regardless of
+                // its adapter tag. This matcher feeds fusion, IR fallback, the
+                // calibrated centroid, and dark IR-only auth — all of them
+                // grant, so all of them get the same filter RGB matching has.
+                if !irlume_core::storage::recognizer_space_matches(
+                    s.embed_space.as_deref(),
+                    embed_space,
+                ) {
+                    return None;
+                }
                 let ir = s.ir.as_ref()?;
                 if ir.len() != probe.len() {
                     return None;
@@ -534,17 +546,20 @@ impl Engine {
     pub fn load(det_path: &str, model_path: &str) -> irlume_common::Result<Self> {
         // Identify the recognizer by its weights, not its path: a file swapped
         // in place under the same name is a different embedding space and must
-        // not silently score against templates from the old one.
-        let embed_space = match std::fs::read(model_path) {
-            Ok(b) => format!("embed:{}", &irlume_common::thirdparty::sha256_hex(&b)[..12]),
-            // Unreadable here means Embedder::load_from_file below will fail
-            // too; keep a value that can never equal a real tag rather than
-            // one that compares equal to everything.
-            Err(_) => "embed:unknown".into(),
-        };
+        // not silently score against templates from the old one. Read the file
+        // ONCE and build the session from those same bytes — hashing one read
+        // and loading another would let a mid-startup file swap run weights the
+        // tag does not describe. Full digest: the tag resists an adversarial
+        // model, and truncation halves its strength per dropped character.
+        let model_bytes = std::fs::read(model_path)
+            .map_err(|e| irlume_common::Error::Io(format!("{model_path}: {e}")))?;
+        let embed_space = format!(
+            "embed:{}",
+            irlume_common::thirdparty::sha256_hex(&model_bytes)
+        );
         Ok(Self {
             det: Detector::load_from_file(det_path)?,
-            emb: Embedder::load_from_file(model_path)?,
+            emb: Embedder::load_from_memory(&model_bytes)?,
             ir_adapter: None,
             ir_space: "raw".into(),
             embed_space,
@@ -617,10 +632,14 @@ impl Engine {
     /// file is absent this is a no-op (raw IR embeddings are used).
     pub fn with_ir_adapter(mut self, path: &str) -> irlume_common::Result<Self> {
         if std::path::Path::new(path).exists() {
-            self.ir_adapter = Some(Adapter::load_from_file(path)?);
+            // One read feeds both the digest and the session, so the tag always
+            // describes the weights that are running (same reasoning as the
+            // recognizer in `load`). The 12-hex prefix is the format existing
+            // enrollments carry in `ir_space`; changing it would orphan them.
             let bytes = std::fs::read(path)
                 .map_err(|e| irlume_common::Error::Io(format!("{path}: {e}")))?;
             let digest = irlume_common::thirdparty::sha256_hex(&bytes);
+            self.ir_adapter = Some(Adapter::load_from_memory(&bytes)?);
             self.ir_space = format!("adapter:{}", &digest[..12]);
         }
         Ok(self)
@@ -638,19 +657,6 @@ impl Engine {
     /// The recognizer embedding space this engine produces and matches in.
     pub fn embed_space(&self) -> &str {
         &self.embed_space
-    }
-
-    /// Is this scan comparable with embeddings this engine produces?
-    ///
-    /// A scan tagged with a different recognizer is not: its vector lives in
-    /// another space and a cosine against it means nothing. `None` is
-    /// grandfathered, the same concession `ir_space` makes for scans enrolled
-    /// before tagging existed.
-    pub fn scan_is_comparable(&self, s: &irlume_core::storage::FaceScan) -> bool {
-        match &s.embed_space {
-            Some(sp) => sp == &self.embed_space,
-            None => true,
-        }
     }
 
     /// Dimensionality of the IR embeddings this engine emits. The recognizer
@@ -672,6 +678,14 @@ impl Engine {
         let dim = self.ir_dim();
         let (mut ir_rows, mut rgb_rows) = (Vec::new(), Vec::new());
         for s in &prof.scans {
+            // A pair from another recognizer would fit one calibration across
+            // incompatible embedding spaces; skip it like matching does.
+            if !irlume_core::storage::recognizer_space_matches(
+                s.embed_space.as_deref(),
+                &self.embed_space,
+            ) {
+                continue;
+            }
             let Some(ir) = &s.ir else { continue };
             if ir.len() != dim || s.rgb.len() != dim {
                 continue;
@@ -695,7 +709,13 @@ impl Engine {
     /// Method wrapper over [`ir_match_in`], bound to the engine's space and
     /// adapter state.
     fn ir_match(&self, enr: &irlume_core::storage::Enrollment, probe: &[f32]) -> IrMatch {
-        ir_match_in(&self.ir_space, self.ir_adapter.is_some(), enr, probe)
+        ir_match_in(
+            &self.ir_space,
+            &self.embed_space,
+            self.ir_adapter.is_some(),
+            enr,
+            probe,
+        )
     }
 
     /// Load MediaPipe FaceMesh for the passive EAR blink liveness (ADR-0002). If
@@ -2038,7 +2058,7 @@ impl Engine {
                     ));
                 }
             }
-            let scans = enr.rgb_scans_in(Some(&self.embed_space));
+            let scans = enr.rgb_scans_in(&self.embed_space);
             let thr = irlume_core::scaled_threshold(irlume_core::RGB_MATCH_THRESHOLD, scans.len());
             let (score, who) = best(&probe, &scans);
             irlume_common::dlog!(
@@ -2306,7 +2326,7 @@ impl Engine {
             let Some(enr) = irlume_core::storage::load(&user)? else {
                 continue;
             };
-            let scans = enr.rgb_scans_in(Some(&self.embed_space));
+            let scans = enr.rgb_scans_in(&self.embed_space);
             if scans.is_empty() {
                 continue;
             }
@@ -2549,7 +2569,7 @@ impl Engine {
                     "no live scan captured; check lighting and framing".into(),
                 )
             })?;
-        let goal = match enroll_merge_target(&enr, &[probe.rgb.as_slice()])? {
+        let goal = match enroll_merge_target(&enr, &[probe.rgb.as_slice()], &self.embed_space)? {
             Some(target) => {
                 let have = enr
                     .profiles
@@ -2581,7 +2601,7 @@ impl Engine {
         // drifting into frame after the probe, and a borderline probe that only
         // crosses the identity threshold on a later scan.
         let rgbs: Vec<&[f32]> = captured.iter().map(|s| s.rgb.as_slice()).collect();
-        if let Some(target) = enroll_merge_target(&enr, &rgbs)? {
+        if let Some(target) = enroll_merge_target(&enr, &rgbs, &self.embed_space)? {
             // The face already owns a profile: merge the capture into it.
             let idx = enr
                 .profiles
@@ -2717,7 +2737,9 @@ impl Engine {
                 )
             })?;
         // Anti-mixing: reject a scan whose face belongs to a different profile.
-        if let Some((other, score)) = colliding_profile(&enr, &captured.rgb, Some(profile_name)) {
+        if let Some((other, score)) =
+            colliding_profile(&enr, &captured.rgb, Some(profile_name), &self.embed_space)
+        {
             let cnt = enr
                 .profiles
                 .iter()
@@ -2991,10 +3013,11 @@ pub enum EnrollOutcome {
 fn enroll_merge_target(
     enr: &irlume_core::storage::Enrollment,
     captured_rgb: &[&[f32]],
+    embed_space: &str,
 ) -> irlume_common::Result<Option<String>> {
     let mut hit: Option<String> = None;
     for rgb in captured_rgb {
-        let Some((other, _score)) = colliding_profile(enr, rgb, None) else {
+        let Some((other, _score)) = colliding_profile(enr, rgb, None, embed_space) else {
             continue;
         };
         match &hit {
@@ -3019,6 +3042,7 @@ fn colliding_profile(
     enr: &irlume_core::storage::Enrollment,
     probe: &[f32],
     exclude: Option<&str>,
+    embed_space: &str,
 ) -> Option<(String, f32)> {
     let mut best: Option<(String, f32)> = None;
     for p in &enr.profiles {
@@ -3026,6 +3050,16 @@ fn colliding_profile(
             continue;
         }
         for s in &p.scans {
+            // A template from another recognizer is in a foreign embedding
+            // space; a cosine against it could merge a stranger's scans into
+            // this profile or reject a legitimate add-scan, so it does not
+            // get compared at all.
+            if !irlume_core::storage::recognizer_space_matches(
+                s.embed_space.as_deref(),
+                embed_space,
+            ) {
+                continue;
+            }
             let c = align::cosine(probe, &s.rgb);
             if c >= irlume_core::RGB_MATCH_THRESHOLD && best.as_ref().is_none_or(|b| c > b.1) {
                 best = Some((p.name.clone(), c));
@@ -3324,7 +3358,7 @@ pub fn eye_glint_contrast(grey: &[u8], w: u32, h: u32, landmarks: &Landmarks5) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use irlume_core::storage::{Enrollment, FaceProfile, FaceScan};
+    use irlume_core::storage::{Enrollment, FaceProfile, FaceScan, LEGACY_RECOGNIZER_SPACE};
 
     /// Serializes access to process-wide env vars (`IRLUME_GRACE_MS`,
     /// `IRLUME_STATE_DIR`, `IRLUME_METHOD_CONF`, ...) across this binary's
@@ -3393,7 +3427,7 @@ mod tests {
         let (prof, probe) = calibrated_profile(16);
         let mut enr = Enrollment::new("u");
         enr.profiles.push(prof);
-        let raw = ir_match_in("raw", false, &enr, &probe);
+        let raw = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
         assert_eq!(raw.n_templates, 5);
         let (cs, who) = raw.centroid.as_ref().expect("centroid expected");
         assert_eq!(who, "p");
@@ -3405,7 +3439,7 @@ mod tests {
         assert!(raw.best > 0.8, "calibrated best degraded: {}", raw.best);
         assert!(*cs > 0.8, "centroid degraded: {cs}");
         // With the adapter loaded the calibration must be ignored entirely.
-        let with_adapter = ir_match_in("raw", true, &enr, &probe);
+        let with_adapter = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, true, &enr, &probe);
         assert!(with_adapter.centroid.is_none());
         assert!(with_adapter.best.is_finite());
     }
@@ -3552,9 +3586,46 @@ mod tests {
         }
         let mut enr = Enrollment::new("u");
         enr.profiles.push(prof);
-        let m = ir_match_in("raw", false, &enr, &probe);
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
         assert_eq!(m.n_templates, 0);
         assert!(m.centroid.is_none());
+    }
+
+    #[test]
+    fn ir_match_skips_templates_from_another_recognizer() {
+        // The recognizer produces the raw IR embedding, so its identity gates
+        // IR matching exactly like RGB matching: a foreign tag is excluded, a
+        // matching tag scores, and an untagged scan belongs to the legacy
+        // recognizer only. This matcher feeds fusion, IR fallback, the
+        // calibrated centroid, and dark IR-only auth, so the one filter covers
+        // all four grant paths.
+        let (prof, probe) = calibrated_profile(16);
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(prof);
+
+        // Untagged (legacy) templates: comparable ONLY under the legacy space.
+        let m = ir_match_in("raw", "embed:not-the-legacy-model", false, &enr, &probe);
+        assert_eq!(
+            m.n_templates, 0,
+            "untagged scans must not reach a foreign recognizer"
+        );
+        assert!(m.centroid.is_none());
+        assert_eq!(m.best, f32::NEG_INFINITY);
+
+        // Tagged templates: comparable exactly under their own space.
+        for s in &mut enr.profiles[0].scans {
+            s.embed_space = Some("embed:model-b".into());
+        }
+        let m = ir_match_in("raw", "embed:model-b", false, &enr, &probe);
+        assert_eq!(
+            m.n_templates, 5,
+            "same-recognizer templates must still score"
+        );
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
+        assert_eq!(
+            m.n_templates, 0,
+            "tagged scans must not reach the legacy recognizer"
+        );
     }
 
     fn scan(v: Vec<f32>) -> FaceScan {
@@ -3686,13 +3757,57 @@ mod tests {
         };
         // Adding face1 under Face Profile 2 -> flagged as belonging to Profile 1.
         assert_eq!(
-            colliding_profile(&enr, &face1, Some("Face Profile 2")).map(|(n, _)| n),
+            colliding_profile(
+                &enr,
+                &face1,
+                Some("Face Profile 2"),
+                LEGACY_RECOGNIZER_SPACE
+            )
+            .map(|(n, _)| n),
             Some("Face Profile 1".to_string())
         );
         // A novel face collides with nothing.
-        assert!(colliding_profile(&enr, &[0.0, 0.0, 1.0], None).is_none());
+        assert!(colliding_profile(&enr, &[0.0, 0.0, 1.0], None, LEGACY_RECOGNIZER_SPACE).is_none());
         // Same face into its OWN profile (excluded) is fine; that's improving it.
-        assert!(colliding_profile(&enr, &face1, Some("Face Profile 1")).is_none());
+        assert!(colliding_profile(
+            &enr,
+            &face1,
+            Some("Face Profile 1"),
+            LEGACY_RECOGNIZER_SPACE
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn collision_never_compares_across_recognizer_spaces() {
+        // A template from another recognizer must not decide enrollment
+        // dispositions, even when its raw vector is IDENTICAL to the probe:
+        // a foreign-space cosine could merge a stranger into an unrelated
+        // profile or reject a legitimate add-scan.
+        let face = vec![1.0, 0.0, 0.0];
+        let mut foreign = scan(face.clone());
+        foreign.embed_space = Some("embed:model-b".into());
+        let enr = Enrollment {
+            user: "u".into(),
+            profiles: vec![FaceProfile {
+                ir_calib: None,
+                name: "P1".into(),
+                scans: vec![foreign],
+            }],
+            ..Default::default()
+        };
+        // Under any OTHER recognizer the identical vector is invisible...
+        assert!(colliding_profile(&enr, &face, None, LEGACY_RECOGNIZER_SPACE).is_none());
+        assert_eq!(
+            enroll_merge_target(&enr, &[&face], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            None
+        );
+        // ...and under its own recognizer it collides as it always did (the
+        // positive control that proves the filter, not the vector, decided).
+        assert_eq!(
+            colliding_profile(&enr, &face, None, "embed:model-b").map(|(n, _)| n),
+            Some("P1".to_string())
+        );
     }
 
     #[test]
@@ -3718,18 +3833,21 @@ mod tests {
 
         // Novel face: no collision, create the new profile.
         let enr = enr_with(vec![ir_scan(face1.clone(), Some("raw"))]);
-        assert_eq!(enroll_merge_target(&enr, &[&novel]).unwrap(), None);
+        assert_eq!(
+            enroll_merge_target(&enr, &[&novel], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            None
+        );
 
         // Same face merges into its profile regardless of IR-template state:
         // healthy current-space templates...
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1]).unwrap(),
+            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
             Some("P1".into())
         );
         // ...untagged legacy templates...
         let enr = enr_with(vec![ir_scan(face1.clone(), None)]);
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1]).unwrap(),
+            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
             Some("P1".into())
         );
         // ...templates stranded by an adapter removal (the 0.2.0 upgrade case)...
@@ -3738,13 +3856,13 @@ mod tests {
             ir_scan(face1.clone(), Some("adapter:deadbeef0123")),
         ]);
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1]).unwrap(),
+            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
             Some("P1".into())
         );
         // ...or a profile that never had IR scans at all.
         let enr = enr_with(vec![scan(face1.clone())]);
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1]).unwrap(),
+            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
             Some("P1".into())
         );
 
@@ -3755,7 +3873,8 @@ mod tests {
             name: "P2".into(),
             scans: vec![ir_scan(face2.clone(), Some("adapter:deadbeef0123"))],
         });
-        let err = enroll_merge_target(&enr, &[&face1, &face2]).unwrap_err();
+        let err =
+            enroll_merge_target(&enr, &[&face1, &face2], LEGACY_RECOGNIZER_SPACE).unwrap_err();
         assert!(err.to_string().contains("two different profiles"));
     }
 
@@ -3855,12 +3974,15 @@ mod tests {
         enr.profiles.push(prof);
         // A probe of a different width matches nothing (adapter-contract change).
         let short_probe = vec![0.5f32; 8];
-        let m = ir_match_in("raw", false, &enr, &short_probe);
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &short_probe);
         assert_eq!(m.n_templates, 0);
         assert!(m.centroid.is_none());
         assert_eq!(m.best, f32::NEG_INFINITY);
         // The right width still matches.
-        assert_eq!(ir_match_in("raw", false, &enr, &probe).n_templates, 5);
+        assert_eq!(
+            ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe).n_templates,
+            5
+        );
     }
 
     #[test]
@@ -3872,7 +3994,7 @@ mod tests {
         let mut enr = Enrollment::new("u");
         enr.profiles.push(prof);
         for space in ["raw", "adapter:deadbeef0123"] {
-            let m = ir_match_in(space, false, &enr, &probe);
+            let m = ir_match_in(space, LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
             assert_eq!(m.n_templates, 5, "untagged templates must match in {space}");
         }
     }
@@ -3899,7 +4021,7 @@ mod tests {
         let mut enr = Enrollment::new("u");
         enr.profiles.push(mk_prof("A", &a));
         enr.profiles.push(mk_prof("B", &b));
-        let m = ir_match_in("raw", false, &enr, &b);
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &b);
         assert_eq!(m.n_templates, 2);
         assert_eq!(m.best_who, "B");
         assert!((m.best - 1.0).abs() < 1e-5);
@@ -4504,6 +4626,17 @@ mod engine_tests {
         let bytes = std::fs::read(model_path("blaze_face_short_range.onnx")).unwrap();
         let digest = irlume_common::thirdparty::sha256_hex(&bytes);
         assert_eq!(s.adapter_space, format!("adapter:{}", &digest[..12]));
+        // The engine loaded the shipped glintr100.onnx, so its embedding space
+        // must BE the pinned legacy space: this ties Engine::load's full-digest
+        // tag, models/SHA256SUMS, and LEGACY_RECOGNIZER_SPACE together. If this
+        // fails after a deliberate recognizer change, mint a NEW space rather
+        // than repointing the legacy constant — untagged templates were made by
+        // the old model, and the constant exists to say exactly that.
+        assert_eq!(
+            e.embed_space(),
+            irlume_core::storage::LEGACY_RECOGNIZER_SPACE,
+            "shipped recognizer no longer matches the pinned legacy space"
+        );
     }
 
     #[test]
@@ -4553,6 +4686,20 @@ mod engine_tests {
         };
         s.engine.refit_profile_calib(&mut foreign);
         assert!(foreign.ir_calib.is_none());
+        // Templates from another RECOGNIZER are skipped too: fitting across
+        // embedding spaces would produce a calibration describing neither.
+        let mut foreign_rec = FaceProfile {
+            name: "foreign-rec".into(),
+            ir_calib: None,
+            scans: (0..5)
+                .map(|i| FaceScan {
+                    embed_space: Some("embed:model-b".into()),
+                    ..scan512(i, true, Some("raw"))
+                })
+                .collect(),
+        };
+        s.engine.refit_profile_calib(&mut foreign_rec);
+        assert!(foreign_rec.ir_calib.is_none());
         // With a global adapter loaded, refit is a no-op: an existing
         // calibration is left untouched and none is fitted.
         let adapter = Adapter::load_from_file(&model_path("blaze_face_short_range.onnx")).unwrap();

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -50,6 +50,22 @@ pub struct FaceScan {
     /// `None` = scan predates space tagging; grandfathered as compatible.
     #[serde(default)]
     pub ir_space: Option<String>,
+    /// The RECOGNIZER that produced `rgb` (and, before any adapter, `ir`),
+    /// as `"embed:<sha256 prefix>"` of its weights.
+    ///
+    /// Cosine similarity is only meaningful WITHIN one embedding space. A
+    /// different recognizer produces a different space, so comparing a fresh
+    /// probe against these templates yields a number with no interpretation
+    /// that may land either side of the threshold, granting or denying at
+    /// random. `ir_space` already guards the adapter for the same reason;
+    /// this guards the model underneath it, which #276 needs before any
+    /// user-supplied recognizer can be considered and which a change to the
+    /// shipped weights would need regardless.
+    ///
+    /// `None` = scan predates this tagging; grandfathered as compatible, the
+    /// same concession `ir_space` makes.
+    #[serde(default)]
+    pub embed_space: Option<String>,
     /// Per-scan IR liveness calibration: the center/edge brightness ratio of the
     /// face region at capture, and the face brightness. The on-disk key stays
     /// `ir_depth` (the name it shipped under) so an enrollment written here still
@@ -139,12 +155,27 @@ impl Enrollment {
 
     /// Every RGB template with its (profile, scan) labels, for 1:N matching.
     pub fn rgb_scans(&self) -> Vec<(&str, &str, &[f32])> {
+        self.rgb_scans_in(None)
+    }
+
+    /// Every RGB template that lives in `space`, with (profile, scan) labels.
+    ///
+    /// `None` keeps every scan, which is what callers with no recognizer
+    /// identity to compare against want. `Some(space)` drops scans tagged with
+    /// a DIFFERENT recognizer: their vectors are in another embedding space and
+    /// a cosine against them is a number with no interpretation, free to land
+    /// either side of the threshold. Untagged scans are kept, the same
+    /// grandfathering `ir_space` applies (#276).
+    pub fn rgb_scans_in(&self, space: Option<&str>) -> Vec<(&str, &str, &[f32])> {
         self.profiles
             .iter()
             .flat_map(|p| {
                 p.scans
                     .iter()
-                    .map(move |s| (p.name.as_str(), s.name.as_str(), s.rgb.as_slice()))
+                    .filter_map(move |s| match (space, s.embed_space.as_deref()) {
+                        (Some(want), Some(have)) if want != have => None,
+                        _ => Some((p.name.as_str(), s.name.as_str(), s.rgb.as_slice())),
+                    })
             })
             .collect()
     }
@@ -329,7 +360,8 @@ fn migrate(old: LegacyProfile) -> Enrollment {
             name: format!("Face Scan {}", i + 1),
             rgb: t.clone(),
             ir: old.ir_templates.get(i).cloned(),
-            ir_space: None, // legacy scans predate space tagging
+            ir_space: None,    // legacy scans predate space tagging
+            embed_space: None, // and predate recognizer tagging
 
             ir_center_edge_ratio: old.ir_depth_samples.get(i).copied().unwrap_or(0.0),
             ir_brightness: old.ir_brightness_samples.get(i).copied().unwrap_or(0.0),
@@ -547,6 +579,55 @@ pub fn list_users() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+
+    fn scan(name: &str, v: f32, space: Option<&str>) -> FaceScan {
+        FaceScan {
+            name: name.into(),
+            rgb: vec![v; 4],
+            ir: None,
+            ir_space: None,
+            embed_space: space.map(str::to_string),
+            ir_center_edge_ratio: 0.0,
+            ir_brightness: 0.0,
+            pitch: 0.0,
+        }
+    }
+
+    #[test]
+    fn rgb_templates_from_another_recognizer_are_not_offered_for_matching() {
+        // Cosine is only meaningful inside one embedding space, so a template
+        // tagged with a different recognizer must not reach the comparison at
+        // all. Untagged scans predate tagging and stay comparable (#276).
+        let enr = Enrollment {
+            user: "u".into(),
+            profiles: vec![FaceProfile {
+                name: "p".into(),
+                scans: vec![
+                    scan("same", 1.0, Some("embed:aaaaaaaaaaaa")),
+                    scan("other", 2.0, Some("embed:bbbbbbbbbbbb")),
+                    scan("legacy", 3.0, None),
+                ],
+                ir_calib: None,
+            }],
+            ..Default::default()
+        };
+        let names = |v: Vec<(&str, &str, &[f32])>| {
+            v.into_iter()
+                .map(|(_, n, _)| n.to_string())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            names(enr.rgb_scans_in(Some("embed:aaaaaaaaaaaa"))),
+            vec!["same", "legacy"],
+            "a template from another recognizer must be excluded"
+        );
+        // No identity to compare against keeps everything, which is what the
+        // unfiltered accessor must still do for callers that have none.
+        assert_eq!(names(enr.rgb_scans()), vec!["same", "other", "legacy"]);
+        // And the whole set can be excluded, which must yield an empty match
+        // rather than a comparison against foreign vectors.
+        assert!(enr.rgb_scans_in(Some("embed:cccccccccccc")).len() == 1);
+    }
     use super::*;
 
     /// The retag marker skips work and answers a question about work only.
@@ -631,6 +712,7 @@ mod tests {
                     rgb: vec![0.1, 0.2, 0.3, 0.4],
                     ir: Some(vec![0.5, 0.6]),
                     ir_space: None,
+                    embed_space: None,
                     ir_center_edge_ratio: 1.4,
                     ir_brightness: 90.0,
                     pitch: 0.52,
@@ -682,6 +764,7 @@ mod tests {
             rgb: vec![0.1; 4],
             ir: Some(vec![0.2; 4]),
             ir_space: None,
+            embed_space: None,
             ir_center_edge_ratio: ratio,
             ir_brightness: bright,
             pitch: 0.0,
@@ -694,6 +777,7 @@ mod tests {
             rgb: vec![0.1; 4],
             ir: None,
             ir_space: None,
+            embed_space: None,
             ir_center_edge_ratio: 0.0,
             ir_brightness: 0.0,
             pitch,
@@ -743,6 +827,7 @@ mod tests {
             rgb: vec![0.1; 4],
             ir: Some(vec![0.2; dim]),
             ir_space: space.map(Into::into),
+            embed_space: None,
             ir_center_edge_ratio: 0.0,
             ir_brightness: 0.0,
             pitch: 0.0,
@@ -823,6 +908,7 @@ mod tests {
                     rgb: vec![0.1; 4],
                     ir: None,
                     ir_space: None,
+                    embed_space: None,
                     ir_center_edge_ratio: 0.0,
                     ir_brightness: 0.0,
                     pitch: 0.0,
@@ -942,6 +1028,7 @@ mod tests {
             rgb: vec![0.0; 4],
             ir: Some(vec![0.0; 4]),
             ir_space: space.map(String::from),
+            embed_space: None,
             ir_center_edge_ratio: 0.0,
             ir_brightness: 0.0,
             pitch: 0.0,

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -51,7 +51,8 @@ pub struct FaceScan {
     #[serde(default)]
     pub ir_space: Option<String>,
     /// The RECOGNIZER that produced `rgb` (and, before any adapter, `ir`),
-    /// as `"embed:<sha256 prefix>"` of its weights.
+    /// as `"embed:<sha256>"` of its weights (full digest: this tag exists to
+    /// resist an adversarial model, and a truncated hash halves per character).
     ///
     /// Cosine similarity is only meaningful WITHIN one embedding space. A
     /// different recognizer produces a different space, so comparing a fresh
@@ -62,8 +63,12 @@ pub struct FaceScan {
     /// user-supplied recognizer can be considered and which a change to the
     /// shipped weights would need regardless.
     ///
-    /// `None` = scan predates this tagging; grandfathered as compatible, the
-    /// same concession `ir_space` makes.
+    /// `None` = scan predates this tagging, which means exactly one recognizer
+    /// can have produced it: the historically shipped one. Compatibility is
+    /// decided by [`recognizer_space_matches`], which accepts `None` only when
+    /// the running recognizer IS [`LEGACY_RECOGNIZER_SPACE`] — not the blanket
+    /// grandfathering `ir_space` applies, because a template handed to an
+    /// arbitrary future model is the hole this field closes.
     #[serde(default)]
     pub embed_space: Option<String>,
     /// Per-scan IR liveness calibration: the center/edge brightness ratio of the
@@ -136,6 +141,30 @@ pub struct Enrollment {
     pub closure_calibration: Option<(f32, f32)>,
 }
 
+/// The one recognizer irlume ever shipped before templates recorded their
+/// producer: `glintr100.onnx` (AuraFace), as `"embed:<sha256>"` of its weights,
+/// pinned in `models/SHA256SUMS`. Every scan that deserializes with
+/// `embed_space: None` was produced by it, because no other recognizer existed
+/// when those scans were written.
+pub const LEGACY_RECOGNIZER_SPACE: &str =
+    "embed:a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60";
+
+/// Is a template tagged `have` comparable with embeddings from the recognizer
+/// whose space is `want`?
+///
+/// Cosine similarity is only meaningful inside one embedding space, so a
+/// mismatch means the comparison must not happen at all. An untagged template
+/// (`None`) is comparable ONLY when the running recognizer is the historical
+/// shipped one: grandfathering it into any space would hand every pre-tagging
+/// enrollment to whatever model is loaded, which is the exact hole the tag
+/// exists to close.
+pub fn recognizer_space_matches(have: Option<&str>, want: &str) -> bool {
+    match have {
+        Some(have) => have == want,
+        None => want == LEGACY_RECOGNIZER_SPACE,
+    }
+}
+
 impl Enrollment {
     pub fn new(user: &str) -> Self {
         Self {
@@ -153,29 +182,40 @@ impl Enrollment {
         self.profiles.iter().map(|p| p.scans.len()).sum()
     }
 
-    /// Every RGB template with its (profile, scan) labels, for 1:N matching.
-    pub fn rgb_scans(&self) -> Vec<(&str, &str, &[f32])> {
-        self.rgb_scans_in(None)
-    }
-
-    /// Every RGB template that lives in `space`, with (profile, scan) labels.
+    /// Every RGB template with its (profile, scan) labels, unfiltered.
     ///
-    /// `None` keeps every scan, which is what callers with no recognizer
-    /// identity to compare against want. `Some(space)` drops scans tagged with
-    /// a DIFFERENT recognizer: their vectors are in another embedding space and
-    /// a cosine against them is a number with no interpretation, free to land
-    /// either side of the threshold. Untagged scans are kept, the same
-    /// grandfathering `ir_space` applies (#276).
-    pub fn rgb_scans_in(&self, space: Option<&str>) -> Vec<(&str, &str, &[f32])> {
+    /// Diagnostic/export callers only. Anything that COMPARES vectors must go
+    /// through [`Self::rgb_scans_in`]: this accessor returns templates from
+    /// every embedding space, and a cosine across spaces is meaningless.
+    pub fn rgb_scans(&self) -> Vec<(&str, &str, &[f32])> {
         self.profiles
             .iter()
             .flat_map(|p| {
                 p.scans
                     .iter()
-                    .filter_map(move |s| match (space, s.embed_space.as_deref()) {
-                        (Some(want), Some(have)) if want != have => None,
-                        _ => Some((p.name.as_str(), s.name.as_str(), s.rgb.as_slice())),
-                    })
+                    .map(move |s| (p.name.as_str(), s.name.as_str(), s.rgb.as_slice()))
+            })
+            .collect()
+    }
+
+    /// Every RGB template that lives in `space`, with (profile, scan) labels.
+    ///
+    /// Drops scans from a DIFFERENT recognizer: their vectors are in another
+    /// embedding space and a cosine against them is a number with no
+    /// interpretation, free to land either side of the threshold. Untagged
+    /// scans are compatible only with [`LEGACY_RECOGNIZER_SPACE`], the one
+    /// recognizer that can have produced them (#276).
+    pub fn rgb_scans_in(&self, space: &str) -> Vec<(&str, &str, &[f32])> {
+        self.profiles
+            .iter()
+            .flat_map(|p| {
+                p.scans.iter().filter_map(move |s| {
+                    recognizer_space_matches(s.embed_space.as_deref(), space).then_some((
+                        p.name.as_str(),
+                        s.name.as_str(),
+                        s.rgb.as_slice(),
+                    ))
+                })
             })
             .collect()
     }
@@ -597,7 +637,8 @@ mod tests {
     fn rgb_templates_from_another_recognizer_are_not_offered_for_matching() {
         // Cosine is only meaningful inside one embedding space, so a template
         // tagged with a different recognizer must not reach the comparison at
-        // all. Untagged scans predate tagging and stay comparable (#276).
+        // all, and an untagged scan is comparable only with the one recognizer
+        // that can have produced it (#276).
         let enr = Enrollment {
             user: "u".into(),
             profiles: vec![FaceProfile {
@@ -617,16 +658,37 @@ mod tests {
                 .collect::<Vec<_>>()
         };
         assert_eq!(
-            names(enr.rgb_scans_in(Some("embed:aaaaaaaaaaaa"))),
-            vec!["same", "legacy"],
-            "a template from another recognizer must be excluded"
+            names(enr.rgb_scans_in("embed:aaaaaaaaaaaa")),
+            vec!["same"],
+            "a foreign tag and an untagged scan must both be excluded \
+             under a non-legacy recognizer"
         );
-        // No identity to compare against keeps everything, which is what the
-        // unfiltered accessor must still do for callers that have none.
+        assert_eq!(
+            names(enr.rgb_scans_in(LEGACY_RECOGNIZER_SPACE)),
+            vec!["legacy"],
+            "an untagged scan is comparable only with the legacy recognizer"
+        );
+        // The unfiltered accessor is for diagnostics and keeps everything.
         assert_eq!(names(enr.rgb_scans()), vec!["same", "other", "legacy"]);
-        // And the whole set can be excluded, which must yield an empty match
-        // rather than a comparison against foreign vectors.
-        assert!(enr.rgb_scans_in(Some("embed:cccccccccccc")).len() == 1);
+        // A recognizer nothing was enrolled under gets NO templates: matching
+        // must come up empty rather than score across spaces.
+        assert!(enr.rgb_scans_in("embed:cccccccccccc").is_empty());
+    }
+
+    #[test]
+    fn recognizer_space_matching_pins_the_legacy_concession() {
+        // Tagged scans compare by equality.
+        assert!(recognizer_space_matches(Some("embed:aa"), "embed:aa"));
+        assert!(!recognizer_space_matches(Some("embed:aa"), "embed:bb"));
+        // Untagged scans belong to the one recognizer that predates tagging,
+        // and to nothing else: `None` under an arbitrary model would hand every
+        // pre-tagging enrollment to whatever weights are loaded.
+        assert!(recognizer_space_matches(None, LEGACY_RECOGNIZER_SPACE));
+        assert!(!recognizer_space_matches(None, "embed:aa"));
+        // The pinned digest is the full 64-hex sha256 of glintr100.onnx from
+        // models/SHA256SUMS; a truncated pin would weaken every comparison
+        // above.
+        assert_eq!(LEGACY_RECOGNIZER_SPACE.len(), "embed:".len() + 64);
     }
     use super::*;
 

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -4562,6 +4562,7 @@ mod tests {
             rgb: unit512(seed),
             ir: None,
             ir_space: None,
+            embed_space: None,
             ir_center_edge_ratio: 0.0,
             ir_brightness: 0.0,
             pitch: 0.0,

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -448,11 +448,15 @@ mod onnx {
     }
 
     impl Adapter {
+        pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
+            Ok(Self {
+                session: build(model)?,
+            })
+        }
+
         pub fn load_from_file(path: &str) -> irlume_common::Result<Self> {
             let bytes = std::fs::read(path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
-            Ok(Self {
-                session: build(&bytes)?,
-            })
+            Self::load_from_memory(&bytes)
         }
 
         /// Adapt one IR embedding -> adapted vector (already L2-normalized).


### PR DESCRIPTION
Step 1 of #276, and a latent bug worth fixing on its own merits.

## The bug

Cosine similarity is only meaningful *inside* one embedding space. `Enrollment` recorded nothing about which recognizer produced a template, so if the model ever changed, irlume would compare fresh probes against vectors from a different space. That does not error: it produces a number with no interpretation, free to land either side of the threshold. A silent grant or a silent denial, with nothing to indicate which.

This bites on any change to the shipped weights, not only on a user-supplied model. It simply has to be true before #276 can consider opening the recognition stage at all.

## The fix

`FaceScan` gains `embed_space`, `"embed:<sha256>"` of the recognizer's weights (the full 64-hex digest; a truncated hash halves collision strength per dropped character, and this tag exists to resist an adversarial model). One `std::fs::read` feeds both the digest and the ONNX session, so the tag always describes the weights that are running; the IR adapter loader got the same single-read treatment.

Compatibility is decided in one place, `storage::recognizer_space_matches`:

- A tagged template matches only its own recognizer's hash.
- An untagged template (every enrollment written before this PR) is comparable **only when the loaded recognizer is the one that could have produced it**: the shipped `glintr100.onnx`, whose digest is pinned as `LEGACY_RECOGNIZER_SPACE` and matches `models/SHA256SUMS`. Grandfathering untagged scans into *any* space would hand every existing enrollment to whatever model gets loaded, which is the hole this PR closes.

Every comparison site applies it:

- `rgb_scans_in` at the single point both RGB match paths gather templates.
- `ir_match_in`: the recognizer produces the raw IR embedding, so its identity gates IR matching too. One filter covers fusion, IR fallback, the calibrated centroid, and dark IR-only auth.
- `refit_profile_calib` skips foreign-recognizer pairs rather than fitting one calibration across incompatible spaces.
- `colliding_profile` / `enroll_merge_target` take the engine's space, so a re-enrollment under a new model can never merge into or be rejected by templates from the old one.

## Testing

- An engine test asserts `Engine::load`'s tag of the real shipped weights equals `LEGACY_RECOGNIZER_SPACE`, tying the loader, the constant, and `models/SHA256SUMS` together.
- Storage, IR-match, collision, and refit tests each prove their filter excludes a foreign space and keeps the same space, including a foreign tag on a vector byte-identical to the probe (the case where only the filter, not the score, can refuse).
- Seven mutants, each deleting or weakening one guard (blanket `None` grandfathering back, `Some` arm to `true`, each of the four call-site filters removed, digest truncated back to 12 hex): all seven fail named tests that match the mutant's semantics, run with `--no-fail-fast`, tree restored byte-identical and the suite re-run green afterwards.
- Full workspace suite green (1084 tests), workspace clippy clean with `-D warnings`, rustfmt clean.

## Not covered

- The check-then-act window itself (a file swap between hash and session load) is closed structurally by the single read but has no test; producing that race deterministically needs filesystem fault injection.
- No authentication was scored across two genuinely different recognizers on hardware; the exclusion is established at the template-gathering layer.
- The user-visible half: irlume does not yet *tell* someone their templates were made by a different recognizer, it just declines to match them, which presents as a failed login falling back to password. A message naming re-enrollment as the fix belongs with the `stage` work in #276, where there is a reason for the situation to arise.
