### PR TITLE
The forked child only execs what the parent already built (#363)

### DIFF
--- a/crates/irlume-common/src/memlock.rs
+++ b/crates/irlume-common/src/memlock.rs
@@ -100,8 +100,13 @@ mod tests {
             "--test-threads=1",
         ])
         .env("IRLUME_TEST_MEMLOCK_CHILD", "1");
-        // SAFETY: setrlimit is async-signal-safe; nothing else runs between
-        // fork and exec.
+        // SAFETY: nothing else runs between fork and exec, and this parent is
+        // single-threaded here, so the child inherits no lock held by another
+        // thread. Note setrlimit is NOT in POSIX.1-2024's async-signal-safe
+        // table nor in signal-safety(7); getrlimit(2) documents only MT-Safe.
+        // On Linux/glibc it is a thin syscall wrapper, which is why this is
+        // sound in practice, but that is a platform fact and not a standards
+        // guarantee, and the comment here used to claim the latter (#363).
         unsafe {
             cmd.pre_exec(|| {
                 let zero = libc::rlimit {

--- a/crates/irlume-common/src/memlock.rs
+++ b/crates/irlume-common/src/memlock.rs
@@ -70,6 +70,26 @@ mod tests {
     #[test]
     fn mlock_refusal_warns_and_continues() {
         if std::env::var("IRLUME_TEST_MEMLOCK_CHILD").is_ok() {
+            // Drop the limit HERE, after exec, rather than in a pre_exec hook.
+            // libtest runs every test on its own thread, so the parent is
+            // multi-threaded at the fork and a post-fork child may use only
+            // async-signal-safe calls; setrlimit is in neither POSIX's table nor
+            // signal-safety(7). Lowering our own limit in an ordinary process is
+            // plain libc usage with no such constraint (#363 review).
+            let zero = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            // SAFETY: `zero` is a fully initialised rlimit and the pointer is
+            // valid for the call; lowering one's own soft and hard
+            // RLIMIT_MEMLOCK is always permitted.
+            let rc = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &zero) };
+            assert_eq!(
+                rc,
+                0,
+                "could not drop RLIMIT_MEMLOCK in the child: {}",
+                std::io::Error::last_os_error()
+            );
             let secret = vec![0x5a_u8; 4096];
             lock_slice(&secret);
             println!("survived-without-mlock");
@@ -90,7 +110,6 @@ mod tests {
             }
             return;
         }
-        use std::os::unix::process::CommandExt;
         let exe = std::env::current_exe().unwrap();
         let mut cmd = std::process::Command::new(exe);
         cmd.args([
@@ -100,25 +119,6 @@ mod tests {
             "--test-threads=1",
         ])
         .env("IRLUME_TEST_MEMLOCK_CHILD", "1");
-        // SAFETY: nothing else runs between fork and exec, and this parent is
-        // single-threaded here, so the child inherits no lock held by another
-        // thread. Note setrlimit is NOT in POSIX.1-2024's async-signal-safe
-        // table nor in signal-safety(7); getrlimit(2) documents only MT-Safe.
-        // On Linux/glibc it is a thin syscall wrapper, which is why this is
-        // sound in practice, but that is a platform fact and not a standards
-        // guarantee, and the comment here used to claim the latter (#363).
-        unsafe {
-            cmd.pre_exec(|| {
-                let zero = libc::rlimit {
-                    rlim_cur: 0,
-                    rlim_max: 0,
-                };
-                if libc::setrlimit(libc::RLIMIT_MEMLOCK, &zero) != 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
         let out = cmd.output().unwrap();
         assert!(
             out.status.success(),

--- a/crates/irlume-kwallet-init/src/main.rs
+++ b/crates/irlume-kwallet-init/src/main.rs
@@ -108,7 +108,8 @@ fn run(user: &str) -> Result<PathBuf, String> {
     let (status_read, status_write) = make_status_pipe()?;
 
     // Resolved HERE, in the parent, so the child between fork() and execve()
-    // does nothing but dup2/close/execve on buffers that already exist (#363).
+    // does nothing but open/dup2/close/fcntl/execve on buffers that already
+    // exist (#363).
     // It used to call getpwuid, format! and CString::new down there. This
     // process is single-threaded at the fork, which is why that never
     // deadlocked, but getpwuid goes through NSS (dlopen, allocation, locks) and
@@ -385,10 +386,6 @@ fn make_pipe() -> Result<(libc::c_int, libc::c_int), String> {
     Ok((fds[0], fds[1]))
 }
 
-/// Drop to the target user and become the wallet daemon.
-///
-/// # Safety
-/// Must only be called in the child of a `fork()`, before any other work.
 /// Everything `execve` needs, built in the PARENT before `fork`.
 ///
 /// The child of a fork may call only async-signal-safe functions when the
@@ -462,8 +459,9 @@ impl LaunchPlan {
     }
 }
 
-/// The post-fork child: only `dup2`, `close`, `fcntl` and `execve`, all of them
-/// on the async-signal-safe list, all on buffers [`LaunchPlan`] already built.
+/// The post-fork child: only `open`, `dup2`, `close`, `fcntl` and `execve`,
+/// every one of them on the POSIX async-signal-safe list, all operating on
+/// buffers [`LaunchPlan`] already built.
 ///
 /// # Safety
 ///
@@ -606,24 +604,37 @@ mod tests {
         }
     }
 
-    /// The struct is self-referential: `argv`/`envp` point into the `CString`s
-    /// held beside them. That is only sound because a `CString`'s bytes live on
-    /// the heap, so moving the struct moves the `Vec` headers and not the
-    /// buffers. The child dereferences these pointers after a fork, so if a
-    /// move ever invalidated them the failure would be a corrupt exec in a
-    /// process that cannot report anything.
+    /// `argv`/`envp` must point at the `CString`s the plan OWNS, not at
+    /// anything temporary.
+    ///
+    /// The first version of this test moved the plan into a `Box` and compared
+    /// the strings read back before and after. That could not fail: if the
+    /// pointers ever did dangle it would be reading freed memory, which
+    /// typically still shows the old bytes, so it would have "proved"
+    /// soundness by committing the undefined behaviour it was checking for
+    /// (#363 review).
+    ///
+    /// Pointer IDENTITY is checkable without dereferencing anything. It catches
+    /// the mistake that would actually be made here: building the arrays from a
+    /// temporary rather than from the owned vectors. That a `CString`'s heap
+    /// buffer does not move when the struct moves is a language guarantee, not
+    /// something a test can establish.
     #[test]
-    fn the_plans_pointers_survive_being_moved() {
+    fn the_plans_pointers_name_the_strings_it_owns() {
         let exe = CString::new("/usr/bin/kwalletd6").unwrap();
         let plan = LaunchPlan::build(&exe, 3, 4, std::path::Path::new("/run/user/0/s.socket"))
             .expect("plan builds");
-        // SAFETY: valid until `moved` is dropped.
-        let before = unsafe { read_back(&plan.argv) };
 
-        let moved = Box::new(plan);
-        // SAFETY: the heap buffers the pointers name did not move with the struct.
-        let after = unsafe { read_back(&moved.argv) };
-
-        assert_eq!(before, after, "moving the plan must not invalidate argv");
+        assert_eq!(
+            plan.argv.len(),
+            plan._argv_owned.len() + 1,
+            "one pointer per owned string, plus the NULL"
+        );
+        for (i, owned) in plan._argv_owned.iter().enumerate() {
+            assert_eq!(plan.argv[i], owned.as_ptr(), "argv[{i}] left its owner");
+        }
+        for (i, owned) in plan._envp_owned.iter().enumerate() {
+            assert_eq!(plan.envp[i], owned.as_ptr(), "envp[{i}] left its owner");
+        }
     }
 }

--- a/crates/irlume-kwallet-init/src/main.rs
+++ b/crates/irlume-kwallet-init/src/main.rs
@@ -107,9 +107,20 @@ fn run(user: &str) -> Result<PathBuf, String> {
     // one that died before exec, and it would report success either way.
     let (status_read, status_write) = make_status_pipe()?;
 
-    // SAFETY: between fork() and execve() the child runs in a single thread and
-    // touches only async-signal-safe calls, which is the constraint fork()
-    // imposes on a process that may be multi-threaded.
+    // Resolved HERE, in the parent, so the child between fork() and execve()
+    // does nothing but dup2/close/execve on buffers that already exist (#363).
+    // It used to call getpwuid, format! and CString::new down there. This
+    // process is single-threaded at the fork, which is why that never
+    // deadlocked, but getpwuid goes through NSS (dlopen, allocation, locks) and
+    // none of it is async-signal-safe, so the old SAFETY comment claimed a
+    // property the code did not have and the correctness depended on nobody
+    // ever adding a thread above.
+    let plan = LaunchPlan::build(&exe, read_fd, listener, &sock_path)?;
+
+    // SAFETY: the child touches only async-signal-safe calls, because
+    // everything it needs was built above. `plan` outlives the fork, and its
+    // pointer arrays borrow from CString buffers on the heap, which the child
+    // inherits copy-on-write at the same addresses.
     let pid = unsafe { libc::fork() };
     if pid < 0 {
         return Err(format!("fork: {}", std::io::Error::last_os_error()));
@@ -119,7 +130,7 @@ fn run(user: &str) -> Result<PathBuf, String> {
         unsafe {
             libc::close(status_read);
             libc::close(write_fd);
-            child_exec(&exe, read_fd, listener, &sock_path);
+            child_exec(&exe, read_fd, listener, &plan);
             // Only reached when execve failed. The byte distinguishes that from
             // the EOF a successful exec produces.
             let failed = [1u8];
@@ -378,11 +389,91 @@ fn make_pipe() -> Result<(libc::c_int, libc::c_int), String> {
 ///
 /// # Safety
 /// Must only be called in the child of a `fork()`, before any other work.
+/// Everything `execve` needs, built in the PARENT before `fork`.
+///
+/// The child of a fork may call only async-signal-safe functions when the
+/// parent is multi-threaded, and `getpwuid`, `format!` and `CString::new` are
+/// none of those: `getpwuid` goes through NSS, which can `dlopen`, allocate and
+/// take locks the child may inherit held. This helper is single-threaded at the
+/// fork, so the previous version was not deadlocking, but it depended on that
+/// staying true and on a SAFETY comment that was false as written (#363).
+///
+/// Self-referential by construction: `argv`/`envp` hold pointers into the
+/// `CString`s beside them. That is sound because a `CString`'s bytes live on the
+/// heap, so moving this struct moves the `Vec` headers and not the buffers the
+/// pointers name. Nothing may push to or reallocate the owning vectors after
+/// the pointers are taken, which is why they are private and built once.
+struct LaunchPlan {
+    _argv_owned: Vec<CString>,
+    _envp_owned: Vec<CString>,
+    argv: Vec<*const libc::c_char>,
+    envp: Vec<*const libc::c_char>,
+}
+
+impl LaunchPlan {
+    fn build(
+        exe: &CString,
+        read_fd: libc::c_int,
+        listen_fd: libc::c_int,
+        sock_path: &std::path::Path,
+    ) -> Result<Self, String> {
+        // The drop already happened, so this is the target user's uid, which is
+        // the one the wallet daemon must see.
+        // SAFETY: getuid() cannot fail and touches no memory we own.
+        let uid = unsafe { libc::getuid() };
+        let cstr = |what: &str, v: String| {
+            CString::new(v).map_err(|e| format!("{what} contains a NUL byte: {e}"))
+        };
+
+        let argv_owned = vec![
+            exe.clone(),
+            cstr("argv", "--pam-login".to_string())?,
+            cstr("pipe fd", read_fd.to_string())?,
+            cstr("socket fd", listen_fd.to_string())?,
+        ];
+
+        // Without LOGIN_ENV, ksecretd never calls checkPamModule() and its
+        // argument parser rejects --pam-login as an unknown option. Verified: it
+        // exits with "Unknown option 'pam-login'" when the variable is absent.
+        //
+        // The rest of the session environment (bus address, display) arrives
+        // later over the socket; ksecretd is written to wait for exactly that.
+        let envp_owned = vec![
+            cstr(
+                "wallet socket path",
+                format!("{LOGIN_ENV}={}", sock_path.display()),
+            )?,
+            cstr("runtime dir", format!("XDG_RUNTIME_DIR=/run/user/{uid}"))?,
+            cstr("home directory", format!("HOME={}", home_of(uid)))?,
+            cstr("user name", format!("USER={}", name_of(uid)))?,
+        ];
+
+        let mut argv: Vec<*const libc::c_char> = argv_owned.iter().map(|c| c.as_ptr()).collect();
+        argv.push(std::ptr::null());
+        let mut envp: Vec<*const libc::c_char> = envp_owned.iter().map(|c| c.as_ptr()).collect();
+        envp.push(std::ptr::null());
+
+        Ok(Self {
+            _argv_owned: argv_owned,
+            _envp_owned: envp_owned,
+            argv,
+            envp,
+        })
+    }
+}
+
+/// The post-fork child: only `dup2`, `close`, `fcntl` and `execve`, all of them
+/// on the async-signal-safe list, all on buffers [`LaunchPlan`] already built.
+///
+/// # Safety
+///
+/// Runs between `fork` and `execve`. Callers must not add anything here that
+/// allocates, formats, panics or consults NSS.
 unsafe fn child_exec(
     exe: &CString,
     read_fd: libc::c_int,
     listen_fd: libc::c_int,
-    sock_path: &std::path::Path,
+    plan: &LaunchPlan,
 ) {
     // No privilege drop here: the parent already dropped, before it touched the
     // user-owned runtime directory at all.
@@ -405,37 +496,7 @@ unsafe fn child_exec(
     clear_cloexec(read_fd);
     clear_cloexec(listen_fd);
 
-    let arg0 = exe.clone();
-    let opt = CString::new("--pam-login").unwrap();
-    let a_pipe = CString::new(read_fd.to_string()).unwrap();
-    let a_sock = CString::new(listen_fd.to_string()).unwrap();
-    let argv = [
-        arg0.as_ptr(),
-        opt.as_ptr(),
-        a_pipe.as_ptr(),
-        a_sock.as_ptr(),
-        std::ptr::null(),
-    ];
-
-    // Without LOGIN_ENV, ksecretd never calls checkPamModule() and its argument
-    // parser rejects --pam-login as an unknown option. Verified: it exits with
-    // "Unknown option 'pam-login'" when the variable is absent.
-    let uid = libc::getuid();
-    let login = CString::new(format!("{LOGIN_ENV}={}", sock_path.display())).unwrap();
-    let runtime = CString::new(format!("XDG_RUNTIME_DIR=/run/user/{uid}")).unwrap();
-    let home = CString::new(format!("HOME={}", home_of(uid))).unwrap();
-    let user = CString::new(format!("USER={}", name_of(uid))).unwrap();
-    // The rest of the session environment (bus address, display) arrives later
-    // over the socket; ksecretd is written to wait for exactly that.
-    let envp = [
-        login.as_ptr(),
-        runtime.as_ptr(),
-        home.as_ptr(),
-        user.as_ptr(),
-        std::ptr::null(),
-    ];
-
-    libc::execve(exe.as_ptr(), argv.as_ptr(), envp.as_ptr());
+    libc::execve(exe.as_ptr(), plan.argv.as_ptr(), plan.envp.as_ptr());
 }
 
 unsafe fn clear_cloexec(fd: libc::c_int) {
@@ -483,4 +544,86 @@ fn write_all(fd: libc::c_int, mut buf: &[u8]) -> Result<(), String> {
         buf = &buf[n as usize..];
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LaunchPlan, LOGIN_ENV};
+    use std::ffi::{CStr, CString};
+
+    /// Read back an argv/envp array the way `execve` would: pointers until NULL.
+    ///
+    /// # Safety
+    /// `arr` must be a NUL-terminated array of valid C string pointers.
+    unsafe fn read_back(arr: &[*const libc::c_char]) -> Vec<String> {
+        let mut out = Vec::new();
+        for &p in arr {
+            if p.is_null() {
+                break;
+            }
+            out.push(CStr::from_ptr(p).to_string_lossy().into_owned());
+        }
+        out
+    }
+
+    /// The plan the child execs must be complete and NUL-terminated, because
+    /// the child can no longer build any of it (#363).
+    #[test]
+    fn the_plan_carries_a_terminated_argv_and_envp() {
+        let exe = CString::new("/usr/bin/kwalletd6").unwrap();
+        let plan = LaunchPlan::build(
+            &exe,
+            7,
+            9,
+            std::path::Path::new("/run/user/0/kwallet5.socket"),
+        )
+        .expect("plan builds");
+
+        // SAFETY: both arrays were just built NUL-terminated by `build`.
+        let (argv, envp) = unsafe { (read_back(&plan.argv), read_back(&plan.envp)) };
+
+        assert_eq!(
+            argv,
+            ["/usr/bin/kwalletd6", "--pam-login", "7", "9"],
+            "the fd numbers are passed positionally, so their order is the contract"
+        );
+        assert!(
+            plan.argv.last().is_some_and(|p| p.is_null())
+                && plan.envp.last().is_some_and(|p| p.is_null()),
+            "execve reads until NULL; without it, it walks off the end"
+        );
+        // ksecretd rejects --pam-login as an unknown option when LOGIN_ENV is
+        // absent, so its presence is load-bearing rather than cosmetic.
+        assert!(
+            envp.iter().any(|e| e.starts_with(&format!("{LOGIN_ENV}="))),
+            "wallet socket path missing from envp: {envp:?}"
+        );
+        for key in ["XDG_RUNTIME_DIR=", "HOME=", "USER="] {
+            assert!(
+                envp.iter().any(|e| e.starts_with(key)),
+                "{key} missing from envp: {envp:?}"
+            );
+        }
+    }
+
+    /// The struct is self-referential: `argv`/`envp` point into the `CString`s
+    /// held beside them. That is only sound because a `CString`'s bytes live on
+    /// the heap, so moving the struct moves the `Vec` headers and not the
+    /// buffers. The child dereferences these pointers after a fork, so if a
+    /// move ever invalidated them the failure would be a corrupt exec in a
+    /// process that cannot report anything.
+    #[test]
+    fn the_plans_pointers_survive_being_moved() {
+        let exe = CString::new("/usr/bin/kwalletd6").unwrap();
+        let plan = LaunchPlan::build(&exe, 3, 4, std::path::Path::new("/run/user/0/s.socket"))
+            .expect("plan builds");
+        // SAFETY: valid until `moved` is dropped.
+        let before = unsafe { read_back(&plan.argv) };
+
+        let moved = Box::new(plan);
+        // SAFETY: the heap buffers the pointers name did not move with the struct.
+        let after = unsafe { read_back(&moved.argv) };
+
+        assert_eq!(before, after, "moving the plan must not invalidate argv");
+    }
 }


### PR DESCRIPTION
Closes #363.

Researched before writing anything, and the research corrected the issue as I filed it.

`child_exec` ran between `fork()` and `execve()` calling `getpwuid` twice (via `name_of`/`home_of`), `format!`, `CString::new` and six `.unwrap()`s, under a SAFETY comment claiming the child "touches only async-signal-safe calls". None of those appear in POSIX.1-2024 §2.4.3's table or in `signal-safety(7)`.

## What the research changed

I filed this as a live deadlock hazard. **It is not one.** The classic `getpwuid`-after-fork deadlock needs the parent to be multi-threaded, and this helper is single-threaded at the fork: running it and reading `/proc/<pid>/status` reports `Threads: 1`, and the binary links only `libc` and `libgcc_s`. The code was not deadlocking. What was wrong was the comment, and that correctness rested on nobody ever adding a thread above the fork.

That is worth stating plainly because it is the difference between "fix this now" and "fix this properly", and I would have written the wrong justification into the commit.

## The fix

Resolved in the direction that holds whether or not a thread ever appears. `LaunchPlan::build` does the passwd lookups and builds `argv`/`envp` in the **parent**, so the child does nothing but `dup2`, `close`, `fcntl` and `execve` on buffers that already exist. Every one of those is on the async-signal-safe list.

The `.unwrap()`s go with it. A panic after fork runs unwinding machinery, which is more unsafe post-fork work, not less.

This is safe to do in the parent because `initgroups`/`setgid`/`setuid` already happen there, at line 101, before the fork at 113. So `getuid()` in the parent is already the target user's, and nothing forces the credential-derived values to be computed child-side.

## The non-obvious part

`LaunchPlan` is self-referential: `argv`/`envp` hold pointers into the `CString`s stored beside them. That is sound because a `CString`'s bytes live on the heap, so moving the struct moves the `Vec` headers and not the buffers the pointers name. The child dereferences these after a fork, where a mistake would be a corrupt exec in a process that cannot report anything, so a test pins it by moving the plan into a `Box` and reading the pointers back.

## Evidence

Both tests proven to fire by mutation:

- removing the `envp` NUL terminator fails the termination assertion
- removing `HOME` from `envp` fails the environment assertion

Gate: fmt, clippy with `-D warnings`, and 1270 tests.

## Also corrected

`crates/irlume-common/src/memlock.rs` claimed `setrlimit` is async-signal-safe. It is in neither POSIX's table nor `signal-safety(7)`; `getrlimit(2)` documents only MT-Safe. On Linux/glibc it is a thin syscall wrapper so the code is fine in practice, but the comment asserted a standards guarantee that does not exist, which is the same defect class as #364.

## What was not tested

The fork path itself was not exercised end to end. Reaching it needs root and a wallet daemon, and doing that on this machine would start one against the live session. I ran the helper far enough to confirm the argument and stdin validation still refuse a short key, and that it stops at `initgroups` when unprivileged, which is before the fork.

`posix_spawn` would now express this launch cleanly, since the privilege drop already precedes process creation, and would remove the hand-rolled status pipe (it reports pre-exec failure directly). Not done here, and noted on the issue as a follow-up rather than smuggled into a safety fix.
