### PR TITLE
Package the tflite mesh the spec already installs

### DIFF
--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -232,6 +232,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %dir %{_datadir}/%{name}/schemas
 %{_datadir}/%{name}/schemas/*.json
 %{_datadir}/%{name}/models/*.onnx
+%{_datadir}/%{name}/models/*.tflite
 %{_datadir}/%{name}/onnxruntime/lib/*
 %{_unitdir}/irlumed.service
 %{_unitdir}/irlumed.socket


### PR DESCRIPTION
The native-mesh switch (#315) added Source7 and its buildroot install but never extended %files beyond the *.onnx glob, so Copr builds fail with installed-but-unpackaged on face_landmarks_detector.tflite. First surfaced by the Packit run on #318, the first RPM build since the sync. The %files glob now covers *.tflite; rpmspec parse and packaging parity pass locally, and the Packit lanes on this PR are the real proof.

Signed-off-by: archledger <archledger236@gmail.com>