### PR TITLE
The emitter gate message names the remedy the step can act on (#392)

### DIFF
--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -166,7 +166,7 @@ jobs:
           # Root is also the production context: irlumed drives the emitter as
           # root.
           if ! sudo -n true 2>/dev/null; then
-            echo "::error::passwordless sudo is required to drive the emitter here (#384)"
+            echo "::error::this runner cannot take the emitter lock, so the emitter check cannot run. It is /run/lock/irlume-emitter-*.lock, created 0640 root:root by the daemon under UMask=0027, and this job runs as an unprivileged service account. Either give that account passwordless sudo for the burst, or make the lock reachable by the group that can already drive the camera (/dev/video* is root:video). Tracked on #392; failing rather than passing, because a check that cannot run has not passed"
             exit 1
           fi
           sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -165,8 +165,15 @@ jobs:
           # so an unprivileged run cannot take it and irlume declines to write.
           # Root is also the production context: irlumed drives the emitter as
           # root.
+          #
+          # The gate here and the invocation below must name the same mechanism.
+          # This step runs the burst through `sudo -n`, so passwordless sudo is
+          # what it needs, and a message offering a remedy this step cannot
+          # honour sends an operator to a change that leaves the nightly red.
+          # The #393 review caught exactly that: the group route on #392 is only
+          # half a fix while the burst still goes through sudo.
           if ! sudo -n true 2>/dev/null; then
-            echo "::error::this runner cannot take the emitter lock, so the emitter check cannot run. It is /run/lock/irlume-emitter-*.lock, created 0640 root:root by the daemon under UMask=0027, and this job runs as an unprivileged service account. Either give that account passwordless sudo for the burst, or make the lock reachable by the group that can already drive the camera (/dev/video* is root:video). Tracked on #392; failing rather than passing, because a check that cannot run has not passed"
+            echo "::error::this runner cannot take the emitter lock, so the emitter check cannot run. The lock is /run/lock/irlume-emitter-*.lock, created 0640 root:root by the daemon under UMask=0027, and this job runs as an unprivileged service account. This step invokes the burst through sudo -n, so passwordless sudo for that account is what it needs today. The route tracked on #392 is a pair: make the lock reachable by the group that can already drive the camera (/dev/video* is root:video), and change this step to run the burst unprivileged. Neither half has been run on hardware. Failing rather than passing, because a check that cannot run has not passed"
             exit 1
           fi
           sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -4001,6 +4001,38 @@ mod tests {
         );
     }
 
+    /// The same drift as above, one field over: the gate that refuses to run the
+    /// emitter check and the line that actually runs it must name the same
+    /// mechanism. The step invokes the burst through `sudo -n`, so passwordless
+    /// sudo is the only thing that lets it proceed, and a failure message
+    /// offering any other remedy sends an operator to a change the step ignores.
+    /// #393 shipped exactly that: the message offered a lock-permission route
+    /// while the gate still exited on `sudo -n true`, so following it left the
+    /// nightly red for a reason the message had ruled out.
+    ///
+    /// Both directions matter, which is why the first assertion is here. When
+    /// #392 is decided and the burst stops going through sudo, this fails and
+    /// forces the message to be rewritten in the same commit rather than
+    /// quietly becoming false.
+    ///
+    /// No `concat!` dance is needed: this reads the workflow only, and the
+    /// workflow does not contain this file's source, so a needle cannot match
+    /// itself the way it did in the test above.
+    #[test]
+    fn the_sudo_gate_offers_the_remedy_the_step_can_act_on() {
+        let workflow = include_str!("../../../.github/workflows/hardware-suite.yml");
+        assert!(
+            workflow.contains("sudo -n env IRLUME_LOG_EMITTER_WRITES=1"),
+            "the burst no longer runs through sudo, so the gate message below \
+             has stopped being true; rewrite it with the change (#392)"
+        );
+        assert!(
+            workflow.contains("This step invokes the burst through sudo -n, so passwordless sudo"),
+            "the gate message no longer names passwordless sudo, which is the \
+             only remedy this step can act on while the burst uses it (#393)"
+        );
+    }
+
     use super::*;
 
     /// Build a fake /proc tree: `pids` maps a pid to (comm, fd-targets).


### PR DESCRIPTION
## What & why

Follow-up to #387, tracked on #392.

The nightly fails on archhost with:

```
::error::passwordless sudo is required to drive the emitter here (#384)
```

That names one remedy and never says what the obstacle actually is. The runner account cannot open `/run/lock/irlume-emitter-*.lock`, which the daemon creates `0640 root:root` under `UMask=0027`. This PR replaces the message with one that names the lock, its mode, the account, and what would let the check run.

The failure itself is unchanged and deliberate. A check that cannot run has not passed, which is the whole point of #384; softening it back into a skip would reproduce the eight nights of #383.

## What the review round changed

The first version of this message offered two remedies: passwordless sudo, or making the lock reachable by the group that can already drive the camera. The Codex round rejected it and the code agrees. Line 168 gates on `sudo -n true`, and line 172 runs the burst through `sudo -n` with no unprivileged branch. An operator who changed only the lock permission would still exit at the gate, before anything reached the lock, and read the same red nightly. The message would have sent them to a change this step cannot act on.

It now says passwordless sudo is what this step needs today, and describes the #392 route as the pair it is: the lock permission, and this step dropping sudo. Neither half has been run on hardware.

The group framing needs care on #392 itself for a separate reason. `video` is not a general capability boundary: on the Zenbook the user is not in `video` at all and reaches `/dev/video2` through a systemd-logind uaccess ACL, while on archhost the runner is in `video`. That correction is already on the issue.

## How this reached main

I verified passwordless sudo on archhost over SSH as `archledger` and assumed it applied to the job. The runner is `ghrunner`, which needs a password. That is the environment-versus-artefact mistake, and it is why #387 landed red rather than being caught first.

## The drift now has a test

The mismatch was caught by review rather than by CI, and it would have drifted again with nothing to say so. `the_sudo_gate_offers_the_remedy_the_step_can_act_on` in `crates/irlume-camera/src/ir_emitter.rs` pins the two together, in the same idiom as the emitter-marker test directly above it.

It fails in both directions, which is the point:

- Restore the old wording and the message assertion fires.
- Remove `sudo -n` from the burst line, which is what deciding #392 would do, and the mechanism assertion fires, so the message has to be rewritten in that same commit.

Both were run as mutations rather than reasoned about. The first failed with "the gate message no longer names passwordless sudo", the second with "the burst no longer runs through sudo", and the unmutated file passes. This one reads the workflow only, so a needle cannot match its own source the way the marker test above had to guard against with `concat!`.

## Testing

- [x] YAML parses, and every `run:` body in the file passes `bash -n`
- [x] `cargo fmt --all -- --check` and `cargo clippy -p irlume-camera --all-targets -- -D warnings`, both with the exit status checked
- [x] New test green, and failing under two separate mutations
- [x] `git diff --check` clean; message text passes `slopcheck`
- [ ] Hardware-validated: the nightly stays red until #392 is decided, which is the intended state

What is not covered: the message is pinned by substring, so a rewrite that keeps the phrase "This step invokes the burst through sudo -n, so passwordless sudo" while making the rest of the sentence wrong would still pass. `actionlint` is not installed on this machine, so the YAML parse and the extracted shell bodies are the only static checks that ran against the workflow itself.
