### PR TITLE
Refuse to enable a gate that refuses the user (#386)

### DIFF
--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1129,7 +1129,8 @@ fn usage_profiles() -> std::process::ExitCode {
         delete --profile P [--scan S]           delete a profile or a scan\n  \
         forget-model <model>                    remove one recognizer's scans from every\n  \
                                                 profile (shipped | a catalog name | embed:<sha256>)\n  \
-        eyes-open <on|off>                      require eyes open to unlock\n  \
+        eyes-open off                           turn OFF the eyes-open check\n  \
+        \x20                                       (it cannot be turned on; see issue #386)\n  \
         challenge <on|off>                      opt-in passive blink liveness"
     );
     std::process::ExitCode::from(2)

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3367,6 +3367,17 @@ impl App {
             // Settings.
             (SC_SETTINGS, KeyCode::Enter) | (SC_SETTINGS, KeyCode::Char(' ')) => {
                 let on = !self.eyes_open;
+                // Turning it ON is refused by the daemon (#386), so do not fire
+                // a request known in advance to fail. The refusal still lives
+                // there, because that is the one choke point both this and the
+                // CLI go through; this only avoids offering the user an action
+                // whose only outcome is an error modal.
+                if on {
+                    self.set_error(
+                        "require-eyes-open cannot be enabled: it refuses the user it exists                          to admit (measured 1 of 12 bare-eyed frames with eyes open, 0 of 12                          with glasses). See issue #386.",
+                    );
+                    return;
+                }
                 self.start_async(
                     "toggle require-eyes-open",
                     OpTag::Generic,
@@ -3988,7 +3999,7 @@ impl App {
                     None => "Wires face login into your greeter, lock screen and sudo.",
                 },
                 SC_SETTINGS => {
-                    "[enter] toggles the eyes-open check, [c] the blink challenge; other settings are root or read-only."
+                    "[enter] turns the eyes-open check OFF (it cannot be turned on, see #386), [c] the blink challenge; other settings are root or read-only."
                 }
                 SC_MODELS => {
                     "Measured model options; switching the recognizer means re-enrolling."
@@ -5910,7 +5921,7 @@ impl App {
                 ("s", "show status"),
             ],
             SC_SETTINGS => &[
-                ("enter", "eyes-open"),
+                ("enter", "eyes-open off"),
                 ("c", "blink"),
                 ("g", "keyring gesture"),
                 ("b", "biopolicy"),
@@ -8208,14 +8219,41 @@ mod tests {
     }
 
     #[test]
-    fn settings_enter_toggles_eyes_open_via_the_daemon() {
+    fn settings_enter_refuses_to_enable_eyes_open_and_sends_nothing() {
+        // #386: the daemon refuses to turn this gate on, so Enter from OFF must
+        // not fire a request whose only outcome is an error modal. The refusal
+        // still lives in the daemon, which is the choke point the CLI shares;
+        // this is about not offering the user a dead action.
         let _sock = dead_socket();
         let mut app = test_app();
         app.screen = SC_SETTINGS;
+        assert!(!app.eyes_open, "the fixture starts with the gate off");
+        app.on_key(KeyCode::Enter);
+        assert!(
+            app.op.is_none(),
+            "no request may be sent for an enable the daemon refuses"
+        );
+        let err = app.error.as_deref().unwrap_or_default();
+        assert!(err.contains("cannot be enabled"), "{err}");
+        assert!(
+            err.contains("#386"),
+            "the refusal must name the issue: {err}"
+        );
+    }
+
+    #[test]
+    fn settings_enter_still_turns_eyes_open_off_via_the_daemon() {
+        // The OFF direction is the one an enrollment already carrying the flag
+        // needs, so it must still reach the daemon.
+        let _sock = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.eyes_open = true;
         app.on_key(KeyCode::Enter);
         assert_eq!(
             app.op.as_ref().map(|o| o.label.as_str()),
-            Some("toggle require-eyes-open")
+            Some("toggle require-eyes-open"),
+            "turning the gate OFF must still fire the request"
         );
         wait_op_done(&mut app);
         assert!(

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -400,7 +400,7 @@ fn profiles_usage_errors_exit_2() {
         "rename --profile P [--scan S] --name N",
         "delete --profile P [--scan S]",
         "forget-model <model>",
-        "eyes-open <on|off>",
+        "eyes-open off",
         "challenge <on|off>",
     ] {
         assert!(
@@ -408,6 +408,17 @@ fn profiles_usage_errors_exit_2() {
             "profiles usage must name `{frag}`: {err}"
         );
     }
+    // #386: the daemon refuses to turn this gate on, so the usage must not
+    // offer it. Whoever makes the gate work again changes this line
+    // deliberately, which is the point of pinning it.
+    assert!(
+        !err.contains("eyes-open <on|off>"),
+        "usage must not advertise an enable the daemon refuses: {err}"
+    );
+    assert!(
+        err.contains("#386"),
+        "usage must say where the refusal is recorded: {err}"
+    );
 }
 
 #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3596,6 +3596,33 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             s.name = new_name.clone();
             Ok(format!("renamed scan to '{new_name}'"))
         }),
+        // Refuses to turn ON, and this is deliberate (#386). The gate cannot
+        // admit the user it exists for. Replaying the committed blink corpus
+        // through the shipped `both_eyes_open`, 12 detected frames per state:
+        // bare-eyed with eyes genuinely OPEN reads open 1 time in 12, and with
+        // glasses 0 times in 12, so there is no eyewear or lighting state in
+        // the record where enabling it leaves face authentication usable.
+        //
+        // Refused rather than warned because there is no configuration that
+        // works: a warning implies a tradeoff the measurement does not offer.
+        // Turning it OFF is always allowed, so an enrollment that already has
+        // it set is never trapped by this.
+        //
+        // What would lift the refusal is a cue that survives a change of light
+        // or eyewear, which #386 records as unavailable today: the peak cannot
+        // be retuned (the two distributions overlap behind glasses), and a
+        // per-user EAR threshold fails cross-session, the same subject's median
+        // OPEN reading landing inside the open/closed separation window of
+        // another session.
+        Request::SetRequireEyesOpen { user, on } if on => {
+            let _ = user;
+            Response::Error(
+                "require-eyes-open cannot be enabled: it refuses the user it exists to admit \
+                 (measured 1 of 12 bare-eyed frames with eyes open, 0 of 12 with glasses). \
+                 See issue #386; `irlume profiles eyes-open off` still works."
+                    .into(),
+            )
+        }
         Request::SetRequireEyesOpen { user, on } => mutate_enrollment(&user, |enr| {
             enr.require_eyes_open = on;
             Ok(format!(
@@ -7496,6 +7523,123 @@ mod tests {
     }
 
     #[test]
+    fn require_eyes_open_is_refused_at_the_dispatch_choke_point() {
+        // #386. The gate refuses the user it exists to admit: replaying the
+        // committed blink corpus through the shipped `both_eyes_open` reads
+        // eyes-open 1 time in 12 bare-eyed and 0 times in 12 with glasses, so
+        // no eyewear or lighting state in the record leaves it usable.
+        //
+        // Asserted at DISPATCH because that is the one choke point: `irlume
+        // profiles eyes-open on` and the TUI toggle both send this request, so
+        // a check in either would leave the other open.
+        //
+        // DELIBERATELY UNGUARDED by `tpm_available()`. The refusal returns
+        // before `mutate_enrollment`, so it touches no storage and needs no
+        // TPM-free host. The first version of this test carried the guard
+        // copied from its neighbour, skipped on any developer machine with a
+        // TPM, and survived every mutation of the code it was supposed to pin.
+        let _g = env_lock();
+        let mut e = engine();
+        let root = peer(0);
+        match dispatch(
+            Request::SetRequireEyesOpen {
+                user: "nobody-enrolled".into(),
+                on: true,
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => {
+                assert!(msg.contains("cannot be enabled"), "{msg}");
+                // Name the issue, or the next reader takes this for a bug in
+                // the toggle rather than a recorded decision.
+                assert!(
+                    msg.contains("#386"),
+                    "the refusal must name the issue: {msg}"
+                );
+                // And say the off direction still works, since an enrollment
+                // already carrying the gate would otherwise look trapped by a
+                // refusal that mentions only the ON direction.
+                assert!(
+                    msg.contains("off"),
+                    "the refusal must say off still works: {msg}"
+                );
+            }
+            other => panic!("enabling must be refused, got {other:?}"),
+        }
+
+        // The OFF direction must not be caught by the same arm, and that is
+        // checkable without storage: this user has no enrollment, so a correct
+        // guard lets the request through to `mutate_enrollment`, which reports
+        // the missing enrollment. Only a guard that also swallowed OFF would
+        // answer with the refusal text. Asserted here rather than only in the
+        // storage test below, because that one skips on any host with a TPM
+        // and a widened guard survived it.
+        match dispatch(
+            Request::SetRequireEyesOpen {
+                user: "nobody-enrolled".into(),
+                on: false,
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(
+                !msg.contains("cannot be enabled"),
+                "turning the gate OFF must never hit the enable refusal: {msg}"
+            ),
+            Response::Ok(_) => {}
+            other => panic!("unexpected response to a disable: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refusing_require_eyes_open_writes_nothing_and_off_still_works() {
+        // The storage half of the refusal, which does need a TPM-free host
+        // because the off arm ends in storage::save. Same convention as the
+        // other save-touching tests here.
+        if irlume_core::template_key::tpm_available() {
+            eprintln!("skipping: TPM present; storage::save would touch real hardware");
+            return;
+        }
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("eyes-open-refusal");
+        let _ = &sb;
+        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
+        let root = peer(0);
+
+        let _ = dispatch(
+            Request::SetRequireEyesOpen {
+                user: "carol".into(),
+                on: true,
+            },
+            &root,
+            &mut e,
+        );
+        // A refused enable that persisted anyway would be the worst of both:
+        // told no, locked out regardless.
+        let enr = irlume_core::storage::load("carol")
+            .expect("load")
+            .expect("the enrollment exists");
+        assert!(
+            !enr.require_eyes_open,
+            "a refused enable must leave the stored flag alone"
+        );
+
+        match dispatch(
+            Request::SetRequireEyesOpen {
+                user: "carol".into(),
+                on: false,
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Ok(msg) => assert_eq!(msg, "require-eyes-open disabled"),
+            other => panic!("disabling must still work, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn mutations_that_rewrite_the_enrollment_roundtrip_through_dispatch() {
         // These arms end in storage::save; on a host with /dev/tpm* that would
         // seal a real template key, so this test only runs on no-TPM hosts
@@ -7568,17 +7712,18 @@ mod tests {
             Response::Error(msg) => assert_eq!(msg, "'Work' already exists"),
             other => panic!("rename collision must be refused, got {other:?}"),
         }
-        expect_ok(
-            dispatch(
-                Request::SetRequireEyesOpen {
-                    user: "carol".into(),
-                    on: true,
-                },
-                &root,
-                &mut e,
-            ),
-            "require-eyes-open ENABLED",
-        );
+        // Enabling is refused (#386); the dedicated test below covers why.
+        match dispatch(
+            Request::SetRequireEyesOpen {
+                user: "carol".into(),
+                on: true,
+            },
+            &root,
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("cannot be enabled"), "{msg}"),
+            other => panic!("enabling require-eyes-open must be refused, got {other:?}"),
+        }
         expect_ok(
             dispatch(
                 Request::SetRequireChallenge {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -7802,7 +7802,11 @@ mod tests {
                 assert_eq!(profiles.len(), 1);
                 assert_eq!(profiles[0].name, "Work");
                 assert_eq!(profiles[0].scans, vec!["Front".to_string()]);
-                assert!(require_eyes_open);
+                // The enable above was refused (#386), so the listing must
+                // still report it off. This is the no-write property checked a
+                // second way, through the published enrollment rather than
+                // through storage.
+                assert!(!require_eyes_open);
                 assert!(!require_challenge);
             }
             other => panic!("expected Response::Enrollment, got {other:?}"),

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2767,6 +2767,35 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
     if let Some(resp) = pregate(&req, peer) {
         return resp;
     }
+    // Refuses to turn ON, and this is deliberate (#386). The gate cannot admit
+    // the user it exists for: replaying the committed blink corpus through the
+    // shipped `both_eyes_open`, 12 detected frames per state, bare-eyed with
+    // eyes genuinely OPEN reads open 1 time in 12 and with glasses 0 times in
+    // 12, so no eyewear or lighting state in the record leaves it usable.
+    //
+    // Refused rather than warned because there is no configuration that works:
+    // a warning implies a tradeoff the measurement does not offer. Turning it
+    // OFF is always allowed, so an enrollment already carrying the flag is
+    // never trapped.
+    //
+    // Placed HERE, above the invalidation below, rather than in the match: this
+    // is a refusal, and the invariant in that comment is that a request about
+    // to be refused may not change state. Evicting the summary cache is a state
+    // change, and it is the one #349 exists to prevent.
+    //
+    // What would lift the refusal is a cue that survives a change of light or
+    // eyewear, which #386 records as unavailable: the peak cannot be retuned
+    // because the two distributions overlap behind glasses, and a per-user EAR
+    // threshold fails cross-session, the same subject's median OPEN reading
+    // landing inside another session's open/closed separation window.
+    if matches!(req, Request::SetRequireEyesOpen { on: true, .. }) {
+        return Response::Error(
+            "require-eyes-open cannot be enabled: it refuses the user it exists to admit \
+             (measured 1 of 12 bare-eyed frames with eyes open, 0 of 12 with glasses). \
+             See issue #386; `irlume profiles eyes-open off` still works."
+                .into(),
+        );
+    }
     // AFTER the gate, BEFORE the mutation runs. After the gate because the
     // cache is state, and a request that is about to be refused may not
     // change state: an unprivileged peer could otherwise evict root's summary
@@ -3596,33 +3625,6 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             s.name = new_name.clone();
             Ok(format!("renamed scan to '{new_name}'"))
         }),
-        // Refuses to turn ON, and this is deliberate (#386). The gate cannot
-        // admit the user it exists for. Replaying the committed blink corpus
-        // through the shipped `both_eyes_open`, 12 detected frames per state:
-        // bare-eyed with eyes genuinely OPEN reads open 1 time in 12, and with
-        // glasses 0 times in 12, so there is no eyewear or lighting state in
-        // the record where enabling it leaves face authentication usable.
-        //
-        // Refused rather than warned because there is no configuration that
-        // works: a warning implies a tradeoff the measurement does not offer.
-        // Turning it OFF is always allowed, so an enrollment that already has
-        // it set is never trapped by this.
-        //
-        // What would lift the refusal is a cue that survives a change of light
-        // or eyewear, which #386 records as unavailable today: the peak cannot
-        // be retuned (the two distributions overlap behind glasses), and a
-        // per-user EAR threshold fails cross-session, the same subject's median
-        // OPEN reading landing inside the open/closed separation window of
-        // another session.
-        Request::SetRequireEyesOpen { user, on } if on => {
-            let _ = user;
-            Response::Error(
-                "require-eyes-open cannot be enabled: it refuses the user it exists to admit \
-                 (measured 1 of 12 bare-eyed frames with eyes open, 0 of 12 with glasses). \
-                 See issue #386; `irlume profiles eyes-open off` still works."
-                    .into(),
-            )
-        }
         Request::SetRequireEyesOpen { user, on } => mutate_enrollment(&user, |enr| {
             enr.require_eyes_open = on;
             Ok(format!(
@@ -7590,6 +7592,53 @@ mod tests {
             Response::Ok(_) => {}
             other => panic!("unexpected response to a disable: {other:?}"),
         }
+    }
+
+    #[test]
+    fn a_refused_eyes_open_enable_does_not_evict_the_summary_cache() {
+        // The refusal sits ABOVE `invalidate_enrollment_summary` on purpose.
+        // The comment there states the invariant it protects: a request about
+        // to be refused may not change state, because an unprivileged peer
+        // could otherwise evict root's summary and charge root's next listing a
+        // storage load and its TPM work (#349). A refusal that runs after the
+        // invalidation keeps that cost while doing nothing.
+        let _g = env_lock();
+        let mut e = engine();
+        let root = peer(0);
+        clear_enrollment_summaries();
+        let has_summary = || {
+            enrollment_summaries()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains_key("carol")
+        };
+        publish_enrollment_summary(
+            "carol",
+            EnrollmentSummary {
+                profiles: Vec::new(),
+                require_eyes_open: false,
+                require_challenge: false,
+                closure_calibrated: false,
+                ir_ratio_calibrated: false,
+            },
+        );
+        assert!(
+            has_summary(),
+            "the fixture must start with a published summary"
+        );
+        let _ = dispatch(
+            Request::SetRequireEyesOpen {
+                user: "carol".into(),
+                on: true,
+            },
+            &root,
+            &mut e,
+        );
+        assert!(
+            has_summary(),
+            "a refused enable must leave the published summary in place"
+        );
+        clear_enrollment_summaries();
     }
 
     #[test]

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -36,7 +36,7 @@ Conventions that apply everywhere:
 | `irlume profiles rename --profile P [--scan S] --name N` | rename a profile, or one scan inside it |
 | `irlume profiles delete --profile P [--scan S]` | delete a profile, or one scan inside it |
 | `irlume profiles forget-model <model>` | remove one recognizer's scans (and the calibrations fitted from them) from every profile of a user; the deliberate counterpart to `models disable`, which deletes weights but keeps templates. `<model>` is `shipped`, a catalog name, or an `embed:<sha256>` tag as `profiles list` prints it. A profile left with no scans is deleted with them |
-| `irlume profiles eyes-open <on\|off>` | require eyes open to unlock |
+| `irlume profiles eyes-open off` | turn off the eyes-open check. It cannot be turned ON: the gate refuses the user it exists to admit, so the daemon declines (#386) |
 | `irlume profiles challenge <on\|off>` | opt-in passive blink liveness |
 | `sudo irlume calibrate-closure [--rounds N] [--force] [--measure-only [--pose L]]` | teach the eye-closure consent gesture for app prompts. Captures eyes-open/closed EAR over N rounds (default 3) and stores the median, because a single capture varies enough to leave the threshold sitting on top of your own closures; it then reports how many of your readings the result would actually accept. Replacing an existing calibration asks first, and `--force` is required to do it with no terminal. `--measure-only` prints the EAR readings and stores nothing, and `--pose L` labels what you are holding in that data (e.g. `glasses-on-open`). The head nod is the default and needs no calibration |
 | `irlume identify` | 1:N "who is this?"; as root it checks all users, otherwise scoped to you |


### PR DESCRIPTION
Addresses #386. The issue stays OPEN: this stops the harm, it does not make the gate work.

`require_eyes_open` cannot admit the user it exists for. Replaying the committed
blink corpus through the shipped `both_eyes_open`, twelve detected frames per
state: bare-eyed with eyes genuinely open reads open 1 time in 12, and with
glasses 0 times in 12. Across all six cells the gate admits 1 of 72 genuine
detected frames. There is no eyewear or lighting state in the record where
turning it on leaves face authentication usable.

So turning it on is refused, and turning it off is always allowed. Refused
rather than warned because a warning implies a tradeoff the measurement does not
offer: there is no configuration that works, so there is nothing to trade.

The refusal sits at the daemon's dispatch arm because that is the single choke
point. `irlume profiles eyes-open on` and the TUI toggle both send
`SetRequireEyesOpen`, so a check in either would leave the other open.

An enrollment that already carries the flag is not trapped. The OFF direction
never reaches the refusal, and the message says so, because a refusal that named
only the ON direction would read as a dead end to the one person who most needs
the escape.

What would lift this is a cue that survives a change of light or eyewear, and
#386 now records that none is available: the peak cannot be retuned because the
two distributions overlap completely behind glasses, and a per-user EAR
threshold fails across sessions, the same subject's median OPEN reading landing
inside the open/closed separation window measured in another session.

Proved by mutation, each run and each naming the assertion that caught it:

- The refusal arm removed: fails.
- The message stops naming the issue: fails.
- The message drops the hint that OFF still works: fails.
- The guard widened to swallow OFF as well: fails.

That last one is the reason this test is split in two. The first version carried
a `tpm_available()` skip copied from its neighbour, which meant it returned early
on any developer machine with a TPM and survived all four mutations while
reporting a pass. The refusal touches no storage, so it needs no TPM-free host
and is now asserted unguarded; only the write check and the OFF round trip, which
end in `storage::save`, keep the guard. The OFF direction is additionally
asserted without storage, by dispatching for a user with no enrollment: a correct
guard lets that through to the missing-enrollment error, and only a widened one
answers with the refusal text.

Not covered: no camera. This changes no capture, no verdict and no matching. It
changes which requests the daemon accepts, and the numbers behind the decision
come from stored frames verified against `docs/pad-results/2026-08-07-blink-corpus.sha256`.
