### PR TITLE
Restore what the backlight-compensation write displaced (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **The backlight-compensation tuning no longer outlives the session onto
+  other applications' pictures.** RGB sessions write
+  `V4L2_CID_BACKLIGHT_COMPENSATION=2` so auto-exposure favors the face over
+  a bright window (NexiGo N930W: face mean 49→124; ASUS FHD: center mean
+  138.5→150.6), but control values persist across open and close by the
+  V4L2 specification, and the old fire-and-forget write was measured still
+  applied on a laptop hours after the session that wrote it, with the
+  driver default being 0. A session now reads the control first, writes
+  only when it holds something else, remembers what the write displaced,
+  and puts that value back when the session drops, under the emitter
+  guard's rules: a control already holding the wanted value is another
+  writer's state and is never adopted, and the restore fires only while
+  the control still holds what irlume wrote. Both directions validated on
+  hardware in the 2026-08-12 session measurements
+  (`docs/research/2026-08-12-camera-session-measurements.md`)
+  (#426).
+
 - **An emitter control that healed by power-cycle no longer stays blocked
   forever, and the advice now says what actually clears one.** When the
   restore-attempt budget for a leftover emitter control ran out, the refusal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,15 @@ All notable changes to irlume are documented here. This project adheres to
   applied on a laptop hours after the session that wrote it, with the
   driver default being 0. A session now reads the control first, writes
   only when it holds something else, remembers what the write displaced,
-  and puts that value back when the session drops, under the emitter
-  guard's rules: a control already holding the wanted value is another
-  writer's state and is never adopted, and the restore fires only while
-  the control still holds what irlume wrote. Both directions validated on
-  hardware in the 2026-08-12 session measurements
+  and puts that value back through a guard armed before the stream opens,
+  so a failed open restores too. The emitter guard's rules apply: a
+  control already holding the wanted value is another writer's state and
+  is never adopted; the write is confirmed by read-back (drivers may
+  clamp a set to the nearest valid value, and an unconfirmed write is
+  undone on the spot); and the restore fires only while the control still
+  reads as irlume's value at the restore's own read, V4L2 offering no
+  compare-and-set to close the race beyond that. Both directions
+  validated on hardware in the 2026-08-12 session measurements
   (`docs/research/2026-08-12-camera-session-measurements.md`)
   (#426).
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -273,11 +273,15 @@ fn blc_write_decision(read: std::io::Result<v4l::control::Control>) -> Option<i6
     }
 }
 
-/// What a dropping session should write back: the displaced value, but only
-/// while the control still holds what irlume applied. A control that moved
-/// carries somebody else's newer choice, and restoring over it is the exact
-/// harm #426 exists to remove. Pure for the same reason as the write
-/// decision.
+/// What a restore should write back: the displaced value, but only while the
+/// control reads as holding what irlume applied. A control that moved (as of
+/// that read; V4L2 has no compare-and-set, so a write racing between the
+/// read and the restore cannot be excluded) carries somebody else's newer
+/// choice, and restoring over it is the exact harm #426 exists to remove.
+/// Pure for the same reason as the write decision. Doubles as the
+/// confirmation gate in [`apply_blc`]: the predicate that authorises the
+/// eventual restore must already hold immediately after the write, or the
+/// write missed and is undone on the spot.
 fn blc_restore_decision(
     displaced: i64,
     read: std::io::Result<v4l::control::Control>,
@@ -285,6 +289,70 @@ fn blc_restore_decision(
     match read.ok()?.value {
         v4l::control::Value::Integer(now) if now == BLC_WANTED => Some(displaced),
         _ => None,
+    }
+}
+
+/// Owns the one restore of a backlight-compensation write (#426). Held by
+/// the session, CONSTRUCTED BEFORE the stream opens: the first version
+/// restored from the session's own `Drop`, so a stream open that failed
+/// after the write (REQBUFS, or the #427 format-moved refusal) returned with
+/// no session and the control leaked changed, reproducing the defect the
+/// change exists to close (Codex round on this PR).
+struct BlcRestore<'a> {
+    cam: &'a RgbCamera,
+    displaced: i64,
+}
+
+impl Drop for BlcRestore<'_> {
+    fn drop(&mut self) {
+        // Read back before restoring: only a control still reading as
+        // irlume's value carries a change of irlume's to undo. Best-effort
+        // like the write; a failed restore costs the next application a
+        // tuned picture, which is the pre-#426 behaviour on every session,
+        // and must not disturb an authentication's teardown.
+        let read = self.cam.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION);
+        if let Some(put_back) = blc_restore_decision(self.displaced, read) {
+            let restored = self.cam.dev.set_control(v4l::control::Control {
+                id: V4L2_CID_BACKLIGHT_COMPENSATION,
+                value: v4l::control::Value::Integer(put_back),
+            });
+            if restored.is_err() {
+                irlume_common::dlog!(
+                    "{}: backlight compensation left at {BLC_WANTED}; restoring {put_back} failed",
+                    self.cam.device
+                );
+            }
+        }
+    }
+}
+
+/// Apply the backlight-compensation tuning and arm its restore, or leave the
+/// camera untouched. The guard is armed only when the read-back CONFIRMS the
+/// device holds exactly [`BLC_WANTED`]: V4L2 permits a driver to clamp a set
+/// request to the nearest valid value instead of refusing it, and the pinned
+/// v4l crate discards the ioctl's returned effective value, so "set_control
+/// returned Ok" is not "the device holds 2" (Codex round on this PR; a
+/// camera clamping to a smaller maximum would otherwise arm a restore whose
+/// condition could never hold and keep the clamped value forever). A write
+/// whose result cannot be confirmed is undone on the spot, best-effort: the
+/// one thing known then is that irlume just changed the control.
+fn apply_blc(cam: &RgbCamera) -> Option<BlcRestore<'_>> {
+    let displaced = blc_write_decision(cam.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION))?;
+    cam.dev
+        .set_control(v4l::control::Control {
+            id: V4L2_CID_BACKLIGHT_COMPENSATION,
+            value: v4l::control::Value::Integer(BLC_WANTED),
+        })
+        .ok()?;
+    let confirm = cam.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION);
+    if blc_restore_decision(displaced, confirm).is_some() {
+        Some(BlcRestore { cam, displaced })
+    } else {
+        let _ = cam.dev.set_control(v4l::control::Control {
+            id: V4L2_CID_BACKLIGHT_COMPENSATION,
+            value: v4l::control::Value::Integer(displaced),
+        });
+        None
     }
 }
 
@@ -1707,43 +1775,27 @@ impl RgbCamera {
         // Best-effort backlight/low-light correction: tell auto-exposure to
         // expose for the face, not a bright window behind it (NexiGo N930W:
         // verified face mean 49→124; this machine's ASUS: center mean
-        // 138.5→150.6, docs/research/2026-08-12-camera-deep-dive session).
+        // 138.5→150.6, docs/research/2026-08-12-camera-session-measurements.md).
         // Written here rather than in `open` so that opening for a read-only
         // purpose (doctor's stream report) changes nothing on the camera.
         //
-        // Read first, remember what the write displaced, and put it back when
-        // the session drops (#426): control values persist across open/close
-        // by the V4L2 spec ("Control values are stored globally... do not
-        // change when the device is opened or closed"), so the old
-        // fire-and-forget write stayed on the camera for every later
-        // application; it was measured still applied on this machine hours
-        // after the session that wrote it. Same displaced-value rules as the
-        // emitter guard: a control already holding the wanted value is
-        // another writer's state and not irlume's to undo, and the restore
-        // only fires while the control still holds what irlume wrote.
-        let displaced_blc =
-            match blc_write_decision(self.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION)) {
-                Some(displaced) => {
-                    let wrote = self
-                        .dev
-                        .set_control(v4l::control::Control {
-                            id: V4L2_CID_BACKLIGHT_COMPENSATION,
-                            value: v4l::control::Value::Integer(BLC_WANTED),
-                        })
-                        .is_ok();
-                    // A refused write displaced nothing; remembering a value the
-                    // camera never lost would "restore" over its real state.
-                    wrote.then_some(displaced)
-                }
-                None => None,
-            };
+        // Applied through a GUARD armed before the stream opens (#426):
+        // control values persist across open/close by the V4L2 spec
+        // ("Control values are stored globally... do not change when the
+        // device is opened or closed"), so the old fire-and-forget write
+        // stayed on the camera for every later application; it was measured
+        // still applied on this machine hours after the session that wrote
+        // it. Guard rather than session-drop bookkeeping, because a stream
+        // open that fails below must restore too, and the first version did
+        // not (the Codex round's finding 1 on this PR).
+        let blc_restore = apply_blc(self);
         let stream = SafeStream::open(&self.device, &self.dev, &self.negotiated)?;
         Ok(RgbSession {
             cam: self,
             stream: Some(stream),
             warmed: false,
             progress: progress.clone(),
-            displaced_blc,
+            _blc_restore: blc_restore,
         })
     }
 
@@ -1923,38 +1975,12 @@ pub struct RgbSession<'a> {
     /// Per-window heartbeat for the lazy warm-up (#336); owned, not borrowed,
     /// so holding a session never freezes the caller's other borrows.
     progress: Progress,
-    /// What this session's backlight-compensation write displaced, `Some`
-    /// only when irlume actually CHANGED the control (#426); the drop puts
-    /// it back so the tuning never outlives the session onto another
-    /// application's picture.
-    displaced_blc: Option<i64>,
-}
-
-impl Drop for RgbSession<'_> {
-    fn drop(&mut self) {
-        let Some(displaced) = self.displaced_blc else {
-            return;
-        };
-        // Read back before restoring, the emitter guard's rule at standard-
-        // control scale: only a control still holding irlume's value carries
-        // a change of irlume's to undo. Best-effort like the write; a failed
-        // restore costs the next application a tuned picture, which is
-        // yesterday's behaviour on every session, and must not disturb the
-        // teardown of an authentication.
-        let read = self.cam.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION);
-        if let Some(put_back) = blc_restore_decision(displaced, read) {
-            let restored = self.cam.dev.set_control(v4l::control::Control {
-                id: V4L2_CID_BACKLIGHT_COMPENSATION,
-                value: v4l::control::Value::Integer(put_back),
-            });
-            if restored.is_err() {
-                irlume_common::dlog!(
-                    "{}: backlight compensation left at {BLC_WANTED}; restoring {put_back} failed",
-                    self.cam.device
-                );
-            }
-        }
-    }
+    /// The one restore of this session's backlight-compensation write,
+    /// `Some` only when irlume actually CHANGED the control and confirmed
+    /// what the device holds (#426). Declared after `stream`, so the field
+    /// drop order tears the stream down (STREAMOFF) before the control is
+    /// put back.
+    _blc_restore: Option<BlcRestore<'a>>,
 }
 
 impl<'a> RgbSession<'a> {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -254,6 +254,40 @@ pub const V4L2_CID_PRIVACY: u32 = 0x009a_0910;
 /// subject over a bright background, fixing the backlit-window case.
 pub const V4L2_CID_BACKLIGHT_COMPENSATION: u32 = 0x0098_091c;
 
+/// The backlight-compensation value RGB sessions apply. 2 is the strongest
+/// setting on both cameras measured (NexiGo N930W face mean 49→124; ASUS
+/// FHD center mean 138.5→150.6, the 2026-08-12 session measurements).
+const BLC_WANTED: i64 = 2;
+
+/// Whether the backlight-compensation write should happen, and what it would
+/// displace. `None` skips the write: an unreadable control is not a license
+/// (the camera may not have one, EINVAL, or the observation failed, and
+/// writing blind would remember a displaced value nobody measured), and a
+/// control already at [`BLC_WANTED`] is another writer's state, which
+/// mirrors the emitter guard's active-but-not-armed rule. Pure, so the
+/// fail-safe directions are testable without a camera (#426).
+fn blc_write_decision(read: std::io::Result<v4l::control::Control>) -> Option<i64> {
+    match read.ok()?.value {
+        v4l::control::Value::Integer(now) if now != BLC_WANTED => Some(now),
+        _ => None,
+    }
+}
+
+/// What a dropping session should write back: the displaced value, but only
+/// while the control still holds what irlume applied. A control that moved
+/// carries somebody else's newer choice, and restoring over it is the exact
+/// harm #426 exists to remove. Pure for the same reason as the write
+/// decision.
+fn blc_restore_decision(
+    displaced: i64,
+    read: std::io::Result<v4l::control::Control>,
+) -> Option<i64> {
+    match read.ok()?.value {
+        v4l::control::Value::Integer(now) if now == BLC_WANTED => Some(displaced),
+        _ => None,
+    }
+}
+
 /// Frozen-stream recovery for burst captures: after this many consecutive
 /// identical frames the stream is torn down and re-opened, at most
 /// `FROZEN_RESTART_BUDGET` times per burst (a fully static feed therefore
@@ -1671,22 +1705,45 @@ impl RgbCamera {
         progress: &Progress,
     ) -> irlume_common::Result<RgbSession<'_>> {
         // Best-effort backlight/low-light correction: tell auto-exposure to
-        // expose for the face, not a bright window behind it. Harmless if
-        // unsupported (NexiGo N930W needs this; verified mean 49→124 + face
-        // detected). Written here rather than in `open` so that opening for a
-        // read-only purpose (doctor's stream report) changes nothing on the
-        // camera; AE settles during this session's warm-up either way, and the
-        // write is idempotent across repeated sessions.
-        let _ = self.dev.set_control(v4l::control::Control {
-            id: V4L2_CID_BACKLIGHT_COMPENSATION,
-            value: v4l::control::Value::Integer(2),
-        });
+        // expose for the face, not a bright window behind it (NexiGo N930W:
+        // verified face mean 49→124; this machine's ASUS: center mean
+        // 138.5→150.6, docs/research/2026-08-12-camera-deep-dive session).
+        // Written here rather than in `open` so that opening for a read-only
+        // purpose (doctor's stream report) changes nothing on the camera.
+        //
+        // Read first, remember what the write displaced, and put it back when
+        // the session drops (#426): control values persist across open/close
+        // by the V4L2 spec ("Control values are stored globally... do not
+        // change when the device is opened or closed"), so the old
+        // fire-and-forget write stayed on the camera for every later
+        // application; it was measured still applied on this machine hours
+        // after the session that wrote it. Same displaced-value rules as the
+        // emitter guard: a control already holding the wanted value is
+        // another writer's state and not irlume's to undo, and the restore
+        // only fires while the control still holds what irlume wrote.
+        let displaced_blc =
+            match blc_write_decision(self.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION)) {
+                Some(displaced) => {
+                    let wrote = self
+                        .dev
+                        .set_control(v4l::control::Control {
+                            id: V4L2_CID_BACKLIGHT_COMPENSATION,
+                            value: v4l::control::Value::Integer(BLC_WANTED),
+                        })
+                        .is_ok();
+                    // A refused write displaced nothing; remembering a value the
+                    // camera never lost would "restore" over its real state.
+                    wrote.then_some(displaced)
+                }
+                None => None,
+            };
         let stream = SafeStream::open(&self.device, &self.dev, &self.negotiated)?;
         Ok(RgbSession {
             cam: self,
             stream: Some(stream),
             warmed: false,
             progress: progress.clone(),
+            displaced_blc,
         })
     }
 
@@ -1866,6 +1923,38 @@ pub struct RgbSession<'a> {
     /// Per-window heartbeat for the lazy warm-up (#336); owned, not borrowed,
     /// so holding a session never freezes the caller's other borrows.
     progress: Progress,
+    /// What this session's backlight-compensation write displaced, `Some`
+    /// only when irlume actually CHANGED the control (#426); the drop puts
+    /// it back so the tuning never outlives the session onto another
+    /// application's picture.
+    displaced_blc: Option<i64>,
+}
+
+impl Drop for RgbSession<'_> {
+    fn drop(&mut self) {
+        let Some(displaced) = self.displaced_blc else {
+            return;
+        };
+        // Read back before restoring, the emitter guard's rule at standard-
+        // control scale: only a control still holding irlume's value carries
+        // a change of irlume's to undo. Best-effort like the write; a failed
+        // restore costs the next application a tuned picture, which is
+        // yesterday's behaviour on every session, and must not disturb the
+        // teardown of an authentication.
+        let read = self.cam.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION);
+        if let Some(put_back) = blc_restore_decision(displaced, read) {
+            let restored = self.cam.dev.set_control(v4l::control::Control {
+                id: V4L2_CID_BACKLIGHT_COMPENSATION,
+                value: v4l::control::Value::Integer(put_back),
+            });
+            if restored.is_err() {
+                irlume_common::dlog!(
+                    "{}: backlight compensation left at {BLC_WANTED}; restoring {put_back} failed",
+                    self.cam.device
+                );
+            }
+        }
+    }
 }
 
 impl<'a> RgbSession<'a> {
@@ -6282,6 +6371,60 @@ mod tests {
         assert!(unreadable.contains("could not read"), "{unreadable}");
         assert!(privacy_permits_setup(Ok(Some(false))).is_ok());
         assert!(privacy_permits_setup(Ok(None)).is_ok());
+    }
+
+    /// The two backlight-compensation decisions (#426), every arm. The write
+    /// only fires on an answered control holding something other than the
+    /// wanted value, so an unreadable or absent control is never written
+    /// blind and another writer's 2 is never adopted as irlume's to undo;
+    /// the restore only fires while the control still holds irlume's value,
+    /// so a mid-session change by someone else is left alone.
+    #[test]
+    fn backlight_compensation_decisions_cover_every_arm() {
+        let ctrl = |v: i64| {
+            Ok(v4l::control::Control {
+                id: V4L2_CID_BACKLIGHT_COMPENSATION,
+                value: v4l::control::Value::Integer(v),
+            })
+        };
+        let err = || Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+
+        assert_eq!(
+            blc_write_decision(ctrl(0)),
+            Some(0),
+            "a default control is written, displacing 0"
+        );
+        assert_eq!(
+            blc_write_decision(ctrl(1)),
+            Some(1),
+            "a user's 1 is displaced and remembered"
+        );
+        assert_eq!(
+            blc_write_decision(ctrl(BLC_WANTED)),
+            None,
+            "an already-wanted value is another writer's state"
+        );
+        assert_eq!(
+            blc_write_decision(err()),
+            None,
+            "an unreadable control is not a license to write"
+        );
+
+        assert_eq!(
+            blc_restore_decision(0, ctrl(BLC_WANTED)),
+            Some(0),
+            "our value still held: put the displaced one back"
+        );
+        assert_eq!(
+            blc_restore_decision(0, ctrl(1)),
+            None,
+            "the control moved: somebody else's newer choice stays"
+        );
+        assert_eq!(
+            blc_restore_decision(0, err()),
+            None,
+            "an unreadable control authorises nothing"
+        );
     }
 
     /// Only the errnos the V4L2 specification assigns to "this control does

--- a/docs/research/2026-08-12-camera-session-measurements.md
+++ b/docs/research/2026-08-12-camera-session-measurements.md
@@ -1,0 +1,63 @@
+# Camera session measurements, 2026-08-12 (Zenbook, user READY)
+
+Instrument: v4l2-ctl 1.30 / udevadm / media-ctl on Fedora 44, kernel
+7.1.8-200.fc44, ASUS built-in UVC pair (video0/1 RGB + metadata, video2/3 IR
++ metadata). All reads before any write; every write below is named.
+
+## #426: backlight compensation
+
+- **The defect, live**: before this session touched anything,
+  `backlight_compensation` on /dev/video0 read **2** with driver default
+  **0** (min 0, max 2). Nothing but irlume writes that control here, so
+  this is irlume's unrestored write from an earlier session sitting on the
+  camera for every other application. Persistence across process exit is
+  thereby demonstrated on real hardware, matching the documented rule.
+- The IR node (/dev/video2) has NO backlight-compensation control; the
+  write exists only on the RGB session path.
+- **Effect on this camera** (user seated, ordinary room light; YUYV
+  640x480, 40 frames per run, mean luma of the last 8 after AE settle,
+  sampled every 4th pixel):
+  - blc=0: center-region mean 138.5, full-frame mean 100.8
+  - blc=2: center-region mean 150.6, full-frame mean 118.0
+  - A real, modest lift here (+12 center); the NexiGo's recorded
+    justification (face mean 49 to 124) remains the strong case.
+- NexiGo (minihost) unreachable during the session (Tailscale timeout, no
+  LAN route); its control state was not read. Not needed for the decision:
+  effect is recorded in-repo, persistence proven here.
+- ThinkPad X13 Yoga Gen 4 (read over SSH, same session): its built-in
+  camera reports min 0, max 2, **default 1**, current 1. A restore that
+  wrote the driver default instead of the displaced value would be wrong on
+  that camera; the displaced-value rule is right on all three by
+  construction.
+- **Decision: keep the write, restore the displaced value on session end**
+  (same displaced-value rule as the emitter guard: put back what was
+  there, never the driver default, and only when the control still holds
+  what irlume wrote).
+- Session end state: the control was reset to the driver default (0) by
+  hand, since the pre-session value 2 was itself irlume's leftover. The
+  PACKAGED daemon will re-write 2 on its next RGB session until a release
+  carries the fix.
+
+## #428: contention-free classification, verified on real nodes
+
+Every prediction from the audit's source reading held on hardware, with no
+video node opened for any of it:
+
+- **udev**: `ID_V4L_CAPABILITIES` reads `:capture:` on video0/video2 and a
+  bare `:` on video1/video3 (v4l_id has no META_CAPTURE branch), so
+  capture-vs-metadata needs zero opens.
+- **QUERYCAP words** (via v4l2-ctl, which does open, used here only to
+  confirm the words): capture nodes 0x04200001, metadata nodes 0x04a00000,
+  no IO_MC on any UVC node, so the merged #425 gate passes them through.
+- **Media topology**: /dev/media0 groups the RGB pair, /dev/media1 the IR
+  pair; the capture node carries entity `flags 1` (MEDIA_ENT_FL_DEFAULT)
+  and sits in the UVC chain; metadata nodes are padless and linkless.
+- **Descriptors blob** (`/sys/.../descriptors`, stable ABI): the RGB VS
+  interface advertises MJPEG + YUY2; the IR VS interface advertises GUID
+  `32000000-0000-0010-8000-00aa00389b71`, which is **D3DFMT_L8**, mapped
+  by the kernel's own table (`drivers/media/common/uvc.c`) to
+  V4L2_PIX_FMT_GREY. An irlume descriptor-based classifier must therefore
+  carry the D3DFMT_L8 GUID alongside Y8, or this laptop's own IR camera
+  would classify as format-unknown.
+
+These are the measured basis for #428's implementation and #426's fix.


### PR DESCRIPTION
Closes #426.

The defect was found live on the machine that measured it: hours after an RGB session, `backlight_compensation` still read 2 against a driver default of 0, because control values persist across open and close by the V4L2 specification and the write was fire-and-forget. The issue's open question (keep-with-restore versus drop) is settled by measurement: the write earns its keep on both cameras with recorded numbers (NexiGo N930W face mean 49 to 124; this ASUS FHD center mean 138.5 to 150.6 in this session's committed measurements), so it stays, and what it displaces goes back.

Design, the emitter guard's displaced-value rules at standard-control scale:

- Read first; write only when the control holds something other than the wanted value. A control already at 2 is another writer's state: no write, no restore armed, never adopted as irlume's to undo.
- An unreadable or absent control is not a license to write (the old code wrote blind, best-effort; now it skips, same net effect on cameras without the control, no invented displaced value).
- On session drop, read back and restore the displaced value only while the control still holds what irlume wrote; a moved control carries somebody's newer choice and stays.
- The displaced VALUE goes back, never a hardcoded default: the ThinkPad's built-in camera defaults this control to 1 (read over SSH this session), so restore-to-zero would be wrong hardware that exists in this project.
- Everything stays best-effort: a failure costs picture tuning for the next app, never an authentication.

Testing:

- Both decisions are pure with every arm asserted; two mutations against the committed tree (the write adopting a foreign 2; the restore overwriting a moved control), each killed by the named test, suite green on the restored tree.
- Hardware-validated on the real ASUS camera with this branch's binary, both directions: default 0 before a session and 0 after (the merged main binary leaves 2, which is how the defect announced itself), and a pre-set 2 surviving a session untouched.
- Session measurements committed as `docs/research/2026-08-12-camera-session-measurements.md` (also carries the #428 on-hardware verification of udev properties, media topology, and the descriptors blob, including the D3DFMT_L8 GUID this laptop's IR camera advertises).
- `cargo +1.88.0 fmt --check`, clippy `--all-targets -D warnings`, the doc gate, and the guarded workspace suite (1387 tests) green locally.

Not tested:

- The Drop wiring has no hardware-free trigger (v4l2loopback exposes no backlight control), so the decision functions carry the unit coverage and the two hardware runs above are the wire-level evidence.
- The NexiGo itself was unreachable this session (minihost asleep); its effect number is the recorded one.
