### PR TITLE
Correct comments that assert facts the sources contradict (#364)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,9 @@ missing_errors_doc = "warn"
 missing_panics_doc = "warn"
 undocumented_unsafe_blocks = "warn"
 
-# Shared dependency versions. Heavy/native deps are listed but commented so the
-# scaffold compiles offline as pure stubs; uncomment per crate as you implement.
+# Shared dependency versions, inherited by member crates with
+# `dep = { workspace = true }`. Every entry below is live; the scaffold-era note
+# that used to sit here described stubs that no longer exist.
 [workspace.dependencies]
 irlume-common   = { path = "crates/irlume-common" }
 irlume-camera   = { path = "crates/irlume-camera" }
@@ -82,11 +83,16 @@ ort     = { version = "=2.0.0-rc.12", default-features = false, features = ["loa
 
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "bmp"] }
 
-# --- native deps (enable as you build each crate) -----------------------------
-# nokhwa    = { version = "0.10", features = ["input-native"] }   # V4L2 capture
-# tss-esapi = "7"                                                 # TPM 2.0
-# pamsm     = "0.5"                                               # PAM service module
-# secrecy   = "0.10"
+# --- considered and not used -------------------------------------------------
+# nokhwa  = { version = "0.10", features = ["input-native"] }  # rejected: it
+#           wraps the `v4l` crate this workspace uses directly. See the note in
+#           crates/irlume-camera/Cargo.toml.
+# secrecy = "0.10"                                             # never adopted;
+#           secrets use irlume-common's SecretBytes and zeroize::Zeroizing.
+#
+# tss-esapi and pamsm used to sit in this block as "enable as you build". Both
+# have been live for a long time: tss-esapi above, pamsm in
+# crates/irlume-pam/Cargo.toml.
 
 [profile.release]
 lto = true

--- a/crates/README.md
+++ b/crates/README.md
@@ -77,7 +77,8 @@ gnome-keyring or ksecretd so the wallet opens without a prompt.
 **irlume-cli** is the same socket client grown a full CLI and TUI: setup,
 enrollment, diagnostics, model management, uninstall. For development and
 benchmarks it can also drive the Engine directly, bypassing the daemon
-(the dashed arrow). **irlume-fingerprint** wraps fprintd so a fingerprint
+(the solid `cli --> auth` edge; the dotted one is the socket path it
+bypasses). **irlume-fingerprint** wraps fprintd so a fingerprint
 can stand beside face auth where hardware exists.
 
 ## What the graph does and does not promise

--- a/crates/irlume-camera/src/ir_metadata.rs
+++ b/crates/irlume-camera/src/ir_metadata.rs
@@ -96,8 +96,12 @@ const fn fourcc(c: &[u8; 4]) -> u32 {
 struct V4l2Format {
     kind: u32,
     _pad: u32,
-    /// `struct v4l2_meta_format { __u32 dataformat; __u32 buffersize; }`,
-    /// followed by the rest of the 200-byte union.
+    /// `struct v4l2_meta_format { __u32 dataformat; __u32 buffersize; __u32
+    /// width; __u32 height; __u32 bytesperline; }` packed, followed by the rest
+    /// of the 200-byte union. Only the first two are set: the three line-based
+    /// fields do not apply to UVC metadata. The union is 200 bytes whichever
+    /// fields the kernel adds, so the layout below is unaffected by the three
+    /// that arrived after this comment was first written.
     dataformat: u32,
     buffersize: u32,
     _rest: [u8; 192],

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -1047,7 +1047,7 @@ fn marshal_pcr_selection(pcrs: &[u32]) -> Vec<u8> {
 /// Part 3 §23.7 eq. 20: `policyDigest_new := H(policyDigest_old ||
 /// TPM_CC_PolicyPCR || pcrs || pcrDigest)`. In a trial session the TPM uses the
 /// supplied `pcrDigest` rather than reading PCRs, which is exactly the case
-/// this replaces, so the two must agree; `super_pcr_matches_a_trial_session`
+/// this replaces, so the two must agree; `software_digests_match_a_trial_session`
 /// asserts that against real hardware.
 fn policy_pcr_digest(old: &Digest, pcrs: &[u32], pcr_digest: &Digest) -> Result<Digest> {
     let mut h = Sha256::new();

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1200,9 +1200,12 @@ pub fn contrast_signature(samples: &[EarSample]) -> (f32, f32) {
 /// length and has near-open samples just before and after it. A static print's
 /// jitter is neither deep nor a coherent drop-and-recover; slow drifts (AE
 /// settling, squints) fail the pre/post near-open check or the run-length cap.
-/// Outcome of the shared blink analysis over a sample window. Both
-/// [`detect_blink`] (any blink → live) and [`detect_deliberate_closure`] (the
-/// held-closure consent gesture) derive from this, so the anti-spoof gates and dip
+/// Outcome of the blink analysis over a sample window, consumed by
+/// [`detect_blink`] and nothing else. The consent gesture that shipped is a
+/// HELD CLOSURE, and [`detect_deliberate_closure`] does not come through here:
+/// it walks the EAR samples against per-user calibrated thresholds directly.
+/// The comment this replaces named a `detect_double_blink` that has never
+/// existed, so it described a second consumer as well as a different gesture, so the anti-spoof gates and dip
 /// detection live in exactly one place.
 enum BlinkScan {
     /// No plausibly-open eye anywhere in the window (mesh failed / print / dark).

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1201,8 +1201,8 @@ pub fn contrast_signature(samples: &[EarSample]) -> (f32, f32) {
 /// jitter is neither deep nor a coherent drop-and-recover; slow drifts (AE
 /// settling, squints) fail the pre/post near-open check or the run-length cap.
 /// Outcome of the shared blink analysis over a sample window. Both
-/// [`detect_blink`] (any blink → live) and [`detect_double_blink`] (a deliberate
-/// two-blink consent gesture) derive from this, so the anti-spoof gates and dip
+/// [`detect_blink`] (any blink → live) and [`detect_deliberate_closure`] (the
+/// held-closure consent gesture) derive from this, so the anti-spoof gates and dip
 /// detection live in exactly one place.
 enum BlinkScan {
     /// No plausibly-open eye anywhere in the window (mesh failed / print / dark).

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -39,12 +39,16 @@ WatchdogSec=90s
 # claimed. Stated explicitly so nobody has to re-derive who may ping us.
 NotifyAccess=main
 # Cap the stop wait so a package-upgrade restart can never stall on the default
-# 90s if a request is mid-flight. There is NO SIGTERM handler: the daemon
-# installs no sigaction and the default disposition kills it, so this bounds how
-# long systemd waits before SIGKILL rather than describing a graceful drain. An
-# accepted-but-unanswered request is lost and its client falls back to the
-# password; one still in the socket backlog survives, because irlumed.socket
-# owns the listening fd across the restart.
+# 90s if a request is mid-flight. This bounds how long systemd waits before
+# SIGKILL; it does not describe a graceful drain, because the socket loop has no
+# signal handling and does not stop accepting on SIGTERM. An accepted but
+# unanswered request is lost, and its client falls back to the password.
+#
+# One handler DOES exist and is easy to mistake for a shutdown path: irlume-camera
+# installs SIGINT/SIGTERM/SIGHUP handlers around IR EMITTER DISCOVERY, scoped to
+# that operation and restored after it, so a stop landing mid-`ir-setup` puts the
+# camera control back instead of leaving it changed until the next capture. It
+# aborts that one operation; it drains nothing.
 TimeoutStopSec=10s
 
 # Sandboxing, layered UNDER the SELinux/AppArmor policies (defense in depth).

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -33,20 +33,27 @@ RestartSec=2
 # Generous on purpose: an enrolment captures many scans, and it reports progress
 # between them, so this only has to exceed one capture plus inference.
 WatchdogSec=90s
-# Type=simple, so sd_notify is refused unless this says who may send it.
+# Redundant, and kept as documentation rather than as a mechanism: systemd.service(5)
+# says that when WatchdogSec= is set and NotifyAccess= is not, NotifyAccess is
+# implicitly main. Type= does not enter into it, which the previous comment here
+# claimed. Stated explicitly so nobody has to re-derive who may ping us.
 NotifyAccess=main
-# The socket loop exits promptly on SIGTERM (no long-held camera handle:
-# captures open and drop the device per request). Cap the stop wait so a
-# package-upgrade restart can never stall on the default 90s if a request is
-# mid-flight.
+# Cap the stop wait so a package-upgrade restart can never stall on the default
+# 90s if a request is mid-flight. There is NO SIGTERM handler: the daemon
+# installs no sigaction and the default disposition kills it, so this bounds how
+# long systemd waits before SIGKILL rather than describing a graceful drain. An
+# accepted-but-unanswered request is lost and its client falls back to the
+# password; one still in the socket backlog survives, because irlumed.socket
+# owns the listening fd across the restart.
 TimeoutStopSec=10s
 
 # Sandboxing, layered UNDER the SELinux/AppArmor policies (defense in depth).
 # Scoped to what the daemon actually needs: it opens /dev/video* and the TPM,
 # binds a Unix socket, and reads/writes each target user's enrollment (which is
-# why ProtectHome and PrivateDevices are deliberately NOT set, and CAP_CHOWN et
-# al are kept so it can own enrolled files to the user). MemoryDenyWriteExecute
-# stays off because the ONNX runtime JITs.
+# why ProtectHome and PrivateDevices are deliberately NOT set). The capability
+# set is CAP_DAC_OVERRIDE and CAP_FOWNER; see the note beside
+# CapabilityBoundingSet below for why CAP_CHOWN is NOT among them.
+# MemoryDenyWriteExecute stays off because the ONNX runtime JITs.
 NoNewPrivileges=yes
 # No network in the auth loop: the daemon speaks only a local Unix socket.
 # AF_NETLINK is kept for kernel device/uevent queries; no AF_INET/AF_INET6.


### PR DESCRIPTION
Closes #364.

Every claim below was checked against an authoritative source on this host, not inferred. That matters more in this repo than most: the comments are dense and load-bearing, so a wrong one gets trusted and acted on.

## irlumed.service

- **CAP_CHOWN.** The sandboxing preamble said it is kept "so it can own enrolled files to the user". `CapabilityBoundingSet` is `CAP_DAC_OVERRIDE CAP_FOWNER`. The comment 32 lines below already retracts exactly this claim, so the file asserted both. Confirmed: every `chown` in the tree is in the CLI's `pamwire` and in `irlume-kwallet-init`, none in the daemon or core.
- **NotifyAccess.** Justified with "Type=simple, so sd_notify is refused unless this says who may send it". `systemd.service(5)` states, in both the `WatchdogSec=` and `NotifyAccess=` sections, that when `WatchdogSec=` is set and `NotifyAccess=` is not, it is implicitly set to `main`. `WatchdogSec=90s` is two lines above, so the directive is redundant and `Type=` never enters into it. Kept as documentation and now labelled as such.
- **SIGTERM.** "The socket loop exits promptly on SIGTERM" described a graceful shutdown that does not exist: no `sigaction`, no `signal_hook`, no `ctrlc`, zero matches in the daemon. `TimeoutStopSec` bounds how long systemd waits before `SIGKILL`. What actually happens to an in-flight request is now written down, including that socket activation saves a request still sitting in the backlog.

This one is the same shape as #307: a directive whose comment describes a mechanism it does not have.

## Dead referents

- `irlume-liveness` referenced `detect_double_blink` and "a deliberate two-blink consent gesture". That function has never existed, one hit workspace-wide and it is the comment itself, and the gesture that shipped is a held closure (`detect_deliberate_closure`).
- `irlume-core/src/tpm.rs` pointed at `super_pcr_matches_a_trial_session` for the hardware assertion. It does not exist; the test is `software_digests_match_a_trial_session`. This is on the one function where the software policy math has to match hardware exactly.

## Facts the sources contradict

- `ir_metadata.rs` spelled `v4l2_meta_format` as two fields. `linux/videodev2.h` has five: `dataformat`, `buffersize`, `width`, `height`, `bytesperline`. Harmless to the layout, since the union is 200 bytes either way and only the first two are set, but it is a C type written down as fact that the kernel changed underneath.
- `Cargo.toml` said heavy deps were "commented so the scaffold compiles offline as pure stubs" directly above live dependencies, and listed `tss-esapi` and `pamsm` as "enable as you build" when both have been active for a long time. `nokhwa` and `secrecy` are relabelled as what they are: considered and not used.
- `crates/README.md` said the CLI drives the Engine directly "(the dashed arrow)". By the file's own legend the dotted edge is socket IPC, which is the path being bypassed; the direct one is the solid `cli --> auth` edge.

## What was not changed

No behaviour changes anywhere. `systemd-analyze verify` passes and exposure is unchanged at 3.7, so the CI ratchet stays.

Two claims from the audit are deliberately left alone because I could not close them locally, and guessing is what produced this issue in the first place: the `AF_NETLINK` justification (nothing in-tree uses netlink, but glibc NSS might), and "an abstract socket (the usual case)" in the daemon, where this host has `/run/systemd/notify` as a filesystem socket. Both are flagged in #364 as unverified rather than fixed.
