### PR TITLE
camera: add backend supervisor foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Camera discovery and opens now cross one process-owned backend boundary.**
+  The initial backend remains the existing direct V4L2/UVC implementation, so
+  probing, pairing, negotiation, privacy, emitter, and capture behavior remain
+  unchanged. A v1 evidence schema now fails closed on unknown versions and
+  fields (#452).
+
 ## [0.10.0] - 2026-08-12
 
 ### Added

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Crate-private capture-backend ownership and operation routing.
+
+use std::sync::{Arc, OnceLock};
+
+use crate::{CameraPair, IrCamera, NodeScan, RgbCamera, Role};
+
+/// One capture implementation owned by the process camera supervisor.
+trait CameraBackend: Send + Sync + 'static {
+    fn scan_nodes(&self) -> NodeScan;
+    fn discover_nodes(&self) -> Vec<(String, Role)>;
+    fn list_pairs(&self) -> Vec<CameraPair>;
+    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera>;
+    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera>;
+
+    #[cfg(test)]
+    fn has_exact_production_uvc_delegates(&self) -> bool {
+        false
+    }
+}
+
+/// Process component that owns camera backend instances and routes operations.
+///
+/// This foundation deliberately has no mutex, mutable inventory, cache, lease,
+/// or lifecycle generation. Those would alter contention or hotplug behavior.
+struct CameraSupervisor {
+    backend: Arc<dyn CameraBackend>,
+}
+
+impl CameraSupervisor {
+    fn new(backend: impl CameraBackend) -> Self {
+        Self {
+            backend: Arc::new(backend),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_arc(backend: Arc<dyn CameraBackend>) -> Self {
+        Self { backend }
+    }
+
+    fn scan_nodes(&self) -> NodeScan {
+        self.backend.scan_nodes()
+    }
+
+    fn discover_nodes(&self) -> Vec<(String, Role)> {
+        self.backend.discover_nodes()
+    }
+
+    fn list_pairs(&self) -> Vec<CameraPair> {
+        self.backend.list_pairs()
+    }
+
+    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
+        self.backend.open_rgb(device)
+    }
+
+    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
+        self.backend.open_ir(device)
+    }
+}
+
+/// Existing direct V4L2 backend for video-node-centric UVC cameras.
+///
+/// This delegates to the pre-existing direct functions without changing their
+/// probing, pairing, negotiation, privacy, or emitter behavior.
+type ScanNodes = fn() -> NodeScan;
+type DiscoverNodes = fn() -> Vec<(String, Role)>;
+type ListPairs = fn() -> Vec<CameraPair>;
+type OpenRgb = fn(&str) -> irlume_common::Result<RgbCamera>;
+type OpenIr = fn(&str) -> irlume_common::Result<IrCamera>;
+
+fn production_scan_nodes() -> NodeScan {
+    crate::uvc_scan(true)
+}
+
+fn production_discover_nodes() -> Vec<(String, Role)> {
+    crate::uvc_discover_nodes()
+}
+
+fn production_list_pairs() -> Vec<CameraPair> {
+    crate::uvc_list_pairs()
+}
+
+fn production_open_rgb(device: &str) -> irlume_common::Result<RgbCamera> {
+    RgbCamera::open_uvc(device)
+}
+
+fn production_open_ir(device: &str) -> irlume_common::Result<IrCamera> {
+    IrCamera::open_uvc(device)
+}
+
+#[derive(Clone, Copy)]
+struct UvcV4l2Backend {
+    scan_nodes: ScanNodes,
+    discover_nodes: DiscoverNodes,
+    list_pairs: ListPairs,
+    open_rgb: OpenRgb,
+    open_ir: OpenIr,
+}
+
+impl Default for UvcV4l2Backend {
+    fn default() -> Self {
+        Self {
+            scan_nodes: production_scan_nodes,
+            discover_nodes: production_discover_nodes,
+            list_pairs: production_list_pairs,
+            open_rgb: production_open_rgb,
+            open_ir: production_open_ir,
+        }
+    }
+}
+
+impl CameraBackend for UvcV4l2Backend {
+    fn scan_nodes(&self) -> NodeScan {
+        (self.scan_nodes)()
+    }
+
+    fn discover_nodes(&self) -> Vec<(String, Role)> {
+        (self.discover_nodes)()
+    }
+
+    fn list_pairs(&self) -> Vec<CameraPair> {
+        (self.list_pairs)()
+    }
+
+    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
+        (self.open_rgb)(device)
+    }
+
+    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
+        (self.open_ir)(device)
+    }
+
+    #[cfg(test)]
+    fn has_exact_production_uvc_delegates(&self) -> bool {
+        std::ptr::fn_addr_eq(self.scan_nodes, production_scan_nodes as ScanNodes)
+            && std::ptr::fn_addr_eq(
+                self.discover_nodes,
+                production_discover_nodes as DiscoverNodes,
+            )
+            && std::ptr::fn_addr_eq(self.list_pairs, production_list_pairs as ListPairs)
+            && std::ptr::fn_addr_eq(self.open_rgb, production_open_rgb as OpenRgb)
+            && std::ptr::fn_addr_eq(self.open_ir, production_open_ir as OpenIr)
+    }
+}
+
+static DEFAULT_CAMERA_SUPERVISOR: OnceLock<CameraSupervisor> = OnceLock::new();
+
+fn default_camera_supervisor() -> &'static CameraSupervisor {
+    DEFAULT_CAMERA_SUPERVISOR.get_or_init(|| CameraSupervisor::new(UvcV4l2Backend::default()))
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_BACKEND: std::cell::RefCell<Option<Arc<dyn CameraBackend>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Route one compatibility operation through the process supervisor.
+fn with_camera_supervisor<T>(operation: impl FnOnce(&CameraSupervisor) -> T) -> T {
+    #[cfg(test)]
+    if let Some(backend) = TEST_BACKEND.with(|slot| slot.borrow().clone()) {
+        return operation(&CameraSupervisor::from_arc(backend));
+    }
+
+    operation(default_camera_supervisor())
+}
+
+pub(crate) fn scan_nodes() -> NodeScan {
+    with_camera_supervisor(CameraSupervisor::scan_nodes)
+}
+
+pub(crate) fn discover_nodes() -> Vec<(String, Role)> {
+    with_camera_supervisor(CameraSupervisor::discover_nodes)
+}
+
+pub(crate) fn list_pairs() -> Vec<CameraPair> {
+    with_camera_supervisor(CameraSupervisor::list_pairs)
+}
+
+pub(crate) fn open_rgb(device: &str) -> irlume_common::Result<RgbCamera> {
+    with_camera_supervisor(|supervisor| supervisor.open_rgb(device))
+}
+
+pub(crate) fn open_ir(device: &str) -> irlume_common::Result<IrCamera> {
+    with_camera_supervisor(|supervisor| supervisor.open_ir(device))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::{FailedAt, McCentric, Unreadable};
+
+    struct TestBackendGuard(Option<Arc<dyn CameraBackend>>);
+
+    impl Drop for TestBackendGuard {
+        fn drop(&mut self) {
+            let previous = self.0.take();
+            TEST_BACKEND.with(|slot| *slot.borrow_mut() = previous);
+        }
+    }
+
+    fn install_test_backend(backend: Arc<dyn CameraBackend>) -> TestBackendGuard {
+        let previous = TEST_BACKEND.with(|slot| slot.borrow_mut().replace(backend));
+        TestBackendGuard(previous)
+    }
+
+    #[derive(Clone)]
+    struct RecordingBackend {
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RecordingBackend {
+        fn record(&self, call: impl Into<String>) {
+            self.calls
+                .lock()
+                .expect("recording lock poisoned")
+                .push(call.into());
+        }
+    }
+
+    impl CameraBackend for RecordingBackend {
+        fn scan_nodes(&self) -> NodeScan {
+            self.record("scan_nodes");
+            NodeScan {
+                classified: vec![("/dev/spy-scan".into(), Role::Rgb)],
+                ..NodeScan::default()
+            }
+        }
+
+        fn discover_nodes(&self) -> Vec<(String, Role)> {
+            self.record("discover_nodes");
+            vec![
+                ("/dev/spy-ir".into(), Role::Ir),
+                ("/dev/spy-rgb".into(), Role::Rgb),
+            ]
+        }
+
+        fn list_pairs(&self) -> Vec<CameraPair> {
+            self.record("list_pairs");
+            vec![CameraPair {
+                rgb: "/dev/spy-rgb".into(),
+                ir: "/dev/spy-ir".into(),
+                id: Some("1234:5678".into()),
+                fixed: true,
+            }]
+        }
+
+        fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
+            self.record(format!("open_rgb:{device}"));
+            Err(irlume_common::Error::Hardware("spy RGB refusal".into()))
+        }
+
+        fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
+            self.record(format!("open_ir:{device}"));
+            Err(irlume_common::Error::Hardware("spy IR refusal".into()))
+        }
+    }
+
+    fn fixture_scan_nodes() -> NodeScan {
+        NodeScan {
+            classified: vec![
+                ("/dev/fixture-rgb".into(), Role::Rgb),
+                ("/dev/fixture-ir".into(), Role::Ir),
+            ],
+            unreadable: vec![Unreadable {
+                path: "/dev/fixture-busy".into(),
+                at: FailedAt::Open,
+                errno: Some(libc::EBUSY),
+                holder: Some("fixture-holder".into()),
+            }],
+            mc_centric: vec![(
+                "/dev/fixture-mc".into(),
+                McCentric {
+                    driver: "fixture-driver".into(),
+                    io_mc: true,
+                    mplane_only: true,
+                },
+            )],
+            listing_error: Some("fixture listing warning".into()),
+        }
+    }
+
+    fn fixture_discover_nodes() -> Vec<(String, Role)> {
+        vec![
+            ("/dev/fixture-ir".into(), Role::Ir),
+            ("/dev/fixture-rgb".into(), Role::Rgb),
+        ]
+    }
+
+    fn fixture_list_pairs() -> Vec<CameraPair> {
+        vec![
+            CameraPair {
+                rgb: "/dev/fixed-rgb".into(),
+                ir: "/dev/fixed-ir".into(),
+                id: Some("1111:2222".into()),
+                fixed: true,
+            },
+            CameraPair {
+                rgb: "/dev/usb-rgb".into(),
+                ir: "/dev/usb-ir".into(),
+                id: None,
+                fixed: false,
+            },
+        ]
+    }
+
+    fn fixture_open_rgb(_: &str) -> irlume_common::Result<RgbCamera> {
+        Err(irlume_common::Error::Hardware("fixture RGB".into()))
+    }
+
+    fn fixture_open_ir(_: &str) -> irlume_common::Result<IrCamera> {
+        Err(irlume_common::Error::Hardware("fixture IR".into()))
+    }
+
+    #[test]
+    fn public_camera_entrypoints_route_through_one_supervisor_backend() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let _guard = install_test_backend(Arc::new(RecordingBackend {
+            calls: Arc::clone(&calls),
+        }));
+
+        assert_eq!(crate::scan_nodes().classified[0].0, "/dev/spy-scan");
+        assert_eq!(
+            crate::discover_nodes(),
+            vec![
+                ("/dev/spy-ir".into(), Role::Ir),
+                ("/dev/spy-rgb".into(), Role::Rgb),
+            ]
+        );
+        let pairs = crate::list_pairs();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].rgb, "/dev/spy-rgb");
+        assert_eq!(pairs[0].ir, "/dev/spy-ir");
+        assert_eq!(pairs[0].id.as_deref(), Some("1234:5678"));
+        assert!(pairs[0].fixed);
+        assert!(RgbCamera::open("/dev/spy-rgb")
+            .err()
+            .expect("spy RGB open must refuse")
+            .to_string()
+            .contains("spy RGB refusal"));
+        assert!(IrCamera::open("/dev/spy-ir")
+            .err()
+            .expect("spy IR open must refuse")
+            .to_string()
+            .contains("spy IR refusal"));
+
+        assert_eq!(
+            *calls.lock().expect("recording lock poisoned"),
+            [
+                "scan_nodes",
+                "discover_nodes",
+                "list_pairs",
+                "open_rgb:/dev/spy-rgb",
+                "open_ir:/dev/spy-ir",
+            ]
+        );
+    }
+
+    #[test]
+    fn uvc_adapter_preserves_complete_results_and_order() {
+        let backend = UvcV4l2Backend {
+            scan_nodes: fixture_scan_nodes,
+            discover_nodes: fixture_discover_nodes,
+            list_pairs: fixture_list_pairs,
+            open_rgb: fixture_open_rgb,
+            open_ir: fixture_open_ir,
+        };
+
+        let scan = backend.scan_nodes();
+        assert_eq!(
+            scan.classified,
+            vec![
+                ("/dev/fixture-rgb".into(), Role::Rgb),
+                ("/dev/fixture-ir".into(), Role::Ir),
+            ]
+        );
+        assert_eq!(scan.unreadable.len(), 1);
+        assert_eq!(scan.unreadable[0].path, "/dev/fixture-busy");
+        assert_eq!(scan.unreadable[0].at, FailedAt::Open);
+        assert_eq!(scan.unreadable[0].errno, Some(libc::EBUSY));
+        assert_eq!(scan.unreadable[0].holder.as_deref(), Some("fixture-holder"));
+        assert_eq!(
+            scan.mc_centric,
+            vec![(
+                "/dev/fixture-mc".into(),
+                McCentric {
+                    driver: "fixture-driver".into(),
+                    io_mc: true,
+                    mplane_only: true,
+                },
+            )]
+        );
+        assert_eq!(
+            scan.listing_error.as_deref(),
+            Some("fixture listing warning")
+        );
+        assert_eq!(backend.discover_nodes(), fixture_discover_nodes());
+
+        let pairs = backend.list_pairs();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].rgb, "/dev/fixed-rgb");
+        assert_eq!(pairs[0].ir, "/dev/fixed-ir");
+        assert_eq!(pairs[0].id.as_deref(), Some("1111:2222"));
+        assert!(pairs[0].fixed);
+        assert_eq!(pairs[1].rgb, "/dev/usb-rgb");
+        assert_eq!(pairs[1].ir, "/dev/usb-ir");
+        assert_eq!(pairs[1].id, None);
+        assert!(!pairs[1].fixed);
+
+        assert!(backend
+            .open_rgb("/dev/ignored")
+            .err()
+            .expect("fixture RGB open must refuse")
+            .to_string()
+            .contains("fixture RGB"));
+        assert!(backend
+            .open_ir("/dev/ignored")
+            .err()
+            .expect("fixture IR open must refuse")
+            .to_string()
+            .contains("fixture IR"));
+    }
+
+    #[test]
+    fn default_supervisor_is_process_wide_and_uses_exact_uvc_delegates() {
+        assert!(std::ptr::eq(
+            default_camera_supervisor(),
+            default_camera_supervisor()
+        ));
+        assert!(default_camera_supervisor()
+            .backend
+            .has_exact_production_uvc_delegates());
+    }
+}

--- a/crates/irlume-camera/src/contracts.rs
+++ b/crates/irlume-camera/src/contracts.rs
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Versioned, backend-neutral camera evidence contracts.
+//!
+//! Schema v1 is additive and UVC-only. It does not replace any legacy camera,
+//! enrollment, or emitter state. It deliberately permits only ambiguous physical
+//! identity: stronger binding must be introduced by a later schema together with
+//! the trusted evidence producer that proves it.
+
+use std::{collections::BTreeSet, fmt};
+
+use serde::{Deserialize, Serialize};
+
+/// Current camera evidence schema version.
+pub const CAMERA_CONTRACT_SCHEMA_VERSION: u32 = 1;
+/// Largest accepted serialized camera contract.
+///
+/// Both public readers parse a small header before the complete value. This cap
+/// bounds both passes and every string/vector allocation reachable from them.
+pub const MAX_CAMERA_CONTRACT_BYTES: usize = 64 * 1024;
+
+const MAX_TOPOLOGY_PATH_BYTES: usize = 4096;
+const MAX_SERIAL_BYTES: usize = 256;
+const CAMERA_INSTANCE_ID_HEX_BYTES: usize = 32;
+
+/// Capture backend that produced a normalized contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKind {
+    /// Existing direct V4L2 backend for video-node-centric UVC cameras.
+    UvcV4l2,
+}
+
+/// Raw, untrusted identity evidence for a physical camera.
+///
+/// `topology_path` is the canonical sysfs path relative to `/sys`, beginning
+/// with `/devices/`. It is useful for re-enumeration within one host, but schema
+/// v1 never upgrades it into a strong or portable security identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PhysicalCameraId {
+    topology_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    serial: Option<String>,
+}
+
+impl PhysicalCameraId {
+    /// Validate raw physical-camera identity evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-canonical topology path or an empty, control-
+    /// containing, or oversized serial value.
+    pub fn new(
+        topology_path: impl Into<String>,
+        serial: Option<String>,
+    ) -> Result<Self, CameraContractError> {
+        let topology_path = topology_path.into();
+        validate_topology_path(&topology_path)?;
+        validate_serial(serial.as_deref())?;
+        Ok(Self {
+            topology_path,
+            serial,
+        })
+    }
+
+    /// Canonical sysfs path relative to `/sys`.
+    #[must_use]
+    pub fn topology_path(&self) -> &str {
+        &self.topology_path
+    }
+
+    /// Device-declared serial, when present; not by itself a uniqueness proof.
+    #[must_use]
+    pub fn serial(&self) -> Option<&str> {
+        self.serial.as_deref()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PhysicalCameraIdWire {
+    topology_path: String,
+    #[serde(default)]
+    serial: Option<String>,
+}
+
+impl TryFrom<PhysicalCameraIdWire> for PhysicalCameraId {
+    type Error = CameraContractError;
+
+    fn try_from(wire: PhysicalCameraIdWire) -> Result<Self, Self::Error> {
+        Self::new(wire.topology_path, wire.serial)
+    }
+}
+
+/// Strength of a physical-camera identity claim.
+///
+/// Schema v1 exposes only `Ambiguous`. Callers cannot self-assert a stronger
+/// value. A future schema may add stronger variants only with a trusted evidence
+/// producer and explicit migration rules.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityStrength {
+    /// Evidence is insufficient for a durable anti-swap binding.
+    #[default]
+    Ambiguous,
+}
+
+/// Logical stream role established by a capture backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum StreamRole {
+    /// Visible-light color stream.
+    Rgb,
+    /// Near-infrared monochrome stream.
+    Ir,
+}
+
+/// Evidence relating timing across streams.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum SynchronizationProvenance {
+    /// No synchronization claim is supported.
+    #[default]
+    Unknown,
+    /// Streams are known to run independently.
+    Independent,
+    /// Host timestamps correlated at least two streams.
+    HostCorrelated,
+    /// Device metadata correlated at least two streams.
+    DeviceCorrelated,
+    /// Hardware synchronization was qualified for at least two streams.
+    HardwareSynchronized,
+}
+
+/// Evidence that a frame or stream supports a particular illumination state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum IlluminationProvenance {
+    /// No trustworthy illumination evidence exists.
+    #[default]
+    Unknown,
+    /// Ambient-only illumination is known.
+    Ambient,
+    /// Active near-infrared illumination is known.
+    ActiveIr,
+}
+
+/// Process-scoped identity for one physical-camera incarnation.
+///
+/// A supervisor must mint a new nonzero 128-bit identifier after each process
+/// restart and whenever the prior incarnation cannot be proven continuous. A
+/// generation number has meaning only together with this identifier.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct CameraInstanceId(String);
+
+impl CameraInstanceId {
+    /// Validate a lowercase nonzero 128-bit hexadecimal identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraContractError::InvalidCameraInstanceId`] unless the input
+    /// contains exactly 32 lowercase hexadecimal characters and is not all zero.
+    pub fn new(value: impl Into<String>) -> Result<Self, CameraContractError> {
+        let value = value.into();
+        let valid = value.len() == CAMERA_INSTANCE_ID_HEX_BYTES
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            && value.bytes().any(|byte| byte != b'0');
+        if !valid {
+            return Err(CameraContractError::InvalidCameraInstanceId);
+        }
+        Ok(Self(value))
+    }
+
+    /// Lowercase hexadecimal identifier.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Monotonic lifecycle generation within one [`CameraInstanceId`].
+///
+/// Generation zero is reserved. Before incrementing `u64::MAX`, the supervisor
+/// must retire the instance and mint a new camera-instance identifier; wrapping
+/// or saturating would allow stale frames to alias current ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct CameraGeneration(u64);
+
+impl CameraGeneration {
+    /// First generation of a newly minted camera instance.
+    pub const INITIAL: Self = Self(1);
+
+    /// Construct a nonzero generation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraContractError::ZeroGeneration`] for zero.
+    pub const fn new(value: u64) -> Result<Self, CameraContractError> {
+        if value == 0 {
+            Err(CameraContractError::ZeroGeneration)
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Advance without wrapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraContractError::GenerationExhausted`] at `u64::MAX`; the
+    /// caller must mint a new [`CameraInstanceId`] instead.
+    pub const fn next(self) -> Result<Self, CameraContractError> {
+        match self.0.checked_add(1) {
+            Some(value) => Ok(Self(value)),
+            None => Err(CameraContractError::GenerationExhausted),
+        }
+    }
+
+    /// Numeric generation value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Conservative backend capability declaration.
+///
+/// This is a producer claim, not security proof. Deserializing or constructing
+/// it does not establish that the producer measured the claimed synchronization
+/// or illumination behavior. Authentication consumers must accept capabilities
+/// only from a trusted, qualified backend/profile and validate them against the
+/// current camera instance.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct CameraCapabilities {
+    stream_roles: Vec<StreamRole>,
+    synchronization: SynchronizationProvenance,
+    illumination_provenance: Vec<IlluminationProvenance>,
+}
+
+impl CameraCapabilities {
+    /// Construct a coherent capability set.
+    ///
+    /// Empty lists and `Unknown` are valid and make no capability claim.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicates, active-IR support without an IR stream, and any
+    /// cross-stream correlation claim without at least two distinct streams.
+    pub fn new(
+        stream_roles: Vec<StreamRole>,
+        synchronization: SynchronizationProvenance,
+        illumination_provenance: Vec<IlluminationProvenance>,
+    ) -> Result<Self, CameraContractError> {
+        reject_duplicates(&stream_roles, CameraContractError::DuplicateStreamRole)?;
+        reject_duplicates(
+            &illumination_provenance,
+            CameraContractError::DuplicateIllumination,
+        )?;
+        if illumination_provenance.contains(&IlluminationProvenance::ActiveIr)
+            && !stream_roles.contains(&StreamRole::Ir)
+        {
+            return Err(CameraContractError::ActiveIrRequiresIrStream);
+        }
+        if matches!(
+            synchronization,
+            SynchronizationProvenance::HostCorrelated
+                | SynchronizationProvenance::DeviceCorrelated
+                | SynchronizationProvenance::HardwareSynchronized
+        ) && stream_roles.len() < 2
+        {
+            return Err(CameraContractError::SynchronizationRequiresMultipleStreams(
+                synchronization,
+            ));
+        }
+        Ok(Self {
+            stream_roles,
+            synchronization,
+            illumination_provenance,
+        })
+    }
+
+    /// Established logical stream roles.
+    #[must_use]
+    pub fn stream_roles(&self) -> &[StreamRole] {
+        &self.stream_roles
+    }
+
+    /// Established cross-stream timing provenance.
+    #[must_use]
+    pub const fn synchronization(&self) -> SynchronizationProvenance {
+        self.synchronization
+    }
+
+    /// Established illumination evidence mechanisms.
+    #[must_use]
+    pub fn illumination_provenance(&self) -> &[IlluminationProvenance] {
+        &self.illumination_provenance
+    }
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CameraCapabilitiesWire {
+    #[serde(default)]
+    stream_roles: Vec<StreamRole>,
+    #[serde(default)]
+    synchronization: SynchronizationProvenance,
+    #[serde(default)]
+    illumination_provenance: Vec<IlluminationProvenance>,
+}
+
+impl TryFrom<CameraCapabilitiesWire> for CameraCapabilities {
+    type Error = CameraContractError;
+
+    fn try_from(wire: CameraCapabilitiesWire) -> Result<Self, Self::Error> {
+        Self::new(
+            wire.stream_roles,
+            wire.synchronization,
+            wire.illumination_provenance,
+        )
+    }
+}
+
+/// Versioned normalized description of one physical-camera incarnation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CameraDescriptor {
+    schema_version: u32,
+    backend: BackendKind,
+    physical_id: PhysicalCameraId,
+    identity_strength: IdentityStrength,
+    camera_instance_id: CameraInstanceId,
+    generation: CameraGeneration,
+    capabilities: CameraCapabilities,
+}
+
+impl CameraDescriptor {
+    /// Construct a schema-v1 descriptor with fail-closed identity strength.
+    #[must_use]
+    pub fn new(
+        backend: BackendKind,
+        physical_id: PhysicalCameraId,
+        camera_instance_id: CameraInstanceId,
+        generation: CameraGeneration,
+        capabilities: CameraCapabilities,
+    ) -> Self {
+        Self {
+            schema_version: CAMERA_CONTRACT_SCHEMA_VERSION,
+            backend,
+            physical_id,
+            identity_strength: IdentityStrength::Ambiguous,
+            camera_instance_id,
+            generation,
+            capabilities,
+        }
+    }
+
+    /// Parse one bounded schema-v1 descriptor.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized/malformed input, unsupported versions, unknown fields
+    /// or enum variants, invalid identity evidence, contradictory capabilities,
+    /// and self-asserted identity strength.
+    pub fn from_json(input: &str) -> Result<Self, CameraContractReadError> {
+        check_input_size(input)?;
+        require_supported_version(input)?;
+        let wire: CameraDescriptorWire = serde_json::from_str(input)?;
+        Self::try_from(wire).map_err(CameraContractReadError::Invalid)
+    }
+
+    /// Schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Capture backend kind.
+    #[must_use]
+    pub const fn backend(&self) -> BackendKind {
+        self.backend
+    }
+
+    /// Raw physical-camera identity evidence.
+    #[must_use]
+    pub const fn physical_id(&self) -> &PhysicalCameraId {
+        &self.physical_id
+    }
+
+    /// Conservative identity strength; always `Ambiguous` in schema v1.
+    #[must_use]
+    pub const fn identity_strength(&self) -> IdentityStrength {
+        self.identity_strength
+    }
+
+    /// Camera-incarnation scope shared with every frame.
+    #[must_use]
+    pub const fn camera_instance_id(&self) -> &CameraInstanceId {
+        &self.camera_instance_id
+    }
+
+    /// Current generation within the camera instance.
+    #[must_use]
+    pub const fn generation(&self) -> CameraGeneration {
+        self.generation
+    }
+
+    /// Conservative backend capabilities.
+    #[must_use]
+    pub const fn capabilities(&self) -> &CameraCapabilities {
+        &self.capabilities
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CameraDescriptorWire {
+    schema_version: u32,
+    backend: BackendKind,
+    physical_id: PhysicalCameraIdWire,
+    #[serde(default)]
+    identity_strength: IdentityStrength,
+    camera_instance_id: String,
+    generation: u64,
+    #[serde(default)]
+    capabilities: CameraCapabilitiesWire,
+}
+
+impl TryFrom<CameraDescriptorWire> for CameraDescriptor {
+    type Error = CameraContractError;
+
+    fn try_from(wire: CameraDescriptorWire) -> Result<Self, Self::Error> {
+        if wire.schema_version != CAMERA_CONTRACT_SCHEMA_VERSION {
+            return Err(CameraContractError::UnsupportedSchemaVersion(
+                wire.schema_version,
+            ));
+        }
+        match wire.identity_strength {
+            IdentityStrength::Ambiguous => {}
+        }
+        Ok(Self::new(
+            wire.backend,
+            PhysicalCameraId::try_from(wire.physical_id)?,
+            CameraInstanceId::new(wire.camera_instance_id)?,
+            CameraGeneration::new(wire.generation)?,
+            CameraCapabilities::try_from(wire.capabilities)?,
+        ))
+    }
+}
+
+/// Per-frame evidence emitted by a capture backend.
+///
+/// This structure records what a producer claims for one frame; it does not
+/// authenticate that producer or prove hardware synchronization/illumination.
+/// Security-sensitive consumers must bind it to a trusted backend session and
+/// a currently qualified camera profile before treating any field as evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FrameMetadata {
+    schema_version: u32,
+    camera_instance_id: CameraInstanceId,
+    generation: CameraGeneration,
+    stream_role: StreamRole,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sequence: Option<u64>,
+    synchronization: SynchronizationProvenance,
+    illumination: IlluminationProvenance,
+}
+
+impl FrameMetadata {
+    /// Construct coherent metadata from explicit backend evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects active-IR provenance on a non-IR frame.
+    pub fn new(
+        camera_instance_id: CameraInstanceId,
+        generation: CameraGeneration,
+        stream_role: StreamRole,
+        sequence: Option<u64>,
+        synchronization: SynchronizationProvenance,
+        illumination: IlluminationProvenance,
+    ) -> Result<Self, CameraContractError> {
+        if matches!(illumination, IlluminationProvenance::ActiveIr)
+            && matches!(stream_role, StreamRole::Rgb)
+        {
+            return Err(CameraContractError::ActiveIrRequiresIrStream);
+        }
+        Ok(Self {
+            schema_version: CAMERA_CONTRACT_SCHEMA_VERSION,
+            camera_instance_id,
+            generation,
+            stream_role,
+            sequence,
+            synchronization,
+            illumination,
+        })
+    }
+
+    /// Parse one bounded schema-v1 frame metadata value.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized/malformed input, unsupported versions, unknown fields
+    /// or enum variants, invalid instance/generation values, and contradictory
+    /// role/illumination evidence.
+    pub fn from_json(input: &str) -> Result<Self, CameraContractReadError> {
+        check_input_size(input)?;
+        require_supported_version(input)?;
+        let wire: FrameMetadataWire = serde_json::from_str(input)?;
+        Self::try_from(wire).map_err(CameraContractReadError::Invalid)
+    }
+
+    /// Camera-incarnation scope for the generation and sequence.
+    #[must_use]
+    pub const fn camera_instance_id(&self) -> &CameraInstanceId {
+        &self.camera_instance_id
+    }
+
+    /// Camera generation that produced the frame.
+    #[must_use]
+    pub const fn generation(&self) -> CameraGeneration {
+        self.generation
+    }
+
+    /// Logical stream role.
+    #[must_use]
+    pub const fn stream_role(&self) -> StreamRole {
+        self.stream_role
+    }
+
+    /// Backend sequence number, when available.
+    #[must_use]
+    pub const fn sequence(&self) -> Option<u64> {
+        self.sequence
+    }
+
+    /// Proven synchronization relationship.
+    #[must_use]
+    pub const fn synchronization(&self) -> SynchronizationProvenance {
+        self.synchronization
+    }
+
+    /// Per-frame illumination evidence.
+    #[must_use]
+    pub const fn illumination(&self) -> IlluminationProvenance {
+        self.illumination
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FrameMetadataWire {
+    schema_version: u32,
+    camera_instance_id: String,
+    generation: u64,
+    stream_role: StreamRole,
+    #[serde(default)]
+    sequence: Option<u64>,
+    #[serde(default)]
+    synchronization: SynchronizationProvenance,
+    #[serde(default)]
+    illumination: IlluminationProvenance,
+}
+
+impl TryFrom<FrameMetadataWire> for FrameMetadata {
+    type Error = CameraContractError;
+
+    fn try_from(wire: FrameMetadataWire) -> Result<Self, Self::Error> {
+        if wire.schema_version != CAMERA_CONTRACT_SCHEMA_VERSION {
+            return Err(CameraContractError::UnsupportedSchemaVersion(
+                wire.schema_version,
+            ));
+        }
+        Self::new(
+            CameraInstanceId::new(wire.camera_instance_id)?,
+            CameraGeneration::new(wire.generation)?,
+            wire.stream_role,
+            wire.sequence,
+            wire.synchronization,
+            wire.illumination,
+        )
+    }
+}
+
+fn validate_topology_path(value: &str) -> Result<(), CameraContractError> {
+    let canonical = value.starts_with("/devices/")
+        && !value.ends_with('/')
+        && value.len() <= MAX_TOPOLOGY_PATH_BYTES
+        && value.is_ascii()
+        && !value.bytes().any(|byte| byte.is_ascii_control())
+        && value
+            .split('/')
+            .skip(1)
+            .all(|component| !component.is_empty() && component != "." && component != "..");
+    if canonical {
+        Ok(())
+    } else {
+        Err(CameraContractError::InvalidTopologyPath)
+    }
+}
+
+fn validate_serial(value: Option<&str>) -> Result<(), CameraContractError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if value.trim().is_empty() {
+        return Err(CameraContractError::EmptySerial);
+    }
+    if value.len() > MAX_SERIAL_BYTES || value.chars().any(char::is_control) {
+        return Err(CameraContractError::InvalidSerial);
+    }
+    Ok(())
+}
+
+fn reject_duplicates<T: Copy + Ord>(
+    values: &[T],
+    error: impl Fn(T) -> CameraContractError,
+) -> Result<(), CameraContractError> {
+    let mut seen = BTreeSet::new();
+    for &value in values {
+        if !seen.insert(value) {
+            return Err(error(value));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct SchemaHeader {
+    schema_version: u32,
+}
+
+fn check_input_size(input: &str) -> Result<(), CameraContractReadError> {
+    if input.len() > MAX_CAMERA_CONTRACT_BYTES {
+        return Err(CameraContractReadError::Invalid(
+            CameraContractError::InputTooLarge {
+                actual: input.len(),
+                maximum: MAX_CAMERA_CONTRACT_BYTES,
+            },
+        ));
+    }
+    Ok(())
+}
+
+fn require_supported_version(input: &str) -> Result<(), CameraContractReadError> {
+    let header: SchemaHeader = serde_json::from_str(input)?;
+    if header.schema_version != CAMERA_CONTRACT_SCHEMA_VERSION {
+        return Err(CameraContractReadError::Invalid(
+            CameraContractError::UnsupportedSchemaVersion(header.schema_version),
+        ));
+    }
+    Ok(())
+}
+
+/// Semantic camera-contract validation error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CameraContractError {
+    /// Input exceeded the documented parser ceiling.
+    InputTooLarge { actual: usize, maximum: usize },
+    /// Exact schema version is not supported.
+    UnsupportedSchemaVersion(u32),
+    /// Sysfs topology path is not in canonical `/devices/...` form.
+    InvalidTopologyPath,
+    /// A present serial was empty.
+    EmptySerial,
+    /// A serial was oversized or contained control characters.
+    InvalidSerial,
+    /// Camera-instance identifier was malformed or all zero.
+    InvalidCameraInstanceId,
+    /// Generation zero could allow stale and current instances to alias.
+    ZeroGeneration,
+    /// Generation cannot advance without wrapping.
+    GenerationExhausted,
+    /// A logical stream role appeared more than once.
+    DuplicateStreamRole(StreamRole),
+    /// An illumination provenance value appeared more than once.
+    DuplicateIllumination(IlluminationProvenance),
+    /// Active-IR evidence was claimed without an IR stream.
+    ActiveIrRequiresIrStream,
+    /// A cross-stream synchronization claim had fewer than two streams.
+    SynchronizationRequiresMultipleStreams(SynchronizationProvenance),
+}
+
+impl fmt::Display for CameraContractError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InputTooLarge { actual, maximum } => write!(
+                formatter,
+                "camera contract is {actual} bytes; maximum is {maximum} bytes"
+            ),
+            Self::UnsupportedSchemaVersion(version) => write!(
+                formatter,
+                "unsupported camera contract schema version {version}"
+            ),
+            Self::InvalidTopologyPath => formatter
+                .write_str("camera topology path must be canonical ASCII /devices/... form"),
+            Self::EmptySerial => formatter.write_str("camera serial is empty"),
+            Self::InvalidSerial => formatter.write_str("camera serial is invalid"),
+            Self::InvalidCameraInstanceId => formatter
+                .write_str("camera instance id must be nonzero 128-bit lowercase hexadecimal"),
+            Self::ZeroGeneration => formatter.write_str("camera generation must be non-zero"),
+            Self::GenerationExhausted => {
+                formatter.write_str("camera generation exhausted; mint a new camera instance id")
+            }
+            Self::DuplicateStreamRole(role) => {
+                write!(formatter, "camera capabilities repeat stream role {role:?}")
+            }
+            Self::DuplicateIllumination(illumination) => write!(
+                formatter,
+                "camera capabilities repeat illumination provenance {illumination:?}"
+            ),
+            Self::ActiveIrRequiresIrStream => {
+                formatter.write_str("active-IR evidence requires an IR stream")
+            }
+            Self::SynchronizationRequiresMultipleStreams(provenance) => write!(
+                formatter,
+                "synchronization provenance {provenance:?} requires at least two streams"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CameraContractError {}
+
+/// Error returned while decoding a serialized camera contract.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CameraContractReadError {
+    /// JSON syntax, type, duplicate-field, or unknown-field error.
+    Malformed(serde_json::Error),
+    /// Well-formed JSON that violated a semantic contract rule.
+    Invalid(CameraContractError),
+}
+
+impl fmt::Display for CameraContractReadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed(error) => write!(formatter, "malformed camera contract: {error}"),
+            Self::Invalid(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for CameraContractReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Malformed(error) => Some(error),
+            Self::Invalid(error) => Some(error),
+        }
+    }
+}
+
+impl From<serde_json::Error> for CameraContractReadError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Malformed(error)
+    }
+}

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -29,6 +29,9 @@
 //! RGB8. FOOTGUN: enumerate V4L2 controls defensively; naive control queries
 //! panic on some drivers. Probe, don't assume.
 
+mod backend;
+/// Versioned, backend-neutral camera data contracts.
+pub mod contracts;
 pub mod emitter_journal;
 pub mod ir_dark;
 pub mod ir_emitter;
@@ -1283,7 +1286,7 @@ fn file_node(scan: &mut NodeScan, path: String, outcome: Result<NodeKind, Unread
 /// `with_holders` walks /proc for each busy node to name what holds it. That
 /// is worth a report a person reads and not worth it for the camera-picking
 /// callers, which run on the TUI's refresh path.
-fn scan(with_holders: bool) -> NodeScan {
+fn uvc_scan(with_holders: bool) -> NodeScan {
     let mut scan = NodeScan::default();
     let listing = video_node_paths();
     scan.listing_error = listing.error;
@@ -1299,15 +1302,19 @@ fn scan(with_holders: bool) -> NodeScan {
     scan
 }
 
+fn uvc_discover_nodes() -> Vec<(String, Role)> {
+    uvc_scan(false).classified
+}
+
 /// Classify every video node, keeping the failures and naming what holds a
 /// busy one. For reports; use `discover_nodes` to pick a camera.
 pub fn scan_nodes() -> NodeScan {
-    scan(true)
+    backend::scan_nodes()
 }
 
 /// Scan for each readable capture node, returning (path, role).
 pub fn discover_nodes() -> Vec<(String, Role)> {
-    scan(false).classified
+    backend::discover_nodes()
 }
 
 /// Whether a failed privacy-control read means the camera does not HAVE the
@@ -1724,9 +1731,13 @@ pub struct CameraPair {
 /// Every physical camera that exposes both an RGB and an IR node (a Hello pair),
 /// sorted built-in first. Drives the TUI camera picker.
 pub fn list_pairs() -> Vec<CameraPair> {
+    backend::list_pairs()
+}
+
+fn uvc_list_pairs() -> Vec<CameraPair> {
     let mut groups: std::collections::BTreeMap<std::path::PathBuf, (Vec<String>, Vec<String>)> =
         Default::default();
-    for (path, role) in discover_nodes() {
+    for (path, role) in uvc_discover_nodes() {
         if let Some(id) = physical_device_id(&path) {
             let e = groups.entry(id).or_default();
             match role {
@@ -1789,6 +1800,10 @@ impl RgbCamera {
     /// allocated and the capture LED stays off until a session is opened.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
+        backend::open_rgb(device)
+    }
+
+    fn open_uvc(device: &str) -> irlume_common::Result<Self> {
         verify_pinned(device)?;
         if privacy_engaged(device) {
             return Err(Error::Hardware(format!(
@@ -2666,6 +2681,10 @@ pub struct IrCamera {
 impl IrCamera {
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
+        backend::open_ir(device)
+    }
+
+    fn open_uvc(device: &str) -> irlume_common::Result<Self> {
         verify_pinned(device)?;
         if privacy_engaged(device) {
             return Err(Error::Hardware(format!(

--- a/crates/irlume-camera/tests/contracts.rs
+++ b/crates/irlume-camera/tests/contracts.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use irlume_camera::contracts::{
+    BackendKind, CameraCapabilities, CameraDescriptor, CameraGeneration, CameraInstanceId,
+    FrameMetadata, IdentityStrength, IlluminationProvenance, PhysicalCameraId, StreamRole,
+    SynchronizationProvenance, MAX_CAMERA_CONTRACT_BYTES,
+};
+
+const TOPOLOGY: &str = "/devices/pci0000:00/usb1/1-2/1-2.1";
+const INSTANCE_ID: &str = "00000000000000000000000000000001";
+
+fn physical_id() -> PhysicalCameraId {
+    PhysicalCameraId::new(TOPOLOGY, Some("200901010001".into()))
+        .expect("valid raw identity evidence")
+}
+
+fn instance_id() -> CameraInstanceId {
+    CameraInstanceId::new(INSTANCE_ID).expect("valid process camera-instance id")
+}
+
+fn capabilities() -> CameraCapabilities {
+    CameraCapabilities::new(
+        vec![StreamRole::Rgb, StreamRole::Ir],
+        SynchronizationProvenance::HostCorrelated,
+        vec![
+            IlluminationProvenance::Ambient,
+            IlluminationProvenance::ActiveIr,
+        ],
+    )
+    .expect("coherent capability evidence")
+}
+
+#[test]
+fn camera_descriptor_v1_has_a_stable_wire_shape() {
+    let descriptor = CameraDescriptor::new(
+        BackendKind::UvcV4l2,
+        physical_id(),
+        instance_id(),
+        CameraGeneration::new(7).expect("non-zero generation"),
+        capabilities(),
+    );
+
+    let wire = serde_json::to_string(&descriptor).expect("serialize descriptor");
+    assert_eq!(
+        wire,
+        r#"{"schema_version":1,"backend":"uvc_v4l2","physical_id":{"topology_path":"/devices/pci0000:00/usb1/1-2/1-2.1","serial":"200901010001"},"identity_strength":"ambiguous","camera_instance_id":"00000000000000000000000000000001","generation":7,"capabilities":{"stream_roles":["rgb","ir"],"synchronization":"host_correlated","illumination_provenance":["ambient","active_ir"]}}"#
+    );
+    assert_eq!(
+        CameraDescriptor::from_json(&wire).expect("parse supported descriptor"),
+        descriptor
+    );
+}
+
+#[test]
+fn conservative_camera_fields_default_to_no_claim() {
+    let wire = format!(
+        r#"{{"schema_version":1,"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let descriptor = CameraDescriptor::from_json(&wire).expect("parse conservative descriptor");
+
+    assert_eq!(descriptor.identity_strength(), IdentityStrength::Ambiguous);
+    assert_eq!(descriptor.capabilities(), &CameraCapabilities::default());
+    assert_eq!(descriptor.physical_id().serial(), None);
+}
+
+#[test]
+fn frame_metadata_v1_has_a_stable_wire_shape() {
+    let metadata = FrameMetadata::new(
+        instance_id(),
+        CameraGeneration::new(7).expect("non-zero generation"),
+        StreamRole::Ir,
+        Some(42),
+        SynchronizationProvenance::HostCorrelated,
+        IlluminationProvenance::ActiveIr,
+    )
+    .expect("active IR is valid for an IR frame");
+
+    let wire = serde_json::to_string(&metadata).expect("serialize frame metadata");
+    assert_eq!(
+        wire,
+        r#"{"schema_version":1,"camera_instance_id":"00000000000000000000000000000001","generation":7,"stream_role":"ir","sequence":42,"synchronization":"host_correlated","illumination":"active_ir"}"#
+    );
+    assert_eq!(
+        FrameMetadata::from_json(&wire).expect("parse supported frame metadata"),
+        metadata
+    );
+}
+
+#[test]
+fn frame_generation_is_scoped_by_the_same_camera_instance_as_the_descriptor() {
+    let descriptor = CameraDescriptor::new(
+        BackendKind::UvcV4l2,
+        physical_id(),
+        instance_id(),
+        CameraGeneration::INITIAL,
+        CameraCapabilities::default(),
+    );
+    let metadata = FrameMetadata::new(
+        instance_id(),
+        CameraGeneration::INITIAL,
+        StreamRole::Ir,
+        None,
+        SynchronizationProvenance::Unknown,
+        IlluminationProvenance::Unknown,
+    )
+    .expect("unknown evidence is conservative");
+
+    assert_eq!(
+        metadata.camera_instance_id(),
+        descriptor.camera_instance_id()
+    );
+}
+
+#[test]
+fn missing_frame_evidence_defaults_to_unknown_not_proven() {
+    let wire = format!(
+        r#"{{"schema_version":1,"camera_instance_id":"{INSTANCE_ID}","generation":7,"stream_role":"ir"}}"#
+    );
+    let metadata = FrameMetadata::from_json(&wire).expect("parse conservative frame metadata");
+
+    assert_eq!(metadata.sequence(), None);
+    assert_eq!(
+        metadata.synchronization(),
+        SynchronizationProvenance::Unknown
+    );
+    assert_eq!(metadata.illumination(), IlluminationProvenance::Unknown);
+}
+
+#[test]
+fn both_roots_reject_old_and_new_schema_versions() {
+    for version in [0, 2] {
+        let descriptor = format!(
+            r#"{{"schema_version":{version},"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+        );
+        let frame = format!(
+            r#"{{"schema_version":{version},"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"ir"}}"#
+        );
+
+        assert!(CameraDescriptor::from_json(&descriptor)
+            .expect_err("unsupported descriptor schema must fail")
+            .to_string()
+            .contains(&format!(
+                "unsupported camera contract schema version {version}"
+            )));
+        assert!(FrameMetadata::from_json(&frame)
+            .expect_err("unsupported frame schema must fail")
+            .to_string()
+            .contains(&format!(
+                "unsupported camera contract schema version {version}"
+            )));
+    }
+}
+
+#[test]
+fn identity_evidence_is_canonical_and_never_self_upgrades_strength() {
+    for topology in ["", "x", "/devices/", "/devices/a//b", "/devices/a/../b"] {
+        assert!(PhysicalCameraId::new(topology, None).is_err());
+    }
+    assert!(PhysicalCameraId::new(TOPOLOGY, Some(String::new())).is_err());
+
+    let self_asserted = format!(
+        r#"{{"schema_version":1,"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"identity_strength":"topology_bound","camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    assert!(CameraDescriptor::from_json(&self_asserted).is_err());
+}
+
+#[test]
+fn instance_and_generation_identifiers_reject_zero_or_malformed_values() {
+    assert!(CameraGeneration::new(0).is_err());
+    assert!(CameraGeneration::new(u64::MAX)
+        .expect("maximum is a valid current generation")
+        .next()
+        .is_err());
+    for id in [
+        "",
+        "00000000000000000000000000000000",
+        "0000000000000000000000000000000g",
+        "000000000000000000000000000000001",
+    ] {
+        assert!(CameraInstanceId::new(id).is_err());
+    }
+}
+
+#[test]
+fn contradictory_and_duplicate_capability_claims_are_rejected() {
+    assert!(CameraCapabilities::new(
+        vec![StreamRole::Rgb, StreamRole::Rgb],
+        SynchronizationProvenance::Unknown,
+        Vec::new(),
+    )
+    .is_err());
+    assert!(CameraCapabilities::new(
+        vec![StreamRole::Rgb],
+        SynchronizationProvenance::Unknown,
+        vec![IlluminationProvenance::ActiveIr],
+    )
+    .is_err());
+    assert!(CameraCapabilities::new(
+        vec![StreamRole::Rgb],
+        SynchronizationProvenance::HardwareSynchronized,
+        Vec::new(),
+    )
+    .is_err());
+    assert!(CameraCapabilities::new(
+        Vec::new(),
+        SynchronizationProvenance::Unknown,
+        vec![
+            IlluminationProvenance::Ambient,
+            IlluminationProvenance::Ambient,
+        ],
+    )
+    .is_err());
+}
+
+#[test]
+fn active_ir_is_rejected_on_an_rgb_frame() {
+    assert!(FrameMetadata::new(
+        instance_id(),
+        CameraGeneration::INITIAL,
+        StreamRole::Rgb,
+        None,
+        SynchronizationProvenance::Unknown,
+        IlluminationProvenance::ActiveIr,
+    )
+    .is_err());
+}
+
+#[test]
+fn malformed_duplicate_unknown_and_oversized_inputs_fail_closed() {
+    let duplicate_version = format!(
+        r#"{{"schema_version":1,"schema_version":1,"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let unknown_backend = format!(
+        r#"{{"schema_version":1,"backend":"libcamera","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let unknown_role = format!(
+        r#"{{"schema_version":1,"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"depth"}}"#
+    );
+    let unknown_field = format!(
+        r#"{{"schema_version":1,"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"ir","future":true}}"#
+    );
+    let oversized = "x".repeat(MAX_CAMERA_CONTRACT_BYTES + 1);
+
+    assert!(CameraDescriptor::from_json(&duplicate_version).is_err());
+    assert!(CameraDescriptor::from_json(&unknown_backend).is_err());
+    assert!(FrameMetadata::from_json(&unknown_role).is_err());
+    assert!(FrameMetadata::from_json(&unknown_field).is_err());
+    assert!(CameraDescriptor::from_json(&oversized).is_err());
+    assert!(FrameMetadata::from_json(&oversized).is_err());
+}
+
+#[test]
+fn missing_schema_version_is_rejected() {
+    let descriptor = format!(
+        r#"{{"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let frame =
+        format!(r#"{{"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"ir"}}"#);
+    assert!(CameraDescriptor::from_json(&descriptor).is_err());
+    assert!(FrameMetadata::from_json(&frame).is_err());
+}


### PR DESCRIPTION
Closes #452

## Problem

Irlume's direct V4L2 camera implementation was exposed as free functions and concrete open methods. That made every future lifecycle, lease, hotplug, metadata, and libcamera change a cross-cutting rewrite. It also had no versioned, fail-closed representation for camera identity, capability, generation, or per-frame provenance.

## Approach

- add a crate-private `CameraBackend` boundary and process-wide `CameraSupervisor`;
- implement the boundary with the existing direct V4L2/UVC code only;
- route `scan_nodes`, `discover_nodes`, `list_pairs`, `RgbCamera::open`, and `IrCamera::open` through that owner;
- keep the original UVC helpers and their behavior intact;
- add public, independently versioned v1 camera-descriptor and frame-metadata contracts;
- accept only evidence that v1 can represent: UVC, canonical raw topology and an optional device-declared serial, fail-closed ambiguous identity strength, a process-scoped camera-instance ID, non-wrapping generation, RGB/IR roles, synchronization provenance, and illumination provenance;
- reject unknown versions/fields/variants, self-asserted strong identity, non-canonical topology, zero/malformed instance IDs, generation zero, contradictory or duplicate capability evidence, active-IR provenance on RGB frames, and serialized inputs over 64 KiB;
- keep every persisted legacy format untouched.

## Safety and compatibility

- no UVC extension-unit or emitter writes were added or changed;
- no allowlist, pairing, negotiation, privacy, enrollment, authentication, or capture policy changed;
- no schema is persisted or migrated by this PR;
- no libcamera dependency or MIPI authentication path is introduced;
- the backend and supervisor stay crate-private so this PR does not freeze a third-party backend API.

## Tests

- `cargo test -p irlume-camera`
- `cargo clippy -p irlume-camera --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --locked`
- `cargo build --release --locked`
- `bash scripts/fetch-models.sh`
- `./scripts/run-tests-guarded.sh --min 650 -- cargo test --workspace --locked`
- `python3 scripts/machine-api-conformance.py --irlume target/release/irlume --strict` (36 passed)
- `cargo deny check advisories bans licenses sources` (passed with existing duplicate/yanked warnings)

## Regression proof

- bypassing the supervisor in `RgbCamera::open` makes `public_camera_entrypoints_route_through_one_supervisor_backend` fail;
- replacing one default UVC delegate with a wrong same-signature function makes `default_supervisor_is_process_wide_and_uses_exact_uvc_delegates` fail;
- the deterministic UVC adapter fixture checks every scan bucket, pair field, ordering, and RGB/IR error path;
- removing the RGB/active-IR provenance guard makes `active_ir_is_rejected_on_an_rgb_frame` fail;
- all tests pass after restoring the intended implementation.

## Not included

Camera leases, hotplug generations, V4L2 sequence/timestamp population, stronger pairing, optical readiness, profile negotiation, libcamera, MIPI qualification, and biometric/PAD enablement remain separate fail-closed slices.
