### PR TITLE
Add the Ko-fi channel

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Renders the repo's Sponsor button. Ko-fi is the one channel that exists;
+# adding a platform here is a maintainer decision, not a housekeeping edit.
+ko_fi: archledger

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ useful contribution right now:
 [Issues](https://github.com/archledger/irlume/issues) ·
 [Security](SECURITY.md)
 
+If irlume is useful to you and you feel like it, there is a
+[Ko-fi](https://ko-fi.com/archledger). No obligation; the project stays free
+and GPL either way.
+
 ---
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ useful contribution right now:
 [Issues](https://github.com/archledger/irlume/issues) ·
 [Security](SECURITY.md)
 
-If irlume is useful to you and you feel like it, there is a
-[Ko-fi](https://ko-fi.com/archledger). No obligation; the project stays free
-and GPL either way.
+If irlume is useful to you and you feel like it, there is a Ko-fi. No
+obligation; the project stays free and GPL either way.
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/O3J824YGEK)
 
 ---
 


### PR DESCRIPTION
Adds the maintainer's new Ko-fi page (https://ko-fi.com/archledger) as the project's donation channel, per the standing donations-optional decision: `FUNDING.yml` for the repo's Sponsor button, and one no-obligation line in the README's status section beside the other contribution paths. Docs and repo config only.
