### PR TITLE
The self-heal must not reopen a camera the caller is streaming (#187)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -728,6 +728,39 @@ fn sequential_capture_selected(rgb_dev: &str, ir_dev: &str) -> (bool, &'static s
 /// (ASUS) to 1.3 s (NexiGo) of capture latency, and only until a measured
 /// verdict is stored; enrollment now probes an unmeasured pair, so most
 /// installs leave this arm at their first enrollment (#340).
+/// May the cross-spectrum self-heal recapture RGB on its own?
+///
+/// Pure over its five observations, so the one clause that keeps costing
+/// people their enrolment is testable without a camera.
+///
+/// The first four are the degradation signature: the overlapped RGB frame lost
+/// the face, IR kept it (so the user is present), the capture was concurrent,
+/// and RGB has not already been re-fetched.
+///
+/// `held_sessions` is the clause this function exists for. The recapture is a
+/// STANDALONE reopen of the RGB node, and enrolment holds both streams open for
+/// the whole capture loop, so under held sessions it opens a device this very
+/// process is already streaming. Most UVC modules permit that second open and
+/// nothing is visible; a module that answers EBUSY fails the enrolment outright,
+/// which is #187: a Chicony 04f2:b874 that never completed one capture cycle and
+/// reported the camera busy. The hard retry a hundred lines above already
+/// refuses a standalone reopen for exactly this reason and says so; this path
+/// was written later and did not inherit the rule.
+///
+/// Skipping the recovery when sessions are held costs little: the caller is a
+/// loop that captures repeatedly, so the next scan gets a fresh pair of frames
+/// anyway. Authentication is unaffected — it captures one-shot, holds nothing,
+/// and still self-heals exactly as before.
+fn self_heal_may_recapture(
+    rgb_lost_the_face: bool,
+    ir_kept_the_face: bool,
+    sequential: bool,
+    rgb_hard_retried: bool,
+    held_sessions: bool,
+) -> bool {
+    rgb_lost_the_face && ir_kept_the_face && !sequential && !rgb_hard_retried && !held_sessions
+}
+
 fn capture_mode_decision(
     env: Option<&str>,
     stored: Option<irlume_camera::CaptureMode>,
@@ -786,6 +819,26 @@ mod capture_mode_decision_tests {
         // concurrent fallback broke an enrollment on hardware that cannot
         // stream both nodes (#308).
         assert_eq!(capture_mode_decision(None, None), (true, "default"));
+    }
+
+    #[test]
+    fn the_self_heal_never_reopens_a_camera_the_caller_is_streaming() {
+        use super::self_heal_may_recapture;
+        // The degradation signature, on the one-shot path the self-heal was
+        // written for: RGB lost the face, IR kept it, captured concurrently,
+        // nothing re-fetched yet.
+        assert!(self_heal_may_recapture(true, true, false, false, false));
+        // The same signature during ENROLMENT, which holds both streams open
+        // for the whole capture loop. Recapturing here opens a device this
+        // process is already streaming, and a module that answers EBUSY to the
+        // second open fails the enrolment outright (#187). The hard retry
+        // above refuses for exactly this reason; so must this.
+        assert!(!self_heal_may_recapture(true, true, false, false, true));
+        // The rest of the signature still has to hold.
+        assert!(!self_heal_may_recapture(false, true, false, false, false));
+        assert!(!self_heal_may_recapture(true, false, false, false, false));
+        assert!(!self_heal_may_recapture(true, true, true, false, false));
+        assert!(!self_heal_may_recapture(true, true, false, true, false));
     }
 
     #[test]
@@ -1589,7 +1642,13 @@ impl Engine {
         // degradation signature (a genuinely absent user shows no face in
         // either, so this does not fire). Recapture RGB alone on the idle
         // link. Skipped in sequential mode and if RGB was already re-fetched.
-        if rgb_top.is_none() && ir_top.is_some() && !sequential && !rgb_hard_retried {
+        if self_heal_may_recapture(
+            rgb_top.is_none(),
+            ir_top.is_some(),
+            sequential,
+            rgb_hard_retried,
+            held_sessions,
+        ) {
             irlume_common::dlog!(
                 "assess: RGB has no face but IR does; recapturing RGB alone (dim overlapped frame?)"
             );

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -728,6 +728,19 @@ fn sequential_capture_selected(rgb_dev: &str, ir_dev: &str) -> (bool, &'static s
 /// (ASUS) to 1.3 s (NexiGo) of capture latency, and only until a measured
 /// verdict is stored; enrollment now probes an unmeasured pair, so most
 /// installs leave this arm at their first enrollment (#340).
+fn capture_mode_decision(
+    env: Option<&str>,
+    stored: Option<irlume_camera::CaptureMode>,
+) -> (bool, &'static str) {
+    match env {
+        Some(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
+        None => match stored {
+            Some(m) => (m == irlume_camera::CaptureMode::Sequential, "cameras.conf"),
+            None => (true, "default"),
+        },
+    }
+}
+
 /// May the cross-spectrum self-heal recapture RGB on its own?
 ///
 /// Pure over its five observations, so the one clause that keeps costing
@@ -759,19 +772,6 @@ fn self_heal_may_recapture(
     held_sessions: bool,
 ) -> bool {
     rgb_lost_the_face && ir_kept_the_face && !sequential && !rgb_hard_retried && !held_sessions
-}
-
-fn capture_mode_decision(
-    env: Option<&str>,
-    stored: Option<irlume_camera::CaptureMode>,
-) -> (bool, &'static str) {
-    match env {
-        Some(v) => (v.trim() == "1", "IRLUME_SEQUENTIAL_CAPTURE"),
-        None => match stored {
-            Some(m) => (m == irlume_camera::CaptureMode::Sequential, "cameras.conf"),
-            None => (true, "default"),
-        },
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What & why

A fourth double-open on the #187 path, in a site the three earlier fixes did not cover.

The cross-spectrum self-heal recaptures RGB on its own when the overlapped frame lost the face and IR kept it. That recapture is a **standalone reopen** of the RGB node, and it ran with no check for whether the caller is holding the streams:

```rust
if rgb_top.is_none() && ir_top.is_some() && !sequential && !rgb_hard_retried {
    rgb = irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress)?;
```

Enrolment holds both cameras open for the whole capture loop (`capture_scan_loop` → `assess_full_with(Some((rs, is)), …)`), because reopening per frame costs ~700ms of every capture. So during enrolment the self-heal opens a device this same process is already streaming. Most UVC modules permit that second open and nothing is visible, which is why it has sat here unnoticed. A module that answers EBUSY makes it fatal.

**The rule already existed, a hundred lines above, and named this very issue.** The hard RGB retry refuses a standalone reopen under held sessions:

```rust
// Standalone reopen is only safe when THIS call opened one-shot:
// with held sessions the device queue belongs to the caller's
// stream, ... and a reopen here meets our own handle as EBUSY (#187).
Err(e) if !held_sessions => { … }
```

The self-heal was added later and did not inherit it. The condition is now a named function carrying the held-sessions clause, so the rule is stated once and tested.

## Why I think this is the reporter's remaining failure

The #187 thread fixed three double-opens (the per-frame fallback #242, the holder scan that blamed `irlumed` #243, and the TUI/`status`/`setup` probes #300), and the reporter still cannot enrol. On 2026-08-08 they reported it still failing after fresh installs of **both** Arch and Fedora, which is exactly what you would expect if the remaining cause is in irlume rather than on their machine.

Reachability lines up with their versions. The self-heal only runs on a **concurrent** capture. Before `5f89f34` (2026-08-07) an unmeasured pair captured concurrently, so on **0.9.0**, the release they installed on 2026-08-06 and tagged the day before that commit, a first enrolment on an unmeasured camera went straight down this path. Their symptom was "never completes 1 cycle", which is what a hard error inside the first capture looks like.

The sequential default now on `main` **hides** this rather than fixing it: any pair measured or stored as concurrent walks into it again, on enrolment and on add-scan.

## What is and is not verified

Verified by reading the code: the path exists, enrolment reaches it with sessions held, and the sibling path forbids exactly this for exactly this reason.

**Not reproduced on hardware.** Every module here permits the second open, the same wall #242, #243 and #300 all hit. I have not asked the reporter for anything yet; if you would rather confirm before merging, the cheapest test costs them one command and no new build, because forcing sequential capture makes the self-heal unreachable:

```
sudo systemctl edit irlumed     #  [Service]  Environment=IRLUME_SEQUENTIAL_CAPTURE=1
sudo systemctl restart irlumed
```

If enrolment then completes on 0.9.0, this is their bug.

## Testing

- New `the_self_heal_never_reopens_a_camera_the_caller_is_streaming` pins all five clauses, including both directions of the held-sessions one, in the idiom of the neighbouring `capture_mode_decision` tests.
- `irlume-auth`: **73 passed, 0 failed, 2 ignored** (72 on this base plus the new test).
- `cargo fmt --check` and `cargo clippy -p irlume-auth --all-targets` clean.

- [x] `cargo test -p irlume-auth` passes
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [ ] Docs/CHANGELOG updated if user-facing (behaviour fix; no doc states this path)
- [ ] Hardware-validated: **needs a module that answers EBUSY to a second open**, which is the reporter's, not one we have
