### PR TITLE
auth+cli: scan limits count per recognizer, and add-scan takes a count

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2888,11 +2888,17 @@ impl Engine {
 
     /// Add one scan to an existing profile ("improve recognition"). Errors if the
     /// profile is missing or already at MAX_SCANS_PER_PROFILE.
+    /// Add `count` scans to an existing profile, in the LOADED recognizer's
+    /// space. This is also how a profile gains templates for a second
+    /// recognizer without re-enrolling as a new person: the operator names
+    /// the profile, which is the only way the link can be made, since
+    /// comparing vectors across embedding spaces is meaningless (#288).
     pub fn add_scan(
         &mut self,
         user: &str,
         profile_name: &str,
-    ) -> irlume_common::Result<(String, usize)> {
+        count: usize,
+    ) -> irlume_common::Result<(Vec<String>, usize)> {
         use irlume_core::storage::{self, FaceScan, MAX_SCANS_PER_PROFILE};
         let mut enr = storage::load(user)?
             .ok_or_else(|| irlume_common::Error::Protocol(format!("'{user}' is not enrolled")))?;
@@ -2903,62 +2909,74 @@ impl Engine {
             .ok_or_else(|| {
                 irlume_common::Error::Protocol(format!("no face profile '{profile_name}'"))
             })?;
-        if enr.profiles[idx].scans.len() >= MAX_SCANS_PER_PROFILE {
+        // Counted for THIS recognizer: a profile holding another model's
+        // scans must still accept this one's, and the limit's false-accept
+        // rationale is about templates compared in one operation (#288).
+        let have = enr.profiles[idx].scans_in(&self.embed_space);
+        if have >= MAX_SCANS_PER_PROFILE {
             return Err(irlume_common::Error::Protocol(format!(
-                "'{profile_name}' already has the max {MAX_SCANS_PER_PROFILE} scans"
+                "'{profile_name}' already has the max {MAX_SCANS_PER_PROFILE} scans for the \
+                 loaded recognizer"
             )));
         }
-        let captured = self
-            .capture_scans(1, enr.pitch_neutral())?
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                irlume_common::Error::Protocol(
-                    "no live scan captured; check lighting and framing".into(),
-                )
-            })?;
-        // Anti-mixing: reject a scan whose face belongs to a different profile.
-        if let Some((other, score)) = colliding_profile(
-            &enr,
-            &captured.rgb,
-            Some(profile_name),
-            &self.embed_space,
-            self.rgb_threshold,
-        ) {
-            let cnt = enr
-                .profiles
-                .iter()
-                .find(|p| p.name == other)
-                .map_or(0, |p| p.scans.len());
-            let hint = if cnt < MAX_SCANS_PER_PROFILE {
-                format!("if you want this face, add the scan to '{other}' (it has {cnt}/{MAX_SCANS_PER_PROFILE})")
-            } else {
-                format!("'{other}' is already at the max {MAX_SCANS_PER_PROFILE} scans")
-            };
-            return Err(irlume_common::Error::Protocol(format!(
-                "the scanned face belongs to '{other}' (match {score:.2}), not '{profile_name}'; {hint}. \
-                 Scans of different faces can't be mixed in one profile."
-            )));
+        let want = count.clamp(1, MAX_SCANS_PER_PROFILE - have);
+        let captured = self.capture_scans(want, enr.pitch_neutral())?;
+        if captured.is_empty() {
+            return Err(irlume_common::Error::Protocol(
+                "no live scan captured; check lighting and framing".into(),
+            ));
         }
-        let sname = enr.profiles[idx].next_scan_name();
-        let ir_space = captured.ir.as_ref().map(|_| self.ir_space.clone());
-        enr.profiles[idx].scans.push(FaceScan {
-            name: sname.clone(),
-            rgb: captured.rgb,
-            ir: captured.ir,
-            ir_space,
-            embed_space: Some(self.embed_space.clone()),
-            ir_center_edge_ratio: captured.center_edge_ratio,
-            ir_brightness: captured.brightness,
-            pitch: captured.pitch,
-        });
+        // Anti-mixing: reject scans whose face belongs to a different profile.
+        // Checked on every capture, not just the first, so a second person
+        // stepping in partway through is caught (the enroll path checks the
+        // whole capture for the same reason).
+        for c in &captured {
+            if let Some((other, score)) = colliding_profile(
+                &enr,
+                &c.rgb,
+                Some(profile_name),
+                &self.embed_space,
+                self.rgb_threshold,
+            ) {
+                let cnt = enr
+                    .profiles
+                    .iter()
+                    .find(|p| p.name == other)
+                    .map_or(0, |p| p.scans_in(&self.embed_space));
+                let hint = if cnt < MAX_SCANS_PER_PROFILE {
+                    format!("if you want this face, add the scan to '{other}' (it has {cnt}/{MAX_SCANS_PER_PROFILE})")
+                } else {
+                    format!("'{other}' is already at the max {MAX_SCANS_PER_PROFILE} scans")
+                };
+                return Err(irlume_common::Error::Protocol(format!(
+                    "the scanned face belongs to '{other}' (match {score:.2}), not '{profile_name}'; {hint}. \
+                     Scans of different faces can't be mixed in one profile."
+                )));
+            }
+        }
+        let mut added = Vec::with_capacity(captured.len());
+        for c in captured {
+            let sname = enr.profiles[idx].next_scan_name();
+            let ir_space = c.ir.as_ref().map(|_| self.ir_space.clone());
+            enr.profiles[idx].scans.push(FaceScan {
+                name: sname.clone(),
+                rgb: c.rgb,
+                ir: c.ir,
+                ir_space,
+                embed_space: Some(self.embed_space.clone()),
+                ir_center_edge_ratio: c.center_edge_ratio,
+                ir_brightness: c.brightness,
+                pitch: c.pitch,
+            });
+            added.push(sname);
+        }
         self.refit_profile_calib(&mut enr.profiles[idx]);
         if enr.camera_binding.is_none() {
             enr.camera_binding = Some(self.current_binding());
         }
-        let total = enr.profiles[idx].scans.len();
+        let total = enr.profiles[idx].scans_in(&self.embed_space);
         storage::save(&enr)?;
-        Ok((sname, total))
+        Ok((added, total))
     }
 
     /// One framing-guide sample for guided enrollment: capture, detect, and
@@ -5714,7 +5732,7 @@ mod engine_tests {
         let mut s = shared();
         let dir = state_sandbox("addscan");
         // Unknown user.
-        let err = s.engine.add_scan("irlume-test-ghost", "P1").unwrap_err();
+        let err = s.engine.add_scan("irlume-test-ghost", "P1", 1).unwrap_err();
         assert!(err.to_string().contains("is not enrolled"), "{err}");
         // Known user, unknown profile.
         let mut e = Enrollment::new("irlume-test-add");
@@ -5725,7 +5743,7 @@ mod engine_tests {
             ir_calibs: Default::default(),
         });
         write_enrollment(&dir, &e);
-        let err = s.engine.add_scan("irlume-test-add", "nope").unwrap_err();
+        let err = s.engine.add_scan("irlume-test-add", "nope", 1).unwrap_err();
         assert!(err.to_string().contains("no face profile 'nope'"), "{err}");
         // Full profile: refused before any capture.
         let mut e = Enrollment::new("irlume-test-full");
@@ -5738,10 +5756,37 @@ mod engine_tests {
             ir_calibs: Default::default(),
         });
         write_enrollment(&dir, &e);
-        let err = s.engine.add_scan("irlume-test-full", "P1").unwrap_err();
+        let err = s.engine.add_scan("irlume-test-full", "P1", 1).unwrap_err();
         assert!(err.to_string().contains("already has the max"), "{err}");
+        // #288: the SAME profile, full of ANOTHER recognizer's scans, is not
+        // full for the loaded one. Without per-space counting a profile that
+        // had reached the limit under one model could never gain templates
+        // for a second, which is the case this feature exists for. It reaches
+        // the capture boundary instead of refusing.
+        let mut e = Enrollment::new("irlume-test-otherfull");
+        e.profiles.push(FaceProfile {
+            name: "P1".into(),
+            scans: (0..irlume_core::storage::MAX_SCANS_PER_PROFILE)
+                .map(|i| FaceScan {
+                    embed_space: Some("embed:another-model".into()),
+                    ..scan512(i, false, None)
+                })
+                .collect(),
+            ir_calib: None,
+            ir_calibs: Default::default(),
+        });
+        write_enrollment(&dir, &e);
+        let err = s
+            .engine
+            .add_scan("irlume-test-otherfull", "P1", 1)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no camera found"),
+            "a profile full of another recognizer's scans must still accept \
+             this one's, got: {err}"
+        );
         // Room in the profile: proceeds to the capture boundary.
-        let err = s.engine.add_scan("irlume-test-add", "P1").unwrap_err();
+        let err = s.engine.add_scan("irlume-test-add", "P1", 1).unwrap_err();
         assert!(err.to_string().contains("no camera found"), "{err}");
         teardown_sandbox(&dir);
     }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2749,16 +2749,18 @@ impl Engine {
             self.rgb_threshold,
         )? {
             Some(target) => {
-                let have = enr
+                let room = enr
                     .profiles
                     .iter()
                     .find(|p| p.name == target)
-                    .map_or(0, |p| p.scans.len());
-                let room = MAX_SCANS_PER_PROFILE - have;
+                    .map_or(MAX_SCANS_PER_PROFILE, |p| {
+                        scan_room_in(p, &self.embed_space)
+                    });
                 if room == 0 {
                     return Err(irlume_common::Error::Protocol(format!(
                         "this face is already enrolled as '{target}', which is at the max \
-                         {MAX_SCANS_PER_PROFILE} scans; delete some of its scans first"
+                         {MAX_SCANS_PER_PROFILE} scans for the loaded recognizer; delete \
+                         some of its scans first"
                     )));
                 }
                 want.min(room)
@@ -2788,11 +2790,12 @@ impl Engine {
                 .iter()
                 .position(|p| p.name == target)
                 .expect("merge target came from these profiles");
-            let room = MAX_SCANS_PER_PROFILE - enr.profiles[idx].scans.len();
+            let room = scan_room_in(&enr.profiles[idx], &self.embed_space);
             if room == 0 {
                 return Err(irlume_common::Error::Protocol(format!(
                     "this face is already enrolled as '{target}', which is at the max \
-                     {MAX_SCANS_PER_PROFILE} scans; delete some of its scans first"
+                     {MAX_SCANS_PER_PROFILE} scans for the loaded recognizer; delete \
+                     some of its scans first"
                 )));
             }
             let added = captured.len().min(room);
@@ -2886,9 +2889,9 @@ impl Engine {
         None
     }
 
-    /// Add one scan to an existing profile ("improve recognition"). Errors if the
+    /// Add scans to an existing profile ("improve recognition"). Errors if the
     /// profile is missing or already at MAX_SCANS_PER_PROFILE.
-    /// Add `count` scans to an existing profile, in the LOADED recognizer's
+    /// Add `count` scans (at least one) to an existing profile, in the LOADED recognizer's
     /// space. This is also how a profile gains templates for a second
     /// recognizer without re-enrolling as a new person: the operator names
     /// the profile, which is the only way the link can be made, since
@@ -2912,19 +2915,25 @@ impl Engine {
         // Counted for THIS recognizer: a profile holding another model's
         // scans must still accept this one's, and the limit's false-accept
         // rationale is about templates compared in one operation (#288).
-        let have = enr.profiles[idx].scans_in(&self.embed_space);
-        if have >= MAX_SCANS_PER_PROFILE {
+        let room = scan_room_in(&enr.profiles[idx], &self.embed_space);
+        if room == 0 {
             return Err(irlume_common::Error::Protocol(format!(
                 "'{profile_name}' already has the max {MAX_SCANS_PER_PROFILE} scans for the \
                  loaded recognizer"
             )));
         }
-        let want = count.clamp(1, MAX_SCANS_PER_PROFILE - have);
+        let want = count.clamp(1, room);
         let captured = self.capture_scans(want, enr.pitch_neutral())?;
-        if captured.is_empty() {
-            return Err(irlume_common::Error::Protocol(
-                "no live scan captured; check lighting and framing".into(),
-            ));
+        // capture_scans is best-effort and may return fewer than asked. A
+        // partial save would report success while leaving the recognizer
+        // under-enrolled, so refuse before anything is written, exactly as
+        // enrollment does.
+        if captured.len() < want {
+            return Err(irlume_common::Error::Protocol(format!(
+                "only {} live scans captured (need {want}); nothing was saved, check \
+                 lighting and framing",
+                captured.len()
+            )));
         }
         // Anti-mixing: reject scans whose face belongs to a different profile.
         let rgbs: Vec<&[f32]> = captured.iter().map(|c| c.rgb.as_slice()).collect();
@@ -3233,6 +3242,18 @@ fn enroll_merge_target(
         }
     }
     Ok(hit)
+}
+
+/// How many more scans this profile may hold for `space`.
+///
+/// Saturating, and counted per recognizer: a profile may legally hold the
+/// limit under each of several recognizers (#288), so subtracting the total
+/// from the limit underflows once a second model's templates exist. Every
+/// site that decides room uses this one function, because the enroll merge
+/// path had two more subtractions that the first cut of the per-space change
+/// missed entirely.
+fn scan_room_in(profile: &irlume_core::storage::FaceProfile, space: &str) -> usize {
+    irlume_core::storage::MAX_SCANS_PER_PROFILE.saturating_sub(profile.scans_in(space))
 }
 
 /// The first captured scan whose face belongs to a DIFFERENT profile, if any.
@@ -4061,6 +4082,48 @@ mod tests {
             irlume_core::RGB_MATCH_THRESHOLD
         )
         .is_none());
+    }
+
+    #[test]
+    fn room_is_counted_in_the_loaded_space_and_never_underflows() {
+        // The bug the per-space limit created: a profile may legally hold the
+        // limit under each of several recognizers, so subtracting the TOTAL
+        // from the limit underflows once a second model's templates exist,
+        // which panics a checked build and wraps to a huge room in release,
+        // bypassing the cap. The enroll merge path had two such subtractions
+        // (#290 review).
+        let mut profile = FaceProfile {
+            name: "P1".into(),
+            scans: Vec::new(),
+            ir_calib: None,
+            ir_calibs: Default::default(),
+        };
+        profile.scans.extend(
+            (0..irlume_core::storage::MAX_SCANS_PER_PROFILE).map(|i| FaceScan {
+                embed_space: Some("embed:model-a".into()),
+                ..scan(vec![i as f32, 0.0, 0.0])
+            }),
+        );
+        profile.scans.extend((0..5).map(|i| FaceScan {
+            embed_space: Some("embed:model-b".into()),
+            ..scan(vec![0.0, i as f32, 0.0])
+        }));
+        assert_eq!(
+            profile.scans.len(),
+            irlume_core::storage::MAX_SCANS_PER_PROFILE + 5,
+            "more total scans than the per-recognizer limit, which is legal"
+        );
+        assert_eq!(scan_room_in(&profile, "embed:model-a"), 0);
+        assert_eq!(
+            scan_room_in(&profile, "embed:model-b"),
+            irlume_core::storage::MAX_SCANS_PER_PROFILE - 5
+        );
+        // A recognizer with nothing enrolled has the full allowance, and the
+        // computation never underflows for any space.
+        assert_eq!(
+            scan_room_in(&profile, "embed:model-c"),
+            irlume_core::storage::MAX_SCANS_PER_PROFILE
+        );
     }
 
     #[test]

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2924,16 +2924,8 @@ impl Engine {
         }
         let want = count.clamp(1, room);
         let captured = self.capture_scans(want, enr.pitch_neutral())?;
-        // capture_scans is best-effort and may return fewer than asked. A
-        // partial save would report success while leaving the recognizer
-        // under-enrolled, so refuse before anything is written, exactly as
-        // enrollment does.
-        if captured.len() < want {
-            return Err(irlume_common::Error::Protocol(format!(
-                "only {} live scans captured (need {want}); nothing was saved, check \
-                 lighting and framing",
-                captured.len()
-            )));
+        if let Some(why) = short_capture_refusal(captured.len(), want) {
+            return Err(irlume_common::Error::Protocol(why));
         }
         // Anti-mixing: reject scans whose face belongs to a different profile.
         let rgbs: Vec<&[f32]> = captured.iter().map(|c| c.rgb.as_slice()).collect();
@@ -3242,6 +3234,22 @@ fn enroll_merge_target(
         }
     }
     Ok(hit)
+}
+
+/// Why a capture that came back short must be refused, or `None` when it is
+/// complete.
+///
+/// `capture_scans` is best-effort and may return fewer scans than asked for.
+/// A partial save would report success while leaving the recognizer
+/// under-enrolled, so the refusal happens before anything is written, exactly
+/// as enrollment does. A value because the capture it guards sits behind a
+/// camera, so this is the only shape a test can observe.
+fn short_capture_refusal(got: usize, want: usize) -> Option<String> {
+    (got < want).then(|| {
+        format!(
+            "only {got} live scans captured (need {want}); nothing was saved, check              lighting and framing"
+        )
+    })
 }
 
 /// How many more scans this profile may hold for `space`.
@@ -4082,6 +4090,27 @@ mod tests {
             irlume_core::RGB_MATCH_THRESHOLD
         )
         .is_none());
+    }
+
+    #[test]
+    fn a_short_capture_is_refused_before_anything_is_saved() {
+        // capture_scans is best-effort, so a request for ten that yields one
+        // must refuse rather than save a partial set and report success
+        // (#290 review). The capture sits behind a camera, so the decision is
+        // the observable shape.
+        assert!(short_capture_refusal(3, 3).is_none());
+        assert!(short_capture_refusal(1, 1).is_none());
+        let why = short_capture_refusal(1, 10).expect("a short capture must refuse");
+        assert!(
+            why.contains("only 1 live scans captured (need 10)"),
+            "{why}"
+        );
+        assert!(
+            why.contains("nothing was saved"),
+            "the refusal must say the enrollment is unchanged: {why}"
+        );
+        // Zero is short too, which is the case that always refused.
+        assert!(short_capture_refusal(0, 1).is_some());
     }
 
     #[test]

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2927,32 +2927,28 @@ impl Engine {
             ));
         }
         // Anti-mixing: reject scans whose face belongs to a different profile.
-        // Checked on every capture, not just the first, so a second person
-        // stepping in partway through is caught (the enroll path checks the
-        // whole capture for the same reason).
-        for c in &captured {
-            if let Some((other, score)) = colliding_profile(
-                &enr,
-                &c.rgb,
-                Some(profile_name),
-                &self.embed_space,
-                self.rgb_threshold,
-            ) {
-                let cnt = enr
-                    .profiles
-                    .iter()
-                    .find(|p| p.name == other)
-                    .map_or(0, |p| p.scans_in(&self.embed_space));
-                let hint = if cnt < MAX_SCANS_PER_PROFILE {
-                    format!("if you want this face, add the scan to '{other}' (it has {cnt}/{MAX_SCANS_PER_PROFILE})")
-                } else {
-                    format!("'{other}' is already at the max {MAX_SCANS_PER_PROFILE} scans")
-                };
-                return Err(irlume_common::Error::Protocol(format!(
-                    "the scanned face belongs to '{other}' (match {score:.2}), not '{profile_name}'; {hint}. \
-                     Scans of different faces can't be mixed in one profile."
-                )));
-            }
+        let rgbs: Vec<&[f32]> = captured.iter().map(|c| c.rgb.as_slice()).collect();
+        if let Some((other, score)) = foreign_owner_in_capture(
+            &enr,
+            &rgbs,
+            profile_name,
+            &self.embed_space,
+            self.rgb_threshold,
+        ) {
+            let cnt = enr
+                .profiles
+                .iter()
+                .find(|p| p.name == other)
+                .map_or(0, |p| p.scans_in(&self.embed_space));
+            let hint = if cnt < MAX_SCANS_PER_PROFILE {
+                format!("if you want this face, add the scan to '{other}' (it has {cnt}/{MAX_SCANS_PER_PROFILE})")
+            } else {
+                format!("'{other}' is already at the max {MAX_SCANS_PER_PROFILE} scans")
+            };
+            return Err(irlume_common::Error::Protocol(format!(
+                "the scanned face belongs to '{other}' (match {score:.2}), not '{profile_name}'; {hint}. \
+                 Scans of different faces can't be mixed in one profile."
+            )));
         }
         let mut added = Vec::with_capacity(captured.len());
         for c in captured {
@@ -3237,6 +3233,25 @@ fn enroll_merge_target(
         }
     }
     Ok(hit)
+}
+
+/// The first captured scan whose face belongs to a DIFFERENT profile, if any.
+///
+/// Every capture is checked, not just the first, so a second person stepping
+/// into frame partway through an add-scan session is caught; the enroll path
+/// checks its whole capture for the same reason. Extracted as a value because
+/// the loop it guards sits behind a camera, so this is the only shape a test
+/// can observe.
+fn foreign_owner_in_capture(
+    enr: &irlume_core::storage::Enrollment,
+    captured_rgb: &[&[f32]],
+    exclude: &str,
+    embed_space: &str,
+    threshold: f32,
+) -> Option<(String, f32)> {
+    captured_rgb
+        .iter()
+        .find_map(|rgb| colliding_profile(enr, rgb, Some(exclude), embed_space, threshold))
 }
 
 /// Best-matching OTHER profile for `probe` (excluding `exclude`), if it reaches
@@ -4046,6 +4061,69 @@ mod tests {
             irlume_core::RGB_MATCH_THRESHOLD
         )
         .is_none());
+    }
+
+    #[test]
+    fn every_capture_is_checked_for_a_foreign_owner_not_only_the_first() {
+        // A second person stepping into frame partway through an add-scan
+        // session must be caught. The loop sits behind a camera, so the
+        // decision is the testable shape: a capture whose FIRST scan is clean
+        // and whose second belongs to another profile must still refuse.
+        let mine = unit(vec![1.0, 0.0, 0.0]);
+        let theirs = unit(vec![0.0, 1.0, 0.0]);
+        let enr = Enrollment {
+            user: "u".into(),
+            profiles: vec![
+                FaceProfile {
+                    ir_calib: None,
+                    ir_calibs: Default::default(),
+                    name: "Mine".into(),
+                    scans: vec![scan(mine.clone())],
+                },
+                FaceProfile {
+                    ir_calib: None,
+                    ir_calibs: Default::default(),
+                    name: "Theirs".into(),
+                    scans: vec![scan(theirs.clone())],
+                },
+            ],
+            ..Default::default()
+        };
+        let thr = irlume_core::RGB_MATCH_THRESHOLD;
+        // All mine: nothing to refuse.
+        assert!(foreign_owner_in_capture(
+            &enr,
+            &[&mine, &mine],
+            "Mine",
+            LEGACY_RECOGNIZER_SPACE,
+            thr
+        )
+        .is_none());
+        // The intruder arrives on the SECOND capture: checking only the first
+        // would miss it.
+        assert_eq!(
+            foreign_owner_in_capture(
+                &enr,
+                &[&mine, &theirs],
+                "Mine",
+                LEGACY_RECOGNIZER_SPACE,
+                thr
+            )
+            .map(|(n, _)| n),
+            Some("Theirs".to_string())
+        );
+        // And on the first, the case that always worked.
+        assert_eq!(
+            foreign_owner_in_capture(
+                &enr,
+                &[&theirs, &mine],
+                "Mine",
+                LEGACY_RECOGNIZER_SPACE,
+                thr
+            )
+            .map(|(n, _)| n),
+            Some("Theirs".to_string())
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -323,10 +323,22 @@ fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
         },
         Some("add-scan") => match flag(args, "--profile") {
             Some(p) => {
-                eprintln!("[profiles] adding a scan to '{p}'; stay in frame…");
+                let scans = flag(args, "--scans").and_then(|s| s.parse::<usize>().ok());
+                match scans {
+                    Some(n) if n > 1 => eprintln!(
+                        "[profiles] adding {n} scans to '{p}'; stay in frame, vary your pose slightly…"
+                    ),
+                    _ => eprintln!("[profiles] adding a scan to '{p}'; stay in frame…"),
+                }
+                eprintln!(
+                    "[profiles] scans are recorded for the recognizer the daemon has loaded; \
+                     this is also how a profile gains templates for a second model without \
+                     re-enrolling as a new person."
+                );
                 Request::AddScan {
                     user,
                     profile: p.into(),
+                    scans,
                 }
             }
             None => return usage_profiles(),
@@ -881,7 +893,8 @@ fn usage_profiles() -> std::process::ExitCode {
     eprintln!(
         "usage: irlume profiles [--user U] <subcommand>\n  \
         (no sub) | list                         list profiles + scans\n  \
-        add-scan --profile P                    add a scan to P (improve recognition)\n  \
+        add-scan --profile P [--scans N]         add scans to P (improve recognition, or\n  \
+                                                add templates for a second model)\n  \
         rename --profile P [--scan S] --name N  rename a profile or a scan\n  \
         delete --profile P [--scan S]           delete a profile or a scan\n  \
         eyes-open <on|off>                      require eyes open to unlock\n  \

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -323,7 +323,19 @@ fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
         },
         Some("add-scan") => match flag(args, "--profile") {
             Some(p) => {
-                let scans = flag(args, "--scans").and_then(|s| s.parse::<usize>().ok());
+                // A state-changing biometric command must not silently
+                // substitute a different operation: an unparseable or zero
+                // count is a usage error, not "capture one".
+                let scans = match flag(args, "--scans") {
+                    None => None,
+                    Some(raw) => match raw.parse::<usize>() {
+                        Ok(n) if n > 0 => Some(n),
+                        _ => {
+                            eprintln!("[profiles] --scans must be a positive integer");
+                            return std::process::ExitCode::from(2);
+                        }
+                    },
+                };
                 match scans {
                     Some(n) if n > 1 => eprintln!(
                         "[profiles] adding {n} scans to '{p}'; stay in frame, vary your pose slightly…"

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -5645,6 +5645,7 @@ fn enroll_worker(
                 Request::AddScan {
                     user: user.clone(),
                     profile: profile.clone(),
+                    scans: None,
                 }
             };
             match crate::daemon_request(&req) {

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -410,7 +410,8 @@ fn add_scan_rejects_a_non_positive_or_unparseable_count() {
     // daemon running, a request attempt would exit 1.
     let sb = Sandbox::new("addscanbad");
     for bad in ["0", "-1", "abc", ""] {
-        let (code, _, err) = run(&mut sb.cmd(&["profiles", "add-scan", "--profile", "P", "--scans", bad]));
+        let (code, _, err) =
+            run(&mut sb.cmd(&["profiles", "add-scan", "--profile", "P", "--scans", bad]));
         assert_eq!(code, 2, "--scans {bad:?} must be a usage error: {err}");
         assert!(
             err.contains("--scans must be a positive integer"),
@@ -418,7 +419,8 @@ fn add_scan_rejects_a_non_positive_or_unparseable_count() {
         );
     }
     // A valid count parses and reaches the (dead) socket instead.
-    let (code, _, err) = run(&mut sb.cmd(&["profiles", "add-scan", "--profile", "P", "--scans", "5"]));
+    let (code, _, err) =
+        run(&mut sb.cmd(&["profiles", "add-scan", "--profile", "P", "--scans", "5"]));
     assert_eq!(code, 1, "a valid count must build a request: {err}");
     assert!(err.contains("adding 5 scans"), "{err}");
 }

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -389,7 +389,7 @@ fn profiles_usage_errors_exit_2() {
     // The full usage text names the real subcommands and flags.
     let (_, _, err) = run(&mut sb.cmd(&["profiles", "bogus"]));
     for frag in [
-        "add-scan --profile P",
+        "add-scan --profile P [--scans N]",
         "rename --profile P [--scan S] --name N",
         "delete --profile P [--scan S]",
         "eyes-open <on|off>",
@@ -400,6 +400,27 @@ fn profiles_usage_errors_exit_2() {
             "profiles usage must name `{frag}`: {err}"
         );
     }
+}
+
+#[test]
+fn add_scan_rejects_a_non_positive_or_unparseable_count() {
+    // A state-changing biometric command must refuse an invalid count rather
+    // than silently capturing one scan instead (#290 review). Exit 2 is the
+    // usage code, and it must happen before any daemon request: with no
+    // daemon running, a request attempt would exit 1.
+    let sb = Sandbox::new("addscanbad");
+    for bad in ["0", "-1", "abc", ""] {
+        let (code, _, err) = run(&mut sb.cmd(&["profiles", "add-scan", "--profile", "P", "--scans", bad]));
+        assert_eq!(code, 2, "--scans {bad:?} must be a usage error: {err}");
+        assert!(
+            err.contains("--scans must be a positive integer"),
+            "--scans {bad:?}: {err}"
+        );
+    }
+    // A valid count parses and reaches the (dead) socket instead.
+    let (code, _, err) = run(&mut sb.cmd(&["profiles", "add-scan", "--profile", "P", "--scans", "5"]));
+    assert_eq!(code, 1, "a valid count must build a request: {err}");
+    assert!(err.contains("adding 5 scans"), "{err}");
 }
 
 #[test]

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -366,7 +366,14 @@ pub enum Request {
     /// "root or self", which never matched the dispatch gate.)
     SetCameras { rgb: String, ir: String },
     /// Add one scan to an existing profile ("improve recognition"). PRIVILEGED.
-    AddScan { user: String, profile: String },
+    AddScan {
+        user: String,
+        profile: String,
+        /// How many scans to capture. Absent (an older CLI) means one, the
+        /// behaviour this request always had.
+        #[serde(default)]
+        scans: Option<usize>,
+    },
     /// List enrolled profiles + their scans for `user`.
     ListProfiles {
         user: String,

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -365,7 +365,10 @@ pub enum Request {
     /// under /etc/irlume, which is not an arbitrary peer's to change. (This said
     /// "root or self", which never matched the dispatch gate.)
     SetCameras { rgb: String, ir: String },
-    /// Add one scan to an existing profile ("improve recognition"). PRIVILEGED.
+    /// Add scans to an existing profile ("improve recognition"). PRIVILEGED.
+    /// Add scans to an existing profile, in the recognizer space the daemon
+    /// has loaded. Also how a profile gains a second recognizer's templates
+    /// without re-enrolling as a new person (#288).
     AddScan {
         user: String,
         profile: String,

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -114,6 +114,21 @@ pub struct FaceProfile {
 }
 
 impl FaceProfile {
+    /// How many of this profile's scans belong to `space`.
+    ///
+    /// The scan limit is counted per recognizer, not per profile, because the
+    /// limit exists to bound false-accept inflation from taking the best of N
+    /// templates, and a comparison only ever ranges over one embedding space
+    /// (#288). Ten scans under each of two recognizers is two independent
+    /// best-of-ten operations, and a profile full of one model's scans must
+    /// still be able to hold another's.
+    pub fn scans_in(&self, space: &str) -> usize {
+        self.scans
+            .iter()
+            .filter(|s| recognizer_space_matches(s.embed_space.as_deref(), space))
+            .count()
+    }
+
     /// This profile's calibration for `space`, or `None`.
     ///
     /// Falls back to the legacy single slot for the shipped recognizer, so a
@@ -719,6 +734,32 @@ mod tests {
         // A recognizer nothing was enrolled under gets NO templates: matching
         // must come up empty rather than score across spaces.
         assert!(enr.rgb_scans_in("embed:cccccccccccc").is_empty());
+    }
+
+    #[test]
+    fn scans_are_counted_per_recognizer() {
+        // #288: the scan limit bounds best-of-N false-accept inflation, and a
+        // comparison only ranges over one space, so a profile full of one
+        // model's scans must still be able to hold another's.
+        let p = FaceProfile {
+            name: "p".into(),
+            ir_calib: None,
+            ir_calibs: Default::default(),
+            scans: vec![
+                scan("a", 1.0, Some("embed:model-a")),
+                scan("b", 2.0, Some("embed:model-a")),
+                scan("c", 3.0, Some("embed:model-b")),
+                scan("legacy", 4.0, None),
+            ],
+        };
+        assert_eq!(p.scans_in("embed:model-a"), 2);
+        assert_eq!(p.scans_in("embed:model-b"), 1);
+        // Untagged scans belong to the shipped recognizer, the same rule
+        // matching applies, so they count there and nowhere else.
+        assert_eq!(p.scans_in(LEGACY_RECOGNIZER_SPACE), 1);
+        assert_eq!(p.scans_in("embed:model-c"), 0);
+        // And the total is not the per-recognizer count.
+        assert_eq!(p.scans.len(), 4);
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2288,14 +2288,23 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 }
             }
         }
-        Request::AddScan { user, profile } => {
+        Request::AddScan {
+            user,
+            profile,
+            scans,
+        } => {
             if !authorized_for(peer, &user) {
                 return Response::Error(format!("not authorized to modify '{user}'"));
             }
-            match engine.add_scan(&user, &profile) {
-                Ok((scan, total)) => {
-                    Response::Ok(format!("added '{scan}' to '{profile}' ({total} scans)"))
-                }
+            match engine.add_scan(&user, &profile, scans.unwrap_or(1)) {
+                Ok((added, total)) => Response::Ok(format!(
+                    "added {} to '{profile}' ({total} scans for the loaded recognizer)",
+                    added
+                        .iter()
+                        .map(|s| format!("'{s}'"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )),
                 Err(e) => Response::Error(e.to_string()),
             }
         }
@@ -3495,6 +3504,7 @@ mod tests {
             Request::AddScan {
                 user: u(),
                 profile: "p".into(),
+                scans: None,
             },
             Request::SetRequireEyesOpen {
                 user: u(),
@@ -3909,6 +3919,7 @@ mod tests {
             Request::AddScan {
                 user: u(),
                 profile: "p".into(),
+                scans: None,
             },
             Request::DeleteProfile {
                 user: u(),
@@ -5413,6 +5424,7 @@ mod tests {
             Request::AddScan {
                 user: "ghost".into(),
                 profile: "Face Profile 1".into(),
+                scans: None,
             },
             &peer(0),
             &mut e,
@@ -5429,6 +5441,7 @@ mod tests {
             Request::AddScan {
                 user: "carol".into(),
                 profile: "Face Profile 1".into(),
+                scans: None,
             },
             &peer(0),
             &mut e,

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -32,7 +32,7 @@ Conventions that apply everywhere:
 |---|---|
 | `irlume enroll [--name N] [--scans K] [--reset]` | capture a face profile; `--reset` starts the profile space over |
 | `irlume profiles` (or `profiles list`) | list profiles and their scans; `profiles list --json` uses the read-only public [machine API](MACHINE-API.md) |
-| `irlume profiles add-scan --profile P` | add a scan to profile P (improves recognition in new conditions) |
+| `irlume profiles add-scan --profile P [--scans N]` | add scans to profile P: improves recognition in new conditions, and adds templates for a second recognizer without re-enrolling as a new person (scans belong to the recognizer the daemon has loaded) |
 | `irlume profiles rename --profile P [--scan S] --name N` | rename a profile, or one scan inside it |
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
 | `irlume profiles eyes-open <on\|off>` | require eyes open to unlock |


### PR DESCRIPTION
Step 2 of #288. Adding a second recognizer's templates to an existing profile already worked in principle: each scan carries its producer's digest (#277), and the anti-mixing check filters by space, so the operator naming a profile is the identity link. Two things stopped it being usable.

**The scan limit counted every scan in the profile, regardless of recognizer.** A profile that had reached the limit under one model could never gain a template for another, which is the case this feature exists for. `FaceProfile::scans_in` counts per space and both limit sites use it. The rationale is the limit's own: it bounds false-accept inflation from taking the best of N templates, and a comparison only ever ranges over one embedding space, so ten scans under each of two recognizers is two independent best-of-ten operations rather than one best-of-twenty.

**`add-scan` captured exactly one scan.** It now takes a count, so a second model's templates arrive in one session. The request field is optional and defaults to the previous behaviour, so an older CLI keeps working against a newer daemon. The anti-mixing check now runs on every capture rather than only the first, matching what enrollment already does, so a second person stepping into frame partway through is caught. The CLI states plainly that scans are recorded for the recognizer the daemon has loaded, and that this is how a profile gains a second model's templates without re-enrolling as a new person.

## Testing

Per-space counting over a mixed profile; a profile full of another recognizer's scans reaching the capture boundary instead of refusing, which is the regression this step exists to prevent; and the capture-collision decision extracted as a value so the every-capture rule can be observed at all, since the loop it guards sits behind a camera.

Four mutants, each failing a named test: `scans_in` ignoring the space, the limit counting all scans, the collision check narrowed to the first capture, and the earlier keying mutants still covered. Workspace 1111 tests, clippy clean with `-D warnings`.

## Not covered

No hardware run: a real second-model add-scan session needs a camera and a second installed recognizer, and archhost currently has buffalo disabled. The pieces it would exercise are the capture loop and the calibration refit, both of which have unit coverage; the end-to-end version belongs with the next hardware session.
