### PR TITLE
cli+daemon+tui: profiles forget-model, per-model profile view, disable note (#288 step 4)

### DIFF
--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -327,6 +327,18 @@ fn shell_single_quote(value: &str) -> String {
 /// to-3 face profiles and their scans via the daemon.
 fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
     use irlume_common::{Request, Response};
+    // A supplied `--user` must carry a real username. `user_arg` falls back
+    // to SUDO_USER/$USER when the flag is ABSENT, which is right for the bare
+    // commands, but a dangling `--user` inheriting that fallback would point
+    // a destructive subcommand (forget-model, delete) at the invoking user's
+    // own enrollment. Checked here, not in `user_arg`: the fallback semantics
+    // of an absent flag belong to every caller, this omission does not.
+    if args.iter().any(|a| a == "--user")
+        && !matches!(flag(args, "--user"), Some(u) if !u.is_empty() && !u.starts_with("--"))
+    {
+        eprintln!("[profiles] --user requires a username");
+        return std::process::ExitCode::from(2);
+    }
     let user = user_arg(args);
     let req = match sub {
         None | Some("list") => Request::ListProfiles {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -367,6 +367,25 @@ fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
             }
             None => return usage_profiles(),
         },
+        Some("forget-model") => {
+            // Positional: `irlume profiles forget-model <model>` (args[0] is
+            // "profiles", args[1] the subcommand). A flag must not be read as
+            // the model name when the positional is missing.
+            match args
+                .get(2)
+                .map(String::as_str)
+                .filter(|a| !a.starts_with("--"))
+            {
+                Some(name) => match crate::models::recognizer_space_for(name) {
+                    Ok(space) => Request::ForgetRecognizer { user, space },
+                    Err(e) => {
+                        eprintln!("[profiles] {e}");
+                        return std::process::ExitCode::from(2);
+                    }
+                },
+                None => return usage_profiles(),
+            }
+        }
         Some("delete") => match (flag(args, "--profile"), flag(args, "--scan")) {
             (Some(p), Some(s)) => Request::DeleteScan {
                 user,
@@ -949,6 +968,8 @@ fn usage_profiles() -> std::process::ExitCode {
                                                 add templates for a second model)\n  \
         rename --profile P [--scan S] --name N  rename a profile or a scan\n  \
         delete --profile P [--scan S]           delete a profile or a scan\n  \
+        forget-model <model>                    remove one recognizer's scans from every\n  \
+                                                profile (shipped | a catalog name | embed:<sha256>)\n  \
         eyes-open <on|off>                      require eyes open to unlock\n  \
         challenge <on|off>                      opt-in passive blink liveness"
     );

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -155,7 +155,10 @@ pub(crate) fn recognizer_space_for(name: &str) -> Result<String, String> {
     }
     if let Some(hex) = name.strip_prefix("embed:") {
         if hex.len() == 64 && hex.bytes().all(|b| b.is_ascii_hexdigit()) {
-            return Ok(name.to_string());
+            // Lowercased: stored tags are lowercase `sha256_hex` output and
+            // the daemon compares case-sensitively, so uppercase input could
+            // only ever match nothing.
+            return Ok(format!("embed:{}", hex.to_ascii_lowercase()));
         }
         return Err(format!(
             "'{name}' is not a recognizer space tag (embed: followed by 64 hex digits)"
@@ -846,6 +849,11 @@ mod tests {
         // how a recognizer the catalog no longer carries stays forgettable.
         let raw = format!("embed:{}", "a".repeat(64));
         assert_eq!(super::recognizer_space_for(&raw).unwrap(), raw);
+        // Uppercase hex normalizes: stored tags are lowercase `sha256_hex`
+        // output and the daemon compares case-sensitively, so passing the
+        // case through could only ever match nothing (Codex, #292).
+        let upper = format!("embed:{}", "A".repeat(64));
+        assert_eq!(super::recognizer_space_for(&upper).unwrap(), raw);
         let e = super::recognizer_space_for("embed:nothex").unwrap_err();
         assert!(e.contains("64 hex"), "{e}");
         let e = super::recognizer_space_for(other.name).unwrap_err();

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -141,6 +141,52 @@ fn enabled_entries() -> Vec<(&'static ThirdPartyModel, &'static str)> {
         .collect()
 }
 
+/// The embedding-space tag `profiles forget-model` acts on for `name`.
+///
+/// Accepts the shipped recognizer (`shipped`), a catalog recognizer's name,
+/// or a raw `embed:<64 hex>` tag as `profiles list` prints it, so an operator
+/// can forget a recognizer the catalog no longer carries. A catalog entry
+/// from another stage is refused by name: detection, landmarks, and the PAD
+/// cue store no enrollment data, so there is nothing to forget.
+pub(crate) fn recognizer_space_for(name: &str) -> Result<String, String> {
+    use irlume_common::thirdparty::Stage;
+    if name == "shipped" {
+        return Ok(irlume_core::storage::LEGACY_RECOGNIZER_SPACE.to_string());
+    }
+    if let Some(hex) = name.strip_prefix("embed:") {
+        if hex.len() == 64 && hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Ok(name.to_string());
+        }
+        return Err(format!(
+            "'{name}' is not a recognizer space tag (embed: followed by 64 hex digits)"
+        ));
+    }
+    match thirdparty::by_name(name) {
+        // The space tag is `embed:<sha256 of the weights>`, and the catalog
+        // pin IS that sha256: the daemon verified the loaded bytes against it
+        // before hashing them into the tag.
+        Some(m) if m.stage == Stage::Recognition => Ok(format!("embed:{}", m.sha256)),
+        Some(m) => Err(format!(
+            "'{name}' is a {} model; that stage stores no enrollment data",
+            m.stage.as_str()
+        )),
+        None => {
+            let known: Vec<&str> = std::iter::once("shipped")
+                .chain(
+                    thirdparty::CATALOG
+                        .iter()
+                        .filter(|m| m.stage == Stage::Recognition)
+                        .map(|m| m.name),
+                )
+                .collect();
+            Err(format!(
+                "unknown model '{name}'; recognizers: {}",
+                known.join(", ")
+            ))
+        }
+    }
+}
+
 fn file_state(m: &ThirdPartyModel) -> &'static str {
     use thirdparty::WeightState::*;
     match thirdparty::weight_state(m) {
@@ -526,6 +572,17 @@ fn disable(name: Option<&str>) -> ExitCode {
         "[models] '{}' disabled: weights deleted, daemon back on the shipped stack.",
         m.name
     );
+    if m.stage == thirdparty::Stage::Recognition {
+        // Deliberate asymmetry (#288): disabling deletes the WEIGHTS but keeps
+        // the enrollment templates recorded under this recognizer, so
+        // re-enabling it later needs no re-enrollment.
+        println!(
+            "[models] enrollment scans recorded under '{}' are kept; re-enabling needs no \
+             re-enrollment. To erase that biometric material instead: \
+             `sudo irlume profiles forget-model {} --user <user>`.",
+            m.name, m.name
+        );
+    }
     ExitCode::SUCCESS
 }
 
@@ -762,6 +819,43 @@ pub fn doctor_line() -> String {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn forget_model_space_resolution_accepts_recognizers_and_refuses_the_rest() {
+        use irlume_common::thirdparty::Stage;
+        // Names come from the live catalog, so this keeps holding as entries
+        // are added: any recognizer resolves to its pin's space, any other
+        // stage is refused because it stores no enrollment data.
+        let rec = thirdparty::CATALOG
+            .iter()
+            .find(|m| m.stage == Stage::Recognition)
+            .expect("the catalog carries a recognizer");
+        let other = thirdparty::CATALOG
+            .iter()
+            .find(|m| m.stage != Stage::Recognition)
+            .expect("the catalog carries a non-recognizer");
+        assert_eq!(
+            super::recognizer_space_for("shipped").unwrap(),
+            irlume_core::storage::LEGACY_RECOGNIZER_SPACE
+        );
+        assert_eq!(
+            super::recognizer_space_for(rec.name).unwrap(),
+            format!("embed:{}", rec.sha256)
+        );
+        // The raw tag, as `profiles list` prints it, passes through: it is
+        // how a recognizer the catalog no longer carries stays forgettable.
+        let raw = format!("embed:{}", "a".repeat(64));
+        assert_eq!(super::recognizer_space_for(&raw).unwrap(), raw);
+        let e = super::recognizer_space_for("embed:nothex").unwrap_err();
+        assert!(e.contains("64 hex"), "{e}");
+        let e = super::recognizer_space_for(other.name).unwrap_err();
+        assert!(e.contains("stores no enrollment data"), "{e}");
+        let e = super::recognizer_space_for("nonsense").unwrap_err();
+        assert!(
+            e.contains("shipped") && e.contains(rec.name),
+            "an unknown name must list the recognizers: {e}"
+        );
+    }
 
     /// A synthetic bring-your-own entry. The catalog has no such model yet, so
     /// the tier the code must handle would otherwise be untested until one is

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3810,13 +3810,40 @@ impl App {
             .map(|r| match r {
                 Row::Profile(pi) => {
                     let p = &self.profiles[*pi];
-                    ListItem::new(Line::from(vec![
+                    // Same rule as the CLI listing (#288): only the loaded
+                    // recognizer's scans can match, so a bare total would let
+                    // a profile look usable when none of it is. The breakdown
+                    // appears when the total would mislead; an old daemon
+                    // reports neither field and keeps the flat count.
+                    let live = p.live_recognizer.as_deref();
+                    let live_count = live
+                        .and_then(|l| p.scans_by_recognizer.get(l).copied())
+                        .unwrap_or(0);
+                    let misleading = p.scans_by_recognizer.len() > 1
+                        || (live.is_some() && live_count != p.scans.len());
+                    let count = if misleading {
+                        format!(
+                            "   ({} scans, {} for the loaded recognizer)",
+                            p.scans.len(),
+                            live_count
+                        )
+                    } else {
+                        format!("   ({} scans)", p.scans.len())
+                    };
+                    let mut item = vec![Line::from(vec![
                         Span::styled(
                             format!("● {}", p.name),
                             Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
                         ),
-                        Span::styled(format!("   ({} scans)", p.scans.len()), Style::new().dim()),
-                    ]))
+                        Span::styled(count, Style::new().dim()),
+                    ])];
+                    if misleading && live_count == 0 {
+                        item.push(Line::from(Span::styled(
+                            "     none of these match the loaded recognizer; add scans with [a] Improve Recognition",
+                            Style::new().fg(th().warn),
+                        )));
+                    }
+                    ListItem::new(item)
                 }
                 Row::Scan(pi, si) => ListItem::new(Line::from(Span::raw(format!(
                     "     ↳ {}",
@@ -4510,6 +4537,25 @@ impl App {
         f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
     }
 
+    /// How many enrolled scans the LOADED recognizer can match, or `None`
+    /// when the daemon predates per-recognizer reporting (then nothing can be
+    /// said and the flat total stands). Feeds [`count_badge`]: a profile full
+    /// of another recognizer's scans is not healthy enrollment (#288).
+    fn live_scans(&self) -> Option<usize> {
+        // One daemon, one loaded recognizer: every summary carries the same
+        // live_recognizer, so the first is the answer.
+        let live = self
+            .profiles
+            .iter()
+            .find_map(|p| p.live_recognizer.as_deref())?;
+        Some(
+            self.profiles
+                .iter()
+                .map(|p| p.scans_by_recognizer.get(live).copied().unwrap_or(0))
+                .sum(),
+        )
+    }
+
     /// Hub rows for the Welcome screen: each visible section with its live
     /// state, selectable and Enter-jumpable (hub-and-spoke: the summary IS
     /// the navigation, the tab ribbon stays for direct access).
@@ -4642,7 +4688,7 @@ impl App {
                 style = style.fg(th().accent).add_modifier(Modifier::BOLD);
             }
             let badge = if label == "enrollment" {
-                count_badge(self.profiles.len(), scans)
+                count_badge(self.profiles.len(), scans, self.live_scans())
             } else {
                 onoff(ok)
             };
@@ -5076,7 +5122,7 @@ impl App {
             ]),
             Line::from(vec![
                 Span::raw("  enrollment        "),
-                count_badge(self.profiles.len(), scans),
+                count_badge(self.profiles.len(), scans, self.live_scans()),
             ]),
             Line::from(vec![
                 Span::raw("  eyes-open gate    "),
@@ -5441,15 +5487,23 @@ fn method_label(method: &str) -> String {
     }
 }
 
-/// "N profile(s), M scan(s)" or a dim "none".
-fn count_badge(profiles: usize, scans: usize) -> Span<'static> {
+/// "N profile(s), M scan(s)" or a dim "none". `live` is how many of those
+/// scans the loaded recognizer can match, `None` when the daemon does not
+/// report it. Zero live scans is a warning, not a green badge: enrollment
+/// that cannot match is not healthy, however many scans it holds (#288).
+fn count_badge(profiles: usize, scans: usize, live: Option<usize>) -> Span<'static> {
     if profiles == 0 {
-        Span::styled("○ none", Style::new().dim())
-    } else {
-        Span::styled(
+        return Span::styled("○ none", Style::new().dim());
+    }
+    match live {
+        Some(0) => Span::styled(
+            format!("● {profiles} profile(s), {scans} scan(s), none for the loaded recognizer"),
+            Style::new().fg(th().warn).add_modifier(Modifier::BOLD),
+        ),
+        _ => Span::styled(
             format!("● {profiles} profile(s), {scans} scan(s)"),
             Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-        )
+        ),
     }
 }
 
@@ -7816,6 +7870,72 @@ mod tests {
             text.contains("Improve Recognition"),
             "the add-scan guidance is missing"
         );
+    }
+
+    #[test]
+    fn profiles_screen_separates_live_scans_from_another_recognizers() {
+        // Only the loaded recognizer's scans can match, so a flat count let a
+        // profile read as healthy when none of it was usable (#288). The
+        // breakdown appears exactly when the flat count would mislead.
+        let live_space = "embed:model-b";
+        let mut app = test_app();
+        app.screen = SC_PROFILES;
+        // All scans live: the flat count stands, no warning.
+        let mut p = profile("Alice", &["scan-a", "scan-b"]);
+        p.scans_by_recognizer = [(live_space.to_string(), 2)].into();
+        p.live_recognizer = Some(live_space.into());
+        app.profiles = vec![p];
+        let text = draw_text(&app);
+        assert!(text.contains("(2 scans)"), "{text}");
+        assert!(!text.contains("for the loaded recognizer"), "{text}");
+        // No scan lives in the loaded space: the count says so, and the row
+        // grows the warning naming the fix.
+        let mut p = profile("Alice", &["scan-a", "scan-b"]);
+        p.scans_by_recognizer = [("embed:model-a".to_string(), 2)].into();
+        p.live_recognizer = Some(live_space.into());
+        app.profiles = vec![p];
+        let text = draw_text(&app);
+        assert!(
+            text.contains("(2 scans, 0 for the loaded recognizer)"),
+            "{text}"
+        );
+        assert!(
+            text.contains("none of these match the loaded recognizer"),
+            "{text}"
+        );
+        // An old daemon reports neither field: nothing can be said, so the
+        // flat count stands rather than a false all-clear or a false warning.
+        app.profiles = vec![profile("Alice", &["scan-a", "scan-b"])];
+        let text = draw_text(&app);
+        assert!(text.contains("(2 scans)"), "{text}");
+        assert!(!text.contains("for the loaded recognizer"), "{text}");
+    }
+
+    #[test]
+    fn welcome_badge_warns_when_no_scan_matches_the_loaded_recognizer() {
+        // The Welcome hub's enrollment badge fed off the same flat total; a
+        // green "1 profile(s), 2 scan(s)" over zero usable scans is the same
+        // lie one screen earlier.
+        let mut app = test_app();
+        app.screen = SC_WELCOME;
+        // The enrollment hub row only exists when SC_PROFILES is visible,
+        // which needs an RGB camera.
+        app.caps.rgb = true;
+        app.visible = App::compute_visible(&app.caps, VisibilityInputs::default(), &[]);
+        let mut p = profile("Alice", &["scan-a", "scan-b"]);
+        p.scans_by_recognizer = [("embed:model-a".to_string(), 2)].into();
+        p.live_recognizer = Some("embed:model-b".into());
+        app.profiles = vec![p];
+        let text = draw_text(&app);
+        assert!(text.contains("none for the loaded recognizer"), "{text}");
+        // With live scans (or an old daemon), the badge is the plain count.
+        let mut p = profile("Alice", &["scan-a", "scan-b"]);
+        p.scans_by_recognizer = [("embed:model-b".to_string(), 2)].into();
+        p.live_recognizer = Some("embed:model-b".into());
+        app.profiles = vec![p];
+        let text = draw_text(&app);
+        assert!(text.contains("1 profile(s), 2 scan(s)"), "{text}");
+        assert!(!text.contains("none for the loaded recognizer"), "{text}");
     }
 
     #[test]

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -381,8 +381,9 @@ fn profiles_usage_errors_exit_2() {
         &["profiles", "eyes-open", "on", "off"],
         &["profiles", "challenge"],
         // forget-model with no model name; a flag must not be read as one.
+        // (A dangling `--user` gets its own specific error, tested in
+        // a_dangling_user_flag_never_reaches_the_daemon.)
         &["profiles", "forget-model"],
-        &["profiles", "forget-model", "--user"],
     ];
     for argv in cases {
         let (code, _, err) = run(&mut sb.cmd(argv));
@@ -483,6 +484,34 @@ fn forget_model_refuses_a_name_that_is_not_a_recognizer() {
         "a malformed space tag must be a usage error: {err}"
     );
     assert!(err.contains("64 hex"), "{err}");
+}
+
+#[test]
+fn a_dangling_user_flag_never_reaches_the_daemon() {
+    // `--user` with no value used to fall back to SUDO_USER/$USER, so
+    // `sudo irlume profiles forget-model shipped --user` would have deleted
+    // the INVOKING user's own enrollment (Codex, #292). The request must die
+    // as a usage error before the socket: with no daemon running, reaching
+    // the socket shows as exit 1 and "irlumed is not running".
+    let sb = Sandbox::new("dangleuser");
+    let cases: &[&[&str]] = &[
+        &["profiles", "forget-model", "shipped", "--user"],
+        &["profiles", "delete", "--profile", "P", "--user"],
+        // A flag where the username should be is the same omission.
+        &["profiles", "forget-model", "shipped", "--user", "--json"],
+    ];
+    for argv in cases {
+        let (code, _, err) = run(&mut sb.cmd(argv));
+        assert_eq!(code, 2, "{argv:?} must be a usage error: {err}");
+        assert!(
+            err.contains("--user requires a username"),
+            "{argv:?}: {err}"
+        );
+        assert!(
+            !err.contains("irlumed is not running"),
+            "{argv:?} must not build a request: {err}"
+        );
+    }
 }
 
 // ---------------------------------------------------------- daemon-backed cmds

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -380,6 +380,9 @@ fn profiles_usage_errors_exit_2() {
         &["profiles", "eyes-open"],
         &["profiles", "eyes-open", "on", "off"],
         &["profiles", "challenge"],
+        // forget-model with no model name; a flag must not be read as one.
+        &["profiles", "forget-model"],
+        &["profiles", "forget-model", "--user"],
     ];
     for argv in cases {
         let (code, _, err) = run(&mut sb.cmd(argv));
@@ -392,6 +395,7 @@ fn profiles_usage_errors_exit_2() {
         "add-scan --profile P [--scans N]",
         "rename --profile P [--scan S] --name N",
         "delete --profile P [--scan S]",
+        "forget-model <model>",
         "eyes-open <on|off>",
         "challenge <on|off>",
     ] {
@@ -449,6 +453,7 @@ fn profiles_valid_subcommands_build_requests_and_fail_without_a_daemon() {
         ],
         &["profiles", "eyes-open", "on"],
         &["profiles", "challenge", "off"],
+        &["profiles", "forget-model", "shipped"],
     ];
     for argv in cases {
         let (code, _, err) = run(&mut sb.cmd(argv));
@@ -459,6 +464,25 @@ fn profiles_valid_subcommands_build_requests_and_fail_without_a_daemon() {
         );
         assert!(!err.contains("usage:"), "{argv:?} parsed fine: {err}");
     }
+}
+
+#[test]
+fn forget_model_refuses_a_name_that_is_not_a_recognizer() {
+    // Refused at resolution, before any daemon request: with no daemon
+    // running, a request attempt would exit 1, so exit 2 proves the order.
+    let sb = Sandbox::new("forgetbad");
+    let (code, _, err) = run(&mut sb.cmd(&["profiles", "forget-model", "nonsense"]));
+    assert_eq!(code, 2, "an unknown model must be a usage error: {err}");
+    assert!(
+        err.contains("unknown model 'nonsense'") && err.contains("shipped"),
+        "the error must list the recognizers: {err}"
+    );
+    let (code, _, err) = run(&mut sb.cmd(&["profiles", "forget-model", "embed:nothex"]));
+    assert_eq!(
+        code, 2,
+        "a malformed space tag must be a usage error: {err}"
+    );
+    assert!(err.contains("64 hex"), "{err}");
 }
 
 // ---------------------------------------------------------- daemon-backed cmds

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -684,6 +684,32 @@ fn daemon_error_responses_surface_per_command() {
     }
 }
 
+#[test]
+fn forget_model_sends_the_resolved_space_over_the_wire() {
+    // The CLI resolves a catalog name to its embedding-space tag; the daemon
+    // only ever sees the tag. The fake daemon asserts the exact request, so a
+    // resolver regression (wrong pin, name passed through raw) fails here and
+    // not on a real enrollment.
+    let sb = Sandbox::new("forgetwire");
+    let rec = irlume_common::thirdparty::CATALOG
+        .iter()
+        .find(|m| m.stage == irlume_common::thirdparty::Stage::Recognition)
+        .expect("the catalog carries a recognizer");
+    let want = format!("embed:{}", rec.sha256);
+    serve(&sb.sock(), move |req| match req {
+        Request::ForgetRecognizer { user, space } if user == "tester" && *space == want => {
+            Response::Ok(format!("forgot recognizer {space}: 2 scan(s) removed"))
+        }
+        other => Response::Error(format!("unexpected request {other:?}")),
+    });
+    let (code, out, err) = run(
+        &mut sb.cmd(&["profiles", "forget-model", rec.name, "--user", "tester"]),
+        "forget-model",
+    );
+    assert_eq!(code, 0, "{err}");
+    assert!(out.contains("2 scan(s) removed"), "{out}");
+}
+
 // The write-side commands' unexpected-response arms (keyring arm/forget,
 // recovery setup/restore/forget). cli.rs's Pong sweep does not include these.
 #[test]

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -403,6 +403,19 @@ pub enum Request {
         profile: String,
         scan: String,
     },
+    /// Remove every scan `user` holds in one recognizer's embedding space,
+    /// plus the calibrations fitted from them (#288). PRIVILEGED, same rule
+    /// as DeleteProfile.
+    ///
+    /// `models disable` deletes a recognizer's weights and deliberately keeps
+    /// its templates, so that re-enabling it later needs no re-enrollment.
+    /// This request is the deliberate counterpart for when the operator wants
+    /// that biometric material gone. `space` is the embedding-space tag
+    /// (`embed:<sha256>` of the recognizer weights); the CLI resolves a
+    /// catalog name to it. A profile left with no scans is deleted with them:
+    /// an empty profile can never match, and `DeleteScan` upholds the same
+    /// never-orphaned rule.
+    ForgetRecognizer { user: String, space: String },
     /// Rename a profile. PRIVILEGED.
     RenameProfile {
         user: String,

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1559,6 +1559,7 @@ fn request_user(req: &Request) -> Option<&str> {
         | ListProfiles { user, .. }
         | DeleteProfile { user, .. }
         | DeleteScan { user, .. }
+        | ForgetRecognizer { user, .. }
         | RenameProfile { user, .. }
         | RenameScan { user, .. }
         | AddScan { user, .. }
@@ -1746,6 +1747,7 @@ fn enrollment_mutating_user(req: &Request) -> Option<&str> {
         | AddScan { user, .. }
         | DeleteProfile { user, .. }
         | DeleteScan { user, .. }
+        | ForgetRecognizer { user, .. }
         | RenameProfile { user, .. }
         | RenameScan { user, .. }
         | SetRequireEyesOpen { user, .. }
@@ -2698,6 +2700,69 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 } else {
                     Ok(format!("deleted scan '{scan}' from '{profile}'"))
                 }
+            })
+        }
+        Request::ForgetRecognizer { user, space } => {
+            if !authorized_for(peer, &user) {
+                return Response::Error(format!("not authorized to modify '{user}'"));
+            }
+            // Read before mutating: is the loaded recognizer the one being
+            // forgotten? Decided here because the closure below has no engine.
+            let forgetting_live = space == engine.embed_space();
+            mutate_enrollment(&user, |enr| {
+                let mut scans_removed = 0usize;
+                let mut calibs_removed = 0usize;
+                for p in &mut enr.profiles {
+                    let before = p.scans.len();
+                    p.scans.retain(|s| {
+                        !irlume_core::storage::recognizer_space_matches(
+                            s.embed_space.as_deref(),
+                            &space,
+                        )
+                    });
+                    scans_removed += before - p.scans.len();
+                    // The calibration for this space was fitted from the scans
+                    // just removed; it is derived biometric material and goes
+                    // with them. Cleared even when the scans are already gone
+                    // (deleted one by one), because a stale fit can outlive
+                    // its scans.
+                    if p.calib_for(&space).is_some() {
+                        calibs_removed += 1;
+                        p.set_calib_for(&space, None);
+                    }
+                }
+                if scans_removed == 0 && calibs_removed == 0 {
+                    return Err(format!("no enrollment data from recognizer {space}"));
+                }
+                // Same rule as DeleteScan: a profile is never left empty. A
+                // profile whose only scans were this recognizer's goes with
+                // them, and when the last profile goes, mutate_enrollment
+                // erases the file.
+                let emptied: Vec<String> = enr
+                    .profiles
+                    .iter()
+                    .filter(|p| p.scans.is_empty())
+                    .map(|p| p.name.clone())
+                    .collect();
+                enr.profiles.retain(|p| !p.scans.is_empty());
+                let mut msg = format!("forgot recognizer {space}: {scans_removed} scan(s) removed");
+                if !emptied.is_empty() {
+                    msg.push_str(&format!(
+                        " (profile(s) {} deleted: no scans left)",
+                        emptied
+                            .iter()
+                            .map(|n| format!("'{n}'"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+                if forgetting_live && scans_removed > 0 {
+                    msg.push_str(
+                        "; these were the LOADED recognizer's templates, so face \
+                         authentication needs a re-enroll or an add-scan",
+                    );
+                }
+                Ok(msg)
             })
         }
         Request::RenameProfile {
@@ -5288,6 +5353,203 @@ mod tests {
             Response::Error(msg) => assert_eq!(msg, "'carol' is not enrolled"),
             other => panic!("second delete must report unenrolled, got {other:?}"),
         }
+    }
+
+    /// A two-model enrollment for the forget-recognizer tests: 'BEN' holds two
+    /// untagged (shipped-space) scans; 'Mixed' holds one shipped scan, two
+    /// scans in `embed:model-b`, and calibrations for both spaces.
+    fn two_model_enrollment(user: &str) -> Enrollment {
+        let calib = |pairs: usize| irlume_core::calib::IrCalibration {
+            m: vec![],
+            n_rows: vec![],
+            lambda: 0.0,
+            fitted_pairs: pairs,
+        };
+        let tagged = |name: &str, seed: usize, space: &str| FaceScan {
+            embed_space: Some(space.into()),
+            ..rgb_scan(name, seed)
+        };
+        let mut mixed = FaceProfile {
+            name: "Mixed".into(),
+            ir_calib: None,
+            ir_calibs: Default::default(),
+            scans: vec![
+                rgb_scan("Face Scan 1", 3),
+                tagged("Face Scan 2", 4, "embed:model-b"),
+                tagged("Face Scan 3", 5, "embed:model-b"),
+            ],
+        };
+        mixed.set_calib_for(
+            irlume_core::storage::LEGACY_RECOGNIZER_SPACE,
+            Some(calib(1)),
+        );
+        mixed.set_calib_for("embed:model-b", Some(calib(2)));
+        let mut e = enrollment_with(user, &["Face Scan 1", "Face Scan 2"]);
+        e.profiles[0].name = "BEN".into();
+        e.profiles.push(mixed);
+        e
+    }
+
+    #[test]
+    fn forget_recognizer_refuses_a_foreign_peer_and_an_unknown_space() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("forget-deny");
+        write_enrollment(&sb.dir, &two_model_enrollment("carol"));
+        match dispatch(
+            Request::ForgetRecognizer {
+                user: "carol".into(),
+                space: "embed:model-b".into(),
+            },
+            &peer(NOBODY),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert_eq!(msg, "not authorized to modify 'carol'"),
+            other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+        // A space with no scans and no calibration anywhere: an error, so an
+        // operator learns the name did not match rather than reading success.
+        match dispatch(
+            Request::ForgetRecognizer {
+                user: "carol".into(),
+                space: "embed:model-c".into(),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert_eq!(msg, "no enrollment data from recognizer embed:model-c")
+            }
+            other => panic!("unknown space must be an error, got {other:?}"),
+        }
+        // Both deny paths left the enrollment untouched.
+        let enr = irlume_core::storage::load("carol").unwrap().unwrap();
+        assert_eq!(enr.profiles.len(), 2);
+        assert_eq!(enr.profiles[1].scans.len(), 3);
+    }
+
+    #[test]
+    fn forget_recognizer_removes_scans_and_calibs_drops_emptied_profiles_and_erases_the_file() {
+        // The keep-path ends in storage::save; on a host with /dev/tpm* that
+        // would seal a real template key, so this runs on no-TPM hosts (CI,
+        // the container suite). Same convention as the other mutation tests.
+        if irlume_core::template_key::tpm_available() {
+            eprintln!("skipping: TPM present; storage::save would touch real hardware");
+            return;
+        }
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("forget-two-model");
+        write_enrollment(&sb.dir, &two_model_enrollment("carol"));
+        let root = peer(0);
+        // Forget the third-party space: its scans and its calibration go, the
+        // shipped-space material (including untagged scans) stays.
+        match dispatch(
+            Request::ForgetRecognizer {
+                user: "carol".into(),
+                space: "embed:model-b".into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Ok(msg) => {
+                assert_eq!(msg, "forgot recognizer embed:model-b: 2 scan(s) removed")
+            }
+            other => panic!("forget model-b must succeed, got {other:?}"),
+        }
+        let enr = irlume_core::storage::load("carol").unwrap().unwrap();
+        assert_eq!(enr.profiles.len(), 2, "no profile was emptied yet");
+        let mixed = &enr.profiles[1];
+        assert_eq!(
+            mixed
+                .scans
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>(),
+            ["Face Scan 1"]
+        );
+        assert!(
+            mixed.calib_for("embed:model-b").is_none(),
+            "the forgotten space's calibration is derived biometric material"
+        );
+        assert!(
+            mixed
+                .calib_for(irlume_core::storage::LEGACY_RECOGNIZER_SPACE)
+                .is_some(),
+            "another recognizer's calibration must survive"
+        );
+        // Forget the shipped space, which the test engine has loaded: every
+        // remaining scan is untagged or shipped, so both profiles empty out
+        // and the enrollment file goes with them, and the reply says the
+        // loaded recognizer's templates are gone.
+        assert_eq!(
+            e.embed_space(),
+            irlume_core::storage::LEGACY_RECOGNIZER_SPACE,
+            "test engine is expected to hold the shipped recognizer"
+        );
+        match dispatch(
+            Request::ForgetRecognizer {
+                user: "carol".into(),
+                space: irlume_core::storage::LEGACY_RECOGNIZER_SPACE.into(),
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Ok(msg) => assert_eq!(
+                msg,
+                format!(
+                    "forgot recognizer {}: 3 scan(s) removed (profile(s) 'BEN', 'Mixed' \
+                     deleted: no scans left); these were the LOADED recognizer's templates, \
+                     so face authentication needs a re-enroll or an add-scan",
+                    irlume_core::storage::LEGACY_RECOGNIZER_SPACE
+                )
+            ),
+            other => panic!("forget shipped must succeed, got {other:?}"),
+        }
+        assert!(
+            !sb.dir.join("carol.json").exists(),
+            "an enrollment with zero profiles must not linger on disk"
+        );
+    }
+
+    #[test]
+    fn forget_recognizer_clears_a_calibration_that_outlived_its_scans() {
+        if irlume_core::template_key::tpm_available() {
+            eprintln!("skipping: TPM present; storage::save would touch real hardware");
+            return;
+        }
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("forget-stale-calib");
+        // Only shipped-space scans, but a stale model-b calibration left over
+        // from scans deleted one by one. Forgetting model-b is a real change.
+        let mut enr = enrollment_with("carol", &["Face Scan 1"]);
+        enr.profiles[0].set_calib_for(
+            "embed:model-b",
+            Some(irlume_core::calib::IrCalibration {
+                m: vec![],
+                n_rows: vec![],
+                lambda: 0.0,
+                fitted_pairs: 7,
+            }),
+        );
+        write_enrollment(&sb.dir, &enr);
+        match dispatch(
+            Request::ForgetRecognizer {
+                user: "carol".into(),
+                space: "embed:model-b".into(),
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Ok(msg) => {
+                assert_eq!(msg, "forgot recognizer embed:model-b: 0 scan(s) removed")
+            }
+            other => panic!("calibration-only forget must succeed, got {other:?}"),
+        }
+        let enr = irlume_core::storage::load("carol").unwrap().unwrap();
+        assert_eq!(enr.profiles[0].scans.len(), 1, "scans are untouched");
+        assert!(enr.profiles[0].calib_for("embed:model-b").is_none());
     }
 
     #[test]

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -35,6 +35,7 @@ Conventions that apply everywhere:
 | `irlume profiles add-scan --profile P [--scans N]` | add scans to profile P: improves recognition in new conditions, and adds templates for a second recognizer without re-enrolling as a new person (scans belong to the recognizer the daemon has loaded) |
 | `irlume profiles rename --profile P [--scan S] --name N` | rename a profile, or one scan inside it |
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
+| `irlume profiles forget-model <model>` | remove one recognizer's scans (and the calibrations fitted from them) from every profile of a user; the deliberate counterpart to `models disable`, which deletes weights but keeps templates. `<model>` is `shipped`, a catalog name, or an `embed:<sha256>` tag as `profiles list` prints it. A profile left with no scans is deleted with them |
 | `irlume profiles eyes-open <on\|off>` | require eyes open to unlock |
 | `irlume profiles challenge <on\|off>` | opt-in passive blink liveness |
 | `sudo irlume calibrate-closure [--rounds N] [--force]` | teach the eye-closure consent gesture for app prompts. Captures eyes-open/closed EAR over N rounds (default 3) and stores the median, because a single capture varies enough to leave the threshold sitting on top of your own closures; it then reports how many of your readings the result would actually accept. Replacing an existing calibration asks first, and `--force` is required to do it with no terminal. The head nod is the default and needs no calibration |


### PR DESCRIPTION
Step 4 of #288, the last of that design.

## What this adds

**`irlume profiles forget-model <model>`.** `models disable` deletes a recognizer's weights and deliberately keeps its templates, so re-enabling needs no re-enrollment. This command is the counterpart for when the operator wants that biometric material gone: it removes every scan a user holds in one recognizer's embedding space, plus the per-profile calibrations fitted from those scans. A profile left with no scans is deleted with them, and deleting the last profile erases the enrollment file; the same never-orphaned rule `DeleteScan` upholds, via the same `mutate_enrollment` path.

The CLI resolves the model name (`shipped`, a catalog name, or a raw `embed:<sha256>` tag as `profiles list` prints it) and the daemon only ever sees the space tag, so a recognizer the catalog no longer carries stays forgettable. A catalog entry from another stage is refused by name: detection, landmarks, and the PAD cue store no enrollment data. Untagged pre-#277 scans are matched through `recognizer_space_matches`, so forgetting `shipped` covers them. When the forgotten space is the one the daemon has loaded, the reply says so and names the fix.

**The TUI stops reporting misleading flat scan counts.** Only the loaded recognizer's scans can match. The profile screen now shows "(N scans, M for the loaded recognizer)" when the two differ, with a warning line naming Improve Recognition when M is 0; the Welcome and Done enrollment badges warn instead of showing green in the same case. An old daemon reports neither field and keeps the flat count, since nothing can be said. Wording follows the CLI listing from #291.

**`models disable` on a recognizer now prints the asymmetry**: scans are kept, re-enabling needs no re-enrollment, and `profiles forget-model` erases them.

## Testing

- `cargo test --workspace` green; clippy clean; fmt checked at commit time.
- The two save-path daemon tests self-skip on TPM hosts, so they were also run under `unshare -Umr` with tmpfs over `/dev` (the repo's no-TPM reproduction from #226): all three forget tests execute their real paths there, including the erase-the-file case.
- 8 hand-run mutants, each killed by the test written for it, applied and reverted by inverse patch: CLI stage guard inverted, TUI breakdown condition inverted, badge warn arm disabled, daemon no-data error disabled, scan retain filter disabled, calibration clearing dropped (kill confirmed on both the counting and the clearing half), emptied-profile retain disabled, loaded-recognizer note disabled.
- Wire test: a fake daemon asserts the request carries the resolved `embed:<pin>` for a catalog name, so a resolver regression fails in CI rather than on an enrollment.

## Not tested

- No hardware run yet. archhost holds the two-model fixture (`BEN` 10 shipped-space scans, `Face Profile 1` 5 buffalo-space scans); I will validate `forget-model buffalo`, the TUI view against the mixed enrollment, and the `models disable` note there before merge, per the container-first protocol.
- An old daemon meeting a new CLI answers `bad request` to `ForgetRecognizer` (unknown variant), the same behavior every added request variant has during an upgrade window; not exercised by a test.
