### PR TITLE
Hold RGB/IR sessions across grace window retries (#346)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1814,6 +1814,24 @@ impl Engine {
                 }
             }
         }
+        // One IR capture from a HELD session, recovering the stream in place
+        // on a mid-stream fault. Mirrors held_rgb_capture; the same EBUSY
+        // reasoning applies: a standalone reopen would collide with the held
+        // session's own fd on a double-open-rejecting camera.
+        fn held_ir_capture(
+            ir_s: &mut irlume_camera::IrSession<'_>,
+        ) -> irlume_common::Result<(irlume_camera::Frame, irlume_camera::IrCaptureStats)> {
+            match ir_s.capture_with_stats() {
+                Ok(f) => Ok(f),
+                Err(e) => {
+                    irlume_common::dlog!(
+                        "assess: held ir stream broke ({e}); recovering it in place"
+                    );
+                    ir_s.recover()?;
+                    ir_s.capture_with_stats()
+                }
+            }
+        }
         let held_sessions = held.is_some();
         // Every one-shot capture below carries the per-window heartbeat
         // (#336); held sessions already carry theirs from `capture_scans`.
@@ -1827,14 +1845,14 @@ impl Engine {
                     (rgb, rgb_ms, Ok(None), 0)
                 } else {
                     let t = std::time::Instant::now();
-                    let ir = ir_s.capture_with_stats();
+                    let ir = held_ir_capture(ir_s);
                     (rgb, rgb_ms, ir.map(Some), t.elapsed().as_millis())
                 }
             } else {
                 std::thread::scope(|s| {
                     let ir_thread = s.spawn(move || {
                         let t = std::time::Instant::now();
-                        (ir_s.capture_with_stats(), t.elapsed().as_millis())
+                        (held_ir_capture(ir_s), t.elapsed().as_millis())
                     });
                     let t = std::time::Instant::now();
                     let rgb = held_rgb_capture(rgb_s);
@@ -2845,6 +2863,10 @@ impl Engine {
     /// can never leak its gate into a later login, and a credential release can
     /// never be mistaken for a plain verify.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "unwrap on a logically impossible state"
+    )]
     pub fn authenticate_for(
         &mut self,
         user: &str,
@@ -2864,10 +2886,54 @@ impl Engine {
                 self.gesture_seen_before_match = self.early_consent_watch(&enr)?;
             }
         }
+        // Hold the camera sessions across the grace window's retries. Every retry
+        // otherwise re-opens, re-negotiates, re-maps and re-warms both streams
+        // (~700ms of setup per attempt, 58% of a one-shot capture). The enrolment
+        // path already holds sessions for its whole capture loop; the auth path
+        // extends that to the retry loop. The shape matches capture_scans: open
+        // the devices, create sessions from them, fall back to per-capture when
+        // the session path cannot hold them (sequential mode, or a camera that
+        // cannot be opened).
+        let (rgb_dev, ir_dev) = (self.rgb_dev.clone(), self.ir_dev.clone());
+        let cams = if self.ir_available {
+            match (
+                irlume_camera::RgbCamera::open(&rgb_dev),
+                irlume_camera::IrCamera::open(&ir_dev),
+            ) {
+                (Ok(r), Ok(i)) => Some((r, i)),
+                _ => None,
+            }
+        } else {
+            None
+        };
+        let (sequential, _mode_source) = sequential_capture_selected(&rgb_dev, &ir_dev);
+        // Declared in reverse drop order: `held` borrows from `_rs`/`_is` which
+        // borrow from `cams`. Rust drops locals in reverse declaration order, so
+        // `held` drops first (releasing the borrow), then the sessions, then the
+        // cameras.
+        let mut _rs: Option<irlume_camera::RgbSession<'_>> = None;
+        let mut _is: Option<irlume_camera::IrSession<'_>> = None;
+        let mut held: Option<(
+            &mut irlume_camera::RgbSession<'_>,
+            &mut irlume_camera::IrSession<'_>,
+        )> = None;
+        if !sequential {
+            if let Some((r, i)) = &cams {
+                let progress = self.capture_progress();
+                if let (Ok(rs), Ok(is)) = (
+                    r.session_with_progress(&progress),
+                    i.session_with_progress(&progress),
+                ) {
+                    _rs = Some(rs);
+                    _is = Some(is);
+                    held = Some((_rs.as_mut().unwrap(), _is.as_mut().unwrap()));
+                }
+            }
+        }
         let mut attempt = 0u32;
         let out = loop {
             attempt += 1;
-            let out = self.authenticate_once(user, purpose)?;
+            let out = self.authenticate_once(user, purpose, &mut held)?;
             if !presence_retryable(&out) || std::time::Instant::now() >= deadline {
                 if attempt > 1 {
                     irlume_common::dlog!(
@@ -2895,6 +2961,10 @@ impl Engine {
         &mut self,
         user: &str,
         purpose: AuthenticationPurpose,
+        held: &mut Option<(
+            &mut irlume_camera::RgbSession<'_>,
+            &mut irlume_camera::IrSession<'_>,
+        )>,
     ) -> irlume_common::Result<Outcome> {
         // Fingerprint mode: face is disabled so pam_fprintd drives; never engage
         // the camera, decline so the PAM stack cascades to fingerprint/password.
@@ -2923,7 +2993,11 @@ impl Engine {
                 return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
             }
         }
-        let a = self.assess()?;
+        let a = if let Some((ref mut rs, ref mut is)) = held {
+            self.assess_full_with(Some((*rs, *is)), None)?
+        } else {
+            self.assess()?
+        };
 
         // An unreadable frame is reported as unreadable BEFORE anything derived
         // from it is consulted. The eye cue below is computed from the same IR
@@ -3018,6 +3092,7 @@ impl Engine {
                 scans.len()
             );
             if score >= thr {
+                *held = None;
                 return self.challenge_if_required(
                     &enr,
                     purpose,
@@ -3049,6 +3124,7 @@ impl Engine {
                         f.prob, f.grant, a.signals.rgb_face_brightness, a.ir_brightness);
                     if f.grant {
                         let who = if ir_score >= score { ir_who } else { who };
+                        *held = None;
                         return self.challenge_if_required(
                     &enr,
                     purpose, Outcome::grant(f.prob,
@@ -3069,6 +3145,7 @@ impl Engine {
                         self.ir_adapter.is_some()
                     );
                     if ir_score >= ir_thr {
+                        *held = None;
                         return self.challenge_if_required(
                     &enr,
                     purpose, Outcome::grant(ir_score,
@@ -3082,6 +3159,7 @@ impl Engine {
                             + irlume_core::IR_FALLBACK_MARGIN;
                         irlume_common::dlog!("match(ir-centroid): {cs:.3} vs thr {cthr:.3}");
                         if *cs >= cthr {
+                            *held = None;
                             return self.challenge_if_required(
                     &enr,
                     purpose, Outcome::grant(*cs,
@@ -3215,6 +3293,7 @@ impl Engine {
             // calibrated centroid at the base threshold (no best-of-N FAR
             // inflation; the prototype-validated mean-template protocol).
             if score >= ir_thr {
+                *held = None;
                 return self.challenge_if_required(
                     &enr,
                     purpose,
@@ -3225,6 +3304,7 @@ impl Engine {
                 let cthr = irlume_core::scaled_threshold(ir_base, enr.profiles.len());
                 irlume_common::dlog!("match(ir/dark centroid): {cs:.3} vs thr {cthr:.3}");
                 if *cs >= cthr {
+                    *held = None;
                     return self.challenge_if_required(
                         &enr,
                         purpose,
@@ -3235,6 +3315,7 @@ impl Engine {
                     );
                 }
             }
+            *held = None;
             return self.challenge_if_required(
                 &enr,
                 purpose,

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2927,35 +2927,38 @@ impl Engine {
         // the devices, create sessions from them, fall back to per-capture when
         // the session path cannot hold them (sequential mode, or a camera that
         // cannot be opened).
+        //
+        // The cameras are only opened when sessions will be created. Opening them
+        // unconditionally would leave them held in `cams` while the one-shot path
+        // below tries to open the same device again, which is EBUSY on a
+        // single-consumer camera and on any v4l2loopback node with a producer
+        // attached.
         let (rgb_dev, ir_dev) = (self.rgb_dev.clone(), self.ir_dev.clone());
-        let cams = if self.ir_available {
-            match (
-                irlume_camera::RgbCamera::open(&rgb_dev),
-                irlume_camera::IrCamera::open(&ir_dev),
-            ) {
-                (Ok(r), Ok(i)) => Some((r, i)),
-                _ => None,
-            }
-        } else {
-            None
-        };
         let (sequential, _mode_source) = sequential_capture_selected(&rgb_dev, &ir_dev);
         // Declared in reverse drop order: `held` borrows from `_rs`/`_is` which
         // borrow from `cams`. Rust drops locals in reverse declaration order, so
         // `held` drops first (releasing the borrow), then the sessions, then the
         // cameras.
+        let mut _cams: Option<(irlume_camera::RgbCamera, irlume_camera::IrCamera)> = None;
         let mut _rs: Option<irlume_camera::RgbSession<'_>> = None;
         let mut _is: Option<irlume_camera::IrSession<'_>> = None;
         let mut held: Option<(
             &mut irlume_camera::RgbSession<'_>,
             &mut irlume_camera::IrSession<'_>,
         )> = None;
-        if !sequential {
-            if let Some((r, i)) = &cams {
+        if !sequential && self.ir_available {
+            if let (Ok(r), Ok(i)) = (
+                irlume_camera::RgbCamera::open(&rgb_dev),
+                irlume_camera::IrCamera::open(&ir_dev),
+            ) {
+                _cams = Some((r, i));
                 let progress = self.capture_progress();
+                // SAFETY: _cams is Some, and _rs/_is borrow from it. _cams is
+                // declared before _rs/_is so it outlives them.
+                let (ref cam_r, ref cam_i) = _cams.as_ref().unwrap();
                 if let (Ok(rs), Ok(is)) = (
-                    r.session_with_progress(&progress),
-                    i.session_with_progress(&progress),
+                    cam_r.session_with_progress(&progress),
+                    cam_i.session_with_progress(&progress),
                 ) {
                     _rs = Some(rs);
                     _is = Some(is);

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -2875,6 +2875,41 @@ impl Engine {
     ) -> irlume_common::Result<Outcome> {
         let window = grace_window_ms(service);
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(window);
+        // Fingerprint mode: face is disabled so pam_fprintd drives; never engage
+        // the camera, decline so the PAM stack cascades to fingerprint/password.
+        if irlume_core::policy::method().face_disabled() {
+            return Ok(Outcome::deny(
+                OutcomeKind::OtherDeny,
+                "face disabled (fingerprint mode)",
+            ));
+        }
+        // Load the enrollment once per authentication, not once per retry.
+        // Every retry in the loop below was re-reading the profile file and
+        // re-calling template_key::load_key → tpm::unseal. On a discrete TPM
+        // that unseal costs 2.7s quiet and 18.97s contended, and TPM and
+        // camera are independent devices, so it can leave the critical path
+        // entirely. The key is dropped inside load; only the decrypted
+        // Enrollment is held, which is already plaintext in memory during
+        // each authenticate_once today.
+        let Some(enr) = irlume_core::storage::load(user)? else {
+            return Ok(Outcome::deny(
+                OutcomeKind::OtherDeny,
+                format!("'{user}' is not enrolled"),
+            ));
+        };
+        if enr.profiles.iter().all(|p| p.scans.is_empty()) {
+            return Ok(Outcome::deny(
+                OutcomeKind::OtherDeny,
+                format!("'{user}' has no face scans enrolled"),
+            ));
+        }
+        // Anti-swap: refuse if the live camera no longer matches the one this
+        // user enrolled on (only enforced once an enrollment carries a binding).
+        if let Some(bind) = &enr.camera_binding {
+            if let Some(reason) = self.binding_mismatch(bind) {
+                return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
+            }
+        }
         // Watch for the consent gesture BEFORE the first capture, so a user who
         // nods when the greeter asks is not ignored for the seconds it takes to
         // capture and match a face. Once per authentication, never per retry: a
@@ -2882,9 +2917,7 @@ impl Engine {
         // for a gesture already given.
         self.gesture_seen_before_match = false;
         if purpose.demands_gesture() {
-            if let Some(enr) = irlume_core::storage::load(user)? {
-                self.gesture_seen_before_match = self.early_consent_watch(&enr)?;
-            }
+            self.gesture_seen_before_match = self.early_consent_watch(&enr)?;
         }
         // Hold the camera sessions across the grace window's retries. Every retry
         // otherwise re-opens, re-negotiates, re-maps and re-warms both streams
@@ -2933,7 +2966,7 @@ impl Engine {
         let mut attempt = 0u32;
         let out = loop {
             attempt += 1;
-            let out = self.authenticate_once(user, purpose, &mut held)?;
+            let out = self.authenticate_once(&enr, purpose, &mut held)?;
             if !presence_retryable(&out) || std::time::Instant::now() >= deadline {
                 if attempt > 1 {
                     irlume_common::dlog!(
@@ -2959,40 +2992,13 @@ impl Engine {
 
     fn authenticate_once(
         &mut self,
-        user: &str,
+        enr: &irlume_core::storage::Enrollment,
         purpose: AuthenticationPurpose,
         held: &mut Option<(
             &mut irlume_camera::RgbSession<'_>,
             &mut irlume_camera::IrSession<'_>,
         )>,
     ) -> irlume_common::Result<Outcome> {
-        // Fingerprint mode: face is disabled so pam_fprintd drives; never engage
-        // the camera, decline so the PAM stack cascades to fingerprint/password.
-        if irlume_core::policy::method().face_disabled() {
-            return Ok(Outcome::deny(
-                OutcomeKind::OtherDeny,
-                "face disabled (fingerprint mode)",
-            ));
-        }
-        let Some(enr) = irlume_core::storage::load(user)? else {
-            return Ok(Outcome::deny(
-                OutcomeKind::OtherDeny,
-                format!("'{user}' is not enrolled"),
-            ));
-        };
-        if enr.profiles.iter().all(|p| p.scans.is_empty()) {
-            return Ok(Outcome::deny(
-                OutcomeKind::OtherDeny,
-                format!("'{user}' has no face scans enrolled"),
-            ));
-        }
-        // Anti-swap: refuse if the live camera no longer matches the one this
-        // user enrolled on (only enforced once an enrollment carries a binding).
-        if let Some(bind) = &enr.camera_binding {
-            if let Some(reason) = self.binding_mismatch(bind) {
-                return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
-            }
-        }
         let a = if let Some((ref mut rs, ref mut is)) = held {
             self.assess_full_with(Some((*rs, *is)), None)?
         } else {
@@ -3094,7 +3100,7 @@ impl Engine {
             if score >= thr {
                 *held = None;
                 return self.challenge_if_required(
-                    &enr,
+                    enr,
                     purpose,
                     Outcome::grant(score, format!("match: {who} (rgb)")),
                 );
@@ -3110,7 +3116,7 @@ impl Engine {
             // (thresholds AND the fusion Platt calibration are shipped-model
             // measurements), so a marginal RGB miss ends here: password.
             if let Some(ir_probe) = a.ir_embedding.as_ref().filter(|_| self.ir_matching) {
-                let m = self.ir_match(&enr, ir_probe);
+                let m = self.ir_match(enr, ir_probe);
                 if m.n_templates > 0 {
                     let (ir_score, ir_who) = (m.best, m.best_who.clone());
                     // (a) calibrated quality-weighted fusion: the dim/mixed-light path.
@@ -3126,7 +3132,7 @@ impl Engine {
                         let who = if ir_score >= score { ir_who } else { who };
                         *held = None;
                         return self.challenge_if_required(
-                    &enr,
+                    enr,
                     purpose, Outcome::grant(f.prob,
                             format!("match: {who} (rgb+ir fusion p={:.2}; rgb {score:.2}/ir {ir_score:.2})", f.prob)));
                     }
@@ -3147,7 +3153,7 @@ impl Engine {
                     if ir_score >= ir_thr {
                         *held = None;
                         return self.challenge_if_required(
-                    &enr,
+                    enr,
                     purpose, Outcome::grant(ir_score,
                             format!("match: {ir_who} (ir-fallback, dim light; rgb {score:.2}<{thr:.2})")));
                     }
@@ -3161,7 +3167,7 @@ impl Engine {
                         if *cs >= cthr {
                             *held = None;
                             return self.challenge_if_required(
-                    &enr,
+                    enr,
                     purpose, Outcome::grant(*cs,
                                 format!("match: {cwho} (calibrated centroid, dim light; rgb {score:.2}<{thr:.2})")));
                         }
@@ -3193,7 +3199,7 @@ impl Engine {
                      the shipped recognizer",
                 ));
             }
-            let m = self.ir_match(&enr, &probe);
+            let m = self.ir_match(enr, &probe);
             if m.n_templates == 0 {
                 let reason = if enr.ir_scans().is_empty() {
                     "dark, but no IR scans enrolled; re-enroll to enable dark unlock"
@@ -3295,7 +3301,7 @@ impl Engine {
             if score >= ir_thr {
                 *held = None;
                 return self.challenge_if_required(
-                    &enr,
+                    enr,
                     purpose,
                     Outcome::grant(score, format!("match: {who} (ir/dark)")),
                 );
@@ -3306,7 +3312,7 @@ impl Engine {
                 if *cs >= cthr {
                     *held = None;
                     return self.challenge_if_required(
-                        &enr,
+                        enr,
                         purpose,
                         Outcome::grant(
                             *cs,
@@ -3317,7 +3323,7 @@ impl Engine {
             }
             *held = None;
             return self.challenge_if_required(
-                &enr,
+                enr,
                 purpose,
                 Outcome::deny_live(OutcomeKind::BelowThreshold, score, "below threshold (ir)"),
             );

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2283,7 +2283,7 @@ impl IrCamera {
         warm_up_stream(&self.device, &mut stream, progress)?;
         Ok(IrSession {
             cam: self,
-            stream,
+            stream: Some(stream),
             dec: IrDecoder::new(self.pix, self.quantization),
             lit: mode.lit(),
             _mode: mode,
@@ -2295,7 +2295,10 @@ impl IrCamera {
 /// A running IR stream with its emitter lit.
 pub struct IrSession<'a> {
     cam: &'a IrCamera,
-    stream: SafeStream<'a>,
+    /// `None` only transiently inside [`Self::recover`]: the broken stream
+    /// must be DROPPED (STREAMOFF + buffer release) before its replacement
+    /// negotiates, and a plain re-assignment builds the new value first.
+    stream: Option<SafeStream<'a>>,
     dec: IrDecoder,
     lit: bool,
     /// The camera's own per-frame illumination reporting, when it has any.
@@ -2322,13 +2325,20 @@ impl IrSession<'_> {
     /// a blown frame both flattens the liveness cues and blinds the PAD model
     /// (#221).
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "expect on a logically impossible state"
+    )]
     pub fn capture_with_stats(&mut self) -> irlume_common::Result<(Frame, IrCaptureStats)> {
         let device = self.cam.device.as_str();
         let (w, h) = (self.cam.width, self.cam.height);
         let card = &self.cam.card;
         let lit = self.lit;
         let white_level = self.dec.white_level();
-        let stream = &mut self.stream;
+        let stream = self
+            .stream
+            .as_mut()
+            .expect("stream is None only transiently inside recover");
         let dec = &mut self.dec;
         // The emitter may STROBE (pulse), so grab a burst and keep the brightest
         // frame, the lit strobe phase (linhello lesson). Keep every frame so the
@@ -2648,6 +2658,28 @@ impl IrSession<'_> {
                 white_level,
             },
         ))
+    }
+
+    /// Recover a broken stream in place, on the fd this session already holds.
+    ///
+    /// Drops the failed stream (STREAMOFF + buffer release), then opens a fresh
+    /// one on the same device fd. The metadata queue is reopened and the emitter
+    /// control is re-enabled. The decoder is reset to its initial state.
+    /// No new device open, so no EBUSY from a double-open-rejecting camera.
+    #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+    pub fn recover(&mut self) -> irlume_common::Result<()> {
+        self.stream = None; // drop first: STREAMOFF + buffer release
+        self.meta = None; // drop the metadata queue
+        let stream = SafeStream::open(&self.cam.device, &self.cam.dev)?;
+        let meta = ir_metadata::IlluminationLog::open(&self.cam.device);
+        let mode = ir_emitter::enable(self.cam.dev.handle(), &self.cam.card, &self.cam.device);
+        let lit = mode.lit();
+        self.stream = Some(stream);
+        self.meta = meta;
+        self._mode = mode;
+        self.dec = IrDecoder::new(self.cam.pix, self.cam.quantization);
+        self.lit = lit;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Every retry in `authenticate_for` re-opens, re-negotiates, re-maps, and re-warms both camera streams. Measured cost: ~700ms of setup per attempt (58% of a 1912ms one-shot capture vs 797ms held). The enrolment path has held sessions for its capture loop since day one; this extends it to the auth retry loop.

## What changed

**`IrSession::recover()`** ;  mirrors `RgbSession::recover()`. `IrSession.stream` is now `Option<SafeStream>` (matching `RgbSession`) so the old stream can be dropped before the replacement negotiates. The metadata queue and emitter control are also reopened.

**`held_ir_capture`** ;  mirrors `held_rgb_capture` in `assess_full_with`. A held IR stream that breaks mid-capture is recovered in place rather than triggering a standalone reopen that would collide with the held session's own fd.

**`authenticate_for`** ;  opens cameras and creates sessions before the retry loop, matching the pattern in `capture_scans`. Sequential-capture cameras fall back to one-shot, same as enrolment.

**`authenticate_once`** ;  accepts held sessions, uses them for the capture, and drops them before `challenge_if_required` (whose consent/passive-liveness capture opens its own IR stream). A grant is never retried, so dropping here is safe.

Closes #346.

## Also in this PR

**Load enrollment once per authenticate_for** — every retry was calling `storage::load(user)` which unseals the key from the TPM. On a discrete TPM that costs 2.7s quiet, 18.97s contended. The enrollment is now loaded once at the top of `authenticate_for` and passed to `authenticate_once` as `&Enrollment`. The key is dropped inside `load`; only the decrypted `Enrollment` is held, which is already plaintext in memory today.