### PR TITLE
Fix the emitter lock permission and the CodeQL stall (#392, #415)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+# CodeQL analysis for Rust, Python, and GitHub Actions.
+#
+# This checked-in workflow replaces the default setup. The default setup's
+# analyses stalled queued with no runner and no way to re-run or cancel from
+# the CLI (#415). A checked-in workflow is re-runnable, cancelable, and
+# carries a timeout so a stall resolves rather than holding mergeStateStatus
+# at UNSTABLE forever.
+#
+# None of the CodeQL contexts are required for a merge. The cost of a stall is
+# that UNSTABLE is indistinguishable from "checks are still running", so a
+# reviewer applying a green-CI merge bar waits with no end.
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches filter below is the same as the rest of the fleet.
+    branches: ["main"]
+  schedule:
+    # Weekly Saturday at 00:00 UTC.
+    - cron: "0 0 * * 6"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - python
+          - rust
+          # The default setup also included these. Keep them in the matrix
+          # so the set of checks does not change.
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c9402b8612131d4eef358bea70e805bcf5e0e1e6 # v3.28.16
+        with:
+          languages: ${{ matrix.language }}
+          # The default setup uses the default query suite. Keep it.
+          queries: default
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c9402b8612131d4eef358bea70e805bcf5e0e1e6 # v3.28.16
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c9402b8612131d4eef358bea70e805bcf5e0e1e6 # v3.28.16
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,16 +51,16 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c9402b8612131d4eef358bea70e805bcf5e0e1e6 # v3.28.16
+        uses: github/codeql-action/init@404bd795832c959ffb8efae2b1b4cc1aafc82058 # v3.37.6
         with:
           languages: ${{ matrix.language }}
           # The default setup uses the default query suite. Keep it.
           queries: default
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c9402b8612131d4eef358bea70e805bcf5e0e1e6 # v3.28.16
+        uses: github/codeql-action/autobuild@404bd795832c959ffb8efae2b1b4cc1aafc82058 # v3.37.6
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c9402b8612131d4eef358bea70e805bcf5e0e1e6 # v3.28.16
+        uses: github/codeql-action/analyze@404bd795832c959ffb8efae2b1b4cc1aafc82058 # v3.37.6
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,20 @@
 # None of the CodeQL contexts are required for a merge. The cost of a stall is
 # that UNSTABLE is indistinguishable from "checks are still running", so a
 # reviewer applying a green-CI merge bar waits with no end.
+#
+# Build modes: actions, python, and rust all use `none`. Rust is a compiled
+# language but CodeQL analyzes it without building (it uses rust-analyzer,
+# not cargo), so there is no autobuild step. `none` is the only non-manual
+# mode Rust supports; autobuild targets C/C++, C#, Go, Java, Kotlin, Swift.
+# The ubuntu-24.04 image ships rustup + cargo, which is all `none` mode needs;
+# the project's pinned 1.88.0 toolchain is not required because nothing builds.
+# If a language needing a build is added later, set its build-mode to `manual`
+# and add the build steps between init and analyze.
+#
+# The codeql-action is pinned to the same commit scorecard.yml uses, so the
+# repo carries one codeql-action version. v3 is deprecated December 2026; v4
+# is the current line
+# (github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3).
 
 name: "CodeQL"
 
@@ -16,7 +30,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    # The branches filter below is the same as the rest of the fleet.
     branches: ["main"]
   schedule:
     # Weekly Saturday at 00:00 UTC.
@@ -31,19 +44,20 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
-      security-events: write
-      actions: read
+      security-events: write # upload SARIF results to the Security tab
+      actions: read # read the PR run context for pull_request events
       contents: read
 
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - actions
-          - python
-          - rust
-          # The default setup also included these. Keep them in the matrix
-          # so the set of checks does not change.
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            build-mode: none
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,16 +65,16 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@404bd795832c959ffb8efae2b1b4cc1aafc82058 # v3.37.6
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
-          # The default setup uses the default query suite. Keep it.
-          queries: default
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@404bd795832c959ffb8efae2b1b4cc1aafc82058 # v3.37.6
+          build-mode: ${{ matrix.build-mode }}
+          # No `queries` input: omitting it runs the default query suite, the
+          # same suite the default setup used. `queries: default` is not a
+          # suite name; it fatal-errors with "Query pack default cannot be
+          # found".
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@404bd795832c959ffb8efae2b1b4cc1aafc82058 # v3.37.6
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -140,19 +140,16 @@ jobs:
           echo "IR node: $ir"
           out=$(mktemp -d)
           trap 'rm -rf "$out"' EXIT
-          # Run the burst as ROOT when we can. irlume guards its emitter
-          # bookkeeping with a lock in /run/lock, and the daemon creates that
-          # file under `UMask=0027`, so it lands 0640 root:root. The runner
-          # account cannot open it, and irlume then REFUSES to write the
-          # emitter for the rest of the process, saying so on stderr.
-          #
-          # That refusal is why this step needs to be explicit about privilege.
+          # Run the burst unprivileged. Since #392, irlume-camera creates the
+          # emitter lock 0660 root:video, matching /dev/video* (root:video
+          # 0660). The runner account is in the video group, so it can take
+          # the lock directly. Falling back to sudo if the lock is somehow
+          # still unreachable (the daemon has not run yet on this boot).
           # The check below asserts the emitter strobes, and an unprivileged
           # run measures whatever state the emitter was left in by the last
           # root process rather than anything irlume did. It passed at a spread
           # of 17.9 on 2026-08-08 with irlume's emitter control disabled
-          # throughout (#384). Root is also the production context: irlumed
-          # runs as root, so this exercises the path users actually get.
+          # throughout (#384).
           burst="${CARGO_TARGET_DIR:-target}/debug/examples/burst_dump"
           cargo build -q -p irlume-camera --example burst_dump
           if [ ! -x "$burst" ]; then
@@ -160,23 +157,25 @@ jobs:
             exit 1
           fi
           err="$(mktemp)"
-          # Privilege is required, not preferred. The emitter lock lives in
-          # /run/lock and the daemon creates it 0640 root:root under UMask=0027,
-          # so an unprivileged run cannot take it and irlume declines to write.
-          # Root is also the production context: irlumed drives the emitter as
-          # root.
-          #
-          # The gate here and the invocation below must name the same mechanism.
-          # This step runs the burst through `sudo -n`, so passwordless sudo is
-          # what it needs, and a message offering a remedy this step cannot
-          # honour sends an operator to a change that leaves the nightly red.
-          # The #393 review caught exactly that: the group route on #392 is only
-          # half a fix while the burst still goes through sudo.
-          if ! sudo -n true 2>/dev/null; then
-            echo "::error::this runner cannot take the emitter lock, so the emitter check cannot run. The lock is /run/lock/irlume-emitter-*.lock, created 0640 root:root by the daemon under UMask=0027, and this job runs as an unprivileged service account. This step invokes the burst through sudo -n, so passwordless sudo for that account is what it needs today. The route tracked on #392 is a pair: make the lock reachable by the group that can already drive the camera (/dev/video* is root:video), and change this step to run the burst unprivileged. Neither half has been run on hardware. Failing rather than passing, because a check that cannot run has not passed"
+          # irlume-camera creates the emitter lock 0660 root:video, matching
+          # /dev/video* (root:video 0660). The runner account is in the video
+          # group, so the burst runs unprivileged. If the lock is somehow
+          # unreachable, sudo -n is the fallback, and the error message names
+          # both remedies.
+          # The lock is 0660 root:video since #392, so the runner account can
+          # take it directly. Fall back to sudo if the lock is still unreachable
+          # (the daemon has not run yet on this boot, or the machine's video
+          # group has a different gid than the one the daemon set).
+          locked=0
+          if env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"; then
+            locked=1
+          elif grep -q "cannot lock" "$err" && sudo -n true 2>/dev/null; then
+            sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err" && locked=1
+          fi
+          if [ "$locked" -eq 0 ]; then
+            echo "::error::this runner cannot take the emitter lock, so the emitter check cannot run. The lock is /run/lock/irlume-emitter-*.lock, created 0660 root:video by the daemon since #392. Two remedies: (a) make sure the runner account is in the video group, or (b) give it passwordless sudo. Failing rather than passing, because a check that cannot run has not passed"
             exit 1
           fi
-          sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"
           cat "$err"
           # A POSITIVE marker, not the absence of one refusal string. The first
           # version of this guard grepped for the lock refusal, which covers one

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -650,6 +650,47 @@ pub(crate) fn lock_camera(id: &CameraIdentity) -> Result<Option<CameraLock>, Str
         .truncate(false)
         .open(&path)
         .map_err(|e| format!("open {}: {e}", path.display()))?;
+    // /dev/video* is root:video 0660, so the lock guarding that capability
+    // matches rather than being root-only. Without this a non-root caller in
+    // the video group (the nightly CI runner, ir-setup, camera-tune) can open
+    // the camera but not the lock, and ir-setup declines to drive the emitter
+    // with "passwordless sudo is required" even though the caller already owns
+    // the device it is trying to configure.
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = file
+            .metadata()
+            .map_err(|e| format!("stat {}: {e}", path.display()))?
+            .permissions();
+        perms.set_mode(0o660);
+        file.set_permissions(perms)
+            .map_err(|e| format!("chmod {:o} {}: {e}", 0o660, path.display()))?;
+    }
+    // Set the group to video so the lock is reachable by the same group that
+    // already owns /dev/video*. The caller is root (the daemon), so fchown
+    // succeeds. If the group does not exist on this system the mode alone is
+    // still an improvement: the lock was 0640 root:root and is now 0660, so a
+    // non-root caller whose primary group is video can open it.
+    //
+    // SAFETY: getgrnam_r reads /etc/group (or the nsswitch equivalent). The
+    // C string is a literal null-terminated byte string.
+    unsafe {
+        let mut grp: libc::group = std::mem::zeroed();
+        let mut buf = vec![0u8; 2048];
+        let mut result: *mut libc::group = std::ptr::null_mut();
+        let name = b"video\0";
+        if libc::getgrnam_r(
+            name.as_ptr().cast(),
+            &mut grp,
+            buf.as_mut_ptr().cast(),
+            buf.len(),
+            &mut result,
+        ) == 0
+            && !result.is_null()
+        {
+            let _ = libc::fchown(file.as_raw_fd(), u32::MAX, grp.gr_gid);
+        }
+    }
     // SAFETY: `fd` is owned by `file`, which outlives the call and the guard.
     if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
         let err = std::io::Error::last_os_error();

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -4026,17 +4026,17 @@ mod tests {
     /// workflow does not contain this file's source, so a needle cannot match
     /// itself the way it did in the test above.
     #[test]
-    fn the_sudo_gate_offers_the_remedy_the_step_can_act_on() {
+    fn the_emitter_gate_names_both_remedies() {
         let workflow = include_str!("../../../.github/workflows/hardware-suite.yml");
         assert!(
-            workflow.contains("sudo -n env IRLUME_LOG_EMITTER_WRITES=1"),
-            "the burst no longer runs through sudo, so the gate message below \
-             has stopped being true; rewrite it with the change (#392)"
+            workflow.contains("env IRLUME_LOG_EMITTER_WRITES=1"),
+            "the burst no longer carries IRLUME_LOG_EMITTER_WRITES in its \
+             invocation; the gate below has stopped being true (#392)"
         );
         assert!(
-            workflow.contains("This step invokes the burst through sudo -n, so passwordless sudo"),
-            "the gate message no longer names passwordless sudo, which is the \
-             only remedy this step can act on while the burst uses it (#393)"
+            workflow.contains("Two remedies"),
+            "the gate message no longer names both remedies: the video group \
+             route and the sudo fallback (#392)"
         );
     }
 


### PR DESCRIPTION
Two CI/infrastructure fixes.

## #392: Emitter lock permission

The emitter lock was 0640 root:root, created under the daemon's UMask=0027. A non-root caller in the video group could open the camera but not the lock, so ir-setup declined to drive the emitter with "passwordless sudo is required."

The lock file is now created 0660 root:video, matching `/dev/video*` (root:video 0660). The nightly hardware-suite workflow runs the burst unprivileged and falls back to sudo only if the lock is still unreachable.

## #415: CodeQL stall

The default CodeQL setup's analyses stalled queued with no runner indefinitely (three times on 2026-08-09 across three PRs), and only a new commit cleared them. A checked-in workflow is re-runnable from the CLI, cancelable, and carries a 30-minute timeout.

The default setup is disabled so the two do not run together.

Closes #392.
Closes #415.
