### PR TITLE
auth+daemon: wire a third-party recognizer, dark-launched behind the stage gate

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -39,6 +39,18 @@ pub struct Engine {
     /// weights. Stamped onto every scan enrolled and required to match at
     /// verification: cosine scores are only meaningful inside one space.
     embed_space: String,
+    /// The RGB match threshold for THIS recognizer. The shipped constant for
+    /// the shipped model; a third-party recognizer brings its own measured
+    /// value (#276), because a threshold is a property of one model's cosine
+    /// scale and applying another model's number to it is a guess.
+    rgb_threshold: f32,
+    /// Whether IR matching (fusion, IR fallback, calibrated centroid, dark
+    /// IR-only auth) may run. False under a third-party recognizer: the IR
+    /// thresholds and the fusion Platt calibration are measurements of the
+    /// SHIPPED model's cosine scale, and no catalog entry carries IR-side
+    /// measurements yet. RGB-only matching stays; the dark path refuses with
+    /// its own reason and falls back to the password.
+    ir_matching: bool,
     /// Optional MediaPipe FaceMesh: dense landmarks for the passive EAR blink
     /// liveness (ADR-0002). Loaded iff the model file is present; `None` disables
     /// the opt-in passive-liveness gate (it can't run without landmarks).
@@ -563,6 +575,8 @@ impl Engine {
             ir_adapter: None,
             ir_space: "raw".into(),
             embed_space,
+            rgb_threshold: irlume_core::RGB_MATCH_THRESHOLD,
+            ir_matching: true,
             mesh: None,
             blaze: None,
             tp_pad: None,
@@ -659,6 +673,29 @@ impl Engine {
         &self.embed_space
     }
 
+    /// Configure this engine for a THIRD-PARTY recognizer (#276 stage 4): the
+    /// entry's measured RGB threshold replaces the shipped constant, and IR
+    /// matching is disabled wholesale — fusion, IR fallback, the calibrated
+    /// centroid, and dark IR-only auth are all measurements of the shipped
+    /// model's cosine scale (thresholds and Platt calibration alike), and no
+    /// catalog entry carries IR-side measurements. The liveness gate is
+    /// unaffected: it reads pixels, not embeddings. Dark logins refuse with
+    /// their own reason and fall back to the password.
+    pub fn with_thirdparty_recognizer(mut self, rgb_threshold: f32) -> Self {
+        self.rgb_threshold = rgb_threshold;
+        self.ir_matching = false;
+        self
+    }
+
+    /// The RGB grant threshold for a comparison against `n_templates`
+    /// templates: this recognizer's measured base, scaled for best-of-N FAR
+    /// inflation. The ONE place both RGB match paths get their bar, so a
+    /// third-party recognizer's threshold cannot reach one path and miss the
+    /// other.
+    fn rgb_grant_threshold(&self, n_templates: usize) -> f32 {
+        irlume_core::scaled_threshold(self.rgb_threshold, n_templates)
+    }
+
     /// Dimensionality of the IR embeddings this engine emits. The recognizer
     /// emits 512-D and the deployed adapter contract is 512→512; an adapter
     /// with a different output width must change this too (the per-scan dim
@@ -673,6 +710,12 @@ impl Engine {
     /// `None` (matching then behaves exactly as before the feature).
     fn refit_profile_calib(&self, prof: &mut irlume_core::storage::FaceProfile) {
         if self.ir_adapter.is_some() {
+            return;
+        }
+        // A third-party recognizer's IR matching never runs, so fitting a
+        // calibration over its embeddings would only produce an artifact that
+        // LOOKS like dark support exists.
+        if !self.ir_matching {
             return;
         }
         let dim = self.ir_dim();
@@ -709,6 +752,19 @@ impl Engine {
     /// Method wrapper over [`ir_match_in`], bound to the engine's space and
     /// adapter state.
     fn ir_match(&self, enr: &irlume_core::storage::Enrollment, probe: &[f32]) -> IrMatch {
+        // The choke point for the third-party-recognizer policy: with IR
+        // matching disabled, no caller — present or future — can score an IR
+        // template, because every IR grant path funnels through here. The
+        // call sites additionally check `ir_matching` where a specific
+        // refusal reason is owed to the user (the dark path).
+        if !self.ir_matching {
+            return IrMatch {
+                best: f32::NEG_INFINITY,
+                best_who: String::new(),
+                n_templates: 0,
+                centroid: None,
+            };
+        }
         ir_match_in(
             &self.ir_space,
             &self.embed_space,
@@ -2059,7 +2115,7 @@ impl Engine {
                 }
             }
             let scans = enr.rgb_scans_in(&self.embed_space);
-            let thr = irlume_core::scaled_threshold(irlume_core::RGB_MATCH_THRESHOLD, scans.len());
+            let thr = self.rgb_grant_threshold(scans.len());
             let (score, who) = best(&probe, &scans);
             irlume_common::dlog!(
                 "match(rgb): best {score:.3} vs thr {thr:.3} ({} scans, best profile '{who}')",
@@ -2079,7 +2135,10 @@ impl Engine {
             // grant while FMR stays bounded (an impostor must fool BOTH at once). The
             // cross-spectrum liveness gate + per-user IR floor already passed above.
             // This is the bright→RGB / dark→IR / dim→FUSE story.
-            if let Some(ir_probe) = &a.ir_embedding {
+            // With a third-party recognizer the whole IR side is unmeasured
+            // (thresholds AND the fusion Platt calibration are shipped-model
+            // measurements), so a marginal RGB miss ends here: password.
+            if let Some(ir_probe) = a.ir_embedding.as_ref().filter(|_| self.ir_matching) {
                 let m = self.ir_match(&enr, ir_probe);
                 if m.n_templates > 0 {
                     let (ir_score, ir_who) = (m.best, m.best_who.clone());
@@ -2148,6 +2207,18 @@ impl Engine {
         // Dark path: no RGB face, but an IR face -> IR-only liveness + IR
         // recognition (Windows-Hello-style dark operation) across all profiles.
         if let Some(probe) = a.ir_embedding {
+            // Fail-closed, with the real reason: dark unlock is an IR MATCH,
+            // and no third-party recognizer has a measured IR threshold. A
+            // generic "no match" here would send the user debugging their
+            // enrollment instead of reading the actual limitation.
+            if !self.ir_matching {
+                return Ok(Outcome::deny(
+                    OutcomeKind::OtherDeny,
+                    "dark unlock unavailable with a third-party recognizer (its IR \
+                     matching is unmeasured); use the password, or switch back to \
+                     the shipped recognizer",
+                ));
+            }
             let m = self.ir_match(&enr, &probe);
             if m.n_templates == 0 {
                 let reason = if enr.ir_scans().is_empty() {
@@ -2330,7 +2401,7 @@ impl Engine {
             if scans.is_empty() {
                 continue;
             }
-            let thr = irlume_core::scaled_threshold(irlume_core::RGB_MATCH_THRESHOLD, scans.len());
+            let thr = self.rgb_grant_threshold(scans.len());
             let (score, who) = scans
                 .iter()
                 .map(|(prof, _scan, t)| (align::cosine(&probe, t), *prof))
@@ -2569,7 +2640,12 @@ impl Engine {
                     "no live scan captured; check lighting and framing".into(),
                 )
             })?;
-        let goal = match enroll_merge_target(&enr, &[probe.rgb.as_slice()], &self.embed_space)? {
+        let goal = match enroll_merge_target(
+            &enr,
+            &[probe.rgb.as_slice()],
+            &self.embed_space,
+            self.rgb_threshold,
+        )? {
             Some(target) => {
                 let have = enr
                     .profiles
@@ -2601,7 +2677,9 @@ impl Engine {
         // drifting into frame after the probe, and a borderline probe that only
         // crosses the identity threshold on a later scan.
         let rgbs: Vec<&[f32]> = captured.iter().map(|s| s.rgb.as_slice()).collect();
-        if let Some(target) = enroll_merge_target(&enr, &rgbs, &self.embed_space)? {
+        if let Some(target) =
+            enroll_merge_target(&enr, &rgbs, &self.embed_space, self.rgb_threshold)?
+        {
             // The face already owns a profile: merge the capture into it.
             let idx = enr
                 .profiles
@@ -2737,9 +2815,13 @@ impl Engine {
                 )
             })?;
         // Anti-mixing: reject a scan whose face belongs to a different profile.
-        if let Some((other, score)) =
-            colliding_profile(&enr, &captured.rgb, Some(profile_name), &self.embed_space)
-        {
+        if let Some((other, score)) = colliding_profile(
+            &enr,
+            &captured.rgb,
+            Some(profile_name),
+            &self.embed_space,
+            self.rgb_threshold,
+        ) {
             let cnt = enr
                 .profiles
                 .iter()
@@ -3014,10 +3096,12 @@ fn enroll_merge_target(
     enr: &irlume_core::storage::Enrollment,
     captured_rgb: &[&[f32]],
     embed_space: &str,
+    threshold: f32,
 ) -> irlume_common::Result<Option<String>> {
     let mut hit: Option<String> = None;
     for rgb in captured_rgb {
-        let Some((other, _score)) = colliding_profile(enr, rgb, None, embed_space) else {
+        let Some((other, _score)) = colliding_profile(enr, rgb, None, embed_space, threshold)
+        else {
             continue;
         };
         match &hit {
@@ -3043,6 +3127,7 @@ fn colliding_profile(
     probe: &[f32],
     exclude: Option<&str>,
     embed_space: &str,
+    threshold: f32,
 ) -> Option<(String, f32)> {
     let mut best: Option<(String, f32)> = None;
     for p in &enr.profiles {
@@ -3061,7 +3146,7 @@ fn colliding_profile(
                 continue;
             }
             let c = align::cosine(probe, &s.rgb);
-            if c >= irlume_core::RGB_MATCH_THRESHOLD && best.as_ref().is_none_or(|b| c > b.1) {
+            if c >= threshold && best.as_ref().is_none_or(|b| c > b.1) {
                 best = Some((p.name.clone(), c));
             }
         }
@@ -3761,21 +3846,62 @@ mod tests {
                 &enr,
                 &face1,
                 Some("Face Profile 2"),
-                LEGACY_RECOGNIZER_SPACE
+                LEGACY_RECOGNIZER_SPACE,
+                irlume_core::RGB_MATCH_THRESHOLD
             )
             .map(|(n, _)| n),
             Some("Face Profile 1".to_string())
         );
         // A novel face collides with nothing.
-        assert!(colliding_profile(&enr, &[0.0, 0.0, 1.0], None, LEGACY_RECOGNIZER_SPACE).is_none());
+        assert!(colliding_profile(
+            &enr,
+            &[0.0, 0.0, 1.0],
+            None,
+            LEGACY_RECOGNIZER_SPACE,
+            irlume_core::RGB_MATCH_THRESHOLD
+        )
+        .is_none());
         // Same face into its OWN profile (excluded) is fine; that's improving it.
         assert!(colliding_profile(
             &enr,
             &face1,
             Some("Face Profile 1"),
-            LEGACY_RECOGNIZER_SPACE
+            LEGACY_RECOGNIZER_SPACE,
+            irlume_core::RGB_MATCH_THRESHOLD
         )
         .is_none());
+    }
+
+    #[test]
+    fn collision_uses_the_engines_threshold_not_the_shipped_constant() {
+        // A third-party recognizer brings its own measured threshold, and the
+        // enrollment anti-mixing decision must use it: a pair that counts as
+        // "same person" on the shipped scale may be strangers on another
+        // model's scale. cos(a,b) here is ~0.6: a collision at the shipped
+        // 0.55, not a collision at a stricter 0.8.
+        // Exact by construction: cos(a,b) = 0.65 for unit a=[1,0,0] and
+        // b=[0.65, sqrt(1-0.65^2), 0].
+        let a = unit(vec![1.0, 0.0, 0.0]);
+        let b = unit(vec![0.65, (1.0f32 - 0.65 * 0.65).sqrt(), 0.0]);
+        let c = align::cosine(&a, &b);
+        assert!(c > 0.55 && c < 0.8, "fixture cosine drifted: {c}");
+        let enr = Enrollment {
+            user: "u".into(),
+            profiles: vec![FaceProfile {
+                ir_calib: None,
+                name: "P1".into(),
+                scans: vec![scan(b)],
+            }],
+            ..Default::default()
+        };
+        assert!(
+            colliding_profile(&enr, &a, None, LEGACY_RECOGNIZER_SPACE, 0.55).is_some(),
+            "must collide at the shipped threshold"
+        );
+        assert!(
+            colliding_profile(&enr, &a, None, LEGACY_RECOGNIZER_SPACE, 0.8).is_none(),
+            "must not collide at a stricter model threshold"
+        );
     }
 
     #[test]
@@ -3797,15 +3923,35 @@ mod tests {
             ..Default::default()
         };
         // Under any OTHER recognizer the identical vector is invisible...
-        assert!(colliding_profile(&enr, &face, None, LEGACY_RECOGNIZER_SPACE).is_none());
+        assert!(colliding_profile(
+            &enr,
+            &face,
+            None,
+            LEGACY_RECOGNIZER_SPACE,
+            irlume_core::RGB_MATCH_THRESHOLD
+        )
+        .is_none());
         assert_eq!(
-            enroll_merge_target(&enr, &[&face], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            enroll_merge_target(
+                &enr,
+                &[&face],
+                LEGACY_RECOGNIZER_SPACE,
+                irlume_core::RGB_MATCH_THRESHOLD
+            )
+            .unwrap(),
             None
         );
         // ...and under its own recognizer it collides as it always did (the
         // positive control that proves the filter, not the vector, decided).
         assert_eq!(
-            colliding_profile(&enr, &face, None, "embed:model-b").map(|(n, _)| n),
+            colliding_profile(
+                &enr,
+                &face,
+                None,
+                "embed:model-b",
+                irlume_core::RGB_MATCH_THRESHOLD
+            )
+            .map(|(n, _)| n),
             Some("P1".to_string())
         );
     }
@@ -3834,20 +3980,38 @@ mod tests {
         // Novel face: no collision, create the new profile.
         let enr = enr_with(vec![ir_scan(face1.clone(), Some("raw"))]);
         assert_eq!(
-            enroll_merge_target(&enr, &[&novel], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            enroll_merge_target(
+                &enr,
+                &[&novel],
+                LEGACY_RECOGNIZER_SPACE,
+                irlume_core::RGB_MATCH_THRESHOLD
+            )
+            .unwrap(),
             None
         );
 
         // Same face merges into its profile regardless of IR-template state:
         // healthy current-space templates...
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            enroll_merge_target(
+                &enr,
+                &[&face1],
+                LEGACY_RECOGNIZER_SPACE,
+                irlume_core::RGB_MATCH_THRESHOLD
+            )
+            .unwrap(),
             Some("P1".into())
         );
         // ...untagged legacy templates...
         let enr = enr_with(vec![ir_scan(face1.clone(), None)]);
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            enroll_merge_target(
+                &enr,
+                &[&face1],
+                LEGACY_RECOGNIZER_SPACE,
+                irlume_core::RGB_MATCH_THRESHOLD
+            )
+            .unwrap(),
             Some("P1".into())
         );
         // ...templates stranded by an adapter removal (the 0.2.0 upgrade case)...
@@ -3856,13 +4020,25 @@ mod tests {
             ir_scan(face1.clone(), Some("adapter:deadbeef0123")),
         ]);
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            enroll_merge_target(
+                &enr,
+                &[&face1],
+                LEGACY_RECOGNIZER_SPACE,
+                irlume_core::RGB_MATCH_THRESHOLD
+            )
+            .unwrap(),
             Some("P1".into())
         );
         // ...or a profile that never had IR scans at all.
         let enr = enr_with(vec![scan(face1.clone())]);
         assert_eq!(
-            enroll_merge_target(&enr, &[&face1], LEGACY_RECOGNIZER_SPACE).unwrap(),
+            enroll_merge_target(
+                &enr,
+                &[&face1],
+                LEGACY_RECOGNIZER_SPACE,
+                irlume_core::RGB_MATCH_THRESHOLD
+            )
+            .unwrap(),
             Some("P1".into())
         );
 
@@ -3873,8 +4049,13 @@ mod tests {
             name: "P2".into(),
             scans: vec![ir_scan(face2.clone(), Some("adapter:deadbeef0123"))],
         });
-        let err =
-            enroll_merge_target(&enr, &[&face1, &face2], LEGACY_RECOGNIZER_SPACE).unwrap_err();
+        let err = enroll_merge_target(
+            &enr,
+            &[&face1, &face2],
+            LEGACY_RECOGNIZER_SPACE,
+            irlume_core::RGB_MATCH_THRESHOLD,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("two different profiles"));
     }
 
@@ -4719,6 +4900,83 @@ mod engine_tests {
         s.engine.refit_profile_calib(&mut fresh);
         assert!(fresh.ir_calib.is_none(), "adapter mode must not fit anew");
         s.engine.ir_adapter = None; // restore the shared baseline
+    }
+
+    #[test]
+    fn thirdparty_recognizer_policy_threshold_and_ir_shutdown() {
+        let _g = env_guard();
+        let mut s = shared();
+        // Default: the shipped constant, scaled; IR matching on.
+        assert_eq!(
+            s.engine.rgb_grant_threshold(1),
+            irlume_core::RGB_MATCH_THRESHOLD
+        );
+        assert!(s.engine.ir_matching);
+        // An IR-scanned enrollment the choke point can be proven against.
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(FaceProfile {
+            name: "p".into(),
+            ir_calib: None,
+            scans: (0..3).map(|i| scan512(i, true, Some("raw"))).collect(),
+        });
+        let probe = unit512(0);
+        assert_eq!(
+            s.engine.ir_match(&enr, &probe).n_templates,
+            3,
+            "control: IR matching must work before the policy flips"
+        );
+
+        // The third-party policy: measured threshold in, IR matching dead.
+        s.engine.rgb_threshold = 0.60;
+        s.engine.ir_matching = false;
+        assert_eq!(s.engine.rgb_grant_threshold(1), 0.60);
+        // Scaling still applies on top of the model's own base.
+        assert!(s.engine.rgb_grant_threshold(8) > 0.60);
+        // The choke point: no IR template is scored, whoever asks.
+        let m = s.engine.ir_match(&enr, &probe);
+        assert_eq!(m.n_templates, 0);
+        assert_eq!(m.best, f32::NEG_INFINITY);
+        assert!(m.centroid.is_none());
+        // And no calibration is fitted, so nothing on disk implies dark
+        // support that cannot exist for this model.
+        let mut prof = FaceProfile {
+            name: "p2".into(),
+            ir_calib: None,
+            scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
+        };
+        s.engine.refit_profile_calib(&mut prof);
+        assert!(prof.ir_calib.is_none());
+
+        // Restore the shared baseline; prove the restore took (a poisoned
+        // shared engine would fail every later test for the wrong reason).
+        s.engine.rgb_threshold = irlume_core::RGB_MATCH_THRESHOLD;
+        s.engine.ir_matching = true;
+        assert_eq!(s.engine.ir_match(&enr, &probe).n_templates, 3);
+        s.engine.refit_profile_calib(&mut prof);
+        assert!(prof.ir_calib.is_some(), "restored engine must fit again");
+    }
+
+    #[test]
+    fn with_thirdparty_recognizer_sets_both_halves_of_the_policy() {
+        // The builder is the public face of the policy: one call, both
+        // effects. Split halves would let a future caller set the threshold
+        // and forget the IR shutdown.
+        let _g = env_guard();
+        let s = shared();
+        // Cheap structural check on a rebuilt engine is not possible without
+        // loading models again; assert via the builder on a clone of the
+        // shared engine's config instead: consume-and-rebuild is what the
+        // daemon does, so exercise exactly that shape.
+        drop(s);
+        let e = Engine::load(
+            &model_path("face_detection_yunet_2023mar.onnx"),
+            &model_path("glintr100.onnx"),
+        )
+        .expect("engine load")
+        .with_devices(NO_RGB, NO_IR)
+        .with_thirdparty_recognizer(0.6);
+        assert_eq!(e.rgb_grant_threshold(1), 0.6);
+        assert!(!e.ir_matching);
     }
 
     #[test]

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -559,19 +559,34 @@ impl Engine {
         // Identify the recognizer by its weights, not its path: a file swapped
         // in place under the same name is a different embedding space and must
         // not silently score against templates from the old one. Read the file
-        // ONCE and build the session from those same bytes — hashing one read
-        // and loading another would let a mid-startup file swap run weights the
-        // tag does not describe. Full digest: the tag resists an adversarial
-        // model, and truncation halves its strength per dropped character.
+        // ONCE and hand those bytes to the byte loader below.
         let model_bytes = std::fs::read(model_path)
             .map_err(|e| irlume_common::Error::Io(format!("{model_path}: {e}")))?;
+        Self::load_with_recognizer_bytes(det_path, &model_bytes)
+    }
+
+    /// [`Self::load`], from recognizer bytes the CALLER already holds.
+    ///
+    /// For callers that verified those bytes against a pin: re-reading a path
+    /// here would let a swap between their check and this load pair the new
+    /// weights with a threshold measured for the old ones — the digest below
+    /// would honestly tag the new space, but the POLICY attached to the engine
+    /// would belong to a different artifact. One byte buffer flows from the
+    /// caller's checksum through the digest into the ONNX session, so the
+    /// three can never disagree.
+    pub fn load_with_recognizer_bytes(
+        det_path: &str,
+        model_bytes: &[u8],
+    ) -> irlume_common::Result<Self> {
+        // Full digest: the tag resists an adversarial model, and truncation
+        // halves its strength per dropped character.
         let embed_space = format!(
             "embed:{}",
-            irlume_common::thirdparty::sha256_hex(&model_bytes)
+            irlume_common::thirdparty::sha256_hex(model_bytes)
         );
         Ok(Self {
             det: Detector::load_from_file(det_path)?,
-            emb: Embedder::load_from_memory(&model_bytes)?,
+            emb: Embedder::load_from_memory(model_bytes)?,
             ir_adapter: None,
             ir_space: "raw".into(),
             embed_space,
@@ -4954,6 +4969,25 @@ mod engine_tests {
         assert_eq!(s.engine.ir_match(&enr, &probe).n_templates, 3);
         s.engine.refit_profile_calib(&mut prof);
         assert!(prof.ir_calib.is_some(), "restored engine must fit again");
+    }
+
+    #[test]
+    fn verified_recognizer_bytes_are_the_loaded_embedding_space() {
+        // The byte loader exists so a caller's pin check, the template-space
+        // digest, and the ONNX session all come from ONE buffer: the digest
+        // must be of exactly the bytes handed in, or a path swap between a
+        // caller's checksum and this load could pair new weights with a
+        // threshold measured for old ones (#279 review).
+        let _g = env_guard();
+        let _s = shared(); // ensure ORT is initialized for this process
+        let bytes = std::fs::read(model_path("glintr100.onnx")).unwrap();
+        let expected = format!("embed:{}", irlume_common::thirdparty::sha256_hex(&bytes));
+        let engine = Engine::load_with_recognizer_bytes(
+            &model_path("face_detection_yunet_2023mar.onnx"),
+            &bytes,
+        )
+        .expect("engine from bytes");
+        assert_eq!(engine.embed_space(), expected);
     }
 
     #[test]

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -397,9 +397,14 @@ fn place_verified(m: &ThirdPartyModel, bytes: &[u8]) -> bool {
         eprintln!("[models] could not install {}: {e}", path.display());
         return false;
     }
-    if let Err(e) =
-        irlume_common::config::write_kv("settings.conf", thirdparty::SETTINGS_KEY, m.name)
-    {
+    // The key is the entry's STAGE's key: naming a recognizer under the PAD
+    // key would wire it as an anti-spoof cue (the daemon refuses that, but the
+    // installer should not write nonsense for a guard to catch).
+    if let Err(e) = irlume_common::config::write_kv(
+        "settings.conf",
+        thirdparty::settings_key_for(m.stage),
+        m.name,
+    ) {
         eprintln!("[models] weights installed but settings.conf update failed: {e}");
         return false;
     }

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -22,8 +22,58 @@
 
 use std::path::{Path, PathBuf};
 
-/// `settings.conf` key naming the enabled model (absent/empty = disabled).
+/// `settings.conf` key naming the enabled PAD model (absent/empty = disabled).
 pub const SETTINGS_KEY: &str = "third_party_pad";
+
+/// `settings.conf` key naming the enabled third-party RECOGNIZER (absent/empty
+/// = the shipped recognizer). Separate keys per stage: one key naming entries
+/// of two different stages would make "what is enabled" ambiguous the day two
+/// stages are open at once.
+pub const RECOGNIZER_SETTINGS_KEY: &str = "third_party_recognizer";
+
+/// The stage-appropriate settings key for a catalog entry.
+pub const fn settings_key_for(stage: Stage) -> &'static str {
+    match stage {
+        Stage::Pad => SETTINGS_KEY,
+        Stage::Recognition => RECOGNIZER_SETTINGS_KEY,
+        // No key exists for stages with no wiring; the installer refuses
+        // closed stages long before this matters, and giving them a real key
+        // here would silently enable whatever wiring later reads it.
+        Stage::Detection | Stage::Landmarks => "third_party_unwired",
+    }
+}
+
+/// Why a settings value cannot be used as the third-party recognizer.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecognizerRefusal {
+    /// The name is not in the catalog.
+    NotInCatalog,
+    /// The entry exists but is not a recognition-stage model.
+    WrongStage(&'static str),
+    /// The recognition stage is not open to third-party models.
+    StageClosed,
+}
+
+/// Decide whether a catalog lookup result may be wired as THE recognizer.
+///
+/// Pure so the refusals are testable with fixture entries; the daemon composes
+/// this with [`by_name`], the pin check, and the file read. The stage-open
+/// check is here rather than trusted to the installer because the settings key
+/// is root-editable text the installer never saw.
+pub fn recognizer_override(
+    entry: Option<&ThirdPartyModel>,
+) -> Result<&ThirdPartyModel, RecognizerRefusal> {
+    let Some(entry) = entry else {
+        return Err(RecognizerRefusal::NotInCatalog);
+    };
+    if entry.stage != Stage::Recognition {
+        return Err(RecognizerRefusal::WrongStage(entry.stage.as_str()));
+    }
+    if !Stage::Recognition.open() {
+        return Err(RecognizerRefusal::StageClosed);
+    }
+    Ok(entry)
+}
 
 /// The pipeline stage a catalog model plugs into.
 ///
@@ -79,6 +129,7 @@ impl Stage {
 /// Subdirectory of the state dir holding fetched third-party weights.
 pub const SUBDIR: &str = "models-thirdparty";
 
+#[derive(Debug)]
 pub struct ThirdPartyModel {
     /// Catalog name, what the user types to enable (`irlume models enable X`).
     pub name: &'static str,
@@ -265,6 +316,57 @@ mod tests {
     fn lookup_by_name() {
         assert!(by_name("flir").is_some());
         assert!(by_name("nope").is_none());
+    }
+
+    #[test]
+    fn recognizer_override_refuses_everything_but_an_open_recognition_entry() {
+        let fixture = |stage: Stage| ThirdPartyModel {
+            name: "fixture",
+            stage,
+            file: "fixture.onnx",
+            url: None,
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+            license: "fixture",
+            provenance: "fixture",
+            threshold: 0.6,
+            summary: "fixture",
+        };
+        // Unknown name.
+        assert_eq!(
+            recognizer_override(None).unwrap_err(),
+            RecognizerRefusal::NotInCatalog
+        );
+        // A PAD entry must never be wired as the recognizer, whatever the
+        // settings key says: it is a different kind of model entirely.
+        let pad = fixture(Stage::Pad);
+        assert_eq!(
+            recognizer_override(Some(&pad)).unwrap_err(),
+            RecognizerRefusal::WrongStage("pad")
+        );
+        // A recognition entry is refused while the stage is closed. When
+        // stage 4 opens (Stage::Recognition.open() flips), this arm changes to
+        // Ok — that flip and this test must land in the same commit as the
+        // first measured entry.
+        let rec = fixture(Stage::Recognition);
+        assert_eq!(
+            recognizer_override(Some(&rec)).unwrap_err(),
+            RecognizerRefusal::StageClosed
+        );
+    }
+
+    #[test]
+    fn settings_keys_are_per_stage_and_distinct() {
+        assert_eq!(settings_key_for(Stage::Pad), SETTINGS_KEY);
+        assert_eq!(
+            settings_key_for(Stage::Recognition),
+            RECOGNIZER_SETTINGS_KEY
+        );
+        assert_ne!(SETTINGS_KEY, RECOGNIZER_SETTINGS_KEY);
+        // Unwired stages get a key nothing reads, not one of the real ones.
+        for s in [Stage::Detection, Stage::Landmarks] {
+            assert_ne!(settings_key_for(s), SETTINGS_KEY);
+            assert_ne!(settings_key_for(s), RECOGNIZER_SETTINGS_KEY);
+        }
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -252,13 +252,79 @@ fn main() {
                         entry.name.to_string(),
                     ))
                 });
+            // Opt-in third-party RECOGNIZER (#276 stage 4). Same trust chain
+            // as the PAD cue — catalog entry, stage check, pinned checksum —
+            // but a failure here falls back to the SHIPPED recognizer rather
+            // than to "no cue": a daemon with no recognizer at all cannot
+            // authenticate anything, and the shipped stack is the measured
+            // default. The stage gate refuses until Stage::Recognition opens,
+            // so today this resolves to None on every machine.
+            let tp_rec: Option<(String, f32, String)> = std::env::var("IRLUME_THIRDPARTY_RECOGNIZER")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| {
+                    irlume_common::config::read_kv(
+                        "settings.conf",
+                        irlume_common::thirdparty::RECOGNIZER_SETTINGS_KEY,
+                    )
+                })
+                .and_then(|name| {
+                    let name = name.trim().to_string();
+                    let entry = match irlume_common::thirdparty::recognizer_override(
+                        irlume_common::thirdparty::by_name(&name),
+                    ) {
+                        Ok(e) => e,
+                        Err(why) => {
+                            eprintln!(
+                                "irlumed: WARNING: third_party_recognizer='{name}' refused ({why:?}); using the shipped recognizer"
+                            );
+                            return None;
+                        }
+                    };
+                    let path = irlume_common::thirdparty::model_path(entry);
+                    let bytes = match std::fs::read(&path) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            eprintln!(
+                                "irlumed: WARNING: third-party recognizer '{name}' enabled but {} unreadable ({e}); using the shipped recognizer",
+                                path.display()
+                            );
+                            return None;
+                        }
+                    };
+                    let digest = irlume_common::thirdparty::sha256_hex(&bytes);
+                    if digest != entry.sha256 {
+                        eprintln!(
+                            "irlumed: WARNING: third-party recognizer '{name}' checksum mismatch (sha256 {digest}); refusing unpinned weights, using the shipped recognizer"
+                        );
+                        return None;
+                    }
+                    Some((
+                        path.to_string_lossy().into_owned(),
+                        entry.threshold,
+                        entry.name.to_string(),
+                    ))
+                });
             // Engine factory: (re)loads the models and rebinds devices/adapters. Used
             // once at startup and again by the camera worker to rebuild the engine after
             // a caught panic, so a fresh request never runs against ONNX sessions left in
             // an unproven state by an unwind. It owns its inputs so it can move to the
             // worker thread, and it is Fn, so startup calls it before that move.
             let build_engine = move || {
-                irlume_auth::Engine::load(&det, &model)
+                let (rec_model, rec_override) = match &tp_rec {
+                    Some((path, thr, name)) => (path.as_str(), Some((*thr, name.as_str()))),
+                    None => (model.as_str(), None),
+                };
+                irlume_auth::Engine::load(&det, rec_model)
+                    .map(|e| match rec_override {
+                        Some((thr, name)) => {
+                            eprintln!(
+                                "irlumed: third-party recognizer '{name}' loaded (threshold {thr}; IR matching disabled — unmeasured for this model)"
+                            );
+                            e.with_thirdparty_recognizer(thr)
+                        }
+                        None => e,
+                    })
                     .map(|e| e.with_devices(&rgb_dev, &ir_dev))
                     .and_then(|e| e.with_ir_adapter(&adapter))
                     .and_then(|e| e.with_mesh(&mesh))

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -83,6 +83,58 @@ fn models_to_verify<'a>(shipped: [&'a str; 4], adapter: &'a str) -> Vec<&'a str>
     v
 }
 
+/// Resolve the opt-in third-party RECOGNIZER selection (#276 stage 4), or EXIT.
+///
+/// The failure policy is the opposite of the PAD cue's fall-back-to-nothing:
+/// an explicit `third_party_recognizer` selection is an authentication-policy
+/// choice, and silently substituting the shipped recognizer would run a
+/// DIFFERENT grant-capable decision system against the templates the operator
+/// kept. Any invalid explicit selection refuses to start; PAM treats an
+/// unavailable daemon as password fallback, so fail-closed means "password",
+/// never lockout. `None` = nothing selected, use the shipped default. The
+/// returned VERIFIED BYTES are what the engine must load: re-reading the path
+/// later (or at a post-panic rebuild) would let a swap pair new weights with
+/// the threshold measured for the old ones.
+fn resolve_thirdparty_recognizer() -> Option<(Vec<u8>, f32, String)> {
+    std::env::var("IRLUME_THIRDPARTY_RECOGNIZER")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            irlume_common::config::read_kv(
+                "settings.conf",
+                irlume_common::thirdparty::RECOGNIZER_SETTINGS_KEY,
+            )
+        })
+        .map(|name| {
+            let name = name.trim().to_string();
+            let entry = irlume_common::thirdparty::recognizer_override(
+                irlume_common::thirdparty::by_name(&name),
+            )
+            .unwrap_or_else(|why| {
+                eprintln!(
+                    "irlumed: third_party_recognizer='{name}' refused ({why:?}); refusing to start so face auth falls back to the password"
+                );
+                std::process::exit(1);
+            });
+            let path = irlume_common::thirdparty::model_path(entry);
+            let bytes = std::fs::read(&path).unwrap_or_else(|e| {
+                eprintln!(
+                    "irlumed: third-party recognizer '{name}' selected but {} unreadable ({e}); refusing to start so face auth falls back to the password",
+                    path.display()
+                );
+                std::process::exit(1);
+            });
+            let digest = irlume_common::thirdparty::sha256_hex(&bytes);
+            if digest != entry.sha256 {
+                eprintln!(
+                    "irlumed: third-party recognizer '{name}' checksum mismatch (sha256 {digest}); refusing to start so face auth falls back to the password"
+                );
+                std::process::exit(1);
+            }
+            (bytes, entry.threshold, entry.name.to_string())
+        })
+}
+
 fn main() {
     // FIRST, before models load. The watchdog deadline starts ticking the moment
     // systemd execs us, and loading the ONNX sessions takes tens of seconds on a
@@ -254,77 +306,39 @@ fn main() {
                 });
             // Opt-in third-party RECOGNIZER (#276 stage 4). Same trust chain
             // as the PAD cue — catalog entry, stage check, pinned checksum —
-            // but a failure here falls back to the SHIPPED recognizer rather
-            // than to "no cue": a daemon with no recognizer at all cannot
-            // authenticate anything, and the shipped stack is the measured
-            // default. The stage gate refuses until Stage::Recognition opens,
-            // so today this resolves to None on every machine.
-            let tp_rec: Option<(String, f32, String)> = std::env::var("IRLUME_THIRDPARTY_RECOGNIZER")
-                .ok()
-                .filter(|v| !v.trim().is_empty())
-                .or_else(|| {
-                    irlume_common::config::read_kv(
-                        "settings.conf",
-                        irlume_common::thirdparty::RECOGNIZER_SETTINGS_KEY,
-                    )
-                })
-                .and_then(|name| {
-                    let name = name.trim().to_string();
-                    let entry = match irlume_common::thirdparty::recognizer_override(
-                        irlume_common::thirdparty::by_name(&name),
-                    ) {
-                        Ok(e) => e,
-                        Err(why) => {
-                            eprintln!(
-                                "irlumed: WARNING: third_party_recognizer='{name}' refused ({why:?}); using the shipped recognizer"
-                            );
-                            return None;
-                        }
-                    };
-                    let path = irlume_common::thirdparty::model_path(entry);
-                    let bytes = match std::fs::read(&path) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            eprintln!(
-                                "irlumed: WARNING: third-party recognizer '{name}' enabled but {} unreadable ({e}); using the shipped recognizer",
-                                path.display()
-                            );
-                            return None;
-                        }
-                    };
-                    let digest = irlume_common::thirdparty::sha256_hex(&bytes);
-                    if digest != entry.sha256 {
-                        eprintln!(
-                            "irlumed: WARNING: third-party recognizer '{name}' checksum mismatch (sha256 {digest}); refusing unpinned weights, using the shipped recognizer"
-                        );
-                        return None;
-                    }
-                    Some((
-                        path.to_string_lossy().into_owned(),
-                        entry.threshold,
-                        entry.name.to_string(),
-                    ))
-                });
+            // but the failure policy is the opposite of the cue's: an explicit
+            // third_party_recognizer selection is an authentication-policy
+            // choice, and silently substituting the shipped recognizer would
+            // run a DIFFERENT grant-capable decision system against the
+            // templates the operator kept. Any invalid selection refuses to
+            // start; PAM treats an unavailable daemon as password fallback, so
+            // fail-closed here means "password", never lockout. Absence of
+            // the setting selects the shipped default as always. The VERIFIED
+            // BYTES are retained and handed to the engine: re-reading the path
+            // at load (or at a post-panic rebuild) would let a swap pair new
+            // weights with the threshold measured for the old ones. The stage
+            // gate refuses until Stage::Recognition opens, so today an
+            // explicit selection always refuses.
+            let tp_rec: Option<(Vec<u8>, f32, String)> = resolve_thirdparty_recognizer();
             // Engine factory: (re)loads the models and rebinds devices/adapters. Used
             // once at startup and again by the camera worker to rebuild the engine after
             // a caught panic, so a fresh request never runs against ONNX sessions left in
             // an unproven state by an unwind. It owns its inputs so it can move to the
             // worker thread, and it is Fn, so startup calls it before that move.
             let build_engine = move || {
-                let (rec_model, rec_override) = match &tp_rec {
-                    Some((path, thr, name)) => (path.as_str(), Some((*thr, name.as_str()))),
-                    None => (model.as_str(), None),
-                };
-                irlume_auth::Engine::load(&det, rec_model)
-                    .map(|e| match rec_override {
-                        Some((thr, name)) => {
+                match &tp_rec {
+                    // The RETAINED verified bytes, not the path: a post-panic
+                    // rebuild must run exactly the artifact the pin check saw.
+                    Some((bytes, thr, name)) => {
+                        irlume_auth::Engine::load_with_recognizer_bytes(&det, bytes).map(|e| {
                             eprintln!(
                                 "irlumed: third-party recognizer '{name}' loaded (threshold {thr}; IR matching disabled — unmeasured for this model)"
                             );
-                            e.with_thirdparty_recognizer(thr)
-                        }
-                        None => e,
-                    })
+                            e.with_thirdparty_recognizer(*thr)
+                        })
+                    }
+                    None => irlume_auth::Engine::load(&det, &model),
+                }
                     .map(|e| e.with_devices(&rgb_dev, &ir_dev))
                     .and_then(|e| e.with_ir_adapter(&adapter))
                     .and_then(|e| e.with_mesh(&mesh))
@@ -3226,6 +3240,54 @@ mod tests {
         assert_eq!(v.len(), 5);
         assert_eq!(v[4], ap);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // An invalid explicit third_party_recognizer selection must REFUSE TO
+    // START, never silently substitute the shipped recognizer: that would run
+    // a different grant-capable decision system than the operator selected
+    // (#279 review). resolve_thirdparty_recognizer exits the process, so
+    // re-exec this test binary as the child that makes the call.
+    #[test]
+    fn recognizer_selection_failures_refuse_to_start() {
+        if std::env::var("IRLUME_TEST_RECOGNIZER_CHILD").is_ok() {
+            // Child: resolution of the env-selected name must exit(1) inside
+            // this call for both an unknown name and a wrong-stage name.
+            let _ = resolve_thirdparty_recognizer();
+            return; // reaching this line means the selection was NOT refused
+        }
+        let exe = std::env::current_exe().unwrap();
+        let run = |selection: &str| {
+            std::process::Command::new(&exe)
+                .args([
+                    "tests::recognizer_selection_failures_refuse_to_start",
+                    "--exact",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env("IRLUME_TEST_RECOGNIZER_CHILD", "1")
+                .env("IRLUME_THIRDPARTY_RECOGNIZER", selection)
+                .output()
+                .unwrap()
+        };
+        // Not in the catalog at all.
+        let out = run("ghost");
+        assert!(!out.status.success(), "an unknown selection must refuse");
+        let err = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            err.contains("refused (NotInCatalog)") && err.contains("falls back to the password"),
+            "stderr was: {err}"
+        );
+        // In the catalog, but a PAD model: naming it as THE recognizer is
+        // nonsense the daemon must refuse, not reinterpret.
+        let out = run("flir");
+        assert!(!out.status.success(), "a wrong-stage selection must refuse");
+        let err = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            err.contains("refused (WrongStage(\"pad\"))"),
+            "stderr was: {err}"
+        );
+        // StageClosed is unreachable until a Recognition entry exists in the
+        // catalog; the decision itself is pinned in irlume-common's tests.
     }
 
     // Regression: 834c71e (companion guard). Excluding the optional adapter


### PR DESCRIPTION
Stage-4 plumbing for #276, landing while `Stage::Recognition` stays **closed**: every new path refuses today, and opening the stage is a deliberate one-line flip that ships with the first measured catalog entry. The measurement side is done — the split-source protocol proposal and buffalo_l's full FAR tables are on #276 — so this is the wiring that makes an entry loadable once the live genuine floor is captured.

## What it wires

**Engine policy, one builder call.** `with_thirdparty_recognizer(threshold)` does two inseparable things: the entry's measured RGB threshold replaces the shipped constant (`rgb_grant_threshold` is now the single place both RGB match paths and the enrollment collision decision get their bar), and IR matching dies wholesale. The IR thresholds and the fusion Platt calibration are measurements of the shipped model's cosine scale; no catalog entry carries IR-side measurements, so fusion, IR fallback, calibrated centroid, and dark IR-only auth are all off under a foreign recognizer. `ir_match` is the choke point — no present or future caller can score an IR template — and the dark path refuses with a reason naming the real limitation ("its IR matching is unmeasured") instead of a generic miss that would send the user debugging their enrollment. `refit_profile_calib` stops fitting calibrations that would imply dark support which cannot exist. The liveness gate is untouched: it reads pixels, not embeddings.

**Daemon resolution, pure and refusal-first.** A new `third_party_recognizer` settings key (per-stage keys — one key naming entries of two stages would make "what is enabled" ambiguous) resolves through `recognizer_override`, a pure decision function: not-in-catalog, wrong-stage, and stage-closed each refuse with their own reason. Any refusal falls back to the **shipped** recognizer, unlike the PAD cue's fall-back-to-nothing, because a daemon with no recognizer cannot authenticate anyone. The file read and pin check mirror the PAD block; `IRLUME_THIRDPARTY_RECOGNIZER` is the sandbox env override, same shape as the PAD one.

**Installer.** `place_verified` writes the stage-appropriate key via `settings_key_for`, so a recognition entry can never be named under the PAD key.

**Template safety needs nothing new**: #277 already tags every template with the full digest of the loaded weights, so a foreign recognizer's templates are isolated automatically, and #278's stage gate already refuses installation.

## Testing

- Workspace green (1094 tests), clippy `-D warnings` clean, rustfmt clean.
- Eight guard-deletion mutants, each killed by a named test: threshold field ignored, builder forgetting the IR shutdown, the `ir_match` choke deleted, the refit gate deleted, the collision threshold reverted to the constant, the override's stage check deleted, its open check deleted, and the recognizer key collapsed onto the PAD key.
- The engine policy test carries positive controls both directions: IR matching proven working before the flip and again after the restore.

## Not covered

- The daemon resolution closure runs only at startup and is not unit-tested; the decision it composes (`recognizer_override`, the pin check) is. Same standing as the PAD wiring block.
- No end-to-end authentication ran under a third-party recognizer: no catalog entry exists yet, which is the point of the dark launch. The full path gets exercised on hardware when the buffalo_l entry lands with the stage flip.
- `models disable` and the human `models` listing still speak only the PAD key; generalising the disable UX belongs with the first recognition entry, when there is something to disable.
