### PR TITLE
A model number is not a camera identity (#341)

### DIFF
--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -119,6 +119,13 @@ fn known_control(vid: u16, pid: u16) -> Option<EmitterControl> {
             payload: HELLO_FACE_AUTH.to_vec(),
         }),
         // NexiGo HelloCam N930W; MS-XU is unit 4.
+        //
+        // The product NAME is ambiguous and the identity here is not. NexiGo
+        // also sells a 60fps N930W with no IR sensor and no Hello support,
+        // which enumerates as 3443:930d and is known to the kernel through an
+        // unrelated audio quirk. Only c803 is the HelloCam this payload was
+        // validated against, so do not "correct" this entry to the other id on
+        // the strength of a matching model number (#341 survey).
         (0x3443, 0xc803) => Some(EmitterControl {
             unit: 4,
             selector: crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
@@ -7382,6 +7389,13 @@ mod tests {
             nexigo.selector,
             crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION
         );
+
+        // The SAME model name, a different product. NexiGo sells a 60fps N930W
+        // with no IR sensor that enumerates as 3443:930d. It must get nothing,
+        // because the payload above was validated against the HelloCam and a
+        // model-number match is not an identity match. This is the assertion
+        // that fails if someone reconciles the table to the other id (#341).
+        assert_eq!(known_control(0x3443, 0x930d), None);
 
         // A different camera gets nothing, however it names itself. The old
         // table matched `card.contains("ASUS")`, so any camera with that word

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1177,48 +1177,7 @@ pub fn select_pair() -> (String, String) {
             best = Some((p.rgb, p.ir));
         }
     }
-    // Evidence before convention. `list_pairs` only yields nodes it could pair
-    // to ONE physical device, so it comes up empty on a machine whose RGB and
-    // IR sit on separate devices, or where the sysfs link that pairs them could
-    // not be read. Falling straight to the compiled numbers there discards the
-    // classification that DID succeed.
-    best.or_else(|| pair_from_classified(&discover_nodes()))
-        .unwrap_or_else(|| (DEFAULT_RGB_DEVICE.into(), DEFAULT_IR_DEVICE.into()))
-}
-
-/// Last-resort pair from already-classified nodes, before the compiled numbers.
-///
-/// Pure over its input so the choice is testable without a camera; the caller
-/// does the enumerating.
-///
-/// This exists because `/dev/video2` is a convention, not a measurement, and two
-/// separate findings landed on it. The #341 external-camera survey names the
-/// pattern directly: the node count is not a class invariant, so nodes must be
-/// selected by capability and advertised formats rather than by "video2
-/// folklore". #385 named the consequence: the compiled fallback is one of three
-/// paths by which a COLOUR node can arrive in the IR slot, where
-/// `exposure_refusal`'s `!ir_ceiling_known` branch is currently the only thing
-/// stopping cues fitted on an emitter-lit IR image from judging a room-lit
-/// colour frame.
-///
-/// A node that classified as [`Role::Ir`] is evidence. The number 2 is not.
-/// This does not remove the compiled fallback, which still covers the case
-/// where nothing classified at all; it stops that fallback being reached while
-/// a positively identified IR node was sitting in the list unused.
-///
-/// Deliberately NOT a ranking: `list_pairs` above already ranks by pin,
-/// allowlist and built-in, and it had its chance. This is the floor.
-fn pair_from_classified(nodes: &[(String, Role)]) -> Option<(String, String)> {
-    let first = |want: Role| {
-        nodes
-            .iter()
-            .find(|(_, role)| *role == want)
-            .map(|(path, _)| path.clone())
-    };
-    // BOTH or nothing. An IR node with no RGB partner is not a pair, and
-    // inventing the RGB half from the compiled default would reintroduce the
-    // guess this function exists to avoid.
-    Some((first(Role::Rgb)?, first(Role::Ir)?))
+    best.unwrap_or_else(|| (DEFAULT_RGB_DEVICE.into(), DEFAULT_IR_DEVICE.into()))
 }
 
 fn device_exists(dev: &str) -> bool {
@@ -5480,47 +5439,6 @@ mod tests {
         );
         // A bogus identity never matches a real node either.
         assert_eq!(find_node_by_identity("dead:beef:none", Role::Ir), None);
-    }
-
-    /// `/dev/video2` is a convention. A node that CLASSIFIED as IR is evidence,
-    /// and evidence must win, which is what stops the compiled fallback being
-    /// reached while a real IR node sits unused in the list (#341, #385).
-    #[test]
-    fn a_classified_ir_node_beats_the_compiled_number() {
-        let nodes = vec![
-            ("/dev/video0".to_string(), Role::Rgb),
-            ("/dev/video1".to_string(), Role::Other),
-            // Deliberately NOT video2: the whole point is that the number does
-            // not decide, so a machine whose IR node is video3 must still pair.
-            ("/dev/video3".to_string(), Role::Ir),
-        ];
-        assert_eq!(
-            pair_from_classified(&nodes),
-            Some(("/dev/video0".to_string(), "/dev/video3".to_string()))
-        );
-    }
-
-    /// Both halves or nothing. Half a pair completed from the compiled default
-    /// would reintroduce exactly the guess this function exists to remove, and
-    /// an all-colour machine is the shape that puts a colour node in the IR
-    /// slot.
-    #[test]
-    fn a_pair_is_never_completed_from_a_guess() {
-        let no_ir = vec![
-            ("/dev/video0".to_string(), Role::Rgb),
-            ("/dev/video2".to_string(), Role::Rgb),
-        ];
-        assert_eq!(pair_from_classified(&no_ir), None);
-
-        let no_rgb = vec![("/dev/video2".to_string(), Role::Ir)];
-        assert_eq!(pair_from_classified(&no_rgb), None);
-
-        // An unreadable node never reaches here: `discover_nodes` yields only
-        // what classified. `Other` answered and is neither, so it must not
-        // stand in for either half.
-        let only_other = vec![("/dev/video0".to_string(), Role::Other)];
-        assert_eq!(pair_from_classified(&only_other), None);
-        assert_eq!(pair_from_classified(&[]), None);
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1177,7 +1177,48 @@ pub fn select_pair() -> (String, String) {
             best = Some((p.rgb, p.ir));
         }
     }
-    best.unwrap_or_else(|| (DEFAULT_RGB_DEVICE.into(), DEFAULT_IR_DEVICE.into()))
+    // Evidence before convention. `list_pairs` only yields nodes it could pair
+    // to ONE physical device, so it comes up empty on a machine whose RGB and
+    // IR sit on separate devices, or where the sysfs link that pairs them could
+    // not be read. Falling straight to the compiled numbers there discards the
+    // classification that DID succeed.
+    best.or_else(|| pair_from_classified(&discover_nodes()))
+        .unwrap_or_else(|| (DEFAULT_RGB_DEVICE.into(), DEFAULT_IR_DEVICE.into()))
+}
+
+/// Last-resort pair from already-classified nodes, before the compiled numbers.
+///
+/// Pure over its input so the choice is testable without a camera; the caller
+/// does the enumerating.
+///
+/// This exists because `/dev/video2` is a convention, not a measurement, and two
+/// separate findings landed on it. The #341 external-camera survey names the
+/// pattern directly: the node count is not a class invariant, so nodes must be
+/// selected by capability and advertised formats rather than by "video2
+/// folklore". #385 named the consequence: the compiled fallback is one of three
+/// paths by which a COLOUR node can arrive in the IR slot, where
+/// `exposure_refusal`'s `!ir_ceiling_known` branch is currently the only thing
+/// stopping cues fitted on an emitter-lit IR image from judging a room-lit
+/// colour frame.
+///
+/// A node that classified as [`Role::Ir`] is evidence. The number 2 is not.
+/// This does not remove the compiled fallback, which still covers the case
+/// where nothing classified at all; it stops that fallback being reached while
+/// a positively identified IR node was sitting in the list unused.
+///
+/// Deliberately NOT a ranking: `list_pairs` above already ranks by pin,
+/// allowlist and built-in, and it had its chance. This is the floor.
+fn pair_from_classified(nodes: &[(String, Role)]) -> Option<(String, String)> {
+    let first = |want: Role| {
+        nodes
+            .iter()
+            .find(|(_, role)| *role == want)
+            .map(|(path, _)| path.clone())
+    };
+    // BOTH or nothing. An IR node with no RGB partner is not a pair, and
+    // inventing the RGB half from the compiled default would reintroduce the
+    // guess this function exists to avoid.
+    Some((first(Role::Rgb)?, first(Role::Ir)?))
 }
 
 fn device_exists(dev: &str) -> bool {
@@ -5217,6 +5258,47 @@ mod tests {
         );
         // A bogus identity never matches a real node either.
         assert_eq!(find_node_by_identity("dead:beef:none", Role::Ir), None);
+    }
+
+    /// `/dev/video2` is a convention. A node that CLASSIFIED as IR is evidence,
+    /// and evidence must win, which is what stops the compiled fallback being
+    /// reached while a real IR node sits unused in the list (#341, #385).
+    #[test]
+    fn a_classified_ir_node_beats_the_compiled_number() {
+        let nodes = vec![
+            ("/dev/video0".to_string(), Role::Rgb),
+            ("/dev/video1".to_string(), Role::Other),
+            // Deliberately NOT video2: the whole point is that the number does
+            // not decide, so a machine whose IR node is video3 must still pair.
+            ("/dev/video3".to_string(), Role::Ir),
+        ];
+        assert_eq!(
+            pair_from_classified(&nodes),
+            Some(("/dev/video0".to_string(), "/dev/video3".to_string()))
+        );
+    }
+
+    /// Both halves or nothing. Half a pair completed from the compiled default
+    /// would reintroduce exactly the guess this function exists to remove, and
+    /// an all-colour machine is the shape that puts a colour node in the IR
+    /// slot.
+    #[test]
+    fn a_pair_is_never_completed_from_a_guess() {
+        let no_ir = vec![
+            ("/dev/video0".to_string(), Role::Rgb),
+            ("/dev/video2".to_string(), Role::Rgb),
+        ];
+        assert_eq!(pair_from_classified(&no_ir), None);
+
+        let no_rgb = vec![("/dev/video2".to_string(), Role::Ir)];
+        assert_eq!(pair_from_classified(&no_rgb), None);
+
+        // An unreadable node never reaches here: `discover_nodes` yields only
+        // what classified. `Other` answered and is neither, so it must not
+        // stand in for either half.
+        let only_other = vec![("/dev/video0".to_string(), Role::Other)];
+        assert_eq!(pair_from_classified(&only_other), None);
+        assert_eq!(pair_from_classified(&[]), None);
     }
 
     #[test]

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -29,7 +29,7 @@ arm64 onnxruntime + rebuild validation, not anything in the code.
 | Ubuntu 26.04 LTS GNOME | ThinkPad X13 Yoga G4, Chicony RGB camera + Synaptics fingerprint | Convenience | PPA install end to end, lock-screen face unlock, fingerprint companion, correct password-only refusals for login and sudo, AppArmor profile enforcing (soak-tested, zero denials) |
 | Arch | desktop, no camera | none | package build, daemon + full CLI stack, PAM wiring dry-run, clean camera-less refusals |
 | Debian 12 | container (no camera) | none | from-source build, `.deb` install, `irlume doctor` |
-| external IR camera | NexiGo HelloCam N930W (USB) | IR/Secure | presentation-attack testing (photo, screen, replay denied), daemon-to-password fallback end to end |
+| external IR camera | NexiGo HelloCam N930W (`3443:c803`) | IR/Secure | presentation-attack testing (photo, screen, replay denied), daemon-to-password fallback end to end |
 | external IR camera | Logitech Brio 4K (046d:085e) | link-dependent, see below | sequential capture both links; emitter strobe and dark-room IR measured on USB3; RGB starvation measured on both links |
 
 ### Logitech Brio 4K: capability depends on the USB link
@@ -55,6 +55,39 @@ emitter (the NexiGo above). On USB3 the measured pieces (emitter, dark-room
 IR, sequential capture) support Hello-class use, but full enrollment and
 authentication on that link are not yet exercised; the verdict is only as
 wide as those measurements.
+
+### Buying an external camera: what the model name does not tell you
+
+**The NexiGo N930W name covers two different products.** The one measured above
+is the HelloCam, `3443:c803`, which carries an IR sensor. NexiGo also sells a
+60fps N930W with no IR sensor and no Hello support, enumerating as `3443:930d`.
+Check the USB id with `lsusb`, not the box.
+
+More generally, a camera advertised as "Windows Hello compatible" is not
+evidence of anything irlume can use. Microsoft's own implementation guide
+describes three arrangements: RGB-only, IR-only, and one camera carrying both.
+Only the last, or a paired RGB and IR pair inside one physical device, gives a
+secure tier. What to check before trusting a camera:
+
+- It presents a node advertising a GREY or Y-family format, not only YUYV and
+  MJPEG. `irlume doctor` reports what each node advertises.
+- The node count tells you nothing. A simple RGB plus IR camera commonly shows
+  four `/dev/video*` entries, two of them image nodes and two secondary, and
+  more elaborate devices show more. Never select by number; irlume selects by
+  advertised format and device topology, and so should you when reading `lsusb`
+  output.
+- The emitter is the part most likely to be missing. irlume discovers it
+  through the Microsoft camera extension unit where present, and `irlume
+  ir-setup` covers the rest, but a camera whose vendor exposes no control at all
+  can still capture IR only when the room supplies infrared.
+
+Two models turn up often in searches and are **not** recommendable on current
+evidence: the Dell UltraSharp WB7022 and the Lenovo 510 / Performance FHD. Both
+are documented by their vendors as Hello cameras and both plausibly work, but
+neither has a public, reproducible Linux report pairing an IR stream with a
+working emitter, and neither has been measured here. Absence of a report is not
+a verdict against them; it is a reason not to spend money on this project's
+say-so.
 
 The first cross-distro survey (build, daemon, PAM plan, tier detection on
 Arch and Ubuntu) is written up in


### PR DESCRIPTION
What survives of the original PR is the camera-identity documentation. The selection change it opened with was reverted; see below, because the reason is worth reading before anyone attempts it again.

## What this now contains

**A model number is not a camera identity.** The NexiGo N930W name covers two products: the HelloCam measured here is `3443:c803` and carries an IR sensor, and NexiGo also sells a 60fps N930W with no IR sensor and no Hello support enumerating as `3443:930d`.

PLATFORMS.md recommended "NexiGo HelloCam N930W (USB)" with no USB id, while the Brio entry beside it carried one. A reader acting on that table could buy the wrong device, and the failure would present as irlume not supporting a camera its own documentation recommends. The id is in the table now, the emitter table carries a comment saying why the other id must not be adopted on a matching model number, and a test pins it: reconciling the two ids in the match arm fails with `left: Some(EmitterControl { unit: 4, ... }), right: None`.

PLATFORMS.md also gains what the #341 external-camera survey establishes about choosing a camera before buying one: "Hello compatible" spans RGB-only, IR-only and combined arrangements and only the last serves a secure tier; the node count is not a class invariant; and the emitter is the part most likely to be absent. The Dell UltraSharp WB7022 and Lenovo 510 are recorded as not recommendable on current evidence, stated as absence of evidence rather than as a verdict against them.

## Why the selection change was reverted

The Codex round returned DO NOT SHIP, and it was right on a point the original PR body asserted the opposite of.

`role_from_formats` assigns `Role::Ir` when a node advertises GREY, Y8, Y800, Y16, Y10 or Y12. The kernel defines GREY as a sample representation, greyscale Y' data, and says nothing about the sensor's spectrum. **`Role::Ir` is evidence of a pixel format, not of infrared sensing.** The reverted commit claimed it was evidence, in a doc comment, and built on that.

`pair_from_classified` took the first RGB node and the first greyscale node from a system-wide scan and returned them as a pair, keeping no device identity or ancestry. That manufactures a pair from two unrelated cameras. `selected_ir_available` then tests only that the IR path exists, so an RGB-only machine with any separate monochrome camera attached would have been promoted from convenience tier into the full cross-spectrum path, on a combination the operator never chose and whose two views need not share a viewpoint, exposure, timing or subject. Cross-spectrum correspondence is what the threat model rests on.

It also contradicted `select_pair`'s own contract three lines above, which says auto-discovery means one physical device exposing both nodes, and invalidated the premise of an existing test that treats an empty `list_pairs` as sufficient to reach the compiled fallback.

**The underlying problem is still real.** `/dev/video2` is a convention, the #341 survey names "video2 folklore" directly, and #385 identified the compiled fallback as a path by which a colour node reaches the IR slot. The fix is not to infer a pair from two roles. It needs an explicit persisted pairing or stable identity supplied by the platform, and that deserves doing properly rather than approximated. Recorded on #385 so the next attempt starts from the correct premise.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- [x] `cargo test --workspace`

Each the exact `ci.yml` line with the exit status captured.

The surviving change is documentation, one code comment, and one test assertion, mutation-proved above. `select_pair` is byte-identical to main.

## Review coverage

The Codex round covered the selection commit, which is now reverted. The camera-identity commit was pushed after the round started and is therefore unreviewed. Under the one-round policy no second round was started. What is unreviewed is a documentation edit, a comment, and an assertion.
