### PR TITLE
The daemon's config root is created, not merely permitted (#307)

### DIFF
--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -5511,6 +5511,56 @@ mod tests {
         );
     }
 
+    /// The config root has to be GRANTED, not merely permitted (#307).
+    ///
+    /// `ReadWritePaths=-/etc/irlume` reads like a write grant and is not one on
+    /// a fresh install: the leading `-` makes systemd skip an entry whose path
+    /// does not exist, no packaging lane creates this directory, and the
+    /// daemon then saw an entirely read-only /etc. `camera-tune` failed with
+    /// EROFS after a full minute of measurement, and `set-cameras` was worse
+    /// still, reporting success and silently losing the pin at restart.
+    ///
+    /// So the assertion is on `ConfigurationDirectory=`, which creates the
+    /// directory before the namespace is assembled and cannot be skipped.
+    /// Measured on Arch/systemd 261 with the directory absent: with
+    /// `ReadWritePaths` alone the write failed "Read-only file system"; with
+    /// `ConfigurationDirectory` alone it succeeded.
+    ///
+    /// Reads the shipped unit for the same reason the watchdog test above
+    /// does. What it cannot see is `nix/module.nix`, which carries a
+    /// hand-mirrored copy of these directives that nothing in CI compares.
+    #[test]
+    fn the_shipped_unit_creates_the_config_root_it_writes_into() {
+        let unit_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../packaging/systemd/irlumed.service"
+        );
+        let unit =
+            std::fs::read_to_string(unit_path).unwrap_or_else(|e| panic!("read {unit_path}: {e}"));
+        let declared: Vec<&str> = unit
+            .lines()
+            .filter_map(|l| l.trim().strip_prefix("ConfigurationDirectory="))
+            .map(str::trim)
+            .collect();
+        // The name is relative to /etc, so it must be the bare directory name;
+        // an absolute path here is a config error systemd would reject.
+        assert_eq!(
+            declared,
+            ["irlume"],
+            "irlumed.service must declare ConfigurationDirectory=irlume so the \
+             config root exists before the namespace is built (#307); \
+             ReadWritePaths alone is skipped when the path is missing"
+        );
+        // The path the daemon actually writes, so the unit and the code cannot
+        // drift apart into a grant for a directory nothing uses.
+        assert_eq!(
+            irlume_common::config::CONFIG_ROOT,
+            "/etc/irlume",
+            "ConfigurationDirectory=irlume grants /etc/irlume; the daemon's \
+             config root moved without the unit following it"
+        );
+    }
+
     /// The explanatory refusal line is printed once per uid, so a local process
     /// spinning on a request it knows will be refused cannot fill the journal,
     /// while each distinct surface still gets its one explanation.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -247,8 +247,13 @@ in
         ProtectSystem = "full";
         # The daemon writes the camera pin and the stored capture mode under
         # /etc/irlume, which ProtectSystem=full would otherwise mount read-only.
-        # Leading "-" so a host that has never had the directory still starts.
-        ReadWritePaths = [ "-/etc/irlume" ];
+        # ConfigurationDirectory creates the directory before the namespace is
+        # assembled and binds it read-write; the ReadWritePaths entry that used
+        # to be here did not, because its leading "-" makes systemd skip a path
+        # that does not exist and no lane creates this one (#307). Kept in sync
+        # by hand with packaging/systemd/irlumed.service, which nothing in CI
+        # enforces.
+        ConfigurationDirectory = "irlume";
         PrivateTmp = true;
         ProtectKernelTunables = true;
         ProtectKernelModules = true;

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -59,11 +59,40 @@ ProtectSystem=full
 # ...but the daemon owns two files under the config root: the camera pin written
 # by `set-cameras` (which is also the anti-injection binding, re-anchored by
 # vid:pid:serial after a udev renumber) and the capture mode stored by
-# `camera-tune`. ProtectSystem=full mounts /etc read-only, so without this both
-# writes fail on a packaged install and neither setting survives a restart. The
-# leading `-` is required: no lane creates /etc/irlume, so a host that has never
-# had one would otherwise fail to start.
-ReadWritePaths=-/etc/irlume
+# `camera-tune`. ProtectSystem=full mounts /etc read-only, so without a
+# writable exception both writes fail on a packaged install and neither
+# setting survives a restart.
+#
+# ConfigurationDirectory is what grants it, and it is here because
+# ReadWritePaths alone did NOT (#307). NO packaging lane creates /etc/irlume,
+# on any distro, and the leading `-` that kept a fresh host bootable made
+# systemd SKIP the entry when the path was missing, so the daemon got an
+# entirely read-only /etc and `camera-tune` died with EROFS after a full
+# minute of measurement.
+#
+# It was reported on Arch, but the variable is HOST STATE, not the lane. The
+# only thing that has ever created this directory is `policy::set_method`,
+# reached from `irlume fingerprint enable`, which runs in the unsandboxed CLI
+# and so succeeds. A host that ran it has the directory and never sees the
+# bug; a fresh host on any lane does. Do not read this as an Arch fix.
+#
+# ConfigurationDirectory has no such hole: systemd creates the directory
+# before it assembles the namespace, then binds it read-write, so the grant
+# cannot depend on anything else having made the directory first.
+#
+# Measured with the directory absent beforehand, on Arch/systemd 261 (bare
+# metal) and on Ubuntu 22.04/systemd 249 and Debian 12/systemd 252
+# (privileged containers, sandbox confirmed live): ReadWritePaths alone
+# failed "Read-only file system" on all three, ConfigurationDirectory alone
+# succeeded on all three. 249 is the oldest systemd any lane ships to, so
+# the ReadWritePaths line that used to sit here is gone rather than kept as
+# a belt. It granted nothing, and a directive that reads like the write
+# grant without being one is what cost a release this bug.
+#
+# Left root-owned at 0755. ConfigurationDirectory is the one directory
+# directive systemd does NOT chown to User=, and this unit has no User=
+# anyway; the files inside are written 0600 by the daemon.
+ConfigurationDirectory=irlume
 PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes


### PR DESCRIPTION
Closes #307.

On a fresh Arch install `sudo irlume camera-tune` failed with `Read-only file system (os error 30)` after a full minute of measurement and stored nothing.

`ReadWritePaths=-/etc/irlume` reads like a write grant and is not one. The leading `-` makes systemd skip an entry whose path is missing, no packaging lane creates `/etc/irlume`, so the daemon got an entirely read-only `/etc`. The failure was sticky in a confusing way too: creating the directory by hand changed nothing until the daemon restarted, because the namespace had already been assembled.

## The issue blamed the wrong thing, and that correction matters more than the fix

The issue says Fedora never sees this because the RPM owns the directory. That is false, and I checked before repeating it: `packaging/fedora/irlume.spec` does not mention `/etc` anywhere, in `%install` or `%files`. No lane creates this directory, on any distro.

The only thing that has ever created it is `policy::set_method`, reached from `irlume fingerprint enable`, which runs in the unsandboxed CLI and therefore succeeds. So the variable is **host state, not the lane**: a machine that has run that command has the directory and never sees the bug, and a fresh machine on any lane does. The Fedora boxes had run it.

This means the bug was never Arch-specific, and a fix scoped to the Arch package would have left every other lane broken on a fresh host.

`ConfigurationDirectory=irlume` has no such hole. systemd creates the directory before assembling the namespace and then binds it read-write, so the grant no longer depends on a lane having made the directory first. That covers every lane and every install method, which the alternative in the issue (ship an empty directory from four packaging lanes) does not.

The `ReadWritePaths` line is removed rather than kept as a belt. It granted nothing on the install that reported this, and a directive that reads like the write grant without being one is what made the bug survive review.

## Measured

Directory absent beforehand, one-shot units under `ProtectSystem=full`:

| Platform | systemd | ReadWritePaths alone | ConfigurationDirectory alone |
|---|---|---|---|
| Arch, bare metal | 261 | EROFS, nothing created | wrote, file persisted |
| Ubuntu 22.04, container | 249 | EROFS | wrote |
| Debian 12, container | 252 | EROFS | wrote |

249 is the oldest systemd any lane ships to.

The container measurements needed `--privileged` and a sanity unit proving the sandbox actually applied. Rootless podman lacks `CAP_SYS_ADMIN`, and systemd then skips `ProtectSystem` setup and logs nothing for the affected unit, which produced a false pass on the first attempt. Anyone measuring sandbox directives in containers should assume the same trap.

Then end to end on archhost with the real shipped unit and the fresh-install state reproduced: systemd created `/etc/irlume` as `root:root 0755`, the daemon's `/proc/PID/mountinfo` showed `/etc/irlume /etc/irlume rw`, and a write inside that namespace succeeded. The unit and both config files were restored afterwards and compared byte for byte by sha256.

Exposure is unchanged at 3.7, so the CI ratchet's `37` stays as it is in both places it appears. `systemd-analyze verify` passes on every shipped unit, and packaging parity passes.

## Regression test

A unit test reads the shipped unit and asserts `ConfigurationDirectory=irlume`, cross-checked against `config::CONFIG_ROOT` so the unit and the code cannot drift into a grant for a directory nothing uses. Deleting the directive makes it fail, which was confirmed rather than assumed.

`nix/module.nix` carries a hand-mirrored copy of these directives and is updated in step. Nothing in CI compares the two, and the comments in both files now say so.

## What was not tested

systemd 255 and 257 sit between the measured endpoints and were not run. Not measured either: a non-root `User=`, SELinux enforcing on the service, or an explicit `ConfigurationDirectoryMode`. All runs were root with the default mode.

The install-matrix workflow still does not exercise a daemon config write on any image, which is why this escaped. Closing that needs systemd inside those containers and is not attempted here.

`set-cameras` has the same root cause with a worse shape: it catches the write failure and reports success while silently losing the camera pin at restart. This fix removes the cause on every lane, but that swallowing branch is untouched and deserves its own issue.
