### PR TITLE
apparmor: the emitter locks and /dev discovery need rules the 0.7 soak predates

### DIFF
--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -70,11 +70,13 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
 
   # The emitter undo-journal's per-camera lock (flock over the whole
   # check/act window; emitter_journal.rs). Lives under /run/lock because a
-  # lock's lifetime is a boot. 'k' is the flock permission; without these
-  # rules the daemon refuses to drive the IR emitter and logs the #283
+  # lock's lifetime is a boot. 'k' is the flock permission; without this
+  # rule the daemon refuses to drive the IR emitter and logs the #283
   # warning on every start. The profile's 2026-07-09 soak predates the
-  # journal (0.8.x), which is how the gap shipped.
-  /run/lock/ rw,
+  # journal (0.8.x), which is how the gap shipped. No rule on the /run/lock
+  # directory itself: creation is authorized on the new file's pathname, the
+  # recorded denials named only the file path, and enumerate/modify authority
+  # over every service's lock is nothing this daemon needs.
   /run/lock/irlume-emitter-*.lock rwk,
 
   # The per-stream emitter bookkeeping lock is a flock too, and it lives

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -55,6 +55,11 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
 
   # Cameras: capture nodes + the sysfs identity walk of the anti-injection
   # camera pinning (canonicalized device path, USB ids, privacy switch).
+  # The /dev/ directory read is the discovery walk (discover_nodes lists
+  # /dev to find video nodes); without it, capabilities() sees no cameras
+  # from inside the daemon while sysfs-based selection still works, and the
+  # engine mis-tiers (found enforcing on Arch, 2026-08-05; issues #281/#283).
+  /dev/ r,
   /dev/video[0-9]* rw,
   /sys/class/video4linux/ r,
   /sys/class/video4linux/** r,
@@ -62,6 +67,21 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
 
   # IPC socket (thin PAM module and CLI connect here; SO_PEERCRED authz).
   /run/irlume.sock rw,
+
+  # The emitter undo-journal's per-camera lock (flock over the whole
+  # check/act window; emitter_journal.rs). Lives under /run/lock because a
+  # lock's lifetime is a boot. 'k' is the flock permission; without these
+  # rules the daemon refuses to drive the IR emitter and logs the #283
+  # warning on every start. The profile's 2026-07-09 soak predates the
+  # journal (0.8.x), which is how the gap shipped.
+  /run/lock/ rw,
+  /run/lock/irlume-emitter-*.lock rwk,
+
+  # The per-stream emitter bookkeeping lock is a flock too, and it lives
+  # under the state dir, whose ** rule grants rw WITHOUT the flock 'k'
+  # permission. Fixing the /run/lock rule above unmasked this one on the
+  # same machine, one restart later: locks need naming wherever they live.
+  /var/lib/irlume/ir-emitter-stream/*.lock rwk,
 
   # TPM (template-key sealing, keyring unlock).
   /dev/tpmrm[0-9] rw,

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -9,7 +9,7 @@
 # so enforce is fail-safe; still soak new hardware/derivatives in complain
 # before trusting enforce there (drop in `flags=(complain)` below to do so).
 #
-# Reload:  apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed
+# Reload:  apparmor_parser -r /etc/apparmor.d/usr.local.bin.irlumed
 # Complain (per-box soak):  add `flags=(complain)` to the profile line + reload.
 
 abi <abi/4.0>,
@@ -52,6 +52,9 @@ profile irlumed /usr/local/bin/irlumed {
 
   # Cameras: capture nodes + the sysfs identity walk of the anti-injection
   # camera pinning (canonicalized device path, USB ids, privacy switch).
+  # /dev/ readdir is the discovery walk; without it capabilities() sees no
+  # cameras inside the daemon while sysfs selection works (#281/#283).
+  /dev/ r,
   /dev/video[0-9]* rw,
   /sys/class/video4linux/ r,
   /sys/class/video4linux/** r,
@@ -61,6 +64,12 @@ profile irlumed /usr/local/bin/irlumed {
   /run/irlume.sock rw,
 
   # TPM (template-key sealing, keyring unlock).
+  # Emitter locks: the undo-journal per-camera flock under /run/lock, and
+  # the per-stream bookkeeping flock, whose 'k' the state-dir ** rule does
+  # not grant (#283).
+  /run/lock/irlume-emitter-*.lock rwk,
+  /var/lib/irlume/ir-emitter-stream/*.lock rwk,
+
   /dev/tpmrm[0-9] rw,
   /dev/tpm[0-9] rw,
 

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -78,7 +78,7 @@ contents:
     dst: /usr/lib/systemd/system/irlume-reconcile.service
   - src: ../systemd/irlume-reconcile.timer
     dst: /usr/lib/systemd/system/irlume-reconcile.timer
-  # AppArmor profile (ships in complain mode; see the profile header)
+  # AppArmor profile (enforces by default; see the profile header)
   - src: ../apparmor/usr.bin.irlumed
     dst: /etc/apparmor.d/usr.bin.irlumed
   - src: ../../LICENSE

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -101,6 +101,28 @@ for derived in packaging/ppa/build-ppa-container.sh nix/package.nix; do
 done
 
 echo
+echo
+echo "== AppArmor runtime rules in both executable-path variants =="
+APPARMOR_PROFILES=(
+  packaging/apparmor/usr.bin.irlumed
+  packaging/apparmor/usr.local.bin.irlumed
+)
+APPARMOR_RUNTIME_RULES=(
+  "/dev/ r,"
+  "/run/lock/irlume-emitter-*.lock rwk,"
+  "/var/lib/irlume/ir-emitter-stream/*.lock rwk,"
+)
+for profile in "${APPARMOR_PROFILES[@]}"; do
+  for rule in "${APPARMOR_RUNTIME_RULES[@]}"; do
+    if grep -Fqx "  $rule" "$profile"; then
+      printf '  ok    %-48s %s\n' "$rule" "$profile"
+    else
+      printf '  MISS  %-48s %s\n' "$rule" "$profile"
+      fail=1
+    fi
+  done
+done
+
 if [ "$fail" -ne 0 ]; then
   echo "packaging parity: FAILED"
   exit 1


### PR DESCRIPTION
Fixes #283 and corrects the recorded mechanism of #281.

The strace on the enforcing Arch box settled it: the emitter-lock EACCES was never the unit sandbox or filesystem permissions. The `irlumed` AppArmor profile attaches by binary path (which is why running the bare binary reproduced it and a `/bin/sh` probe did not), and it predates three daemon needs from 0.8.x:

- `/run/lock/irlume-emitter-*.lock` open+flock: the #283 warning on every start.
- `/dev/` readdir: `capabilities()` saw no cameras inside the daemon while sysfs selection worked, so the engine mis-tiered. That is the deterministic mechanism behind #281; the "startup race" framing in that issue was wrong, and the #282 fix stands for a better reason than the one it was written under, because the engine must not depend on a probe the platform's MAC can scope differently from the daemon's own selection.
- `/var/lib/irlume/ir-emitter-stream/*.lock`: the state-dir `**` rule grants `rw` without the flock `k` permission. The first fix unmasked this one on the next restart.

Validation is the before/after on the enforcing machine: every daemon start logged the refusal warning and audit DENIED lines for both lock paths; after the profile reload, a restart produces zero warnings, the emitter reports ready, buffalo loads, and the only remaining denial is the #207 consumer scan's `sys_ptrace`, which that issue documents as an accepted fail-safe degradation and which this PR deliberately does not grant.

No code changes; there is no CI lane that exercises AppArmor, so the enforcing-machine measurement above is the validation.
