### PR TITLE
Say what IRLUME_MODELS_STRICT actually covers (#346)

### DIFF
--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -146,8 +146,23 @@ fn verify_models(paths: &[&str], keep: Option<&str>) -> Option<irlume_common::Ha
                 "irlumed: WARNING: {path} does not match any release model checksum (sha256 {digest})"
             );
             if strict {
+                // Says "start", not "run", and the distinction is real. This
+                // gate covers the STARTUP load and nothing after it: the camera
+                // worker's post-panic rebuild reaches `Engine::load` with no
+                // verified bytes and no manifest comparison, so a file swapped
+                // after this point is loaded unchecked (#346).
+                //
+                // That path fails CLOSED rather than granting: a substituted
+                // recognizer produces a different `embed:<sha256>` space tag and
+                // `recognizer_space_matches` is strict, so every stored scan is
+                // filtered out and the attempt denies to password. Worth saying
+                // plainly here anyway, because an operator who sets this expects
+                // a promise about the process, and what it covers is the load.
                 eprintln!(
-                    "irlumed: IRLUME_MODELS_STRICT=1: refusing to start with unverified models"
+                    "irlumed: IRLUME_MODELS_STRICT=1: refusing to start with unverified models \
+                     (this checks the models loaded at startup; a rebuild after a worker panic \
+                     reloads from disk without re-checking, and denies rather than granting if \
+                     the file changed)"
                 );
                 std::process::exit(1);
             }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -146,23 +146,21 @@ fn verify_models(paths: &[&str], keep: Option<&str>) -> Option<irlume_common::Ha
                 "irlumed: WARNING: {path} does not match any release model checksum (sha256 {digest})"
             );
             if strict {
-                // Says "start", not "run", and the distinction is real. This
-                // gate covers the STARTUP load and nothing after it: the camera
-                // worker's post-panic rebuild reaches `Engine::load` with no
-                // verified bytes and no manifest comparison, so a file swapped
-                // after this point is loaded unchecked (#346).
+                // Strict verification runs once in the startup thread. Only the
+                // recognizer's verified bytes are carried into the initial load;
+                // the detector, adapter, mesh and Blaze models are reopened by
+                // path, and a post-panic rebuild reopens every model path without
+                // repeating this manifest check (#346).
                 //
-                // That path fails CLOSED rather than granting: a substituted
-                // recognizer produces a different `embed:<sha256>` space tag and
-                // `recognizer_space_matches` is strict, so every stored scan is
-                // filtered out and the attempt denies to password. Worth saying
-                // plainly here anyway, because an operator who sets this expects
-                // a promise about the process, and what it covers is the load.
+                // A changed recognizer fails closed for identity matching: its
+                // full digest changes the `embed:<sha256>` space tag, so
+                // `recognizer_space_matches` excludes every stored scan from the
+                // old space. That argument does not cover the other artifacts.
                 eprintln!(
                     "irlumed: IRLUME_MODELS_STRICT=1: refusing to start with unverified models \
-                     (this checks the models loaded at startup; a rebuild after a worker panic \
-                     reloads from disk without re-checking, and denies rather than granting if \
-                     the file changed)"
+                     (verification is a one-time startup path check; only the recognizer bytes \
+                     are carried from this check into the initial load, and a rebuild after a \
+                     worker panic reloads model paths without re-checking)"
                 );
                 std::process::exit(1);
             }
@@ -6532,6 +6530,12 @@ mod tests {
         assert!(
             err.contains("refusing to start with unverified models"),
             "stderr: {err}"
+        );
+        assert!(
+            err.contains(
+                "verification is a one-time startup path check; only the recognizer bytes"
+            ),
+            "the refusal must not claim every checked path stays verified through load: {err}"
         );
         let _ = std::fs::remove_dir_all(&dir);
 


### PR DESCRIPTION
Message and regression test only. Found while checking the #346 residual.

## The overclaim

`IRLUME_MODELS_STRICT=1` verifies model paths once during startup. Only the recognizer's verified bytes reach the initial loader. The detector, adapter, mesh, and Blaze models are reopened by path, and a worker rebuild after a caught panic reopens every model path without repeating the manifest check.

The old refusal text did not state that boundary. The first revision of this PR then claimed every changed model would deny. The Codex review caught that the digest-based embedding-space guard proves denial only for a changed recognizer. It says nothing about a replaced detector, adapter, mesh, or Blaze artifact.

The message and adjacent comment now state the narrower property. The residual stays on #346 because closing it requires bytes-based builders for the four path-reopened artifacts and a verified rebuild path.

## Testing

- [x] Added an assertion for the new qualification.
- [x] Ran that assertion against the first revision and watched it fail on the broad message.
- [x] Ran the exact test after the fix: 1 passed, 0 failed.
- [x] `cargo fmt --all -- --check`
- [x] Final CI on commit `198b737` was green before the review fix. A fresh CI run is required on the amended commit.

## Review follow-up

The review also found that the known-model half of `strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one` returns success when the repository model fixture is absent. That pre-existing test gap is tracked separately rather than folded into this message fix.

## Not covered

No model file was replaced during a live daemon run. This PR changes a refusal message and its test; it does not close the verification windows described above.
