### PR TITLE
A railed eye window cannot report an open eye (#386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,39 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Security
 
+- **The require-eyes-open gate granted with the eyes closed, behind glasses.**
+  `both_eyes_open` took the maximum grey level in a window around each eye
+  landmark and compared it against a fixed 200, with no notion of the sensor's
+  ceiling. Its sibling `eye_glint_of` was made ceiling-aware for #222 and its
+  doc already records why: the measurements committed here pin the eye peak at
+  255 in all 30 frames with glasses on, where the window reads the lens specular
+  rather than the cornea. This gate sampled the same statistic and never got the
+  same treatment.
+
+  Demonstrated on hardware 2026-08-08 on the ASUS FHD IR module, one variable at
+  a time. Bare-eyed with the eyes OPEN it denied 5 of 5. With glasses on and the
+  eyes CLOSED it granted 3 of 3. Eye-window peaks read 170 to 226 bare-eyed, 0 of
+  10 railed, against 255 with glasses, 10 of 10 railed. The gate whose only
+  purpose is refusing a sleeping or unconscious user was admitting exactly that
+  case (#386).
+
+  A railed eye window now establishes nothing, and since this gate is deny-only
+  and answers a bool, nothing collapses to `false`. The call also moves to the
+  RAW frame and the negotiated ceiling, the pair its two siblings already take:
+  ambient subtraction moves a railed 255 to 254, so on a subtracted frame the
+  refusal would never fire. A format that names no ceiling passes the peak
+  through unchanged, which is #237's settled precedent.
+
+  This DENIES more than before, for profiles that opted in; the gate defaults
+  off. The other half of #386 is not fixed here. A peak of 170 to 226 still fails
+  a threshold of 200, so bare-eyed users are still denied, and no replacement
+  threshold can be certified from what the repository holds:
+  `ClosureCalibration` records the same subject's median open EAR at 0.109 under
+  an ambient of 22-42 and 0.166 under an ambient of 1, a 52% shift, and states
+  that no single calibration spans both sessions. A global constant on any of
+  these statistics reproduces this defect in the other direction. That half stays
+  open and wants the per-user `calibrate-closure` route.
+
 - **The IR exposure gate was off, not lenient, on every IR camera that is not
   8-bit grey.** `exposure_refusal` read "could not measure" as "clean", so on a
   node negotiating `Y16`/`Y10`/`Y12`/`NV12`/`YUYV` the #237 gate never ran and
@@ -954,7 +987,7 @@ Fixes a camera-firmware hazard present in 0.7.1. Please upgrade.
 
 - **Six checks reported success having checked nothing.** One theme in six places:
   a zero-match, zero-iteration or zero-sample case indistinguishable from a clean
-  pass — a conformance run that attempted nothing and exited 0, a set comparison
+  pass: a conformance run that attempted nothing and exited 0, a set comparison
   where no line carried the field, a `zip()` over an empty side. Each was proved
   by reproducing the failure first. Closes [#161], [#162], [#163], [#164], [#165]
   and [#166].

--- a/crates/irlume-auth/examples/landmark_failure_probe.rs
+++ b/crates/irlume-auth/examples/landmark_failure_probe.rs
@@ -182,7 +182,10 @@ fn main() {
             "| {name} | {} | {} | {} | {} | {} | {align} |",
             fmt(eye_glint(&ir, W, H, &lm)),
             fmt(eye_glint_contrast(&ir, W, H, &lm)),
-            both_eyes_open(&ir, W, H, &lm),
+            // `None`: these are synthetic pathology frames with no negotiated
+            // format behind them, so there is no ceiling to honour. The probe
+            // measures landmark failure, not clipping (#386).
+            both_eyes_open(&ir, W, H, &lm, None),
             fmt(pose.yaw_asym),
             fmt(pose.pitch_frac),
         );

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1905,9 +1905,24 @@ impl Engine {
         // Eyes-open (IR corneal-glint heuristic), for the opt-in require-eyes-open
         // gate. Needs an IR face (the emitter lights the cornea); conservative:
         // false when it can't be verified.
+        //
+        // Same RAW-frame and ceiling pair its two siblings above take, and for
+        // the same reasons: subtraction moves a railed 255 to 254 so the
+        // clipping test must see `saturation_frame`, and a railed eye window
+        // reads the lens rather than the cornea (#386, #238 review). This call
+        // passed `&ir.data` with no ceiling until then, which is both halves of
+        // that mistake at once.
         let eyes_open = ir_top
             .as_ref()
-            .map(|f| both_eyes_open(&ir.data, ir.width, ir.height, &f.landmarks))
+            .map(|f| {
+                both_eyes_open(
+                    ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
+                    ir.width,
+                    ir.height,
+                    &f.landmarks,
+                    ir_stats.white_level,
+                )
+            })
             .unwrap_or(false);
         Ok(Assessment {
             verdict,
@@ -3910,7 +3925,38 @@ const EYE_OPEN_PEAK_MIN: f32 = 200.0;
 /// eyelid does not. Conservative: requires the glint, so an unverifiable eye
 /// reads closed (auth falls back to password). Heuristic; used only when a
 /// profile opts into the require-eyes-open gate.
-pub fn both_eyes_open(grey: &[u8], w: u32, h: u32, lm: &irlume_vision::Landmarks5) -> bool {
+///
+/// `white` is the negotiated format's ceiling, and passing it is what stops
+/// this gate reading a lens instead of an eye. [`eye_glint_of`] next door
+/// already refuses a railed peak, and its doc records why: the repo's own
+/// measurements pin the peak at 255 in all 30 frames with glasses on, where it
+/// reads the lens specular rather than the cornea. This function sampled the
+/// same statistic and never got the same treatment, so on 2026-08-08 it
+/// GRANTED 3/3 with the eyes CLOSED behind glasses while denying 5/5 bare-eyed
+/// with them open (#386). A maximum is exactly the statistic clipping
+/// destroys: a railed window says the true value was at least the ceiling and
+/// never what it was, so no eyelid state can be read out of it.
+///
+/// Unlike `eye_glint_of`, which answers `None` for "not established", this gate
+/// is deny-only and returns a bool, so unreadable collapses to `false`. That is
+/// the fail-safe direction for a gate whose whole purpose is refusing a
+/// sleeping or unconscious user.
+///
+/// `white` of `None` means the format named no ceiling (`Grey16`, `Nv12Luma`,
+/// `YuyvLuma`) and the peak passes through unchanged, which is #237's settled
+/// precedent and the same choice `eye_glint_of` makes.
+///
+/// Pass the RAW frame. Ambient subtraction moves a railed 255 to 254, so a
+/// subtracted frame stops reading as railed and this refusal would not fire;
+/// the callers of `eye_glint_of` and `saturated_frac_of` already pass
+/// `saturation_frame` for that reason (#238 review) and this one now does too.
+pub fn both_eyes_open(
+    grey: &[u8],
+    w: u32,
+    h: u32,
+    lm: &irlume_vision::Landmarks5,
+    white: Option<u8>,
+) -> bool {
     // Same w*h invariant guard as eye_glint/mean_in_bbox: eye_open_at's in-bounds
     // test is against the logical w/h, so a truncated IR frame (buffer < w*h)
     // would index past the slice and panic the root daemon. A short frame reads
@@ -3931,10 +3977,19 @@ pub fn both_eyes_open(grey: &[u8], w: u32, h: u32, lm: &irlume_vision::Landmarks
     }
     let iod = ((lm[1].0 - lm[0].0).powi(2) + (lm[1].1 - lm[0].1).powi(2)).sqrt();
     let r = (iod * 0.20).max(2.0) as i32;
-    eye_open_at(grey, w, h, lm[0], r) && eye_open_at(grey, w, h, lm[1], r)
+    // BOTH eyes, so one readable eye cannot vouch for a railed one. Same
+    // whole-set rule `eye_glint_contrast` states for unplaceable landmarks.
+    eye_open_at(grey, w, h, lm[0], r, white) && eye_open_at(grey, w, h, lm[1], r, white)
 }
 
-fn eye_open_at(grey: &[u8], w: u32, h: u32, (ex, ey): (f32, f32), r: i32) -> bool {
+fn eye_open_at(
+    grey: &[u8],
+    w: u32,
+    h: u32,
+    (ex, ey): (f32, f32),
+    r: i32,
+    white: Option<u8>,
+) -> bool {
     let (cx, cy) = (ex as i32, ey as i32);
     let mut peak = 0u8;
     for dy in -r..=r {
@@ -3945,7 +4000,14 @@ fn eye_open_at(grey: &[u8], w: u32, h: u32, (ex, ey): (f32, f32), r: i32) -> boo
             }
         }
     }
-    peak as f32 >= EYE_OPEN_PEAK_MIN
+    match white {
+        // Railed: the window carries the sensor's limit, not the eye. Checked
+        // BEFORE the threshold, because a railed peak clears
+        // EYE_OPEN_PEAK_MIN by construction and that is precisely the path
+        // that granted with closed eyes (#386).
+        Some(ceiling) if peak >= ceiling => false,
+        _ => peak as f32 >= EYE_OPEN_PEAK_MIN,
+    }
 }
 
 /// Mean luma (0–255) and the fraction of near-white ("hot") pixels inside `bbox`
@@ -5811,7 +5873,7 @@ mod tests {
         let nan: Landmarks5 = [(f32::NAN, f32::NAN); 5];
         assert_eq!(eye_glint(&grey, 64, 48, &nan), 0.0);
         assert_eq!(eye_glint_contrast(&grey, 64, 48, &nan), 0.0);
-        assert!(!both_eyes_open(&grey, 64, 48, &nan));
+        assert!(!both_eyes_open(&grey, 64, 48, &nan, Some(255)));
         // One placeable eye is still not both eyes, and the glint helpers
         // score the whole set 0.0 rather than letting the valid eye vouch
         // for a set whose producer emitted a non-finite point (#293 review:
@@ -5826,7 +5888,7 @@ mod tests {
         }
         bright[0] = 255;
         let one: Landmarks5 = [lm[0], (f32::NAN, 20.0), lm[2], lm[3], lm[4]];
-        assert!(!both_eyes_open(&bright, 64, 48, &one));
+        assert!(!both_eyes_open(&bright, 64, 48, &one, Some(255)));
         assert_eq!(eye_glint(&bright, 64, 48, &one), 0.0);
         assert_eq!(eye_glint_contrast(&bright, 64, 48, &one), 0.0);
     }
@@ -5834,12 +5896,50 @@ mod tests {
     #[test]
     fn both_eyes_open_requires_a_glint_at_each_eye() {
         let (grey, lm) = ir_frame_with_glints(true, true);
-        assert!(both_eyes_open(&grey, 64, 48, &lm));
+        assert!(both_eyes_open(&grey, 64, 48, &lm, Some(255)));
         // One closed lid (no specular point) fails the gate, conservatively.
         let (grey, lm) = ir_frame_with_glints(true, false);
-        assert!(!both_eyes_open(&grey, 64, 48, &lm));
+        assert!(!both_eyes_open(&grey, 64, 48, &lm, Some(255)));
         let (grey, lm) = ir_frame_with_glints(false, false);
-        assert!(!both_eyes_open(&grey, 64, 48, &lm));
+        assert!(!both_eyes_open(&grey, 64, 48, &lm, Some(255)));
+    }
+
+    /// #386, and the reason the suite above never went red: `ir_frame_with_glints`
+    /// models a closed eye as NO specular at all. A real closed lid behind a
+    /// spectacle lens still returns the emitter, railed. On hardware on
+    /// 2026-08-08 that granted 3/3 with the eyes shut, and every frame with
+    /// glasses on in the repo's own measurements has the eye peak pinned at 255.
+    ///
+    /// A railed window is therefore built here explicitly. It clears
+    /// EYE_OPEN_PEAK_MIN by construction, so before this fix it read as an open
+    /// eye no matter what the eyelid was doing.
+    #[test]
+    fn a_railed_eye_window_cannot_report_an_open_eye() {
+        let (mut grey, lm) = ir_frame_with_glints(false, false);
+        // Rail both eye windows, the lens-specular signature.
+        for &(ex, ey) in &lm[0..2] {
+            let (cx, cy) = (ex as usize, ey as usize);
+            for dy in 0..3usize {
+                for dx in 0..3usize {
+                    grey[(cy + dy - 1) * 64 + (cx + dx - 1)] = 255;
+                }
+            }
+        }
+        assert!(
+            !both_eyes_open(&grey, 64, 48, &lm, Some(255)),
+            "a window at the sensor ceiling establishes nothing about the eyelid"
+        );
+        // The refusal is the CEILING's doing, not a lower threshold sneaking in:
+        // told the format names no ceiling, the same buffer still reads open,
+        // which is #237's settled precedent for Grey16/NV12/YUYV.
+        assert!(
+            both_eyes_open(&grey, 64, 48, &lm, None),
+            "with no ceiling to compare against, the peak passes through"
+        );
+        // And a genuine sub-ceiling corneal glint is untouched: this fix must
+        // not deny the users the gate is supposed to admit.
+        let (open, lm) = ir_frame_with_glints(true, true);
+        assert!(both_eyes_open(&open, 64, 48, &lm, Some(255)));
     }
 
     #[test]
@@ -5868,7 +5968,7 @@ mod tests {
         // The require-eyes-open gate reads the same frame via a different index
         // path; a truncated frame there must fail-closed (eyes read closed), not
         // panic the daemon on an out-of-bounds index.
-        assert!(!both_eyes_open(short, 64, 48, &lm));
+        assert!(!both_eyes_open(short, 64, 48, &lm, Some(255)));
     }
 }
 

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1915,8 +1915,9 @@ impl Engine {
         let eyes_open = ir_top
             .as_ref()
             .map(|f| {
-                both_eyes_open(
-                    ir_stats.saturation_frame.as_deref().unwrap_or(&ir.data),
+                eyes_open_from_capture(
+                    &ir.data,
+                    ir_stats.saturation_frame.as_deref(),
                     ir.width,
                     ir.height,
                     &f.landmarks,
@@ -3950,6 +3951,31 @@ const EYE_OPEN_PEAK_MIN: f32 = 200.0;
 /// subtracted frame stops reading as railed and this refusal would not fire;
 /// the callers of `eye_glint_of` and `saturated_frac_of` already pass
 /// `saturation_frame` for that reason (#238 review) and this one now does too.
+/// Which buffer the eyes-open gate measures, as a value a test can observe.
+///
+/// This exists because the ceiling refusal and the choice of frame are two
+/// independently necessary halves, and a test that calls [`both_eyes_open`]
+/// with an already-railed buffer proves only the first. Revert the selection to
+/// the returned frame and the fail-open comes straight back with every such
+/// test still green: ambient subtraction moves a railed 255 to 254, which is
+/// under the ceiling and over `EYE_OPEN_PEAK_MIN`, so both eyes report open
+/// (#397 review).
+///
+/// `saturation_frame` is the RAW gate frame, preserved by `capture_with_stats`
+/// precisely so a clipping test can see the samples that actually railed. It is
+/// `None` when nothing replaced the payload, and then the returned frame IS the
+/// raw one.
+fn eyes_open_from_capture(
+    returned: &[u8],
+    saturation_frame: Option<&[u8]>,
+    w: u32,
+    h: u32,
+    lm: &irlume_vision::Landmarks5,
+    white: Option<u8>,
+) -> bool {
+    both_eyes_open(saturation_frame.unwrap_or(returned), w, h, lm, white)
+}
+
 pub fn both_eyes_open(
     grey: &[u8],
     w: u32,
@@ -5940,6 +5966,41 @@ mod tests {
         // not deny the users the gate is supposed to admit.
         let (open, lm) = ir_frame_with_glints(true, true);
         assert!(both_eyes_open(&open, 64, 48, &lm, Some(255)));
+    }
+
+    /// The other half of #386, which the test above cannot see. Rejecting a
+    /// railed peak is worth nothing if the gate is handed the SUBTRACTED frame,
+    /// because subtraction moves every railed 255 to 254: under the ceiling and
+    /// over `EYE_OPEN_PEAK_MIN`, so both eyes report open again.
+    ///
+    /// The first assertion states that trap as a fact rather than describing
+    /// it, so the second one has something to be different from.
+    #[test]
+    fn the_eyes_open_gate_measures_the_raw_frame_not_the_subtracted_one() {
+        let (mut raw, lm) = ir_frame_with_glints(false, false);
+        for &(ex, ey) in &lm[0..2] {
+            let (cx, cy) = (ex as usize, ey as usize);
+            for dy in 0..3usize {
+                for dx in 0..3usize {
+                    raw[(cy + dy - 1) * 64 + (cx + dx - 1)] = 255;
+                }
+            }
+        }
+        // What ambient subtraction does to a railed sample.
+        let returned: Vec<u8> = raw.iter().map(|&p| p.saturating_sub(1)).collect();
+        assert!(
+            both_eyes_open(&returned, 64, 48, &lm, Some(255)),
+            "the subtracted frame alone reads open; this is the regression the \
+             selection exists to prevent"
+        );
+        assert!(
+            !eyes_open_from_capture(&returned, Some(&raw), 64, 48, &lm, Some(255)),
+            "the ceiling test must run against the preserved raw frame"
+        );
+        // With nothing preserved, the returned frame IS the raw one, so the
+        // fallback must not become a second way to skip the check.
+        let (open, lm2) = ir_frame_with_glints(true, true);
+        assert!(eyes_open_from_capture(&open, None, 64, 48, &lm2, Some(255)));
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3287,8 +3287,17 @@ fn calcapture(args: &[String]) -> std::process::ExitCode {
                 rec.insert("ir_iod_px".into(), json_f32(iod_px(&t.landmarks)));
                 rec.insert(
                     "ir_eyes_open".into(),
-                    irlume_auth::both_eyes_open(&irf.data, irf.width, irf.height, &t.landmarks)
-                        .into(),
+                    // Same raw frame and ceiling the daemon passes, so a corpus
+                    // recorded here answers the question production answers. A
+                    // railed eye window reads the lens, not the cornea (#386).
+                    irlume_auth::both_eyes_open(
+                        ir_stats.saturation_frame.as_deref().unwrap_or(&irf.data),
+                        irf.width,
+                        irf.height,
+                        &t.landmarks,
+                        ir_stats.white_level,
+                    )
+                    .into(),
                 );
                 rec.insert(
                     "ir_center_edge_ratio".into(),


### PR DESCRIPTION
Fixes the fail-open half of #386. The issue stays open for the other half; see the last section.

## The defect

`both_eyes_open` took the window maximum around each eye landmark and compared it against a fixed 200, with no notion of the sensor's ceiling. A maximum is exactly the statistic clipping destroys: a railed window says the true value was at least the ceiling and never what it was, so nothing about the eyelid can be read out of it.

Its sibling `eye_glint_of` was given this treatment for #222, and its doc already states the reason:

> The peak reached `white`, the negotiated format's ceiling. A clipped sample tells you the true value was AT LEAST that, never what it was, and a maximum is exactly the statistic that destroys. This is the #222 reading: the repo's own measurements have the peak pinned at 255 in all 30 frames with glasses on, where it is reading the lens specular rather than the cornea.

`both_eyes_open` sampled the same statistic in the same eye window and was left alone.

Measured on hardware 2026-08-08, ASUS FHD IR module, one variable at a time:

| condition | gate | result |
|---|---|---|
| bare-eyed, eyes OPEN | on | denied 5/5 |
| glasses, eyes CLOSED | on | **granted 3/3** |

Eye-window peaks: 170 to 226 bare-eyed with 0 of 10 railed, 255 with glasses with 10 of 10 railed. The gate whose only purpose is refusing a sleeping or unconscious user was admitting exactly that case.

## The change

A railed window establishes nothing, and because this gate is deny-only and answers a bool, nothing collapses to `false`. The ceiling test runs **before** the threshold, since a railed peak clears 200 by construction and that is the path that granted.

The call also moves to the RAW frame and the negotiated ceiling, the pair `eye_glint_of` and `saturated_frac_of` already take at their call sites. Ambient subtraction moves a railed 255 to 254, so on a subtracted frame the refusal would silently never fire. The old call passed `&ir.data` with no ceiling, which is both halves of that mistake at once.

A format that names no ceiling (`Grey16`, `Nv12Luma`, `YuyvLuma`) passes the peak through unchanged, which is #237's settled precedent and the same choice `eye_glint_of` makes.

## Why the suite was green through all of this

`ir_frame_with_glints` models a closed eye as **no specular at all**. A real closed lid behind a spectacle lens still returns the emitter, railed. "Closed" in the old tests meant a condition that does not occur in the failing case, so nothing was ever red.

`a_railed_eye_window_cannot_report_an_open_eye` builds a railed window explicitly and was checked by mutation, not by reading it: deleting the ceiling arm fails it on "a window at the sensor ceiling establishes nothing about the eyelid", and restoring passes. Two further assertions stop a lazy fix passing anyway, since the refusal must come from the ceiling rather than from a lowered threshold, and a genuine sub-ceiling corneal glint must still read open.

## The review round found the half that test could not see

Codex returned DO NOT SHIP on `0c427a1` with one finding, and it was right. The fix has two independently necessary halves, and rejecting a railed peak buys nothing if the gate is handed the subtracted frame: subtraction moves every railed 255 to 254, which is under the ceiling and over `EYE_OPEN_PEAK_MIN`, so both eyes report open again. A test calling `both_eyes_open` with an already-railed buffer cannot observe which buffer production supplied, so reverting that line would have landed green.

`eyes_open_from_capture` makes the selection observable, and `the_eyes_open_gate_measures_the_raw_frame_not_the_subtracted_one` asserts it. Mutating the helper to ignore `saturation_frame` fails the new test on "the ceiling test must run against the preserved raw frame" while the ceiling test above still passes, which is the gap demonstrated rather than argued.

## The peak cannot be tuned into working, and the corpus says so

Recomputed here from `~/irlume-research/2026-08-07-blink-corpus`, whose 288 frames all verify against the committed `docs/pad-results/2026-08-07-blink-corpus.sha256`. Counting pixels at exactly 255 in each lit IR frame, glasses on:

| segment | pixels at 255, per frame |
|---|---|
| open-frontal-glasses | 370, 357, 330, 300, 292, 266, 259, 246, 228, 227, 227, 208 |
| held-closure-glasses | 371, 367, 322, 289, 281, 260, 249, 244, 244, 233, 224, 216 |

Open spans 208 to 370, closed spans 216 to 371. The two distributions are indistinguishable frame for frame, and their medians differ by about 8 pixels out of roughly 250. No threshold orders them.

That is the case for refusing rather than retuning. The lens sits in front of the eyelid, so the specular the window measures does not depend on whether the eye behind it is open. `EYE_OPEN_PEAK_MIN` is not mistuned; the statistic is measuring the wrong object, and the maximum over that window rails at 255 in both states.

The exposure gate is not a safety net here either. In the 8 records of `docs/pad-results/2026-08-04-occluder-gate.jsonl` where the eye peak railed, `ir_saturated_frac` reads 0.0042 to 0.0057 against an `IR_SATURATED_FRAC_MAX` of 0.10, and `ir_exposure_ok` is true in all 26 records. A point highlight is invisible to an area statistic.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- [x] `cargo test --workspace`
- [x] New test verified by mutation

Every command above is the exact line from `ci.yml` with its exit status captured.

- [x] **Hardware-validated 2026-08-10 on the Zenbook.** Glasses on, eyes fully closed: the pre-fix daemon granted 9 of 9, this branch denied 3 of 3, and the same branch with the gate switched OFF granted 3 of 3. That third run is what attributes the denial to this gate rather than to the `flir` PAD cue or to the sixteen commits merged into main since the pre-fix build. Full numbers and limits in a comment below.
- [ ] **The bare-eyed open case was NOT re-run**, so this PR carries no new evidence there. It is expected to keep denying, because peaks of 170 to 226 never reach the ceiling and still fail `EYE_OPEN_PEAK_MIN`, and that half of #386 is untouched here.

## This denies more, and only for opt-in profiles

`require_eyes_open` defaults to false, so the affected population is users who turned it on. For them, a glasses-on capture whose eye window rails will now deny and fall back to the password. That is the fail-safe direction for this gate, and it was previously granting those same users with their eyes shut.

**Measured, rather than described.** Replaying the committed blink corpus through the shipped `both_eyes_open`, twelve detected frames per cell:

| cell | open before | open after |
|---|---|---|
| glasses, eyes closed | 12 of 12 | 0 of 12 |
| glasses, eyes open | 12 of 12 | 0 of 12 |
| bare-eyed, eyes open | 1 of 12 | 1 of 12 |

So this does not make the gate stricter for a glasses wearer, it stops the gate working for them: after this change it refuses them whether their eyes are open or shut. Nothing bare-eyed is newly denied, and the bare-eyed row is the other half of #386 quantified, since eleven of twelve genuinely open frames already read as not-open before this PR touched anything.

Across all six cells the gate goes from admitting 37 of 72 genuine detected frames to admitting 1. Every frame it stops admitting is one where a lens, not an eyelid, was being measured. That is the argument for landing it, and equally the argument that nobody should enable `require_eyes_open` until the per-user `calibrate-closure` route exists.

## What stays open on #386

The bare-eyed half. A peak of 170 to 226 still fails a threshold of 200, so the gate still denies users it should admit, and this PR does not touch that.

I looked at replacing the statistic with the IR mesh EAR and did not, because the evidence does not support a global constant. The committed blink corpus separates the states cleanly on IR (computed from `docs/pad-results/2026-08-07-blendshapes-blink.csv`: worst closed min-EAR 0.1072, worst open 0.1625, glasses included), but `ClosureCalibration` records the same subject's median open EAR at 0.109 under an ambient of 22-42 and 0.166 under an ambient of 1, a 52% shift, and states plainly that no single calibration spans both sessions. A 0.109 open reading sits at the top of that corpus's closed band. A global EAR threshold would reproduce this defect in the other direction, for a different reason.

The certifiable route already exists and is per-user: `closure_calibration` on the enrollment, captured by `sudo irlume calibrate-closure`, which already accepts `--pose glasses-on-open`. Wiring the gate to it is a camera flow and an owner decision, not something to settle here.


