### PR TITLE
Arch installs the mesh model its unit points at (#360)

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -64,9 +64,24 @@ package() {
     # transaction.
     install -Dm0755 target/release/irlume-kwallet-init "$pkgdir/usr/libexec/irlume/irlume-kwallet-init"
     install -Dm0755 target/release/irlume-gkr-unlock "$pkgdir/usr/libexec/irlume/irlume-gkr-unlock"
-    for m in glintr100 face_detection_yunet_2023mar face_landmark blaze_face_short_range; do
-        install -Dm0644 "models/$m.onnx" "$pkgdir/usr/share/irlume/models/$m.onnx"
-    done
+    # One line per model, deliberately not a loop over basenames. The loop that
+    # used to be here was keyed on ".onnx", so the mesh model could not join it
+    # and was simply forgotten: the unit pointed IRLUME_MESH_MODEL at a file
+    # this package never shipped (#360). Being absent is silent, because
+    # Engine::with_mesh treats a missing path as a no-op and returns Ok, so the
+    # daemon starts and passive liveness, the closure gesture and the BlazeFace
+    # rescue just stop working. Spelled out, each model is one line to add and
+    # check-packaging-parity.sh can see every name.
+    install -Dm0644 models/glintr100.onnx \
+        "$pkgdir/usr/share/irlume/models/glintr100.onnx"
+    install -Dm0644 models/face_detection_yunet_2023mar.onnx \
+        "$pkgdir/usr/share/irlume/models/face_detection_yunet_2023mar.onnx"
+    install -Dm0644 models/face_landmark.onnx \
+        "$pkgdir/usr/share/irlume/models/face_landmark.onnx"
+    install -Dm0644 models/blaze_face_short_range.onnx \
+        "$pkgdir/usr/share/irlume/models/blaze_face_short_range.onnx"
+    install -Dm0644 models/face_landmarks_detector.tflite \
+        "$pkgdir/usr/share/irlume/models/face_landmarks_detector.tflite"
     install -Dm0755 "$srcdir/libtensorflowlite_c-v2.19.0-linux-x64/lib/libtensorflowlite_c.so" \
         "$pkgdir/usr/share/irlume/tflite/libtensorflowlite_c.so"
     install -Dm0644 "$srcdir/libtensorflowlite_c-v2.19.0-linux-x64/LICENSE.tensorflow" \

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -88,7 +88,9 @@ done
 # liveness, the closure gesture and the BlazeFace rescue just stop working.
 #
 # So this looks for the filename next to the lane's INSTALL DESTINATION, within
-# a two-line window because two lanes wrap the install across a continuation.
+# a two-line window because two lanes wrap the install across a continuation,
+# and with comments stripped first: a checker that accepts a commented-out
+# install is a checker that passes the exact state it exists to catch.
 echo "== models named by the unit are installed by every lane =="
 unit=packaging/systemd/irlumed.service
 models=$(sed -n 's/.*IRLUME_[A-Z_]*MODEL=\([^"]*\).*/\1/p' "$unit" | xargs -r -n1 basename | sort -u)
@@ -96,31 +98,53 @@ if [ -z "$models" ]; then
   echo "  ERROR: no IRLUME_*_MODEL entries found in $unit; has the unit changed shape?"
   exit 1
 fi
+
 # Where each lane writes its payload. A filename that never appears beside one
 # of these is named but not shipped.
+#
+# An unknown lane is a hard error, not a skip. The first version returned an
+# empty marker for anything unlisted, and `grep -F ''` matches every line, so
+# adding a lane here without adding its destination would have made every model
+# pass vacuously: a guard that reports ok while checking nothing.
+# These markers are literal text to search for, not variables to expand: the
+# manifests contain the strings `$pkgdir` and `$out` verbatim.
+# shellcheck disable=SC2016
 dest_for() {
   case "$1" in
     packaging/fedora/irlume.spec)  echo '%{buildroot}' ;;
     packaging/arch/PKGBUILD)       echo '$pkgdir' ;;
     packaging/debian/nfpm.yaml)    echo 'dst:' ;;
     packaging/ppa/debian/rules)    echo 'debian/irlume' ;;
-    *)                             echo '' ;;
+    *)
+      echo "  ERROR: no install destination known for lane $1;" >&2
+      echo "  add one to dest_for() in $0 rather than leaving it unchecked." >&2
+      exit 1
+      ;;
   esac
 }
+
+# All four manifests use '#' comments. Stripping them is what stops a
+# commented-out install from reading as a live one.
+uncommented() { sed 's/[[:space:]]*#.*$//' "$1"; }
+
 for model in $models; do
   for lane in "${LANES[@]}"; do
     dest="$(dest_for "$lane")"
-    if grep -F -A1 -- "$model" "$lane" | grep -qF -- "$dest"; then
+    if uncommented "$lane" | grep -F -A1 -- "$model" | grep -qF -- "$dest"; then
       printf '  ok    %-34s %s\n' "$model" "$lane"
     else
       printf '  MISS  %-34s %s (named but not installed)\n' "$model" "$lane"
       fail=1
     fi
   done
-  # Nix installs models by extension glob rather than by name, so ask the
-  # question its own way: is this file fetched, and is its extension copied?
+
+  # Nix builds a models derivation and then installs from it by extension glob,
+  # so ask both halves separately. Checking only the fetch would pass a model
+  # that was downloaded and then never copied into the derivation output.
   ext="${model##*.}"
-  if grep -qF -- "$model" nix/package.nix && grep -qE "\*\.$ext\"? +\"?\\\$out" nix/package.nix; then
+  # shellcheck disable=SC2016  # `$out` is literal text in the derivation
+  if uncommented nix/package.nix | grep -F -- "$model" | grep -qF -- '$out' \
+    && uncommented nix/package.nix | grep -qF -- "*.$ext"; then
     printf '  ok    %-34s %s\n' "$model" nix/package.nix
   else
     printf '  MISS  %-34s %s (named but not installed)\n' "$model" nix/package.nix

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -76,6 +76,58 @@ for unit_path in "${units[@]}"; do
   done
 done
 
+# Every model the shipped unit NAMES must actually be INSTALLED by every lane.
+#
+# The units check above greps for a filename anywhere in the manifest, which is
+# not the same question. The Arch PKGBUILD downloaded face_landmarks_detector
+# .tflite, listed it in source=(), staged it in prepare(), installed the TFLite
+# RUNTIME, and never installed the MODEL; the filename was present twice, so a
+# name grep was satisfied while `IRLUME_MESH_MODEL` pointed at a file the
+# package did not ship (#360). Being absent is silent: Engine::with_mesh treats
+# a missing path as a no-op and returns Ok, so the daemon starts and passive
+# liveness, the closure gesture and the BlazeFace rescue just stop working.
+#
+# So this looks for the filename next to the lane's INSTALL DESTINATION, within
+# a two-line window because two lanes wrap the install across a continuation.
+echo "== models named by the unit are installed by every lane =="
+unit=packaging/systemd/irlumed.service
+models=$(sed -n 's/.*IRLUME_[A-Z_]*MODEL=\([^"]*\).*/\1/p' "$unit" | xargs -r -n1 basename | sort -u)
+if [ -z "$models" ]; then
+  echo "  ERROR: no IRLUME_*_MODEL entries found in $unit; has the unit changed shape?"
+  exit 1
+fi
+# Where each lane writes its payload. A filename that never appears beside one
+# of these is named but not shipped.
+dest_for() {
+  case "$1" in
+    packaging/fedora/irlume.spec)  echo '%{buildroot}' ;;
+    packaging/arch/PKGBUILD)       echo '$pkgdir' ;;
+    packaging/debian/nfpm.yaml)    echo 'dst:' ;;
+    packaging/ppa/debian/rules)    echo 'debian/irlume' ;;
+    *)                             echo '' ;;
+  esac
+}
+for model in $models; do
+  for lane in "${LANES[@]}"; do
+    dest="$(dest_for "$lane")"
+    if grep -F -A1 -- "$model" "$lane" | grep -qF -- "$dest"; then
+      printf '  ok    %-34s %s\n' "$model" "$lane"
+    else
+      printf '  MISS  %-34s %s (named but not installed)\n' "$model" "$lane"
+      fail=1
+    fi
+  done
+  # Nix installs models by extension glob rather than by name, so ask the
+  # question its own way: is this file fetched, and is its extension copied?
+  ext="${model##*.}"
+  if grep -qF -- "$model" nix/package.nix && grep -qE "\*\.$ext\"? +\"?\\\$out" nix/package.nix; then
+    printf '  ok    %-34s %s\n' "$model" nix/package.nix
+  else
+    printf '  MISS  %-34s %s (named but not installed)\n' "$model" nix/package.nix
+    fail=1
+  fi
+done
+
 echo
 echo "== version agreement =="
 cargo_v="$(sed -n 's/^version *= *"\([^"]*\)".*/\1/p' Cargo.toml | head -1)"


### PR DESCRIPTION
Closes #360.

The PKGBUILD downloaded `face_landmarks_detector.tflite`, listed it in `source()`, staged it in `prepare()`, installed the TFLite **runtime**, and never installed the **model**. The unit it ships sets `IRLUME_MESH_MODEL=/usr/share/irlume/models/face_landmarks_detector.tflite`.

Every other lane installs it, including Arch's own `build-pkg.sh`. The release recipe was the one Arch path missing the line its sibling already had.

Being absent is silent. `Engine::with_mesh` treats a missing path as a no-op and returns `Ok`, so the daemon starts and logs one line. Then, on Arch only:

- the BlazeFace saturated-frame rescue is dead, even though `blaze_face_short_range.onnx` **is** installed
- passive-liveness EAR sampling is skipped
- the eye-closure consent gesture is unavailable
- any user with `require_challenge` set is denied on every attempt and pushed to the password
- with `IRLUME_MODELS_STRICT=1` the daemon refuses to start

and the journal line names `face_landmark.onnx`, a file that is present.

## The loop is gone

The models were installed by a loop over basenames with `.onnx` appended, so the mesh model could not join it and was simply forgotten. That is why one lane went wrong while five stayed right. It is now one line per model: adding a model is adding a line, in a form a checker can see.

## The parity check that would have caught it

`check-packaging-parity.sh` greps each manifest for filenames, and the filename **was** present, twice, in `source()` and `prepare()`. A name grep was satisfied while the package shipped nothing.

The new check asks the different question: every model the shipped unit names in an `IRLUME_*_MODEL` line must appear beside that lane's install destination (`%{buildroot}`, `$pkgdir`, `dst:`, `debian/irlume`), within a two-line window because two lanes wrap the install across a continuation. Nix is asked its own way, since it installs by extension glob rather than by name.

Proven both directions rather than assumed: with the install line removed the script prints `MISS ... (named but not installed)` and exits 1; with it present it exits 0. Full parity passes.

Writing this check is also what surfaced the loop. Its first run reported the three `.onnx` models as missing on Arch, which was the checker being right about something real: their names never appeared in the manifest at all, so no filename-based verification could ever have covered them.

## What was not tested

No Arch package was built from this recipe, so the resulting file list is not observed, only the recipe. archhost runs 0.7.0, which predates the TFLite switch, so its installed file list does not settle the current recipe either.

The check covers models named by the unit. It does not cover the TFLite runtime, the AppArmor profile, or any other payload, and it still cannot see a lane that installs a file to the wrong path.
