### PR TITLE
tui+cli: the model screen and help speak per-stage, not PAD-only

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -44,6 +44,10 @@ pub struct Engine {
     /// value (#276), because a threshold is a property of one model's cosine
     /// scale and applying another model's number to it is a guess.
     rgb_threshold: f32,
+    /// Name of the loaded third-party recognizer (None = shipped). Display
+    /// and Health reporting only; the POLICY lives in rgb_threshold and
+    /// ir_matching.
+    thirdparty_recognizer: Option<String>,
     /// Whether IR matching (fusion, IR fallback, calibrated centroid, dark
     /// IR-only auth) may run. False under a third-party recognizer: the IR
     /// thresholds and the fusion Platt calibration are measurements of the
@@ -611,6 +615,7 @@ impl Engine {
             ir_space: "raw".into(),
             embed_space,
             rgb_threshold: irlume_core::RGB_MATCH_THRESHOLD,
+            thirdparty_recognizer: None,
             ir_matching: true,
             mesh: None,
             blaze: None,
@@ -731,10 +736,17 @@ impl Engine {
     /// catalog entry carries IR-side measurements. The liveness gate is
     /// unaffected: it reads pixels, not embeddings. Dark logins refuse with
     /// their own reason and fall back to the password.
-    pub fn with_thirdparty_recognizer(mut self, rgb_threshold: f32) -> Self {
+    pub fn with_thirdparty_recognizer(mut self, rgb_threshold: f32, name: &str) -> Self {
         self.rgb_threshold = rgb_threshold;
         self.ir_matching = false;
+        self.thirdparty_recognizer = Some(name.to_string());
         self
+    }
+
+    /// Name of the loaded third-party recognizer, if any; the daemon publishes
+    /// this in Health so an unprivileged TUI sees the authoritative state.
+    pub fn thirdparty_recognizer_name(&self) -> Option<&str> {
+        self.thirdparty_recognizer.as_deref()
     }
 
     /// The RGB grant threshold for a comparison against `n_templates`
@@ -5116,9 +5128,10 @@ mod engine_tests {
         )
         .expect("engine load")
         .with_devices(NO_RGB, NO_IR)
-        .with_thirdparty_recognizer(0.6);
+        .with_thirdparty_recognizer(0.6, "fixture-rec");
         assert_eq!(e.rgb_grant_threshold(1), 0.6);
         assert!(!e.ir_matching);
+        assert_eq!(e.thirdparty_recognizer_name(), Some("fixture-rec"));
     }
 
     #[test]

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1748,7 +1748,7 @@ SYSTEM INTEGRATION
                         camera picker runs this for you)
   camera-tune [--rounds N]        measure whether this camera can stream RGB and
                         IR at once without dimming, and store the answer (sudo)
-  models [enable|disable]         opt-in third-party liveness models: measured,
+  models [enable|disable]         opt-in third-party models (liveness cue, replacement recognizer): measured,
                         checksum-pinned, deny-only; fetched, never shipped
   biopolicy <on|off|status>       opt-in operation-class gate: restrict which
                         services a face may satisfy (advanced; password unaffected)

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -579,8 +579,9 @@ fn stdin_is_tty() -> bool {
 /// Condensed third-party-model state for a TUI status row, so it can show a
 /// ●/○ icon like the other Settings sections instead of a bare text blob.
 pub(crate) enum TuiState {
-    /// A catalog model is enabled in settings.conf; carries its name and the
-    /// weight health (checksum ok / mismatch).
+    /// One or more catalog models are enabled in settings.conf; carries a
+    /// display name (joined when several stages are enabled at once) and the
+    /// weight health per entry (checksum ok / mismatch).
     Enabled { name: String, detail: String },
     /// Weights are installed but the enabled flag is root-only and we are not
     /// root, so we can report presence but not the on/off state.
@@ -590,12 +591,38 @@ pub(crate) enum TuiState {
 }
 
 pub(crate) fn tui_state() -> TuiState {
-    if let Some(name) = enabled_name() {
-        let detail = match thirdparty::by_name(&name) {
-            Some(m) => format!("deny-only cue · {}", file_state(m)),
-            None => "set in settings.conf but NOT in the catalog (daemon ignores it)".into(),
-        };
+    // Every enabled stage, not just PAD: a recognizer selection is
+    // authentication policy, and a settings row reading "none" while one is
+    // enabled would be the TUI lying about it (#280 follow-up).
+    let enabled = enabled_entries();
+    if !enabled.is_empty() {
+        let name = enabled
+            .iter()
+            .map(|(m, _)| m.name)
+            .collect::<Vec<_>>()
+            .join(" + ");
+        let detail = enabled
+            .iter()
+            .map(|(m, _)| format!("{} stage · {}", m.stage.as_str(), file_state(m)))
+            .collect::<Vec<_>>()
+            .join(" · ");
         return TuiState::Enabled { name, detail };
+    }
+    // An enabled name that is not in the catalog (daemon ignores it) still
+    // deserves the Enabled row so the mismatch is visible.
+    for key in [
+        thirdparty::SETTINGS_KEY,
+        thirdparty::RECOGNIZER_SETTINGS_KEY,
+    ] {
+        if let Some(name) = enabled_name_for(key) {
+            if thirdparty::by_name(&name).is_none() {
+                return TuiState::Enabled {
+                    name,
+                    detail: "set in settings.conf but NOT in the catalog (daemon ignores it)"
+                        .into(),
+                };
+            }
+        }
     }
     if !is_root() {
         if let Some(m) = thirdparty::CATALOG
@@ -1048,6 +1075,65 @@ mod tests {
         assert!(got.contains(&("flir", thirdparty::SETTINGS_KEY)));
         assert!(got.contains(&("buffalo", thirdparty::RECOGNIZER_SETTINGS_KEY)));
         assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn tui_state_reports_every_enabled_stage() {
+        // The settings row must not read "none" (or PAD-only) while a
+        // recognizer is enabled: that is authentication policy on display.
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("irlume-tuist-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let (cfg, state) = (root.join("cfg"), root.join("state"));
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::fs::create_dir_all(&state).unwrap();
+        let old_cfg = std::env::var_os("IRLUME_CONFIG_DIR");
+        let old_state = std::env::var_os("IRLUME_STATE_DIR");
+        std::env::set_var("IRLUME_CONFIG_DIR", &cfg);
+        std::env::set_var("IRLUME_STATE_DIR", &state);
+
+        std::fs::write(
+            cfg.join("settings.conf"),
+            "third_party_recognizer=buffalo\n",
+        )
+        .unwrap();
+        let rec_only = tui_state();
+        std::fs::write(
+            cfg.join("settings.conf"),
+            "third_party_pad=flir\nthird_party_recognizer=buffalo\n",
+        )
+        .unwrap();
+        let both = tui_state();
+
+        match old_cfg {
+            Some(v) => std::env::set_var("IRLUME_CONFIG_DIR", v),
+            None => std::env::remove_var("IRLUME_CONFIG_DIR"),
+        }
+        match old_state {
+            Some(v) => std::env::set_var("IRLUME_STATE_DIR", v),
+            None => std::env::remove_var("IRLUME_STATE_DIR"),
+        }
+        let _ = std::fs::remove_dir_all(&root);
+
+        match rec_only {
+            TuiState::Enabled { name, detail } => {
+                assert_eq!(name, "buffalo");
+                assert!(detail.contains("recognition stage"), "got: {detail}");
+            }
+            _ => panic!("a recognizer-only selection must show as Enabled"),
+        }
+        match both {
+            TuiState::Enabled { name, detail } => {
+                assert_eq!(name, "flir + buffalo");
+                assert!(
+                    detail.contains("pad stage") && detail.contains("recognition stage"),
+                    "got: {detail}"
+                );
+            }
+            _ => panic!("two enabled stages must both show"),
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -578,11 +578,20 @@ fn stdin_is_tty() -> bool {
 /// so installed-but-unconfirmable gets reported instead of a false "none".
 /// Condensed third-party-model state for a TUI status row, so it can show a
 /// ●/○ icon like the other Settings sections instead of a bare text blob.
+/// One enabled catalog entry, STRUCTURED: consumers decide wording per stage
+/// and per weight state, so a joined display string cannot smear one entry's
+/// checksum failure across every enabled model (#285 review).
+pub(crate) struct TuiEntry {
+    pub name: &'static str,
+    pub stage: irlume_common::thirdparty::Stage,
+    pub weight_state: irlume_common::thirdparty::WeightState,
+}
+
 pub(crate) enum TuiState {
-    /// One or more catalog models are enabled in settings.conf; carries a
-    /// display name (joined when several stages are enabled at once) and the
-    /// weight health per entry (checksum ok / mismatch).
-    Enabled { name: String, detail: String },
+    /// One or more catalog models are enabled in settings.conf.
+    Enabled { entries: Vec<TuiEntry> },
+    /// A settings key names something not in the catalog (daemon ignores it).
+    UnknownName { name: String },
     /// Weights are installed but the enabled flag is root-only and we are not
     /// root, so we can report presence but not the on/off state.
     InstalledUnknown { name: String },
@@ -596,31 +605,26 @@ pub(crate) fn tui_state() -> TuiState {
     // enabled would be the TUI lying about it (#280 follow-up).
     let enabled = enabled_entries();
     if !enabled.is_empty() {
-        let name = enabled
-            .iter()
-            .map(|(m, _)| m.name)
-            .collect::<Vec<_>>()
-            .join(" + ");
-        let detail = enabled
-            .iter()
-            .map(|(m, _)| format!("{} stage · {}", m.stage.as_str(), file_state(m)))
-            .collect::<Vec<_>>()
-            .join(" · ");
-        return TuiState::Enabled { name, detail };
+        return TuiState::Enabled {
+            entries: enabled
+                .into_iter()
+                .map(|(m, _)| TuiEntry {
+                    name: m.name,
+                    stage: m.stage,
+                    weight_state: thirdparty::weight_state(m),
+                })
+                .collect(),
+        };
     }
     // An enabled name that is not in the catalog (daemon ignores it) still
-    // deserves the Enabled row so the mismatch is visible.
+    // deserves a row so the mismatch is visible.
     for key in [
         thirdparty::SETTINGS_KEY,
         thirdparty::RECOGNIZER_SETTINGS_KEY,
     ] {
         if let Some(name) = enabled_name_for(key) {
             if thirdparty::by_name(&name).is_none() {
-                return TuiState::Enabled {
-                    name,
-                    detail: "set in settings.conf but NOT in the catalog (daemon ignores it)"
-                        .into(),
-                };
+                return TuiState::UnknownName { name };
             }
         }
     }
@@ -1117,20 +1121,21 @@ mod tests {
         }
         let _ = std::fs::remove_dir_all(&root);
 
+        use irlume_common::thirdparty::Stage;
         match rec_only {
-            TuiState::Enabled { name, detail } => {
-                assert_eq!(name, "buffalo");
-                assert!(detail.contains("recognition stage"), "got: {detail}");
+            TuiState::Enabled { entries } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].name, "buffalo");
+                assert_eq!(entries[0].stage, Stage::Recognition);
             }
             _ => panic!("a recognizer-only selection must show as Enabled"),
         }
         match both {
-            TuiState::Enabled { name, detail } => {
-                assert_eq!(name, "flir + buffalo");
-                assert!(
-                    detail.contains("pad stage") && detail.contains("recognition stage"),
-                    "got: {detail}"
-                );
+            TuiState::Enabled { entries } => {
+                let got: Vec<_> = entries.iter().map(|e| (e.name, e.stage)).collect();
+                assert!(got.contains(&("flir", Stage::Pad)));
+                assert!(got.contains(&("buffalo", Stage::Recognition)));
+                assert_eq!(got.len(), 2);
             }
             _ => panic!("two enabled stages must both show"),
         }
@@ -1339,7 +1344,10 @@ mod tests {
 
         // tui_state mirrors the same config: an enabled name -> Enabled row.
         match tui_state() {
-            TuiState::Enabled { name, .. } => assert_eq!(name, m.name),
+            TuiState::Enabled { entries } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].name, m.name);
+            }
             _ => panic!("expected Enabled after setting the config key"),
         }
 

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -356,6 +356,8 @@ struct HealthInfo {
     /// Loaded third-party PAD cue name (authoritative on/off, since
     /// settings.conf is root-only and a non-root TUI can't read it).
     third_party_pad: Option<String>,
+    /// Loaded third-party recognizer name, same authority argument.
+    third_party_recognizer: Option<String>,
     /// The daemon's real AppArmor confinement label ("irlumed (enforce)",
     /// "unconfined", ...), or None when AppArmor is off or the daemon predates
     /// the field. Authoritative: the on-disk profile can exist while the daemon
@@ -727,6 +729,7 @@ impl LightState {
                 adapter,
                 version,
                 third_party_pad,
+                third_party_recognizer,
                 apparmor,
             }) => Some(HealthInfo {
                 tier,
@@ -736,6 +739,7 @@ impl LightState {
                 adapter,
                 version,
                 third_party_pad,
+                third_party_recognizer,
                 apparmor,
             }),
             _ => None, // older daemon / daemon down → Repair falls back to local probes
@@ -1698,23 +1702,51 @@ impl App {
             ));
         }
 
-        // A third-party liveness model enabled but with a CHECKSUM MISMATCH: the
-        // daemon refuses to load it, so the deny-only cue the user opted into is
-        // silently OFF. Only flag it when the daemon is up and did NOT load a
-        // cue (if it loaded one, Health.third_party_pad proves the weights were
-        // fine). doctor reports this; a TUI-only user would never see it.
-        let daemon_loaded_pad = self
-            .health
-            .as_ref()
-            .is_some_and(|h| h.third_party_pad.is_some());
-        if self.daemon_up && !daemon_loaded_pad {
-            if let crate::models::TuiState::Enabled { name, detail } = crate::models::tui_state() {
-                if detail.contains("MISMATCH") {
+        // A third-party model enabled but with a CHECKSUM MISMATCH, reported
+        // PER ENTRY: a joined string smeared one model's failure across every
+        // enabled stage (#285 review). The consequence differs by stage — a
+        // refused PAD cue is silently OFF, a refused recognizer means the
+        // daemon will not start with it selected. Only flag a stage the
+        // daemon did not actually load (Health proves loaded weights fine).
+        if self.daemon_up {
+            if let crate::models::TuiState::Enabled { entries } = crate::models::tui_state() {
+                use irlume_common::thirdparty::{Stage, WeightState};
+                for entry in entries {
+                    if entry.weight_state != WeightState::ChecksumMismatch {
+                        continue;
+                    }
+                    let loaded = match entry.stage {
+                        Stage::Pad => self
+                            .health
+                            .as_ref()
+                            .is_some_and(|h| h.third_party_pad.as_deref() == Some(entry.name)),
+                        Stage::Recognition => self.health.as_ref().is_some_and(|h| {
+                            h.third_party_recognizer.as_deref() == Some(entry.name)
+                        }),
+                        _ => false,
+                    };
+                    if loaded {
+                        continue;
+                    }
+                    let effect = match entry.stage {
+                        Stage::Pad => "the deny-only cue is OFF",
+                        Stage::Recognition => {
+                            "the daemon refuses to start with it selected; face auth falls back to the password"
+                        }
+                        _ => "the daemon refuses the selected model",
+                    };
                     v.push(mk(
                         "Third-party model",
                         Sev::Fail,
-                        format!("'{name}' weights fail their checksum; the daemon refuses them (cue is OFF)"),
-                        Fix::Manual("Settings tab → [m] disable then re-enable the model".into()),
+                        format!(
+                            "'{}' ({} stage) weights fail their checksum; {effect}",
+                            entry.name,
+                            entry.stage.as_str()
+                        ),
+                        Fix::Manual(format!(
+                            "run `sudo irlume models disable {0}`, then re-enable {0}",
+                            entry.name
+                        )),
                     ));
                 }
             }
@@ -3137,42 +3169,53 @@ impl App {
             // confirm in the cooked terminal: that friction is the policy,
             // the TUI hosts it rather than bypassing it.
             (SC_SETTINGS, KeyCode::Char('m')) => {
-                use irlume_common::thirdparty::{weight_state, Stage, WeightState, CATALOG};
-                let installed: Vec<_> = CATALOG
-                    .iter()
-                    .filter(|m| matches!(weight_state(m), WeightState::ChecksumOk))
-                    .collect();
-                match installed.as_slice() {
-                    // Exactly one installed model: the toggle is unambiguous.
-                    [m] => {
+                use irlume_common::thirdparty::{Stage, CATALOG};
+                // Decide from ENABLED state, not installed files: weights can
+                // be orphaned on disk with no settings key (an admitted
+                // partial state of install), and `models disable <name>`
+                // refuses names that are not enabled (#285 review).
+                match crate::models::tui_state() {
+                    crate::models::TuiState::Enabled { entries } if entries.len() == 1 => {
+                        let entry = &entries[0];
                         self.confirm = Some((
                             format!(
                                 "Disable third-party {} model '{}'? (its weights are deleted)",
-                                m.stage.as_str(),
-                                m.name
+                                entry.stage.as_str(),
+                                entry.name
                             ),
                             "Disable",
-                            ConfirmAct::Sus(Suspend::ModelsDisable(m.name.to_string())),
+                            ConfirmAct::Sus(Suspend::ModelsDisable(entry.name.to_string())),
                         ));
                     }
-                    // Several installed (different stages): a single toggle
-                    // key must not guess which authentication policy to
-                    // remove; name them and point at the explicit command.
-                    [_, ..] => {
-                        for m in &installed {
+                    // Several enabled stages: a single toggle key must not
+                    // guess which authentication policy to remove.
+                    crate::models::TuiState::Enabled { entries } => {
+                        for entry in entries {
                             self.log(
                                 '·',
                                 format!(
-                                    "installed: {} ({} stage) — disable with: sudo irlume models disable {}",
-                                    m.name,
-                                    m.stage.as_str(),
-                                    m.name
+                                    "enabled: {} ({} stage) — disable with: sudo irlume models disable {}",
+                                    entry.name,
+                                    entry.stage.as_str(),
+                                    entry.name
                                 ),
                             );
                         }
                     }
-                    [] => {
-                        // Nothing installed: offer the PAD recommendation, the
+                    crate::models::TuiState::UnknownName { name } => {
+                        self.log(
+                            '·',
+                            format!("'{name}' is set in settings.conf but not in the catalog; fix it with `sudo irlume models`"),
+                        );
+                    }
+                    crate::models::TuiState::InstalledUnknown { .. } => {
+                        self.log(
+                            '·',
+                            "weights are installed but the enabled state is root-only; run `sudo irlume models` for the authoritative view",
+                        );
+                    }
+                    crate::models::TuiState::None => {
+                        // Nothing enabled: offer the PAD recommendation, the
                         // same one doctor makes (the built-in gate does not
                         // stop a print).
                         match CATALOG.iter().find(|m| m.stage == Stage::Pad) {
@@ -3924,42 +3967,80 @@ impl App {
                     ),
                 ]),
                 Line::raw(""),
-                section("Third-party liveness models"),
+                section("Third-party models"),
                 {
                     // A ●/○ status row like the sections above, not a text blob.
                     // The daemon's loaded-cue name is authoritative (it knows
                     // what it loaded); fall back to the filesystem probe only
                     // when the daemon can't answer, since settings.conf is
                     // root-only and a non-root TUI can't read the flag itself.
-                    let (icon, icon_style, label) =
-                        match self.health.as_ref().and_then(|h| h.third_party_pad.clone()) {
-                            Some(name) => (
+                    // Every daemon-reported stage, not just PAD: a loaded
+                    // cue must not hide a loaded recognizer (#285 review).
+                    let loaded: Vec<String> = self
+                        .health
+                        .iter()
+                        .flat_map(|h| {
+                            [
+                                h.third_party_pad
+                                    .as_ref()
+                                    .map(|n| format!("{n} (pad stage, loaded)")),
+                                h.third_party_recognizer
+                                    .as_ref()
+                                    .map(|n| format!("{n} (recognition stage, loaded)")),
+                            ]
+                        })
+                        .flatten()
+                        .collect();
+                    let (icon, icon_style, label) = if !loaded.is_empty() {
+                        (
+                            "●",
+                            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                            format!("enabled: {}", loaded.join(" + ")),
+                        )
+                    } else {
+                        // Nothing daemon-reported: could be a daemon too old
+                        // to report the fields OR genuinely none. We can't
+                        // tell the two apart (both deserialize to None), so
+                        // trust the filesystem probe rather than claim "off":
+                        // an older daemon with flir loaded must not read as
+                        // ○ none.
+                        match crate::models::tui_state() {
+                            crate::models::TuiState::Enabled { entries } => (
                                 "●",
                                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-                                format!("enabled: {name}   (loaded by the daemon, deny-only cue)"),
+                                format!(
+                                    "enabled: {}",
+                                    entries
+                                        .iter()
+                                        .map(|e| format!(
+                                            "{} ({} stage · {})",
+                                            e.name,
+                                            e.stage.as_str(),
+                                            match e.weight_state {
+                                                irlume_common::thirdparty::WeightState::ChecksumOk => "checksum ok",
+                                                irlume_common::thirdparty::WeightState::ChecksumMismatch => "CHECKSUM MISMATCH",
+                                                irlume_common::thirdparty::WeightState::Absent => "weights missing",
+                                            }
+                                        ))
+                                        .collect::<Vec<_>>()
+                                        .join(" + ")
+                                ),
                             ),
-                            // No daemon-reported cue: could be a daemon too old
-                            // to report the field (0.6.0 and earlier) OR genuinely
-                            // none. We can't tell the two apart (both deserialize
-                            // to None), so trust the filesystem probe rather than
-                            // claim "off": an older daemon with flir loaded must
-                            // not read as ○ none (regression fixed here).
-                            None => match crate::models::tui_state() {
-                                crate::models::TuiState::Enabled { name, detail } => (
-                                    "●",
-                                    Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-                                    format!("enabled: {name}   {detail}"),
-                                ),
-                                crate::models::TuiState::InstalledUnknown { name } => (
-                                    "◐",
-                                    Style::new().fg(th().warn),
-                                    format!("{name} weights installed; on/off is root-only"),
-                                ),
-                                crate::models::TuiState::None => {
-                                    ("○", Style::new().dim(), "none (default)".to_string())
-                                }
-                            },
-                        };
+                            crate::models::TuiState::UnknownName { name } => (
+                                "◐",
+                                Style::new().fg(th().warn),
+                                format!("'{name}' set in settings.conf but NOT in the catalog (daemon ignores it)"),
+                            ),
+                            crate::models::TuiState::InstalledUnknown { name } => (
+                                "◐",
+                                Style::new().fg(th().warn),
+                                format!("{name} weights installed; on/off is root-only"),
+                            ),
+                            crate::models::TuiState::None => {
+                                ("○", Style::new().dim(), "none (default)".to_string())
+                            }
+                        }
+                    };
                     Line::from(vec![
                         Span::raw("  state  "),
                         Span::styled(format!("{icon} "), icon_style),
@@ -3967,11 +4048,11 @@ impl App {
                     ])
                 },
                 Line::from(Span::styled(
-                    "  Opt-in, measured, deny-only extra anti-spoof cue; fetched from the",
+                    "  Opt-in, measured models by pipeline stage: PAD adds a deny-only cue,",
                     Style::new().dim(),
                 )),
                 Line::from(Span::styled(
-                    "  publisher, checksum-pinned, never shipped by irlume.",
+                    "  recognition replaces RGB matching. Checksum-pinned, never shipped by irlume.",
                     Style::new().dim(),
                 )),
                 Line::from(vec![
@@ -6340,6 +6421,7 @@ mod tests {
             adapter: false,
             version: "test".into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         });
         let start = std::time::Instant::now();
@@ -8133,6 +8215,7 @@ mod tests {
             adapter: false,
             version: "1.0".into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         });
         let text = draw_text(&app);
@@ -8154,11 +8237,46 @@ mod tests {
         assert!(text.contains("Require eyes open"));
         assert!(text.contains("○ no"), "eyes-open starts off");
         assert!(text.contains("Biopolicy operation-class gate"));
-        assert!(text.contains("Third-party liveness models"));
+        assert!(text.contains("Third-party models"));
+        assert!(
+            !text.contains("Third-party liveness models"),
+            "the heading must not claim every model is a liveness cue"
+        );
         assert!(text.contains("Match thresholds (read-only)"));
         app.eyes_open = true;
         let text = draw_text(&app);
         assert!(text.contains("● yes"), "the toggled state must show");
+    }
+
+    #[test]
+    fn settings_row_reports_pad_and_recognizer_together() {
+        // The #285 review's counterexample: with both stages loaded, the
+        // health-driven arm previously showed only the PAD cue — a loaded
+        // deny-only cue hid the replacement RECOGNIZER, the more
+        // consequential of the two.
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.daemon_up = true;
+        // Health constructed EXPLICITLY: test_app leaves it None, and an
+        // `if let Some` mutation here would silently opt the test out of the
+        // very state it exists to render.
+        app.health = Some(HealthInfo {
+            tier: "secure".into(),
+            rgb_dev: None,
+            ir_dev: None,
+            mesh: true,
+            adapter: false,
+            version: "test".into(),
+            third_party_pad: Some("flir".into()),
+            third_party_recognizer: Some("buffalo".into()),
+            apparmor: None,
+        });
+        let text = draw_text(&app);
+        assert!(text.contains("flir (pad stage, loaded)"), "{text}");
+        assert!(
+            text.contains("buffalo (recognition stage, loaded)"),
+            "{text}"
+        );
     }
 
     #[test]
@@ -8177,6 +8295,7 @@ mod tests {
             adapter: false,
             version: "test".into(),
             third_party_pad: Some("flir".into()),
+            third_party_recognizer: None,
             apparmor: None,
         });
         let text = draw_text(&app);
@@ -8506,6 +8625,7 @@ mod tests {
             adapter: true,
             version: env!("CARGO_PKG_VERSION").into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         });
         app.run_checks();
@@ -8560,6 +8680,7 @@ mod tests {
             adapter: false,
             version: "0.0.1-old".into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         });
         app.challenge = true;

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -224,7 +224,7 @@ enum Suspend {
     /// friction is the point of the models policy, so the TUI hosts it in the
     /// cooked terminal instead of bypassing it.
     ModelsEnable(String),
-    ModelsDisable,
+    ModelsDisable(String),
     /// Origin-aware updater; runs unprivileged (it invokes sudo itself for
     /// the package-manager step when one is needed).
     Update,
@@ -2416,12 +2416,12 @@ impl App {
                 &["irlume", "fingerprint", "reset"],
             ),
             Suspend::ModelsEnable(name) => self.sudo_step(
-                "enable a third-party liveness model (license confirm follows)",
+                "enable a third-party model (license confirm follows)",
                 &["irlume", "models", "enable", &name],
             ),
-            Suspend::ModelsDisable => self.sudo_step(
+            Suspend::ModelsDisable(name) => self.sudo_step(
                 "disable the third-party model",
-                &["irlume", "models", "disable"],
+                &["irlume", "models", "disable", &name],
             ),
             Suspend::Update => {
                 crate::commands::update(&none);
@@ -3137,28 +3137,52 @@ impl App {
             // confirm in the cooked terminal: that friction is the policy,
             // the TUI hosts it rather than bypassing it.
             (SC_SETTINGS, KeyCode::Char('m')) => {
-                use irlume_common::thirdparty::{weight_state, WeightState, CATALOG};
-                let installed = CATALOG
+                use irlume_common::thirdparty::{weight_state, Stage, WeightState, CATALOG};
+                let installed: Vec<_> = CATALOG
                     .iter()
-                    .find(|m| matches!(weight_state(m), WeightState::ChecksumOk));
-                match installed {
-                    Some(m) => {
+                    .filter(|m| matches!(weight_state(m), WeightState::ChecksumOk))
+                    .collect();
+                match installed.as_slice() {
+                    // Exactly one installed model: the toggle is unambiguous.
+                    [m] => {
                         self.confirm = Some((
                             format!(
-                                "Disable third-party model '{}'? (its weights are deleted)",
+                                "Disable third-party {} model '{}'? (its weights are deleted)",
+                                m.stage.as_str(),
                                 m.name
                             ),
                             "Disable",
-                            ConfirmAct::Sus(Suspend::ModelsDisable),
+                            ConfirmAct::Sus(Suspend::ModelsDisable(m.name.to_string())),
                         ));
                     }
-                    None => match CATALOG.first() {
-                        Some(m) => {
-                            self.log('→', format!("sudo irlume models enable {}: the license + provenance confirm runs in the terminal", m.name));
-                            self.suspend = Some(Suspend::ModelsEnable(m.name.to_string()));
+                    // Several installed (different stages): a single toggle
+                    // key must not guess which authentication policy to
+                    // remove; name them and point at the explicit command.
+                    [_, ..] => {
+                        for m in &installed {
+                            self.log(
+                                '·',
+                                format!(
+                                    "installed: {} ({} stage) — disable with: sudo irlume models disable {}",
+                                    m.name,
+                                    m.stage.as_str(),
+                                    m.name
+                                ),
+                            );
                         }
-                        None => self.log('·', "no third-party models in the catalog"),
-                    },
+                    }
+                    [] => {
+                        // Nothing installed: offer the PAD recommendation, the
+                        // same one doctor makes (the built-in gate does not
+                        // stop a print).
+                        match CATALOG.iter().find(|m| m.stage == Stage::Pad) {
+                            Some(m) => {
+                                self.log('→', format!("sudo irlume models enable {}: the license + provenance confirm runs in the terminal", m.name));
+                                self.suspend = Some(Suspend::ModelsEnable(m.name.to_string()));
+                            }
+                            None => self.log('·', "no third-party models in the catalog"),
+                        }
+                    }
                 }
             }
             // Daemon debug logging toggle; deny scores land in the journal

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1478,6 +1478,7 @@ fn setup_walks_every_step_noninteractively() {
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -518,6 +518,7 @@ fn setup_already_enrolled_skips_reenroll_and_reports_arm_failure() {
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {
@@ -556,6 +557,7 @@ fn setup_enroll_merge_and_enroll_failure_paths() {
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {
@@ -594,6 +596,7 @@ fn setup_enroll_merge_and_enroll_failure_paths() {
             adapter: false,
             version: env!("CARGO_PKG_VERSION").into(),
             third_party_pad: None,
+            third_party_recognizer: None,
             apparmor: None,
         },
         Request::ListProfiles { .. } => Response::Enrollment {

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -703,6 +703,13 @@ pub enum Response {
         /// no cue is loaded (or an older daemon that predates this field).
         #[serde(default)]
         third_party_pad: Option<String>,
+        /// Name of the loaded third-party RECOGNIZER, if any (#276 stage 4).
+        /// Same authority argument as the PAD field: this is what the daemon
+        /// actually loaded, which a non-root TUI cannot learn from the
+        /// root-only settings file. `None` = shipped recognizer (or an older
+        /// daemon predating the field).
+        #[serde(default)]
+        third_party_recognizer: Option<String>,
         /// The daemon's OWN AppArmor confinement, read from its /proc/self/attr
         /// at request time: e.g. `irlumed (enforce)`, `irlumed (complain)`, or
         /// `unconfined`. `None` when AppArmor is not enabled on this boot (or an

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -334,7 +334,7 @@ fn main() {
                             eprintln!(
                                 "irlumed: third-party recognizer '{name}' loaded (threshold {thr}; IR matching disabled — unmeasured for this model)"
                             );
-                            e.with_thirdparty_recognizer(*thr)
+                            e.with_thirdparty_recognizer(*thr, name)
                         })
                     }
                     None => irlume_auth::Engine::load(&det, &model),
@@ -1593,6 +1593,7 @@ struct EngineBits {
     mesh: bool,
     adapter: bool,
     third_party_pad: Option<String>,
+    third_party_recognizer: Option<String>,
 }
 
 fn engine_bits() -> &'static std::sync::Mutex<EngineBits> {
@@ -1609,6 +1610,7 @@ fn publish_engine_bits(engine: &irlume_auth::Engine) {
         mesh: engine.has_mesh(),
         adapter: engine.has_ir_adapter(),
         third_party_pad: engine.thirdparty_pad_name().map(String::from),
+        third_party_recognizer: engine.thirdparty_recognizer_name().map(String::from),
     });
 }
 
@@ -1792,6 +1794,7 @@ fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
                 // Authoritative loaded-cue name so a non-root TUI can show the
                 // real on/off state (settings.conf is root-only).
                 third_party_pad: bits.third_party_pad.clone(),
+                third_party_recognizer: bits.third_party_recognizer.clone(),
                 apparmor: apparmor_confinement(),
             }
         }
@@ -3983,6 +3986,7 @@ mod tests {
             mesh: true,
             adapter: true,
             third_party_pad: Some("flir".into()),
+            third_party_recognizer: None,
         });
         let peer = Peer {
             uid: 0,


### PR DESCRIPTION
The #280 review deferred this follow-up; buffalo enabled on a real machine made it urgent. The TUI's settings row read the PAD key only, so the primary interactive surface showed "none" while a replacement recognizer was selected.

What changed, after the review round:

- The daemon publishes its loaded recognizer. `Engine::with_thirdparty_recognizer` carries the name, `EngineBits` and `Response::Health` expose it (`#[serde(default)]`, so an older daemon deserializes as None), and the Settings row renders every loaded stage. Before the fix, a loaded PAD cue hid a loaded recognizer entirely.
- `TuiState` is structured. Each enabled entry carries its name, stage, and weight state, so the Repair check names exactly the model whose checksum failed and states the stage's real consequence: a refused PAD cue is off, a refused recognizer stops the daemon from starting. The previous joined string attributed one model's failure to every enabled model.
- The `[m]` toggle decides from enabled state, not installed files. Orphaned weights (the partial state `install_verified` itself admits) no longer produce a disable offer that `models disable` would refuse. With several stages enabled it lists each with its explicit disable command instead of guessing which authentication policy to remove.
- The section heading and help text stop calling every model a liveness cue.

Tests: a renderer regression drives both loaded stages through the draw harness (health constructed explicitly, because `test_app` leaves it None and an `if let Some` mutation silently skips the state under test); a sandboxed-config test drives recognizer-only and both-stages selections through `tui_state()`. Mutants killed: the renderer's recognizer half dropped, and `tui_state` truncated to its first entry. Workspace suite 1104 tests, clippy clean with `-D warnings`.

Not covered: the Repair rows have no test harness in this repo, so the per-stage wording arms are unexercised like the rest of that method, and the `[m]` handler is TUI event code without tests. The tested part is the state logic both consume.
