### PR TITLE
An IR exposure that cannot be measured is refused, not passed (#358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Security
 
+- **The IR exposure gate was off, not lenient, on every IR camera that is not
+  8-bit grey.** `exposure_refusal` read "could not measure" as "clean", so on a
+  node negotiating `Y16`/`Y10`/`Y12`/`NV12`/`YUYV` the #237 gate never ran and
+  every liveness cue below it judged a frame nobody had checked.
+  `clipping_white_level` answers `None` for those formats, and `is_none_or`
+  turned that into a pass. The gate now states its own precondition,
+  `Signals::ir_ceiling_known`, defaulting to false, and a format that names no
+  ceiling is refused rather than passed: a gate that could not run is not a
+  gate that passed.
+
+  The refusal is not presence-retryable on either evaluator. It is a property
+  of the camera, identical on every frame, so retrying would spend the whole
+  grace window reaching the same answer while advising something that cannot
+  help; the message deliberately does not say "move back".
+
+  Blast radius, measured: `IR_CANDIDATES` tries `GREY`/`Y8`/`Y800` first, so any
+  module offering 8-bit grey is untouched. Every IR camera in the project's
+  record negotiates GREY, including both user-reported ones, and no camera
+  without a grey path has ever been reported. Such a camera can no longer
+  enroll or authenticate, and `docs/PLATFORMS.md` now says so instead of
+  listing it as untested.
+
 - **One socket request reached the keyring with an unscreened username.**
   The daemon screens the account name in every request against path
   traversal before it builds a `<user>.json` path, but the guard read a

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2714,11 +2714,20 @@ impl Engine {
                 // Dark-path kinds: Uncertain retries under grace, any Spoof
                 // does not (the retryable RGB-yes/IR-no transient cannot occur
                 // here: this path only runs when RGB saw no face).
-                let kind = if verdict == Verdict::Uncertain {
-                    OutcomeKind::Uncertain
-                } else {
-                    OutcomeKind::Spoof
-                };
+                //
+                // Routed through the shared classifier rather than mapped
+                // inline. `exposure_refusal` is deliberately shared by BOTH
+                // evaluators, so the unmeasurable-format refusal arrives here
+                // as Uncertain too, and an inline map would leave it in the
+                // retryable class on exactly the camera this gate exists for:
+                // six full captures reaching the identical answer, every dark
+                // login, forever. The classifier holds the one prefix rule
+                // (#358 review).
+                //
+                // `reason` here is the raw liveness string; the "dark liveness"
+                // prefix is applied in the `format!` below, after this call, so
+                // the prefix match still sees what irlume-liveness produced.
+                let kind = liveness_deny_kind(verdict, &reason);
                 return Ok(Outcome::deny(
                     kind,
                     format!("dark liveness {verdict:?}: {reason}"),
@@ -4337,6 +4346,77 @@ mod tests {
         let bk = liveness_deny_kind(bv, &br);
         assert_eq!(bk, OutcomeKind::Uncertain, "{br}");
         assert!(presence_retryable(&denied(bk, &br, false)), "{br}");
+
+        // The DARK evaluator reaches the same refusal, because
+        // `exposure_refusal` is deliberately shared by both. The first version
+        // of this fix routed only the cross-spectrum site and left the dark
+        // site mapping inline, so on the one camera class this gate exists for
+        // a dark login burned the whole grace window reaching this answer
+        // repeatedly (#358 review).
+        let (dv, _, dr) = irlume_liveness::LivenessGate::new().evaluate_ir_only(&sig);
+        assert_eq!(dv, Verdict::Uncertain, "precondition: {dr}");
+        assert!(
+            dr.starts_with(EXPOSURE_UNMEASURABLE_PREFIX),
+            "the dark evaluator stopped producing the pinned prefix: {dr}"
+        );
+        let dk = liveness_deny_kind(dv, &dr);
+        assert_eq!(dk, OutcomeKind::OtherDeny, "{dr}");
+        assert!(!presence_retryable(&denied(dk, &dr, false)), "{dr}");
+
+        // And the dark path's ordinary refusals stay exactly as they were, so
+        // routing it through the shared classifier changed nothing else.
+        let mut dark_flat = sig.clone();
+        dark_flat.ir_ceiling_known = true;
+        dark_flat.ir_saturated_frac = Some(0.0);
+        dark_flat.ir_center_edge_ratio = 0.1;
+        let (fv, _, fr) = irlume_liveness::LivenessGate::new().evaluate_ir_only(&dark_flat);
+        assert_eq!(fv, Verdict::Spoof, "precondition: {fr}");
+        assert_eq!(liveness_deny_kind(fv, &fr), OutcomeKind::Spoof, "{fr}");
+    }
+
+    /// Every liveness verdict becomes an `OutcomeKind` through
+    /// [`liveness_deny_kind`], never through a comparison written at the call
+    /// site.
+    ///
+    /// The rule exists because the failure mode is a NEW deny site, or an old
+    /// one nobody revisited, classifying inline. `liveness_deny_kind` is where
+    /// the retryability rules live; a site that maps `Verdict::Uncertain`
+    /// itself silently opts out of all of them. That is exactly what happened
+    /// with the dark path in #358: the classifier gained the unmeasurable arm,
+    /// the dark site kept `let kind = if verdict == Verdict::Uncertain`, and no
+    /// behavioural test could see it because the refusal is only reachable
+    /// with a camera whose format names no ceiling.
+    #[test]
+    fn no_deny_site_classifies_a_liveness_verdict_by_hand() {
+        let src = include_str!("lib.rs");
+        let offenders: Vec<(usize, &str)> = src
+            .lines()
+            .enumerate()
+            .filter(|(_, l)| {
+                let l = l.trim();
+                // The shape that was removed, and the shape a future site would
+                // most naturally reintroduce.
+                (l.starts_with("let kind = if") || l.starts_with("let kind = match"))
+                    && !l.contains("liveness_deny_kind")
+            })
+            .map(|(i, l)| (i + 1, l.trim()))
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "these sites classify a liveness verdict by hand instead of calling \
+             liveness_deny_kind, so they do not inherit its retryability rules: {offenders:?}"
+        );
+        // Not vacuous: the call site must actually be there, or this test
+        // would pass by having nothing to look at. The needle is assembled
+        // from pieces so it does not appear verbatim in the file it scans;
+        // spelled inline, the assertion matched its own source and stayed
+        // green with the real call site deleted.
+        let needle = concat!("liveness_deny_kind", "(verdict, &reason)");
+        assert!(
+            src.matches(needle).count() >= 2,
+            "the deny sites that route through liveness_deny_kind are gone; \
+             the rule this test pins has nothing left to hold"
+        );
     }
 
     #[test]

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -508,12 +508,27 @@ pub fn presence_retryable(o: &Outcome) -> bool {
     )
 }
 
+/// Start of the reason irlume-liveness produces when the IR format defines no
+/// sensor ceiling. Pinned against that text by
+/// `an_unmeasurable_exposure_is_not_retryable`, the same way the `no face in IR`
+/// prefix below is pinned.
+const EXPOSURE_UNMEASURABLE_PREFIX: &str = "IR exposure unmeasurable";
+
 /// Kind of a non-Live cross-spectrum gate verdict on the RGB primary path.
 /// The `no face in IR` reason is singled out because it is the retryable
 /// RGB-yes/IR-no transient; the prefix is pinned against the string
 /// irlume-liveness produces by `grace_retries_only_presence_failures`.
 fn liveness_deny_kind(verdict: Verdict, reason: &str) -> OutcomeKind {
     match verdict {
+        // Uncertain normally means framing or quality, which the grace window
+        // retries. An unmeasurable IR format is neither: it is a property of
+        // the camera that will hold for every frame, so retrying spends the
+        // whole window to reach the same answer while telling the user to
+        // adjust something that cannot help (#358). OtherDeny is the
+        // non-retryable class for a state refusal like this.
+        Verdict::Uncertain if reason.starts_with(EXPOSURE_UNMEASURABLE_PREFIX) => {
+            OutcomeKind::OtherDeny
+        }
         Verdict::Uncertain => OutcomeKind::Uncertain,
         Verdict::Spoof if reason.starts_with("no face in IR") => OutcomeKind::SpoofNoIrFace,
         Verdict::Spoof => OutcomeKind::Spoof,
@@ -1299,6 +1314,7 @@ impl Engine {
             face_frac: face_frac_of(rgb_top.as_ref().map(|f| &f.bbox), rgb.width),
             // RGB-only path: no IR frame exists to clip.
             ir_saturated_frac: None,
+            ir_ceiling_known: false,
             rgb_face_brightness: rgb_brightness,
             rgb_specular_frac: rgb_specular,
             rgb_moire_score: rgb_moire,
@@ -1707,6 +1723,10 @@ impl Engine {
                 ir_top.as_ref().map(|f| &f.bbox),
                 ir_stats.white_level,
             ),
+            // Whether the FORMAT could be measured, which is not the same
+            // question as whether this capture produced a number: the call
+            // above also yields None when no face was found (#358).
+            ir_ceiling_known: ir_stats.white_level.is_some(),
             rgb_face_brightness: rgb_brightness,
             rgb_moire_score: 0.0,
             rgb_specular_frac: 0.0,
@@ -4258,6 +4278,65 @@ mod tests {
             irlume_common::pam_service::classify("doas"),
             Some(ServiceKind::Elevation)
         );
+    }
+
+    /// An unmeasurable IR exposure must NOT be retried (#358).
+    ///
+    /// It arrives as `Verdict::Uncertain`, which is the retryable class, and
+    /// that is the trap: the condition is a property of the camera's negotiated
+    /// format, identical on every frame. Retrying spends the entire grace
+    /// window to reach the same answer and then falls back to the password
+    /// anyway, while the user is told to adjust something that cannot help.
+    #[test]
+    fn an_unmeasurable_exposure_is_not_retryable() {
+        use irlume_liveness::Verdict;
+        // Built from the real producer's wording, not a literal, so a reword in
+        // irlume-liveness that drops the prefix fails here instead of silently
+        // making the refusal retryable again.
+        let mut sig = irlume_liveness::Signals {
+            rgb_face: Some(irlume_liveness::FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: 0.9,
+            }),
+            ir_face: Some(irlume_liveness::FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: 0.9,
+            }),
+            ir_face_brightness: 90.0,
+            ir_center_edge_ratio: 1.2,
+            ir_eye_glint: 220.0,
+            ..Default::default()
+        };
+        sig.ir_ceiling_known = false;
+        let (verdict, _, reason) = irlume_liveness::LivenessGate::new().evaluate(&sig);
+        assert_eq!(verdict, Verdict::Uncertain, "precondition for this test");
+        assert!(
+            reason.starts_with(EXPOSURE_UNMEASURABLE_PREFIX),
+            "the prefix this routing keys on moved: {reason}"
+        );
+
+        let kind = liveness_deny_kind(verdict, &reason);
+        assert_eq!(
+            kind,
+            OutcomeKind::OtherDeny,
+            "must leave the retryable class"
+        );
+        assert!(
+            !presence_retryable(&denied(kind, &reason, false)),
+            "retrying an unmeasurable format burns the grace window for nothing"
+        );
+
+        // A blown-out frame IS still retryable: moving back really can fix it,
+        // so this change must not have swept the ordinary case out with it.
+        let mut blown = sig.clone();
+        blown.ir_ceiling_known = true;
+        blown.ir_saturated_frac = Some(0.9);
+        let (bv, _, br) = irlume_liveness::LivenessGate::new().evaluate(&blown);
+        let bk = liveness_deny_kind(bv, &br);
+        assert_eq!(bk, OutcomeKind::Uncertain, "{br}");
+        assert!(presence_retryable(&denied(bk, &br, false)), "{br}");
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2609,7 +2609,15 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
             // Dev gate probe: a single frame with no burst stats, so the
             // negotiated format's ceiling is not available here and the
             // reading is honestly absent rather than guessed at 255.
+            //
+            // Which means this probe now stops at the exposure gate with the
+            // unmeasurable refusal instead of running the cues below it (#358).
+            // The measured values printed after this still come from the locals
+            // above, so the diagnostic output is unchanged; what changes is that
+            // the verdict no longer claims a liveness decision this probe was
+            // never in a position to make.
             ir_saturated_frac: None,
+            ir_ceiling_known: false,
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2553,8 +2553,11 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
             rgb_faces.len(),
             rgb_top
         );
-        // IR
-        let ir = irlume_camera::capture_ir(ir_dev)?;
+        // IR. Taken with stats rather than bare, because the exposure gate
+        // needs the negotiated format's ceiling and `capture_ir` is literally
+        // `capture_ir_with_stats(..)?.0`, so the burst already happened and the
+        // plain call was only throwing the answer away (#358 review).
+        let (ir, ir_stats) = irlume_camera::capture_ir_with_stats(ir_dev)?;
         let (mn, mx, sum) = ir.data.iter().fold((255u8, 0u8, 0u64), |(mn, mx, s), &p| {
             (mn.min(p), mx.max(p), s + p as u64)
         });
@@ -2606,18 +2609,28 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
             face_frac: ir_top_face
                 .map(|f| irlume_auth::bbox_width_frac(&f.bbox, ir.width))
                 .unwrap_or(0.0),
-            // Dev gate probe: a single frame with no burst stats, so the
-            // negotiated format's ceiling is not available here and the
-            // reading is honestly absent rather than guessed at 255.
+            // Measured the same way the auth path and `padcapture` measure it,
+            // off the same burst stats, so this probe judges the frame instead
+            // of refusing it.
             //
-            // Which means this probe now stops at the exposure gate with the
-            // unmeasurable refusal instead of running the cues below it (#358).
-            // The measured values printed after this still come from the locals
-            // above, so the diagnostic output is unchanged; what changes is that
-            // the verdict no longer claims a liveness decision this probe was
-            // never in a position to make.
-            ir_saturated_frac: None,
-            ir_ceiling_known: false,
+            // Hardcoding `None`/`false` here was wrong twice over: the ceiling
+            // is a property of the negotiated format, not of the burst, and the
+            // burst existed anyway. It made `evaluate` return at the exposure
+            // gate before `ir_reflectance_ok`, `center_edge_ratio_ok` and
+            // `glint_present` were ever assigned, so the cue line printed three
+            // constants and the probe told the operator that a GREY camera
+            // whose ceiling is 255 defines no ceiling (#358 review).
+            //
+            // Raw frame, not the subtracted one: ambient subtraction moves a
+            // railed 255 to 254 and hides the clipping this measures.
+            ir_saturated_frac: irlume_auth::saturated_frac_of(
+                ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
+                ir.width,
+                ir.height,
+                ir_top_face.map(|f| &f.bbox),
+                ir_stats.white_level,
+            ),
+            ir_ceiling_known: ir_stats.white_level.is_some(),
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -151,6 +151,13 @@ fn capture_once(
             ir_top.as_ref().map(|f| &f.bbox),
             ir_stats.white_level,
         ),
+        // Set from the SAME white level the fraction above is computed from.
+        // `Signals::default()` says false, the fail-safe answer for a struct
+        // nobody filled in, and `..Default::default()` below would silently
+        // apply it here: PAD capture would refuse every frame as unmeasurable
+        // on a camera that measures perfectly well, and produce none of the
+        // corpus rows this gate exists to be tuned from (#358 review).
+        ir_ceiling_known: ir_stats.white_level.is_some(),
         ..Default::default()
     };
     let gate = LivenessGate::new();
@@ -786,6 +793,10 @@ mod tests {
             "ir_brightness",
             "ir_saturated_frac",
             "ir_exposure_ok",
+            // Added with the field itself: this list IS the corpus schema, so a
+            // key missing from it can be deleted from the record with every
+            // assertion here still passing (#358 review).
+            "ir_exposure_measured",
             "ir_center_edge_ratio",
             "ir_glint",
             "cross_dist",

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -219,6 +219,15 @@ fn presentation_record(
         },
     );
     rec.insert("ir_exposure_ok".into(), cues.ir_exposure_ok.into());
+    // Recorded beside it so a row the gate never read is distinguishable from a
+    // row it read and found clean. Without this the corpus said "clean" for
+    // every frame on a camera whose format defines no ceiling, which is exactly
+    // the population any retune of IR_SATURATED_FRAC_MAX would be fitted on
+    // (#358).
+    rec.insert(
+        "ir_exposure_measured".into(),
+        cues.ir_exposure_measured.into(),
+    );
     rec.insert(
         "ir_center_edge_ratio".into(),
         crate::json_f32(s.ir_center_edge_ratio),

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -63,6 +63,20 @@ pub struct Signals {
     /// not measured (RGB-only path, older callers); the flood rewording below
     /// then never triggers. See [`IR_AMBIENT_FLOOD`].
     pub ir_ambient: f32,
+    /// Whether the negotiated IR format defines where its sensor ceiling is,
+    /// i.e. whether [`Self::ir_saturated_frac`] could be measured at all.
+    ///
+    /// Separate from `ir_saturated_frac` being `None`, which is ambiguous:
+    /// `saturated_frac_of` also yields `None` when no face was detected. The
+    /// evaluators happen to require an IR face before they reach the exposure
+    /// gate, so today the two cannot be confused there, but that is a distant
+    /// invariant in another crate and the gate now states its own precondition
+    /// rather than inheriting one (#358).
+    ///
+    /// Defaults to FALSE, the fail-safe direction: a `Signals` nobody filled in
+    /// measured no ceiling, and a permissive default here is what let the gate
+    /// pass unread frames in the first place.
+    pub ir_ceiling_known: bool,
     /// Face width as a fraction of frame width, from the frame the IR cues
     /// were measured in (the RGB frame on the RGB-only path). 0.0 when no
     /// face was found.
@@ -129,7 +143,8 @@ impl Default for Signals {
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
-            ir_ambient: 0.0, // not measured
+            ir_ambient: 0.0,
+            ir_ceiling_known: false, // not measured
         }
     }
 }
@@ -318,10 +333,18 @@ pub struct Cues {
     /// head-orientation gate.
     pub frontal_ok: bool,
     /// The IR face region is readable rather than blown out: at most
-    /// [`IR_SATURATED_FRAC_MAX`] of it sits at the sensor ceiling, or the format
-    /// cannot say where its ceiling is. False means no cue below it was worth
-    /// reading (#237).
+    /// [`IR_SATURATED_FRAC_MAX`] of it sits at the sensor ceiling. False means
+    /// no cue below it was worth reading (#237).
+    ///
+    /// Read together with [`Self::ir_exposure_measured`]. This used to be true
+    /// when the format could not say where its ceiling was, which recorded
+    /// "clean" into the PAD corpus for frames the gate never read, on exactly
+    /// the cameras where the question is hardest (#358).
     pub ir_exposure_ok: bool,
+    /// Whether the exposure above was actually measured. False means the
+    /// negotiated IR format defines no sensor ceiling, so nothing was read and
+    /// `ir_exposure_ok` carries no information.
+    pub ir_exposure_measured: bool,
 }
 
 /// IR face region must be at least this bright (0..255). A lit live face ran ~83
@@ -648,9 +671,34 @@ impl LivenessGate {
 /// accepting the frames the cross-spectrum path had just started refusing.
 /// Adding a third evaluator means calling this, not copying it.
 fn exposure_refusal(s: &Signals, cues: &mut Cues) -> Option<(Verdict, String)> {
+    // Not measurable at all. This used to read as "clean" and let every cue
+    // below run on a frame nobody had checked, which is off on any IR node that
+    // negotiates Y16/Y10/Y12/NV12/YUYV rather than 8-bit grey (#358).
+    //
+    // Refused rather than passed: the cues below degrade together as clipping
+    // rises, so running them on an unverified frame is reading noise, and a
+    // gate that cannot run is not a gate that passed.
+    //
+    // Worded so it does NOT say "move back". Moving cannot repair a format that
+    // defines no ceiling, and the reason prefix is what keeps this out of the
+    // presence-retryable set: retrying would burn the whole grace window every
+    // login and then fall back to the password anyway, while advising something
+    // that cannot help. See `liveness_deny_kind` in irlume-auth.
+    cues.ir_exposure_measured = s.ir_ceiling_known;
+    if !s.ir_ceiling_known {
+        cues.ir_exposure_ok = false;
+        return Some((
+            Verdict::Uncertain,
+            "IR exposure unmeasurable: this camera's IR format defines no sensor \
+             ceiling, so clipping cannot be checked and the liveness cues cannot \
+             be trusted. Report the camera so its format can be supported."
+                .to_string(),
+        ));
+    }
+
     cues.ir_exposure_ok = s
         .ir_saturated_frac
-        .is_none_or(|f| f <= IR_SATURATED_FRAC_MAX);
+        .is_some_and(|f| f <= IR_SATURATED_FRAC_MAX);
     if cues.ir_exposure_ok {
         return None;
     }
@@ -2218,6 +2266,17 @@ mod tests {
             ir_face_brightness: 90.0,
             ir_center_edge_ratio: 1.2,
             ir_eye_glint: 220.0,
+            // A Grey8 camera, which is what the fleet actually runs and what
+            // every cue below this is written against. Stated rather than
+            // defaulted: the default is FALSE (fail-safe), so a fixture that
+            // wants to exercise a cue past the exposure gate has to say so
+            // (#358).
+            ir_ceiling_known: true,
+            // ...and a face that was actually read and found unclipped. Leaving
+            // this None while claiming a known ceiling is a state production
+            // cannot reach, because a measurable format with a face present
+            // always yields a number (#358).
+            ir_saturated_frac: Some(0.0),
             ..Default::default() // frontal pose
         }
     }
@@ -2261,7 +2320,12 @@ mod tests {
     #[test]
     fn a_readable_ir_face_is_judged_as_before() {
         let gate = LivenessGate::new();
-        for frac in [None, Some(0.0), Some(0.063), Some(IR_SATURATED_FRAC_MAX)] {
+        // `None` was in this list and asserted Live, which is the fail-open
+        // #358 removed: on a camera whose format defines no ceiling the gate
+        // was passing frames it had not read. A measurable camera with a face
+        // present always yields Some, so the readable cases are the Some ones;
+        // the unmeasurable case has its own test below.
+        for frac in [Some(0.0), Some(0.063), Some(IR_SATURATED_FRAC_MAX)] {
             let mut live = live_signals();
             live.ir_saturated_frac = frac;
             let mut flat = live_signals();
@@ -2405,9 +2469,71 @@ mod tests {
             rgb_face: Some(fb(0.5, 0.5)),
             ir_face: Some(fb(0.5, 0.5)),
             ir_face_brightness: 12.0,
+            // A readable Grey8 frame, so the darkness below is what decides
+            // this and not the exposure gate above it (#358).
+            ir_ceiling_known: true,
+            ir_saturated_frac: Some(0.0),
             ..Default::default()
         };
         assert_eq!(LivenessGate::new().evaluate(&s).0, Verdict::Spoof);
+    }
+
+    /// A camera whose IR format defines no sensor ceiling is refused, not
+    /// passed (#358).
+    ///
+    /// This was the fail-open: `is_none_or` read "could not measure" as "clean",
+    /// so on any IR node negotiating Y16/Y10/Y12/NV12/YUYV the #237 exposure
+    /// gate was off entirely and every cue below it ran on a frame nobody had
+    /// checked. The signals here are otherwise a textbook live face, so only
+    /// the missing ceiling can move the verdict.
+    #[test]
+    fn an_unmeasurable_ir_format_is_refused_on_every_credential_releasing_path() {
+        let gate = LivenessGate::new();
+        let mut s = live_signals();
+        s.ir_ceiling_known = false;
+        s.ir_saturated_frac = None;
+
+        for (path, (verdict, cues, reason)) in [
+            ("cross-spectrum", gate.evaluate(&s)),
+            ("ir-only", gate.evaluate_ir_only(&s)),
+        ] {
+            assert_eq!(
+                verdict,
+                Verdict::Uncertain,
+                "{path}: an unread frame is not a passed frame"
+            );
+            assert!(
+                !cues.ir_exposure_measured,
+                "{path}: the corpus must record that nothing was measured"
+            );
+            assert!(
+                !cues.ir_exposure_ok,
+                "{path}: an unmeasured exposure is not a clean one"
+            );
+            // The wording carries two jobs: it must not tell the user to move,
+            // which cannot help, and its prefix is what keeps the refusal out
+            // of the presence-retryable set in irlume-auth.
+            assert!(
+                reason.starts_with("IR exposure unmeasurable"),
+                "{path}: prefix is pinned by irlume-auth's liveness_deny_kind: {reason}"
+            );
+            assert!(
+                !reason.contains("move back"),
+                "{path}: moving cannot repair a format with no ceiling: {reason}"
+            );
+        }
+    }
+
+    /// The same signals with a measurable ceiling stay Live, so the refusal
+    /// above is attributable to the missing ceiling and nothing else.
+    #[test]
+    fn a_measurable_ceiling_still_passes_a_live_face() {
+        let gate = LivenessGate::new();
+        let s = live_signals();
+        assert!(s.ir_ceiling_known);
+        let (verdict, cues, _) = gate.evaluate(&s);
+        assert_eq!(verdict, Verdict::Live);
+        assert!(cues.ir_exposure_measured && cues.ir_exposure_ok);
     }
 
     #[test]

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -406,8 +406,11 @@ pub const MIN_CENTER_EDGE_RATIO: f32 = 1.03;
 /// widen the corpus before trusting it elsewhere (#101).
 ///
 /// Only measurable where the source format names its ceiling
-/// (`clipping_white_level`); an unmeasurable frame is judged as before, since
-/// refusing on a number nobody produced would deny every non-GREY8 module.
+/// (`clipping_white_level`), which today means the 8-bit greys. A frame whose
+/// format names no ceiling is REFUSED rather than judged, because a gate that
+/// could not run is not a gate that passed; see [`Signals::ir_ceiling_known`]
+/// (#358). This sentence used to say the opposite, and anyone retuning the
+/// constant should know the population it is fitted to is GREY8 only.
 pub const IR_SATURATED_FRAC_MAX: f32 = 0.10;
 
 /// Ambient IR (see [`Signals::ir_ambient`]) above which the brightness and
@@ -2315,8 +2318,13 @@ mod tests {
     }
 
     /// The refusal is an exposure ceiling, not a new spoof cue: everything at
-    /// or under the limit is judged exactly as before, and an unmeasurable
-    /// fraction (a format with no known ceiling) must not deny anyone.
+    /// or under the limit is judged exactly as before.
+    ///
+    /// The unmeasurable case is deliberately NOT here. This doc used to claim
+    /// that a format with no known ceiling "must not deny anyone", which is the
+    /// fail-open #358 removed, and the body three lines down now asserts the
+    /// opposite. A test whose documentation states the inverse of its own
+    /// assertions is worse than an undocumented one.
     #[test]
     fn a_readable_ir_face_is_judged_as_before() {
         let gate = LivenessGate::new();

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -96,6 +96,11 @@ PAM changes.
   was validated on a NixOS VM with camera passthrough (see
   [NIXOS.md](NIXOS.md)); a face login on a physical NixOS machine has not been
   reported.
-- Other IR cameras: any Windows Hello-capable module that exposes a V4L2 IR
-  node should work; only the two above are confirmed.
+- Other IR cameras: a module whose IR node offers an 8-bit grey format
+  (`GREY`, `Y8`, `Y800`) should work; only the two above are confirmed. A node
+  that offers **only** `Y16`/`Y10`/`Y12`/`NV12`/`YUYV` is refused rather than
+  untested: those formats name no sensor ceiling, so the IR exposure check
+  cannot run, and irlume refuses instead of judging a frame it never read
+  (#358). No such camera has been reported; every module in the record,
+  including the two user-reported ones, offers grey.
 - musl-based distros (Alpine): untested; the release binaries assume glibc.


### PR DESCRIPTION
Closes #358.

`exposure_refusal` read "could not measure" as "clean":

```rust
cues.ir_exposure_ok = s.ir_saturated_frac.is_none_or(|f| f <= IR_SATURATED_FRAC_MAX);
```

`ir_saturated_frac` is `None` whenever the negotiated format defines no sensor ceiling, which is every IR node on Y16/Y10/Y12/NV12/YUYV. On those cameras the #237 exposure gate was not lenient, it was **off**, and every cue below it ran on a frame nobody had checked. This repo states the opposite rule in three places and implements it correctly in `ir_metadata.rs`: failure to observe must not authorize.

## Why not the one-word fix

`is_some_and` alone is wrong. `saturated_frac_of` also returns `None` when no **face** was found, so flipping the combinator would refuse every faceless frame on every camera, including the GREY ones that work today. The evaluators happen to require an IR face before reaching the gate, so the two cannot be confused there right now, but that is an invariant in a different crate that nothing pins.

The gate now states its own precondition instead: `Signals::ir_ceiling_known`, set from `ir_stats.white_level.is_some()`, defaulting to **false**. The default direction is deliberate; a permissive default is what the bug was.

## Refused, not tiered

Dropping these cameras to a lower assurance tier that still releases credentials would be the same fail-open with better paperwork. The honest outcome for "the gate could not run" is a refusal.

## The part that was easy to get wrong

The refusal is **not presence-retryable**. It arrives as `Verdict::Uncertain`, which is the retryable class, and that is the trap: the condition is a property of the camera and identical on every frame. Retrying would spend the entire grace window reaching the same answer, then fall back to the password anyway, while telling the user to move back, which cannot help. It is routed out by reason prefix in `liveness_deny_kind`, the same mechanism `no face in IR` already uses, and the message deliberately does not say "move back".

## The corpus fix, which stands on its own

`Cues::ir_exposure_measured` is now recorded beside `ir_exposure_ok`, so a row the gate never read is distinguishable from a row it read and found clean. Every retune of `IR_SATURATED_FRAC_MAX` was being fitted on data that claimed "clean" for unread frames, on exactly the cameras where the question is hardest to see.

## Blast radius, measured

Both IR cameras in the fleet negotiate `GREY`: Zenbook `/dev/video2` and archhost's NexiGo `/dev/video2`, checked with `v4l2-ctl --list-formats`. `IR_CANDIDATES` is walked in order with `GREY`/`Y8`/`Y800` first, so **any** camera offering 8-bit grey is untouched. Only a camera with no grey path at all changes behaviour, and it now gets a refusal naming the problem instead of a silent pass.

## Evidence

Both guards proven by mutation:

- restoring `is_none_or` and deleting the unmeasurable branch fails `an_unmeasurable_ir_format_is_refused_on_every_credential_releasing_path`
- deleting the routing arm fails `an_unmeasurable_exposure_is_not_retryable`

The retryability test also asserts a blown-out frame stays retryable, so this did not sweep the ordinary case out with the new one.

Gate: fmt, clippy `-D warnings`, doc lane, and the four touched crates green (`irlume-liveness` 51, `irlume-auth` 72, `irlume-cli` 34, `irlume-vision` 69).

## What was not done, and one thing to know about my local run

Implementing the ceiling for Y10/Y12 (raw maxima 1023/4095) and NV12/YUYV (via quantization) is achievable and is the better long-term answer. We own no camera in any of those formats, and writing a saturation ceiling that cannot be validated is how a gate goes wrong in the other direction. The refusal message asks for the camera to be reported, which is what would supply one. Generic Y16 may stay unmeasurable permanently, since V4L2 allows its real precision to be unknown.

The dev `liveness_probe` now stops at this gate, because it captures a single frame with no burst stats and never had a ceiling. Its measured values still print from its own locals; what it no longer does is claim a liveness verdict it was not in a position to make.

Local full-workspace `cargo test` currently fails 9 `irlume-vision` model tests in my checkout with `Io("No such file or directory")`. That is **not** from this change: it reproduces identically on `main`, only in the concurrent workspace run, and each crate passes on its own. CI runs the same command and is green on main, so it is local to this machine and I could not reproduce it per-crate. Flagging it rather than quietly working around it.
