### PR TITLE
chore: enforce the documentation lints that were never running

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,28 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/archledger/irlume"
 authors = ["archledger <archledger236@gmail.com>"]
 
+# Documentation lints for a crate that authenticates people. All three are
+# `allow` in stock clippy, so the coding standard requiring documented panics,
+# error conditions and unsafe preconditions was never actually enforced.
+#
+# The pre-existing sites carry `#[expect(...)]` rather than a hand-waved
+# comment, so CI stays green while NEW code is gated from today. `#[expect]`
+# self-cleans: once a site is documented the expectation goes unfulfilled and
+# `-D warnings` fails until the attribute is removed, so this backlog can only
+# shrink. Each member crate opts in with `[lints] workspace = true`, which is
+# required; without it none of these apply.
+#
+# Unsafe debt is expected on each INDIVIDUAL unsafe expression, never on the
+# enclosing function. One `#[expect]` is fulfilled by one matching diagnostic
+# anywhere inside the item it sits on, so a function-level attribute would let
+# a later undocumented unsafe block in that same function ride along on an
+# already-fulfilled expectation and reach CI unflagged. Per-expression
+# placement is what makes a new unsafe block a build failure.
+[workspace.lints.clippy]
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+undocumented_unsafe_blocks = "warn"
+
 # Shared dependency versions. Heavy/native deps are listed but commented so the
 # scaffold compiles offline as pure stubs; uncomment per crate as you implement.
 [workspace.dependencies]

--- a/crates/irlume-auth/Cargo.toml
+++ b/crates/irlume-auth/Cargo.toml
@@ -18,3 +18,6 @@ irlume-core.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -806,6 +806,7 @@ mod capture_mode_decision_tests {
 }
 
 impl Engine {
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn load(det_path: &str, model_path: &str) -> irlume_common::Result<Self> {
         // Identify the recognizer by its weights, not its path: a file swapped
         // in place under the same name is a different embedding space and must
@@ -825,6 +826,7 @@ impl Engine {
     /// would belong to a different artifact. One byte buffer flows from the
     /// caller's checksum through the digest into the ONNX session, so the
     /// three can never disagree.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn load_with_recognizer_bytes(
         det_path: &str,
         model_bytes: &[u8],
@@ -972,6 +974,7 @@ impl Engine {
 
     /// Load the IR domain-adaptation adapter (improves dark recognition). If the
     /// file is absent this is a no-op (raw IR embeddings are used).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn with_ir_adapter(mut self, path: &str) -> irlume_common::Result<Self> {
         if std::path::Path::new(path).exists() {
             // One read feeds both the digest and the session, so the tag always
@@ -1118,6 +1121,7 @@ impl Engine {
     /// Load MediaPipe FaceMesh for the passive EAR blink liveness (ADR-0002). If
     /// the file is absent this is a no-op; the opt-in passive gate then can't run
     /// and is skipped (logged), so face auth keeps working.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn with_mesh(mut self, path: &str) -> irlume_common::Result<Self> {
         if std::path::Path::new(path).exists() {
             self.mesh = Some(irlume_vision::FaceMesh::load_from_file(path)?);
@@ -1127,6 +1131,7 @@ impl Engine {
 
     /// Load the BlazeFace short-range rescue detector (improves detection on
     /// saturated outdoor frames). No-op if the file is absent.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn with_blaze_rescue(mut self, path: &str) -> irlume_common::Result<Self> {
         // Shipped short-range rescue (ONNX).
         if std::path::Path::new(path).exists() {
@@ -1142,6 +1147,7 @@ impl Engine {
     /// the session constructor re-checks the same buffer), the entry's
     /// measured operating threshold, and its catalog name for reporting.
     /// Replaces whatever rescue was loaded: one slot, one occupant.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn with_full_range_rescue(
         mut self,
         bytes: &[u8],
@@ -1172,6 +1178,7 @@ impl Engine {
     /// Load an opt-in third-party PAD classifier (deny-only cue on the lit IR
     /// frame). No-op if the file is absent, so a deleted model degrades to the
     /// built-in gate, never to a startup failure.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn with_thirdparty_pad(
         mut self,
         path: &str,
@@ -1241,6 +1248,7 @@ impl Engine {
     /// One capture: RGB+IR → liveness verdict + (if a face) its embedding.
     /// Capture + assess, choosing the path from the hardware: full cross-spectrum
     /// (RGB+IR) when an IR camera is present, else RGB-only (convenience).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn assess(&mut self) -> irlume_common::Result<Assessment> {
         if self.ir_available {
             self.assess_full()
@@ -1854,6 +1862,12 @@ impl Engine {
     /// detection must not masquerade as a blink) but keep their brightness so the
     /// detector can classify the emitter strobe. Returns an empty vec when the
     /// FaceMesh model is not loaded (the gate cannot run).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "cannot panic: the `self.mesh.is_none()` guard above returns early, \
+                  so `expect(\"mesh present\")` runs only when it is Some"
+    )]
     pub fn capture_ear_samples(
         &mut self,
         samples: usize,
@@ -1907,6 +1921,7 @@ impl Engine {
     /// gesture. Needs only the detector, not the FaceMesh, so it works at head
     /// angles and in IR-only light where the eye-based EAR gesture collapses. A
     /// frame with no detected face carries `None` pose.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn capture_pose_samples(
         &mut self,
         samples: usize,
@@ -2379,6 +2394,7 @@ impl Engine {
     /// `service` (the PAM service name) selects the window: `sudo`/`su` get the
     /// shorter [`SUDO_GRACE_WINDOW_MS`]; login and lock services (and `None`)
     /// get the full [`GRACE_WINDOW_MS`]. `IRLUME_GRACE_MS` overrides both.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn authenticate(
         &mut self,
         user: &str,
@@ -2395,6 +2411,7 @@ impl Engine {
     /// The purpose is computed once per call and threaded down, so a polkit verify
     /// can never leak its gate into a later login, and a credential release can
     /// never be mistaken for a plain verify.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn authenticate_for(
         &mut self,
         user: &str,
@@ -2794,6 +2811,7 @@ impl Engine {
     /// daemon restricts a non-root caller to [`Self::identify_within`] so the
     /// returned score can't become a hill-climbing oracle against other
     /// users' templates.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn identify(&mut self) -> irlume_common::Result<IdentifyOutcome> {
         self.identify_impl(None)
     }
@@ -2801,6 +2819,7 @@ impl Engine {
     /// Identify scoped to a single enrolled user ("is this `user`?"). Same
     /// liveness gate and RGB match as [`Self::identify`], but the search set is
     /// just this one account: what a non-root peer is allowed to ask about itself.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn identify_within(&mut self, user: &str) -> irlume_common::Result<IdentifyOutcome> {
         self.identify_impl(Some(user))
     }
@@ -2880,6 +2899,7 @@ impl Engine {
     /// IR liveness self-test: capture and run the algorithmic PAD gate, reporting
     /// the verdict plus the cues behind it. Backs the TUI Calibrate screen and
     /// `Request::SelfTest { Liveness }`.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn liveness_selftest(&mut self) -> irlume_common::Result<(bool, String)> {
         let a = self.assess()?;
         let s = &a.signals;
@@ -2902,6 +2922,7 @@ impl Engine {
     /// Alignment-determinism self-test: embed the same aligned chip twice; the
     /// cosine MUST be ~1.0. Catches the AuraFace alignment/normalization trap
     /// (the "identical images score 0.6" failure). `Request::SelfTest { AlignmentIdentity }`.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn alignment_selftest(&mut self) -> irlume_common::Result<(bool, String)> {
         let rgb = irlume_camera::capture_rgb_denoised_with_progress(
             &self.rgb_dev,
@@ -3085,6 +3106,13 @@ impl Engine {
     /// is the 0.2.0 upgrade remedy, fresh scans reviving dark/dim login after
     /// an embedding-space change). A novel face gets a NEW profile; that errors
     /// if the account is already at MAX_PROFILES.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "cannot panic: `target` is a profile name returned by \
+                  `enroll_merge_target` from this same `enr`, so the `position` \
+                  lookup that follows always finds it"
+    )]
     pub fn enroll_profile(
         &mut self,
         user: &str,
@@ -3293,6 +3321,7 @@ impl Engine {
     /// recognizer without re-enrolling as a new person: the operator names
     /// the profile, which is the only way the link can be made, since
     /// comparing vectors across embedding spaces is meaningless (#288).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn add_scan(
         &mut self,
         user: &str,
@@ -3389,6 +3418,7 @@ impl Engine {
     /// `user` (the account being enrolled) tunes the pitch band to that user's
     /// calibrated neutral when they already have scans, so the guide coaches to
     /// the same window the capture gate will accept.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn position_sample(
         &mut self,
         user: Option<&str>,

--- a/crates/irlume-camera/Cargo.toml
+++ b/crates/irlume-camera/Cargo.toml
@@ -12,3 +12,6 @@ serde_json.workspace = true
 # Hello-class hardware, and builds from cache. nokhwa wraps this crate anyway.
 v4l = "0.14"
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -220,6 +220,7 @@ fn load_conf(id: &crate::uvc_descriptor::CameraIdentity) -> Option<(u8, u8)> {
 /// Versions before 0.7.1 stored the payload too, and a second "brightness boost"
 /// line found by writing 0xFF across a control of unknown meaning. Neither is
 /// written or read any more.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn save_conf(
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
@@ -1498,6 +1499,7 @@ impl StreamMode {
     /// replacement; `Drop` remains the ordinary end-of-session path, and can
     /// only print. `Err(Bookkeeping)` means no camera request was made at
     /// all — the mode is still applied, on purpose.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn restore(&mut self) -> std::result::Result<(), RestoreError> {
         if !self.armed {
             return Ok(());
@@ -1902,6 +1904,7 @@ fn override_key(
 ) -> std::io::Result<OverrideKey> {
     // SAFETY: fstat writes into `st` and borrows `fd` for the call only.
     let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::fstat(fd, &mut st) } != 0 {
         return Err(std::io::Error::last_os_error());
     }
@@ -3233,6 +3236,7 @@ impl RecoveryOutcome {
 /// Preference order is IR Torch first (its whole purpose is the lamp), then Face
 /// Authentication (which drives the illuminator as a side effect of putting a
 /// streaming interface into face-auth mode).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
@@ -3356,12 +3360,14 @@ impl Discovered {
     ///
     /// Call BEFORE writing the configuration. Failing here drops `self`, which
     /// puts the control back, and nothing durable has been published about it.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn confirm_applied(&mut self) -> std::result::Result<(), String> {
         self.pending.confirm_applied()
     }
 
     /// Release the undo record. Call only once the configuration naming this
     /// control is durable.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn committed(mut self) -> std::result::Result<(), String> {
         self.pending.commit()
     }
@@ -3380,6 +3386,7 @@ impl Discovered {
     /// last, because until the configuration is durable the camera is changed
     /// with nothing saying which control did it, and dropping `self` unresolved
     /// puts it back.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn finish(
         mut self,
         id: &crate::uvc_descriptor::CameraIdentity,
@@ -3906,6 +3913,7 @@ pub(crate) fn ir_torch_default_is_usable(
 /// This is what `ir-setup --dry-run` reports. It sends nothing to the device at
 /// all: the previous version issued `GET_LEN` to all 512 unit and selector
 /// combinations, which is traffic to controls the camera never claimed to have.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn describe_units(device: &str) -> std::io::Result<Vec<String>> {
     let (desc, interface) = crate::uvc_descriptor::usb_context(device)?;
     Ok(
@@ -5133,7 +5141,10 @@ mod tests {
             .permissions()
             .mode()
             & 0o777;
-        unsafe { libc::umask(previous) };
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        unsafe {
+            libc::umask(previous)
+        };
         assert_eq!(
             masked_mode, 0o640,
             "a requested 0644 under UMask=0027 is 0640, which is what the shipped \
@@ -6405,6 +6416,7 @@ mod tests {
         // Staged via an UNREADABLE record file (EACCES), which is machine
         // trouble rather than a protected record. Meaningless as root, where
         // mode 000 still reads.
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         if unsafe { libc::geteuid() } == 0 {
             eprintln!("skipped: running as root, mode 000 does not refuse reads");
             return;

--- a/crates/irlume-camera/src/ir_metadata.rs
+++ b/crates/irlume-camera/src/ir_metadata.rs
@@ -464,6 +464,7 @@ impl IlluminationLog {
         let node = metadata_node_for(ir_device)?;
         // SAFETY: a NUL-terminated path built directly below.
         let path = std::ffi::CString::new(node.as_bytes()).ok()?;
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDWR | libc::O_NONBLOCK) };
         if fd < 0 {
             irlume_common::dlog!(

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -635,6 +635,7 @@ impl Unreadable {
 /// keeping a failure to read the node apart from a node that read as neither
 /// kind. Defensive: enumerate FORMATS (safe), never `query_controls` (panics on
 /// some UVC drivers; a hard-won linhello lesson).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn classify_node(device: &str) -> Result<Role, Unreadable> {
     let unreadable = |at, e: std::io::Error| Unreadable {
         path: device.to_string(),
@@ -661,6 +662,7 @@ pub fn classify_node(device: &str) -> Result<Role, Unreadable> {
 /// index 0 directly is the only way to tell those apart with this crate
 /// version, and telling them apart is the whole of #227.
 fn capture_formats_answered(dev: &Device) -> std::io::Result<()> {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut desc: v4l::v4l_sys::v4l2_fmtdesc = unsafe { std::mem::zeroed() };
     desc.index = 0;
     desc.type_ = v4l::buffer::Type::VideoCapture as u32;
@@ -913,6 +915,7 @@ fn backend_from_caps(driver: String, bus: &str) -> (String, bool) {
 /// exactly this by shell script; `doctor` now reads it itself. A failure is an
 /// `Err` the caller must render, never silence: an unobserved backend on a
 /// diagnostic surface has to say "unknown" (#195 review).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn node_backend(device: &str) -> std::io::Result<(String, bool)> {
     let dev = Device::with_path(device)?;
     let caps = dev.query_caps()?;
@@ -955,6 +958,7 @@ fn find_attr_dir(start: &std::path::Path, attr: &str) -> Option<std::path::PathB
 /// attribute must read `fixed` (rejects a hot-plugged external camera;
 /// supplementary, and intentionally *off* by default so external Hello cameras
 /// work; `removable` is also frequently `unknown` even for legitimate devices).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn verify_pinned(device: &str) -> irlume_common::Result<()> {
     // Distinguish "no camera at all" from "a node that isn't physical"; the
     // anti-injection message only makes sense when something answered to the path.
@@ -1305,6 +1309,7 @@ pub struct RgbCamera {
 impl RgbCamera {
     /// Verify, open and negotiate. Does not start streaming: no buffers are
     /// allocated and the capture LED stays off until a session is opened.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
         verify_pinned(device)?;
         if privacy_engaged(device) {
@@ -1340,6 +1345,7 @@ impl RgbCamera {
     /// Start streaming. The returned session holds the buffers and the running
     /// stream until it is dropped, so keep it exactly as long as the burst of
     /// captures that needs it and no longer.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn session(&self) -> irlume_common::Result<RgbSession<'_>> {
         self.session_with_progress(&no_progress())
     }
@@ -1348,6 +1354,7 @@ impl RgbCamera {
     /// through `progress` (#336). The session KEEPS the reporter: its warm-up
     /// runs lazily on the first capture and again after [`RgbSession::recover`],
     /// both long after this call returned.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn session_with_progress(
         &self,
         progress: &Progress,
@@ -1463,6 +1470,7 @@ fn fps_from_params(p: v4l::video::capture::Parameters) -> Option<f64> {
 /// `set_format`, so this is the same raw-ioctl shape as the VIDIOC_ENUM_FMT
 /// probe above.
 fn try_format(dev: &Device, fmt: &Format) -> std::io::Result<Format> {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut wire: v4l::v4l_sys::v4l2_format = unsafe { std::mem::zeroed() };
     wire.type_ = v4l::buffer::Type::VideoCapture as u32;
     wire.fmt.pix = (*fmt).into();
@@ -1479,6 +1487,7 @@ fn try_format(dev: &Device, fmt: &Format) -> std::io::Result<Format> {
     if rc < 0 {
         return Err(std::io::Error::last_os_error());
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     Ok(Format::from(unsafe { wire.fmt.pix }))
 }
 
@@ -1489,6 +1498,7 @@ fn try_format(dev: &Device, fmt: &Format) -> std::io::Result<Format> {
 /// no streaming, LED off. The candidate selection is shared with the real
 /// open paths rather than reimplemented, so this report cannot drift from
 /// what capture actually asks for (#223).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn negotiated_stream(device: &str, role: Role) -> irlume_common::Result<StreamSpec> {
     verify_pinned(device)?;
     if privacy_engaged(device) {
@@ -1571,6 +1581,7 @@ impl<'a> RgbSession<'a> {
     /// this session already holds, so nothing new opens and nothing collides.
     /// Same drop-then-reopen shape as the frozen-stream restart in the IR
     /// one-shot path.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn recover(&mut self) -> irlume_common::Result<()> {
         self.stream = None; // drop first: STREAMOFF + buffer release
         self.stream = Some(SafeStream::open(&self.cam.device, &self.cam.dev)?);
@@ -1598,6 +1609,7 @@ impl<'a> RgbSession<'a> {
     }
 
     /// Capture `n` (≥1) frames. All share the same dimensions.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn burst(&mut self, n: usize) -> irlume_common::Result<Vec<Frame>> {
         self.warm_up()?;
         let (w, h) = (self.cam.width, self.cam.height);
@@ -1623,6 +1635,7 @@ impl<'a> RgbSession<'a> {
     }
 
     /// One frame (framing guide, liveness probe).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn frame(&mut self) -> irlume_common::Result<Frame> {
         self.burst(1)?
             .pop()
@@ -1631,6 +1644,7 @@ impl<'a> RgbSession<'a> {
 
     /// The recognition path's denoised frame: a per-pixel temporal median over
     /// the burst, so one blurry or over-exposed frame cannot decide a match.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn denoised(&mut self) -> irlume_common::Result<Frame> {
         Ok(median_frame(self.burst(RGB_BURST)?))
     }
@@ -1640,6 +1654,7 @@ impl<'a> RgbSession<'a> {
 /// single streaming session (YUYV → RGB8). All frames share the same dimensions.
 /// One-shot: opens and tears down a session. Callers that capture more than once
 /// should hold an [`RgbCamera`] and its session instead.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_rgb_burst(device: &str, n: usize) -> irlume_common::Result<Vec<Frame>> {
     capture_rgb_burst_with_progress(device, n, &no_progress())
 }
@@ -1648,6 +1663,7 @@ pub fn capture_rgb_burst(device: &str, n: usize) -> irlume_common::Result<Vec<Fr
 /// through `progress` (#336). The daemon-facing paths pass a real reporter so
 /// a frameless camera heartbeats through its retry budget instead of looking
 /// wedged to the watchdog.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_rgb_burst_with_progress(
     device: &str,
     n: usize,
@@ -1973,6 +1989,7 @@ impl IrDecoder {
 }
 
 /// Capture one AE-warmed RGB frame (fast path: framing guide, liveness probe).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_rgb(device: &str) -> irlume_common::Result<Frame> {
     let mut frames = capture_rgb_burst(device, 1)?;
     frames
@@ -1985,12 +2002,14 @@ pub fn capture_rgb(device: &str) -> irlume_common::Result<Frame> {
 /// transiently corrupt frame is rejected by the median, so it can't drop a
 /// genuine match below threshold (false reject). Used for auth/enroll; the
 /// framing guide stays single-shot for latency.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_rgb_denoised(device: &str) -> irlume_common::Result<Frame> {
     capture_rgb_denoised_with_progress(device, &no_progress())
 }
 
 /// [`capture_rgb_denoised`] with the per-window progress reporting of
 /// [`capture_rgb_burst_with_progress`] (#336).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_rgb_denoised_with_progress(
     device: &str,
     progress: &Progress,
@@ -2077,6 +2096,7 @@ pub const SUBTRACT_MIN_RESULT: f64 = 12.0;
 /// it often fires when the stream opens, otherwise `ir_emitter::enable` sends
 /// the UVC-XU write on the open fd (its `known_control` table holds the
 /// per-camera unit/selector/payload).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_ir(device: &str) -> irlume_common::Result<Frame> {
     Ok(capture_ir_with_stats(device)?.0)
 }
@@ -2084,12 +2104,14 @@ pub fn capture_ir(device: &str) -> irlume_common::Result<Frame> {
 /// [`capture_ir`] plus the burst statistics the plain call discards. The
 /// darkest burst frame's mean is a free per-capture ambient-IR reading (the
 /// input the ambient-relative gates key on), only available at capture time.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_ir_with_stats(device: &str) -> irlume_common::Result<(Frame, IrCaptureStats)> {
     capture_ir_with_stats_and_progress(device, &no_progress())
 }
 
 /// [`capture_ir_with_stats`], reporting each completed silent warm-up window
 /// through `progress` (#336); see [`capture_rgb_burst_with_progress`].
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_ir_with_stats_and_progress(
     device: &str,
     progress: &Progress,
@@ -2120,6 +2142,7 @@ pub struct IrCamera {
 }
 
 impl IrCamera {
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
         verify_pinned(device)?;
         if privacy_engaged(device) {
@@ -2166,6 +2189,7 @@ impl IrCamera {
     /// frames rather than leaving brightness to guess. The residual risk is a
     /// module nobody here has seen going dark for a window, which costs the user
     /// a password fallback rather than the hardware.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn session(&self) -> irlume_common::Result<IrSession<'_>> {
         self.session_with_progress(&no_progress())
     }
@@ -2173,6 +2197,7 @@ impl IrCamera {
     /// [`Self::session`], reporting each completed silent warm-up window
     /// through `progress` (#336). Used transiently: the IR warm-up runs right
     /// here, and nothing in [`IrSession`] warms up again.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn session_with_progress(
         &self,
         progress: &Progress,
@@ -2255,6 +2280,7 @@ impl IrSession<'_> {
     /// known it is the brightest one clipping at most 5% of its pixels, since
     /// a blown frame both flattens the liveness cues and blinds the PAD model
     /// (#221).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn capture_with_stats(&mut self) -> irlume_common::Result<(Frame, IrCaptureStats)> {
         let device = self.cam.device.as_str();
         let (w, h) = (self.cam.width, self.cam.height);
@@ -2645,6 +2671,7 @@ pub mod ir_probe {
 
     /// [`capture_raw_burst_timed`] without the timing column, for callers that
     /// only need the frames.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn capture_raw_burst(device: &str, n: usize) -> irlume_common::Result<Vec<Frame>> {
         Ok(capture_raw_burst_timed(device, n)?
             .into_iter()
@@ -2658,6 +2685,7 @@ pub mod ir_probe {
     /// strobe cadence; the driver's nominal fps is not the delivered fps under
     /// USB contention). Used to inspect the strobe pattern, prototype
     /// subtraction, and audit capture timing offline.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn capture_raw_burst_timed(
         device: &str,
         n: usize,
@@ -2758,6 +2786,7 @@ pub struct IrStreamFrame {
 /// Usable = the same set [`capture_ir_sequence`] historically kept: emitter-off
 /// (dark) frames ARE delivered, because a consumer classifying the strobe needs
 /// them; only frozen and blown frames are dropped.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_ir_streaming<B>(
     device: &str,
     max_frames: usize,
@@ -2891,6 +2920,13 @@ pub fn capture_ir_streaming<B>(
 /// This keeps its own burst/de-strobe loop rather than delegating to
 /// [`capture_ir_streaming`], which delivers raw single frames; the blink watch
 /// uses the streaming core, this stays for the `burst>=2` diagnostic path.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "cannot panic: `stream` is Some from its initialisation, and the one \
+              `take()` on the frozen-restart path reopens it in the same branch; \
+              both failure paths in between return early with `?`"
+)]
 pub fn capture_ir_sequence(
     device: &str,
     samples: usize,
@@ -3200,6 +3236,7 @@ fn retained(concurrent: f32, sequential: f32) -> f32 {
 /// Failed captures are skipped rather than aborting the probe: a camera that
 /// errors under load is exactly what we are trying to characterize, and the
 /// round counts in the report say how much evidence each arm really has.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn measure_contention(
     rgb_dev: &str,
     ir_dev: &str,
@@ -3220,6 +3257,7 @@ pub fn measure_contention(
 /// detection honest while removing the false kill. The same reporter is handed
 /// into every capture and session open, so the per-window warm-up heartbeat
 /// (#336) covers the probe's captures too.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn measure_contention_with_progress(
     rgb_dev: &str,
     ir_dev: &str,
@@ -3485,6 +3523,7 @@ fn resolve_stored_pair_mode(
 /// Persist the capture mode for the RGB+IR pairing behind these two devices.
 /// Writes `/etc/irlume/cameras.conf`, so it needs root. Overwrites; the
 /// check-before-write callers use [`store_capture_mode_if_absent`].
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn store_capture_mode(
     rgb_dev: &str,
     ir_dev: &str,
@@ -3520,6 +3559,7 @@ pub enum StoreIfAbsent {
 /// configuration manager editing the file in that window. Checking again
 /// under the lock means an automatic probe can only ever FILL an empty
 /// verdict; a verdict that appeared mid-probe wins and is returned.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn store_capture_mode_if_absent(
     rgb_dev: &str,
     ir_dev: &str,
@@ -3547,6 +3587,7 @@ pub fn store_capture_mode_if_absent(
 ///
 /// A control is only written when its current value could be read back first, so
 /// anything changed can be undone.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     verify_pinned(device)?;
     // Open only long enough to read the standard V4L2 privacy control, and
@@ -3658,6 +3699,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
 /// Read entirely from the USB descriptors, so it sends the camera nothing at
 /// all. The previous version issued `GET_LEN` to all 512 unit and selector
 /// combinations, which is traffic to controls the camera never claimed to have.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn list_ir_controls(device: &str) -> irlume_common::Result<Vec<String>> {
     verify_pinned(device)?;
     ir_emitter::describe_units(device).map_err(|e| map_io(device, e))
@@ -3677,6 +3719,7 @@ pub fn list_ir_controls(device: &str) -> irlume_common::Result<Vec<String>> {
 /// means the room is dark, or nobody is in front of the camera, or the emitter
 /// needs a control this machine does not know. None of those justify writing
 /// guessed values to camera firmware.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn apply_known_ir_emitter(device: &str) -> irlume_common::Result<bool> {
     let mean_of =
         |f: &Frame| f.data.iter().map(|&p| p as f64).sum::<f64>() / f.data.len().max(1) as f64;

--- a/crates/irlume-camera/src/stream_record.rs
+++ b/crates/irlume-camera/src/stream_record.rs
@@ -961,6 +961,7 @@ mod tests {
             // The sleep is for DETERMINISM, not correctness: without it the
             // parent usually still wins the race, so its absence does not
             // falsify the assertion below.
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
             unsafe {
                 libc::sleep(1);
                 libc::_exit(0);

--- a/crates/irlume-camera/src/uvc_descriptor.rs
+++ b/crates/irlume-camera/src/uvc_descriptor.rs
@@ -175,6 +175,7 @@ fn parse_extension_unit(d: &[u8]) -> Option<ExtensionUnit> {
 /// A camera is identified by what the USB bus says it is, not by the V4L card
 /// string. `card.contains("ASUS")` matched any camera with that word in its
 /// name and wrote nine bytes to it.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn usb_ids(video_device: &str) -> std::io::Result<(u16, u16)> {
     let dir = usb_device_dir(video_device)?;
     let vid = read_hex_u16(&dir.join("idVendor"))
@@ -197,6 +198,7 @@ fn read_hex_u16(path: &Path) -> Option<u16> {
 /// the two-function camera above.
 ///
 /// An unreadable descriptor is an error, never a reason to fall back to probing.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn usb_context(video_device: &str) -> std::io::Result<(Vec<u8>, u8)> {
     let iface_dir = interface_dir(video_device)?;
     let interface_number = read_hex_u8(&iface_dir.join("bInterfaceNumber")).ok_or_else(|| {
@@ -247,6 +249,7 @@ pub struct CameraIdentity {
     pub usb_devpath: String,
 }
 
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn identity_from_fd(fd: std::os::raw::c_int) -> std::io::Result<CameraIdentity> {
     let (major, minor) = device_numbers(fd)?;
     let node = std::fs::canonicalize(format!("/sys/dev/char/{major}:{minor}"))?;
@@ -321,6 +324,7 @@ impl CameraIdentity {
 fn device_numbers(fd: std::os::raw::c_int) -> std::io::Result<(u32, u32)> {
     // SAFETY: fstat writes into a zeroed stat owned here; fd is the caller's.
     let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::fstat(fd, &mut st) } != 0 {
         return Err(std::io::Error::last_os_error());
     }

--- a/crates/irlume-cli/Cargo.toml
+++ b/crates/irlume-cli/Cargo.toml
@@ -25,3 +25,6 @@ rand.workspace = true   # session and operation identifiers for the machine even
 image = { workspace = true }
 rpassword = "7"   # no-echo password prompt for `keyring arm`
 ratatui = "0.30"  # TUI (MIT), bundles crossterm; powers `irlume tui`
+
+[lints]
+workspace = true

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -359,6 +359,7 @@ fn gz_lists_irlume(gz: &[u8]) -> Option<bool> {
 /// through interactive sudo so dnf/apt keep their own transaction prompt (the
 /// user still confirms the actual change). Stops at the first failure.
 fn run_pkg_steps(steps: &[&[&str]]) -> ExitCode {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let root = unsafe { libc::geteuid() } == 0;
     for step in steps {
         let display = step.join(" ");

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -964,6 +964,8 @@ mod tests {
     #[test]
     fn effective_uid_matches_the_real_euid() {
         // The /proc/self/status parse must yield the kernel's effective uid.
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         assert_eq!(effective_uid(), unsafe { libc::geteuid() });
     }
 

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -72,6 +72,7 @@ fn main() -> std::process::ExitCode {
     // `| less` then quit, `| grep -q`) into a "failed printing to stdout: Broken
     // pipe" panic + exit 101. Restore the Unix default so we exit quietly like any
     // other CLI when a downstream reader goes away.
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
@@ -1611,6 +1612,8 @@ pub(crate) fn user_arg(args: &[String]) -> String {
             // always means their own profile: prefer the invoking user.
             std::env::var("SUDO_USER")
                 .ok()
+                // SAFETY: geteuid takes no arguments, reads only this process's own
+                // effective uid, and is specified as always succeeding.
                 .filter(|s| !s.is_empty() && unsafe { libc::geteuid() } == 0)
                 .or_else(|| std::env::var("USER").ok())
                 .unwrap_or_else(|| "user".into())
@@ -1703,7 +1706,10 @@ pub(crate) fn camera_pair() -> (String, String) {
 }
 
 pub(crate) fn is_root() -> bool {
-    unsafe { libc::geteuid() == 0 }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+    unsafe {
+        libc::geteuid() == 0
+    }
 }
 
 /// Build an Engine: optional --rgb/--ir device overrides, and load an IR
@@ -4826,6 +4832,7 @@ mod tests {
         let _guard = crate::testenv::ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         if unsafe { libc::geteuid() } == 0 {
             return; // the SUDO_USER preference only applies to root; not this run
         }

--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -675,7 +675,10 @@ fn remove_weights(path: &std::path::Path) -> Result<(), String> {
 }
 
 fn stdin_is_tty() -> bool {
-    unsafe { libc::isatty(0) == 1 }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+    unsafe {
+        libc::isatty(0) == 1
+    }
 }
 
 /// One doctor line: which third-party model is enabled and whether its file

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -1885,6 +1885,7 @@ mod tests {
         // this account rather than root, because the test does not run as root
         // and a chown to another owner is refused; production rollback --apply
         // is root-only and the refusal is reported there rather than ignored.
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
         let gone = dir.join("kde-fingerprint");
         restore_surface(&gone, Some("restored\n"), Some((0o600, uid, gid))).expect("restore");
@@ -3965,6 +3966,8 @@ auth required pam_fprintd.so\n\
 
     #[test]
     fn effective_uid_matches_the_real_euid() {
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         assert_eq!(effective_uid(), unsafe { libc::geteuid() });
     }
 

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2470,8 +2470,10 @@ impl App {
                 // fn-item-to-integer cast trips clippy::fn_to_numeric_cast_any.
                 let handler =
                     noop_sigint as extern "C" fn(libc::c_int) as *const () as libc::sighandler_t;
+                #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
                 let old_int = unsafe { libc::signal(libc::SIGINT, handler) };
                 self.run_suspended(s);
+                #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
                 unsafe {
                     libc::signal(libc::SIGINT, old_int);
                 }
@@ -2593,9 +2595,13 @@ impl App {
                 Ok(())
             });
         }
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let old_int = unsafe { libc::signal(libc::SIGINT, libc::SIG_IGN) };
         let status = cmd.status();
-        unsafe { libc::signal(libc::SIGINT, old_int) };
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        unsafe {
+            libc::signal(libc::SIGINT, old_int)
+        };
         match status {
             Ok(st) if st.success() => self.log('✓', format!("{what}: done")),
             Ok(st) => {

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -607,7 +607,10 @@ fn yn(b: bool) -> &'static str {
 }
 
 fn stdin_is_tty() -> bool {
-    unsafe { libc::isatty(0) == 1 }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+    unsafe {
+        libc::isatty(0) == 1
+    }
 }
 
 #[cfg(test)]

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -18,7 +18,10 @@ use std::process::{Command, Stdio};
 const BIN: &str = env!("CARGO_BIN_EXE_irlume");
 
 fn is_root() -> bool {
-    unsafe { libc::geteuid() == 0 }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+    unsafe {
+        libc::geteuid() == 0
+    }
 }
 
 /// Per-test sandbox tree; dropped (deleted) when the test ends.

--- a/crates/irlume-cli/tests/cli_capture.rs
+++ b/crates/irlume-cli/tests/cli_capture.rs
@@ -131,6 +131,7 @@ fn run_timeboxed(what: &str, cmd: &mut Command) -> (i32, String, String) {
             }
             if !done.load(Ordering::SeqCst) {
                 timed_out.store(true, Ordering::SeqCst);
+                #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
                 unsafe {
                     libc::kill(pid, libc::SIGKILL);
                 }

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -32,7 +32,10 @@ const BIN: &str = env!("CARGO_BIN_EXE_irlume");
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn is_root() -> bool {
-    unsafe { libc::geteuid() == 0 }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+    unsafe {
+        libc::geteuid() == 0
+    }
 }
 
 /// Per-test sandbox tree; deleted when the test ends.

--- a/crates/irlume-common/Cargo.toml
+++ b/crates/irlume-common/Cargo.toml
@@ -11,3 +11,6 @@ thiserror.workspace = true
 zeroize.workspace = true
 libc.workspace = true
 sha2.workspace = true
+
+[lints]
+workspace = true

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -59,6 +59,7 @@ pub fn secure_env(name: &str) -> Option<std::ffi::OsString> {
     if ptr.is_null() {
         return None;
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let bytes = unsafe { std::ffi::CStr::from_ptr(ptr) }.to_bytes().to_vec();
     Some(std::ffi::OsString::from_vec(bytes))
 }
@@ -74,6 +75,7 @@ pub fn socket_path() -> PathBuf {
 }
 
 /// Send `req` with the default read/write timeout.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn request(req: &Request) -> io::Result<Response> {
     request_with_timeout(req, DEFAULT_RW_TIMEOUT)
 }
@@ -81,12 +83,14 @@ pub fn request(req: &Request) -> io::Result<Response> {
 /// A short-budget poll: used by the TUI's periodic status refresh so a busy or
 /// wedged daemon (mid-capture, not accepting) fails fast instead of stalling the
 /// UI thread for the full connect/read budget on every probe.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn request_poll(req: &Request) -> io::Result<Response> {
     request_with_timeouts(req, POLL_CONNECT_TIMEOUT, POLL_RW_TIMEOUT)
 }
 
 /// Send `req`, allowing `rw_timeout` for the reply (e.g. a longer budget for an
 /// unseal that does a full camera capture + liveness + match first).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn request_with_timeout(req: &Request, rw_timeout: Duration) -> io::Result<Response> {
     request_with_timeouts(req, CONNECT_TIMEOUT, rw_timeout)
 }
@@ -555,8 +559,10 @@ mod tests {
         // A listener that never accepts, with the smallest backlog Linux
         // allows, so queued fillers exhaust it and further connects BLOCK
         // (the exact hang connect_with_timeout exists to bound).
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
         assert!(fd >= 0);
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
         addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
         let bytes = path.as_os_str().as_encoded_bytes();
@@ -574,6 +580,8 @@ mod tests {
             )
         };
         assert_eq!(rc, 0, "bind: {}", io::Error::last_os_error());
+        // SAFETY: `fd` is the socket created above and bound on the line before
+        // this one, and it stays open for the rest of this function.
         assert_eq!(unsafe { libc::listen(fd, 0) }, 0);
 
         // Saturate the accept queue. The fillers that no longer fit block in
@@ -594,7 +602,10 @@ mod tests {
             "got: {err}"
         );
         std::env::remove_var("IRLUME_SOCKET");
-        unsafe { libc::close(fd) };
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        unsafe {
+            libc::close(fd)
+        };
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -40,6 +40,7 @@ pub struct ConfigLock {
 /// between. The lock is a sidecar `<file>.lock` under the config root, taken
 /// with flock, so plain readers are never blocked and see whole files either
 /// way; only check-then-write callers need to take it.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn lock_exclusive(file: &str) -> std::io::Result<ConfigLock> {
     use std::os::fd::AsRawFd;
     use std::os::unix::fs::OpenOptionsExt;
@@ -121,6 +122,9 @@ pub fn read_kv(file: &str, key: &str) -> Option<String> {
         // for root and for non-permission errors; stay quiet for the expected
         // EACCES an ordinary user gets.
         KvObservation::Unknown(e) => {
+            // SAFETY: `geteuid` takes no arguments, reads only the calling
+            // process's own credentials, and is specified as always succeeding,
+            // so it has no preconditions for the caller to uphold.
             let unprivileged_eacces =
                 e.kind() == std::io::ErrorKind::PermissionDenied && unsafe { libc::geteuid() } != 0;
             if !unprivileged_eacces {
@@ -138,6 +142,7 @@ pub fn read_kv(file: &str, key: &str) -> Option<String> {
 
 /// Insert or update `key=value`, preserving every other line (including
 /// comments) and dropping duplicate keys. Creates the file at 0600 if absent.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn write_kv(file: &str, key: &str, val: &str) -> std::io::Result<()> {
     let path = config_path(file);
     if let Some(dir) = path.parent() {
@@ -465,6 +470,7 @@ mod tests {
 
         // 0600-root-style file we cannot read: the expected unprivileged EACCES
         // is the quiet branch. Only meaningful when not running as root.
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         if unsafe { libc::geteuid() } != 0 {
             use std::os::unix::fs::PermissionsExt;
             let p = config_path("locked.conf");

--- a/crates/irlume-common/src/gkr_wire.rs
+++ b/crates/irlume-common/src/gkr_wire.rs
@@ -96,6 +96,7 @@ pub fn encode_request(op: Op, args: &[&[u8]]) -> Vec<u8> {
 /// Decode the fixed 8-byte response. Errors name what was malformed rather than
 /// collapsing into a result code, because a garbled reply and a `Failed` ask
 /// for different reactions (report a bug vs. report the outcome).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn decode_response(bytes: &[u8]) -> Result<ControlResult, String> {
     if bytes.len() != 8 {
         return Err(format!(
@@ -116,6 +117,7 @@ pub fn decode_response(bytes: &[u8]) -> Result<ControlResult, String> {
 ///
 /// Generic over the stream so tests can drive it with an in-memory pipe; the
 /// real caller passes a `UnixStream` connected to `control_socket_path`.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn call<S: Read + Write>(
     stream: &mut S,
     op: Op,

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -127,6 +127,7 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 /// `/var/lib/irlume` makes `login-transactions` findable, and does nothing for
 /// `irlume` itself, whose entry is in `/var/lib`. A record fsynced into a
 /// directory whose name did not survive is not a record.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn fsync_ancestors(dir: &std::path::Path) -> std::result::Result<(), String> {
     for parent in ancestor_chain(dir) {
         fsync_dir(&parent)?;
@@ -166,6 +167,7 @@ pub fn ancestor_chain(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
 /// `fsync(2)` is explicit that syncing a file does not necessarily persist the
 /// directory entry naming it; the directory has to be synced too. Opening a
 /// directory read-only and syncing that descriptor is the way to do it.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn fsync_dir(dir: &std::path::Path) -> std::result::Result<(), String> {
     std::fs::File::open(dir)
         .and_then(|d| d.sync_all())
@@ -173,6 +175,7 @@ pub fn fsync_dir(dir: &std::path::Path) -> std::result::Result<(), String> {
 }
 
 /// Set `path`'s permission bits, naming the path when it fails.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn restrict(path: &std::path::Path, mode: u32) -> std::result::Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
@@ -186,6 +189,7 @@ pub fn restrict(path: &std::path::Path, mode: u32) -> std::result::Result<(), St
 /// cache when the machine loses power brings the record back, and a record that
 /// comes back is acted on again. Already-gone is success, because the caller's
 /// postcondition is that nothing is there.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn remove_durable(path: &std::path::Path) -> std::result::Result<(), String> {
     match std::fs::remove_file(path) {
         Ok(()) => {}
@@ -203,6 +207,7 @@ pub fn remove_durable(path: &std::path::Path) -> std::result::Result<(), String>
 /// mode, open keeps its permissions, so the mode is re-asserted after the
 /// write. `sync_all` makes the bytes durable before any caller renames the
 /// file over a live one. Non-unix builds fall back to a plain write.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn write_0600(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -233,6 +238,7 @@ pub fn write_0600(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
 /// greeter unseal) sees either the whole old file or the whole new one, never a
 /// torn write. Temp and target must share a directory so the rename stays within
 /// one filesystem (where rename is atomic).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn write_0600_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
     write_atomic_mode(path, bytes, 0o600)
 }
@@ -251,6 +257,7 @@ pub fn write_0600_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Resul
 /// WIDEN permissions on machines already running. The 0600 callers are
 /// unaffected: a umask can only remove bits, and every ordinary umask removes
 /// none of those.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn write_atomic_mode(path: &std::path::Path, bytes: &[u8], mode: u32) -> std::io::Result<()> {
     match write_atomic_reporting(path, bytes, mode)? {
         AtomicWrite::Durable => Ok(()),
@@ -283,6 +290,7 @@ pub enum AtomicWrite {
 
 /// [`write_atomic_mode`], reporting whether the content became visible when the
 /// durability step failed. `Err` means nothing was published.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn write_atomic_reporting(
     path: &std::path::Path,
     bytes: &[u8],

--- a/crates/irlume-common/src/memlock.rs
+++ b/crates/irlume-common/src/memlock.rs
@@ -19,6 +19,7 @@ pub fn lock_slice(buf: &[u8]) {
     // `madvise(MADV_DONTDUMP)` returns EINVAL unless the address is page-aligned,
     // so a raw Vec pointer silently failed DONTDUMP. Align the start down and
     // extend the length so both calls cover the pages backing the secret.
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let page = match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
         n if n > 0 => n as usize,
         _ => 4096,
@@ -77,6 +78,7 @@ mod tests {
             // the syscall, so RLIMIT_MEMLOCK refuses nothing and the warning
             // this test looks for is never printed. Say so, rather than leaving
             // the parent to read an intercepted call as a missing warning.
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
             let page = match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
                 n if n > 0 => n as usize,
                 _ => 4096,

--- a/crates/irlume-common/src/platform.rs
+++ b/crates/irlume-common/src/platform.rs
@@ -138,6 +138,7 @@ fn session_is_active_user(session: &str) -> bool {
 /// Resolve a user name to its uid via NSS (`getpwnam_r`). `None` if absent.
 fn uid_for_name(name: &str) -> Option<u32> {
     let cname = std::ffi::CString::new(name).ok()?;
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
     let mut buf = vec![0 as libc::c_char; 4096];
     let mut result: *mut libc::passwd = std::ptr::null_mut();

--- a/crates/irlume-common/src/thirdparty.rs
+++ b/crates/irlume-common/src/thirdparty.rs
@@ -71,6 +71,7 @@ pub enum RecognizerRefusal {
 /// this with [`by_name`], the pin check, and the file read. The stage-open
 /// check is here rather than trusted to the installer because the settings key
 /// is root-editable text the installer never saw.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn recognizer_override(
     entry: Option<&ThirdPartyModel>,
 ) -> Result<&ThirdPartyModel, RecognizerRefusal> {
@@ -79,6 +80,7 @@ pub fn recognizer_override(
 
 /// [`recognizer_override`] for the detection stage: may this entry be wired
 /// as the RESCUE detector?
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn detector_override(
     entry: Option<&ThirdPartyModel>,
 ) -> Result<&ThirdPartyModel, RecognizerRefusal> {

--- a/crates/irlume-core/Cargo.toml
+++ b/crates/irlume-core/Cargo.toml
@@ -21,3 +21,6 @@ pbkdf2.workspace = true
 # O_NONBLOCK/O_NOFOLLOW when reading a file inside a user-writable home.
 libc.workspace = true
 rand.workspace = true
+
+[lints]
+workspace = true

--- a/crates/irlume-core/src/crypto.rs
+++ b/crates/irlume-core/src/crypto.rs
@@ -31,6 +31,7 @@ pub fn generate_key() -> Zeroizing<Vec<u8>> {
 }
 
 /// Encrypt `plaintext` under `key`, returning `nonce ‖ ciphertext+tag`.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn encrypt(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
     if key.len() != KEY_LEN {
         return Err(Error::Policy(format!(
@@ -58,6 +59,7 @@ pub fn encrypt(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
 /// Decrypt a `nonce ‖ ciphertext+tag` blob under `key`. A wrong key or tampered
 /// data fails the GCM tag check and returns a generic error (indistinguishable
 /// by design).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn decrypt(key: &[u8], blob: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
     if key.len() != KEY_LEN {
         return Err(Error::Policy(format!(

--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -156,6 +156,7 @@ pub struct SealedEnvelope {
 }
 
 impl SealedEnvelope {
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn load(path: &Path) -> Result<Self> {
         let s = fs::read_to_string(path).map_err(|e| Error::Io(e.to_string()))?;
         serde_json::from_str(&s).map_err(|e| Error::Protocol(e.to_string()))
@@ -163,6 +164,7 @@ impl SealedEnvelope {
 
     /// Write the envelope as a root-only (0600) file: it contains the wrapped
     /// secret blob; only the TPM can unseal it, but keep it unreadable anyway.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn save(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| Error::Io(e.to_string()))?;

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -35,6 +35,7 @@ pub fn envelope_path(user: &str) -> PathBuf {
 
 /// Seal `password` for `user` so a later face login can release it. Overwrites
 /// any existing sealed password (re-arming, e.g. after a password change).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn seal_password(user: &str, password: &[u8]) -> Result<()> {
     seal_secret(user, password, SecretKind::LoginPassword)
 }
@@ -43,6 +44,7 @@ pub fn seal_password(user: &str, password: &[u8]) -> Result<()> {
 ///
 /// The kind is stamped here rather than in [`tpm::seal`], which wraps bytes and
 /// has no business knowing what they mean.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn seal_secret(user: &str, secret: &[u8], kind: SecretKind) -> Result<()> {
     if kind == SecretKind::GnomeKeyringToken {
         // Tokens are armed through [`arm_gnome_token`], which mints the bytes
@@ -110,6 +112,7 @@ fn mint_gnome_token() -> Zeroizing<String> {
 /// keyring still keyed to the password (the envelope's token merely goes
 /// unused until a re-arm); the other order would re-key the keyring to a token
 /// that no longer exists anywhere, which is unrecoverable.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn arm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<String>> {
     if password.is_empty() {
         return Err(Error::Protocol(
@@ -133,6 +136,7 @@ pub fn arm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<String>>
 /// is recovered (TPM seal first, password wrap second, so this also works
 /// after PCR drift), the envelope is rebuilt against today's policy and
 /// re-wrapped under the possibly-new password, and the SAME token is returned.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn rearm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
     let path = envelope_path(user);
     let env = SealedEnvelope::load(&path)?;
@@ -176,6 +180,7 @@ pub fn rearm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<Vec<u8
 /// key that does not open it. That is not a regression we introduce; it is
 /// exactly what `pam_kwallet5` does with the new password, and the user fixes
 /// it the same way, by changing the wallet password.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn derive_secret(
     kind: SecretKind,
     password: &[u8],
@@ -219,6 +224,7 @@ pub fn sealed_kind(user: &str) -> Option<SecretKind> {
 /// and the difference between "no token here" and "could not tell" is the
 /// difference between a safe teardown and erasing the only copy of the secret
 /// a login keyring is encrypted under.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn list_sealed_kinds() -> Result<Vec<(String, SecretKind)>> {
     let dir = keyring_dir();
     let entries = match std::fs::read_dir(&dir) {
@@ -268,6 +274,7 @@ pub struct Unsealed {
 /// Fails if none is armed or if the bound PCR policy is no longer satisfied
 /// (e.g. Secure Boot config changed); the caller then falls back to the typed
 /// password and the wallet stays locked until the user re-arms.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn unseal_secret(user: &str) -> Result<Unsealed> {
     let path = envelope_path(user);
     if !path.exists() {
@@ -287,6 +294,7 @@ pub fn unseal_secret(user: &str) -> Result<Unsealed> {
 ///
 /// Only for callers that genuinely do not route on the kind. Anything that
 /// delivers the secret somewhere must use [`unseal_secret`].
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn unseal_password(user: &str) -> Result<Zeroizing<Vec<u8>>> {
     unseal_secret(user).map(|u| u.secret)
 }
@@ -331,6 +339,7 @@ pub enum Reseal {
 /// The "unseal fails" branch is what fixes a dbx/Secure-Boot update: the old
 /// envelope's PCR7 policy no longer satisfies, so we rebind to today's PCRs
 /// using the password the user just proved (via a successful login) they know.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn reseal_password(
     user: &str,
     password: &[u8],
@@ -475,6 +484,7 @@ fn reseal_token(user: &str, password: &[u8], env: SealedEnvelope) -> Result<Rese
 /// works with the TPM seal broken, which is exactly when a disarm matters
 /// most. Fails closed: a wrong password, a stale wrap (password changed with
 /// no login since), and a non-token envelope are all refusals, each named.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn release_token_with_password(user: &str, password: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
     let path = envelope_path(user);
     if !path.exists() {
@@ -507,6 +517,7 @@ pub fn has_sealed_password(user: &str) -> bool {
 }
 
 /// Erase `user`'s sealed password (disarms keyring unlock). Idempotent.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn forget_password(user: &str) -> Result<()> {
     let path = envelope_path(user);
     if path.exists() {

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -115,6 +115,7 @@ fn read_regular_file_capped(path: &Path, max: u64) -> std::io::Result<Vec<u8>> {
 /// creates one on first login. Absent salt means this user has no KDE wallet
 /// yet, and inventing one here would derive a key that opens nothing while
 /// looking like a successful arm.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn read_salt(home: &Path) -> Result<Zeroizing<Vec<u8>>> {
     let path = salt_path(home);
     let raw = read_regular_file_capped(&path, MAX_SALT_BYTES).map_err(|e| {
@@ -142,6 +143,7 @@ pub fn read_salt(home: &Path) -> Result<Zeroizing<Vec<u8>>> {
 /// PBKDF2-HMAC-SHA512, [`ITERATIONS`] rounds, [`KEY_LEN`] output. This is
 /// `kwallet_hash()` in `pam_kwallet.c`, which calls `gcry_kdf_derive` with
 /// `GCRY_KDF_PBKDF2` and `GCRY_MD_SHA512`.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn derive_key(secret: &[u8], salt: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
     if salt.len() != SALT_LEN {
         return Err(Error::Protocol(format!(
@@ -155,6 +157,7 @@ pub fn derive_key(secret: &[u8], salt: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
 }
 
 /// Derive `home`'s wallet key from the login password.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn derive_for_home(password: &[u8], home: &Path) -> Result<Zeroizing<Vec<u8>>> {
     let salt = read_salt(home)?;
     derive_key(password, &salt)
@@ -203,6 +206,8 @@ mod tests {
         let path = dir.join("kdewallet.salt");
         let c = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
         assert_eq!(
+            // SAFETY: `c` is a live CString that outlives this call, so the pointer is
+            // a valid NUL-terminated path for the duration of mkfifo.
             unsafe { libc::mkfifo(c.as_ptr(), 0o600) },
             0,
             "mkfifo failed"

--- a/crates/irlume-core/src/pcrsig.rs
+++ b/crates/irlume-core/src/pcrsig.rs
@@ -92,6 +92,7 @@ pub fn signed_policy_available() -> bool {
 }
 
 /// Read the authorizing public key as PEM text.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn load_pubkey_pem() -> Result<String> {
     let path = discover_pubkey_path()
         .ok_or_else(|| Error::Policy("no TPM2 PCR public key found".into()))?;
@@ -99,6 +100,7 @@ pub fn load_pubkey_pem() -> Result<String> {
 }
 
 /// Parse all signatures for `bank` from the discovered signature file.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn load_signatures(bank: &str) -> Result<Vec<PcrSignature>> {
     let path = discover_signature_path()
         .ok_or_else(|| Error::Policy("no TPM2 PCR signature file found".into()))?;
@@ -108,6 +110,7 @@ pub fn load_signatures(bank: &str) -> Result<Vec<PcrSignature>> {
 
 /// Parse signatures for `bank` from in-memory JSON (the testable core of
 /// [`load_signatures`]).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn parse_signatures(text: &str, bank: &str) -> Result<Vec<PcrSignature>> {
     let raw: HashMap<String, Vec<RawEntry>> =
         serde_json::from_str(text).map_err(|e| Error::Protocol(e.to_string()))?;

--- a/crates/irlume-core/src/policy.rs
+++ b/crates/irlume-core/src/policy.rs
@@ -66,6 +66,7 @@ pub fn method() -> Method {
 }
 
 /// Persist the active method (creates `/etc/irlume` if needed; needs root).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn set_method(m: Method) -> irlume_common::Result<()> {
     let p = path();
     if let Some(dir) = p.parent() {

--- a/crates/irlume-core/src/recovery.rs
+++ b/crates/irlume-core/src/recovery.rs
@@ -70,6 +70,7 @@ fn derive_key(
 }
 
 /// Wrap `template_key` under a fresh Argon2id-derived key from `passphrase`.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn wrap(passphrase: &[u8], template_key: &[u8]) -> Result<RecoveryEnvelope> {
     if passphrase.is_empty() {
         return Err(Error::Policy("empty recovery passphrase".into()));
@@ -92,6 +93,7 @@ pub fn wrap(passphrase: &[u8], template_key: &[u8]) -> Result<RecoveryEnvelope> 
 /// Recover the template key from a recovery envelope and passphrase. Returns a
 /// generic error on a wrong passphrase (AES-GCM tag mismatch), indistinguishable
 /// from tampering, by design.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn unwrap(passphrase: &[u8], env: &RecoveryEnvelope) -> Result<Zeroizing<Vec<u8>>> {
     if env.kdf != "argon2id" {
         return Err(Error::Policy(format!(

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -597,6 +597,7 @@ fn save_key(user: &str) -> irlume_common::Result<Option<Zeroizing<Vec<u8>>>> {
     }
 }
 
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn save(e: &Enrollment) -> irlume_common::Result<()> {
     let dir = state_dir();
     fs::create_dir_all(&dir).map_err(|er| irlume_common::Error::Io(er.to_string()))?;
@@ -617,6 +618,7 @@ pub fn save(e: &Enrollment) -> irlume_common::Result<()> {
 /// single-profile format. A plaintext file loads without touching the TPM; an
 /// encrypted file unseals the template key (and fails cleanly, with face auth
 /// falling back to the password, if the seal can no longer be satisfied).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
     let path = profile_path(user);
     if !path.exists() {
@@ -654,6 +656,7 @@ pub fn store_is_encrypted(user: &str) -> Option<bool> {
     )
 }
 
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn delete(user: &str) -> irlume_common::Result<bool> {
     let path = profile_path(user);
     let existed = path.exists();

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -70,6 +70,7 @@ pub fn has_recovery(user: &str) -> bool {
 
 /// The template key for `user`, generating and TPM-sealing a fresh one if none
 /// exists. Used on the write path ([`crate::storage::save`]).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn ensure_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
     if has_key(user) {
         return load_key(user);
@@ -81,6 +82,7 @@ pub fn ensure_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
 
 /// Unseal the existing template key for `user`. Errors if none is sealed (the
 /// caller must NOT generate one here; that would orphan already-encrypted data).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn load_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
     let path = key_path(user);
     if !path.exists() {
@@ -111,6 +113,7 @@ pub fn load_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
 
 /// (Re-)seal `key` for `user` against the current TPM PCR policy and persist it.
 /// Used at first enrollment and by recovery-restore to re-bind after a PCR move.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn reseal_key(user: &str, key: &[u8]) -> Result<()> {
     if key.len() != crypto::KEY_LEN {
         return Err(Error::Policy(format!(
@@ -128,6 +131,7 @@ pub fn reseal_key(user: &str, key: &[u8]) -> Result<()> {
 
 /// Erase `user`'s sealed template key (e.g. when their enrollment is deleted).
 /// Idempotent. Does NOT touch the recovery envelope.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn forget_key(user: &str) -> Result<()> {
     let path = key_path(user);
     if path.exists() {
@@ -140,6 +144,7 @@ pub fn forget_key(user: &str) -> Result<()> {
 
 /// Create (or replace) `user`'s recovery envelope: wrap the live template key
 /// under `passphrase`. Requires a sealed template key to already exist.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn setup_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
     let key = load_key(user)?;
     let env = crate::recovery::wrap(passphrase, &key)?;
@@ -149,6 +154,7 @@ pub fn setup_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
 /// Restore `user`'s template key from the recovery envelope using `passphrase`,
 /// and re-seal it against the *current* TPM PCRs (healing a PCR move / TPM
 /// clear / disk move). Errors on a wrong passphrase or a missing envelope.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn restore_from_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
     let path = recovery_path(user);
     if !path.exists() {
@@ -162,6 +168,7 @@ pub fn restore_from_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
 }
 
 /// Erase `user`'s recovery envelope. Idempotent.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn forget_recovery(user: &str) -> Result<()> {
     let path = recovery_path(user);
     if path.exists() {

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -397,6 +397,7 @@ pub fn stronger_tier_available_than(current: &PolicyKind) -> bool {
 /// reseal self-heals), so a reseal re-runs the ladder: it can move an envelope
 /// up a tier when one became available, and only lands on a lower tier when
 /// the higher one genuinely does not unseal on this machine.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn seal(secret: &[u8]) -> Result<SealedEnvelope> {
     if crate::pcrsig::signed_policy_available() {
         match seal_authorized(secret) {
@@ -447,6 +448,7 @@ pub fn seal(secret: &[u8]) -> Result<SealedEnvelope> {
 
 /// Seal `secret` under a literal `PolicyPCR` over `pcrs` (empty ⇒ no binding:
 /// any boot state can unseal; use only for testing).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn seal_with_pcrs(secret: &[u8], pcrs: &[u32]) -> Result<SealedEnvelope> {
     let pcrs = pcrs.to_vec();
     let mut ctx = open_context()?;
@@ -549,6 +551,7 @@ pub fn is_pcr_changed_race(e: &Error) -> bool {
 /// not re-issuing the failed command. This is the same gap systemd closed in
 /// systemd/systemd#35657, where unsealing already retried but the `PolicyPCR`
 /// leg did not.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn unseal(env: &SealedEnvelope) -> Result<Zeroizing<Vec<u8>>> {
     let out = retry_on_pcr_race(
         PCR_CHANGED_RETRIES,
@@ -1316,6 +1319,7 @@ fn unseal_pcrlock(env: &SealedEnvelope, nv_index: u32) -> Result<Zeroizing<Vec<u
 
 /// Public entry point used by the CLI / daemon to arm a pcrlock-bound seal once
 /// a pcrlock policy has been provisioned at `nv_index`.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn seal_with_pcrlock(secret: &[u8], nv_index: u32) -> Result<SealedEnvelope> {
     seal_pcrlock(secret, nv_index)
 }
@@ -1362,6 +1366,7 @@ pub fn is_pcr_mismatch(e: &Error) -> bool {
 
 /// Compare current PCR values against those stored in the envelope. Returns the
 /// PCRs whose SHA-256 differs (empty ⇒ no drift, or no values captured at seal).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn diagnose_pcrs(env: &SealedEnvelope) -> Result<Vec<u32>> {
     if env.pcr_values.is_empty() {
         return Ok(Vec::new());

--- a/crates/irlume-daemon/Cargo.toml
+++ b/crates/irlume-daemon/Cargo.toml
@@ -17,3 +17,6 @@ serde_json.workspace = true
 zeroize.workspace = true
 sha2.workspace = true
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1081,6 +1081,7 @@ fn password_matches_login(user: &str, password: &[u8]) -> Option<bool> {
     if out.is_null() {
         return None; // unsupported hash format on this libcrypt
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let computed = unsafe { std::ffi::CStr::from_ptr(out) };
     Some(computed.to_bytes() == stored.as_bytes())
 }
@@ -3887,6 +3888,7 @@ mod tests {
         assert_eq!(identify_scope(&peer(0)), IdentifyScope::Full);
         // The uid running this test resolves to a real account; its scope must
         // be exactly that username, never Full.
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let me = unsafe { libc::geteuid() };
         if me != 0 {
             let name = users::name_for_uid(me).expect("test uid has an account");
@@ -4631,7 +4633,11 @@ mod tests {
     fn peer_cred_reports_our_own_identity_on_a_socketpair() {
         let (a, _b) = UnixStream::pair().unwrap();
         let peer = peer_cred(&a).unwrap();
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         assert_eq!(peer.uid, unsafe { libc::geteuid() });
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         assert_eq!(peer.gid, unsafe { libc::getegid() });
         assert_eq!(peer.pid, std::process::id() as i32);
     }
@@ -4724,6 +4730,7 @@ mod tests {
     #[test]
     fn an_unpublished_listing_reaches_the_worker_instead_of_erroring() {
         let _summary_guard = enrollment_summary_test_lock();
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let me = users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into());
         invalidate_enrollment_summary(&me);
 
@@ -4860,6 +4867,8 @@ mod tests {
                 // Own-uid query: authorized, answered from files, no engine.
                 format!(
                     "{{\"HasSealedPassword\":{{\"user\":\"{}\"}}}}\n",
+                    // SAFETY: getuid takes no arguments, reads only this process's own real
+                    // uid, and is specified as always succeeding.
                     users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into())
                 ),
                 Box::new(|r: &Response| matches!(r, Response::HasPassword(_))),
@@ -4926,8 +4935,10 @@ mod tests {
     #[test]
     fn a_listing_serves_the_published_summary_and_misses_queue_to_the_worker() {
         let _summary_guard = enrollment_summary_test_lock();
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let me = users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into());
         let peer = Peer {
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
             uid: unsafe { libc::getuid() },
             gid: 0,
             pid: 1,

--- a/crates/irlume-daemon/src/users.rs
+++ b/crates/irlume-daemon/src/users.rs
@@ -14,6 +14,7 @@ use std::ffi::CString;
 /// Resolve a username to its uid via NSS. `None` if absent / un-encodable.
 pub fn uid_for_name(name: &str) -> Option<u32> {
     let cname = CString::new(name).ok()?;
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
     let mut buf = vec![0 as libc::c_char; 4096];
     let mut result: *mut libc::passwd = std::ptr::null_mut();
@@ -38,6 +39,7 @@ pub fn uid_for_name(name: &str) -> Option<u32> {
 /// scope a non-root peer's 1:N identify to its own account. `None` if the uid
 /// has no local/NSS account.
 pub fn name_for_uid(uid: u32) -> Option<String> {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
     let mut buf = vec![0 as libc::c_char; 4096];
     let mut result: *mut libc::passwd = std::ptr::null_mut();
@@ -60,6 +62,7 @@ pub fn name_for_uid(uid: u32) -> Option<String> {
 /// reentrant NSS lookups here exist to serve.
 pub fn home_for_name(name: &str) -> Option<std::path::PathBuf> {
     let cname = CString::new(name).ok()?;
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
     let mut buf = vec![0 as libc::c_char; 4096];
     let mut result: *mut libc::passwd = std::ptr::null_mut();
@@ -129,6 +132,7 @@ mod tests {
         assert_eq!(uid_for_name("root"), Some(0));
         assert_eq!(name_for_uid(0).as_deref(), Some("root"));
         // The uid running this test resolves to a name that resolves back.
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let me = unsafe { libc::geteuid() };
         let name = name_for_uid(me).expect("test uid must have an account");
         assert!(!name.is_empty());

--- a/crates/irlume-daemon/tests/shutdown.rs
+++ b/crates/irlume-daemon/tests/shutdown.rs
@@ -90,6 +90,7 @@ fn daemon_exits_promptly_on_sigterm() {
     // SIGTERM and require exit within 3s (default disposition is immediate;
     // this fails loudly if a handler ever swallows it).
     let pid = child.id() as i32;
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
     assert_eq!(
         rc,

--- a/crates/irlume-fingerprint/Cargo.toml
+++ b/crates/irlume-fingerprint/Cargo.toml
@@ -9,3 +9,6 @@ license.workspace = true
 # Detection/enroll-orchestration only: drives fprintd's CLI tools via
 # std::process. No deps; verification is done by pam_fprintd in the PAM stack,
 # not here, so irlume never claims the sensor and coexists with the greeter.
+
+[lints]
+workspace = true

--- a/crates/irlume-fingerprint/src/lib.rs
+++ b/crates/irlume-fingerprint/src/lib.rs
@@ -549,6 +549,7 @@ pub fn verify_once(user: &str) -> VerifyOutcome {
 /// for chip/host template desync, where the sensor's on-chip storage holds
 /// prints the host database no longer matches (dual-boot Windows enrollment,
 /// OS reinstall, BIOS "clear fingerprints"; libfprint#301, fprintd#126).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn delete_all(user: &str) -> Result<(), String> {
     let Some(del) = tool("fprintd-delete") else {
         return Err("fprintd-delete not installed".into());

--- a/crates/irlume-gkr-unlock/Cargo.toml
+++ b/crates/irlume-gkr-unlock/Cargo.toml
@@ -14,3 +14,6 @@ path = "src/main.rs"
 [dependencies]
 irlume-common.workspace = true
 libc.workspace = true
+
+[lints]
+workspace = true

--- a/crates/irlume-gkr-unlock/src/main.rs
+++ b/crates/irlume-gkr-unlock/src/main.rs
@@ -146,6 +146,7 @@ fn run(user: &str) -> Result<(), String> {
 fn connect_with_deadline(sock: &std::path::Path) -> Result<UnixStream, String> {
     use std::os::unix::io::{AsRawFd, FromRawFd};
 
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
     let bytes = sock.as_os_str().as_bytes();
     if bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
@@ -168,6 +169,7 @@ fn connect_with_deadline(sock: &std::path::Path) -> Result<UnixStream, String> {
     if fd < 0 {
         return Err(format!("socket: {}", std::io::Error::last_os_error()));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let stream = unsafe { UnixStream::from_raw_fd(fd) };
 
     // SAFETY: addr is fully initialised above; the length is its real size.
@@ -282,6 +284,7 @@ fn login_keyring_path(pw: &User) -> Result<PathBuf, String> {
 
 /// Whether this process holds privilege that the environment must not steer.
 fn privileged() -> bool {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let (euid, uid) = unsafe { (libc::geteuid(), libc::getuid()) };
     euid == 0 || uid == 0
 }
@@ -338,6 +341,9 @@ fn drop_privileges(pw: &User) -> Result<(), String> {
     // runs in-session): there is nothing to drop, and `initgroups` would fail
     // with EPERM for an unprivileged process. Verified below either way, so
     // this cannot skip a drop that was actually needed.
+    // SAFETY: getuid, geteuid, getgid and getegid take no arguments, read
+    // only the calling process's own credentials, and are specified as
+    // always succeeding, so none has a precondition for the caller to uphold.
     let already = unsafe { libc::getuid() } == pw.uid
         && unsafe { libc::geteuid() } == pw.uid
         && unsafe { libc::getgid() } == pw.gid
@@ -345,18 +351,30 @@ fn drop_privileges(pw: &User) -> Result<(), String> {
     if already {
         return Ok(());
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::initgroups(pw.name.as_ptr(), pw.gid) } != 0 {
         return Err(format!("initgroups: {}", std::io::Error::last_os_error()));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::setgid(pw.gid) } != 0 {
         return Err(format!("setgid: {}", std::io::Error::last_os_error()));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::setuid(pw.uid) } != 0 {
         return Err(format!("setuid: {}", std::io::Error::last_os_error()));
     }
+    // SAFETY: getuid, geteuid, getgid and getegid take no arguments, read
+    // only the calling process's own credentials, and are specified as
+    // always succeeding, so none has a precondition for the caller to uphold.
     if unsafe { libc::getuid() } != pw.uid
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         || unsafe { libc::geteuid() } != pw.uid
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         || unsafe { libc::getgid() } != pw.gid
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         || unsafe { libc::getegid() } != pw.gid
     {
         return Err("privilege drop did not take effect".into());
@@ -381,6 +399,7 @@ fn lookup_user(user: &str) -> Result<User, String> {
     if pw.is_null() {
         return Err(format!("no such user: {user}"));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let (uid, gid) = unsafe { ((*pw).pw_uid, (*pw).pw_gid) };
     if uid == 0 {
         return Err("refusing to unlock a keyring for uid 0".to_string());

--- a/crates/irlume-kwallet-init/Cargo.toml
+++ b/crates/irlume-kwallet-init/Cargo.toml
@@ -13,3 +13,6 @@ path = "src/main.rs"
 [dependencies]
 irlume-common.workspace = true
 libc.workspace = true
+
+[lints]
+workspace = true

--- a/crates/irlume-kwallet-init/src/main.rs
+++ b/crates/irlume-kwallet-init/src/main.rs
@@ -115,6 +115,7 @@ fn run(user: &str) -> Result<PathBuf, String> {
         return Err(format!("fork: {}", std::io::Error::last_os_error()));
     }
     if pid == 0 {
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         unsafe {
             libc::close(status_read);
             libc::close(write_fd);
@@ -127,6 +128,7 @@ fn run(user: &str) -> Result<PathBuf, String> {
         }
     }
 
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     unsafe {
         libc::close(status_write);
         libc::close(read_fd);
@@ -139,7 +141,10 @@ fn run(user: &str) -> Result<PathBuf, String> {
     // leaves the wallet locked AND removes the fallback that would have opened
     // it.
     if let Err(e) = await_exec(status_read) {
-        unsafe { libc::close(write_fd) };
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        unsafe {
+            libc::close(write_fd)
+        };
         return Err(e);
     }
 
@@ -147,7 +152,10 @@ fn run(user: &str) -> Result<PathBuf, String> {
     // waitForEnvironment() until Plasma's pam_kwallet_init connects, so we
     // deliberately do NOT wait for it to finish starting.
     write_all(write_fd, &key)?;
-    unsafe { libc::close(write_fd) };
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+    unsafe {
+        libc::close(write_fd)
+    };
     Ok(sock_path)
 }
 
@@ -156,20 +164,32 @@ fn run(user: &str) -> Result<PathBuf, String> {
 /// Order matters: supplementary groups and the gid must be set before the uid,
 /// or the process no longer holds the privilege needed to drop them.
 fn drop_privileges(pw: &User) -> Result<(), String> {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::initgroups(pw.name.as_ptr(), pw.gid) } != 0 {
         return Err(format!("initgroups: {}", std::io::Error::last_os_error()));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::setgid(pw.gid) } != 0 {
         return Err(format!("setgid: {}", std::io::Error::last_os_error()));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::setuid(pw.uid) } != 0 {
         return Err(format!("setuid: {}", std::io::Error::last_os_error()));
     }
     // Checked rather than assumed: a drop that silently did not take would leave
     // every path below running as root, which is the whole thing being avoided.
+    // SAFETY: getuid, geteuid, getgid and getegid take no arguments, read
+    // only the calling process's own credentials, and are specified as
+    // always succeeding, so none has a precondition for the caller to uphold.
     if unsafe { libc::getuid() } != pw.uid
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         || unsafe { libc::geteuid() } != pw.uid
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         || unsafe { libc::getgid() } != pw.gid
+        // SAFETY: takes no arguments, reads only this process's own
+        // credentials, and is specified as always succeeding.
         || unsafe { libc::getegid() } != pw.gid
     {
         return Err("privilege drop did not take effect".into());
@@ -179,6 +199,7 @@ fn drop_privileges(pw: &User) -> Result<(), String> {
 
 fn make_status_pipe() -> Result<(libc::c_int, libc::c_int), String> {
     let mut fds = [0 as libc::c_int; 2];
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } < 0 {
         return Err(format!("status pipe: {}", std::io::Error::last_os_error()));
     }
@@ -190,18 +211,28 @@ fn make_status_pipe() -> Result<(libc::c_int, libc::c_int), String> {
 fn await_exec(status_fd: libc::c_int) -> Result<(), String> {
     let mut byte = 0u8;
     loop {
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let n = unsafe { libc::read(status_fd, &mut byte as *mut u8 as *mut libc::c_void, 1) };
         if n == 0 {
-            unsafe { libc::close(status_fd) };
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+            unsafe {
+                libc::close(status_fd)
+            };
             return Ok(());
         }
         if n == 1 {
-            unsafe { libc::close(status_fd) };
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+            unsafe {
+                libc::close(status_fd)
+            };
             return Err("the wallet daemon failed to start (exec did not happen)".into());
         }
         let e = std::io::Error::last_os_error();
         if e.kind() != std::io::ErrorKind::Interrupted {
-            unsafe { libc::close(status_fd) };
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+            unsafe {
+                libc::close(status_fd)
+            };
             return Err(format!("reading the wallet daemon's start status: {e}"));
         }
     }
@@ -221,6 +252,7 @@ fn lookup_user(user: &str) -> Result<User, String> {
     if pw.is_null() {
         return Err(format!("no such user: {user}"));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let (uid, gid) = unsafe { ((*pw).pw_uid, (*pw).pw_gid) };
     if uid == 0 {
         return Err("refusing to open a wallet for uid 0".to_string());
@@ -235,6 +267,7 @@ fn lookup_user(user: &str) -> Result<User, String> {
 /// Whether this process holds privilege that the environment must not steer.
 /// The same check `irlume-gkr-unlock` applies to its two overrides.
 fn privileged() -> bool {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let (euid, uid) = unsafe { (libc::geteuid(), libc::getuid()) };
     euid == 0 || uid == 0
 }
@@ -275,6 +308,7 @@ fn wallet_daemon() -> Result<CString, String> {
 /// directory's owner redirect it at any root-owned file.
 fn bind_listener(path: &std::path::Path) -> Result<libc::c_int, String> {
     let bytes = path.as_os_str().as_bytes();
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
     if bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
         return Err(format!("socket path too long: {}", path.display()));
@@ -301,6 +335,7 @@ fn bind_listener(path: &std::path::Path) -> Result<libc::c_int, String> {
     if fd < 0 {
         return Err(format!("socket: {}", std::io::Error::last_os_error()));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     let rc = unsafe {
         libc::bind(
             fd,
@@ -310,12 +345,19 @@ fn bind_listener(path: &std::path::Path) -> Result<libc::c_int, String> {
     };
     if rc < 0 {
         let e = std::io::Error::last_os_error();
-        unsafe { libc::close(fd) };
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        unsafe {
+            libc::close(fd)
+        };
         return Err(format!("bind {}: {e}", path.display()));
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::listen(fd, 5) } < 0 {
         let e = std::io::Error::last_os_error();
-        unsafe { libc::close(fd) };
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        unsafe {
+            libc::close(fd)
+        };
         return Err(format!("listen: {e}"));
     }
     Ok(fd)
@@ -325,6 +367,7 @@ fn make_pipe() -> Result<(libc::c_int, libc::c_int), String> {
     let mut fds = [0 as libc::c_int; 2];
     // Plain pipe(), not O_CLOEXEC: the read end must survive execve into
     // ksecretd, which is handed its number on the command line.
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
         return Err(format!("pipe: {}", std::io::Error::last_os_error()));
     }
@@ -408,6 +451,7 @@ fn name_of(uid: libc::uid_t) -> String {
     if pw.is_null() {
         return String::new();
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     unsafe { std::ffi::CStr::from_ptr((*pw).pw_name) }
         .to_string_lossy()
         .into_owned()
@@ -419,6 +463,7 @@ fn home_of(uid: libc::uid_t) -> String {
     if pw.is_null() {
         return String::new();
     }
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     unsafe { std::ffi::CStr::from_ptr((*pw).pw_dir) }
         .to_string_lossy()
         .into_owned()
@@ -426,6 +471,7 @@ fn home_of(uid: libc::uid_t) -> String {
 
 fn write_all(fd: libc::c_int, mut buf: &[u8]) -> Result<(), String> {
     while !buf.is_empty() {
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let n = unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
         if n < 0 {
             let e = std::io::Error::last_os_error();

--- a/crates/irlume-liveness/Cargo.toml
+++ b/crates/irlume-liveness/Cargo.toml
@@ -7,3 +7,6 @@ license.workspace = true
 [dependencies]
 irlume-common.workspace = true
 irlume-vision.workspace = true
+
+[lints]
+workspace = true

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1157,6 +1157,11 @@ pub fn face_speeds(samples: &[EarSample]) -> (Vec<f32>, f32, f32) {
 /// bright when open and collapses under the lid on a blink, so open ≫ dip; a
 /// diffuse print has no glint to lose, so open ≈ dip. Returns (open, dip);
 /// both 0 if no usable face frames. Diagnostic for calibrating the second cue.
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "cannot panic: `faces` is filtered on `ear.is_some_and(..)`, so every \
+              `ear.unwrap()` below is on a value already proven to be Some"
+)]
 pub fn contrast_signature(samples: &[EarSample]) -> (f32, f32) {
     let faces: Vec<&EarSample> = samples
         .iter()

--- a/crates/irlume-pam/Cargo.toml
+++ b/crates/irlume-pam/Cargo.toml
@@ -20,3 +20,6 @@ serde_json.workspace = true
 zeroize.workspace = true
 pamsm = { version = "0.5", features = ["libpam"] }
 libc.workspace = true   # O_NONBLOCK on the kwallet helper's stdout, so the read can carry a deadline
+
+[lints]
+workspace = true

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -643,6 +643,7 @@ fn read_stdout_bounded(
     let fd = stdout.as_raw_fd();
     // SAFETY: fcntl on an fd this process owns; F_GETFL/F_SETFL touch no memory.
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
     if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
         return kill_and_fail(child);
     }

--- a/crates/irlume-vision/Cargo.toml
+++ b/crates/irlume-vision/Cargo.toml
@@ -39,3 +39,6 @@ rustfft.workspace = true
 [[example]]
 name = "tflite_runtime_probe"
 required-features = ["tflite"]
+
+[lints]
+workspace = true

--- a/crates/irlume-vision/src/align.rs
+++ b/crates/irlume-vision/src/align.rs
@@ -76,6 +76,12 @@ impl Affine2 {
 /// Each correspondence gives two linear rows in the unknowns θ = `[a, b, tx, ty]`;
 /// we solve the 4x4 normal equations directly (no SVD needed for a non-reflective
 /// similarity; equivalent to the Umeyama/`skimage.SimilarityTransform` result).
+///
+/// # Panics
+///
+/// Panics if `src` and `dst` have different lengths. Each source point must be
+/// paired with exactly one destination point for the correspondence rows to be
+/// well formed.
 pub fn estimate_similarity(src: &[(f32, f32)], dst: &[(f32, f32)]) -> Option<Affine2> {
     assert_eq!(src.len(), dst.len());
     let mut n = [[0.0f64; 4]; 4]; // AᵀA
@@ -187,6 +193,7 @@ impl RgbView<'_> {
 /// Align `frame` to the ArcFace template using `src` landmarks; return a
 /// 112x112x3 interleaved chip in **RGB** order (u8). Deterministic for fixed
 /// inputs (the property the Phase-1 identity gate relies on).
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn align_to_arcface(frame: &RgbView, src: &Landmarks5) -> irlume_common::Result<Vec<u8>> {
     // A NaN landmark slides through the least-squares fit as a NaN transform
     // that the pivoted solve does not always reject, and the sampler then

--- a/crates/irlume-vision/src/blaze_full.rs
+++ b/crates/irlume-vision/src/blaze_full.rs
@@ -107,6 +107,7 @@ impl FullRangeBlaze {
     /// Load from model bytes; the pin is enforced by the session
     /// constructor, and the tensor contract is verified here so a wrong
     /// (but correctly pinned) artifact fails at load, not at decode.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn from_pinned_bytes(bytes: &[u8]) -> irlume_common::Result<Self> {
         let session = TfliteSession::from_pinned_bytes(bytes, FULL_RANGE_BLAZE_SHA256, 2)?;
         let shape = session.input_shape()?;
@@ -126,6 +127,7 @@ impl FullRangeBlaze {
     /// Preprocessing matches the short-range rescue: square zero-pad
     /// letterbox to the larger frame side, center-of-pixel bilinear
     /// sampling, `[-1,1]` normalization.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn detect_top(
         &mut self,
         frame: &align::RgbView,
@@ -137,6 +139,7 @@ impl FullRangeBlaze {
     /// setting an operating threshold needs the sub-floor score
     /// distribution (what an empty room scores), which the default floor
     /// hides by design.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn detect_top_at(
         &mut self,
         frame: &align::RgbView,

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -539,12 +539,14 @@ mod onnx {
     }
 
     impl Embedder {
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
             Ok(Self {
                 session: build(model)?,
             })
         }
 
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_file(path: &str) -> irlume_common::Result<Self> {
             let bytes = std::fs::read(path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
             Self::load_from_memory(&bytes)
@@ -555,6 +557,7 @@ mod onnx {
         /// Preprocessing MUST match AuraFace/InsightFace exactly or genuine pairs
         /// collapse (the "identical images score 0.6" trap): channel order per
         /// [`align::INPUT_IS_RGB`], (px-127.5)/128.0, NCHW; output L2-normalized.
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn embed(&mut self, chip_rgb: &[u8]) -> irlume_common::Result<Embedding> {
             Ok(self.embed_with_norm(chip_rgb)?.0)
         }
@@ -564,6 +567,7 @@ mod onnx {
         /// at thr 0.50; FRR@0.55 13.6%→9.5%) with FAR unchanged (≤1e-4). RGB PATH
         /// ONLY: on NIR it over-smooths the low-texture embedding (no EER gain,
         /// slightly worse at low FAR), so the IR path keeps plain `embed`.
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn embed_tta(&mut self, chip_rgb: &[u8]) -> irlume_common::Result<Embedding> {
             let a = self.embed(chip_rgb)?;
             let b = self.embed(&crate::align::flip_h(chip_rgb))?;
@@ -581,6 +585,7 @@ mod onnx {
         /// embedding is still L2-normalized; the norm is the quality signal for
         /// fusion weighting / low-quality gating. (AuraFace is ArcFace-trained, not
         /// AdaFace, so the norm↔quality correlation must be validated empirically.)
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn embed_with_norm(
             &mut self,
             chip_rgb: &[u8],
@@ -614,18 +619,21 @@ mod onnx {
     }
 
     impl Adapter {
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
             Ok(Self {
                 session: build(model)?,
             })
         }
 
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_file(path: &str) -> irlume_common::Result<Self> {
             let bytes = std::fs::read(path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
             Self::load_from_memory(&bytes)
         }
 
         /// Adapt one IR embedding -> adapted vector (already L2-normalized).
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn apply(&mut self, emb: &[f32]) -> irlume_common::Result<Vec<f32>> {
             let tensor =
                 Tensor::from_array(([1i64, emb.len() as i64], emb.to_vec())).map_err(err)?;
@@ -690,6 +698,7 @@ mod onnx {
     pub const MESH_N_IRIS: usize = 478;
 
     impl FaceMesh {
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
             // TFLite flatbuffers carry the "TFL3" identifier at offset 4;
             // everything else goes to the ONNX loader, whose own parser
@@ -729,6 +738,7 @@ mod onnx {
                 input,
             })
         }
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_file(path: &str) -> irlume_common::Result<Self> {
             let bytes = std::fs::read(path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
             Self::load_from_memory(&bytes)
@@ -750,6 +760,7 @@ mod onnx {
         /// alignment refine through `.ok()`. A new caller that `?`s this
         /// error re-creates the #293 defect (one refused frame costing the
         /// whole consent watch).
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn landmarks(
             &mut self,
             frame: &align::RgbView,
@@ -815,6 +826,7 @@ mod onnx {
     /// cannot be skipped without losing the coordinates themselves (the
     /// pattern where a validation bolted on beside the data path quietly
     /// stops being called).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn map_checked_mesh_output(
         raw: &[f32],
         input: f32,
@@ -866,6 +878,7 @@ mod onnx {
     /// smear; every one came back `Ok`. Each is a broken or hostile DETECTOR,
     /// the stage #276 wants to open to third-party models, and the mesh
     /// output built on one feeds the liveness cues as confident numbers.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn mesh_box_valid(bbox: &[f32; 4], frame_w: u32, frame_h: u32) -> Result<(), String> {
         if !bbox.iter().all(|v| v.is_finite()) {
             return Err("non-finite coordinates".into());
@@ -901,6 +914,7 @@ mod onnx {
     /// mostly lives elsewhere. Non-finite output is a broken op in a
     /// converted model, and a collapsed extent is a stuck output head; both
     /// were observed as `Ok` before this gate (see the probe example).
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn mesh_output_plausible(
         lm: &[(f32, f32)],
         x0: f32,
@@ -973,11 +987,13 @@ mod onnx {
     }
 
     impl Detector {
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
             Ok(Self {
                 session: build(model)?,
             })
         }
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_file(path: &str) -> irlume_common::Result<Self> {
             let bytes = std::fs::read(path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
             Self::load_from_memory(&bytes)
@@ -986,6 +1002,7 @@ mod onnx {
         /// Detect faces in an RGB frame. Letterboxes to YuNet's square input,
         /// runs the net, groups outputs by tensor shape (cls/obj=1ch, bbox=4ch,
         /// kps=10ch) per stride, decodes, NMS, and maps coords back to the frame.
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn detect(&mut self, frame: &align::RgbView) -> irlume_common::Result<Vec<Detection>> {
             use crate::detect::{
                 decode_stride, letterbox_scale, nms, unletterbox, INPUT_SIZE, NMS_IOU,
@@ -1092,12 +1109,14 @@ mod onnx {
     }
 
     impl BlazeRescue {
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
             Ok(Self {
                 session: build(model)?,
                 anchors: blaze_anchors(),
             })
         }
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_file(path: &str) -> irlume_common::Result<Self> {
             let bytes = std::fs::read(path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
             Self::load_from_memory(&bytes)
@@ -1106,6 +1125,7 @@ mod onnx {
         /// Top-scoring face, or `None` below threshold. Returns the bbox in
         /// frame pixels (x1,y1,x2,y2) and the score. No keypoints: they are
         /// too coarse for alignment; refine with [`FaceMesh::landmarks`].
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn detect_top(
             &mut self,
             frame: &align::RgbView,
@@ -1116,6 +1136,7 @@ mod onnx {
         /// Same decode at an explicit floor, for measurement harnesses that
         /// need sub-threshold scores (the `FullRangeBlaze::detect_top_at`
         /// pattern). Production callers use [`Self::detect_top`].
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn detect_top_at(
             &mut self,
             frame: &align::RgbView,
@@ -1260,17 +1281,20 @@ mod onnx {
     }
 
     impl PadIr {
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
             Ok(Self {
                 session: build(model)?,
             })
         }
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn load_from_file(path: &str) -> irlume_common::Result<Self> {
             let bytes = std::fs::read(path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
             Self::load_from_memory(&bytes)
         }
 
         /// P(fake) for the face at `bbox` (frame pixel coords, `[x1,y1,x2,y2]`).
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn p_fake(
             &mut self,
             frame: &align::RgbView,
@@ -1571,6 +1595,7 @@ mod onnx {
                 GetApi: get_api,
                 GetVersionString: get_version,
             };
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
             let err = unsafe { inspect_api_base(&base) }.unwrap_err();
             assert_eq!(
                 err,
@@ -1581,6 +1606,7 @@ mod onnx {
 
         #[test]
         fn a_null_api_base_is_refused() {
+            #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
             let err = unsafe { inspect_api_base(std::ptr::null()) }.unwrap_err();
             assert!(
                 err.contains("OrtGetApiBase returned null"),

--- a/crates/irlume-vision/src/tflite.rs
+++ b/crates/irlume-vision/src/tflite.rs
@@ -120,6 +120,7 @@ pub fn tflite_lib_candidates(
 /// installing the runtime (or fixing the override) works without a daemon
 /// restart of whatever probing surface asked first. dlopen attempts on a
 /// handful of explicit paths are cheap.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn tflite_runtime() -> Result<&'static Library, TfliteUnavailable> {
     static LIB: OnceLock<Library> = OnceLock::new();
     if let Some(lib) = LIB.get() {
@@ -186,6 +187,7 @@ impl TfliteSession {
     /// delegate creator; 2026-08-06 research note): the explicit delegate
     /// pins the thread count and keeps delegation independent of how a
     /// replacement shared library was built.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn from_pinned_bytes(
         bytes: &[u8],
         expected_sha256: &str,
@@ -220,6 +222,7 @@ impl TfliteSession {
     /// Int64 tensor would silently write half of each element and read
     /// garbage as numbers (#296 review). A model with a different contract
     /// is refused by name, not reinterpreted.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn input_shape(&self) -> irlume_common::Result<Vec<usize>> {
         let inputs = self.interp.inputs().map_err(err)?;
         if inputs.len() != 1 {
@@ -241,6 +244,7 @@ impl TfliteSession {
     /// Run one f32 input tensor through the model and return every output
     /// as `(shape, data)`. The input length must match the input shape's
     /// element count; refusing here beats a silent partial write.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn run_f32(&mut self, input: &[f32]) -> irlume_common::Result<Vec<(Vec<usize>, Vec<f32>)>> {
         // input_shape() carries the single-input + Float32 contract checks;
         // running them here too keeps run_f32 safe for a caller that never


### PR DESCRIPTION
## What this changes

`missing_errors_doc`, `missing_panics_doc` and `undocumented_unsafe_blocks` are
all `allow` in stock clippy, and this workspace had no `[workspace.lints]` and
no `clippy.toml`. None of the three had ever fired, so 252 sites across 45 files
carried no documented panic, error condition or unsafe precondition.

All three are now `warn` at workspace level, with each of the twelve member
crates opting in through `[lints] workspace = true`. That opt-in is required:
without it no workspace lint applies at all.

## Why the existing sites use `#[expect]`

CI runs `cargo clippy --all-targets -- -D warnings` and the tree was otherwise
clean, so switching the lints on without a plan would have turned the build red
on all 252 at once.

Each remaining site is marked `#[expect(...)]` instead of being given an
invented docstring. A plausible but unchecked `// SAFETY:` comment on FFI in a
daemon that authenticates people is worse than a visible gap, so the debt is
marked rather than papered over.

`#[expect]` self-cleans: documenting a marked site makes its expectation
unfulfilled, and `unfulfilled_lint_expectations` is `warn` by default, so
`-D warnings` rejects the change until the attribute is removed. The backlog can
only shrink. This is the migration path the Rust 1.81 release notes describe for
this exact case.

## Unsafe expectations are per-expression, and that is load-bearing

A single `#[expect]` is fulfilled by one matching diagnostic anywhere inside the
item carrying it. A function-level attribute would therefore let a later
undocumented unsafe block in that same function ride along on an
already-fulfilled expectation and reach CI unflagged.

The first revision of this PR had exactly that hole. Review caught it, and every
unsafe expectation now sits on the individual unsafe expression. Proved by
planting the failure: adding an undocumented `unsafe { libc::getpid() }` inside
`password_matches_login`, which already carries one expectation, is now rejected.

21 of the 95 unsafe sites turned out to be credential getters with no
preconditions for the caller (`getuid`, `geteuid`, `getgid`, `getegid`,
`isatty`, `umask`, and `mkfifo` on a live `CString`). Those carry real safety
comments rather than debt markers. 74 remain marked.

## The five panic sites

Only `estimate_similarity` can actually panic, on its `assert_eq!` over
mismatched slice lengths, and it gets a real `# Panics` section. The other four
are guarded and cannot panic, so a `# Panics` section would have stated
something untrue. Each `#[expect]` on those names the guard instead:

- `contrast_signature`: every `unwrap` sits behind the `ear.is_some_and(..)` filter
- `capture_ear_samples`: the `mesh.is_none()` early return
- `enroll_profile`: `target` comes from the same profile list the lookup searches
- `capture_ir_sequence`: the single `take()` reopens the stream in the same branch, and both failure paths in between return early

## Verification

Run on the 1.88 MSRV and again on stable 1.96, both green:

| check | result |
| --- | --- |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo fmt --all -- --check` | pass |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked` | pass |
| `cargo test --workspace` | pass |

Three gate directions were proved by planting the failure rather than assuming:

1. a new undocumented `pub fn` returning `Result` is rejected
2. documenting a marked site is rejected until its attribute is deleted
3. a new undocumented unsafe block inside an already-marked function is rejected

The 15 deletions are rustfmt expanding `unsafe { … }` one-liners that now carry
an attribute. No executable logic changed.

## What this does not do

It does not write the remaining docs. The ratchet stops the backlog growing;
clearing it is separate work. Hardware lanes were not exercised locally, though
nothing here touches a code path that reaches hardware.
