### PR TITLE
readme: the status section names 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ unlock · **fingerprint** → companion factor.
 
 ## Status
 
-**v0.9.0**, working on real hardware across Fedora, Ubuntu and Arch. Self-tested
+**v0.10.0**, working on real hardware across Fedora, Ubuntu and Arch. Self-tested
 against ISO/IEC 30107-3, not lab-certified. Interfaces may shift before 1.0.
 
 Hardware reports from laptops with IR cameras, working or not, are the most


### PR DESCRIPTION
The Status section still said v0.9.0 after the 0.10.0 cut. One line.