### PR TITLE
The routing comment on the required checks was left behind by the rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,20 @@ concurrency:
 #   "systemd units (verify + exposure ratchet)"
 #   "nix flake check"
 # Renaming a job below without updating the protection rule leaves a PR waiting
-# on a check that never reports, so it can never merge. Change both together.
-# Five of the seven can only run on `arch` (archhost); the two on the shared
-# `ci` label can run on either machine.
+# on a check that never reports, so it can never merge. Change both together,
+# and note that "the protection rule" is TWO settings: classic branch protection
+# lists all seven, the active ruleset (id 19429289) lists five of them, and the
+# effective requirement is the union. Editing one alone does not drop a check.
+#
+# All seven run on `ubuntu-24.04`. Nothing required for a merge runs on a
+# self-hosted machine, which is the fork-PR rule in hardware-checks.yml holding:
+# a `pull_request` trigger executes the workflow file from the PR head, so a
+# required self-hosted check would let a fork edit its way onto a personal
+# machine. An earlier version of this comment said five of the seven could only
+# run on `arch` and two could run on either machine; that predates the 2026-08-07
+# capability routing and was false when #407 was written on its authority.
+# `runs-on: [self-hosted, ci]` needs a runner carrying EVERY listed label, so
+# `ci` never resolves to a hosted runner either.
 jobs:
   check:
     name: fmt · clippy · build · test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,10 @@ name: CI
 # Every job here runs on GitHub-hosted runners, so pull_request is safe and
 # fork PRs get the full required gate. Anything needing the maintainer's
 # hardware lives in hardware-checks.yml, which is push-triggered precisely
-# because a pull_request run would execute the PR head's workflow file on a
-# personal machine.
+# because a pull_request run executes the PR's own merge branch, workflow file
+# included, and a fork controls what goes into it. Observed in this repo's logs:
+# "HEAD is now at 593ba54 Merge 3e20d8c into e971020". Not the raw PR head, and
+# not the base branch either; that second one is `pull_request_target`.
 on:
   push:
     branches: [main]
@@ -62,10 +64,11 @@ concurrency:
 #
 # All seven run on `ubuntu-24.04`. Nothing required for a merge runs on a
 # self-hosted machine, which is the fork-PR rule in hardware-checks.yml holding:
-# a `pull_request` trigger executes the workflow file from the PR head, so a
-# required self-hosted check would let a fork edit its way onto a personal
-# machine. An earlier version of this comment said five of the seven could only
-# run on `arch` and two could run on either machine; that predates the 2026-08-07
+# a `pull_request` run executes the PR's own merge branch, so a required
+# self-hosted check would let a fork run its code on a personal machine.
+#
+# An earlier version of this comment said five of the seven could only run on
+# `arch` and two could run on either machine; that predates the 2026-08-07
 # capability routing and was false when #407 was written on its authority.
 # `runs-on: [self-hosted, ci]` needs a runner carrying EVERY listed label, so
 # `ci` never resolves to a hosted runner either.


### PR DESCRIPTION
`ci.yml` told readers that five of the seven required checks could only run on
`arch` and that two could run on either machine. Both halves are false. All
seven run on `ubuntu-24.04`, and `runs-on: [self-hosted, ci]` needs a runner
carrying every listed label, so `ci` never resolves to a hosted runner in the
other direction either.

The comment predates the 2026-08-07 capability routing. It was not harmless:
#407 was written on its authority and its central premise, that the same job
runs on a hosted runner and on the self-hosted Arch runner, came from these two
lines. That premise decided the issue's recommendation, and correcting it took a
reviewer plus a reading of the workflow files.

The comment also implied one place to change. There are two: classic branch
protection lists all seven contexts, the active ruleset lists five of them, and
what is enforced is the union. Read from the API rather than from the previous
comment: `repos/archledger/irlume/branches/main/protection` returns the seven,
`repos/archledger/irlume/rulesets/19429289` returns five. Editing one alone does
not drop a check, which is the trap worth naming.

Comment only. No job, trigger, runner label or step changes.
