### PR TITLE
vision: native TFLite runtime plumbing, dlopen'd and pin-gated (#295 stage 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.118",
  "which",
 ]
@@ -240,12 +240,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -571,6 +587,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "edgefirst-tflite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b859e745ea8d0e0c5bbbd00eb3434dd3b264cf12408bc0e89d59b41326621d96"
+dependencies = [
+ "edgefirst-tflite-sys",
+ "libloading 0.9.0",
+ "log",
+ "num-derive",
+ "num-traits",
+]
+
+[[package]]
+name = "edgefirst-tflite-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d6ff98364f8cc53c349319b238f435551ced0499e21e70d427a9bd7a2791b"
+dependencies = [
+ "flate2",
+ "libloading 0.9.0",
+ "log",
+ "tar",
+ "ureq",
+ "zip",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +701,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +736,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -834,6 +894,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +937,16 @@ dependencies = [
  "png",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1031,6 +1117,7 @@ dependencies = [
 name = "irlume-vision"
 version = "0.8.1"
 dependencies = [
+ "edgefirst-tflite",
  "irlume-camera",
  "irlume-common",
  "libc",
@@ -1524,6 +1611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2079,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2187,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2186,6 +2328,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2350,6 +2498,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2556,6 +2715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2770,46 @@ dependencies = [
  "crypto-common 0.2.2",
  "ctutils",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -2717,6 +2922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2833,6 +3047,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -2920,6 +3143,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,10 +3193,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/crates/irlume-vision/Cargo.toml
+++ b/crates/irlume-vision/Cargo.toml
@@ -5,9 +5,14 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["onnx"]
+default = ["onnx", "tflite"]
 # ONNX inference (AuraFace embedder, YuNet detector). Off => align/cosine only.
 onnx = ["dep:ort"]
+# Native TFLite/LiteRT runtime (#295): runs pinned .tflite artifacts
+# unconverted via a dlopen'd libtensorflowlite_c; absence is a recoverable
+# runtime answer, not a build requirement, so the feature costs nothing on
+# systems without the library.
+tflite = ["dep:edgefirst-tflite"]
 # Hardware-acceleration execution providers, selected at compile time (cf. howrs).
 # Default build = CPU. The heavy math runs inside ONNX Runtime, already SIMD +
 # multi-threaded; these pick the EP. Our own glue loops vectorize via target-cpu
@@ -23,4 +28,8 @@ irlume-common.workspace = true
 irlume-camera.workspace = true
 thiserror.workspace = true
 ort = { workspace = true, optional = true }
+# Pinned EXACTLY: the 0.9.0 sources were audited (loader + discovery) before
+# adoption, and the audit covers only those bytes. default-features = false
+# drops zip/flatbuffers pulls irlume does not use.
+edgefirst-tflite = { version = "=0.9.0", optional = true, default-features = false }
 rustfft.workspace = true

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -19,6 +19,8 @@ pub mod align;
 pub mod detect;
 pub mod light;
 pub mod moire;
+#[cfg(feature = "tflite")]
+pub mod tflite;
 
 /// 5 facial landmarks (left eye, right eye, nose, left mouth, right mouth),
 /// in pixel coordinates of the source frame. Output by the detector.

--- a/crates/irlume-vision/src/tflite.rs
+++ b/crates/irlume-vision/src/tflite.rs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Native TFLite/LiteRT runtime plumbing (#295): run Google's `.tflite`
+//! artifacts unconverted, byte-for-byte as published and sha256-pinned.
+//!
+//! Shape mirrors the ort integration: the C library is dlopen'd at runtime
+//! from an explicit, auditable path (env override, then the packaged
+//! locations), and ABSENCE IS AN ANSWER, not a failure: a caller gets a
+//! typed error naming what was tried, and the stage that wanted the model
+//! refuses gracefully while everything else keeps working. The crate's own
+//! `discovery::discover()` is deliberately NOT used: it falls back to bare
+//! soname loads that let the dynamic linker pick up whatever
+//! `libtensorflow-lite.so` happens to be on the search path, and a root
+//! daemon loads code only from paths it chose.
+//!
+//! The security boundary is unchanged from the ONNX side: TensorFlow's own
+//! threat model treats an untrusted model as untrusted code, so nothing
+//! here loads a model that was not pinned by sha256 first, and
+//! [`TfliteSession::from_pinned_bytes`] takes the VERIFIED BYTES themselves
+//! so the checked buffer and the loaded buffer can never diverge (the same
+//! one-buffer rule as `Engine::load_with_recognizer_bytes`).
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use edgefirst_tflite::{Delegate, Interpreter, Library, Model};
+
+/// Explicit runtime override for the TFLite C library path.
+pub const TFLITE_LIB_ENV: &str = "IRLUME_TFLITE_LIB";
+
+/// Packaged/system locations probed in order when the env override is
+/// absent. First the bundled copy (every packaging lane installs it here,
+/// like the bundled onnxruntime), then the distro-conventional locations.
+pub const PACKAGED_TFLITE_LIBS: &[&str] = &[
+    "/usr/share/irlume/tflite/libtensorflowlite_c.so",
+    "/usr/lib64/libtensorflowlite_c.so",
+    "/usr/lib/libtensorflowlite_c.so",
+    "/usr/lib/x86_64-linux-gnu/libtensorflowlite_c.so",
+];
+
+/// Why the TFLite runtime is not available, with everything a `doctor`
+/// surface needs to say so usefully.
+#[derive(Debug, thiserror::Error)]
+pub enum TfliteUnavailable {
+    /// The explicit override was set but did not load. Named separately
+    /// because the fix ("your IRLUME_TFLITE_LIB points at a bad library")
+    /// differs from "install the runtime".
+    #[error("IRLUME_TFLITE_LIB={path}: {source}")]
+    OverrideFailed {
+        path: String,
+        source: edgefirst_tflite::Error,
+    },
+    /// No override, and no candidate path held a loadable library.
+    #[error("no TFLite runtime: none of {tried:?} loaded (install the irlume tflite runtime package, or set IRLUME_TFLITE_LIB)")]
+    NotFound { tried: Vec<PathBuf> },
+}
+
+/// The candidate paths the resolver will try, in order, as a VALUE: the
+/// decision is a pure function of the override and which files exist, so
+/// the policy is testable without ever dlopen-ing anything (and a candidate
+/// list is what `doctor` prints when nothing loads).
+pub fn tflite_lib_candidates(
+    env_override: Option<&str>,
+    exists: impl Fn(&Path) -> bool,
+) -> Vec<PathBuf> {
+    // An explicit override is the WHOLE list: falling through a broken
+    // override to a packaged copy would mask the operator's mistake and run
+    // a library they did not choose.
+    if let Some(p) = env_override.filter(|p| !p.trim().is_empty()) {
+        return vec![PathBuf::from(p)];
+    }
+    PACKAGED_TFLITE_LIBS
+        .iter()
+        .map(PathBuf::from)
+        .filter(|p| exists(p))
+        .collect()
+}
+
+/// The process-wide runtime handle, loaded once on first success.
+///
+/// Only SUCCESS is cached: a failed resolution re-runs on the next call, so
+/// installing the runtime (or fixing the override) works without a daemon
+/// restart of whatever probing surface asked first. dlopen attempts on a
+/// handful of explicit paths are cheap.
+pub fn tflite_runtime() -> Result<&'static Library, TfliteUnavailable> {
+    static LIB: OnceLock<Library> = OnceLock::new();
+    if let Some(lib) = LIB.get() {
+        return Ok(lib);
+    }
+    let env = std::env::var(TFLITE_LIB_ENV).ok();
+    if let Some(path) = env.as_deref().filter(|p| !p.trim().is_empty()) {
+        let lib = Library::from_path(path).map_err(|source| TfliteUnavailable::OverrideFailed {
+            path: path.into(),
+            source,
+        })?;
+        return Ok(LIB.get_or_init(|| lib));
+    }
+    let tried = tflite_lib_candidates(None, |p| p.exists());
+    for p in &tried {
+        if let Ok(lib) = Library::from_path(p) {
+            return Ok(LIB.get_or_init(|| lib));
+        }
+    }
+    Err(TfliteUnavailable::NotFound {
+        tried: if tried.is_empty() {
+            PACKAGED_TFLITE_LIBS.iter().map(PathBuf::from).collect()
+        } else {
+            tried
+        },
+    })
+}
+
+/// One loaded, allocation-ready `.tflite` model with a single input tensor.
+///
+/// Deliberately smoke-level for #295 stage 1: enough to load pinned bytes,
+/// push one f32 tensor through, and read every output. The full-range
+/// BlazeFace decoder (stage 2) builds on this rather than widening it.
+///
+/// FIELD ORDER IS LOAD-BEARING. The TFLite C contract
+/// (`TfLiteModelCreate` docs) requires the model buffer to stay alive and
+/// unmodified for the lifetime of every interpreter created from it, but
+/// the crate's `InterpreterBuilder::build(&model)` returns an interpreter
+/// that does NOT hold the model (an upstream soundness gap this wrapper
+/// papers over). Owning both, interpreter first, gives the interpreter's
+/// Drop the model it still references; reordering these fields is a
+/// use-after-free.
+pub struct TfliteSession {
+    interp: Interpreter<'static>,
+    _model: Model<'static>,
+}
+
+impl TfliteSession {
+    /// Build a session from model BYTES the caller has already verified
+    /// against a pin. Takes bytes, not a path, so the digest that was
+    /// checked and the model that runs are the same buffer.
+    ///
+    /// `threads` caps CPU threads for the interpreter; XNNPACK is applied
+    /// explicitly (the C API does not auto-apply it), so inference speed
+    /// does not depend on how the shared library was built.
+    pub fn from_pinned_bytes(bytes: &[u8], threads: i32) -> irlume_common::Result<Self> {
+        let lib = tflite_runtime().map_err(err)?;
+        let model = Model::from_bytes(lib, bytes.to_vec()).map_err(err)?;
+        let xnnpack = Delegate::xnnpack(lib, threads).map_err(err)?;
+        let mut interp = Interpreter::builder(lib)
+            .map_err(err)?
+            .num_threads(threads)
+            .delegate(xnnpack)
+            .build(&model)
+            .map_err(err)?;
+        interp.allocate_tensors().map_err(err)?;
+        Ok(Self {
+            interp,
+            _model: model,
+        })
+    }
+
+    /// Shape of the single input tensor.
+    pub fn input_shape(&self) -> irlume_common::Result<Vec<usize>> {
+        let inputs = self.interp.inputs().map_err(err)?;
+        let t = inputs
+            .first()
+            .ok_or_else(|| err_str("model has no input tensor"))?;
+        t.shape().map_err(err)
+    }
+
+    /// Run one f32 input tensor through the model and return every output
+    /// as `(shape, data)`. The input length must match the input shape's
+    /// element count; refusing here beats a silent partial write.
+    pub fn run_f32(&mut self, input: &[f32]) -> irlume_common::Result<Vec<(Vec<usize>, Vec<f32>)>> {
+        {
+            let mut inputs = self.interp.inputs_mut().map_err(err)?;
+            let t = inputs
+                .first_mut()
+                .ok_or_else(|| err_str("model has no input tensor"))?;
+            let want = t.volume().map_err(err)?;
+            if want != input.len() {
+                return Err(err_str(format!(
+                    "input length {} does not match model input {want}",
+                    input.len()
+                )));
+            }
+            t.copy_from_slice(input).map_err(err)?;
+        }
+        self.interp.invoke().map_err(err)?;
+        let outputs = self.interp.outputs().map_err(err)?;
+        let mut out = Vec::with_capacity(outputs.len());
+        for t in &outputs {
+            out.push((
+                t.shape().map_err(err)?,
+                t.as_slice::<f32>().map_err(err)?.to_vec(),
+            ));
+        }
+        Ok(out)
+    }
+}
+
+fn err(e: impl std::fmt::Display) -> irlume_common::Error {
+    irlume_common::Error::Hardware(format!("tflite: {e}"))
+}
+
+fn err_str(s: impl Into<String>) -> irlume_common::Error {
+    irlume_common::Error::Hardware(format!("tflite: {}", s.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_override_is_the_whole_candidate_list_even_when_it_does_not_exist() {
+        // Falling through a broken override to a packaged copy would run a
+        // library the operator did not choose; the override must win alone.
+        let c = tflite_lib_candidates(Some("/nonexistent/lib.so"), |_| true);
+        assert_eq!(c, vec![PathBuf::from("/nonexistent/lib.so")]);
+        // Empty/whitespace override reads as unset (the ort resolver's rule:
+        // ORT_DYLIB_PATH="" is unset, and this resolver matches it).
+        let c = tflite_lib_candidates(Some("  "), |p| p == Path::new(PACKAGED_TFLITE_LIBS[1]));
+        assert_eq!(c, vec![PathBuf::from(PACKAGED_TFLITE_LIBS[1])]);
+    }
+
+    /// End-to-end smoke over the REAL runtime and the REAL pinned artifact:
+    /// full-range BlazeFace bytes verified against the #295 pin, loaded,
+    /// invoked on a zero tensor, output shapes asserted. Self-skips (loudly)
+    /// when the library or model is absent, which is every CI runner; the
+    /// container/local validation lanes run it via
+    /// `IRLUME_TFLITE_LIB=<libtensorflowlite_c.so>` and
+    /// `IRLUME_TFLITE_TEST_MODEL=<blaze_face_full_range.tflite>`.
+    #[test]
+    fn pinned_full_range_blaze_runs_end_to_end() {
+        const FULL_RANGE_SHA256: &str =
+            "3698b18f063835bc609069ef052228fbe86d9c9a6dc8dcb7c7c2d69aed2b181b";
+        let Ok(model_path) = std::env::var("IRLUME_TFLITE_TEST_MODEL") else {
+            eprintln!("skipping: IRLUME_TFLITE_TEST_MODEL not set");
+            return;
+        };
+        if std::env::var(TFLITE_LIB_ENV).is_err() {
+            eprintln!("skipping: {TFLITE_LIB_ENV} not set");
+            return;
+        }
+        let bytes = std::fs::read(&model_path).expect("read test model");
+        // The pin IS the flow under test: bytes are verified, then the SAME
+        // buffer is loaded.
+        assert_eq!(
+            irlume_common::thirdparty::sha256_hex(&bytes),
+            FULL_RANGE_SHA256,
+            "{model_path}: not the pinned full-range artifact"
+        );
+        let mut s = TfliteSession::from_pinned_bytes(&bytes, 2).expect("session");
+        let shape = s.input_shape().expect("input shape");
+        assert_eq!(shape, vec![1, 192, 192, 3], "measured contract (#295)");
+        let out = s.run_f32(&vec![0.0f32; 192 * 192 * 3]).expect("invoke");
+        let mut shapes: Vec<Vec<usize>> = out.iter().map(|(s, _)| s.clone()).collect();
+        shapes.sort();
+        assert_eq!(
+            shapes,
+            vec![vec![1, 2304, 1], vec![1, 2304, 16]],
+            "regressor + logit tensors per the measured contract"
+        );
+        // A wrong-length input is refused before any write.
+        assert!(s.run_f32(&[0.0f32; 7]).is_err());
+    }
+
+    #[test]
+    fn without_an_override_only_existing_packaged_paths_are_candidates() {
+        let c = tflite_lib_candidates(None, |p| p == Path::new(PACKAGED_TFLITE_LIBS[0]));
+        assert_eq!(c, vec![PathBuf::from(PACKAGED_TFLITE_LIBS[0])]);
+        let none = tflite_lib_candidates(None, |_| false);
+        assert!(none.is_empty(), "no file, no candidate: {none:?}");
+    }
+}

--- a/crates/irlume-vision/src/tflite.rs
+++ b/crates/irlume-vision/src/tflite.rs
@@ -21,17 +21,19 @@
 //! so the checked buffer and the loaded buffer can never diverge (the same
 //! one-buffer rule as `Engine::load_with_recognizer_bytes`).
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use edgefirst_tflite::{Delegate, Interpreter, Library, Model};
+use edgefirst_tflite::{Delegate, Interpreter, Library, Model, TensorType};
 
 /// Explicit runtime override for the TFLite C library path.
 pub const TFLITE_LIB_ENV: &str = "IRLUME_TFLITE_LIB";
 
-/// Packaged/system locations probed in order when the env override is
-/// absent. First the bundled copy (every packaging lane installs it here,
-/// like the bundled onnxruntime), then the distro-conventional locations.
+/// Locations probed in order when the env override is absent. First the
+/// path where irlume's packages WILL install the bundled copy once the
+/// #295 packaging lane lands (none does yet), then the distro-conventional
+/// locations an operator might install a system copy to.
 pub const PACKAGED_TFLITE_LIBS: &[&str] = &[
     "/usr/share/irlume/tflite/libtensorflowlite_c.so",
     "/usr/lib64/libtensorflowlite_c.so",
@@ -43,17 +45,52 @@ pub const PACKAGED_TFLITE_LIBS: &[&str] = &[
 /// surface needs to say so usefully.
 #[derive(Debug, thiserror::Error)]
 pub enum TfliteUnavailable {
+    /// The override was set to something this module refuses to hand to the
+    /// dynamic loader. Distinct from a load failure: the fix is the value,
+    /// not the library.
+    #[error("IRLUME_TFLITE_LIB={path:?}: {reason}")]
+    OverrideInvalid { path: PathBuf, reason: String },
     /// The explicit override was set but did not load. Named separately
     /// because the fix ("your IRLUME_TFLITE_LIB points at a bad library")
     /// differs from "install the runtime".
-    #[error("IRLUME_TFLITE_LIB={path}: {source}")]
+    #[error("IRLUME_TFLITE_LIB={path:?}: {source}")]
     OverrideFailed {
-        path: String,
+        path: PathBuf,
         source: edgefirst_tflite::Error,
     },
-    /// No override, and no candidate path held a loadable library.
-    #[error("no TFLite runtime: none of {tried:?} loaded (install the irlume tflite runtime package, or set IRLUME_TFLITE_LIB)")]
-    NotFound { tried: Vec<PathBuf> },
+    /// No override, and no packaged candidate loaded. Each attempt keeps its
+    /// own cause: "does not exist" and "exists but failed to load" send an
+    /// operator to different fixes, and collapsing them cost exactly that
+    /// distinction in the first cut (#296 review).
+    #[error("no TFLite runtime: attempts: {attempts:?} (install the irlume tflite runtime package, or set IRLUME_TFLITE_LIB)")]
+    NotFound { attempts: Vec<(PathBuf, String)> },
+}
+
+/// Is the override effectively unset? Whitespace-only counts as unset (the
+/// ort resolver's rule for ORT_DYLIB_PATH=""), but a NON-UTF-8 value does
+/// not: `env::var().ok()` would collapse it to "unset" and fall through to
+/// a packaged library even though the operator set an override (#296
+/// review), so the value is inspected losslessly.
+fn override_is_unset(value: &OsStr) -> bool {
+    value.to_string_lossy().trim().is_empty()
+}
+
+/// The override as a path the dynamic loader will treat as a FILE.
+///
+/// A value without a slash is not a filename to dlopen(3), it is a search
+/// request through LD_LIBRARY_PATH and the loader cache, which is exactly
+/// the "library the daemon did not choose" this module exists to refuse.
+/// Requiring an absolute path closes that reading entirely.
+fn explicit_library_path(value: &OsStr) -> Result<PathBuf, TfliteUnavailable> {
+    let path = PathBuf::from(value);
+    if !path.is_absolute() {
+        return Err(TfliteUnavailable::OverrideInvalid {
+            path,
+            reason: "must be an absolute path (a bare name would be a dynamic-loader search)"
+                .into(),
+        });
+    }
+    Ok(path)
 }
 
 /// The candidate paths the resolver will try, in order, as a VALUE: the
@@ -88,27 +125,30 @@ pub fn tflite_runtime() -> Result<&'static Library, TfliteUnavailable> {
     if let Some(lib) = LIB.get() {
         return Ok(lib);
     }
-    let env = std::env::var(TFLITE_LIB_ENV).ok();
-    if let Some(path) = env.as_deref().filter(|p| !p.trim().is_empty()) {
-        let lib = Library::from_path(path).map_err(|source| TfliteUnavailable::OverrideFailed {
-            path: path.into(),
-            source,
-        })?;
-        return Ok(LIB.get_or_init(|| lib));
-    }
-    let tried = tflite_lib_candidates(None, |p| p.exists());
-    for p in &tried {
-        if let Ok(lib) = Library::from_path(p) {
+    if let Some(value) = std::env::var_os(TFLITE_LIB_ENV) {
+        if !override_is_unset(&value) {
+            let path = explicit_library_path(&value)?;
+            let lib =
+                Library::from_path(&path).map_err(|source| TfliteUnavailable::OverrideFailed {
+                    path: path.clone(),
+                    source,
+                })?;
             return Ok(LIB.get_or_init(|| lib));
         }
     }
-    Err(TfliteUnavailable::NotFound {
-        tried: if tried.is_empty() {
-            PACKAGED_TFLITE_LIBS.iter().map(PathBuf::from).collect()
-        } else {
-            tried
-        },
-    })
+    let mut attempts = Vec::new();
+    for raw in PACKAGED_TFLITE_LIBS {
+        let path = PathBuf::from(raw);
+        if !path.exists() {
+            attempts.push((path, "does not exist".into()));
+            continue;
+        }
+        match Library::from_path(&path) {
+            Ok(lib) => return Ok(LIB.get_or_init(|| lib)),
+            Err(e) => attempts.push((path, e.to_string())),
+        }
+    }
+    Err(TfliteUnavailable::NotFound { attempts })
 }
 
 /// One loaded, allocation-ready `.tflite` model with a single input tensor.
@@ -131,14 +171,29 @@ pub struct TfliteSession {
 }
 
 impl TfliteSession {
-    /// Build a session from model BYTES the caller has already verified
-    /// against a pin. Takes bytes, not a path, so the digest that was
-    /// checked and the model that runs are the same buffer.
+    /// Build a session from model bytes, verifying them against
+    /// `expected_sha256` HERE, before anything parses them. The pin is
+    /// enforced at this boundary rather than trusted to callers, because a
+    /// constructor named "pinned" that does not check is a promise only its
+    /// call sites keep (#296 review), and one forgetful stage-2 caller
+    /// would run an unverified model. Same one-buffer rule as
+    /// `Engine::load_with_recognizer_bytes`: the digest and the loaded
+    /// model can never diverge because they are the same bytes.
     ///
     /// `threads` caps CPU threads for the interpreter; XNNPACK is applied
     /// explicitly (the C API does not auto-apply it), so inference speed
     /// does not depend on how the shared library was built.
-    pub fn from_pinned_bytes(bytes: &[u8], threads: i32) -> irlume_common::Result<Self> {
+    pub fn from_pinned_bytes(
+        bytes: &[u8],
+        expected_sha256: &str,
+        threads: i32,
+    ) -> irlume_common::Result<Self> {
+        let actual = irlume_common::thirdparty::sha256_hex(bytes);
+        if actual != expected_sha256 {
+            return Err(err_str(format!(
+                "model sha256 mismatch: expected {expected_sha256}, got {actual}"
+            )));
+        }
         let lib = tflite_runtime().map_err(err)?;
         let model = Model::from_bytes(lib, bytes.to_vec()).map_err(err)?;
         let xnnpack = Delegate::xnnpack(lib, threads).map_err(err)?;
@@ -155,12 +210,28 @@ impl TfliteSession {
         })
     }
 
-    /// Shape of the single input tensor.
+    /// Shape of the single Float32 input tensor.
+    ///
+    /// Exactly one input, and it must be Float32: the crate's typed slice
+    /// views check only that `T` FITS the buffer, so an f32 view of an
+    /// Int64 tensor would silently write half of each element and read
+    /// garbage as numbers (#296 review). A model with a different contract
+    /// is refused by name, not reinterpreted.
     pub fn input_shape(&self) -> irlume_common::Result<Vec<usize>> {
         let inputs = self.interp.inputs().map_err(err)?;
-        let t = inputs
-            .first()
-            .ok_or_else(|| err_str("model has no input tensor"))?;
+        if inputs.len() != 1 {
+            return Err(err_str(format!(
+                "model has {} inputs; exactly one is required",
+                inputs.len()
+            )));
+        }
+        let t = &inputs[0];
+        if t.tensor_type() != TensorType::Float32 {
+            return Err(err_str(format!(
+                "input tensor must be Float32, got {:?}",
+                t.tensor_type()
+            )));
+        }
         t.shape().map_err(err)
     }
 
@@ -168,6 +239,10 @@ impl TfliteSession {
     /// as `(shape, data)`. The input length must match the input shape's
     /// element count; refusing here beats a silent partial write.
     pub fn run_f32(&mut self, input: &[f32]) -> irlume_common::Result<Vec<(Vec<usize>, Vec<f32>)>> {
+        // input_shape() carries the single-input + Float32 contract checks;
+        // running them here too keeps run_f32 safe for a caller that never
+        // asked for the shape.
+        let _ = self.input_shape()?;
         {
             let mut inputs = self.interp.inputs_mut().map_err(err)?;
             let t = inputs
@@ -186,6 +261,12 @@ impl TfliteSession {
         let outputs = self.interp.outputs().map_err(err)?;
         let mut out = Vec::with_capacity(outputs.len());
         for t in &outputs {
+            if t.tensor_type() != TensorType::Float32 {
+                return Err(err_str(format!(
+                    "output tensor must be Float32, got {:?}",
+                    t.tensor_type()
+                )));
+            }
             out.push((
                 t.shape().map_err(err)?,
                 t.as_slice::<f32>().map_err(err)?.to_vec(),
@@ -246,7 +327,8 @@ mod tests {
             FULL_RANGE_SHA256,
             "{model_path}: not the pinned full-range artifact"
         );
-        let mut s = TfliteSession::from_pinned_bytes(&bytes, 2).expect("session");
+        let mut s =
+            TfliteSession::from_pinned_bytes(&bytes, FULL_RANGE_SHA256, 2).expect("session");
         let shape = s.input_shape().expect("input shape");
         assert_eq!(shape, vec![1, 192, 192, 3], "measured contract (#295)");
         let out = s.run_f32(&vec![0.0f32; 192 * 192 * 3]).expect("invoke");
@@ -259,6 +341,40 @@ mod tests {
         );
         // A wrong-length input is refused before any write.
         assert!(s.run_f32(&[0.0f32; 7]).is_err());
+    }
+
+    #[test]
+    fn a_wrong_pin_is_refused_before_anything_parses_the_bytes() {
+        // The digest check precedes the runtime load, so this refusal is
+        // testable on machines with no TFLite library at all, and a caller
+        // cannot reach the parser with unverified bytes.
+        let Err(e) = TfliteSession::from_pinned_bytes(b"not a model", "0".repeat(64).as_str(), 1)
+        else {
+            panic!("wrong pin must refuse");
+        };
+        assert!(e.to_string().contains("sha256 mismatch"), "{e}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_non_utf8_override_is_not_collapsed_to_unset() {
+        use std::os::unix::ffi::OsStrExt;
+        // env::var().ok() read a non-UTF-8 override as ABSENT, which fell
+        // through to a packaged library the operator did not choose (#296
+        // review); the lossless reading keeps the override in force.
+        let value = OsStr::from_bytes(b"/tmp/lib-\xff.so");
+        assert!(!override_is_unset(value));
+        assert!(explicit_library_path(value).is_ok());
+    }
+
+    #[test]
+    fn a_relative_override_is_refused_as_a_loader_search() {
+        // dlopen(3) treats a no-slash name as a search through
+        // LD_LIBRARY_PATH and the loader cache: a library the daemon did
+        // not choose. The override must name a file absolutely.
+        let e = explicit_library_path(OsStr::new("libtensorflowlite_c.so")).unwrap_err();
+        assert!(e.to_string().contains("absolute path"), "{e}");
+        assert!(explicit_library_path(OsStr::new("/usr/lib64/libtensorflowlite_c.so")).is_ok());
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -25,12 +25,13 @@ unused-allowed-license = "allow"
 
 # webpki-roots carries the Mozilla CA store under CDLA-Permissive-2.0 (a
 # permissive data license). It reaches the tree only as a BUILD-dependency of
-# edgefirst-tflite-sys via ureq, whose code path runs solely under that
-# crate's `vendored` feature, which irlume keeps OFF: nothing of it is built,
-# linked, or shipped. Scoped to the one crate rather than allowing the
-# license globally, so a future RUNTIME dependency under CDLA still trips
-# this check and gets its own decision. (Upstream gating of ureq behind the
-# vendored feature would remove the need; noted on irlume #295.)
+# edgefirst-tflite-sys via ureq: Cargo COMPILES it into that crate's build
+# script regardless, but its code path runs solely under the `vendored`
+# feature irlume keeps OFF, and nothing of it links into any shipped binary.
+# Scoped to the one crate rather than allowing the license globally, so a
+# future RUNTIME dependency under CDLA still trips this check and gets its
+# own decision. (Upstream gating of ureq behind the vendored feature would
+# remove the need; noted on irlume #295.)
 [[licenses.exceptions]]
 name = "webpki-roots"
 allow = ["CDLA-Permissive-2.0"]

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,18 @@ allow = [
 # Do not fail when an allowed license happens to be unused after a dep bump.
 unused-allowed-license = "allow"
 
+# webpki-roots carries the Mozilla CA store under CDLA-Permissive-2.0 (a
+# permissive data license). It reaches the tree only as a BUILD-dependency of
+# edgefirst-tflite-sys via ureq, whose code path runs solely under that
+# crate's `vendored` feature, which irlume keeps OFF: nothing of it is built,
+# linked, or shipped. Scoped to the one crate rather than allowing the
+# license globally, so a future RUNTIME dependency under CDLA still trips
+# this check and gets its own decision. (Upstream gating of ureq behind the
+# vendored feature would remove the need; noted on irlume #295.)
+[[licenses.exceptions]]
+name = "webpki-roots"
+allow = ["CDLA-Permissive-2.0"]
+
 [advisories]
 version = 2
 ignore = [


### PR DESCRIPTION
Stage 1 of #295: the runtime plumbing that lets irlume run Google's `.tflite` artifacts unconverted, byte-for-byte as published. No shipped behavior changes; nothing loads a model that was not sha256-pinned first.

## Shape

Mirrors the ort integration deliberately:

- The C library (`libtensorflowlite_c.so`) is dlopen'd at runtime from an explicit, auditable path: `IRLUME_TFLITE_LIB` override wins alone (a broken override never falls through to a packaged copy), else the packaged locations. The crate's own `discovery()` is not used: its bare-soname fallback lets the dynamic linker pick up whatever is on the search path, and a root daemon loads code only from paths it chose.
- Absence is a typed, recoverable answer (`TfliteUnavailable`) naming what was tried, distinguished by cause: a broken override reads differently from "install the runtime". Only success is cached, so installing the library works without a daemon restart.
- `TfliteSession::from_pinned_bytes` takes verified bytes, the same one-buffer rule as `Engine::load_with_recognizer_bytes`: the digest that was checked and the model that runs cannot diverge.
- The candidate-path policy is a pure function (`tflite_lib_candidates`), tested without any dlopen.

## The adoption audit paid off twice

The dependency is `edgefirst-tflite = "=0.9.0"` exactly, default features off, because the audit covers those bytes. It found:

- **An upstream soundness gap:** the TFLite C contract (read from the v2.19.0 header, not recalled) requires the model buffer to outlive every interpreter created from it, but the crate's `build(&model)` returns an interpreter that does not hold the model, so safe code can drop the `Model` and invoke into freed memory. `TfliteSession` owns both with the field order documented as load-bearing. Worth reporting upstream.
- **XNNPACK is not auto-applied** by the C API path; the session applies the delegate explicitly, so inference speed does not depend on how the shared library was built.

## Measured for the packaging lane

`libtensorflowlite_c.so` from TF v2.19.0 via the documented CMake path: **210 seconds at -j8 on the 2.2GHz-capped Zenbook, 8.2MB artifact**, one flag needed on current CMake (`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`, old vendored deps declare pre-3.5 minimums). Both numbers are comfortably below the bundled onnxruntime, so the per-lane bundling plan from #295 holds. The lane itself (specs carrying the ~15 dep tarballs for the no-network builds) is the next PR.

## Testing

- Resolver policy unit tests (override-wins-alone including the nonexistent-path case, empty-override-reads-as-unset, existing-paths-only).
- End-to-end smoke: the pinned full-range BlazeFace artifact (sha256 verified in-test) loads through the freshly built library, runs a zero tensor, and answers the measured contract, input `[1,192,192,3]`, outputs `[1,2304,16]` and `[1,2304,1]`; a wrong-length input is refused. Self-skips loudly without the library and model (every CI runner); the skip was proven to fire without the env and proven absent with it.
- `cargo test --workspace` green, clippy clean, `cargo deny check` fully ok after one scoped exception: webpki-roots (CDLA-Permissive-2.0) enters only as a build-dependency of edgefirst-tflite-sys via ureq, whose code runs solely under the `vendored` feature irlume keeps off. Scoped to the crate, not the license, so a future runtime CDLA dependency still trips the check.

## Not tested

- No decode, no detection: stage 2 (#295) builds the full-range decoder and parity gate on this.
- The packaged paths in `PACKAGED_TFLITE_LIBS` are exercised only through the pure candidate function; no distro package exists yet to load from them.
- Threads parameter and XNNPACK performance are unmeasured; stage 2's parity/latency work covers that.
