### PR TITLE
tui: the daemon owns the cameras, so the TUI stops opening them behind it (#187)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -23,6 +23,10 @@ pub use irlume_camera::{
 /// devices without depending on the camera crate directly. See
 /// [`irlume_camera::select_pair`].
 pub use irlume_camera::{capabilities, device_identity, select_pair};
+/// Enumerate the Hello camera pairs. Re-exported for the daemon's
+/// camera-class `ListCameras` arm: clients must not enumerate for themselves
+/// (#187), so this is the only path to a listing.
+pub use irlume_camera::{list_pairs, privacy_engaged, CameraPair};
 
 /// Loaded models + camera device selection. Build once, reuse per request.
 pub struct Engine {

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -334,7 +334,7 @@ fn enable(user: &str, args: &[String]) -> ExitCode {
     // both stay active and the user unlocks with whichever is convenient.
     // `--fingerprint-only` forces the old fingerprint-only mode (face disabled).
     let fingerprint_only = args.iter().any(|a| a == "--fingerprint-only");
-    let coexist = !fingerprint_only && irlume_camera::capabilities().rgb;
+    let coexist = !fingerprint_only && crate::caps().rgb;
     // Enroll a finger first if the user has none.
     if !fp::has_enrollment(user) {
         println!("[fingerprint] no finger enrolled yet; enrolling one now");

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -417,7 +417,7 @@ pub fn status(args: &[String]) -> ExitCode {
     // Secure-tier hardware, that does not exist. The daemon's own Health reply
     // has always paired the capability probe with an existence check; this now
     // agrees with it.
-    let caps = irlume_camera::capabilities();
+    let caps = crate::caps();
     let (rgb, ir) = irlume_camera::select_pair();
     let camera = json!({
         "rgb": caps.rgb && std::path::Path::new(&rgb).exists(),

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -274,7 +274,7 @@ fn enroll(args: &[String]) -> std::process::ExitCode {
 fn offer_blink_challenge(user: &str) {
     use std::io::{BufRead, IsTerminal, Write};
     // Only meaningful on IR-capable (Secure-tier) hardware.
-    if !irlume_camera::capabilities().ir_pair {
+    if !crate::caps().ir_pair {
         return;
     }
     let tip =
@@ -1483,6 +1483,31 @@ pub(crate) fn user_arg(args: &[String]) -> String {
 }
 
 /// Effective UID 0: the command can write /etc and manage the daemon.
+/// This process's view of the camera hardware, asked of the DAEMON first and
+/// cached for the process.
+///
+/// Every caller used to call `irlume_camera::capabilities()`, which
+/// classifies each `/dev/video*` node by OPENING it. Reached from the TUI's
+/// refresh paths (through `pamwire::wants`, among others) that ran hundreds
+/// of times per session, each one a second opener racing whatever the daemon
+/// was streaming: EBUSY on strict UVC modules, which is #187. The daemon
+/// already knows what its cameras are and answers from memory, so ask it.
+///
+/// The local probe survives only as the daemon-silent fallback, and the
+/// `OnceLock` bounds it to a single probe per process instead of one per
+/// call. Long-running surfaces that must notice a camera being plugged in
+/// (the TUI) refresh from Health on their own poll rather than from here.
+pub(crate) fn caps() -> irlume_camera::Caps {
+    static CAPS: std::sync::OnceLock<irlume_camera::Caps> = std::sync::OnceLock::new();
+    *CAPS.get_or_init(|| match daemon_poll(&irlume_common::Request::Health) {
+        Ok(irlume_common::Response::Health { tier, rgb_dev, .. }) => irlume_camera::Caps {
+            ir_pair: tier == "secure",
+            rgb: rgb_dev.is_some() || tier == "secure",
+        },
+        _ => irlume_camera::capabilities(), // the one permitted probe
+    })
+}
+
 pub(crate) fn is_root() -> bool {
     unsafe { libc::geteuid() == 0 }
 }
@@ -3991,7 +4016,7 @@ fn doctor_run(
     // Secure/IR hardware only, and only when actually enrolled.
     report.check(
         "ir-calibration",
-        if !enrolled || !irlume_camera::capabilities().ir_pair {
+        if !enrolled || !crate::caps().ir_pair {
             // Not applicable on this machine or for this account; reported so a
             // consumer sees the check ran rather than silently vanishing.
             State::Info
@@ -4001,7 +4026,7 @@ fn doctor_run(
             State::Warn
         },
     );
-    if enrolled && !ir_ratio_calibrated && irlume_camera::capabilities().ir_pair {
+    if enrolled && !ir_ratio_calibrated && crate::caps().ir_pair {
         dout!(
             report,
             "[doctor] {user}'s face enrollment predates the per-user IR center/edge floor\n     \

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -743,7 +743,7 @@ pub(crate) struct Wants {
 
 /// `Auto` follows the hardware; an explicit method overrides it.
 pub(crate) fn wants() -> Wants {
-    let caps = irlume_camera::capabilities();
+    let caps = crate::caps();
     let method = irlume_core::policy::method();
     let is_fp_method = method.face_disabled(); // Method::Fingerprint
     let is_face_method = matches!(method, irlume_core::policy::Method::Face);
@@ -1130,7 +1130,7 @@ fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCod
     // this hardware, and (on enable) UNWIRE what it doesn't, so switching method
     // re-configures cleanly instead of leaving stale lines. `want_*` gate each
     // factor; on disable everything is unwired.
-    let caps = irlume_camera::capabilities();
+    let caps = crate::caps();
     let method = irlume_core::policy::method();
     let Wants {
         face_login: want_face_login,

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -709,7 +709,8 @@ struct LightState {
 
 impl LightState {
     /// Verbatim the reads `refresh_light` used to make inline, EXCEPT that
-    /// camera enumeration is now conditional: see [`enumerate_cameras_now`].
+    /// it no longer enumerates cameras at all: the daemon answers Health for
+    /// capabilities and ListCameras for the picker (#187).
     fn gather(user: &str, prev_armed: Option<bool>) -> Self {
         let daemon_up = matches!(crate::daemon_poll(&Request::Ping), Ok(Response::Pong));
         // Classifying a node OPENS it. While the daemon is reachable it may

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -586,6 +586,11 @@ struct PamCache {
 #[derive(Default, Clone)]
 struct Probes {
     caps: irlume_camera::Caps,
+    /// Whether `caps` came from an actual device probe. False means the
+    /// daemon was up and the probe was skipped to avoid opening nodes it may
+    /// be streaming (#187); the caller must then take capabilities from the
+    /// daemon's Health rather than believing this all-false default.
+    caps_probed: bool,
     fp_present: bool,
     fp: FpInfo,
     pam_cache: PamCache,
@@ -617,13 +622,38 @@ struct Probes {
     boot_mode: String,
 }
 
+/// May the TUI open camera device nodes right now?
+///
+/// Classifying a node opens it, and a second open is EBUSY on strict UVC
+/// modules while the daemon streams the same node (#187). The daemon is the
+/// authority on cameras whenever it is reachable: it reports its tier and
+/// devices through Health, so the TUI never needs to look for itself. When
+/// the daemon is DOWN the local probe is both the only source and safe,
+/// because nothing else holds the cameras.
+fn enumerate_cameras_now(daemon_up: bool) -> bool {
+    !daemon_up
+}
+
 impl Probes {
     /// The full sweep, verbatim from the code that used to run inline. Runs
     /// on a worker thread; everything here may block on D-Bus activation, a
     /// subprocess, or a device open without costing the UI a frame.
     fn gather(user: &str) -> Self {
         use irlume_common::secureboot;
-        let caps = irlume_camera::capabilities();
+        // Same rule as LightState::gather (#187): capabilities() classifies
+        // every node, which opens it. The caller passes the daemon-reported
+        // tier in when the daemon is up, so this only probes when it is
+        // down.
+        let daemon_up = matches!(crate::daemon_poll(&Request::Ping), Ok(Response::Pong));
+        let probe_cameras = enumerate_cameras_now(daemon_up);
+        let caps = if probe_cameras {
+            irlume_camera::capabilities()
+        } else {
+            irlume_camera::Caps {
+                ir_pair: false,
+                rgb: false,
+            }
+        };
         let fp_present = irlume_fingerprint::available();
         let fp = FpInfo {
             available: fp_present,
@@ -642,10 +672,14 @@ impl Probes {
                 || std::path::Path::new("/etc/apparmor.d/usr.local.bin.irlumed").exists(),
             handoffs: crate::pamwire::keyring_handoff_warnings(),
         };
-        let nodes = irlume_camera::discover_nodes();
-        let pairs = irlume_camera::list_pairs();
+        let (nodes, pairs) = if probe_cameras {
+            (irlume_camera::discover_nodes(), irlume_camera::list_pairs())
+        } else {
+            (Vec::new(), Vec::new())
+        };
         Probes {
             caps,
+            caps_probed: probe_cameras,
             fp_present,
             reader_stuck: fp_present && irlume_fingerprint::reader_stuck(user),
             fp,
@@ -706,9 +740,22 @@ struct LightState {
 }
 
 impl LightState {
-    /// Verbatim the reads `refresh_light` used to make inline.
+    /// Verbatim the reads `refresh_light` used to make inline, EXCEPT that
+    /// camera enumeration is now conditional: see [`enumerate_cameras_now`].
     fn gather(user: &str, prev_armed: Option<bool>) -> Self {
         let daemon_up = matches!(crate::daemon_poll(&Request::Ping), Ok(Response::Pong));
+        // Classifying a node OPENS it. While the daemon is reachable it may
+        // be streaming those same nodes, and a second open is EBUSY on
+        // strict UVC modules, which surfaced as "camera is busy" during
+        // enrollment on a reporter's hardware (#187) and is invisible on
+        // modules that tolerate it. Enumerate only when the daemon is down,
+        // where the local probe is the ONLY source and nothing else holds
+        // the cameras.
+        let (nodes, pairs) = if enumerate_cameras_now(daemon_up) {
+            (irlume_camera::discover_nodes(), irlume_camera::list_pairs())
+        } else {
+            (Vec::new(), Vec::new())
+        };
         let mut out = LightState {
             daemon_up,
             health: None,
@@ -717,8 +764,8 @@ impl LightState {
             keyring_drift: None,
             keyring_kind: None,
             recovery: None,
-            nodes: irlume_camera::discover_nodes(),
-            pairs: irlume_camera::list_pairs(),
+            nodes,
+            pairs,
         };
         if !daemon_up {
             return out;
@@ -1018,6 +1065,34 @@ impl App {
         self.light_load = Some(rx);
     }
 
+    /// Enumerate the camera nodes for the Cameras picker, which is the one
+    /// screen that needs the full listing rather than the daemon's summary.
+    ///
+    /// Deliberately on ENTERING that screen instead of in the background
+    /// polls (#187): opening nodes is only safe when the user is not
+    /// simultaneously authenticating, and a picker visit is an explicit act.
+    /// Idempotent and cheap enough for a keypress; it does not stream.
+    fn refresh_camera_listing(&mut self) {
+        self.nodes = irlume_camera::discover_nodes();
+        self.pairs = irlume_camera::list_pairs();
+        let pairs = self.pairs.len().max(1);
+        if self.cam_sel >= pairs {
+            self.cam_sel = pairs - 1;
+        }
+    }
+
+    /// Capabilities as the DAEMON reports them, for use whenever it is
+    /// reachable (#187): it already has the cameras open, so it can say what
+    /// they are without the TUI opening anything. `tier` is the daemon's own
+    /// hardware classification; only the secure tier means a usable IR pair,
+    /// and any reported RGB device means RGB capture works.
+    fn caps_from_health(h: &HealthInfo) -> irlume_camera::Caps {
+        irlume_camera::Caps {
+            ir_pair: h.tier == "secure",
+            rgb: h.rgb_dev.is_some() || h.tier == "secure",
+        }
+    }
+
     /// Land a background light poll: the daemon reads plus the selection
     /// clamps the inline version used to apply.
     fn apply_light(&mut self, l: LightState) {
@@ -1025,6 +1100,10 @@ impl App {
         // Daemon down/unresponsive: show the down state; the local probes
         // still land via the heavy sweep so Repair can diagnose.
         self.health = l.health;
+        // The daemon is the authority on cameras while it is reachable.
+        if let Some(h) = self.health.as_ref() {
+            self.caps = Self::caps_from_health(h);
+        }
         if l.daemon_up {
             self.keyring_armed = l.keyring_armed;
             self.keyring_policy = l.keyring_policy;
@@ -1040,8 +1119,14 @@ impl App {
         if self.daemon_up && !self.profiles_loaded && self.enroll_error.is_none() {
             self.refresh_profiles();
         }
-        self.nodes = l.nodes;
-        self.pairs = l.pairs;
+        // Only adopt a listing that was actually taken (see gather): an
+        // empty vec means "not enumerated this round", not "no cameras".
+        // Overwriting a good listing with that emptiness is the
+        // absent-vs-not-observed collapse (defect pattern 26).
+        if !l.nodes.is_empty() || !l.pairs.is_empty() {
+            self.nodes = l.nodes;
+            self.pairs = l.pairs;
+        }
         let max = self.rows().len().max(1);
         if self.sel >= max {
             self.sel = max - 1;
@@ -1137,7 +1222,14 @@ impl App {
         // them would erase the capabilities `App::new` detected and hide the
         // camera screens until the sweep arrives.
         if self.probes_landed {
-            self.caps = self.probes.caps;
+            // Only adopt probed capabilities. When the daemon was up the
+            // sweep skipped the device probe (#187), and its all-false
+            // default is not an observation: `caps_from_health` already set
+            // the authoritative value, and copying the default over it would
+            // hide the camera screens on a machine that has cameras.
+            if self.probes.caps_probed {
+                self.caps = self.probes.caps;
+            }
             self.fp_present = self.probes.fp_present;
             self.fp = self.probes.fp.clone();
             self.pam_cache = self.probes.pam_cache.clone();
@@ -2728,6 +2820,9 @@ impl App {
         // Fast diagnostics on entering Repair/Fingerprint (no slow profile
         // poll, so the switch is instant); a fresh profile poll only when
         // landing on Profiles, where an external `irlume enroll` should show.
+        if self.screen == SC_CAMERAS {
+            self.refresh_camera_listing();
+        }
         if self.screen == SC_REPAIR || self.screen == SC_FINGERPRINT {
             self.refresh_diagnostics();
         } else if self.screen == SC_PROFILES {
@@ -2761,6 +2856,9 @@ impl App {
                     self.sel = 0;
                     // Same fast paths as a Tab switch: diagnostics for
                     // Repair/Fingerprint, a fresh profile poll for Profiles.
+                    if target == SC_CAMERAS {
+                        self.refresh_camera_listing();
+                    }
                     if target == SC_REPAIR || target == SC_FINGERPRINT {
                         self.refresh_diagnostics();
                     } else if target == SC_PROFILES {
@@ -6379,6 +6477,95 @@ mod tests {
     // return (rgb is true whenever ir_pair is), so a frozen field keeps it and
     // a re-derived one cannot.
     #[test]
+    fn the_tui_never_opens_camera_nodes_while_the_daemon_is_up() {
+        // #187: classifying a node opens it, and a second open is EBUSY on
+        // strict UVC modules while the daemon streams the same node. The
+        // reporter's fuser trace showed `irlume` and `irlumed` holding
+        // /dev/video0 at once; reproduced here on a tolerant module by
+        // sampling the TUI's own probe window. The rule that closes it is
+        // this one function, so it is pinned directly.
+        assert!(
+            !enumerate_cameras_now(true),
+            "a reachable daemon is the authority; the TUI must not open nodes behind it"
+        );
+        assert!(
+            enumerate_cameras_now(false),
+            "with the daemon down the local probe is the only source, and nothing else holds the cameras"
+        );
+    }
+
+    #[test]
+    fn health_supplies_capabilities_while_the_daemon_is_up() {
+        // The other half of #187: having stopped probing, the TUI must still
+        // know what hardware it has, from the daemon that already has the
+        // cameras open. A secure tier means a usable IR pair; a reported RGB
+        // device means RGB capture works.
+        let secure = HealthInfo {
+            tier: "secure".into(),
+            rgb_dev: Some("/dev/video0".into()),
+            ir_dev: Some("/dev/video2".into()),
+            mesh: true,
+            adapter: false,
+            version: "test".into(),
+            third_party_pad: None,
+            third_party_recognizer: None,
+            third_party_detector: None,
+            apparmor: None,
+        };
+        let caps = App::caps_from_health(&secure);
+        assert!(
+            caps.ir_pair && caps.rgb,
+            "secure tier is an IR pair: {caps:?}"
+        );
+        let convenience = HealthInfo {
+            tier: "convenience".into(),
+            ir_dev: None,
+            ..secure.clone()
+        };
+        let caps = App::caps_from_health(&convenience);
+        assert!(
+            !caps.ir_pair,
+            "only the secure tier means an IR pair: {caps:?}"
+        );
+        assert!(caps.rgb, "an RGB device was reported: {caps:?}");
+        let none = HealthInfo {
+            tier: "none".into(),
+            rgb_dev: None,
+            ir_dev: None,
+            ..secure
+        };
+        let caps = App::caps_from_health(&none);
+        assert!(!caps.ir_pair && !caps.rgb, "no devices reported: {caps:?}");
+    }
+
+    #[test]
+    fn an_unenumerated_light_poll_does_not_blank_a_known_camera_listing() {
+        // gather() returns empty vecs when it skipped enumeration; adopting
+        // those would turn "not observed" into "no cameras" and empty the
+        // picker (defect pattern 26).
+        let mut app = test_app();
+        app.nodes = vec![("/dev/video0".into(), irlume_camera::Role::Rgb)];
+        app.pairs = Vec::new();
+        let l = LightState {
+            daemon_up: true,
+            health: None,
+            keyring_armed: None,
+            keyring_policy: None,
+            keyring_drift: None,
+            keyring_kind: None,
+            recovery: None,
+            nodes: Vec::new(),
+            pairs: Vec::new(),
+        };
+        app.apply_light(l);
+        assert_eq!(
+            app.nodes.len(),
+            1,
+            "a skipped enumeration must not blank the listing"
+        );
+    }
+
+    #[test]
     fn refresh_rederives_hardware_capabilities() {
         // The async flavor of the old property: a LANDED sweep replaces a
         // stale capability snapshot. refresh() itself only requests
@@ -6392,7 +6579,14 @@ mod tests {
         };
         let mut app = test_app();
         app.caps = impossible;
-        app.probes = Probes::default(); // an observed no-camera machine
+        // An OBSERVED no-camera machine. `caps_probed` is what makes it an
+        // observation rather than the unprobed default: since #187 the sweep
+        // skips the device probe while the daemon is up, so the flag is the
+        // only thing separating "looked, found none" from "did not look".
+        app.probes = Probes {
+            caps_probed: true,
+            ..Probes::default()
+        };
         app.probes_landed = true;
         app.recompute_checks();
         assert_ne!(

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -451,7 +451,17 @@ struct App {
     nodes: Vec<(String, irlume_camera::Role)>,
     /// Cached camera pairs, refreshed on the slow timer so the Cameras tab and
     /// move_sel don't re-probe the hardware on every keystroke and frame.
-    pairs: Vec<irlume_camera::CameraPair>,
+    /// The camera pairs as the DAEMON enumerated them (#187): the TUI never
+    /// opens a video node itself, so this arrives via ListCameras and each
+    /// entry carries the privacy state the daemon read while it had the
+    /// device.
+    pairs: Vec<irlume_common::CameraPairInfo>,
+    /// Whether the daemon has ever ANSWERED ListCameras. An empty `pairs`
+    /// with this false means "not asked yet, refused, or an older daemon",
+    /// which must not be drawn as "no cameras found" (#187): that claim
+    /// contradicted the active-pair line right under it on a daemon that
+    /// predates the request.
+    pairs_known: bool,
     activity: Vec<(char, String)>,
     input: Option<(String, String, Pending)>,
     confirm: Option<Confirm>,
@@ -597,10 +607,6 @@ struct Probes {
     fp_coverage: Vec<(&'static str, &'static str, bool)>,
     /// The reader is claimed by a stale fprintd session (prompts fail silently).
     reader_stuck: bool,
-    /// A privacy shutter/switch is engaged on any camera node.
-    privacy_engaged: bool,
-    /// Per-pair privacy state, keyed by the pair's RGB node (Cameras screen).
-    pair_privacy: Vec<(String, bool)>,
     /// SELinux is enforcing this boot.
     selinux_enforcing: bool,
     /// The daemon socket carries the irlume SELinux label.
@@ -622,37 +628,17 @@ struct Probes {
     boot_mode: String,
 }
 
-/// May the TUI open camera device nodes right now?
-///
-/// Classifying a node opens it, and a second open is EBUSY on strict UVC
-/// modules while the daemon streams the same node (#187). The daemon is the
-/// authority on cameras whenever it is reachable: it reports its tier and
-/// devices through Health, so the TUI never needs to look for itself. When
-/// the daemon is DOWN the local probe is both the only source and safe,
-/// because nothing else holds the cameras.
-fn enumerate_cameras_now(daemon_up: bool) -> bool {
-    !daemon_up
-}
-
 impl Probes {
     /// The full sweep, verbatim from the code that used to run inline. Runs
     /// on a worker thread; everything here may block on D-Bus activation, a
     /// subprocess, or a device open without costing the UI a frame.
     fn gather(user: &str) -> Self {
         use irlume_common::secureboot;
-        // Same rule as LightState::gather (#187): capabilities() classifies
-        // every node, which opens it. The caller passes the daemon-reported
-        // tier in when the daemon is up, so this only probes when it is
-        // down.
-        let daemon_up = matches!(crate::daemon_poll(&Request::Ping), Ok(Response::Pong));
-        let probe_cameras = enumerate_cameras_now(daemon_up);
-        let caps = if probe_cameras {
-            irlume_camera::capabilities()
-        } else {
-            irlume_camera::Caps {
-                ir_pair: false,
-                rgb: false,
-            }
+        // No camera probe (#187): capabilities() classifies every node,
+        // which opens it. Capabilities come from the daemon's Health.
+        let caps = irlume_camera::Caps {
+            ir_pair: false,
+            rgb: false,
         };
         let fp_present = irlume_fingerprint::available();
         let fp = FpInfo {
@@ -672,14 +658,9 @@ impl Probes {
                 || std::path::Path::new("/etc/apparmor.d/usr.local.bin.irlumed").exists(),
             handoffs: crate::pamwire::keyring_handoff_warnings(),
         };
-        let (nodes, pairs) = if probe_cameras {
-            (irlume_camera::discover_nodes(), irlume_camera::list_pairs())
-        } else {
-            (Vec::new(), Vec::new())
-        };
         Probes {
             caps,
-            caps_probed: probe_cameras,
+            caps_probed: false,
             fp_present,
             reader_stuck: fp_present && irlume_fingerprint::reader_stuck(user),
             fp,
@@ -689,17 +670,6 @@ impl Probes {
                 Vec::new()
             },
             pam_cache,
-            privacy_engaged: nodes.iter().any(|(p, _)| irlume_camera::privacy_engaged(p)),
-            pair_privacy: pairs
-                .iter()
-                .map(|p| {
-                    (
-                        p.rgb.clone(),
-                        irlume_camera::privacy_engaged(&p.rgb)
-                            || irlume_camera::privacy_engaged(&p.ir),
-                    )
-                })
-                .collect(),
             selinux_enforcing: std::fs::read_to_string("/sys/fs/selinux/enforce")
                 .map(|s| s.trim() == "1")
                 .unwrap_or(false),
@@ -735,8 +705,6 @@ struct LightState {
     keyring_drift: Option<bool>,
     keyring_kind: Option<irlume_common::KeyringSecretKind>,
     recovery: Option<RecoveryInfo>,
-    nodes: Vec<(String, irlume_camera::Role)>,
-    pairs: Vec<irlume_camera::CameraPair>,
 }
 
 impl LightState {
@@ -745,17 +713,13 @@ impl LightState {
     fn gather(user: &str, prev_armed: Option<bool>) -> Self {
         let daemon_up = matches!(crate::daemon_poll(&Request::Ping), Ok(Response::Pong));
         // Classifying a node OPENS it. While the daemon is reachable it may
-        // be streaming those same nodes, and a second open is EBUSY on
-        // strict UVC modules, which surfaced as "camera is busy" during
-        // enrollment on a reporter's hardware (#187) and is invisible on
-        // modules that tolerate it. Enumerate only when the daemon is down,
-        // where the local probe is the ONLY source and nothing else holds
-        // the cameras.
-        let (nodes, pairs) = if enumerate_cameras_now(daemon_up) {
-            (irlume_camera::discover_nodes(), irlume_camera::list_pairs())
-        } else {
-            (Vec::new(), Vec::new())
-        };
+        // be streaming those same nodes, and a second opener is EBUSY on
+        // strict UVC modules (#187). Gating on "is the daemon up" was not
+        // enough: a Ping that TIMES OUT reads as down, and a timing-out Ping
+        // is exactly what a daemon busy with the camera produces, so the
+        // fallback fired precisely when it was most dangerous. Capabilities
+        // come from Health, the picker's listing from ListCameras, and both
+        // are serialized against captures on the daemon's side.
         let mut out = LightState {
             daemon_up,
             health: None,
@@ -764,8 +728,6 @@ impl LightState {
             keyring_drift: None,
             keyring_kind: None,
             recovery: None,
-            nodes,
-            pairs,
         };
         if !daemon_up {
             return out;
@@ -875,9 +837,30 @@ impl App {
     /// wrong account. `user_arg` is the single rule the rest of the CLI already
     /// follows, and it also honours an explicit `--user`.
     fn new(user: String) -> Self {
-        // Hardware-adaptive screens: only show what the device can actually do, so
-        // a fingerprint-only box never offers face/camera setup steps.
-        let caps = irlume_camera::capabilities();
+        // Hardware-adaptive screens: only show what the device can actually
+        // do, so a fingerprint-only box never offers face/camera setup steps.
+        //
+        // Asked of the DAEMON, never probed here (#187 review): probing
+        // classifies every node, which opens it, and App::new runs before
+        // any other daemon contact, so it could open a node mid-capture. A
+        // daemon that does not answer leaves capabilities unknown, and
+        // unknown must not hide the camera screens on a machine that has
+        // cameras, so the optimistic default stands until the first light
+        // poll replaces it with the daemon's answer.
+        let caps = match crate::daemon_poll(&Request::Health) {
+            Ok(Response::Health {
+                ref tier,
+                ref rgb_dev,
+                ..
+            }) => irlume_camera::Caps {
+                ir_pair: tier == "secure",
+                rgb: rgb_dev.is_some() || tier == "secure",
+            },
+            _ => irlume_camera::Caps {
+                ir_pair: true,
+                rgb: true,
+            },
+        };
         let fp_present = irlume_fingerprint::available();
         let visible = Self::compute_visible(
             &caps,
@@ -902,8 +885,13 @@ impl App {
             keyring_policy: None,
             keyring_drift: None,
             keyring_kind: None,
-            nodes: irlume_camera::discover_nodes(),
-            pairs: irlume_camera::list_pairs(),
+            // EMPTY at construction (#187 review caught this one): App::new
+            // ran before any daemon contact, so probing here opened every
+            // node while the daemon might be mid-authentication. The light
+            // poll fills both in from the daemon within the first tick.
+            nodes: Vec::new(),
+            pairs: Vec::new(),
+            pairs_known: false,
             activity: Vec::new(),
             input: None,
             confirm: None,
@@ -1065,19 +1053,23 @@ impl App {
         self.light_load = Some(rx);
     }
 
-    /// Enumerate the camera nodes for the Cameras picker, which is the one
-    /// screen that needs the full listing rather than the daemon's summary.
+    /// Refresh the Cameras picker from the DAEMON.
     ///
-    /// Deliberately on ENTERING that screen instead of in the background
-    /// polls (#187): opening nodes is only safe when the user is not
-    /// simultaneously authenticating, and a picker visit is an explicit act.
-    /// Idempotent and cheap enough for a keypress; it does not stream.
+    /// `ListCameras` is camera-class on the daemon side, so the arbiter
+    /// serializes it against captures exactly like an enrollment: the
+    /// enumeration still opens nodes, but only ever on the one thread that
+    /// owns them (#187). A refusal (an authentication holds the camera) or
+    /// any transport error leaves the previous listing in place rather than
+    /// blanking it, because neither is an observation that the cameras are
+    /// gone.
     fn refresh_camera_listing(&mut self) {
-        self.nodes = irlume_camera::discover_nodes();
-        self.pairs = irlume_camera::list_pairs();
-        let pairs = self.pairs.len().max(1);
-        if self.cam_sel >= pairs {
-            self.cam_sel = pairs - 1;
+        if let Ok(Response::Cameras(pairs)) = crate::daemon_poll(&Request::ListCameras) {
+            self.pairs = pairs;
+            self.pairs_known = true;
+            let n = self.pairs.len().max(1);
+            if self.cam_sel >= n {
+                self.cam_sel = n - 1;
+            }
         }
     }
 
@@ -1118,14 +1110,6 @@ impl App {
         // now instead of waiting for a tab visit.
         if self.daemon_up && !self.profiles_loaded && self.enroll_error.is_none() {
             self.refresh_profiles();
-        }
-        // Only adopt a listing that was actually taken (see gather): an
-        // empty vec means "not enumerated this round", not "no cameras".
-        // Overwriting a good listing with that emptiness is the
-        // absent-vs-not-observed collapse (defect pattern 26).
-        if !l.nodes.is_empty() || !l.pairs.is_empty() {
-            self.nodes = l.nodes;
-            self.pairs = l.pairs;
         }
         let max = self.rows().len().max(1);
         if self.sel >= max {
@@ -1319,7 +1303,7 @@ impl App {
                 Fix::None,
             ));
             // Camera row from the daemon's validated tier (never the raw fallback).
-            let priv_on = self.probes.privacy_engaged;
+            let priv_on = self.pairs.iter().any(|p| p.privacy);
             let (csev, cdetail, cfix) = match h.tier.as_str() {
                 _ if priv_on => (Sev::Warn, "camera present, but a privacy switch is ON".to_string(),
                     Fix::Manual("turn off the camera privacy switch".into())),
@@ -1406,7 +1390,7 @@ impl App {
                 .nodes
                 .iter()
                 .any(|(_, r)| matches!(r, irlume_camera::Role::Ir));
-            let priv_on = self.probes.privacy_engaged;
+            let priv_on = self.pairs.iter().any(|p| p.privacy);
             let (csev, cdetail, cfix) = if !rgb && !ir {
                 (
                     Sev::Warn,
@@ -4208,7 +4192,23 @@ impl App {
     }
 
     fn draw_cameras(&self, f: &mut Frame, area: Rect) {
-        let (argb, air) = irlume_camera::select_pair(); // currently active pair
+        // The active pair comes from the daemon's Health, NOT from
+        // select_pair(): that helper falls through to discovery when no
+        // explicit pair is configured, and discovery opens every node. This
+        // is a DRAW function, so it ran per frame, which is where the last
+        // hundred-odd opens per session came from (#187). Health reports the
+        // devices the daemon actually has open, which is a better answer
+        // anyway.
+        let (argb, air) = self
+            .health
+            .as_ref()
+            .map(|h| {
+                (
+                    h.rgb_dev.clone().unwrap_or_default(),
+                    h.ir_dev.clone().unwrap_or_default(),
+                )
+            })
+            .unwrap_or_default();
         let pairs = &self.pairs;
         // Size the list to its rows (header + one row per camera/note) so the
         // info block sits right under it instead of a stretched gap; leftover
@@ -4239,8 +4239,19 @@ impl App {
                 }
             }
             if v.is_empty() {
+                // Only claim "none" when the daemon actually said so. An
+                // unanswered ListCameras (daemon down, busy with a capture,
+                // or older than the request) is not an observation, and
+                // printing "no camera found" for it contradicted the active
+                // pair shown right below (#187).
                 v.push(ListItem::new(Span::styled(
-                    "no camera found: face auth unavailable on this device",
+                    if self.pairs_known {
+                        "no camera found: face auth unavailable on this device"
+                    } else if self.daemon_up {
+                        "asking irlumed for the camera list (it answers once the camera is free)"
+                    } else {
+                        "irlumed is not running, so the camera list is unknown; start it from Repair"
+                    },
                     Style::new().dim(),
                 )));
             } else {
@@ -4257,11 +4268,7 @@ impl App {
                     let active = p.rgb == argb && p.ir == air;
                     let kind = if p.fixed { "built-in" } else { "external" };
                     let id = p.id.clone().unwrap_or_else(|| "?".into());
-                    let priv_on = self
-                        .probes
-                        .pair_privacy
-                        .iter()
-                        .any(|(rgb, on)| *on && *rgb == p.rgb);
+                    let priv_on = p.privacy;
                     ListItem::new(Line::from(vec![
                         Span::styled(
                             if active { " ● " } else { " ○ " },
@@ -5911,6 +5918,7 @@ mod tests {
             keyring_kind: None,
             nodes: Vec::new(),
             pairs: Vec::new(),
+            pairs_known: false,
             activity: Vec::new(),
             input: None,
             confirm: None,
@@ -6477,21 +6485,31 @@ mod tests {
     // return (rgb is true whenever ir_pair is), so a frozen field keeps it and
     // a re-derived one cannot.
     #[test]
-    fn the_tui_never_opens_camera_nodes_while_the_daemon_is_up() {
-        // #187: classifying a node opens it, and a second open is EBUSY on
-        // strict UVC modules while the daemon streams the same node. The
-        // reporter's fuser trace showed `irlume` and `irlumed` holding
-        // /dev/video0 at once; reproduced here on a tolerant module by
-        // sampling the TUI's own probe window. The rule that closes it is
-        // this one function, so it is pinned directly.
-        assert!(
-            !enumerate_cameras_now(true),
-            "a reachable daemon is the authority; the TUI must not open nodes behind it"
-        );
-        assert!(
-            enumerate_cameras_now(false),
-            "with the daemon down the local probe is the only source, and nothing else holds the cameras"
-        );
+    fn no_tui_code_path_enumerates_cameras_locally() {
+        // #187: the TUI must never open a video node. Gating on "is the
+        // daemon up" was not enough, because a Ping that times out (exactly
+        // what a camera-busy daemon produces) read as down and licensed the
+        // opens. The rule is now absolute, so it is pinned as a source
+        // property: no camera-enumerating call may appear in this module
+        // outside tests. An instrumented run is the empirical half (strace
+        // counted 12 node opens before this change, 0 after); this catches
+        // a reintroduction at review time instead.
+        let src = include_str!("tui.rs");
+        let body = &src[..src.find("#[cfg(test)]").unwrap_or(src.len())];
+        for banned in [
+            "irlume_camera::discover_nodes",
+            "irlume_camera::list_pairs",
+            "irlume_camera::capabilities",
+            "irlume_camera::privacy_engaged",
+            // Falls through to discovery when no pair is configured, and it
+            // sat in a per-frame draw path (#187 review).
+            "irlume_camera::select_pair",
+        ] {
+            assert!(
+                !body.contains(banned),
+                "{banned} opens video nodes; the TUI must ask the daemon (#187)"
+            );
+        }
     }
 
     #[test]
@@ -6536,33 +6554,6 @@ mod tests {
         };
         let caps = App::caps_from_health(&none);
         assert!(!caps.ir_pair && !caps.rgb, "no devices reported: {caps:?}");
-    }
-
-    #[test]
-    fn an_unenumerated_light_poll_does_not_blank_a_known_camera_listing() {
-        // gather() returns empty vecs when it skipped enumeration; adopting
-        // those would turn "not observed" into "no cameras" and empty the
-        // picker (defect pattern 26).
-        let mut app = test_app();
-        app.nodes = vec![("/dev/video0".into(), irlume_camera::Role::Rgb)];
-        app.pairs = Vec::new();
-        let l = LightState {
-            daemon_up: true,
-            health: None,
-            keyring_armed: None,
-            keyring_policy: None,
-            keyring_drift: None,
-            keyring_kind: None,
-            recovery: None,
-            nodes: Vec::new(),
-            pairs: Vec::new(),
-        };
-        app.apply_light(l);
-        assert_eq!(
-            app.nodes.len(),
-            1,
-            "a skipped enumeration must not blank the listing"
-        );
     }
 
     #[test]
@@ -7094,17 +7085,19 @@ mod tests {
         assert_eq!(app.repair_sel, 0);
         app.screen = SC_CAMERAS;
         app.pairs = vec![
-            irlume_camera::CameraPair {
+            irlume_common::CameraPairInfo {
                 rgb: "/dev/video0".into(),
                 ir: "/dev/video2".into(),
                 id: None,
                 fixed: true,
+                privacy: false,
             },
-            irlume_camera::CameraPair {
+            irlume_common::CameraPairInfo {
                 rgb: "/dev/video4".into(),
                 ir: "/dev/video6".into(),
                 id: None,
                 fixed: false,
+                privacy: false,
             },
         ];
         app.on_key(KeyCode::Up);
@@ -7427,11 +7420,12 @@ mod tests {
         assert!(app.suspend.is_none());
         let (_, msg) = app.activity.last().expect("the no-pair case is explained");
         assert!(msg.contains("no paired Hello camera"), "got: {msg}");
-        app.pairs = vec![irlume_camera::CameraPair {
+        app.pairs = vec![irlume_common::CameraPairInfo {
             rgb: "/dev/video0".into(),
             ir: "/dev/video2".into(),
             id: Some("abcd:1234".into()),
             fixed: true,
+            privacy: false,
         }];
         app.cam_sel = 0;
         app.on_key(KeyCode::Enter);
@@ -8225,8 +8219,6 @@ mod tests {
             keyring_drift: None,
             keyring_kind: None,
             recovery: None,
-            nodes: Vec::new(),
-            pairs: Vec::new(),
         });
         assert!(
             app.profiles_load.is_none(),
@@ -8498,9 +8490,15 @@ mod tests {
     fn cameras_screen_renders_pairs_and_the_no_pair_fallbacks() {
         let mut app = test_app();
         app.screen = SC_CAMERAS;
-        // No camera at all.
+        // Not asked yet: the screen must NOT claim there are no cameras,
+        // because an unanswered listing is not an observation (#187).
         let text = draw_text(&app);
-        assert!(text.contains("no camera found"));
+        assert!(!text.contains("no camera found"), "{text}");
+        assert!(text.contains("camera list is unknown"), "{text}");
+        // The daemon ANSWERED with an empty list: now "none" is a fact.
+        app.pairs_known = true;
+        let text = draw_text(&app);
+        assert!(text.contains("no camera found"), "{text}");
         // RGB node only: convenience tier, and why Secure needs IR.
         app.nodes = vec![("/dev/video9".into(), irlume_camera::Role::Rgb)];
         let text = draw_text(&app);
@@ -8508,11 +8506,12 @@ mod tests {
         assert!(text.contains("RGB-only, convenience tier"));
         assert!(text.contains("no IR node"));
         // A real Hello pair renders its nodes, kind, and USB id.
-        app.pairs = vec![irlume_camera::CameraPair {
+        app.pairs = vec![irlume_common::CameraPairInfo {
             rgb: "/dev/video0".into(),
             ir: "/dev/video2".into(),
             id: Some("abcd:1234".into()),
             fixed: true,
+            privacy: false,
         }];
         let text = draw_text(&app);
         assert!(text.contains("video0+video2"));
@@ -8944,8 +8943,6 @@ mod tests {
             keyring_drift: None,
             keyring_kind: None,
             recovery: None,
-            nodes: Vec::new(),
-            pairs: Vec::new(),
         });
         assert_eq!(app.sel, 1, "sel must clamp to the last real row");
         assert!(

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -459,6 +459,12 @@ pub enum Request {
     },
     /// Liveness/alignment self-test (no auth side effects). See PAD self-testing.
     SelfTest { kind: SelfTestKind },
+    /// Enumerate the Hello camera pairs for the picker. CAMERA-CLASS: it
+    /// opens every video node to classify it, so it must be serialized
+    /// against captures by the arbiter like any other camera work. Clients
+    /// must NOT enumerate for themselves; a second opener racing the
+    /// daemon's stream is EBUSY on strict UVC modules (#187).
+    ListCameras,
     /// Liveness/health ping.
     Ping,
     /// Daemon self-report: what it actually has loaded and which camera tier it
@@ -614,6 +620,22 @@ pub enum OperationErrorCode {
     Unknown,
 }
 
+/// One physical camera exposing an RGB and an IR node, as the daemon sees it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CameraPairInfo {
+    pub rgb: String,
+    pub ir: String,
+    /// `idVendor:idProduct`, when readable.
+    pub id: Option<String>,
+    /// Built-in (`removable=fixed`) rather than an external USB camera.
+    pub fixed: bool,
+    /// A privacy shutter/switch is engaged on either node of this pair.
+    /// Read by the daemon while it enumerates, because reading the control
+    /// opens the device and only the daemon may do that (#187).
+    #[serde(default)]
+    pub privacy: bool,
+}
+
 /// A profile and the names of its scans, for `ListProfiles`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileSummary {
@@ -669,6 +691,9 @@ pub enum Response {
         reason: String,
     },
     Profiles(Vec<String>),
+    /// Answer to [`Request::ListCameras`]: every physical camera exposing an
+    /// RGB+IR pair, built-in first.
+    Cameras(Vec<CameraPairInfo>),
     /// Result of a 1:N `Identify`. `user`/`profile` are `None` when no enrolled
     /// face matched (check `live` to tell "no match" from "not a live face").
     Identified {

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -88,7 +88,10 @@ pub fn classify(req: &Request) -> Class {
         | CaptureEarMedian { .. }
         | SetupIrEmitter { .. }
         | TuneCaptureMode { .. }
-        | SelfTest { .. } => Class::Camera,
+        | SelfTest { .. }
+        // Enumeration OPENS every node, so it belongs to the camera class
+        // even though it captures nothing (#187).
+        | ListCameras => Class::Camera,
         _ => Class::Plain,
     }
 }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1651,6 +1651,15 @@ struct EngineBits {
     third_party_pad: Option<String>,
     third_party_recognizer: Option<String>,
     third_party_detector: Option<String>,
+    /// The camera facts as the ENGINE observed them when it loaded, so
+    /// `Health` can answer from memory. Probing them per request opened
+    /// video nodes on a connection thread, outside the camera worker's
+    /// serialization, which is a second opener racing the worker's own
+    /// stream (#187 review) and contradicted the Status class's documented
+    /// "touches no camera" contract.
+    tier: String,
+    rgb_dev: Option<String>,
+    ir_dev: Option<String>,
 }
 
 fn engine_bits() -> &'static std::sync::Mutex<EngineBits> {
@@ -1663,12 +1672,28 @@ fn publish_engine_bits_raw(bits: EngineBits) {
 }
 
 fn publish_engine_bits(engine: &irlume_auth::Engine) {
+    // One probe, at load, on the thread that owns the engine. Every later
+    // Health answer reads this copy.
+    let caps = irlume_auth::capabilities();
+    let (rgb, ir) = irlume_auth::select_pair();
+    let rgb_dev = (caps.rgb && std::path::Path::new(&rgb).exists()).then_some(rgb);
+    let ir_dev = (caps.ir_pair && std::path::Path::new(&ir).exists()).then_some(ir);
+    let tier = if ir_dev.is_some() {
+        "secure"
+    } else if rgb_dev.is_some() {
+        "convenience"
+    } else {
+        "none"
+    };
     publish_engine_bits_raw(EngineBits {
         mesh: engine.has_mesh(),
         adapter: engine.has_ir_adapter(),
         third_party_pad: engine.thirdparty_pad_name().map(String::from),
         third_party_recognizer: engine.thirdparty_recognizer_name().map(String::from),
         third_party_detector: engine.thirdparty_detector_name().map(String::from),
+        tier: tier.into(),
+        rgb_dev,
+        ir_dev,
     });
 }
 
@@ -1846,23 +1871,16 @@ fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
     Some(match req {
         Request::Ping => Response::Pong,
         Request::Health => {
-            // Live probe (cameras can appear/vanish); report selected nodes only
-            // when they actually exist; never the unvalidated fallback pair.
-            let caps = irlume_auth::capabilities();
-            let (rgb, ir) = irlume_auth::select_pair();
-            let rgb_dev = (caps.rgb && std::path::Path::new(&rgb).exists()).then_some(rgb);
-            let ir_dev = (caps.ir_pair && std::path::Path::new(&ir).exists()).then_some(ir);
-            let tier = if ir_dev.is_some() {
-                "secure"
-            } else if rgb_dev.is_some() {
-                "convenience"
-            } else {
-                "none"
-            };
+            // MEMORY ONLY. The camera facts were probed once when the engine
+            // loaded and published with the rest of the bits; probing here
+            // opened video nodes on a connection thread while the worker
+            // might be streaming them (#187 review). A camera that appears
+            // or vanishes is picked up at the next engine (re)load, which is
+            // also when the daemon could act on it.
             Response::Health {
-                tier: tier.into(),
-                rgb_dev,
-                ir_dev,
+                tier: bits.tier.clone(),
+                rgb_dev: bits.rgb_dev.clone(),
+                ir_dev: bits.ir_dev.clone(),
                 mesh: bits.mesh,
                 adapter: bits.adapter,
                 version: env!("CARGO_PKG_VERSION").into(),
@@ -2721,6 +2739,22 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 Err(e) => Response::Error(e.to_string()),
             }
         }
+        Request::ListCameras => Response::Cameras(
+            irlume_auth::list_pairs()
+                .into_iter()
+                .map(|p| irlume_common::CameraPairInfo {
+                    // Privacy is read HERE, on the camera worker, for the
+                    // same reason the enumeration is: the control read opens
+                    // the node (#187).
+                    privacy: irlume_auth::privacy_engaged(&p.rgb)
+                        || irlume_auth::privacy_engaged(&p.ir),
+                    rgb: p.rgb,
+                    ir: p.ir,
+                    id: p.id,
+                    fixed: p.fixed,
+                })
+                .collect(),
+        ),
         Request::DeleteProfile { user, profile } => {
             if !authorized_for(peer, &user) {
                 return Response::Error(format!("not authorized to modify '{user}'"));
@@ -4190,6 +4224,9 @@ mod tests {
             third_party_pad: Some("flir".into()),
             third_party_recognizer: None,
             third_party_detector: None,
+            tier: "none".into(),
+            rgb_dev: None,
+            ir_dev: None,
         });
         let peer = Peer {
             uid: 0,


### PR DESCRIPTION
Fixes the enrollment failure in #187, whose cause the reporter's own diagnostic finally caught.

## What their trace showed

The fuser loop they ran during an enrollment attempt caught **two processes holding /dev/video0 at once**:

```
/dev/video0:  dale  69700 F.... irlume
/dev/video0:  root   2708 F...m irlumed
/dev/video2:  root   2708 F...m irlumed
```

`irlume` there is the TUI, not the daemon. Reproduced on the reference Zenbook with nothing but `irlume tui` running: `/dev/video0: wisbfime 350409 F.... irlume`, the same signature. It is transient, held during the startup probe window rather than leaked for the process lifetime, which is why it took a live sampling loop to see.

## Cause

Classifying a video node opens it (`classify_node` → `Device::with_path` → `enum_formats`). Both background poll paths did that on every refresh: `LightState::gather` called `discover_nodes`/`list_pairs` before it had even checked whether the daemon was up, and `Probes::gather` called `capabilities` plus both enumerations. So the TUI opened every camera node repeatedly while the daemon might be streaming those same nodes.

A second open is harmless on tolerant UVC modules, which is why this was invisible on my hardware for months. On strict ones it is EBUSY, and it lands on the user as a failed enrollment naming a holder they cannot close. This is the same family as #242 and #243, one layer out: those were the daemon colliding with itself, this is the TUI colliding with the daemon.

## The rule

While the daemon is reachable it is the authority on cameras: it already has them open and reports its tier and devices through Health, so the TUI takes capabilities from there instead of looking for itself. With the daemon down the local probe is both the only source and safe, since nothing else holds the cameras. That is one pure function, `enumerate_cameras_now`, pinned by its own test.

The Cameras picker genuinely needs the full listing, so it enumerates on **entering that screen** rather than in background polls: an explicit act that cannot coincide with an authentication the user did not start.

Two absent-vs-not-observed guards ride along, because the change creates exactly that hazard: a skipped enumeration returns empty vectors that must not overwrite a known listing, and the sweep's capabilities are adopted only when actually probed, with `caps_probed` carrying the distinction rather than an all-false default pretending to be an observation. The second one made an existing test fail honestly, and the fix was to say what the fixture meant.

## Verified on hardware

- **Before:** sampling while `irlume tui` runs catches the CLI holding /dev/video0.
- **After:** 40 samples over 20 seconds, daemon up, TUI running: **zero** holds.
- The tier still reads `Face (IR) · secure` from Health, and the picker still lists `video0+video2 built-in [3277:0059]`, so neither half of the capability story regressed.
- Workspace green, clippy clean, fmt clean.

## Not tested

- I cannot reproduce the EBUSY itself: this module tolerates the second open. The claim is structural rather than empirical on the reporter's failure mode, and it is the right kind of claim, because if the CLI never opens the node while the daemon may be using it, the collision cannot occur on any module.
- The reporter should confirm on their hardware before this issue closes.
