### PR TITLE
Keep the clipping-ceiling comments true after #427 (#385)

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -213,10 +213,14 @@ pub struct IrCaptureStats {
     /// correction the second draft of this comment needed.
     /// `Quantization::Default` is not itself an effective range: V4L2 resolves
     /// it with `V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb_or_hsv, colsp, ycbcr_enc)`,
-    /// which needs the COLORSPACE, and `IrCamera` keeps only the quantization
-    /// out of the negotiated `Format`. A `Default` YUV stream therefore cannot
-    /// be told apart from a JPEG-colorspace one, and answering 235 for all of
-    /// them is wrong for the second while 255 is wrong for the first.
+    /// which needs the COLORSPACE. Since #427 `IrCamera` retains the whole
+    /// negotiated `Format`, colorspace included, so the resolution has
+    /// become COMPUTABLE; a third draft of this comment must not claim
+    /// otherwise. What has not changed is that nobody has computed and
+    /// validated it: a `Default` YUV stream resolves limited unless the
+    /// colorspace is JPEG, 235 is wrong for the JPEG case and 255 for the
+    /// rest, and no NV12 or YUYV IR camera exists in this project's record
+    /// to validate either arm against.
     ///
     /// The `None` is also load-bearing, which matters more than either.
     /// `role_from_formats` calls any node advertising either fourcc

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -209,18 +209,20 @@ pub struct IrCaptureStats {
     /// irlume does: `IrCamera::open` stores `fmt.quantization` and
     /// `clipping_white_level` already takes it.
     ///
-    /// Carrying it is still not enough to compute their ceiling, which is the
-    /// correction the second draft of this comment needed.
-    /// `Quantization::Default` is not itself an effective range: V4L2 resolves
-    /// it with `V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb_or_hsv, colsp, ycbcr_enc)`,
-    /// which needs the COLORSPACE. Since #427 `IrCamera` retains the whole
-    /// negotiated `Format`, colorspace included, so the resolution has
-    /// become COMPUTABLE; a third draft of this comment must not claim
-    /// otherwise. What has not changed is that nobody has computed and
-    /// validated it: a `Default` YUV stream resolves limited unless the
-    /// colorspace is JPEG, 235 is wrong for the JPEG case and 255 for the
-    /// rest, and no NV12 or YUYV IR camera exists in this project's record
-    /// to validate either arm against.
+    /// Carrying it is still not enough to compute their ceiling, and each
+    /// draft of this comment has mislocated why, which is itself the lesson:
+    /// `Quantization::Default` is not an effective range, V4L2 resolves it
+    /// with `V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb_or_hsv, colsp, ycbcr_enc)`.
+    /// Since #427 `IrCamera` retains the negotiated `v4l::Format` with its
+    /// colorspace, but the pinned v4l 0.14 `Format` drops the driver-echoed
+    /// Y'CbCr ENCODING on conversion, and the encoding is a live input:
+    /// default YUV is full range for JPEG colorspace AND for XV601/XV709
+    /// encodings, limited otherwise (the Codex round on this PR caught the
+    /// second draft classifying every non-JPEG case as limited, a
+    /// 235-ceiling that would falsely refuse legitimate frames). The
+    /// resolution is therefore still not generally computable here, and no
+    /// NV12 or YUYV IR camera exists in this project's record to validate
+    /// either arm against.
     ///
     /// The `None` is also load-bearing, which matters more than either.
     /// `role_from_formats` calls any node advertising either fourcc

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -128,9 +128,10 @@ pub struct Signals {
     /// path, or a negotiated format the camera crate declines to give a ceiling
     /// for (the Y16 family is rescaled per frame, so its 255 is the frame's own
     /// maximum; NV12 and YUYV are declined so that a colour stream placed in
-    /// the IR slot is refused rather than judged, and because resolving their
-    /// `Default` quantization needs a colorspace irlume does not retain, see
-    /// `clipping_white_level` and #385). `None` is NOT zero clipping.
+    /// the IR slot is refused rather than judged; resolving their `Default`
+    /// quantization needs the colorspace, which irlume retains since #427,
+    /// but the refusal is the load-bearing part, see `clipping_white_level`
+    /// and #385). `None` is NOT zero clipping.
     ///
     /// GATED since #237, at [`IR_SATURATED_FRAC_MAX`]. Saturation compresses
     /// [`ir_center_edge_ratio`] toward 1 the way an ambient pedestal does,

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -129,9 +129,10 @@ pub struct Signals {
     /// for (the Y16 family is rescaled per frame, so its 255 is the frame's own
     /// maximum; NV12 and YUYV are declined so that a colour stream placed in
     /// the IR slot is refused rather than judged; resolving their `Default`
-    /// quantization needs the colorspace, which irlume retains since #427,
-    /// but the refusal is the load-bearing part, see `clipping_white_level`
-    /// and #385). `None` is NOT zero clipping.
+    /// quantization needs the colorspace AND the Y'CbCr encoding, and the
+    /// pinned v4l crate drops the encoding, so it stays uncomputable; the
+    /// refusal is the load-bearing part either way, see
+    /// `clipping_white_level` and #385). `None` is NOT zero clipping.
     ///
     /// GATED since #237, at [`IR_SATURATED_FRAC_MAX`]. Saturation compresses
     /// [`ir_center_edge_ratio`] toward 1 the way an ambient pedestal does,


### PR DESCRIPTION
Doc-only. The `white_level` explanation and its liveness mirror said the colorspace needed to resolve `Default` quantization "is not retained"; since #427 the camera stores the whole driver-echoed `Format`, so that sentence joined the one it had replaced in being stale. The comments now say the resolution is computable but unvalidated (no NV12/YUYV IR camera exists in this project's record), and that the `None` is load-bearing regardless: it is what makes `exposure_refusal` refuse a colour stream arriving through the role-blind paths, which is the reason #385's item 2 stays unbuilt.

With this, #385's actionable items are complete across sessions: the stale claims are corrected (item 1, twice over now), the GREY arm cites the committed corpora rather than v4l2-ctl (item 3, done earlier), Grey16 keeps answering `None` for its own reason (item 4), and item 2 carries its do-not-build analysis on the issue. Closing the issue with this merge.
