### PR TITLE
The strobe check drives the emitter it claims to test (#384)

### DIFF
--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -160,18 +160,31 @@ jobs:
             exit 1
           fi
           err="$(mktemp)"
-          if sudo -n true 2>/dev/null; then
-            sudo -n "$burst" "$out" "$ir" 6 2>"$err"
-          else
-            echo "::warning::no passwordless sudo; running the burst unprivileged"
-            "$burst" "$out" "$ir" 6 2>"$err"
+          # Privilege is required, not preferred. The emitter lock lives in
+          # /run/lock and the daemon creates it 0640 root:root under UMask=0027,
+          # so an unprivileged run cannot take it and irlume declines to write.
+          # Root is also the production context: irlumed drives the emitter as
+          # root.
+          if ! sudo -n true 2>/dev/null; then
+            echo "::error::passwordless sudo is required to drive the emitter here (#384)"
+            exit 1
           fi
+          sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"
           cat "$err"
-          # "Could not manage the emitter" must not read as "the emitter is
-          # fine". Same rule as the node parse above and as #227: a check that
-          # could not run is not a check that passed.
-          if grep -q "will not write to this camera.s emitter" "$err"; then
-            echo "::error::irlume could not take the emitter lock, so it never drove the emitter. Any spread below is the emitter's leftover state, not evidence that irlume can light it (#384)"
+          # A POSITIVE marker, not the absence of one refusal string. The first
+          # version of this guard grepped for the lock refusal, which covers one
+          # of at least six inert paths through `ir_emitter::enable`: an
+          # unreadable USB identity, a recovery reporting Busy or
+          # OwnerStillRunning (both silent by design), no applicable control, and
+          # a failed apply_device_default or apply_known_payload. Any of those
+          # captures frames that look exactly like a successful run.
+          #
+          # `AlreadyHeld` is deliberately NOT accepted: it shows the control
+          # holds the wanted value, which is not the same as this invocation
+          # having driven it, and driving it is what this step claims to test
+          # (#384 review).
+          if ! grep -Fxq "irlume: capture emitter write completed" "$err"; then
+            echo "::error::irlume did not complete the emitter write, so the spread below is the emitter's leftover state rather than evidence irlume can light it (#384)"
             exit 1
           fi
           frames=$(find "$out" -name "frame*.pgm" | wc -l)

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -140,7 +140,40 @@ jobs:
           echo "IR node: $ir"
           out=$(mktemp -d)
           trap 'rm -rf "$out"' EXIT
-          cargo run -q -p irlume-camera --example burst_dump -- "$out" "$ir" 6
+          # Run the burst as ROOT when we can. irlume guards its emitter
+          # bookkeeping with a lock in /run/lock, and the daemon creates that
+          # file under `UMask=0027`, so it lands 0640 root:root. The runner
+          # account cannot open it, and irlume then REFUSES to write the
+          # emitter for the rest of the process, saying so on stderr.
+          #
+          # That refusal is why this step needs to be explicit about privilege.
+          # The check below asserts the emitter strobes, and an unprivileged
+          # run measures whatever state the emitter was left in by the last
+          # root process rather than anything irlume did. It passed at a spread
+          # of 17.9 on 2026-08-08 with irlume's emitter control disabled
+          # throughout (#384). Root is also the production context: irlumed
+          # runs as root, so this exercises the path users actually get.
+          burst="${CARGO_TARGET_DIR:-target}/debug/examples/burst_dump"
+          cargo build -q -p irlume-camera --example burst_dump
+          if [ ! -x "$burst" ]; then
+            echo "::error::burst_dump not built at $burst"
+            exit 1
+          fi
+          err="$(mktemp)"
+          if sudo -n true 2>/dev/null; then
+            sudo -n "$burst" "$out" "$ir" 6 2>"$err"
+          else
+            echo "::warning::no passwordless sudo; running the burst unprivileged"
+            "$burst" "$out" "$ir" 6 2>"$err"
+          fi
+          cat "$err"
+          # "Could not manage the emitter" must not read as "the emitter is
+          # fine". Same rule as the node parse above and as #227: a check that
+          # could not run is not a check that passed.
+          if grep -q "will not write to this camera.s emitter" "$err"; then
+            echo "::error::irlume could not take the emitter lock, so it never drove the emitter. Any spread below is the emitter's leftover state, not evidence that irlume can light it (#384)"
+            exit 1
+          fi
           frames=$(find "$out" -name "frame*.pgm" | wc -l)
           echo "captured $frames frames"
           test "$frames" -ge 4

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -177,9 +177,22 @@ jobs:
           frames=$(find "$out" -name "frame*.pgm" | wc -l)
           echo "captured $frames frames"
           test "$frames" -ge 4
-          # The strobe must actually strobe: require a real spread between the
-          # brightest (emitter-lit) and darkest frame means, the same signal
-          # capture_ir keys on. A dead emitter shows as a flat, dark burst.
+          # A flat, dark burst means no usable IR frames at all, which is worth
+          # catching. It does NOT mean irlume drove the emitter, and the comment
+          # here used to say it did.
+          #
+          # Measured 2026-08-08 on both modules, five consecutive runs per
+          # condition so no run inherits the previous one's emitter state:
+          #
+          #   NexiGo, IRLUME_IR_EMITTER=off   brightest frame 134.5 31.6 139.9 27.8 134.5
+          #   NexiGo, irlume managing it       brightest frame  31.1 139.5 29.1 148.0 25.1
+          #
+          # Both alternate between roughly 30 and roughly 135: the camera cycles
+          # its own state between capture sessions (#264's self-strobing seen
+          # from the other side), and every run clears this floor by a wide
+          # margin either way. So this asserts that the camera delivers
+          # alternating frames, not that irlume's extension-unit write reached
+          # it. A discriminator that depends on the write is tracked on #384.
           awk '{print $2}' "$out/means.txt" | sort -n | awk 'NR==1{min=$1} END{max=$1; d=max-min; printf "mean spread: %.1f\n", d; exit (d < 5)}'
 
       # Forensics on failure only. A hardware-only failure is otherwise

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1308,6 +1308,31 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
     let active = write
         .as_ref()
         .is_some_and(|w| w.outcome != Applied::Nothing);
+    // A POSITIVE statement of what the emitter path did, for a caller that
+    // needs to verify it rather than infer it.
+    //
+    // The nightly hardware suite used to assert this by the ABSENCE of one
+    // refusal message, which only covers the lock branch. `enable` returns
+    // inert from several others: an unreadable USB identity, a recovery that
+    // reports Busy or OwnerStillRunning (both deliberately silent), no
+    // applicable control, and a failed `apply_device_default` or
+    // `apply_known_payload`. Every one of those produces a capture that looks
+    // exactly like a successful one from outside, and the comment beside
+    // `applied_known_payload` already warns that a bool cannot tell "no ioctl
+    // reached the device" from "the device rejected it" (#384 review).
+    //
+    // Off unless asked for: this is per-capture and would otherwise be noise on
+    // the authentication path.
+    if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
+        eprintln!(
+            "irlume: capture emitter {}",
+            match write.as_ref().map(|w| w.outcome) {
+                Some(Applied::Wrote) => "write completed",
+                Some(Applied::AlreadyHeld) => "already held the requested value",
+                Some(Applied::Nothing) | None => "was not activated",
+            }
+        );
+    }
     // What the guard owns: a write of its own, with the value it displaced —
     // or a crash leftover claimed through the stream record (#188). A control
     // already holding the wanted bytes is another writer's state EXCEPT when a
@@ -3942,6 +3967,40 @@ pub fn describe_units(device: &str) -> std::io::Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
+    /// The nightly hardware suite greps for this line EXACTLY
+    /// (`grep -Fxq` in .github/workflows/hardware-suite.yml), so a reword here
+    /// silently turns that gate into one that can never pass, and the camera
+    /// stage would fail every night for a reason nobody would look for in this
+    /// file.
+    ///
+    /// That is not hypothetical: #383 is the same drift one layer over, where
+    /// doctor's node line gained a suffix and the workflow's anchored match
+    /// stopped firing for eight nights. Change the string here and change it
+    /// there in the same commit (#384).
+    #[test]
+    fn the_emitter_write_marker_matches_what_ci_greps_for() {
+        let workflow = include_str!("../../../.github/workflows/hardware-suite.yml");
+        assert!(
+            workflow.contains("irlume: capture emitter write completed"),
+            "the workflow no longer greps for the marker this file emits"
+        );
+        // ...and the source really does emit that exact text, so the assertion
+        // above cannot pass against a workflow string with no producer.
+        //
+        // The needles are assembled with `concat!` because `include_str!` pulls
+        // in THIS module: spelled inline, they match their own assertion and the
+        // check stays green with the marker reworded. Caught by mutation, which
+        // is the only reason this comment exists (defect pattern 70, hit for the
+        // third time in one session).
+        let src = include_str!("ir_emitter.rs");
+        let produced = concat!("\"write ", "completed\"");
+        let format = concat!("irlume: capture ", "emitter {}");
+        assert!(
+            src.contains(produced) && src.contains(format),
+            "the marker is no longer produced here; the workflow gate has no source"
+        );
+    }
+
     use super::*;
 
     /// Build a fake /proc tree: `pids` maps a pid to (comm, fd-targets).


### PR DESCRIPTION
## What & why

Closes #384.

The nightly's emitter check passed on 2026-08-08 with irlume's emitter control disabled for the entire run, and nothing in the output said so. This is the check the whole hardware lane exists for: it is the only thing in the repo that drives the real IR emitter.

irlume guards its emitter bookkeeping with a lock in `/run/lock`. The daemon creates that file under `UMask=0027`, so it lands `0640 root:root`:

```
drwxr-xr-x. 6 root root  /run/lock
-rw-r-----. 1 root root  /run/lock/irlume-emitter-209e9051….lock
```

The runner account cannot open it, so irlume takes its refusal branch and declines to write the emitter for the rest of the process. The step never read stderr, and the spread it measures is whatever state the emitter was left in by the last root process. A regression in irlume's own emitter path would not move it.

## Measured, with a control

Zenbook, ASUS FHD IR module, same binary, back to back:

| run | stderr | mean spread |
|---|---|---|
| unprivileged | `will not write to this camera's emitter` | **49.6** |
| under `sudo -n` | clean | **57.9** |

The existing check passes at 49.6 having proven nothing. Both clear its `< 5` floor, which is exactly the problem: the number cannot distinguish the two runs, so the floor was never testing what its comment claims.

## The change

The burst runs under `sudo -n` when available. That is also the production context: `irlumed` drives the emitter as root, so this exercises the path users actually get rather than one no shipped component uses. archhost's runner has passwordless sudo and is in `video`; without it the step warns and continues unprivileged.

The step then reads stderr. If irlume reports it could not take the lock, the step fails and says the spread below it is the emitter's leftover state rather than evidence. Same rule as the node parse above it and as #227: a check that could not run is not a check that passed.

Verified against real output rather than a guessed pattern: the guard fires on the actual unprivileged stderr and does not fire on the privileged run.

## Scope of the permission gap, narrowed

While checking this I established the user-facing path is unaffected. `ir-setup` goes through the daemon, which runs as root and gates on it. What cannot take the lock is the `IRLUME_DEV=1` tooling that opens the camera directly, which is dev tools and this CI step.

So the permission question the issue raised is a tooling question, not a user-facing one, and this makes the tooling honest without touching the lock's mode or ownership. I would rather not widen a lock on a security daemon to solve a CI problem.

## Testing

- Guard fires on the real unprivileged stderr; does not fire under sudo.
- Both burst runs captured 6 frames at 640x400.
- Workflow parses.

Not covered: whether the spread collapses with the emitter genuinely off. That needs a run with it deliberately disabled, which I did not want to do to the runner unattended. So the check now proves "irlume drove the emitter and the scene strobed" rather than "irlume is what made it strobe".

- [x] Measured before and after, with a control
- [x] Guard verified against real output
- [ ] Hardware-validated on archhost: pending a `workflow_dispatch` after merge
