### PR TITLE
Camera: fit the frameless capture worst case inside the 90s watchdog (#336)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -15,7 +15,7 @@ use irlume_vision::{align, Adapter, Detection, Detector, Embedder, Landmarks5, E
 /// the daemon. See [`irlume_camera::setup_ir_emitter`].
 pub use irlume_camera::{
     apply_known_ir_emitter, list_ir_controls, measure_contention, measure_contention_with_progress,
-    setup_ir_emitter, store_capture_mode, CaptureMode, ContentionReport,
+    no_progress, setup_ir_emitter, store_capture_mode, CaptureMode, ContentionReport, Progress,
 };
 /// Auto-select the RGB+IR camera pair (built-in or external Hello webcam), plus
 /// the stable per-device identity the daemon records alongside a persisted pair
@@ -302,35 +302,34 @@ pub const GRACE_WINDOW_MS: u64 = 15000;
 /// away they want a quick drop to the password prompt, not a long freeze.
 pub const SUDO_GRACE_WINDOW_MS: u64 = 5000;
 
-/// Worst-case wall time of ONE [`Engine::assess`] against a FRAMELESS camera
-/// (#336): a device that opens and arms but never delivers a frame, the shape
-/// an unfed v4l2loopback node reproduces and a starved or half-dead UVC module
-/// presents in the field.
+/// The longest a capture path wired through [`irlume_camera::Progress`] can go
+/// without reporting watchdog progress (#336), against ANY defined camera
+/// failure, a frameless device included.
 ///
-/// The multiplier is exactly two frameless stream opens back to back, and the
-/// code cannot stack a third: the concurrent capture pair OVERLAPS on threads
-/// (one open's worth of wall time even when both sides are frameless), a hard
-/// failure earns ONE standalone retry of the failed side (`?` on its failure
-/// ends the assess), and the dimming self-heal recapture is skipped whenever
-/// that retry already ran (`rgb_hard_retried`), so its one recapture can only
-/// replace the retry, never add to it.
+/// The warm-up heartbeats after every completed silent window, so the silent
+/// pieces left are the windows nothing reports: a post-warm-up burst dequeue
+/// errors out on its FIRST timeout (one unreported window), the seam to the
+/// retry then runs detection or a reopen, and the retry's own first warm-up
+/// window ends with the next heartbeat. Two windows plus one seam; no code
+/// path stacks a third unreported window, because every warm-up window
+/// heartbeats and every burst loop propagates its first timeout.
 ///
-/// The allowance covers everything a frameless assess spends outside the two
-/// silent opens: the healthy side's capture (measured 1912ms for a cold RGB+IR
-/// pair on the ASUS built-in, `examples/session_bench.rs`; worst full
-/// sequential pair on hardware here is the NexiGo N930W at ~3.6s, the
-/// `MAX_CROSS_SPECTRUM_SKEW` record), detection and rescue-detection on that
-/// frame, and the device open/negotiation ioctls. 10s is roughly triple that
-/// sum, for slow CPUs.
+/// The window term is PROVEN arithmetic (the poll timeout the camera crate
+/// sets). The seam term is an ALLOWANCE, stated as such: detection and
+/// embedding inference and device re-open ioctls have no deadline in code, so
+/// no constant can bound them; 10s is over double the slowest full sequential
+/// RGB+IR pair measured on hardware here (~3.6s, NexiGo N930W, the
+/// `MAX_CROSS_SPECTRUM_SKEW` record), and the daemon test's margin sits on
+/// top of it.
 ///
 /// An `irlume-daemon` test holds this constant against the `WatchdogSec` in
-/// `packaging/systemd/irlumed.service`, so a timeout or retry edit anywhere
-/// under this sum that outgrows the watchdog fails the suite (#336).
-pub const FRAMELESS_ASSESS_WORST_MS: u64 =
-    2 * irlume_camera::FRAMELESS_STREAM_OPEN_WORST_MS + FRAMELESS_OVERHEAD_ALLOWANCE_MS;
+/// `packaging/systemd/irlumed.service`, so lengthening a dequeue window (or
+/// shrinking the watchdog) past what the other tolerates fails the suite.
+pub const CAPTURE_MAX_SILENT_STRETCH_MS: u64 =
+    2 * irlume_camera::CAPTURE_SILENT_WINDOW_WORST_MS + RETRY_SEAM_ALLOWANCE_MS;
 
-/// The non-silent part of [`FRAMELESS_ASSESS_WORST_MS`]; see there.
-const FRAMELESS_OVERHEAD_ALLOWANCE_MS: u64 = 10_000;
+/// The seam term of [`CAPTURE_MAX_SILENT_STRETCH_MS`]; see there.
+const RETRY_SEAM_ALLOWANCE_MS: u64 = 10_000;
 
 /// How far apart the RGB and IR frames of ONE decision may be captured.
 ///
@@ -869,6 +868,28 @@ impl Engine {
         let _ = self.should_stop();
     }
 
+    /// The per-window heartbeat handed into camera captures (#336).
+    ///
+    /// Polls the same daemon closure [`Self::note_capture_boundary`] does, for
+    /// the same effect: the daemon marks watchdog progress on every poll, so a
+    /// frameless camera reporting each returned dequeue window never looks
+    /// wedged, while a driver call that never returns still does. The yield
+    /// answer is dropped for the boundary's reason too, and one more: this
+    /// fires INSIDE a capture, where nothing can safely stop anyway. Owned
+    /// (`Arc`) so the concurrent capture pair can carry it across scoped
+    /// threads without borrowing the engine.
+    fn capture_progress(&self) -> irlume_camera::Progress {
+        match &self.stop_requested {
+            Some(f) => {
+                let f = std::sync::Arc::clone(f);
+                std::sync::Arc::new(move || {
+                    let _ = f();
+                })
+            }
+            None => irlume_camera::no_progress(),
+        }
+    }
+
     /// Assurance tier from the hardware: `Secure` with a real RGB+IR camera,
     /// `Convenience` on an RGB-only device.
     pub fn tier(&self) -> Tier {
@@ -1206,7 +1227,10 @@ impl Engine {
     /// (well-lit + frontal + screen/glare heuristic), which is why this tier is
     /// limited to lock-screen unlock and never releases credentials.
     fn assess_rgb_only(&mut self) -> irlume_common::Result<Assessment> {
-        let rgb = irlume_camera::capture_rgb_denoised(&self.rgb_dev)?;
+        let rgb = irlume_camera::capture_rgb_denoised_with_progress(
+            &self.rgb_dev,
+            &self.capture_progress(),
+        )?;
         let rgb_view = align::RgbView {
             data: &rgb.data,
             width: rgb.width,
@@ -1369,6 +1393,9 @@ impl Engine {
             }
         }
         let held_sessions = held.is_some();
+        // Every one-shot capture below carries the per-window heartbeat
+        // (#336); held sessions already carry theirs from `capture_scans`.
+        let progress = self.capture_progress();
         let (rgb_res, rgb_ms, ir_res, ir_ms) = if let Some((rgb_s, ir_s)) = held {
             if sequential {
                 let t = std::time::Instant::now();
@@ -1403,7 +1430,7 @@ impl Engine {
             }
         } else if sequential {
             let t = std::time::Instant::now();
-            let rgb = irlume_camera::capture_rgb_denoised(&self.rgb_dev);
+            let rgb = irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress);
             let rgb_ms = t.elapsed().as_millis();
             // Match the old short-circuit: don't fire the IR emitter after an
             // RGB fault (privacy switch, missing node); the shared retry below
@@ -1412,21 +1439,23 @@ impl Engine {
                 (rgb, rgb_ms, Ok(None), 0)
             } else {
                 let t = std::time::Instant::now();
-                let ir = irlume_camera::capture_ir_with_stats(&self.ir_dev);
+                let ir = irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress);
                 (rgb, rgb_ms, ir.map(Some), t.elapsed().as_millis())
             }
         } else {
             std::thread::scope(|s| {
                 let ir_dev = self.ir_dev.clone();
+                let ir_progress = progress.clone();
                 let ir_thread = s.spawn(move || {
                     let t = std::time::Instant::now();
                     (
-                        irlume_camera::capture_ir_with_stats(&ir_dev),
+                        irlume_camera::capture_ir_with_stats_and_progress(&ir_dev, &ir_progress),
                         t.elapsed().as_millis(),
                     )
                 });
                 let t = std::time::Instant::now();
-                let rgb = irlume_camera::capture_rgb_denoised(&self.rgb_dev);
+                let rgb =
+                    irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress);
                 let rgb_ms = t.elapsed().as_millis();
                 let (ir, ir_ms) = ir_thread.join().unwrap_or_else(|_| {
                     (
@@ -1460,7 +1489,7 @@ impl Engine {
                     }
                 );
                 rgb_hard_retried = true;
-                irlume_camera::capture_rgb_denoised(&self.rgb_dev)?
+                irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress)?
             }
             Err(e) => return Err(e),
         };
@@ -1493,10 +1522,10 @@ impl Engine {
         // but capture alone rather than unwrap to stay panic-free.
         let (ir, ir_stats) = match ir_res {
             Ok(Some(f)) => f,
-            Ok(None) => irlume_camera::capture_ir_with_stats(&self.ir_dev)?,
+            Ok(None) => irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?,
             Err(e) => {
                 irlume_common::dlog!("assess: ir capture retry (concurrent failed: {e})");
-                irlume_camera::capture_ir_with_stats(&self.ir_dev)?
+                irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?
             }
         };
         let ir_grey_rgb = irlume_camera::grey_to_rgb(&ir.data);
@@ -1535,7 +1564,7 @@ impl Engine {
             irlume_common::dlog!(
                 "assess: RGB has no face but IR does; recapturing RGB alone (dim overlapped frame?)"
             );
-            rgb = irlume_camera::capture_rgb_denoised(&self.rgb_dev)?;
+            rgb = irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress)?;
             rgb_faces = self.det.detect(&align::RgbView {
                 data: &rgb.data,
                 width: rgb.width,
@@ -2847,7 +2876,10 @@ impl Engine {
     /// cosine MUST be ~1.0. Catches the AuraFace alignment/normalization trap
     /// (the "identical images score 0.6" failure). `Request::SelfTest { AlignmentIdentity }`.
     pub fn alignment_selftest(&mut self) -> irlume_common::Result<(bool, String)> {
-        let rgb = irlume_camera::capture_rgb_denoised(&self.rgb_dev)?;
+        let rgb = irlume_camera::capture_rgb_denoised_with_progress(
+            &self.rgb_dev,
+            &self.capture_progress(),
+        )?;
         let view = align::RgbView {
             data: &rgb.data,
             width: rgb.width,
@@ -2932,7 +2964,11 @@ impl Engine {
                  both streams, capturing per-frame"
             );
         } else if let Some((r, i)) = &cams {
-            if let (Ok(mut rs), Ok(mut is)) = (r.session(), i.session()) {
+            let progress = self.capture_progress();
+            if let (Ok(mut rs), Ok(mut is)) = (
+                r.session_with_progress(&progress),
+                i.session_with_progress(&progress),
+            ) {
                 return self.capture_scan_loop(
                     want,
                     pitch_neutral,
@@ -3344,7 +3380,13 @@ impl Engine {
             .and_then(|u| irlume_core::storage::load(u).ok().flatten())
             .and_then(|e| e.pitch_neutral());
 
-        let rgb = irlume_camera::capture_rgb(&self.rgb_dev)?;
+        let rgb = irlume_camera::capture_rgb_burst_with_progress(
+            &self.rgb_dev,
+            1,
+            &self.capture_progress(),
+        )?
+        .pop()
+        .ok_or_else(|| irlume_common::Error::Hardware("no frames captured".into()))?;
         let view = align::RgbView {
             data: &rgb.data,
             width: rgb.width,

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -302,6 +302,36 @@ pub const GRACE_WINDOW_MS: u64 = 15000;
 /// away they want a quick drop to the password prompt, not a long freeze.
 pub const SUDO_GRACE_WINDOW_MS: u64 = 5000;
 
+/// Worst-case wall time of ONE [`Engine::assess`] against a FRAMELESS camera
+/// (#336): a device that opens and arms but never delivers a frame, the shape
+/// an unfed v4l2loopback node reproduces and a starved or half-dead UVC module
+/// presents in the field.
+///
+/// The multiplier is exactly two frameless stream opens back to back, and the
+/// code cannot stack a third: the concurrent capture pair OVERLAPS on threads
+/// (one open's worth of wall time even when both sides are frameless), a hard
+/// failure earns ONE standalone retry of the failed side (`?` on its failure
+/// ends the assess), and the dimming self-heal recapture is skipped whenever
+/// that retry already ran (`rgb_hard_retried`), so its one recapture can only
+/// replace the retry, never add to it.
+///
+/// The allowance covers everything a frameless assess spends outside the two
+/// silent opens: the healthy side's capture (measured 1912ms for a cold RGB+IR
+/// pair on the ASUS built-in, `examples/session_bench.rs`; worst full
+/// sequential pair on hardware here is the NexiGo N930W at ~3.6s, the
+/// `MAX_CROSS_SPECTRUM_SKEW` record), detection and rescue-detection on that
+/// frame, and the device open/negotiation ioctls. 10s is roughly triple that
+/// sum, for slow CPUs.
+///
+/// An `irlume-daemon` test holds this constant against the `WatchdogSec` in
+/// `packaging/systemd/irlumed.service`, so a timeout or retry edit anywhere
+/// under this sum that outgrows the watchdog fails the suite (#336).
+pub const FRAMELESS_ASSESS_WORST_MS: u64 =
+    2 * irlume_camera::FRAMELESS_STREAM_OPEN_WORST_MS + FRAMELESS_OVERHEAD_ALLOWANCE_MS;
+
+/// The non-silent part of [`FRAMELESS_ASSESS_WORST_MS`]; see there.
+const FRAMELESS_OVERHEAD_ALLOWANCE_MS: u64 = 10_000;
+
 /// How far apart the RGB and IR frames of ONE decision may be captured.
 ///
 /// The cross-spectrum cues treat the two frames as one scene: the face must sit
@@ -821,6 +851,22 @@ impl Engine {
     /// True when something has asked this operation to stop.
     fn should_stop(&self) -> bool {
         self.stop_requested.as_ref().is_some_and(|f| f())
+    }
+
+    /// Report a between-captures boundary without acting on the yield request.
+    ///
+    /// Polling the stop signal is what marks watchdog progress in the daemon
+    /// (#141: its closure notes progress, then answers), and the grace loop
+    /// needs that mark between attempts: `IRLUME_GRACE_MS` can stretch the
+    /// window arbitrarily, and a window of healthy no-face captures followed
+    /// by one frameless capture chain summed past `WatchdogSec` with no
+    /// progress reported anywhere between (#336). The answer itself is
+    /// deliberately dropped: only a queued authentication raises it, and
+    /// cutting a RUNNING authentication's grace window for a queued one would
+    /// hand the first user a password prompt whenever a polkit verify races
+    /// the lock screen. Enrolment keeps honoring it via [`Self::should_stop`].
+    fn note_capture_boundary(&self) {
+        let _ = self.should_stop();
     }
 
     /// Assurance tier from the hardware: `Secure` with a real RGB+IR camera,
@@ -2329,6 +2375,10 @@ impl Engine {
                 "grace: attempt {attempt} found no usable face ({}); retrying within window",
                 out.reason
             );
+            // A whole capture ended and another is about to start: the safe
+            // boundary the watchdog counts as progress (#336). Without it the
+            // entire grace window is one silent stretch on the daemon's clock.
+            self.note_capture_boundary();
         };
         // The gesture belongs to the authentication that just ended.
         self.gesture_seen_before_match = false;

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -5403,15 +5403,55 @@ mod tests {
     #[test]
     #[ignore = "needs an unfed v4l2loopback node; set IRLUME_TEST_SPARE_DEVICE (CI does this)"]
     fn loopback_frameless_capture_fits_the_watchdog_budget() {
-        // The #336 measurement: a camera that streams and then delivers
-        // nothing more (feeder killed under an open device, so the negotiated
-        // format survives) spends the FULL warm-up budget, and what must fit
-        // the watchdog is not that total but the longest stretch between
-        // progress reports. This measures both legs the daemon arithmetic
-        // stands on: the warm-up reported every one of its silent windows
-        // (path assertion, Codex round: the first cut of this test accepted a
-        // residual-buffer branch that never touched the warm-up), and no gap
-        // between reports exceeded CAPTURE_SILENT_WINDOW_WORST_MS plus slack.
+        // The #336 measurement: a frameless capture spends the FULL warm-up
+        // budget, and what must fit the watchdog is not that total but the
+        // longest stretch between progress reports. This measures both legs
+        // the daemon arithmetic stands on: the warm-up reported every one of
+        // its silent windows, and no gap between reports exceeded
+        // CAPTURE_SILENT_WINDOW_WORST_MS plus slack.
+        //
+        // The frameless state is a STALLED PRODUCER built by this test: the
+        // output side of the loopback node armed (S_FMT + REQBUFS + STREAMON),
+        // exactly ONE frame queued, then silence with the tokens still held.
+        // Everything below is from the pinned module source (v4l2loopback
+        // 0.15.4 @0f9ee86; state machine research in
+        // ~/irlume-research/2026-08-07-v4l2loopback-readiness/RESEARCH.md) and
+        // was verified against the real module on the CI runner's exact
+        // kernel (6.17.0-1021-azure VM harness, 2026-08-07):
+        //
+        // - No producer at all (or killed before the consumer's first
+        //   dequeue, which is where STREAMON happens): close releases the
+        //   output stream token, the consumer's STREAMON fails the token
+        //   guard (v4l2loopback.c:2074-2076) with EIO instantly (41ms in the
+        //   research, 7ms remeasured), and no dequeue window ever opens. CI
+        //   run 31205302426 failed this test's first shape exactly there.
+        // - A producer holding the token means the consumer's STREAMON
+        //   passes, and a dequeue then blocks whenever nothing has been
+        //   written past this opener's read position (can_read,
+        //   v4l2loopback.c:1936); only the 5s poll timeout this crate sets
+        //   ends the wait. Measured: a blocking consumer against that state
+        //   sat the full 8s until killed.
+        // - BUT dev->write_position survives for the module's lifetime, and
+        //   each FRESH opener is served one catch-up frame whenever it lags
+        //   (v4l2loopback.c:1972-1977). CI's spare node always has write
+        //   history (the ambient-subtract test feeds it earlier in this same
+        //   binary), so a fresh consumer's warm-up eats that one stale frame
+        //   and the silence lands in the unreported burst loop instead.
+        //   Measured on the VM: 5.0s failure, zero heartbeats.
+        //
+        // So the producer queues ONE frame on purpose, making every node
+        // history equivalent, and the capture below runs TWICE on ONE open
+        // camera: sessions on the same fd share the same opener, whose read
+        // position persists across STREAMOFF/REQBUFS (neither touches it,
+        // v4l2loopback.c:2113-2127, :1694-1712). The first, drain session
+        // consumes the opener's one catch-up frame and fails in the burst's
+        // first silent window; the second, measured session then faces a
+        // fully caught-up queue, and its warm-up walks every silent window
+        // reporting each one. Verified end to end on the VM harness: drain
+        // ~5s, measured session all 8 heartbeats, 40.9s, gaps inside the
+        // bound. If a harness ever set the module's sustain_framerate,
+        // timeout, or keep_format options, frames would flow instead and the
+        // is_err assertions below name the harness loudly.
         let _lock = env_lock();
         let Some(spare) = spare_device() else {
             eprintln!(
@@ -5421,11 +5461,45 @@ mod tests {
             return;
         };
         let _esc = allow_virtual(&spare);
-        let feeder = FfmpegFeeder::spawn(&spare, "color=c=gray:size=640x400:rate=15");
-        // Open (and negotiate GREY) while frames flow; the held fd keeps the
-        // loopback node's format across the feeder's death.
-        let cam = IrCamera::open(&spare).expect("open the fed node");
-        drop(feeder); // now it is a frameless camera
+
+        // The stalled producer. Held (device AND armed stream) until after
+        // the capture: dropping either releases the output token and turns
+        // the state back into the fast-EIO one mid-test.
+        let producer = Device::with_path(&spare).expect("open the spare node's output side");
+        let fmt = Format::new(IR_W, IR_H, FourCC::new(b"GREY"));
+        v4l::video::Output::set_format(&producer, &fmt).expect("set the producer format");
+        let mut producer_stream =
+            v4l::io::mmap::Stream::with_buffers(&producer, Type::VideoOutput, 1)
+                .expect("allocate the producer buffer");
+        {
+            use v4l::io::traits::OutputStream;
+            // First next(): STREAMON (token taken), hands the buffer to fill.
+            let (frame, meta) =
+                OutputStream::next(&mut producer_stream).expect("arm the stalled producer");
+            frame[..(IR_W * IR_H) as usize].fill(128);
+            meta.bytesused = IR_W * IR_H;
+            // Second next(): queues that one frame (the single write), then
+            // returns the next buffer, which is never filled or queued: the
+            // producer now stalls with its tokens held.
+            OutputStream::next(&mut producer_stream).expect("queue the single frame");
+        }
+
+        // Consumer open + GREY negotiation succeed against the armed,
+        // stalled producer, same as against a live feeder.
+        let cam = IrCamera::open(&spare).expect("open the consumer side");
+
+        // Drain session: consumes this opener's one catch-up frame in its
+        // warm-up, then fails on the burst's first silent window.
+        let drained = cam
+            .session()
+            .and_then(|mut s| s.capture_with_stats())
+            .map(|_| ());
+        assert!(
+            drained.is_err(),
+            "the drain capture must fail against a stalled producer; frames \
+             are flowing (module timeout/sustain/keep_format set on this \
+             node?)"
+        );
 
         // Record the gap ending at each progress report, and the start of the
         // stretch a report closes.
@@ -5445,22 +5519,23 @@ mod tests {
             .session_with_progress(&progress)
             .and_then(|mut s| s.capture_with_stats());
         let ms = t0.elapsed().as_millis() as u64;
-        assert!(
-            shot.is_err(),
-            "a frameless node must fail the capture, got a frame after {ms}ms"
-        );
+        let err = match shot {
+            Err(e) => e,
+            Ok(_) => panic!("a frameless node must fail the capture, got a frame after {ms}ms"),
+        };
         // Path assertion: the warm-up itself must have run dry, reporting one
         // heartbeat per silent window for its whole budget. Fewer reports
-        // means a residual loopback buffer let the warm-up succeed and the
-        // failure landed elsewhere; that run proves nothing about the wiring
-        // this test exists to measure, so it fails rather than passes.
+        // means the capture failed somewhere OTHER than the silent warm-up
+        // (the error and wall time in the message say where); that run proves
+        // nothing about the wiring this test exists to measure, so it fails
+        // rather than passes.
         let gaps = gaps.lock().unwrap();
         assert_eq!(
             gaps.len(),
             WARMUP_TRIES as usize,
             "expected one progress report per silent warm-up window \
              (WARMUP_TRIES={WARMUP_TRIES}), saw {}; the warm-up path was not \
-             the one exercised (residual loopback frame?)",
+             the one exercised (capture failed after {ms}ms with: {err})",
             gaps.len()
         );
         // The measured leg of the daemon's watchdog arithmetic: no silent

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -268,6 +268,45 @@ struct SafeStream<'a> {
 /// be well inside it.
 const STREAM_DEQUEUE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Warm-up retry budget (see [`warm_up_stream`]): how many dequeue attempts
+/// the post-resume race gets, and the pause between them. The race it covers
+/// (uvcvideo re-initializing after suspend or USB re-enumeration) fails FAST,
+/// with EIO/ENODEV in milliseconds, so eight tries spaced 120ms apart cover
+/// roughly a second of re-init without adding meaningful wall time.
+const WARMUP_TRIES: u32 = 8;
+const WARMUP_GAP: std::time::Duration = std::time::Duration::from_millis(120);
+
+/// How many of the warm-up tries may be FULL SILENT dequeue windows, i.e. end
+/// in `TimedOut` after blocking for the whole [`STREAM_DEQUEUE_TIMEOUT`].
+///
+/// Split out from [`WARMUP_TRIES`] for #336. A timeout try is nothing like a
+/// resume-race try: it already waited five full seconds with the device armed
+/// and answering poll, so eight of them was 40s inside ONE stream open, and the
+/// auth path stacks two opens back to back (a capture plus the standalone retry
+/// of the failed side), which put a frameless camera past the unit's
+/// `WatchdogSec=90s` and got a working daemon killed. Two windows still
+/// tolerate ten seconds of continuous silence before giving up, which is over
+/// an order of magnitude above every settle time this project has measured
+/// (resume re-init: a few hundred ms; worst full sequential RGB+IR pair, NexiGo
+/// N930W: ~3.6s), so no camera that ever delivered a frame inside the old
+/// budget starts failing under this one.
+const WARMUP_SILENT_TRIES: u32 = 2;
+
+/// Worst-case wall time, in milliseconds, for one stream open against a
+/// FRAMELESS camera (a device that opens, negotiates and arms, then never
+/// delivers a frame; an unfed v4l2loopback node reproduces it exactly).
+///
+/// Derived from the same constants the warm-up runs on, so editing any of them
+/// moves this bound with it: at most `WARMUP_SILENT_TRIES` silent dequeue
+/// windows of `STREAM_DEQUEUE_TIMEOUT` each, plus every inter-try gap the
+/// fast-error retries could add. `irlume-auth` builds its capture-chain worst
+/// case on top of this, and an `irlume-daemon` test holds that sum against the
+/// `WatchdogSec` in `packaging/systemd/irlumed.service` (#336), so a future
+/// edit here that outgrows the watchdog fails the suite instead of shipping.
+pub const FRAMELESS_STREAM_OPEN_WORST_MS: u64 = WARMUP_SILENT_TRIES as u64
+    * STREAM_DEQUEUE_TIMEOUT.as_millis() as u64
+    + WARMUP_TRIES as u64 * WARMUP_GAP.as_millis() as u64;
+
 impl<'a> SafeStream<'a> {
     /// Open a stream on `dev` with the standard buffer ring.
     ///
@@ -3543,18 +3582,25 @@ pub fn nv12_to_rgb(nv12: &[u8], width: u32, height: u32) -> Vec<u8> {
 /// request, so there is no stale handle to recover; the only gap is that the
 /// very first `stream.next()` can return EIO/ENODEV for a few hundred ms after
 /// resume. Retry that, then let the normal AE warmup run.
+///
+/// `TimedOut` gets its own, smaller budget ([`WARMUP_SILENT_TRIES`]): each such
+/// try already blocked for the full [`STREAM_DEQUEUE_TIMEOUT`], so retrying it
+/// as freely as the fast resume-race errors turned a frameless camera into a
+/// 40s stall per open and, stacked with the auth path's standalone retry, a
+/// watchdog kill of a working daemon (#336). The error returned is the same
+/// one the exhausted loop returned before; a camera silent this long only
+/// fails SOONER, never where it used to succeed.
 fn warm_up_stream(
     device: &str,
     stream: &mut v4l::io::mmap::Stream<'_>,
 ) -> irlume_common::Result<()> {
     use std::io::ErrorKind;
-    const TRIES: u32 = 8;
-    const GAP: std::time::Duration = std::time::Duration::from_millis(120);
-    for attempt in 0..TRIES {
+    let mut silent = 0u32;
+    for attempt in 0..WARMUP_TRIES {
         match stream.next() {
             Ok(_) => return Ok(()),
             Err(e)
-                if attempt + 1 < TRIES
+                if attempt + 1 < WARMUP_TRIES
                     && matches!(
                         e.kind(),
                         ErrorKind::BrokenPipe
@@ -3563,7 +3609,13 @@ fn warm_up_stream(
                             | ErrorKind::TimedOut
                     ) =>
             {
-                std::thread::sleep(GAP);
+                if e.kind() == ErrorKind::TimedOut {
+                    silent += 1;
+                    if silent >= WARMUP_SILENT_TRIES {
+                        return Err(map_io(device, e));
+                    }
+                }
+                std::thread::sleep(WARMUP_GAP);
             }
             Err(e) => return Err(map_io(device, e)),
         }
@@ -5256,6 +5308,60 @@ mod tests {
             assert_eq!((f.width, f.height), (IR_W, IR_H));
             assert_eq!(f.spectrum, Spectrum::Ir);
         }
+    }
+
+    #[test]
+    #[ignore = "needs an unfed v4l2loopback node; set IRLUME_TEST_SPARE_DEVICE (CI does this)"]
+    fn loopback_frameless_capture_fits_the_watchdog_budget() {
+        // The #336 measurement: a camera that streams and then delivers
+        // nothing more (feeder killed under an open device, so the negotiated
+        // format survives) must fail one whole capture inside
+        // FRAMELESS_STREAM_OPEN_WORST_MS plus setup slack. That bound is what
+        // irlume-auth's chain constant and the daemon's WatchdogSec test are
+        // built on, so this is the measured leg of that arithmetic. Before the
+        // warm-up's silent-try split, the same capture ran ~41s (8 timeout
+        // tries of 5s), and two of them stacked by the auth retry crossed the
+        // 90s watchdog.
+        let _lock = env_lock();
+        let Some(spare) = spare_device() else {
+            eprintln!(
+                "SKIPPED loopback_frameless_capture_fits_the_watchdog_budget: \
+                 no IRLUME_TEST_SPARE_DEVICE in this environment"
+            );
+            return;
+        };
+        let _esc = allow_virtual(&spare);
+        let feeder = FfmpegFeeder::spawn(&spare, "color=c=gray:size=640x400:rate=15");
+        // Open (and negotiate GREY) while frames flow; the held fd keeps the
+        // loopback node's format across the feeder's death.
+        let cam = IrCamera::open(&spare).expect("open the fed node");
+        drop(feeder); // now it is a frameless camera
+        let t = std::time::Instant::now();
+        let shot = cam.session().and_then(|mut s| s.capture_with_stats());
+        let ms = t.elapsed().as_millis() as u64;
+        assert!(
+            shot.is_err(),
+            "a frameless node must fail the capture, got a frame after {ms}ms"
+        );
+        // Loopback may replay a residual buffer, so the failure lands either in
+        // the warm-up (two silent windows) or on the burst's first dequeue (one
+        // window). Both must have actually waited a full silent window: an
+        // instant error means this measured an open failure, not the frameless
+        // dequeue path the watchdog arithmetic is about.
+        let window_ms = STREAM_DEQUEUE_TIMEOUT.as_millis() as u64;
+        assert!(
+            ms >= window_ms,
+            "capture failed in {ms}ms, under one {window_ms}ms dequeue window; \
+             this did not exercise the frameless path"
+        );
+        // 2s of slack for session setup (emitter control writes, metadata
+        // queue) on a loaded runner.
+        let bound_ms = FRAMELESS_STREAM_OPEN_WORST_MS + 2_000;
+        assert!(
+            ms <= bound_ms,
+            "frameless capture took {ms}ms, over the {bound_ms}ms budget the \
+             watchdog arithmetic (#336) is built on"
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -272,40 +272,43 @@ const STREAM_DEQUEUE_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// the post-resume race gets, and the pause between them. The race it covers
 /// (uvcvideo re-initializing after suspend or USB re-enumeration) fails FAST,
 /// with EIO/ENODEV in milliseconds, so eight tries spaced 120ms apart cover
-/// roughly a second of re-init without adding meaningful wall time.
+/// roughly a second of re-init without adding meaningful wall time. `TimedOut`
+/// keeps the same full budget on purpose: a camera that sits silent for two
+/// windows and delivers on its third succeeded before #336 and must keep
+/// succeeding after it (Codex review of PR #338), so the watchdog problem is
+/// solved by REPORTING each returned window, never by shrinking this budget.
 const WARMUP_TRIES: u32 = 8;
 const WARMUP_GAP: std::time::Duration = std::time::Duration::from_millis(120);
 
-/// How many of the warm-up tries may be FULL SILENT dequeue windows, i.e. end
-/// in `TimedOut` after blocking for the whole [`STREAM_DEQUEUE_TIMEOUT`].
+/// A between-boundaries progress reporter for long camera work (#141, #336).
 ///
-/// Split out from [`WARMUP_TRIES`] for #336. A timeout try is nothing like a
-/// resume-race try: it already waited five full seconds with the device armed
-/// and answering poll, so eight of them was 40s inside ONE stream open, and the
-/// auth path stacks two opens back to back (a capture plus the standalone retry
-/// of the failed side), which put a frameless camera past the unit's
-/// `WatchdogSec=90s` and got a working daemon killed. Two windows still
-/// tolerate ten seconds of continuous silence before giving up, which is over
-/// an order of magnitude above every settle time this project has measured
-/// (resume re-init: a few hundred ms; worst full sequential RGB+IR pair, NexiGo
-/// N930W: ~3.6s), so no camera that ever delivered a frame inside the old
-/// budget starts failing under this one.
-const WARMUP_SILENT_TRIES: u32 = 2;
+/// The daemon's watchdog decides the worker has wedged when nothing reports
+/// progress for half of `WatchdogSec`, and a frameless camera legitimately
+/// spends many 5s dequeue windows inside ONE capture. Each COMPLETED window is
+/// reported through this callback: a dequeue that RETURNED `TimedOut` proves
+/// the thread was not stuck in the kernel, while an ioctl that never returns
+/// reports nothing and still looks wedged, which is exactly the distinction
+/// the watchdog exists to make. `Send + Sync` because the concurrent capture
+/// pair polls it from scoped threads. Callers without a watchdog pass
+/// [`no_progress`].
+pub type Progress = std::sync::Arc<dyn Fn() + Send + Sync>;
 
-/// Worst-case wall time, in milliseconds, for one stream open against a
-/// FRAMELESS camera (a device that opens, negotiates and arms, then never
-/// delivers a frame; an unfed v4l2loopback node reproduces it exactly).
-///
-/// Derived from the same constants the warm-up runs on, so editing any of them
-/// moves this bound with it: at most `WARMUP_SILENT_TRIES` silent dequeue
-/// windows of `STREAM_DEQUEUE_TIMEOUT` each, plus every inter-try gap the
-/// fast-error retries could add. `irlume-auth` builds its capture-chain worst
-/// case on top of this, and an `irlume-daemon` test holds that sum against the
-/// `WatchdogSec` in `packaging/systemd/irlumed.service` (#336), so a future
-/// edit here that outgrows the watchdog fails the suite instead of shipping.
-pub const FRAMELESS_STREAM_OPEN_WORST_MS: u64 = WARMUP_SILENT_TRIES as u64
-    * STREAM_DEQUEUE_TIMEOUT.as_millis() as u64
-    + WARMUP_TRIES as u64 * WARMUP_GAP.as_millis() as u64;
+/// A [`Progress`] that reports nowhere, for callers without a watchdog (the
+/// CLI, examples, tests).
+pub fn no_progress() -> Progress {
+    std::sync::Arc::new(|| {})
+}
+
+/// The longest a correctly wired capture path can wait inside ONE driver call
+/// before either delivering, erroring, or reporting progress: a full dequeue
+/// window plus the warm-up pause that precedes the next one. In milliseconds,
+/// derived from the constants it names so an edit to either moves this bound
+/// with it. `irlume-auth` builds its worst-case silent stretch on top of this,
+/// and an `irlume-daemon` test holds that stretch against the `WatchdogSec` in
+/// `packaging/systemd/irlumed.service` (#336), so lengthening a dequeue window
+/// past what the watchdog tolerates fails the suite instead of shipping.
+pub const CAPTURE_SILENT_WINDOW_WORST_MS: u64 =
+    STREAM_DEQUEUE_TIMEOUT.as_millis() as u64 + WARMUP_GAP.as_millis() as u64;
 
 impl<'a> SafeStream<'a> {
     /// Open a stream on `dev` with the standard buffer ring.
@@ -1317,6 +1320,17 @@ impl RgbCamera {
     /// stream until it is dropped, so keep it exactly as long as the burst of
     /// captures that needs it and no longer.
     pub fn session(&self) -> irlume_common::Result<RgbSession<'_>> {
+        self.session_with_progress(&no_progress())
+    }
+
+    /// [`Self::session`], reporting each completed silent warm-up window
+    /// through `progress` (#336). The session KEEPS the reporter: its warm-up
+    /// runs lazily on the first capture and again after [`RgbSession::recover`],
+    /// both long after this call returned.
+    pub fn session_with_progress(
+        &self,
+        progress: &Progress,
+    ) -> irlume_common::Result<RgbSession<'_>> {
         // Best-effort backlight/low-light correction: tell auto-exposure to
         // expose for the face, not a bright window behind it. Harmless if
         // unsupported (NexiGo N930W needs this; verified mean 49→124 + face
@@ -1333,6 +1347,7 @@ impl RgbCamera {
             cam: self,
             stream: Some(stream),
             warmed: false,
+            progress: progress.clone(),
         })
     }
 
@@ -1506,6 +1521,9 @@ pub struct RgbSession<'a> {
     /// negotiates, and a plain re-assignment builds the new value first.
     stream: Option<SafeStream<'a>>,
     warmed: bool,
+    /// Per-window heartbeat for the lazy warm-up (#336); owned, not borrowed,
+    /// so holding a session never freezes the caller's other borrows.
+    progress: Progress,
 }
 
 impl<'a> RgbSession<'a> {
@@ -1549,7 +1567,8 @@ impl<'a> RgbSession<'a> {
             return Ok(());
         }
         let device = self.cam.device.clone();
-        warm_up_stream(&device, self.stream()?)?;
+        let progress = self.progress.clone();
+        warm_up_stream(&device, self.stream()?, &progress)?;
         for _ in 0..AE_WARMUP {
             self.stream()?.next().map_err(|e| map_io(&device, e))?; // discard while AE settles
         }
@@ -1601,8 +1620,20 @@ impl<'a> RgbSession<'a> {
 /// One-shot: opens and tears down a session. Callers that capture more than once
 /// should hold an [`RgbCamera`] and its session instead.
 pub fn capture_rgb_burst(device: &str, n: usize) -> irlume_common::Result<Vec<Frame>> {
+    capture_rgb_burst_with_progress(device, n, &no_progress())
+}
+
+/// [`capture_rgb_burst`], reporting each completed silent warm-up window
+/// through `progress` (#336). The daemon-facing paths pass a real reporter so
+/// a frameless camera heartbeats through its retry budget instead of looking
+/// wedged to the watchdog.
+pub fn capture_rgb_burst_with_progress(
+    device: &str,
+    n: usize,
+    progress: &Progress,
+) -> irlume_common::Result<Vec<Frame>> {
     let cam = RgbCamera::open(device)?;
-    let mut session = cam.session()?;
+    let mut session = cam.session_with_progress(progress)?;
     let frames = session.burst(n);
     // Drop the stream before `cam`: the session borrows the device.
     drop(session);
@@ -1934,7 +1965,18 @@ pub fn capture_rgb(device: &str) -> irlume_common::Result<Frame> {
 /// genuine match below threshold (false reject). Used for auth/enroll; the
 /// framing guide stays single-shot for latency.
 pub fn capture_rgb_denoised(device: &str) -> irlume_common::Result<Frame> {
-    Ok(median_frame(capture_rgb_burst(device, RGB_BURST)?))
+    capture_rgb_denoised_with_progress(device, &no_progress())
+}
+
+/// [`capture_rgb_denoised`] with the per-window progress reporting of
+/// [`capture_rgb_burst_with_progress`] (#336).
+pub fn capture_rgb_denoised_with_progress(
+    device: &str,
+    progress: &Progress,
+) -> irlume_common::Result<Frame> {
+    Ok(median_frame(capture_rgb_burst_with_progress(
+        device, RGB_BURST, progress,
+    )?))
 }
 
 /// Per-pixel temporal median across same-sized frames (sorts each byte position
@@ -2022,8 +2064,17 @@ pub fn capture_ir(device: &str) -> irlume_common::Result<Frame> {
 /// darkest burst frame's mean is a free per-capture ambient-IR reading (the
 /// input the ambient-relative gates key on), only available at capture time.
 pub fn capture_ir_with_stats(device: &str) -> irlume_common::Result<(Frame, IrCaptureStats)> {
+    capture_ir_with_stats_and_progress(device, &no_progress())
+}
+
+/// [`capture_ir_with_stats`], reporting each completed silent warm-up window
+/// through `progress` (#336); see [`capture_rgb_burst_with_progress`].
+pub fn capture_ir_with_stats_and_progress(
+    device: &str,
+    progress: &Progress,
+) -> irlume_common::Result<(Frame, IrCaptureStats)> {
     let cam = IrCamera::open(device)?;
-    let mut session = cam.session()?;
+    let mut session = cam.session_with_progress(progress)?;
     let shot = session.capture_with_stats();
     // Drop the stream before `cam`: the session borrows the device.
     drop(session);
@@ -2095,6 +2146,16 @@ impl IrCamera {
     /// module nobody here has seen going dark for a window, which costs the user
     /// a password fallback rather than the hardware.
     pub fn session(&self) -> irlume_common::Result<IrSession<'_>> {
+        self.session_with_progress(&no_progress())
+    }
+
+    /// [`Self::session`], reporting each completed silent warm-up window
+    /// through `progress` (#336). Used transiently: the IR warm-up runs right
+    /// here, and nothing in [`IrSession`] warms up again.
+    pub fn session_with_progress(
+        &self,
+        progress: &Progress,
+    ) -> irlume_common::Result<IrSession<'_>> {
         // DECLARED before the stream so it drops AFTER it. Locals drop in
         // reverse declaration order, and `warm_up_stream` below can fail: with
         // the guard declared second, that `?` dropped it first and sent the
@@ -2132,7 +2193,7 @@ impl IrCamera {
         mode = ir_emitter::enable(self.dev.handle(), &self.card, &self.device);
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
-        warm_up_stream(&self.device, &mut stream)?;
+        warm_up_stream(&self.device, &mut stream, progress)?;
         Ok(IrSession {
             cam: self,
             stream,
@@ -3123,7 +3184,7 @@ pub fn measure_contention(
     ir_dev: &str,
     rounds: usize,
 ) -> irlume_common::Result<ContentionReport> {
-    measure_contention_with_progress(rgb_dev, ir_dev, rounds, &|| {})
+    measure_contention_with_progress(rgb_dev, ir_dev, rounds, &no_progress())
 }
 
 /// [`measure_contention`], reporting between captures.
@@ -3135,18 +3196,20 @@ pub fn measure_contention(
 /// and concurrent captures and can exceed the no-progress deadline, at which
 /// point systemd would kill a daemon that is working perfectly. Reporting at the
 /// same granularity the Engine does, between whole captures, keeps the wedge
-/// detection honest while removing the false kill.
+/// detection honest while removing the false kill. The same reporter is handed
+/// into every capture and session open, so the per-window warm-up heartbeat
+/// (#336) covers the probe's captures too.
 pub fn measure_contention_with_progress(
     rgb_dev: &str,
     ir_dev: &str,
     rounds: usize,
-    progress: &dyn Fn(),
+    progress: &Progress,
 ) -> irlume_common::Result<ContentionReport> {
     verify_pinned(rgb_dev)?;
     verify_pinned(ir_dev)?;
     measure_contention_impl(
-        || capture_rgb_denoised(rgb_dev),
-        || capture_ir_with_stats(ir_dev),
+        || capture_rgb_denoised_with_progress(rgb_dev, progress),
+        || capture_ir_with_stats_and_progress(ir_dev, progress),
         held_concurrent_arm(rgb_dev, ir_dev),
         rounds,
         progress,
@@ -3170,7 +3233,7 @@ pub fn measure_contention_with_progress(
 fn held_concurrent_arm<'d>(
     rgb_dev: &'d str,
     ir_dev: &'d str,
-) -> impl FnOnce(usize, &dyn Fn(), &mut PairSample) -> irlume_common::Result<()> + 'd {
+) -> impl FnOnce(usize, &Progress, &mut PairSample) -> irlume_common::Result<()> + 'd {
     move |rounds, progress, into| {
         let held = RgbCamera::open(rgb_dev).and_then(|r| IrCamera::open(ir_dev).map(|i| (r, i)));
         let (rgb_cam, ir_cam) = match held {
@@ -3185,8 +3248,8 @@ fn held_concurrent_arm<'d>(
             }
         };
         let sessions = rgb_cam
-            .session()
-            .and_then(|rs| ir_cam.session().map(|is| (rs, is)));
+            .session_with_progress(progress)
+            .and_then(|rs| ir_cam.session_with_progress(progress).map(|is| (rs, is)));
         let (mut rs, mut is) = match sessions {
             Ok(pair) => pair,
             Err(e) => {
@@ -3227,12 +3290,12 @@ fn measure_contention_impl<R, I, H>(
     ir_cap: I,
     concurrent_arm: H,
     rounds: usize,
-    progress: &dyn Fn(),
+    progress: &Progress,
 ) -> irlume_common::Result<ContentionReport>
 where
     R: Fn() -> irlume_common::Result<Frame>,
     I: Fn() -> irlume_common::Result<(Frame, IrCaptureStats)>,
-    H: FnOnce(usize, &dyn Fn(), &mut PairSample) -> irlume_common::Result<()>,
+    H: FnOnce(usize, &Progress, &mut PairSample) -> irlume_common::Result<()>,
 {
     let rounds = rounds.max(1);
     let mut report = ContentionReport::default();
@@ -3583,23 +3646,54 @@ pub fn nv12_to_rgb(nv12: &[u8], width: u32, height: u32) -> Vec<u8> {
 /// very first `stream.next()` can return EIO/ENODEV for a few hundred ms after
 /// resume. Retry that, then let the normal AE warmup run.
 ///
-/// `TimedOut` gets its own, smaller budget ([`WARMUP_SILENT_TRIES`]): each such
-/// try already blocked for the full [`STREAM_DEQUEUE_TIMEOUT`], so retrying it
-/// as freely as the fast resume-race errors turned a frameless camera into a
-/// 40s stall per open and, stacked with the auth path's standalone retry, a
-/// watchdog kill of a working daemon (#336). The error returned is the same
-/// one the exhausted loop returned before; a camera silent this long only
-/// fails SOONER, never where it used to succeed.
+/// Every retryable kind, `TimedOut` included, keeps the FULL retry budget: a
+/// camera silent for two 5s windows that delivers on its third warmed up
+/// before #336 and still does (an earlier cut of that fix capped the silent
+/// tries at two and was rejected in review for exactly that regression). What
+/// #336 changed instead is reporting: `progress` is invoked after EACH
+/// COMPLETED `TimedOut` return, so a frameless camera spending its whole
+/// budget here reports a heartbeat every window and the daemon's watchdog
+/// (#141) only starves when a driver call genuinely never returns.
 fn warm_up_stream(
     device: &str,
     stream: &mut v4l::io::mmap::Stream<'_>,
+    progress: &Progress,
 ) -> irlume_common::Result<()> {
+    warm_up_with(
+        device,
+        || stream.next().map(|_| ()),
+        std::thread::sleep,
+        progress,
+    )
+}
+
+/// [`warm_up_stream`] over an injected dequeue and sleep, so the retry budget
+/// and the per-window progress reporting are testable without a camera: the
+/// silent-recovery and reporting contracts each have a unit test whose failure
+/// names the regression (Codex review of PR #338).
+fn warm_up_with<N, S>(
+    device: &str,
+    mut next: N,
+    mut sleep: S,
+    progress: &Progress,
+) -> irlume_common::Result<()>
+where
+    N: FnMut() -> std::io::Result<()>,
+    S: FnMut(std::time::Duration),
+{
     use std::io::ErrorKind;
-    let mut silent = 0u32;
     for attempt in 0..WARMUP_TRIES {
-        match stream.next() {
-            Ok(_) => return Ok(()),
-            Err(e)
+        match next() {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                // The window COMPLETED: the driver call came back, the thread
+                // was never stuck, and the watchdog clock resets before the
+                // caller spends unbounded time (inference, a retry's reopen)
+                // on the way to the next window. Reported on the terminal try
+                // too, for the same reason.
+                if e.kind() == ErrorKind::TimedOut {
+                    progress();
+                }
                 if attempt + 1 < WARMUP_TRIES
                     && matches!(
                         e.kind(),
@@ -3607,17 +3701,13 @@ fn warm_up_stream(
                             | ErrorKind::NotConnected
                             | ErrorKind::Other
                             | ErrorKind::TimedOut
-                    ) =>
-            {
-                if e.kind() == ErrorKind::TimedOut {
-                    silent += 1;
-                    if silent >= WARMUP_SILENT_TRIES {
-                        return Err(map_io(device, e));
-                    }
+                    )
+                {
+                    sleep(WARMUP_GAP);
+                } else {
+                    return Err(map_io(device, e));
                 }
-                std::thread::sleep(WARMUP_GAP);
             }
-            Err(e) => return Err(map_io(device, e)),
         }
     }
     Ok(())
@@ -3944,7 +4034,7 @@ mod tests {
     fn scripted_arm<'a, R, I>(
         rgb: &'a R,
         ir: &'a I,
-    ) -> impl FnOnce(usize, &dyn Fn(), &mut PairSample) -> irlume_common::Result<()> + 'a
+    ) -> impl FnOnce(usize, &Progress, &mut PairSample) -> irlume_common::Result<()> + 'a
     where
         R: Fn() -> irlume_common::Result<Frame>,
         I: Fn() -> irlume_common::Result<(Frame, IrCaptureStats)>,
@@ -3978,7 +4068,7 @@ mod tests {
         };
         let prev = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {})); // keep the test log clean
-        let got = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &|| {});
+        let got = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &no_progress());
         std::panic::set_hook(prev);
         let err = got.expect_err("a panic must abort the probe, never report");
         assert!(err.to_string().contains("panicked"), "{err}");
@@ -4004,7 +4094,7 @@ mod tests {
             }
         };
         let ir = || Ok((frame(&[10; 4]), stats(50.0)));
-        let report = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &|| {})
+        let report = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &no_progress())
             .expect("an answering camera with an impossible concurrent arm is a verdict");
         assert!(report.concurrent_impossible());
         assert_eq!(report.recommended_mode(), CaptureMode::Sequential);
@@ -4025,11 +4115,11 @@ mod tests {
     fn a_pair_that_cannot_arm_held_streams_is_a_sequential_verdict() {
         let rgb = || Ok(frame(&[100; 4]));
         let ir = || Ok((frame(&[10; 4]), stats(50.0)));
-        let arming_fails = |rounds: usize, _p: &dyn Fn(), into: &mut PairSample| {
+        let arming_fails = |rounds: usize, _p: &Progress, into: &mut PairSample| {
             into.failed += rounds;
             Ok(())
         };
-        let report = measure_contention_impl(&rgb, &ir, arming_fails, 2, &|| {})
+        let report = measure_contention_impl(&rgb, &ir, arming_fails, 2, &no_progress())
             .expect("an unarmable held pair with an answering camera is a verdict");
         assert!(report.concurrent_impossible());
         assert_eq!(report.recommended_mode(), CaptureMode::Sequential);
@@ -4052,7 +4142,7 @@ mod tests {
             }
         };
         let ir = || Ok((frame(&[10; 4]), stats(50.0)));
-        let got = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &|| {});
+        let got = measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &no_progress());
         let err = got.expect_err("a dead camera is a failed probe");
         assert!(err.to_string().contains("trailing"), "{err}");
     }
@@ -5315,13 +5405,13 @@ mod tests {
     fn loopback_frameless_capture_fits_the_watchdog_budget() {
         // The #336 measurement: a camera that streams and then delivers
         // nothing more (feeder killed under an open device, so the negotiated
-        // format survives) must fail one whole capture inside
-        // FRAMELESS_STREAM_OPEN_WORST_MS plus setup slack. That bound is what
-        // irlume-auth's chain constant and the daemon's WatchdogSec test are
-        // built on, so this is the measured leg of that arithmetic. Before the
-        // warm-up's silent-try split, the same capture ran ~41s (8 timeout
-        // tries of 5s), and two of them stacked by the auth retry crossed the
-        // 90s watchdog.
+        // format survives) spends the FULL warm-up budget, and what must fit
+        // the watchdog is not that total but the longest stretch between
+        // progress reports. This measures both legs the daemon arithmetic
+        // stands on: the warm-up reported every one of its silent windows
+        // (path assertion, Codex round: the first cut of this test accepted a
+        // residual-buffer branch that never touched the warm-up), and no gap
+        // between reports exceeded CAPTURE_SILENT_WINDOW_WORST_MS plus slack.
         let _lock = env_lock();
         let Some(spare) = spare_device() else {
             eprintln!(
@@ -5336,31 +5426,193 @@ mod tests {
         // loopback node's format across the feeder's death.
         let cam = IrCamera::open(&spare).expect("open the fed node");
         drop(feeder); // now it is a frameless camera
-        let t = std::time::Instant::now();
-        let shot = cam.session().and_then(|mut s| s.capture_with_stats());
-        let ms = t.elapsed().as_millis() as u64;
+
+        // Record the gap ending at each progress report, and the start of the
+        // stretch a report closes.
+        let t0 = std::time::Instant::now();
+        let gaps: std::sync::Arc<std::sync::Mutex<Vec<std::time::Duration>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let progress: Progress = {
+            let gaps = std::sync::Arc::clone(&gaps);
+            let last = std::sync::Mutex::new(std::time::Instant::now());
+            std::sync::Arc::new(move || {
+                let mut last = last.lock().unwrap();
+                gaps.lock().unwrap().push(last.elapsed());
+                *last = std::time::Instant::now();
+            })
+        };
+        let shot = cam
+            .session_with_progress(&progress)
+            .and_then(|mut s| s.capture_with_stats());
+        let ms = t0.elapsed().as_millis() as u64;
         assert!(
             shot.is_err(),
             "a frameless node must fail the capture, got a frame after {ms}ms"
         );
-        // Loopback may replay a residual buffer, so the failure lands either in
-        // the warm-up (two silent windows) or on the burst's first dequeue (one
-        // window). Both must have actually waited a full silent window: an
-        // instant error means this measured an open failure, not the frameless
-        // dequeue path the watchdog arithmetic is about.
+        // Path assertion: the warm-up itself must have run dry, reporting one
+        // heartbeat per silent window for its whole budget. Fewer reports
+        // means a residual loopback buffer let the warm-up succeed and the
+        // failure landed elsewhere; that run proves nothing about the wiring
+        // this test exists to measure, so it fails rather than passes.
+        let gaps = gaps.lock().unwrap();
+        assert_eq!(
+            gaps.len(),
+            WARMUP_TRIES as usize,
+            "expected one progress report per silent warm-up window \
+             (WARMUP_TRIES={WARMUP_TRIES}), saw {}; the warm-up path was not \
+             the one exercised (residual loopback frame?)",
+            gaps.len()
+        );
+        // The measured leg of the daemon's watchdog arithmetic: no silent
+        // stretch inside camera code may exceed the exported per-window
+        // bound. 2s of slack for session setup (emitter control writes,
+        // metadata queue) and scheduler jitter on a loaded runner.
+        let bound_ms = CAPTURE_SILENT_WINDOW_WORST_MS + 2_000;
+        let worst_ms = gaps
+            .iter()
+            .map(|d| d.as_millis() as u64)
+            .max()
+            .expect("gaps is non-empty");
+        assert!(
+            worst_ms <= bound_ms,
+            "longest gap between progress reports was {worst_ms}ms, over the \
+             {bound_ms}ms per-window bound the watchdog arithmetic (#336) is \
+             built on"
+        );
+        // And each window must be a real wait, not an instant error loop: a
+        // full poll timeout is the shape being measured.
         let window_ms = STREAM_DEQUEUE_TIMEOUT.as_millis() as u64;
         assert!(
-            ms >= window_ms,
-            "capture failed in {ms}ms, under one {window_ms}ms dequeue window; \
-             this did not exercise the frameless path"
+            worst_ms >= window_ms,
+            "longest gap was {worst_ms}ms, under one {window_ms}ms dequeue \
+             window; this did not exercise the silent-window path"
         );
-        // 2s of slack for session setup (emitter control writes, metadata
-        // queue) on a loaded runner.
-        let bound_ms = FRAMELESS_STREAM_OPEN_WORST_MS + 2_000;
+    }
+
+    // ---- warm-up retry/reporting contract (#336, Codex round) ----------
+    // Over the injected core, so both halves are pinned without a camera:
+    // the FULL silent retry budget (a slow camera that delivers late must
+    // keep succeeding) and the per-window heartbeat (a frameless camera must
+    // never look wedged to the watchdog while its driver calls return).
+
+    /// The regression the Codex review of PR #338 caught in the first cut of
+    /// this fix: a camera silent for two full windows that delivers on its
+    /// third warmed up on main and must keep warming up. Reintroducing any
+    /// cap on TimedOut retries fails here.
+    #[test]
+    fn a_camera_delivering_on_its_third_silent_window_still_warms_up() {
+        use std::io::{Error, ErrorKind};
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = std::cell::Cell::new(0u32);
+        let pings = std::sync::Arc::new(AtomicU32::new(0));
+        let progress: Progress = {
+            let pings = std::sync::Arc::clone(&pings);
+            std::sync::Arc::new(move || {
+                pings.fetch_add(1, Ordering::SeqCst);
+            })
+        };
+        let result = warm_up_with(
+            "/dev/test",
+            || {
+                calls.set(calls.get() + 1);
+                if calls.get() <= 2 {
+                    Err(Error::new(ErrorKind::TimedOut, "synthetic silent window"))
+                } else {
+                    Ok(())
+                }
+            },
+            |_| {},
+            &progress,
+        );
         assert!(
-            ms <= bound_ms,
-            "frameless capture took {ms}ms, over the {bound_ms}ms budget the \
-             watchdog arithmetic (#336) is built on"
+            result.is_ok(),
+            "two silent windows then a frame is a WORKING camera: {result:?}"
+        );
+        assert_eq!(calls.get(), 3, "the third dequeue must have been made");
+        assert_eq!(
+            pings.load(Ordering::SeqCst),
+            2,
+            "each completed silent window reports exactly once"
+        );
+    }
+
+    /// A fully frameless warm-up spends its whole budget and reports EVERY
+    /// window, the terminal one included: the report is what resets the
+    /// watchdog clock before the caller spends unbounded time (inference, a
+    /// reopen) on the way to the next window. Dropping the `progress()` call
+    /// in `warm_up_with`, or shrinking the TimedOut budget, fails here.
+    #[test]
+    fn a_frameless_warm_up_reports_every_completed_silent_window() {
+        use std::io::{Error, ErrorKind};
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = std::cell::Cell::new(0u32);
+        let pings = std::sync::Arc::new(AtomicU32::new(0));
+        let progress: Progress = {
+            let pings = std::sync::Arc::clone(&pings);
+            std::sync::Arc::new(move || {
+                pings.fetch_add(1, Ordering::SeqCst);
+            })
+        };
+        let result = warm_up_with(
+            "/dev/test",
+            || {
+                calls.set(calls.get() + 1);
+                Err(Error::new(ErrorKind::TimedOut, "synthetic silent window"))
+            },
+            |_| {},
+            &progress,
+        );
+        assert!(result.is_err(), "a fully frameless warm-up must fail");
+        assert_eq!(
+            calls.get(),
+            WARMUP_TRIES,
+            "TimedOut keeps the FULL retry budget; a smaller count is the \
+             fail-closed regression the Codex round rejected"
+        );
+        assert_eq!(
+            pings.load(Ordering::SeqCst),
+            WARMUP_TRIES,
+            "one heartbeat per completed silent window, terminal window included"
+        );
+    }
+
+    /// The resume race keeps its full budget and stays silent on the
+    /// reporter: its errors return in milliseconds, so there is no window to
+    /// report, and asserting zero pins that only TimedOut heartbeats.
+    #[test]
+    fn fast_resume_errors_keep_the_full_retry_budget_without_heartbeats() {
+        use std::io::{Error, ErrorKind};
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = std::cell::Cell::new(0u32);
+        let pings = std::sync::Arc::new(AtomicU32::new(0));
+        let progress: Progress = {
+            let pings = std::sync::Arc::clone(&pings);
+            std::sync::Arc::new(move || {
+                pings.fetch_add(1, Ordering::SeqCst);
+            })
+        };
+        let result = warm_up_with(
+            "/dev/test",
+            || {
+                calls.set(calls.get() + 1);
+                if calls.get() == WARMUP_TRIES {
+                    Ok(())
+                } else {
+                    Err(Error::new(ErrorKind::NotConnected, "synthetic resume race"))
+                }
+            },
+            |_| {},
+            &progress,
+        );
+        assert!(
+            result.is_ok(),
+            "the last-try frame must warm up: {result:?}"
+        );
+        assert_eq!(calls.get(), WARMUP_TRIES);
+        assert_eq!(
+            pings.load(Ordering::SeqCst),
+            0,
+            "fast errors are not silent windows and must not heartbeat"
         );
     }
 

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -4492,6 +4492,56 @@ mod tests {
         assert!(!worker_wedged(short), "idle after a job is still healthy");
     }
 
+    /// The #336 arithmetic gate: the longest silent stretch a defined capture
+    /// failure can produce must fit inside HALF the unit's `WatchdogSec`, with
+    /// margin. Half, because that is the bound under which the watchdog can
+    /// never miss a ping regardless of phase: `spawn_watchdog` ticks every
+    /// `period / 2` and withholds a tick only when the worker has been quiet
+    /// longer than that interval, so a stretch under it always has its tick
+    /// answered, while a stretch past it can line up so the last real ping was
+    /// at the stretch's start and systemd's deadline expires before the next
+    /// one. A frameless camera used to produce ~82-96s of exactly such silence
+    /// in one assess chain (two 40s warm-up stalls plus the grace window) and
+    /// systemd killed a daemon that was working through a defined worst case.
+    ///
+    /// Reads the shipped unit rather than repeating "90", so retuning EITHER
+    /// side (a capture timeout, a retry count, or `WatchdogSec` itself) without
+    /// the other fails here instead of shipping a daemon that dies on frameless
+    /// hardware. The chain constant is derived, not free-floating: it is built
+    /// from `irlume-camera`'s dequeue/warm-up constants, and the CI loopback
+    /// test `loopback_frameless_capture_fits_the_watchdog_budget` measures a
+    /// real frameless capture against its camera-side term.
+    #[test]
+    fn frameless_capture_worst_case_fits_inside_the_watchdog() {
+        let unit_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../packaging/systemd/irlumed.service"
+        );
+        let unit =
+            std::fs::read_to_string(unit_path).unwrap_or_else(|e| panic!("read {unit_path}: {e}"));
+        let secs: u64 = unit
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("WatchdogSec="))
+            .expect("irlumed.service declares WatchdogSec")
+            .trim()
+            .trim_end_matches('s')
+            .parse()
+            .expect("WatchdogSec is plain seconds (e.g. 90s)");
+        let period_ms = secs * 1000;
+        let never_missed_ping_ms = period_ms / 2;
+        // 20% margin under the phase-safe bound, for scheduler jitter, model
+        // inference on a loaded CPU, and open/negotiation ioctls on a sick bus.
+        let budget_ms = never_missed_ping_ms * 8 / 10;
+        assert!(
+            irlume_auth::FRAMELESS_ASSESS_WORST_MS <= budget_ms,
+            "a frameless capture chain can go {}ms without reporting progress, \
+             over the {budget_ms}ms budget (80% of half of WatchdogSec={secs}s); \
+             shrink a capture timeout or retry count, or raise WatchdogSec in \
+             packaging/systemd/irlumed.service (#336)",
+            irlume_auth::FRAMELESS_ASSESS_WORST_MS
+        );
+    }
+
     /// The explanatory refusal line is printed once per uid, so a local process
     /// spinning on a request it knows will be refused cannot fill the journal,
     /// while each distinct surface still gets its one explanation.

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2311,12 +2311,11 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
                 engine.ir_device().to_string(),
             );
             // Reports between captures so a long but healthy tune is not read
-            // as a wedged driver by the watchdog (#141).
+            // as a wedged driver by the watchdog (#141), and per silent
+            // warm-up window inside each capture (#336).
+            let progress: irlume_auth::Progress = std::sync::Arc::new(note_worker_progress);
             match irlume_auth::measure_contention_with_progress(
-                &rgb_dev,
-                &ir_dev,
-                rounds,
-                &note_worker_progress,
+                &rgb_dev, &ir_dev, rounds, &progress,
             ) {
                 Ok(report) => {
                     let mode = report.recommended_mode();
@@ -4492,25 +4491,31 @@ mod tests {
         assert!(!worker_wedged(short), "idle after a job is still healthy");
     }
 
-    /// The #336 arithmetic gate: the longest silent stretch a defined capture
-    /// failure can produce must fit inside HALF the unit's `WatchdogSec`, with
-    /// margin. Half, because that is the bound under which the watchdog can
-    /// never miss a ping regardless of phase: `spawn_watchdog` ticks every
-    /// `period / 2` and withholds a tick only when the worker has been quiet
-    /// longer than that interval, so a stretch under it always has its tick
-    /// answered, while a stretch past it can line up so the last real ping was
-    /// at the stretch's start and systemd's deadline expires before the next
-    /// one. A frameless camera used to produce ~82-96s of exactly such silence
-    /// in one assess chain (two 40s warm-up stalls plus the grace window) and
-    /// systemd killed a daemon that was working through a defined worst case.
+    /// The #336 arithmetic gate: the longest stretch a defined capture failure
+    /// can go WITHOUT reporting progress must fit inside HALF the unit's
+    /// `WatchdogSec`, with margin. Half, because that is the bound under which
+    /// the watchdog can never miss a ping regardless of phase: `spawn_watchdog`
+    /// ticks every `period / 2` and withholds a tick only when the worker has
+    /// been quiet longer than that interval, so a stretch under it always has
+    /// its tick answered, while a stretch past it can line up so the last real
+    /// ping was at the stretch's start and systemd's deadline expires before
+    /// the next one. A frameless camera used to produce ~82-96s of exactly
+    /// such silence in one assess chain (two 40s warm-up stalls plus the grace
+    /// window) and systemd killed a daemon that was working through a defined
+    /// worst case. The fix reports each RETURNED dequeue window as progress
+    /// (a window that returned proves the thread was never stuck; a wedged
+    /// ioctl still reports nothing), so the bound here is the per-window
+    /// silent stretch, not the capture chain's total.
     ///
     /// Reads the shipped unit rather than repeating "90", so retuning EITHER
-    /// side (a capture timeout, a retry count, or `WatchdogSec` itself) without
-    /// the other fails here instead of shipping a daemon that dies on frameless
-    /// hardware. The chain constant is derived, not free-floating: it is built
-    /// from `irlume-camera`'s dequeue/warm-up constants, and the CI loopback
-    /// test `loopback_frameless_capture_fits_the_watchdog_budget` measures a
-    /// real frameless capture against its camera-side term.
+    /// side (a dequeue window, the warm-up pacing, or `WatchdogSec` itself)
+    /// without the other fails here instead of shipping a daemon that dies on
+    /// frameless hardware. The stretch constant is derived, not free-floating:
+    /// it is built from `irlume-camera`'s dequeue/warm-up constants; the
+    /// per-window heartbeat WIRING it assumes is pinned by irlume-camera's
+    /// `a_frameless_warm_up_reports_every_completed_silent_window`, and the CI
+    /// loopback test `loopback_frameless_capture_fits_the_watchdog_budget`
+    /// measures both on a real frameless capture.
     #[test]
     fn frameless_capture_worst_case_fits_inside_the_watchdog() {
         let unit_path = concat!(
@@ -4529,16 +4534,16 @@ mod tests {
             .expect("WatchdogSec is plain seconds (e.g. 90s)");
         let period_ms = secs * 1000;
         let never_missed_ping_ms = period_ms / 2;
-        // 20% margin under the phase-safe bound, for scheduler jitter, model
-        // inference on a loaded CPU, and open/negotiation ioctls on a sick bus.
+        // 20% margin under the phase-safe bound, for scheduler jitter and
+        // whatever the seam allowance underestimates on a loaded CPU.
         let budget_ms = never_missed_ping_ms * 8 / 10;
         assert!(
-            irlume_auth::FRAMELESS_ASSESS_WORST_MS <= budget_ms,
-            "a frameless capture chain can go {}ms without reporting progress, \
-             over the {budget_ms}ms budget (80% of half of WatchdogSec={secs}s); \
-             shrink a capture timeout or retry count, or raise WatchdogSec in \
+            irlume_auth::CAPTURE_MAX_SILENT_STRETCH_MS <= budget_ms,
+            "a capture path can go {}ms without reporting progress, over the \
+             {budget_ms}ms budget (80% of half of WatchdogSec={secs}s); shorten \
+             the dequeue window, or raise WatchdogSec in \
              packaging/systemd/irlumed.service (#336)",
-            irlume_auth::FRAMELESS_ASSESS_WORST_MS
+            irlume_auth::CAPTURE_MAX_SILENT_STRETCH_MS
         );
     }
 


### PR DESCRIPTION
Fixes #336, built by a delegated agent under a fail-closed rule (no timeout a slow-but-working camera relies on may shrink) and reviewed here.

The frameless worst case was ~96s of watchdog silence against a 90s deadline: a frameless stream open retried its full 5s dequeue window 8 times (~41s), one assess stacks two such opens, and the grace window marked no progress in between. The numbers are derived from the code's constants and labeled as such in the commit; Secure Boot blocked a local loopback measurement, so the CI harness carries the measured proof instead.

Three layers, each covering a hole the others cannot:
- Retry reshaping, not timeout shortening: only the full-window SILENT tries are capped (2), the 8 fast resume-race retries and every dequeue timeout stay untouched; measured settle times (1912ms cold pair, 3.6s NexiGo worst) sit far under the retained budget. Frameless open now fails at ~10s, the whole chain bound is 31.9s, asserted under 80% of half the watchdog period.
- A progress mark at the grace-loop boundary, since IRLUME_GRACE_MS can stretch past any static budget; it polls the stop signal without honoring the yield, with the lockscreen-vs-polkit reasoning documented.
- A daemon test parses WatchdogSec from the packaged unit and asserts the derived chain constant fits half the period with 20% margin, so a future timeout edit or unit change goes red instead of silently exceeding the deadline again; verified red both ways (the old retry count fails it at 91.9s, and a hypothetical WatchdogSec=30 fails it too). A loopback CI test measures the real frameless chain where the harness provisions an unfed node, self-skipping loudly elsewhere.

Deliberately unchanged, documented: a camera pacing frames just under the dequeue window can still stretch a sequential capture, because fixing that means shortening timeouts slow cameras rely on; and no pings inside driver calls, so a genuinely stuck ioctl still looks wedged, per the watchdog contract.

Review round applied, taking the report's second replacement option: the retry cap is deleted (full original 8-window budget for every retryable error, so no camera that recovered before can start failing), WatchdogSec stays 90s (the 240s alternative would delay restart of every genuinely wedged hang by four minutes), and a progress reporter now fires after each COMPLETED timeout return through every capture caller, so a returned timeout proves liveness while a stuck ioctl still looks wedged per the watchdog contract. The provable bound became the max silent stretch (20,240ms, from the code's own constants plus a documented seam allowance) against 80% of half the period, and the loopback test now asserts which path ran and the inter-report gaps. Mutation runs verified the retry budget, the reporter wiring, and the daemon gate each go red when broken.
