### PR TITLE
Every typed secret in the CLI is read into a wiping string (#348)

### DIFF
--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1445,8 +1445,9 @@ pub fn reseal(args: &[String]) -> ExitCode {
 /// for scripts/tests. Returns `None` on mismatch / empty / read error.
 ///
 /// Reads through [`crate::read_password`], so the password and its confirm copy
-/// are both wiped on drop. Callers must keep the value inside the wrapper: a
-/// `.clone()` or a `to_string()` makes a second copy that nothing wipes.
+/// are both wiped on drop. Callers must keep the value inside the wrapper:
+/// anything that leaves it, such as `to_string()` or `format!`, produces a
+/// plain `String` that nothing wipes.
 pub(crate) fn prompt_login_password() -> Option<zeroize::Zeroizing<String>> {
     // Sampled once, and used only to decide whether a confirm prompt makes
     // sense; `read_password` makes the same terminal/pipe split itself.

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1420,7 +1420,9 @@ pub fn reseal(args: &[String]) -> ExitCode {
     let req = Request::SealPassword {
         kind: None, // let the daemon judge from what the user has
         user,
-        password: irlume_common::SecretBytes::new(pw.into_bytes()),
+        // Copy the bytes out rather than moving the `String`: `Zeroizing` owns
+        // the buffer and wipes it on drop, and `SecretBytes` wipes the copy.
+        password: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
     };
     match daemon_request(&req) {
         Ok(Response::PasswordSealed) => {
@@ -1441,30 +1443,34 @@ pub fn reseal(args: &[String]) -> ExitCode {
 /// Shared no-echo login-password prompt with a confirm step (catches typos that
 /// would silently break wallet unlock). Falls back to a single piped stdin line
 /// for scripts/tests. Returns `None` on mismatch / empty / read error.
-pub(crate) fn prompt_login_password() -> Option<String> {
-    use std::io::IsTerminal;
-    if std::io::stdin().is_terminal() {
-        let a = rpassword::prompt_password("Login password: ").ok()?;
-        let b = rpassword::prompt_password("Confirm login password: ").ok()?;
-        if a != b {
+///
+/// Reads through [`crate::read_password`], so the password and its confirm copy
+/// are both wiped on drop. Callers must keep the value inside the wrapper: a
+/// `.clone()` or a `to_string()` makes a second copy that nothing wipes.
+pub(crate) fn prompt_login_password() -> Option<zeroize::Zeroizing<String>> {
+    // Sampled once, and used only to decide whether a confirm prompt makes
+    // sense; `read_password` makes the same terminal/pipe split itself.
+    let interactive = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    let pw = crate::read_password("Login password: ")
+        .map_err(|e| eprintln!("{e}"))
+        .ok()?;
+    // Confirm only on a terminal. On a pipe there is nothing to retype: a
+    // second read would consume the NEXT line of the script's stdin and
+    // compare the password against whatever happened to follow it.
+    if interactive {
+        let again = crate::read_password("Confirm login password: ")
+            .map_err(|e| eprintln!("{e}"))
+            .ok()?;
+        if pw != again {
             eprintln!("passwords do not match; aborted (nothing changed).");
             return None;
         }
-        if a.is_empty() {
-            eprintln!("empty password; aborted.");
-            return None;
-        }
-        Some(a)
-    } else {
-        use std::io::BufRead;
-        let mut line = String::new();
-        std::io::stdin().lock().read_line(&mut line).ok()?;
-        let pw = line.trim_end_matches(['\n', '\r']).to_string();
-        if pw.is_empty() {
-            return None;
-        }
-        Some(pw)
     }
+    if pw.is_empty() {
+        eprintln!("empty password; aborted.");
+        return None;
+    }
+    Some(pw)
 }
 
 /// `irlume setup`: guided onboarding that ties the existing pieces together:
@@ -1578,7 +1584,10 @@ pub fn setup(args: &[String]) -> ExitCode {
             match daemon_request(&Request::SealPassword {
                 kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
-                password: irlume_common::SecretBytes::new(pw.clone().into_bytes()),
+                // `pw` has to outlive this request for the token branch below,
+                // so the bytes are copied rather than moved. The old `.clone()`
+                // here left a whole second password on the heap unwiped.
+                password: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
             }) {
                 Ok(Response::PasswordSealed) => println!("  armed {OK}"),
                 // GNOME token arm: the wizard runs in the user's session, so

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1189,8 +1189,9 @@ pub(crate) fn finish_token_arm(
     }
 }
 
-/// Read the user's login password without echo, mirroring the arm prompt's
-/// terminal/pipe split.
+/// Read a typed secret without echo, mirroring the arm prompt's terminal/pipe
+/// split. Every no-echo prompt in this binary reads through here: the login
+/// password (`keyring arm`, `reseal`, `setup`) and the recovery passphrase.
 ///
 /// The secret is wrapped in `Zeroizing` at the point it is first held, the same
 /// as the TUI's `Pending::KeyringPw`, so it is wiped from the heap on drop
@@ -4607,6 +4608,17 @@ mod tests {
         fn accepts_only_a_wiping_reader(_: fn(&str) -> Result<zeroize::Zeroizing<String>, String>) {
         }
         accepts_only_a_wiping_reader(read_password);
+    }
+
+    #[test]
+    fn every_login_password_prompt_hands_back_a_wiping_string() {
+        // Same pin, one level up (#348). `read_password` returning `Zeroizing`
+        // bought nothing on the paths most users actually take, because the
+        // setup wizard and `reseal` read through `prompt_login_password`, which
+        // kept its own plain `String`. Pinning the reader alone did not stop
+        // that, so the prompt that wraps it is pinned too.
+        fn accepts_only_a_wiping_prompt(_: fn() -> Option<zeroize::Zeroizing<String>>) {}
+        accepts_only_a_wiping_prompt(commands::prompt_login_password);
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1194,10 +1194,15 @@ pub(crate) fn finish_token_arm(
 /// password (`keyring arm`, `reseal`, `setup`) and the recovery passphrase.
 ///
 /// The secret is wrapped in `Zeroizing` at the point it is first held, the same
-/// as the TUI's `Pending::KeyringPw`, so it is wiped from the heap on drop
-/// rather than left in swappable memory for the rest of the process. Callers
-/// must keep it inside the wrapper: a `.clone()` or a `to_string()` makes a
-/// second copy that nothing wipes.
+/// as the TUI's `Pending::KeyringPw`, so the buffer is overwritten on drop
+/// instead of being freed with the password still in it. That bounds how long
+/// the plaintext lives; it cannot undo a page that was already swapped out, and
+/// nothing here excludes it from a core dump.
+///
+/// Callers must keep it inside the wrapper. `.clone()` is safe (a cloned
+/// `Zeroizing` wipes itself too), but anything that leaves the wrapper does
+/// not: `to_string()`, `as_str().to_owned()`, or `format!` all produce a plain
+/// `String` that nothing wipes.
 fn read_password(prompt: &str) -> Result<zeroize::Zeroizing<String>, String> {
     if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         rpassword::prompt_password(prompt)

--- a/crates/irlume-cli/src/recovery.rs
+++ b/crates/irlume-cli/src/recovery.rs
@@ -91,7 +91,9 @@ fn setup(user: &str) -> ExitCode {
     };
     match daemon_request(&Request::RecoverySetup {
         user: user.into(),
-        passphrase: SecretBytes::new(pass.into_bytes()),
+        // Copy out rather than move: `Zeroizing` owns the buffer and wipes
+        // it on drop, and `SecretBytes` wipes the copy.
+        passphrase: SecretBytes::new(pass.as_bytes().to_vec()),
     }) {
         Ok(Response::Ok(msg)) => {
             println!("[recovery] ✓ {msg}");
@@ -122,7 +124,9 @@ fn restore(user: &str) -> ExitCode {
     };
     match daemon_request(&Request::RecoveryRestore {
         user: user.into(),
-        passphrase: SecretBytes::new(pass.into_bytes()),
+        // Copy out rather than move: `Zeroizing` owns the buffer and wipes
+        // it on drop, and `SecretBytes` wipes the copy.
+        passphrase: SecretBytes::new(pass.as_bytes().to_vec()),
     }) {
         Ok(Response::Ok(msg)) => {
             println!("[recovery] ✓ {msg}");
@@ -168,33 +172,28 @@ fn forget(user: &str) -> ExitCode {
 }
 
 /// No-echo passphrase prompt with confirmation (for `setup`); falls back to a
-/// plain stdin line when piped (scripts / tests).
-fn read_passphrase_confirmed() -> Option<String> {
-    let pass = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-        let first = rpassword::prompt_password("Recovery passphrase: ").ok()?;
-        let mut confirm = rpassword::prompt_password("Confirm recovery passphrase: ").ok()?;
-        let matched = first == confirm;
-        // Wipe the extra plaintext copy of the passphrase; the accepted one is
-        // zeroized downstream once wrapped in SecretBytes.
-        use zeroize::Zeroize;
-        confirm.zeroize();
-        if !matched {
+/// plain stdin line when piped (scripts / tests). Reads through
+/// [`crate::read_password`], so both the passphrase and its confirm copy are
+/// wiped on drop.
+fn read_passphrase_confirmed() -> Option<zeroize::Zeroizing<String>> {
+    let pass = crate::read_password("Recovery passphrase: ").ok()?;
+    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        let confirm = crate::read_password("Confirm recovery passphrase: ").ok()?;
+        if pass != confirm {
             eprintln!("[recovery] passphrases do not match; aborted (nothing set).");
             return None;
         }
-        first
-    } else {
-        // No second read to compare against on a pipe, so confirmation is the one
-        // check that cannot apply here. The strength floor below still does, and
-        // it is checked AFTER this branch on purpose: it used to live inside the
-        // terminal arm, which let `irlume recovery setup </dev/null` wrap the
-        // template key under an EMPTY passphrase and report success.
-        read_piped_line()?
-    };
+    }
     // Strength floor: this passphrase is the only barrier on the recovery
     // envelope against an offline attacker with the disk, so reject a trivial
     // one (a `1`). It is a recovery key, not a login PIN; length is the cheap,
     // language-neutral proxy for entropy.
+    //
+    // Checked out here rather than inside the terminal arm on purpose. A pipe
+    // has no second read to compare against, so confirmation is the one check
+    // that cannot apply there; when the floor lived beside it, `irlume recovery
+    // setup </dev/null` wrapped the template key under an EMPTY passphrase and
+    // reported success.
     if pass.chars().count() < MIN_RECOVERY_PASSPHRASE_CHARS {
         let what = if pass.is_empty() {
             "empty passphrase".to_string()
@@ -212,12 +211,8 @@ fn read_passphrase_confirmed() -> Option<String> {
 /// 12 characters is a modest floor that still allows a memorable phrase.
 const MIN_RECOVERY_PASSPHRASE_CHARS: usize = 12;
 
-fn read_passphrase_once(prompt: &str) -> Option<String> {
-    let pass = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-        rpassword::prompt_password(prompt).ok()?
-    } else {
-        read_piped_line()?
-    };
+fn read_passphrase_once(prompt: &str) -> Option<zeroize::Zeroizing<String>> {
+    let pass = crate::read_password(prompt).ok()?;
     if pass.is_empty() {
         eprintln!("[recovery] empty passphrase; aborted.");
         return None;
@@ -225,9 +220,22 @@ fn read_passphrase_once(prompt: &str) -> Option<String> {
     Some(pass)
 }
 
-fn read_piped_line() -> Option<String> {
-    use std::io::BufRead;
-    let mut line = String::new();
-    std::io::stdin().lock().read_line(&mut line).ok()?;
-    Some(line.trim_end_matches(['\n', '\r']).to_string())
+#[cfg(test)]
+mod tests {
+    use super::{read_passphrase_confirmed, read_passphrase_once};
+
+    #[test]
+    fn both_passphrase_prompts_hand_back_a_wiping_string() {
+        // Type-level pin, the same one `read_password` and
+        // `prompt_login_password` carry: heap hygiene is invisible at runtime,
+        // so the type is what gets checked. A recovery passphrase unwraps the
+        // template key, so it is worth no less than the login password (#348).
+        fn accepts_only_a_wiping_prompt(_: fn() -> Option<zeroize::Zeroizing<String>>) {}
+        fn accepts_only_a_wiping_prompt_with_text(
+            _: fn(&str) -> Option<zeroize::Zeroizing<String>>,
+        ) {
+        }
+        accepts_only_a_wiping_prompt(read_passphrase_confirmed);
+        accepts_only_a_wiping_prompt_with_text(read_passphrase_once);
+    }
 }

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -17,7 +17,7 @@ use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 
 /// Bounded wait for the initial connect (distinct from the read timeout, which
 /// must be long enough for a camera capture).
@@ -153,6 +153,21 @@ fn map_connect_failure(e: io::Error) -> io::Error {
     }
 }
 
+/// Serialize a request into a buffer that wipes itself on every exit path.
+///
+/// `SealPassword`, `ResealPassword`, `RecoverySetup` and `RecoveryRestore`
+/// carry a `SecretBytes`, and serialization copies those bytes into this buffer
+/// as plain JSON. Returning a wiping owner rather than wiping after the send is
+/// what covers the error paths: the send is two fallible calls, and an early
+/// return from either used to free this buffer with the secret still in it.
+fn serialize_request(req: &Request) -> io::Result<Zeroizing<Vec<u8>>> {
+    let mut line = Zeroizing::new(
+        serde_json::to_vec(req).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+    );
+    line.push(b'\n');
+    Ok(line)
+}
+
 fn request_with_timeouts(
     req: &Request,
     connect_timeout: Duration,
@@ -163,18 +178,19 @@ fn request_with_timeouts(
     stream.set_read_timeout(Some(rw_timeout))?;
     stream.set_write_timeout(Some(rw_timeout))?;
 
-    let mut line =
-        serde_json::to_vec(req).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    line.push(b'\n');
+    let line = serialize_request(req)?;
     // Map send/first-read failures too, not just connect: on newer kernels
     // (7.1.4-zen, found by the self-hosted runner) a stale socket file CONNECTS
     // successfully and only resets on the first write/read, so a connect-only
     // mapping left a raw ECONNRESET. Before any bytes are exchanged, a reset or
     // broken pipe still means "nobody is really listening".
+    //
+    // Those two `?` are why `line` is a wiping owner rather than a plain Vec
+    // wiped after the writes: either one returns early, and the buffer holding
+    // the serialized password would have been freed unwiped on exactly the
+    // path the comment above says happens in the field.
     (&stream).write_all(&line).map_err(map_connect_failure)?;
     (&stream).flush().map_err(map_connect_failure)?;
-    // The request may carry a password (SealPassword/RecoverySetup); wipe it.
-    line.zeroize();
 
     // Capped, like the daemon caps requests. `SO_RCVTIMEO` restarts on every
     // read, so the rw budget bounds one read and not the exchange: a peer that
@@ -639,5 +655,26 @@ mod tests {
                 "{kind:?} lost its message"
             );
         }
+    }
+
+    #[test]
+    fn a_serialized_request_is_owned_by_a_wiping_buffer() {
+        // The send is two fallible calls, and `?` on either skips anything
+        // written after them, so wiping the buffer after the flush left the
+        // secret on the heap on exactly the reset/broken-pipe path this file
+        // documents as happening in the field. The wipe therefore has to ride
+        // on the type, and the type is what gets pinned: heap hygiene is not
+        // observable at runtime, so this stops compiling rather than failing.
+        fn accepts_only_a_wiping_serializer(_: fn(&Request) -> io::Result<Zeroizing<Vec<u8>>>) {}
+        accepts_only_a_wiping_serializer(serialize_request);
+
+        // The buffer still has to be the wire format the daemon parses: one
+        // JSON object, newline-terminated.
+        let line = serialize_request(&Request::Ping).expect("Ping serializes");
+        assert!(line.ends_with(b"\n"), "requests are newline-terminated");
+        assert!(
+            serde_json::from_slice::<Request>(&line[..line.len() - 1]).is_ok(),
+            "the wiping buffer still carries parseable JSON"
+        );
     }
 }


### PR DESCRIPTION
Closes #348.

PR #347 wrapped `keyring arm`'s password read in `Zeroizing` and pinned it with a type-level test. The two paths most users actually take kept their own plain `String`: the setup wizard's step 4 and `reseal` both read through `prompt_login_password`, which held the password, its confirm copy, and on a pipe the untrimmed line, in allocations nothing wipes. The setup wizard then made a fourth copy with `.clone()`, which the reader's own doc forbids.

All three now read through `read_password`. The confirm step and the empty check stay in `prompt_login_password`, because the CLI tests pin their exit codes. The confirm prompt is guarded by `is_terminal`: `read_password`'s pipe branch consumes a line, so a second read would compare the password against whatever followed it in the script's stdin.

## The recovery passphrase came along

`recovery.rs` had the identical defect one file over, down to the same untrimmed original in its piped branch. Fixing only the login password would have left the crate with the exact defect this PR claims to close, under a different name, and no way for the next reader to tell whether it was considered. `read_piped_line` goes away with it.

## Evidence

Heap residue is not observable from a test, so both new guards are type-level, and both were proven to fire by reverting the return type to `String`:

- `prompt_login_password` back to `String`: one compile error, at the pin. The call sites still compiled, so the pin is the only thing standing between this and a silent regression.
- `read_passphrase_once` back to `String`: one compile error, at the pin.

The tree was restored from a pre-mutant snapshot and byte-compared afterwards.

Gate: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, the doc lane, and `run-tests-guarded.sh --min 650` at 1266 tests. All green.

## What was not tested

No hardware path is involved; this is terminal input handling in the CLI. Nothing here proves memory is wiped, only that the type carrying the wipe cannot be dropped without a build failure. The TUI and PAM paths were already on wiping types and are untouched.

One deliberate behaviour change: an empty piped password now says why it aborted instead of exiting 2 in silence. Exit codes are unchanged, which is what the existing tests assert.
