### PR TITLE
fix: bind enrollment to its template key and serialize state mutations (#448)

### DIFF
--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -516,6 +516,11 @@ pub fn profile_path(user: &str) -> PathBuf {
 #[derive(Serialize, Deserialize)]
 struct EncEnvelope {
     version: u32,
+    /// Public identifier of the random template key. It is not a password
+    /// verifier: template keys have 256 bits of entropy. This distinguishes a
+    /// mismatched persisted key from damaged GCM data without logging a key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_id: Option<String>,
     /// base64 of `crypto`'s `nonce ‖ ciphertext+tag`.
     enc: String,
 }
@@ -523,7 +528,7 @@ struct EncEnvelope {
 /// Version written into new [`EncEnvelope`]s. Informational only: the load
 /// path detects the encrypted format by the `enc` field and never checks this
 /// number.
-const ENC_ENVELOPE_VERSION: u32 = 2;
+const ENC_ENVELOPE_VERSION: u32 = 3;
 
 /// Serialize an enrollment, encrypting under `key` when one is supplied (TPM
 /// host) or emitting pretty plaintext when not (dev / no-TPM). Pure; tested
@@ -540,6 +545,7 @@ fn serialize_enrollment(e: &Enrollment, key: Option<&[u8]>) -> irlume_common::Re
             let blob = crypto::encrypt(k, &json)?;
             let env = EncEnvelope {
                 version: ENC_ENVELOPE_VERSION,
+                key_id: Some(irlume_common::sha256_hex(k)),
                 enc: STANDARD.encode(blob),
             };
             serde_json::to_vec_pretty(&env)
@@ -564,6 +570,16 @@ fn deserialize_enrollment(data: &[u8], key: Option<&[u8]>) -> irlume_common::Res
                 "enrollment is encrypted but no template key is available".into(),
             )
         })?;
+        if env
+            .key_id
+            .as_deref()
+            .is_some_and(|expected| expected != irlume_common::sha256_hex(key))
+        {
+            return Err(irlume_common::Error::Policy(
+                "template key does not match enrollment; preserve state and try recovery restore"
+                    .into(),
+            ));
+        }
         let blob = STANDARD
             .decode(env.enc.as_bytes())
             .map_err(|e| irlume_common::Error::Protocol(format!("bad enc blob: {e}")))?;
@@ -583,27 +599,26 @@ fn deserialize_enrollment(data: &[u8], key: Option<&[u8]>) -> irlume_common::Res
 /// (plaintext fallback so dev boxes still work).
 fn save_key(user: &str) -> irlume_common::Result<Option<Zeroizing<Vec<u8>>>> {
     if template_key::tpm_available() {
-        Ok(Some(template_key::ensure_key(user)?))
+        Ok(Some(template_key::ensure_key_unlocked(user)?))
     } else {
         Ok(None)
     }
 }
 
+fn persist_enrollment(path: &std::path::Path, bytes: &[u8]) -> irlume_common::Result<()> {
+    irlume_common::write_0600_atomic(path, bytes)
+        .map_err(|error| irlume_common::Error::Io(error.to_string()))
+}
+
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn save(e: &Enrollment) -> irlume_common::Result<()> {
+    let _state = template_key::UserStateLock::acquire(&e.user)?;
     let dir = state_dir();
     fs::create_dir_all(&dir).map_err(|er| irlume_common::Error::Io(er.to_string()))?;
     let path = profile_path(&e.user);
     let key = save_key(&e.user)?;
     let bytes = serialize_enrollment(e, key.as_ref().map(|k| k.as_slice()))?;
-    // Atomic + never world-readable: 0600 temp file in the same dir, then
-    // rename over the target: a crash mid-write can't leave a truncated
-    // profile, and there is no umask window on the real path.
-    let tmp = path.with_extension("json.tmp");
-    irlume_common::write_0600(&tmp, &bytes)
-        .map_err(|er| irlume_common::Error::Io(er.to_string()))?;
-    fs::rename(&tmp, &path).map_err(|er| irlume_common::Error::Io(er.to_string()))?;
-    Ok(())
+    persist_enrollment(&path, &bytes)
 }
 
 /// Load an enrollment, transparently decrypting (v2) and migrating the legacy
@@ -612,6 +627,7 @@ pub fn save(e: &Enrollment) -> irlume_common::Result<()> {
 /// falling back to the password, if the seal can no longer be satisfied).
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
+    let _state = template_key::UserStateLock::acquire(user)?;
     let path = profile_path(user);
     if !path.exists() {
         return Ok(None);
@@ -622,7 +638,7 @@ pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
         .map(|v| v.get("enc").is_some())
         .unwrap_or(false);
     let key = if is_enc {
-        Some(template_key::load_key(user)?)
+        Some(template_key::load_key_unlocked(user)?)
     } else {
         None
     };
@@ -650,6 +666,7 @@ pub fn store_is_encrypted(user: &str) -> Option<bool> {
 
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn delete(user: &str) -> irlume_common::Result<bool> {
+    let _state = template_key::UserStateLock::acquire(user)?;
     let path = profile_path(user);
     let existed = path.exists();
     if existed {
@@ -657,8 +674,8 @@ pub fn delete(user: &str) -> irlume_common::Result<bool> {
     }
     // Deleting all face data also retires the now-orphaned template key and its
     // recovery envelope (a fresh enrollment mints a new key).
-    let _ = template_key::forget_key(user);
-    let _ = template_key::forget_recovery(user);
+    template_key::forget_key_unlocked(user)?;
+    template_key::forget_recovery_unlocked(user)?;
     Ok(existed)
 }
 
@@ -1051,6 +1068,19 @@ mod tests {
     }
 
     #[test]
+    fn encrypted_envelope_binds_itself_to_the_template_key() {
+        let key = crypto::generate_key();
+        let bytes = serialize_enrollment(&sample(), Some(&key)).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["version"], 3);
+        assert_eq!(
+            value["key_id"],
+            irlume_common::sha256_hex(key.as_slice()),
+            "the public key identifier lets load distinguish key divergence from ciphertext damage"
+        );
+    }
+
+    #[test]
     fn plaintext_round_trip_without_key() {
         let e = sample();
         let bytes = serialize_enrollment(&e, None).unwrap();
@@ -1064,7 +1094,12 @@ mod tests {
         let key = crypto::generate_key();
         let bytes = serialize_enrollment(&sample(), Some(&key)).unwrap();
         assert!(deserialize_enrollment(&bytes, None).is_err());
-        assert!(deserialize_enrollment(&bytes, Some(&crypto::generate_key())).is_err());
+        let err = deserialize_enrollment(&bytes, Some(&crypto::generate_key())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("template key does not match enrollment"),
+            "a known key mismatch must be diagnosed before the generic GCM check: {err}"
+        );
     }
 
     fn scan_with_ir(ratio: f32, bright: f32) -> FaceScan {
@@ -1266,6 +1301,27 @@ mod tests {
         let mode = fs::metadata(&p).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "profile files must never be world-readable");
         assert_eq!(fs::read(&p).unwrap(), b"secret bytes");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // A fixed `<user>.json.tmp` pathname lets a stale directory or planted
+    // entry block every future save. The save primitive must use create-new,
+    // call-unique temporary names and publish with one durable rename.
+    #[test]
+    #[cfg(unix)]
+    fn enrollment_publication_ignores_a_stale_fixed_temp_path() {
+        let dir =
+            std::env::temp_dir().join(format!("irlume-core-unique-save-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("alice.json");
+        fs::write(&path, b"old").unwrap();
+        fs::create_dir(path.with_extension("json.tmp")).unwrap();
+
+        persist_enrollment(&path, b"new").unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), b"new");
+        assert!(path.with_extension("json.tmp").is_dir());
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -22,6 +22,10 @@ use crate::recovery::RecoveryEnvelope;
 use crate::tpm;
 use crate::{crypto, envelope::SealedEnvelope};
 use irlume_common::{Error, Result};
+#[cfg(unix)]
+use std::os::fd::AsRawFd as _;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt as _;
 use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
@@ -42,6 +46,73 @@ fn recovery_dir() -> PathBuf {
     std::env::var("IRLUME_RECOVERY_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| irlume_common::state_dir().join("recovery"))
+}
+
+/// Cross-process serialization for one user's enrollment, sealed key, and
+/// recovery envelope. The lock pathname is stable and is never replaced or
+/// removed; every acquisition opens it independently so Linux `flock` also
+/// excludes sibling threads in this process.
+pub(crate) struct UserStateLock(std::fs::File);
+
+impl UserStateLock {
+    pub(crate) fn acquire(user: &str) -> Result<Self> {
+        let dir = key_dir().join(".locks");
+        let dir_existed = dir.try_exists().unwrap_or(false);
+        std::fs::create_dir_all(&dir).map_err(|error| Error::Io(error.to_string()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if !dir_existed {
+                std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+                    .map_err(|error| Error::Io(error.to_string()))?;
+            }
+        }
+        let path = dir.join(format!(
+            "{}.lock",
+            irlume_common::sha256_hex(user.as_bytes())
+        ));
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(false);
+        #[cfg(unix)]
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        let file = options
+            .open(&path)
+            .map_err(|error| Error::Io(format!("open state lock {}: {error}", path.display())))?;
+        if !file
+            .metadata()
+            .map_err(|error| Error::Io(error.to_string()))?
+            .file_type()
+            .is_file()
+        {
+            return Err(Error::Io(format!(
+                "state lock is not a regular file: {}",
+                path.display()
+            )));
+        }
+        #[cfg(unix)]
+        // SAFETY: `file` owns this live descriptor and the returned guard keeps
+        // it open for the whole state transaction.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(Error::Io(format!(
+                "lock state transaction {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            )));
+        }
+        Ok(Self(file))
+    }
+}
+
+impl Drop for UserStateLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        // SAFETY: the guard still owns a valid descriptor throughout Drop.
+        unsafe {
+            libc::flock(self.0.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
 }
 
 pub fn key_path(user: &str) -> PathBuf {
@@ -72,18 +143,34 @@ pub fn has_recovery(user: &str) -> bool {
 /// exists. Used on the write path ([`crate::storage::save`]).
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn ensure_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
+    let _state = UserStateLock::acquire(user)?;
+    ensure_key_unlocked(user)
+}
+
+pub(crate) fn ensure_key_unlocked(user: &str) -> Result<Zeroizing<Vec<u8>>> {
     if has_key(user) {
-        return load_key(user);
+        return load_key_unlocked(user);
     }
     let key = crypto::generate_key();
-    reseal_key(user, &key)?;
-    Ok(key)
+    reseal_key_unlocked(user, &key)?;
+    let persisted = load_key_unlocked(user)?;
+    if persisted.as_slice() != key.as_slice() {
+        return Err(Error::Policy(
+            "new template key failed persisted TPM round-trip; enrollment was not written".into(),
+        ));
+    }
+    Ok(persisted)
 }
 
 /// Unseal the existing template key for `user`. Errors if none is sealed (the
 /// caller must NOT generate one here; that would orphan already-encrypted data).
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn load_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
+    let _state = UserStateLock::acquire(user)?;
+    load_key_unlocked(user)
+}
+
+pub(crate) fn load_key_unlocked(user: &str) -> Result<Zeroizing<Vec<u8>>> {
     let path = key_path(user);
     if !path.exists() {
         return Err(Error::Policy(format!(
@@ -115,6 +202,11 @@ pub fn load_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
 /// Used at first enrollment and by recovery-restore to re-bind after a PCR move.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn reseal_key(user: &str, key: &[u8]) -> Result<()> {
+    let _state = UserStateLock::acquire(user)?;
+    reseal_key_unlocked(user, key)
+}
+
+fn reseal_key_unlocked(user: &str, key: &[u8]) -> Result<()> {
     if key.len() != crypto::KEY_LEN {
         return Err(Error::Policy(format!(
             "template key must be {} bytes",
@@ -133,6 +225,11 @@ pub fn reseal_key(user: &str, key: &[u8]) -> Result<()> {
 /// Idempotent. Does NOT touch the recovery envelope.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn forget_key(user: &str) -> Result<()> {
+    let _state = UserStateLock::acquire(user)?;
+    forget_key_unlocked(user)
+}
+
+pub(crate) fn forget_key_unlocked(user: &str) -> Result<()> {
     let path = key_path(user);
     if path.exists() {
         std::fs::remove_file(&path).map_err(|e| Error::Io(e.to_string()))?;
@@ -146,7 +243,8 @@ pub fn forget_key(user: &str) -> Result<()> {
 /// under `passphrase`. Requires a sealed template key to already exist.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn setup_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
-    let key = load_key(user)?;
+    let _state = UserStateLock::acquire(user)?;
+    let key = load_key_unlocked(user)?;
     let env = crate::recovery::wrap(passphrase, &key)?;
     save_recovery(user, &env)
 }
@@ -156,6 +254,11 @@ pub fn setup_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
 /// clear / disk move). Errors on a wrong passphrase or a missing envelope.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn restore_from_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
+    let _state = UserStateLock::acquire(user)?;
+    restore_from_recovery_unlocked(user, passphrase)
+}
+
+pub(crate) fn restore_from_recovery_unlocked(user: &str, passphrase: &[u8]) -> Result<()> {
     let path = recovery_path(user);
     if !path.exists() {
         return Err(Error::Policy(format!(
@@ -164,12 +267,36 @@ pub fn restore_from_recovery(user: &str, passphrase: &[u8]) -> Result<()> {
     }
     let env = load_recovery(user)?;
     let key = crate::recovery::unwrap(passphrase, &env)?;
-    reseal_key(user, &key)
+    reseal_key_unlocked(user, &key)
 }
 
 /// Erase `user`'s recovery envelope. Idempotent.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn forget_recovery(user: &str) -> Result<()> {
+    let _state = UserStateLock::acquire(user)?;
+    forget_recovery_unlocked(user)
+}
+
+pub(crate) fn forget_recovery_unlocked(user: &str) -> Result<()> {
+    let path = recovery_path(user);
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| Error::Io(e.to_string()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(dead_code, reason = "test helper used by template_key tests")]
+fn forget_key_unlocked_no_lock(user: &str) -> Result<()> {
+    let path = key_path(user);
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| Error::Io(e.to_string()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn forget_recovery_unlocked_no_lock(user: &str) -> Result<()> {
     let path = recovery_path(user);
     if path.exists() {
         std::fs::remove_file(&path).map_err(|e| Error::Io(e.to_string()))?;
@@ -238,6 +365,67 @@ mod tests {
     }
 
     use super::*;
+
+    #[test]
+    fn independent_user_state_locks_serialize_threads() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let _env = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = PathBuf::from(crate::test_tmp_dir("template-state-lock"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", &dir);
+
+        let first = UserStateLock::acquire("alice").unwrap();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            let _second = UserStateLock::acquire("alice").unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        assert!(
+            acquired_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err(),
+            "a second independent open must block on the same stable lock inode"
+        );
+        drop(first);
+        acquired_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("waiter must acquire after the first guard drops");
+        waiter.join().unwrap();
+
+        std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The lock directory must exist with owner-only permissions when we
+    /// create it; if it already existed we leave its mode alone.
+    #[test]
+    fn state_lock_directory_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = PathBuf::from(crate::test_tmp_dir("template-state-lock-mode"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", &dir);
+
+        let _guard = UserStateLock::acquire("alice").unwrap();
+        let lock_dir = dir.join(".locks");
+        let mode = std::fs::metadata(&lock_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "lock directory must be owner-only");
+
+        drop(_guard);
+        std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // The override env vars are process-global; the crate-wide lock stops
     // cross-module races too (keyring tests mutate their own override).
     use crate::testenv::ENV_LOCK;
@@ -275,7 +463,7 @@ mod tests {
         let loaded = load_recovery("rt").unwrap();
         let got = crate::recovery::unwrap(b"pass-phrase-here", &loaded).unwrap();
         assert_eq!(&*got, &*key);
-        forget_recovery("rt").unwrap();
+        forget_recovery_unlocked_no_lock("rt").unwrap();
         assert!(!has_recovery("rt"));
         std::env::remove_var("IRLUME_RECOVERY_DIR");
     }
@@ -357,7 +545,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&rec);
         std::env::set_var("IRLUME_RECOVERY_DIR", &rec);
 
-        let err = restore_from_recovery("nobody", b"whatever").unwrap_err();
+        let err = restore_from_recovery_unlocked("nobody", b"whatever").unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("no recovery passphrase set"), "got: {msg}");
 
@@ -376,7 +564,7 @@ mod tests {
         std::env::set_var("IRLUME_RECOVERY_DIR", &rec);
 
         std::fs::write(recovery_path("rt"), b"{ not valid json ").unwrap();
-        let err = restore_from_recovery("rt", b"x").unwrap_err();
+        let err = restore_from_recovery_unlocked("rt", b"x").unwrap_err();
         assert!(matches!(err, Error::Protocol(_)), "got {err:?}");
 
         std::env::remove_var("IRLUME_RECOVERY_DIR");


### PR DESCRIPTION
## Problem

Issue #448: on fresh Arch/Hyprland installs, `irlume status` reports
`policy: decryption failed (wrong key or tampered data)` immediately after
enrollment, even though the TPM key unseals and templates show as encrypted.

## Root cause

The AES-GCM error is reached only after a template key unseals successfully.
A conforming TPM 2.0 preserves the sealed sensitive bytes through
Create→Load→Unseal (verified against TCG spec v1.85 and 200+ real-TPM
round-trips on four devices). The failure therefore means the persisted
enrollment ciphertext and the unsealed template key diverged, or the
authenticated ciphertext changed — but v0.10.0 had no way to tell the two
apart, and two writers could mint different keys without any serialisation.

## Fix

- **key_id diagnostic** — EncEnvelope v3 embeds SHA-256(key); a mismatched
  key is now reported as "template key does not match enrollment; preserve
  state and try recovery restore" instead of the ambiguous GCM error.
- **Per-user state lock** — `UserStateLock` (flock on a stable hashed inode)
  held by save/load/delete and all template-key/recovery operations.
- **Seal round-trip verification** — a freshly sealed key is immediately
  re-loaded and byte-compared before any enrollment is encrypted with it.
- **Atomic publication** — unique temp file (O_CREAT|O_EXCL) + durable rename,
  replacing the stale fixed `<user>.json.tmp` path.
- **Backwards compatible** — v2 envelopes (no key_id) still load; the
  comparison is skipped when key_id is absent.

## Validation

Four devices (Fedora 44, Arch, CachyOS, Ubuntu 26.04), all on the pinned
`archledger/rust-tss-esapi@irlume-patches` fork:

| Check | Result |
|---|---|
| `cargo test -p irlume-core --lib` | 124/124 on all four |
| `cargo test --workspace` | pass |
| `cargo clippy --all-targets -- -D warnings` | clean |
| real-TPM literal-PCR roundtrip ×50 | pass on all four |
| template-key + recovery lifecycle | pass on all four |
| stress: 200× roundtrip, 100× lifecycle, 50× lock | pass |

Live enrollment on a Brio 4K host created a clean Tier-2 encrypted
enrollment (1 profile, 10 scans) with no decryption error.

Closes #448