### PR TITLE
fix(vision): restore optional ort provider builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,17 @@ jobs:
       - name: clippy (warnings are errors)
         run: cargo clippy --all-targets -- -D warnings
 
+      # Optional ONNX Runtime execution providers are compile-time APIs. The
+      # default CPU build cannot catch an upstream rename in one of these paths
+      # (issue #454), so compile every supported provider independently and in
+      # combination whenever dependencies are updated.
+      - name: optional ONNX execution providers compile
+        run: |
+          for feature in cuda openvino coreml tensorrt; do
+            cargo check -p irlume-vision --features "$feature" --locked
+          done
+          cargo check -p irlume-vision --all-features --locked
+
       - name: doc (broken intra-doc links are errors)
         run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ### Added
 
 - **Camera discovery and opens now cross one process-owned backend boundary.**
@@ -29,7 +30,15 @@ All notable changes to irlume are documented here. This project adheres to
   diagnostics, preview, setup, raw controls, and legacy single-node opens use the same
   authority. Lifecycle invalidation makes held permits stale before the next dequeue or
   control, explicit operation scopes cross only opted-in worker threads, and drop/panic
-  paths release leases without path-only identity fallbacks (#461).
+ paths release leases without path-only identity fallbacks (#461).
+
+### Fixed
+
+- **CUDA and OpenVINO feature builds compile against pinned `ort` rc.13 again.**
+  The dependency update removed deprecated execution-provider aliases while these
+  two optional paths still referenced them. CI now compiles every supported ONNX
+  execution provider independently and together so future API drift is caught
+  before release (#454).
 
 ## [0.10.0] - 2026-08-12
 

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -514,17 +514,13 @@ mod onnx {
         #[cfg(feature = "cuda")]
         {
             b = b
-                .with_execution_providers([
-                    ort::execution_providers::CUDAExecutionProvider::default().build(),
-                ])
+                .with_execution_providers([ort::ep::CUDA::default().build()])
                 .map_err(err)?;
         }
         #[cfg(feature = "openvino")]
         {
             b = b
-                .with_execution_providers([
-                    ort::execution_providers::OpenVINOExecutionProvider::default().build(),
-                ])
+                .with_execution_providers([ort::ep::OpenVINO::default().build()])
                 .map_err(err)?;
         }
         b.with_optimization_level(GraphOptimizationLevel::Level3)


### PR DESCRIPTION
## Summary

- update CUDA and OpenVINO registration to the pinned `ort` rc.13 `ort::ep` API
- compile every supported optional ONNX execution provider independently in CI
- compile the combined `irlume-vision --all-features` configuration in CI

Closes #454.

## Root cause

`ort` 2.0.0-rc.13 removed the deprecated `execution_providers::*ExecutionProvider` compatibility aliases. The default CPU build never compiled the CUDA or OpenVINO blocks, so the dependency bump passed canonical CI while those optional configurations retained rc.12-only symbol paths.

The provider behavior is unchanged: each selected EP is still registered with its default configuration and retains `ort`'s existing silent CPU fallback when registration fails.

## Verification

- reproduced both failures on unmodified `origin/main`
- `cargo check -p irlume-vision --features cuda --locked`
- `cargo check -p irlume-vision --features openvino --locked`
- `cargo check -p irlume-vision --features coreml --locked`
- `cargo check -p irlume-vision --features tensorrt --locked`
- `cargo check -p irlume-vision --all-features --locked`
- `cargo test --workspace --all-features --locked --no-run`
- 1,395 workspace tests passed
- strict all-feature vision clippy, fmt, and docs passed
- release build and machine API conformance: 36/36
- cargo-deny passed
- workflow YAML parses

## Regression proof

Restoring each removed rc.12 alias independently makes its corresponding new CI command fail with `E0433`. Restoring the rc.13 path makes the full provider loop pass.

## Scope

This is a compile/API compatibility fix. It does not claim runtime CUDA or OpenVINO hardware validation and does not alter CPU, CoreML, or TensorRT behavior.
