### PR TITLE
auth: the device selection carries IR availability, not a load-time probe

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -548,6 +548,26 @@ pub fn thirdparty_abstains(p_fake: Option<f32>, threshold: f32) -> bool {
         .is_some_and(|p| p >= irlume_common::thirdparty::MEASURED_GENUINE_CEILING && p < threshold)
 }
 
+/// IR availability for a caller-selected IR device path.
+///
+/// The path half answers #281 (the selection, not a racy probe, is the truth);
+/// the forced-off half preserves `IRLUME_FORCE_NO_IR=1`, the documented
+/// drop-to-convenience override, which must outrank the selection exactly as
+/// it outranks `capabilities()` — the first cut of #282 overwrote it and
+/// silently re-secured a forced-convenience machine whose IR node existed.
+fn selected_ir_available(ir: &str) -> bool {
+    ir_selection_available(
+        std::path::Path::new(ir).exists(),
+        irlume_camera::ir_forced_off(),
+    )
+}
+
+/// The decision itself, as a value: testable without touching the
+/// process-wide override the engine test suite keeps set.
+fn ir_selection_available(ir_exists: bool, forced_off: bool) -> bool {
+    ir_exists && !forced_off
+}
+
 /// Highest-scoring detection: the face every pipeline stage keys on when a
 /// frame holds more than one.
 fn top_detection(faces: &[Detection]) -> Option<&Detection> {
@@ -645,8 +665,9 @@ impl Engine {
         // as the selected path existing (its tier log uses exactly that), so
         // the engine adopts the same definition when devices are handed to it;
         // the NO_IR test sentinel is a nonexistent path and keeps reading as
-        // unavailable.
-        self.ir_available = std::path::Path::new(ir).exists();
+        // unavailable, and the operator's forced-convenience override outranks
+        // the selection exactly as it outranks the probe (#282 review).
+        self.ir_available = selected_ir_available(ir);
         self
     }
 
@@ -668,7 +689,7 @@ impl Engine {
         // Same rule as with_devices: the selection carries IR availability, so
         // a runtime camera switch to (or from) an IR-less pair retiers the
         // engine instead of trusting the load-time snapshot (#281).
-        self.ir_available = std::path::Path::new(ir).exists();
+        self.ir_available = selected_ir_available(ir);
     }
 
     /// Load the IR domain-adaptation adapter (improves dark recognition). If the
@@ -4875,24 +4896,32 @@ mod engine_tests {
     }
 
     #[test]
-    fn device_selection_carries_ir_availability() {
-        // #281: the engine's one-shot capabilities() probe at load can lose a
-        // startup race against the emitter setup holding the IR node, leaving
-        // the engine in convenience tier while the daemon (whose selection
-        // FOUND the pair) logs secure tier. The caller's selection is the
-        // truth: a selected IR path that exists retiers the engine Secure, a
-        // nonexistent one (the test sentinel, or an IR-less box's fallback
-        // default) reads Convenience. /dev/null stands in for "an existing
-        // node" — the rule is exists(), the daemon's own definition of usable.
+    fn device_selection_carries_ir_availability_and_honours_forced_off() {
+        // #281: the selection, not the load-time probe, decides IR
+        // availability. The truth table is the testable decision (this suite
+        // keeps IRLUME_FORCE_NO_IR=1 set process-wide, so the positive arm is
+        // unreachable through a real engine here):
+        assert!(ir_selection_available(true, false));
+        assert!(!ir_selection_available(false, false));
+        // The #282 review's regression: the operator's forced-convenience
+        // override must outrank an existing selected path. The first cut
+        // overwrote it — and the first version of THIS test only passed
+        // because of that cancellation.
+        assert!(!ir_selection_available(true, true));
+        assert!(!ir_selection_available(false, true));
+
+        // Through the real engine, under the suite's forced-off env: an
+        // existing IR path must STAY unavailable via both entry points, and a
+        // nonexistent one reads unavailable either way.
         let _g = env_guard();
         let mut s = shared();
         s.engine.set_devices(NO_RGB, "/dev/null");
-        assert!(s.engine.ir_available(), "an existing IR path must retier");
-        assert_eq!(s.engine.tier(), Tier::Secure);
-        s.engine.set_devices(NO_RGB, NO_IR);
-        assert!(!s.engine.ir_available(), "a nonexistent IR path must not");
+        assert!(
+            !s.engine.ir_available(),
+            "forced-off must survive a runtime switch to an existing IR path"
+        );
         assert_eq!(s.engine.tier(), Tier::Convenience);
-        // The builder path applies the same rule.
+        s.engine.set_devices(NO_RGB, NO_IR); // restore the shared baseline
         drop(s);
         let e = Engine::load(
             &model_path("face_detection_yunet_2023mar.onnx"),
@@ -4900,9 +4929,29 @@ mod engine_tests {
         )
         .expect("engine load")
         .with_devices(NO_RGB, "/dev/null");
-        assert!(e.ir_available());
+        assert!(
+            !e.ir_available(),
+            "forced-off must survive the builder with an existing IR path"
+        );
+        // The assignment itself, discriminated: under this suite's forced-off
+        // env every computed value is false, so a deleted assignment is
+        // invisible to the asserts above (its mutant survived exactly that
+        // way). Pre-forcing the field TRUE makes the entry points' write the
+        // only thing that can restore the truth.
+        let mut e = e;
+        e.ir_available = true;
         let e = e.with_devices(NO_RGB, NO_IR);
-        assert!(!e.ir_available());
+        assert!(
+            !e.ir_available(),
+            "with_devices must WRITE the selection's answer, not keep state"
+        );
+        let mut e = e;
+        e.ir_available = true;
+        e.set_devices(NO_RGB, NO_IR);
+        assert!(
+            !e.ir_available(),
+            "set_devices must WRITE the selection's answer, not keep state"
+        );
     }
 
     #[test]

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -637,6 +637,16 @@ impl Engine {
     pub fn with_devices(mut self, rgb: &str, ir: &str) -> Self {
         self.rgb_dev = rgb.into();
         self.ir_dev = ir.into();
+        // The caller's selection is the truth about IR availability (#281).
+        // Engine::load's one-shot capabilities() probe can lose a startup race
+        // against the emitter setup holding the IR node, and then the engine
+        // sits in convenience tier for its whole life while the daemon logs
+        // secure tier from ITS selection. The daemon already defines "usable"
+        // as the selected path existing (its tier log uses exactly that), so
+        // the engine adopts the same definition when devices are handed to it;
+        // the NO_IR test sentinel is a nonexistent path and keeps reading as
+        // unavailable.
+        self.ir_available = std::path::Path::new(ir).exists();
         self
     }
 
@@ -655,6 +665,10 @@ impl Engine {
     pub fn set_devices(&mut self, rgb: &str, ir: &str) {
         self.rgb_dev = rgb.into();
         self.ir_dev = ir.into();
+        // Same rule as with_devices: the selection carries IR availability, so
+        // a runtime camera switch to (or from) an IR-less pair retiers the
+        // engine instead of trusting the load-time snapshot (#281).
+        self.ir_available = std::path::Path::new(ir).exists();
     }
 
     /// Load the IR domain-adaptation adapter (improves dark recognition). If the
@@ -4858,6 +4872,37 @@ mod engine_tests {
         assert_eq!(s.engine.rgb_device(), "/dev/irlume-test-alt-rgb");
         assert_eq!(s.engine.ir_device(), "/dev/irlume-test-alt-ir");
         s.engine.set_devices(NO_RGB, NO_IR); // restore the shared baseline
+    }
+
+    #[test]
+    fn device_selection_carries_ir_availability() {
+        // #281: the engine's one-shot capabilities() probe at load can lose a
+        // startup race against the emitter setup holding the IR node, leaving
+        // the engine in convenience tier while the daemon (whose selection
+        // FOUND the pair) logs secure tier. The caller's selection is the
+        // truth: a selected IR path that exists retiers the engine Secure, a
+        // nonexistent one (the test sentinel, or an IR-less box's fallback
+        // default) reads Convenience. /dev/null stands in for "an existing
+        // node" — the rule is exists(), the daemon's own definition of usable.
+        let _g = env_guard();
+        let mut s = shared();
+        s.engine.set_devices(NO_RGB, "/dev/null");
+        assert!(s.engine.ir_available(), "an existing IR path must retier");
+        assert_eq!(s.engine.tier(), Tier::Secure);
+        s.engine.set_devices(NO_RGB, NO_IR);
+        assert!(!s.engine.ir_available(), "a nonexistent IR path must not");
+        assert_eq!(s.engine.tier(), Tier::Convenience);
+        // The builder path applies the same rule.
+        drop(s);
+        let e = Engine::load(
+            &model_path("face_detection_yunet_2023mar.onnx"),
+            &model_path("glintr100.onnx"),
+        )
+        .expect("engine load")
+        .with_devices(NO_RGB, "/dev/null");
+        assert!(e.ir_available());
+        let e = e.with_devices(NO_RGB, NO_IR);
+        assert!(!e.ir_available());
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1117,11 +1117,18 @@ pub struct Caps {
     pub rgb: bool,
 }
 
-pub fn capabilities() -> Caps {
-    let force_no_ir = std::env::var("IRLUME_FORCE_NO_IR")
+/// Whether the operator explicitly disabled IR-backed authentication
+/// (`IRLUME_FORCE_NO_IR=1`, the documented drop-to-convenience override in
+/// docs/VERIFY.md). One reader, so a second consumer cannot drift on the
+/// accepted value.
+pub fn ir_forced_off() -> bool {
+    std::env::var("IRLUME_FORCE_NO_IR")
         .map(|v| v == "1")
-        .unwrap_or(false);
-    let ir_pair = !force_no_ir && !list_pairs().is_empty();
+        .unwrap_or(false)
+}
+
+pub fn capabilities() -> Caps {
+    let ir_pair = !ir_forced_off() && !list_pairs().is_empty();
     let rgb = ir_pair || discover_nodes().iter().any(|(_, r)| matches!(r, Role::Rgb));
     Caps { ir_pair, rgb }
 }


### PR DESCRIPTION
Fixes #281 — full mechanism and the archhost evidence are on the issue. `Engine::load`'s one-shot `capabilities()` probe can lose a startup race against the emitter setup holding the IR node; the engine then enforces convenience-tier policy for its whole life while the daemon logs secure tier from its own selection. Found by the first authentication ever run on archhost, during buffalo_l's first-use validation.

The fix makes the device selection carry IR availability: `with_devices` and `set_devices` derive it from the selected IR path existing — the daemon's own definition of usable, applied to the same pair its tier log uses — so a runtime camera switch retiers as well. The `NO_IR` test sentinel stays a nonexistent path and keeps reading unavailable; an engine that never receives devices keeps the load-time probe.

Tested: a new engine test drives both directions through both entry points (existing path retiers Secure, nonexistent reads Convenience); two stale-snapshot mutants (each assignment deleted) fail it. Workspace 1102 tests green, clippy clean. After merge, archhost re-runs the buffalo grant test that this bug blocked.


Signed-off-by: archledger <archledger236@gmail.com>
