### PR TITLE
The tier-climb tests establish the tier they climb to (#361)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,9 @@ jobs:
         env:
           IRLUME_TCTI: swtpm:host=127.0.0.1,port=2321
         run: |
-          ./scripts/run-tests-guarded.sh --require seal_unseal_roundtrip_real_tpm,arm_and_unseal_roundtrip,reseal_only_when_stale,tpm_key_and_recovery_lifecycle,tpm_tampered_seal_falls_back_then_recovery_heals,seal_unseal_pcrlock_roundtrip_provisioned_nv,a_token_envelope_heals_from_whichever_half_survives,rearming_reuses_the_existing_token_rather_than_minting,releasing_a_token_for_disarm_needs_the_right_password \
+          ./scripts/run-tests-guarded.sh --require seal_unseal_roundtrip_real_tpm,arm_and_unseal_roundtrip,reseal_only_when_stale,tpm_key_and_recovery_lifecycle,tpm_tampered_seal_falls_back_then_recovery_heals,seal_unseal_pcrlock_roundtrip_provisioned_nv,a_token_envelope_heals_from_whichever_half_survives,rearming_reuses_the_existing_token_rather_than_minting,releasing_a_token_for_disarm_needs_the_right_password,resealing_preserves_the_secret_kind,a_tier_climb_keeps_both_the_kind_and_the_recovery_wrap \
             -- cargo test -p irlume-core --lib --locked -- --ignored \
-            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle tpm_tampered_seal_falls_back_then_recovery_heals seal_unseal_pcrlock_roundtrip_provisioned_nv a_token_envelope_heals_from_whichever_half_survives rearming_reuses_the_existing_token_rather_than_minting releasing_a_token_for_disarm_needs_the_right_password --test-threads=1
+            seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale tpm_key_and_recovery_lifecycle tpm_tampered_seal_falls_back_then_recovery_heals seal_unseal_pcrlock_roundtrip_provisioned_nv a_token_envelope_heals_from_whichever_half_survives rearming_reuses_the_existing_token_rather_than_minting releasing_a_token_for_disarm_needs_the_right_password resealing_preserves_the_secret_kind a_tier_climb_keeps_both_the_kind_and_the_recovery_wrap --test-threads=1
           ./scripts/run-tests-guarded.sh --min 1 \
             -- cargo test -p irlume-daemon --locked -- --ignored tpm_ --test-threads=1
 

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -644,9 +644,14 @@ mod tests {
     /// downgrades the envelope to `LoginPassword` and the next login hands 56
     /// bytes of raw key to `pam_gnome_keyring` as an `AUTHTOK`.
     #[test]
-    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI. NOT run by CI: measured failing against a bare swtpm, the tier climb reports Unchanged (#361)"]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn resealing_preserves_the_secret_kind() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
+        // Same missing precondition as the climb test below (#361): without a
+        // stronger tier available, the rewrite this test inspects never runs and
+        // `reseal_password` answers Unchanged. A distinct NV index from the
+        // other fixtures, so a leftover from one cannot mask another.
+        let _pcrlock = tpm::tests::PcrlockFixture::provision(0x0181_C222);
         let dir = crate::test_tmp_dir("kr-kind");
         std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
@@ -862,12 +867,22 @@ mod tests {
     /// token into `PAM_AUTHTOK` on the next login. This is #253's
     /// `resealing_preserves_the_secret_kind` trap, one field wider.
     #[test]
-    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI. NOT run by CI: measured failing against a bare swtpm, the tier climb reports Unchanged (#361)"]
+    #[ignore = "requires a TPM: real /dev/tpmrm0, or swtpm via IRLUME_TCTI (CI does this)"]
     fn a_tier_climb_keeps_both_the_kind_and_the_recovery_wrap() {
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
         let dir = crate::test_tmp_dir("kr-token-climb");
         std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
+
+        // The precondition this test never established (#361): a climb needs a
+        // stronger tier to exist, and `stronger_tier_available_than(PcrLiteral)`
+        // is `signed_policy_available() || pcrlock_provisioned().is_some()`. On
+        // a bare swtpm neither holds, so `reseal_password` correctly answered
+        // Unchanged and the assertion below could never pass. Provisioning a
+        // synthetic Tier 2 makes the climb real: a genuine PolicyAuthorizeNV
+        // session and TPM round trip, which is the boundary the credential-leak
+        // regression lives behind.
+        let _pcrlock = tpm::tests::PcrlockFixture::provision(0x0181_C111);
 
         let pw = b"climb-password";
         let token = mint_gnome_token();

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -1675,9 +1675,6 @@ pub(crate) mod tests {
         assert_eq!(&*got, secret, "signed-PCR round-trip must match");
     }
 
-    /// Real Tier-2 pcrlock seal→unseal on the host TPM. Ignored by default: needs
-    /// /dev/tpmrm0, root, and a provisioned pcrlock policy
-    /// (`systemd-pcrlock make-policy`, NV index in /var/lib/systemd/pcrlock.json).
     /// A synthetic systemd-pcrlock policy, provisioned for the guard's lifetime.
     ///
     /// Extracted from `seal_unseal_pcrlock_roundtrip_provisioned_nv`, which built

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -1383,7 +1383,7 @@ pub fn diagnose_pcrs(env: &SealedEnvelope) -> Result<Vec<u32>> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     #[test]
@@ -1678,6 +1678,138 @@ mod tests {
     /// Real Tier-2 pcrlock seal→unseal on the host TPM. Ignored by default: needs
     /// /dev/tpmrm0, root, and a provisioned pcrlock policy
     /// (`systemd-pcrlock make-policy`, NV index in /var/lib/systemd/pcrlock.json).
+    /// A synthetic systemd-pcrlock policy, provisioned for the guard's lifetime.
+    ///
+    /// Extracted from `seal_unseal_pcrlock_roundtrip_provisioned_nv`, which built
+    /// this inline, so the tier-climb tests can establish the precondition they
+    /// were missing: `stronger_tier_available_than(PcrLiteral)` is
+    /// `signed_policy_available() || pcrlock_provisioned().is_some()`, and on a
+    /// bare swtpm neither holds, so those tests asserted a climb that could not
+    /// happen (#361).
+    ///
+    /// What this IS: a real owner-hierarchy NV space holding the alg-tagged
+    /// policy digest of the live PCR state, laid out the way
+    /// `systemd-pcrlock make-policy` writes it, plus a matching prediction JSON.
+    /// A seal against it runs a genuine `PolicyAuthorizeNV` session and a real
+    /// TPM round trip.
+    ///
+    /// What it is NOT: real systemd provisioning. It does not exercise
+    /// `make-policy`, protected NV updates, event-log prediction, real firmware
+    /// PCR movement, or Tier-1 signed-PCR behaviour. Those stay hardware work.
+    ///
+    /// Drop undefines the NV space and clears the override, so an assertion
+    /// failure mid-test does not leave the index or the env var behind for the
+    /// next one.
+    pub(crate) struct PcrlockFixture {
+        nv_index: u32,
+        dir: std::path::PathBuf,
+    }
+
+    impl PcrlockFixture {
+        /// Provision `nv_index` against the live PCR 7. The caller must hold
+        /// `ENV_LOCK`: this sets a process-global override.
+        pub(crate) fn provision(nv_index: u32) -> Self {
+            use tss_esapi::attributes::NvIndexAttributes;
+            use tss_esapi::structures::{MaxNvBuffer, NvPublic};
+
+            let mut ctx = open_context().expect("tpm context");
+            let pcr7 = read_pcr_values(&mut ctx, &[7])
+                .expect("read pcr7")
+                .remove(0);
+            assert_eq!(pcr7.value.len(), 32, "sha256 bank expected");
+            let hex: String = pcr7.value.iter().map(|b| format!("{b:02x}")).collect();
+
+            let dir = std::env::temp_dir().join(format!(
+                "irlume-pcrlock-{}-{nv_index:08x}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            let json_path = dir.join("pcrlock.json");
+            std::fs::write(
+                &json_path,
+                format!(
+                    r#"{{"pcrBank":"sha256","pcrValues":[{{"pcr":7,"values":["{hex}"]}}],"nvIndex":{nv_index}}}"#
+                ),
+            )
+            .unwrap();
+            std::env::set_var("IRLUME_PCRLOCK_JSON", &json_path);
+
+            // A leftover index from an aborted run has a different name lineage;
+            // drop it before defining ours.
+            let nv_handle_t = NvIndexTpmHandle::new(nv_index).unwrap();
+            if let Ok(obj) = ctx.tr_from_tpm_public(TpmHandle::NvIndex(nv_handle_t)) {
+                let _ = ctx.execute_with_nullauth_session(|ctx| {
+                    ctx.nv_undefine_space(Provision::Owner, NvIndexHandle::from(obj))
+                });
+            }
+
+            // Owner-hierarchy NV space, owner read/write, 34 bytes: a 2-byte
+            // hash alg id plus the sha256 policy digest, systemd-pcrlock's
+            // layout.
+            let attrs = NvIndexAttributes::builder()
+                .with_owner_write(true)
+                .with_owner_read(true)
+                .build()
+                .unwrap();
+            let public = NvPublic::builder()
+                .with_nv_index(nv_handle_t)
+                .with_index_name_algorithm(HashingAlgorithm::Sha256)
+                .with_index_attributes(attrs)
+                .with_data_area_size(34)
+                .build()
+                .unwrap();
+            let nv = ctx
+                .execute_with_nullauth_session(|ctx| {
+                    ctx.nv_define_space(Provision::Owner, None, public)
+                })
+                .expect("nv define");
+
+            // The digest a session holds after PolicyPCR(sel=[7], composite):
+            // what the live unseal session presents when PolicyAuthorizeNV
+            // compares it against the NV content.
+            let composite: [u8; 32] = Sha256::digest(&pcr7.value).into();
+            let policy_digest = with_session(&mut ctx, SessionType::Trial, |ctx, session| {
+                let policy = PolicySession::try_from(session).map_err(tpm_err)?;
+                ctx.policy_pcr(
+                    policy,
+                    Digest::try_from(composite.to_vec()).map_err(tpm_err)?,
+                    pcr_selection(&[7])?,
+                )
+                .map_err(tpm_err)?;
+                ctx.policy_get_digest(policy).map_err(tpm_err)
+            })
+            .expect("trial policy digest");
+
+            let mut content = vec![0x00u8, 0x0B]; // TPM2_ALG_SHA256, big-endian
+            content.extend_from_slice(policy_digest.value());
+            ctx.execute_with_nullauth_session(|ctx| {
+                ctx.nv_write(
+                    NvAuth::Owner,
+                    nv,
+                    MaxNvBuffer::try_from(content).unwrap(),
+                    0,
+                )
+            })
+            .expect("nv write");
+
+            Self { nv_index, dir }
+        }
+    }
+
+    impl Drop for PcrlockFixture {
+        fn drop(&mut self) {
+            if let Ok(mut ctx) = open_context() {
+                if let Ok(nv) = nv_index_handle(&mut ctx, self.nv_index) {
+                    let _ = ctx.execute_with_nullauth_session(|ctx| {
+                        ctx.nv_undefine_space(Provision::Owner, nv)
+                    });
+                }
+            }
+            std::env::remove_var("IRLUME_PCRLOCK_JSON");
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
     /// Tier-2 pcrlock seal/unseal without systemd-pcrlock: the test provisions
     /// the NV index the way `systemd-pcrlock make-policy` does (owner-hierarchy
     /// NV space holding the alg-tagged policy digest of the predicted PCR
@@ -1687,90 +1819,14 @@ mod tests {
     #[test]
     #[ignore = "requires a TPM: real /dev/tpmrm0 (root), or swtpm via IRLUME_TCTI (CI does this)"]
     fn seal_unseal_pcrlock_roundtrip_provisioned_nv() {
-        use tss_esapi::attributes::NvIndexAttributes;
-        use tss_esapi::structures::{MaxNvBuffer, NvPublic};
-
         let _g = crate::testenv::ENV_LOCK.lock().unwrap();
         const NV_INDEX: u32 = 0x0181_C0DE;
         let secret = b"irlume-pcrlock-roundtrip-secret!";
 
-        let mut ctx = open_context().expect("tpm context");
-        // Current PCR 7 feeds both the prediction JSON and the policy digest.
-        let pcr7 = read_pcr_values(&mut ctx, &[7])
-            .expect("read pcr7")
-            .remove(0);
-        assert_eq!(pcr7.value.len(), 32, "sha256 bank expected");
-        let hex: String = pcr7.value.iter().map(|b| format!("{b:02x}")).collect();
-
-        let dir = std::env::temp_dir().join(format!("irlume-pcrlock-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let json_path = dir.join("pcrlock.json");
-        std::fs::write(
-            &json_path,
-            format!(
-                r#"{{"pcrBank":"sha256","pcrValues":[{{"pcr":7,"values":["{hex}"]}}],"nvIndex":{NV_INDEX}}}"#
-            ),
-        )
-        .unwrap();
-        std::env::set_var("IRLUME_PCRLOCK_JSON", &json_path);
-
-        // A leftover index from an aborted run has a different name lineage;
-        // drop it before defining ours.
-        let nv_handle_t = NvIndexTpmHandle::new(NV_INDEX).unwrap();
-        if let Ok(obj) = ctx.tr_from_tpm_public(TpmHandle::NvIndex(nv_handle_t)) {
-            let _ = ctx.execute_with_nullauth_session(|ctx| {
-                ctx.nv_undefine_space(Provision::Owner, NvIndexHandle::from(obj))
-            });
-        }
-
-        // Owner-hierarchy NV space, owner read/write, 34 bytes: a 2-byte hash
-        // alg id plus the sha256 policy digest, systemd-pcrlock's layout.
-        let attrs = NvIndexAttributes::builder()
-            .with_owner_write(true)
-            .with_owner_read(true)
-            .build()
-            .unwrap();
-        let public = NvPublic::builder()
-            .with_nv_index(nv_handle_t)
-            .with_index_name_algorithm(HashingAlgorithm::Sha256)
-            .with_index_attributes(attrs)
-            .with_data_area_size(34)
-            .build()
-            .unwrap();
-        let nv = ctx
-            .execute_with_nullauth_session(|ctx| {
-                ctx.nv_define_space(Provision::Owner, None, public)
-            })
-            .expect("nv define");
-
-        // The digest a session holds after PolicyPCR(sel=[7], composite): what
-        // the live unseal session presents when PolicyAuthorizeNV compares it
-        // against the NV content.
-        let composite: [u8; 32] = Sha256::digest(&pcr7.value).into();
-        let policy_digest = with_session(&mut ctx, SessionType::Trial, |ctx, session| {
-            let policy = PolicySession::try_from(session).map_err(tpm_err)?;
-            ctx.policy_pcr(
-                policy,
-                Digest::try_from(composite.to_vec()).map_err(tpm_err)?,
-                pcr_selection(&[7])?,
-            )
-            .map_err(tpm_err)?;
-            ctx.policy_get_digest(policy).map_err(tpm_err)
-        })
-        .expect("trial policy digest");
-
-        let mut content = vec![0x00u8, 0x0B]; // TPM2_ALG_SHA256, big-endian
-        content.extend_from_slice(policy_digest.value());
-        ctx.execute_with_nullauth_session(|ctx| {
-            ctx.nv_write(
-                NvAuth::Owner,
-                nv,
-                MaxNvBuffer::try_from(content).unwrap(),
-                0,
-            )
-        })
-        .expect("nv write");
-        drop(ctx);
+        // Provisioning moved into PcrlockFixture so the tier-climb tests can
+        // establish the same precondition; using it here is what keeps the two
+        // honest, since a fixture only this test's twin exercised would drift.
+        let fixture = PcrlockFixture::provision(NV_INDEX);
 
         // Round trip through the public Tier-2 entry points.
         let env = seal_with_pcrlock(secret, NV_INDEX).expect("pcrlock seal");
@@ -1780,6 +1836,7 @@ mod tests {
 
         // Drift: rewrite the NV policy to one the live PCRs cannot satisfy
         // (what a firmware change looks like) and the unseal must refuse.
+        use tss_esapi::structures::MaxNvBuffer;
         let mut ctx = open_context().unwrap();
         let nv = nv_index_handle(&mut ctx, NV_INDEX).unwrap();
         let mut bogus = vec![0x00u8, 0x0B];
@@ -1791,13 +1848,9 @@ mod tests {
         drop(ctx);
         assert!(unseal(&env).is_err(), "stale policy must not unseal");
 
-        // Cleanup: the NV space, the override, the fixture.
-        let mut ctx = open_context().unwrap();
-        let nv = nv_index_handle(&mut ctx, NV_INDEX).unwrap();
-        let _ =
-            ctx.execute_with_nullauth_session(|ctx| ctx.nv_undefine_space(Provision::Owner, nv));
-        std::env::remove_var("IRLUME_PCRLOCK_JSON");
-        let _ = std::fs::remove_dir_all(&dir);
+        // Cleanup is the fixture's Drop, which also runs if an assertion above
+        // fails; the hand-rolled version here did not.
+        drop(fixture);
     }
 
     /// The software digests must equal what a trial session produces.


### PR DESCRIPTION
Closes #361.

The two remaining orphaned keyring tests are not broken and the code is not wrong. They encode a **precondition they never establish**: that this machine has a tier above Tier 3 to climb to.

`stronger_tier_available_than(PcrLiteral)` is `signed_policy_available() || pcrlock_provisioned().is_some()`. On a bare swtpm neither holds, so `reseal_password` correctly answers `Unchanged` and the assertion for `Upgraded` could never pass.

## Why neither obvious reading was right

Adding the names to the required list turns the TPM lane red. Relabelling them hardware-only leaves three documented credential-leak regressions guarded by tests no machine runs, which is protection on paper only.

Researched before choosing. The regression these guard lives in **envelope reconstruction after `tpm::seal`**: losing the `secret` kind across a rewrite routes 56 or 64 raw key bytes into `PAM_AUTHTOK` on the next login. That failure does not depend on how systemd predicted the PCR values, and real Tier 1 and Tier 2 hand the same semantic `SealedEnvelope` to the same reconstruction code. So a synthetic Tier 2 crosses the right production boundary.

The failure mode to avoid would be a fixture that merely sets `policy = PcrlockNv` without executing the TPM policy. This one does substantially more: the candidate still has to pass a genuine `PolicyAuthorizeNV` session and unseal before its kind and wrap can be inspected.

I also assessed extracting the field-transfer into a testable helper. It would give fast mutation coverage but would not prove `reseal_password` calls it in both branches, that the ladder returns the candidate shape it expects, or that the round trip and unseal still work, and it would carve a test-only seam into security-sensitive code. Reasonable as additional defence, not as a reason to leave the end-to-end tests unrun.

## What changed

Provisioning is extracted as `PcrlockFixture` from `seal_unseal_pcrlock_roundtrip_provisioned_nv`, which built it inline: a real owner-hierarchy NV space holding the alg-tagged policy digest of the live PCR state, laid out as `systemd-pcrlock` writes it, plus a matching prediction JSON.

`Drop` undefines the NV space and clears the override, so an assertion failure no longer strands the index for the next test; the hand-rolled cleanup it replaces ran only on success. The existing roundtrip test is refactored onto the fixture, which is what keeps it honest, since a fixture only its twin exercised would drift. Distinct NV indices per test so a leftover from one cannot mask another.

## Evidence

- Both tests pass against a swtpm started with `ci.yml`'s exact flags.
- The full eleven-name CI invocation passes: **11 passed**, up from 6 when this issue was filed.
- Proven load-bearing rather than incidental: remove the fixture from the climb test and the exact original failure returns, `left: Unchanged, right: Upgraded`.
- Both ignore strings now say `(CI does this)` truthfully, and both names are in `--require` so a rename cannot silently drop them.

Gate: fmt, clippy `-D warnings`, doc lane, and `run-tests-guarded --min 650` at 1279 tests.

## What this does not cover

The fixture is a faithful exercise of the irlume code path, not of systemd's provisioning. Real `systemd-pcrlock make-policy`, protected NV updates, real event-log prediction, real firmware PCR movement, Tier-1 signed-PCR behaviour and physical TPM differences all remain hardware work and should keep honestly labelled manual campaigns.

Nothing here was run against a real TPM. The local runs are swtpm, matching what CI does.
