### PR TITLE
release: 0.9.0, with a sandbox escape, a passphrase floor, and the AppArmor rule that broke Tier 2 unseal

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install nightly Rust (-Zsanitizer is unstable)
         # @master (declares the `toolchain` input); the version tag branches
         # have no such input and ignore `with: toolchain:`.
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: nightly
           # The sanitizer runtimes ship with the standard library for the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,22 @@ jobs:
       - name: packaging parity (units in every lane, versions agree)
         run: ./scripts/check-packaging-parity.sh
 
+      # Nothing validated the AppArmor profiles until 0.9.0, and they are the
+      # only confinement on the Debian/Ubuntu lane. A profile that fails to
+      # parse does not confine, and the two bugs this release fixed (a missing
+      # pcrlock rule that broke every Tier 2 unseal, and a granted-vs-denied
+      # capability) both live in these files. The runner ships apparmor_parser;
+      # -Q parses and exits without loading, so no privileges are needed.
+      - name: apparmor profiles parse
+        run: |
+          set -euo pipefail
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y apparmor
+          for f in packaging/apparmor/*; do
+            echo "checking $f"
+            apparmor_parser -Q "$f"
+          done
+
       # The guard that stops a zero-match test filter from reporting success is
       # itself a parser, so it gets the same treatment it enforces: prove it can
       # still tell a real run from an empty one. Fixtures only, no Rust build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,8 +424,10 @@ jobs:
       # only confinement on the Debian/Ubuntu lane. A profile that fails to
       # parse does not confine, and the two bugs this release fixed (a missing
       # pcrlock rule that broke every Tier 2 unseal, and a granted-vs-denied
-      # capability) both live in these files. The runner ships apparmor_parser;
-      # -Q parses and exits without loading, so no privileges are needed.
+      # capability) both live in these files. -Q parses without loading into the
+      # kernel and -K skips the policy cache, which together let this run
+      # unprivileged: -Q alone still writes /var/cache/apparmor and dies on
+      # permission, which is how the first version of this step failed.
       - name: apparmor profiles parse
         run: |
           set -euo pipefail
@@ -433,7 +435,7 @@ jobs:
           sudo apt-get -qq install -y apparmor
           for f in packaging/apparmor/*; do
             echo "checking $f"
-            apparmor_parser -Q "$f"
+            apparmor_parser -QK "$f"
           done
 
       # The guard that stops a zero-match test filter from reporting success is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,7 +527,7 @@ jobs:
   nix:
     name: nix flake check
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       # No model fetch here: flake check --no-build only evaluates the outputs
       # (flake structure, the package derivation, the NixOS module, the dev
@@ -545,9 +545,7 @@ jobs:
             experimental-features = nix-command flakes
 
       # Evaluates packages.default, nixosModules.irlume, and the dev shell.
-      # Catches eval and type errors in flake.nix and nix/*.nix before merge;
-      # the full source build (packages.default) is covered by `nix build`
-      # locally and the RPM/deb CI, so keep this eval-only and quick.
+      # Catches eval and type errors in flake.nix and nix/*.nix before merge.
       - name: nix flake check
         run: nix flake check --no-build --show-trace
 
@@ -557,6 +555,16 @@ jobs:
       # passes eval. Realizing just the FODs fetches against the recorded
       # hashes and fails on exactly that class of bug, without building the
       # workspace.
+      # ACTUALLY BUILD IT. This job used to stop at eval, on the reasoning that
+      # the source build was "covered by `nix build` locally", which meant
+      # nobody ran it: 0.9.0 was cut with `nix build` failing at the irlumed
+      # link step with "cannot find -lcrypt", because nixpkgs stopped providing
+      # libcrypt transitively and the daemon declares #[link(name = "crypt")].
+      # Eval passed on that same tree, and the RPM and deb lanes cannot see a
+      # Nix derivation's buildInputs. Nothing but building it catches this.
+      - name: nix build (the Nix lane is a shipped lane)
+        run: nix build .#default --no-link --print-out-paths --show-trace
+
       - name: Build fixed-output derivations (catches stale vendor hashes)
         run: nix build --no-link .#default.cargoDeps .#onnxruntime-bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
 
       - name: Install Rust 1.88 (MSRV) with rustfmt + clippy
-        uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0 # 1.88.0
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           # Pinned to a SHA, the action can't read the version from the tag, so
           # name the toolchain explicitly (it is a required input then).
@@ -227,7 +227,7 @@ jobs:
       - name: Install stable Rust
         # @master (declares the `toolchain` input); the version tag branches
         # (e.g. @1.88.0) have no such input and ignore `with: toolchain:`.
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
 
@@ -287,7 +287,7 @@ jobs:
       - name: Install stable Rust with llvm-tools
         # @master (declares the `toolchain` input); the version tag branches
         # (e.g. @1.88.0) have no such input and ignore `with: toolchain:`.
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           components: llvm-tools-preview
@@ -564,7 +564,7 @@ jobs:
       - name: Install nightly Rust (cargo-fuzz needs it)
         # @master so `toolchain: nightly-...` is honored (the version-branch pin
         # ignored it; nightly only worked via the RUSTUP_TOOLCHAIN env fallback).
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: nightly-2026-07-15
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,9 +434,29 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get -qq install -y apparmor
           for f in packaging/apparmor/*; do
-            echo "checking $f"
+            echo "checking $f on the runner's parser"
             apparmor_parser -QK "$f"
           done
+
+      # The runner's parser is 4.x. The universal .deb declares
+      # libc6 (>= 2.35) so it installs on Debian 12 and Ubuntu 22.04, whose
+      # apparmor is 3.0.x, and a profile can parse here and fail there: an
+      # `abi <abi/4.0>` line did exactly that, and since the postinstall did not
+      # report the failure, those installs ran unconfined with nothing said.
+      # Check the OLDEST supported parser too, in the distro that ships it.
+      - name: apparmor profiles parse on the oldest supported parser
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD/packaging/apparmor:/p:ro" ubuntu:22.04 bash -c '
+            set -euo pipefail
+            apt-get -qq update >/dev/null
+            apt-get -qq install -y apparmor >/dev/null
+            apparmor_parser --version
+            useradd -m checker
+            for f in /p/*; do
+              echo "checking $f"
+              su checker -c "apparmor_parser -QK $f"
+            done'
 
       # The guard that stops a zero-match test filter from reporting success is
       # itself a parser, so it gets the same treatment it enforces: prove it can

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -156,6 +156,12 @@ jobs:
           # identical in the job log without this.
           {
             ls -l /dev/video* /dev/media* 2>&1
+            # WHO holds the nodes, recorded BEFORE anything below opens them.
+            # The format probe below is itself an opener, so on a strict UVC
+            # module it can report EBUSY that it caused; this line says whether
+            # irlumed already had the node, which is the difference between "the
+            # camera is wedged" and "the daemon was mid-capture" (#187).
+            echo "--- holders ---"; fuser -v /dev/video* 2>&1 || echo "(none)"
             echo "--- v4l2 devices ---"; v4l2-ctl --list-devices 2>&1
             for d in /dev/video*; do
               echo "--- $d formats ---"; v4l2-ctl -d "$d" --list-formats-ext 2>&1

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,13 @@ upstream_package_name: irlume
 downstream_package_name: irlume
 # Tags are v-prefixed (v0.1.1); without this the RPM Version keeps the "v".
 upstream_tag_template: "v{version}"
+# Only release tags are versions. The repo also carries a tag for the bundled
+# TFLite C runtime artifact (tflite-runtime-v2.19.0), and Packit takes the
+# NEWEST tag to determine the version, so from the moment that tag was pushed
+# every SRPM build failed with:
+#   Unable to extract "version" from tflite-runtime-v2.19.0 using v{version}
+# Anchored with re.match, so a tag not starting with vN.N.N is not a candidate.
+upstream_tag_include: 'v\d+\.\d+\.\d+$'
 
 jobs:
   - job: copr_build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,237 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-05
+
+### Security
+
+- **A sandboxed run could delete live template keys, and it did.** The
+  `IRLUME_STATE_DIR` override that the model tooling and the project's own
+  testing procedure set moved the profile store, but the template-key,
+  recovery-envelope, and keyring-seal directories were built from the bare
+  path constant and ignored it. A sandboxed root command therefore reached
+  through into `/var/lib/irlume`: on 2026-08-05 a sandboxed
+  `profiles forget-model` emptied the real `template-keys/` and `recovery/`
+  on a test machine, leaving an encrypted enrollment whose key existed
+  nowhere, which no recovery path can open. All three directories now resolve
+  through the override-aware accessor, and a test walks every crate to fail
+  the build if a new state path is built from the constant again.
+
+- **`recovery setup` accepted an empty passphrase when stdin was a pipe.**
+  The 12-character floor and the confirmation prompt were both inside the
+  interactive branch, so `irlume recovery setup </dev/null` wrapped the
+  template key under an empty passphrase and reported success. That
+  passphrase is the only barrier on the recovery envelope against someone
+  holding the disk. The floor now applies to both paths; only the
+  confirmation, which needs a second read, remains terminal-only.
+
+### Added
+
+- **A profile can hold templates for more than one recognizer, and the
+  tooling manages that state.** Every scan records the model that produced
+  it, the scan limit counts per recognizer rather than per profile, and
+  `irlume profiles add-scan --profile P --scans N` captures a second model's
+  templates in one session, refusing a short capture before anything is
+  written. `profiles list` prints the per-recognizer breakdown when it says
+  something the total does not, and names the add-scan command when none of
+  a profile's scans belong to the loaded recognizer. `irlume profiles
+  forget-model <model>` removes one recognizer's scans, and the calibrations
+  fitted from them, from every profile of a user: the deliberate counterpart
+  to `models disable`, which deletes weights and keeps templates so
+  re-enabling needs no re-enrollment. A profile left with no scans is
+  deleted with them. The machine API gains a per-profile `recognizers`
+  array. Closes #288.
+
+- **The recognition stage opens to a measured third-party model, starting
+  with buffalo_l.** `sudo irlume models add buffalo <path>` installs
+  InsightFace's `w600k_r50.onnx`, which irlume does not fetch because
+  obtaining it is the user's licensing decision; the file is verified
+  against the sha256 irlume measured and anything else is refused. Enabling
+  it REPLACES the shipped recognizer for RGB matching at its measured 0.55
+  threshold; IR matching, fusion, and dark login turn off because they are
+  unmeasured for this model, and existing profiles need scans for it before
+  it can match. An invalid selection in `settings.conf` stops the daemon
+  from starting rather than silently substituting the shipped model, and
+  PAM treats the unavailable daemon as password fallback. The measured
+  basis is committed: LFW EER 3.9% against the shipped 4.2% through
+  irlume's own pipeline, demographic spread 3.9x against 6.1x at the
+  enabled threshold, live genuine floors on two cameras
+  (docs/recognition-results/2026-08-05-buffalo-l.md).
+
+- **Every catalog entry names its pipeline stage, and doctor reports each
+  stage.** Only the PAD and recognition stages accept third-party entries;
+  detection and landmarks refuse them at the models commands, the
+  installer, and the daemon's settings wiring, because their failure modes
+  are not equally safe. `irlume doctor` gains a pipeline-stages section and
+  `irlume models list --json` is a new machine-API capability
+  (`models-list-json`) reporting each stage's candidate model, tier, and
+  weight state. `models disable [name]` clears exactly the selected entry.
+  docs/THIRD-PARTY-MODELS.md documents what irlume measured, the threshold
+  it measured, and why a publisher's default is never used.
+
+- **A native TFLite runtime, bundled on every FHS lane, behind a stage
+  gate that stays closed.** irlume builds `libtensorflowlite_c.so` from
+  the pinned tensorflow v2.19.0 commit (Google publishes no prebuilt Linux
+  C-API artifact at stable URLs), publishes it with signed checksums, and
+  all four packaged lanes install it at `/usr/share/irlume/tflite/`, the
+  first path the daemon's resolver probes; `IRLUME_TFLITE_LIB` overrides,
+  absence is a recoverable answer, and Nix does not bundle it (a flake user
+  sets the variable). On it runs a full-range BlazeFace decoder,
+  parity-gated against the official runtime (mean IoU 0.9354 over 320
+  frames) with an operating point of 0.55 measured through irlume's own
+  pipeline, where an empty room on near-black IR reaches 0.5293, refuting
+  the publisher's 0.5 floor. The detection stage does NOT open: the rescue
+  slot is grant-capable and the end-to-end false-grant corpus does not
+  exist yet, so the wiring lands dormant and the daemon and TUI report the
+  loaded detector.
+
+- **Setup offers the anti-spoof model as a recommended numbered step.**
+  Default yes on a terminal, with the license and provenance on screen; a
+  non-TTY run declines, because an unattended install must not fetch
+  third-party weights unseen. The built-in gate accepts the measured print
+  attack, so the step names the one command that closes it.
+
+- **Doctor reports the negotiated camera streams against the Windows Hello
+  minimums.** IR 340x340 at 15fps, RGB 480x480 at 7.5fps, probed through
+  `VIDIOC_TRY_FMT` so doctor changes nothing on the camera; an unreported
+  frame rate reads as cannot-say rather than a pass. Closes #223.
+
+- **`calibrate-closure --measure-only` takes EAR readings without
+  storing.** N rounds under an operator-supplied `--pose` label, reduced by
+  the same median the calibration path stores, for measuring eye-closure
+  distributions against one stored calibration. Part of #173.
+
+- **The dark-frame diagnosis gains an inter-frame arm.** A bright frame the
+  camera's own metadata flags emitter-lit vouches for the emitter and
+  outranks the failed-LED guess; a bright frame flagged dark is what
+  ambient light looks like and stays quiet. Part of #264.
+
+### Fixed
+
+- **The AppArmor profile blocked every Tier 2 TPM unseal.** The profile
+  granted the two signed-policy artifacts but not
+  `/var/lib/systemd/pcrlock.json`, which is the pcrlock tier's policy input,
+  so on an AppArmor-enforcing install the keyring stopped opening at login
+  and the error text sent the user to re-run `systemd-pcrlock make-policy`,
+  which cannot help. Measured on a ThinkPad where 16 denials accumulated
+  over two days without a single visible cause. Both attachment variants
+  carry the rule and the packaging-parity script fails on a deleted line.
+
+- **The TUI and CLI answered "off" to questions they could not read.** With
+  the daemon unreachable the Profiles, Welcome, Repair, and Done screens
+  reported "no profiles", "keyring not armed", and "templates plaintext at
+  rest" for a machine whose templates are encrypted and enrolled, which
+  invites a user to re-enroll over working data; the Recovery tab reported a
+  security downgrade that had not happened. Unprivileged `models list`,
+  `biopolicy status`, and `status` reported root-only settings as definitely
+  off, so a user whose anti-spoof model was enabled read "none enabled".
+  An unanswered question now renders as unknown everywhere, distinct from a
+  definite no, which is what the machine API already did.
+
+- **`irlume enroll --scans abc` captured at the default count.** The parse
+  failure was swallowed and the enrollment proceeded, firing a biometric
+  capture the user did not ask for. The rule was already written into
+  `profiles add-scan`, which exits 2 on the same input; both now share one
+  parser so they cannot drift apart again.
+
+- **The TUI opened camera nodes behind the daemon's back.** Classifying a
+  video node means opening it, and the TUI did that on every background
+  refresh, including while the daemon was streaming the same nodes for an
+  enrollment. Most UVC modules permit the second open and the collision is
+  invisible; a module that answers EBUSY fails the enrollment, with nothing
+  in the logs naming the cause. While the daemon runs it is now the only
+  authority on cameras and answers over the socket. Measured with strace:
+  1144 opens of `/dev/video*` in 16 seconds before, zero after. Closes #187.
+
+- **Templates carry the recognizer that produced them, and every comparison
+  filters by it.** Cosine similarity means nothing across embedding spaces:
+  before the tag, changing the model compared fresh probes against vectors
+  from a different space, free to land either side of the threshold as a
+  silent grant or denial. Scans written before this release match only the
+  shipped recognizer.
+
+- **Calibrations are keyed by recognizer.** One slot per profile meant
+  adding scans under model B replaced model A's calibration, and switching
+  back applied B's numbers to A's templates. The on-disk shape is additive
+  in both directions, so an enrollment written before this change keeps its
+  calibration and an older irlume still finds the shipped model's value.
+
+- **Dark login was unreachable.** The 0.8.0 exposure short-circuit (#238)
+  denied every Uncertain verdict, including "no face in RGB" with an IR
+  face present, which is the dark IR-only path's entry condition. The
+  short-circuit now keys on the structural shape, and nothing is granted on
+  the Uncertain that falls through: the dark branch derives its own verdict
+  with the same exposure refusal. Six dark-room attempts on hardware
+  granted at 0.816 to 0.888 against the 0.600 threshold. Closes #284.
+
+- **Garbage landmark geometry abstains instead of scoring.** A NaN landmark
+  saturated to pixel (0,0), so the eyes-open gate answered true from a
+  bright frame corner, eye_glint scored 255 from landmarks that do not
+  exist, and alignment returned an all-black chip as Ok. Detector output,
+  the mesh's input and output, the glint cues, and alignment now refuse
+  non-finite or implausible geometry with named reasons; the new gates
+  refused none of 196 genuine detected frames in the live bench.
+
+- **The engine derives IR availability from the device selection, not a
+  one-shot load-time probe.** The probe could lose /dev enumeration to the
+  platform's MAC policy or to the emitter setup holding the node, leaving
+  the engine on convenience-tier policy while the daemon logged secure
+  tier. `IRLUME_FORCE_NO_IR=1` still outranks the selection. Closes #281.
+
+- **The AppArmor profile grants what the 0.8.x daemon does.** The emitter
+  undo-journal lock in /run/lock, /dev directory enumeration, and the
+  per-stream flock all postdate the 0.7 soak the profile was written
+  against; every start logged refusal warnings. Both attachment variants
+  now carry the rules (the /usr/local/bin variant claimed parity and had
+  none of them), and the parity script fails on a deleted line. Closes
+  #283.
+
+- **A wedged kwallet helper can no longer hold a login.** The helper's
+  stdout is read on a non-blocking pipe under the 15-second budget with a
+  4096-byte cap, and every kill-then-wait is bounded at 200ms, so neither
+  a stuck helper nor a leaked pipe write end blocks the PAM session phase.
+  Closes #257.
+
+- **`--fingerprint-only` requires a PAM surface that reaches
+  pam_fprintd.** A package can ship a service file nothing invokes, so the
+  old existence check could leave face down while every real prompt stayed
+  password-only. Recording the method now requires a tracked surface whose
+  stack reaches an active `pam_fprintd.so` line, modelling the one
+  guaranteed exit (`requisite pam_deny.so`). Closes #234.
+
+- **An all-error concurrent arm is a Sequential verdict.** camera-tune
+  required both arms to complete a round, so a camera whose concurrent
+  captures only error (the BRIO's EINVAL) reported nothing and the
+  strongest evidence the probe can produce was discarded. The verdict
+  stands only when a trailing one-at-a-time control proves the camera is
+  still answering. The probe half of #192.
+
+- **The consent gesture is judged on the completed take.** The in-loop
+  check ran every six poses and never evaluated the finished series, so a
+  nod completing in the trailing poses was refused with evidence that
+  passes every gate. Hardware replay: nod releases 7 of 8 against the
+  prior session's 6 of 8, stills 0 of 5, and zero false accepts over 17
+  refused windows. Part of #101.
+
+- **An unresolvable onnxruntime is an error, not a silent hang.** ort's
+  load-dynamic failure parks the process in a futex with no output. The
+  resolver now probes loadability with its own dlopen and an
+  `OrtGetApiBase` check first, reports failures in the loader's own words
+  in about 60 milliseconds, and keeps the successful handle for the life
+  of the process. Closes #266.
+
+### Changed
+
+- **The relief and occluder record for the print attack is committed, and
+  it is why setup now offers the model.** An infrared-absorbing cotton
+  occluder moves the print past every committed genuine sample on the
+  centre/edge cue, a window collapses the raw relief ratio below the face
+  band (the emitter-off differential restores it), and no native cue
+  survives both; the opt-in flir cue denies the same presentations at
+  p_fake 0.988 to 1.000. The corpora, the `landmark_replay` offline
+  instrument, and checkers that fail on an edited figure are in
+  docs/pad-results/.
+
 ## [0.8.1] - 2026-08-04
 
 ### Security
@@ -1945,7 +2176,8 @@ is always the fallback: no lockout, ever.
   credentials).
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
-[Unreleased]: https://github.com/archledger/irlume/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/archledger/irlume/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/archledger/irlume/releases/tag/v0.9.0
 [0.8.1]: https://github.com/archledger/irlume/releases/tag/v0.8.1
 [0.8.0]: https://github.com/archledger/irlume/releases/tag/v0.8.0
 [0.7.2]: https://github.com/archledger/irlume/releases/tag/v0.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,71 @@ All notable changes to irlume are documented here. This project adheres to
   `profiles add-scan`, which exits 2 on the same input; both now share one
   parser so they cannot drift apart again.
 
+- **The CLI and TUI opened camera nodes behind the daemon's back.**
+  Classifying a video node means opening it, so any of these racing the daemon
+  is EBUSY on a strict UVC module, which fails the user's enrollment with
+  nothing in the logs naming the cause. `irlume status` and `status --json`
+  each opened /dev/video0 through video3 with the daemon running, and `setup`
+  probed in its preflight and then enrolled seconds later on the nodes it had
+  just touched. All of them now ask the daemon, which already holds the nodes
+  and reports the pair it picked; the local probe survives only as the
+  daemon-silent fallback, where nothing else holds the cameras. Measured with
+  strace, four opens to zero. A source-property test pins the rule, and the two
+  probes that remain deliberate (doctor inspecting hardware, the dev engine
+  resolving the node it is about to open) carry the reason at the call site.
+
+- **A scan budget the daemon did not report read as zero.** `room` defaulted
+  to 0, which is what a genuinely full profile also reports, so a 0.9.0 client
+  against a still-running 0.8.1 daemon offered no continuation scans: the user
+  asked for ten and got the one merged scan with nothing saying why. That is
+  the window every upgrade passes through, between the package swap and the
+  daemon restart. The field is optional now, and unknown means ask for what
+  the user requested and let the daemon refuse what it will.
+
+- **Per-recognizer counts a daemon never sent were reported as none.**
+  `profiles list --json` emitted `"recognizers": []` beside ten scans against
+  a pre-0.9.0 daemon, which claims no recognizer can match this profile and
+  would send a consumer to prompt for re-enrollment. The key is omitted when
+  the answer is unknown; a profile that genuinely has no scans still reports
+  an empty list.
+
+- **The TUI chrome claimed state its own body had not established.** An
+  enrolled user was told "New here? Press [e] to scan your face", an armed
+  keyring was told to arm, a set recovery passphrase was told to set one, and
+  the Done footer offered to wire a login that was already wired, where the
+  key fires a real `sudo irlume login enable --apply`. The Profiles tips
+  truncated mid-sentence at every terminal width, the Settings biopolicy row
+  disagreed with the Done screen about the same root-only setting, and the
+  `?` overlay was missing four keys it claims to list in full.
+
+- **`irlume deps` told users to install onnxruntime on machines that have
+  it.** Its path list had neither location the irlume packages use, and the
+  packages hand `ORT_DYLIB_PATH` to the daemon through a unit drop-in that a
+  bare CLI run never sees, so with irlumed stopped it reported the runtime
+  missing. That is exactly when someone runs `deps`. The list now lives in one
+  place that the vision crate shares.
+
+- **`camera-tune --rounds` with a non-numeric value fired the IR emitter for
+  a minute at the default count** instead of refusing, the same silent
+  substitution `enroll --scans` had. Three usage errors also answered exit 1
+  where every sibling answers 2 (`logs`, `selinux`, and bare `suncal`).
+
+- **Packit could not build an SRPM, so tagging 0.9.0 would have produced no
+  Copr package at all.** Publishing the TFLite runtime as a GitHub release
+  added the tag `tflite-runtime-v2.19.0`, and Packit derives the version from
+  the newest tag: "Unable to extract version from tflite-runtime-v2.19.0 using
+  v{version}". Both rpm-build checks had been red on every PR since, read as
+  background noise; the same code path runs on the release trigger, where
+  Packit failures are silent. `.packit.yaml` now filters to release tags.
+
+- **The AppArmor profiles are checked by CI, and stop asking for ptrace.**
+  Nothing validated them before, and they are the only confinement on the
+  Debian/Ubuntu lane: a profile that fails to parse does not confine. The
+  camera-consumer scan's `sys_ptrace` request is now explicitly denied rather
+  than left to log about 30 audit refusals per boot; granting it would let
+  irlumed inspect any process on the machine, which is more than a diagnostic
+  message is worth, and the scan already degrades and proceeds.
+
 - **The TUI opened camera nodes behind the daemon's back.** Classifying a
   video node means opening it, and the TUI did that on every background
   refresh, including while the daemon was streaming the same nodes for an
@@ -235,6 +300,32 @@ All notable changes to irlume are documented here. This project adheres to
   p_fake 0.988 to 1.000. The corpora, the `landmark_replay` offline
   instrument, and checkers that fail on an edited figure are in
   docs/pad-results/.
+
+### Upgrading from 0.8.1
+
+Enrollments written by 0.8.1 load unchanged: untagged scans count under the
+shipped recognizer, and a calibration written before this release keeps
+working. The upgrade was tested both ways with fixtures produced by real
+0.8.1 code, including sealed template keys, and with every combination of
+0.8.1 and 0.9.0 client and daemon. Three things are worth knowing.
+
+- **Restart the daemon.** Between the package swap and the restart you are
+  running a 0.9.0 CLI against an 0.8.1 daemon. Nothing breaks and no data is
+  at risk, but that older daemon cannot answer the questions this release
+  added, so a few surfaces read as unknown until it comes back. The RPM and
+  Debian packages request the restart themselves.
+
+- **A downgrade must be read-only.** 0.8.1 can READ a store written by 0.9.0,
+  but if it WRITES one it drops what it does not understand: the per-scan
+  recognizer tags and the per-recognizer calibrations. That only matters if
+  you have enrolled scans under a third-party recognizer, and only if you go
+  back to 0.8.1 and then enroll or edit a profile. Reading with 0.8.1 leaves
+  the file untouched.
+
+- **`enforce_biopolicy=TRUE` was never in effect.** Both daemons accept only
+  `1`, `true`, `yes`, or `on`, all lowercase, so an uppercase value has always
+  been off. 0.8.1's `status` displayed it as ENFORCING anyway; 0.9.0 shows what
+  the daemon actually does. If you set it that way, lowercase it.
 
 ## [0.8.1] - 2026-08-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi"
 version = "7.7.0"
-source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
+source = "git+https://github.com/archledger/rust-tss-esapi?rev=7567f6048d2bcb42779e80c0dad90e7eacf6185c#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -2707,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi-sys"
 version = "0.6.0"
-source = "git+https://github.com/archledger/rust-tss-esapi?branch=irlume-patches#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
+source = "git+https://github.com/archledger/rust-tss-esapi?rev=7567f6048d2bcb42779e80c0dad90e7eacf6185c#7567f6048d2bcb42779e80c0dad90e7eacf6185c"
 dependencies = [
  "pkg-config",
  "target-lexicon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "image",
  "irlume-auth",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "libc",
  "serde",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.8.1"
+version = "0.9.0"
 
 [[package]]
 name = "irlume-gkr-unlock"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-kwallet-init"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-liveness"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "edgefirst-tflite",
  "irlume-camera",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,6 @@ dependencies = [
 name = "irlume-liveness"
 version = "0.9.0"
 dependencies = [
- "irlume-camera",
  "irlume-common",
  "irlume-vision",
 ]
@@ -1118,7 +1117,6 @@ name = "irlume-vision"
 version = "0.9.0"
 dependencies = [
  "edgefirst-tflite",
- "irlume-camera",
  "irlume-common",
  "libc",
  "ort",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ dependencies = [
  "base64 0.23.0",
  "irlume-common",
  "irlume-vision",
+ "libc",
  "pbkdf2",
  "rand 0.10.2",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,4 +101,4 @@ strip = true
 # policy commands to required_session_1 only as an 8.0 break (PR #624). Only move to
 # a plain crates.io release after that release exists AND passes the HW round-trip.
 [patch.crates-io]
-tss-esapi = { git = "https://github.com/archledger/rust-tss-esapi", branch = "irlume-patches" }
+tss-esapi = { git = "https://github.com/archledger/rust-tss-esapi", rev = "7567f6048d2bcb42779e80c0dad90e7eacf6185c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Enrollment on IR hardware offers to enable it. See [Honest limitations](#-honest
 
 ## 📦 Install
 
-> **v0.8.1.** Works end-to-end on real hardware across all three families,
+> **v0.9.0.** Works end-to-end on real hardware across all three families,
 > including face-approved app prompts (Bitwarden). Not certified (no iBeta lab
 > pass), and a printed photograph of an enrolled face passes the built-in
 > liveness gate: see [Honest limitations](#-honest-limitations) before you wire
@@ -464,7 +464,7 @@ see [Honest limitations](#-honest-limitations).
 | **Write software that drives irlume** | [`docs/INTEGRATION.md`](docs/INTEGRATION.md) |
 | Look up the versioned **machine API**, field by field | [`docs/MACHINE-API.md`](docs/MACHINE-API.md) |
 | Understand the **architecture** | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
-| Choose a **third-party liveness model** irlume has measured | [`docs/THIRD-PARTY-MODELS.md`](docs/THIRD-PARTY-MODELS.md) |
+| Choose a **third-party model** irlume has measured | [`docs/THIRD-PARTY-MODELS.md`](docs/THIRD-PARTY-MODELS.md) |
 | Read the **threat model** and standards mapping | [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) · [`docs/STANDARDS.md`](docs/STANDARDS.md) |
 | **Verify the claims** on my own machine | [`docs/VERIFY.md`](docs/VERIFY.md) |
 | **Debug** a login or trace every stage | [`docs/DEBUGGING.md`](docs/DEBUGGING.md) |
@@ -474,7 +474,7 @@ see [Honest limitations](#-honest-limitations).
 
 ## 🛠️ Status
 
-**v0.8.1: working and validated on real hardware.** Fedora runs the full IR
+**v0.9.0: working and validated on real hardware.** Fedora runs the full IR
 Secure tier end to end, including face-approved app prompts (Bitwarden biometric
 unlock via polkit, verified live); Ubuntu / Pop!_OS runs the RGB Convenience tier
 plus a fingerprint; Arch is validated for packaging and the CLI/daemon on a
@@ -496,7 +496,7 @@ Interfaces may still shift before 1.0.
   [developer guide](docs/DEVELOPMENT.md); CI runs fmt / clippy / build / test on
   every push and PR.
 
-The per-release detail (0.1.x through 0.8.1) lives in [`CHANGELOG.md`](CHANGELOG.md).
+The per-release detail (0.1.x through 0.9.0) lives in [`CHANGELOG.md`](CHANGELOG.md).
 
 ## 🙏 Credits
 

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -678,7 +678,15 @@ impl Engine {
             gate: LivenessGate::new(),
             rgb_dev: irlume_camera::DEFAULT_RGB_DEVICE.into(),
             ir_dev: irlume_camera::DEFAULT_IR_DEVICE.into(),
-            ir_available: irlume_camera::capabilities().ir_pair,
+            // From the DEFAULT selection's mere existence, not a probe.
+            // `capabilities()` opens every /dev/video* node to classify it, and
+            // every shipped caller then chains `.with_devices(...)`, which
+            // recomputes this field the non-probing way and throws the probed
+            // answer away. So it was pure dead work of exactly the shape that
+            // races the daemon's own capture (#187), and it used the racy
+            // source #281 removed everywhere else. Same helper as
+            // `with_devices`, so `IRLUME_FORCE_NO_IR=1` still outranks it.
+            ir_available: selected_ir_available(irlume_camera::DEFAULT_IR_DEVICE),
             gesture_seen_before_match: false,
             stop_requested: None,
         })

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2886,11 +2886,16 @@ impl Engine {
             }
             self.refit_profile_calib(&mut enr.profiles[idx]);
             let total = enr.profiles[idx].scans.len();
+            // The budget the caller may still spend is per RECOGNIZER
+            // (#290), so compute it from the same helper enrollment itself
+            // uses rather than leaving a client to derive it from `total`.
+            let room = scan_room_in(&enr.profiles[idx], &self.embed_space);
             storage::save(&enr)?;
             return Ok(EnrollOutcome::Merged {
                 name: target,
                 added,
                 total,
+                room,
                 added_scans,
             });
         }
@@ -3265,6 +3270,8 @@ pub enum EnrollOutcome {
     /// after an embedding-space change strands the old IR templates).
     Merged {
         name: String,
+        /// Remaining scans allowed in the LOADED recognizer's space.
+        room: usize,
         added: usize,
         total: usize,
         /// Names of the scans this capture appended, so a caller can undo the

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -154,9 +154,15 @@ pub(crate) fn control_is_documented(
 
 /// Persisted config path (written by `ir-setup`, read by [`enable`]).
 fn conf_path() -> PathBuf {
+    // Through `state_dir()`, like `emitter_journal::store_dir` and
+    // `stream_record`, not the literal. This file decides whether the IR
+    // emitter lights at login, and a sandboxed `ir-setup` set up exactly as
+    // docs/INTEGRATION.md documents (SOCKET, STATE, KEYRING, RECOVERY,
+    // TEMPLATE_KEY) would have written straight through to the live one. Same
+    // split-resolution shape that emptied a real machine's template keys.
     std::env::var("IRLUME_IR_EMITTER_CONF")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/var/lib/irlume/ir_emitter.conf"))
+        .unwrap_or_else(|_| irlume_common::state_dir().join("ir_emitter.conf"))
 }
 
 /// Which control `ir-setup` found, if it was recorded for the camera now

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1001,6 +1001,37 @@ fn physical_device_id(device: &str) -> Option<std::path::PathBuf> {
     find_attr_dir(&real, "idVendor")
 }
 
+/// The configured pair, using ONLY sources that never open a device: the
+/// explicit env override, then the pair persisted in `cameras.conf` exactly as
+/// saved. `None` when neither is set, because answering then would require
+/// enumerating, and enumerating opens every node.
+///
+/// Exists for one caller shape: something that wants the pair while a daemon
+/// MIGHT be mid-capture. A short socket poll timing out does not prove the
+/// daemon is gone, and a busy capture is exactly what a timeout looks like, so
+/// falling back to [`select_pair`] there would open the nodes at the worst
+/// possible moment (#187). Identity re-resolution is deliberately skipped: it
+/// probes, which is the thing being avoided.
+pub fn configured_pair_no_probe() -> Option<(String, String)> {
+    let nonblank_pair =
+        |r: String, i: String| (!r.trim().is_empty() && !i.trim().is_empty()).then_some((r, i));
+    if let (Ok(r), Ok(i)) = (
+        std::env::var("IRLUME_RGB_DEVICE"),
+        std::env::var("IRLUME_IR_DEVICE"),
+    ) {
+        if let Some(pair) = nonblank_pair(r, i) {
+            return Some(pair);
+        }
+    }
+    match (
+        irlume_common::config::read_kv("cameras.conf", "rgb"),
+        irlume_common::config::read_kv("cameras.conf", "ir"),
+    ) {
+        (Some(r), Some(i)) => nonblank_pair(r, i),
+        _ => None,
+    }
+}
+
 /// Select the RGB+IR camera pair to authenticate with. Supports the built-in
 /// Hello camera *and* external USB Hello webcams (Logitech Brio, NexiGo HelloCam)
 /// without hard-coded node numbers. Precedence:

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -785,8 +785,16 @@ pub fn status(args: &[String]) -> ExitCode {
         }
     );
 
-    // Cameras.
-    let (rgb, ir) = irlume_camera::select_pair();
+    // Cameras. Ask the DAEMON first: it already holds these nodes and reports
+    // the pair it selected, and classifying a node locally means OPENING it.
+    // On a UVC module that answers EBUSY to a second open, `irlume status` run
+    // during an enrollment fails that enrollment. That is #187, and the #300
+    // fix covered the TUI but left this path enumerating: measured with strace,
+    // `status` opened /dev/video0 through video3 with the daemon running.
+    // Falling back to a local probe when the daemon is down is safe for the
+    // same reason it is in the TUI: nothing else holds the cameras then, and it
+    // is the only source of an answer.
+    let (rgb, ir) = crate::camera_pair();
     println!("  cameras       : rgb={rgb} ir={ir}");
 
     // Fingerprint.
@@ -1476,7 +1484,7 @@ pub fn setup(args: &[String]) -> ExitCode {
     }
     println!("  daemon running {OK}");
     let _ = deps(args);
-    let (rgb, ir) = irlume_camera::select_pair();
+    let (rgb, ir) = crate::camera_pair();
     println!("  cameras: rgb={rgb} ir={ir}");
 
     // 2. Enroll (reset if already enrolled and the user wants a clean start).

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -752,15 +752,12 @@ pub fn status(args: &[String]) -> ExitCode {
     }
 
     // Biopolicy enforcement (opt-in).
-    let bio = irlume_common::config::read_kv("settings.conf", "enforce_biopolicy")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
     println!(
         "  biopolicy     : {}",
-        if bio {
-            format!("ENFORCING {OK} (operation-class gate)")
-        } else {
-            "off (default)".into()
+        match irlume_common::config::enforce_biopolicy_visible() {
+            Some(true) => format!("ENFORCING {OK} (operation-class gate)"),
+            Some(false) => "off (default)".into(),
+            None => "unknown: root-only setting, re-run with sudo".into(),
         }
     );
 
@@ -1209,14 +1206,16 @@ pub fn deps(_args: &[String]) -> ExitCode {
 /// so enabling it can restrict which services a face may satisfy but never
 /// locks anyone out.
 pub fn biopolicy(sub: Option<&str>, _args: &[String]) -> ExitCode {
-    let on = irlume_common::config::read_kv("settings.conf", "enforce_biopolicy")
-        .map(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
-        .unwrap_or(false);
+    let visible = irlume_common::config::enforce_biopolicy_visible();
     match sub {
         None | Some("status") => {
             println!(
                 "[biopolicy] operation-class gate: {}",
-                if on { "ENFORCING" } else { "off (default)" }
+                match visible {
+                    Some(true) => "ENFORCING",
+                    Some(false) => "off (default)",
+                    None => "unknown: root-only setting, re-run with sudo",
+                }
             );
             ExitCode::SUCCESS
         }

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -730,15 +730,21 @@ pub fn status(args: &[String]) -> ExitCode {
     if let Ok(Response::RecoveryStatus {
         encrypted,
         recovery_set,
+        key_present,
         ..
     }) = daemon_request(&Request::RecoveryStatus { user: user.clone() })
     {
         println!(
             "  templates     : {}",
-            if encrypted {
-                format!("encrypted at rest {OK}")
-            } else {
-                format!("plaintext {WARN} (run `irlume recovery setup`)")
+            match (encrypted, key_present) {
+                (true, true) => format!("encrypted at rest {OK}"),
+                // Reporting this as plaintext both understates the posture and
+                // hides that the enrollment is gone.
+                (true, false) => format!(
+                    "encrypted, but the TEMPLATE KEY IS MISSING {WARN} \
+                     (unreadable; re-enroll)"
+                ),
+                (false, _) => format!("plaintext {WARN} (run `irlume recovery setup`)"),
             }
         );
         println!(

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1049,7 +1049,8 @@ pub fn selinux(sub: Option<&str>, _args: &[String]) -> ExitCode {
         }
         Some(other) => {
             eprintln!("[selinux] unknown subcommand '{other}' (use: status | load)");
-            ExitCode::FAILURE
+            // Usage error, not a runtime failure; see the note in logs::view.
+            ExitCode::from(2)
         }
     }
 }
@@ -1131,6 +1132,26 @@ pub(crate) const REQUIRED_MODELS: [(&str, &str); 2] = [
     ("face_detection_yunet_2023mar.onnx", "IRLUME_DET_MODEL"),
 ];
 
+/// Whether onnxruntime is on disk anywhere irlume or a distro puts it. Pure over
+/// `exists` so the path set is testable without a filesystem, matching
+/// `configured_ort` in irlume-vision.
+///
+/// The distro paths alone are not enough: the irlume packages bundle their own
+/// copy and hand `ORT_DYLIB_PATH` to the daemon through a unit drop-in, which a
+/// bare CLI run never sees. Probing only /usr/lib* made `deps` report the
+/// runtime missing on a machine where the package had installed it.
+fn ort_on_disk(exists: impl Fn(&str) -> bool) -> bool {
+    const DISTRO_ORTS: &[&str] = &[
+        "/usr/lib64/libonnxruntime.so",
+        "/usr/lib/libonnxruntime.so",
+        "/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
+    ];
+    DISTRO_ORTS
+        .iter()
+        .chain(irlume_common::PACKAGED_ORT_PATHS.iter())
+        .any(|p| exists(p))
+}
+
 pub fn deps(_args: &[String]) -> ExitCode {
     let mut ok = true;
     let mut check = |label: &str, present: bool, hint: &str| {
@@ -1153,13 +1174,7 @@ pub fn deps(_args: &[String]) -> ExitCode {
     let ort_env = std::env::var("ORT_DYLIB_PATH")
         .ok()
         .filter(|p| std::path::Path::new(p).exists());
-    let ort_sys = [
-        "/usr/lib64/libonnxruntime.so",
-        "/usr/lib/libonnxruntime.so",
-        "/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
-    ]
-    .iter()
-    .any(|p| std::path::Path::new(p).exists());
+    let ort_sys = ort_on_disk(|p| std::path::Path::new(p).exists());
     check(
         "onnxruntime",
         loaded || ort_env.is_some() || ort_sys,
@@ -1714,7 +1729,7 @@ SETUP & STATUS
 
 ENROLLMENT & AUTH
   enroll [--name N] [--scans K] [--reset]   capture a face profile
-  profiles [list|add-scan|rename|delete|eyes-open|challenge <on|off>]   manage profiles
+  profiles [list|add-scan|rename|delete|forget-model|eyes-open|challenge <on|off>]   manage profiles
   identify              1:N \"who is this?\" (all users as root; else scoped to you)
   calibrate-closure [--rounds N] [--force]   teach the eye-closure gesture for app
                         prompts; captures N rounds (default 3) and stores the median
@@ -1754,8 +1769,10 @@ SYSTEM INTEGRATION
                         camera picker runs this for you)
   camera-tune [--rounds N]        measure whether this camera can stream RGB and
                         IR at once without dimming, and store the answer (sudo)
-  models [enable|disable]         opt-in third-party models (liveness cue, replacement recognizer): measured,
-                        checksum-pinned, deny-only; fetched, never shipped
+  models [list|add|enable|disable [name]]   opt-in third-party models, measured
+                        and checksum-pinned. A PAD entry is a deny-only liveness
+                        cue; a recognition entry REPLACES the RGB matcher at its
+                        measured threshold. Fetched or user-supplied, never shipped
   biopolicy <on|off|status>       opt-in operation-class gate: restrict which
                         services a face may satisfy (advanced; password unaffected)
   credential-release-challenge <on|off|status>
@@ -1769,7 +1786,8 @@ SYSTEM INTEGRATION
   version                         print the installed irlume version
 
 MACHINE-READABLE OUTPUT (for desktop integrations; see docs/INTEGRATION.md)
-  --json                on version, status, doctor, profiles list, login status:
+  --json                on version, status, doctor, profiles list, models list,
+                        login status, login plan/verify, auth test --events=jsonl:
                         one line of JSON on stdout, stable check ids and error
                         codes, nothing else printed
   --contract N          declare the contract version you implement; omitted
@@ -1784,6 +1802,30 @@ MACHINE-READABLE OUTPUT (for desktop integrations; see docs/INTEGRATION.md)
 
 #[cfg(test)]
 mod origin_tests {
+    use super::ort_on_disk;
+
+    /// A packaged install puts onnxruntime somewhere no distro path covers and
+    /// exports ORT_DYLIB_PATH to the daemon only, so with irlumed stopped `deps`
+    /// used to print "install onnxruntime" on a machine that already had it.
+    /// That is the exact moment a user runs `deps`, so the advice has to be right.
+    #[test]
+    fn deps_finds_onnxruntime_where_the_packages_put_it() {
+        for packaged in irlume_common::PACKAGED_ORT_PATHS {
+            assert!(
+                ort_on_disk(|p| p == *packaged),
+                "a package-installed runtime at {packaged} must count as present"
+            );
+        }
+        assert!(
+            ort_on_disk(|p| p == "/usr/lib64/libonnxruntime.so"),
+            "a distro-installed runtime must still count"
+        );
+        assert!(
+            !ort_on_disk(|_| false),
+            "nothing on disk anywhere is still absent"
+        );
+    }
+
     use super::{
         arch_names, gz_lists_irlume, installed_version_via, is_copr_repo, latest_release_via,
         ppa_serves_via, ubuntu_codename, version_gt, InstallOrigin,

--- a/crates/irlume-cli/src/logs.rs
+++ b/crates/irlume-cli/src/logs.rs
@@ -87,7 +87,10 @@ fn view(opts: &[String]) -> ExitCode {
         Ok(a) => a,
         Err(msg) => {
             eprintln!("{msg}");
-            return ExitCode::FAILURE;
+            // A bad option is a usage error (2), not a runtime failure (1);
+            // every other command in the CLI answers 2 here and a wrapper that
+            // branches on the code was told the journal read had failed.
+            return ExitCode::from(2);
         }
     };
     let mut cmd = Command::new(&argv[0]);

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -2062,27 +2062,44 @@ fn profiles_data(
     let profiles = profiles
         .into_iter()
         .map(|profile| {
-            json!({
+            // Per-recognizer counts, and which recognizer is loaded, so a
+            // consumer can say which templates are live right now (#288).
+            // A profile can hold several recognizers' templates, and only
+            // the loaded one's can match; "scans" alone cannot say that.
+            //
+            // A daemon older than 0.9.0 never sends the counts, and they arrive
+            // as an empty map. Rendering that as `"recognizers": []` next to ten
+            // scans claims no recognizer can match this profile, which is the
+            // "unknown is not zero" mistake this file's own contract forbids and
+            // would invite a consumer to prompt for re-enrollment. A 0.9.0
+            // daemon always populates the map for a profile that has scans
+            // (untagged ones count under the legacy space), so empty-with-scans
+            // means only that nobody told us: omit the key instead.
+            let live = profile.live_recognizer.clone();
+            let recognizers = (!profile.scans_by_recognizer.is_empty() || profile.scans.is_empty())
+                .then(|| {
+                    profile
+                        .scans_by_recognizer
+                        .iter()
+                        .map(|(space, count)| {
+                            json!({
+                                "space": space,
+                                "scans": count,
+                                "live": live.as_deref() == Some(space.as_str()),
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                });
+            let mut obj = json!({
                 "display_name": profile.name,
                 "scans": profile.scans.into_iter().map(|name| {
                     json!({ "display_name": name })
                 }).collect::<Vec<_>>(),
-                // Per-recognizer counts, and which recognizer is loaded, so a
-                // consumer can say which templates are live right now (#288).
-                // A profile can hold several recognizers' templates, and only
-                // the loaded one's can match; "scans" alone cannot say that.
-                "recognizers": profile
-                    .scans_by_recognizer
-                    .into_iter()
-                    .map(|(space, count)| {
-                        json!({
-                            "space": space,
-                            "scans": count,
-                            "live": profile.live_recognizer.as_deref() == Some(space.as_str()),
-                        })
-                    })
-                    .collect::<Vec<_>>()
-            })
+            });
+            if let Some(recognizers) = recognizers {
+                obj["recognizers"] = json!(recognizers);
+            }
+            obj
         })
         .collect::<Vec<_>>();
     json!({
@@ -2198,6 +2215,52 @@ mod tests {
         assert!(document.get("error").is_none());
     }
 
+    /// A daemon older than 0.9.0 does not send per-recognizer counts, so they
+    /// deserialize to an empty map. Emitting `"recognizers": []` beside ten
+    /// scans asserts that no recognizer can match this profile, which is false
+    /// and would invite a consumer to prompt for re-enrollment. This is the
+    /// upgrade window: a 0.9.0 CLI against a running 0.8.1 daemon, which is
+    /// exactly what a user sees between `dnf upgrade` and the daemon restart.
+    #[test]
+    fn an_old_daemons_missing_recognizer_counts_are_absent_not_empty() {
+        let data = profiles_data(
+            vec![ProfileSummary {
+                name: "BEN".into(),
+                scans: vec!["s1".into(), "s2".into()],
+                scans_by_recognizer: Default::default(),
+                live_recognizer: None,
+            }],
+            false,
+            false,
+        );
+        let profile = &data["profiles"][0];
+        assert_eq!(profile["scans"].as_array().unwrap().len(), 2);
+        assert!(
+            profile.get("recognizers").is_none(),
+            "unknown counts must be ABSENT, not an empty array: {profile}"
+        );
+
+        // A profile that genuinely has no scans is not the unknown case, and
+        // an empty list there is the honest answer.
+        let empty = profiles_data(
+            vec![ProfileSummary {
+                name: "Fresh".into(),
+                scans: vec![],
+                scans_by_recognizer: Default::default(),
+                live_recognizer: None,
+            }],
+            false,
+            false,
+        );
+        assert_eq!(
+            empty["profiles"][0]["recognizers"]
+                .as_array()
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+
     #[test]
     fn profiles_report_each_recognizer_and_mark_only_the_loaded_one_live() {
         // #288: a profile can hold several recognizers' templates and only
@@ -2249,10 +2312,15 @@ mod tests {
         assert!(old_wire.scans_by_recognizer.is_empty());
         assert!(old_wire.live_recognizer.is_none());
         let data = profiles_data(vec![old_wire], false, false);
-        assert!(data["profiles"][0]["recognizers"]
-            .as_array()
-            .unwrap()
-            .is_empty());
+        // This used to assert an empty ARRAY. It now asserts the key is absent:
+        // an empty array beside a populated `scans` list says "no recognizer has
+        // templates in this profile", which is a definite claim the CLI cannot
+        // support and which would send a consumer to re-enroll a working
+        // profile. Absent means unknown, which is what an older daemon leaves us
+        // with. The wire-decode half of this test is unchanged and is the point:
+        // decoding from real JSON rather than a struct literal is what keeps it
+        // honest if the serde defaults are ever removed (#291 review).
+        assert!(data["profiles"][0].get("recognizers").is_none());
     }
 
     #[test]

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -427,7 +427,7 @@ pub fn status(args: &[String]) -> ExitCode {
     // has always paired the capability probe with an existence check; this now
     // agrees with it.
     let caps = crate::caps();
-    let (rgb, ir) = irlume_camera::select_pair();
+    let (rgb, ir) = crate::camera_pair();
     let camera = json!({
         "rgb": caps.rgb && std::path::Path::new(&rgb).exists(),
         "ir": caps.ir_pair && std::path::Path::new(&ir).exists(),

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -398,10 +398,19 @@ pub fn status(args: &[String]) -> ExitCode {
         Ok(Response::RecoveryStatus {
             encrypted,
             recovery_set,
+            key_present,
             ..
         }) => (
+            // `templates` stays the documented STRING with its two values, so a
+            // contract 1 consumer is unaffected. The orphaned case rides along
+            // on `recovery.key_present`, an ADDED field, which contract 1
+            // permits; a new enum value in `templates` would not be.
             json!(if encrypted { "encrypted" } else { "plaintext" }),
-            json!({ "known": true, "passphrase_set": recovery_set }),
+            json!({
+                "known": true,
+                "passphrase_set": recovery_set,
+                "key_present": key_present,
+            }),
         ),
         _ => (json!("unknown"), json!({ "known": false })),
     };

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3899,15 +3899,16 @@ fn doctor_run(
         Ok(irlume_common::Response::RecoveryStatus {
             encrypted,
             recovery_set,
+            key_present,
             ..
         }) => {
             dout!(
                 report,
                 "[doctor] templates ({user}): {} · recovery passphrase {}",
-                if encrypted {
-                    "ENCRYPTED ✓"
-                } else {
-                    "plaintext at rest"
+                match (encrypted, key_present) {
+                    (true, true) => "ENCRYPTED ✓",
+                    (true, false) => "ENCRYPTED but the TEMPLATE KEY IS MISSING (unreadable)",
+                    (false, _) => "plaintext at rest",
                 },
                 if recovery_set {
                     "SET ✓"

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1534,13 +1534,40 @@ pub(crate) fn user_arg(args: &[String]) -> String {
 /// (the TUI) refresh from Health on their own poll rather than from here.
 pub(crate) fn caps() -> irlume_camera::Caps {
     static CAPS: std::sync::OnceLock<irlume_camera::Caps> = std::sync::OnceLock::new();
-    *CAPS.get_or_init(|| match daemon_poll(&irlume_common::Request::Health) {
-        Ok(irlume_common::Response::Health { tier, rgb_dev, .. }) => irlume_camera::Caps {
-            ir_pair: tier == "secure",
-            rgb: rgb_dev.is_some() || tier == "secure",
-        },
-        _ => irlume_camera::capabilities(), // the one permitted probe
+    *CAPS.get_or_init(|| {
+        match irlume_common::client::request_poll(&irlume_common::Request::Health) {
+            Ok(irlume_common::Response::Health { tier, rgb_dev, .. }) => irlume_camera::Caps {
+                ir_pair: tier == "secure",
+                rgb: rgb_dev.is_some() || tier == "secure",
+            },
+            // Enumerating opens every node, so it needs POSITIVE evidence that no
+            // daemon holds them. Only a failure that proves nobody is listening is
+            // that evidence; a timeout is what a daemon busy mid-capture looks
+            // like, which is the worst moment to probe.
+            Err(e) if daemon_proven_absent(&e) => irlume_camera::capabilities(), // the one permitted probe
+            // Ambiguous: answer from the configured pair's mere existence, which
+            // never opens anything, and assume the shipped shape when there is no
+            // configuration to read.
+            _ => match irlume_camera::configured_pair_no_probe() {
+                Some((rgb, ir)) => irlume_camera::Caps {
+                    ir_pair: std::path::Path::new(&ir).exists(),
+                    rgb: std::path::Path::new(&rgb).exists(),
+                },
+                None => irlume_camera::Caps {
+                    ir_pair: false,
+                    rgb: false,
+                },
+            },
+        }
     })
+}
+
+/// These two accessors call `request_poll` directly rather than `daemon_poll`,
+/// because `daemon_poll` flattens `io::Error` into a String for its callers'
+/// messages and the error KIND is exactly what decides whether probing the
+/// cameras is safe here.
+fn daemon_proven_absent(e: &std::io::Error) -> bool {
+    irlume_common::client::proves_daemon_absent(e)
 }
 
 /// The RGB and IR node paths in use, asked of the DAEMON first and cached for
@@ -1558,14 +1585,19 @@ pub(crate) fn caps() -> irlume_camera::Caps {
 /// else holds the cameras and it is the only source of an answer.
 pub(crate) fn camera_pair() -> (String, String) {
     static PAIR: std::sync::OnceLock<(String, String)> = std::sync::OnceLock::new();
-    PAIR.get_or_init(|| match daemon_poll(&irlume_common::Request::Health) {
-        Ok(irlume_common::Response::Health {
-            rgb_dev, ir_dev, ..
-        }) => (
-            rgb_dev.unwrap_or_else(|| "none".into()),
-            ir_dev.unwrap_or_else(|| "none".into()),
-        ),
-        _ => irlume_camera::select_pair(), // the one permitted probe
+    PAIR.get_or_init(|| {
+        match irlume_common::client::request_poll(&irlume_common::Request::Health) {
+            Ok(irlume_common::Response::Health {
+                rgb_dev, ir_dev, ..
+            }) => (
+                rgb_dev.unwrap_or_else(|| "none".into()),
+                ir_dev.unwrap_or_else(|| "none".into()),
+            ),
+            // Same rule as `caps`: probe only on proven absence.
+            Err(e) if daemon_proven_absent(&e) => irlume_camera::select_pair(), // the one permitted probe
+            _ => irlume_camera::configured_pair_no_probe()
+                .unwrap_or_else(|| ("unknown".into(), "unknown".into())),
+        }
     })
     .clone()
 }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1543,6 +1543,33 @@ pub(crate) fn caps() -> irlume_camera::Caps {
     })
 }
 
+/// The RGB and IR node paths in use, asked of the DAEMON first and cached for
+/// the process.
+///
+/// The sibling of [`caps`], and for the same reason: `select_pair` classifies
+/// nodes by OPENING them, so calling it while the daemon streams is a second
+/// opener racing it, which is EBUSY on strict UVC modules (#187). #300 fixed
+/// the TUI; `status`, `status --json`, and `setup` were still enumerating,
+/// measured with strace as four opens of /dev/video0..3 each with the daemon
+/// running. `setup` was the worst: it probed in preflight and enrolled seconds
+/// later on the nodes it had just touched.
+///
+/// The local probe survives only as the daemon-silent fallback, where nothing
+/// else holds the cameras and it is the only source of an answer.
+pub(crate) fn camera_pair() -> (String, String) {
+    static PAIR: std::sync::OnceLock<(String, String)> = std::sync::OnceLock::new();
+    PAIR.get_or_init(|| match daemon_poll(&irlume_common::Request::Health) {
+        Ok(irlume_common::Response::Health {
+            rgb_dev, ir_dev, ..
+        }) => (
+            rgb_dev.unwrap_or_else(|| "none".into()),
+            ir_dev.unwrap_or_else(|| "none".into()),
+        ),
+        _ => irlume_camera::select_pair(), // the one permitted probe
+    })
+    .clone()
+}
+
 pub(crate) fn is_root() -> bool {
     unsafe { libc::geteuid() == 0 }
 }
@@ -1629,6 +1656,8 @@ pub(crate) fn engine(
 ) -> irlume_common::Result<irlume_auth::Engine> {
     let e = irlume_auth::Engine::load(det, model)?;
     let e = match devices_from_flags(flag(args, "--rgb"), flag(args, "--ir"), || {
+        // deliberate camera probe: this engine is about to OPEN the node it
+        // resolves, so resolving it is the first step of using it.
         irlume_camera::select_pair()
     }) {
         Some((r, i)) => e.with_devices(&r, &i),
@@ -3710,6 +3739,9 @@ fn doctor_run(
 
     // --- stream vs the Windows Hello minimums (#223) -----------------------
     {
+        // deliberate camera probe: doctor's job is to inspect the hardware,
+        // and negotiating a stream format needs the node open. Foreground and
+        // occasional, not a refresh loop, so it is not the #187 shape.
         let (rgb_node, ir_node) = irlume_camera::select_pair();
         stream_minimum_checks(report, &rgb_node, &ir_node);
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -9,7 +9,7 @@
 //! guided setup. Developer/benchmark tools are gated behind `IRLUME_DEV=1`.
 //! A selection of the main subcommands:
 //!   irlume tui                                   guided setup + live dashboard
-//!   irlume enroll [--user U] [--profile NAME]   register a face profile
+//!   irlume enroll [--user U] [--name NAME] [--scans N]  register a face profile
 //!   irlume identify                              1:N "who is this?"
 //!   irlume doctor                                check cameras/IR/TPM/models
 //!   irlume keyring <arm|status|forget>           TPM-sealed keyring/wallet unlock
@@ -19,7 +19,6 @@
 //!   irlume fingerprint <status|add|verify|reset|enable|disable> fprintd companion (face OR fingerprint)
 //!   irlume login <status|enable|disable|reconcile> wire face auth into PAM (+--with-polkit for apps)
 //!   irlume logs [-f] [debug on|off]              face-auth journal view + tracing switch
-//!   irlume tui                                   interactive setup/management UI
 
 mod bitwarden;
 mod blinkcap;
@@ -210,6 +209,25 @@ fn main() -> std::process::ExitCode {
     }
 }
 
+/// Parse `--scans N` for a command that captures biometrics. A state-changing
+/// biometric command must not silently substitute a different operation: an
+/// unparseable or zero count is a usage error, not "capture the default". This
+/// lives in one place because `enroll` was written without the check that
+/// `profiles add-scan` documents, so `enroll --scans abc` fired a real capture
+/// at the default count. `Ok(None)` means the flag was absent.
+fn scans_flag(args: &[String], tool: &str) -> Result<Option<usize>, std::process::ExitCode> {
+    match flag(args, "--scans") {
+        None => Ok(None),
+        Some(raw) => match raw.parse::<usize>() {
+            Ok(n) if n > 0 => Ok(Some(n)),
+            _ => {
+                eprintln!("[{tool}] --scans must be a positive integer");
+                Err(std::process::ExitCode::from(2))
+            }
+        },
+    }
+}
+
 /// `irlume enroll --user U [--name "..."]`: enroll a NEW face profile (captures
 /// the default number of scans) via the daemon, which owns the camera. Default
 /// profile name is "Face Profile N".
@@ -217,7 +235,10 @@ fn enroll(args: &[String]) -> std::process::ExitCode {
     use irlume_common::{Request, Response};
     let user = user_arg(args);
     let name = flag(args, "--name").map(String::from);
-    let scans = flag(args, "--scans").and_then(|s| s.parse::<usize>().ok());
+    let scans = match scans_flag(args, "enroll") {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
     let reset = args.iter().any(|a| a == "--reset");
     if reset {
         eprintln!("[enroll] --reset: wiping '{user}'s existing enrollment first (clears any stale camera binding)");
@@ -347,18 +368,9 @@ fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
         },
         Some("add-scan") => match flag(args, "--profile") {
             Some(p) => {
-                // A state-changing biometric command must not silently
-                // substitute a different operation: an unparseable or zero
-                // count is a usage error, not "capture one".
-                let scans = match flag(args, "--scans") {
-                    None => None,
-                    Some(raw) => match raw.parse::<usize>() {
-                        Ok(n) if n > 0 => Some(n),
-                        _ => {
-                            eprintln!("[profiles] --scans must be a positive integer");
-                            return std::process::ExitCode::from(2);
-                        }
-                    },
+                let scans = match scans_flag(args, "profiles") {
+                    Ok(s) => s,
+                    Err(code) => return code,
                 };
                 match scans {
                     Some(n) if n > 1 => eprintln!(
@@ -3766,10 +3778,25 @@ fn doctor_run(
         dout!(report, "  {}: {line}", s.stage);
         report.check_detail(id, state, line);
     }
-    dout!(
-        report,
-        "  (third-party models: the pad stage only today, #276; `irlume models` lists them)"
-    );
+    // Derived from the catalog, never spelled out: this line said "the pad stage
+    // only today" through the release that opened recognition, so doctor denied a
+    // feature the same binary shipped.
+    {
+        let open: Vec<&str> = irlume_common::thirdparty::Stage::ALL
+            .iter()
+            .filter(|st| st.open())
+            .map(|st| st.as_str())
+            .collect();
+        dout!(
+            report,
+            "  (third-party models accepted for: {}; #276. `irlume models` lists them)",
+            if open.is_empty() {
+                "no stage".to_string()
+            } else {
+                open.join(", ")
+            }
+        );
+    }
     dout!(
         report,
         "[doctor] third-party PAD model: {}",

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -165,6 +165,15 @@ fn main() -> std::process::ExitCode {
         {
             machine::models_list(&args)
         }
+        // Refuse rather than ignore: `models --json` reached the human renderer
+        // and printed prose, so a script that asked for JSON silently got
+        // something it could not parse. The capability is `models list --json`.
+        (Some("models"), _) if args.iter().any(|a| a == "--json") => {
+            eprintln!(
+                "[models] --json is available on `models list`; try: irlume models list --json"
+            );
+            std::process::ExitCode::from(2)
+        }
         (Some("models"), sub) => models::run(sub, &args),
         (Some("biopolicy"), sub) => commands::biopolicy(sub, &args),
         (Some("credential-release-challenge"), sub) => {
@@ -695,7 +704,9 @@ fn calibrate_closure(args: &[String]) -> std::process::ExitCode {
             Ok(n) if (1..=10).contains(&n) => n,
             _ => {
                 eprintln!("[calibrate] --rounds takes a number from 1 to 10 (got {v:?})");
-                return std::process::ExitCode::FAILURE;
+                // Usage error, not a runtime failure; the refusal itself was
+                // already right, only the code disagreed with every sibling.
+                return std::process::ExitCode::from(2);
             }
         },
     };
@@ -973,7 +984,19 @@ fn ir_setup(args: &[String]) -> std::process::ExitCode {
 /// measurement on the camera in front of the user can tell the two apart.
 fn camera_tune(args: &[String]) -> std::process::ExitCode {
     use irlume_common::Request;
-    let rounds = flag(args, "--rounds").and_then(|v| v.parse::<usize>().ok());
+    // Same rule as `enroll --scans`: this command fires the IR emitter for up to
+    // a minute, so an unparseable count is a usage error rather than a silent
+    // substitution of the default round count.
+    let rounds = match flag(args, "--rounds") {
+        None => None,
+        Some(raw) => match raw.parse::<usize>() {
+            Ok(n) if n > 0 => Some(n),
+            _ => {
+                eprintln!("[camera-tune] --rounds must be a positive integer");
+                return std::process::ExitCode::from(2);
+            }
+        },
+    };
     eprintln!(
         "[camera-tune] measuring this camera under load; it fires the IR emitter \
          for up to a minute…"

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -419,18 +419,31 @@ fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
                 None => return usage_profiles(),
             }
         }
-        Some("delete") => match (flag(args, "--profile"), flag(args, "--scan")) {
-            (Some(p), Some(s)) => Request::DeleteScan {
-                user,
-                profile: p.into(),
-                scan: s.into(),
-            },
-            (Some(p), None) => Request::DeleteProfile {
-                user,
-                profile: p.into(),
-            },
-            _ => return usage_profiles(),
-        },
+        Some("delete") => {
+            // A `--scan` with no value must not widen the deletion from one
+            // scan to the whole profile. `flag` cannot tell "absent" from
+            // "present with nothing after it", and the arms below read absence
+            // as "the user meant the profile", so `profiles delete --profile P
+            // --scan` put `DeleteProfile` on the wire from a command whose
+            // visible intent was a single scan. Same shape as the dangling
+            // `--user` this file resolves above.
+            if args.iter().any(|a| a == "--scan") && flag(args, "--scan").is_none() {
+                eprintln!("[profiles] --scan requires a scan name");
+                return std::process::ExitCode::from(2);
+            }
+            match (flag(args, "--profile"), flag(args, "--scan")) {
+                (Some(p), Some(s)) => Request::DeleteScan {
+                    user,
+                    profile: p.into(),
+                    scan: s.into(),
+                },
+                (Some(p), None) => Request::DeleteProfile {
+                    user,
+                    profile: p.into(),
+                },
+                _ => return usage_profiles(),
+            }
+        }
         Some("rename") => match (
             flag(args, "--profile"),
             flag(args, "--scan"),
@@ -1502,6 +1515,27 @@ fn toggle_value(args: &[String], sub: &str) -> Option<bool> {
 }
 
 pub(crate) fn user_arg(args: &[String]) -> String {
+    // A `--user` with nothing after it is a usage error, never a request to
+    // operate on whoever is invoking.
+    //
+    // `flag` answers None both for "absent" and for "present with no value", so
+    // a trailing `--user` fell through to the SUDO_USER default and silently
+    // retargeted the command at the person typing it. On the destructive verbs
+    // that is total, unconfirmed data loss: `sudo irlume enroll --reset --user`
+    // put `{"Enroll":{"user":"<you>","reset":true}}` on the wire, and the
+    // daemon's reset deletes the enrollment, the template key, and the recovery
+    // envelope together. `recovery forget --user` and `keyring forget --user`
+    // did the same.
+    //
+    // The guard existed, but only inside `profiles`, so it covered one of the
+    // four. It belongs here, where all 24 callers share it: this is a resolver,
+    // and the one thing a resolver must not do is quietly resolve to the wrong
+    // subject. Exiting rather than returning an error keeps every caller's
+    // signature, and there is no sensible way to continue.
+    if args.iter().any(|a| a == "--user") && flag(args, "--user").is_none() {
+        eprintln!("irlume: --user requires a username");
+        std::process::exit(2);
+    }
     flag(args, "--user")
         .map(str::to_string)
         .filter(|s| !s.is_empty())

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -129,6 +129,22 @@ fn enabled_name_for(key: &str) -> Option<String> {
     irlume_common::config::read_kv("settings.conf", key)
 }
 
+/// Whether this process can read settings.conf at all.
+///
+/// settings.conf is 0600 root-only, so `read_kv` returns None for an
+/// unprivileged caller whether the key is absent or merely unreadable. Rendering
+/// that None as "disabled" told a user whose anti-spoof model IS enabled that
+/// none was, which invites them to re-run enable or to believe the PAD layer is
+/// off. `models list --json` already reports `enabled: {known: false}` here; the
+/// human list has to say the same thing.
+fn enabled_state_readable() -> bool {
+    use irlume_common::config::KvObservation;
+    !matches!(
+        irlume_common::config::observe_kv("settings.conf", thirdparty::SETTINGS_KEY),
+        KvObservation::Unknown(_)
+    )
+}
+
 /// Every (entry, its stage's settings key) currently enabled, across stages.
 fn enabled_entries() -> Vec<(&'static ThirdPartyModel, &'static str)> {
     thirdparty::CATALOG
@@ -204,13 +220,16 @@ fn list() -> ExitCode {
     println!("Nothing is listed here that was not measured on real hardware");
     println!("(docs/pad-results/, docs/recognition-results/, docs/THIRD-PARTY-MODELS.md).");
     println!();
+    let readable = enabled_state_readable();
     for m in thirdparty::CATALOG {
         let enabled_here =
             enabled_name_for(thirdparty::settings_key_for(m.stage)).as_deref() == Some(m.name);
         let state = if enabled_here {
             format!("ENABLED ({})", file_state(m))
-        } else {
+        } else if readable {
             "disabled".into()
+        } else {
+            format!("enabled state unknown, root-only ({})", file_state(m))
         };
         println!("  {}  [{state}]", m.name);
         println!("    license:    {}", m.license);
@@ -239,7 +258,13 @@ fn list() -> ExitCode {
     }
     println!();
     let enabled = enabled_entries();
-    if enabled.is_empty() {
+    if !readable {
+        println!(
+            "cannot read /etc/irlume/settings.conf (root-only), so the enabled \
+             state above is unknown"
+        );
+        println!("for the authoritative answer: sudo irlume models list");
+    } else if enabled.is_empty() {
         println!("none enabled · see the 'obtain' line above for each model");
     } else {
         for (m, _) in &enabled {

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -285,7 +285,8 @@ fn reconcile() -> ExitCode {
         return ExitCode::FAILURE;
     }
     eprintln!("[login] greeter PAM configuration changed; re-applying irlume wiring");
-    act(true, true, with_sudo, with_polkit)
+    // The lock is already held above; taking it again would deadlock.
+    act_holding_lock(true, true, with_sudo, with_polkit)
 }
 
 /// Whether the ACTIVE display manager's own greeter service carries the module.
@@ -1123,6 +1124,19 @@ fn act(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCod
     } else {
         None
     };
+    act_holding_lock(enable, apply, with_sudo, with_polkit)
+}
+
+/// The body of [`act`], for a caller that ALREADY holds the PAM lock.
+///
+/// `flock` is per open file description, so a second `lock_pam()` from the same
+/// process blocks on the first one forever. `reconcile` took the lock, found a
+/// regression, and called `act`, which took it again: the self-heal deadlocked
+/// on exactly the condition it exists to repair, so it had never once worked.
+/// The hung process is root and holds the lock exclusively, so every other
+/// irlume PAM operation blocked behind it too, and the unit's `Type=oneshot`
+/// default of `TimeoutStartUSec=infinity` meant systemd never killed it.
+fn act_holding_lock(enable: bool, apply: bool, with_sudo: bool, with_polkit: bool) -> ExitCode {
     if !apply {
         println!("[login] DRY RUN: showing what `--apply` would change (nothing is written):");
     }
@@ -1629,6 +1643,47 @@ fn effective_uid() -> u32 {
 
 #[cfg(test)]
 mod tests {
+
+    /// `flock` is per open file description, so a second `lock_pam()` from the
+    /// SAME process blocks on the first one forever rather than succeeding.
+    ///
+    /// `reconcile` took the lock, found a regression, and called `act`, which
+    /// took it again: the self-heal deadlocked on exactly the condition it
+    /// exists to repair, so it had never once worked. The hung process is root
+    /// and holds the lock exclusively, so every other irlume PAM operation
+    /// queued behind it, and the unit's `Type=oneshot` default of
+    /// `TimeoutStartUSec=infinity` meant systemd never killed it.
+    ///
+    /// This pins the hazard rather than the call graph, because the call graph
+    /// is what drifts. If `lock_pam` is ever made reentrant this test fails and
+    /// the split in `act`/`act_holding_lock` can be revisited.
+    #[test]
+    fn a_second_pam_lock_in_the_same_process_does_not_succeed() {
+        let dir = std::env::temp_dir().join(format!("irlume-lock-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let lock_path = dir.join("pam.lock");
+        std::env::set_var("IRLUME_PAM_LOCK", &lock_path);
+
+        let first = super::lock_pam().expect("the first lock must be granted");
+
+        // The second attempt runs on a thread so a deadlock cannot hang the
+        // suite: we assert on whether it reports back, not on it returning.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _second = super::lock_pam();
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(2)).is_err(),
+            "a second lock_pam() returned, so re-locking is now safe and the \
+             act/act_holding_lock split should be re-examined"
+        );
+
+        drop(first);
+        std::env::remove_var("IRLUME_PAM_LOCK");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     use super::*;
     // Reached through the submodule because the parent has no production use
     // for it; `use super::*` only carries what the parent itself imports.

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1453,15 +1453,39 @@ fn wire_service(
                 );
             }
             let current = read(s.etc)?;
-            // Rebuild from the pristine stock: the backup if we've wired before,
-            // else the current file, then strip any irlume lines and re-apply.
+            // Rebuild from the CURRENT file with irlume's own lines stripped,
+            // not from the backup.
+            //
+            // Taking the backup as origin discarded every change made to the
+            // stack after irlume first wired it. A distro update that adds
+            // `pam_faillock` lines is the ordinary case, and re-running
+            // `login enable --apply` deleted them: a security control removed
+            // with no mention, from a command whose stated job is to add a
+            // line. The tail risk is worse than that, since a months-old backup
+            // can name a module the system no longer ships, which is a stack
+            // that denies every login.
+            //
+            // Stripping is a complete inverse: `unwire_lines` matches irlume's
+            // module on the PAM directive and its landing lines on irlume's own
+            // comment tags, so it removes what irlume added and nothing else.
+            // The disable path already refuses to restore a backup that no
+            // longer matches the stripped current file, for this same reason.
             let bak = PathBuf::from(format!("{}{BACKUP}", s.etc));
-            let origin = if bak.exists() {
-                read(&bak.to_string_lossy())?
-            } else {
-                current.clone()
-            };
-            let (base, _) = unwire_lines(&origin);
+            let (base, _) = unwire_lines(&current);
+            // Say so when the stack has moved since irlume wired it. Not a
+            // failure: the rebuild above already keeps the change. The operator
+            // should know their backup no longer describes the file.
+            if bak.exists() {
+                if let Ok(bak_content) = read(&bak.to_string_lossy()) {
+                    if bak_content.trim() != base.trim() {
+                        eprintln!(
+                            "[login] note: {} changed since irlume first wired it; keeping \
+                             those changes and re-applying irlume's lines on top",
+                            s.etc
+                        );
+                    }
+                }
+            }
             let (wired, changed) = wire(&base);
             if !changed {
                 return out(
@@ -1643,6 +1667,41 @@ fn effective_uid() -> u32 {
 
 #[cfg(test)]
 mod tests {
+
+    /// Re-wiring rebuilds from the CURRENT file stripped of irlume's lines, not
+    /// from the `.pre-irlume` backup.
+    ///
+    /// Taking the backup as origin discarded every change made to the stack
+    /// after irlume first wired it. A distro update adding `pam_faillock` is the
+    /// ordinary case, and `login enable --apply` then deleted it: a security
+    /// control removed without a word, by a command whose job is to add a line.
+    /// This pins the property the rebuild rests on, that stripping is a complete
+    /// inverse which touches irlume's lines and nothing else.
+    #[test]
+    fn stripping_a_wired_stack_keeps_what_the_distro_added_later() {
+        let stock = "auth       required     pam_env.so\n                     auth       sufficient   pam_unix.so try_first_pass nullok\n";
+        let (wired, changed) = wire_greeter_impl(stock, true, true, false);
+        assert!(changed, "the fixture must actually wire");
+
+        // The distro later adds faillock above and below, as it does on a real
+        // update; irlume never saw these lines and has no backup containing them.
+        let after_update = wired.replace(
+            "auth       required     pam_env.so",
+            "auth       required     pam_faillock.so preauth\n             auth       required     pam_env.so",
+        ) + "account    required     pam_faillock.so\n";
+
+        let (base, _) = super::unwire_lines(&after_update);
+        assert!(
+            base.contains("pam_faillock.so preauth")
+                && base.contains("account    required     pam_faillock.so"),
+            "stripping must keep every line irlume did not add: {base}"
+        );
+        assert!(
+            !base.contains("pam_irlume.so"),
+            "and must remove every line irlume did add: {base}"
+        );
+        assert!(base.contains("pam_unix.so"), "{base}");
+    }
 
     /// `flock` is per open file description, so a second `lock_pam()` from the
     /// SAME process blocks on the first one forever rather than succeeding.

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -182,7 +182,12 @@ pub(crate) fn write_wired_marker(
     // plantable by a non-root user, since reconcile trusts its with_sudo flag.
     // A silent failure would leave self-heal disabled without the user knowing,
     // so warn rather than swallow it.
-    if let Err(e) = irlume_common::write_0600(&path, body.as_bytes()) {
+    // Atomic: a short write here reads back as all-false (see
+    // `read_wired_marker`), which silently drops the sudo, polkit and lock
+    // scopes from the self-heal. Reproduced on a full filesystem, where the
+    // truncating helper left 4096 bytes of a partial marker while the atomic
+    // one left the previous marker intact.
+    if let Err(e) = irlume_common::write_0600_atomic(&path, body.as_bytes()) {
         eprintln!(
             "[login] warning: could not write the self-heal marker {}: {e}\n\
              [login] automatic re-wiring after a distro PAM update will not run.",

--- a/crates/irlume-cli/src/recovery.rs
+++ b/crates/irlume-cli/src/recovery.rs
@@ -33,14 +33,21 @@ fn status(user: &str) -> ExitCode {
             encrypted,
             recovery_set,
             tpm_present,
+            key_present,
         }) => {
             println!("[recovery] '{user}':");
             println!(
                 "  templates encrypted : {}",
-                if encrypted {
-                    "yes ✓ (template key sealed in the TPM)"
-                } else {
-                    "no (plaintext at rest)"
+                match (encrypted, key_present) {
+                    (true, true) => "yes ✓ (template key sealed in the TPM)",
+                    // The one state the old bool could not say. Naming it
+                    // matters more than any other line here: the templates are
+                    // safe from a stolen disk and unreadable by their owner, and
+                    // neither `recovery setup` nor a reseal brings them back.
+                    (true, false) =>
+                        "yes, but the TEMPLATE KEY IS GONE: this enrollment \
+                         cannot be opened. Re-enroll to use face login again.",
+                    (false, _) => "no (plaintext at rest)",
                 }
             );
             println!(

--- a/crates/irlume-cli/src/recovery.rs
+++ b/crates/irlume-cli/src/recovery.rs
@@ -163,7 +163,7 @@ fn forget(user: &str) -> ExitCode {
 /// No-echo passphrase prompt with confirmation (for `setup`); falls back to a
 /// plain stdin line when piped (scripts / tests).
 fn read_passphrase_confirmed() -> Option<String> {
-    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+    let pass = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         let first = rpassword::prompt_password("Recovery passphrase: ").ok()?;
         let mut confirm = rpassword::prompt_password("Confirm recovery passphrase: ").ok()?;
         let matched = first == confirm;
@@ -175,21 +175,29 @@ fn read_passphrase_confirmed() -> Option<String> {
             eprintln!("[recovery] passphrases do not match; aborted (nothing set).");
             return None;
         }
-        // Strength floor: this passphrase is the only barrier on the recovery
-        // envelope against an offline attacker with the disk, so reject a trivial
-        // one (a `1`). It is a recovery key, not a login PIN; length is the cheap,
-        // language-neutral proxy for entropy.
-        if first.chars().count() < MIN_RECOVERY_PASSPHRASE_CHARS {
-            eprintln!(
-                "[recovery] passphrase too short (minimum {MIN_RECOVERY_PASSPHRASE_CHARS} \
-                 characters); aborted (nothing set)."
-            );
-            return None;
-        }
-        Some(first)
+        first
     } else {
-        read_piped_line()
+        // No second read to compare against on a pipe, so confirmation is the one
+        // check that cannot apply here. The strength floor below still does, and
+        // it is checked AFTER this branch on purpose: it used to live inside the
+        // terminal arm, which let `irlume recovery setup </dev/null` wrap the
+        // template key under an EMPTY passphrase and report success.
+        read_piped_line()?
+    };
+    // Strength floor: this passphrase is the only barrier on the recovery
+    // envelope against an offline attacker with the disk, so reject a trivial
+    // one (a `1`). It is a recovery key, not a login PIN; length is the cheap,
+    // language-neutral proxy for entropy.
+    if pass.chars().count() < MIN_RECOVERY_PASSPHRASE_CHARS {
+        let what = if pass.is_empty() {
+            "empty passphrase".to_string()
+        } else {
+            format!("passphrase too short (minimum {MIN_RECOVERY_PASSPHRASE_CHARS} characters)")
+        };
+        eprintln!("[recovery] {what}; aborted (nothing set).");
+        return None;
     }
+    Some(pass)
 }
 
 /// Minimum recovery-passphrase length. A recovery key protects the template-key

--- a/crates/irlume-cli/src/suncal.rs
+++ b/crates/irlume-cli/src/suncal.rs
@@ -97,7 +97,8 @@ pub(crate) fn run(args: &[String]) -> ExitCode {
     // args[0] is the "suncal" subcommand itself.
     let (Some(det_path), Some(dir)) = (args.get(1), args.get(2)) else {
         eprintln!("usage: IRLUME_DEV=1 irlume suncal <det.onnx> <dataset_dir>");
-        return ExitCode::FAILURE;
+        // Usage error, not a runtime failure; every sibling dev tool answers 2.
+        return ExitCode::from(2);
     };
     let mut det = match irlume_vision::Detector::load_from_file(det_path) {
         Ok(d) => d,

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -389,7 +389,9 @@ enum WMsg {
     /// `added_scans` are the scan(s) already appended (undo target on decline).
     MergePrompt {
         profile: String,
-        total: usize,
+        /// Scans the daemon will still accept for this profile in the LOADED
+        /// recognizer's space (#290 made the limit per recognizer).
+        room: usize,
         added_scans: Vec<String>,
     },
 }
@@ -2208,14 +2210,17 @@ impl App {
                     }
                     WMsg::MergePrompt {
                         profile,
-                        total,
+                        room,
                         added_scans,
                     } => {
-                        // The rest of the requested scans, capped at the profile's
-                        // remaining 30-scan budget (scan 1 already merged in).
-                        let remaining = target
-                            .saturating_sub(1)
-                            .min(irlume_core::storage::MAX_SCANS_PER_PROFILE.saturating_sub(total));
+                        // The rest of the requested scans, capped at the room
+                        // the DAEMON reports for the loaded recognizer. It was
+                        // computed here from the profile's total scan count,
+                        // which is wrong since the limit became per-recognizer
+                        // (#290): a profile holding two models' templates
+                        // under-counted and the UI refused scans the daemon
+                        // would have accepted.
+                        let remaining = target.saturating_sub(1).min(room);
                         merge = Some(MergeConfirm {
                             profile,
                             added_scans,
@@ -5824,13 +5829,13 @@ fn enroll_worker(
                 Ok(Response::Enrolled {
                     created: false,
                     profile: resolved,
-                    total,
+                    room,
                     added_scans,
                     ..
                 }) => {
                     let _ = send(WMsg::MergePrompt {
                         profile: resolved,
-                        total,
+                        room,
                         added_scans,
                     });
                     return;
@@ -7812,10 +7817,11 @@ mod tests {
         let mut app = test_app();
         let (tx, enroll) = fake_enroll(0, ENROLL_SCANS);
         app.enroll = Some(enroll);
-        // 28 of 30 scans already on the profile: only 2 more fit the budget.
+        // Two slots left for the loaded recognizer, so the modal offers 2 even
+        // though the requested target is larger.
         tx.send(WMsg::MergePrompt {
             profile: "Alice".into(),
-            total: 28,
+            room: 2,
             added_scans: vec!["scan28".into()],
         })
         .unwrap();
@@ -7823,17 +7829,14 @@ mod tests {
         assert!(app.enroll.is_none(), "the worker hands off to the modal");
         let mc = app.enroll_merge.as_ref().expect("the merge modal is up");
         assert_eq!(mc.profile, "Alice");
-        assert_eq!(
-            mc.remaining, 2,
-            "remaining = min(target-1, 30-scan budget left)"
-        );
+        assert_eq!(mc.remaining, 2, "remaining = min(target-1, room)");
         // Below the budget the requested count minus the merged scan survives.
         let (tx, enroll) = fake_enroll(0, ENROLL_SCANS);
         app.enroll = Some(enroll);
         app.enroll_merge = None;
         tx.send(WMsg::MergePrompt {
             profile: "Alice".into(),
-            total: 5,
+            room: 25,
             added_scans: vec!["scan5".into()],
         })
         .unwrap();
@@ -7841,6 +7844,34 @@ mod tests {
         assert_eq!(
             app.enroll_merge.as_ref().unwrap().remaining,
             ENROLL_SCANS - 1
+        );
+    }
+
+    /// The mixed-recognizer state this release creates: a profile can hold more
+    /// than MAX_SCANS_PER_PROFILE scans in total across recognizers while the
+    /// loaded one still has room. Deriving remaining from `total` computed 0
+    /// here, so the user asked for ten scans, got the one merged scan, and the
+    /// new recognizer was left under-enrolled with no message saying so. The
+    /// daemon counts per recognizer and sends the answer; the TUI uses it.
+    #[test]
+    fn merge_remaining_follows_the_daemons_room_not_the_profile_total() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        let (tx, enroll) = fake_enroll(0, ENROLL_SCANS);
+        app.enroll = Some(enroll);
+        tx.send(WMsg::MergePrompt {
+            profile: "Alice".into(),
+            // The profile holds more than MAX_SCANS_PER_PROFILE across both
+            // recognizers, yet the loaded one still has most of its own budget.
+            room: 25,
+            added_scans: vec!["scan1".into()],
+        })
+        .unwrap();
+        app.poll();
+        assert_eq!(
+            app.enroll_merge.as_ref().expect("modal is up").remaining,
+            ENROLL_SCANS - 1,
+            "a full profile-wide count must not zero out a recognizer with room"
         );
     }
 

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -374,6 +374,10 @@ struct RecoveryInfo {
     encrypted: bool,
     recovery_set: bool,
     tpm_present: bool,
+    /// Whether the key that opens an encrypted store still exists. Encrypted
+    /// with no key means the enrollment cannot be opened by anything, which
+    /// `encrypted` alone cannot say.
+    key_present: bool,
 }
 
 /// Messages streamed from the guided-enroll worker to the UI.
@@ -797,6 +801,7 @@ impl LightState {
         }) {
             out.recovery = Some(RecoveryInfo {
                 encrypted,
+                key_present,
                 recovery_set,
                 tpm_present,
             });
@@ -4478,9 +4483,16 @@ impl App {
         // on a TPM machine, one Tab away from the Keyring tab saying "TPM
         // ● present"; a failed read establishes nothing (docs/MACHINE-API.md).
         let enc = match self.recovery {
-            Some(r) if r.encrypted => Span::styled(
+            Some(r) if r.encrypted && r.key_present => Span::styled(
                 "● encrypted",
                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+            ),
+            // Encrypted with the key gone: safe from a stolen disk and
+            // unreadable by its owner. Neither a reseal nor a recovery
+            // passphrase brings it back, so say re-enroll and say it loudly.
+            Some(r) if r.encrypted => Span::styled(
+                "✗ encrypted, TEMPLATE KEY MISSING (re-enroll)",
+                Style::new().fg(th().err).add_modifier(Modifier::BOLD),
             ),
             Some(_) => Span::styled("○ plaintext at rest", Style::new().dim()),
             None => Span::styled("◐ unknown (daemon unreachable)", Style::new().fg(th().warn)),
@@ -8558,6 +8570,7 @@ mod tests {
         // No TPM: plaintext + the recovery-N/A line.
         app.recovery = Some(RecoveryInfo {
             encrypted: false,
+            key_present: false,
             recovery_set: false,
             tpm_present: false,
         });
@@ -8567,6 +8580,7 @@ mod tests {
         // Encrypted without a backstop: the warning line.
         app.recovery = Some(RecoveryInfo {
             encrypted: true,
+            key_present: true,
             recovery_set: false,
             tpm_present: true,
         });
@@ -8577,6 +8591,7 @@ mod tests {
         // Fully set: both badges green, no warning.
         app.recovery = Some(RecoveryInfo {
             encrypted: true,
+            key_present: true,
             recovery_set: true,
             tpm_present: true,
         });
@@ -9348,6 +9363,30 @@ mod tests {
         assert!(
             row_with(&text, "recovery pass").contains("◐ unknown"),
             "{text}"
+        );
+    }
+
+    /// The store is encrypted and its key is gone, which is what a lost
+    /// template key looks like from the panel. Rendering that as "encrypted"
+    /// hides that the enrollment can no longer be opened by anything.
+    #[test]
+    fn recovery_screen_names_an_encrypted_store_whose_key_is_gone() {
+        let mut app = test_app();
+        app.screen = SC_RECOVERY;
+        app.recovery = Some(RecoveryInfo {
+            encrypted: true,
+            key_present: false,
+            recovery_set: false,
+            tpm_present: true,
+        });
+        let text = draw_text(&app);
+        assert!(
+            text.contains("TEMPLATE KEY MISSING"),
+            "an orphaned store must be named, not shown as healthy: {text}"
+        );
+        assert!(
+            !text.contains("● encrypted"),
+            "it must not read as a clean encrypted state: {text}"
         );
     }
 

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -1275,7 +1275,12 @@ impl App {
             if up {
                 "running, socket reachable".into()
             } else {
-                "not reachable on /run/irlume.sock".into()
+                // Name the socket the ping actually used: with IRLUME_SOCKET
+                // set, "/run/irlume.sock" described a path nobody probed.
+                format!(
+                    "not reachable on {}",
+                    irlume_common::client::socket_path().display()
+                )
             },
             if up {
                 Fix::None
@@ -1340,23 +1345,10 @@ impl App {
                 .ok()
                 .filter(|p| std::path::Path::new(p).exists())
                 .is_some()
-                || ["/usr/lib64/libonnxruntime.so", "/usr/lib/libonnxruntime.so"]
+                || ORT_FALLBACK_PATHS
                     .iter()
                     .any(|p| std::path::Path::new(p).exists());
-            v.push(mk(
-                "ONNX Runtime",
-                if ort { Sev::Ok } else { Sev::Fail },
-                if ort {
-                    "library found".into()
-                } else {
-                    "libonnxruntime.so not found (daemon down; local probe)".into()
-                },
-                if ort {
-                    Fix::None
-                } else {
-                    Fix::Manual("install onnxruntime or set ORT_DYLIB_PATH".into())
-                },
-            ));
+            v.push(ort_fallback_check(ort));
 
             // Resolve models the way the daemon does (env → /usr/share/irlume/models
             // → repo cwd), NOT just cwd-relative; a packaged install keeps them in
@@ -1474,6 +1466,17 @@ impl App {
                 "Enrollment",
                 Sev::Ok,
                 "loading profiles…".into(),
+                Fix::None,
+            ));
+        } else if !self.profiles_loaded {
+            // No ListProfiles has ever landed (the daemon was down before the
+            // first answer). "no face enrolled yet" here sent users with a
+            // working encrypted enrollment to [e], overwriting good data; an
+            // unanswered question renders as unknown, never as a negative.
+            v.push(mk(
+                "Enrollment",
+                Sev::Warn,
+                "unknown (profile list not read yet)".into(),
                 Fix::None,
             ));
         } else {
@@ -1608,25 +1611,27 @@ impl App {
                 // line. Surface it so the user isn't left typing the keyring
                 // password after every fingerprint login.
                 if fprintd_wired && !self.fp.enrolled.is_empty() && self.probes.tpm_present {
-                    let armed = self.keyring_armed.unwrap_or(false);
                     // DM-aware: the keyring line must be in EVERY login service
                     // the active DM uses (GDM: gdm-password AND gdm-fingerprint).
                     let wired = self.probes.fp_keyring_wired;
-                    if !armed {
+                    // None = the daemon never answered; neither "arm it" nor
+                    // "all good" is supportable, so no row at all (the Daemon
+                    // row above already carries the failure).
+                    if self.keyring_armed == Some(false) {
                         v.push(mk(
                             "FP keyring unlock",
                             Sev::Warn,
                             "wallet won't auto-unlock on fingerprint login; arm the keyring".into(),
                             Fix::Manual("Keyring tab → [a] arm (seal your login password)".into()),
                         ));
-                    } else if !wired {
+                    } else if self.keyring_armed == Some(true) && !wired {
                         v.push(mk(
                             "FP keyring unlock",
                             Sev::Warn,
                             "keyring armed but the login stack lacks the unlock line".into(),
                             Fix::Root(RootFix::LoginEnable),
                         ));
-                    } else {
+                    } else if self.keyring_armed == Some(true) {
                         v.push(mk(
                             "FP keyring unlock",
                             Sev::Ok,
@@ -3890,9 +3895,20 @@ impl App {
             // saying "no profiles" would tell an enrolled user their face is
             // gone every time they open this tab.
             let msg = if self.profiles_load.is_some() {
-                "\nLoading profiles… (decrypting the enrollment under the TPM key)"
+                "\nLoading profiles… (decrypting the enrollment under the TPM key)".to_string()
+            } else if let Some(err) = &self.enroll_error {
+                // The load FAILED (daemon up, enrollment unreadable). The [e]
+                // prompt here invited overwriting an enrollment that exists;
+                // Repair carries the recovery guidance.
+                format!("\nProfile list unreadable: {err}\n\nDo not re-enroll over it; see the Repair tab first.")
+            } else if !self.profiles_loaded {
+                // Never answered (daemon unreachable): the enrollment may
+                // exist and be fine, so no "none" and no enroll prompt.
+                "\nProfile list not read yet: irlumed is not reachable, so nothing is known about your enrollment.\n\nStart the daemon (Repair tab) and this list loads by itself."
+                    .to_string()
             } else {
                 "\nNo face profiles yet.\n\nPress [e] to enroll; irlume will guide your framing and capture automatically."
+                    .to_string()
             };
             f.render_widget(Paragraph::new(msg).wrap(Wrap { trim: false }).dim(), area);
             return;
@@ -4456,22 +4472,25 @@ impl App {
     }
 
     fn draw_recovery(&self, f: &mut Frame, area: Rect) {
-        let r = self.recovery.unwrap_or_default();
-        let enc = if r.encrypted {
-            Span::styled(
+        // None = RecoveryStatus never answered. The old default here claimed
+        // "plaintext at rest" and "No TPM" about templates that are encrypted
+        // on a TPM machine, one Tab away from the Keyring tab saying "TPM
+        // ● present"; a failed read establishes nothing (docs/MACHINE-API.md).
+        let enc = match self.recovery {
+            Some(r) if r.encrypted => Span::styled(
                 "● encrypted",
                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-            )
-        } else {
-            Span::styled("○ plaintext at rest", Style::new().dim())
+            ),
+            Some(_) => Span::styled("○ plaintext at rest", Style::new().dim()),
+            None => Span::styled("◐ unknown (daemon unreachable)", Style::new().fg(th().warn)),
         };
-        let rec = if r.recovery_set {
-            Span::styled(
+        let rec = match self.recovery {
+            Some(r) if r.recovery_set => Span::styled(
                 "● set",
                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-            )
-        } else {
-            Span::styled("○ not set", Style::new().dim())
+            ),
+            Some(_) => Span::styled("○ not set", Style::new().dim()),
+            None => Span::styled("◐ unknown (daemon unreachable)", Style::new().fg(th().warn)),
         };
         let mut lines = vec![
             section("Recovery + template encryption"),
@@ -4488,16 +4507,26 @@ impl App {
             )),
             Line::raw(""),
         ];
-        if !r.tpm_present {
-            lines.push(Line::from(Span::styled(
-                "  No TPM on this host: templates stay plaintext; recovery N/A.",
-                Style::new().fg(th().err),
-            )));
-        } else if r.encrypted && !r.recovery_set {
-            lines.push(Line::from(Span::styled(
-                "  ⚠ No backstop: set one now, or a broken seal means re-enrolling.",
-                Style::new().fg(th().err),
-            )));
+        match self.recovery {
+            Some(r) if !r.tpm_present => {
+                lines.push(Line::from(Span::styled(
+                    "  No TPM on this host: templates stay plaintext; recovery N/A.",
+                    Style::new().fg(th().err),
+                )));
+            }
+            Some(r) if r.encrypted && !r.recovery_set => {
+                lines.push(Line::from(Span::styled(
+                    "  ⚠ No backstop: set one now, or a broken seal means re-enrolling.",
+                    Style::new().fg(th().err),
+                )));
+            }
+            Some(_) => {}
+            None => {
+                lines.push(Line::from(Span::styled(
+                    "  Nothing here has been read; start irlumed (Repair tab) to see it.",
+                    Style::new().dim(),
+                )));
+            }
         }
         lines.push(Line::raw(""));
         lines.push(action_line(&[
@@ -4555,13 +4584,15 @@ impl App {
                 ),
             ]));
         }
-        // Show the envelope's actual policy tier when the daemon reports it;
-        // the static text is the pre-KeyringInfo default (and what a fresh
-        // arm lands on when neither Tier 1 nor Tier 2 exists on this box).
-        let binding = self
-            .keyring_policy
-            .clone()
-            .unwrap_or_else(|| "PCR-7 (Secure Boot state)".to_string());
+        // Show the envelope's actual policy tier when the daemon reports it.
+        // The static text is the pre-KeyringInfo default; it only applies once
+        // the daemon has ANSWERED (an old daemon, or a fresh arm landing on
+        // the literal tier). Unanswered, it read as this machine's binding.
+        let binding = match (&self.keyring_policy, self.keyring_armed) {
+            (Some(p), _) => p.clone(),
+            (None, None) => "unknown (daemon unreachable)".to_string(),
+            (None, Some(_)) => "PCR-7 (Secure Boot state)".to_string(),
+        };
         lines.extend([
             Line::from(vec![
                 Span::raw("  TPM      "),
@@ -4626,7 +4657,10 @@ impl App {
                     Style::new().dim(),
                 )));
             }
-        } else {
+        } else if self.keyring_armed == Some(false) {
+            // Only an OBSERVED not-armed earns this line; with the daemon
+            // unreachable the state row above already says unknown, and
+            // "won't open your wallet" would contradict it.
             let how = if self.caps.ir_pair {
                 "face"
             } else {
@@ -4678,25 +4712,27 @@ impl App {
     /// Hub rows for the Welcome screen: each visible section with its live
     /// state, selectable and Enter-jumpable (hub-and-spoke: the summary IS
     /// the navigation, the tab ribbon stays for direct access).
-    fn hub_rows(&self) -> Vec<(&'static str, bool, usize)> {
+    fn hub_rows(&self) -> Vec<(&'static str, Option<bool>, usize)> {
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
-        let rec = self.recovery.unwrap_or_default();
-        let all: [(&'static str, bool, usize); 7] = [
-            ("checks & repair", self.daemon_up, SC_REPAIR),
-            ("cameras", self.caps.rgb, SC_CAMERAS),
-            ("enrollment", scans > 0, SC_PROFILES),
+        // None = never observed (the daemon has not answered); the badge
+        // renders it as unknown. `unwrap_or(false)` here turned every
+        // unanswered question into "○ no", two of them security claims.
+        let all: [(&'static str, Option<bool>, usize); 7] = [
+            ("checks & repair", Some(self.daemon_up), SC_REPAIR),
+            ("cameras", Some(self.caps.rgb), SC_CAMERAS),
             (
-                "keyring unlock",
-                self.keyring_armed.unwrap_or(false),
-                SC_KEYRING,
+                "enrollment",
+                self.profiles_loaded.then_some(scans > 0),
+                SC_PROFILES,
             ),
+            ("keyring unlock", self.keyring_armed, SC_KEYRING),
             (
                 "recovery + encryption",
-                rec.encrypted && rec.recovery_set,
+                self.recovery.map(|r| r.encrypted && r.recovery_set),
                 SC_RECOVERY,
             ),
-            ("login wiring", self.probes.login_wired, SC_PAM),
-            ("settings", true, SC_SETTINGS),
+            ("login wiring", Some(self.probes.login_wired), SC_PAM),
+            ("settings", Some(true), SC_SETTINGS),
         ];
         all.into_iter()
             .filter(|(_, _, sc)| self.visible.contains(sc))
@@ -4807,9 +4843,14 @@ impl App {
                 style = style.fg(th().accent).add_modifier(Modifier::BOLD);
             }
             let badge = if label == "enrollment" {
-                count_badge(self.profiles.len(), scans, self.live_scans())
+                count_badge(
+                    self.profiles_loaded,
+                    self.profiles.len(),
+                    scans,
+                    self.live_scans(),
+                )
             } else {
-                onoff(ok)
+                onoff_opt(ok)
             };
             let marker = if selected { '▸' } else { ' ' };
             lines.insert(
@@ -4939,15 +4980,26 @@ impl App {
             Span::styled(format!("Secure Boot {} · ", sb.0), Style::new().fg(sb.1)),
             Span::styled(self.probes.boot_mode.clone(), Style::new().dim()),
         ]));
+        // The seal tier is a three-rung ladder (signed PCR-11 > pcrlock NV >
+        // literal PCR-7; see irlume-core/src/pcrsig.rs). The daemon's
+        // KeyringInfo names the armed envelope's actual rung, which is what
+        // the Keyring tab shows; a local artifact probe can only prove Tier 1
+        // availability, so without an answer this line told every Tier-2
+        // pcrlock user their seal sat on the weakest tier.
         lines.push(Line::from(vec![
             Span::styled("  PCR policy ", Style::new().dim()),
             Span::styled(
-                if irlume_core::pcrsig::signed_policy_available() {
-                    "signed (PCR-11)"
+                if let Some(p) = &self.keyring_policy {
+                    p.clone()
+                } else if !self.daemon_up {
+                    "unknown (daemon unreachable)".to_string()
+                } else if self.keyring_armed == Some(true) {
+                    "unreported by this daemon".to_string()
+                } else if irlume_core::pcrsig::signed_policy_available() {
+                    "signed (PCR-11, Tier 1) available".to_string()
                 } else {
-                    "literal PCR-7"
-                }
-                .to_string(),
+                    "not armed; tier decided at arm time".to_string()
+                },
                 Style::new().dim(),
             ),
         ]));
@@ -5226,7 +5278,6 @@ impl App {
 
     fn draw_done(&self, f: &mut Frame, area: Rect) {
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
-        let rec = self.recovery.unwrap_or_default();
         let wired = self.probes.login_wired;
         let lines = vec![
             section("Setup dashboard"),
@@ -5241,7 +5292,12 @@ impl App {
             ]),
             Line::from(vec![
                 Span::raw("  enrollment        "),
-                count_badge(self.profiles.len(), scans, self.live_scans()),
+                count_badge(
+                    self.profiles_loaded,
+                    self.profiles.len(),
+                    scans,
+                    self.live_scans(),
+                ),
             ]),
             Line::from(vec![
                 Span::raw("  eyes-open gate    "),
@@ -5253,7 +5309,7 @@ impl App {
             ]),
             Line::from(vec![
                 Span::raw("  keyring unlock    "),
-                onoff(self.keyring_armed.unwrap_or(false)),
+                onoff_opt(self.keyring_armed),
             ]),
             Line::from(vec![
                 Span::raw("  keyring gesture   "),
@@ -5265,15 +5321,22 @@ impl App {
             ]),
             Line::from(vec![
                 Span::raw("  templates enc     "),
-                onoff(rec.encrypted),
+                onoff_opt(self.recovery.map(|r| r.encrypted)),
             ]),
             Line::from(vec![
                 Span::raw("  recovery pass     "),
-                onoff(rec.recovery_set),
+                onoff_opt(self.recovery.map(|r| r.recovery_set)),
             ]),
             Line::from(vec![
                 Span::raw("  biopolicy         "),
-                onoff(biopolicy_on()),
+                // Same tri-state as the gesture row above: the CLI half fixed
+                // this in `status` (settings.conf is 0600 root-only, so an
+                // unreadable key must not print as off), and the two surfaces
+                // must agree on the daemon's truthy set and env override.
+                match irlume_common::config::enforce_biopolicy_visible() {
+                    Some(v) => onoff(v),
+                    None => Span::styled("◐ root-only", Style::new().fg(th().warn)),
+                },
             ]),
             Line::from(vec![
                 Span::raw("  fingerprint       "),
@@ -5573,6 +5636,16 @@ fn onoff(on: bool) -> Span<'static> {
     }
 }
 
+/// [`onoff`] with the honest third state: `None` means the question was never
+/// answered (daemon unreachable), which must render as unknown, never as "no".
+/// Same glyph and reasoning as the Done tab's root-only badge.
+fn onoff_opt(state: Option<bool>) -> Span<'static> {
+    match state {
+        Some(v) => onoff(v),
+        None => Span::styled("◐ unknown", Style::new().fg(th().warn)),
+    }
+}
+
 /// A screen state row: 2-space indent, label padded to `w`, then the value
 /// span. One shape for every status line so screens line up the same way.
 fn state_row(label: &str, w: usize, value: Span<'static>) -> Line<'static> {
@@ -5610,8 +5683,16 @@ fn method_label(method: &str) -> String {
 /// scans the loaded recognizer can match, `None` when the daemon does not
 /// report it. Zero live scans is a warning, not a green badge: enrollment
 /// that cannot match is not healthy, however many scans it holds (#288).
-fn count_badge(profiles: usize, scans: usize, live: Option<usize>) -> Span<'static> {
+/// `known` = a ListProfiles has landed; an empty list before that is "not
+/// observed", and "○ none" there prompted enrolled users to re-enroll.
+fn count_badge(known: bool, profiles: usize, scans: usize, live: Option<usize>) -> Span<'static> {
     if profiles == 0 {
+        if !known {
+            return Span::styled(
+                "◐ unknown (profile list not read)",
+                Style::new().fg(th().warn),
+            );
+        }
         return Span::styled("○ none", Style::new().dim());
     }
     match live {
@@ -5623,6 +5704,40 @@ fn count_badge(profiles: usize, scans: usize, live: Option<usize>) -> Span<'stat
             format!("● {profiles} profile(s), {scans} scan(s)"),
             Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
         ),
+    }
+}
+
+/// Where the down-mode fallback probe looks for libonnxruntime.so. The first
+/// two are the packaged bundle locations (keep in step with PACKAGED_ORTS in
+/// crates/irlume-vision/src/lib.rs, the canonical list): the packages export
+/// ORT_DYLIB_PATH only inside the daemon's unit drop-in, so this process's
+/// environment cannot see it and the probe false-failed on every packaged
+/// install until these paths were scanned too.
+const ORT_FALLBACK_PATHS: &[&str] = &[
+    "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+    "/opt/irlume/onnxruntime/lib/libonnxruntime.so",
+    "/usr/lib64/libonnxruntime.so",
+    "/usr/lib/libonnxruntime.so",
+];
+
+/// The Repair row for the ONNX fallback probe (daemon down). Not-found is a
+/// Warn, not a Fail: with the daemon down the probe is a guess about an env
+/// it cannot see, and the Daemon row above already carries the real failure;
+/// a Fail here sent users off to install packages they may already have.
+fn ort_fallback_check(found: bool) -> Check {
+    Check {
+        label: "ONNX Runtime".into(),
+        sev: if found { Sev::Ok } else { Sev::Warn },
+        detail: if found {
+            "library found".into()
+        } else {
+            "not seen by a local probe; the daemon's unit may set its own path".into()
+        },
+        fix: if found {
+            Fix::None
+        } else {
+            Fix::Manual("start the daemon first; it reports its real ONNX state".into())
+        },
     }
 }
 
@@ -5641,6 +5756,22 @@ fn map_ok(resp: Response) -> (bool, String) {
         Response::Error(e) => (false, e),
         o => (false, format!("unexpected: {o:?}")),
     }
+}
+
+/// Does `reason` carry any word the summary line does not already say?
+/// Word-set based, not equality: daemons phrase the echo with connectives
+/// ("live face, BUT no enrolled match"), so an exact compare never fires.
+fn reason_adds_information(summary: &str, reason: &str) -> bool {
+    let words = |s: &str| -> Vec<String> {
+        s.split(|c: char| !c.is_alphanumeric())
+            .filter(|w| !w.is_empty())
+            .map(str::to_lowercase)
+            .collect()
+    };
+    let known = words(summary);
+    words(reason)
+        .iter()
+        .any(|w| w != "but" && !known.contains(w))
 }
 
 fn map_identify(resp: Response) -> (bool, String) {
@@ -5662,14 +5793,25 @@ fn map_identify(resp: Response) -> (bool, String) {
             live,
             reason,
             ..
-        } => (
-            false,
-            if live {
-                format!("live face, no enrolled match ({reason})")
+        } => {
+            let summary = if live {
+                "live face, no enrolled match"
             } else {
-                format!("no live face ({reason})")
-            },
-        ),
+                "no live face"
+            };
+            // The daemon's reason often restates the summary ("live face, but
+            // no enrolled match"), which rendered as "live face, no enrolled
+            // match (live face, but no enrolled match)". Append it only when
+            // it says something the summary does not.
+            (
+                false,
+                if reason_adds_information(summary, &reason) {
+                    format!("{summary} ({reason})")
+                } else {
+                    summary.to_string()
+                },
+            )
+        }
         Response::Error(e) => (false, e),
         o => (false, format!("unexpected: {o:?}")),
     }
@@ -6075,6 +6217,14 @@ mod tests {
         let mut term = Terminal::new(TestBackend::new(120, 50)).unwrap();
         term.draw(|f| app.draw(f)).unwrap();
         rendered(&term)
+    }
+
+    /// The first rendered line containing `needle`, for row-scoped assertions:
+    /// a badge must be tied to ITS row, not merely found somewhere on screen.
+    fn row_with<'a>(text: &'a str, needle: &str) -> &'a str {
+        text.lines()
+            .find(|l| l.contains(needle))
+            .unwrap_or_else(|| panic!("no line contains '{needle}':\n{text}"))
     }
 
     fn profile(name: &str, scans: &[&str]) -> ProfileSummary {
@@ -8087,6 +8237,9 @@ mod tests {
     fn profiles_screen_renders_empty_state_and_scan_tree() {
         let mut app = test_app();
         app.screen = SC_PROFILES;
+        // The empty state requires an OBSERVED empty list; unobserved renders
+        // unknown (see the unanswered-question tests).
+        app.profiles_loaded = true;
         let text = draw_text(&app);
         assert!(text.contains("No face profiles yet"));
         assert!(text.contains("Press [e] to enroll"));
@@ -8991,6 +9144,8 @@ mod tests {
     fn run_checks_trusts_daemon_health_over_local_probes() {
         let _sock = dead_socket();
         let mut app = test_app();
+        // The "no face enrolled yet" verdict needs an observed empty list.
+        app.profiles_loaded = true;
         app.health = Some(HealthInfo {
             tier: "secure".into(),
             rgb_dev: Some("/dev/video0".into()),
@@ -9120,5 +9275,230 @@ mod tests {
             Fix::Manual(m) => assert!(m.contains("reseal"), "fix points at reseal: {m}"),
             _ => panic!("expected a manual fix pointing at reseal"),
         }
+    }
+
+    // ---- an unanswered question renders as unknown, never as a negative ----
+    // The machine-API contract (docs/MACHINE-API.md): a failed read
+    // "established nothing", and a consumer must not render it as disabled.
+    // These pin the TUI surfaces that used to claim "none"/"no"/"plaintext"
+    // while the daemon had never answered.
+
+    #[test]
+    fn an_unanswered_profile_list_renders_unknown_not_none() {
+        // Daemon down before the first ListProfiles landed: every surface
+        // that said "none" here invited a re-enroll over an enrollment that
+        // exists (reproduced on three machines).
+        let mut app = test_app();
+        assert!(!app.profiles_loaded && app.profiles_load.is_none());
+
+        // Profiles tab: no absence claim, no [e] invitation.
+        app.screen = SC_PROFILES;
+        let text = draw_text(&app);
+        assert!(!text.contains("No face profiles yet"), "{text}");
+        assert!(!text.contains("Press [e] to enroll"), "{text}");
+        assert!(text.contains("Profile list not read yet"), "{text}");
+
+        // Repair: the Enrollment verdict is unknown, not "no face enrolled".
+        app.run_checks();
+        let enroll = app
+            .repair
+            .iter()
+            .find(|c| c.label == "Enrollment")
+            .expect("an Enrollment row");
+        assert!(enroll.detail.contains("unknown"), "{}", enroll.detail);
+        assert!(
+            !enroll.detail.contains("no face enrolled"),
+            "{}",
+            enroll.detail
+        );
+
+        // Welcome hub: the three unanswered rows carry the unknown badge.
+        app.screen = SC_WELCOME;
+        app.visible = (0..SCREENS.len()).collect();
+        let text = draw_text(&app);
+        assert!(
+            row_with(&text, "enrollment").contains("◐ unknown"),
+            "{text}"
+        );
+        assert!(
+            row_with(&text, "keyring unlock").contains("◐ unknown"),
+            "{text}"
+        );
+        assert!(
+            row_with(&text, "recovery + encryption").contains("◐ unknown"),
+            "{text}"
+        );
+
+        // Done dashboard: same rule for its four claim rows.
+        app.screen = SC_DONE;
+        let text = draw_text(&app);
+        assert!(
+            row_with(&text, "enrollment").contains("◐ unknown"),
+            "{text}"
+        );
+        assert!(
+            row_with(&text, "keyring unlock").contains("◐ unknown"),
+            "{text}"
+        );
+        assert!(
+            row_with(&text, "templates enc").contains("◐ unknown"),
+            "{text}"
+        );
+        assert!(
+            row_with(&text, "recovery pass").contains("◐ unknown"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn recovery_screen_renders_unknown_when_never_answered() {
+        // recovery = None used to default-render "plaintext at rest" and
+        // "No TPM on this host", both false on the machines that hit it, and
+        // one Tab away from the Keyring tab saying "TPM ● present".
+        let mut app = test_app();
+        app.screen = SC_RECOVERY;
+        assert!(app.recovery.is_none());
+        let text = draw_text(&app);
+        assert!(!text.contains("plaintext at rest"), "{text}");
+        assert!(!text.contains("No TPM on this host"), "{text}");
+        assert!(!text.contains("○ not set"), "{text}");
+        assert!(text.contains("◐ unknown (daemon unreachable)"), "{text}");
+    }
+
+    #[test]
+    fn the_ort_fallback_probe_covers_packaged_installs_and_never_hard_fails() {
+        // The packages bundle onnxruntime outside the system lib dirs and set
+        // ORT_DYLIB_PATH only inside the daemon's unit drop-in, so the probe
+        // must scan the PACKAGED_ORTS locations (irlume-vision/src/lib.rs)
+        // itself or it false-fails on every packaged install.
+        for packaged in [
+            "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+            "/opt/irlume/onnxruntime/lib/libonnxruntime.so",
+        ] {
+            assert!(
+                ORT_FALLBACK_PATHS.contains(&packaged),
+                "fallback probe misses the packaged path {packaged}"
+            );
+        }
+        // With the daemon down the probe is a guess about an env it cannot
+        // see; a Fail sent users to install packages they already have.
+        let miss = ort_fallback_check(false);
+        assert!(miss.sev == Sev::Warn, "a guess must not be a hard failure");
+        assert!(miss.detail.contains("local probe"), "{}", miss.detail);
+        let hit = ort_fallback_check(true);
+        assert!(hit.sev == Sev::Ok);
+    }
+
+    #[test]
+    fn repair_reports_the_daemons_seal_tier_not_the_weakest_rung() {
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        // Down: the tier is unknown; "literal PCR-7" told a Tier-2 pcrlock
+        // user their seal sat on the weakest rung, contradicting the Keyring
+        // tab one Tab away.
+        let text = draw_text(&app);
+        assert!(!text.contains("literal PCR-7"), "{text}");
+        assert!(
+            row_with(&text, "PCR policy").contains("unknown (daemon unreachable)"),
+            "{text}"
+        );
+        // The daemon's KeyringInfo names the rung: show it verbatim, exactly
+        // as the Keyring tab does.
+        app.daemon_up = true;
+        app.keyring_armed = Some(true);
+        app.keyring_policy = Some("pcrlock NV 0x1a2b (Tier 2)".into());
+        let text = draw_text(&app);
+        assert!(
+            row_with(&text, "PCR policy").contains("pcrlock NV 0x1a2b (Tier 2)"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn the_daemon_row_names_the_socket_actually_probed() {
+        // IRLUME_SOCKET redirects every request the TUI makes; the row
+        // hardcoded /run/irlume.sock, a path nobody probed.
+        let _guard = dead_socket();
+        let mut app = test_app();
+        app.run_checks();
+        let d = app
+            .repair
+            .iter()
+            .find(|c| c.label == "Daemon (irlumed)")
+            .expect("a Daemon row");
+        assert!(
+            d.detail.contains("/nonexistent/irlume-test.sock"),
+            "{}",
+            d.detail
+        );
+    }
+
+    #[test]
+    fn keyring_binding_and_advice_wait_for_the_daemon() {
+        let mut app = test_app();
+        app.screen = SC_KEYRING;
+        let text = draw_text(&app);
+        // The pre-KeyringInfo default described a binding nobody read.
+        assert!(!text.contains("PCR-7 (Secure Boot state)"), "{text}");
+        assert!(
+            row_with(&text, "binding").contains("unknown (daemon unreachable)"),
+            "{text}"
+        );
+        // And no armed-state consequence line off an unanswered question.
+        assert!(!text.contains("Not armed;"), "{text}");
+    }
+
+    #[test]
+    fn identify_deny_reasons_that_echo_the_summary_are_not_repeated() {
+        // The daemon's deny reason restates the summary with a connective;
+        // appending it rendered "live face, no enrolled match (live face,
+        // but no enrolled match)". Informative reasons keep their
+        // parenthetical (pinned by map_identify_formats_match_and_both_miss_reasons).
+        let (ok, msg) = map_identify(Response::Identified {
+            user: None,
+            profile: None,
+            score: 0.0,
+            live: true,
+            reason: "live face, but no enrolled match".into(),
+        });
+        assert!(!ok);
+        assert_eq!(msg, "live face, no enrolled match");
+        let (_, msg) = map_identify(Response::Identified {
+            user: None,
+            profile: None,
+            score: 0.0,
+            live: false,
+            reason: "no live face".into(),
+        });
+        assert_eq!(msg, "no live face");
+        // An empty reason: no dangling "()" either.
+        let (_, msg) = map_identify(Response::Identified {
+            user: None,
+            profile: None,
+            score: 0.0,
+            live: true,
+            reason: String::new(),
+        });
+        assert_eq!(msg, "live face, no enrolled match");
+    }
+
+    #[test]
+    fn done_biopolicy_row_uses_the_shared_tri_state_reader() {
+        // Same rule the CLI `status` fix established (commit 156417f): the
+        // daemon's truthy set and its env override decide what displays, not
+        // a bare settings.conf read that shows "enforce_biopolicy=yes" as no.
+        let _g = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let old = std::env::var_os("IRLUME_ENFORCE_BIOPOLICY");
+        std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", "yes");
+        let mut app = test_app();
+        app.screen = SC_DONE;
+        let text = draw_text(&app);
+        match old {
+            Some(v) => std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", v),
+            None => std::env::remove_var("IRLUME_ENFORCE_BIOPOLICY"),
+        }
+        assert!(row_with(&text, "biopolicy").contains("● yes"), "{text}");
     }
 }

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -791,6 +791,7 @@ impl LightState {
             encrypted,
             recovery_set,
             tpm_present,
+            key_present,
         }) = crate::daemon_poll(&Request::RecoveryStatus {
             user: user.to_string(),
         }) {

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -394,8 +394,9 @@ enum WMsg {
     MergePrompt {
         profile: String,
         /// Scans the daemon will still accept for this profile in the LOADED
-        /// recognizer's space (#290 made the limit per recognizer).
-        room: usize,
+        /// recognizer's space (#290 made the limit per recognizer). `None`
+        /// when the daemon did not say, which is any daemon older than 0.9.0.
+        room: Option<usize>,
         added_scans: Vec<String>,
     },
 }
@@ -1010,10 +1011,34 @@ impl App {
         }
     }
 
+    /// Enrollment as the chrome may claim it. `None` until ListProfiles has
+    /// ever answered (`profiles_loaded`): an unanswered question must not
+    /// render as "not enrolled", the same rule the Profiles empty state and
+    /// the Done badge already follow.
+    fn enrolled_known(&self) -> Option<bool> {
+        if !self.profiles.is_empty() {
+            Some(true)
+        } else if self.profiles_loaded {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    /// Login wiring as the chrome may claim it. `Probes` holds `login_wired:
+    /// false` until the first sweep lands, and the hint, the Done body and the
+    /// Done footer must not read that default as "not wired" (#187's rule:
+    /// a default is not an observation).
+    fn login_wired_known(&self) -> Option<bool> {
+        self.probes_landed.then_some(self.probes.login_wired)
+    }
+
     /// Capability-aware recommended unlock method (item: "suggest the best one").
     fn recommended(&self) -> &'static str {
         match (self.caps.ir_pair, self.caps.rgb, self.fp_present) {
-            (true, _, _) => "Face (IR) · secure: login, sudo, lock screen, dark mode",
+            // "in the dark", never "dark mode": IR needs no visible light,
+            // but "dark mode" reads as a UI theme.
+            (true, _, _) => "Face (IR) · secure: login, sudo, lock screen, in the dark",
             (false, true, true) => "Fingerprint (secure), or Face (RGB) for lock-screen only",
             (false, true, false) => "Face (RGB) · convenience: lock-screen unlock only",
             (false, false, true) => "Fingerprint",
@@ -2231,7 +2256,20 @@ impl App {
                         // (#290): a profile holding two models' templates
                         // under-counted and the UI refused scans the daemon
                         // would have accepted.
-                        let remaining = target.saturating_sub(1).min(room);
+                        //
+                        // A daemon older than 0.9.0 does not report room at
+                        // all. Treating that silence as zero offered no
+                        // continuation scans and silently under-enrolled, the
+                        // very failure #290 exists to prevent, in the window
+                        // every upgrade passes through between the package
+                        // swap and the daemon restart. Unknown means ask for
+                        // what the user wanted and let the daemon refuse what
+                        // it will; it is the authority either way.
+                        let rest = target.saturating_sub(1);
+                        let remaining = match room {
+                            Some(room) => rest.min(room),
+                            None => rest,
+                        };
                         merge = Some(MergeConfirm {
                             profile,
                             added_scans,
@@ -3744,15 +3782,27 @@ impl App {
     /// lands on a screen not knowing why they're there: no jargon, names the key.
     fn draw_hint(&self, f: &mut Frame, area: Rect) {
         // During a capture the whole UI is about holding still; don't distract.
-        // Kept to ~70 chars so it never wraps off this single row on an 80-col
+        // Kept to ~72 chars so it never wraps off this single row on an 80-col
         // terminal (the "  ℹ " prefix eats ~4). Each names the key to press.
+        //
+        // The four setup screens key their hint off observed state: a fixed
+        // "go configure this" line told a fully configured user to redo every
+        // step, which reads as "your setup did not take". Unknown state
+        // (daemon unreachable, sweep not landed) asserts neither direction;
+        // the tri-state rule the rest of this file follows.
         let text = if self.enroll.is_some() {
             "Look at the camera and hold still; the checklist turns green as you go."
         } else {
             match self.screen {
-                SC_WELCOME => {
-                    "New here? Press [e] to scan your face; your password still works too."
-                }
+                SC_WELCOME => match self.enrolled_known() {
+                    Some(true) => {
+                        "You're enrolled; ↑↓ + Enter opens a section, [i] tests recognition."
+                    }
+                    Some(false) => {
+                        "New here? Press [e] to scan your face; your password still works too."
+                    }
+                    None => "Guided setup: Tab walks the steps; each screen names its keys.",
+                },
                 SC_REPAIR => {
                     "A red row is a problem: highlight it, press [f] to fix or [g] for logs."
                 }
@@ -3761,12 +3811,38 @@ impl App {
                     "Press [e] to add a face, or [a] to add scans so it knows you better."
                 }
                 SC_IDENTIFY => "A 'does it recognize me?' test. Press [i] and look at the camera.",
-                SC_KEYRING => {
-                    "Let your login open your password wallet: press [a], type your password."
-                }
-                SC_RECOVERY => "Set a backup passphrase so a broken TPM seal never forces a re-enroll; press [s].",
+                SC_KEYRING => match self.keyring_armed {
+                    Some(true) => {
+                        "Armed: face login opens your wallet. New password? Re-arm with [a]."
+                    }
+                    Some(false) => {
+                        "Let your login open your password wallet: press [a], type your password."
+                    }
+                    None => {
+                        "Seals your login password in the TPM so face login opens your wallet."
+                    }
+                },
+                SC_RECOVERY => match self.recovery.map(|r| r.recovery_set) {
+                    Some(true) => {
+                        "Recovery passphrase set; [t] restores access if the TPM seal breaks."
+                    }
+                    Some(false) => {
+                        "Set a backup passphrase so a broken TPM seal can't force re-enroll: [s]."
+                    }
+                    None => {
+                        "A backup passphrase keeps your enrollment usable if the TPM seal breaks."
+                    }
+                },
                 SC_FINGERPRINT => "Optional backup: press [a] to add a fingerprint too.",
-                SC_PAM => "Turn on face login for your screen: press [w] (asks for your password).",
+                SC_PAM => match self.login_wired_known() {
+                    Some(true) => {
+                        "Face login is wired in; [s] shows status, [x] un-wires a service."
+                    }
+                    Some(false) => {
+                        "Turn on face login for your screen: press [w] (asks for your password)."
+                    }
+                    None => "Wires face login into your greeter, lock screen and sudo.",
+                },
                 SC_SETTINGS => {
                     "[enter] toggles the eyes-open check, [c] the blink challenge; other settings are root or read-only."
                 }
@@ -3970,8 +4046,16 @@ impl App {
         // these: `sel` is clamped to the real rows above).
         let mut items = items;
         items.push(ListItem::new(Line::raw("")));
+        // Pre-split like the two lines below: ratatui Lists never wrap a
+        // ListItem, so one long line here was clipped at the terminal edge
+        // and the sentence ended mid-word at every width. 74 columns is the
+        // budget (80-col terminal minus borders and padding).
         items.push(ListItem::new(Line::from(Span::styled(
-            "  Tips: look different sometimes (glasses, low light)? Add scans to your profile with Improve Recognition ([a]); same identity, not a second profile.",
+            "  Tips: look different sometimes (glasses, low light)? Add scans with",
+            Style::new().dim(),
+        ))));
+        items.push(ListItem::new(Line::from(Span::styled(
+            "  Improve Recognition ([a]); same identity, not a second profile.",
             Style::new().dim(),
         ))));
         items.push(ListItem::new(Line::from(Span::styled(
@@ -4050,7 +4134,7 @@ impl App {
                 // Kept to FOUR lines: this panel does not scroll, so a fifth line
                 // pushes the bottom section off a short terminal.
                 Line::from(Span::styled(
-                    "  Releasing your TPM-sealed keyring password needs CONTINUOUS NODDING (or a",
+                    "  Releasing your TPM-sealed keyring password needs CONTINUOUS NODDING (or an",
                     Style::new().dim(),
                 )),
                 Line::from(Span::styled(
@@ -4074,17 +4158,32 @@ impl App {
                 ]),
                 Line::raw(""),
                 section("Biopolicy operation-class gate"),
-                Line::from(vec![
-                    Span::raw("  state  "),
-                    if bio {
-                        Span::styled(
-                            "● ENFORCING",
-                            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-                        )
-                    } else {
-                        Span::styled("○ off (default)", Style::new().dim())
-                    },
-                ]),
+                {
+                    // The shared tri-state reader, not the raw config read the
+                    // [b] direction uses: settings.conf is 0600 root-only, so
+                    // the raw read showed "off (default)" here while the Done
+                    // dashboard said "◐ root-only" for the same key. Same
+                    // truthy set and env override as the daemon.
+                    let (icon, icon_style, label) =
+                        match irlume_common::config::enforce_biopolicy_visible() {
+                            Some(true) => (
+                                "●",
+                                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                                "ENFORCING",
+                            ),
+                            Some(false) => ("○", Style::new().dim(), "off (default)"),
+                            None => (
+                                "◐",
+                                Style::new().fg(th().warn),
+                                "on/off is root-only; run the TUI with sudo to see it",
+                            ),
+                        };
+                    Line::from(vec![
+                        Span::raw("  state  "),
+                        Span::styled(format!("{icon} "), icon_style),
+                        Span::styled(label, Style::new().dim()),
+                    ])
+                },
                 Line::from(Span::styled(
                     "  When on: only Login/Elevation may release the keyring; lock-screen",
                     Style::new().dim(),
@@ -4744,7 +4843,7 @@ impl App {
                 self.recovery.map(|r| r.encrypted && r.recovery_set),
                 SC_RECOVERY,
             ),
-            ("login wiring", Some(self.probes.login_wired), SC_PAM),
+            ("login wiring", self.login_wired_known(), SC_PAM),
             ("settings", Some(true), SC_SETTINGS),
         ];
         all.into_iter()
@@ -5291,7 +5390,10 @@ impl App {
 
     fn draw_done(&self, f: &mut Frame, area: Rect) {
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
-        let wired = self.probes.login_wired;
+        // Tri-state, not the raw probe bool: before the first sweep lands the
+        // bool is a default, and this screen must not read a default as "one
+        // step left" (nor as done).
+        let wired = self.login_wired_known();
         let lines = vec![
             section("Setup dashboard"),
             Line::raw(""),
@@ -5355,7 +5457,7 @@ impl App {
                 Span::raw("  fingerprint       "),
                 onoff(self.fp.available),
             ]),
-            Line::from(vec![Span::raw("  login wiring      "), onoff(wired)]),
+            Line::from(vec![Span::raw("  login wiring      "), onoff_opt(wired)]),
             Line::raw(""),
             Line::from(Span::styled(
                 if !self.daemon_up {
@@ -5364,14 +5466,16 @@ impl App {
                     "  Not set up yet; enroll a face (Welcome [e]) to begin."
                 } else if self.profiles.is_empty() {
                     "  No face hardware; fingerprint/password remain your methods."
-                } else if !wired {
+                } else if wired == Some(false) {
                     "  One step left: your login screen isn't wired yet; press [w] (sudo; password stays the fallback)."
+                } else if wired.is_none() {
+                    "  Checking login wiring; the row above fills in when the probe lands."
                 } else {
                     "  All set. irlume keeps running as a daemon; this panel is safe to quit."
                 },
                 Style::new().dim(),
             )),
-            if !self.profiles.is_empty() && !wired {
+            if !self.profiles.is_empty() && wired == Some(false) {
                 Line::from(vec![
                     Span::styled("  [w]", Style::new().fg(th().accent)),
                     Span::styled(" wire login    [r] refresh    [q] quit", Style::new().dim()),
@@ -5435,13 +5539,17 @@ impl App {
     }
 
     /// Per-screen action keys, ordered primary-first: the footer shows
-    /// the first three, the [?] overlay shows them all.
+    /// the first three, the [?] overlay shows them all. Every bound key of a
+    /// screen belongs here; the overlay claims to be the full keymap, so a
+    /// key documented only in body text is invisible once the body scrolls
+    /// or the user reaches for [?].
     fn screen_actions(&self) -> &'static [(&'static str, &'static str)] {
         match self.screen {
             SC_WELCOME => &[
                 ("e", "enroll"),
                 ("i", "identify"),
                 ("r", "refresh"),
+                ("enter", "open the selected section"),
                 ("U", "uninstall"),
             ],
             SC_REPAIR => &[
@@ -5456,6 +5564,7 @@ impl App {
                 ("enter", "use"),
                 ("s", "setup emitter"),
                 ("p", "list units"),
+                ("t", "tune capture"),
             ],
             SC_PROFILES => &[
                 ("e", "enroll"),
@@ -5464,7 +5573,12 @@ impl App {
                 ("d", "delete"),
             ],
             SC_IDENTIFY => &[("i", "identify")],
-            SC_KEYRING => &[("a", "arm"), ("r", "reseal"), ("f", "forget")],
+            SC_KEYRING => &[
+                ("a", "arm"),
+                ("r", "reseal"),
+                ("f", "forget"),
+                ("p", "refresh pcrlock policy"),
+            ],
             SC_RECOVERY => &[("s", "set"), ("t", "restore"), ("f", "forget")],
             SC_FINGERPRINT => &[
                 ("a", "enroll finger"),
@@ -5489,7 +5603,17 @@ impl App {
                 ("b", "biopolicy"),
                 ("m", "3rd-party model"),
             ],
-            SC_DONE => &[("w", "wire login"), ("u", "update"), ("r", "refresh")],
+            // [w] only while wiring is OBSERVED missing: the body hides its
+            // [w] line on a wired box, and a footer still offering it invites
+            // a needless `sudo irlume login enable --apply` re-run. Unknown
+            // state (no sweep yet) advertises nothing either way.
+            SC_DONE => {
+                if self.login_wired_known() == Some(false) {
+                    &[("w", "wire login"), ("u", "update"), ("r", "refresh")]
+                } else {
+                    &[("u", "update"), ("r", "refresh")]
+                }
+            }
             _ => &[("r", "refresh")],
         }
     }
@@ -5553,7 +5677,7 @@ impl App {
     /// of the CURRENT screen (tier two of the disclosure ladder).
     fn help_body(&self) -> String {
         let mut b = String::from(
-            "Global\n  Tab / \u{2190}\u{2192}  switch tab      \u{2191}\u{2193}  select\n               v  basic/all tabs       PgUp/Dn  activity log\n               M  release mouse (highlight/copy)   q  quit\n\nThis screen\n",
+            "Global\n  Tab / \u{2190}\u{2192}  switch tab      \u{2191}\u{2193}  select\n               v  basic/all tabs       PgUp/Dn  activity log\n               h  home (the Welcome tab)\n               M  release mouse (highlight/copy)   q  quit\n\nThis screen\n",
         );
         for (k, d) in self.screen_actions() {
             b.push_str(&format!("  {k:<7} {d}\n"));
@@ -7984,7 +8108,7 @@ mod tests {
         // though the requested target is larger.
         tx.send(WMsg::MergePrompt {
             profile: "Alice".into(),
-            room: 2,
+            room: Some(2),
             added_scans: vec!["scan28".into()],
         })
         .unwrap();
@@ -7999,7 +8123,7 @@ mod tests {
         app.enroll_merge = None;
         tx.send(WMsg::MergePrompt {
             profile: "Alice".into(),
-            room: 25,
+            room: Some(25),
             added_scans: vec!["scan5".into()],
         })
         .unwrap();
@@ -8007,6 +8131,50 @@ mod tests {
         assert_eq!(
             app.enroll_merge.as_ref().unwrap().remaining,
             ENROLL_SCANS - 1
+        );
+    }
+
+    /// The upgrade window: a 0.9.0 TUI talking to a still-running 0.8.1
+    /// daemon, which is every upgrade between the package swap and the daemon
+    /// restart. That daemon never sends `room`. While the field was a plain
+    /// `usize` it defaulted to 0, indistinguishable from a genuinely full
+    /// profile, so the modal offered zero continuation scans and the user who
+    /// asked for ten got the one merged scan with nothing saying so. That is
+    /// the silent under-enrollment #290 exists to prevent.
+    #[test]
+    fn an_unreported_room_falls_back_to_the_requested_count() {
+        let _sock = dead_socket();
+        let mut app = test_app();
+        let (tx, enroll) = fake_enroll(0, ENROLL_SCANS);
+        app.enroll = Some(enroll);
+        tx.send(WMsg::MergePrompt {
+            profile: "Alice".into(),
+            room: None,
+            added_scans: vec!["scan1".into()],
+        })
+        .unwrap();
+        app.poll();
+        assert_eq!(
+            app.enroll_merge.as_ref().expect("modal is up").remaining,
+            ENROLL_SCANS - 1,
+            "a daemon that did not say must not read as a full profile"
+        );
+
+        // Some(0) is a different answer and still means full.
+        let (tx, enroll) = fake_enroll(0, ENROLL_SCANS);
+        app.enroll = Some(enroll);
+        app.enroll_merge = None;
+        tx.send(WMsg::MergePrompt {
+            profile: "Alice".into(),
+            room: Some(0),
+            added_scans: vec!["scan1".into()],
+        })
+        .unwrap();
+        app.poll();
+        assert_eq!(
+            app.enroll_merge.as_ref().expect("modal is up").remaining,
+            0,
+            "an explicit zero is a real answer and must still cap"
         );
     }
 
@@ -8026,7 +8194,7 @@ mod tests {
             profile: "Alice".into(),
             // The profile holds more than MAX_SCANS_PER_PROFILE across both
             // recognizers, yet the loaded one still has most of its own budget.
-            room: 25,
+            room: Some(25),
             added_scans: vec!["scan1".into()],
         })
         .unwrap();
@@ -8235,9 +8403,11 @@ mod tests {
             text.contains("Face (IR)"),
             "the IR tier must be recommended on IR hardware"
         );
+        // Enrolled (a profile is present), so the hint must not read as a
+        // first-run greeting; the state-aware variants have their own test.
         assert!(
-            text.contains("New here? Press [e]"),
-            "the Welcome hint line is missing"
+            text.contains("You're enrolled"),
+            "the Welcome hint line is missing:\n{text}"
         );
         assert!(text.contains("step 1/"), "the wizard position is missing");
         // No-camera tier: the recommendation flips to password-only.
@@ -8999,7 +9169,10 @@ mod tests {
 
     #[test]
     fn footer_lists_each_screens_action_keys() {
-        let app = test_app();
+        let mut app = test_app();
+        // The Done footer offers [w] only on OBSERVED-unwired state; give the
+        // sweep so the case below exercises the offer, not the unknown state.
+        app.probes_landed = true;
         let footer = |app: &App| {
             let mut term = Terminal::new(TestBackend::new(200, 3)).unwrap();
             term.draw(|f| app.draw_footer(f, f.area())).unwrap();
@@ -9020,7 +9193,6 @@ mod tests {
             (SC_SETTINGS, "eyes-open", "3rd-party model"),
             (SC_DONE, "wire login", "refresh"),
         ];
-        let mut app = app;
         for (screen, primary, in_overlay) in cases {
             app.screen = screen;
             assert!(
@@ -9540,5 +9712,188 @@ mod tests {
             None => std::env::remove_var("IRLUME_ENFORCE_BIOPOLICY"),
         }
         assert!(row_with(&text, "biopolicy").contains("● yes"), "{text}");
+    }
+
+    #[test]
+    fn settings_biopolicy_row_uses_the_shared_tri_state_reader() {
+        // The Done dashboard and this row must agree: on a box whose 0600
+        // settings.conf holds `enforce_biopolicy=yes`, Done said "◐ root-only"
+        // (or "● yes" under the env override) while the raw read here showed
+        // "○ off (default)". The env override is how the test pins the shared
+        // reader: the raw read ignores it.
+        let _g = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let old = std::env::var_os("IRLUME_ENFORCE_BIOPOLICY");
+        std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", "yes");
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        let text = draw_text(&app);
+        match old {
+            Some(v) => std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", v),
+            None => std::env::remove_var("IRLUME_ENFORCE_BIOPOLICY"),
+        }
+        assert!(
+            text.contains("ENFORCING"),
+            "the Settings biopolicy row must read the shared tri-state:\n{text}"
+        );
+    }
+
+    #[test]
+    fn setup_hints_follow_observed_state_not_defaults() {
+        // Each setup hint has three honest states: not done (instruct), done
+        // (describe), never observed (assert neither). The fixed per-screen
+        // instruction told a fully configured box to redo every step.
+        let mut app = test_app();
+
+        // Welcome: unknown until ListProfiles has answered.
+        assert!(!draw_text(&app).contains("New here?"));
+        app.profiles_loaded = true;
+        assert!(draw_text(&app).contains("New here? Press [e]"));
+        app.profiles = vec![profile("a", &["s1"])];
+        assert!(draw_text(&app).contains("You're enrolled"));
+
+        // Keyring: keyring_armed is already tri-state.
+        app.screen = SC_KEYRING;
+        let text = draw_text(&app);
+        assert!(!text.contains("press [a], type your password"), "{text}");
+        app.keyring_armed = Some(false);
+        assert!(draw_text(&app).contains("press [a], type your password"));
+        app.keyring_armed = Some(true);
+        assert!(draw_text(&app).contains("Armed: face login opens your wallet"));
+
+        // Recovery: unknown until RecoveryStatus has answered.
+        app.screen = SC_RECOVERY;
+        let text = draw_text(&app);
+        assert!(!text.contains("Set a backup passphrase"), "{text}");
+        app.recovery = Some(RecoveryInfo {
+            encrypted: true,
+            recovery_set: false,
+            tpm_present: true,
+            key_present: true,
+        });
+        assert!(draw_text(&app).contains("Set a backup passphrase"));
+        app.recovery = Some(RecoveryInfo {
+            encrypted: true,
+            recovery_set: true,
+            tpm_present: true,
+            key_present: true,
+        });
+        assert!(draw_text(&app).contains("Recovery passphrase set"));
+
+        // Login wiring: unknown until the first probe sweep lands.
+        app.screen = SC_PAM;
+        let text = draw_text(&app);
+        assert!(!text.contains("Turn on face login"), "{text}");
+        app.probes_landed = true;
+        app.probes.login_wired = false;
+        assert!(draw_text(&app).contains("Turn on face login"));
+        app.probes.login_wired = true;
+        assert!(draw_text(&app).contains("Face login is wired in"));
+    }
+
+    #[test]
+    fn profiles_tips_fit_an_80_column_terminal_whole() {
+        // ratatui Lists never wrap a ListItem, so the tips must be pre-split;
+        // the old single-line tip ended mid-sentence ("…same identity, not a")
+        // at every width. Rendering at 80 columns proves the whole sentence
+        // survives the narrowest supported terminal.
+        let mut app = test_app();
+        app.screen = SC_PROFILES;
+        app.profiles_loaded = true;
+        app.profiles = vec![profile("Alice", &["s1"])];
+        let mut term = Terminal::new(TestBackend::new(80, 45)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        let text = rendered(&term);
+        assert!(
+            text.contains("second profile."),
+            "the Tips sentence is cut off mid-sentence:\n{text}"
+        );
+    }
+
+    #[test]
+    fn done_offers_wire_login_only_when_wiring_is_observed_missing() {
+        let mut app = test_app();
+        app.screen = SC_DONE;
+        app.daemon_up = true;
+        app.profiles = vec![profile("a", &["s1"])];
+        let footer = |app: &App| {
+            let mut term = Terminal::new(TestBackend::new(200, 3)).unwrap();
+            term.draw(|f| app.draw_footer(f, f.area())).unwrap();
+            rendered(&term)
+        };
+        // No sweep yet: the probe default is not an observation, so neither
+        // the footer, the overlay, nor the body may claim wiring is missing.
+        assert!(!footer(&app).contains("wire login"), "{}", footer(&app));
+        assert!(!app.help_body().contains("wire login"));
+        let text = draw_text(&app);
+        assert!(!text.contains("One step left"), "{text}");
+        assert!(!text.contains("All set"), "{text}");
+        // Observed unwired: the offer appears in body and footer.
+        app.probes_landed = true;
+        app.probes.login_wired = false;
+        assert!(footer(&app).contains("wire login"));
+        assert!(draw_text(&app).contains("One step left"));
+        // Observed wired: the body says done and no chrome advertises [w],
+        // which on a wired box would re-run `sudo irlume login enable`.
+        app.probes.login_wired = true;
+        let f = footer(&app);
+        assert!(!f.contains("wire login"), "{f}");
+        assert!(!app.help_body().contains("wire login"));
+        let text = draw_text(&app);
+        assert!(text.contains("All set"), "{text}");
+        assert!(row_with(&text, "login wiring").contains("● yes"), "{text}");
+    }
+
+    #[test]
+    fn ir_recommendation_names_darkness_not_a_ui_theme() {
+        let mut app = test_app();
+        app.caps = irlume_camera::Caps {
+            ir_pair: true,
+            rgb: true,
+        };
+        let text = draw_text(&app);
+        assert!(
+            row_with(&text, "Recommended").contains("in the dark"),
+            "{text}"
+        );
+        // "dark mode" reads as a UI theme, not an IR capability.
+        assert!(!text.contains("dark mode"), "{text}");
+    }
+
+    #[test]
+    fn gesture_explainer_uses_the_right_article_across_its_line_break() {
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        let text = draw_text(&app);
+        // The hand-wrapped pair rendered "…NODDING (or a / eye closure)".
+        assert!(
+            row_with(&text, "CONTINUOUS NODDING").contains("(or an"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn help_overlay_lists_every_bound_key_of_the_screen() {
+        let mut app = test_app();
+        // Global: 'h' jumps home from any tab.
+        assert!(app.help_body().contains("home"), "{}", app.help_body());
+        // Welcome: Enter opens the selected hub section.
+        app.screen = SC_WELCOME;
+        assert!(
+            app.help_body().contains("open the selected section"),
+            "{}",
+            app.help_body()
+        );
+        // Cameras: [t] tune capture is bound and documented in body text.
+        app.screen = SC_CAMERAS;
+        assert!(
+            app.help_body().contains("tune capture"),
+            "{}",
+            app.help_body()
+        );
+        // Keyring: [p] refreshes the pcrlock policy on a Tier-2 seal.
+        app.screen = SC_KEYRING;
+        assert!(app.help_body().contains("pcrlock"), "{}", app.help_body());
     }
 }

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -336,8 +336,29 @@ pub fn perform_teardown(keep_data: bool) -> TeardownReport {
     //    remaining sealed envelopes, cameras.conf/settings.conf. Guarded so
     //    --keep-data leaves them for a later reinstall.
     if !keep_data {
-        let _ = std::fs::remove_dir_all(irlume_common::STATE_DIR);
-        let _ = std::fs::remove_dir_all(irlume_common::config::CONFIG_ROOT);
+        // Through `state_dir()`, not the bare constant: the user enumeration
+        // above already honors IRLUME_STATE_DIR, so deleting the literal path
+        // here meant a SANDBOXED teardown reached into live /var/lib/irlume and
+        // took the enrollments, template keys, recovery envelopes and keyring
+        // seals with it. That is not hypothetical; the same split resolution in
+        // template_key.rs destroyed a real machine's keys on 2026-08-05.
+        //
+        // A failure is reported rather than swallowed: this used to discard the
+        // result, so a partial teardown still announced success and left secrets
+        // on disk under a directory the user believes is gone.
+        for dir in [
+            irlume_common::state_dir(),
+            irlume_common::config::CONFIG_ROOT.into(),
+        ] {
+            if let Err(e) = std::fs::remove_dir_all(&dir) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    eprintln!(
+                        "[uninstall] could not remove {}: {e} (files may remain)",
+                        dir.display()
+                    );
+                }
+            }
+        }
     }
 
     TeardownReport {

--- a/crates/irlume-cli/tests/camera_authority.rs
+++ b/crates/irlume-cli/tests/camera_authority.rs
@@ -1,0 +1,110 @@
+//! While the daemon runs, it is the authority on cameras; nobody else opens a
+//! video node to find out what it is.
+//!
+//! Classifying a `/dev/video*` node means OPENING it. On a UVC module that
+//! answers EBUSY to a second open, doing that while the daemon streams fails
+//! the user's enrollment, and nothing in the logs names the cause. That is
+//! issue #187. #300 fixed the TUI and left three CLI callers enumerating:
+//! measured with strace, `irlume status` and `status --json` each opened
+//! /dev/video0 through video3 with the daemon running, and `setup` probed in
+//! its preflight and then enrolled seconds later on the nodes it had just
+//! touched.
+//!
+//! The behavioral proof lives in cli.rs (a fake daemon reporting device paths
+//! that exist on no machine, so seeing them proves the answer came over the
+//! socket). This one pins the RULE, because the failure mode is a NEW call
+//! site added later, which no existing behavioral test would notice.
+
+use std::path::Path;
+
+/// Whether this probe is deliberately exempt.
+///
+/// The exemption is a marker written AT the call site rather than a list kept
+/// here, so the reason sits next to the code and a reader of that code sees it.
+/// `// the one permitted probe` marks an accessor's daemon-silent fallback;
+/// `// deliberate camera probe:` marks a caller that is about to use the node.
+fn allowed(line: &str, preceding: &str) -> bool {
+    line.contains("// the one permitted probe") || preceding.contains("// deliberate camera probe:")
+}
+
+/// Files where a direct probe is the point rather than a mistake.
+fn exempt_file(file: &str) -> bool {
+    // Dev capture tools open the camera they are about to record from, so
+    // resolving a node is the first step of using it, not a lookup.
+    matches!(
+        file,
+        "blinkcap.rs" | "pad.rs" | "suncal.rs" | "capture.rs" | "calibrate.rs"
+    )
+}
+
+#[test]
+fn no_cli_surface_classifies_a_video_node_behind_the_daemons_back() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    let mut scanned = 0usize;
+
+    let mut stack = vec![src.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read src") {
+            let path = entry.expect("entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default()
+                .to_string();
+            if exempt_file(&name) {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("read source");
+            scanned += 1;
+            let mut in_test_mod = false;
+            for (n, line) in text.lines().enumerate() {
+                // Tests construct whatever they like; they never touch real /dev.
+                if line.trim_start().starts_with("mod tests") {
+                    in_test_mod = true;
+                }
+                if in_test_mod {
+                    continue;
+                }
+                let probes = line.contains("irlume_camera::select_pair")
+                    || line.contains("irlume_camera::capabilities");
+                if !probes || line.trim_start().starts_with("//") {
+                    continue;
+                }
+                // Look back a few lines: the marker sits in the comment block
+                // above the call, where the reasoning belongs.
+                let start = n.saturating_sub(4);
+                let preceding = text
+                    .lines()
+                    .skip(start)
+                    .take(n - start)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if allowed(line, &preceding) {
+                    continue;
+                }
+                offenders.push(format!("{}:{}: {}", name, n + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        scanned > 5,
+        "scanned only {scanned} files; the walker is broken, not the code"
+    );
+    assert!(
+        offenders.is_empty(),
+        "these classify a video node by opening it, which races the daemon and \
+         is EBUSY on strict UVC modules (#187). Use crate::camera_pair() or \
+         crate::caps(), which ask the daemon and keep one cached fallback, or \
+         add the site to `allowed()` with a reason:\n  {}",
+        offenders.join("\n  ")
+    );
+}

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1241,6 +1241,41 @@ fn keyring_success_paths_with_a_live_daemon() {
     assert_eq!(sealed.1, b"hunter2");
 }
 
+/// An encrypted store whose template key is gone is the one state the old
+/// `encrypted` bool could not express, because it was computed FROM the key's
+/// presence. It reported "plaintext at rest", which understates the posture and
+/// hides that the enrollment can no longer be opened by anything, then pointed
+/// the user at `recovery setup`. It happened for real on 2026-08-05 when a
+/// sandboxed root command deleted the live key directory.
+#[test]
+fn an_encrypted_store_with_no_key_says_so_instead_of_plaintext() {
+    let sb = Sandbox::new("orphanedkey");
+    serve(&sock(&sb), |req| match req {
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: false,
+            tpm_present: true,
+            key_present: false,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (code, out, _) = run(&mut sb.cmd(&["recovery", "status", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(
+        !out.contains("plaintext at rest"),
+        "an encrypted store must never be called plaintext: {out}"
+    );
+    assert!(
+        out.contains("TEMPLATE KEY IS GONE"),
+        "the user must be told the enrollment cannot be opened: {out}"
+    );
+    assert!(
+        out.contains("Re-enroll"),
+        "and told the only remaining move: {out}"
+    );
+}
+
 #[test]
 fn recovery_success_paths_with_a_live_daemon() {
     let sb = Sandbox::new("recoveryok");
@@ -1249,6 +1284,7 @@ fn recovery_success_paths_with_a_live_daemon() {
             encrypted: true,
             recovery_set: false,
             tpm_present: true,
+            key_present: true,
         },
         Request::RecoverySetup { .. } => Response::Ok("recovery passphrase set".into()),
         Request::RecoveryRestore { .. } => Response::Ok("template key restored".into()),
@@ -1508,6 +1544,7 @@ fn status_renders_the_full_dashboard_from_daemon_answers() {
             encrypted: true,
             recovery_set: true,
             tpm_present: true,
+            key_present: true,
         },
         _ => Response::Error("unexpected request".into()),
     });

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -583,7 +583,7 @@ fn recovery_usage_and_daemon_failures() {
 
     let (code, _, err) = run_stdin(
         &mut sb.cmd(&["recovery", "setup", "--user", "tester"]),
-        "passphrase\n",
+        "correct horse battery\n",
     );
     assert_eq!(code, 1);
     assert!(err.contains("setup failed"), "{err}");
@@ -1283,6 +1283,37 @@ fn recovery_success_paths_with_a_live_daemon() {
     assert!(out.contains("recovery envelope erased"), "{out}");
 }
 
+/// The recovery passphrase is the only barrier on the template-key envelope
+/// against someone holding the disk, and the strength floor used to live inside
+/// the interactive branch. `irlume recovery setup </dev/null` therefore wrapped
+/// the key under an EMPTY passphrase and reported success. Both piped rejections
+/// must happen in the CLI, before any request reaches the daemon.
+#[test]
+fn recovery_setup_enforces_the_strength_floor_on_the_piped_path() {
+    let sb = Sandbox::new("recoveryfloor");
+    // A daemon that would happily accept whatever arrives, so a passing test
+    // means the CLI stopped it rather than the socket being dead.
+    let log = serve(&sock(&sb), |_| Response::Ok("recovery set".into()));
+
+    for (piped, want) in [("", "empty passphrase"), ("short\n", "too short")] {
+        let (code, _, err) = run_stdin(
+            &mut sb.cmd(&["recovery", "setup", "--user", "tester"]),
+            piped,
+        );
+        assert_eq!(code, 2, "must exit 2 on a refused passphrase: {err}");
+        assert!(err.contains(want), "expected {want:?} in: {err}");
+        assert!(
+            err.contains("nothing set"),
+            "the user must be told no envelope was written: {err}"
+        );
+    }
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "a refused passphrase must not reach the daemon: {:?}",
+        log.lock().unwrap()
+    );
+}
+
 #[test]
 fn recovery_setup_error_names_the_enroll_first_remedy() {
     let sb = Sandbox::new("recoveryerr");
@@ -1291,7 +1322,7 @@ fn recovery_setup_error_names_the_enroll_first_remedy() {
     });
     let (code, _, err) = run_stdin(
         &mut sb.cmd(&["recovery", "setup", "--user", "tester"]),
-        "pass\n",
+        "correct horse battery\n",
     );
     assert_eq!(code, 1);
     assert!(err.contains("setup failed: no template key"), "{err}");
@@ -1363,6 +1394,7 @@ fn enroll_reports_a_new_profile_and_forwards_the_flags() {
         created: true,
         added: 3,
         total: 3,
+        room: 27,
         added_scans: vec!["Scan 1".into(), "Scan 2".into(), "Scan 3".into()],
     });
     let (code, out, _) = run(&mut sb.cmd(&[
@@ -1396,6 +1428,7 @@ fn enroll_merge_points_at_add_scan() {
         created: false,
         added: 2,
         total: 8,
+        room: 22,
         added_scans: vec!["Scan 7".into(), "Scan 8".into()],
     });
     let (code, out, _) = run(&mut sb.cmd(&["enroll", "--user", "tester"]));
@@ -1574,6 +1607,7 @@ fn setup_walks_every_step_noninteractively() {
             created: true,
             added: 6,
             total: 6,
+            room: 24,
             added_scans: Vec::new(),
         },
         Request::SealPassword { .. } => Response::PasswordSealed,

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -250,7 +250,7 @@ fn dev_commands_with_env_reach_their_usage_errors() {
         (&["enrolldev"], 2, "usage: irlume enrolldev --user U --det"),
         (&["padcapture"], 2, "usage: irlume padcapture --species"),
         (&["padreport"], 2, "usage: irlume padreport --in"),
-        (&["suncal"], 1, "usage: IRLUME_DEV=1 irlume suncal"),
+        (&["suncal"], 2, "usage: IRLUME_DEV=1 irlume suncal"),
         (
             &["selftest", "align"],
             2,
@@ -809,7 +809,8 @@ fn logs_option_errors_never_run_journalctl() {
     sb.fake_tool("journalctl", r#"printf 'JOURNALCTL RAN\n'"#);
 
     let (code, out, err) = run(&mut sb.cmd_with_fakes(&["logs", "--since"]));
-    assert_eq!(code, 1);
+    // A bad option is a usage error (2), not a runtime failure (1).
+    assert_eq!(code, 2);
     assert!(err.contains("--since needs a value"), "{err}");
     assert!(
         !out.contains("JOURNALCTL RAN"),
@@ -946,7 +947,8 @@ fn selinux_status_classifies_module_state_from_probe_output() {
     assert!(out.contains("unknown"), "{out}");
 
     let (code, _, err) = run(&mut sb.cmd(&["selinux", "bogus"]));
-    assert_eq!(code, 1);
+    // A bad subcommand is a usage error (2), not a runtime failure (1).
+    assert_eq!(code, 2);
     assert!(err.contains("unknown subcommand 'bogus'"), "{err}");
 }
 

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1276,6 +1276,41 @@ fn an_encrypted_store_with_no_key_says_so_instead_of_plaintext() {
     );
 }
 
+/// #187: classifying a video node means OPENING it, and on a UVC module that
+/// answers EBUSY to a second open, doing that while the daemon streams fails the
+/// user's enrollment. #300 stopped the TUI doing it; `status` was still
+/// enumerating, measured with strace as four opens of /dev/video0..3 with the
+/// daemon running. The daemon already reports the pair it selected, so a running
+/// daemon is the authority here too.
+///
+/// The fixture reports device paths that exist on no machine, so seeing them in
+/// the output proves the answer came over the socket rather than from a probe.
+#[test]
+fn status_takes_the_camera_pair_from_the_daemon_not_a_local_probe() {
+    let sb = Sandbox::new("statuscam");
+    serve(&sock(&sb), |req| match req {
+        Request::Health => Response::Health {
+            tier: "secure".into(),
+            rgb_dev: Some("/dev/video91".into()),
+            ir_dev: Some("/dev/video92".into()),
+            mesh: true,
+            adapter: false,
+            version: env!("CARGO_PKG_VERSION").into(),
+            third_party_pad: None,
+            third_party_recognizer: None,
+            third_party_detector: None,
+            apparmor: None,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (_, out, _) = run(&mut sb.cmd(&["status", "--user", "tester"]));
+    assert!(
+        out.contains("/dev/video91") && out.contains("/dev/video92"),
+        "status must report the daemon's pair, not one it probed: {out}"
+    );
+}
+
 #[test]
 fn recovery_success_paths_with_a_live_daemon() {
     let sb = Sandbox::new("recoveryok");

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1276,6 +1276,53 @@ fn an_encrypted_store_with_no_key_says_so_instead_of_plaintext() {
     );
 }
 
+/// A flag with nothing after it must never silently become a different, wider
+/// operation.
+///
+/// `flag()` answers None both for "absent" and for "present with no value", and
+/// two resolvers read that None as a default: `--user` fell back to SUDO_USER,
+/// and `profiles delete`'s missing `--scan` meant "the whole profile". So
+/// `sudo irlume enroll --reset --user` deleted the enrollment, the template key
+/// and the recovery envelope of the person typing it, unconfirmed, and
+/// `profiles delete --profile P --scan` deleted P. The guard existed but only
+/// inside `profiles`, so it covered one of four commands.
+///
+/// The fixture serves nothing: every case here must be refused BEFORE any
+/// request reaches a daemon, which the empty request log proves.
+#[test]
+fn a_flag_with_no_value_is_refused_before_anything_is_destroyed() {
+    let sb = Sandbox::new("danglingflag");
+    let log = serve(&sock(&sb), |_| Response::Ok("must not be reached".into()));
+
+    let destructive: &[&[&str]] = &[
+        &["enroll", "--reset", "--user"],
+        &["recovery", "forget", "--user"],
+        &["keyring", "forget", "--user"],
+        &["profiles", "delete", "--profile", "P", "--user"],
+        &["profiles", "forget-model", "shipped", "--user"],
+        &["profiles", "delete", "--profile", "P", "--scan"],
+    ];
+    for argv in destructive {
+        let (code, _, err) = run(sb.cmd(argv).env("SUDO_USER", "victim"));
+        assert_eq!(code, 2, "`{}` must be a usage error: {err}", argv.join(" "));
+        assert!(
+            err.contains("requires a"),
+            "`{}` must say what is missing: {err}",
+            argv.join(" ")
+        );
+    }
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "nothing may reach the daemon: {:?}",
+        log.lock().unwrap()
+    );
+
+    // The ordinary forms are untouched.
+    let (code, out, _) = run(&mut sb.cmd(&["status", "--user", "tester"]));
+    assert_eq!(code, 0);
+    assert!(out.contains("tester"), "{out}");
+}
+
 /// A slow daemon is not an absent daemon.
 ///
 /// `caps()` and `camera_pair()` fall back to a local probe when the socket poll

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1276,6 +1276,61 @@ fn an_encrypted_store_with_no_key_says_so_instead_of_plaintext() {
     );
 }
 
+/// A slow daemon is not an absent daemon.
+///
+/// `caps()` and `camera_pair()` fall back to a local probe when the socket poll
+/// fails, and that probe OPENS every video node. The short poll allows 1.2s to
+/// connect and 1.5s to read. A daemon busy mid-capture is exactly what blowing
+/// that budget looks like, and it is also exactly when it holds the nodes, so
+/// treating any failure as absence put the probe at the worst possible moment
+/// (#187 again, by a different route). Only an error that PROVES nobody is
+/// listening licenses the probe.
+///
+/// The fixture accepts the connection and then never answers, which no
+/// existing test did: every other one either serves promptly or has no socket
+/// at all, so both took the success path or the proven-absent path. The
+/// cameras.conf pair is reported back, proving the answer came from
+/// configuration rather than from enumerating hardware.
+#[test]
+fn a_daemon_that_accepts_but_never_answers_is_not_treated_as_absent() {
+    let sb = Sandbox::new("slowdaemon");
+    std::fs::create_dir_all(sb.path("cfg")).unwrap();
+    std::fs::write(
+        sb.path("cfg").join("cameras.conf"),
+        "rgb=/dev/video81
+ir=/dev/video82
+",
+    )
+    .unwrap();
+
+    // Accept, read the request, then hold the connection open and answer
+    // nothing. The client must time out rather than see a closed socket.
+    let sock_path = sock(&sb);
+    let _ = std::fs::remove_file(&sock_path);
+    let listener = std::os::unix::net::UnixListener::bind(&sock_path).unwrap();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            std::thread::spawn(move || {
+                use std::io::{BufRead, BufReader};
+                let mut line = String::new();
+                let _ = BufReader::new(&stream).read_line(&mut line);
+                // Outlive the client's 1.5s read budget, holding the fd so the
+                // peer sees a timeout and not an EOF.
+                std::thread::sleep(std::time::Duration::from_secs(6));
+                drop(stream);
+            });
+        }
+    });
+
+    let (_, out, _) = run(&mut sb.cmd(&["status", "--user", "tester"]));
+    assert!(
+        out.contains("/dev/video81") && out.contains("/dev/video82"),
+        "a timed-out poll must fall back to the CONFIGURED pair, never to \
+         enumeration, which opens the nodes the daemon may be holding: {out}"
+    );
+}
+
 /// #187: classifying a video node means OPENING it, and on a UVC module that
 /// answers EBUSY to a second open, doing that while the daemon streams fails the
 /// user's enrollment. #300 stopped the TUI doing it; `status` was still

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -818,7 +818,7 @@ fn logs_option_errors_never_run_journalctl() {
     );
 
     let (code, out, err) = run(&mut sb.cmd_with_fakes(&["logs", "--bogus"]));
-    assert_eq!(code, 1);
+    assert_eq!(code, 2);
     assert!(err.contains("unknown option '--bogus'"), "{err}");
     assert!(
         !out.contains("JOURNALCTL RAN"),

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1467,7 +1467,7 @@ fn enroll_reports_a_new_profile_and_forwards_the_flags() {
         created: true,
         added: 3,
         total: 3,
-        room: 27,
+        room: Some(27),
         added_scans: vec!["Scan 1".into(), "Scan 2".into(), "Scan 3".into()],
     });
     let (code, out, _) = run(&mut sb.cmd(&[
@@ -1501,7 +1501,7 @@ fn enroll_merge_points_at_add_scan() {
         created: false,
         added: 2,
         total: 8,
-        room: 22,
+        room: Some(22),
         added_scans: vec!["Scan 7".into(), "Scan 8".into()],
     });
     let (code, out, _) = run(&mut sb.cmd(&["enroll", "--user", "tester"]));
@@ -1681,7 +1681,7 @@ fn setup_walks_every_step_noninteractively() {
             created: true,
             added: 6,
             total: 6,
-            room: 24,
+            room: Some(24),
             added_scans: Vec::new(),
         },
         Request::SealPassword { .. } => Response::PasswordSealed,

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -576,6 +576,7 @@ fn setup_enroll_merge_and_enroll_failure_paths() {
             created: false,
             added: 2,
             total: 8,
+            room: 22,
             added_scans: Vec::new(),
         },
         Request::SealPassword { .. } => Response::PasswordSealed,
@@ -722,7 +723,9 @@ fn unexpected_responses_for_keyring_and_recovery_writes() {
     let cases: &[(&[&str], &str)] = &[
         (&["keyring", "arm", "--user", "tester"], "pw\n"),
         (&["keyring", "forget", "--user", "tester"], ""),
-        (&["recovery", "setup", "--user", "tester"], "pass\n"),
+        // Must clear the 12-character floor, or the CLI refuses it before the
+        // daemon is asked and this case stops testing the response handling.
+        (&["recovery", "setup", "--user", "tester"], "correct horse battery\n"),
         (&["recovery", "restore", "--user", "tester"], "pass\n"),
         (&["recovery", "forget", "--user", "tester"], ""),
     ];

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -725,7 +725,10 @@ fn unexpected_responses_for_keyring_and_recovery_writes() {
         (&["keyring", "forget", "--user", "tester"], ""),
         // Must clear the 12-character floor, or the CLI refuses it before the
         // daemon is asked and this case stops testing the response handling.
-        (&["recovery", "setup", "--user", "tester"], "correct horse battery\n"),
+        (
+            &["recovery", "setup", "--user", "tester"],
+            "correct horse battery\n",
+        ),
         (&["recovery", "restore", "--user", "tester"], "pass\n"),
         (&["recovery", "forget", "--user", "tester"], ""),
     ];

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -233,6 +233,7 @@ fn status_eyes_open_unarmed_plaintext_and_biopolicy_enforcing() {
             encrypted: false,
             recovery_set: false,
             tpm_present: true,
+            key_present: false,
         },
         _ => Response::Error("unexpected request".into()),
     });

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -577,7 +577,7 @@ fn setup_enroll_merge_and_enroll_failure_paths() {
             created: false,
             added: 2,
             total: 8,
-            room: 22,
+            room: Some(22),
             added_scans: Vec::new(),
         },
         Request::SealPassword { .. } => Response::PasswordSealed,

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -39,7 +39,7 @@ const DEFAULT_RW_TIMEOUT: Duration = Duration::from_secs(30);
 /// capabilities), so in exactly those contexts the compiled default wins, while
 /// the daemon (a clean systemd environment) and dev/test clients keep the
 /// override.
-fn secure_env(name: &str) -> Option<std::ffi::OsString> {
+pub fn secure_env(name: &str) -> Option<std::ffi::OsString> {
     use std::os::unix::ffi::OsStringExt;
     // glibc's secure_getenv; not surfaced by the `libc` crate, so declare it
     // (the shipping targets are all glibc: Fedora, Debian/Ubuntu, Arch).

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -102,6 +102,26 @@ pub fn request_with_timeout(req: &Request, rw_timeout: Duration) -> io::Result<R
 /// EACCES/EPERM means the opposite: the socket is there and the daemon is very
 /// likely fine, but this uid may not connect. Say that, and do not suggest
 /// `sudo` or a chmod, because both hide whatever set the mode.
+/// Whether this failure PROVES nobody is listening on the socket.
+///
+/// The distinction matters wherever "the daemon is not there" licenses an act
+/// that would be unsafe if it were: classifying camera nodes is the case that
+/// motivated this. A timeout does NOT prove absence. A daemon busy mid-capture
+/// is exactly what a timed-out short poll looks like, and that is precisely
+/// when it holds the video nodes, so treating a timeout as absence would open
+/// the devices at the worst possible moment (#187). EACCES says the same thing
+/// from the other side: the socket is there and the daemon is very likely fine,
+/// this uid just may not connect.
+pub fn proves_daemon_absent(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::NotFound
+            | io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::BrokenPipe
+    )
+}
+
 fn map_connect_failure(e: io::Error) -> io::Error {
     match e.kind() {
         io::ErrorKind::NotFound

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -13,7 +13,7 @@
 //! unsealed secret in transit, before it lands inside a zeroizing `SecretBytes`).
 
 use crate::{Request, Response, SOCKET_PATH};
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Read as _, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -26,6 +26,11 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// UI: fail fast and let the next tick retry.
 const POLL_CONNECT_TIMEOUT: Duration = Duration::from_millis(1200);
 const POLL_RW_TIMEOUT: Duration = Duration::from_millis(1500);
+/// Largest response this client will accept. The daemon's own replies are far
+/// smaller; the cap exists so a peer that is not the daemon cannot make a
+/// client read forever. Matches the daemon's request cap.
+const MAX_RESPONSE_BYTES: u64 = 64 * 1024;
+
 /// Default read/write timeout for management requests.
 const DEFAULT_RW_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -167,9 +172,22 @@ fn request_with_timeouts(
     // The request may carry a password (SealPassword/RecoverySetup); wipe it.
     line.zeroize();
 
-    let mut reader = BufReader::new(&stream);
+    // Capped, like the daemon caps requests. `SO_RCVTIMEO` restarts on every
+    // read, so the rw budget bounds one read and not the exchange: a peer that
+    // dribbles bytes with no newline holds the caller forever and grows the
+    // buffer without bound. That caller can be `pam_irlume` inside a login.
+    // The daemon is honest, but `IRLUME_SOCKET` redirects any non-setuid
+    // invocation, so the peer is not always the daemon.
+    let mut reader = BufReader::new((&stream).take(MAX_RESPONSE_BYTES));
     let mut buf = String::new();
     reader.read_line(&mut buf).map_err(map_connect_failure)?;
+    if buf.len() as u64 >= MAX_RESPONSE_BYTES {
+        buf.zeroize();
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "response exceeded the size limit; refusing it",
+        ));
+    }
     if buf.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
@@ -206,7 +224,6 @@ fn connect_with_timeout(path: &Path, timeout: Duration) -> io::Result<UnixStream
 mod tests {
     use super::*;
     use crate::testenv;
-    use std::io::Read as _;
     use std::os::unix::net::UnixListener;
     use std::path::PathBuf;
 

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -102,7 +102,6 @@ pub fn read_kv(file: &str, key: &str) -> Option<String> {
 /// Insert or update `key=value`, preserving every other line (including
 /// comments) and dropping duplicate keys. Creates the file at 0600 if absent.
 pub fn write_kv(file: &str, key: &str, val: &str) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
     let path = config_path(file);
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
@@ -131,21 +130,14 @@ pub fn write_kv(file: &str, key: &str, val: &str) -> std::io::Result<()> {
         out.push_str(&format!("{key}={val}\n"));
     }
 
-    // Create with mode 0600 so the file is never briefly world-readable in the
-    // window between write and chmod (umask can only clear bits, so 0600 stays
-    // at most 0600); set_permissions still normalizes an already-existing file.
-    use std::io::Write as _;
-    use std::os::unix::fs::OpenOptionsExt as _;
-    let mut f = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&path)?;
-    f.write_all(out.as_bytes())?;
-    f.flush()?;
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
-    Ok(())
+    // Published atomically, not truncated in place. Truncate-then-write means a
+    // full disk or a power loss mid-write leaves a partial file, and these hold
+    // the camera binding and the third-party model selection: on a full tmpfs
+    // this left cameras.conf as 4096 bytes of half a config. `write_0600_atomic`
+    // creates the temp at the final mode, fsyncs it, renames, then fsyncs the
+    // directory, so a reader sees either the whole old file or the whole new
+    // one, and the same helper already protects the envelopes and template keys.
+    crate::write_0600_atomic(&path, out.as_bytes())
 }
 
 /// The settings.conf key for the credential-release temporal-liveness gate.

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -266,6 +266,31 @@ pub fn credential_release_challenge_visible() -> Option<bool> {
     }
 }
 
+/// Whether the operation-class gate (`enforce_biopolicy`) is on, or `None` when
+/// settings.conf exists and this process may not read it.
+///
+/// Same reasoning as [`credential_release_challenge_visible`]: the file is 0600
+/// root-only, so an unprivileged `irlume status` cannot tell "key absent" (off,
+/// the default) from "key set to on". Printing "off (default)" in that case
+/// reports a guessed security state as a fact, which is what this returns None
+/// to prevent.
+pub fn enforce_biopolicy_visible() -> Option<bool> {
+    // Must agree with the daemon's `biopolicy_enforced()`, which is the only
+    // opinion that decides anything: same truthy set, same env override. The two
+    // display sites used to accept "1"|"true" alone, so `enforce_biopolicy=yes`
+    // printed "off" while the daemon was enforcing.
+    let truthy = |s: &str| matches!(s.trim(), "1" | "true" | "yes" | "on");
+    if let Ok(v) = std::env::var("IRLUME_ENFORCE_BIOPOLICY") {
+        return Some(truthy(&v));
+    }
+    match observe_kv("settings.conf", "enforce_biopolicy") {
+        KvObservation::Value(v) => Some(truthy(&v)),
+        // No file, or no key in it, is unambiguous: the default is off.
+        KvObservation::Absent => Some(false),
+        KvObservation::Unknown(_) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -94,6 +94,10 @@ pub const PACKAGED_ORT_PATHS: &[&str] = &[
     "/opt/irlume/onnxruntime/lib/libonnxruntime.so",
 ];
 
+fn default_true() -> bool {
+    true
+}
+
 /// Per-user enrolled templates + TPM-sealed release secrets.
 pub const STATE_DIR: &str = "/var/lib/irlume";
 
@@ -904,9 +908,16 @@ pub enum Response {
     /// (`RecoveryStatus`): whether templates are encrypted (a sealed key exists)
     /// and whether a recovery passphrase is set.
     RecoveryStatus {
+        /// Whether the STORE is encrypted at rest, from its own on-disk shape.
         encrypted: bool,
         recovery_set: bool,
         tpm_present: bool,
+        /// Whether the template key that opens an encrypted store still exists.
+        /// False with `encrypted` true means the enrollment cannot be opened by
+        /// anything, which no other field can express. Defaults to true so a
+        /// pre-0.9.0 daemon, which never sends it, does not read as key-missing.
+        #[serde(default = "default_true")]
+        key_present: bool,
     },
 }
 

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -733,7 +733,19 @@ pub enum Response {
         profile: String,
         created: bool,
         added: usize,
+        /// Scans in the profile across EVERY recognizer. Display only: the
+        /// scan limit is counted per recognizer (#290), so this is not the
+        /// number to compute a remaining budget from. Use `room`.
         total: usize,
+        /// How many more scans this profile may take IN THE LOADED
+        /// RECOGNIZER'S SPACE, which is what the limit actually governs.
+        /// Carried rather than recomputed by the client: deriving it from
+        /// `total` under-counts on a multi-model profile and refuses scans
+        /// the daemon would accept. `serde(default)` so an older daemon
+        /// still decodes (its 0 then reads as "no room known", and the
+        /// caller falls back to its requested count).
+        #[serde(default)]
+        room: usize,
         added_scans: Vec<String>,
     },
     SelfTest {
@@ -1320,6 +1332,7 @@ mod tests {
                 created: true,
                 added: 3,
                 total: 3,
+                room: 27,
                 added_scans: vec![],
             },
             Response::Enrolled {
@@ -1327,6 +1340,7 @@ mod tests {
                 created: false,
                 added: 1,
                 total: 8,
+                room: 22,
                 added_scans: vec!["scan8".into()],
             },
         ] {
@@ -1339,6 +1353,7 @@ mod tests {
                         created: c1,
                         added: a1,
                         total: t1,
+                        room: r1,
                         added_scans: s1,
                     },
                     Response::Enrolled {
@@ -1346,10 +1361,11 @@ mod tests {
                         created: c2,
                         added: a2,
                         total: t2,
+                        room: r2,
                         added_scans: s2,
                     },
                 ) => {
-                    assert_eq!((p1, c1, a1, t1, s1), (p2, c2, a2, t2, s2));
+                    assert_eq!((p1, c1, a1, t1, r1, s1), (p2, c2, a2, t2, r2, s2));
                 }
                 _ => panic!("Enrolled did not round-trip to Enrolled"),
             }

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -80,6 +80,20 @@ impl std::fmt::Debug for SecretBytes {
     }
 }
 
+/// Where the irlume packages install onnxruntime: Fedora/Copr first, then the
+/// Debian/Ubuntu universal .deb and PPA layout (packaging/README.md records
+/// both). Their systemd drop-in hands `ORT_DYLIB_PATH` to the DAEMON only, so
+/// anything running as a bare CLI has to probe these paths itself.
+///
+/// Shared rather than restated: `irlume deps` kept its own shorter list that
+/// had neither packaged path, so with the daemon stopped it told users to
+/// install onnxruntime on machines where the package had already installed it,
+/// at exactly the moment they were debugging a failed login.
+pub const PACKAGED_ORT_PATHS: &[&str] = &[
+    "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
+    "/opt/irlume/onnxruntime/lib/libonnxruntime.so",
+];
+
 /// Per-user enrolled templates + TPM-sealed release secrets.
 pub const STATE_DIR: &str = "/var/lib/irlume";
 

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -759,11 +759,19 @@ pub enum Response {
         /// RECOGNIZER'S SPACE, which is what the limit actually governs.
         /// Carried rather than recomputed by the client: deriving it from
         /// `total` under-counts on a multi-model profile and refuses scans
-        /// the daemon would accept. `serde(default)` so an older daemon
-        /// still decodes (its 0 then reads as "no room known", and the
-        /// caller falls back to its requested count).
+        /// the daemon would accept.
+        ///
+        /// `None` means the daemon did not say, which is every daemon older
+        /// than 0.9.0. That is NOT the same as `Some(0)`, a profile that is
+        /// genuinely full, and the difference is load-bearing: a plain
+        /// `usize` defaulted to 0, so a 0.9.0 client talking to a
+        /// still-running 0.8.1 daemon (the window every upgrade passes
+        /// through, between the package swap and the daemon restart) offered
+        /// zero continuation scans and silently under-enrolled, which is the
+        /// failure #290 exists to prevent. A caller seeing `None` uses its
+        /// own requested count and lets the daemon refuse what it will.
         #[serde(default)]
-        room: usize,
+        room: Option<usize>,
         added_scans: Vec<String>,
     },
     SelfTest {
@@ -1357,7 +1365,7 @@ mod tests {
                 created: true,
                 added: 3,
                 total: 3,
-                room: 27,
+                room: Some(27),
                 added_scans: vec![],
             },
             Response::Enrolled {
@@ -1365,7 +1373,7 @@ mod tests {
                 created: false,
                 added: 1,
                 total: 8,
-                room: 22,
+                room: Some(22),
                 added_scans: vec!["scan8".into()],
             },
         ] {

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -137,6 +137,17 @@ pub enum Stage {
 }
 
 impl Stage {
+    /// Every stage, in pipeline order. Callers that report on the stage set must
+    /// iterate this rather than spelling stages out, or they go stale the moment
+    /// one opens (doctor claimed "the pad stage only today" through the release
+    /// that opened recognition).
+    pub const ALL: [Stage; 4] = [
+        Stage::Detection,
+        Stage::Landmarks,
+        Stage::Recognition,
+        Stage::Pad,
+    ];
+
     /// Stable lowercase name, used in CLI output and the machine API.
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -303,10 +314,7 @@ pub fn by_name(name: &str) -> Option<&'static ThirdPartyModel> {
 /// Directory for fetched third-party weights: `$IRLUME_STATE_DIR` (sandbox
 /// override) else `/var/lib/irlume`, plus [`SUBDIR`].
 pub fn dir() -> PathBuf {
-    let root = std::env::var_os("IRLUME_STATE_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(crate::STATE_DIR));
-    root.join(SUBDIR)
+    crate::state_dir().join(SUBDIR)
 }
 
 /// On-disk path for a catalog entry.

--- a/crates/irlume-core/Cargo.toml
+++ b/crates/irlume-core/Cargo.toml
@@ -18,4 +18,6 @@ rsa.workspace = true
 aes-gcm.workspace = true
 argon2.workspace = true
 pbkdf2.workspace = true
+# O_NONBLOCK/O_NOFOLLOW when reading a file inside a user-writable home.
+libc.workspace = true
 rand.workspace = true

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -21,10 +21,12 @@ use std::path::PathBuf;
 use zeroize::Zeroizing;
 
 /// Root-only directory for sealed-password envelopes.
+// See the template-key note: the fallback must honor `IRLUME_STATE_DIR`, or a
+// sandboxed root `keyring forget` deletes the live armed seal.
 fn keyring_dir() -> PathBuf {
     std::env::var("IRLUME_KEYRING_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(irlume_common::STATE_DIR).join("keyring"))
+        .unwrap_or_else(|_| irlume_common::state_dir().join("keyring"))
 }
 
 pub fn envelope_path(user: &str) -> PathBuf {
@@ -515,6 +517,25 @@ pub fn forget_password(user: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The armed seal is live cryptographic state; a sandboxed root `keyring
+    /// forget` must delete the sandbox copy, never `/var/lib/irlume/keyring`.
+    #[test]
+    fn sandbox_override_contains_keyring_dir() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let sandbox = crate::test_tmp_dir("sandbox-containment-kr");
+        std::env::remove_var("IRLUME_KEYRING_DIR");
+        std::env::set_var("IRLUME_STATE_DIR", &sandbox);
+        let env = envelope_path("someuser");
+        std::env::remove_var("IRLUME_STATE_DIR");
+        assert!(
+            env.starts_with(&sandbox),
+            "keyring envelope escaped the sandbox: {}",
+            env.display()
+        );
+        assert!(!env.starts_with(irlume_common::STATE_DIR));
+    }
+
     use super::*;
 
     #[test]

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -46,6 +46,69 @@ pub fn salt_path(home: &Path) -> PathBuf {
     home.join(SALT_RELPATH)
 }
 
+/// The most this file can be and still be a wallet salt. A real one is
+/// [`SALT_LEN`] bytes; the headroom is for a future format, not for a payload.
+const MAX_SALT_BYTES: u64 = 4096;
+
+/// Read a REGULAR file of at most `max` bytes, without blocking and without
+/// following a symlink at the final component.
+///
+/// This path lives inside the user's own home, so its contents and its type are
+/// theirs to choose, and the daemon reads it as root on the worker thread. A
+/// plain `fs::read` here was a wedge: `mkfifo`ing the salt path blocks in
+/// `open(2)` until a writer appears, which stalls the camera worker forever
+/// while the connection threads keep answering Ping, so the daemon looks
+/// healthy while every capture and mutation is dead. The systemd watchdog then
+/// kills and restarts it, and the file is still a FIFO, so it happens again.
+/// Pointing it at /dev/zero gives unbounded allocation instead.
+///
+/// `O_NONBLOCK` makes opening a FIFO return instead of waiting, `O_NOFOLLOW`
+/// stops a symlink redirecting the final component elsewhere, and the fstat
+/// rejects anything that is not a regular file, which covers FIFOs, devices,
+/// and directories together. The size cap bounds the allocation.
+fn read_regular_file_capped(path: &Path, max: u64) -> std::io::Result<Vec<u8>> {
+    use std::io::Read as _;
+    use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW)
+        .open(path)?;
+    let meta = file.metadata()?;
+    let ft = meta.file_type();
+    if !ft.is_file() {
+        let what = if ft.is_fifo() {
+            "a FIFO"
+        } else if ft.is_char_device() || ft.is_block_device() {
+            "a device"
+        } else if ft.is_dir() {
+            "a directory"
+        } else if ft.is_socket() {
+            "a socket"
+        } else {
+            "not a regular file"
+        };
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} is {what}, not a regular file", path.display()),
+        ));
+    }
+    if meta.len() > max {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "{} is {} bytes, over the {max}-byte limit",
+                path.display(),
+                meta.len()
+            ),
+        ));
+    }
+    let mut buf = Vec::with_capacity(meta.len() as usize);
+    // Cap the read as well as the stat: the file can grow between the two.
+    file.take(max).read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
 /// Read `home`'s wallet salt.
 ///
 /// Deliberately does NOT create a missing salt, unlike `pam_kwallet5`, which
@@ -54,7 +117,7 @@ pub fn salt_path(home: &Path) -> PathBuf {
 /// looking like a successful arm.
 pub fn read_salt(home: &Path) -> Result<Zeroizing<Vec<u8>>> {
     let path = salt_path(home);
-    let raw = std::fs::read(&path).map_err(|e| {
+    let raw = read_regular_file_capped(&path, MAX_SALT_BYTES).map_err(|e| {
         Error::Policy(format!(
             "no KDE wallet salt at {}: {e}. Log into a Plasma session once so \
              the wallet exists, then arm again",
@@ -125,6 +188,49 @@ pub fn detect_kind(home: &Path) -> crate::envelope::SecretKind {
 
 #[cfg(test)]
 mod tests {
+
+    /// The salt path lives in the user's own home, so its TYPE is theirs to
+    /// choose. `fs::read` on a FIFO blocks in `open(2)` until a writer appears,
+    /// which stalls the daemon's camera worker forever while the connection
+    /// threads keep answering Ping: the daemon looks healthy while every capture
+    /// is dead, the watchdog kills it, and the FIFO is still there on restart.
+    #[test]
+    fn a_non_regular_salt_is_refused_instead_of_blocking() {
+        let dir = std::path::PathBuf::from(crate::test_tmp_dir("kwallet-fifo"))
+            .join(".local/share/kwalletd");
+        let _ = std::fs::remove_dir_all(dir.parent().unwrap().parent().unwrap());
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("kdewallet.salt");
+        let c = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            unsafe { libc::mkfifo(c.as_ptr(), 0o600) },
+            0,
+            "mkfifo failed"
+        );
+
+        let home = dir.parent().unwrap().parent().unwrap().parent().unwrap();
+        // Must RETURN. Before the fix this call never came back.
+        let err = read_salt(home).expect_err("a FIFO must not be read as a salt");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("FIFO"),
+            "the refusal must name what it found: {msg}"
+        );
+
+        // A real salt still reads.
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, vec![7u8; SALT_LEN]).unwrap();
+        assert_eq!(read_salt(home).unwrap().len(), SALT_LEN);
+
+        // And an implausibly large one is refused rather than allocated.
+        std::fs::write(&path, vec![0u8; (MAX_SALT_BYTES + 1) as usize]).unwrap();
+        assert!(
+            read_salt(home).is_err(),
+            "an oversized salt must be refused"
+        );
+        let _ = std::fs::remove_dir_all(home);
+    }
+
     use super::*;
 
     #[test]

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -612,6 +612,25 @@ pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
     deserialize_enrollment(&data, key.as_ref().map(|k| k.as_slice())).map(Some)
 }
 
+/// Whether the on-disk store for `user` is encrypted, or `None` when there is
+/// no store at all.
+///
+/// Read from the file's own `enc` envelope, NOT from whether a template key
+/// exists. Those two answers disagree in exactly one state, and it is the state
+/// the user most needs told about: an encrypted store whose key has been lost.
+/// Reporting that as "plaintext at rest" both understates the privacy posture
+/// and hides the data loss, and it points the user at `recovery setup` when the
+/// only remaining move is to re-enroll.
+pub fn store_is_encrypted(user: &str) -> Option<bool> {
+    let path = profile_path(user);
+    let data = fs::read(&path).ok()?;
+    Some(
+        serde_json::from_slice::<serde_json::Value>(&data)
+            .map(|v| v.get("enc").is_some())
+            .unwrap_or(false),
+    )
+}
+
 pub fn delete(user: &str) -> irlume_common::Result<bool> {
     let path = profile_path(user);
     let existed = path.exists();

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -224,6 +224,10 @@ pub fn recognizer_space_matches(have: Option<&str>, want: &str) -> bool {
     }
 }
 
+/// The IR embedding space of the shipped pipeline with no adapter loaded. The
+/// only space an untagged legacy scan can have come from.
+pub const IR_RAW_SPACE: &str = "raw";
+
 impl Enrollment {
     pub fn new(user: &str) -> Self {
         Self {
@@ -351,6 +355,25 @@ impl Enrollment {
     /// explicitly tagged and can fail loud ("re-enroll") instead of scoring
     /// across spaces. Idempotent; returns how many scans were stamped.
     pub fn retag_untagged_ir(&mut self, space: &str, dim: usize) -> usize {
+        // Only ever stamp the RAW space, and never an adapter's.
+        //
+        // An untagged scan predates tagging, and no IR adapter has ever shipped
+        // (ADR-0004), so an untagged IR template is raw by construction. The
+        // caller passes the LIVE pipeline's space, which is taken after
+        // `with_ir_adapter` has run, so on a machine whose first tagging-aware
+        // start already has `IRLUME_IR_ADAPTER` set, every legacy raw template
+        // would be permanently relabelled adapter-space. `ir_match_in` would
+        // then compare an ADAPTED probe against RAW templates at the adapted
+        // threshold of 0.40, the lowest number in the codebase, on a
+        // grant-capable path: a genuine cross-space cosine, which is the one
+        // thing the space tag exists to prevent.
+        //
+        // Refusing here loses nothing. The scans stay untagged, which
+        // `recognizer_space_matches` already treats as legacy, and the next
+        // start without an adapter stamps them correctly.
+        if space != IR_RAW_SPACE {
+            return 0;
+        }
         let mut n = 0;
         for p in &mut self.profiles {
             for s in &mut p.scans {
@@ -698,6 +721,51 @@ pub fn list_users() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// An untagged IR scan predates tagging, and no adapter has ever shipped,
+    /// so it is raw by construction. The daemon passes the LIVE pipeline's
+    /// space, taken after any adapter loads, so a machine whose first
+    /// tagging-aware start already had IRLUME_IR_ADAPTER set would have had
+    /// every legacy raw template relabelled adapter-space. `ir_match_in` would
+    /// then score an ADAPTED probe against RAW templates at the adapted
+    /// threshold of 0.40, the lowest in the codebase, on a grant-capable path.
+    #[test]
+    fn retag_refuses_to_stamp_legacy_ir_with_an_adapter_space() {
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(FaceProfile {
+            ir_calib: None,
+            ir_calibs: Default::default(),
+            name: "P".into(),
+            scans: vec![FaceScan {
+                name: "s1".into(),
+                rgb: vec![0.1; 4],
+                ir: Some(vec![0.2; 4]),
+                // Untagged: what a scan written before tagging existed looks like.
+                ir_space: None,
+                embed_space: None,
+                ir_center_edge_ratio: 0.0,
+                ir_brightness: 0.0,
+                pitch: 0.0,
+            }],
+        });
+
+        assert_eq!(
+            enr.retag_untagged_ir("adapter:deadbeef", 4),
+            0,
+            "an adapter space must never be stamped onto an untagged scan"
+        );
+        assert!(
+            enr.profiles[0].scans[0].ir_space.is_none(),
+            "the scan must stay untagged, which already reads as legacy"
+        );
+
+        // The raw space is still stamped, which is the whole point of the sweep.
+        assert_eq!(enr.retag_untagged_ir(IR_RAW_SPACE, 4), 1);
+        assert_eq!(
+            enr.profiles[0].scans[0].ir_space.as_deref(),
+            Some(IR_RAW_SPACE)
+        );
+    }
 
     fn scan(name: &str, v: f32, space: Option<&str>) -> FaceScan {
         FaceScan {
@@ -1126,15 +1194,18 @@ mod tests {
                 scan_in_space("stale-dim", 2, None),       // wrong dim: left alone
             ],
         });
-        assert_eq!(e.retag_untagged_ir("adapter:abc123", 4), 1);
+        // The space is the RAW one now: stamping an adapter space onto a scan
+        // that predates tagging would invent a provenance it never had, and the
+        // sibling test covers that refusal.
+        assert_eq!(e.retag_untagged_ir(IR_RAW_SPACE, 4), 1);
         assert_eq!(
             e.profiles[0].scans[0].ir_space.as_deref(),
-            Some("adapter:abc123")
+            Some(IR_RAW_SPACE)
         );
         assert_eq!(e.profiles[0].scans[1].ir_space.as_deref(), Some("other"));
         assert!(e.profiles[0].scans[2].ir_space.is_none());
         // Idempotent: nothing left to stamp.
-        assert_eq!(e.retag_untagged_ir("adapter:abc123", 4), 0);
+        assert_eq!(e.retag_untagged_ir(IR_RAW_SPACE, 4), 0);
     }
 
     #[test]

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -25,16 +25,23 @@ use irlume_common::{Error, Result};
 use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
+// The fallback goes through `state_dir()`, NOT the bare `STATE_DIR`
+// constant, so one `IRLUME_STATE_DIR` moves the whole sandbox together.
+// When these two resolved to the literal while the profile store honored
+// the override, a sandboxed ROOT run reached back into live state: on
+// 2026-08-05 a sandboxed `profiles forget-model` emptied the real
+// /var/lib/irlume/template-keys and /var/lib/irlume/recovery, leaving an
+// encrypted enrollment whose key no longer existed anywhere.
 fn key_dir() -> PathBuf {
     std::env::var("IRLUME_TEMPLATE_KEY_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(irlume_common::STATE_DIR).join("template-keys"))
+        .unwrap_or_else(|_| irlume_common::state_dir().join("template-keys"))
 }
 
 fn recovery_dir() -> PathBuf {
     std::env::var("IRLUME_RECOVERY_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(irlume_common::STATE_DIR).join("recovery"))
+        .unwrap_or_else(|_| irlume_common::state_dir().join("recovery"))
 }
 
 pub fn key_path(user: &str) -> PathBuf {
@@ -188,6 +195,41 @@ fn set_0600(_path: &Path) {}
 
 #[cfg(test)]
 mod tests {
+
+    /// A sandboxed run must not reach live cryptographic state. `IRLUME_STATE_DIR`
+    /// moved the profile store but not these two directories, so a sandboxed ROOT
+    /// `profiles forget-model` deleted the real template keys and recovery
+    /// envelopes on 2026-08-05, leaving an encrypted enrollment nothing could
+    /// open. Both fallbacks must land under the override.
+    #[test]
+    fn sandbox_override_contains_key_and_recovery_dirs() {
+        let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        let sandbox = crate::test_tmp_dir("sandbox-containment");
+        // The per-directory overrides outrank IRLUME_STATE_DIR, so clear them or
+        // this test passes for the wrong reason.
+        std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
+        std::env::remove_var("IRLUME_RECOVERY_DIR");
+        std::env::set_var("IRLUME_STATE_DIR", &sandbox);
+
+        let key = key_path("someuser");
+        let rec = recovery_path("someuser");
+
+        std::env::remove_var("IRLUME_STATE_DIR");
+
+        assert!(
+            key.starts_with(&sandbox),
+            "template key escaped the sandbox: {}",
+            key.display()
+        );
+        assert!(
+            rec.starts_with(&sandbox),
+            "recovery envelope escaped the sandbox: {}",
+            rec.display()
+        );
+        assert!(!key.starts_with(irlume_common::STATE_DIR));
+        assert!(!rec.starts_with(irlume_common::STATE_DIR));
+    }
+
     use super::*;
     // The override env vars are process-global; the crate-wide lock stops
     // cross-module races too (keyring tests mutate their own override).

--- a/crates/irlume-core/tests/sandbox_containment.rs
+++ b/crates/irlume-core/tests/sandbox_containment.rs
@@ -56,11 +56,26 @@ fn no_state_path_is_built_from_the_bare_constant() {
                     .to_string();
                 let text = std::fs::read_to_string(&path).expect("read source");
                 scanned += 1;
+                // Tests name the constant on purpose, to assert a resolved path
+                // does NOT start with it. Everything from the first #[cfg(test)]
+                // to the end of the file is theirs.
+                let mut in_test_code = false;
                 for (n, line) in text.lines().enumerate() {
-                    // The escape shape: wrapping the constant in a PathBuf, which
-                    // is what you do right before `.join(...)` a state subdir.
-                    if line.contains("PathBuf::from(irlume_common::STATE_DIR)")
-                        || line.contains("PathBuf::from(crate::STATE_DIR)")
+                    if line.trim() == "#[cfg(test)]" {
+                        in_test_code = true;
+                    }
+                    if in_test_code {
+                        continue;
+                    }
+                    // ANY production reference to the bare constant, not one
+                    // construction spelling. The first version of this test
+                    // matched only `PathBuf::from(...)` and sailed past
+                    // `remove_dir_all(irlume_common::STATE_DIR)` in uninstall,
+                    // which is the same escape with a recursive delete on the
+                    // end. A guard that checks a syntax rather than the fact is
+                    // worse than none: it is believed.
+                    if line.contains("irlume_common::STATE_DIR")
+                        || line.contains("crate::STATE_DIR")
                     {
                         if allowed(&name).is_some() {
                             continue;

--- a/crates/irlume-core/tests/sandbox_containment.rs
+++ b/crates/irlume-core/tests/sandbox_containment.rs
@@ -1,0 +1,91 @@
+//! Every state path must honor the `IRLUME_STATE_DIR` sandbox override.
+//!
+//! The behavioral tests in `template_key.rs` and `keyring.rs` pin the three
+//! resolvers that exist today. This one pins the *rule*, so a new state
+//! subdirectory added later cannot reintroduce the escape: on 2026-08-05 a
+//! sandboxed root `profiles forget-model` emptied the live
+//! /var/lib/irlume/template-keys and /var/lib/irlume/recovery, because those two
+//! resolvers built from the bare `STATE_DIR` constant while the profile store
+//! used the override-aware accessor. The enrollment survived encrypted with its
+//! key deleted, which is unrecoverable.
+
+use std::path::Path;
+
+/// Files allowed to build a path from the bare constant, each with a reason.
+fn allowed(file: &str) -> Option<&'static str> {
+    match file {
+        // Defines both the constant and the accessor.
+        "lib.rs" => Some("declares STATE_DIR and state_dir()"),
+        // Has its own override-aware resolver with a HOME fallback; the constant
+        // is only its last resort.
+        "storage.rs" => Some("own state_dir() reads IRLUME_STATE_DIR first"),
+        _ => None,
+    }
+}
+
+#[test]
+fn no_state_path_is_built_from_the_bare_constant() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .to_path_buf();
+
+    let mut offenders = Vec::new();
+    let mut scanned = 0usize;
+
+    for crate_dir in std::fs::read_dir(&root).expect("read crates/") {
+        let src = crate_dir.expect("entry").path().join("src");
+        if !src.is_dir() {
+            continue;
+        }
+        let mut stack = vec![src];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("read src dir") {
+                let path = entry.expect("entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().is_none_or(|e| e != "rs") {
+                    continue;
+                }
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let text = std::fs::read_to_string(&path).expect("read source");
+                scanned += 1;
+                for (n, line) in text.lines().enumerate() {
+                    // The escape shape: wrapping the constant in a PathBuf, which
+                    // is what you do right before `.join(...)` a state subdir.
+                    if line.contains("PathBuf::from(irlume_common::STATE_DIR)")
+                        || line.contains("PathBuf::from(crate::STATE_DIR)")
+                    {
+                        if allowed(&name).is_some() {
+                            continue;
+                        }
+                        offenders.push(format!(
+                            "{}:{}: {}",
+                            path.strip_prefix(&root).unwrap_or(&path).display(),
+                            n + 1,
+                            line.trim()
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        scanned > 20,
+        "scanned only {scanned} files; the walker is broken, not the code"
+    );
+    assert!(
+        offenders.is_empty(),
+        "these build a state path from the bare STATE_DIR constant, so \
+         IRLUME_STATE_DIR will not contain them. Use irlume_common::state_dir() \
+         instead, or add the file to `allowed()` with a reason:\n  {}",
+        offenders.join("\n  ")
+    );
+}

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3025,7 +3025,7 @@ fn enroll_response(outcome: irlume_auth::EnrollOutcome) -> Response {
             total: scans,
             // A brand-new profile holds only this recognizer's scans, so the
             // per-recognizer room is the plain remainder.
-            room: irlume_core::storage::MAX_SCANS_PER_PROFILE.saturating_sub(scans),
+            room: Some(irlume_core::storage::MAX_SCANS_PER_PROFILE.saturating_sub(scans)),
             added_scans: Vec::new(),
         },
         irlume_auth::EnrollOutcome::Merged {
@@ -3039,7 +3039,7 @@ fn enroll_response(outcome: irlume_auth::EnrollOutcome) -> Response {
             created: false,
             added,
             total,
-            room,
+            room: Some(room),
             added_scans,
         },
     }
@@ -3592,7 +3592,8 @@ mod tests {
                 assert!(!created, "a merge must not claim a new profile was created");
                 assert_eq!((added, total), (1, 8));
                 assert_eq!(
-                    room, 22,
+                    room,
+                    Some(22),
                     "the daemon's per-recognizer room must reach the client, not \
                      be recomputed there from the profile-wide total"
                 );

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1906,9 +1906,13 @@ fn dispatch_status(req: &Request, peer: &Peer) -> Option<Response> {
                 return Some(Response::Error(format!("not authorized to query '{user}'")));
             }
             Response::RecoveryStatus {
-                encrypted: irlume_core::template_key::has_key(user),
+                // The store's own shape, not the key's presence: those differ
+                // exactly when the key is gone, and that case has to be
+                // reportable rather than collapsed into "plaintext".
+                encrypted: irlume_core::storage::store_is_encrypted(user).unwrap_or(false),
                 recovery_set: irlume_core::template_key::has_recovery(user),
                 tpm_present: irlume_core::template_key::tpm_available(),
+                key_present: irlume_core::template_key::has_key(user),
             }
         }
         Request::ListProfiles {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -690,6 +690,10 @@ fn main() {
     // sends requests cannot exhaust memory. Well above any real client: the
     // greeter, the lock screen, a TUI and sudo together are a handful.
     const MAX_CONNECTION_THREADS: usize = 64;
+    /// Slots an unprivileged peer may not take. The greeter, the lock screen
+    /// and a sudo stack together are a handful, so a small reserve is enough to
+    /// keep the login path answerable while an unprivileged peer floods.
+    const ROOT_RESERVED_SLOTS: usize = 16;
     let live_threads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     // How long a throttled connection is held before being closed, and how many
@@ -746,9 +750,25 @@ fn main() {
                     // descriptors one abusive peer can pin.
                     continue;
                 }
+                // Reserve the top of the pool for root.
+                //
+                // The cap is global, and a connection occupies a slot from
+                // accept until its read times out 15 seconds later, so an
+                // unprivileged peer that opens 64 sockets and sends NOTHING is
+                // never charged by `refusal_throttled` (which only counts
+                // arbiter refusals) and locks the socket for everyone: measured,
+                // a root peer's Ping got "daemon busy" for as long as the
+                // attacker held them. Root is where the login path lives, so it
+                // keeps slots an ordinary uid cannot take. The fallback when the
+                // peer cannot be identified is to treat it as unprivileged.
+                let peer_is_root = peer_cred(&stream).is_ok_and(|p| p.uid == 0);
+                let ceiling = if peer_is_root {
+                    MAX_CONNECTION_THREADS
+                } else {
+                    MAX_CONNECTION_THREADS - ROOT_RESERVED_SLOTS
+                };
                 let live = std::sync::Arc::clone(&live_threads);
-                if live.fetch_add(1, std::sync::atomic::Ordering::SeqCst) >= MAX_CONNECTION_THREADS
-                {
+                if live.fetch_add(1, std::sync::atomic::Ordering::SeqCst) >= ceiling {
                     live.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
                     let _ = respond(
                         stream,

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3019,18 +3019,23 @@ fn enroll_response(outcome: irlume_auth::EnrollOutcome) -> Response {
             created: true,
             added: scans,
             total: scans,
+            // A brand-new profile holds only this recognizer's scans, so the
+            // per-recognizer room is the plain remainder.
+            room: irlume_core::storage::MAX_SCANS_PER_PROFILE.saturating_sub(scans),
             added_scans: Vec::new(),
         },
         irlume_auth::EnrollOutcome::Merged {
             name,
             added,
             total,
+            room,
             added_scans,
         } => Response::Enrolled {
             profile: name,
             created: false,
             added,
             total,
+            room,
             added_scans,
         },
     }
@@ -3567,6 +3572,7 @@ mod tests {
             name: "Face Profile 1".into(),
             added: 1,
             total: 8,
+            room: 22,
             added_scans: vec!["Face Scan 8".into()],
         });
         match merged {
@@ -3575,11 +3581,17 @@ mod tests {
                 created,
                 added,
                 total,
+                room,
                 added_scans,
             } => {
                 assert_eq!(profile, "Face Profile 1");
                 assert!(!created, "a merge must not claim a new profile was created");
                 assert_eq!((added, total), (1, 8));
+                assert_eq!(
+                    room, 22,
+                    "the daemon's per-recognizer room must reach the client, not \
+                     be recomputed there from the profile-wide total"
+                );
                 assert_eq!(added_scans, vec!["Face Scan 8".to_string()]);
             }
             other => panic!("merge must answer Enrolled, got {other:?}"),

--- a/crates/irlume-kwallet-init/src/main.rs
+++ b/crates/irlume-kwallet-init/src/main.rs
@@ -232,8 +232,28 @@ fn lookup_user(user: &str) -> Result<User, String> {
     })
 }
 
+/// Whether this process holds privilege that the environment must not steer.
+/// The same check `irlume-gkr-unlock` applies to its two overrides.
+fn privileged() -> bool {
+    let (euid, uid) = unsafe { (libc::geteuid(), libc::getuid()) };
+    euid == 0 || uid == 0
+}
+
 fn wallet_daemon() -> Result<CString, String> {
+    // The override names a binary this program EXECS while holding the
+    // TPM-released wallet key. `secure_getenv` in the PAM parent does not cover
+    // it: AT_SECURE is a property of one execve, and this helper is not setuid,
+    // so its own AT_SECURE is 0 no matter how the parent was entered. The
+    // sibling helper refuses its environment overrides when privileged and this
+    // one, which is the one that execs, did not.
     if let Some(over) = std::env::var_os("IRLUME_KSECRETD") {
+        if privileged() {
+            return Err(
+                "IRLUME_KSECRETD is ignored when running privileged; it names a \
+                 binary this helper would exec while holding the wallet key"
+                    .into(),
+            );
+        }
         return CString::new(over.as_bytes()).map_err(|_| "IRLUME_KSECRETD has a NUL".into());
     }
     for c in CANDIDATES {

--- a/crates/irlume-liveness/Cargo.toml
+++ b/crates/irlume-liveness/Cargo.toml
@@ -6,5 +6,4 @@ license.workspace = true
 
 [dependencies]
 irlume-common.workspace = true
-irlume-camera.workspace = true
 irlume-vision.workspace = true

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -484,6 +484,27 @@ fn deliver_gnome_token(pamh: &Pam, user: &str) {
     let _ = hand_token_to_keyring_daemon(user, &token);
 }
 
+/// Resolve a helper binary, ignoring the environment override under
+/// secure execution.
+///
+/// The same rule `socket_path` already follows, and for the same reason: this
+/// module is linked into PAM stacks that can be entered setuid-root (notably
+/// `/etc/pam.d/sudo` under `--with-sudo`), which inherit the invoking user's
+/// environment. These two helpers are spawned AS ROOT with a TPM-released
+/// secret written to their stdin, so a plain `env::var` there would hand an
+/// attacker root execution and the credential together. `secure_getenv`
+/// returns NULL under AT_SECURE, so the compiled path wins in exactly those
+/// contexts while the daemon and the test harness keep the override.
+///
+/// The shipped wiring does not put `unseal` in a setuid stack today, so this
+/// closes a latent hole rather than a live one.
+fn secure_helper_path(var: &str, compiled: &str) -> String {
+    irlume_common::client::secure_env(var)
+        .and_then(|v| v.into_string().ok())
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| compiled.to_string())
+}
+
 /// Spawn the unlock helper with the token on stdin. The helper drops to the
 /// target user before touching their runtime directory (the daemon's control
 /// socket authenticates the peer uid, and root pathname work inside a
@@ -493,8 +514,7 @@ fn hand_token_to_keyring_daemon(user: &str, token: &irlume_common::SecretBytes) 
     use std::io::Write;
     use std::process::{Command, Stdio};
 
-    let helper = std::env::var("IRLUME_GKR_UNLOCK")
-        .unwrap_or_else(|_| irlume_common::GKR_UNLOCK_PATH.to_string());
+    let helper = secure_helper_path("IRLUME_GKR_UNLOCK", irlume_common::GKR_UNLOCK_PATH);
     if !std::path::Path::new(&helper).is_file() {
         return false;
     }
@@ -804,8 +824,7 @@ fn hand_key_to_wallet_daemon(pamh: &Pam, user: &str, key: &[u8]) -> bool {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
-    let helper = std::env::var("IRLUME_KWALLET_INIT")
-        .unwrap_or_else(|_| irlume_common::KWALLET_INIT_PATH.to_string());
+    let helper = secure_helper_path("IRLUME_KWALLET_INIT", irlume_common::KWALLET_INIT_PATH);
     if !std::path::Path::new(&helper).is_file() {
         return false;
     }

--- a/crates/irlume-vision/Cargo.toml
+++ b/crates/irlume-vision/Cargo.toml
@@ -25,7 +25,6 @@ tensorrt = ["ort/tensorrt"]
 [dependencies]
 libc.workspace = true   # dlopen/dlsym probe: prove a library is loadable ort BEFORE ort can park on it (#266)
 irlume-common.workspace = true
-irlume-camera.workspace = true
 thiserror.workspace = true
 ort = { workspace = true, optional = true }
 # Pinned EXACTLY: the 0.9.0 sources were audited (loader + discovery) before

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -253,10 +253,7 @@ mod onnx {
     /// then the Debian/Ubuntu universal .deb and PPA layout (their systemd
     /// override hands the path to the daemon only, so a bare CLI run needs
     /// this list; packaging/README.md records both).
-    const PACKAGED_ORTS: &[&str] = &[
-        "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so",
-        "/opt/irlume/onnxruntime/lib/libonnxruntime.so",
-    ];
+    const PACKAGED_ORTS: &[&str] = irlume_common::PACKAGED_ORT_PATHS;
 
     /// The candidate the resolver would load, pure over its inputs so the
     /// selection is testable without touching the process environment: an

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -38,7 +38,7 @@ Conventions that apply everywhere:
 | `irlume profiles forget-model <model>` | remove one recognizer's scans (and the calibrations fitted from them) from every profile of a user; the deliberate counterpart to `models disable`, which deletes weights but keeps templates. `<model>` is `shipped`, a catalog name, or an `embed:<sha256>` tag as `profiles list` prints it. A profile left with no scans is deleted with them |
 | `irlume profiles eyes-open <on\|off>` | require eyes open to unlock |
 | `irlume profiles challenge <on\|off>` | opt-in passive blink liveness |
-| `sudo irlume calibrate-closure [--rounds N] [--force]` | teach the eye-closure consent gesture for app prompts. Captures eyes-open/closed EAR over N rounds (default 3) and stores the median, because a single capture varies enough to leave the threshold sitting on top of your own closures; it then reports how many of your readings the result would actually accept. Replacing an existing calibration asks first, and `--force` is required to do it with no terminal. The head nod is the default and needs no calibration |
+| `sudo irlume calibrate-closure [--rounds N] [--force] [--measure-only [--pose L]]` | teach the eye-closure consent gesture for app prompts. Captures eyes-open/closed EAR over N rounds (default 3) and stores the median, because a single capture varies enough to leave the threshold sitting on top of your own closures; it then reports how many of your readings the result would actually accept. Replacing an existing calibration asks first, and `--force` is required to do it with no terminal. `--measure-only` prints the EAR readings and stores nothing, and `--pose L` labels what you are holding in that data (e.g. `glasses-on-open`). The head nod is the default and needs no calibration |
 | `irlume identify` | 1:N "who is this?"; as root it checks all users, otherwise scoped to you |
 
 ## Keyring, TPM, and recovery
@@ -65,7 +65,7 @@ Conventions that apply everywhere:
 | `irlume set-cameras <rgb> <ir>` | yes | persist the RGB+IR camera pair, e.g. `/dev/video0 /dev/video2`; the TUI camera picker runs this for you |
 | `irlume camera-tune [--rounds N]` | yes | measure whether this camera keeps its brightness while both sensors stream, and store the resulting capture mode in `cameras.conf`; some modules starve their own RGB interface (measured: NexiGo HelloCam N930W keeps 56% of its RGB brightness), and this puts those on one-at-a-time capture |
 | `irlume models [list]` | no | show the opt-in third-party models (stage, tier, checksum state); `models list --json` is the [machine API](MACHINE-API.md) per-stage report |
-| `irlume models enable <name>` / `models disable` | yes | fetch and enable one (deny-only, checksum-pinned), or turn it off |
+| `irlume models enable <name>` / `models disable [name]` | yes | fetch and enable one (checksum-pinned; a PAD entry is a deny-only cue, a recognition entry replaces the RGB matcher at its measured threshold), or turn one off; a bare `disable` errors when more than one model is enabled |
 | `irlume models add <name> <path>` | yes | enable a model whose licence means you obtain the file; verified against the pin irlume measured ([THIRD-PARTY-MODELS.md](THIRD-PARTY-MODELS.md)) |
 | `irlume update [--check]` | for install | update via the channel irlume was installed from (Copr/PPA: runs it; .deb/pkg/source: shows the steps); `--check` only reports |
 | `irlume uninstall [--keep-data] [--yes]` | yes | un-wire PAM first (lockout-safe order), stop the daemon, wipe enrolled data unless `--keep-data`, then print the package-removal command |
@@ -77,7 +77,7 @@ bypass the daemon. Not needed for normal use.
 
 `capture`, `eval`, `irbench`, `genuine`, `calcapture`, `normprobe`,
 `liveness`, `meshprobe`, `selftest align`, `padcapture`, `padreport`,
-`verify`, `enrolldev`, `suncal`
+`verify`, `enrolldev`, `suncal`, `blinkcap`
 
 Each prints its own usage line when run without arguments. `padcapture` /
 `padreport` are the presentation-attack self-test pair documented in

--- a/docs/FAIRNESS.md
+++ b/docs/FAIRNESS.md
@@ -56,8 +56,9 @@ against 1.042×10⁻³); it is both fairer and more accurate. The 2026-08-05
 split-source re-run (docs/recognition-results/2026-08-05-buffalo-l.md)
 reproduced this document's AuraFace figures exactly and measured, at
 buffalo_l's enabled 0.55 operating point, a spread of ≈ 3.9× against ≈ 6.1×
-for AuraFace with worst-group FAR near parity — parity by construction, since
-that operating point was chosen to match the shipped FAR posture. The
+for AuraFace with worst-group FAR near parity, which is parity by
+construction since that operating point was chosen to match the shipped FAR
+posture. The
 worst-served group shifts to Middle Eastern under buffalo_l.
 
 **We do not ship it.** WebFace600K is web-scraped without subject consent and

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -30,9 +30,10 @@ irlume status --json --contract 1
 Call `irlume version --json` once at startup:
 
 ```json
-{ "contract_version": 1, "engine_version": "0.7.0", "command": "version", "ok": true,
+{ "contract_version": 1, "engine_version": "0.8.1", "command": "version", "ok": true,
   "data": { "capabilities": ["version-json", "profiles-list-json", "status-json",
-                             "doctor-json", "login-status-json"],
+                             "doctor-json", "login-status-json", "auth-test-events",
+                             "login-plan-json", "login-transactions", "models-list-json"],
             "contract_versions": { "min": 1, "max": 1 },
             "limits": { "max_profiles": 3 } } }
 ```
@@ -59,9 +60,12 @@ behaviour. The version string is not.
 
 ## What contract 1 offers
 
-Five read-only commands. All are safe to call at any time; none of them enroll,
-wire PAM, write to the system, or capture an image. Camera facts come from
-enumerating device nodes, not from opening a stream.
+Nine capabilities. Seven of them only read: they never enroll, wire PAM, write
+to the system, or capture an image, and the camera facts in `status --json`
+come from enumerating device nodes, not from opening a stream. The other two
+are the exceptions a consumer should know before invoking them: `auth test
+--events=jsonl` opens the camera for a live capture, and `login apply` (with
+`login rollback --apply`) rewrites the PAM stack.
 
 | Command | Capability | Answers |
 |---|---|---|
@@ -70,6 +74,10 @@ enumerating device nodes, not from opening a stream.
 | `irlume doctor --json` | `doctor-json` | every readiness check as an id and a state |
 | `irlume profiles list --json [--user U]` | `profiles-list-json` | profile and scan display names, per-user liveness flags |
 | `irlume login status --json` | `login-status-json` | which PAM surfaces carry face auth |
+| `irlume models list --json` | `models-list-json` | every pipeline stage's model candidate, and the third-party state of the open stages |
+| `irlume auth test --events=jsonl` | `auth-test-events` | does the caller's live face match its own enrolment, as a stream of events; captures from the camera, releases nothing |
+| `irlume login plan --action A --json` | `login-plan-json` | what `login enable` or `disable` would change, without changing anything |
+| `irlume login apply` / `verify` / `rollback` | `login-transactions` | carry out, check, and undo a planned PAM change; `apply` and `rollback --apply` write to the system and need root, `verify` only reads |
 
 Three rules run through all of them:
 
@@ -90,11 +98,15 @@ typed. Key off `id`, `state`, and the booleans.
 
 ## What contract 1 does not offer, and what to do instead
 
-- **No mutation.** There is no machine command that enrolls, deletes, wires PAM,
-  or changes configuration. Privileged actions run through the human CLI, where
-  the user sees what is being changed. Launch it, or tell the user the command.
-- **No event stream.** Poll `status --json` when your window is visible. Nothing
-  in contract 1 pushes.
+- **One mutation, and only that one.** `login apply` and `login rollback
+  --apply` (capability `login-transactions`) rewrite the PAM stack, and only
+  after re-deriving a plan the consumer displayed. No machine command enrolls,
+  deletes a profile, or changes any other configuration; those actions run
+  through the human CLI, where the user sees what is being changed. Launch it,
+  or tell the user the command.
+- **No push.** `auth test --events=jsonl` streams events, but only to the
+  invocation that asked for them; nothing in contract 1 pushes state changes
+  to an idle consumer. Poll `status --json` when your window is visible.
 - **No cancellation.** Terminating the process is the cancellation mechanism for
   this contract version.
 - **No D-Bus service and no client library.** The CLI plus JSON keeps a frontend

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -339,6 +339,14 @@ now; the entry whose `live` is true can. None is live when the loaded
 recognizer has no templates in that profile, which is what an operator sees
 after switching models before re-adding scans.
 
+`recognizers` is ABSENT, not empty, when the daemon did not report the counts.
+That happens against a daemon older than 0.9.0, which is what a consumer sees
+between the package upgrade and the daemon restart. An empty array would mean
+"no recognizer has templates here", so emitting it beside a populated `scans`
+list would be the unknown-as-zero mistake. Treat a missing `recognizers` as
+unknown and fall back to `scans`; do not treat it as a profile that needs
+re-enrolling.
+
 ### `irlume models list --json`
 
 Capability: `models-list-json`.

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -338,7 +338,7 @@ CLI process's search order lands on, its origin (`shipped`, `caller-env` when
 the calling process's environment chose the path, or `built-in` for the PAD
 stage's gate, which is code rather than a swappable file), and whether it
 opened as a regular file (`readable`). It is a candidate and not a claim about
-the daemon, because the daemon's service unit — or an administrator's drop-in —
+the daemon, because the daemon's service unit (or an administrator's drop-in)
 sets the daemon's own environment, which a shell invocation cannot observe. On
 a stock install the candidate coincides with what the daemon loads; an
 authoritative loaded-model report can only ever come from the daemon itself.
@@ -347,11 +347,11 @@ unreadable file) means the daemon's load of that same candidate would fail.
 
 Each stage also reports whether the daemon requires the file to start and
 whether the stage is open to third-party models. Stages open one at a time
-because their failure modes differ; the PAD stage is the only open one today,
-and it carries a `third_party` object with the enabled entry and the measured
-catalog, including each entry's tier (`fetched` by irlume, or `user-supplied`
-when the license makes obtaining the file the user's business) and the weight
-file's state against its pin.
+because their failure modes differ; PAD and recognition are the open ones
+today, and each open stage carries a `third_party` object with the enabled
+entry and its own measured catalog, including each entry's tier (`fetched` by
+irlume, or `user-supplied` when the license makes obtaining the file the
+user's business) and the weight file's state against its pin.
 
 The command needs no daemon, so it still answers when the daemon will not
 start.
@@ -359,8 +359,8 @@ start.
 `third_party.enabled.known` is keyed on what the read established, not on who
 asked. Observed absence (no config file or key; the config directory is
 world-readable) is `known: true, name: null` from any caller. A read that
-failed — the root-only file denied to an unprivileged caller, or a wrong
-SELinux label denying even root — established nothing and is `known: false`,
+failed (the root-only file denied to an unprivileged caller, or a wrong
+SELinux label denying even root) established nothing and is `known: false`,
 which a consumer must not render as disabled.
 
 ### Error codes
@@ -576,7 +576,7 @@ the next enable rather than sitting inert.
 A rollback that stops partway records which surfaces it put back, durably, as it
 goes. Re-running it resumes: those surfaces are skipped rather than re-checked,
 because a restored file deliberately no longer matches the digest apply left and
-checking it would refuse the whole record — which used to leave the operator
+checking it would refuse the whole record, which used to leave the operator
 rebuilding the rest from the JSON by hand. `verify` reports them as
 `already_restored` and excludes them from `rollback_available`, so drift caused
 by irlume's own restore is not reported as somebody's edit.
@@ -599,8 +599,8 @@ an engine will not do is act on the parts of a newer record it recognises: the
 fields would parse and look reasonable while meaning something else, and a
 record is the recovery path for a machine's login stack.
 
-Every irlume path that changes PAM — `login apply`, `login rollback --apply`,
-the human `login enable`/`disable`, and the self-heal reconcile — holds one
+Every irlume path that changes PAM (`login apply`, `login rollback --apply`,
+the human `login enable`/`disable`, and the self-heal reconcile) holds one
 exclusive lock for the whole operation, so a consumer's transaction cannot
 interleave with another irlume process. The lock does not cover package managers
 or an administrator with an editor, which is why each surface is re-checked

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -536,8 +536,11 @@ would change something nobody was shown. The supplied id is never trusted as
 input, only compared. On success it returns a `transaction_id`.
 
 A partial apply is reported as a failure and still records its transaction, so
-the surfaces that did change can be rolled back. The id is written to standard
-error in that case, because an error document carries no `data`.
+the surfaces that did change can be rolled back. The id travels IN THE
+DOCUMENT in that case, as a top-level `transaction_id` beside `failed`, not on
+standard error: machine mode promises stdout carries the answer and stderr
+stays empty, and a caller recovering from a half-changed login stack needs the
+id from the same place it reads everything else.
 
 **verify** answers whether the machine is still as that transaction left it,
 per surface: `as-applied`, `changed-since-apply`, or `unreadable`. It also
@@ -562,7 +565,9 @@ rejected rather than sanitised, because the id becomes a filename.
 Error codes: `plan-stale`, `changed-since-apply`, `not-found`,
 `not-authorized` (apply and `rollback --apply` need root, checked before
 anything is written rather than left to a write failing partway),
-`unconfirmed-transaction`, `unsupported-record`, `operation-failed`.
+`unconfirmed-transaction`, `unsupported-record`, `unmanaged-path` (a record
+names a file irlume does not manage, so rollback refuses to touch it),
+`operation-failed`.
 
 A surface's `.pre-irlume` backup is part of the surface. The plan id covers it,
 so a backup that changes between `plan` and `apply` makes the plan stale: wiring

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -145,7 +145,7 @@ asked about.
   "enrollment": { "known": true, "profiles": 1, "scans": 10 },
   "templates": "encrypted",
   "keyring": { "known": true, "armed": true, "policy": "…" },
-  "recovery": { "known": true, "passphrase_set": true },
+  "recovery": { "known": true, "passphrase_set": true, "key_present": true },
   "camera": { "rgb": true, "ir": true },
   "fingerprint": false
 }
@@ -161,6 +161,16 @@ consumer cannot mistake "we could not find out" for "this account has nothing
 enrolled".
 
 `templates` is `encrypted`, `plaintext`, or `unknown`.
+
+`recovery.key_present` is whether the template key that opens an encrypted store
+still exists. It is a separate field rather than a third value of `templates`
+because contract 1 permits added fields and not new enum values, and because the
+two facts are independent: `templates: "encrypted"` with `key_present: false`
+means the enrollment is encrypted and openable by nothing, which no single value
+can say. Treat that combination as needing re-enrollment, not as a recovery
+passphrase problem. A daemon older than 0.9.0 never sends it and it reads as
+`true`, which is the only safe default for a field whose false value means data
+loss.
 
 ### `irlume doctor --json`
 

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -151,6 +151,16 @@ sha256 (not Git LFS), `nix build github:archledger/irlume` gets the real weights
 with no smudge-filter caveat and no LFS bandwidth cost. The daemon still refuses
 to start on a truncated model when `IRLUME_MODELS_STRICT=1` is set.
 
+## Native .tflite models need `IRLUME_TFLITE_LIB`
+
+The FHS packages (Fedora, Arch, Debian, PPA) bundle the TFLite C runtime,
+`libtensorflowlite_c.so`, at `/usr/share/irlume/tflite/`, the first path the
+daemon's resolver probes. The Nix package does not bundle it yet, so to run
+native `.tflite` models set `IRLUME_TFLITE_LIB` to the library's path in the
+daemon's environment (`systemd.services.irlumed.environment`). Without it,
+`.tflite` support reports "runtime not installed" and everything else keeps
+working; a missing runtime is never a startup failure.
+
 ## What was validated
 
 Every row below was exercised on a NixOS VM: log in or unlock with a face, then

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -407,7 +407,7 @@ with none of these checks ([#179]).
 [#159]: https://github.com/archledger/irlume/issues/159
 [#179]: https://github.com/archledger/irlume/issues/179
 
-## Third-party liveness models: optional, and recommended
+## Third-party models: optional, and recommended
 
 **Enable one if a printed photograph of you should not unlock your machine.**
 The built-in gate does not stop a life-size print. Measured twice on the same
@@ -425,23 +425,35 @@ sudo irlume models enable flir
 The rest of this section is why it is opt-in rather than shipped.
 
 irlume's anti-spoof gate is algorithmic by default. `irlume models` lists
-externally-trained models irlume can fetch onto your machine as an extra,
-deny-only liveness cue: one that can reject a presentation but can never
-approve one the built-in gate rejected. These models carry a real license on
-their weights but fail the shipped-stack provenance bar (ADR-0001), so irlume
-does not ship or mirror them; enabling downloads them once from the publisher,
-pinned by checksum, after you confirm the license and provenance on screen.
-Each catalog entry was measured on real hardware first
+externally-trained models, and what enabling one does depends on the pipeline
+stage its entry names. A PAD entry is an extra, deny-only liveness cue: it can
+reject a presentation but can never approve one the built-in gate rejected. A
+recognition entry is not deny-only: enabling it replaces the shipped
+recognizer for RGB matching at the threshold irlume measured, and it turns off
+IR matching, fusion, and dark login, which are unmeasured for that model. How
+you obtain the file is also per entry. `flir` is fetched once from the
+publisher by irlume, pinned by checksum, after you confirm the license and
+provenance on screen; `buffalo` you supply yourself with `sudo irlume models
+add buffalo <path>`, because its licence makes obtaining it your decision.
+Either way, these models carry a real license on their weights but fail the
+shipped-stack provenance bar (ADR-0001), so irlume does not ship or mirror
+them, and each catalog entry was measured on real hardware first
 ([docs/pad-results/](pad-results/)).
 
 ```sh
 irlume models                     # what exists, what it measured, what's enabled
 sudo irlume models enable flir    # fetch + verify + enable (typed confirmation)
-sudo irlume models disable        # delete the weights, back to the shipped stack
+sudo irlume models disable [name] # delete the weights, back to the shipped stack
 ```
 
-`irlume doctor` names the enabled model; the daemon refuses weights whose
-checksum stops matching and falls back to the built-in gate alone.
+A bare `models disable` works while one model is enabled; with more than one
+enabled it errors and asks you to name which.
+
+`irlume doctor` names the enabled models. A refusal costs different things per
+stage: a PAD model whose checksum stops matching has its weights refused, and
+the daemon falls back to the built-in gate alone; a selected recognizer that
+is refused (missing file, failed checksum) stops the daemon from starting at
+all, so face auth falls back to the password.
 
 ---
 
@@ -459,7 +471,7 @@ live in them; sealed envelopes are stored separately (see
 
 | File | Holds | Written by |
 |---|---|---|
-| `/etc/irlume/settings.conf` | `credential_release_challenge=0` opts OUT of the gesture required before your keyring password is released (default: required); `enforce_biopolicy=1` opts into operation-class gating; `third_party_pad=<name>` names an enabled opt-in model; `consent_gesture=nod\|closure` restricts the consent gesture (unset = either) | TUI Settings; `sudo irlume credential-release-challenge on\|off`; `sudo irlume models enable/disable` |
+| `/etc/irlume/settings.conf` | `credential_release_challenge=0` opts OUT of the gesture required before your keyring password is released (default: required); `enforce_biopolicy=1` opts into operation-class gating; `third_party_pad=<name>` names an enabled opt-in PAD model; `third_party_recognizer=<name>` names an enabled opt-in recognizer (`models add buffalo` writes it); `consent_gesture=nod\|closure` restricts the consent gesture (unset = either) | TUI Settings; `sudo irlume credential-release-challenge on\|off`; `sudo irlume models enable/add/disable` |
 | `/etc/irlume/cameras.conf` | `rgb=` / `ir=` device nodes of the active camera pair | TUI camera picker, or `sudo irlume set-cameras <rgb> <ir>` |
 | `/etc/irlume/method` | one line: the active auth method (`auto`, `face`, `fingerprint`, or `both` = face OR fingerprint) | `irlume fingerprint enable/disable` |
 | `/var/lib/irlume/ir_emitter.conf` | the UVC extension-unit control that lights the emitter | `irlume ir-setup` |

--- a/docs/THIRD-PARTY-MODELS.md
+++ b/docs/THIRD-PARTY-MODELS.md
@@ -1,12 +1,9 @@
-# Third-party liveness models irlume has measured
+# Third-party models irlume has measured
 
-irlume's built-in liveness gate does not stop a printed photograph of an
-enrolled face. That is measured, not suspected: the gate returned `Live` for all
-24 presentations of a vinyl print in issue #235, and again for an enhanced
-version of the same attack, so a trained cue is currently the only thing that
-refuses it. See [the PAD results](pad-results/) for every number behind that.
-
-This page lists the models irlume can use for that job. **Everything here was
+This page lists the externally-trained models irlume can run in its two open
+pipeline stages: liveness (PAD) cues that can deny a presentation the built-in
+gate accepted, and a recognizer that replaces the shipped one for RGB matching
+at a measured threshold. **Everything here was
 measured on real hardware by this project before it was listed.** Nothing is
 listed because a publisher claims it works, and a model irlume has not measured
 is not supported, whatever its benchmarks say elsewhere.
@@ -32,9 +29,9 @@ stage can be installed or wired. Two stages are open:
   protocol recorded on issue #276: the false-accept side measured on public
   datasets replayed through irlume's own pipeline, the false-reject side on
   this project's cameras, the threshold set from where those populations were
-  observed. A third-party recognizer runs RGB matching only — IR matching,
+  observed. A third-party recognizer runs RGB matching only: IR matching,
   fusion, and dark login are disabled because no entry carries IR-side
-  measurements — and templates enrolled under a different recognizer never
+  measurements, and templates enrolled under a different recognizer never
   match (each is tagged with the digest of the weights that produced it), so
   enabling one means re-enrolling. If the daemon cannot honour an enabled
   recognizer selection (missing file, failed pin), it refuses to start and
@@ -71,7 +68,14 @@ the two populations were actually seen to sit on its own hardware.
 
 ## The models
 
-### `flir` — irlume fetches it
+The case for the PAD entries is that irlume's built-in liveness gate does not
+stop a printed photograph of an enrolled face. That is measured, not
+suspected: the gate returned `Live` for all 24 presentations of a vinyl print
+in issue #235, and again for an enhanced version of the same attack, so a
+trained cue is currently the only thing that refuses it. See
+[the PAD results](pad-results/) for every number behind that.
+
+### `flir`: irlume fetches it
 
 An infrared anti-spoof cue from Alibaba DAMO, published on ModelScope under MIT.
 
@@ -102,7 +106,7 @@ irlume verifies your file against the published sha256 before enabling it, and
 a non-matching file is refused: that file is not the artifact the threshold was
 measured on.
 
-### `buffalo` — you supply the file (recognition stage)
+### `buffalo`: you supply the file (recognition stage)
 
 The InsightFace `buffalo_l` recognizer (`w600k_r50.onnx`, WebFace600K-trained),
 measured 2026-08-05 under the split-source threshold protocol
@@ -111,7 +115,7 @@ measured 2026-08-05 under the split-source threshold protocol
 - **Measured:** LFW EER 3.9% against the shipped recognizer's 4.2% on the
   identical pipeline. At the enabled 0.55 threshold the demographic FAR
   spread is 3.9x against the shipped model's 6.1x, with the two worst groups
-  at parity — and the worst-served group shifts to Middle Eastern, which
+  at parity, and the worst-served group shifts to Middle Eastern, which
   reads slightly worse than under the shipped model. Live genuine floors
   0.685 to 0.793 across two cameras, anchored by shipped-model control runs.
 - **Threshold:** 0.55. Worst demographic group's FAR there matches the shipped
@@ -119,7 +123,7 @@ measured 2026-08-05 under the split-source threshold protocol
   cross-lighting margin measured zero.
 - **What enabling it does:** replaces the recognizer for RGB matching. IR
   matching, fusion, and dark login are disabled (unmeasured for this model),
-  and templates enrolled under the shipped recognizer will not match —
+  and templates enrolled under the shipped recognizer will not match;
   re-enroll after enabling, and again after disabling.
 - **Provenance:** WebFace600K is scraped web imagery without subject consent,
   and the licence is non-commercial research only. Both fail ADR-0001 for
@@ -161,11 +165,15 @@ irlume prints the licence before enabling anything and distributes no weights.
 
 - **Models irlume has not measured.** Publishing "this probably works" is how a
   page like this becomes a recommendation engine for untested weights.
-- **Any model as a default.** These cues are deny-only: they can refuse a
+- **Any model as a default.** The PAD entries are deny-only: they can refuse a
   presentation the built-in gate accepted, never approve one it rejected. That
   is what makes them safe to add, and it is also why a broken one degrades
   quietly rather than loudly, so `irlume doctor` reports which model is active
-  and whether its weights still match their pin.
+  and whether its weights still match their pin. The recognition entry grants,
+  and its case for staying opt-in is different: enabling it replaces the
+  matcher on the grant path and turns off IR matching, fusion, and dark login,
+  so it runs only at a threshold irlume measured, never at a number the
+  publisher shipped.
 
 ## Adding a model to this page
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,7 @@
   clang,
   tpm2-tss,
   linux-pam,
+  libxcrypt,
   linuxHeaders,
   fetchurl,
   runCommand,

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -84,6 +84,12 @@ rustPlatform.buildRustPackage {
   buildInputs = [
     tpm2-tss # tss-esapi links tss2-*
     linux-pam # the PAM cdylib links libpam
+    # irlumed declares #[link(name = "crypt")] for its /etc/shadow fallback.
+    # nixpkgs stopped providing libcrypt transitively, and `nix build` failed
+    # with "cannot find -lcrypt" at the irlumed link step. CI could not see it:
+    # the nix job runs `nix flake check --no-build`, which passes on the same
+    # tree that fails to build.
+    libxcrypt
   ];
 
   # v4l2-sys-mit's bindgen parses <linux/videodev2.h>; hand clang the kernel

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -38,7 +38,7 @@ the weights, so a running system needs no download.
   (`ppa/debian/` + `scripts/build-ppa-source.sh`: vendored crates, bundled
   onnxruntime, real model weights; LP builders have no network). Update path:
   plain `apt upgrade`. **The lane ends at "binary published", not at "upload
-  accepted"** — `dput` reports only that Launchpad took the upload, and the
+  accepted"**: `dput` reports only that Launchpad took the upload, and the
   build and binary publication after it are both silent. Finish with
   `python3 scripts/verify-ppa-publish.py`, which polls Launchpad and exits
   non-zero unless a binary is actually installable. 0.6.1 was accepted, failed

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -97,6 +97,13 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   # absent on GRUB installs, where the read is existence-gated).
   /{etc,run,usr/lib}/systemd/tpm2-pcr-signature.json r,
   /{etc,run,usr/lib}/systemd/tpm2-pcr-public-key.pem r,
+  # systemd-pcrlock's prediction, which is the TIER 2 policy input. Without
+  # this rule every pcrlock-tier unseal fails on an AppArmor-enforcing
+  # install: measured on a ThinkPad where the keyring silently stopped
+  # opening at login for two days, while the error text sent the user to
+  # re-run `systemd-pcrlock make-policy`, which cannot help. Tier 1's two
+  # artifacts above were granted; this one was missed.
+  /var/lib/systemd/pcrlock.json r,
 
   # Config + state: enrollments (per-user), template keys, recovery blobs.
   /etc/irlume/ r,

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -133,4 +133,12 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   # Reading another user's state dir as the root daemon.
   capability dac_override,
   capability dac_read_search,
+  # The camera-consumer scan (#207) walks /proc to name whatever else holds a
+  # video node, and reading another user's /proc/<pid>/fd asks for sys_ptrace.
+  # DENY it rather than grant it: the capability would let irlumed inspect any
+  # process on the machine, which is far more than a diagnostic message is
+  # worth, and the scan already degrades to "could not inspect every process"
+  # and proceeds. An explicit deny also stops AppArmor auditing the refusal,
+  # which was filling the audit log with about 30 entries per boot.
+  deny capability sys_ptrace,
 }

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -12,7 +12,20 @@
 # Reload:  apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed
 # Complain (per-box soak):  add `flags=(complain)` to the profile line + reload.
 
-abi <abi/4.0>,
+# AppArmor ABI: pin the OLDEST parser we support, not the newest.
+#
+# This said `abi <abi/4.0>`. Debian 12 ships apparmor 3.0.8 and Ubuntu 22.04
+# ships 3.0.4, and neither has an abi/4.0 file, so the parser failed with
+# "Could not open 'abi/4.0'". The postinstall wraps the load in
+# `2>/dev/null || true`, so the package installed cleanly and the daemon ran
+# UNCONFINED with nothing said. The universal .deb declares libc6 (>= 2.35)
+# precisely so it installs on those two releases, and Debian enables AppArmor
+# by default, so that was the shipped configuration for them.
+#
+# 3.0 parses on 3.0.8, 4.0.1 and 4.1.0 (checked in containers), and pinning the
+# floor means one rule semantics everywhere instead of whatever each distro's
+# parser defaults to.
+abi <abi/3.0>,
 include <tunables/global>
 
 profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -117,4 +117,12 @@ profile irlumed /usr/local/bin/irlumed {
   # Reading another user's state dir as the root daemon.
   capability dac_override,
   capability dac_read_search,
+  # The camera-consumer scan (#207) walks /proc to name whatever else holds a
+  # video node, and reading another user's /proc/<pid>/fd asks for sys_ptrace.
+  # DENY it rather than grant it: the capability would let irlumed inspect any
+  # process on the machine, which is far more than a diagnostic message is
+  # worth, and the scan already degrades to "could not inspect every process"
+  # and proceeds. An explicit deny also stops AppArmor auditing the refusal,
+  # which was filling the audit log with about 30 entries per boot.
+  deny capability sys_ptrace,
 }

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -12,7 +12,20 @@
 # Reload:  apparmor_parser -r /etc/apparmor.d/usr.local.bin.irlumed
 # Complain (per-box soak):  add `flags=(complain)` to the profile line + reload.
 
-abi <abi/4.0>,
+# AppArmor ABI: pin the OLDEST parser we support, not the newest.
+#
+# This said `abi <abi/4.0>`. Debian 12 ships apparmor 3.0.8 and Ubuntu 22.04
+# ships 3.0.4, and neither has an abi/4.0 file, so the parser failed with
+# "Could not open 'abi/4.0'". The postinstall wraps the load in
+# `2>/dev/null || true`, so the package installed cleanly and the daemon ran
+# UNCONFINED with nothing said. The universal .deb declares libc6 (>= 2.35)
+# precisely so it installs on those two releases, and Debian enables AppArmor
+# by default, so that was the shipped configuration for them.
+#
+# 3.0 parses on 3.0.8, 4.0.1 and 4.1.0 (checked in containers), and pinning the
+# floor means one rule semantics everywhere instead of whatever each distro's
+# parser defaults to.
+abi <abi/3.0>,
 include <tunables/global>
 
 profile irlumed /usr/local/bin/irlumed {

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -84,6 +84,13 @@ profile irlumed /usr/local/bin/irlumed {
   # absent on GRUB installs, where the read is existence-gated).
   /{etc,run,usr/lib}/systemd/tpm2-pcr-signature.json r,
   /{etc,run,usr/lib}/systemd/tpm2-pcr-public-key.pem r,
+  /var/lib/systemd/pcrlock.json r,
+  # systemd-pcrlock's prediction, which is the TIER 2 policy input. Without
+  # this rule every pcrlock-tier unseal fails on an AppArmor-enforcing
+  # install: measured on a ThinkPad where the keyring silently stopped
+  # opening at login for two days, while the error text sent the user to
+  # re-run `systemd-pcrlock make-policy`, which cannot help. Tier 1's two
+  # artifacts above were granted; this one was missed.
 
   # Config + state: enrollments (per-user), template keys, recovery blobs.
   /etc/irlume/ r,

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.8.1
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux"
 arch=('x86_64')

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -70,6 +70,8 @@ package() {
         "$pkgdir/usr/share/irlume/tflite/LICENSE.tensorflow"
     install -Dm0644 "$srcdir/libtensorflowlite_c-v2.19.0-linux-x64/PROVENANCE" \
         "$pkgdir/usr/share/irlume/tflite/PROVENANCE"
+    install -Dm0644 "$srcdir/$pkgname/packaging/licenses/THIRD-PARTY-NOTICES.tflite" \
+        "$pkgdir/usr/share/irlume/tflite/THIRD-PARTY-NOTICES"
     install -Dm0644 packaging/systemd/irlumed.service "$pkgdir/usr/lib/systemd/system/irlumed.service"
     install -Dm0644 packaging/systemd/irlumed.socket "$pkgdir/usr/lib/systemd/system/irlumed.socket"
     # Self-heal: re-applies irlume's greeter PAM lines if a distro update strips

--- a/packaging/arch/build-pkg.sh
+++ b/packaging/arch/build-pkg.sh
@@ -1,12 +1,31 @@
 #!/usr/bin/env bash
-# Build an installable irlume .pkg.tar.zst from the local checkout, for
-# distribution via GitHub Releases (AUR registration is currently disabled, so
-# `irlume update` on Arch installs this prebuilt package with pacman -U). Run on
-# an Arch box:  bash packaging/arch/build-pkg.sh
+# NOT A RELEASE LANE. Arch users get irlume from the AUR.
 #
-# Unlike the AUR PKGBUILD (which fetches the git tag), this packages the
-# already-built binaries + LFS models in place; no network source.
+# The header here used to say AUR registration was disabled and that
+# `irlume update` on Arch installs this prebuilt package. Neither is true: the
+# CLI's pacman arm points at the AUR, a regression test in
+# crates/irlume-cli/src/commands.rs pins that, and no `.pkg.tar.zst` asset has
+# been referenced since 0.1.x.
+#
+# It matters because the inline PKGBUILD below is not at parity with
+# packaging/arch/PKGBUILD: it omits irlumed.socket, both keyring helpers
+# (irlume-kwallet-init, irlume-gkr-unlock), the TFLite runtime, the machine-API
+# schema, and the AppArmor profile. A package built from it installs a daemon
+# with no socket activation, no wallet unlock, and no confinement.
+# check-packaging-parity.sh does not look at this file, so nothing catches that.
+#
+# Kept for local experiments, behind an explicit opt-in so nobody publishes
+# from it by accident:
+#   IRLUME_ARCH_LOCAL_BUILD=1 bash packaging/arch/build-pkg.sh
 set -euo pipefail
+
+if [ "${IRLUME_ARCH_LOCAL_BUILD:-}" != "1" ]; then
+    echo "packaging/arch/build-pkg.sh is not a release lane; Arch ships via the AUR." >&2
+    echo "It is missing the socket unit, both keyring helpers, the TFLite runtime," >&2
+    echo "the schema, and the AppArmor profile. For a local experiment only:" >&2
+    echo "  IRLUME_ARCH_LOCAL_BUILD=1 bash packaging/arch/build-pkg.sh" >&2
+    exit 2
+fi
 
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 PKGVER="$(grep -m1 '^version' "$REPO/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')"
@@ -17,7 +36,10 @@ command -v makepkg >/dev/null || { echo "run on Arch (needs makepkg)"; exit 1; }
 
 # Fetch + verify the release-hosted model weights (not Git LFS).
 bash scripts/fetch-models.sh
-cargo build --release --locked 2>/dev/null || cargo build --release
+# --locked only. The fallback here silently rebuilt with a fresh resolve, which
+# for the [patch.crates-io] TPM crate meant whatever its branch head was at that
+# moment; that crate performs the sealing.
+cargo build --release --locked
 
 rm -rf "$BUILD"; mkdir -p "$BUILD"
 cp -r target/release "$BUILD/release"

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.8.1
+version: 0.9.0
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -72,6 +72,8 @@ contents:
     dst: /usr/share/irlume/tflite/libtensorflowlite_c.so
   - src: ../../.deb-staging/tflite/LICENSE.tensorflow
     dst: /usr/share/irlume/tflite/LICENSE.tensorflow
+  - src: ../licenses/THIRD-PARTY-NOTICES.tflite
+    dst: /usr/share/irlume/tflite/THIRD-PARTY-NOTICES
   - src: ../../.deb-staging/tflite/PROVENANCE
     dst: /usr/share/irlume/tflite/PROVENANCE
   # systemd unit + an override pointing ORT at the bundled lib

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -5,7 +5,16 @@ set -e
 # try-restart picks up confinement on an upgrade where the daemon is already
 # running (enable --now is a no-op for a running unit).
 if command -v apparmor_parser >/dev/null 2>&1; then
-    apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
+    # SAY SO on failure. This used to discard both the output and the status, so
+    # when the profile declared an ABI the installed parser did not have, every
+    # Debian 12 and Ubuntu 22.04 install came up UNCONFINED and the package still
+    # exited 0. The load is still not fatal (a machine with AppArmor disabled in
+    # the kernel is a normal configuration, and refusing to install there would be
+    # worse), but a confinement that did not take is not something to hide.
+    if ! apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>&1; then
+        echo "irlume: WARNING: the AppArmor profile did not load; irlumed will" >&2
+        echo "irlume: run unconfined. Report the parser error above." >&2
+    fi
 fi
 systemctl daemon-reload 2>/dev/null || true
 # Enable + start ONLY on first install ($2 empty). On an upgrade, re-enabling

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -44,6 +44,16 @@ if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
     systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
     : > /var/lib/irlume/.reconcile-timer-armed
 fi
+# Run one reconcile on UPGRADE too. The block above is fresh-install only, and
+# its comment claimed the run made "an upgrade adopt an already-wired install"
+# while sitting inside the branch an upgrade never takes: traced against the
+# built package, `configure 0.8.1` called daemon-reload, is-enabled,
+# enable-socket and try-restart, and no reconcile. Fedora's %post and Arch's
+# post_upgrade both run it. It self-gates on the login.wired marker, so it is a
+# no-op on a box that never wired login.
+if [ -n "${2:-}" ]; then
+    systemctl start irlume-reconcile.service 2>/dev/null || true
+fi
 # Upgrading from a version without the socket unit.
 if systemctl is-enabled --quiet irlumed.service 2>/dev/null; then
     systemctl enable --now irlumed.socket 2>/dev/null || true

--- a/packaging/fedora/90-irlume.preset
+++ b/packaging/fedora/90-irlume.preset
@@ -14,3 +14,10 @@ enable irlume-reconcile.path
 # Backstop for the path unit, which does not see a file replaced by rename
 # (measured: `sed -i` triggers nothing). Same reconcile, on a schedule.
 enable irlume-reconcile.timer
+# The boot-time trigger. It carries WantedBy=multi-user.target, and Fedora's
+# default preset disables everything not listed here, so leaving it out meant
+# `systemctl enable` never created the symlink and the at-boot reconcile never
+# ran on Fedora: measured as `disabled` on a fresh install while the .deb had it
+# enabled. That is the trigger that catches a PAM strip applied while the
+# machine was off, which the 30-minute timer only bounds after the fact.
+enable irlume-reconcile.service

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -2,7 +2,7 @@
 %global ort_ver 1.24.4
 
 Name:           irlume
-Version:        0.8.1
+Version:        0.9.0
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -239,6 +239,19 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Wed Aug 05 2026 archledger <archledger236@gmail.com> - 0.9.0-1
+- A sandboxed run could delete live template keys and recovery envelopes, because those paths ignored IRLUME_STATE_DIR; all state paths now honor the override
+- recovery setup accepted an empty passphrase when stdin was a pipe; the 12-character floor now applies to both paths
+- The AppArmor profile blocked every Tier 2 TPM unseal by omitting /var/lib/systemd/pcrlock.json, so the keyring stopped opening at login
+- The TUI and CLI reported "off"/"none" for state they could not read; an unanswered question now renders as unknown
+- The TUI no longer opens camera nodes while the daemon streams them, which failed enrollment on strict UVC modules (#187)
+- A profile can hold templates for more than one recognizer; profiles add-scan and profiles forget-model manage that state (#288)
+- The recognition stage opens to measured third-party models, starting with buffalo_l (#276)
+- Every catalog entry names its pipeline stage; detection and landmarks stay closed
+- A native TFLite runtime ships at /usr/share/irlume/tflite/ behind a stage gate that stays closed
+- Dark login was unreachable since 0.8.0 and works again (#284)
+- Garbage landmark geometry abstains instead of scoring confident wrong numbers
+- enroll --scans with a non-numeric value is a usage error, not a default-count capture
 * Tue Aug 04 2026 archledger <archledger236@gmail.com> - 0.8.1-1
 - A printed photograph of an enrolled face passes the built-in liveness gate; the cue cannot be repaired by tuning it, and the mitigation is `irlume models enable flir` (advisory, #235)
 - A blown infrared frame is refused rather than judged, so clipping no longer silences the PAD cue (#237)

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -251,7 +251,11 @@ restorecon /run/irlume.sock 2>/dev/null || :
 - A native TFLite runtime ships at /usr/share/irlume/tflite/ behind a stage gate that stays closed
 - Dark login was unreachable since 0.8.0 and works again (#284)
 - Garbage landmark geometry abstains instead of scoring confident wrong numbers
-- enroll --scans with a non-numeric value is a usage error, not a default-count capture
+- enroll --scans and camera-tune --rounds with a non-numeric value are usage errors, not a capture at the default count
+- The CLI no longer opens video nodes while the daemon streams them, completing the #187 fix that #300 started in the TUI
+- A scan budget an older daemon did not report reads as unknown rather than zero, which had silently under-enrolled during the upgrade window
+- Packit could not build an SRPM at all since the TFLite runtime tag was published; .packit.yaml now filters to release tags
+- CI validates the AppArmor profiles, which nothing checked before
 * Tue Aug 04 2026 archledger <archledger236@gmail.com> - 0.8.1-1
 - A printed photograph of an enrolled face passes the built-in liveness gate; the cue cannot be repaired by tuning it, and the mitigation is `irlume models enable flir` (advisory, #235)
 - A blown infrared frame is refused rather than judged, so clipping no longer silences the PAD cue (#237)

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -133,6 +133,9 @@ install -d %{buildroot}%{_datadir}/%{name}/tflite
 install -m0755 libtensorflowlite_c-%{tflite_ver}-linux-x64/lib/libtensorflowlite_c.so %{buildroot}%{_datadir}/%{name}/tflite/libtensorflowlite_c.so
 install -m0644 libtensorflowlite_c-%{tflite_ver}-linux-x64/LICENSE.tensorflow %{buildroot}%{_datadir}/%{name}/tflite/LICENSE.tensorflow
 install -m0644 libtensorflowlite_c-%{tflite_ver}-linux-x64/PROVENANCE %{buildroot}%{_datadir}/%{name}/tflite/PROVENANCE
+# Not all of libtensorflowlite_c.so is Apache-2.0: it statically links Eigen
+# (MPL-2.0), XNNPACK, ruy and others. Name them beside the library.
+install -m0644 packaging/licenses/THIRD-PARTY-NOTICES.tflite %{buildroot}%{_datadir}/%{name}/tflite/THIRD-PARTY-NOTICES
 install -Dm0644 packaging/fedora/10-ort.conf %{buildroot}%{_unitdir}/irlumed.service.d/10-ort.conf
 install -Dm0644 packaging/selinux/irlume.pp %{buildroot}%{_datadir}/selinux/packages/irlume.pp
 # Preset: the daemon is enabled on install (see %%post); it only serves a local

--- a/packaging/licenses/THIRD-PARTY-NOTICES.tflite
+++ b/packaging/licenses/THIRD-PARTY-NOTICES.tflite
@@ -1,0 +1,45 @@
+Third-party components inside libtensorflowlite_c.so
+====================================================
+
+irlume ships a prebuilt TensorFlow Lite C runtime at
+/usr/share/irlume/tflite/libtensorflowlite_c.so. It is built by
+scripts/build-tflite-runtime.sh from TensorFlow v2.19.0, commit
+e36baa302922ea3c7131b302c2996bd2051ee5c4, and the Apache-2.0 licence of the
+TensorFlow sources ships beside it as LICENSE.tensorflow.
+
+That licence does not cover everything in the file. The build statically links
+several other projects, so their notices belong with the binary too. The list
+below was taken from the shipped library itself, by reading the symbol and
+string tables of the published artifact
+(libtensorflowlite_c-v2.19.0-linux-x64.tar.gz, sha256
+dd3abcdbc0f35a9466a682358955ac3826a9a81590cd6b8abcf98548e17bd311), not from
+TensorFlow's dependency manifest, so it reflects what is actually present:
+
+  XNNPACK        https://github.com/google/XNNPACK
+  ruy            https://github.com/google/ruy
+  Eigen          https://gitlab.com/libeigen/eigen
+  FlatBuffers    https://github.com/google/flatbuffers
+  gemmlowp       https://github.com/google/gemmlowp
+  Abseil         https://github.com/abseil/abseil-cpp
+  cpuinfo        https://github.com/pytorch/cpuinfo
+  pthreadpool    https://github.com/google/pthreadpool
+  fft2d          https://www.kurims.kyoto-u.ac.jp/~ooura/fft.html
+
+Each project's licence text is in the TensorFlow source tree at the pinned
+commit, under third_party/ and the bazel external workspace it fetches. To read
+the exact texts that correspond to this binary, check out that commit:
+
+  git clone https://github.com/tensorflow/tensorflow
+  git -C tensorflow checkout e36baa302922ea3c7131b302c2996bd2051ee5c4
+
+Note for redistributors: these are not all the same licence. Eigen is primarily
+MPL-2.0, which carries source-availability obligations that Apache-2.0 does not,
+and the others are a mix of Apache-2.0, BSD and MIT variants. If you
+redistribute this library, satisfy each licence, not just TensorFlow's.
+
+Known gap, recorded rather than hidden: the ideal fix is for
+scripts/build-tflite-runtime.sh to copy these licence texts into the published
+tarball, so the notices travel with the artifact instead of with the packaging.
+Doing that changes the tarball and therefore its sha256, which is pinned in four
+packaging lanes, so it is a change for the next runtime rebuild rather than a
+same-day edit to a released artifact.

--- a/packaging/ppa/build-ppa-container.sh
+++ b/packaging/ppa/build-ppa-container.sh
@@ -12,8 +12,8 @@
 #   3. Copy the UNSIGNED source artifacts out for host signing.
 #
 # The build is NOT signed here (the container never sees the GPG key) and the
-# result is NOT byte-reproducible against a native Ubuntu build — gzip/cargo
-# vendor differ between environments — so upload from ONE route per release.
+# result is NOT byte-reproducible against a native Ubuntu build (gzip/cargo
+# vendor differ between environments), so upload from ONE route per release.
 #
 # After this, on the host (where the release key lives):
 #   debsign -k <fpr> <out>/irlume_<ver>-0ppa1~<series>1_source.changes   # your passphrase

--- a/packaging/ppa/debian/copyright
+++ b/packaging/ppa/debian/copyright
@@ -13,6 +13,19 @@ License: Apache-2.0
 Comment: TensorFlow Lite C runtime built from TensorFlow v2.19.0,
  commit e36baa302922ea3c7131b302c2996bd2051ee5c4, by
  scripts/build-tflite-runtime.sh. https://github.com/tensorflow/tensorflow
+ .
+ libtensorflowlite_c.so statically links further components whose licences
+ are NOT Apache-2.0: Eigen (MPL-2.0), XNNPACK, ruy, farmhash and fft2d
+ (BSD/MIT/Apache-2.0 variants). Their notices ship beside the library at
+ /usr/share/irlume/tflite/THIRD-PARTY-NOTICES; this stanza covers the
+ TensorFlow sources only.
+
+Files: models/blaze_face_short_range.onnx
+Copyright: 2020-2023 The MediaPipe Authors
+License: Apache-2.0
+Comment: MediaPipe BlazeFace (short range) detector, converted to ONNX.
+ Without this stanza the file fell under `Files: *` above and was declared
+ GPL-3.0+, which is not its licence.
 
 Files: models/glintr100.onnx
 Copyright: fal.ai (AuraFace)

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -62,6 +62,7 @@ override_dh_auto_install:
 	install -m0755 tflite-prebuilt/lib/libtensorflowlite_c.so debian/irlume/usr/share/irlume/tflite/
 	install -m0644 tflite-prebuilt/LICENSE.tensorflow debian/irlume/usr/share/irlume/tflite/
 	install -m0644 tflite-prebuilt/PROVENANCE debian/irlume/usr/share/irlume/tflite/
+	install -m0644 packaging/licenses/THIRD-PARTY-NOTICES.tflite debian/irlume/usr/share/irlume/tflite/THIRD-PARTY-NOTICES
 	install -D -m0644 packaging/systemd/irlumed.service \
 		debian/irlume/usr/lib/systemd/system/irlumed.service
 	# Makes /run/irlume.sock exist before the greeter authenticates (#244).

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -110,6 +110,7 @@ APPARMOR_PROFILES=(
 APPARMOR_RUNTIME_RULES=(
   "/usr/share/irlume/tflite/libtensorflowlite_c.so mr,"
   "/var/lib/systemd/pcrlock.json r,"
+  "deny capability sys_ptrace,"
   "/dev/ r,"
   "/run/lock/irlume-emitter-*.lock rwk,"
   "/var/lib/irlume/ir-emitter-stream/*.lock rwk,"

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -109,6 +109,7 @@ APPARMOR_PROFILES=(
 )
 APPARMOR_RUNTIME_RULES=(
   "/usr/share/irlume/tflite/libtensorflowlite_c.so mr,"
+  "/var/lib/systemd/pcrlock.json r,"
   "/dev/ r,"
   "/run/lock/irlume-emitter-*.lock rwk,"
   "/var/lib/irlume/ir-emitter-stream/*.lock rwk,"


### PR DESCRIPTION
Cuts 0.9.0. Most of this branch is not the release itself: it is what an
exhaustive pre-release audit found. Six independent passes covered the
authentication grant path, data loss, robustness and hangs, camera contention,
packaging across five lanes, upgrade paths from 0.8.1, and the classic
vulnerability classes, plus a walkthrough of every CLI command and TUI screen on
real hardware and one Codex review round.

Nothing below is a hypothesis. Each item was reproduced before it was fixed, and
each fix has a test that fails without it.

## Things that were already broken in the field

**Every Tier 2 TPM unseal has been failing.** The AppArmor profile grants the
two signed-policy artifacts but never granted `/var/lib/systemd/pcrlock.json`,
which is the pcrlock tier's policy input. The keyring stops opening at login and
the error text sends the user to re-run `systemd-pcrlock make-policy`, which
cannot help. Found on a ThinkPad carrying 16 denials over two days with no other
symptom.

**The AppArmor profile does not load at all on Debian 12 or Ubuntu 22.04.** It
declared `abi <abi/4.0>`; those releases ship apparmor 3.0.x, which has no such
file. The postinstall discarded both the output and the exit status, so the
package installed cleanly and irlumed ran unconfined with nothing said. The
universal .deb declares `libc6 (>= 2.35)` precisely so it installs there.

**Packit could not build an SRPM, so tagging would have produced no Copr package
at all.** Publishing the TFLite runtime as a GitHub release added the tag
`tflite-runtime-v2.19.0`, and Packit derives the version from the newest tag.
Both rpm-build checks had been red on every PR since, read as background noise;
the same code path runs on the release trigger, where Packit failures are
silent.

**The Nix package does not build.** `cannot find -lcrypt` at the irlumed link
step. CI could not see it: the job ran `nix flake check --no-build`, which passes
on a tree that fails to build.

**The PAM self-heal has never worked.** `reconcile` took the PAM lock, found a
regression, and called a function that took it again. `flock` is per open file
description, so it deadlocked on exactly the condition it exists to repair. The
hung process is root and holds the lock exclusively, so every other irlume PAM
operation queued behind it, and `Type=oneshot` defaults to no timeout.

## Data loss

**A dangling flag silently widened destructive commands.** `sudo irlume enroll
--reset --user` put `{"Enroll":{"user":"<you>","reset":true}}` on the wire, and
that reset deletes the enrollment, the template key and the recovery envelope
together, unconfirmed. `recovery forget --user` and `keyring forget --user` did
the same, and `profiles delete --profile P --scan` sent DeleteProfile. A guard
for this shape existed inside `profiles` alone.

**A sandboxed run could delete live template keys, and did.** `IRLUME_STATE_DIR`
moved the profile store, but the template-key, recovery and keyring directories
were built from the bare path constant. On 2026-08-05 a sandboxed root
`profiles forget-model` emptied the real directories on a test machine, leaving
an encrypted enrollment whose key exists nowhere. `ir_emitter.conf` had the same
split resolution.

**Re-wiring rebuilt each PAM stack from its months-old backup**, discarding
every change made since. A distro update adding `pam_faillock` is the ordinary
case, and `login enable --apply` deleted it.

## Security

**A FIFO in the user's own home wedged the camera worker.** The KDE wallet salt
is read from a path the user owns, so its type is theirs to choose, and opening
a FIFO blocks until a writer appears. The daemon then looks healthy while every
capture is dead, the watchdog kills it, and the FIFO is still there.

**`recovery setup </dev/null` accepted an empty passphrase.** The floor and the
confirmation both sat inside the interactive branch.

**Any local uid could deny the socket to everyone, root included**, by opening
64 sockets and sending nothing.

Also: an unguarded environment override in a root-spawned helper that holds the
wallet key, an uncapped response read in the client that PAM uses, the PAM
module resolving helper paths without `secure_getenv`, and a retag path that
could stamp legacy IR templates with an adapter's embedding space and then score
across spaces at the lowest threshold in the codebase.

## Honesty

Three independent runs found the same class on three machines: when a question
cannot be answered, the answer was rendered as a definite no. With the daemon
unreachable the TUI told an enrolled user they had no profiles and offered to
enroll, and told them their encrypted templates were plaintext. Unprivileged
`models list` reported "none enabled" on a machine whose anti-spoof model is
enabled. `profiles list --json` reported `"recognizers": []` beside ten scans
against an older daemon. `docs/MACHINE-API.md` already stated the rule; the human
surfaces now follow it.

## Camera

`irlume status`, `status --json` and `setup` still classified video nodes by
opening them, which is issue #187 and fails enrollment on a strict UVC module.
`setup` probed in its preflight and then enrolled seconds later on the nodes it
had just touched. Measured with strace against the live daemon: four opens each,
now zero across twenty commands and a full TUI walk, on an instrument that
counts four on the 0.8.1 binary.

The first fix for this was itself wrong, and the review caught it: the fallback
fired on any poll failure, and a 1.5-second timeout is what a daemon busy
mid-capture looks like, which is exactly when it holds the nodes. Probing now
requires positive evidence of absence.

## Validation

`cargo test --workspace` green. Every new test was proven to fail against the
unfixed code, including the FIFO one, which hangs. Upgrade from 0.8.1 was tested
with fixtures produced by real 0.8.1 code, including sealed template keys, and
with every combination of 0.8.1 and 0.9.0 client and daemon. The Nix package
builds and reports 0.9.0. Both AppArmor profiles parse on apparmor 3.0.4, 3.0.8,
4.0.1 and 4.1.0.

CI gained what would have caught these: an AppArmor parse check on the oldest
supported parser as well as the runner's, and an actual `nix build`.

Known and not fixed here: a camera that is present but delivers no frames can
spend about 95 seconds inside one capture against a 90-second watchdog, so
systemd kills the daemon rather than the capture failing. Changing the retry
budget needs hardware I cannot reproduce, so it is recorded rather than guessed
at.
