### PR TITLE
Per-process temp dirs in tests, closing the shared-/tmp collision

### DIFF
--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -541,10 +541,10 @@ mod tests {
     #[test]
     fn envelope_path_under_keyring_dir() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        std::env::set_var("IRLUME_KEYRING_DIR", "/tmp/irlume-kr-test");
+        std::env::set_var("IRLUME_KEYRING_DIR", crate::test_tmp_dir("kr-test"));
         assert_eq!(
             envelope_path("alice"),
-            PathBuf::from("/tmp/irlume-kr-test/alice.json")
+            PathBuf::from(format!("{}/alice.json", crate::test_tmp_dir("kr-test")))
         );
         std::env::remove_var("IRLUME_KEYRING_DIR");
     }
@@ -555,8 +555,8 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn arm_and_unseal_roundtrip() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-rt";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-rt");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
         let pw = b"correct horse battery staple";
         seal_password("tester", pw).expect("seal");
@@ -576,8 +576,8 @@ mod tests {
     fn reseal_auto_upgrades_weaker_tier_to_signed() {
         use crate::envelope::{PolicyKind, SealedEnvelope};
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-upgrade";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-upgrade");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
         let pw = b"correct horse battery staple";
         // Simulate an "old" arm under the weakest tier (literal PCR 7).
@@ -617,7 +617,7 @@ mod tests {
         // discoverable at a login otherwise: ksecretd blocks on a short key and
         // truncates a long one, and neither says anything.
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        std::env::set_var("IRLUME_KEYRING_DIR", "/tmp/irlume-kr-len");
+        std::env::set_var("IRLUME_KEYRING_DIR", crate::test_tmp_dir("kr-len"));
         for bad in [crate::kwallet::KEY_LEN - 1, crate::kwallet::KEY_LEN + 1] {
             assert!(
                 seal_secret("lentest", &vec![7u8; bad], SecretKind::KdeWalletKey).is_err(),
@@ -636,12 +636,12 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn resealing_preserves_the_secret_kind() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-kind";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-kind");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
 
         // A home with a real salt, so the wallet key can actually be derived.
-        let home = std::path::PathBuf::from("/tmp/irlume-kr-kind-home");
+        let home = std::path::PathBuf::from(crate::test_tmp_dir("kr-kind-home"));
         let _ = std::fs::remove_dir_all(&home);
         std::fs::create_dir_all(crate::kwallet::salt_path(&home).parent().unwrap()).unwrap();
         std::fs::write(
@@ -718,7 +718,7 @@ mod tests {
     #[test]
     fn seal_secret_refuses_a_token_so_it_cannot_be_armed_without_a_wrap() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        std::env::set_var("IRLUME_KEYRING_DIR", "/tmp/irlume-kr-notoken");
+        std::env::set_var("IRLUME_KEYRING_DIR", crate::test_tmp_dir("kr-notoken"));
         let err = seal_secret("t", b"0123456789abcdef", SecretKind::GnomeKeyringToken)
             .expect_err("a token must not be sealable through the generic path");
         assert!(
@@ -751,8 +751,8 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn a_token_envelope_heals_from_whichever_half_survives() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-token-heal";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-token-heal");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
 
         let pw = b"first-password";
@@ -854,8 +854,8 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn a_tier_climb_keeps_both_the_kind_and_the_recovery_wrap() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-token-climb";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-token-climb");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
 
         let pw = b"climb-password";
@@ -913,8 +913,8 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn rearming_reuses_the_existing_token_rather_than_minting() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-rearm";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-rearm");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
 
         let pw = b"a-password";
@@ -958,8 +958,8 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn releasing_a_token_for_disarm_needs_the_right_password() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-disarm";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-disarm");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
 
         assert!(
@@ -1005,8 +1005,8 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn reseal_only_when_stale() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
-        let dir = "/tmp/irlume-kr-reseal";
-        std::env::set_var("IRLUME_KEYRING_DIR", dir);
+        let dir = crate::test_tmp_dir("kr-reseal");
+        std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
 
         // Not armed -> nothing happens.

--- a/crates/irlume-core/src/lib.rs
+++ b/crates/irlume-core/src/lib.rs
@@ -39,7 +39,17 @@ pub mod tpm_pcrlock;
 /// makes each run's dir distinct; ENV_LOCK still serializes within a process.
 #[cfg(test)]
 pub(crate) fn test_tmp_dir(name: &str) -> String {
-    format!("/tmp/irlume-test-{name}-{}", std::process::id())
+    // uid FIRST, then pid (#321 review): the pid alone is not unique over
+    // time (PIDs wrap at kernel.pid_max), so a reused pid could land on
+    // another CI user's stale directory and reproduce the very EACCES
+    // cascade this helper exists to prevent. With the uid in the path, a
+    // stale directory can only ever be OUR OWN, which is why the callers'
+    // `let _ = remove_dir_all(..)` is safe rather than a hidden failure.
+    use std::os::unix::fs::MetadataExt;
+    let uid = std::fs::metadata("/proc/self")
+        .map(|m| m.uid())
+        .unwrap_or_else(|_| u32::MAX);
+    format!("/tmp/irlume-test-{name}-u{uid}-p{}", std::process::id())
 }
 
 /// RGB (visible-light) match threshold. Measured FAR: real faces (LFW, 13,233

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -238,12 +238,15 @@ mod tests {
     #[test]
     fn paths_under_override_dirs() {
         let _g = ENV_LOCK.lock().unwrap();
-        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", "/tmp/irlume-tk");
-        std::env::set_var("IRLUME_RECOVERY_DIR", "/tmp/irlume-rec");
-        assert_eq!(key_path("bob"), PathBuf::from("/tmp/irlume-tk/bob.json"));
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", crate::test_tmp_dir("tk"));
+        std::env::set_var("IRLUME_RECOVERY_DIR", crate::test_tmp_dir("rec"));
+        assert_eq!(
+            key_path("bob"),
+            PathBuf::from(format!("{}/bob.json", crate::test_tmp_dir("tk")))
+        );
         assert_eq!(
             recovery_path("bob"),
-            PathBuf::from("/tmp/irlume-rec/bob.json")
+            PathBuf::from(format!("{}/bob.json", crate::test_tmp_dir("rec")))
         );
         std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
         std::env::remove_var("IRLUME_RECOVERY_DIR");
@@ -276,10 +279,10 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn tpm_key_and_recovery_lifecycle() {
         let _g = ENV_LOCK.lock().unwrap();
-        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", "/tmp/irlume-tk-rt");
-        std::env::set_var("IRLUME_RECOVERY_DIR", "/tmp/irlume-rec-tpm");
-        let _ = std::fs::remove_dir_all("/tmp/irlume-tk-rt");
-        let _ = std::fs::remove_dir_all("/tmp/irlume-rec-tpm");
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", crate::test_tmp_dir("tk-rt"));
+        std::env::set_var("IRLUME_RECOVERY_DIR", crate::test_tmp_dir("rec-tpm"));
+        let _ = std::fs::remove_dir_all(crate::test_tmp_dir("tk-rt"));
+        let _ = std::fs::remove_dir_all(crate::test_tmp_dir("rec-tpm"));
 
         let k1 = ensure_key("rt").unwrap();
         assert!(has_key("rt"));
@@ -381,10 +384,10 @@ mod tests {
     #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn tpm_tampered_seal_falls_back_then_recovery_heals() {
         let _g = ENV_LOCK.lock().unwrap();
-        let tk = "/tmp/irlume-tk-tamper";
-        let rec = "/tmp/irlume-rec-tamper";
-        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", tk);
-        std::env::set_var("IRLUME_RECOVERY_DIR", rec);
+        let tk = crate::test_tmp_dir("tk-tamper");
+        let rec = crate::test_tmp_dir("rec-tamper");
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", &tk);
+        std::env::set_var("IRLUME_RECOVERY_DIR", &rec);
         let _ = std::fs::remove_dir_all(tk);
         let _ = std::fs::remove_dir_all(rec);
 
@@ -421,9 +424,9 @@ mod tests {
         use crate::crypto;
         use crate::envelope::PolicyKind;
         let _g = ENV_LOCK.lock().unwrap();
-        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", "/tmp/irlume-tk-upg");
-        let _ = std::fs::remove_dir_all("/tmp/irlume-tk-upg");
-        std::fs::create_dir_all("/tmp/irlume-tk-upg").unwrap();
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", crate::test_tmp_dir("tk-upg"));
+        let _ = std::fs::remove_dir_all(crate::test_tmp_dir("tk-upg"));
+        std::fs::create_dir_all(crate::test_tmp_dir("tk-upg")).unwrap();
 
         let key = crypto::generate_key();
         // Simulate an "old" seal under the weakest tier (literal PCR 7).


### PR DESCRIPTION
Closes #317. Twenty-six hardcoded /tmp/irlume-* paths predated the test_tmp_dir helper that already appends the process id. With two CI users on one host (archhost runs both the GitHub and GitLab runners), whichever ran first owned the directory and the other failed with EACCES on seal; the first panic poisoned ENV_LOCK and five more tests cascaded as PoisonError. It took down the GitLab hardware stage and then the GitHub coverage job, on code neither PR touched.

All paths now derive from test_tmp_dir, so two users, two runners, or two concurrent processes cannot collide. Verified locally: the four TPM-gated tests that were failing pass against the real TPM, full irlume-core lib suite 120/120.

Signed-off-by: archledger <archledger236@gmail.com>