### PR TITLE
Refuse to classify media-controller video nodes as cameras (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **Media-controller video nodes no longer classify as cameras.** On Intel
+  IPU6/IPU7 laptops the `isys` driver registers up to eight capture nodes per
+  CSI-2 port that all enumerate YUYV from a static table regardless of the
+  attached sensor, so every one of them classified as an RGB camera: scans
+  reported a fleet of phantom cameras and an authentication that selected one
+  failed at STREAMON. Classification now reads `VIDIOC_QUERYCAP` first and
+  refuses nodes whose `device_caps` carry `V4L2_CAP_IO_MC` (the uAPI defines
+  such nodes as MC-centric, where the format list describes the platform's
+  image pipeline, not a camera) or that capture only through the multi-planar
+  API (`ipu3-cio2`, `qcom-camss`, previously ignored by accident of the probe
+  shape). `doctor` names these nodes and the stack behind them instead of
+  listing them as cameras or omitting them. Source audit with the per-driver
+  capability words: `docs/research/2026-08-12-camera-handling-audit.md`
+  (#425).
+
 - **The IR eye-glint cue recorded the sensor's ceiling as the strongest possible
   reading.** `eye_glint` returned the window maximum with no notion of a
   ceiling, so a peak that railed at the negotiated format's white level was

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -578,6 +578,70 @@ pub enum Role {
     Other,
 }
 
+/// A node whose format list is NOT evidence of a camera, so classifying it by
+/// format would be asserting something the kernel never said (#425).
+///
+/// Two shapes, both from `VIDIOC_QUERYCAP`'s `device_caps` word rather than
+/// from the formats:
+///
+/// - `V4L2_CAP_IO_MC`: the uAPI (open.rst) calls such a node MC-centric, and
+///   vidioc-enum-fmt.rst says its format list describes what the IP core can
+///   consume, not what any camera produces. Intel IPU6/IPU7 ISYS nodes
+///   enumerate YUYV from a static table on every node, up to eight per CSI-2
+///   port, so without this gate an IPU6 laptop scans as a fleet of RGB
+///   cameras that all fail at STREAMON with EPIPE.
+/// - Multi-planar without single-planar capture (`ipu3-cio2`, `qcom-camss`):
+///   irlume's single-planar `ENUM_FMT` probe gets EINVAL there and used to
+///   file these under [`Role::Other`] by accident of the probe shape. Naming
+///   them keeps "irlume cannot use this" apart from "nothing to see".
+///
+/// Kept apart from [`Role`] for the same reason [`Unreadable`] is (#227): the
+/// actions differ. `Other` is correctly ignored, `Unreadable` asks the user to
+/// fix access, and this one is working hardware irlume must refuse to touch,
+/// with a message naming the stack. Details and the per-driver capability
+/// words are in `docs/research/2026-08-12-camera-handling-audit.md`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McCentric {
+    /// The driver name from `VIDIOC_QUERYCAP`, e.g. `isys` (Intel IPU6),
+    /// `amd_isp_capture`, `qcom-camss`, `ipu3-cio2`.
+    pub driver: String,
+    /// `V4L2_CAP_IO_MC` was set: input/output is controlled by the media
+    /// controller and the node's format list is not camera evidence.
+    pub io_mc: bool,
+    /// The node captures only through the multi-planar API, which irlume's
+    /// capture path does not speak.
+    pub mplane_only: bool,
+}
+
+impl McCentric {
+    /// The cause without the path, same contract as [`Unreadable::cause`]: a
+    /// caller can state one cause once over several nodes that share it. Pure
+    /// over the struct so the wording is testable without MIPI hardware.
+    pub fn cause(&self) -> String {
+        let stack = if self.io_mc {
+            "behind a media-controller stack; its advertised formats describe \
+             the platform's image pipeline, not a camera"
+        } else {
+            "captures only through the multi-planar V4L2 API, which irlume's \
+             capture path does not use"
+        };
+        format!(
+            "driver '{}', {stack}. irlume needs a UVC camera; the RGB side of \
+             this device may work through libcamera/PipeWire, and its IR side \
+             has no Linux support",
+            self.driver
+        )
+    }
+}
+
+/// What `classify_node` decided about one node: a camera role read from its
+/// formats, or a node whose formats must not be read as a role at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeKind {
+    Camera(Role),
+    McCentric(McCentric),
+}
+
 /// Where reading a node failed. A node that could not be read is kept apart
 /// from `Role::Other` all the way to the report, because the two call for
 /// opposite actions: `Other` is a node correctly ignored, while this is a
@@ -589,6 +653,10 @@ pub enum Role {
 pub enum FailedAt {
     /// `open(2)` on the node itself.
     Open,
+    /// The node opened but `VIDIOC_QUERYCAP` failed, which no V4L2 node is
+    /// permitted to refuse; `/dev/null` reaching this arm with ENOTTY is the
+    /// ordinary non-V4L2 case.
+    QueryCaps,
     /// The node opened, then would not enumerate its formats.
     EnumFormats,
 }
@@ -618,6 +686,7 @@ impl Unreadable {
     pub fn cause(&self) -> String {
         let what = match self.at {
             FailedAt::Open => "could not be opened",
+            FailedAt::QueryCaps => "opened but did not answer VIDIOC_QUERYCAP",
             FailedAt::EnumFormats => "opened but would not list its formats",
         };
         let why = match self.errno {
@@ -655,8 +724,11 @@ impl Unreadable {
 /// keeping a failure to read the node apart from a node that read as neither
 /// kind. Defensive: enumerate FORMATS (safe), never `query_controls` (panics on
 /// some UVC drivers; a hard-won linhello lesson).
+///
+/// `VIDIOC_QUERYCAP` runs first, because on an MC-centric node the format
+/// list is not evidence of anything (#425); see [`McCentric`].
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
-pub fn classify_node(device: &str) -> Result<Role, Unreadable> {
+pub fn classify_node(device: &str) -> Result<NodeKind, Unreadable> {
     let unreadable = |at, e: std::io::Error| Unreadable {
         path: device.to_string(),
         at,
@@ -666,10 +738,83 @@ pub fn classify_node(device: &str) -> Result<Role, Unreadable> {
         holder: None,
     };
     let dev = Device::with_path(device).map_err(|e| unreadable(FailedAt::Open, e))?;
+    let caps = queried_caps(&dev).map_err(|e| unreadable(FailedAt::QueryCaps, e))?;
+    if let Some(mc) = mc_centric_verdict(&caps) {
+        return Ok(NodeKind::McCentric(mc));
+    }
     capture_formats_answered(&dev).map_err(|e| unreadable(FailedAt::EnumFormats, e))?;
     let formats = Capture::enum_formats(&dev).map_err(|e| unreadable(FailedAt::EnumFormats, e))?;
     let fourccs: Vec<[u8; 4]> = formats.iter().map(|f| f.fourcc.repr).collect();
-    Ok(role_from_formats(&fourccs))
+    Ok(NodeKind::Camera(role_from_formats(&fourccs)))
+}
+
+/// `VIDIOC_QUERYCAP`, raw. The pinned v4l crate's `Device::query_caps` cannot
+/// carry this decision: its `Capabilities.capabilities` is filled from the
+/// kernel's `device_caps` word but through `Flags::from_bits_truncate`, and
+/// the crate defines no `IO_MC` bit, so the one flag the gate needs is
+/// silently dropped (v4l 0.14.0, capability.rs:101 and the Flags list at 6-45).
+/// Same direct-ioctl shape as `capture_formats_answered` below.
+fn queried_caps(dev: &Device) -> std::io::Result<v4l::v4l_sys::v4l2_capability> {
+    #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+    let mut caps: v4l::v4l_sys::v4l2_capability = unsafe { std::mem::zeroed() };
+    // SAFETY: `dev` owns the fd for the length of this call, and `caps` is a
+    // correctly sized, zeroed v4l2_capability, which is all VIDIOC_QUERYCAP
+    // writes.
+    let rc = unsafe {
+        libc::ioctl(
+            dev.handle().fd(),
+            v4l::v4l2::vidioc::VIDIOC_QUERYCAP,
+            &mut caps as *mut _ as *mut libc::c_void,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(caps)
+}
+
+/// The `device_caps` word of a QUERYCAP answer, or the whole-device word when
+/// the driver predates the split. `V4L2_CAP_DEVICE_CAPS` has been mandatory
+/// since kernel 3.4, so the fallback arm is for out-of-tree stragglers; using
+/// the wrong word there risks reading a sibling node's capabilities, which for
+/// this gate errs toward refusing, the safe direction.
+fn node_device_caps(caps: &v4l::v4l_sys::v4l2_capability) -> u32 {
+    if caps.capabilities & v4l::v4l_sys::V4L2_CAP_DEVICE_CAPS != 0 {
+        caps.device_caps
+    } else {
+        caps.capabilities
+    }
+}
+
+/// The NUL-terminated driver name from a QUERYCAP answer, lossily.
+fn caps_driver(caps: &v4l::v4l_sys::v4l2_capability) -> String {
+    let end = caps
+        .driver
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(caps.driver.len());
+    String::from_utf8_lossy(&caps.driver[..end]).into_owned()
+}
+
+/// Decide from a QUERYCAP answer whether this node's format list may be read
+/// as a camera role at all. Pure over the struct, so the per-driver capability
+/// words measured in the audit are each pinned by a test without the hardware:
+/// Intel IPU6 ISYS (`V4L2_CAP_IO_MC` on single-planar nodes), AMD ISP4
+/// (IO_MC), Qualcomm camss (IO_MC and MPLANE), ipu3-cio2 (MPLANE only), and
+/// the two UVC node shapes plus v4l2loopback, which must all pass through.
+fn mc_centric_verdict(caps: &v4l::v4l_sys::v4l2_capability) -> Option<McCentric> {
+    let dc = node_device_caps(caps);
+    let io_mc = dc & v4l::v4l_sys::V4L2_CAP_IO_MC != 0;
+    let mplane_only = dc & v4l::v4l_sys::V4L2_CAP_VIDEO_CAPTURE_MPLANE != 0
+        && dc & v4l::v4l_sys::V4L2_CAP_VIDEO_CAPTURE == 0;
+    if !(io_mc || mplane_only) {
+        return None;
+    }
+    Some(McCentric {
+        driver: caps_driver(caps),
+        io_mc,
+        mplane_only,
+    })
 }
 
 /// Whether the node ANSWERED the format enumeration, separate from what it
@@ -720,10 +865,14 @@ fn enum_fmt_failure_means_no_formats(e: &std::io::Error) -> bool {
 }
 
 /// `classify_node` for callers that only act on a node they can use. An
-/// unreadable node answers `Other` here, so anything reporting to a human
-/// wants `classify_node` or `scan_nodes` instead.
+/// unreadable node answers `Other` here, and so does an MC-centric one: both
+/// are nodes a camera-picking caller must not open, so anything reporting to
+/// a human wants `classify_node` or `scan_nodes` instead.
 pub fn classify(device: &str) -> Role {
-    classify_node(device).unwrap_or(Role::Other)
+    match classify_node(device) {
+        Ok(NodeKind::Camera(role)) => role,
+        Ok(NodeKind::McCentric(_)) | Err(_) => Role::Other,
+    }
 }
 
 /// Pure classification over a node's advertised fourccs (unit-testable without
@@ -819,9 +968,28 @@ pub struct NodeScan {
     /// Nodes that answered, excluding `Role::Other`.
     pub classified: Vec<(String, Role)>,
     pub unreadable: Vec<Unreadable>,
+    /// Nodes refused before format enumeration because their format list is
+    /// not camera evidence (#425). Working hardware, deliberately unused;
+    /// reports name these so an IPU6 laptop reads as "MIPI camera irlume
+    /// cannot use", never as a fleet of RGB cameras and never as no camera
+    /// with no explanation.
+    pub mc_centric: Vec<(String, McCentric)>,
     /// Why this scan may be incomplete. An empty scan with this set means the
     /// nodes could not be listed, not that there are none.
     pub listing_error: Option<String>,
+}
+
+/// File one classification outcome into its `NodeScan` bucket. The arms are
+/// the whole point of #425: only `Camera(Rgb|Ir)` may reach `classified`,
+/// because that is the bucket every camera-picking caller consumes. Pure over
+/// the outcome, so the bucketing is testable without a device per arm.
+fn file_node(scan: &mut NodeScan, path: String, outcome: Result<NodeKind, Unreadable>) {
+    match outcome {
+        Ok(NodeKind::Camera(Role::Other)) => {}
+        Ok(NodeKind::Camera(role)) => scan.classified.push((path, role)),
+        Ok(NodeKind::McCentric(mc)) => scan.mc_centric.push((path, mc)),
+        Err(u) => scan.unreadable.push(u),
+    }
 }
 
 /// `with_holders` walks /proc for each busy node to name what holds it. That
@@ -832,16 +1000,13 @@ fn scan(with_holders: bool) -> NodeScan {
     let listing = video_node_paths();
     scan.listing_error = listing.error;
     for path in listing.paths {
-        match classify_node(&path) {
-            Ok(Role::Other) => {}
-            Ok(role) => scan.classified.push((path, role)),
-            Err(mut u) => {
-                if with_holders && u.errno == Some(libc::EBUSY) {
-                    u.holder = camera_holder(&u.path);
-                }
-                scan.unreadable.push(u);
+        let outcome = classify_node(&path).map_err(|mut u| {
+            if with_holders && u.errno == Some(libc::EBUSY) {
+                u.holder = camera_holder(&u.path);
             }
-        }
+            u
+        });
+        file_node(&mut scan, path, outcome);
     }
     scan
 }
@@ -4386,21 +4551,175 @@ mod tests {
     }
 
     /// The branch the Codex round on #229 found unreachable: a node that opens
-    /// and then refuses to enumerate must be reported, not silently classified
+    /// and then refuses to answer must be reported, not silently classified
     /// as `Other` and dropped. `/dev/null` is exactly that node on any Linux
-    /// machine, since `Device::with_path` only opens (no QUERYCAP) and
-    /// VIDIOC_ENUM_FMT on a non-v4l2 character device returns ENOTTY, so this
-    /// needs no camera, no privilege, and no hardware in CI.
+    /// machine; since the #425 gate it fails at the QUERYCAP that now runs
+    /// before format enumeration (ENOTTY on a non-v4l2 character device), so
+    /// this needs no camera, no privilege, and no hardware in CI.
     #[test]
     fn a_node_that_opens_then_refuses_to_enumerate_is_reported_not_dropped() {
         let u = classify_node("/dev/null")
-            .expect_err("a device that cannot enumerate formats must not classify as a role");
-        assert_eq!(u.at, FailedAt::EnumFormats);
+            .expect_err("a device that answers no V4L2 ioctl must not classify as a role");
+        assert_eq!(u.at, FailedAt::QueryCaps);
         assert_eq!(u.errno, Some(libc::ENOTTY));
         assert!(
-            u.explain().contains("would not list its formats"),
+            u.explain().contains("did not answer VIDIOC_QUERYCAP"),
             "{}",
             u.explain()
+        );
+    }
+
+    /// One QUERYCAP answer per driver the audit measured, built from the
+    /// capability words read out of each driver's registration site in the
+    /// kernel source (docs/research/2026-08-12-camera-handling-audit.md,
+    /// taxonomy section). The gate must refuse every MC-centric and
+    /// MPLANE-only shape and pass every shape irlume actually drives.
+    fn caps_answer(driver: &str, device_caps: u32) -> v4l::v4l_sys::v4l2_capability {
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        let mut caps: v4l::v4l_sys::v4l2_capability = unsafe { std::mem::zeroed() };
+        caps.driver[..driver.len()].copy_from_slice(driver.as_bytes());
+        // The kernel ORs DEVICE_CAPS into the whole-device word, never into
+        // device_caps itself (videodev2.h; v4l2-ioctl.c sets it centrally).
+        caps.capabilities = device_caps | v4l::v4l_sys::V4L2_CAP_DEVICE_CAPS;
+        caps.device_caps = device_caps;
+        caps
+    }
+
+    /// The refusal table: Intel IPU6 ISYS (single-planar capture WITH IO_MC,
+    /// the #425 phantom-RGB case), AMD ISP4 (IO_MC), Qualcomm camss (IO_MC
+    /// and MPLANE), ipu3-cio2 (MPLANE only, no IO_MC). Each word is the
+    /// registration site's, quoted in the audit doc.
+    #[test]
+    fn mc_centric_verdict_refuses_every_measured_mipi_shape() {
+        use v4l::v4l_sys::{
+            V4L2_CAP_IO_MC as IO_MC, V4L2_CAP_META_CAPTURE as META, V4L2_CAP_READWRITE as RW,
+            V4L2_CAP_STREAMING as STREAMING, V4L2_CAP_VIDEO_CAPTURE as CAP,
+            V4L2_CAP_VIDEO_CAPTURE_MPLANE as MPLANE,
+        };
+        let ipu6 = mc_centric_verdict(&caps_answer("isys", STREAMING | IO_MC | CAP | META))
+            .expect("an IPU6 ISYS node must refuse format classification");
+        assert!(ipu6.io_mc && !ipu6.mplane_only, "{ipu6:?}");
+        assert_eq!(ipu6.driver, "isys");
+
+        let amd = mc_centric_verdict(&caps_answer("amd_isp_capture", CAP | STREAMING | IO_MC))
+            .expect("an AMD ISP4 node must refuse");
+        assert!(amd.io_mc, "{amd:?}");
+
+        let camss = mc_centric_verdict(&caps_answer("qcom-camss", MPLANE | STREAMING | RW | IO_MC))
+            .expect("a camss node must refuse");
+        assert!(camss.io_mc && camss.mplane_only, "{camss:?}");
+
+        let cio2 = mc_centric_verdict(&caps_answer("ipu3-cio2", MPLANE | STREAMING))
+            .expect("an ipu3-cio2 node must refuse, deliberately rather than by probe shape");
+        assert!(!cio2.io_mc && cio2.mplane_only, "{cio2:?}");
+    }
+
+    /// The pass-through table: both UVC node shapes and v4l2loopback, the
+    /// hardware irlume drives today, must reach format classification exactly
+    /// as before the gate.
+    #[test]
+    fn mc_centric_verdict_passes_every_shape_irlume_drives() {
+        use v4l::v4l_sys::{
+            V4L2_CAP_META_CAPTURE as META, V4L2_CAP_STREAMING as STREAMING,
+            V4L2_CAP_VIDEO_CAPTURE as CAP, V4L2_CAP_VIDEO_OUTPUT as OUT,
+        };
+        for (name, word) in [
+            ("uvcvideo capture", CAP | STREAMING),
+            ("uvcvideo metadata", META | STREAMING),
+            ("v4l2loopback", CAP | OUT | STREAMING),
+        ] {
+            assert_eq!(
+                mc_centric_verdict(&caps_answer("x", word)),
+                None,
+                "{name} must pass through to format classification"
+            );
+        }
+    }
+
+    /// A driver that never learned the device_caps split (pre-3.4 shape) is
+    /// judged on its whole-device word: refusing on a possibly-borrowed word
+    /// is the safe direction for a gate whose cost is one unusable node.
+    #[test]
+    fn a_querycap_without_device_caps_is_judged_on_the_whole_device_word() {
+        use v4l::v4l_sys::{V4L2_CAP_IO_MC, V4L2_CAP_STREAMING, V4L2_CAP_VIDEO_CAPTURE};
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
+        let mut caps: v4l::v4l_sys::v4l2_capability = unsafe { std::mem::zeroed() };
+        caps.capabilities = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING | V4L2_CAP_IO_MC;
+        caps.device_caps = 0; // never filled by such a driver
+        assert!(mc_centric_verdict(&caps).is_some());
+    }
+
+    /// The bucketing arms of `file_node`: only `Camera(Rgb|Ir)` may reach
+    /// `classified`, because that bucket feeds every camera-picking caller;
+    /// an MC-centric outcome lands in its own bucket and nowhere else. This
+    /// pins the scan()-side wiring of #425 without a device per arm.
+    #[test]
+    fn file_node_keeps_mc_centric_nodes_out_of_the_usable_bucket() {
+        let mc = || McCentric {
+            driver: "isys".into(),
+            io_mc: true,
+            mplane_only: false,
+        };
+        let mut scan = NodeScan::default();
+        file_node(
+            &mut scan,
+            "/dev/video0".into(),
+            Ok(NodeKind::Camera(Role::Rgb)),
+        );
+        file_node(
+            &mut scan,
+            "/dev/video1".into(),
+            Ok(NodeKind::Camera(Role::Other)),
+        );
+        file_node(
+            &mut scan,
+            "/dev/video2".into(),
+            Ok(NodeKind::McCentric(mc())),
+        );
+        file_node(
+            &mut scan,
+            "/dev/video3".into(),
+            Err(Unreadable {
+                path: "/dev/video3".into(),
+                at: FailedAt::Open,
+                errno: Some(libc::EACCES),
+                holder: None,
+            }),
+        );
+        assert_eq!(
+            scan.classified,
+            vec![("/dev/video0".to_string(), Role::Rgb)]
+        );
+        assert_eq!(scan.mc_centric.len(), 1);
+        assert_eq!(scan.mc_centric[0].0, "/dev/video2");
+        assert_eq!(scan.unreadable.len(), 1);
+    }
+
+    /// The wording contract of `McCentric::cause`, same as `Unreadable`'s: it
+    /// names the driver and says what the user can and cannot expect, and the
+    /// two refusal shapes get different sentences.
+    #[test]
+    fn mc_centric_cause_names_the_driver_and_the_stack() {
+        let io_mc = McCentric {
+            driver: "isys".into(),
+            io_mc: true,
+            mplane_only: false,
+        };
+        assert!(io_mc.cause().contains("isys"), "{}", io_mc.cause());
+        assert!(
+            io_mc.cause().contains("media-controller"),
+            "{}",
+            io_mc.cause()
+        );
+        let mplane = McCentric {
+            driver: "ipu3-cio2".into(),
+            io_mc: false,
+            mplane_only: true,
+        };
+        assert!(
+            mplane.cause().contains("multi-planar"),
+            "{}",
+            mplane.cause()
         );
     }
 

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -4173,7 +4173,7 @@ fn doctor_run(
             report,
             "  ⚠ {why}; whether this machine has camera nodes is unknown"
         );
-    } else if nodes.is_empty() && scan.unreadable.is_empty() {
+    } else if nodes.is_empty() && scan.unreadable.is_empty() && scan.mc_centric.is_empty() {
         dout!(report, "  (no /dev/video* nodes on this machine)");
     }
     if nodes.is_empty() {
@@ -4236,6 +4236,19 @@ fn doctor_run(
                 );
             }
         }
+    }
+    // MC-centric nodes are working hardware irlume refuses to classify by
+    // format (#425): an Intel IPU6 laptop puts up to eight capture nodes per
+    // CSI-2 port that all enumerate YUYV from a static table, so before this
+    // gate they listed here as a fleet of RGB cameras that fail at capture.
+    // Grouped by cause like the unreadable nodes below: one IPU6 is one fact,
+    // not thirty-two.
+    let mut mc_by_cause: std::collections::BTreeMap<String, Vec<&str>> = Default::default();
+    for (path, mc) in &scan.mc_centric {
+        mc_by_cause.entry(mc.cause()).or_default().push(path);
+    }
+    for (cause, paths) in &mc_by_cause {
+        dout!(report, "  ⚠ {}: {cause}", paths.join(", "));
     }
     // A node irlume could not read is named with its errno, never omitted.
     // Dropping these is what let a permission problem read as absent hardware


### PR DESCRIPTION
Closes #425.

On Intel IPU6/IPU7 laptops the `isys` driver registers up to eight single-planar capture nodes per CSI-2 port, and its ENUM_FMT answers from a static table (YUYV included) regardless of the attached sensor, so `classify_node` called every one of them an RGB camera. Scans reported a fleet of phantom cameras; an authentication that selected one got a state-only S_FMT success and then EPIPE at STREAMON on the unwired media-controller pipeline.

The fix reads `VIDIOC_QUERYCAP` before format enumeration and refuses two shapes the audit measured (`docs/research/2026-08-12-camera-handling-audit.md`, taxonomy section):

- `V4L2_CAP_IO_MC` in `device_caps`: the uAPI defines such nodes as MC-centric, and their format list describes what the platform's image pipeline can consume, not what any camera produces. Covers Intel IPU6/IPU7 (`isys`), AMD ISP4, and Qualcomm camss.
- Multi-planar capture without single-planar: `ipu3-cio2` (Surface) and camss nodes were already invisible, but only by accident of the single-planar probe shape; the refusal is now deliberate and explained.

Design choices:

- The refusal is a new `NodeKind::McCentric` kept apart from `Role`, the same separation `Unreadable` got for #227: the actions differ, and `Role` has no exhaustive matches anywhere, so a new variant would have been inherited silently by every catch-all, including the one in `scan()` that feeds camera-picking callers.
- The raw QUERYCAP helper exists because the pinned v4l 0.14.0 crate cannot carry the decision: its `Capabilities.capabilities` is filled from the kernel's `device_caps` word through `from_bits_truncate`, and the crate defines no IO_MC bit, so the flag the gate needs is silently dropped.
- `classify` collapses the refusal to `Other` (camera-picking callers must not open these nodes either); `scan_nodes` buckets them separately; `doctor` prints them grouped by cause, so one IPU6 reads as one fact, and the existing Intel-IPU warning path now actually fires on those machines because `classified` comes back empty.

Testing:

- Per-driver capability words from the audit, each pinned: IPU6, AMD ISP4, camss, cio2 refuse; both UVC node shapes and v4l2loopback pass through. The pre-device_caps fallback word is pinned refusing.
- The `file_node` bucketing is a pure function with a per-arm test.
- Two call-site mutations run against the committed tree, both killed by the named test written for them (`||`→`&&` in the verdict; MC bucket redirected into `classified`), suite green on the restored tree.
- Real-hardware smoke check with the branch's release binary on this machine's UVC pair: `doctor` classifies video0 Rgb / video2 Ir and negotiates both streams, unchanged.
- `cargo +1.88.0 fmt --check`, `cargo +1.88.0 clippy --all-targets -- -D warnings`, the doc gate, and the guarded workspace suite (1382 tests) are green locally.

Not tested:

- The three-line call site in `classify_node` that invokes the extracted verdict has no hardware-free trigger (no fabricatable node presents IO_MC caps), so a mutant deleting that call would survive; the decision and the bucketing around it are what the tests pin. Recorded in the commit message.
- No IPU6/IPU7/AMD/camss hardware exists in this project, so the refusal path is exercised only through the pinned capability words, not against a live MIPI stack.
- The EnumFormats reporting arm lost its `/dev/null` trigger (QUERYCAP now fails there first); its wording stays covered through `Unreadable::cause`.
