### PR TITLE
The strict acceptance test needs a fixture every checkout has (#406)

### DIFF
--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -6473,7 +6473,9 @@ mod tests {
     // Companion to the missing-model child test: strict mode must also refuse
     // a PRESENT model whose digest is not in the release manifest (tampering),
     // and must ACCEPT a shipped model that matches it. verify_models exits the
-    // process, so both run as re-exec'd children.
+    // process, so both run as re-exec'd children. Both halves assert
+    // unconditionally; the acceptance fixture is the committed mesh so that
+    // there is no environment where the accept direction goes unchecked.
     #[test]
     fn strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one() {
         if let Ok(path) = std::env::var("IRLUME_TEST_VERIFY_TAMPER_CHILD") {
@@ -6520,21 +6522,48 @@ mod tests {
         );
         let _ = std::fs::remove_dir_all(&dir);
 
-        // Shipped: a real release model from the repo matches its manifest
-        // digest and must start even under strict.
-        let shipped = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../models/blaze_face_short_range.onnx");
-        if !shipped.exists() {
-            eprintln!("skipping known-model half: repo models/ not present");
-            return;
-        }
-        let out = run("IRLUME_TEST_VERIFY_KNOWN_CHILD", shipped.to_str().unwrap());
+        // Shipped: a model whose digest IS in the manifest must start under
+        // strict. The fixture is the mesh because it is the one weight
+        // COMMITTED to git; the four .onnx are ignored at `.gitignore:14` and
+        // fetched by `scripts/fetch-models.sh`, so an .onnx fixture is absent
+        // in any tree that has not run the fetch. `verify_models` matches on
+        // digest alone and never looks at the extension, so a .tflite exercises
+        // the same accept path a .onnx would.
+        //
+        // No exists() guard on purpose. This half used to return early when the
+        // fetched .onnx was missing, which reported the whole test as passed in
+        // a build where strict mode rejected every release model (#406).
+        let committed = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../models/face_landmarks_detector.tflite");
+        let out = run(
+            "IRLUME_TEST_VERIFY_KNOWN_CHILD",
+            committed.to_str().unwrap(),
+        );
         assert!(
             out.status.success(),
-            "strict mode must accept a manifest-matching model; stderr: {}",
+            "strict mode must accept a manifest-matching model. If {} is gone, it \
+             stopped being tracked in git and this test needs another committed \
+             fixture, not a skip; stderr: {}",
+            committed.display(),
             String::from_utf8_lossy(&out.stderr)
         );
         assert!(String::from_utf8_lossy(&out.stdout).contains("known-model-accepted"));
+
+        // The fetched weights get the same check when the fetch has run. Only
+        // this half can catch a download whose bytes the compiled-in manifest
+        // does not know, since the committed fixture never crosses the network.
+        // It is guarded, and it sits last so that skipping it cannot hide the
+        // unconditional assertion above.
+        let fetched = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../models/blaze_face_short_range.onnx");
+        if fetched.exists() {
+            let out = run("IRLUME_TEST_VERIFY_KNOWN_CHILD", fetched.to_str().unwrap());
+            assert!(
+                out.status.success(),
+                "strict mode must accept the fetched release model; stderr: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -6486,9 +6486,10 @@ mod tests {
     // Companion to the missing-model child test: strict mode must also refuse
     // a PRESENT model whose digest is not in the release manifest (tampering),
     // and must ACCEPT a shipped model that matches it. verify_models exits the
-    // process, so both run as re-exec'd children. Both halves assert
-    // unconditionally; the acceptance fixture is the committed mesh so that
-    // there is no environment where the accept direction goes unchecked.
+    // process, so both run as re-exec'd children. The refuse and the accept
+    // half both assert unconditionally, the acceptance fixture being the
+    // committed mesh so that no environment leaves the accept direction
+    // unchecked. A third check on the fetched weights is guarded and runs last.
     #[test]
     fn strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one() {
         if let Ok(path) = std::env::var("IRLUME_TEST_VERIFY_TAMPER_CHILD") {

--- a/models/README.md
+++ b/models/README.md
@@ -12,8 +12,16 @@ and warns at startup when a loaded model doesn't match (see ../SECURITY.md).
 The same hashes are pinned in `scripts/fetch-models.sh`, the Fedora spec, the
 Arch PKGBUILD, and `flake.nix`. To change a shipped model: upload the new file
 to a fresh `models-vN` release, regenerate `SHA256SUMS`
-(`cd models && sha256sum *.onnx > SHA256SUMS`), and update the hash in all four
-places above plus the `models-vN` reference.
+(`cd models && sha256sum *.onnx *.tflite > SHA256SUMS`), and update the hash in
+all four places above plus the `models-vN` reference.
+
+The `*.tflite` half of that glob is not decoration. `face_landmarks_detector.tflite`
+is the one weight COMMITTED to git rather than fetched, so it is the only model
+present in a tree that has not run `fetch-models.sh`. Two things depend on its
+digest being in `SHA256SUMS`: the daemon verifies the mesh at startup, and
+`strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one` uses it as
+the fixture proving `IRLUME_MODELS_STRICT=1` still ACCEPTS a manifest-matching
+model. Regenerating with `*.onnx` alone drops the line and breaks both.
 
 | File | Stage | Source | License | Notes |
 |---|---|---|---|---|


### PR DESCRIPTION
Closes #406.

`strict_verify_refuses_a_tampered_model_and_accepts_a_shipped_one` ran its
tampered-model half, then looked for `models/blaze_face_short_range.onnx` and
returned successfully when it was absent. The four .onnx are ignored at
`.gitignore:14` and fetched by `scripts/fetch-models.sh`, so any tree that has
not run the fetch reported the whole test as passed while the accept direction
went unchecked.

## What the fix rests on

The fixture is now `models/face_landmarks_detector.tflite`, the one weight
committed to git rather than fetched. Three things were checked in the tree
before relying on it:

- `MODEL_MANIFEST` is `include_str!("../../../models/SHA256SUMS")`, so the
  manifest is compiled in and is never the missing part. Only the model file
  can be absent.
- `verify_models` builds its known set from the first field of each manifest
  line, which is the digest, and it never looks at the extension. A .tflite
  therefore exercises the same accept path a .onnx would.
- `c7d54204...` is in `models/SHA256SUMS` and matches the committed file today.

The assertion is unconditional. If that file stops being tracked, the failure
message says the test needs another committed fixture rather than a skip.

The fetched weights keep their check behind an `exists()` guard, placed last so
that skipping it cannot hide the assertion above. Only that half can catch a
download whose bytes the compiled-in manifest does not know, since the committed
fixture never crosses the network.

## Testing

Every line below was run, not reasoned about.

- Broke strict mode to reject every model, moved `blaze_face_short_range.onnx`
  out of the tree, and ran both versions of the test: the old one exits 0, this
  one exits 101. That is the defect #406 describes, reproduced and then caught.
- Moved the .tflite out instead: the test fails and names the file.
- Moved only the .onnx out, which is what an unfetched clone looks like: passes.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -D
  warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
  --locked`, and `cargo test -p irlume-daemon --locked` (106 passed, 0 failed),
  all after merging main.

The first revision of this branch would have failed CI on fmt, which is why the
four commands ran locally.

## Which environments run this test

No packaging lane does: the Fedora spec has no `%check`, the Arch PKGBUILD has
no `check()`, the Debian lane packages a prebuilt binary through nfpm, and
`nix/package.nix` sets `doCheck = false`. The runners are the CI Rust jobs and a
developer checkout, and both carry the tracked .tflite. Under the old code the
nix and worktree cases were exactly where the accept direction went untested.

## Not covered

The full workspace test suite was not run locally, only `irlume-daemon`; CI
covers the rest. No source package was built to confirm its tarball carries the
tracked file, because no packaging lane runs this test. `models/README.md` gained
the reason its regeneration command has to glob `*.tflite`, since dropping that
line breaks the daemon's startup check of the mesh and this fixture together.

Signed-off-by: archledger <archledger236@gmail.com>
