### PR TITLE
Cleanup: doc comments back on their own items, and four small defects the audit found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,6 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
  "v4l",
 ]
 

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1995,12 +1995,6 @@ impl Engine {
         ))
     }
 
-    /// Rolling consent watch: drive a held-open IR stream, process each frame,
-    /// and return as SOON as an accepted gesture is seen (`nod` or, when
-    /// `check_closure` supplies a usable calibration, an eye closure), instead of
-    /// draining a fixed window and letting the polkit agent re-run the whole
-    /// prompt. Bounded by `max_frames`. Returns whether a gesture was accepted.
-    /// `check_closure` is `Some(cal)` only when the closure gesture is eligible.
     /// Total frames the consent gesture may be watched for across ONE
     /// authentication, split between a watch before the face match and one
     /// after. `IRLUME_CONSENT_MAX_FRAMES` overrides. At the IR node's ~15fps the
@@ -2072,6 +2066,12 @@ impl Engine {
         (allow_nod, closure_cal)
     }
 
+    /// Rolling consent watch: drive a held-open IR stream, process each frame,
+    /// and return as SOON as an accepted gesture is seen (`nod` or, when
+    /// `closure_cal` supplies a usable calibration, an eye closure), instead of
+    /// draining a fixed window and letting the polkit agent re-run the whole
+    /// prompt. Bounded by `max_frames`. Returns whether a gesture was accepted.
+    /// `closure_cal` is `Some(cal)` only when the closure gesture is eligible.
     fn consent_watch(
         &mut self,
         max_frames: usize,
@@ -3671,8 +3671,9 @@ fn enroll_merge_target(
 /// camera, so this is the only shape a test can observe.
 fn short_capture_refusal(got: usize, want: usize) -> Option<String> {
     (got < want).then(|| {
+        let scans = if got == 1 { "scan" } else { "scans" };
         format!(
-            "only {got} live scans captured (need {want}); nothing was saved, check              lighting and framing"
+            "only {got} live {scans} captured (need {want}); nothing was saved, check lighting and framing"
         )
     })
 }
@@ -4556,14 +4557,19 @@ mod tests {
         assert!(short_capture_refusal(3, 3).is_none());
         assert!(short_capture_refusal(1, 1).is_none());
         let why = short_capture_refusal(1, 10).expect("a short capture must refuse");
-        assert!(
-            why.contains("only 1 live scans captured (need 10)"),
-            "{why}"
-        );
+        assert!(why.contains("only 1 live scan captured (need 10)"), "{why}");
         assert!(
             why.contains("nothing was saved"),
             "the refusal must say the enrollment is unchanged: {why}"
         );
+        // The message reaches a user mid-enrollment, so it must read as a
+        // sentence: no run of spaces, and the noun agreeing with the count.
+        assert!(
+            !why.contains("  "),
+            "doubled space in a user-facing string: {why}"
+        );
+        let plural = short_capture_refusal(2, 10).expect("a short capture must refuse");
+        assert!(plural.contains("only 2 live scans captured"), "{plural}");
         // Zero is short too, which is the case that always refused.
         assert!(short_capture_refusal(0, 1).is_some());
     }

--- a/crates/irlume-camera/Cargo.toml
+++ b/crates/irlume-camera/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 
 [dependencies]
 irlume-common.workspace = true
-thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 # V4L2 capture. Chosen over nokhwa: it's the path linhello proved on this exact

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -970,7 +970,7 @@ mod tests {
         drop(lock); // this process lets go; the child has not.
         assert!(
             matches!(acquire(&id), Err(AcquireError::Busy)),
-            "a forked child must still hold the inherited lock; if this ever              stops being true the crate lock no longer needs to cover spawning"
+            "a forked child must still hold the inherited lock; if this ever stops being true the crate lock no longer needs to cover spawning"
         );
 
         let mut status = 0;

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1190,17 +1190,29 @@ pub(crate) fn finish_token_arm(
 
 /// Read the user's login password without echo, mirroring the arm prompt's
 /// terminal/pipe split.
-fn read_password(prompt: &str) -> Result<String, String> {
+///
+/// The secret is wrapped in `Zeroizing` at the point it is first held, the same
+/// as the TUI's `Pending::KeyringPw`, so it is wiped from the heap on drop
+/// rather than left in swappable memory for the rest of the process. Callers
+/// must keep it inside the wrapper: a `.clone()` or a `to_string()` makes a
+/// second copy that nothing wipes.
+fn read_password(prompt: &str) -> Result<zeroize::Zeroizing<String>, String> {
     if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-        rpassword::prompt_password(prompt).map_err(|e| format!("could not read password: {e}"))
+        rpassword::prompt_password(prompt)
+            .map(zeroize::Zeroizing::new)
+            .map_err(|e| format!("could not read password: {e}"))
     } else {
         use std::io::BufRead;
-        let mut line = String::new();
+        let mut line = zeroize::Zeroizing::new(String::new());
         std::io::stdin()
             .lock()
             .read_line(&mut line)
             .map_err(|e| format!("could not read password: {e}"))?;
-        Ok(line.trim_end_matches(['\n', '\r']).to_string())
+        // Truncate in place: building the trimmed value with `to_string()` would
+        // leave the untrimmed original in a buffer nothing wipes.
+        let keep = line.trim_end_matches(['\n', '\r']).len();
+        line.truncate(keep);
+        Ok(line)
     }
 }
 
@@ -1220,20 +1232,24 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
             );
             // No-echo prompt on a real terminal; fall back to a plain stdin line
             // when piped (scripts / tests), where /dev/tty isn't available.
+            // Every branch keeps the login password inside `Zeroizing` for its
+            // whole life, matching the TUI's `Pending::KeyringPw`: this is the
+            // user's real login password, and a plain `String` copy of it would
+            // sit in swappable heap until the process exits.
             let pw = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-                let first = match rpassword::prompt_password("Login password: ") {
+                let first = match read_password("Login password: ") {
                     Ok(p) => p,
                     Err(e) => {
-                        eprintln!("[keyring] could not read password: {e}");
+                        eprintln!("[keyring] {e}");
                         return std::process::ExitCode::FAILURE;
                     }
                 };
                 // Confirm to catch typos: a mistyped seal silently fails to
                 // unlock the wallet at the next face login (key mismatch).
-                let confirm = match rpassword::prompt_password("Confirm login password: ") {
+                let confirm = match read_password("Confirm login password: ") {
                     Ok(p) => p,
                     Err(e) => {
-                        eprintln!("[keyring] could not read password: {e}");
+                        eprintln!("[keyring] {e}");
                         return std::process::ExitCode::FAILURE;
                     }
                 };
@@ -1243,13 +1259,13 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
                 }
                 first
             } else {
-                use std::io::BufRead;
-                let mut line = String::new();
-                if std::io::stdin().lock().read_line(&mut line).is_err() {
-                    eprintln!("[keyring] could not read password from stdin");
-                    return std::process::ExitCode::FAILURE;
+                match read_password("Login password: ") {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("[keyring] {e}");
+                        return std::process::ExitCode::FAILURE;
+                    }
                 }
-                line.trim_end_matches(['\n', '\r']).to_string()
             };
             if pw.is_empty() {
                 eprintln!("[keyring] empty password; aborted");
@@ -1258,7 +1274,7 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
             let req = irlume_common::Request::SealPassword {
                 kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
-                password: irlume_common::SecretBytes::new(pw.clone().into_bytes()),
+                password: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
             };
             match daemon_request(&req) {
                 Ok(irlume_common::Response::PasswordSealed) => {
@@ -1433,7 +1449,7 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
                 };
                 let token = match daemon_request(&irlume_common::Request::ReleaseTokenForDisarm {
                     user: user.clone(),
-                    password: irlume_common::SecretBytes::new(pw.clone().into_bytes()),
+                    password: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
                 }) {
                     Ok(irlume_common::Response::PasswordUnsealed { secret, .. }) => secret,
                     Ok(irlume_common::Response::Error(e)) => {
@@ -4573,6 +4589,18 @@ mod tests {
 
     fn argv(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn the_login_password_reader_hands_back_a_wiping_string() {
+        // Heap hygiene is invisible at runtime: nothing a test can observe
+        // distinguishes a wiped allocation from a freed one. The type is what
+        // carries the wipe, so the type is what gets pinned. This stops
+        // compiling if `read_password` returns to a plain `String`, which is
+        // the state the TUI's `Pending::KeyringPw` was already out of.
+        fn accepts_only_a_wiping_reader(_: fn(&str) -> Result<zeroize::Zeroizing<String>, String>) {
+        }
+        accepts_only_a_wiping_reader(read_password);
     }
 
     #[test]

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -13,11 +13,11 @@
 //! unsealed secret in transit, before it lands inside a zeroizing `SecretBytes`).
 
 use crate::{Request, Response, SOCKET_PATH};
-use std::io::{self, BufRead, BufReader, Read as _, Write};
+use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 /// Bounded wait for the initial connect (distinct from the read timeout, which
 /// must be long enough for a camera capture).
@@ -91,22 +91,6 @@ pub fn request_with_timeout(req: &Request, rw_timeout: Duration) -> io::Result<R
     request_with_timeouts(req, CONNECT_TIMEOUT, rw_timeout)
 }
 
-/// Map a connect failure to an actionable message.
-///
-/// Two cases, and conflating them was a real bug: a user whose uid could not
-/// open the socket was told the daemon was down and sent to `systemctl status`
-/// on a healthy service.
-///
-/// "Nobody is listening" is the #1 first-run failure (fresh package install,
-/// unit disabled by distro preset policy), so name the daemon and the exact
-/// command instead of a raw errno. Covers every errno that case produces across
-/// kernels: ENOENT (no socket file), ECONNREFUSED (socket file, no accept),
-/// ECONNRESET / EPIPE (stale socket that connects then resets on first I/O,
-/// seen on newer kernels).
-///
-/// EACCES/EPERM means the opposite: the socket is there and the daemon is very
-/// likely fine, but this uid may not connect. Say that, and do not suggest
-/// `sudo` or a chmod, because both hide whatever set the mode.
 /// Whether this failure PROVES nobody is listening on the socket.
 ///
 /// The distinction matters wherever "the daemon is not there" licenses an act
@@ -127,6 +111,22 @@ pub fn proves_daemon_absent(e: &io::Error) -> bool {
     )
 }
 
+/// Map a connect failure to an actionable message.
+///
+/// Two cases, and conflating them was a real bug: a user whose uid could not
+/// open the socket was told the daemon was down and sent to `systemctl status`
+/// on a healthy service.
+///
+/// "Nobody is listening" is the #1 first-run failure (fresh package install,
+/// unit disabled by distro preset policy), so name the daemon and the exact
+/// command instead of a raw errno. Covers every errno that case produces across
+/// kernels: ENOENT (no socket file), ECONNREFUSED (socket file, no accept),
+/// ECONNRESET / EPIPE (stale socket that connects then resets on first I/O,
+/// seen on newer kernels).
+///
+/// EACCES/EPERM means the opposite: the socket is there and the daemon is very
+/// likely fine, but this uid may not connect. Say that, and do not suggest
+/// `sudo` or a chmod, because both hide whatever set the mode.
 fn map_connect_failure(e: io::Error) -> io::Error {
     match e.kind() {
         io::ErrorKind::NotFound
@@ -178,11 +178,9 @@ fn request_with_timeouts(
     // buffer without bound. That caller can be `pam_irlume` inside a login.
     // The daemon is honest, but `IRLUME_SOCKET` redirects any non-setuid
     // invocation, so the peer is not always the daemon.
-    let mut reader = BufReader::new((&stream).take(MAX_RESPONSE_BYTES));
-    let mut buf = String::new();
-    reader.read_line(&mut buf).map_err(map_connect_failure)?;
+    let buf =
+        read_response_line((&stream).take(MAX_RESPONSE_BYTES)).map_err(map_connect_failure)?;
     if buf.len() as u64 >= MAX_RESPONSE_BYTES {
-        buf.zeroize();
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "response exceeded the size limit; refusing it",
@@ -194,12 +192,52 @@ fn request_with_timeouts(
             "daemon closed connection without responding",
         ));
     }
-    let parsed =
-        serde_json::from_str(buf.trim()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e));
-    // The response may carry an unsealed secret; wipe the raw JSON now that the
-    // bytes live inside a zeroizing `SecretBytes` in the parsed value.
-    buf.zeroize();
-    parsed
+    // The response may carry an unsealed secret. `buf` wipes itself when this
+    // frame ends, and by then the bytes live inside a zeroizing `SecretBytes`
+    // in the parsed value.
+    serde_json::from_slice(buf.trim_ascii())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Read one newline-terminated response line into a buffer that wipes itself,
+/// returning it with the newline still attached (like `BufRead::read_line`).
+///
+/// Not `BufReader::read_line`, and that is the whole point: `BufReader` keeps
+/// its own 8 KiB copy of everything it has read, nothing can reach that copy to
+/// wipe it, and an `UnsealPassword` response carries the user's login password
+/// in cleartext JSON. Zeroizing only the caller's `String` left the secret
+/// sitting in the reader's heap until the allocator handed the block out again,
+/// which contradicts this module's own promise.
+///
+/// `src` must already be capped with [`Read::take`]; on hitting the cap this
+/// returns whatever arrived, which the caller refuses on length. The buffer is
+/// sized up front so no reallocation can strand a half-copy of the response in
+/// a freed block. Reading past the newline is harmless and expected: one
+/// response per connection, and the stream is dropped immediately after.
+fn read_response_line(mut src: impl Read) -> io::Result<Zeroizing<Vec<u8>>> {
+    /// One page per syscall. The real responses are a few hundred bytes; the
+    /// cap only matters for a peer that is not the daemon.
+    const CHUNK: usize = 4096;
+    let mut buf = Zeroizing::new(Vec::with_capacity(MAX_RESPONSE_BYTES as usize));
+    let mut chunk = Zeroizing::new([0u8; CHUNK]);
+    loop {
+        let n = match src.read(&mut chunk[..]) {
+            Ok(n) => n,
+            // `read_line` swallows EINTR too; a signal during a login must not
+            // read as a dead daemon.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        if n == 0 {
+            // EOF or the `take` cap: no newline is coming.
+            return Ok(buf);
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(i) = buf.iter().position(|b| *b == b'\n') {
+            buf.truncate(i + 1);
+            return Ok(buf);
+        }
+    }
 }
 
 /// `UnixStream::connect` has no timeout, so a stalled listener (backlog full /
@@ -224,6 +262,9 @@ fn connect_with_timeout(path: &Path, timeout: Duration) -> io::Result<UnixStream
 mod tests {
     use super::*;
     use crate::testenv;
+    // The test servers still use `BufReader`: they are the peer, not the
+    // client, and nothing secret crosses in that direction.
+    use std::io::{BufRead, BufReader};
     use std::os::unix::net::UnixListener;
     use std::path::PathBuf;
 
@@ -342,6 +383,112 @@ mod tests {
             "got: {err}"
         );
         server.join().unwrap();
+        std::env::remove_var("IRLUME_SOCKET");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A `Read` that hands back one scripted answer per call, so the reader's
+    /// loop can be driven through short reads and EINTR without a socket.
+    struct Scripted(std::vec::IntoIter<io::Result<Vec<u8>>>);
+
+    impl Read for Scripted {
+        fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+            match self.0.next() {
+                Some(Ok(bytes)) => {
+                    let n = bytes.len().min(out.len());
+                    out[..n].copy_from_slice(&bytes[..n]);
+                    Ok(n)
+                }
+                Some(Err(e)) => Err(e),
+                None => Ok(0),
+            }
+        }
+    }
+
+    fn scripted(steps: Vec<io::Result<Vec<u8>>>) -> Scripted {
+        Scripted(steps.into_iter())
+    }
+
+    #[test]
+    fn the_response_line_stops_at_the_first_newline_and_keeps_it() {
+        // `read_line`'s contract, which the callers' length check depends on:
+        // the newline counts toward the length, and nothing the peer sends
+        // after it becomes part of the response.
+        let line = read_response_line(scripted(vec![Ok(b"{\"Ok\":\"hi\"}\nJUNK".to_vec())]))
+            .expect("a complete line");
+        assert_eq!(&line[..], b"{\"Ok\":\"hi\"}\n");
+    }
+
+    #[test]
+    fn a_dribbled_response_is_reassembled_across_reads() {
+        // A peer that sends a byte at a time is the case `BufReader` used to
+        // handle; the loop must keep reading until the newline arrives.
+        let steps = b"{\"Ok\":\"hi\"}\n"
+            .iter()
+            .map(|b| Ok(vec![*b]))
+            .collect::<Vec<_>>();
+        let line = read_response_line(scripted(steps)).expect("a complete line");
+        assert_eq!(&line[..], b"{\"Ok\":\"hi\"}\n");
+    }
+
+    #[test]
+    fn an_interrupted_read_is_retried_rather_than_reported_as_a_dead_daemon() {
+        // EINTR maps to ECONNRESET-shaped advice through `map_connect_failure`
+        // at the call site, so swallowing it here is what stops a signal during
+        // a login from printing "irlumed is not running".
+        let line = read_response_line(scripted(vec![
+            Err(io::Error::new(io::ErrorKind::Interrupted, "signal")),
+            Ok(b"{\"Ok\":\"hi\"}\n".to_vec()),
+        ]))
+        .expect("EINTR must not end the read");
+        assert_eq!(&line[..], b"{\"Ok\":\"hi\"}\n");
+    }
+
+    #[test]
+    fn a_read_error_that_is_not_eintr_propagates() {
+        let err = read_response_line(scripted(vec![Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "peer went away",
+        ))]))
+        .expect_err("a reset must not read as a response");
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[test]
+    fn a_truncated_response_comes_back_whole_for_the_caller_to_judge() {
+        // EOF with no newline is not an error here: the caller distinguishes
+        // "nothing at all" (UnexpectedEof) from "some bytes, no newline", and
+        // it can only do that if it receives the bytes.
+        let empty = read_response_line(scripted(vec![])).expect("EOF is not an error");
+        assert!(empty.is_empty());
+        let partial = read_response_line(scripted(vec![Ok(b"{\"Ok\"".to_vec())]))
+            .expect("EOF is not an error");
+        assert_eq!(&partial[..], b"{\"Ok\"");
+    }
+
+    #[test]
+    fn an_oversized_reply_is_refused_by_length_not_read_forever() {
+        let _g = testenv::lock();
+        let path = sock("huge");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            let _ = BufReader::new(&stream).read_line(&mut line);
+            // No newline anywhere, more than the cap: the shape a peer that is
+            // not the daemon uses to make a client read without end.
+            let flood = vec![b'x'; MAX_RESPONSE_BYTES as usize * 2];
+            let _ = (&stream).write_all(&flood);
+        });
+        let err = request_with_timeout(&Request::Ping, Duration::from_secs(5))
+            .expect_err("an unbounded reply must be refused");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("response exceeded the size limit"),
+            "got: {err}"
+        );
+        let _ = server.join();
         std::env::remove_var("IRLUME_SOCKET");
         let _ = std::fs::remove_file(&path);
     }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1369,13 +1369,6 @@ fn refusal_throttled(uid: u32) -> bool {
     b.tokens < 0.0
 }
 
-/// Read and parse one connection, hand the request to the arbiter, write back
-/// what the worker answers.
-///
-/// Everything here runs on the connection's own thread. The only work that
-/// reaches the camera worker is a parsed, authorized-shaped request, which is
-/// what lets an authentication overtake a queue of preview work: before this,
-/// a request nobody had read yet was invisible to the daemon.
 /// The listening socket systemd passed us, if we were socket-activated.
 ///
 /// Implements the sd_listen_fds protocol directly rather than pulling in
@@ -1524,6 +1517,13 @@ fn dispatch_before_engine(req: Request, peer: &Peer) -> Response {
     }
 }
 
+/// Read and parse one connection, hand the request to the arbiter, write back
+/// what the worker answers.
+///
+/// Everything here runs on the connection's own thread. The only work that
+/// reaches the camera worker is a parsed, authorized-shaped request, which is
+/// what lets an authentication overtake a queue of preview work: before this,
+/// a request nobody had read yet was invisible to the daemon.
 fn serve(
     stream: UnixStream,
     arbiter: &arbiter::Arbiter<Queued>,
@@ -3311,14 +3311,6 @@ fn mutate_enrollment(
     }
 }
 
-/// Face-verify `user` and, on a passing match, release the TPM-sealed password.
-/// The biometric check happens HERE (inside unseal), so a caller cannot get the
-/// password without a capture that clears the liveness gate and matches the
-/// enrolled templates. Clearing the gate is evidence, not proof, that a live
-/// person is present: the single-frame IR cues are defeatable by a good print
-/// (docs/PAD_SELFTEST.md), which is why this path additionally requires the
-/// temporal consent gesture by default. We log the decision + cosine score, but
-/// never the password or its length.
 /// Deny-line score display: exact under IRLUME_LOG=debug tracing, else
 /// quantized to one decimal (anti-oracle; see comment at the deny log).
 fn deny_score(s: f32) -> String {
@@ -3398,6 +3390,14 @@ fn credential_release_purpose() -> irlume_auth::AuthenticationPurpose {
     }
 }
 
+/// Face-verify `user` and, on a passing match, release the TPM-sealed password.
+/// The biometric check happens HERE (inside unseal), so a caller cannot get the
+/// password without a capture that clears the liveness gate and matches the
+/// enrolled templates. Clearing the gate is evidence, not proof, that a live
+/// person is present: the single-frame IR cues are defeatable by a good print
+/// (docs/PAD_SELFTEST.md), which is why this path additionally requires the
+/// temporal consent gesture by default. We log the decision + cosine score, but
+/// never the password or its length.
 fn do_unseal_password(
     user: &str,
     service: Option<&str>,

--- a/crates/irlume-gkr-unlock/src/main.rs
+++ b/crates/irlume-gkr-unlock/src/main.rs
@@ -209,7 +209,7 @@ fn connect_with_deadline(sock: &std::path::Path) -> Result<UnixStream, String> {
         let mut err: libc::c_int = 0;
         let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
         // SAFETY: reading a fixed-size option into a matching local.
-        unsafe {
+        let rc = unsafe {
             libc::getsockopt(
                 fd,
                 libc::SOL_SOCKET,
@@ -218,12 +218,12 @@ fn connect_with_deadline(sock: &std::path::Path) -> Result<UnixStream, String> {
                 &mut len,
             )
         };
-        if err != 0 {
-            return Err(format!(
-                "connect {}: {}",
-                sock.display(),
-                std::io::Error::from_raw_os_error(err)
-            ));
+        // Read errno immediately: anything below could clobber it.
+        let probe_errno = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO);
+        if let Some(why) = pending_connect_failure(rc, err, probe_errno) {
+            return Err(format!("connect {}: {why}", sock.display()));
         }
     }
 
@@ -235,7 +235,31 @@ fn connect_with_deadline(sock: &std::path::Path) -> Result<UnixStream, String> {
     Ok(stream)
 }
 
-/// The login keyring file, under the home NSS reports./// The login keyring file, under the home NSS reports.
+/// Why a non-blocking connect that `poll` reported ready did not actually
+/// connect, or `None` when it did.
+///
+/// `rc` is `getsockopt(SO_ERROR)`'s own return value, `so_error` the value it
+/// wrote, `probe_errno` the errno at the moment it failed. Discarding `rc` is
+/// the bug this exists to prevent: a failed `getsockopt` never touches the
+/// out-parameter, so `so_error` keeps its initial 0 and every failed connect
+/// reads as a success, handing the caller an unconnected socket it then tries
+/// to unlock a keyring over. Fail closed, and keep the two causes apart: one
+/// says the connect failed, the other says we could not find out.
+fn pending_connect_failure(
+    rc: libc::c_int,
+    so_error: libc::c_int,
+    probe_errno: libc::c_int,
+) -> Option<String> {
+    if rc != 0 {
+        return Some(format!(
+            "could not read SO_ERROR ({}), so whether the connect succeeded is unknown",
+            std::io::Error::from_raw_os_error(probe_errno)
+        ));
+    }
+    (so_error != 0).then(|| std::io::Error::from_raw_os_error(so_error).to_string())
+}
+
+/// The login keyring file, under the home NSS reports.
 ///
 /// `$HOME` is deliberately not consulted: this may run as root with the login
 /// stack's environment, where `$HOME` is root's or unset.
@@ -375,4 +399,42 @@ fn lookup_user(user: &str) -> Result<User, String> {
         name: cname,
         home,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_failed_so_error_probe_is_a_failed_connect_not_a_successful_one() {
+        // The defect this pins: `getsockopt` writing nothing on failure leaves
+        // the out-parameter at its initial 0, so a caller that reads only the
+        // out-parameter treats "the probe failed" as "the connect succeeded"
+        // and goes on to hand a keyring token to an unconnected socket.
+        let why = pending_connect_failure(-1, 0, libc::EBADF)
+            .expect("a failed SO_ERROR probe must not read as a connected socket");
+        assert!(
+            why.contains("could not read SO_ERROR"),
+            "the two causes must stay apart in the message: {why}"
+        );
+    }
+
+    #[test]
+    fn a_probe_that_reports_a_connect_error_names_that_error() {
+        let why = pending_connect_failure(0, libc::ECONNREFUSED, 0)
+            .expect("ECONNREFUSED in SO_ERROR is a failed connect");
+        assert_eq!(
+            why,
+            std::io::Error::from_raw_os_error(libc::ECONNREFUSED).to_string()
+        );
+        assert!(
+            !why.contains("could not read SO_ERROR"),
+            "a refused connect must not be reported as an unreadable probe: {why}"
+        );
+    }
+
+    #[test]
+    fn a_clean_probe_reporting_no_error_is_a_connected_socket() {
+        assert!(pending_connect_failure(0, 0, 0).is_none());
+    }
 }

--- a/crates/irlume-vision/src/detect.rs
+++ b/crates/irlume-vision/src/detect.rs
@@ -8,10 +8,10 @@
 //! runs the session and feeds these. YuNet input is letterboxed BGR, raw 0–255,
 //! NCHW; outputs per stride are cls(1) · obj(1) → score, bbox(4), kps(10).
 //!
-//! NOTE: validate the exact output layout against a real `face_detection_yunet`
-//! model with `Detector::describe_io()`; but because score = √(cls·obj) is
-//! symmetric and we group outputs by tensor shape, cls/obj order is irrelevant
-//! and naming differences don't matter.
+//! The exact output layout is never asserted from tensor NAMES: because
+//! score = √(cls·obj) is symmetric and `Detector::detect` groups outputs by
+//! tensor shape, cls/obj order is irrelevant and a model that names its outputs
+//! differently still decodes.
 
 use crate::{Detection, Landmarks5};
 

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -736,7 +736,10 @@ mod onnx {
 
         /// Run FaceMesh on the face at `bbox` (frame pixel coords) with `margin`
         /// (fraction of the box size added on each side; MediaPipe uses ~0.25).
-        /// Returns the 468 landmarks as `(x, y)` in ORIGINAL FRAME pixel coords.
+        /// Returns the model's landmarks as `(x, y)` in ORIGINAL FRAME pixel
+        /// coords: [`MESH_N`] of them from a legacy mesh, [`MESH_N_IRIS`] from
+        /// the shipped face_landmarker one, so a caller must read the length
+        /// rather than assume it.
         /// The crop is square and centered so aspect ratio is preserved.
         ///
         /// Errors when the box is not a meaningful face region
@@ -966,7 +969,6 @@ mod onnx {
 
     /// YuNet detector (ONNX). Loaded once in the daemon.
     pub struct Detector {
-        #[allow(dead_code)]
         session: Session,
     }
 


### PR DESCRIPTION
Small defects from today's codebase audit (~/irlume-research/2026-08-07-codebase-audit/RESEARCH.md), each verified at its file and line before touching it. Built by a delegated agent, reviewed here.

- Four misattached doc comments moved back onto the items they describe, all at security-sensitive sites: the rolling-consent-watch contract sat on `consent_budget` instead of `consent_watch`, the daemon's `serve` and `do_unseal_password` paragraphs sat on their neighbours, and `map_connect_failure`'s prose sat on `proves_daemon_absent`. Rust binds `///` to what follows, so each real item had no doc at all and readers were being pointed at the wrong contract.
- The CLI's password reader now returns a `Zeroizing<String>` like the TUI path already used, its pipe branch truncates in place instead of leaving an unwiped copy, and the direct `keyring arm` path routes through it (its terminal branch had been calling rpassword directly). The setup wizard and `reseal` read login passwords on their own paths and are NOT covered here; that gap is filed separately.
- The socket client no longer leaves plaintext in a `BufReader`'s internal buffer after zeroizing its own line: responses are read into a pre-sized `Zeroizing` buffer with EINTR retried as before. Timeouts, the size cap and refusal, the EOF case and every error kind are unchanged.
- A discarded `getsockopt(SO_ERROR)` return in the gkr helper meant a failed probe read as a successful connect; the decision is now a pure function that fails closed and keeps "the connect failed" distinct from "we could not find out".
- Stale docs and dead weight: the "468 landmarks" line (the loader takes 468 or 478), a pointer to a `Detector::describe_io()` that does not exist, an unused `thiserror` dependency, a stale `#[allow(dead_code)]`, a doc line pasted onto itself, and two user-facing strings with embedded space runs (one with a grammar fix its test now asserts).

Six mutants were applied and each killed by a named test, including the original getsockopt defect and a type-level pin that fails compilation if the password wrapper is reverted. The agent flagged what it could not test: heap residue itself, since no runtime observation distinguishes a wiped allocation from a freed one, which is why the socket and password changes are pinned by type and reader behavior instead.
