### PR TITLE
camera: document NexiGo 930d evidence and harden readiness tests

### DIFF
--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -120,12 +120,12 @@ fn known_control(vid: u16, pid: u16) -> Option<EmitterControl> {
         }),
         // NexiGo HelloCam N930W; MS-XU is unit 4.
         //
-        // The product NAME is ambiguous and the identity here is not. NexiGo
-        // also sells a 60fps N930W with no IR sensor and no Hello support,
-        // which enumerates as 3443:930d and is known to the kernel through an
-        // unrelated audio quirk. Only c803 is the HelloCam this payload was
-        // validated against, so do not "correct" this entry to the other id on
-        // the strength of a matching model number (#341 survey).
+        // The product name is ambiguous, and a USB identity still does not
+        // establish payload compatibility. A prior survey classified 3443:930d
+        // as RGB-only, while #449 reports that ID with an IR stream and Windows
+        // Hello. Only c803 is the hardware this payload was validated against,
+        // so do not add 930d without its descriptor and on-device write,
+        // read-back, optical-output, and restoration evidence.
         (0x3443, 0xc803) => Some(EmitterControl {
             unit: 4,
             selector: crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
@@ -7624,11 +7624,11 @@ mod tests {
             crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION
         );
 
-        // The SAME model name, a different product. NexiGo sells a 60fps N930W
-        // with no IR sensor that enumerates as 3443:930d. It must get nothing,
-        // because the payload above was validated against the HelloCam and a
-        // model-number match is not an identity match. This is the assertion
-        // that fails if someone reconciles the table to the other id (#341).
+        // The same model name and a different, unvalidated USB identity. #449
+        // reports 3443:930d with an IR stream, contradicting the earlier
+        // RGB-only survey, but provides no descriptor or write contract. It
+        // must remain fail-closed until that exact hardware validates the
+        // control coordinates, payload, optical effect, and restoration.
         assert_eq!(known_control(0x3443, 0x930d), None);
 
         // A different camera gets nothing, however it names itself. The old

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -58,10 +58,13 @@ wide as those measurements.
 
 ### Buying an external camera: what the model name does not tell you
 
-**The NexiGo N930W name covers two different products.** The one measured above
-is the HelloCam, `3443:c803`, which carries an IR sensor. NexiGo also sells a
-60fps N930W with no IR sensor and no Hello support, enumerating as `3443:930d`.
-Check the USB id with `lsusb`, not the box.
+**The NexiGo N930W name does not identify one camera design.** The HelloCam
+measured by this project is `3443:c803` and carries an IR sensor. A prior survey
+identified `3443:930d` as an RGB-only 60fps N930W, but #449 reports another
+`3443:930d` unit that exposes a 640x360 GREY IR stream and works with Windows
+Hello. Do not infer the sensor or emitter capability from the box or USB ID
+alone. Check the nodes with `irlume doctor`, and inspect an unrecognised emitter
+with `sudo irlume ir-setup --dry-run` before allowing any write.
 
 More generally, a camera advertised as "Windows Hello compatible" is not
 evidence of anything irlume can use. Microsoft's own implementation guide

--- a/scripts/hardware/emitter-stream-record-hardware-test.sh
+++ b/scripts/hardware/emitter-stream-record-hardware-test.sh
@@ -35,6 +35,7 @@ RGB="${3:-/dev/video0}"
 B="$TREE/target/release/irlume"
 D="$TREE/target/release/irlumed"
 XU_SET="$TREE/target/release/examples/xu_set"
+READY_WAIT="$TREE/scripts/hardware/wait-camera-ready.sh"
 OUT=/tmp/emitter-stream-record-hw
 SOCK=/run/irlume-srtest.sock
 STATE=/var/lib/irlume-srtest
@@ -76,6 +77,12 @@ skip() {
     echo "  cargo build --release -p irlume-camera --example xu_set"
     exit 2
 }
+[ -r "$READY_WAIT" ] || {
+    echo "refusing: readiness helper missing: $READY_WAIT"
+    exit 2
+}
+# shellcheck source=wait-camera-ready.sh
+source "$READY_WAIT"
 [ -e "$IR" ] || {
     echo "refusing: $IR does not exist"
     exit 2
@@ -121,16 +128,23 @@ start_daemon() {
         ${ORT:+ORT_DYLIB_PATH="$ORT"} \
         "$D" >"$OUT/daemon-$tag.log" 2>&1 &
     daemon_pid=$!
-    for _ in $(seq 1 1800); do
-        [ -S "$SOCK" ] && return 0
-        kill -0 "$daemon_pid" 2>/dev/null || {
-            echo "  the daemon exited during startup:"
-            tail -4 "$OUT/daemon-$tag.log" | sed 's/^/    /'
-            return 1
-        }
-        sleep 0.1
-    done
-    echo "  the daemon never listened; last lines:"
+    # v0.10 binds and serves the socket before model loading finishes so early
+    # login attempts can fail open to a password instead of finding no daemon.
+    # A socket (or even the accept-loop log line) therefore does not mean the
+    # engine has been published yet. Poll the same read-only camera-bearing
+    # request section 0 needs; success proves the request reached the engine,
+    # while the startup response remains a retry rather than becoming a false
+    # "no Microsoft XU" verdict (#449).
+    if wait_for_camera_ready "$SOCK" "$B" "$daemon_pid"; then
+        return 0
+    else
+        ready_status=$?
+    fi
+    if [ "$ready_status" -eq 2 ]; then
+        echo "  the daemon exited during startup:"
+    else
+        echo "  the daemon never became camera-ready; last lines:"
+    fi
     tail -4 "$OUT/daemon-$tag.log" | sed 's/^/    /'
     return 1
 }

--- a/scripts/hardware/wait-camera-ready-test.sh
+++ b/scripts/hardware/wait-camera-ready-test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=wait-camera-ready.sh
+source "$here/wait-camera-ready.sh"
+
+dir=$(mktemp -d)
+socket="$dir/daemon.sock"
+counter="$dir/calls"
+server_pid=""
+cleanup() {
+    [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+    rm -rf "$dir"
+}
+trap cleanup EXIT
+
+printf '0\n' >"$counter"
+cat >"$dir/fake-irlume" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${IRLUME_READY_TEST_COUNTER:?}"
+count=$(<"$IRLUME_READY_TEST_COUNTER")
+count=$((count + 1))
+printf '%s\n' "$count" >"$IRLUME_READY_TEST_COUNTER"
+if [ "${IRLUME_READY_TEST_NEVER:-0}" = 1 ]; then
+    exit 1
+fi
+# Model loading: the early socket accepts requests, but the first two
+# camera-bearing calls still receive the daemon's "starting" failure.
+[ "$count" -ge 3 ]
+FAKE
+chmod +x "$dir/fake-irlume"
+
+python3 - "$socket" <<'PY' &
+import socket
+import sys
+import time
+
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(sys.argv[1])
+server.listen(1)
+time.sleep(30)
+PY
+server_pid=$!
+for _ in $(seq 1 100); do
+    [ -S "$socket" ] && break
+    sleep 0.01
+done
+[ -S "$socket" ] || {
+    printf '%s\n' 'fake daemon did not create its socket'
+    exit 1
+}
+
+IRLUME_READY_TEST_COUNTER="$counter" \
+    wait_for_camera_ready "$socket" "$dir/fake-irlume" "$server_pid" 10 0.01
+calls=$(<"$counter")
+[ "$calls" -eq 3 ] || {
+    printf 'expected 3 protocol probes, got %s\n' "$calls"
+    exit 1
+}
+printf '%s\n' 'wait-camera-ready: socket alone refused; third protocol probe accepted'
+
+set +e
+IRLUME_READY_TEST_COUNTER="$counter" IRLUME_READY_TEST_NEVER=1 \
+    wait_for_camera_ready "$socket" "$dir/fake-irlume" "$server_pid" 2 0.01
+status=$?
+set -e
+[ "$status" -eq 1 ] || {
+    printf 'expected timeout status 1, got %s\n' "$status"
+    exit 1
+}
+
+dead_pid=$server_pid
+kill "$server_pid"
+wait "$server_pid" 2>/dev/null || true
+server_pid=""
+set +e
+IRLUME_READY_TEST_COUNTER="$counter" IRLUME_READY_TEST_NEVER=1 \
+    wait_for_camera_ready "$socket" "$dir/fake-irlume" "$dead_pid" 2 0.01
+status=$?
+set -e
+[ "$status" -eq 2 ] || {
+    printf 'expected daemon-exited status 2, got %s\n' "$status"
+    exit 1
+}
+printf '%s\n' 'wait-camera-ready: timeout and daemon-exited statuses preserved'

--- a/scripts/hardware/wait-camera-ready.sh
+++ b/scripts/hardware/wait-camera-ready.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Wait until a daemon with an early-bound socket can serve camera-bearing work.
+#
+# Usage after sourcing:
+#   wait_for_camera_ready <socket> <irlume-cli> <daemon-pid> [attempts] [delay]
+#
+# Returns 0 when a read-only emitter dry-run reaches the loaded engine, 2 when
+# the daemon exits first, and 1 when the attempt budget expires.
+wait_for_camera_ready() {
+    local socket="$1" cli="$2" daemon_pid="$3"
+    local attempts="${4:-1800}" delay="${5:-0.1}"
+
+    local _
+    for _ in $(seq 1 "$attempts"); do
+        if [ -S "$socket" ] \
+            && IRLUME_SOCKET="$socket" "$cli" ir-setup --dry-run >/dev/null 2>&1; then
+            return 0
+        fi
+        kill -0 "$daemon_pid" 2>/dev/null || return 2
+        sleep "$delay"
+    done
+    return 1
+}


### PR DESCRIPTION
## What & why

References #449.

The issue reports a NexiGo N930W `3443:930d` with a real 640×360 GREY IR stream, contradicting the existing categorical RGB-only documentation. This PR:

- records the conflicting `930d` evidence without assuming its extension-unit layout;
- keeps `known_control(0x3443, 0x930d) == None`, so no automatic firmware/XU write is introduced;
- updates the nearby safety comments to explain that USB identity alone does not prove sensor or emitter compatibility;
- fixes the emitter hardware harness so v0.10's early-bound socket is not mistaken for engine readiness;
- adds a deterministic readiness test covering startup retries, timeout, and daemon exit.

This intentionally does **not** close #449. The available hardware is `3443:c803`, not `3443:930d`; an automatic `930d` payload remains blocked on exact-device descriptor and controlled hardware evidence.

## Testing

- [x] `cargo test --workspace` passes — 1,395 tests through `run-tests-guarded.sh`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs/CHANGELOG updated if user-facing — `docs/PLATFORMS.md`
- [x] Hardware-validated (if it touches PAM, the daemon, or capture)

Hardware validation:

- NexiGo N930W `3443:c803` on minihost: full fault-injection harness passed 14/14 with the final protocol-readiness helper.
- Recovery stress passed 20/20; final selector value restored to `010301000000000000`, no records remained, packaged daemon active.
- Read-only comparison: Logitech Brio `046d:085e` and RGB-only ThinkPad camera.
- Deterministic helper test refuses socket-only readiness, accepts the third successful protocol probe, and preserves timeout/dead-daemon statuses.
- Deliberate socket-only sabotage made the test fail as expected; restoring the protocol check made it pass.
- Independent review verdict: SHIP, no blockers.

Safety boundary: no `SET_CUR` was attempted against `3443:930d`, and this PR adds no automatic `930d` control.
