### PR TITLE
Verify the format once buffers are claimed, on every stream open (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **A capture now verifies the device still holds the negotiated format once
+  it claims the buffers.** The V4L2 format is per-device state gated only on
+  buffer ownership, and ownership begins at REQBUFS, so between irlume's
+  open-time S_FMT and a session's buffer claim another application could
+  retarget the device and the capture would decode frames against stale
+  width, height and fourcc assumptions. Every stream open (sessions, their
+  recovery paths, the frozen-stream restarts, probes and emitter setup) now
+  reads G_FMT back after claiming the queue, at which point the format can
+  no longer move, and refuses the capture naming what changed and, when
+  visible, who holds the camera. Source audit:
+  `docs/research/2026-08-12-camera-handling-audit.md`, Q3 (#427).
+
 - **The IR eye-glint cue recorded the sensor's ceiling as the strongest possible
   reading.** `eye_glint` returned the window maximum with no notion of a
   ceiling, so a peak that railed at the negotiated format's white level was

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -330,43 +330,82 @@ pub fn no_progress() -> Progress {
 pub const CAPTURE_SILENT_WINDOW_WORST_MS: u64 =
     STREAM_DEQUEUE_TIMEOUT.as_millis() as u64 + WARMUP_GAP.as_millis() as u64;
 
-/// The stream geometry a caller negotiated at open time, re-checked once
-/// buffers are claimed. Width, height and fourcc are exactly the facts the
-/// decode paths assume from the negotiation; quantization is deliberately
-/// absent because the driver derives it from the format, and a device whose
-/// fourcc and dimensions both held has not renegotiated it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ExpectedFormat {
-    width: u32,
-    height: u32,
-    fourcc: [u8; 4],
-}
-
-/// The expectation carried by the one-shot capture paths, whose negotiated
-/// `Format` is still a local at their open point.
-fn expected_of(fmt: &v4l::Format) -> ExpectedFormat {
-    ExpectedFormat {
-        width: fmt.width,
-        height: fmt.height,
-        fourcc: fmt.fourcc.repr,
-    }
-}
-
 /// Whether the device's current format still matches what open negotiated,
 /// naming the first field that moved. Pure, so the comparison is testable
 /// without a second process to race against (#427).
-fn format_moved(expect: ExpectedFormat, now: &v4l::Format) -> Option<String> {
-    if now.fourcc.repr != expect.fourcc {
+///
+/// EVERY field of the negotiated format is compared, not just the geometry
+/// the decoders read directly. The first version checked width, height and
+/// fourcc and argued quantization was derived from them; the Codex round
+/// refuted that from the kernel spec (a capture application can request
+/// colorimetry conversion where the driver offers
+/// `V4L2_PIX_FMT_FLAG_SET_CSC`), and quantization is authentication-relevant
+/// here: it names the clipping ceiling (235 versus 255 in
+/// `clipping_white_level`), so a racing format change that held the geometry
+/// but flipped the range would either false-clip legitimate frames or, in
+/// the inverse direction, suppress the exposure refusal that protects the
+/// liveness cues. Stride matters the same way: the decoders treat rows as
+/// tightly packed, so a changed `bytesperline` at the same geometry would
+/// decode every row at the wrong offset. Comparing the rest costs nothing
+/// and refuses only when the device state genuinely differs from what this
+/// caller negotiated.
+///
+/// The enum fields compare by their wire discriminant (`as u32`) because the
+/// pinned v4l crate derives no `PartialEq` for them.
+fn format_moved(expect: &v4l::Format, now: &v4l::Format) -> Option<String> {
+    if now.fourcc.repr != expect.fourcc.repr {
         return Some(format!(
             "fourcc is now {}, negotiated {}",
             fourcc_str(&now.fourcc.repr),
-            fourcc_str(&expect.fourcc)
+            fourcc_str(&expect.fourcc.repr)
         ));
     }
     if (now.width, now.height) != (expect.width, expect.height) {
         return Some(format!(
             "size is now {}x{}, negotiated {}x{}",
             now.width, now.height, expect.width, expect.height
+        ));
+    }
+    if now.stride != expect.stride {
+        return Some(format!(
+            "stride is now {}, negotiated {}",
+            now.stride, expect.stride
+        ));
+    }
+    if now.size != expect.size {
+        return Some(format!(
+            "image size is now {}, negotiated {}",
+            now.size, expect.size
+        ));
+    }
+    if now.field_order as u32 != expect.field_order as u32 {
+        return Some(format!(
+            "field order is now {:?}, negotiated {:?}",
+            now.field_order, expect.field_order
+        ));
+    }
+    if now.colorspace as u32 != expect.colorspace as u32 {
+        return Some(format!(
+            "colorspace is now {:?}, negotiated {:?}",
+            now.colorspace, expect.colorspace
+        ));
+    }
+    if now.quantization as u32 != expect.quantization as u32 {
+        return Some(format!(
+            "quantization is now {:?}, negotiated {:?}",
+            now.quantization, expect.quantization
+        ));
+    }
+    if now.transfer as u32 != expect.transfer as u32 {
+        return Some(format!(
+            "transfer function is now {:?}, negotiated {:?}",
+            now.transfer, expect.transfer
+        ));
+    }
+    if now.flags.bits() != expect.flags.bits() {
+        return Some(format!(
+            "format flags are now {:?}, negotiated {:?}",
+            now.flags, expect.flags
         ));
     }
     None
@@ -394,7 +433,7 @@ impl<'a> SafeStream<'a> {
     /// without erroring blocks the caller indefinitely. That matters most
     /// during emitter setup: a stall there would hang with a control changed and
     /// the restore never reached. Every wait now ends.
-    fn open(device: &str, dev: &'a Device, expect: ExpectedFormat) -> irlume_common::Result<Self> {
+    fn open(device: &str, dev: &'a Device, expect: &v4l::Format) -> irlume_common::Result<Self> {
         let mut inner = v4l::io::mmap::Stream::with_buffers(dev, Type::VideoCapture, MMAP_BUFFERS)
             .map_err(|e| map_io(device, e))?;
         inner.set_timeout(STREAM_DEQUEUE_TIMEOUT);
@@ -1402,19 +1441,14 @@ pub struct RgbCamera {
     chosen: [u8; 4],
     width: u32,
     height: u32,
+    /// The whole format the driver echoed at open, kept verbatim so sessions
+    /// can verify the device still holds every field of it when they claim
+    /// buffers (#427); see `format_moved` for why the geometry alone is not
+    /// enough.
+    negotiated: v4l::Format,
 }
 
 impl RgbCamera {
-    /// What this camera's sessions must find the device still holding when
-    /// they claim buffers (#427).
-    fn expected_format(&self) -> ExpectedFormat {
-        ExpectedFormat {
-            width: self.width,
-            height: self.height,
-            fourcc: self.chosen,
-        }
-    }
-
     /// Verify, open and negotiate. Does not start streaming: no buffers are
     /// allocated and the capture LED stays off until a session is opened.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
@@ -1447,6 +1481,7 @@ impl RgbCamera {
             chosen,
             width: fmt.width,
             height: fmt.height,
+            negotiated: fmt,
         })
     }
 
@@ -1478,7 +1513,7 @@ impl RgbCamera {
             id: V4L2_CID_BACKLIGHT_COMPENSATION,
             value: v4l::control::Value::Integer(2),
         });
-        let stream = SafeStream::open(&self.device, &self.dev, self.expected_format())?;
+        let stream = SafeStream::open(&self.device, &self.dev, &self.negotiated)?;
         Ok(RgbSession {
             cam: self,
             stream: Some(stream),
@@ -1695,7 +1730,7 @@ impl<'a> RgbSession<'a> {
         self.stream = Some(SafeStream::open(
             &self.cam.device,
             &self.cam.dev,
-            self.cam.expected_format(),
+            &self.cam.negotiated,
         )?);
         // The fresh stream's auto-exposure starts unsettled, like any new
         // session's.
@@ -2269,10 +2304,11 @@ pub struct IrCamera {
     /// The negotiated fourcc, kept for [`Self::spec`]: `pix` names how the
     /// bytes decode, not which of several fourccs mapped to it.
     fourcc: String,
-    /// The same fourcc as the driver spelled it, kept because `fourcc` above
-    /// trims the padding ("Y8  " becomes "Y8") and the buffer-claim read-back
-    /// (#427) must compare against the exact four bytes.
-    fourcc_repr: [u8; 4],
+    /// The whole format the driver echoed at open, kept verbatim so sessions
+    /// can verify the device still holds every field of it when they claim
+    /// buffers (#427); see `format_moved` for why the geometry alone is not
+    /// enough.
+    negotiated: v4l::Format,
     width: u32,
     height: u32,
     card: String,
@@ -2296,21 +2332,11 @@ impl IrCamera {
             pix,
             quantization: fmt.quantization,
             fourcc: fourcc_str(&fmt.fourcc.repr),
-            fourcc_repr: fmt.fourcc.repr,
+            negotiated: fmt,
             width: fmt.width,
             height: fmt.height,
             card,
         })
-    }
-
-    /// What this camera's sessions must find the device still holding when
-    /// they claim buffers (#427).
-    fn expected_format(&self) -> ExpectedFormat {
-        ExpectedFormat {
-            width: self.width,
-            height: self.height,
-            fourcc: self.fourcc_repr,
-        }
     }
 
     /// The stream this open camera negotiated. See [`negotiated_stream`].
@@ -2356,7 +2382,7 @@ impl IrCamera {
         // restore while the stream was still live, the very mid-stream write
         // this change removes. Assigned further down, once the stream exists.
         let mode;
-        let mut stream = SafeStream::open(&self.device, &self.dev, self.expected_format())?;
+        let mut stream = SafeStream::open(&self.device, &self.dev, &self.negotiated)?;
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
         // 25s when video went first). `SafeStream::open` only allocates
@@ -2777,7 +2803,7 @@ impl IrSession<'_> {
     pub fn recover(&mut self) -> irlume_common::Result<()> {
         self.stream = None; // drop first: STREAMOFF + buffer release
         self.meta = None; // drop the metadata queue
-        let stream = SafeStream::open(&self.cam.device, &self.cam.dev, self.cam.expected_format())?;
+        let stream = SafeStream::open(&self.cam.device, &self.cam.dev, &self.cam.negotiated)?;
         let meta = ir_metadata::IlluminationLog::open(&self.cam.device);
         let mode = ir_emitter::enable(self.cam.dev.handle(), &self.cam.card, &self.cam.device);
         let lit = mode.lit();
@@ -2945,7 +2971,7 @@ pub mod ir_probe {
         // buffers; STREAMON happens on the first dequeue, so the set still
         // lands before streaming starts.
         let mode;
-        let mut stream = super::SafeStream::open(device, &dev, super::expected_of(&fmt))?;
+        let mut stream = super::SafeStream::open(device, &dev, &fmt)?;
         mode = ir_emitter::enable(dev.handle(), &card, device);
         // Bound, never read: held for its `Drop`, which restores the control.
         let _ = &mode;
@@ -3047,7 +3073,7 @@ pub fn capture_ir_streaming<B>(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = SafeStream::open(device, &dev, expected_of(&fmt))?;
+    let mut stream = SafeStream::open(device, &dev, &fmt)?;
     mode = ir_emitter::enable(dev.handle(), &card, device);
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
@@ -3116,7 +3142,7 @@ pub fn capture_ir_streaming<B>(
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = SafeStream::open(device, &dev, expected_of(&fmt))?;
+                stream = SafeStream::open(device, &dev, &fmt)?;
                 mode = ir_emitter::enable(dev.handle(), &card, device);
             }
             continue;
@@ -3188,7 +3214,7 @@ pub fn capture_ir_sequence(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = Some(SafeStream::open(device, &dev, expected_of(&fmt))?);
+    let mut stream = Some(SafeStream::open(device, &dev, &fmt)?);
     mode = ir_emitter::enable(dev.handle(), &card, device);
     // Set once above and not re-applied inside the loop. This path also carried
     // an every-eighth-frame re-fire; it went for the same reason, and with the
@@ -3258,7 +3284,7 @@ pub fn capture_ir_sequence(
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = Some(SafeStream::open(device, &dev, expected_of(&fmt))?);
+                stream = Some(SafeStream::open(device, &dev, &fmt)?);
                 mode = ir_emitter::enable(dev.handle(), &card, device);
             }
             continue;
@@ -4117,7 +4143,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
-    let mut stream = SafeStream::open(device, &dev, expected_of(&fmt))?;
+    let mut stream = SafeStream::open(device, &dev, &fmt)?;
     let fd = dev.handle().fd();
     for _ in 0..4 {
         let _ = stream.next(); // let the sensor settle before baseline
@@ -5247,51 +5273,54 @@ mod tests {
     /// process retargeted between the caller's S_FMT and this handle's
     /// REQBUFS must be named field-by-field, and an unchanged one must pass.
     /// The race itself needs a second process and real queue ownership, so
-    /// the DECISION is what carries the coverage.
+    /// the DECISION is what carries the coverage. Quantization and stride
+    /// are asserted by name: the Codex round on this change showed a
+    /// same-geometry quantization flip moves the clipping ceiling that the
+    /// exposure refusal reads (235 versus 255), and a stride change decodes
+    /// every row at the wrong offset, so those two are the fields a
+    /// geometry-only guard would have waved through.
     #[test]
     fn format_moved_names_the_field_that_moved_and_passes_a_match() {
         use v4l::{Format, FourCC};
-        let expect = ExpectedFormat {
-            width: 640,
-            height: 400,
-            fourcc: *b"GREY",
-        };
-        assert_eq!(
-            format_moved(expect, &Format::new(640, 400, FourCC::new(b"GREY"))),
-            None
-        );
+        let expect = Format::new(640, 400, FourCC::new(b"GREY"));
+        assert_eq!(format_moved(&expect, &expect), None);
 
-        let refourcc = format_moved(expect, &Format::new(640, 400, FourCC::new(b"YUYV")))
+        let refourcc = format_moved(&expect, &Format::new(640, 400, FourCC::new(b"YUYV")))
             .expect("a changed fourcc must refuse");
         assert!(
             refourcc.contains("YUYV") && refourcc.contains("GREY"),
             "{refourcc}"
         );
 
-        let resized = format_moved(expect, &Format::new(1280, 720, FourCC::new(b"GREY")))
+        let resized = format_moved(&expect, &Format::new(1280, 720, FourCC::new(b"GREY")))
             .expect("a changed size must refuse");
         assert!(
             resized.contains("1280x720") && resized.contains("640x400"),
             "{resized}"
         );
 
-        // Both moved: the fourcc names the mismatch, because decoding bytes
-        // as the wrong format is the worse failure of the two.
-        let both = format_moved(expect, &Format::new(1280, 720, FourCC::new(b"YUYV")))
-            .expect("a fully retargeted format must refuse");
-        assert!(both.contains("fourcc"), "{both}");
-    }
+        let mut requantized = expect;
+        requantized.quantization = v4l::format::quantization::Quantization::LimitedRange;
+        if requantized.quantization as u32 == expect.quantization as u32 {
+            requantized.quantization = v4l::format::quantization::Quantization::FullRange;
+        }
+        let msg = format_moved(&expect, &requantized)
+            .expect("a changed quantization must refuse: it moves the clipping ceiling");
+        assert!(msg.contains("quantization"), "{msg}");
 
-    /// `expected_of` must carry exactly the negotiated geometry, because every
-    /// one-shot capture path (probe, streaming, sequence, emitter setup)
-    /// builds its read-back expectation through it.
-    #[test]
-    fn expected_of_carries_the_negotiated_geometry() {
-        use v4l::{Format, FourCC};
-        let fmt = Format::new(640, 400, FourCC::new(b"Y8  "));
-        let e = expected_of(&fmt);
-        assert_eq!((e.width, e.height), (640, 400));
-        assert_eq!(e.fourcc, *b"Y8  ");
+        let mut restrided = expect;
+        restrided.stride = expect.stride + 64;
+        let msg = format_moved(&expect, &restrided)
+            .expect("a changed stride must refuse: rows would decode at wrong offsets");
+        assert!(msg.contains("stride"), "{msg}");
+
+        let mut recolored = expect;
+        recolored.colorspace = v4l::format::colorspace::Colorspace::SRGB;
+        if recolored.colorspace as u32 == expect.colorspace as u32 {
+            recolored.colorspace = v4l::format::colorspace::Colorspace::Rec709;
+        }
+        let msg = format_moved(&expect, &recolored).expect("a changed colorspace must refuse");
+        assert!(msg.contains("colorspace"), "{msg}");
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -330,22 +330,100 @@ pub fn no_progress() -> Progress {
 pub const CAPTURE_SILENT_WINDOW_WORST_MS: u64 =
     STREAM_DEQUEUE_TIMEOUT.as_millis() as u64 + WARMUP_GAP.as_millis() as u64;
 
+/// The stream geometry a caller negotiated at open time, re-checked once
+/// buffers are claimed. Width, height and fourcc are exactly the facts the
+/// decode paths assume from the negotiation; quantization is deliberately
+/// absent because the driver derives it from the format, and a device whose
+/// fourcc and dimensions both held has not renegotiated it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExpectedFormat {
+    width: u32,
+    height: u32,
+    fourcc: [u8; 4],
+}
+
+/// The expectation carried by the one-shot capture paths, whose negotiated
+/// `Format` is still a local at their open point.
+fn expected_of(fmt: &v4l::Format) -> ExpectedFormat {
+    ExpectedFormat {
+        width: fmt.width,
+        height: fmt.height,
+        fourcc: fmt.fourcc.repr,
+    }
+}
+
+/// Whether the device's current format still matches what open negotiated,
+/// naming the first field that moved. Pure, so the comparison is testable
+/// without a second process to race against (#427).
+fn format_moved(expect: ExpectedFormat, now: &v4l::Format) -> Option<String> {
+    if now.fourcc.repr != expect.fourcc {
+        return Some(format!(
+            "fourcc is now {}, negotiated {}",
+            fourcc_str(&now.fourcc.repr),
+            fourcc_str(&expect.fourcc)
+        ));
+    }
+    if (now.width, now.height) != (expect.width, expect.height) {
+        return Some(format!(
+            "size is now {}x{}, negotiated {}x{}",
+            now.width, now.height, expect.width, expect.height
+        ));
+    }
+    None
+}
+
 impl<'a> SafeStream<'a> {
-    /// Open a stream on `dev` with the standard buffer ring.
+    /// Open a stream on `dev` with the standard buffer ring, and verify the
+    /// device still holds the format the caller negotiated.
+    ///
+    /// The verification exists because the negotiated format is per-device
+    /// state, not per-file-handle: uvcvideo writes S_FMT to the shared
+    /// streaming struct gated only on buffer ownership, and ownership begins
+    /// at REQBUFS, not at open (#427; the audit in
+    /// docs/research/2026-08-12-camera-handling-audit.md, Q3). Between the
+    /// caller's S_FMT and the REQBUFS here, any other process can retarget
+    /// the device, and the capture would then decode frames against stale
+    /// width, height and fourcc assumptions. Once `with_buffers` returns,
+    /// this handle owns the queue and S_FMT answers EBUSY to everyone, so a
+    /// G_FMT read taken HERE is stable for the stream's whole life; the same
+    /// window recurs at every reopen (recover, the frozen-stream restarts),
+    /// which is why the check lives in the one function they all call.
     ///
     /// A dequeue timeout is set explicitly. v4l leaves it unset, which polls
     /// with -1 and waits forever, so a camera that stops delivering frames
     /// without erroring blocks the caller indefinitely. That matters most
     /// during emitter setup: a stall there would hang with a control changed and
     /// the restore never reached. Every wait now ends.
-    fn open(device: &str, dev: &'a Device) -> irlume_common::Result<Self> {
+    fn open(device: &str, dev: &'a Device, expect: ExpectedFormat) -> irlume_common::Result<Self> {
         let mut inner = v4l::io::mmap::Stream::with_buffers(dev, Type::VideoCapture, MMAP_BUFFERS)
             .map_err(|e| map_io(device, e))?;
         inner.set_timeout(STREAM_DEQUEUE_TIMEOUT);
-        Ok(Self {
+        // Constructed before the read-back so every error path below releases
+        // the queue through the guarded Drop (STREAMOFF + REQBUFS(0)), never
+        // through the v4l crate's panicking one.
+        let stream = Self {
             inner: Some(inner),
             device: device.to_string(),
-        })
+        };
+        let now = Capture::format(dev).map_err(|e| map_io(device, e))?;
+        if let Some(moved) = format_moved(expect, &now) {
+            // Refusing rather than renegotiating, for the same reason the
+            // emitter stands down under a foreign consumer (#169): a format
+            // that moved means another application is actively configuring
+            // this camera, and fighting it over shared state serves nobody.
+            // The cost is one refused capture, which degrades toward the
+            // password prompt.
+            let who = match camera_holder(device) {
+                Some(h) => format!(", likely {h}"),
+                None => String::new(),
+            };
+            return Err(Error::Hardware(format!(
+                "{device}: the stream format changed between negotiation and \
+                 buffer claim ({moved}). Another application is configuring \
+                 this camera{who}; refusing this capture"
+            )));
+        }
+        Ok(stream)
     }
 }
 
@@ -1327,6 +1405,16 @@ pub struct RgbCamera {
 }
 
 impl RgbCamera {
+    /// What this camera's sessions must find the device still holding when
+    /// they claim buffers (#427).
+    fn expected_format(&self) -> ExpectedFormat {
+        ExpectedFormat {
+            width: self.width,
+            height: self.height,
+            fourcc: self.chosen,
+        }
+    }
+
     /// Verify, open and negotiate. Does not start streaming: no buffers are
     /// allocated and the capture LED stays off until a session is opened.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
@@ -1390,7 +1478,7 @@ impl RgbCamera {
             id: V4L2_CID_BACKLIGHT_COMPENSATION,
             value: v4l::control::Value::Integer(2),
         });
-        let stream = SafeStream::open(&self.device, &self.dev)?;
+        let stream = SafeStream::open(&self.device, &self.dev, self.expected_format())?;
         Ok(RgbSession {
             cam: self,
             stream: Some(stream),
@@ -1604,7 +1692,11 @@ impl<'a> RgbSession<'a> {
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn recover(&mut self) -> irlume_common::Result<()> {
         self.stream = None; // drop first: STREAMOFF + buffer release
-        self.stream = Some(SafeStream::open(&self.cam.device, &self.cam.dev)?);
+        self.stream = Some(SafeStream::open(
+            &self.cam.device,
+            &self.cam.dev,
+            self.cam.expected_format(),
+        )?);
         // The fresh stream's auto-exposure starts unsettled, like any new
         // session's.
         self.warmed = false;
@@ -2177,6 +2269,10 @@ pub struct IrCamera {
     /// The negotiated fourcc, kept for [`Self::spec`]: `pix` names how the
     /// bytes decode, not which of several fourccs mapped to it.
     fourcc: String,
+    /// The same fourcc as the driver spelled it, kept because `fourcc` above
+    /// trims the padding ("Y8  " becomes "Y8") and the buffer-claim read-back
+    /// (#427) must compare against the exact four bytes.
+    fourcc_repr: [u8; 4],
     width: u32,
     height: u32,
     card: String,
@@ -2200,10 +2296,21 @@ impl IrCamera {
             pix,
             quantization: fmt.quantization,
             fourcc: fourcc_str(&fmt.fourcc.repr),
+            fourcc_repr: fmt.fourcc.repr,
             width: fmt.width,
             height: fmt.height,
             card,
         })
+    }
+
+    /// What this camera's sessions must find the device still holding when
+    /// they claim buffers (#427).
+    fn expected_format(&self) -> ExpectedFormat {
+        ExpectedFormat {
+            width: self.width,
+            height: self.height,
+            fourcc: self.fourcc_repr,
+        }
     }
 
     /// The stream this open camera negotiated. See [`negotiated_stream`].
@@ -2249,7 +2356,7 @@ impl IrCamera {
         // restore while the stream was still live, the very mid-stream write
         // this change removes. Assigned further down, once the stream exists.
         let mode;
-        let mut stream = SafeStream::open(&self.device, &self.dev)?;
+        let mut stream = SafeStream::open(&self.device, &self.dev, self.expected_format())?;
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
         // 25s when video went first). `SafeStream::open` only allocates
@@ -2670,7 +2777,7 @@ impl IrSession<'_> {
     pub fn recover(&mut self) -> irlume_common::Result<()> {
         self.stream = None; // drop first: STREAMOFF + buffer release
         self.meta = None; // drop the metadata queue
-        let stream = SafeStream::open(&self.cam.device, &self.cam.dev)?;
+        let stream = SafeStream::open(&self.cam.device, &self.cam.dev, self.cam.expected_format())?;
         let meta = ir_metadata::IlluminationLog::open(&self.cam.device);
         let mode = ir_emitter::enable(self.cam.dev.handle(), &self.cam.card, &self.cam.device);
         let lit = mode.lit();
@@ -2838,7 +2945,7 @@ pub mod ir_probe {
         // buffers; STREAMON happens on the first dequeue, so the set still
         // lands before streaming starts.
         let mode;
-        let mut stream = super::SafeStream::open(device, &dev)?;
+        let mut stream = super::SafeStream::open(device, &dev, super::expected_of(&fmt))?;
         mode = ir_emitter::enable(dev.handle(), &card, device);
         // Bound, never read: held for its `Drop`, which restores the control.
         let _ = &mode;
@@ -2940,7 +3047,7 @@ pub fn capture_ir_streaming<B>(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = SafeStream::open(device, &dev)?;
+    let mut stream = SafeStream::open(device, &dev, expected_of(&fmt))?;
     mode = ir_emitter::enable(dev.handle(), &card, device);
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
@@ -3009,7 +3116,7 @@ pub fn capture_ir_streaming<B>(
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = SafeStream::open(device, &dev)?;
+                stream = SafeStream::open(device, &dev, expected_of(&fmt))?;
                 mode = ir_emitter::enable(dev.handle(), &card, device);
             }
             continue;
@@ -3081,7 +3188,7 @@ pub fn capture_ir_sequence(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = Some(SafeStream::open(device, &dev)?);
+    let mut stream = Some(SafeStream::open(device, &dev, expected_of(&fmt))?);
     mode = ir_emitter::enable(dev.handle(), &card, device);
     // Set once above and not re-applied inside the loop. This path also carried
     // an every-eighth-frame re-fire; it went for the same reason, and with the
@@ -3151,7 +3258,7 @@ pub fn capture_ir_sequence(
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = Some(SafeStream::open(device, &dev)?);
+                stream = Some(SafeStream::open(device, &dev, expected_of(&fmt))?);
                 mode = ir_emitter::enable(dev.handle(), &card, device);
             }
             continue;
@@ -4010,7 +4117,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
-    let mut stream = SafeStream::open(device, &dev)?;
+    let mut stream = SafeStream::open(device, &dev, expected_of(&fmt))?;
     let fd = dev.handle().fd();
     for _ in 0..4 {
         let _ = stream.next(); // let the sensor settle before baseline
@@ -5134,6 +5241,57 @@ mod tests {
     fn fourcc_str_trims_padding() {
         assert_eq!(fourcc_str(b"YUYV"), "YUYV");
         assert_eq!(fourcc_str(b"Y8  "), "Y8");
+    }
+
+    /// The buffer-claim read-back's comparison (#427): a format another
+    /// process retargeted between the caller's S_FMT and this handle's
+    /// REQBUFS must be named field-by-field, and an unchanged one must pass.
+    /// The race itself needs a second process and real queue ownership, so
+    /// the DECISION is what carries the coverage.
+    #[test]
+    fn format_moved_names_the_field_that_moved_and_passes_a_match() {
+        use v4l::{Format, FourCC};
+        let expect = ExpectedFormat {
+            width: 640,
+            height: 400,
+            fourcc: *b"GREY",
+        };
+        assert_eq!(
+            format_moved(expect, &Format::new(640, 400, FourCC::new(b"GREY"))),
+            None
+        );
+
+        let refourcc = format_moved(expect, &Format::new(640, 400, FourCC::new(b"YUYV")))
+            .expect("a changed fourcc must refuse");
+        assert!(
+            refourcc.contains("YUYV") && refourcc.contains("GREY"),
+            "{refourcc}"
+        );
+
+        let resized = format_moved(expect, &Format::new(1280, 720, FourCC::new(b"GREY")))
+            .expect("a changed size must refuse");
+        assert!(
+            resized.contains("1280x720") && resized.contains("640x400"),
+            "{resized}"
+        );
+
+        // Both moved: the fourcc names the mismatch, because decoding bytes
+        // as the wrong format is the worse failure of the two.
+        let both = format_moved(expect, &Format::new(1280, 720, FourCC::new(b"YUYV")))
+            .expect("a fully retargeted format must refuse");
+        assert!(both.contains("fourcc"), "{both}");
+    }
+
+    /// `expected_of` must carry exactly the negotiated geometry, because every
+    /// one-shot capture path (probe, streaming, sequence, emitter setup)
+    /// builds its read-back expectation through it.
+    #[test]
+    fn expected_of_carries_the_negotiated_geometry() {
+        use v4l::{Format, FourCC};
+        let fmt = Format::new(640, 400, FourCC::new(b"Y8  "));
+        let e = expected_of(&fmt);
+        assert_eq!((e.width, e.height), (640, 400));
+        assert_eq!(e.fourcc, *b"Y8  ");
     }
 
     #[test]


### PR DESCRIPTION
Closes #427.

The negotiated format is per-device state, not per-file-handle: uvcvideo writes S_FMT to the shared `uvc_streaming` struct gated only by `vb2_is_busy`, and buffer ownership begins at REQBUFS, never at open (`docs/research/2026-08-12-camera-handling-audit.md`, Q3). So between irlume's open-time negotiation and a session's buffer claim, another process can retarget the device, and the capture would decode frames against stale width, height and fourcc assumptions. The same window recurs at every recovery reopen and both frozen-stream restarts.

`SafeStream::open` now takes the caller's negotiated expectation, reads G_FMT back after `with_buffers` (from which point this handle owns the vb2 queue and S_FMT answers EBUSY to everyone, so the reading is stable for the stream's life), and refuses on mismatch, naming the field that moved and the holding process when the scan can see one. Refusing rather than renegotiating follows the emitter's foreign-consumer stand-down: a moved format means another application is mid-configuration, and the stand-down costs one capture degraded toward the password prompt.

Design choices:

- The expectation travels in `SafeStream::open`'s signature, so all ten open sites (both sessions, both recover paths, both frozen-stream restarts, the raw probe, streaming and sequence captures, emitter setup) are covered by one check, and a future call site cannot compile without stating what it expects.
- The struct is constructed before the read-back so every error path releases the queue through the guarded Drop rather than the v4l crate's panicking one.
- `IrCamera` gains the exact four-byte fourcc next to its trimmed display string, because `"Y8  "` must compare as the driver spelled it.

Testing:

- `format_moved` is pure and tested per field (match passes; fourcc, size, and both-moved each refuse with the values named); `expected_of` pinned.
- Two mutations against the committed tree (equality flip on the fourcc check; size check disabled), both killed by the named test, suite green on the restored tree.
- The CI loopback lane exercises the matching path end-to-end on every session open it makes.
- Real-hardware smoke with this branch's release binary: a dev capture on the machine's UVC RGB camera opened a session through the new read-back and delivered a 640x480 frame, no refusal.
- `cargo +1.88.0 fmt --check`, `cargo +1.88.0 clippy --all-targets -- -D warnings`, the doc gate, and the guarded workspace suite (1379 tests) green locally.

Not tested:

- The mismatch arm has never fired against a real racing process; producing one needs a second process timed into a microsecond window, and whether v4l2loopback even permits a capture-side S_FMT while another handle sits between S_FMT and REQBUFS is unmeasured (noted in the audit), so no loopback race test is included rather than an unverified one.
- A mutant deleting the whole read-back inside `SafeStream::open` would survive the hardware-free suite; the decision function is the tested surface, and the loopback lane covers the wiring's matching path only.
