### PR TITLE
One table decides what a PAM service name is (#362)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -351,14 +351,6 @@ const RETRY_SEAM_ALLOWANCE_MS: u64 = 10_000;
 /// kind is presence-retryable, so the grace window just captures again.
 const MAX_CROSS_SPECTRUM_SKEW: std::time::Duration = std::time::Duration::from_secs(3);
 
-/// True for the sudo/su family of PAM services, which take the shorter window.
-fn is_sudo_like(service: &str) -> bool {
-    matches!(
-        service,
-        "sudo" | "sudo-i" | "su" | "su-l" | "runuser" | "runuser-l"
-    )
-}
-
 /// Grace window for a given PAM service. `IRLUME_GRACE_MS` overrides everything
 /// (testing); otherwise sudo/su and polkit get the short window (the user is
 /// already at the machine, and the KDE polkit agent re-runs the stack up to 3
@@ -372,8 +364,11 @@ fn grace_window_ms(service: Option<&str>) -> u64 {
     {
         return v;
     }
-    match service {
-        Some(s) if is_sudo_like(s) || s == "polkit-1" || s == "polkit" => SUDO_GRACE_WINDOW_MS,
+    // From the shared table, not a local list. The list this replaced was
+    // missing `doas`, which is Elevation for the policy, so a doas prompt held
+    // the camera for the 15s login window instead of the 5s one (#362).
+    match service.and_then(irlume_common::pam_service::classify) {
+        Some(kind) if kind.wants_short_grace() => SUDO_GRACE_WINDOW_MS,
         _ => GRACE_WINDOW_MS,
     }
 }
@@ -4225,6 +4220,44 @@ mod tests {
         assert_eq!(grace_window_ms(Some("kde")), GRACE_WINDOW_MS);
         assert_eq!(grace_window_ms(Some("gdm-password")), GRACE_WINDOW_MS);
         assert_eq!(grace_window_ms(None), GRACE_WINDOW_MS);
+        assert_eq!(
+            grace_window_ms(Some("service-invented-tomorrow")),
+            GRACE_WINDOW_MS,
+            "an unrecognised service takes the long window, not a shortcut"
+        );
+    }
+
+    /// Every service the policy calls Elevation must also take the SHORT
+    /// window, which is the invariant the two hard-coded lists broke (#362).
+    ///
+    /// `doas` is the instance that was live: Elevation in
+    /// `biopolicy::classify`, absent from the grace list, so it held the camera
+    /// and the worker for 15s instead of 5s on a request this project already
+    /// classifies as terminal elevation. Walking the shared table rather than
+    /// naming doas alone means the next name added cannot reintroduce the split.
+    #[test]
+    fn every_elevation_and_consent_service_takes_the_short_window() {
+        let _g = env_guard();
+        std::env::remove_var("IRLUME_GRACE_MS");
+        use irlume_common::pam_service::{ServiceKind, SERVICES};
+        let mut checked = 0;
+        for (name, kind) in SERVICES {
+            let want = if kind.wants_short_grace() {
+                SUDO_GRACE_WINDOW_MS
+            } else {
+                GRACE_WINDOW_MS
+            };
+            assert_eq!(grace_window_ms(Some(name)), want, "{name} ({kind:?})");
+            checked += 1;
+        }
+        assert!(checked >= 30, "the table shrank to {checked} rows");
+        // The two that motivated this, named so a reader sees them.
+        assert_eq!(grace_window_ms(Some("doas")), SUDO_GRACE_WINDOW_MS);
+        assert_eq!(grace_window_ms(Some("polkit-1")), SUDO_GRACE_WINDOW_MS);
+        assert_eq!(
+            irlume_common::pam_service::classify("doas"),
+            Some(ServiceKind::Elevation)
+        );
     }
 
     #[test]

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod dbglog;
 pub mod gkr_wire;
 pub mod memlock;
+pub mod pam_service;
 pub mod platform;
 pub mod secureboot;
 pub mod thirdparty;

--- a/crates/irlume-common/src/pam_service.rs
+++ b/crates/irlume-common/src/pam_service.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! What a PAM service name is, in one place.
+//!
+//! Three consumers used to keep their own hard-coded lists and had already
+//! drifted (#362): `biopolicy::classify` in irlume-core decided the operation
+//! class, `is_sudo_like` in irlume-auth decided the grace window, and
+//! `irlume-pam` decided whether to tell the user which consent gesture to make.
+//! `doas` was in the first and missing from the second, so it got the 15s login
+//! window instead of the 5s elevation one.
+//!
+//! This lives in irlume-common rather than irlume-core because irlume-pam
+//! depends only on common, and a table one of the three consumers cannot reach
+//! is not a shared table.
+//!
+//! What this CANNOT do is make the set exhaustive: the key is a string, so no
+//! compiler check can notice a service name some upstream package invents
+//! tomorrow. What it does guarantee is that once a name is here, every consumer
+//! gets its answer from the same row instead of three lists drifting apart.
+
+/// What a service is, as far as any consumer needs to know.
+///
+/// Deliberately not tier-aware and not session-aware: the greeter
+/// services that drive both a cold login and a live lock screen are separated
+/// by session state, which only irlume-core tracks, so this reports the
+/// ambiguity rather than guessing at it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceKind {
+    /// A lock screen in an already-running session.
+    ScreenUnlock,
+    /// A display-manager greeter. Some of these also serve the live lock
+    /// screen; the caller resolves that with session state.
+    Greeter,
+    /// Terminal privilege elevation.
+    Elevation,
+    /// An application asking for approval, via polkit.
+    AppConsent,
+    /// Remote or network access, never satisfiable by a face at this machine.
+    Remote,
+}
+
+/// Every service name irlume recognises, with what it is.
+///
+/// Sourced, not guessed. The sudo/su/runuser names are the pam.d files util-linux
+/// and sudo ship; `doas` is OpenDoas; `polkit-1` is what polkit's agent helper
+/// passes to `pam_start`, and `polkit` is kept for any downstream that renames
+/// the service file. Names nobody could show shipping somewhere are NOT added
+/// here, because inventing plausible ones is how the three lists diverged.
+///
+/// `runuser` and `runuser-l` are present but note that standard util-linux
+/// `runuser` starts a PAM transaction for account and session handling and
+/// deliberately skips `pam_authenticate()`, so it does not normally reach an
+/// irlume authentication at all.
+pub const SERVICES: &[(&str, ServiceKind)] = &[
+    // Lock screens (live session).
+    ("kde", ServiceKind::ScreenUnlock),
+    ("kde-fingerprint", ServiceKind::ScreenUnlock),
+    ("kscreensaver", ServiceKind::ScreenUnlock),
+    ("xscreensaver", ServiceKind::ScreenUnlock),
+    ("gnome-screensaver", ServiceKind::ScreenUnlock),
+    ("swaylock", ServiceKind::ScreenUnlock),
+    ("i3lock", ServiceKind::ScreenUnlock),
+    ("hyprlock", ServiceKind::ScreenUnlock),
+    // Display-manager greeters (cold login), including GDM's separate
+    // fingerprint login service, same login class.
+    ("sddm", ServiceKind::Greeter),
+    ("sddm-greeter", ServiceKind::Greeter),
+    ("plasmalogin", ServiceKind::Greeter),
+    ("gdm-password", ServiceKind::Greeter),
+    ("gdm-fingerprint", ServiceKind::Greeter),
+    ("gdm", ServiceKind::Greeter),
+    ("gdm3", ServiceKind::Greeter),
+    ("lightdm", ServiceKind::Greeter),
+    ("login", ServiceKind::Greeter),
+    ("greetd", ServiceKind::Greeter),
+    ("ly", ServiceKind::Greeter),
+    ("cosmic-greeter", ServiceKind::Greeter),
+    // Elevation.
+    ("sudo", ServiceKind::Elevation),
+    ("sudo-i", ServiceKind::Elevation),
+    ("su", ServiceKind::Elevation),
+    ("su-l", ServiceKind::Elevation),
+    ("runuser", ServiceKind::Elevation),
+    ("runuser-l", ServiceKind::Elevation),
+    ("doas", ServiceKind::Elevation),
+    // Application consent.
+    ("polkit-1", ServiceKind::AppConsent),
+    ("polkit", ServiceKind::AppConsent),
+    // Remote / network.
+    ("sshd", ServiceKind::Remote),
+    ("remote", ServiceKind::Remote),
+    ("cockpit", ServiceKind::Remote),
+];
+
+/// Look a service name up, trimmed and case-folded the way every caller did
+/// separately before. `None` is an unrecognised name, which every consumer
+/// treats as its own most restrictive answer.
+#[must_use]
+pub fn classify(service: &str) -> Option<ServiceKind> {
+    let s = service.trim().to_ascii_lowercase();
+    SERVICES
+        .iter()
+        .find(|(name, _)| *name == s)
+        .map(|(_, kind)| *kind)
+}
+
+impl ServiceKind {
+    /// Whether this service should get the SHORT grace window.
+    ///
+    /// Elevation and consent prompts are both "the user is already at the
+    /// machine": a long window holds the camera and, for the KDE polkit agent
+    /// which re-runs the stack up to three times, holds its dialog busy. An
+    /// unrecognised name gets the long login window, which is what the caller's
+    /// `None` branch does.
+    #[must_use]
+    pub fn wants_short_grace(self) -> bool {
+        matches!(self, ServiceKind::Elevation | ServiceKind::AppConsent)
+    }
+
+    /// Whether the user should be TOLD which consent gesture to make.
+    ///
+    /// Only the polkit path: it is the one where a gesture is demanded by a
+    /// dialog the user did not open, so an unnamed requirement reads as a
+    /// failure. Getting this out of step with the class above is exactly what
+    /// #362 was about.
+    #[must_use]
+    pub fn wants_consent_instruction(self) -> bool {
+        matches!(self, ServiceKind::AppConsent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify, ServiceKind, SERVICES};
+
+    /// A duplicate row would make the table's answer depend on its order, which
+    /// is the ambiguity a single source of truth exists to remove.
+    #[test]
+    fn no_service_is_listed_twice() {
+        let mut seen = std::collections::HashSet::new();
+        for (name, _) in SERVICES {
+            assert!(seen.insert(*name), "{name} appears more than once");
+        }
+    }
+
+    /// Every row must already be normalised, or `classify` could never match it.
+    #[test]
+    fn every_row_is_stored_normalised() {
+        for (name, _) in SERVICES {
+            assert_eq!(*name, name.trim().to_ascii_lowercase(), "{name}");
+            assert!(!name.is_empty());
+        }
+    }
+
+    /// The lookup normalises what it is given, because PAM service strings have
+    /// arrived with case and whitespace differences.
+    #[test]
+    fn lookup_is_case_and_whitespace_insensitive() {
+        for probe in ["SUDO", " sudo ", "Sudo"] {
+            assert_eq!(classify(probe), Some(ServiceKind::Elevation), "{probe}");
+        }
+    }
+
+    /// The divergence that prompted this: doas was Elevation for the policy and
+    /// missing from the grace-window list, so it got the long window.
+    #[test]
+    fn doas_is_elevation_and_takes_the_short_window() {
+        let kind = classify("doas").expect("doas is a recognised elevation service");
+        assert_eq!(kind, ServiceKind::Elevation);
+        assert!(kind.wants_short_grace());
+    }
+
+    /// Consent instruction and short grace must agree for polkit, because the
+    /// two used to be decided by two different hard-coded lists.
+    #[test]
+    fn app_consent_implies_both_the_short_window_and_the_instruction() {
+        for (name, kind) in SERVICES {
+            if *kind == ServiceKind::AppConsent {
+                assert!(kind.wants_short_grace(), "{name}");
+                assert!(kind.wants_consent_instruction(), "{name}");
+            } else {
+                assert!(
+                    !kind.wants_consent_instruction(),
+                    "{name}: only the consent path prompts for a gesture"
+                );
+            }
+        }
+    }
+
+    /// An unknown name must fail closed on every question the table answers.
+    #[test]
+    fn an_unknown_service_is_none_and_takes_no_shortcut() {
+        assert_eq!(classify("some-service-invented-tomorrow"), None);
+        assert_eq!(classify(""), None);
+    }
+}

--- a/crates/irlume-core/src/biopolicy.rs
+++ b/crates/irlume-core/src/biopolicy.rs
@@ -80,30 +80,28 @@ pub enum SessionState {
 }
 
 /// Classify a PAM service name into an [`OperationClass`].
+///
+/// The NAMES live in `irlume_common::pam_service`, shared with the grace-window
+/// and consent-instruction decisions that used to keep their own copies and had
+/// drifted (#362). What stays here is the part only this crate can answer: a
+/// greeter service that drives both a cold login and a live lock screen is
+/// split by session state.
 pub fn classify(service: &str, session: SessionState) -> OperationClass {
-    let s = service.trim().to_ascii_lowercase();
-    match s.as_str() {
-        // Lock screens (live session).
-        "kde" | "kde-fingerprint" | "kscreensaver" | "xscreensaver" | "gnome-screensaver"
-        | "swaylock" | "i3lock" | "hyprlock" => OperationClass::ScreenUnlock,
-        // Display-manager greeters (cold login), incl. GDM's separate
-        // fingerprint login service (`gdm-fingerprint`), same login class.
-        // `cosmic-greeter` (COSMIC / Pop!_OS) uses one service for both the cold
-        // login and the live lock screen, so the session state below is what
-        // separates its login from its screen-unlock.
-        "sddm" | "sddm-greeter" | "plasmalogin" | "gdm-password" | "gdm-fingerprint" | "gdm"
-        | "gdm3" | "lightdm" | "login" | "greetd" | "ly" | "cosmic-greeter" => match session {
+    use irlume_common::pam_service::ServiceKind;
+    match irlume_common::pam_service::classify(service) {
+        Some(ServiceKind::ScreenUnlock) => OperationClass::ScreenUnlock,
+        // `cosmic-greeter` (COSMIC / Pop!_OS) and `gdm-password` use one service
+        // for both the cold login and the live lock screen, so the session state
+        // is what separates them.
+        Some(ServiceKind::Greeter) => match session {
             SessionState::Warm => OperationClass::ScreenUnlock,
             SessionState::Cold => OperationClass::Login,
         },
-        // Elevation.
-        "sudo" | "sudo-i" | "su" | "su-l" | "doas" => OperationClass::Elevation,
-        // polkit's agent helper hardcodes pam_start("polkit-1", ...); "polkit"
-        // is kept for any downstream that renames the service file.
-        "polkit-1" | "polkit" => OperationClass::AppConsent,
-        // Remote / network: never satisfiable by face.
-        "sshd" | "remote" | "cockpit" => OperationClass::Remote,
-        _ => OperationClass::Unknown,
+        Some(ServiceKind::Elevation) => OperationClass::Elevation,
+        Some(ServiceKind::AppConsent) => OperationClass::AppConsent,
+        Some(ServiceKind::Remote) => OperationClass::Remote,
+        // Fails closed: `decide` maps Unknown to Deny.
+        None => OperationClass::Unknown,
     }
 }
 

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -281,10 +281,17 @@ impl PamServiceModule for IrlumePam {
             // to be a hardcoded string naming both gestures, which told a
             // `closure`-only user to nod at a gate that would not accept a nod: the
             // failure `ConsentGesture` was introduced to prevent.
-            let is_polkit = matches!(
-                pamh.get_service().ok().flatten().and_then(|c| c.to_str().ok().map(str::to_string)),
-                Some(ref s) if s == "polkit-1" || s == "polkit"
-            );
+            // From the shared table, so this cannot drift from the class the
+            // daemon enforces or the window the grace loop uses (#362). Out of
+            // step, this produces the worst version of the bug: a mandatory
+            // gesture the user is never told to make.
+            let is_polkit = pamh
+                .get_service()
+                .ok()
+                .flatten()
+                .and_then(|c| c.to_str().ok().map(str::to_string))
+                .and_then(|s| irlume_common::pam_service::classify(&s))
+                .is_some_and(irlume_common::pam_service::ServiceKind::wants_consent_instruction);
             if is_polkit && !unseal {
                 let how = irlume_common::config::consent_gesture_mode().instruction("approve");
                 let _ = pamh.conv(


### PR DESCRIPTION
Closes #362.

Three consumers kept their own hard-coded lists of PAM service names, and they had already drifted: `biopolicy::classify` decided the operation class, `is_sudo_like` decided the grace window, and `irlume-pam` decided whether to tell the user which consent gesture to make.

The live consequence: `doas` was `Elevation` for the policy and missing from the grace list, so it took the 15s login window instead of the 5s elevation one, holding the camera and the worker three times as long on a request this project already classifies as terminal elevation.

## Research removed half the issue

I filed this claiming `runuser` classifies `Unknown` and is denied under `enforce_biopolicy=1`. That is not so. Standard util-linux `runuser` starts a PAM transaction for account and session handling and deliberately skips `pam_authenticate()`, so it never reaches an irlume authentication at all. It is in the table with that written down, because it is a name irlume should recognise if it ever does arrive, not because it was broken.

The `doas` half is real but smaller than I described: it does not turn a rejected face into an accepted one, because the retry loop only re-runs presence and framing failures. It is a latency and UX bug, plus a modest widening of the window in which a pending prompt can observe the enrolled user entering frame.

## Where the table lives, and why

`irlume-common`, not `irlume-core`. `irlume-pam` depends only on `common`, and a table that one of the three consumers cannot reach is not a shared table. That constraint decided the design.

Each consumer keeps its own question. `ServiceKind` says what a service **is**; `wants_short_grace` and `wants_consent_instruction` answer the other two, so adding a name yields all three answers from one row. `biopolicy` keeps the part only it can answer: a greeter serving both a cold login and a live lock screen is still split by session state.

## What this does not do

The key is a string, so nothing makes the set exhaustive the way #344 and #351 made their enums exhaustive. A service name invented upstream tomorrow is still unknown, and unknown still fails closed. What is guaranteed is that a name **known to irlume** cannot be known to only one of the three consumers.

Names are sourced rather than invented. Only names that could be shown shipping somewhere are listed, since inventing plausible ones is how the lists diverged in the first place.

## Evidence

Table tests: no duplicate rows (a duplicate would make the answer order-dependent), every row already normalised, lookup is case and whitespace insensitive, `AppConsent` implies both the short window and the instruction while nothing else prompts, and an unknown name fails closed on every question.

The auth-side test walks the entire table rather than naming `doas`, so the next name added cannot reintroduce the split. Proven by deleting the `doas` row: the walk fails, and so does the table's own test.

Gate: fmt, clippy `-D warnings`, doc lane, and every touched crate green (`irlume-common` 78, `irlume-core` 120, `irlume-auth` 72, `irlume-pam` 8, `irlume-daemon` 104, `irlume-cli` 389). The doc lane caught a broken intra-doc link in my own new comment before it shipped.

## What was not tested

No live PAM transaction was run for `doas` or polkit; the grace-window change is verified by unit test against the same function the authenticate path calls, not by timing a real prompt. The `runuser` finding comes from upstream behaviour, not from an integration test on this machine.
