### PR TITLE
True sequential capture, in-place stream recovery, honest capture errors (Brio hardware session)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -645,12 +645,71 @@ fn top_detection(faces: &[Detection]) -> Option<&Detection> {
 /// live anyway, which on a bandwidth-starved camera is indistinguishable
 /// from concurrent (#187).
 fn sequential_capture_selected(rgb_dev: &str) -> (bool, &'static str) {
-    match std::env::var("IRLUME_SEQUENTIAL_CAPTURE") {
-        Ok(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
-        Err(_) => match irlume_camera::stored_capture_mode(rgb_dev) {
+    capture_mode_decision(
+        std::env::var("IRLUME_SEQUENTIAL_CAPTURE").ok().as_deref(),
+        irlume_camera::stored_capture_mode(rgb_dev),
+    )
+}
+
+/// The decision itself, pure over its two observations so every arm is
+/// testable without a camera or an environment mutation: a set env var
+/// decides alone (even when it says concurrent, because setting it is an
+/// explicit instruction and the stored answer must not outrank it), then the
+/// stored per-camera measurement, then the concurrent default.
+fn capture_mode_decision(
+    env: Option<&str>,
+    stored: Option<irlume_camera::CaptureMode>,
+) -> (bool, &'static str) {
+    match env {
+        Some(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
+        None => match stored {
             Some(m) => (m == irlume_camera::CaptureMode::Sequential, "cameras.conf"),
             None => (false, "default"),
         },
+    }
+}
+
+#[cfg(test)]
+mod capture_mode_decision_tests {
+    use super::capture_mode_decision;
+    use irlume_camera::CaptureMode;
+
+    #[test]
+    fn a_set_env_var_decides_alone_in_both_directions() {
+        assert_eq!(
+            capture_mode_decision(Some("1"), None),
+            (true, "IRLUME_SEQUENTIAL_CAPTURE")
+        );
+        // Explicit concurrent outranks a stored sequential: setting the var
+        // is an instruction, and a mutant that consults `stored` here would
+        // sequentialize a run the operator forced concurrent.
+        assert_eq!(
+            capture_mode_decision(Some("0"), Some(CaptureMode::Sequential)),
+            (false, "IRLUME_SEQUENTIAL_CAPTURE")
+        );
+        assert_eq!(
+            capture_mode_decision(Some(" 1 "), Some(CaptureMode::Concurrent)),
+            (true, "IRLUME_SEQUENTIAL_CAPTURE")
+        );
+    }
+
+    #[test]
+    fn the_stored_measurement_decides_when_no_env_is_set() {
+        // Both directions, because a mutant flipping the comparison passes
+        // any test that only checks one of them.
+        assert_eq!(
+            capture_mode_decision(None, Some(CaptureMode::Sequential)),
+            (true, "cameras.conf")
+        );
+        assert_eq!(
+            capture_mode_decision(None, Some(CaptureMode::Concurrent)),
+            (false, "cameras.conf")
+        );
+    }
+
+    #[test]
+    fn nothing_stored_defaults_to_concurrent() {
+        assert_eq!(capture_mode_decision(None, None), (false, "default"));
     }
 }
 
@@ -1303,7 +1362,11 @@ impl Engine {
             Err(e) if !held_sessions => {
                 irlume_common::dlog!(
                     "assess: rgb capture retry ({} capture failed: {e})",
-                    if sequential { "sequential" } else { "concurrent" }
+                    if sequential {
+                        "sequential"
+                    } else {
+                        "concurrent"
+                    }
                 );
                 rgb_hard_retried = true;
                 irlume_camera::capture_rgb_denoised(&self.rgb_dev)?

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -633,6 +633,27 @@ fn top_detection(faces: &[Detection]) -> Option<&Detection> {
     faces.iter().max_by(|a, b| a.score.total_cmp(&b.score))
 }
 
+/// Whether captures on `rgb_dev` should run one stream at a time, and where
+/// that answer came from. Order of authority: the explicit env override, then
+/// what `irlume camera-tune` measured on THIS camera (cameras.conf, per
+/// camera identity), then the concurrent default.
+///
+/// One resolver for every consumer, because the two halves of the answer must
+/// agree: the ASSESS path uses it to order its reads, and the ENROLL path
+/// uses it to decide whether both streams may be armed at once. When they
+/// disagreed, "sequential" ordered the reads of two streams that were both
+/// live anyway, which on a bandwidth-starved camera is indistinguishable
+/// from concurrent (#187).
+fn sequential_capture_selected(rgb_dev: &str) -> (bool, &'static str) {
+    match std::env::var("IRLUME_SEQUENTIAL_CAPTURE") {
+        Ok(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
+        Err(_) => match irlume_camera::stored_capture_mode(rgb_dev) {
+            Some(m) => (m == irlume_camera::CaptureMode::Sequential, "cameras.conf"),
+            None => (false, "default"),
+        },
+    }
+}
+
 impl Engine {
     pub fn load(det_path: &str, model_path: &str) -> irlume_common::Result<Self> {
         // Identify the recognizer by its weights, not its path: a file swapped
@@ -1160,13 +1181,7 @@ impl Engine {
         // brightness when both of its interfaces stream, the ASUS built-in keeps
         // all of it, and only a measurement on the actual camera can tell which
         // kind is plugged in.
-        let (sequential, mode_source) = match std::env::var("IRLUME_SEQUENTIAL_CAPTURE") {
-            Ok(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
-            Err(_) => match irlume_camera::stored_capture_mode(&self.rgb_dev) {
-                Some(m) => (m == irlume_camera::CaptureMode::Sequential, "cameras.conf"),
-                None => (false, "default"),
-            },
-        };
+        let (sequential, mode_source) = sequential_capture_selected(&self.rgb_dev);
         // Name the mode AND where it came from. Without this the only way to
         // tell which path ran is to infer it from timings, which is exactly the
         // guessing this measurement work exists to remove.
@@ -1182,10 +1197,32 @@ impl Engine {
         // just the frames. Every RETRY below deliberately stays on the one-shot
         // path: a retry exists because something went wrong with this capture,
         // and re-opening is what makes a broken stream recoverable.
+        // One denoised capture from a HELD session, recovering the stream in
+        // place on a mid-stream fault. The broken stream owns the device's
+        // buffer queue, so the standalone-reopen retry below answers EBUSY
+        // from our own handle and surfaces as "camera busy, close that app"
+        // with nothing to close (#187 hardware session: Brio QBUF EINVAL at
+        // .266366, retry's S_FMT EBUSY at .269393, no close between).
+        // Recovery renegotiates on the fd the session already holds.
+        fn held_rgb_capture(
+            rgb_s: &mut irlume_camera::RgbSession<'_>,
+        ) -> irlume_common::Result<irlume_camera::Frame> {
+            match rgb_s.denoised() {
+                Ok(f) => Ok(f),
+                Err(e) => {
+                    irlume_common::dlog!(
+                        "assess: held rgb stream broke ({e}); recovering it in place"
+                    );
+                    rgb_s.recover()?;
+                    rgb_s.denoised()
+                }
+            }
+        }
+        let held_sessions = held.is_some();
         let (rgb_res, rgb_ms, ir_res, ir_ms) = if let Some((rgb_s, ir_s)) = held {
             if sequential {
                 let t = std::time::Instant::now();
-                let rgb = rgb_s.denoised();
+                let rgb = held_rgb_capture(rgb_s);
                 let rgb_ms = t.elapsed().as_millis();
                 if rgb.is_err() {
                     (rgb, rgb_ms, Ok(None), 0)
@@ -1201,7 +1238,7 @@ impl Engine {
                         (ir_s.capture_with_stats(), t.elapsed().as_millis())
                     });
                     let t = std::time::Instant::now();
-                    let rgb = rgb_s.denoised();
+                    let rgb = held_rgb_capture(rgb_s);
                     let rgb_ms = t.elapsed().as_millis();
                     let (ir, ir_ms) = ir_thread.join().unwrap_or_else(|_| {
                         (
@@ -1259,11 +1296,19 @@ impl Engine {
         let mut rgb_hard_retried = false;
         let mut rgb = match rgb_res {
             Ok(f) => f,
-            Err(e) => {
-                irlume_common::dlog!("assess: rgb capture retry (concurrent failed: {e})");
+            // Standalone reopen is only safe when THIS call opened one-shot:
+            // with held sessions the device queue belongs to the caller's
+            // stream, the in-place recovery above already had its attempt,
+            // and a reopen here meets our own handle as EBUSY (#187).
+            Err(e) if !held_sessions => {
+                irlume_common::dlog!(
+                    "assess: rgb capture retry ({} capture failed: {e})",
+                    if sequential { "sequential" } else { "concurrent" }
+                );
                 rgb_hard_retried = true;
                 irlume_camera::capture_rgb_denoised(&self.rgb_dev)?
             }
+            Err(e) => return Err(e),
         };
         let mut rgb_faces = self.det.detect(&align::RgbView {
             data: &rgb.data,
@@ -2703,7 +2748,24 @@ impl Engine {
             None
         };
         // Fast path: hold both streams for the whole loop.
-        if let Some((r, i)) = &cams {
+        //
+        // NOT under sequential capture mode. A held session arms its stream
+        // at creation, so holding both means both stream at once and
+        // "sequential" only orders the reads. Measured on a Logitech Brio on
+        // a USB2 link (#187 hardware session, strace + dmesg): with the IR
+        // stream armed, the RGB stream gets no isochronous bandwidth at all;
+        // STREAMON succeeds, no frame ever arrives, and the queue dies with
+        // QBUF EINVAL ("Failed to resubmit video URB" in dmesg). Sequential
+        // mode exists for exactly the cameras that cannot sustain both
+        // streams, so on them this loop takes the per-frame path, which
+        // opens one stream at a time and releases it before the other.
+        let (sequential, mode_source) = sequential_capture_selected(&rgb_dev);
+        if sequential {
+            irlume_common::dlog!(
+                "enroll: sequential capture mode (from {mode_source}); not holding \
+                 both streams, capturing per-frame"
+            );
+        } else if let Some((r, i)) = &cams {
             if let (Ok(mut rs), Ok(mut is)) = (r.session(), i.session()) {
                 return self.capture_scan_loop(want, pitch_neutral, Some((&mut rs, &mut is)));
             }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1206,7 +1206,7 @@ impl Engine {
     /// applications, keeps the capture LED lit, and would go stale across a
     /// suspend.
     fn assess_full(&mut self) -> irlume_common::Result<Assessment> {
-        self.assess_full_with(None)
+        self.assess_full_with(None, None)
     }
 
     /// [`Self::assess_full`], optionally reusing already-streaming cameras.
@@ -1216,6 +1216,7 @@ impl Engine {
             &mut irlume_camera::RgbSession<'_>,
             &mut irlume_camera::IrSession<'_>,
         )>,
+        capture_mode: Option<(bool, &'static str)>,
     ) -> irlume_common::Result<Assessment> {
         // Median-denoise the RGB frame so a single blurry/over-exposed frame
         // can't false-reject a genuine user (IR is already brightest-of-burst).
@@ -1240,7 +1241,14 @@ impl Engine {
         // brightness when both of its interfaces stream, the ASUS built-in keeps
         // all of it, and only a measurement on the actual camera can tell which
         // kind is plugged in.
-        let (sequential, mode_source) = sequential_capture_selected(&self.rgb_dev);
+        // The caller's snapshot when sessions are HELD, a fresh read only when
+        // this call opens one-shot. Two reads of cameras.conf around one held
+        // capture are a check-to-act window (#313 review): the first read
+        // arms both streams for concurrent, a config write lands, and the
+        // second read orders "sequential" reads over two already-live
+        // streams, the exact state the mode exists to prevent.
+        let (sequential, mode_source) =
+            capture_mode.unwrap_or_else(|| sequential_capture_selected(&self.rgb_dev));
         // Name the mode AND where it came from. Without this the only way to
         // tell which path ran is to infer it from timings, which is exactly the
         // guessing this measurement work exists to remove.
@@ -2830,7 +2838,12 @@ impl Engine {
             );
         } else if let Some((r, i)) = &cams {
             if let (Ok(mut rs), Ok(mut is)) = (r.session(), i.session()) {
-                return self.capture_scan_loop(want, pitch_neutral, Some((&mut rs, &mut is)));
+                return self.capture_scan_loop(
+                    want,
+                    pitch_neutral,
+                    Some((&mut rs, &mut is)),
+                    Some((sequential, mode_source)),
+                );
             }
         }
         // No held session. RELEASE THE DEVICES FIRST. The per-frame path below
@@ -2844,7 +2857,11 @@ impl Engine {
         irlume_common::dlog!(
             "enroll: capturing per-frame (no held camera session; released the devices first)"
         );
-        self.capture_scan_loop(want, pitch_neutral, None)
+        // The same snapshot as the held path: one enrollment, one policy. A
+        // config flip mid-loop would otherwise change the one-shot capture
+        // shape between scans, which on a starvation-prone camera turns some
+        // scans into the failure the stored mode exists to avoid.
+        self.capture_scan_loop(want, pitch_neutral, None, Some((sequential, mode_source)))
     }
 
     /// The enrolment capture loop, over held streams when `sessions` is given
@@ -2861,6 +2878,7 @@ impl Engine {
             &mut irlume_camera::RgbSession<'_>,
             &mut irlume_camera::IrSession<'_>,
         )>,
+        capture_mode: Option<(bool, &'static str)>,
     ) -> irlume_common::Result<Vec<CapturedScan>> {
         let mut out = Vec::new();
         // Budget (was ×4) absorbs the added frontality gate (a frame grabbed the
@@ -2879,7 +2897,7 @@ impl Engine {
                 ));
             }
             let a = match &mut sessions {
-                Some((rs, is)) => self.assess_full_with(Some((rs, is)))?,
+                Some((rs, is)) => self.assess_full_with(Some((rs, is)), capture_mode)?,
                 None => self.assess()?,
             };
             // Authoritative capture gate: LIVE *and* squarely frontal. The guided

--- a/crates/irlume-camera/src/ir_metadata.rs
+++ b/crates/irlume-camera/src/ir_metadata.rs
@@ -759,6 +759,17 @@ fn zeroed_buffer(index: u32) -> V4l2Buffer {
 /// on the interface rather than on `videoN + 1` is what keeps this correct on a
 /// machine with several cameras, where numbering interleaves.
 fn metadata_node_for(ir_device: &str) -> Option<String> {
+    // Diagnostic kill switch, added while working #187's hardware session.
+    // On a camera whose four nodes share ONE USB interface (Logitech Brio),
+    // the lowest-number-first sibling search below picks the RGB stream's
+    // metadata node for the IR camera, and arming that queue is suspected of
+    // breaking the RGB stream it belongs to (VIDIOC_QBUF EINVAL mid-burst).
+    // The switch exists so that suspicion can be tested on hardware without
+    // a rebuild; absence of the variable changes nothing.
+    if std::env::var_os("IRLUME_NO_ILLUM_META").is_some_and(|v| v == "1") {
+        irlume_common::dlog!("{ir_device}: illumination metadata disabled (IRLUME_NO_ILLUM_META)");
+        return None;
+    }
     let sysfs = std::path::Path::new("/sys/class/video4linux");
     let found = siblings_on_same_interface(ir_device, sysfs)
         .into_iter()

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1286,7 +1286,7 @@ impl RgbCamera {
         let stream = SafeStream::open(&self.device, &self.dev)?;
         Ok(RgbSession {
             cam: self,
-            stream,
+            stream: Some(stream),
             warmed: false,
         })
     }
@@ -1456,11 +1456,46 @@ pub fn negotiated_stream(device: &str, role: Role) -> irlume_common::Result<Stre
 /// A running RGB stream. Every capture after the first skips the warm-up.
 pub struct RgbSession<'a> {
     cam: &'a RgbCamera,
-    stream: SafeStream<'a>,
+    /// `None` only transiently inside [`Self::recover`]: the broken stream
+    /// must be DROPPED (STREAMOFF + buffer release) before its replacement
+    /// negotiates, and a plain re-assignment builds the new value first.
+    stream: Option<SafeStream<'a>>,
     warmed: bool,
 }
 
-impl RgbSession<'_> {
+impl<'a> RgbSession<'a> {
+    /// The live stream. `recover` is the only path that leaves the slot
+    /// empty, and it either refills it or returns the error; a `None` here
+    /// outside that window is a bug, reported as hardware trouble rather
+    /// than a panic because this sits in the authentication path.
+    fn stream(&mut self) -> irlume_common::Result<&mut SafeStream<'a>> {
+        self.stream
+            .as_mut()
+            .ok_or_else(|| Error::Hardware("RGB stream missing after a failed recovery".into()))
+    }
+
+    /// Rebuild this session's stream on the SAME open device after a
+    /// mid-stream fault.
+    ///
+    /// The broken stream owns the device's buffer queue until it is torn
+    /// down, so a recapture through a SECOND open answers EBUSY from our own
+    /// handle. Measured on a Logitech Brio (#187 hardware session, strace
+    /// 2026-08-06): `VIDIOC_QBUF` on the live stream failed EINVAL at
+    /// .266366, the standalone retry's `VIDIOC_S_FMT` on a fresh open failed
+    /// EBUSY at .269393, and no close ran in between. Dropping the stream
+    /// first releases the queue, and the replacement renegotiates on the fd
+    /// this session already holds, so nothing new opens and nothing collides.
+    /// Same drop-then-reopen shape as the frozen-stream restart in the IR
+    /// one-shot path.
+    pub fn recover(&mut self) -> irlume_common::Result<()> {
+        self.stream = None; // drop first: STREAMOFF + buffer release
+        self.stream = Some(SafeStream::open(&self.cam.device, &self.cam.dev)?);
+        // The fresh stream's auto-exposure starts unsettled, like any new
+        // session's.
+        self.warmed = false;
+        Ok(())
+    }
+
     /// Discard frames until auto-exposure has settled, once per session. A
     /// second capture on the same stream is already settled, and re-running the
     /// warm-up would throw away good frames to no purpose.
@@ -1468,11 +1503,12 @@ impl RgbSession<'_> {
         if self.warmed {
             return Ok(());
         }
-        warm_up_stream(&self.cam.device, &mut self.stream)?;
+        let device = self.cam.device.clone();
+        warm_up_stream(&device, self.stream()?)?;
         for _ in 0..AE_WARMUP {
-            self.stream
+            self.stream()?
                 .next()
-                .map_err(|e| map_io(&self.cam.device, e))?; // discard while AE settles
+                .map_err(|e| map_io(&device, e))?; // discard while AE settles
         }
         self.warmed = true;
         Ok(())
@@ -1482,14 +1518,16 @@ impl RgbSession<'_> {
     pub fn burst(&mut self, n: usize) -> irlume_common::Result<Vec<Frame>> {
         self.warm_up()?;
         let (w, h) = (self.cam.width, self.cam.height);
+        let device = self.cam.device.clone();
+        let chosen = self.cam.chosen;
         let mut frames = Vec::with_capacity(n.max(1));
         for _ in 0..n.max(1) {
             let (buf, _meta) = self
-                .stream
+                .stream()?
                 .next()
-                .map_err(|e| map_io(&self.cam.device, e))?;
+                .map_err(|e| map_io(&device, e))?;
             let taken = std::time::Instant::now();
-            let data = match &self.cam.chosen {
+            let data = match &chosen {
                 b"NV12" => nv12_to_rgb(buf, w, h),
                 _ => yuyv_to_rgb(buf, w, h),
             };

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1506,9 +1506,7 @@ impl<'a> RgbSession<'a> {
         let device = self.cam.device.clone();
         warm_up_stream(&device, self.stream()?)?;
         for _ in 0..AE_WARMUP {
-            self.stream()?
-                .next()
-                .map_err(|e| map_io(&device, e))?; // discard while AE settles
+            self.stream()?.next().map_err(|e| map_io(&device, e))?; // discard while AE settles
         }
         self.warmed = true;
         Ok(())
@@ -1522,10 +1520,7 @@ impl<'a> RgbSession<'a> {
         let chosen = self.cam.chosen;
         let mut frames = Vec::with_capacity(n.max(1));
         for _ in 0..n.max(1) {
-            let (buf, _meta) = self
-                .stream()?
-                .next()
-                .map_err(|e| map_io(&device, e))?;
+            let (buf, _meta) = self.stream()?.next().map_err(|e| map_io(&device, e))?;
             let taken = std::time::Instant::now();
             let data = match &chosen {
                 b"NV12" => nv12_to_rgb(buf, w, h),


### PR DESCRIPTION
The camera-layer fixes from the #187 hardware session on a Logitech Brio over USB2, where enrollment failed with "no face detected" and the diagnosis ran four defects deep. Companion issues: #308 (camera-tune probe shape), #309 (TUI message), #310 (metadata sibling), #311 (Brio hardware notes), #312 (enrollment lighting warning).

## The defects, each syscall-proven on hardware

1. **"Sequential" only ordered the reads.** Held sessions arm their streams at creation, so sequential mode still had both streams live, and on the Brio the armed IR stream starves RGB of isochronous bandwidth entirely: STREAMON succeeds, zero frames ever arrive (a 6-second all-EAGAIN gap in the strace), the queue dies with QBUF EINVAL, and dmesg logs `Failed to resubmit video URB`.
2. **The capture retry collided with its own dead stream.** On a held-session failure, the retry re-opened the device while the caller's broken session still owned the buffer queue: QBUF EINVAL at .266366, the retry's S_FMT EBUSY at .269393, no close between. The user-facing result was "camera busy, close that app" with nothing to close, the same phantom-holder family as #242/#243.
3. **The retry log hardcoded "concurrent"** whatever mode actually ran.

## The fixes

- Sequential mode now vetoes the held-session fast path in `capture_scans`; the per-frame path opens one stream at a time and releases it before the other starts. One resolver (`sequential_capture_selected`) serves both the assess read-ordering and the enroll session decision, so the two halves of the answer cannot disagree again.
- The resolver's decision is a pure function over its two observations (env override, stored per-camera measurement), tested in both directions of every arm, three mutants run and killed (stored-arm flip, env-arm consulting stored, default flip).
- `RgbSession` recovers a broken stream in place: the stream field is an `Option` so the dead stream drops (STREAMOFF, buffer release) before its replacement negotiates on the same fd, the assign-order trap spelled out in the comment. A held-session capture failure gets one in-place recovery, then propagates; the standalone reopen retry runs only when this call opened one-shot.
- The retry log names the mode that ran. `IRLUME_NO_ILLUM_META=1` skips the illumination-metadata reader as a diagnostic (used to cleanly refute that reader as the queue-killer; its wrong-sibling defect is #310).

## Hardware validation (CachyOS mini PC, N100)

With all fixes: enrollment completed on the Brio (10 scans, daylight supplying IR per #311), and on a NexiGo on the same box, enrollment and a live identify match at 0.661 through the full liveness gate with the emitter at ambient=0. Before the fixes, the same box produced the reporter's exact failure signatures. The EINVAL-at-stream-start now propagates truthfully when recovery cannot save the capture, instead of masquerading as a phantom camera holder.

## Not tested

- `RgbSession::recover` and the held-failure propagation have no CI-reachable test (they need a camera whose stream breaks mid-capture); their validation is the hardware session above.
- The IR session side has the same held-stream shape; sequential mode sidesteps it, but an in-place IR recovery is not implemented here.