### PR TITLE
core+auth: calibrations are keyed by recognizer, not one slot per profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ __pycache__/
 # Mutation-harness backups. One was committed by a `git add -A` run while the
 # harness had files out, which put a 1938-line copy of a source file in a commit.
 *.rs.bak
+.aider*

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -3800,6 +3800,39 @@ mod tests {
     }
 
     #[test]
+    fn the_matcher_picks_the_calibration_by_recognizer_space() {
+        // #288: a profile can hold calibrations for several recognizers, and
+        // ir_match_in must apply the LOADED one. Discriminated by presence:
+        // with the calibration filed under a different space, the loaded
+        // recognizer has none, so the calibrated-centroid protocol does not
+        // run at all. Reaching for any available calibration instead of the
+        // keyed one puts another model's transform on these templates.
+        let (mut prof, probe) = calibrated_profile(16);
+        // Control: the calibration is in the legacy slot and the scans are
+        // untagged, so the shipped recognizer finds it and scores a centroid.
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(prof.clone());
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
+        assert!(
+            m.centroid.is_some(),
+            "control: the shipped recognizer's own calibration must apply"
+        );
+
+        // Same scans, but the only calibration on file belongs to another
+        // recognizer: the loaded one must score raw.
+        let calib = prof.ir_calib.take().expect("fixture calibration");
+        prof.ir_calibs.insert("embed:model-b".into(), calib);
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(prof);
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
+        assert_eq!(m.n_templates, 5, "the templates still score");
+        assert!(
+            m.centroid.is_none(),
+            "another recognizer's calibration must not be applied"
+        );
+    }
+
+    #[test]
     fn ir_match_skips_templates_from_another_recognizer() {
         // The recognizer produces the raw IR embedding, so its identity gates
         // IR matching exactly like RGB matching: a foreign tag is excluded, a

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -488,10 +488,14 @@ fn ir_match_in(
             continue;
         }
         m.n_templates += tmpls.len();
+        // The calibration for THIS recognizer: a profile can hold scans (and
+        // calibrations) from several, and applying one model's calibration to
+        // another's templates puts uninterpretable numbers into the matcher
+        // (#288).
         let calib = if adapter_loaded {
             None
         } else {
-            p.ir_calib.as_ref()
+            p.calib_for(embed_space)
         };
         let cprobe = calib.and_then(|c| c.apply(probe));
         if let (Some(c), Some(cprobe)) = (calib, &cprobe) {
@@ -820,14 +824,20 @@ impl Engine {
             ir_rows.push(ir.clone());
             rgb_rows.push(s.rgb.clone());
         }
-        prof.ir_calib = irlume_core::calib::fit(&ir_rows, &rgb_rows);
-        if let Some(c) = &prof.ir_calib {
+        // Recorded against THIS recognizer only: a single slot was overwritten
+        // by whichever model happened to be loaded at refit, which silently
+        // replaced the calibration of the model the user switched away from
+        // (#288).
+        let fitted = irlume_core::calib::fit(&ir_rows, &rgb_rows);
+        if let Some(c) = &fitted {
             irlume_common::dlog!(
-                "calib: fitted '{}' from {} scan pairs",
+                "calib: fitted '{}' from {} scan pairs (space {})",
                 prof.name,
-                c.fitted_pairs
+                c.fitted_pairs,
+                self.embed_space
             );
         }
+        prof.set_calib_for(&self.embed_space, fitted);
     }
 
     /// Method wrapper over [`ir_match_in`], bound to the engine's space and
@@ -2820,6 +2830,7 @@ impl Engine {
         let name = profile_name.unwrap_or_else(|| enr.next_profile_name());
         let mut prof = FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: name.clone(),
             scans: Vec::new(),
         };
@@ -3594,6 +3605,7 @@ mod tests {
                 name: "p".into(),
                 scans,
                 ir_calib: calib,
+                ir_calibs: Default::default(),
             },
             probe,
         )
@@ -3941,11 +3953,13 @@ mod tests {
             profiles: vec![
                 FaceProfile {
                     ir_calib: None,
+                    ir_calibs: Default::default(),
                     name: "Face Profile 1".into(),
                     scans: vec![scan(face1.clone())],
                 },
                 FaceProfile {
                     ir_calib: None,
+                    ir_calibs: Default::default(),
                     name: "Face Profile 2".into(),
                     scans: vec![scan(face2.clone())],
                 },
@@ -4000,6 +4014,7 @@ mod tests {
             user: "u".into(),
             profiles: vec![FaceProfile {
                 ir_calib: None,
+                ir_calibs: Default::default(),
                 name: "P1".into(),
                 scans: vec![scan(b)],
             }],
@@ -4028,6 +4043,7 @@ mod tests {
             user: "u".into(),
             profiles: vec![FaceProfile {
                 ir_calib: None,
+                ir_calibs: Default::default(),
                 name: "P1".into(),
                 scans: vec![foreign],
             }],
@@ -4082,6 +4098,7 @@ mod tests {
             let mut enr = Enrollment::new("u");
             enr.profiles.push(FaceProfile {
                 ir_calib: None,
+                ir_calibs: Default::default(),
                 name: "P1".into(),
                 scans,
             });
@@ -4157,6 +4174,7 @@ mod tests {
         let mut enr = enr_with(vec![ir_scan(face1.clone(), Some("adapter:deadbeef0123"))]);
         enr.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "P2".into(),
             scans: vec![ir_scan(face2.clone(), Some("adapter:deadbeef0123"))],
         });
@@ -4299,6 +4317,7 @@ mod tests {
         let mk_prof = |name: &str, v: &[f32]| FaceProfile {
             name: name.into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: vec![FaceScan {
                 name: "s".into(),
                 rgb: vec![0.0; 4],
@@ -5023,6 +5042,7 @@ mod engine_tests {
         let mut prof = FaceProfile {
             name: "p".into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
         };
         s.engine.refit_profile_calib(&mut prof);
@@ -5032,6 +5052,7 @@ mod engine_tests {
         let mut bad = FaceProfile {
             name: "bad".into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: (0..5)
                 .map(|i| FaceScan {
                     ir: Some(vec![0.1; 256]),
@@ -5045,6 +5066,7 @@ mod engine_tests {
         let mut foreign = FaceProfile {
             name: "foreign".into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: (0..5)
                 .map(|i| scan512(i, true, Some("adapter:deadbeef0123")))
                 .collect(),
@@ -5056,6 +5078,7 @@ mod engine_tests {
         let mut foreign_rec = FaceProfile {
             name: "foreign-rec".into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: (0..5)
                 .map(|i| FaceScan {
                     embed_space: Some("embed:model-b".into()),
@@ -5079,6 +5102,7 @@ mod engine_tests {
         let mut fresh = FaceProfile {
             name: "fresh".into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
         };
         s.engine.refit_profile_calib(&mut fresh);
@@ -5101,6 +5125,7 @@ mod engine_tests {
         enr.profiles.push(FaceProfile {
             name: "p".into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: (0..3).map(|i| scan512(i, true, Some("raw"))).collect(),
         });
         let probe = unit512(0);
@@ -5126,6 +5151,7 @@ mod engine_tests {
         let mut prof = FaceProfile {
             name: "p2".into(),
             ir_calib: None,
+            ir_calibs: Default::default(),
             scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
         };
         s.engine.refit_profile_calib(&mut prof);
@@ -5184,6 +5210,56 @@ mod engine_tests {
     }
 
     #[test]
+    fn a_refit_under_one_recognizer_leaves_another_models_calibration_alone() {
+        // #288, the switching scenario end to end through the engine: a
+        // profile calibrated under the shipped recognizer, then refitted
+        // while a different recognizer is loaded, must keep BOTH. The single
+        // slot made the second refit destroy the first, so switching back
+        // applied the wrong model's calibration inside ir_match_in.
+        let _g = env_guard();
+        let mut s = shared();
+        let shipped = s.engine.embed_space().to_string();
+        let mut prof = FaceProfile {
+            name: "p".into(),
+            ir_calib: None,
+            ir_calibs: Default::default(),
+            scans: (0..5).map(|i| scan512(i, true, Some("raw"))).collect(),
+        };
+        s.engine.refit_profile_calib(&mut prof);
+        let shipped_pairs = prof
+            .calib_for(&shipped)
+            .expect("shipped calibration fitted")
+            .fitted_pairs;
+
+        // Now the same profile gains scans from another recognizer, and a
+        // refit runs with that recognizer loaded.
+        let other = "embed:model-b";
+        prof.scans.extend((10..15).map(|i| FaceScan {
+            embed_space: Some(other.to_string()),
+            ..scan512(i, true, Some("raw"))
+        }));
+        s.engine.embed_space = other.to_string();
+        s.engine.refit_profile_calib(&mut prof);
+        s.engine.embed_space = shipped.clone(); // restore the shared baseline
+
+        assert!(
+            prof.calib_for(other).is_some(),
+            "the loaded recognizer must get its own calibration"
+        );
+        assert_eq!(
+            prof.calib_for(&shipped).map(|c| c.fitted_pairs),
+            Some(shipped_pairs),
+            "the other recognizer's calibration must survive the refit"
+        );
+        // And the matcher picks by space: the shipped engine must not see
+        // model B's calibration.
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(prof);
+        let m = ir_match_in("raw", other, false, &enr, &unit512(0));
+        assert_eq!(m.n_templates, 5, "only model B's templates score under B");
+    }
+
+    #[test]
     fn binding_mismatch_refuses_swapped_or_vanished_cameras() {
         let _g = env_guard();
         let s = shared();
@@ -5239,6 +5315,7 @@ mod engine_tests {
             name: "P1".into(),
             scans: vec![],
             ir_calib: None,
+            ir_calibs: Default::default(),
         });
         write_enrollment(&dir, &e);
         let o = s.engine.authenticate("irlume-test-empty", None).unwrap();
@@ -5251,6 +5328,7 @@ mod engine_tests {
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
+            ir_calibs: Default::default(),
         });
         e.camera_binding = Some(CameraBinding {
             rgb: Some("dead:beef".into()),
@@ -5272,6 +5350,7 @@ mod engine_tests {
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
+            ir_calibs: Default::default(),
         });
         write_enrollment(&dir, &e);
         let err = s.engine.authenticate("irlume-test-cam", None).unwrap_err();
@@ -5560,6 +5639,7 @@ mod engine_tests {
             name: "Work Laptop".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
+            ir_calibs: Default::default(),
         });
         write_enrollment(&dir, &e);
         let err = s
@@ -5590,6 +5670,7 @@ mod engine_tests {
             name: "P1".into(),
             scans: vec![scan512(1, false, None)],
             ir_calib: None,
+            ir_calibs: Default::default(),
         });
         write_enrollment(&dir, &e);
         let err = s.engine.add_scan("irlume-test-add", "nope").unwrap_err();
@@ -5602,6 +5683,7 @@ mod engine_tests {
                 .map(|i| scan512(i, false, None))
                 .collect(),
             ir_calib: None,
+            ir_calibs: Default::default(),
         });
         write_enrollment(&dir, &e);
         let err = s.engine.add_scan("irlume-test-full", "P1").unwrap_err();
@@ -5749,6 +5831,7 @@ mod engine_tests {
                 closure_calibration: None,
                 profiles: vec![FaceProfile {
                     ir_calib: None,
+                    ir_calibs: Default::default(),
                     name: "Face Profile 1".into(),
                     scans: vec![scan512(1, false, None)],
                 }],

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -5284,12 +5284,31 @@ mod engine_tests {
             Some(shipped_pairs),
             "the other recognizer's calibration must survive the refit"
         );
-        // And the matcher picks by space: the shipped engine must not see
-        // model B's calibration.
+        // Both recognizers must remain fully usable: their own templates
+        // score AND their own calibration runs. n_templates alone proves
+        // only the space filter, since it is counted before the calibration
+        // lookup; the calibrated-centroid protocol running is what shows the
+        // keyed calibration actually reached the matcher (#289 review).
         let mut enr = Enrollment::new("u");
         enr.profiles.push(prof);
-        let m = ir_match_in("raw", other, false, &enr, &unit512(0));
-        assert_eq!(m.n_templates, 5, "only model B's templates score under B");
+        let model_b = ir_match_in("raw", other, false, &enr, &unit512(0));
+        assert_eq!(
+            model_b.n_templates, 5,
+            "only model B's templates score under B"
+        );
+        assert!(
+            model_b.centroid.is_some(),
+            "model B's keyed calibration must run the calibrated-centroid protocol"
+        );
+        let shipped_match = ir_match_in("raw", &shipped, false, &enr, &unit512(0));
+        assert_eq!(
+            shipped_match.n_templates, 5,
+            "only the shipped recognizer's templates score after switching back"
+        );
+        assert!(
+            shipped_match.centroid.is_some(),
+            "the shipped recognizer's preserved calibration must still apply"
+        );
     }
 
     #[test]

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -93,12 +93,56 @@ pub struct FaceScan {
 pub struct FaceProfile {
     pub name: String,
     pub scans: Vec<FaceScan>,
-    /// Per-profile IR calibration (ADR-0004), fitted from this profile's own
-    /// scan pairs at enroll/add-scan time. Only fitted and applied when no
-    /// global IR adapter is loaded (raw embedding space); `None` otherwise
-    /// and on profiles from before the feature.
+    /// The LEGACY single calibration slot: the shipped recognizer's
+    /// calibration, and the only one an irlume older than per-model keying
+    /// can read. Kept in step with `ir_calibs[LEGACY_RECOGNIZER_SPACE]` so a
+    /// downgrade still finds it. New code reads [`Self::calib_for`].
     #[serde(default)]
     pub ir_calib: Option<crate::calib::IrCalibration>,
+    /// Per-profile IR calibration (ADR-0004) KEYED BY RECOGNIZER, fitted from
+    /// this profile's own scan pairs at enroll/add-scan time. Only fitted and
+    /// applied when no global IR adapter is loaded (raw embedding space).
+    ///
+    /// Keyed because a calibration maps one recognizer's IR embeddings onto
+    /// its own RGB embeddings: applying model A's calibration to model B's
+    /// templates puts uninterpretable numbers into the matcher. A single slot
+    /// was silently overwritten by a refit under whichever model happened to
+    /// be loaded (#288), which is what made switching models corrupt the
+    /// calibration of the model you switched away from.
+    #[serde(default)]
+    pub ir_calibs: std::collections::BTreeMap<String, crate::calib::IrCalibration>,
+}
+
+impl FaceProfile {
+    /// This profile's calibration for `space`, or `None`.
+    ///
+    /// Falls back to the legacy single slot for the shipped recognizer, so a
+    /// profile written before per-model keying keeps its calibration.
+    pub fn calib_for(&self, space: &str) -> Option<&crate::calib::IrCalibration> {
+        self.ir_calibs.get(space).or_else(|| {
+            (space == LEGACY_RECOGNIZER_SPACE)
+                .then_some(self.ir_calib.as_ref())
+                .flatten()
+        })
+    }
+
+    /// Record (or clear) this profile's calibration for `space`, leaving every
+    /// other recognizer's calibration untouched.
+    pub fn set_calib_for(&mut self, space: &str, calib: Option<crate::calib::IrCalibration>) {
+        match &calib {
+            Some(c) => {
+                self.ir_calibs.insert(space.to_string(), c.clone());
+            }
+            None => {
+                self.ir_calibs.remove(space);
+            }
+        }
+        // Mirror the shipped recognizer's calibration into the legacy slot so
+        // an older irlume reading this file still finds it.
+        if space == LEGACY_RECOGNIZER_SPACE {
+            self.ir_calib = calib;
+        }
+    }
 }
 
 /// The physical camera(s) an enrollment was captured on, for anti-swap binding:
@@ -412,6 +456,7 @@ fn migrate(old: LegacyProfile) -> Enrollment {
         user: old.user,
         profiles: vec![FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "Face Profile 1".into(),
             scans,
         }],
@@ -649,6 +694,7 @@ mod tests {
                     scan("legacy", 3.0, None),
                 ],
                 ir_calib: None,
+                ir_calibs: Default::default(),
             }],
             ..Default::default()
         };
@@ -673,6 +719,84 @@ mod tests {
         // A recognizer nothing was enrolled under gets NO templates: matching
         // must come up empty rather than score across spaces.
         assert!(enr.rgb_scans_in("embed:cccccccccccc").is_empty());
+    }
+
+    #[test]
+    fn calibrations_are_per_recognizer_and_the_legacy_slot_still_reads() {
+        use crate::calib::IrCalibration;
+        let calib = |pairs: usize| IrCalibration {
+            m: vec![vec![1.0]],
+            n_rows: vec![vec![1.0]],
+            lambda: 0.1,
+            fitted_pairs: pairs,
+        };
+        let mut p = FaceProfile {
+            name: "p".into(),
+            scans: Vec::new(),
+            ir_calib: None,
+            ir_calibs: Default::default(),
+        };
+
+        // A profile written before per-model keying carries only the legacy
+        // slot; it must still read under the shipped recognizer, and must NOT
+        // be handed to another model.
+        p.ir_calib = Some(calib(5));
+        assert_eq!(
+            p.calib_for(LEGACY_RECOGNIZER_SPACE).map(|c| c.fitted_pairs),
+            Some(5)
+        );
+        assert!(p.calib_for("embed:model-b").is_none());
+
+        // Recording model B's calibration must leave the shipped one intact.
+        // This is the #288 bug: one slot, overwritten by whichever model was
+        // loaded at refit, so switching back applied B's calibration to A's
+        // templates.
+        p.set_calib_for("embed:model-b", Some(calib(7)));
+        assert_eq!(
+            p.calib_for("embed:model-b").map(|c| c.fitted_pairs),
+            Some(7)
+        );
+        assert_eq!(
+            p.calib_for(LEGACY_RECOGNIZER_SPACE).map(|c| c.fitted_pairs),
+            Some(5),
+            "another model's refit must not touch the shipped calibration"
+        );
+
+        // Recording the shipped recognizer's calibration mirrors into the
+        // legacy slot, so an older irlume reading this file still finds it.
+        p.set_calib_for(LEGACY_RECOGNIZER_SPACE, Some(calib(9)));
+        assert_eq!(p.ir_calib.as_ref().map(|c| c.fitted_pairs), Some(9));
+        assert_eq!(
+            p.calib_for("embed:model-b").map(|c| c.fitted_pairs),
+            Some(7)
+        );
+
+        // Clearing is per model, and clears the mirror for the shipped one.
+        p.set_calib_for("embed:model-b", None);
+        assert!(p.calib_for("embed:model-b").is_none());
+        assert_eq!(
+            p.calib_for(LEGACY_RECOGNIZER_SPACE).map(|c| c.fitted_pairs),
+            Some(9)
+        );
+        p.set_calib_for(LEGACY_RECOGNIZER_SPACE, None);
+        assert!(p.ir_calib.is_none());
+        assert!(p.calib_for(LEGACY_RECOGNIZER_SPACE).is_none());
+    }
+
+    #[test]
+    fn an_enrollment_written_before_keying_still_deserializes() {
+        // On-disk compatibility: the keyed map is additive, so a file from an
+        // older irlume (legacy slot only, no ir_calibs key) must load and keep
+        // its calibration.
+        let json = r#"{"user":"u","profiles":[{"name":"p","scans":[],
+            "ir_calib":{"m":[[1.0]],"n_rows":[[1.0]],"lambda":0.1,"fitted_pairs":4}}]}"#;
+        let enr: Enrollment = serde_json::from_str(json).expect("old file must load");
+        let p = &enr.profiles[0];
+        assert!(p.ir_calibs.is_empty());
+        assert_eq!(
+            p.calib_for(LEGACY_RECOGNIZER_SPACE).map(|c| c.fitted_pairs),
+            Some(4)
+        );
     }
 
     #[test]
@@ -768,6 +892,7 @@ mod tests {
             user: "u".into(),
             profiles: vec![FaceProfile {
                 ir_calib: None,
+                ir_calibs: Default::default(),
                 name: "Face Profile 1".into(),
                 scans: vec![FaceScan {
                     name: "Face Scan 1".into(),
@@ -852,6 +977,7 @@ mod tests {
         // One calibrated scan -> not enough.
         e.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "p".into(),
             scans: vec![scan_with_pitch(0.60)],
         });
@@ -871,6 +997,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "p".into(),
             scans: vec![scan_with_ir(1.5, 100.0)],
         });
@@ -901,6 +1028,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "p".into(),
             scans: vec![
                 scan_in_space("legacy-untagged", 4, None),
@@ -930,6 +1058,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "p".into(),
             scans: vec![
                 scan_in_space("legacy", 4, None),          // stamped
@@ -963,6 +1092,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "p".into(),
             scans: vec![
                 FaceScan {
@@ -987,6 +1117,7 @@ mod tests {
         assert_eq!(e.next_profile_name(), "Face Profile 1");
         e.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "Face Profile 1".into(),
             scans: vec![],
         });
@@ -1098,6 +1229,7 @@ mod tests {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
             ir_calib: None,
+            ir_calibs: Default::default(),
             name: "P".into(),
             scans: vec![
                 ir_scan("adapter-era", Some("adapter:deadbeef0123")),

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -4719,6 +4719,7 @@ mod tests {
             profiles: vec![FaceProfile {
                 name: "Face Profile 1".into(),
                 ir_calib: None,
+                ir_calibs: Default::default(),
                 scans: scans
                     .iter()
                     .enumerate()


### PR DESCRIPTION
Step 1 of #288, and a correctness fix on its own merits.

`FaceProfile` held a single `ir_calib`, and `refit_profile_calib` fitted it from scans in the loaded recognizer's space and then overwrote the field. A profile holding scans from two recognizers is already possible, since templates started carrying their producer's digest in #277 and archhost demonstrated the two-model state last night. In that state, adding scans under model B replaced the calibration belonging to model A; switching back to A applied B's calibration to A's templates inside `ir_match_in`, which puts uninterpretable numbers into the matcher rather than failing.

`ir_calibs` keys calibrations by embedding space. `calib_for` reads the map and falls back to the legacy slot for the shipped recognizer, so a profile written before this change keeps its calibration. `set_calib_for` records one model's value without touching another's, and mirrors the shipped recognizer's value back into the legacy slot so an older irlume reading the same file still finds it. The on-disk shape is additive in both directions, matching how `embed_space` and `ir_space` were added.

Tests: a storage truth table over legacy-only reads, cross-model isolation, the mirror, and per-model clearing; a deserialization test that loads a pre-change enrollment; an engine test running the switching scenario, refitting under a second recognizer and asserting the first survives; and a matcher test proving the calibration is chosen by space, discriminated by presence, because a loaded recognizer with no calibration of its own must skip the calibrated-centroid protocol that another model's calibration would run. The existing engine assertions on the legacy field now also exercise the mirror.

Five mutants, each failing a named test: clearing other models on set, ignoring the space on read, dropping the legacy fallback, dropping the mirror, and the matcher reaching for any calibration on file. That last one survived the first pass and is why the matcher test exists.

Workspace 1109 tests, clippy clean with `-D warnings`.
