### PR TITLE
Startup: read and hash the 260MB recognizer once, not twice (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Changed
 
+- **The daemon reads and hashes the 260MB recognizer once per start instead
+  of twice.** Startup checksummed it against the release manifest and then
+  handed the loader a path, which read and sha256'd the same file again. The
+  verified weights now travel to the engine with the digest they were checked
+  under, so nothing is read or hashed twice, and the artifact that reaches the
+  ONNX session is provably the one the checksum accepted. Measured on a
+  Zenbook S 14 over 15 interleaved pairs of exec-to-serving: median 1284 ms
+  before against 1044 ms after, 14 of 15 pairs faster; with the model files
+  evicted from the page cache first, 1287 ms against 1015 ms over another 15
+  pairs. Bytes read before the socket serves fall from 527.8 MB to 267.2 MB,
+  which is one recognizer. Resident memory is unchanged, because the buffer is
+  released as soon as the session owns its copy (#346).
 - **An unmeasured camera pair now captures one stream at a time, and the
   first enrollment measures the real answer.** The old fallback assumed
   concurrent capture, which broke an enrollment outright on a module whose

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -810,34 +810,33 @@ impl Engine {
         // Identify the recognizer by its weights, not its path: a file swapped
         // in place under the same name is a different embedding space and must
         // not silently score against templates from the old one. Read the file
-        // ONCE and hand those bytes to the byte loader below.
+        // ONCE and hand those bytes to the weights loader below.
         let model_bytes = std::fs::read(model_path)
             .map_err(|e| irlume_common::Error::Io(format!("{model_path}: {e}")))?;
-        Self::load_with_recognizer_bytes(det_path, &model_bytes)
+        Self::load_with_recognizer_weights(det_path, &irlume_common::HashedModel::new(model_bytes))
     }
 
-    /// [`Self::load`], from recognizer bytes the CALLER already holds.
+    /// [`Self::load`], from recognizer weights the CALLER already holds.
     ///
-    /// For callers that verified those bytes against a pin: re-reading a path
+    /// For callers that verified those weights against a pin: re-reading a path
     /// here would let a swap between their check and this load pair the new
-    /// weights with a threshold measured for the old ones — the digest below
+    /// weights with a threshold measured for the old ones. The digest below
     /// would honestly tag the new space, but the POLICY attached to the engine
-    /// would belong to a different artifact. One byte buffer flows from the
-    /// caller's checksum through the digest into the ONNX session, so the
-    /// three can never disagree.
-    pub fn load_with_recognizer_bytes(
+    /// would belong to a different artifact. One
+    /// [`irlume_common::HashedModel`] flows from the caller's checksum through
+    /// the embedding-space tag into the ONNX session, so the three can never
+    /// disagree, and the 260MB hash happens once per start rather than once
+    /// here and once at the caller (#346).
+    pub fn load_with_recognizer_weights(
         det_path: &str,
-        model_bytes: &[u8],
+        model: &irlume_common::HashedModel,
     ) -> irlume_common::Result<Self> {
         // Full digest: the tag resists an adversarial model, and truncation
         // halves its strength per dropped character.
-        let embed_space = format!(
-            "embed:{}",
-            irlume_common::thirdparty::sha256_hex(model_bytes)
-        );
+        let embed_space = format!("embed:{}", model.sha256());
         Ok(Self {
             det: Detector::load_from_file(det_path)?,
-            emb: Embedder::load_from_memory(model_bytes)?,
+            emb: Embedder::load_from_memory(model.bytes())?,
             ir_adapter: None,
             ir_space: "raw".into(),
             embed_space,
@@ -5885,18 +5884,19 @@ mod engine_tests {
 
     #[test]
     fn verified_recognizer_bytes_are_the_loaded_embedding_space() {
-        // The byte loader exists so a caller's pin check, the template-space
-        // digest, and the ONNX session all come from ONE buffer: the digest
-        // must be of exactly the bytes handed in, or a path swap between a
-        // caller's checksum and this load could pair new weights with a
-        // threshold measured for old ones (#279 review).
+        // The weights loader exists so a caller's pin check, the
+        // template-space digest, and the ONNX session all come from ONE
+        // buffer: the digest must be of exactly the bytes handed in, or a path
+        // swap between a caller's checksum and this load could pair new
+        // weights with a threshold measured for old ones (#279 review).
         let _g = env_guard();
         let _s = shared(); // ensure ORT is initialized for this process
         let bytes = std::fs::read(model_path("glintr100.onnx")).unwrap();
         let expected = format!("embed:{}", irlume_common::thirdparty::sha256_hex(&bytes));
-        let engine = Engine::load_with_recognizer_bytes(
+        let weights = irlume_common::HashedModel::new(bytes);
+        let engine = Engine::load_with_recognizer_weights(
             &model_path("face_detection_yunet_2023mar.onnx"),
-            &bytes,
+            &weights,
         )
         .expect("engine from bytes");
         assert_eq!(engine.embed_space(), expected);

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -120,6 +120,43 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
         .collect()
 }
 
+/// A model's weights together with the sha256 of THOSE weights.
+///
+/// Whoever checks a model against a manifest or a catalog pin, and whoever
+/// loads it, both need the digest, and hashing a 260MB recognizer twice per
+/// start cost measurable time for nothing (#346). Carrying the pair in one
+/// value removes the second pass, and it removes the failure mode that would
+/// have come with passing a loose digest alongside loose bytes: the constructor
+/// is the only way in and it takes the digest from the buffer it stores, so the
+/// two cannot be from different artifacts.
+///
+/// ```
+/// let m = irlume_common::HashedModel::new(b"weights".to_vec());
+/// assert_eq!(m.sha256(), irlume_common::sha256_hex(m.bytes()));
+/// ```
+pub struct HashedModel {
+    bytes: Vec<u8>,
+    sha256: String,
+}
+
+impl HashedModel {
+    /// Hash `bytes` once and keep both halves.
+    pub fn new(bytes: Vec<u8>) -> Self {
+        let sha256 = sha256_hex(&bytes);
+        Self { bytes, sha256 }
+    }
+
+    /// Hex sha256 of [`Self::bytes`].
+    pub fn sha256(&self) -> &str {
+        &self.sha256
+    }
+
+    /// The weights themselves.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
 /// Make every directory above `dir` durable, so the names leading to it survive
 /// a power loss.
 ///

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -128,12 +128,11 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 /// value removes the second pass, and it removes the failure mode that would
 /// have come with passing a loose digest alongside loose bytes: the constructor
 /// is the only way in and it takes the digest from the buffer it stores, so the
-/// two cannot be from different artifacts.
-///
-/// ```
-/// let m = irlume_common::HashedModel::new(b"weights".to_vec());
-/// assert_eq!(m.sha256(), irlume_common::sha256_hex(m.bytes()));
-/// ```
+/// two cannot be from different artifacts. The invariant is pinned by
+/// `the_digest_always_belongs_to_the_bytes_it_was_built_from` rather than by a
+/// doctest: the sanitizer lane builds with an explicit target and no
+/// instrumented std, so a doctest there fails to link while a unit test runs
+/// in every lane.
 pub struct HashedModel {
     bytes: Vec<u8>,
     sha256: String,
@@ -1024,6 +1023,19 @@ pub(crate) mod testenv {
 
 #[cfg(test)]
 mod tests {
+
+    /// The digest a `HashedModel` reports must be the digest of the bytes it
+    /// carries, because callers skip their own hashing on the strength of it
+    /// (#346). Fails if the constructor ever stores a digest from anywhere
+    /// but its own buffer.
+    #[test]
+    fn the_digest_always_belongs_to_the_bytes_it_was_built_from() {
+        for payload in [b"weights".to_vec(), Vec::new(), vec![0u8; 4096]] {
+            let m = super::HashedModel::new(payload.clone());
+            assert_eq!(m.bytes(), &payload[..]);
+            assert_eq!(m.sha256(), super::sha256_hex(&payload));
+        }
+    }
     use std::path::{Path, PathBuf};
 
     /// The upgrade window: a 0.9.1 client reading an Enrolled reply from a

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -27,13 +27,23 @@ const MODEL_MANIFEST: &str = include_str!("../../../models/SHA256SUMS");
 /// Unknown weights WARN by default: operators legitimately deploy self-trained
 /// adapters, and refusing to start would turn a model swap into a lockout.
 /// `IRLUME_MODELS_STRICT=1` upgrades the warning to a startup refusal.
-fn verify_models(paths: &[&str]) {
+///
+/// `keep` names the one model the caller wants back, returned with the digest
+/// this function checked and only when the file was actually read (an
+/// unreadable model in non-strict mode returns `None` and the loader reports
+/// it). The recognizer is what the daemon asks for: without this the 260MB file
+/// was read and sha256'd here, then read and sha256'd AGAIN inside
+/// [`irlume_auth::Engine::load`] (#346). Handing the checked artifact over is
+/// also the stronger guarantee, because what reaches the ONNX session is then
+/// what this digest was taken from, with no window for a swap in between.
+fn verify_models(paths: &[&str], keep: Option<&str>) -> Option<irlume_common::HashedModel> {
     let known: std::collections::HashSet<&str> = MODEL_MANIFEST
         .lines()
         .filter_map(|l| l.split_whitespace().next())
         .collect();
     let strict = std::env::var("IRLUME_MODELS_STRICT")
         .is_ok_and(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"));
+    let mut kept = None;
     for path in paths {
         let bytes = match std::fs::read(path) {
             Ok(b) => b,
@@ -50,8 +60,11 @@ fn verify_models(paths: &[&str]) {
                 continue;
             }
         };
-        let digest = irlume_common::thirdparty::sha256_hex(&bytes);
-        if !known.contains(digest.as_str()) {
+        // Hashed once, here: the digest checked below is the same one the
+        // engine tags the embedding space with (#346).
+        let model = irlume_common::HashedModel::new(bytes);
+        let digest = model.sha256();
+        if !known.contains(digest) {
             eprintln!(
                 "irlumed: WARNING: {path} does not match any release model checksum (sha256 {digest})"
             );
@@ -66,6 +79,35 @@ fn verify_models(paths: &[&str]) {
                  self-trained models; set IRLUME_MODELS_STRICT=1 to refuse instead)"
             );
         }
+        // After the checks, so what is handed back is what this loop hashed
+        // and (in strict mode) accepted.
+        if keep == Some(*path) {
+            kept = Some(model);
+        }
+    }
+    kept
+}
+
+/// Build the engine on the SHIPPED-recognizer path.
+///
+/// `verified` carries what [`verify_models`] already read and checksummed at
+/// startup; handing it to the weights loader is what makes a start read and
+/// sha256 the 260MB recognizer once instead of twice (#346). It is also the
+/// tighter guarantee: [`irlume_auth::Engine::load`] re-opens the path, so a file
+/// swapped between the check and the load would reach the session unverified.
+///
+/// `None` is the camera worker's post-panic rebuild, which pays the read as it
+/// always has. Keeping the 260MB buffer alive for the daemon's whole life to
+/// save that one re-read would cost more resident memory than the entire rest
+/// of the process, so startup drops it as soon as the session owns its copy.
+fn load_shipped_recognizer(
+    det_path: &str,
+    model_path: &str,
+    verified: Option<&irlume_common::HashedModel>,
+) -> irlume_common::Result<irlume_auth::Engine> {
+    match verified {
+        Some(weights) => irlume_auth::Engine::load_with_recognizer_weights(det_path, weights),
+        None => irlume_auth::Engine::load(det_path, model_path),
     }
 }
 
@@ -92,10 +134,11 @@ fn models_to_verify<'a>(shipped: [&'a str; 4], adapter: &'a str) -> Vec<&'a str>
 /// kept. Any invalid explicit selection refuses to start; PAM treats an
 /// unavailable daemon as password fallback, so fail-closed means "password",
 /// never lockout. `None` = nothing selected, use the shipped default. The
-/// returned VERIFIED BYTES are what the engine must load: re-reading the path
+/// returned VERIFIED WEIGHTS are what the engine must load: re-reading the path
 /// later (or at a post-panic rebuild) would let a swap pair new weights with
-/// the threshold measured for the old ones.
-fn resolve_thirdparty_recognizer() -> Option<(Vec<u8>, f32, String)> {
+/// the threshold measured for the old ones. They carry the digest checked here,
+/// so the engine tags the embedding space without hashing them again (#346).
+fn resolve_thirdparty_recognizer() -> Option<(irlume_common::HashedModel, f32, String)> {
     std::env::var("IRLUME_THIRDPARTY_RECOGNIZER")
         .ok()
         .filter(|v| !v.trim().is_empty())
@@ -124,14 +167,15 @@ fn resolve_thirdparty_recognizer() -> Option<(Vec<u8>, f32, String)> {
                 );
                 std::process::exit(1);
             });
-            let digest = irlume_common::thirdparty::sha256_hex(&bytes);
-            if digest != entry.sha256 {
+            let weights = irlume_common::HashedModel::new(bytes);
+            if weights.sha256() != entry.sha256 {
                 eprintln!(
-                    "irlumed: third-party recognizer '{name}' checksum mismatch (sha256 {digest}); refusing to start so face auth falls back to the password"
+                    "irlumed: third-party recognizer '{name}' checksum mismatch (sha256 {}); refusing to start so face auth falls back to the password",
+                    weights.sha256()
                 );
                 std::process::exit(1);
             }
-            (bytes, entry.threshold, entry.name.to_string())
+            (weights, entry.threshold, entry.name.to_string())
         })
 }
 
@@ -258,7 +302,11 @@ fn main() {
             .name("irlume-startup".into())
             .spawn(move || {
             eprintln!("irlumed: loading models (det={det}, model={model})…");
-            verify_models(&models_to_verify([&det, &model, &mesh, &blaze], &adapter));
+            // The recognizer's verified bytes come back and go straight into the
+            // engine below (#346), so the 260MB file is read and hashed once per
+            // start rather than once here and once again inside the loader.
+            let mut verified_recognizer =
+                verify_models(&models_to_verify([&det, &model, &mesh, &blaze], &adapter), Some(&model));
             // Auto-select the camera pair: explicit IRLUME_RGB_DEVICE/IR_DEVICE, else a
             // discovered Hello camera (built-in or external Brio/NexiGo), else defaults.
             let (rgb_dev, ir_dev) = irlume_auth::select_pair();
@@ -363,26 +411,38 @@ fn main() {
             // weights with the threshold measured for the old ones. The stage
             // gate refuses until Stage::Recognition opens, so today an
             // explicit selection always refuses.
-            let tp_rec: Option<(Vec<u8>, f32, String)> = resolve_thirdparty_recognizer();
+            let tp_rec: Option<(irlume_common::HashedModel, f32, String)> =
+                resolve_thirdparty_recognizer();
             let tp_det: Option<(Vec<u8>, f32, String)> = resolve_thirdparty_detector();
+            // A third-party selection replaces the shipped recognizer outright,
+            // so the shipped bytes are dead weight from here on; free them
+            // before the load instead of carrying 260MB through it.
+            if tp_rec.is_some() {
+                verified_recognizer = None;
+            }
             // Engine factory: (re)loads the models and rebinds devices/adapters. Used
             // once at startup and again by the camera worker to rebuild the engine after
             // a caught panic, so a fresh request never runs against ONNX sessions left in
             // an unproven state by an unwind. It owns its inputs so it can move to the
             // worker thread, and it is Fn, so startup calls it before that move.
-            let build_engine = move || {
+            //
+            // `recognizer` is what startup already read, hashed and verified
+            // (#346); the worker's post-panic rebuild passes None and re-reads
+            // the path, which is why the closure takes it as an argument instead
+            // of capturing it and holding 260MB for the daemon's life.
+            let build_engine = move |recognizer: Option<&irlume_common::HashedModel>| {
                 match &tp_rec {
                     // The RETAINED verified bytes, not the path: a post-panic
                     // rebuild must run exactly the artifact the pin check saw.
-                    Some((bytes, thr, name)) => {
-                        irlume_auth::Engine::load_with_recognizer_bytes(&det, bytes).map(|e| {
+                    Some((weights, thr, name)) => {
+                        irlume_auth::Engine::load_with_recognizer_weights(&det, weights).map(|e| {
                             eprintln!(
                                 "irlumed: third-party recognizer '{name}' loaded (threshold {thr}; IR matching disabled — unmeasured for this model)"
                             );
                             e.with_thirdparty_recognizer(*thr, name)
                         })
                     }
-                    None => irlume_auth::Engine::load(&det, &model),
+                    None => load_shipped_recognizer(&det, &model, recognizer),
                 }
                     .map(|e| e.with_devices(&rgb_dev, &ir_dev))
                     .and_then(|e| e.with_ir_adapter(&adapter))
@@ -403,7 +463,7 @@ fn main() {
             };
             // Bits are published before the socket binds (bind happens after the
             // models load), so no connection can observe the default EngineBits.
-            let mut engine = match build_engine() {
+            let mut engine = match build_engine(verified_recognizer.as_ref()) {
                 Ok(e) => {
                     eprintln!(
                         "irlumed: IR adapter {}",
@@ -450,6 +510,10 @@ fn main() {
                     std::process::exit(1);
                 }
             };
+            // ORT copied the weights into its own session at commit time, so
+            // this buffer is 260MB of dead memory from here on: release it
+            // before the enrollment sweep rather than at the end of startup.
+            drop(verified_recognizer);
             publish_engine_bits(&engine);
 
             // One-time inoculation: stamp legacy (untagged) IR scans with the current
@@ -649,7 +713,11 @@ fn main() {
                                     // login path down entirely. If the rebuild fails,
                                     // the old engine is kept: still better than a dead
                                     // daemon.
-                                    match build_engine() {
+                                    // No bytes in hand here: the startup buffer
+                                    // was released once the first session owned
+                                    // its copy, so this rebuild re-reads the
+                                    // recognizer from disk (#346).
+                                    match build_engine(None) {
                                         Ok(fresh) => {
                                             engine = fresh;
                                             publish_engine_bits(&engine);
@@ -3845,6 +3913,82 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    // Startup asks for one model and gets back exactly that file's bytes with
+    // exactly the digest this loop checked; every other path is verified and
+    // dropped as before (#346). A mutant that hands back the wrong file, or one
+    // that keeps something it never verified, fails below.
+    #[test]
+    fn verify_models_hands_back_the_model_it_was_asked_for_with_its_digest() {
+        let dir = std::env::temp_dir().join(format!("irlume-keep-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let wanted = dir.join("recognizer.onnx");
+        let other = dir.join("other.onnx");
+        std::fs::write(&wanted, b"recognizer weights").unwrap();
+        std::fs::write(&other, b"some other model").unwrap();
+        let (w, o) = (
+            wanted.to_str().unwrap().to_string(),
+            other.to_str().unwrap().to_string(),
+        );
+
+        let kept = verify_models(&[&o, &w], Some(&w)).expect("the asked-for model comes back");
+        assert_eq!(
+            kept.bytes(),
+            b"recognizer weights",
+            "the requested model's own bytes must come back"
+        );
+        // The digest travels WITH those bytes, which is what lets the engine
+        // tag the embedding space without hashing 260MB a second time.
+        assert_eq!(
+            kept.sha256(),
+            irlume_common::sha256_hex(b"recognizer weights"),
+            "the digest must be of the bytes handed back"
+        );
+        assert!(
+            verify_models(&[&o, &w], None).is_none(),
+            "asking for nothing keeps nothing"
+        );
+        assert!(
+            verify_models(&[&o], Some(&w)).is_none(),
+            "a model that was never verified must not be handed back"
+        );
+        // Non-strict, unreadable: the loader reports it, and nothing invented
+        // is handed over in the meantime.
+        assert!(
+            verify_models(&[&o], Some("/nonexistent/irlume-test/face.onnx")).is_none(),
+            "an unread model must not produce bytes"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The verified bytes must reach the ONNX session WITHOUT the recognizer
+    // path being opened again (#346). Both halves matter: the first proves the
+    // byte path never touches the file, the second proves the assertion has
+    // teeth, because reintroducing a read is exactly what makes the missing
+    // path show up in the error.
+    #[test]
+    fn the_verified_recognizer_bytes_load_without_reading_the_path() {
+        let det = "/nonexistent/irlume-test/det.onnx";
+        let model = "/nonexistent/irlume-test/face.onnx";
+        // `Engine` is not Debug, so unwrap the Result by hand.
+        let why = |r: irlume_common::Result<irlume_auth::Engine>| match r {
+            Ok(_) => panic!("no model file exists here, so a load cannot succeed"),
+            Err(e) => e.to_string(),
+        };
+        let weights = irlume_common::HashedModel::new(b"pinned recognizer weights".to_vec());
+        let err = why(load_shipped_recognizer(det, model, Some(&weights)));
+        assert!(
+            !err.contains(model),
+            "the recognizer path was read despite bytes in hand: {err}"
+        );
+        // No bytes: the post-panic rebuild, which does read the path.
+        let err = why(load_shipped_recognizer(det, model, None));
+        assert!(
+            err.contains(model),
+            "the rebuild must read the recognizer path: {err}"
+        );
+    }
+
     // An invalid explicit third_party_recognizer selection must REFUSE TO
     // START, never silently substitute the shipped recognizer: that would run
     // a different grant-capable decision system than the operator selected
@@ -3902,7 +4046,7 @@ mod tests {
     fn strict_verify_still_refuses_a_missing_shipped_model() {
         if std::env::var("IRLUME_TEST_VERIFY_CHILD").is_ok() {
             // Child: strict verify of an unreadable model must exit(1) here.
-            verify_models(&["/nonexistent/irlume-test/det.onnx"]);
+            verify_models(&["/nonexistent/irlume-test/det.onnx"], None);
             return; // reaching this line means strict did NOT refuse
         }
         let exe = std::env::current_exe().unwrap();
@@ -5165,10 +5309,13 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let unknown = dir.join("custom_adapter.onnx");
         std::fs::write(&unknown, b"self-trained weights").unwrap();
-        verify_models(&[
-            unknown.to_str().unwrap(),
-            "/nonexistent/irlume-test/missing.onnx",
-        ]);
+        verify_models(
+            &[
+                unknown.to_str().unwrap(),
+                "/nonexistent/irlume-test/missing.onnx",
+            ],
+            None,
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -5179,11 +5326,11 @@ mod tests {
     #[test]
     fn strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one() {
         if let Ok(path) = std::env::var("IRLUME_TEST_VERIFY_TAMPER_CHILD") {
-            verify_models(&[&path]); // must exit(1) before the return
+            verify_models(&[&path], None); // must exit(1) before the return
             return;
         }
         if let Ok(path) = std::env::var("IRLUME_TEST_VERIFY_KNOWN_CHILD") {
-            verify_models(&[&path]); // digest is in the manifest: must survive
+            verify_models(&[&path], None); // digest is in the manifest: must survive
             println!("known-model-accepted");
             std::process::exit(0);
         }

--- a/crates/irlume-vision/src/tflite.rs
+++ b/crates/irlume-vision/src/tflite.rs
@@ -19,7 +19,7 @@
 //! here loads a model that was not pinned by sha256 first, and
 //! [`TfliteSession::from_pinned_bytes`] takes the VERIFIED BYTES themselves
 //! so the checked buffer and the loaded buffer can never diverge (the same
-//! one-buffer rule as `Engine::load_with_recognizer_bytes`).
+//! one-buffer rule as `Engine::load_with_recognizer_weights`).
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -177,7 +177,7 @@ impl TfliteSession {
     /// constructor named "pinned" that does not check is a promise only its
     /// call sites keep (#296 review), and one forgetful stage-2 caller
     /// would run an unverified model. Same one-buffer rule as
-    /// `Engine::load_with_recognizer_bytes`: the digest and the loaded
+    /// `Engine::load_with_recognizer_weights`: the digest and the loaded
     /// model can never diverge because they are the same bytes.
     ///
     /// `threads` caps CPU threads for the interpreter. XNNPACK is applied


### PR DESCRIPTION
Implements item 3 of #346 only (session reuse and enrollment loading stay parked: they need hardware measurements first). Built by a delegated agent, reviewed here, and the committed file's md5 matches the one every cited number was measured against.

Startup read and sha256-hashed the 260 MB recognizer twice, once to verify it and again to load it. The verified bytes now travel to the loader inside a `HashedModel`, whose only constructor takes the digest from the buffer it holds, so a digest can never be paired with foreign bytes; the bytes-taking engine API already existed and the third-party path already used it. Only the recognizer gets this: the other stages take paths with no bytes-taking API, and they are 0.23 to 2.6 MB against 260.7 MB.

Measured on the Zenbook, exec to the daemon's serving line, before and after binaries interleaved and order-alternated in one loop: warm median 1284 ms to 1044 ms (paired median 198 ms, 14 of 15 pairs faster), cold 1287 ms to 1015 ms (paired 276 ms, 14 of 15), with repeat runs at 208 to 298 ms and one null cold run recorded honestly, taken while the whole machine slowed on both arms. The noise-free corroboration is rchar at the serving line: 527.8 MB before, 267.2 MB after, a difference of exactly one recognizer.

The agent also corrected the issue's own premise: the expected extra cold read does not exist, because the second read always hit the page cache the first had just filled, so the saving is the same warm or cold. Peak RSS and resident-at-serving are unchanged (the old path held the same buffer inside the loader); the buffer drops right after the engine build and is skipped entirely when a third-party recognizer is selected.

Two tests, each mutation-verified: the digest that comes back belongs to the bytes that were verified and nothing is kept for a model that was not asked for, and the bytes path must not touch the file again (a nonexistent recognizer path must not appear in the error when weights are in hand).

Process note the agent disclosed: an editing tool rewrote the daemon source from a stale snapshot mid-run and silently restored two reverted mutation edits. It was caught by the rchar probe reading 527.8 MB instead of 267.2 MB, the source was restored, and the full gate plus every cited measurement was re-run against the committed file.
