### PR TITLE
PAD corpus records face_frac, and the thresholds carry the measured distance answer (#174)

### DIFF
--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -161,6 +161,93 @@ fn capture_once(
     Ok((verdict, cues, reason, signals))
 }
 
+/// One presentation's JSONL record: the operator labels, the verdict with its
+/// attribution, and every signal the gate read. A function rather than inline
+/// in the capture loop so the schema is testable without a camera: the
+/// 2026-08-04 distance campaign (#174 thread) was captured through this tool
+/// while `capture_once` computed `face_frac` and this record dropped it, so
+/// the one corpus built to answer the distance correlation could not, and the
+/// per-condition table had to be rebuilt by hand from debug lines. The record
+/// now carries the field; a `face_frac` of 0.0 means no face was detected
+/// (see `irlume_auth::face_frac_of`), so an analysis can drop those rows
+/// instead of reading "a face filling nothing".
+#[allow(clippy::too_many_arguments)] // the record IS these nine facts; a struct would rename, not reduce
+fn presentation_record(
+    species: &str,
+    kind: &str,
+    path_str: &str,
+    idx: usize,
+    verdict: Verdict,
+    cues: &irlume_liveness::Cues,
+    reason: &str,
+    caught: Option<&'static str>,
+    s: &Signals,
+) -> serde_json::Value {
+    let mut rec = serde_json::Map::new();
+    rec.insert("species".into(), species.into());
+    rec.insert("kind".into(), kind.into());
+    rec.insert("path".into(), path_str.into());
+    rec.insert("idx".into(), idx.into());
+    rec.insert("verdict".into(), verdict_str(verdict).into());
+    rec.insert("reason".into(), reason.into());
+    rec.insert(
+        "caught".into(),
+        serde_json::to_value(caught.map(|c| vec![c]).unwrap_or_default()).unwrap(),
+    );
+    rec.insert("rgb_present".into(), s.rgb_face.is_some().into());
+    rec.insert("ir_present".into(), s.ir_face.is_some().into());
+    rec.insert(
+        "rgb_score".into(),
+        crate::json_f32(s.rgb_face.map(|f| f.score).unwrap_or(0.0)),
+    );
+    rec.insert(
+        "ir_score".into(),
+        crate::json_f32(s.ir_face.map(|f| f.score).unwrap_or(0.0)),
+    );
+    rec.insert(
+        "ir_brightness".into(),
+        crate::json_f32(s.ir_face_brightness),
+    );
+    // The exposure gate's input and its answer. A record that reported
+    // the cues without these could not distinguish a frame the gate
+    // judged from one it refused unread (#237).
+    rec.insert(
+        "ir_saturated_frac".into(),
+        match s.ir_saturated_frac {
+            Some(f) => crate::json_f32(f),
+            None => serde_json::Value::Null,
+        },
+    );
+    rec.insert("ir_exposure_ok".into(), cues.ir_exposure_ok.into());
+    rec.insert(
+        "ir_center_edge_ratio".into(),
+        crate::json_f32(s.ir_center_edge_ratio),
+    );
+    rec.insert("ir_glint".into(), crate::json_f32(s.ir_eye_glint));
+    let cross = match (s.rgb_face, s.ir_face) {
+        (Some(r), Some(i)) => ((r.cx - i.cx).powi(2) + (r.cy - i.cy).powi(2)).sqrt(),
+        _ => f32::NAN,
+    };
+    rec.insert("cross_dist".into(), crate::json_f32(cross));
+    rec.insert("yaw_asym".into(), crate::json_f32(s.head_yaw_asym));
+    rec.insert("pitch_frac".into(), crate::json_f32(s.head_pitch_frac));
+    // The seating-distance proxy, recorded so the next corpus can correlate
+    // the cues above against it (#174); it gates nothing (see
+    // `irlume_liveness::Signals::face_frac`).
+    rec.insert("face_frac".into(), crate::json_f32(s.face_frac));
+    let cues_json = serde_json::json!({
+        "face_in_rgb": cues.face_in_rgb,
+        "face_in_ir": cues.face_in_ir,
+        "cross_spectrum_aligned": cues.cross_spectrum_aligned,
+        "ir_reflectance_ok": cues.ir_reflectance_ok,
+        "center_edge_ratio_ok": cues.center_edge_ratio_ok,
+        "glint_present": cues.glint_present,
+        "frontal_ok": cues.frontal_ok,
+    });
+    rec.insert("cues".into(), cues_json);
+    serde_json::Value::Object(rec)
+}
+
 /// `irlume padcapture --species NAME --kind attack|bonafide --det <yunet.onnx>
 ///   --out pad.jsonl [--path full|ir-only] [--n 10] [--rgb ..] [--ir ..] [--no-prompt]`
 pub(crate) fn padcapture(args: &[String]) -> std::process::ExitCode {
@@ -242,67 +329,11 @@ pub(crate) fn padcapture(args: &[String]) -> std::process::ExitCode {
                 None
             };
 
-            let mut rec = serde_json::Map::new();
-            rec.insert("species".into(), species.into());
-            rec.insert("kind".into(), kind.into());
-            rec.insert("path".into(), path_str.into());
-            rec.insert("idx".into(), idx.into());
-            rec.insert("verdict".into(), verdict_str(verdict).into());
-            rec.insert("reason".into(), reason.clone().into());
-            rec.insert(
-                "caught".into(),
-                serde_json::to_value(caught.map(|c| vec![c]).unwrap_or_default()).unwrap(),
+            let rec = presentation_record(
+                species, kind, path_str, idx, verdict, &cues, &reason, caught, &s,
             );
-            rec.insert("rgb_present".into(), s.rgb_face.is_some().into());
-            rec.insert("ir_present".into(), s.ir_face.is_some().into());
-            rec.insert(
-                "rgb_score".into(),
-                crate::json_f32(s.rgb_face.map(|f| f.score).unwrap_or(0.0)),
-            );
-            rec.insert(
-                "ir_score".into(),
-                crate::json_f32(s.ir_face.map(|f| f.score).unwrap_or(0.0)),
-            );
-            rec.insert(
-                "ir_brightness".into(),
-                crate::json_f32(s.ir_face_brightness),
-            );
-            // The exposure gate's input and its answer. A record that reported
-            // the cues without these could not distinguish a frame the gate
-            // judged from one it refused unread (#237).
-            rec.insert(
-                "ir_saturated_frac".into(),
-                match s.ir_saturated_frac {
-                    Some(f) => crate::json_f32(f),
-                    None => serde_json::Value::Null,
-                },
-            );
-            rec.insert("ir_exposure_ok".into(), cues.ir_exposure_ok.into());
-            rec.insert(
-                "ir_center_edge_ratio".into(),
-                crate::json_f32(s.ir_center_edge_ratio),
-            );
-            rec.insert("ir_glint".into(), crate::json_f32(s.ir_eye_glint));
-            let cross = match (s.rgb_face, s.ir_face) {
-                (Some(r), Some(i)) => ((r.cx - i.cx).powi(2) + (r.cy - i.cy).powi(2)).sqrt(),
-                _ => f32::NAN,
-            };
-            rec.insert("cross_dist".into(), crate::json_f32(cross));
-            rec.insert("yaw_asym".into(), crate::json_f32(s.head_yaw_asym));
-            rec.insert("pitch_frac".into(), crate::json_f32(s.head_pitch_frac));
-            let cues_json = serde_json::json!({
-                "face_in_rgb": cues.face_in_rgb,
-                "face_in_ir": cues.face_in_ir,
-                "cross_spectrum_aligned": cues.cross_spectrum_aligned,
-                "ir_reflectance_ok": cues.ir_reflectance_ok,
-                "center_edge_ratio_ok": cues.center_edge_ratio_ok,
-                "glint_present": cues.glint_present,
-                "frontal_ok": cues.frontal_ok,
-            });
-            rec.insert("cues".into(), cues_json);
 
-            writeln!(f, "{}", serde_json::Value::Object(rec))
-                .map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+            writeln!(f, "{rec}").map_err(|e| irlume_common::Error::Io(e.to_string()))?;
             written += 1;
 
             // Live-progress feedback. For an attack, an accepted verdict is a BREACH.
@@ -648,6 +679,104 @@ mod tests {
         s.ir_center_edge_ratio = MIN_CENTER_EDGE_RATIO - 0.1;
         assert_eq!(caught_cue(Path::IrOnly, &s), Some("center_edge"));
         assert_eq!(caught_cue(Path::IrOnly, &passing_signals()), None);
+    }
+
+    /// #174's plumbing at the corpus layer: `capture_once` computes
+    /// `face_frac` and the record must not drop it, because this file's
+    /// output is what a distance correlation is computed FROM. The
+    /// 2026-08-04 campaign in the #174 thread ran through this tool while
+    /// the loop dropped the field, so its per-condition table had to be
+    /// rebuilt by hand from debug lines instead of read off the corpus.
+    #[test]
+    fn presentation_record_carries_face_frac() {
+        let mut s = passing_signals();
+        s.face_frac = 0.3;
+        let rec = presentation_record(
+            "live_normal",
+            "bonafide",
+            "full",
+            0,
+            Verdict::Live,
+            &irlume_liveness::Cues::default(),
+            "live",
+            None,
+            &s,
+        );
+        let got = rec["face_frac"]
+            .as_f64()
+            .expect("face_frac must be in every record");
+        assert!((got - 0.3).abs() < 1e-6, "recorded {got}, measured 0.3");
+
+        // No detection is recorded as 0.0, the "no face" spelling
+        // `face_frac_of` promises, not a missing key a reader would have to
+        // special-case; an analysis drops those rows.
+        s.face_frac = 0.0;
+        let rec = presentation_record(
+            "print_glossy",
+            "attack",
+            "ir-only",
+            1,
+            Verdict::Spoof,
+            &irlume_liveness::Cues::default(),
+            "no face in IR",
+            None,
+            &s,
+        );
+        assert_eq!(rec["face_frac"].as_f64(), Some(0.0));
+    }
+
+    /// Moving the record out of the capture loop must not change what an
+    /// existing analysis reads back: every key the loop wrote is still
+    /// written, under the same name. The literal list is the corpus schema
+    /// docs/pad-results/*.jsonl readers depend on; dropping or renaming a
+    /// key fails here before it silently breaks one of them.
+    #[test]
+    fn presentation_record_keeps_the_corpus_schema() {
+        let rec = presentation_record(
+            "print_glossy",
+            "attack",
+            "ir-only",
+            3,
+            Verdict::Spoof,
+            &irlume_liveness::Cues::default(),
+            "IR too flat",
+            Some("center_edge"),
+            &passing_signals(),
+        );
+        let obj = rec.as_object().unwrap();
+        for key in [
+            "species",
+            "kind",
+            "path",
+            "idx",
+            "verdict",
+            "reason",
+            "caught",
+            "rgb_present",
+            "ir_present",
+            "rgb_score",
+            "ir_score",
+            "ir_brightness",
+            "ir_saturated_frac",
+            "ir_exposure_ok",
+            "ir_center_edge_ratio",
+            "ir_glint",
+            "cross_dist",
+            "yaw_asym",
+            "pitch_frac",
+            "face_frac",
+            "cues",
+        ] {
+            assert!(obj.contains_key(key), "corpus schema lost key {key}");
+        }
+        assert_eq!(rec["species"], "print_glossy");
+        assert_eq!(rec["idx"], 3);
+        assert_eq!(rec["verdict"], "Spoof");
+        assert_eq!(rec["caught"], serde_json::json!(["center_edge"]));
+        // passing_signals has no RGB face, so the cross-spectrum distance is
+        // unmeasurable and must stay the null `json_f32` writes for a
+        // non-finite value, never a fabricated number.
+        assert_eq!(rec["cross_dist"], serde_json::Value::Null);
     }
 
     #[test]

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -231,6 +231,13 @@ fn presentation_record(
     rec.insert("cross_dist".into(), crate::json_f32(cross));
     rec.insert("yaw_asym".into(), crate::json_f32(s.head_yaw_asym));
     rec.insert("pitch_frac".into(), crate::json_f32(s.head_pitch_frac));
+    // Ambient IR rides with the distance proxy because the two confound each
+    // other in exactly the analysis this corpus exists for: brightness moves
+    // with both seating distance and the scene's own infrared, so near
+    // captures in a dark room against far captures under daylight would be
+    // inseparable without the ambient reading (#174 review). The gate also
+    // reads it, to reword a denial past IR_AMBIENT_FLOOD.
+    rec.insert("ir_ambient".into(), crate::json_f32(s.ir_ambient));
     // The seating-distance proxy, recorded so the next corpus can correlate
     // the cues above against it (#174); it gates nothing (see
     // `irlume_liveness::Signals::face_frac`).
@@ -682,15 +689,19 @@ mod tests {
     }
 
     /// #174's plumbing at the corpus layer: `capture_once` computes
-    /// `face_frac` and the record must not drop it, because this file's
-    /// output is what a distance correlation is computed FROM. The
-    /// 2026-08-04 campaign in the #174 thread ran through this tool while
-    /// the loop dropped the field, so its per-condition table had to be
-    /// rebuilt by hand from debug lines instead of read off the corpus.
+    /// `face_frac` and `ir_ambient` and the record must drop neither,
+    /// because this file's output is what a distance correlation is
+    /// computed FROM, and brightness moves with both seating distance and
+    /// the scene's own infrared, so a corpus with only one of the two
+    /// cannot attribute a change to either. The 2026-08-04 campaign in the
+    /// #174 thread ran through this tool while the loop dropped face_frac,
+    /// so its per-condition table had to be rebuilt by hand from debug
+    /// lines instead of read off the corpus.
     #[test]
     fn presentation_record_carries_face_frac() {
         let mut s = passing_signals();
         s.face_frac = 0.3;
+        s.ir_ambient = 123.5;
         let rec = presentation_record(
             "live_normal",
             "bonafide",
@@ -706,6 +717,13 @@ mod tests {
             .as_f64()
             .expect("face_frac must be in every record");
         assert!((got - 0.3).abs() < 1e-6, "recorded {got}, measured 0.3");
+        // A distinct value, so a record that wrote some other field's number
+        // (or a constant) here fails, not just a record that dropped the key.
+        assert_eq!(
+            rec["ir_ambient"].as_f64(),
+            Some(123.5),
+            "ir_ambient must round-trip into the record"
+        );
 
         // No detection is recorded as 0.0, the "no face" spelling
         // `face_frac_of` promises, not a missing key a reader would have to
@@ -764,6 +782,7 @@ mod tests {
             "cross_dist",
             "yaw_asym",
             "pitch_frac",
+            "ir_ambient",
             "face_frac",
             "cues",
         ] {

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -83,7 +83,8 @@ pub struct Signals {
     /// v4l2 exposure control exposed, so raw brightness is an AE output
     /// rather than irradiance, and dividing it by face_frac squared tracks
     /// the AE instead of the physics (measured 87 at 67.5 cm where 1/d^2
-    /// from the 45 cm baseline predicts 43, #174 thread); the ratio needs no
+    /// from the 45 cm baseline predicts 43, #174 thread); for the ratio, the
+    /// available one-subject, one-module measurements do not justify a
     /// distance term in the measured band. The field stays recorded so
     /// padcapture corpora and the debug lines can re-answer the question on
     /// other modules and outside 20 to 80 cm, where nothing is measured.
@@ -221,10 +222,13 @@ pub const MIN_FACE_SCORE: f32 = 0.6;
 /// 69 of 70 trials (docs/pad-results/2026-06-30-ir-liveness-selftest.md). Treat
 /// it as one weak cue, never as proof of a live face.
 ///
-/// Seating distance does NOT move it: across a 2.7x distance change (~30 to
-/// ~80 cm) the genuine range stayed 1.39-1.56, overlapping at every distance,
-/// so this floor needs no `face_frac` term in that band (#174, measured
-/// 2026-08-04). Eyewear moves it more than seating does: bare-eyed 1.33-1.43
+/// The 2026-08-04 campaign did not show a distance-separated ratio range:
+/// across a 2.7x distance change (~30 to ~80 cm), all observed genuine values
+/// remained within 1.39-1.56 and the condition ranges overlapped (#174). On
+/// one subject and one ASUS module, that supplies no evidence for adding a
+/// `face_frac` term in the measured band, but it does not establish that
+/// distance has zero effect. Re-measure across subjects and modules before
+/// generalising. Eyewear moves it more than seating did: bare-eyed 1.33-1.43
 /// against glasses-on 1.44-1.53, disjoint ranges on the same subject at the
 /// same distance. What does collapse the ratio is saturation up close, which
 /// the exposure gate (#237) refuses before this cue reads it. A retune of the
@@ -1651,15 +1655,13 @@ mod tests {
         }
     }
 
-    /// `face_frac` is RECORDED with the cues and read by nothing. The #174
-    /// measurements (2026-08-04) answered the question it was recorded for:
-    /// brightness moves with seating distance but keeps 2.1x margin over its
-    /// floor at ~80 cm, and the center/edge ratio does not move at all in
-    /// the 30 to 80 cm band, so no cue is normalised by this field (see
-    /// `Signals::face_frac` for why brightness cannot be either: it is an
-    /// auto-exposure output). A verdict that changed with this field would
-    /// be a normalisation nobody derived from data, which is exactly what
-    /// this test exists to catch.
+    /// The limited #174 campaign (2026-08-04) did not justify a
+    /// distance-normalised gate: observed center/edge ranges overlapped
+    /// across ~30 to ~80 cm on one subject and one module, and brightness
+    /// is an auto-exposure output no 1/d^2 model can hold against (see
+    /// `Signals::face_frac`). This test pins the current contract that
+    /// `face_frac` remains observational and cannot change a verdict until
+    /// a distance-aware rule is separately derived and reviewed.
     #[test]
     fn face_frac_changes_no_verdict() {
         let gate = LivenessGate::new();

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -69,15 +69,26 @@ pub struct Signals {
     ///
     /// RECORDED, NEVER GATED. The framing guide accepts 0.12 to 0.55, a 4.6x
     /// span, and several cues above are absolute thresholds on quantities
-    /// that may move across it: emitter irradiance falls with distance, and
-    /// the center-to-edge contrast a near-coaxial emitter produces depends on
-    /// how large the face's own depth is relative to its distance. The
-    /// geometry of [`ir_center_edge_ratio`] is bbox-relative and so scale
-    /// invariant by construction, but neither the physics nor the pixel count
-    /// behind it is, and nobody has measured which way that cuts (#174). This
-    /// field exists so the correlation is answerable from ordinary debug
-    /// output instead of a special capture campaign.
+    /// that could move across it. Which ones do is now measured (#174 thread,
+    /// 2026-08-04, ASUS FHD IR module, one subject, 40 bona-fide
+    /// presentations through this gate at ~30 cm, normal seating, and
+    /// ~80 cm): [`ir_face_brightness`] falls 1.8x across that band, the
+    /// [`ir_center_edge_ratio`] stays inside 1.39-1.56 with overlap at every
+    /// distance, and the glint peak tracks eyewear, not seating. The field
+    /// itself is a working 1/d proxy: face_frac times tape-measured distance
+    /// came out 9.3, 9.0 and 10.7 at 20, 45 and 67.5 cm (#174 thread).
     ///
+    /// No cue is normalised by it, and the measurements are the reason, not
+    /// an omission: the module's firmware runs its own auto-exposure with no
+    /// v4l2 exposure control exposed, so raw brightness is an AE output
+    /// rather than irradiance, and dividing it by face_frac squared tracks
+    /// the AE instead of the physics (measured 87 at 67.5 cm where 1/d^2
+    /// from the 45 cm baseline predicts 43, #174 thread); the ratio needs no
+    /// distance term in the measured band. The field stays recorded so
+    /// padcapture corpora and the debug lines can re-answer the question on
+    /// other modules and outside 20 to 80 cm, where nothing is measured.
+    ///
+    /// [`ir_face_brightness`]: Self::ir_face_brightness
     /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
     pub face_frac: f32,
     /// Fraction (0-1) of the IR face region at or above the sensor's ceiling,
@@ -187,6 +198,17 @@ pub struct Cues {
 /// IR face region must be at least this bright (0..255). A lit live face ran ~83
 /// mean overall on the Shinetech module; the face region is brighter still. A
 /// screen reflects far less 850nm.
+///
+/// Seating distance moves this cue more than any other (#174, measured
+/// 2026-08-04, ASUS FHD IR module, 10 bona-fide presentations per condition):
+/// settled readings were 112.0-136.0 at ~30 cm, 104.8-113.5 at normal
+/// seating, and 75.1-96.2 at ~80 cm, a 1.8x fall. The weakest genuine
+/// reading still clears this floor 2.1x, so the gate holds where users
+/// actually sit, but the margin is a function of distance: re-measure the
+/// far end before raising this. If a distance-aware form of this gate is
+/// ever built, this absolute floor stays as a lower bound underneath it,
+/// because a normalisation must never admit at any distance what the floor
+/// refuses (#174).
 pub const IR_FACE_MIN_BRIGHTNESS: f32 = 35.0;
 /// Max normalized center distance between the RGB and IR face.
 pub const CROSS_SPECTRUM_TOLERANCE: f32 = 0.30;
@@ -198,6 +220,16 @@ pub const MIN_FACE_SCORE: f32 = 0.6;
 /// across poses, and that leniency is measured: a glossy IR print cleared it in
 /// 69 of 70 trials (docs/pad-results/2026-06-30-ir-liveness-selftest.md). Treat
 /// it as one weak cue, never as proof of a live face.
+///
+/// Seating distance does NOT move it: across a 2.7x distance change (~30 to
+/// ~80 cm) the genuine range stayed 1.39-1.56, overlapping at every distance,
+/// so this floor needs no `face_frac` term in that band (#174, measured
+/// 2026-08-04). Eyewear moves it more than seating does: bare-eyed 1.33-1.43
+/// against glasses-on 1.44-1.53, disjoint ranges on the same subject at the
+/// same distance. What does collapse the ratio is saturation up close, which
+/// the exposure gate (#237) refuses before this cue reads it. A retune of the
+/// 1.03 floor therefore argues against the flat-print attack range (a vinyl
+/// print read 1.12-1.17 on the same cue, #235), not against distance.
 pub const MIN_CENTER_EDGE_RATIO: f32 = 1.03;
 
 /// Fraction of the IR face region at the sensor ceiling above which the frame
@@ -245,6 +277,14 @@ fn flood_reason(ambient: f32) -> String {
     )
 }
 /// Eye IR peak above this counts as a corneal glint (supporting cue).
+///
+/// Supporting-only is load-bearing, not caution (#174, measured 2026-08-04):
+/// with glasses on the peak pinned at 255 in all 30 frames, so it reads the
+/// lens specular, not the cornea (#222), and bare-eyed genuine frames read
+/// 164-247 with 6 of 10 below this value. As a hard gate it would
+/// false-reject a bare-eyed user at normal distance more often than not.
+/// The cue is an eyewear-state variable before it is anything else; it does
+/// not track seating distance.
 pub const GLINT_MIN: f32 = 180.0;
 /// Head-orientation gate (Windows-Hello-style ±15° frontality), approximated
 /// from 2D landmarks. Deliberately PERMISSIVE: rejects only clearly off-angle
@@ -1611,11 +1651,15 @@ mod tests {
         }
     }
 
-    /// `face_frac` is RECORDED with the cues and read by nothing: the whole
-    /// point of #174 is to find out whether the existing thresholds move with
-    /// seating distance BEFORE anything is normalised by it. A verdict that
-    /// changed with this field would be exactly the retune-against-
-    /// contaminated-samples the issue warns off.
+    /// `face_frac` is RECORDED with the cues and read by nothing. The #174
+    /// measurements (2026-08-04) answered the question it was recorded for:
+    /// brightness moves with seating distance but keeps 2.1x margin over its
+    /// floor at ~80 cm, and the center/edge ratio does not move at all in
+    /// the 30 to 80 cm band, so no cue is normalised by this field (see
+    /// `Signals::face_frac` for why brightness cannot be either: it is an
+    /// auto-exposure output). A verdict that changed with this field would
+    /// be a normalisation nobody derived from data, which is exactly what
+    /// this test exists to catch.
     #[test]
     fn face_frac_changes_no_verdict() {
         let gate = LivenessGate::new();


### PR DESCRIPTION
The #174 question was whether the absolute liveness thresholds move
with seating distance, which face_frac was recorded to answer (#220).
The 2026-08-04 campaign in the issue thread answered it on one module:
brightness falls 1.8x from ~30 cm to ~80 cm and still clears its 35
floor 2.1x at the far end, the center/edge ratio stays inside 1.39-1.56
at every distance, and the glint peak follows eyewear, not seating. No
gate changes here, and that is the finding, not a gap: raw IR
brightness is the firmware auto-exposure's output rather than
irradiance (measured 87 at 67.5 cm where 1/d^2 predicts 43), so
dividing it by face_frac^2 would normalise the AE loop, and the ratio
needs no distance term in the band people sit in. The threshold
rationale comments now carry those numbers so the next retune starts
from them, with the standing rule stated at the brightness floor: any
future distance-aware form keeps the absolute floor as a lower bound,
because normalising must never admit at any distance what the floor
refuses.

The code change closes the one recording hole left: padcapture ran
that campaign while its JSONL record dropped the face_frac that
capture_once had computed, so the corpus meant to answer the
correlation could not, and the per-condition table had to be rebuilt
by hand from debug lines. The record construction moves out of the
capture loop into presentation_record(), which now writes face_frac
(0.0 keeps meaning "no face detected", so an analysis drops those
rows), and as a function it is testable without a camera: one test
pins that the field reaches the record, another pins the whole
pre-existing key set so a reader of docs/pad-results/*.jsonl cannot be
broken by a silent schema change. Both tests were run against mutants
(the field replaced by a constant, a renamed key) and failed as they
should before being trusted.

Built by a delegated implementation agent under a no-invented-thresholds rule; gate behavior is byte-for-byte unchanged (no data exists yet to justify a normalization curve, and the branch fixes exactly why: the corpus never recorded face_frac). Reviewed: the cited measurements were verified against the #174 thread, and both new tests were re-run and pass. The mutation checks in the tests were verified by the implementer (constant-value and renamed-key mutations both produced failures).