### PR TITLE
Camera: the tune probe measures the held-session shape it governs, verified Sequential on the Brio (#308)

### DIFF
--- a/crates/irlume-camera/examples/contention_probe.rs
+++ b/crates/irlume-camera/examples/contention_probe.rs
@@ -15,7 +15,18 @@ fn main() {
     let mut a = std::env::args().skip(1);
     let rgb = a.next().unwrap_or_else(|| "/dev/video0".into());
     let ir = a.next().unwrap_or_else(|| "/dev/video2".into());
-    let rounds: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(3);
+    // Same rule as camera-tune's --rounds: an unparseable count is a usage
+    // error, not a silent substitution of the default (Codex round).
+    let rounds: usize = match a.next() {
+        None => 3,
+        Some(raw) => match raw.parse() {
+            Ok(n) if n > 0 => n,
+            _ => {
+                eprintln!("contention_probe: rounds must be a positive integer, got {raw:?}");
+                std::process::exit(2);
+            }
+        },
+    };
     println!("contention_probe: rgb={rgb} ir={ir} rounds={rounds}");
     match measure_contention(&rgb, &ir, rounds) {
         Ok(r) => {

--- a/crates/irlume-camera/examples/contention_probe.rs
+++ b/crates/irlume-camera/examples/contention_probe.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Run the tune contention probe (the same `measure_contention` the daemon's
+//! TuneCaptureMode uses) directly against a camera pair and print the report,
+//! so a capture-mode verdict can be validated on hardware without the daemon
+//! or a config write. Stop irlumed first; both devices are opened directly.
+//!
+//! Usage: cargo run --release -p irlume-camera --example contention_probe -- \
+//!   [rgb_dev] [ir_dev] [rounds]
+
+use irlume_camera::measure_contention;
+
+fn main() {
+    let mut a = std::env::args().skip(1);
+    let rgb = a.next().unwrap_or_else(|| "/dev/video0".into());
+    let ir = a.next().unwrap_or_else(|| "/dev/video2".into());
+    let rounds: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(3);
+    println!("contention_probe: rgb={rgb} ir={ir} rounds={rounds}");
+    match measure_contention(&rgb, &ir, rounds) {
+        Ok(r) => {
+            let arm = |name: &str, s: &irlume_camera::PairSample| {
+                println!(
+                    "{name}: rounds {} failed {} rgb_mean {:.1} ir_mean {:.1} {:.0} ms",
+                    s.rounds, s.failed, s.rgb_mean, s.ir_mean, s.total_ms
+                );
+            };
+            arm("sequential", &r.sequential);
+            arm("concurrent", &r.concurrent);
+            println!(
+                "retained: rgb {:.2} ir {:.2}  concurrent_impossible: {}",
+                r.retained_rgb(),
+                r.retained_ir(),
+                r.concurrent_impossible()
+            );
+            println!("verdict: {:?}", r.recommended_mode());
+        }
+        Err(e) => {
+            eprintln!("probe error: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -3104,10 +3104,13 @@ pub fn measure_contention_with_progress(
 
 /// The concurrent arm over HELD sessions: the shape a `concurrent` verdict
 /// licenses `capture_scans` to run (#308) — both cameras open, both streams
-/// armed for the whole loop, reads interleaved on one thread, exactly like
-/// the enrollment loop. The old arm re-opened each device per round, an
-/// order the Brio tolerates while its held shape starves RGB completely, so
-/// the stored verdict was measured on a shape the consumer never runs.
+/// held for the whole loop, and each round dequeuing IR on a scoped worker
+/// WHILE RGB captures on this thread, which is the assess path's actual
+/// concurrent schedule (Codex round: the first cut serialized the reads on
+/// one thread, a schedule the consumer never runs, the same class of
+/// mismatch this fix exists to end). The old arm re-opened each device per
+/// round, an order the Brio tolerates while its held shape starves RGB
+/// completely.
 ///
 /// Failing to OPEN or ARM the held pair is itself the measurement (the
 /// camera cannot enter the shape at all): every round is recorded as failed
@@ -3147,8 +3150,17 @@ fn held_concurrent_arm<'d>(
         for _ in 0..rounds {
             progress();
             let t0 = std::time::Instant::now();
-            let rgb = rs.burst(RGB_BURST).map(median_frame);
-            let ir = is.capture_with_stats();
+            let (rgb, ir) = std::thread::scope(|scope| {
+                let ir_thread = scope.spawn(|| is.capture_with_stats());
+                let rgb = rs.burst(RGB_BURST).map(median_frame);
+                let ir = match ir_thread.join() {
+                    Ok(result) => result,
+                    // Re-raise into the composer's catch_unwind: a panic is a
+                    // software defect, never a stored hardware verdict (#263).
+                    Err(payload) => std::panic::resume_unwind(payload),
+                };
+                (rgb, ir)
+            });
             accumulate(into, &rgb, &ir, t0.elapsed());
         }
         Ok(())

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -3096,23 +3096,80 @@ pub fn measure_contention_with_progress(
     measure_contention_impl(
         || capture_rgb_denoised(rgb_dev),
         || capture_ir_with_stats(ir_dev),
+        held_concurrent_arm(rgb_dev, ir_dev),
         rounds,
         progress,
     )
 }
 
-/// [`measure_contention_with_progress`] over injected captures, so the
-/// decisions below are testable without a camera (a panicking capture, an
-/// arm that always errors, a trailing control that fails).
-fn measure_contention_impl<R, I>(
+/// The concurrent arm over HELD sessions: the shape a `concurrent` verdict
+/// licenses `capture_scans` to run (#308) — both cameras open, both streams
+/// armed for the whole loop, reads interleaved on one thread, exactly like
+/// the enrollment loop. The old arm re-opened each device per round, an
+/// order the Brio tolerates while its held shape starves RGB completely, so
+/// the stored verdict was measured on a shape the consumer never runs.
+///
+/// Failing to OPEN or ARM the held pair is itself the measurement (the
+/// camera cannot enter the shape at all): every round is recorded as failed
+/// and the composer's trailing one-at-a-time control decides whether the
+/// camera was still answering, same as an all-error arm.
+fn held_concurrent_arm<'d>(
+    rgb_dev: &'d str,
+    ir_dev: &'d str,
+) -> impl FnOnce(usize, &dyn Fn(), &mut PairSample) -> irlume_common::Result<()> + 'd {
+    move |rounds, progress, into| {
+        let held = RgbCamera::open(rgb_dev).and_then(|r| IrCamera::open(ir_dev).map(|i| (r, i)));
+        let (rgb_cam, mut ir_cam) = match held {
+            Ok(pair) => pair,
+            Err(e) => {
+                irlume_common::dlog!(
+                    "capture-mode probe: cannot OPEN the held camera pair ({e}); \
+                     recording every concurrent round as failed"
+                );
+                into.failed += rounds;
+                return Ok(());
+            }
+        };
+        let sessions = rgb_cam
+            .session()
+            .and_then(|rs| ir_cam.session().map(|is| (rs, is)));
+        let (mut rs, mut is) = match sessions {
+            Ok(pair) => pair,
+            Err(e) => {
+                irlume_common::dlog!(
+                    "capture-mode probe: cannot ARM the held session pair ({e}); \
+                     recording every concurrent round as failed"
+                );
+                into.failed += rounds;
+                return Ok(());
+            }
+        };
+        for _ in 0..rounds {
+            progress();
+            let t0 = std::time::Instant::now();
+            let rgb = rs.burst(RGB_BURST).map(median_frame);
+            let ir = is.capture_with_stats();
+            accumulate(into, &rgb, &ir, t0.elapsed());
+        }
+        Ok(())
+    }
+}
+
+/// [`measure_contention_with_progress`] over injected captures and an
+/// injected concurrent-arm runner, so the decisions below are testable
+/// without a camera (a panicking capture, an arm that always errors, a
+/// trailing control that fails).
+fn measure_contention_impl<R, I, H>(
     rgb_cap: R,
     ir_cap: I,
+    concurrent_arm: H,
     rounds: usize,
     progress: &dyn Fn(),
 ) -> irlume_common::Result<ContentionReport>
 where
     R: Fn() -> irlume_common::Result<Frame>,
-    I: Fn() -> irlume_common::Result<(Frame, IrCaptureStats)> + Sync,
+    I: Fn() -> irlume_common::Result<(Frame, IrCaptureStats)>,
+    H: FnOnce(usize, &dyn Fn(), &mut PairSample) -> irlume_common::Result<()>,
 {
     let rounds = rounds.max(1);
     let mut report = ContentionReport::default();
@@ -3124,29 +3181,21 @@ where
         let ir = ir_cap();
         accumulate(&mut report.sequential, &rgb, &ir, t0.elapsed());
     }
-    for _ in 0..rounds {
-        progress();
-        let t0 = std::time::Instant::now();
-        // A capture that returns Err is a measured failed round. A capture
-        // that PANICS is not a measurement of anything: counting it as a
-        // failed round would let a software defect that only trips off the
-        // main thread masquerade as "this camera cannot stream both nodes"
-        // and be persisted as durable policy, so a panic aborts the whole
-        // probe instead (#263 review).
-        let (rgb, ir) = std::thread::scope(|s| {
-            let ir_t = s.spawn(&ir_cap);
-            let rgb = rgb_cap();
-            match ir_t.join() {
-                Ok(ir) => Ok((rgb, ir)),
-                Err(_) => Err(Error::Hardware(
-                    "capture-mode probe: the IR capture worker panicked; this is \
-                     a software defect, not a camera measurement"
-                        .into(),
-                )),
-            }
-        })?;
-        accumulate(&mut report.concurrent, &rgb, &ir, t0.elapsed());
-    }
+    // A capture that returns Err is a measured failed round. A capture that
+    // PANICS is not a measurement of anything: counting it as a failed round
+    // would let a software defect masquerade as "this camera cannot stream
+    // both nodes" and be persisted as durable policy, so a panic aborts the
+    // whole probe instead (#263 review).
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        concurrent_arm(rounds, progress, &mut report.concurrent)
+    }))
+    .map_err(|_| {
+        Error::Hardware(
+            "capture-mode probe: the concurrent capture arm panicked; this is \
+             a software defect, not a camera measurement"
+                .into(),
+        )
+    })??;
     // Only a dead SEQUENTIAL arm is a failed probe: one capture at a time is
     // the mode every camera must manage, so nothing was learned.
     if report.sequential.rounds == 0 {
@@ -3809,6 +3858,30 @@ mod tests {
         }
     }
 
+    /// The tests' concurrent arm: per-call scripted captures through the SAME
+    /// accumulate/round shape the production held-session arm uses, so the
+    /// composer's decisions (panic abort, dead arms, trailing control) are
+    /// exercised without a camera.
+    fn scripted_arm<'a, R, I>(
+        rgb: &'a R,
+        ir: &'a I,
+    ) -> impl FnOnce(usize, &dyn Fn(), &mut PairSample) -> irlume_common::Result<()> + 'a
+    where
+        R: Fn() -> irlume_common::Result<Frame>,
+        I: Fn() -> irlume_common::Result<(Frame, IrCaptureStats)>,
+    {
+        move |rounds, progress, into| {
+            for _ in 0..rounds {
+                progress();
+                let t0 = std::time::Instant::now();
+                let r = rgb();
+                let i = ir();
+                accumulate(into, &r, &i, t0.elapsed());
+            }
+            Ok(())
+        }
+    }
+
     #[test]
     fn a_panicking_capture_aborts_the_probe_instead_of_becoming_a_verdict() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -3816,19 +3889,16 @@ mod tests {
         // those as failed rounds would persist "this camera cannot stream both
         // nodes" over a software defect (#263 review); the probe must abort.
         let ir_calls = AtomicUsize::new(0);
+        let rgb = || Ok(frame(&[100; 4]));
+        let ir = || {
+            if ir_calls.fetch_add(1, Ordering::SeqCst) >= 2 {
+                panic!("injected defect");
+            }
+            Ok((frame(&[10; 4]), stats(50.0)))
+        };
         let prev = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {})); // keep the test log clean
-        let got = measure_contention_impl(
-            || Ok(frame(&[100; 4])),
-            || {
-                if ir_calls.fetch_add(1, Ordering::SeqCst) >= 2 {
-                    panic!("injected defect");
-                }
-                Ok((frame(&[10; 4]), stats(50.0)))
-            },
-            2,
-            &|| {},
-        );
+        let got = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &|| {});
         std::panic::set_hook(prev);
         let err = got.expect_err("a panic must abort the probe, never report");
         assert!(err.to_string().contains("panicked"), "{err}");
@@ -3841,23 +3911,20 @@ mod tests {
         // RGB open errors, and the trailing control finds the camera still
         // answering — a real contention verdict.
         let rgb_calls = AtomicUsize::new(0);
-        let report = measure_contention_impl(
-            || {
-                let n = rgb_calls.fetch_add(1, Ordering::SeqCst);
-                // Calls 0-1: sequential. 2-3: concurrent (error). 4: control.
-                if (2..4).contains(&n) {
-                    Err(Error::Hardware(
-                        "EINVAL while the IR sibling streams".into(),
-                    ))
-                } else {
-                    Ok(frame(&[100; 4]))
-                }
-            },
-            || Ok((frame(&[10; 4]), stats(50.0))),
-            2,
-            &|| {},
-        )
-        .expect("an answering camera with an impossible concurrent arm is a verdict");
+        let rgb = || {
+            let n = rgb_calls.fetch_add(1, Ordering::SeqCst);
+            // Calls 0-1: sequential. 2-3: concurrent (error). 4: control.
+            if (2..4).contains(&n) {
+                Err(Error::Hardware(
+                    "EINVAL while the IR sibling streams".into(),
+                ))
+            } else {
+                Ok(frame(&[100; 4]))
+            }
+        };
+        let ir = || Ok((frame(&[10; 4]), stats(50.0)));
+        let report = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &|| {})
+            .expect("an answering camera with an impossible concurrent arm is a verdict");
         assert!(report.concurrent_impossible());
         assert_eq!(report.recommended_mode(), CaptureMode::Sequential);
         assert_eq!(
@@ -3865,6 +3932,25 @@ mod tests {
             5,
             "the trailing control must actually run"
         );
+    }
+
+    /// #308: a camera pair that cannot even ENTER the held shape (open or arm
+    /// fails with both streams held) is an all-failed concurrent arm, and with
+    /// the trailing control answering, that is a sequential VERDICT, not a
+    /// probe error. This is the Brio's held-session starvation as the
+    /// composer sees it.
+    #[test]
+    fn a_pair_that_cannot_arm_held_streams_is_a_sequential_verdict() {
+        let rgb = || Ok(frame(&[100; 4]));
+        let ir = || Ok((frame(&[10; 4]), stats(50.0)));
+        let arming_fails = |rounds: usize, _p: &dyn Fn(), into: &mut PairSample| {
+            into.failed += rounds;
+            Ok(())
+        };
+        let report = measure_contention_impl(&rgb, &ir, arming_fails, 2, &|| {})
+            .expect("an unarmable held pair with an answering camera is a verdict");
+        assert!(report.concurrent_impossible());
+        assert_eq!(report.recommended_mode(), CaptureMode::Sequential);
     }
 
     #[test]
@@ -3875,18 +3961,15 @@ mod tests {
         // stopped answering, not that concurrency fails, and must not persist
         // a capability verdict (#263 review).
         let rgb_calls = AtomicUsize::new(0);
-        let got = measure_contention_impl(
-            || {
-                if rgb_calls.fetch_add(1, Ordering::SeqCst) >= 2 {
-                    Err(Error::Hardware("ENODEV".into()))
-                } else {
-                    Ok(frame(&[100; 4]))
-                }
-            },
-            || Ok((frame(&[10; 4]), stats(50.0))),
-            2,
-            &|| {},
-        );
+        let rgb = || {
+            if rgb_calls.fetch_add(1, Ordering::SeqCst) >= 2 {
+                Err(Error::Hardware("ENODEV".into()))
+            } else {
+                Ok(frame(&[100; 4]))
+            }
+        };
+        let ir = || Ok((frame(&[10; 4]), stats(50.0)));
+        let got = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &|| {});
         let err = got.expect_err("a dead camera is a failed probe");
         assert!(err.to_string().contains("trailing"), "{err}");
     }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -3122,7 +3122,7 @@ fn held_concurrent_arm<'d>(
 ) -> impl FnOnce(usize, &dyn Fn(), &mut PairSample) -> irlume_common::Result<()> + 'd {
     move |rounds, progress, into| {
         let held = RgbCamera::open(rgb_dev).and_then(|r| IrCamera::open(ir_dev).map(|i| (r, i)));
-        let (rgb_cam, mut ir_cam) = match held {
+        let (rgb_cam, ir_cam) = match held {
             Ok(pair) => pair,
             Err(e) => {
                 irlume_common::dlog!(
@@ -3873,7 +3873,9 @@ mod tests {
     /// The tests' concurrent arm: per-call scripted captures through the SAME
     /// accumulate/round shape the production held-session arm uses, so the
     /// composer's decisions (panic abort, dead arms, trailing control) are
-    /// exercised without a camera.
+    /// exercised without a camera. Callers pass `&closure` twice on purpose
+    /// (the same script feeds the sequential caps AND this arm), which
+    /// clippy's needless-borrow lint cannot see; the tests carry the allow.
     fn scripted_arm<'a, R, I>(
         rgb: &'a R,
         ir: &'a I,
@@ -3895,6 +3897,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn a_panicking_capture_aborts_the_probe_instead_of_becoming_a_verdict() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         // Sequential IR captures succeed; every concurrent one PANICS. Counting
@@ -3917,6 +3920,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn an_all_error_concurrent_arm_needs_the_trailing_control_to_pass() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         // The BRIO shape, injected: sequential rounds fine, every concurrent
@@ -3952,6 +3956,7 @@ mod tests {
     /// probe error. This is the Brio's held-session starvation as the
     /// composer sees it.
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn a_pair_that_cannot_arm_held_streams_is_a_sequential_verdict() {
         let rgb = || Ok(frame(&[100; 4]));
         let ir = || Ok((frame(&[10; 4]), stats(50.0)));
@@ -3966,6 +3971,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn a_camera_that_stops_answering_fails_the_probe_not_the_verdict() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         // Sequential rounds fine, then the camera dies: every later capture


### PR DESCRIPTION
camera-tune stored a `concurrent` verdict for the Brio measured at 93% RGB and 81% IR retention, and the next enrollment on the same camera failed every attempt (#187 session, mini PC). The probe's concurrent arm re-opened each device per round; a `concurrent` verdict licenses `capture_scans` to hold both cameras open with both streams held for its whole loop, dequeuing IR on a worker thread while RGB captures. The stored mode was measured on a shape the consumer never runs.

The concurrent arm now runs the licensed schedule: both cameras opened and both sessions held after the sequential baseline, and each round spawns IR on a scoped worker while RGB captures on the main thread (the assess path's concurrent schedule; the first cut serialized the reads and the Codex round caught it as the same mismatch class this PR fixes). RGB goes through the held session's burst with the same median denoise, IR through `IrSession::capture_with_stats`, so both arms' figures stay comparable. Failure to open or arm the held pair is recorded as an all-failed arm for the existing trailing-control logic to referee, not a probe error. A worker panic re-raises into the composer's catch_unwind, keeping the panic-aborts-the-probe contract. The composer keeps its injected-capture tests through a scripted arm, plus a new test that an unarmable held pair with an answering camera is a sequential verdict.

Measured on the USB3 Brio (archhost, new `contention_probe` example, daemon stopped), re-run after the threaded-schedule round: sequential 3 of 3 rounds clean, held concurrent arm 0 of 3, `concurrent_impossible: true`, verdict Sequential. That is the mode enrollment needs on this camera on both links; the wrong `concurrent` verdict itself was recorded on the USB2 mini PC per #308, where the per-call arm streams happily.
