### PR TITLE
The reason NV12 and YUYV get no clipping ceiling was never the quantization (#385)

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -198,10 +198,22 @@ pub struct IrCaptureStats {
     /// sensor's full-scale sample. The Y16 family does not, because
     /// `grey16_shift` picks the shift from the frame's OWN maximum, so a
     /// decoded 255 means "the brightest pixel in this frame" and a dim frame
-    /// full of them is ordinary. NV12 and YUYV do not either, because their
-    /// ceiling depends on the negotiated quantization (limited range puts
-    /// nominal white at 235, full range at 255) and irlume does not carry that
-    /// field, so a clipped face could read as no clipping at all.
+    /// full of them is ordinary.
+    ///
+    /// NV12 and YUYV answer `None` for a different reason, and it is NOT that
+    /// the quantization is unknown. This comment used to say irlume does not
+    /// carry that field; it does. `IrCamera::open` stores `fmt.quantization`
+    /// and `clipping_white_level` already takes it, so their ceiling is
+    /// computable (limited range puts nominal white at 235, full range at 255).
+    ///
+    /// The `None` is load-bearing somewhere else. `role_from_formats` calls any
+    /// node advertising either fourcc `Role::Rgb`, whatever else it advertises,
+    /// so no DISCOVERED pair ever reaches an IR decode with them. The ones that
+    /// do arrive by the `IRLUME_CAMERA_*` override, a saved pin, or the
+    /// `/dev/video2` fallback, and there this `None` is what makes
+    /// `exposure_refusal` refuse the frame. Answering a ceiling would delete
+    /// that refusal and hand cues fitted on an emitter-lit IR image a room-lit
+    /// colour frame (#385).
     pub white_level: Option<u8>,
     /// The gate frame's RAW pixels, present only when the returned frame is no
     /// longer them: ambient subtraction replaces the payload, and a caller
@@ -1926,6 +1938,19 @@ fn grey16_shift(buf: &[u8]) -> u32 {
 /// there instead would be the cautious-looking choice and would disable the
 /// gate on every camera anyone actually has, which is the failure this exists
 /// to prevent. If a module ever reports limited range, the 235 arm covers it.
+///
+/// That citation is a userspace tool's opinion, and the kernel's own format
+/// table disagrees with it: `V4L2_MAP_QUANTIZATION_DEFAULT` resolves `Default`
+/// to LIMITED for Y'CbCr unless the colorspace is JPEG, and `v4l2-ctl` prints
+/// GREY as full range only because its `is_rgb_or_hsv` fourcc switch ends in
+/// `default: return true` and GREY is not in the list. The committed corpora
+/// settle it by measurement rather than by either claim: across
+/// `docs/pad-results/2026-08-02-center-edge-corpus.jsonl` and
+/// `2026-08-04-occluder-gate.jsonl`, `ir_saturated_frac` is nonzero in 75 of
+/// the 129 records carrying it (59 of 103, peaking at 0.547, and 16 of 26),
+/// and those captures were measured against a 255 ceiling. Real GREY8 frames
+/// from the ASUS module do reach 255, so the stream is full range in fact,
+/// whatever the metadata says (#385).
 pub(crate) fn clipping_white_level(pix: IrPixel, quantization: Quantization) -> Option<u8> {
     match (pix, quantization) {
         (IrPixel::Grey8, Quantization::LimitedRange) => Some(235),
@@ -4444,9 +4469,13 @@ mod tests {
 
     /// Which formats can support a clipping claim at all. A decoded 255 means
     /// "the sensor's full-scale sample" ONLY for the native 8-bit greys: the
-    /// Y16 family is rescaled by a shift taken from the frame's own maximum,
-    /// and the YUV ceilings depend on a quantization irlume does not carry.
-    /// Saying None there is what keeps #221's corpus interpretable.
+    /// Y16 family is rescaled by a shift taken from the frame's own maximum.
+    /// The YUV pair is a different case and this comment used to get it wrong:
+    /// irlume does carry their quantization, so their ceiling is computable,
+    /// and the `None` is there because no discovered pair reaches an IR decode
+    /// with those fourccs and the refusal it produces is what stops a colour
+    /// node in the IR slot (#385). Saying None keeps #221's corpus
+    /// interpretable either way.
     #[test]
     fn only_native_8bit_grey_can_claim_a_clipping_ceiling() {
         for q in [

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -200,20 +200,28 @@ pub struct IrCaptureStats {
     /// decoded 255 means "the brightest pixel in this frame" and a dim frame
     /// full of them is ordinary.
     ///
-    /// NV12 and YUYV answer `None` for a different reason, and it is NOT that
-    /// the quantization is unknown. This comment used to say irlume does not
-    /// carry that field; it does. `IrCamera::open` stores `fmt.quantization`
-    /// and `clipping_white_level` already takes it, so their ceiling is
-    /// computable (limited range puts nominal white at 235, full range at 255).
+    /// NV12 and YUYV answer `None`, and the reason this comment used to give
+    /// was wrong. It said irlume does not carry the negotiated quantization.
+    /// irlume does: `IrCamera::open` stores `fmt.quantization` and
+    /// `clipping_white_level` already takes it.
     ///
-    /// The `None` is load-bearing somewhere else. `role_from_formats` calls any
-    /// node advertising either fourcc `Role::Rgb`, whatever else it advertises,
-    /// so no DISCOVERED pair ever reaches an IR decode with them. The ones that
-    /// do arrive by the `IRLUME_CAMERA_*` override, a saved pin, or the
-    /// `/dev/video2` fallback, and there this `None` is what makes
-    /// `exposure_refusal` refuse the frame. Answering a ceiling would delete
-    /// that refusal and hand cues fitted on an emitter-lit IR image a room-lit
-    /// colour frame (#385).
+    /// Carrying it is still not enough to compute their ceiling, which is the
+    /// correction the second draft of this comment needed.
+    /// `Quantization::Default` is not itself an effective range: V4L2 resolves
+    /// it with `V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb_or_hsv, colsp, ycbcr_enc)`,
+    /// which needs the COLORSPACE, and `IrCamera` keeps only the quantization
+    /// out of the negotiated `Format`. A `Default` YUV stream therefore cannot
+    /// be told apart from a JPEG-colorspace one, and answering 235 for all of
+    /// them is wrong for the second while 255 is wrong for the first.
+    ///
+    /// The `None` is also load-bearing, which matters more than either.
+    /// `role_from_formats` calls any node advertising either fourcc
+    /// `Role::Rgb`, whatever else it advertises, so no DISCOVERED pair ever
+    /// reaches an IR decode with them. The ones that do arrive by the
+    /// `IRLUME_CAMERA_*` override, a saved pin, or the `/dev/video2` fallback,
+    /// and there this `None` is what makes `exposure_refusal` refuse. Do not
+    /// add a ceiling here without first adding something that guarantees the
+    /// selected node is an emitter-lit IR source (#385).
     pub white_level: Option<u8>,
     /// The gate frame's RAW pixels, present only when the returned frame is no
     /// longer them: ambient subtraction replaces the payload, and a caller
@@ -1939,18 +1947,26 @@ fn grey16_shift(buf: &[u8]) -> u32 {
 /// gate on every camera anyone actually has, which is the failure this exists
 /// to prevent. If a module ever reports limited range, the 235 arm covers it.
 ///
-/// That citation is a userspace tool's opinion, and the kernel's own format
-/// table disagrees with it: `V4L2_MAP_QUANTIZATION_DEFAULT` resolves `Default`
-/// to LIMITED for Y'CbCr unless the colorspace is JPEG, and `v4l2-ctl` prints
-/// GREY as full range only because its `is_rgb_or_hsv` fourcc switch ends in
-/// `default: return true` and GREY is not in the list. The committed corpora
-/// settle it by measurement rather than by either claim: across
+/// That citation is a userspace tool's opinion, and the kernel's own mapping
+/// disagrees with it: `V4L2_MAP_QUANTIZATION_DEFAULT` resolves `Default` to
+/// LIMITED for Y'CbCr unless the colorspace is JPEG, and `v4l2-ctl` prints GREY
+/// as full range only because its `is_rgb_or_hsv` fourcc switch ends in
+/// `default: return true` with GREY absent from the list. Neither settles how
+/// GREY should be classified, because the kernel does not class it explicitly.
+///
+/// The committed corpora carry the evidence this arm actually rests on, and it
+/// is per-device rather than universal. Across
 /// `docs/pad-results/2026-08-02-center-edge-corpus.jsonl` and
 /// `2026-08-04-occluder-gate.jsonl`, `ir_saturated_frac` is nonzero in 75 of
-/// the 129 records carrying it (59 of 103, peaking at 0.547, and 16 of 26),
-/// and those captures were measured against a 255 ceiling. Real GREY8 frames
-/// from the ASUS module do reach 255, so the stream is full range in fact,
-/// whatever the metadata says (#385).
+/// 129 non-null readings (59 of 103, peaking at 0.547, and 16 of 26), and those
+/// captures were evaluated against a 255 threshold, so decoded ASUS frames did
+/// contain samples equal to 255.
+///
+/// That supports the 255 policy for these modules. It does NOT establish a
+/// V4L2 rule for GREY in general: the corpora record no fourcc, colorspace,
+/// quantization or white level per row, and a decoded 255 is consistent with
+/// clipping or with metadata that does not describe what the device emits. A
+/// module reporting limited-range GREY still needs the 235 arm (#385).
 pub(crate) fn clipping_white_level(pix: IrPixel, quantization: Quantization) -> Option<u8> {
     match (pix, quantization) {
         (IrPixel::Grey8, Quantization::LimitedRange) => Some(235),
@@ -4471,11 +4487,12 @@ mod tests {
     /// "the sensor's full-scale sample" ONLY for the native 8-bit greys: the
     /// Y16 family is rescaled by a shift taken from the frame's own maximum.
     /// The YUV pair is a different case and this comment used to get it wrong:
-    /// irlume does carry their quantization, so their ceiling is computable,
-    /// and the `None` is there because no discovered pair reaches an IR decode
-    /// with those fourccs and the refusal it produces is what stops a colour
-    /// node in the IR slot (#385). Saying None keeps #221's corpus
-    /// interpretable either way.
+    /// irlume does carry their raw quantization, but resolving `Default` also
+    /// needs the colorspace, which `IrCamera` discards. The `None` is there
+    /// mainly because no discovered pair reaches an IR decode with those
+    /// fourccs, and the refusal it produces is what stops a colour node that
+    /// arrives in the IR slot some other way (#385). Saying None keeps #221's
+    /// corpus interpretable either way.
     #[test]
     fn only_native_8bit_grey_can_claim_a_clipping_ceiling() {
         for q in [

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -125,9 +125,11 @@ pub struct Signals {
     pub face_frac: f32,
     /// Fraction (0-1) of the IR face region at or above the sensor's ceiling,
     /// or `None` when the reading could not be taken: no IR face, the RGB-only
-    /// path, or a negotiated format whose decode cannot say where its ceiling
-    /// is (the Y16 family is rescaled per frame; YUV ceilings depend on a
-    /// quantization irlume does not carry). `None` is NOT zero clipping.
+    /// path, or a negotiated format the camera crate declines to give a ceiling
+    /// for (the Y16 family is rescaled per frame, so its 255 is the frame's own
+    /// maximum; the YUV pair is refused for a reason that is not about the
+    /// quantization being unknown, which irlume does carry, see
+    /// `clipping_white_level` and #385). `None` is NOT zero clipping.
     ///
     /// GATED since #237, at [`IR_SATURATED_FRAC_MAX`]. Saturation compresses
     /// [`ir_center_edge_ratio`] toward 1 the way an ambient pedestal does,

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -127,8 +127,9 @@ pub struct Signals {
     /// or `None` when the reading could not be taken: no IR face, the RGB-only
     /// path, or a negotiated format the camera crate declines to give a ceiling
     /// for (the Y16 family is rescaled per frame, so its 255 is the frame's own
-    /// maximum; the YUV pair is refused for a reason that is not about the
-    /// quantization being unknown, which irlume does carry, see
+    /// maximum; NV12 and YUYV are declined so that a colour stream placed in
+    /// the IR slot is refused rather than judged, and because resolving their
+    /// `Default` quantization needs a colorspace irlume does not retain, see
     /// `clipping_white_level` and #385). `None` is NOT zero clipping.
     ///
     /// GATED since #237, at [`IR_SATURATED_FRAC_MAX`]. Saturation compresses


### PR DESCRIPTION
## What & why

Items 1 and 3 of #385. Documentation only.

Three comments claimed irlume does not carry the negotiated quantization, so the YUV ceiling could not be known:

- `crates/irlume-camera/src/lib.rs:203`, the `white_level` doc
- `crates/irlume-camera/src/lib.rs:4448`, the doc on `only_native_8bit_grey_can_claim_a_clipping_ceiling`
- `crates/irlume-liveness/src/lib.rs:130`, the `ir_saturated_frac` doc

`IrCamera::open` stores `quantization: fmt.quantization`, and `clipping_white_level(pix, quantization)` already takes it and already uses it for the GREY arm. The stated reason has been false since that field was threaded through.

Carrying the field is not the same as knowing the ceiling, which is what the review round caught in my first draft. `Quantization::Default` is not itself an effective range: V4L2 resolves it with `V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb_or_hsv, colsp, ycbcr_enc)`, which needs the colorspace. `v4l::Format` carries `colorspace` and `IrCamera` keeps only `quantization`, so a `Default` YUV stream cannot be distinguished from a JPEG-colorspace one, and 235 for all of them is wrong for the second while 255 is wrong for the first. The comments now say that rather than calling the ceiling computable.

## The real reason is a guard, not a gap

This is the part worth having in the code rather than only on the issue. `role_from_formats` at `:724` returns `Role::Rgb` for any node advertising NV12 or YUYV, whatever else it advertises, so no discovered pair ever reaches an IR decode with those fourccs. The ones that do arrive by the `IRLUME_CAMERA_*` override, a saved pin, or the `/dev/video2` fallback at `:1160`, and there the `None` is what makes `exposure_refusal` refuse the frame.

So a future change that answers a ceiling for those two formats does not enable hardware. It deletes a refusal and hands cues fitted on an emitter-lit IR image a room-lit colour frame. The old comment invited exactly that change by describing the `None` as a missing field. The analysis is on #385.

## The GREY arm now cites the corpora

Its doc cited `v4l2-ctl` printing "maps to Full Range", which the kernel's own table contradicts: `V4L2_MAP_QUANTIZATION_DEFAULT` resolves `Default` to limited range for Y'CbCr unless the colorspace is JPEG, and `v4l2-ctl` prints GREY as full range because its `is_rgb_or_hsv` fourcc switch ends in `default: return true` with GREY absent from the list.

The issue's own citation for this was wrong, so I counted at `6ddcec0` rather than copying it. `ir_brightness` peaks at 206.77 across 130 records and never exceeds 235, so the issue's "24 records above 235" does not describe that field. `ir_saturated_frac` does carry the claim: nonzero in 75 of 129 non-null readings, 59 of 103 in `2026-08-02-center-edge-corpus.jsonl` peaking at 0.547 and 16 of 26 in `2026-08-04-occluder-gate.jsonl`.

What that establishes is narrower than my first draft said, and the review round was right to push back. Those captures were evaluated against a 255 threshold, so decoded ASUS frames contained samples equal to 255. The corpora record no fourcc, colorspace, quantization or white level per row, so they support the 255 policy for these modules and settle nothing about GREY in general. The comment says that, and keeps the 235 arm's reason for existing intact.

## Review round

Codex returned DO NOT SHIP on `726dc17` with two documentation findings, both correct and both fixed in `73acbb7`: the "computable" claim above, and the corpus paragraph asserting the stream is full range in fact when the data shows decoded samples reaching 255 on one module. It also corrected the count wording, since the first corpus has 104 rows carrying the key and 103 non-null.

I verified both against the tree before applying them: `v4l::Format` declares `colorspace` and `quantization` as separate fields, `IrCamera` retains only the second, and the kernel macro at `include/uapi/linux/videodev2.h` takes `colsp` as a parameter.

## Testing

- [x] `cargo fmt --all -- --check`, exit status captured
- [x] `cargo clippy -p irlume-camera -p irlume-liveness --all-targets -- -D warnings`, exit status captured
- [x] `cargo doc --no-deps` on both crates, so no intra-doc link broke
- [x] `cargo test -p irlume-camera -p irlume-liveness`: 267 and 53 pass, 11 ignored
- [x] Corpus counts recomputed from the committed `.jsonl` files rather than taken from the issue

No test fails when this is reverted, because what changed is comment text. The claims were checked site by site against the code instead, and each file:line above was read. There is no behaviour change in this PR: `clipping_white_level` still returns `None` for `Nv12Luma` and `YuyvLuma`, and item 2 of the issue is deliberately not implemented.

## Not covered

Whether item 2 should ever be implemented is open on #385 and needs a decision about what refuses an RGB-classified node in the IR slot. Separately, #394 records that a `Some(235)` would not be read by the per-frame clipping instrument even where it fires.
