### PR TITLE
Make the eight ONNX Runtime pins agree, or fail the build (#411)

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -78,14 +78,20 @@ let
       };
     };
 
-  # The pinned onnxruntime 1.24.4 build. NixOS stable ships 1.22.2, which is
-  # below irlume's 1.24 API floor and deadlocks the `ort` loader at startup, so
-  # bundle the exact upstream release the RPM and .deb carry.
+  # The pinned onnxruntime build. NixOS stable ships 1.22.2, which is below
+  # irlume's 1.24 API floor and deadlocks the `ort` loader at startup, so bundle
+  # the exact upstream release the RPM and .deb carry.
+  #
+  # One binding, interpolated into the label and the URL, the way flake.nix
+  # already does it. Written out three times, a bump could change the derivation
+  # label while still fetching the old archive, and the parity check in
+  # scripts/check-packaging-parity.sh reads the label (#411).
+  ortVersion = "1.24.4";
   onnxruntime-bin = pkgs.stdenv.mkDerivation {
     pname = "onnxruntime-linux-x64";
-    version = "1.24.4";
+    version = ortVersion;
     src = pkgs.fetchurl {
-      url = "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-1.24.4.tgz";
+      url = "https://github.com/microsoft/onnxruntime/releases/download/v${ortVersion}/onnxruntime-linux-x64-${ortVersion}.tgz";
       hash = "sha256-OiEfvqJSweZikGWPG3NbdyBWFJ8oMh5xwwiULNtUt0c=";
     };
     nativeBuildInputs = [ pkgs.autoPatchelfHook ];

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -177,6 +177,86 @@ for derived in packaging/ppa/build-ppa-container.sh nix/package.nix; do
 done
 
 echo
+echo "== every lane pins the same ONNX Runtime =="
+# irlume builds `ort` with `load-dynamic`, so libonnxruntime.so is whatever the
+# host supplies at runtime and the version each lane bundles IS the version its
+# users run. Eight files name it and nothing made them agree (#411): a lane
+# bumped on its own ships a runtime no CI job ever executed, and the embedding
+# gate in irlume-vision (#407) would stay green while the numbers it pins moved
+# under the shipped package.
+#
+# Each lane spells the pin its own way, so extraction is per file and an
+# unlisted file is a hard error rather than a skip. Same reason as dest_for()
+# above: a pattern that silently matches nothing yields an empty string, and two
+# empty strings compare equal, which is a guard reporting ok while checking
+# nothing.
+ort_pin_of() {
+  case "$1" in
+    .github/workflows/ci.yml|.github/workflows/asan.yml|.github/workflows/install-matrix.yml)
+      sed -n 's/^[[:space:]]*ver=\([0-9][0-9.]*\)[[:space:]]*$/\1/p' "$1" | sort -u ;;
+    flake.nix|nix/module.nix)
+      sed -n 's/.*[oO]rt[Vv]ersion = "\([0-9][0-9.]*\)".*/\1/p; s/^[[:space:]]*version = "\([0-9][0-9.]*\)";[[:space:]]*$/\1/p' "$1" | sort -u ;;
+    packaging/fedora/irlume.spec)
+      sed -n 's/^%global ort_ver \([0-9][0-9.]*\).*/\1/p' "$1" ;;
+    packaging/debian/build-deb.sh|scripts/build-ppa-source.sh)
+      # shellcheck disable=SC2016  # ${ORT_VER:-...} is literal text in those files
+      sed -n 's/^ORT_VER="${ORT_VER:-\([0-9][0-9.]*\)}".*/\1/p' "$1" ;;
+    *)
+      echo "  ERROR: no ONNX Runtime pin pattern known for $1;" >&2
+      echo "  add one to ort_pin_of() in $0 rather than leaving it unchecked." >&2
+      exit 1
+      ;;
+  esac
+}
+
+ORT_PINNED_BY=(
+  .github/workflows/ci.yml
+  .github/workflows/asan.yml
+  .github/workflows/install-matrix.yml
+  flake.nix
+  nix/module.nix
+  packaging/fedora/irlume.spec
+  packaging/debian/build-deb.sh
+  scripts/build-ppa-source.sh
+)
+
+ort_ref=""
+for f in "${ORT_PINNED_BY[@]}"; do
+  # A file may name the version on several lines; sort -u collapses them, so
+  # more than one line here means that file disagrees with ITSELF, and the count
+  # check catches that before the cross-file comparison runs.
+  found="$(ort_pin_of "$f")"
+  n="$(printf '%s' "$found" | grep -c . || true)"
+  if [ "$n" -ne 1 ]; then
+    printf '  MISS  %-42s expected one version, extracted %s\n' "$f" "$n"
+    fail=1
+    continue
+  fi
+  printf '  ok    %-42s %s\n' "$f" "$found"
+  if [ -z "$ort_ref" ]; then
+    ort_ref="$found"
+  elif [ "$found" != "$ort_ref" ]; then
+    printf '  ERROR %-42s pins %s, but %s pins %s\n' \
+      "$f" "$found" "${ORT_PINNED_BY[0]}" "$ort_ref"
+    fail=1
+  fi
+done
+
+# The developer guide hands out copy-paste setup commands carrying the version,
+# so a contributor who follows it after a bump installs a runtime no lane ships.
+# The dated survey under docs/cross-distro/ is deliberately NOT checked: it
+# records what was true on its date and is not instructions.
+if [ -z "$ort_ref" ]; then
+  echo "  ERROR: no ONNX Runtime version could be read from any lane"
+  fail=1
+elif ! grep -Fq "onnxruntime-linux-x64-$ort_ref.tgz" docs/DEVELOPMENT.md; then
+  printf '  ERROR %-42s does not hand out %s\n' docs/DEVELOPMENT.md "$ort_ref"
+  fail=1
+else
+  printf '  ok    %-42s hands out %s\n' docs/DEVELOPMENT.md "$ort_ref"
+fi
+
+echo
 echo
 echo "== AppArmor runtime rules in both executable-path variants =="
 APPARMOR_PROFILES=(

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -193,9 +193,13 @@ echo "== every lane pins the same ONNX Runtime =="
 ort_pin_of() {
   case "$1" in
     .github/workflows/ci.yml|.github/workflows/asan.yml|.github/workflows/install-matrix.yml)
-      sed -n 's/^[[:space:]]*ver=\([0-9][0-9.]*\)[[:space:]]*$/\1/p' "$1" | sort -u ;;
+      sed -n 's/^[[:space:]]*ver=\([0-9][0-9.]*\)[[:space:]]*$/\1/p' "$1" ;;
     flake.nix|nix/module.nix)
-      sed -n 's/.*[oO]rt[Vv]ersion = "\([0-9][0-9.]*\)".*/\1/p; s/^[[:space:]]*version = "\([0-9][0-9.]*\)";[[:space:]]*$/\1/p' "$1" | sort -u ;;
+      # Only the `ortVersion` binding. Both files interpolate it into the
+      # derivation label and the fetch URL, so reading the binding reads what is
+      # actually downloaded. Matching a bare `version =` instead would read a
+      # label that a bump could move while the URL kept fetching the old archive.
+      sed -n 's/.*[oO]rt[Vv]ersion = "\([0-9][0-9.]*\)".*/\1/p' "$1" ;;
     packaging/fedora/irlume.spec)
       sed -n 's/^%global ort_ver \([0-9][0-9.]*\).*/\1/p' "$1" ;;
     packaging/debian/build-deb.sh|scripts/build-ppa-source.sh)
@@ -220,15 +224,39 @@ ORT_PINNED_BY=(
   scripts/build-ppa-source.sh
 )
 
+# How many times each file is expected to name it. Counting DISTINCT values is
+# not enough: ci.yml fetches the runtime in three separate jobs, and deleting
+# one of those steps leaves the other two agreeing, so a uniqueness check would
+# report ok for a workflow that had silently stopped pinning a lane.
+declare -A ORT_PIN_COUNT=(
+  [.github/workflows/ci.yml]=3
+  [.github/workflows/asan.yml]=1
+  [.github/workflows/install-matrix.yml]=1
+  [flake.nix]=1
+  [nix/module.nix]=1
+  [packaging/fedora/irlume.spec]=1
+  [packaging/debian/build-deb.sh]=1
+  [scripts/build-ppa-source.sh]=1
+)
+
 ort_ref=""
 for f in "${ORT_PINNED_BY[@]}"; do
-  # A file may name the version on several lines; sort -u collapses them, so
-  # more than one line here means that file disagrees with ITSELF, and the count
-  # check catches that before the cross-file comparison runs.
-  found="$(ort_pin_of "$f")"
-  n="$(printf '%s' "$found" | grep -c . || true)"
-  if [ "$n" -ne 1 ]; then
-    printf '  MISS  %-42s expected one version, extracted %s\n' "$f" "$n"
+  want="${ORT_PIN_COUNT[$f]:-}"
+  if [ -z "$want" ]; then
+    echo "  ERROR: no expected pin count for $f; add one to ORT_PIN_COUNT in $0" >&2
+    exit 1
+  fi
+  all="$(ort_pin_of "$f")"
+  n="$(printf '%s' "$all" | grep -c . || true)"
+  if [ "$n" -ne "$want" ]; then
+    printf '  MISS  %-42s expected %s pin(s), found %s\n' "$f" "$want" "$n"
+    fail=1
+    continue
+  fi
+  found="$(printf '%s\n' "$all" | sort -u)"
+  u="$(printf '%s' "$found" | grep -c . || true)"
+  if [ "$u" -ne 1 ]; then
+    printf '  MISS  %-42s names %s different versions\n' "$f" "$u"
     fail=1
     continue
   fi
@@ -249,11 +277,28 @@ done
 if [ -z "$ort_ref" ]; then
   echo "  ERROR: no ONNX Runtime version could be read from any lane"
   fail=1
-elif ! grep -Fq "onnxruntime-linux-x64-$ort_ref.tgz" docs/DEVELOPMENT.md; then
-  printf '  ERROR %-42s does not hand out %s\n' docs/DEVELOPMENT.md "$ort_ref"
-  fail=1
 else
-  printf '  ok    %-42s hands out %s\n' docs/DEVELOPMENT.md "$ort_ref"
+  # EVERY place the recipe names it, not just one. The version appears in the
+  # download URL, the tarball, the tar command, the exported library path, the
+  # dependency table and the .deb soname example. Checking one of them passes a
+  # document that downloads one version and puts a different one on
+  # ORT_DYLIB_PATH, which is a working command sequence that loads the wrong
+  # library.
+  doc_needs=(
+    "onnxruntime **$ort_ref** (\`ORT_DYLIB_PATH\`)"
+    "releases/download/v$ort_ref/onnxruntime-linux-x64-$ort_ref.tgz"
+    "tar xzf onnxruntime-linux-x64-$ort_ref.tgz"
+    "ORT_DYLIB_PATH=\"\$PWD/onnxruntime-linux-x64-$ort_ref/lib/libonnxruntime.so\""
+    "libonnxruntime.so.$ort_ref"
+  )
+  for need in "${doc_needs[@]}"; do
+    if grep -Fq -- "$need" docs/DEVELOPMENT.md; then
+      printf '  ok    %-42s %s\n' docs/DEVELOPMENT.md "$need"
+    else
+      printf '  MISS  %-42s %s\n' docs/DEVELOPMENT.md "$need"
+      fail=1
+    fi
+  done
 fi
 
 echo


### PR DESCRIPTION
Closes #411.

irlume builds `ort` with `load-dynamic`, so libonnxruntime.so is whatever the
host supplies and the version a lane bundles is the version its users run. Eight
files name it and nothing made them agree:

    .github/workflows/ci.yml (three times)
    .github/workflows/asan.yml
    .github/workflows/install-matrix.yml
    flake.nix
    nix/module.nix
    packaging/fedora/irlume.spec
    packaging/debian/build-deb.sh
    scripts/build-ppa-source.sh

They agree today, which is the only thing that kept the divergence invisible.
Bump the Fedora spec alone and every required check keeps testing the old
runtime, keeps passing, and Fedora users get a runtime nothing executed. The
embedding gate that landed in #410 would stay green while the numbers it pins
moved under the shipped package, which is the failure it exists to prevent.

`check-packaging-parity.sh` already exists for this class. Its header says every
lane "must agree on the version" and it was written because the same bug shipped
three times. It compared units, helper programs, models and the irlume version,
and not this.

The check reads each pin, refuses to proceed when a listed file has no
extraction pattern, and fails when any file yields zero or more than one
version. That last part matters: a pattern that stops matching yields an empty
string, two empty strings compare equal, and the result is a guard that reports
ok while checking nothing. That is the failure mode this script's own dest_for()
comment was written about.

`docs/DEVELOPMENT.md` is checked too, because it hands out copy-paste setup
commands carrying the version and a contributor who follows it after a bump
installs a runtime no lane ships. The dated survey under docs/cross-distro/ is
deliberately excluded: it records what was true on its date and is not
instructions.

Proved by mutation, each one run:

- flake.nix moved to 1.24.5: fails, naming both files and both versions.
- The spec's `%global ort_ver` renamed so the pattern misses: fails on the count
  rather than passing with an empty string.
- DEVELOPMENT.md left on 1.24.3: fails.
- `packaging/arch/PKGBUILD` added to the list with no pattern for it: hard error,
  exit before any comparison.
- Unmutated: passes, and shellcheck is clean.

Not covered: the tarball sha256 digests, which several lanes pin beside the
version and which have to change with it. Arch is not in the list because it
depends on the rolling system `onnxruntime` package and pins nothing, so there
is no version there to compare; that its CI lane downloads 1.24.4 instead of
installing that dependency is a separate gap, recorded on #411.
