### PR TITLE
ci: stop ASan runs stacking, and correct three false comments

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -10,9 +10,9 @@
 #
 # Deliberately NOT a required check, and deliberately not on the fast path: it
 # needs a nightly toolchain (`-Zsanitizer` is unstable), so an unrelated nightly
-# regression must not be able to block a pull request. It runs on pull requests
-# that touch the code, on main, and weekly, so a break is visible without being
-# in the way.
+# regression must not be able to block a pull request. It runs on pushes that
+# touch the code, on main, and weekly, so a break is visible without being in
+# the way.
 #
 # Two known interactions, both handled rather than papered over:
 #   * the sanitizer runtime defines its own `mlock`, so the RLIMIT_MEMLOCK
@@ -22,8 +22,10 @@
 #     the reasoning are in .github/lsan-suppressions.txt.
 name: ASan
 
-# Push-trigger only: this job runs on the self-hosted runner (see ci.yml's
-# security note; a fork PR must never reach it).
+# Push-triggered on every branch, so a same-repo pull request picks this up
+# through its own branch. A fork PR fires no push event here and therefore gets
+# no ASan run, which is acceptable precisely because this is not a required
+# check.
 on:
   push:
     branches: ["**"]
@@ -36,6 +38,26 @@ on:
   schedule:
     - cron: "40 4 * * 3" # Wednesdays 04:40 UTC, clear of the other scheduled jobs
   workflow_dispatch:
+
+# Rapid pushes to a branch should not stack ASan runs; only the newest commit is
+# worth sanitizing, and this job is one of the slowest in the repo. Cancelling is
+# safe because ASan is not a required check, so a superseded run going away
+# cannot block a merge.
+#
+# The schedule gets its OWN group, and that separation is the load-bearing part.
+# A scheduled run fires on the default branch, so keying the group on the ref
+# alone would put the weekly run in `asan-refs/heads/main` alongside ordinary
+# main pushes. A concurrency group holds exactly one PENDING run, and a newly
+# queued run "is canceled and replaced" per GitHub's concurrency documentation.
+# `cancel-in-progress: false` does not save it: that protects the run already
+# executing, not the one waiting behind it. So a main push landing while the
+# weekly run sat pending would have silently deleted the weekly run, which is
+# the opposite of what this block exists to do.
+#
+# Cancelling stays off on main so an in-flight run there still finishes.
+concurrency:
+  group: asan-${{ github.event_name == 'schedule' && 'weekly' || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/workflow-audit.yml
+++ b/.github/workflows/workflow-audit.yml
@@ -17,7 +17,9 @@
 # Deliberately hosted-runner only. Nothing here touches the self-hosted runner.
 name: Workflow audit
 
-# Push-trigger only (self-hosted runner; see ci.yml's security note).
+# Push-trigger only. Both jobs below use GitHub-hosted runners, as the note
+# three lines above says; an earlier version of this line claimed self-hosted
+# and contradicted it.
 on:
   push:
     branches: ["**"]


### PR DESCRIPTION
## The concurrency group

`asan.yml` runs on push to every branch and had no `concurrency` block, so
several runs of one of the slowest jobs in the repo could sit alive at once
while a branch was being iterated on. `ci.yml`, `hardware-checks.yml`,
`hardware-suite.yml`, `verify-release.yml` and `update-flake-lock.yml` all
already have one; this was the gap.

Cancelling superseded runs is safe here because ASan is deliberately not a
required check on main, so a run disappearing cannot block a merge. Checked
against branch protection rather than assumed: the required contexts are
`fmt · clippy · build · test`, `nix flake check`, `cargo-deny`, `test (stable)`,
`coverage`, `fuzz` and `systemd units`. ASan is not among them.

## Why the schedule needs its own group

The first revision of this PR keyed the group on `github.ref` alone and set
`cancel-in-progress: false` on main, on the reasoning that main runs would
simply queue. Review showed that reasoning was wrong, and GitHub's own
concurrency documentation is explicit: with the default queue behaviour, "any
existing `pending` job or workflow run in the same group is canceled and
replaced."

A scheduled run fires on the default branch, so it would have landed in
`asan-refs/heads/main` next to ordinary main pushes. A group holds exactly one
pending run, and `cancel-in-progress: false` protects the run already executing,
not the one queued behind it. So a main push arriving while the weekly run sat
pending would have silently deleted the weekly run, defeating the exact property
the block was written to protect.

The schedule now resolves to its own `asan-weekly` group:

| event | ref | group | cancel |
| --- | --- | --- | --- |
| schedule | refs/heads/main | `asan-weekly` | false |
| push | refs/heads/main | `asan-refs/heads/main` | false |
| push | a feature branch | `asan-<ref>` | true |

## Three comments that were wrong

All found while reading these files for the change above.

`asan.yml` said the job runs on the self-hosted runner and that a fork PR must
never reach it. Its only `runs-on` is `ubuntu-24.04` and the file has no
self-hosted label, so that described a security property the workflow does not
have. What is true: a fork PR fires no push event in this repository, so it gets
no ASan run, which is acceptable because the check is not required.

`asan.yml` also said the workflow runs on pull requests. There is no
`pull_request` trigger; a same-repo pull request picks the job up through pushes
to its own branch, which is why ASan appears on those PRs at all.

`workflow-audit.yml` said `Push-trigger only (self-hosted runner; see ci.yml's
security note)` three lines below `Deliberately hosted-runner only. Nothing here
touches the self-hosted runner.` Both of its jobs are `ubuntu-24.04`, so the
file contradicted itself. Included here because it is the same defect in the
same sweep rather than a new one.

## Verification

Run with the same pinned `actionlint` 1.7.12 that the `workflow-audit` job uses,
checksum-verified against the value in that workflow before running, and with
`shellcheck` present so `run:` block findings are not silently dropped. Clean
across every workflow in the repository.

Both files parse, and the `concurrency` block resolves to the groups in the
table above. No job body, step, trigger or permission changed.
