### PR TITLE
The clipping measurement reads the ceiling it was handed (#394)

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2686,15 +2686,18 @@ pub mod ir_probe {
     /// capture-quality signal, not a hard gate.
     ///
     /// `white` is a parameter rather than a hardcoded 255 because
-    /// [`clipping_white_level`] can answer 235: a limited-range stream rails at
+    /// `clipping_white_level` can answer 235: a limited-range stream rails at
     /// nominal white, not at the type's maximum. Counting only `== 255` on such
     /// a stream reports every frame as pristine, which does not merely lose a
     /// signal. `Some(_)` is what switches ON #221's clip-aware gate-frame
     /// selection, so the selection would run against an all-zero measurement,
     /// pass every frame under `CLIPPED_FRAC_MAX`, and hand back the brightest
     /// lit frame, which is the blown one #221 exists to avoid. The face-region
-    /// instrument [`irlume_auth::saturated_frac_in_bbox`] has always taken the
-    /// ceiling, so the two disagreed about the same burst (#394).
+    /// instrument `saturated_frac_in_bbox` in irlume-auth has always taken the
+    /// ceiling, so the two disagreed about the same burst (#394). Named in
+    /// backticks and not as an intra-doc link: irlume-camera cannot depend on
+    /// irlume-auth, so the link would not resolve and CI treats that as an
+    /// error.
     ///
     /// `>=` rather than `==` for the same reason the bbox instrument uses it: a
     /// sample above nominal white is out-of-range excursion, which is still not

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2426,10 +2426,14 @@ impl IrSession<'_> {
         // only when the camera classified frames; on either fallback this is
         // the first frame holding the max mean, exactly the original
         // incremental scan.
-        let clipped_fracs: Option<Vec<f64>> = white_level.map(|_| {
+        // `map(|w| ...)`, NOT `map(|_| ...)`. Binding the ceiling and discarding
+        // it is what made this measurement disagree with the one that judges the
+        // face region: presence switched the clip-aware selection on while the
+        // count stayed pinned to 255 (#394).
+        let clipped_fracs: Option<Vec<f64>> = white_level.map(|w| {
             frames
                 .iter()
-                .map(|f| ir_probe::saturated_fraction(f))
+                .map(|f| ir_probe::saturated_fraction(f, w))
                 .collect()
         });
         let best_i =
@@ -2496,7 +2500,16 @@ impl IrSession<'_> {
                         ir_window = ir_window.union(CaptureWindow::at(taken[ai]));
                     }
                     if debug_ir {
-                        let clipped = ir_probe::saturated_fraction(&frames[best_i]);
+                        // Reads the same ceiling the gate-frame selection above
+                        // used, so the debug percentage and the decision cannot
+                        // disagree. `unwrap_or(u8::MAX)` only affects a format
+                        // that names no ceiling, where this line is the sole
+                        // consumer and 255 is the most conservative reading
+                        // available (#394).
+                        let clipped = ir_probe::saturated_fraction(
+                            &frames[best_i],
+                            white_level.unwrap_or(u8::MAX),
+                        );
                         let action = if sub_mean >= SUBTRACT_MIN_RESULT {
                             "applied"
                         } else {
@@ -2666,15 +2679,31 @@ pub mod ir_probe {
             .collect()
     }
 
-    /// Fraction of pixels at the 8-bit ceiling (255). A high clipped fraction in
-    /// the lit frame means the exposure is blown: those pixels lost their true
-    /// emitter return, so both the raw and the ambient-subtracted frame are
-    /// unreliable there. Used as a capture-quality signal, not a hard gate.
-    pub fn saturated_fraction(data: &[u8]) -> f64 {
+    /// Fraction of pixels at or above `white`, the ceiling the negotiated format
+    /// actually reports. A high clipped fraction in the lit frame means the
+    /// exposure is blown: those pixels lost their true emitter return, so both
+    /// the raw and the ambient-subtracted frame are unreliable there. Used as a
+    /// capture-quality signal, not a hard gate.
+    ///
+    /// `white` is a parameter rather than a hardcoded 255 because
+    /// [`clipping_white_level`] can answer 235: a limited-range stream rails at
+    /// nominal white, not at the type's maximum. Counting only `== 255` on such
+    /// a stream reports every frame as pristine, which does not merely lose a
+    /// signal. `Some(_)` is what switches ON #221's clip-aware gate-frame
+    /// selection, so the selection would run against an all-zero measurement,
+    /// pass every frame under `CLIPPED_FRAC_MAX`, and hand back the brightest
+    /// lit frame, which is the blown one #221 exists to avoid. The face-region
+    /// instrument [`irlume_auth::saturated_frac_in_bbox`] has always taken the
+    /// ceiling, so the two disagreed about the same burst (#394).
+    ///
+    /// `>=` rather than `==` for the same reason the bbox instrument uses it: a
+    /// sample above nominal white is out-of-range excursion, which is still not
+    /// a pixel carrying a usable emitter return.
+    pub fn saturated_fraction(data: &[u8], white: u8) -> f64 {
         if data.is_empty() {
             return 0.0;
         }
-        let clipped = data.iter().filter(|&&p| p == 255).count();
+        let clipped = data.iter().filter(|&&p| p >= white).count();
         clipped as f64 / data.len() as f64
     }
 
@@ -4562,9 +4591,38 @@ mod tests {
 
     #[test]
     fn saturated_fraction_counts_clipped_pixels() {
-        assert_eq!(ir_probe::saturated_fraction(&[255, 255, 0, 0]), 0.5);
-        assert_eq!(ir_probe::saturated_fraction(&[0, 1, 254]), 0.0);
-        assert_eq!(ir_probe::saturated_fraction(&[]), 0.0);
+        assert_eq!(
+            ir_probe::saturated_fraction(&[255, 255, 0, 0], u8::MAX),
+            0.5
+        );
+        assert_eq!(ir_probe::saturated_fraction(&[0, 1, 254], u8::MAX), 0.0);
+        assert_eq!(ir_probe::saturated_fraction(&[], u8::MAX), 0.0);
+    }
+
+    /// The whole of #394: a limited-range stream rails at 235, and counting
+    /// `== 255` reported it as pristine. Both readings below come from the SAME
+    /// buffer, so this fails on the old signature no matter what ceiling is
+    /// passed: it could only ever answer 0.0 for these pixels.
+    ///
+    /// The second half is what makes it a regression test rather than a
+    /// tautology: at a 255 ceiling the same frame must still read clean, so a
+    /// fix that simply lowered the constant is not enough to pass.
+    #[test]
+    fn a_frame_railed_at_nominal_white_is_clipped_only_against_its_own_ceiling() {
+        let railed_at_235 = [235u8, 235, 235, 235];
+        assert_eq!(
+            ir_probe::saturated_fraction(&railed_at_235, 235),
+            1.0,
+            "a limited-range frame at nominal white is entirely clipped"
+        );
+        assert_eq!(
+            ir_probe::saturated_fraction(&railed_at_235, u8::MAX),
+            0.0,
+            "the same pixels are not clipped on a full-range stream"
+        );
+        // Out-of-range excursion above nominal white still carries no usable
+        // emitter return, so `>=` and not `==`.
+        assert_eq!(ir_probe::saturated_fraction(&[236u8, 0, 0, 0], 235), 0.25);
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2502,27 +2502,34 @@ impl IrSession<'_> {
                     if debug_ir {
                         // Reads the same ceiling the gate-frame selection above
                         // used, so the debug percentage and the decision cannot
-                        // disagree. `unwrap_or(u8::MAX)` only affects a format
-                        // that names no ceiling, where this line is the sole
-                        // consumer and 255 is the most conservative reading
-                        // available (#394).
-                        let clipped = ir_probe::saturated_fraction(
-                            &frames[best_i],
-                            white_level.unwrap_or(u8::MAX),
-                        );
+                        // disagree.
+                        //
+                        // `None` prints no percentage at all rather than
+                        // substituting 255. Defaulting was the wrong instinct
+                        // twice over: the count is `p >= white`, so 255 passes
+                        // the FEWEST pixels and under-reports, which on a
+                        // diagnostic means failing to warn; and a format that
+                        // names no ceiling has no clipping figure to report, so
+                        // printing one states a measurement nobody took. Same
+                        // rule `eye_glint_of` and `saturated_frac_of` follow
+                        // next door (#394).
+                        let clipped =
+                            white_level.map(|w| ir_probe::saturated_fraction(&frames[best_i], w));
                         let action = if sub_mean >= SUBTRACT_MIN_RESULT {
                             "applied"
                         } else {
                             "reverted (result too dark; face would vanish)"
                         };
+                        let clip_note = match clipped {
+                            Some(c) if c > ir_metadata::CLIPPED_FRAC_MAX => format!(
+                                "; lit clipped {:.1}% (blown exposure; subtracted frame unreliable)",
+                                c * 100.0
+                            ),
+                            Some(c) => format!("; lit clipped {:.1}%", c * 100.0),
+                            None => String::new(),
+                        };
                         eprintln!(
-                        "[ir] ambient-subtract {action}: lit {best_i} ({lit_mean:.0}) - ambient {ai} ({amb_mean:.0}) => mean {sub_mean:.0}; lit clipped {:.1}%{}",
-                        clipped * 100.0,
-                        if clipped > ir_metadata::CLIPPED_FRAC_MAX {
-                            " (blown exposure; subtracted frame unreliable)"
-                        } else {
-                            ""
-                        }
+                        "[ir] ambient-subtract {action}: lit {best_i} ({lit_mean:.0}) - ambient {ai} ({amb_mean:.0}) => mean {sub_mean:.0}{clip_note}"
                     );
                     }
                 } else if debug_ir {
@@ -2702,6 +2709,17 @@ pub mod ir_probe {
     /// `>=` rather than `==` for the same reason the bbox instrument uses it: a
     /// sample above nominal white is out-of-range excursion, which is still not
     /// a pixel carrying a usable emitter return.
+    ///
+    /// KILL CONDITION for the first limited-range module anyone finds. At a 235
+    /// ceiling `>=` also counts 236..=255, which BT.601/709 calls legal
+    /// excursion rather than saturation, so this governs a strictly larger
+    /// pixel population than the one `CLIPPED_FRAC_MAX` (0.05) was fitted on:
+    /// #221's captures were taken against a 255 ceiling, where 236..=254 was
+    /// ordinary signal counting for nothing. If a healthy frame from such a
+    /// module puts more than 5% of its pixels above 235, `best_gate_frame`
+    /// takes its `least` branch on every burst. Dump the per-frame fractions
+    /// from a real limited-range device before trusting 0.05 there; do not
+    /// assume the constant transfers.
     pub fn saturated_fraction(data: &[u8], white: u8) -> f64 {
         if data.is_empty() {
             return 0.0;


### PR DESCRIPTION
Closes #394.

## What & why

`saturated_fraction` counted `p == 255`. `clipping_white_level` can answer `Some(235)`. The caller bound the ceiling and then discarded it:

```rust
let clipped_fracs: Option<Vec<f64>> = white_level.map(|_| {
```

So on a limited-range stream every frame measured as pristine.

That is not merely a lost signal. `Some(_)` is what switches on #221's clip-aware gate-frame selection, so the selection ran against an all-zero measurement, every frame passed under `CLIPPED_FRAC_MAX`, and `best_gate_frame` returned the brightest lit frame. That is the blown one #221 exists to avoid; its own doc records a gated frame with 78.8% of its pixels at the ceiling, which denied a real user as a spoof.

Meanwhile the face-region instrument disagreed. `saturated_frac_in_bbox(grey, w, h, bbox, white: u8)` in `irlume-auth` has always taken the ceiling and compared against it. The same burst could read pristine to the code choosing a frame and blown to the code judging it, with nothing in the log to say which was right.

## The change

`saturated_fraction(data: &[u8], white: u8)` comparing `>=`, matching the bbox instrument. `white_level` is passed through at the selection site instead of being discarded, and the debug line reads the same ceiling the selection used so the printed percentage and the decision cannot disagree.

Both production callers and the one existing test were the only call sites; there are no others in the workspace.

## Reachability

Latent today. The only arm returning 235 is `(IrPixel::Grey8, Quantization::LimitedRange)` and no module in this project's record reports LIMITED for GREY8, so the wrong branch has never been observed running. It stops being latent the moment any format gains a 235 arm.

## Testing

- [x] `cargo fmt --all -- --check`, exit status captured
- [x] `cargo clippy --all-targets -- -D warnings` across the workspace, exit status captured
- [x] `cargo test -p irlume-camera`
- [x] New test checked by mutation, not by reading it

`a_frame_railed_at_nominal_white_is_clipped_only_against_its_own_ceiling` asserts a buffer of 235s reads 1.0 against a 235 ceiling and 0.0 against a 255 ceiling. Changing the counter back to `p == 255` fails it on "a limited-range frame at nominal white is entirely clipped"; restoring passes. The second assertion is what stops it being a tautology: the same buffer must still read clean at 255, so a fix that merely lowered a constant would not pass.

## Not covered

No hardware ran. No camera in the record reports LIMITED for GREY8, so there is no capture showing the two instruments disagreeing in the field; what is established is that they read the same ceiling by different rules, which is decidable from the two signatures.

`saturation_frame = white_level.map(|_| frames[best_i].clone())` still discards the value deliberately and is left alone: it decides whether to KEEP a raw frame for a later measurement, and presence of a ceiling is the whole question there.
