### PR TITLE
Four places where an unrecognised or new value chose the permissive answer (#365)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2060,18 +2060,23 @@ impl Engine {
         enr: &irlume_core::storage::Enrollment,
     ) -> (bool, Option<irlume_liveness::ClosureCalibration>) {
         let mode = consent_gesture_mode();
-        let allow_nod = mode != ConsentGesture::Closure;
-        let closure_cal = (mode != ConsentGesture::Nod && self.mesh.is_some())
-            .then(|| {
-                enr.closure_calibration.and_then(|(ear_open, ear_closed)| {
-                    let cal = irlume_liveness::ClosureCalibration {
-                        ear_open,
-                        ear_closed,
-                    };
-                    cal.is_usable().then_some(cal)
-                })
+        // Positive membership, not `!= Closure` / `!= Nod`. Those read as YES
+        // for any state that is neither, so `Misconfigured` would have enabled
+        // BOTH gestures, which is the failure this state exists to prevent
+        // (#365).
+        let allow_nod = matches!(mode, ConsentGesture::Nod | ConsentGesture::Either);
+        let closure_cal = (matches!(mode, ConsentGesture::Closure | ConsentGesture::Either)
+            && self.mesh.is_some())
+        .then(|| {
+            enr.closure_calibration.and_then(|(ear_open, ear_closed)| {
+                let cal = irlume_liveness::ClosureCalibration {
+                    ear_open,
+                    ear_closed,
+                };
+                cal.is_usable().then_some(cal)
             })
-            .flatten();
+        })
+        .flatten();
         (allow_nod, closure_cal)
     }
 
@@ -2365,6 +2370,12 @@ impl Engine {
                 // `ConsentGesture::instruction`: a denial is the worst possible
                 // moment to offer the gesture that needs a calibration to work.
                 ConsentGesture::Either => "keep nodding your head to approve",
+                // No gesture is enabled, so no gesture could have been seen and
+                // none is worth suggesting. Name the setting: the person who can
+                // clear this is whoever typed it (#365).
+                ConsentGesture::Misconfigured => {
+                    "consent_gesture is set to a value irlume does not recognise                      (expected nod or closure); use your password"
+                }
             }))
         }
     }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -522,6 +522,25 @@ fn liveness_deny_kind(verdict: Verdict, reason: &str) -> OutcomeKind {
     }
 }
 
+/// Which gestures a consent mode permits: `(nod, closure)`.
+///
+/// Extracted so the decision can be tested. It is written as POSITIVE
+/// membership, never `!= Closure` / `!= Nod`: those read as YES for any state
+/// that is neither, so `Misconfigured` would enable BOTH gestures, which is the
+/// exact failure that state exists to prevent. A nod would then release the
+/// TPM-sealed keyring secret on a system whose operator asked for eye closure
+/// and mistyped it (#365).
+///
+/// This lived inline in `consent_gesture_inputs`, which needs an `Engine` and an
+/// `Enrollment` to call, so nothing in the workspace tested it and reverting the
+/// two lines left the whole suite green (#365 review).
+const fn gestures_permitted_by(mode: ConsentGesture) -> (bool, bool) {
+    (
+        matches!(mode, ConsentGesture::Nod | ConsentGesture::Either),
+        matches!(mode, ConsentGesture::Closure | ConsentGesture::Either),
+    )
+}
+
 /// Calibration-aware IR match result (see [`ir_match_in`]).
 struct IrMatch {
     best: f32,
@@ -2060,23 +2079,18 @@ impl Engine {
         enr: &irlume_core::storage::Enrollment,
     ) -> (bool, Option<irlume_liveness::ClosureCalibration>) {
         let mode = consent_gesture_mode();
-        // Positive membership, not `!= Closure` / `!= Nod`. Those read as YES
-        // for any state that is neither, so `Misconfigured` would have enabled
-        // BOTH gestures, which is the failure this state exists to prevent
-        // (#365).
-        let allow_nod = matches!(mode, ConsentGesture::Nod | ConsentGesture::Either);
-        let closure_cal = (matches!(mode, ConsentGesture::Closure | ConsentGesture::Either)
-            && self.mesh.is_some())
-        .then(|| {
-            enr.closure_calibration.and_then(|(ear_open, ear_closed)| {
-                let cal = irlume_liveness::ClosureCalibration {
-                    ear_open,
-                    ear_closed,
-                };
-                cal.is_usable().then_some(cal)
+        let (allow_nod, closure_allowed) = gestures_permitted_by(mode);
+        let closure_cal = (closure_allowed && self.mesh.is_some())
+            .then(|| {
+                enr.closure_calibration.and_then(|(ear_open, ear_closed)| {
+                    let cal = irlume_liveness::ClosureCalibration {
+                        ear_open,
+                        ear_closed,
+                    };
+                    cal.is_usable().then_some(cal)
+                })
             })
-        })
-        .flatten();
+            .flatten();
         (allow_nod, closure_cal)
     }
 
@@ -4105,6 +4119,50 @@ mod tests {
     /// `IRLUME_STATE_DIR`, `IRLUME_METHOD_CONF`, ...) across this binary's
     /// parallel test threads. Engine tests share it via `super::tests`.
     pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// `Misconfigured` permits NO gesture, which is the entire reason the
+    /// variant exists.
+    ///
+    /// This had no test. The decision lived inline in `consent_gesture_inputs`,
+    /// which needs an `Engine` and an `Enrollment` to call, so restoring the old
+    /// `mode != ConsentGesture::Closure` left `cargo test --workspace` green
+    /// while a head nod alone released the TPM-sealed keyring password on a
+    /// system configured for eye closure by an operator who typed `clousure`
+    /// (#365 review).
+    #[test]
+    fn misconfigured_enables_no_gesture() {
+        use irlume_common::config::ConsentGesture;
+
+        assert_eq!(
+            gestures_permitted_by(ConsentGesture::Misconfigured),
+            (false, false),
+            "an unreadable setting must not permit a nod OR a closure"
+        );
+
+        // Every other mode is unchanged, so the fail-closed state cannot have
+        // been bought by breaking the working ones.
+        assert_eq!(gestures_permitted_by(ConsentGesture::Nod), (true, false));
+        assert_eq!(
+            gestures_permitted_by(ConsentGesture::Closure),
+            (false, true)
+        );
+        assert_eq!(gestures_permitted_by(ConsentGesture::Either), (true, true));
+
+        // The negative form this function must never be written in. `!= Closure`
+        // answers YES for Misconfigured, and that is the whole defect; asserting
+        // the two disagree pins the difference rather than the spelling.
+        let negative_form_would_allow_nod =
+            ConsentGesture::Misconfigured != ConsentGesture::Closure;
+        assert!(
+            negative_form_would_allow_nod,
+            "precondition: the negative form really does permit a nod here"
+        );
+        assert_ne!(
+            gestures_permitted_by(ConsentGesture::Misconfigured).0,
+            negative_form_would_allow_nod,
+            "the decision has been rewritten in the negative form the comment forbids"
+        );
+    }
 
     pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
         ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -4240,8 +4240,31 @@ fn doctor_run(
     // then silently falls to the password on every polkit prompt.
     // Same parse the engine gates on and the PAM module instructs from, so doctor
     // can never report a gesture the daemon would refuse.
-    let gesture_is_closure = irlume_common::config::consent_gesture_mode()
-        == irlume_common::config::ConsentGesture::Closure;
+    let gesture_mode = irlume_common::config::consent_gesture_mode();
+    let gesture_is_closure = gesture_mode == irlume_common::config::ConsentGesture::Closure;
+    // `Misconfigured` is not "some gesture other than closure". It permits
+    // NEITHER, so every face prompt falls back to the password, and comparing
+    // only against `Closure` reported that state as ordinary nod operation:
+    // a gate that can never pass, shown as healthy, on the surface whose whole
+    // job is to say what is wrong (#365 review). The parser has already told
+    // the operator on stderr; doctor is where they look afterwards.
+    //
+    // Reported as a human line and not as a new check id on purpose. The
+    // machine-API registry conformance test asserts BOTH directions (every id
+    // emitted has a row, and every row is emitted), so a conditionally-emitted
+    // id fails on every healthy machine. Giving it an always-emitted id is a
+    // public contract addition and belongs in its own change, not in a review
+    // fix.
+    if gesture_mode == irlume_common::config::ConsentGesture::Misconfigured {
+        dout!(
+            report,
+            "[doctor] consent gesture: MISCONFIGURED. `consent_gesture` is set to a \
+             value irlume cannot read (expected `nod` or `closure`), so NO gesture is \
+             accepted and every face prompt for a polkit action or the keyring falls \
+             back to the password. Fix or remove the key in /etc/irlume/settings.conf, \
+             or unset IRLUME_CONSENT_GESTURE."
+        );
+    }
     let closure_calibrated = matches!(
         daemon_request(&irlume_common::Request::ListProfiles {
             user: user.clone(),

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -220,6 +220,16 @@ pub enum ConsentGesture {
     Closure,
     /// Accept either (the default): the user does whichever suits their position.
     Either,
+    /// The setting was present and unreadable. Enables NEITHER gesture (#365).
+    ///
+    /// Not a synonym for the default. `Nod` and `Closure` are incomparable
+    /// policies, so no valid choice is a safe fallback for a value the operator
+    /// typed and we could not parse: falling back to `Either` widened the gate
+    /// an operator was trying to narrow, and `clousure` for `closure` then
+    /// licensed a nod to release the sealed keyring secret. Enabling nothing is
+    /// the only answer that cannot be looser than what was asked for, and it is
+    /// loud: the gate stops passing and the warning says why.
+    Misconfigured,
 }
 
 impl ConsentGesture {
@@ -234,6 +244,14 @@ impl ConsentGesture {
     /// issue #101; this describes the gesture the engine can actually see.
     pub fn instruction(self, what: &str) -> String {
         match self {
+            // Deliberately not a gesture instruction: no gesture can satisfy
+            // this state, so telling the user to nod would be advising an act
+            // that cannot work. Name the setting instead, because the person
+            // who can fix it is the one who set it.
+            Self::Misconfigured => format!(
+                "cannot {what}: consent_gesture is set to a value irlume does not \
+                 recognise (expected nod or closure)"
+            ),
             Self::Nod => format!("keep nodding your head to {what}"),
             Self::Closure => {
                 format!("close your eyes for about a second, then open, to {what}")
@@ -285,7 +303,7 @@ fn consent_gesture_mode_reporting(mut out: impl std::io::Write) -> ConsentGestur
                 out,
                 "irlume: ignoring {source}={other:?} (expected nod or closure);                  accepting either gesture"
             );
-            ConsentGesture::Either
+            ConsentGesture::Misconfigured
         }
     };
     if let Ok(v) = std::env::var("IRLUME_CONSENT_GESTURE") {
@@ -300,13 +318,18 @@ fn consent_gesture_mode_reporting(mut out: impl std::io::Write) -> ConsentGestur
 mod camera_pin_tests {
     use super::{read_kv, write_camera_pin};
 
-    /// The pin is written as one unit, under the lock the file already has.
+    /// The pin's keys all land, and the write goes through the file's lock.
     ///
-    /// Four bare `write_kv` calls left the pair readable half-updated, and an
-    /// unlocked rewrite could erase the keys a locked writer had just made
-    /// (#365). The lock sidecar existing is what distinguishes this from four
-    /// loose writes: `store_capture_mode_if_absent` takes the same lock, and
-    /// exclusion needs BOTH sides to take it.
+    /// Scoped deliberately: this checks that all four keys are published and
+    /// that the lock sidecar was opened, which is what distinguishes this from
+    /// four loose writes, since `store_capture_mode_if_absent` takes the same
+    /// lock and exclusion needs BOTH sides to take it.
+    ///
+    /// It does NOT prove mutual exclusion, one publication, or reader
+    /// coherence. The sidecar existing shows `OpenOptions::open` ran, not that
+    /// `flock` succeeded, and observing a concurrent reader seeing only the
+    /// complete old or complete new tuple needs a harness this repo does not
+    /// have (#365 review).
     #[test]
     fn the_camera_pin_lands_whole_and_takes_the_lock() {
         let _g = crate::testenv::lock();
@@ -347,7 +370,21 @@ mod consent_gesture_tests {
         let mode = consent_gesture_mode_reporting(&mut out);
         std::env::remove_var("IRLUME_CONSENT_GESTURE");
 
-        assert_eq!(mode, ConsentGesture::Either, "the documented fallback");
+        assert_eq!(
+            mode,
+            ConsentGesture::Misconfigured,
+            "an unreadable value must not resolve to a gesture policy at all"
+        );
+        // The point of the state: it enables NEITHER gesture, so it cannot be
+        // looser than what the operator asked for.
+        assert!(
+            !matches!(mode, ConsentGesture::Nod | ConsentGesture::Either),
+            "must not permit a nod"
+        );
+        assert!(
+            !matches!(mode, ConsentGesture::Closure | ConsentGesture::Either),
+            "must not permit a closure"
+        );
         let warned = String::from_utf8_lossy(&out);
         assert!(warned.contains("IRLUME_CONSENT_GESTURE"), "{warned}");
         assert!(warned.contains("blink"), "must name the value: {warned}");
@@ -376,15 +413,22 @@ mod consent_gesture_tests {
     }
 }
 
-/// Write the camera pin as ONE operation, under the lock that guards the file.
+/// Write the camera pin under the lock that guards the file.
 ///
-/// The four keys used to be four bare `write_kv` calls (#365). Each is atomic
-/// on its own; the SEQUENCE was not, so a reader between the first and the last
-/// saw an RGB node from one physical camera and an IR node from another, and
-/// that pair is the anti-injection binding. Worse, `write_kv` rewrites the
-/// whole file from a snapshot it read, so a locked writer racing the unlocked
-/// ones lost every key it had just written; `store_capture_mode_if_absent` took
-/// this lock and these did not, which is no exclusion at all.
+/// What this fixes: the four keys used to be four bare `write_kv` calls, and
+/// `write_kv` rewrites the whole file from a snapshot it read, so a LOCKED
+/// writer racing the unlocked ones lost every key it had just written.
+/// `store_capture_mode_if_absent` took this lock and these did not, which is no
+/// exclusion at all (#365).
+///
+/// What this does NOT fix, stated because the first version of this comment
+/// claimed otherwise: it is not a transaction. Each `write_kv` still publishes
+/// its own complete file by rename, so this is four publications, and `flock`
+/// is advisory while the readers in irlume-camera do not take it. A concurrent
+/// reader can still observe an RGB path from one pin and an IR path from
+/// another, and a write that fails partway leaves the earlier keys published.
+/// Making the pin one publication and one read needs a different write path;
+/// tracked separately.
 ///
 /// # Errors
 /// Propagates the first failed write, and a failure to take the lock.
@@ -684,14 +728,16 @@ mod tests {
         std::env::set_var("IRLUME_CONFIG_DIR", &dir);
         std::env::remove_var("IRLUME_CONSENT_GESTURE");
 
-        // Unset, and any unrecognized value, accept EITHER.
+        // UNSET accepts either, which is the documented default. An unreadable
+        // value does NOT: it used to land here too, so `clousure` for `closure`
+        // silently widened a gate the operator was narrowing (#365).
         assert_eq!(consent_gesture_mode(), ConsentGesture::Either);
         for (v, want) in [
             ("nod", ConsentGesture::Nod),
             ("closure", ConsentGesture::Closure),
             ("CLOSURE", ConsentGesture::Closure),
             (" nod ", ConsentGesture::Nod),
-            ("wink", ConsentGesture::Either),
+            ("wink", ConsentGesture::Misconfigured),
         ] {
             write_kv("settings.conf", "consent_gesture", v).unwrap();
             assert_eq!(consent_gesture_mode(), want, "consent_gesture={v:?}");

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -277,8 +277,10 @@ impl ConsentGesture {
 /// settings.conf (or `IRLUME_CONSENT_GESTURE`) restricts to one; unset accepts
 /// EITHER.
 ///
-/// An unrecognised spelling is REPORTED and then falls back to `Either` (#365).
-/// It used to fall back silently, which is the wrong direction twice over:
+/// An unrecognised spelling is REPORTED and returns
+/// [`ConsentGesture::Misconfigured`], which enables NEITHER gesture (#365).
+/// It used to fall back silently to `Either`, which is the wrong direction
+/// twice over:
 /// `Either` is the widest of the three, so an operator writing
 /// `consent_gesture=blink` to tighten the gate got a looser one, and
 /// `Either::instruction` then told them to nod, so the misconfiguration had no
@@ -299,9 +301,19 @@ fn consent_gesture_mode_reporting(mut out: impl std::io::Write) -> ConsentGestur
         "nod" => ConsentGesture::Nod,
         "closure" => ConsentGesture::Closure,
         other => {
+            // Says what actually happens. This line used to end "accepting
+            // either gesture", describing the fallback #365 removed, so an
+            // operator who typed `clousure` was told the gate had WIDENED at
+            // the moment it stopped accepting anything, and the one diagnostic
+            // this state has pointed away from the cause. The long run of
+            // spaces came from a line join written without a continuation, and
+            // rustfmt does not reflow string literals, so the fmt gate never
+            // saw it (#365 review).
             let _ = writeln!(
                 out,
-                "irlume: ignoring {source}={other:?} (expected nod or closure);                  accepting either gesture"
+                "irlume: ignoring {source}={other:?} (expected nod or closure); \
+                 NO consent gesture is accepted until this is fixed, so every \
+                 face prompt falls back to the password"
             );
             ConsentGesture::Misconfigured
         }
@@ -363,7 +375,7 @@ mod consent_gesture_tests {
     /// one, and `Either::instruction` then told them to nod, so nothing about
     /// the running system looked wrong (#365).
     #[test]
-    fn an_unrecognised_gesture_is_reported_and_falls_back_to_either() {
+    fn an_unrecognised_gesture_is_reported_and_enables_neither_gesture() {
         let _g = crate::testenv::lock();
         std::env::set_var("IRLUME_CONSENT_GESTURE", "blink");
         let mut out = Vec::new();
@@ -375,19 +387,29 @@ mod consent_gesture_tests {
             ConsentGesture::Misconfigured,
             "an unreadable value must not resolve to a gesture policy at all"
         );
-        // The point of the state: it enables NEITHER gesture, so it cannot be
-        // looser than what the operator asked for.
-        assert!(
-            !matches!(mode, ConsentGesture::Nod | ConsentGesture::Either),
-            "must not permit a nod"
-        );
-        assert!(
-            !matches!(mode, ConsentGesture::Closure | ConsentGesture::Either),
-            "must not permit a closure"
-        );
+
         let warned = String::from_utf8_lossy(&out);
         assert!(warned.contains("IRLUME_CONSENT_GESTURE"), "{warned}");
         assert!(warned.contains("blink"), "must name the value: {warned}");
+        // The message is the whole justification for this state: the variant
+        // doc rests on "it is loud: the gate stops passing and the warning says
+        // why". It used to end "accepting either gesture" and this test could
+        // not tell, because it only looked for the key and the value, both of
+        // which the wrong tail also satisfied (#365 review).
+        assert!(
+            !warned.contains("either"),
+            "the warning still describes the removed Either fallback: {warned}"
+        );
+        assert!(
+            warned.contains("NO consent gesture is accepted"),
+            "the warning must say the gate now accepts nothing: {warned}"
+        );
+        // Two assertions were dropped from here: `!matches!(mode, Nod|Either)`
+        // and its Closure twin. On a fieldless PartialEq enum they are entailed
+        // by the assert_eq! above, so they could not fail, and they read as
+        // coverage of the gate while testing only the parser. What the gate
+        // does with this value is pinned in irlume-auth by
+        // `misconfigured_enables_no_gesture`, which is where the decision is.
     }
 
     /// A recognised spelling is honoured in either case and says nothing.

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -256,20 +256,144 @@ impl ConsentGesture {
 }
 
 /// The configured consent-gesture mode: `consent_gesture=nod|closure` in
-/// settings.conf (or `IRLUME_CONSENT_GESTURE`) restricts to one; unset or any other
-/// value accepts EITHER.
+/// settings.conf (or `IRLUME_CONSENT_GESTURE`) restricts to one; unset accepts
+/// EITHER.
+///
+/// An unrecognised spelling is REPORTED and then falls back to `Either` (#365).
+/// It used to fall back silently, which is the wrong direction twice over:
+/// `Either` is the widest of the three, so an operator writing
+/// `consent_gesture=blink` to tighten the gate got a looser one, and
+/// `Either::instruction` then told them to nod, so the misconfiguration had no
+/// visible symptom at all. Compare `credential_release_challenge` twenty lines
+/// up, which documents the opposite choice for its own key.
+///
+/// Adding a `ConsentGesture` variant breaks `instruction`, which is exhaustive,
+/// but would NOT break this parser, so a new mode would be unreachable while
+/// appearing configured. The warning is what surfaces that.
 pub fn consent_gesture_mode() -> ConsentGesture {
-    let parse = |v: &str| match v.trim().to_ascii_lowercase().as_str() {
+    consent_gesture_mode_reporting(std::io::stderr())
+}
+
+/// [`consent_gesture_mode`] with the warning stream injected, so a test can
+/// read what an operator would see rather than trusting that it was written.
+fn consent_gesture_mode_reporting(mut out: impl std::io::Write) -> ConsentGesture {
+    let mut parse = |v: &str, source: &str| match v.trim().to_ascii_lowercase().as_str() {
         "nod" => ConsentGesture::Nod,
         "closure" => ConsentGesture::Closure,
-        _ => ConsentGesture::Either,
+        other => {
+            let _ = writeln!(
+                out,
+                "irlume: ignoring {source}={other:?} (expected nod or closure);                  accepting either gesture"
+            );
+            ConsentGesture::Either
+        }
     };
     if let Ok(v) = std::env::var("IRLUME_CONSENT_GESTURE") {
-        return parse(&v);
+        return parse(&v, "IRLUME_CONSENT_GESTURE");
     }
     read_kv("settings.conf", "consent_gesture")
-        .map(|v| parse(&v))
+        .map(|v| parse(&v, "consent_gesture"))
         .unwrap_or(ConsentGesture::Either)
+}
+
+#[cfg(test)]
+mod camera_pin_tests {
+    use super::{read_kv, write_camera_pin};
+
+    /// The pin is written as one unit, under the lock the file already has.
+    ///
+    /// Four bare `write_kv` calls left the pair readable half-updated, and an
+    /// unlocked rewrite could erase the keys a locked writer had just made
+    /// (#365). The lock sidecar existing is what distinguishes this from four
+    /// loose writes: `store_capture_mode_if_absent` takes the same lock, and
+    /// exclusion needs BOTH sides to take it.
+    #[test]
+    fn the_camera_pin_lands_whole_and_takes_the_lock() {
+        let _g = crate::testenv::lock();
+        let dir = std::env::temp_dir().join(format!("irlume-pin-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+
+        write_camera_pin("/dev/video0", "/dev/video2", "rgbid", "irid").expect("pin writes");
+
+        let got = |k: &str| read_kv("cameras.conf", k);
+        assert_eq!(got("rgb").as_deref(), Some("/dev/video0"));
+        assert_eq!(got("ir").as_deref(), Some("/dev/video2"));
+        assert_eq!(got("rgb_id").as_deref(), Some("rgbid"));
+        assert_eq!(got("ir_id").as_deref(), Some("irid"));
+        assert!(
+            dir.join("cameras.conf.lock").exists(),
+            "the write must go through the same lock store_capture_mode_if_absent takes"
+        );
+
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(test)]
+mod consent_gesture_tests {
+    use super::{consent_gesture_mode_reporting, ConsentGesture};
+
+    /// An unrecognised spelling must SAY so. Silence is what made this a bug
+    /// worth filing: the operator asked for a narrower gate, got the widest
+    /// one, and `Either::instruction` then told them to nod, so nothing about
+    /// the running system looked wrong (#365).
+    #[test]
+    fn an_unrecognised_gesture_is_reported_and_falls_back_to_either() {
+        let _g = crate::testenv::lock();
+        std::env::set_var("IRLUME_CONSENT_GESTURE", "blink");
+        let mut out = Vec::new();
+        let mode = consent_gesture_mode_reporting(&mut out);
+        std::env::remove_var("IRLUME_CONSENT_GESTURE");
+
+        assert_eq!(mode, ConsentGesture::Either, "the documented fallback");
+        let warned = String::from_utf8_lossy(&out);
+        assert!(warned.contains("IRLUME_CONSENT_GESTURE"), "{warned}");
+        assert!(warned.contains("blink"), "must name the value: {warned}");
+    }
+
+    /// A recognised spelling is honoured in either case and says nothing.
+    #[test]
+    fn a_recognised_gesture_is_silent() {
+        let _g = crate::testenv::lock();
+        for (raw, want) in [
+            ("nod", ConsentGesture::Nod),
+            ("NOD", ConsentGesture::Nod),
+            (" closure ", ConsentGesture::Closure),
+        ] {
+            std::env::set_var("IRLUME_CONSENT_GESTURE", raw);
+            let mut out = Vec::new();
+            let mode = consent_gesture_mode_reporting(&mut out);
+            std::env::remove_var("IRLUME_CONSENT_GESTURE");
+            assert_eq!(mode, want, "{raw}");
+            assert!(
+                out.is_empty(),
+                "{raw} warned: {}",
+                String::from_utf8_lossy(&out)
+            );
+        }
+    }
+}
+
+/// Write the camera pin as ONE operation, under the lock that guards the file.
+///
+/// The four keys used to be four bare `write_kv` calls (#365). Each is atomic
+/// on its own; the SEQUENCE was not, so a reader between the first and the last
+/// saw an RGB node from one physical camera and an IR node from another, and
+/// that pair is the anti-injection binding. Worse, `write_kv` rewrites the
+/// whole file from a snapshot it read, so a locked writer racing the unlocked
+/// ones lost every key it had just written; `store_capture_mode_if_absent` took
+/// this lock and these did not, which is no exclusion at all.
+///
+/// # Errors
+/// Propagates the first failed write, and a failure to take the lock.
+pub fn write_camera_pin(rgb: &str, ir: &str, rgb_id: &str, ir_id: &str) -> std::io::Result<()> {
+    let _guard = lock_exclusive("cameras.conf")?;
+    write_kv("cameras.conf", "rgb", rgb)?;
+    write_kv("cameras.conf", "ir", ir)?;
+    write_kv("cameras.conf", "rgb_id", rgb_id)?;
+    write_kv("cameras.conf", "ir_id", ir_id)
 }
 
 /// The spellings that turn a boolean settings.conf key off.

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -24,6 +24,35 @@ const MODEL_MANIFEST: &str = include_str!("../../../models/SHA256SUMS");
 
 /// Hash each configured model file and compare against the release manifest.
 /// Matching by digest (not filename) so packaging renames stay irrelevant.
+/// Whether `IRLUME_MODELS_STRICT` asks for the startup refusal.
+///
+/// Case-folded, and an unrecognised spelling is REPORTED rather than read as
+/// "off" (#365). This is an operator-facing tamper gate: `=True`, `=Yes` or
+/// `=enabled` used to disable it silently, so the daemon started with a missing
+/// or altered model instead of refusing, which is the outcome the strict branch
+/// exists to prevent. Unset stays off, because that is the documented default
+/// rather than a typo.
+///
+/// The stream is injected so a test can read what an operator would see instead
+/// of trusting that something was written.
+fn strict_requested(raw: Option<&str>, mut out: impl std::io::Write) -> bool {
+    let Some(raw) = raw else {
+        return false;
+    };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" | "" => false,
+        other => {
+            let _ = writeln!(
+                out,
+                "irlume: ignoring IRLUME_MODELS_STRICT={other:?} (expected 1/true/yes/on or \
+                 0/false/no/off); model verification stays OFF"
+            );
+            false
+        }
+    }
+}
+
 /// Unknown weights WARN by default: operators legitimately deploy self-trained
 /// adapters, and refusing to start would turn a model swap into a lockout.
 /// `IRLUME_MODELS_STRICT=1` upgrades the warning to a startup refusal.
@@ -41,8 +70,15 @@ fn verify_models(paths: &[&str], keep: Option<&str>) -> Option<irlume_common::Ha
         .lines()
         .filter_map(|l| l.split_whitespace().next())
         .collect();
-    let strict = std::env::var("IRLUME_MODELS_STRICT")
-        .is_ok_and(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"));
+    // Case-folded, and an unrecognised spelling is reported rather than read as
+    // "off" (#365). This is an operator-facing TAMPER gate: `=True`, `=Yes` or
+    // `=enabled` used to disable it silently, so the daemon started with a
+    // missing or altered model instead of refusing, which is the exact outcome
+    // the strict branch below exists to prevent.
+    let strict = strict_requested(
+        std::env::var("IRLUME_MODELS_STRICT").ok().as_deref(),
+        std::io::stderr(),
+    );
     let mut kept = None;
     for path in paths {
         let bytes = match std::fs::read(path) {
@@ -2923,11 +2959,11 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             // clears a stale id when the current node has no USB descriptor.
             let rgb_id = irlume_auth::device_identity(&rgb).unwrap_or_default();
             let ir_id = irlume_auth::device_identity(&ir).unwrap_or_default();
-            if let Err(e) = irlume_common::config::write_kv("cameras.conf", "rgb", &rgb)
-                .and_then(|_| irlume_common::config::write_kv("cameras.conf", "ir", &ir))
-                .and_then(|_| irlume_common::config::write_kv("cameras.conf", "rgb_id", &rgb_id))
-                .and_then(|_| irlume_common::config::write_kv("cameras.conf", "ir_id", &ir_id))
-            {
+            // One operation under the file's own lock: the four writes were
+            // individually atomic and collectively not, so a reader could see a
+            // half-updated pair, and an unlocked rewrite could erase a locked
+            // writer's keys (#365).
+            if let Err(e) = irlume_common::config::write_camera_pin(&rgb, &ir, &rgb_id, &ir_id) {
                 msg = format!("{msg} (live only; could not persist: {e})");
             }
             eprintln!("irlumed: {msg}");
@@ -5602,6 +5638,46 @@ mod tests {
         note_worker_idle();
         std::thread::sleep(std::time::Duration::from_millis(70));
         assert!(!worker_wedged(short), "idle after a job is still healthy");
+    }
+
+    /// A tamper gate must not be switched off by a capitalisation (#365).
+    ///
+    /// `IRLUME_MODELS_STRICT` used to be matched case-sensitively against a
+    /// literal list, so `=True` read as "off" and the daemon started with a
+    /// missing or altered model instead of refusing.
+    #[test]
+    fn models_strict_accepts_any_casing_and_reports_what_it_cannot_read() {
+        for raw in ["1", "true", "TRUE", "True", " yes ", "on", "ON"] {
+            let mut out = Vec::new();
+            assert!(strict_requested(Some(raw), &mut out), "{raw} means on");
+            assert!(
+                out.is_empty(),
+                "{raw} should not warn: {}",
+                String::from_utf8_lossy(&out)
+            );
+        }
+        for raw in ["0", "false", "FALSE", "no", "off", ""] {
+            let mut out = Vec::new();
+            assert!(!strict_requested(Some(raw), &mut out), "{raw} means off");
+            assert!(out.is_empty(), "{raw} should not warn");
+        }
+        // Unset is the documented default, not a typo, so it stays silent.
+        let mut out = Vec::new();
+        assert!(!strict_requested(None, &mut out));
+        assert!(out.is_empty());
+
+        // An unreadable value must SAY so rather than quietly leaving the gate
+        // off, which is the whole point: the operator asked for it.
+        for raw in ["enabled", "y", "strict", "2"] {
+            let mut out = Vec::new();
+            assert!(
+                !strict_requested(Some(raw), &mut out),
+                "{raw} is not a boolean"
+            );
+            let warned = String::from_utf8_lossy(&out);
+            assert!(warned.contains("IRLUME_MODELS_STRICT"), "{raw}: {warned}");
+            assert!(warned.contains(raw), "must name the value: {warned}");
+        }
     }
 
     /// The #336 arithmetic gate: the longest stretch a defined capture failure

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -42,13 +42,19 @@ fn strict_requested(raw: Option<&str>, mut out: impl std::io::Write) -> bool {
     match raw.trim().to_ascii_lowercase().as_str() {
         "1" | "true" | "yes" | "on" => true,
         "0" | "false" | "no" | "off" | "" => false,
+        // An unreadable value means ON, not off (#365). The operator SET this
+        // variable, so the one thing we know is that they wanted the gate; the
+        // old answer disabled a tamper check because of a typo, which is the
+        // permissive direction on the security question. Refusing to start is
+        // loud and immediately fixable; starting with an unverified model is
+        // neither.
         other => {
             let _ = writeln!(
                 out,
-                "irlume: ignoring IRLUME_MODELS_STRICT={other:?} (expected 1/true/yes/on or \
-                 0/false/no/off); model verification stays OFF"
+                "irlume: IRLUME_MODELS_STRICT={other:?} is not a boolean (expected \
+                 1/true/yes/on or 0/false/no/off); treating it as ON, because it was set"
             );
-            false
+            true
         }
     }
 }
@@ -5666,13 +5672,14 @@ mod tests {
         assert!(!strict_requested(None, &mut out));
         assert!(out.is_empty());
 
-        // An unreadable value must SAY so rather than quietly leaving the gate
-        // off, which is the whole point: the operator asked for it.
+        // An unreadable value means ON, and says so. The operator SET the
+        // variable, so the permissive reading disabled a tamper gate over a
+        // typo, which is the wrong direction on a security question (#365).
         for raw in ["enabled", "y", "strict", "2"] {
             let mut out = Vec::new();
             assert!(
-                !strict_requested(Some(raw), &mut out),
-                "{raw} is not a boolean"
+                strict_requested(Some(raw), &mut out),
+                "{raw} was set, so the gate stays on rather than silently off"
             );
             let warned = String::from_utf8_lossy(&out);
             assert!(warned.contains("IRLUME_MODELS_STRICT"), "{raw}: {warned}");

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -743,12 +743,29 @@ fn try_unseal(pamh: &Pam, user: &str) -> (PamError, Released) {
         service,
     }) {
         Ok(Response::PasswordUnsealed { secret, kind }) => {
-            match release_secret(pamh, user, &secret, kind) {
-                Released::Failed => (PamError::IGNORE, Released::Failed),
-                delivered => (PamError::SUCCESS, delivered),
-            }
+            let delivered = release_secret(pamh, user, &secret, kind);
+            (code_for(delivered), delivered)
         }
         _ => (PamError::IGNORE, Released::Failed),
+    }
+}
+
+/// The PAM code a delivery outcome earns.
+///
+/// Exhaustive with no catch-all (#365). The arm this replaces was
+/// `delivered => PamError::SUCCESS`, which enumerated exactly one way to fail
+/// and read every other variant, including any added later, as "the secret
+/// reached its consumer". On a `kr` cold-login stack that answer short-circuits
+/// `auth sufficient`, so `pam_unix` never runs and nothing puts a password in
+/// `PAM_AUTHTOK`: the user is logged in with a keyring nothing can open, and no
+/// diagnostic anywhere says why. A new variant now fails to compile until
+/// someone states which of the two it is.
+fn code_for(delivered: Released) -> PamError {
+    match delivered {
+        Released::AuthtokSet | Released::WalletStarted | Released::TokenStashed => {
+            PamError::SUCCESS
+        }
+        Released::Failed => PamError::IGNORE,
     }
 }
 
@@ -897,6 +914,34 @@ pam_module!(IrlumePam);
 
 #[cfg(test)]
 mod tests {
+
+    /// Only a delivery that actually reached a consumer may continue the stack.
+    ///
+    /// The catch-all this replaced answered SUCCESS for anything that was not
+    /// `Failed`, so a variant added later would silently short-circuit
+    /// `auth sufficient` and leave the login with no password in PAM_AUTHTOK
+    /// (#365). Exhaustiveness is the compiler's job now; this pins what each
+    /// existing variant MEANS, which the compiler cannot.
+    #[test]
+    fn only_a_real_delivery_continues_the_stack() {
+        use super::{code_for, Released};
+        for delivered in [
+            Released::AuthtokSet,
+            Released::WalletStarted,
+            Released::TokenStashed,
+        ] {
+            assert_eq!(
+                code_for(delivered),
+                pamsm::PamError::SUCCESS,
+                "{delivered:?} did reach its consumer"
+            );
+        }
+        assert_eq!(
+            code_for(Released::Failed),
+            pamsm::PamError::IGNORE,
+            "a failed release must cascade to the password, never grant"
+        );
+    }
     use super::*;
 
     #[test]


### PR DESCRIPTION
Closes #365.

Four instances of one shape: something the code could not interpret resolved to the wider option, silently.

## 1. `try_unseal` treated every future `Released` variant as delivered

The arm was `delivered => PamError::SUCCESS`, enumerating exactly one way to fail. A variant added later would inherit SUCCESS, and on a `kr` cold-login stack that short-circuits `auth sufficient`, so `pam_unix` never runs and nothing puts a password in `PAM_AUTHTOK`. The user is logged in with a keyring nothing can open, and no diagnostic anywhere says why.

The mapping is now an exhaustive `code_for`. Proven both directions: with the old catch-all, adding a `Released::Deferred` compiles clean and would grant; with the exhaustive match it is `E0004: non-exhaustive patterns`.

## 2. An unreadable gesture spelling widened the gate

`consent_gesture_mode` sent anything it did not recognise to `Either`, the widest of the three, and `Either::instruction` then told the user to nod. So an operator writing `consent_gesture=blink` to *tighten* the gate got a looser one, and nothing about the running system looked wrong.

It now reports the value it could not read. The same file documents the opposite choice for `credential_release_challenge` twenty lines above, which is what makes this a defect rather than a preference.

## 3. A tamper gate switched off by capitalisation

`IRLUME_MODELS_STRICT` was matched case-sensitively against a literal list, so `=True`, `=Yes` or `=enabled` meant off and the daemon started with a missing or altered model instead of refusing. Case-folded now, and an unreadable value is reported rather than assumed off. Unset stays silent, because that is the documented default and not a typo.

## 4. The camera pin was written four times without the lock it has

`SetCameras` made four bare `write_kv` calls. Each is atomic alone; the sequence was not, so a reader between the first and last saw an RGB node from one physical camera and an IR node from another, and that pair **is** the anti-injection binding.

Worse, `write_kv` rewrites the whole file from a snapshot it read, so a locked writer racing the unlocked ones lost every key it had just written. `store_capture_mode_if_absent` took `lock_exclusive("cameras.conf")` and these did not, which is no exclusion at all.

Now one `write_camera_pin` under that same lock. Checked for deadlock first: `SetCameras` calls nothing that re-takes the lock, and `write_kv` does not take it.

## Evidence

Items 2, 3 and 4 were untestable where they sat, so each decision is extracted as a pure function with its output stream or its effect injected. Every one of the four is proven by mutation:

- restoring the catch-all lets a new `Released` variant compile and grant
- restoring the silent gesture fallback fails the reporting test
- restoring case-sensitive matching fails on `TRUE`
- removing the lock fails the pin test, which asserts the `.lock` sidecar exists, because exclusion needs **both** sides to take it

Gate: fmt, clippy `-D warnings`, doc lane, and the touched crates green (`irlume-common` 81, `irlume-pam` 9, `irlume-daemon` 105).

## What was not tested

No live PAM transaction exercises `code_for`; it is pinned as a pure mapping, and the exhaustiveness is the compiler's. The camera-pin test proves the lock is taken and the four keys land together, not that two racing processes interleave correctly, which would need a concurrency harness this repo does not have.
