### PR TITLE
Share the light CI jobs across both self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Runner routing: heavy jobs (build, test, coverage, fuzz, nix) stay on
+# `arch`, which only the Ryzen carries. The two light jobs take the
+# shared `ci` label, so either machine can run them and neither is a
+# single point of failure for a REQUIRED check. The N100 never sees a
+# release build.
+#
 # Branch protection on `main` requires these four job names as status checks:
 #   "fmt · clippy · build · test", "cargo-deny (advisories · licenses ·
 #   duplicate versions)", "nix flake check", "fuzz (untrusted-input parsers)".
@@ -431,7 +437,7 @@ jobs:
 
   deny:
     name: cargo-deny (advisories · licenses · duplicate versions)
-    runs-on: [self-hosted, arch]
+    runs-on: [self-hosted, ci]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -443,7 +449,7 @@ jobs:
 
   units:
     name: systemd units (verify + exposure ratchet)
-    runs-on: [self-hosted, arch]
+    runs-on: [self-hosted, ci]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
minihost (Intel N100, CachyOS, NexiGo attached, headless, Tailscale-reachable) joins archhost as a second runner. Both now carry a shared `ci` label; cargo-deny and the systemd units job move to it so either machine can run them.

The split is deliberate. Heavy jobs (build+test, stable, coverage, fuzz, nix) stay on `arch`, which only the Ryzen carries: an N100 would stretch a 4-minute release build considerably and make CI latency depend on which machine happened to be free. And sharing beats pinning for these two, because both are required checks and a required check bound to one machine makes that machine a single point of failure for every merge.

minihost is also provisioned for hardware work (TPM, ir-camera labels, v4l2loopback nodes 8/9/10), so the hardware-suite workflow can already land on either box.

Signed-off-by: archledger <archledger236@gmail.com>