### PR TITLE
The dev probe reads the glint ceiling the same way everything else does (#222)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -5766,6 +5766,28 @@ mod tests {
         // Landmarks fully outside the frame: nothing sampled, peak 0.
         let far: Landmarks5 = [(-500.0, -500.0); 5];
         assert_eq!(eye_glint(&grey, 64, 48, &far), 0.0);
+
+        // The window is BOUNDED: a bright pixel away from both eyes must not
+        // be picked up. Moved here from a duplicate of this function that
+        // irlume-cli carried for its dev probe; the probe now calls this one
+        // (#222), and the copy went with it rather than the assertion.
+        let (w, h) = (64u32, 48u32);
+        let mut plain = vec![0u8; (w * h) as usize];
+        let lm: Landmarks5 = [
+            (10.0, 10.0),
+            (30.0, 10.0),
+            (20.0, 20.0),
+            (12.0, 28.0),
+            (28.0, 28.0),
+        ];
+        assert_eq!(eye_glint(&plain, w, h, &lm), 0.0);
+        plain[(12 * w + 12) as usize] = 200; // inside radius 8 of the left eye
+        plain[(44 * w + 60) as usize] = 255; // far from both: must not count
+        assert_eq!(
+            eye_glint(&plain, w, h, &lm),
+            200.0,
+            "a bright pixel outside both eye windows must not become the peak"
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2504,24 +2504,6 @@ fn collect_images(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
     }
 }
 
-/// Peak IR brightness near the eye landmarks (corneal glint, supporting cue).
-fn eye_glint(grey: &[u8], w: u32, h: u32, landmarks: &irlume_vision::Landmarks5) -> f32 {
-    let mut peak = 0u8;
-    for &(ex, ey) in &landmarks[0..2] {
-        let r = 8i32;
-        for dy in -r..=r {
-            for dx in -r..=r {
-                let x = ex as i32 + dx;
-                let y = ey as i32 + dy;
-                if x >= 0 && y >= 0 && (x as u32) < w && (y as u32) < h {
-                    peak = peak.max(grey[(y as u32 * w + x as u32) as usize]);
-                }
-            }
-        }
-    }
-    peak as f32
-}
-
 /// P2 probe: capture RGB + IR and report what the IR stream gives us: mean/min/
 /// max brightness (is the emitter illuminating?), and whether YuNet finds a face
 /// in each spectrum (the basis for the cross-spectrum liveness cue). Diagnostic,
@@ -5344,22 +5326,5 @@ mod tests {
         let mut out = Vec::new();
         collect_images(std::path::Path::new("/nonexistent/irlume-imgs"), &mut out);
         assert!(out.is_empty());
-    }
-
-    #[test]
-    fn eye_glint_takes_the_peak_near_the_eye_landmarks_only() {
-        let (w, h) = (64u32, 64u32);
-        let mut grey = vec![0u8; (w * h) as usize];
-        let landmarks: irlume_vision::Landmarks5 = [
-            (10.0, 10.0), // left eye
-            (30.0, 10.0), // right eye
-            (20.0, 20.0),
-            (12.0, 28.0),
-            (28.0, 28.0),
-        ];
-        assert_eq!(eye_glint(&grey, w, h, &landmarks), 0.0);
-        grey[(12 * w + 12) as usize] = 200; // within radius 8 of the left eye
-        grey[(60 * w + 60) as usize] = 255; // far from both eyes: must not count
-        assert_eq!(eye_glint(&grey, w, h, &landmarks), 200.0);
     }
 }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2592,11 +2592,24 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
         let ir_center_edge_ratio = ir_top_face
             .map(|f| center_edge_ratio(&ir.data, ir.width, ir.height, &f.bbox))
             .unwrap_or(0.0);
-        // Single frame, no burst stats, so no white level is known: the
-        // `white: None` arm passes the peak through exactly as before, the same
-        // honesty this probe already applies to ir_saturated_frac below (#222).
-        let ir_eye_glint =
-            ir_top_face.map(|f| eye_glint(&ir.data, ir.width, ir.height, &f.landmarks));
+        // Ceiling-aware, the same call `padcapture` makes. The comment here used
+        // to say no white level was known, which was true while this probe
+        // captured without burst stats; it takes them now (#358), so the ceiling
+        // is in scope and there is no reason left to read the peak raw.
+        //
+        // Measured 2026-08-08 on the ASUS FHD IR module: with glasses on, ten
+        // consecutive probes read the eye-window peak at exactly 255, the
+        // format's ceiling. Read raw, every one of those reported as the
+        // STRONGEST POSSIBLE glint, which is the conflation #222 removed from
+        // the auth path and the corpus. The tool a developer opens to diagnose a
+        // glint problem was the one place still giving the old answer.
+        let ir_eye_glint = irlume_auth::eye_glint_of(
+            ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
+            ir.width,
+            ir.height,
+            ir_top_face.map(|f| &f.landmarks),
+            ir_stats.white_level,
+        );
         let rgb_top = rgb_faces.iter().max_by(|a, b| a.score.total_cmp(&b.score));
         let pose = rgb_top.map(|f| irlume_vision::head_pose(&f.landmarks));
         let signals = irlume_liveness::Signals {


### PR DESCRIPTION
## What & why

Found while measuring #386 on hardware. `liveness_probe` computed the eye-window peak with the raw `eye_glint`, so a peak at the format's ceiling came back as `Some(255.0)` and printed as the strongest possible reading:

```rust
let ir_eye_glint = ir_top_face.map(|f| eye_glint(&ir.data, ...));            // liveness_probe
let ir_eye_glint = irlume_auth::eye_glint_of(..., ir_stats.white_level);     // pad.rs
```

`pad.rs` and the authentication path both apply #222's ceiling logic and answer `None` on a railed peak. The dev probe, which is what a developer opens to diagnose a glint problem, was the one place still giving the pre-#222 answer.

The comment justifying it said no white level was known here. That was true while this probe captured without burst stats; #358 switched it to `capture_ir_with_stats` for the exposure gate, so the ceiling has been in scope and unused since. That loose end is mine, from that change.

## Measured before and after

ASUS FHD IR module, glasses on, which is the condition that rails this peak. #222 recorded 255 in all 30 frames; ten probes tonight read 255 in all ten.

Same camera, same seat, minutes apart:

| | eye-glint | glint_readable |
|---|---|---|
| before | `255` | `true` |
| after | `n/a` | `false` |

`ir=true` in both, so the `n/a` is the ceiling test firing rather than a missing IR face. Bare-eyed the peak reads 170-226 on this module and still prints a number, so this does not simply suppress the cue.

## Detail

Reads the raw frame via `saturation_frame`, matching `pad.rs`, for the reason stated beside `ir_saturated_frac`: ambient subtraction moves a railed 255 to 254, so a subtracted frame would quietly stop reading as railed.

## Testing

- Before/after on the railing condition, above.
- Bare-eyed control: still prints a number rather than `n/a`.
- `cargo build --release -p irlume-cli` clean.

Not covered: no unit test. The probe captures from a camera, so its behaviour is not reachable from the test suite; the function it now calls, `eye_glint_of`, is already covered by #222's tests on both evaluators.

- [x] Verified on hardware, before and after, on the condition that exposes it
- [x] Bare-eyed control run
- [ ] Docs/CHANGELOG (dev-only diagnostic, no user-facing surface)
