### PR TITLE
A glint reading that railed measured nothing (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **The IR eye-glint cue recorded the sensor's ceiling as the strongest possible
+  reading.** `eye_glint` returned the window maximum with no notion of a
+  ceiling, so a peak that railed at the negotiated format's white level was
+  stored as a measurement rather than as a reading that established nothing. A
+  clipped sample says the true value was AT LEAST the ceiling and never what it
+  was, and a maximum is exactly the statistic that destroys.
+
+  Measured in the corpora already committed here. In
+  `docs/pad-results/2026-08-04-occluder-gate.jsonl` all 8 records that recorded
+  a glint are railed at exactly 255, and no record has `glint_present` with an
+  unpegged peak, so "glint present" and "the peak railed" named the same set;
+  the highest genuine reading in that file is 126, far under `GLINT_MIN` (180).
+  In `docs/pad-results/2026-08-02-center-edge-corpus.jsonl` 16 of 104 are railed
+  while 20 records carry a genuine sub-ceiling glint, so a real population does
+  exist and marking the railed ones absent separates it rather than erasing it.
+  This is the shape #222 named after measuring all three supported modules.
+
+  #237's exposure gate cannot catch it: on those railed records the FACE region
+  clipped 0.42% to 1.57%, far below `IR_SATURATED_FRAC_MAX` (0.10), because a
+  specular blob inside a 17x17 eye window is a rounding error against a whole
+  face. `Signals::ir_eye_glint` is now `Option<f32>`, `None` for a railed peak,
+  a missing IR face, or the RGB-only path; the corpus writes `ir_glint: null`
+  and a new `cues.glint_readable` separates "read and dim" from "not readable".
+  No threshold moved: `GLINT_MIN` stays 180, and the ceiling comes from
+  `clipping_white_level`, which was already plumbed to both call sites. A format
+  that cannot name its ceiling (Grey16, NV12, YUYV) passes the peak through
+  unchanged, which is #237's own settled precedent.
+
+  No authentication verdict changes: the cue reaches the PAD corpus and a dev
+  probe print, and nothing else. Records written BEFORE this change keep the old
+  semantics, so any future re-derivation of `GLINT_MIN` must treat the existing
+  corpora as railed-contaminated.
+
 ### Security
 
 - **One socket request reached the keyring with an unscreened username.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,14 @@ All notable changes to irlume are documented here. This project adheres to
   exist and marking the railed ones absent separates it rather than erasing it.
   This is the shape #222 named after measuring all three supported modules.
 
-  #237's exposure gate cannot catch it: on those railed records the FACE region
-  clipped 0.42% to 1.57%, far below `IR_SATURATED_FRAC_MAX` (0.10), because a
-  specular blob inside a 17x17 eye window is a rounding error against a whole
-  face. `Signals::ir_eye_glint` is now `Option<f32>`, `None` for a railed peak,
+  #237's exposure gate mostly cannot catch it, because a specular blob inside a
+  17x17 eye window is a rounding error against a whole face region. Of the 24
+  railed records across both corpora, 22 clip 0.42% to 7.70% of the face, under
+  `IR_SATURATED_FRAC_MAX` (0.10), and are judged normally. The other two are
+  `live_close` captures clipping 30.5% and 54.7%, which that gate already
+  refuses as `Uncertain` for whole-face blowout: a different failure from the
+  one #222 names, and the reason this is a distinct defect rather than a
+  duplicate. `Signals::ir_eye_glint` is now `Option<f32>`, `None` for a railed peak,
   a missing IR face, or the RGB-only path; the corpus writes `ir_glint: null`
   and a new `cues.glint_readable` separates "read and dim" from "not readable".
   No threshold moved: `GLINT_MIN` stays 180, and the ceiling comes from

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1292,7 +1292,8 @@ impl Engine {
             ir_face: None,
             ir_face_brightness: 0.0,
             ir_center_edge_ratio: 0.0,
-            ir_eye_glint: 0.0,
+            // RGB-only path: no IR frame exists to glint.
+            ir_eye_glint: None,
             head_yaw_asym: pose.map(|p| p.yaw_asym).unwrap_or(0.0),
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: 0.0, // RGB-only path: no IR burst to measure
@@ -1686,10 +1687,16 @@ impl Engine {
             ir_face: ir_top.as_ref().map(|f| fbox(f, ir.width, ir.height)),
             ir_face_brightness: ir_brightness,
             ir_center_edge_ratio,
-            ir_eye_glint: ir_top
-                .as_ref()
-                .map(|f| eye_glint(&ir.data, ir.width, ir.height, &f.landmarks))
-                .unwrap_or(0.0),
+            // Same RAW-frame rule as `ir_saturated_frac` below, for the same
+            // reason: the ceiling test has to see the samples that actually
+            // railed, and subtraction moves a 255 to 254 (#238 review).
+            ir_eye_glint: eye_glint_of(
+                ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
+                ir.width,
+                ir.height,
+                ir_top.as_ref().map(|f| &f.landmarks),
+                ir_stats.white_level,
+            ),
             head_yaw_asym: pose.map(|p| p.yaw_asym).unwrap_or(0.0),
             head_pitch_frac: pose.map(|p| p.pitch_frac).unwrap_or(0.5),
             ir_ambient: ir_stats.ambient_mean,
@@ -1715,8 +1722,14 @@ impl Engine {
         // Log the cue values on PASS too; a near-miss on a genuine user is
         // invisible in the outcome line but obvious here.
         irlume_common::dlog!(
-            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} ir_clipped={} (face_frac #174, recorded only; clipped #237, refused past the limit)",
-            signals.ir_face_brightness, signals.ir_center_edge_ratio, signals.ir_eye_glint,
+            "liveness(cross-spectrum): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={} ambient={:.0} yaw_asym={:.2} pitch={:.2} face_frac={:.3} ir_clipped={} (face_frac #174, recorded only; clipped #237, refused past the limit)",
+            signals.ir_face_brightness, signals.ir_center_edge_ratio,
+            // Same "n/a" rule as ir_clipped: a peak that railed measured
+            // nothing, and printing a number would claim otherwise (#222).
+            signals
+                .ir_eye_glint
+                .map(|g| format!("{g:.2}"))
+                .unwrap_or_else(|| "n/a".into()),
             signals.ir_ambient, signals.head_yaw_asym, signals.head_pitch_frac,
             signals.face_frac,
             // "n/a" is a real answer: this format cannot say where its ceiling
@@ -2687,8 +2700,12 @@ impl Engine {
                 return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
             }
             let (verdict, _cues, reason) = self.gate.evaluate_ir_only(&a.signals);
-            irlume_common::dlog!("liveness(ir-only/dark): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={:.2} ambient={:.0}",
-                a.signals.ir_face_brightness, a.signals.ir_center_edge_ratio, a.signals.ir_eye_glint,
+            irlume_common::dlog!("liveness(ir-only/dark): {verdict:?} ({reason}); ir_bright={:.0} ir_center_edge_ratio={:.2} glint={} ambient={:.0}",
+                a.signals.ir_face_brightness, a.signals.ir_center_edge_ratio,
+                a.signals
+                    .ir_eye_glint
+                    .map(|g| format!("{g:.2}"))
+                    .unwrap_or_else(|| "n/a".into()),
                 a.signals.ir_ambient);
             if verdict != Verdict::Live {
                 // Dark-path kinds: Uncertain retries under grace, any Spoof
@@ -2900,12 +2917,14 @@ impl Engine {
         let live = a.verdict == Verdict::Live;
         let detail = if live {
             format!(
-                "Live: RGB face {}, IR face {} · IR brightness {:.0}, center/edge {:.2}, glint {:.0}",
+                "Live: RGB face {}, IR face {} · IR brightness {:.0}, center/edge {:.2}, glint {}",
                 if s.rgb_face.is_some() { "✓" } else { "✗" },
                 if s.ir_face.is_some() { "✓" } else { "✗" },
                 a.ir_brightness,
                 a.ir_center_edge_ratio,
-                s.ir_eye_glint,
+                s.ir_eye_glint
+                    .map(|g| format!("{g:.0}"))
+                    .unwrap_or_else(|| "n/a".into()),
             )
         } else {
             format!("{:?}: {}", a.verdict, a.reason)
@@ -4034,6 +4053,48 @@ pub fn eye_glint(grey: &[u8], w: u32, h: u32, landmarks: &Landmarks5) -> f32 {
         }
     }
     peak as f32
+}
+
+/// [`eye_glint`], but honest about a reading that reached the sensor's ceiling.
+///
+/// `None` means the peak established nothing, for one of three reasons, and it
+/// is NOT a dark eye. Same distinction [`saturated_frac_of`] draws next door,
+/// and for the same reason: a number nobody could measure must not be recorded
+/// as a number that was measured.
+///
+/// - No IR face (`landmarks` is `None`), so no eye window exists to sample.
+/// - The peak reached `white`, the negotiated format's ceiling. A clipped
+///   sample tells you the true value was AT LEAST that, never what it was, and
+///   a maximum is exactly the statistic that destroys. This is the #222
+///   reading: the repo's own measurements have the peak pinned at 255 in all
+///   30 frames with glasses on, where it is reading the lens specular rather
+///   than the cornea, and 8 of 8 `glint_present` records in
+///   `docs/pad-results/2026-08-04-occluder-gate.jsonl` are railed at exactly
+///   255. In that corpus "glint present" and "the peak railed" are the same
+///   set, so the cue records the sensor's limit rather than the eye.
+///
+/// `white` of `None` means the format could not name a ceiling (`Grey16`,
+/// `Nv12Luma`, `YuyvLuma`), and there the peak passes through unchanged. That
+/// is #237's settled precedent, not a fresh judgement: refusing on a number
+/// nobody produced would deny every module that does not negotiate GREY8.
+///
+/// Note the ceiling test wants the RAW frame. Ambient subtraction moves a
+/// railed 255 to 254, so a subtracted frame would quietly stop reading as
+/// railed; callers pass the same unsubtracted samples `saturated_frac_of` gets.
+pub fn eye_glint_of(
+    grey: &[u8],
+    w: u32,
+    h: u32,
+    landmarks: Option<&Landmarks5>,
+    white: Option<u8>,
+) -> Option<f32> {
+    // Delegates so the truncated-frame and NaN-landmark guards above are
+    // inherited rather than copied; a second copy would drift.
+    let peak = eye_glint(grey, w, h, landmarks?);
+    match white {
+        Some(ceiling) if peak >= f32::from(ceiling) => None,
+        _ => Some(peak),
+    }
 }
 
 /// Specular contrast at the eyes = peak − local-mean brightness, max over both
@@ -5363,6 +5424,47 @@ mod tests {
             grey[20 * w + 44] = 250;
         }
         (grey, lm)
+    }
+
+    /// A peak that reached the format's ceiling measured nothing, and must not
+    /// be recorded as the strongest possible reading (#222).
+    #[test]
+    fn a_glint_at_the_ceiling_reads_as_absent_not_as_maximal() {
+        // ONE glint, so the peak over both eye windows is the value set here;
+        // with two the other eye's 250 would mask what is being tested.
+        let (mut grey, lm) = ir_frame_with_glints(true, false);
+        grey[20 * 64 + 20] = 255;
+
+        // Full-range GREY8: 255 is the ceiling, so the reading says nothing.
+        assert_eq!(eye_glint_of(&grey, 64, 48, Some(&lm), Some(255)), None);
+        // One grey level below the ceiling is a real measurement.
+        grey[20 * 64 + 20] = 254;
+        assert_eq!(
+            eye_glint_of(&grey, 64, 48, Some(&lm), Some(255)),
+            Some(254.0)
+        );
+
+        // Limited-range (235) rails earlier, and `>=` covers 236..=255 as well,
+        // matching how the saturation fraction tests its own ceiling.
+        grey[20 * 64 + 20] = 235;
+        assert_eq!(eye_glint_of(&grey, 64, 48, Some(&lm), Some(235)), None);
+        assert_eq!(
+            eye_glint_of(&grey, 64, 48, Some(&lm), Some(255)),
+            Some(235.0)
+        );
+
+        // A format that cannot name its ceiling passes the peak through, which
+        // is exactly today's behaviour. #237 settled this direction: refusing on
+        // a number nobody produced would deny every non-GREY8 module.
+        grey[20 * 64 + 20] = 255;
+        assert_eq!(
+            eye_glint_of(&grey, 64, 48, Some(&lm), None),
+            Some(255.0),
+            "no known ceiling means no ceiling test"
+        );
+
+        // No IR face is an absence, not a measured dark eye.
+        assert_eq!(eye_glint_of(&grey, 64, 48, None, Some(255)), None);
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2589,9 +2589,11 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
         let ir_center_edge_ratio = ir_top_face
             .map(|f| center_edge_ratio(&ir.data, ir.width, ir.height, &f.bbox))
             .unwrap_or(0.0);
-        let ir_eye_glint = ir_top_face
-            .map(|f| eye_glint(&ir.data, ir.width, ir.height, &f.landmarks))
-            .unwrap_or(0.0);
+        // Single frame, no burst stats, so no white level is known: the
+        // `white: None` arm passes the peak through exactly as before, the same
+        // honesty this probe already applies to ir_saturated_frac below (#222).
+        let ir_eye_glint =
+            ir_top_face.map(|f| eye_glint(&ir.data, ir.width, ir.height, &f.landmarks));
         let rgb_top = rgb_faces.iter().max_by(|a, b| a.score.total_cmp(&b.score));
         let pose = rgb_top.map(|f| irlume_vision::head_pose(&f.landmarks));
         let signals = irlume_liveness::Signals {
@@ -2615,19 +2617,25 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
             rgb_moire_score: 0.0,
         };
         let (verdict, cues, reason) = irlume_liveness::LivenessGate::new().evaluate(&signals);
-        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {ir_eye_glint:.0}  face_frac {:.3}  clipped {}", signals.face_frac,
+        println!("[gate] IR face brightness {ir_face_brightness:.0}  center/edge {ir_center_edge_ratio:.2}  eye-glint {}  face_frac {:.3}  clipped {}",
+            signals
+                .ir_eye_glint
+                .map(|g| format!("{g:.0}"))
+                .unwrap_or_else(|| "n/a".into()),
+            signals.face_frac,
             signals
                 .ir_saturated_frac
                 .map(|f| format!("{:.1}%", f * 100.0))
                 .unwrap_or_else(|| "n/a".into()));
         println!(
-            "[gate] cues: rgb={} ir={} aligned={} ir_reflective={} center_edge={} glint={}",
+            "[gate] cues: rgb={} ir={} aligned={} ir_reflective={} center_edge={} glint={} glint_readable={}",
             cues.face_in_rgb,
             cues.face_in_ir,
             cues.cross_spectrum_aligned,
             cues.ir_reflectance_ok,
             cues.center_edge_ratio_ok,
-            cues.glint_present
+            cues.glint_present,
+            cues.glint_readable
         );
         println!("[GATE] {verdict:?}: {reason}");
         Ok(())

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -127,10 +127,16 @@ fn capture_once(
         .as_ref()
         .map(|f| crate::center_edge_ratio(&ir.data, ir.width, ir.height, &f.bbox))
         .unwrap_or(0.0);
-    let ir_eye_glint = ir_top
-        .as_ref()
-        .map(|f| crate::eye_glint(&ir.data, ir.width, ir.height, &f.landmarks))
-        .unwrap_or(0.0);
+    // Ceiling-aware, and on the RAW frame for the same reason the saturation
+    // fraction below uses it: a railed peak measured nothing, and subtraction
+    // would move it off the ceiling and hide that (#222).
+    let ir_eye_glint = irlume_auth::eye_glint_of(
+        ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
+        ir.width,
+        ir.height,
+        ir_top.as_ref().map(|f| &f.landmarks),
+        ir_stats.white_level,
+    );
 
     let signals = Signals {
         rgb_face,
@@ -223,7 +229,13 @@ fn presentation_record(
         "ir_center_edge_ratio".into(),
         crate::json_f32(s.ir_center_edge_ratio),
     );
-    rec.insert("ir_glint".into(), crate::json_f32(s.ir_eye_glint));
+    rec.insert(
+        "ir_glint".into(),
+        match s.ir_eye_glint {
+            Some(g) => crate::json_f32(g),
+            None => serde_json::Value::Null,
+        },
+    );
     let cross = match (s.rgb_face, s.ir_face) {
         (Some(r), Some(i)) => ((r.cx - i.cx).powi(2) + (r.cy - i.cy).powi(2)).sqrt(),
         _ => f32::NAN,
@@ -249,6 +261,7 @@ fn presentation_record(
         "ir_reflectance_ok": cues.ir_reflectance_ok,
         "center_edge_ratio_ok": cues.center_edge_ratio_ok,
         "glint_present": cues.glint_present,
+        "glint_readable": cues.glint_readable,
         "frontal_ok": cues.frontal_ok,
     });
     rec.insert("cues".into(), cues_json);
@@ -353,12 +366,14 @@ pub(crate) fn padcapture(args: &[String]) -> std::process::ExitCode {
                 ""
             };
             println!(
-                "      -> {} | ir {} bri {:>5.1} c/e {:>5.2} glint {:>3.0} | {}{}",
+                "      -> {} | ir {} bri {:>5.1} c/e {:>5.2} glint {} | {}{}",
                 verdict_str(verdict),
                 if s.ir_face.is_some() { "✓" } else { "·" },
                 s.ir_face_brightness,
                 s.ir_center_edge_ratio,
-                s.ir_eye_glint,
+                s.ir_eye_glint
+                    .map(|g| format!("{g:>3.0}"))
+                    .unwrap_or_else(|| "n/a".into()),
                 reason,
                 flag,
             );

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -2330,6 +2330,47 @@ mod tests {
     /// `Signals::face_frac`). This test pins the current contract that
     /// `face_frac` remains observational and cannot change a verdict until
     /// a distance-aware rule is separately derived and reviewed.
+    #[test]
+    fn face_frac_changes_no_verdict() {
+        let gate = LivenessGate::new();
+        // Across the framing guide's whole accepted band and past both ends.
+        for frac in [0.0, 0.05, 0.12, 0.3, 0.55, 0.9] {
+            let mut live = live_signals();
+            live.face_frac = frac;
+            assert_eq!(
+                gate.evaluate(&live).0,
+                Verdict::Live,
+                "a live face must stay Live at face_frac {frac}"
+            );
+            // And the same on the spoof side: a flat target does not become
+            // live by sitting closer, nor a live face a spoof by sitting back.
+            let mut flat = live_signals();
+            flat.face_frac = frac;
+            flat.ir_center_edge_ratio = 1.0; // flat
+            assert_ne!(
+                gate.evaluate(&flat).0,
+                Verdict::Live,
+                "a flat target must not pass at face_frac {frac}"
+            );
+        }
+    }
+
+    /// The cue is still supporting-only. Making it honest must not promote it
+    /// into something decisive, on either evaluator.
+    #[test]
+    fn an_unreadable_glint_changes_no_verdict() {
+        let gate = LivenessGate::new();
+        for glint in [None, Some(0.0), Some(126.0), Some(255.0)] {
+            let mut live = live_signals();
+            live.ir_eye_glint = glint;
+            assert_eq!(
+                gate.evaluate(&live).0,
+                Verdict::Live,
+                "a live face must stay Live at glint {glint:?}"
+            );
+        }
+    }
+
     /// A railed eye peak records as ABSENT, and absent is not "present".
     ///
     /// The corpus this cue feeds is what any future re-derivation of
@@ -2364,47 +2405,6 @@ mod tests {
         let (_, cues, _) = gate.evaluate_ir_only(&dark);
         assert!(!cues.glint_present, "an absent glint is not a present one");
         assert!(!cues.glint_readable);
-    }
-
-    /// The cue is still supporting-only. Making it honest must not promote it
-    /// into something decisive, on either evaluator.
-    #[test]
-    fn an_unreadable_glint_changes_no_verdict() {
-        let gate = LivenessGate::new();
-        for glint in [None, Some(0.0), Some(126.0), Some(255.0)] {
-            let mut live = live_signals();
-            live.ir_eye_glint = glint;
-            assert_eq!(
-                gate.evaluate(&live).0,
-                Verdict::Live,
-                "a live face must stay Live at glint {glint:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn face_frac_changes_no_verdict() {
-        let gate = LivenessGate::new();
-        // Across the framing guide's whole accepted band and past both ends.
-        for frac in [0.0, 0.05, 0.12, 0.3, 0.55, 0.9] {
-            let mut live = live_signals();
-            live.face_frac = frac;
-            assert_eq!(
-                gate.evaluate(&live).0,
-                Verdict::Live,
-                "a live face must stay Live at face_frac {frac}"
-            );
-            // And the same on the spoof side: a flat target does not become
-            // live by sitting closer, nor a live face a spoof by sitting back.
-            let mut flat = live_signals();
-            flat.face_frac = frac;
-            flat.ir_center_edge_ratio = 1.0; // flat
-            assert_ne!(
-                gate.evaluate(&flat).0,
-                Verdict::Live,
-                "a flat target must not pass at face_frac {frac}"
-            );
-        }
     }
 
     #[test]

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -42,7 +42,24 @@ pub struct Signals {
     pub ir_center_edge_ratio: f32,
     /// Peak IR brightness (0..255) at the eyes: the emitter's specular corneal
     /// glint. Supporting cue only (glint alone is not decisive).
-    pub ir_eye_glint: f32,
+    ///
+    /// `None` = the reading established nothing, and it is NOT a dark eye. Three
+    /// ways to get there: no IR face was found, the RGB-only path ran (no IR
+    /// frame at all), or the peak reached the negotiated format's ceiling, where
+    /// a clipped sample says the value was AT LEAST that and never what it was.
+    ///
+    /// The railed case is #222, and it is the common one rather than a corner:
+    /// with glasses on the peak pinned at 255 in all 30 frames measured
+    /// 2026-08-04, reading the lens specular rather than the cornea, and in
+    /// `docs/pad-results/2026-08-04-occluder-gate.jsonl` all 8 records that
+    /// recorded a glint are railed at exactly 255, so "glint present" and "the
+    /// peak railed" name the same set. A cue recorded that way cannot separate
+    /// two populations, which is what re-deriving [`GLINT_MIN`] would need.
+    ///
+    /// `None` is NOT zero: the same distinction [`Signals::ir_saturated_frac`]
+    /// draws, and it exists so a maximum nobody could measure is never recorded
+    /// as one that was.
+    pub ir_eye_glint: Option<f32>,
     /// Head-orientation yaw asymmetry from the RGB face landmarks (0 frontal,
     /// →1 turned). Defaults to 0 (frontal) when not computed.
     pub head_yaw_asym: f32,
@@ -121,7 +138,7 @@ impl Default for Signals {
             ir_face: None,
             ir_face_brightness: 0.0,
             ir_center_edge_ratio: 0.0,
-            ir_eye_glint: 0.0,
+            ir_eye_glint: None,
             head_yaw_asym: 0.0,   // frontal
             head_pitch_frac: 0.5, // frontal
             face_frac: 0.0,
@@ -313,7 +330,18 @@ pub struct Cues {
     /// passes it (see docs/PAD_SELFTEST.md).
     pub center_edge_ratio_ok: bool,
     /// Corneal glint present (supporting; logged, not decisive).
+    ///
+    /// FALSE when the peak could not be read at all, not only when it was dim.
+    /// [`Cues::glint_readable`] separates those two, because merging them is the
+    /// same conflation this field used to carry from the other direction.
     pub glint_present: bool,
+    /// The eye peak was IN BAND rather than at the sensor's ceiling (#222).
+    ///
+    /// Without this, `glint_present: false` would merge "the eye was dim" with
+    /// "the reading railed and says nothing", and the corpus would trade one
+    /// conflation for another. False also on the early-refusal paths where the
+    /// cue is never reached, exactly like `glint_present`.
+    pub glint_readable: bool,
     /// Face is frontal enough (≈±15°) to make a decision; Windows-Hello-style
     /// head-orientation gate.
     pub frontal_ok: bool,
@@ -526,7 +554,8 @@ impl LivenessGate {
         }
 
         // Corneal glint: supporting only; logged, never decisive on its own.
-        cues.glint_present = s.ir_eye_glint >= GLINT_MIN;
+        cues.glint_readable = s.ir_eye_glint.is_some();
+        cues.glint_present = s.ir_eye_glint.is_some_and(|g| g >= GLINT_MIN);
 
         (
             Verdict::Live,
@@ -626,7 +655,8 @@ impl LivenessGate {
             };
             return (Verdict::Spoof, cues, reason);
         }
-        cues.glint_present = s.ir_eye_glint >= GLINT_MIN;
+        cues.glint_readable = s.ir_eye_glint.is_some();
+        cues.glint_present = s.ir_eye_glint.is_some_and(|g| g >= GLINT_MIN);
         (
             Verdict::Live,
             cues,
@@ -2217,7 +2247,7 @@ mod tests {
             ir_face: Some(fb(0.52, 0.49)),
             ir_face_brightness: 90.0,
             ir_center_edge_ratio: 1.2,
-            ir_eye_glint: 220.0,
+            ir_eye_glint: Some(220.0),
             ..Default::default() // frontal pose
         }
     }
@@ -2300,6 +2330,58 @@ mod tests {
     /// `Signals::face_frac`). This test pins the current contract that
     /// `face_frac` remains observational and cannot change a verdict until
     /// a distance-aware rule is separately derived and reviewed.
+    /// A railed eye peak records as ABSENT, and absent is not "present".
+    ///
+    /// The corpus this cue feeds is what any future re-derivation of
+    /// [`GLINT_MIN`] would be fitted to, and you cannot observe two populations
+    /// in a variable that is pinned at the sensor's ceiling. In
+    /// `docs/pad-results/2026-08-04-occluder-gate.jsonl` all 8 records carrying
+    /// a glint are railed at exactly 255, so before this change "glint present"
+    /// and "the peak railed" named the same 8 records (#222).
+    #[test]
+    fn a_railed_glint_records_as_absent_not_as_the_strongest_reading() {
+        let gate = LivenessGate::new();
+        for signals in [live_signals()] {
+            // Three-way separation, which is the whole point: unreadable, read
+            // and dim, read and strong. Before this, the first and third were
+            // the same value.
+            for (glint, want_readable, want_present) in [
+                (None, false, false),
+                (Some(126.0), true, false), // the highest unpegged reading in that corpus
+                (Some(220.0), true, true),
+            ] {
+                let mut s = signals.clone();
+                s.ir_eye_glint = glint;
+                let (_, cues, _) = gate.evaluate(&s);
+                assert_eq!(cues.glint_readable, want_readable, "readable for {glint:?}");
+                assert_eq!(cues.glint_present, want_present, "present for {glint:?}");
+            }
+        }
+        // BOTH evaluators. #237's first version gated one path and left the
+        // dark-room path accepting what the other refused.
+        let mut dark = live_signals();
+        dark.ir_eye_glint = None;
+        let (_, cues, _) = gate.evaluate_ir_only(&dark);
+        assert!(!cues.glint_present, "an absent glint is not a present one");
+        assert!(!cues.glint_readable);
+    }
+
+    /// The cue is still supporting-only. Making it honest must not promote it
+    /// into something decisive, on either evaluator.
+    #[test]
+    fn an_unreadable_glint_changes_no_verdict() {
+        let gate = LivenessGate::new();
+        for glint in [None, Some(0.0), Some(126.0), Some(255.0)] {
+            let mut live = live_signals();
+            live.ir_eye_glint = glint;
+            assert_eq!(
+                gate.evaluate(&live).0,
+                Verdict::Live,
+                "a live face must stay Live at glint {glint:?}"
+            );
+        }
+    }
+
     #[test]
     fn face_frac_changes_no_verdict() {
         let gate = LivenessGate::new();

--- a/docs/PAD_SELFTEST.md
+++ b/docs/PAD_SELFTEST.md
@@ -55,7 +55,8 @@ Attack Instrument categories, ISO term). Constants are the current values in
 | `ir_reflectance_ok` | active-emitter skin remission floor (melanin-independent > 1.2 µm → skin-tone fair) | dark / low-reflectance flat media | IR face mean ≥ `IR_FACE_MIN_BRIGHTNESS` (35) |
 | `center_edge_ratio_ok` | shape-from-shading: a lit 3D face is brighter center→edge under a near-coaxial emitter; flat matte media are uniform. A brightness ratio, not a range measurement, and a glossy print clears it (see the 2026-06-30 result below). Raising the floor has been measured twice and does not work: the same banner reaches 1.51 to 1.58 when it is ANGLED, above the genuine range, so no value separates them (2026-06-30, and again 2026-08-02) | **printed photo** (matte), flat screen, paper **cutout** | center/edge ratio ≥ `MIN_CENTER_EDGE_RATIO` (1.03) |
 | `frontal_ok` | Windows-Hello-style ±15° pose gate (quality, not spoof → `Uncertain`) | off-angle / partial captures | yaw ≤ 0.40, pitch ∈ [0.20, 0.80] |
-| `glint_present` | corneal retro-reflection of the emitter | *supporting only*, never decisive (standalone-glint liveness is refuted) | eye peak ≥ `GLINT_MIN` (180) |
+| `glint_present` | corneal retro-reflection of the emitter | *supporting only*, never decisive (standalone-glint liveness is refuted) | eye peak ≥ `GLINT_MIN` (180) **and** the peak did not reach the format's ceiling |
+| `glint_readable` | whether the eye peak was in band at all | recorded only | peak below the negotiated format's ceiling. A railed peak records `ir_glint: null` and both flags false: a clipped sample says the value was AT LEAST the ceiling, never what it was (#222) |
 
 The **per-user calibrated IR floor** (a center/edge-ratio floor stored at
 enrollment by `irlume-core`, enforced in `Engine::authenticate`) tightens that


### PR DESCRIPTION
## What & why

Part of #222, the remainder you named after settling the retroreflection half: *"the actionable remainder is the peak semantics (saturation-aware reading plus the least-clipped-frame selection on #221)"*. The #221 half landed; this is the peak semantics.

`eye_glint` returned the eye-window maximum with no notion of a ceiling, so a peak that reached the negotiated format's white level was recorded as the **strongest possible reading** rather than as a reading that established nothing. A clipped sample says the true value was at least the ceiling and never what it was.

### The corpora already in this repo show how total the conflation is

I computed these from the committed files rather than quoting them:

| file | records | railed at 255 | `glint_present` | present **and** unpegged |
|---|---|---|---|---|
| `2026-08-04-occluder-gate.jsonl` | 26 | 8 | 8 | **0** |
| `2026-08-02-center-edge-corpus.jsonl` | 104 | 16 | 34 | 20 |

In the occluder-gate file `glint_present` is a perfect synonym for "the peak railed": every record carrying a glint is pegged at exactly 255, and the highest genuine reading is 126, far under `GLINT_MIN` (180). In the older center-edge corpus a real sub-ceiling population does exist (20 records, max 253), so marking the railed ones absent **separates** the populations rather than erasing them.

That matches what you measured before settling the issue: with glasses on the peak pinned at 255 in all 30 frames, reading the lens specular rather than the cornea.

### #237's exposure gate structurally cannot catch this

On those railed records the **face** region clipped only 0.42%–1.57%, far below `IR_SATURATED_FRAC_MAX` (0.10), so `ir_exposure_ok` is true and the capture is judged normally. A specular blob inside a 17×17 eye window is a rounding error against a whole face region. Distinct defect, not a duplicate.

### The change

`Signals::ir_eye_glint` becomes `Option<f32>`, returning `None` for a railed peak, a missing IR face, or the RGB-only path. The corpus writes `ir_glint: null`, and a new `cues.glint_readable` keeps "read and dim" distinct from "not readable" so the record does not simply trade one conflation for another. The three display sites print `n/a`, the idiom `ir_clipped` already uses beside them.

**No number is invented.** `GLINT_MIN` stays 180, `IR_SATURATED_FRAC_MAX` stays 0.10. The ceiling is `clipping_white_level`, which already derives it from the negotiated format and was **already passed to `saturated_frac_of` at both call sites**, so the value was sitting in scope. In-band versus at-the-rail is a property of the format, not a threshold anyone has to measure. A format that cannot name its ceiling (Grey16, NV12, YUYV) passes the peak through unchanged, which is #237's own settled precedent.

The ceiling test reads the **raw** frame, for the reason stated beside `ir_saturated_frac`: ambient subtraction moves a railed 255 to 254, so a subtracted frame would quietly stop reading as railed (#238 review).

## What this is NOT

**It moves no verdict, and it is not a security fix.** `glint_present` reaches the PAD corpus and a dev probe print; both assignments sit after every `Spoof` return in their evaluators, so the cue is structurally incapable of changing an outcome. A regression test locks that on both evaluators, so making the cue honest cannot quietly promote it.

The value is narrower and worth stating plainly: any future re-derivation of `GLINT_MIN` would be fitted to this corpus, and two populations cannot be observed in a variable pinned at the sensor's limit.

## A finding this surfaced that I did NOT act on

The same ceiling-unaware peak is read by `eye_open_at` (`irlume-auth/src/lib.rs:3816`), which returns `peak >= EYE_OPEN_PEAK_MIN` (200.0), feeding `Assessment::eyes_open`, which **is** enforced as a real deny at `:2516` (`if enr.require_eyes_open && !a.eyes_open`).

A railed 255 satisfies `255 >= 200` unconditionally, so on a frame whose eye windows clip, that opt-in gate can be satisfied by **saturation rather than by an open eye**, which is a fail-open.

I deliberately left it alone, because the fix is a posture decision that is yours: your own measurement records the peak pinned at 255 in **all 30** frames with glasses on, so treating railed as "not open" would deny effectively every glasses wearer who has `require_eyes_open` enabled. That is a lockout-shaped change and it needs your call, not mine. Worth its own issue.

## Testing

Container-run, full workspace, every result line read.

- **1,280 passed** against a **1,277 baseline measured on this same base**, so the +3 are the new tests. The only two failures are the container's pre-existing root-only artifacts (`ir_emitter::…failed_save_keeps_the_record`, `tui::…models_screen_unprivileged…`), identical before and after, and both pass in CI which runs non-root.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets`, and `RUSTDOCFLAGS="-D warnings" cargo doc` all clean.
- New tests: the ceiling arm at full range and limited range (235), the unmeasurable-format arm pinning #237's precedent, the no-face arm, the three-way readable/present separation on **both** evaluators, and a regression lock that an unreadable glint changes no verdict.
- The ceiling test is **proven to have teeth**: a mutant that ignores the white level makes it fail (`left: Some(255.0), right: None`).

- [x] `cargo test --workspace` passes (1280; 2 pre-existing root-only failures)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` clean
- [x] Docs/CHANGELOG updated (PAD_SELFTEST cue table, CHANGELOG entry recording the corpus counts and that pre-change records are railed-contaminated)
- [ ] Hardware-validated (not required: no verdict moves, and the ceiling comes from the negotiated format rather than a measurement)
