### PR TITLE
Refuse an ONNX Runtime below the pinned API level instead of parking forever

### DIFF
--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3852,6 +3852,35 @@ fn doctor_run(
             ort
         }
     );
+    // Which ONNX Runtime this shell would actually load, and whether it is
+    // usable. The resolver prefers a packaged copy over the system library,
+    // so a stale file at a packaged path silently outranks a healthy system
+    // install; naming the resolved candidate and its version here is what
+    // makes that visible (#187: a below-floor leftover from a previous
+    // distro's package hung the daemon, and nothing reported which library
+    // had been chosen).
+    {
+        let (candidate, verdict) = irlume_vision::runtime_resolution();
+        let source = match &candidate {
+            Some(path) => path.display().to_string(),
+            None => "system libonnxruntime.so".to_string(),
+        };
+        match verdict {
+            Ok(version) => {
+                report.check("onnxruntime", State::Pass);
+                dout!(report, "[doctor] ONNX Runtime: {source} ({version}) ✓");
+            }
+            Err(why) => {
+                report.check("onnxruntime", State::Fail);
+                dout!(
+                    report,
+                    "[doctor] ONNX Runtime: {source} UNUSABLE ✗ ({why}). The daemon \
+                     cannot load models from this; if a packaged path above is a \
+                     leftover from a previous install, remove it"
+                );
+            }
+        }
+    }
     // --- pipeline stages (#276) -----------------------------------------
     // Each stage's model CANDIDATE from this process's search order. A
     // candidate, not a claim about the daemon: the service unit (or a

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3867,11 +3867,12 @@ fn doctor_run(
         };
         match verdict {
             Ok(version) => {
-                report.check("onnxruntime", State::Pass);
-                dout!(report, "[doctor] ONNX Runtime: {source} ({version}) ✓");
+                let detail = format!("{source} ({version})");
+                report.check_detail("onnxruntime", State::Pass, &detail);
+                dout!(report, "[doctor] ONNX Runtime: {detail} ✓");
             }
             Err(why) => {
-                report.check("onnxruntime", State::Fail);
+                report.check_detail("onnxruntime", State::Fail, format!("{source}: {why}"));
                 dout!(
                     report,
                     "[doctor] ONNX Runtime: {source} UNUSABLE ✗ ({why}). The daemon \

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -297,6 +297,35 @@ fn every_doctor_check_id_is_documented_and_every_documented_id_exists() {
     );
 }
 
+/// The registry says the `onnxruntime` check carries the resolved path and
+/// version, and the whole point of the check is that a support tool can see
+/// WHICH library was chosen (#187). A bare pass/fail with no detail is the
+/// documented diagnostic silently disappearing (#304 review), so this pins
+/// the detail's presence in the machine output on both verdicts: pass names
+/// the path and version, fail names the path and the refusal.
+#[test]
+fn doctor_onnxruntime_check_names_its_resolved_candidate() {
+    let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+        .args(["doctor", "--json"])
+        .env("IRLUME_SOCKET", "/nonexistent/irlume-doctor-ort-test.sock")
+        .output()
+        .expect("run irlume");
+    let document: Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    let check = document["data"]["checks"]
+        .as_array()
+        .expect("checks array")
+        .iter()
+        .find(|c| c["id"] == "onnxruntime")
+        .cloned()
+        .expect("onnxruntime check present");
+    assert!(
+        check["detail"]
+            .as_str()
+            .is_some_and(|detail| !detail.is_empty()),
+        "onnxruntime must identify its resolved candidate and verdict: {check}"
+    );
+}
+
 #[test]
 fn login_status_json_lists_every_surface_by_service_name() {
     // The surface list is COMPLETE: services that do not exist on this machine

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -273,8 +273,9 @@ mod onnx {
             .find(|path| is_file(path))
     }
 
-    /// Prove `name` (a path or a bare soname) is a loadable library exporting
-    /// `OrtGetApiBase`, with the loader's own words when it is not.
+    /// Prove `name` (a path or a bare soname) is a loadable ONNX Runtime that
+    /// provides the API level pinned ort will demand, with the loader's own
+    /// words when it is not. On success, returns the runtime's version string.
     ///
     /// This CANNOT be delegated to `ort::init_from`: measured on 2026-08-04,
     /// a load failure inside ort parks the process in a futex exactly like
@@ -288,10 +289,21 @@ mod onnx {
     /// on a C++ runtime orphans the allocations its static initializers made
     /// (measured in CI: 80 bytes in 2 allocations from libonnxruntime's init
     /// under dlopen).
-    fn probe_loadable(name: &std::ffi::CStr) -> Result<(), String> {
+    ///
+    /// The API-level floor is checked here for the same reason: handed a
+    /// runtime below the floor, `ort::init_from` does not return. Measured on
+    /// 2026-08-06 against onnxruntime 1.20.1 (#187): the calling thread
+    /// parked in `futex_do_wait` with no output and no CPU, so the daemon
+    /// answered every client "still starting" indefinitely while systemd
+    /// showed it healthy. `GetApi` documents null as "this version is
+    /// unsupported", so null IS the version answer, not a call failure.
+    fn probe_runtime(name: &std::ffi::CStr) -> Result<String, String> {
         // SAFETY: dlopen/dlerror/dlsym/dlclose with valid NUL-terminated
         // strings; the handle is non-null when dlsym runs, retained on
-        // success, and closed on the one failure past it.
+        // success, and closed on the failures past it. The two OrtApiBase
+        // calls go through `ort_sys`'s own declarations, so the signatures
+        // match the ABI ort itself uses, and every returned pointer is
+        // null-checked before it is read.
         unsafe {
             let handle = libc::dlopen(name.as_ptr(), libc::RTLD_NOW | libc::RTLD_LOCAL);
             if handle.is_null() {
@@ -305,8 +317,8 @@ mod onnx {
             }
             let sym = libc::dlsym(handle, c"OrtGetApiBase".as_ptr());
             if sym.is_null() {
-                // The one place dlclose is right: a foreign library that will
-                // not be used again. A future test exercising this path under
+                // Where dlclose is right: a foreign library that will not be
+                // used again. A future test exercising this path under
                 // LeakSanitizer will see that library's own initializer
                 // allocations; that is this close, not a defect in the probe.
                 libc::dlclose(handle);
@@ -316,21 +328,51 @@ mod onnx {
                         .to_string(),
                 );
             }
-            Ok(())
+            let get_base: unsafe extern "system" fn() -> *const ort::sys::OrtApiBase =
+                std::mem::transmute(sym);
+            let base = get_base();
+            if base.is_null() {
+                libc::dlclose(handle);
+                return Err(
+                    "OrtGetApiBase returned null; the library is not a usable ONNX Runtime"
+                        .to_string(),
+                );
+            }
+            // Copied to an owned String while the library is still mapped:
+            // the pointer aims into the library's own data.
+            let version_ptr = ((*base).GetVersionString)();
+            let version = if version_ptr.is_null() {
+                "(unknown version)".to_string()
+            } else {
+                std::ffi::CStr::from_ptr(version_ptr)
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            if ((*base).GetApi)(ort::MINOR_VERSION).is_null() {
+                libc::dlclose(handle);
+                return Err(format!(
+                    "this is ONNX Runtime {version}, which does not provide API level {api} \
+                     (first shipped in ONNX Runtime 1.{api}); irlume needs 1.{api} or newer",
+                    api = ort::MINOR_VERSION
+                ));
+            }
+            Ok(version)
         }
     }
 
     /// Probe, then hand the SAME name to pinned ort, which retains the handle
-    /// in its own global and applies its api-24 version floor. A version-floor
-    /// rejection inside ort is the one failure class the probe cannot
-    /// pre-empt; whether it errors or parks there is untested, since no
-    /// pre-1.24 library was on hand.
-    fn load_ort(path: &std::path::Path) -> Result<(), String> {
+    /// in its own global. The probe has already established everything ort's
+    /// own init would park on: the library loads, it is an ONNX Runtime, and
+    /// it provides the pinned API level (ort re-checks that floor, but only
+    /// ever against a runtime the probe passed). Measured 2026-08-06, #187:
+    /// before the probe checked the floor, a below-floor runtime made this
+    /// call park forever instead of returning.
+    fn load_ort(path: &std::path::Path) -> Result<String, String> {
         let name = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
             .map_err(|_| format!("{} contains a NUL byte", path.display()))?;
-        probe_loadable(&name)
+        let version = probe_runtime(&name)
             .map_err(|why| format!("cannot load ONNX Runtime from {}: {why}", path.display()))?;
-        ort::init_from(path).map(|_| ()).map_err(|e| {
+        ort::init_from(path).map(|_| version).map_err(|e| {
             format!(
                 "cannot initialize ONNX Runtime from {}: {e}",
                 path.display()
@@ -370,21 +412,53 @@ mod onnx {
                             PACKAGED_ORTS[1]
                         ));
                     }
-                    return load_ort(&path);
+                    return load_ort(&path).map(|version| {
+                        irlume_common::dlog!(
+                            "onnxruntime {version} loaded from {}",
+                            path.display()
+                        );
+                    });
                 }
                 // No explicit path, no packaged copy: ask the system loader,
                 // through ort so acceptance and retention still apply.
-                load_ort(std::path::Path::new("libonnxruntime.so")).map_err(|system_error| {
-                    format!(
-                        "libonnxruntime.so was not loadable (no ORT_DYLIB_PATH, nothing \
-                         at {} or {}, and the system loader failed: {system_error}); \
-                         install the irlume package's onnxruntime or set ORT_DYLIB_PATH",
-                        PACKAGED_ORTS[0], PACKAGED_ORTS[1]
-                    )
-                })
+                load_ort(std::path::Path::new("libonnxruntime.so"))
+                    .map(|version| {
+                        irlume_common::dlog!("onnxruntime {version} loaded via the system loader");
+                    })
+                    .map_err(|system_error| {
+                        format!(
+                            "libonnxruntime.so was not loadable (no ORT_DYLIB_PATH, nothing \
+                             at {} or {}, and the system loader failed: {system_error}); \
+                             install the irlume package's onnxruntime or set ORT_DYLIB_PATH",
+                            PACKAGED_ORTS[0], PACKAGED_ORTS[1]
+                        )
+                    })
             })
             .clone()
             .map_err(irlume_common::Error::Hardware)
+    }
+
+    /// What the onnxruntime resolver would use in this process, for `irlume
+    /// doctor`: the candidate (an explicit or packaged path, or the system
+    /// loader when `None`) plus the probe's verdict on it, `Ok` carrying the
+    /// runtime's own version string.
+    ///
+    /// A dlopen probe, not a full `ort` init: doctor must be able to report a
+    /// broken runtime and move on, and `ort`'s global init is the code whose
+    /// failure mode is a silent park (#187). dlopen of a runtime already
+    /// loaded by this process is a reference-count bump, so calling this
+    /// after models loaded costs nothing new.
+    pub fn runtime_resolution() -> (Option<std::path::PathBuf>, Result<String, String>) {
+        let explicit = std::env::var_os("ORT_DYLIB_PATH");
+        let candidate = configured_ort(explicit.as_deref(), |p| p.is_file());
+        let name = candidate
+            .as_deref()
+            .unwrap_or(std::path::Path::new("libonnxruntime.so"));
+        let verdict = match std::ffi::CString::new(name.as_os_str().as_encoded_bytes()) {
+            Ok(name) => probe_runtime(&name),
+            Err(_) => Err(format!("{} contains a NUL byte", name.display())),
+        };
+        (candidate, verdict)
     }
 
     fn build(model: &[u8]) -> irlume_common::Result<Session> {
@@ -1304,14 +1378,42 @@ mod onnx {
         fn nothing_found_defers_to_the_system_loader() {
             assert_eq!(configured_ort(None, |_| false), None);
         }
+
+        // The version-floor refusal itself (a runtime that loads, is an ONNX
+        // Runtime, and answers null for API level 24) needs a pre-1.24
+        // libonnxruntime, which CI does not have; it was validated against
+        // onnxruntime 1.20.1 in a container (#187), where the unpatched
+        // probe let the process park forever and this one returns the
+        // version-naming error. The two refusal classes below are the ones a
+        // stock Linux runner can produce deterministically.
+
+        #[test]
+        fn an_unloadable_path_reports_the_loaders_words() {
+            let err = probe_runtime(c"/nonexistent/libonnxruntime.so").unwrap_err();
+            assert!(
+                err.contains("cannot open shared object file"),
+                "expected the loader's own message, got: {err}"
+            );
+        }
+
+        #[test]
+        fn a_library_without_ortgetapibase_is_not_an_onnx_runtime() {
+            // libc is loadable on every supported platform and exports no
+            // OrtGetApiBase, so it exercises the loads-but-is-not-ort branch.
+            let err = probe_runtime(c"libc.so.6").unwrap_err();
+            assert!(
+                err.contains("exports no OrtGetApiBase"),
+                "expected the not-an-ONNX-Runtime refusal, got: {err}"
+            );
+        }
     }
 }
 
 #[cfg(feature = "onnx")]
 pub use onnx::{
-    eye_ear, mesh_box_valid, mesh_min_ear, mesh_output_plausible, selftest_alignment_identity,
-    Adapter, BlazeRescue, Detector, Embedder, FaceMesh, PadIr, BLAZE_SCORE_THRESHOLD, EAR_LEFT,
-    EAR_RIGHT, MESH_INPUT, MESH_N, MESH_N_IRIS,
+    eye_ear, mesh_box_valid, mesh_min_ear, mesh_output_plausible, runtime_resolution,
+    selftest_alignment_identity, Adapter, BlazeRescue, Detector, Embedder, FaceMesh, PadIr,
+    BLAZE_SCORE_THRESHOLD, EAR_LEFT, EAR_RIGHT, MESH_INPUT, MESH_N, MESH_N_IRIS,
 };
 
 /// Model-backed pipeline tests: run the REAL shipped ONNX models (fetched to

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -328,13 +328,37 @@ mod onnx {
                         .to_string(),
                 );
             }
+            // The FILE the loader mapped, not the soname it was asked for.
+            // The two diverge exactly when it matters: on the #187 reporter's
+            // machine, "libonnxruntime.so" resolved to a third-party
+            // /usr/lib/libonnxruntime_x64.so that no package manager owned,
+            // and the mapped path in /proc was the fact that solved the
+            // issue. dladdr on the symbol we already resolved answers it for
+            // free; a null or absent dli_fname degrades to the asked-for
+            // name rather than failing a probe that otherwise succeeded.
+            let mut info: libc::Dl_info = std::mem::zeroed();
+            let mapped = if libc::dladdr(sym, &mut info) != 0 && !info.dli_fname.is_null() {
+                let reported = std::ffi::CStr::from_ptr(info.dli_fname).to_string_lossy();
+                // dladdr reports the path dlopen was given, which through a
+                // symlink is the symlink; canonicalize so the message names
+                // the file that is actually mapped (measured: a 1.20.1
+                // behind a symlink reported the symlink until this).
+                std::fs::canonicalize(reported.as_ref())
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|_| reported.into_owned())
+            } else {
+                name.to_string_lossy().into_owned()
+            };
             let get_base: unsafe extern "system" fn() -> *const ort::sys::OrtApiBase =
                 std::mem::transmute(sym);
             let verdict = inspect_api_base(get_base());
             if verdict.is_err() {
                 libc::dlclose(handle);
             }
-            verdict
+            match verdict {
+                Ok(version) => Ok(format!("{version}, mapped from {mapped}")),
+                Err(why) => Err(format!("{why} (the loader mapped {mapped})")),
+            }
         }
     }
 

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -330,34 +330,54 @@ mod onnx {
             }
             let get_base: unsafe extern "system" fn() -> *const ort::sys::OrtApiBase =
                 std::mem::transmute(sym);
-            let base = get_base();
-            if base.is_null() {
+            let verdict = inspect_api_base(get_base());
+            if verdict.is_err() {
                 libc::dlclose(handle);
-                return Err(
-                    "OrtGetApiBase returned null; the library is not a usable ONNX Runtime"
-                        .to_string(),
-                );
             }
-            // Copied to an owned String while the library is still mapped:
-            // the pointer aims into the library's own data.
-            let version_ptr = ((*base).GetVersionString)();
-            let version = if version_ptr.is_null() {
-                "(unknown version)".to_string()
-            } else {
-                std::ffi::CStr::from_ptr(version_ptr)
-                    .to_string_lossy()
-                    .into_owned()
-            };
-            if ((*base).GetApi)(ort::MINOR_VERSION).is_null() {
-                libc::dlclose(handle);
-                return Err(format!(
-                    "this is ONNX Runtime {version}, which does not provide API level {api} \
-                     (first shipped in ONNX Runtime 1.{api}); irlume needs 1.{api} or newer",
-                    api = ort::MINOR_VERSION
-                ));
-            }
-            Ok(version)
+            verdict
         }
+    }
+
+    /// The verdict on an `OrtApiBase`: the runtime's version string when it
+    /// provides the API level pinned ort will demand, the refusal naming its
+    /// version and the floor when it does not.
+    ///
+    /// Separate from [`probe_runtime`] so the floor decision is testable
+    /// against an in-process fake `OrtApiBase` (#304 review): the real
+    /// refusal needs a pre-1.24 libonnxruntime, which CI does not have, and
+    /// both probe tests return before reaching the floor check, so a mutant
+    /// deleting it would have survived them.
+    ///
+    /// # Safety
+    ///
+    /// `base` must be null or point to a live `OrtApiBase` whose function
+    /// pointers are callable; the version string, when non-null, is copied
+    /// out while the library backing it is still mapped (the caller holds
+    /// the dlopen handle across this call).
+    unsafe fn inspect_api_base(base: *const ort::sys::OrtApiBase) -> Result<String, String> {
+        if base.is_null() {
+            return Err(
+                "OrtGetApiBase returned null; the library is not a usable ONNX Runtime".to_string(),
+            );
+        }
+        let version_ptr = ((*base).GetVersionString)();
+        let version = if version_ptr.is_null() {
+            "(unknown version)".to_string()
+        } else {
+            std::ffi::CStr::from_ptr(version_ptr)
+                .to_string_lossy()
+                .into_owned()
+        };
+        // `GetApi` documents null as "this version is unsupported", so null
+        // IS the version answer, not a call failure.
+        if ((*base).GetApi)(ort::MINOR_VERSION).is_null() {
+            return Err(format!(
+                "this is ONNX Runtime {version}, which does not provide API level {api} \
+                 (first shipped in ONNX Runtime 1.{api}); irlume needs 1.{api} or newer",
+                api = ort::MINOR_VERSION
+            ));
+        }
+        Ok(version)
     }
 
     /// Probe, then hand the SAME name to pinned ort, which retains the handle
@@ -1404,6 +1424,40 @@ mod onnx {
             assert!(
                 err.contains("exports no OrtGetApiBase"),
                 "expected the not-an-ONNX-Runtime refusal, got: {err}"
+            );
+        }
+
+        #[test]
+        fn a_runtime_below_the_pinned_api_floor_is_refused() {
+            // An in-process fake of a pre-1.24 runtime: GetApi answers null
+            // for every level, exactly the upstream contract for "this
+            // version is unsupported". The exact-string assertion is what
+            // discriminates: a wrong API number, a reversed null check, or a
+            // deleted floor check each produce a different value here.
+            unsafe extern "system" fn get_api(_version: u32) -> *const ort::sys::OrtApi {
+                std::ptr::null()
+            }
+            unsafe extern "system" fn get_version() -> *const std::ffi::c_char {
+                c"1.20.1".as_ptr()
+            }
+            let base = ort::sys::OrtApiBase {
+                GetApi: get_api,
+                GetVersionString: get_version,
+            };
+            let err = unsafe { inspect_api_base(&base) }.unwrap_err();
+            assert_eq!(
+                err,
+                "this is ONNX Runtime 1.20.1, which does not provide API level 24 \
+                 (first shipped in ONNX Runtime 1.24); irlume needs 1.24 or newer"
+            );
+        }
+
+        #[test]
+        fn a_null_api_base_is_refused() {
+            let err = unsafe { inspect_api_base(std::ptr::null()) }.unwrap_err();
+            assert!(
+                err.contains("OrtGetApiBase returned null"),
+                "expected the null-base refusal, got: {err}"
             );
         }
     }

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -222,7 +222,8 @@ reused for a different meaning. The registry as of this contract:
 | `stage-detection-model` | the face-detection stage's model: the resolved file and whether it is shipped or an env override. `fail` when missing, because the daemon cannot start |
 | `stage-landmarks-model` | the landmarks (mesh) stage's model. `warn` when missing: mesh-dependent gates (passive blink liveness, consent gesture) are disabled |
 | `stage-recognition-model` | the recognizer stage's model. `fail` when missing, because the daemon cannot start |
-| `ort-dylib-path` | which ONNX runtime library will be loaded |
+| `ort-dylib-path` | the `ORT_DYLIB_PATH` override, when one is set |
+| `onnxruntime` | the ONNX Runtime the resolver would load in this shell: the resolved path (or the system library) and its version. `fail` when that library is unloadable or below the API level irlume needs, because model loading cannot succeed against it (#187) |
 | `third-party-pad-model` | optional third-party presentation-attack weights, if installed |
 | `fingerprint-reader` | whether a fingerprint reader was found |
 | `templates` | face templates encrypted at rest for the account asked about |


### PR DESCRIPTION
Fixes the silent-hang failure class found while working the latest round of #187.

## The defect

`ort` with `load-dynamic` does not return an error when the resolved `libonnxruntime.so` is below the pinned API level (`api-24`, ONNX Runtime 1.24): its init parks the calling thread in a futex, forever, with no output. In the daemon that thread is `irlume-startup`, so the journal stops after the camera lines, the socket keeps answering "irlumed is still starting (loading models)", systemd shows the service healthy, and the watchdog keeps getting fed. Measured in a CachyOS container against onnxruntime 1.20.1: 380-490ms of CPU total, startup thread in `futex_do_wait`.

The existing #266 probe turned "unloadable library" into an error, and its own comment recorded the remaining gap: a version-floor rejection inside ort was untested because no pre-1.24 library was on hand. This is that gap, measured.

## Relation to #187

The outward signature matches the reporter's stuck daemon exactly, and 0.9.0's resolver made a new trigger possible: it checks the packaged paths (`/usr/share/irlume/onnxruntime/lib/`, `/opt/irlume/onnxruntime/lib/`) before the system loader, so a stale library there outranks a healthy system runtime with nothing reporting the choice. The reporter has since answered the confirming commands: their machine has nothing at either packaged path and a current system 1.28, so THEIR trigger is still under investigation in the issue. The defect this PR fixes is real and container-measured either way, and the doctor line plus the named refusal are what the next investigation round needs.

## The fix

- `probe_runtime` (was `probe_loadable`) additionally checks the runtime's answer to `GetApi(24)` through `ort_sys`'s own declarations and turns a null answer into an error carrying the resolved path, the runtime's version string from `GetVersionString()`, and the 1.24 floor. Null is the documented "this version is unsupported" answer. The interpretation lives in `inspect_api_base`, testable against an in-process fake.
- The daemon now fails startup with `failed to load models: ... this is ONNX Runtime 1.20.1, which does not provide API level 24 ...` and exits, instead of hanging.
- `irlume doctor` prints the resolved runtime and its version, reports `fail` with the reason when it is unusable, and carries the same detail in `doctor --json`. New `onnxruntime` check id documented in MACHINE-API.md.
- On success the resolution is visible under `irlume logs debug on`.
- The probe reports the FILE the loader actually mapped (dladdr, canonicalized), not just the soname asked for: on the #187 reporter's machine `libonnxruntime.so` resolved to a third-party `/usr/lib/libonnxruntime_x64.so` no package owned, and the mapped path was the fact that solved the issue (added in c1d7b8f, container-validated through a symlink).

## Review round (applied in 8c326b9)

Codex raised two merge-blocking findings, both applied:
- `doctor --json` carried no detail for the new check, so machine consumers got a bare pass/fail; it now goes through `check_detail` and a machine_api test pins the detail's presence.
- Neither probe test reached the floor check, so a mutant deleting it survived; `inspect_api_base` is now tested against a fake `OrtApiBase` whose `GetApi` answers null, asserting the exact refusal string. Mutant re-run: deleting the floor check now fails the test.

## Validation

Container (CachyOS image, released 0.9.0 package, real models):
- Stock 0.9.0 + onnxruntime 1.20.1 via `ORT_DYLIB_PATH`: parks (reproduces the silent-hang journal shape).
- Stock 0.9.0 + stale 1.20.1 at `/usr/share/irlume/onnxruntime/lib/` + healthy system 1.28: parks.
- Patched daemon, same two setups: refuses with the path and version named, exit 1.
- Patched daemon + system 1.28 only: full startup to `serving`. Same under the real systemd unit in a `--systemd=always` container.
- Fedora host, bundled 1.24.4: doctor prints the path and version, daemon unaffected.

Gate: fmt, clippy -D warnings, workspace tests, check-action-pins, check-packaging-parity green locally. `machine-api-conformance.py --strict` has one failure (`status --json` emits `key_present` the schema does not document) that reproduces identically on a main-built binary on this machine and is unrelated; filed to fix separately.

## Hardware validation (CachyOS, Intel N100, Logitech Brio, TPM)

The reporter's poisoned state recreated on a real CachyOS install (onnxruntime-cpu removed, a 1.20.1 planted as /usr/lib/libonnxruntime_x64.so behind the soname symlink):

- Stock 0.9.0: parks. Journal stops after IR emitter ready, 4 tasks, 485ms CPU, irlume-startup in futex_wait, foreign file in /proc maps. Byte-for-byte the reporter's failure shape, now on hardware.
- This branch, same state, under the systemd unit: refuses with the version, the floor, and the loader-mapped foreign file named in one journal line, and exits, so systemd shows a visible failure instead of a healthy hang.
- This branch, runtime restored to the real 1.28: full startup to serving with the Brio in secure tier, and doctor prints the soname plus the mapped file.

The reporter's own machine independently confirmed the failure class live: their stuck daemon had mapped a third-party /usr/lib/libonnxruntime_x64.so, and pinning ORT_DYLIB_PATH to a known-good 1.24.4 brought it up.

## Not tested

- Enrollment on the test box (nobody in front of the camera); the reporter's enrollment run on their Yoga is pending in #187.
