### PR TITLE
camera: monitor udev lifecycle changes

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -87,7 +87,7 @@ jobs:
           command -v apt-get >/dev/null || { echo "deps preinstalled on the self-hosted runner"; exit 0; }
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev llvm
+            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev llvm
 
       # A leak suppression matches the SYMBOL NAMES in an allocation stack, so
       # without a symbolizer it matches nothing and the deliberate test leak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi
@@ -334,7 +334,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi
@@ -583,7 +583,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libtss2-dev
+              build-essential pkg-config clang libclang-dev libtss2-dev libudev-dev
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to irlume are documented here. This project adheres to
   permanently, and rediscovery starts a fresh identifier at generation one. Stale,
   forged, foreign-instance, duplicate, exhausted, and poisoned states fail closed.
   Capture and hardware-control behavior remain unchanged (#455).
+- **Linux camera lifecycle changes now invalidate stale inventory tokens.**
+  A monitor-before-scan libudev adapter coalesces UVC and USB-parent events, detects
+  monitor socket errors, and rebuilds one authoritative sysfs snapshot without opening video
+  nodes. Monitor loss, overflow, unstable scans, and continuity loss retire stale
+  references before replacements become visible; capture and hardware-control behavior
+  remain unchanged (#456).
 
 ## [0.10.0] - 2026-08-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +987,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "irlume-auth"
 version = "0.10.0"
 dependencies = [
@@ -1002,6 +1019,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
+ "udev",
  "v4l",
 ]
 
@@ -1214,6 +1232,16 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "line-clipping"
@@ -2732,6 +2760,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "udev"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,11 +3086,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3059,7 +3108,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3073,19 +3122,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3095,9 +3165,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3113,9 +3195,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3125,9 +3219,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ argon2     = "0.5"      # Argon2id KDF for the recovery passphrase
 pbkdf2     = { version = "0.13", default-features = false, features = ["hmac"] }  # PBKDF2-HMAC-SHA512: the KDE wallet key ksecretd expects
 rand       = "0.10"      # CSPRNG for template keys, nonces, recovery salts
 libc       = "0.2"      # mlock/madvise (memlock), NSS getpwnam_r, SO_PEERCRED
+udev       = { version = "0.9.3", features = ["send"] } # persistent V4L2 hotplug monitor + sysfs snapshots
 rustfft    = "6"        # 2D FFT for the RGB-only moiré/screen-replay PAD cue
 
 # ONNX inference. `load-dynamic` => libonnxruntime.so is dlopened at runtime, so

--- a/crates/irlume-camera/Cargo.toml
+++ b/crates/irlume-camera/Cargo.toml
@@ -13,6 +13,7 @@ serde_json.workspace = true
 v4l = "0.14"
 libc = "0.2"
 rand.workspace = true
+udev.workspace = true
 
 [lints]
 workspace = true

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -56,12 +56,48 @@ impl CameraSupervisor {
             .reconcile(observations)
     }
 
+    pub(crate) fn reconcile_inventory_guarded<F>(
+        &self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnMut() -> bool,
+    {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .reconcile_guarded(observations, quiet)
+    }
+
     pub(crate) fn invalidate_inventory(&self) -> Result<(), CameraInventoryError> {
         self.inventory
             .lock()
             .map_err(|_| CameraInventoryError::Poisoned)?
             .invalidate_all();
         Ok(())
+    }
+
+    pub(crate) fn invalidate_inventory_topologies(
+        &self,
+        topologies: &std::collections::BTreeSet<String>,
+    ) -> Result<(), CameraInventoryError> {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .invalidate_topologies(topologies);
+        Ok(())
+    }
+
+    pub(crate) fn retire_inventory_topologies(
+        &self,
+        topologies: &std::collections::BTreeSet<String>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        Ok(self
+            .inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .retire_topologies(topologies))
     }
 
     #[cfg_attr(

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -29,7 +29,7 @@ trait CameraBackend: Send + Sync + 'static {
 ///
 /// Inventory mutation is isolated from capture routing. Leases and hotplug event
 /// subscription remain later slices and therefore cannot alter behavior here.
-struct CameraSupervisor {
+pub(crate) struct CameraSupervisor {
     backend: Arc<dyn CameraBackend>,
     inventory: Mutex<CameraInventory>,
 }
@@ -46,14 +46,7 @@ impl CameraSupervisor {
         }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the udev adapter will feed inventory observations"
-        )
-    )]
-    fn reconcile_inventory(
+    pub(crate) fn reconcile_inventory(
         &self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
@@ -63,6 +56,14 @@ impl CameraSupervisor {
             .reconcile(observations)
     }
 
+    pub(crate) fn invalidate_inventory(&self) -> Result<(), CameraInventoryError> {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .invalidate_all();
+        Ok(())
+    }
+
     #[cfg_attr(
         not(test),
         expect(
@@ -70,7 +71,7 @@ impl CameraSupervisor {
             reason = "later frame and session slices validate descriptors"
         )
     )]
-    fn validate_descriptor(
+    pub(crate) fn validate_descriptor(
         &self,
         descriptor: &CameraDescriptor,
     ) -> Result<(), CameraInventoryError> {
@@ -186,10 +187,18 @@ impl CameraBackend for UvcV4l2Backend {
     }
 }
 
-static DEFAULT_CAMERA_SUPERVISOR: OnceLock<CameraSupervisor> = OnceLock::new();
+static DEFAULT_CAMERA_SUPERVISOR: OnceLock<Arc<CameraSupervisor>> = OnceLock::new();
 
 fn default_camera_supervisor() -> &'static CameraSupervisor {
-    DEFAULT_CAMERA_SUPERVISOR.get_or_init(|| CameraSupervisor::new(UvcV4l2Backend::default()))
+    DEFAULT_CAMERA_SUPERVISOR
+        .get_or_init(|| {
+            let supervisor = Arc::new(CameraSupervisor::new(UvcV4l2Backend::default()));
+            if let Err(error) = crate::lifecycle::spawn(Arc::downgrade(&supervisor)) {
+                eprintln!("irlume: camera lifecycle monitor unavailable: {error}");
+            }
+            supervisor
+        })
+        .as_ref()
 }
 
 #[cfg(test)]

--- a/crates/irlume-camera/src/inventory.rs
+++ b/crates/irlume-camera/src/inventory.rs
@@ -23,6 +23,7 @@ pub(crate) struct CameraObservation {
     backend: BackendKind,
     physical_id: PhysicalCameraId,
     capabilities: CameraCapabilities,
+    lifecycle_evidence: Vec<String>,
 }
 
 impl CameraObservation {
@@ -35,11 +36,32 @@ impl CameraObservation {
             backend,
             physical_id,
             capabilities,
+            lifecycle_evidence: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_lifecycle_evidence(
+        backend: BackendKind,
+        physical_id: PhysicalCameraId,
+        capabilities: CameraCapabilities,
+        mut lifecycle_evidence: Vec<String>,
+    ) -> Self {
+        lifecycle_evidence.sort();
+        lifecycle_evidence.dedup();
+        Self {
+            backend,
+            physical_id,
+            capabilities,
+            lifecycle_evidence,
         }
     }
 
     pub(crate) fn physical_id(&self) -> &PhysicalCameraId {
         &self.physical_id
+    }
+
+    pub(crate) fn lifecycle_evidence(&self) -> &[String] {
+        &self.lifecycle_evidence
     }
 
     fn descriptor(
@@ -115,9 +137,26 @@ pub(crate) enum CameraInventoryError {
     UnknownCamera,
     Removed,
     StaleGeneration,
+    ContinuityLost,
     DescriptorMismatch,
     InstanceIdExhausted,
     Poisoned,
+}
+
+/// Descriptor-bound handle for a currently observed backend object.
+///
+/// Endpoint evidence remains private: callers must validate the whole token
+/// rather than treating a `/dev/videoN` path as proof of freshness.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CameraInventoryRef {
+    descriptor: CameraDescriptor,
+    lifecycle_evidence: Vec<String>,
+}
+
+impl CameraInventoryRef {
+    pub(crate) fn descriptor(&self) -> &CameraDescriptor {
+        &self.descriptor
+    }
 }
 
 /// Process-scoped physical-camera lifecycle state.
@@ -128,6 +167,7 @@ pub(crate) struct CameraInventory {
     active: BTreeMap<String, InventoryEntry>,
     tombstones: BTreeSet<String>,
     retired_instance_ids: BTreeSet<CameraInstanceId>,
+    invalidated_instance_ids: BTreeSet<CameraInstanceId>,
     instance_id_source: InstanceIdSource,
 }
 
@@ -141,6 +181,7 @@ impl CameraInventory {
             active: BTreeMap::new(),
             tombstones: BTreeSet::new(),
             retired_instance_ids: BTreeSet::new(),
+            invalidated_instance_ids: BTreeSet::new(),
             instance_id_source,
         }
     }
@@ -248,7 +289,16 @@ impl CameraInventory {
         self.active = next_active;
         self.tombstones = next_tombstones;
         self.retired_instance_ids = next_retired_instance_ids;
+        self.invalidated_instance_ids.clear();
         Ok(events)
+    }
+
+    pub(crate) fn invalidate_all(&mut self) {
+        self.invalidated_instance_ids = self
+            .active
+            .values()
+            .map(|entry| entry.descriptor.camera_instance_id().clone())
+            .collect();
     }
 
     pub(crate) fn active_descriptors(&self) -> Vec<CameraDescriptor> {
@@ -256,6 +306,36 @@ impl CameraInventory {
             .values()
             .map(|entry| entry.descriptor.clone())
             .collect()
+    }
+
+    pub(crate) fn active_references(&self) -> Vec<CameraInventoryRef> {
+        self.active
+            .values()
+            .filter(|entry| {
+                !self
+                    .invalidated_instance_ids
+                    .contains(entry.descriptor.camera_instance_id())
+            })
+            .map(|entry| CameraInventoryRef {
+                descriptor: entry.descriptor.clone(),
+                lifecycle_evidence: entry.observation.lifecycle_evidence.clone(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn validate_reference(
+        &self,
+        reference: &CameraInventoryRef,
+    ) -> Result<(), CameraInventoryError> {
+        self.validate(reference.descriptor())?;
+        let active = self
+            .active
+            .get(reference.descriptor().physical_id().topology_path())
+            .ok_or(CameraInventoryError::UnknownCamera)?;
+        if active.observation.lifecycle_evidence != reference.lifecycle_evidence {
+            return Err(CameraInventoryError::DescriptorMismatch);
+        }
+        Ok(())
     }
 
     pub(crate) fn validate(
@@ -272,6 +352,12 @@ impl CameraInventory {
         };
         if descriptor.camera_instance_id() != active.descriptor.camera_instance_id() {
             return Err(CameraInventoryError::ForeignInstance);
+        }
+        if self
+            .invalidated_instance_ids
+            .contains(descriptor.camera_instance_id())
+        {
+            return Err(CameraInventoryError::ContinuityLost);
         }
         if descriptor.generation() != active.descriptor.generation() {
             return Err(CameraInventoryError::StaleGeneration);
@@ -301,6 +387,7 @@ impl CameraInventory {
             )]),
             tombstones: BTreeSet::new(),
             retired_instance_ids: BTreeSet::new(),
+            invalidated_instance_ids: BTreeSet::new(),
             instance_id_source: Box::new(move || replacement_id.clone()),
         }
     }
@@ -348,6 +435,45 @@ mod tests {
 
     fn generation(event: &CameraInventoryEvent) -> u64 {
         event.descriptor().generation().get()
+    }
+
+    #[test]
+    fn references_are_descriptor_bound_and_hidden_while_invalidated() {
+        let mut inventory = CameraInventory::new();
+        let camera = CameraObservation::with_lifecycle_evidence(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new("/devices/pci/a", Some("A".into())).unwrap(),
+            CameraCapabilities::new(vec![StreamRole::Rgb], Default::default(), Vec::new()).unwrap(),
+            vec!["/devices/pci/a/video4linux/video0".into()],
+        );
+        inventory.reconcile(vec![camera]).unwrap();
+        let reference = inventory.active_references().pop().unwrap();
+        assert_eq!(inventory.validate_reference(&reference), Ok(()));
+
+        inventory.invalidate_all();
+        assert!(inventory.active_references().is_empty());
+        assert_eq!(
+            inventory.validate_reference(&reference),
+            Err(CameraInventoryError::ContinuityLost)
+        );
+    }
+
+    #[test]
+    fn invalidation_blocks_old_descriptor_until_authoritative_reconcile() {
+        let mut inventory = CameraInventory::new();
+        let camera = observation("/devices/pci/a", Some("A"), &[StreamRole::Rgb]);
+        let descriptor = inventory.reconcile(vec![camera.clone()]).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        inventory.invalidate_all();
+        assert_eq!(
+            inventory.validate(&descriptor),
+            Err(CameraInventoryError::ContinuityLost)
+        );
+
+        assert!(inventory.reconcile(vec![camera]).unwrap().is_empty());
+        assert_eq!(inventory.validate(&descriptor), Ok(()));
     }
 
     #[test]

--- a/crates/irlume-camera/src/inventory.rs
+++ b/crates/irlume-camera/src/inventory.rs
@@ -207,6 +207,19 @@ impl CameraInventory {
         &mut self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        let (events, committed) = self.reconcile_guarded(observations, || true)?;
+        debug_assert!(committed);
+        Ok(events)
+    }
+
+    pub(crate) fn reconcile_guarded<F>(
+        &mut self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnOnce() -> bool,
+    {
         let mut incoming = BTreeMap::new();
         for observation in observations {
             let key = observation.physical_id().topology_path().to_owned();
@@ -245,7 +258,11 @@ impl CameraInventory {
                     );
                     events.push(CameraInventoryEvent::Added(descriptor));
                 }
-                (Some(previous), Some(observation)) if previous.observation == observation => {}
+                (Some(previous), Some(observation))
+                    if previous.observation == observation
+                        && !self
+                            .invalidated_instance_ids
+                            .contains(previous.descriptor.camera_instance_id()) => {}
                 (Some(previous), Some(observation)) => {
                     let (instance_id, generation) = match previous.descriptor.generation().next() {
                         Ok(generation) => {
@@ -286,11 +303,15 @@ impl CameraInventory {
                 .then_with(|| left.topology_path().cmp(right.topology_path()))
         });
 
+        if !quiet() {
+            return Ok((Vec::new(), false));
+        }
+
         self.active = next_active;
         self.tombstones = next_tombstones;
         self.retired_instance_ids = next_retired_instance_ids;
         self.invalidated_instance_ids.clear();
-        Ok(events)
+        Ok((events, true))
     }
 
     pub(crate) fn invalidate_all(&mut self) {
@@ -299,6 +320,34 @@ impl CameraInventory {
             .values()
             .map(|entry| entry.descriptor.camera_instance_id().clone())
             .collect();
+    }
+
+    pub(crate) fn invalidate_topologies(&mut self, topologies: &BTreeSet<String>) {
+        self.invalidated_instance_ids.extend(
+            topologies
+                .iter()
+                .filter_map(|topology| self.active.get(topology))
+                .map(|entry| entry.descriptor.camera_instance_id().clone()),
+        );
+    }
+
+    pub(crate) fn retire_topologies(
+        &mut self,
+        topologies: &BTreeSet<String>,
+    ) -> Vec<CameraInventoryEvent> {
+        let mut events = Vec::new();
+        for topology in topologies {
+            let Some(entry) = self.active.remove(topology) else {
+                continue;
+            };
+            self.invalidated_instance_ids
+                .remove(entry.descriptor.camera_instance_id());
+            self.retired_instance_ids
+                .insert(entry.descriptor.camera_instance_id().clone());
+            self.tombstones.insert(topology.clone());
+            events.push(CameraInventoryEvent::Removed(entry.descriptor));
+        }
+        events
     }
 
     pub(crate) fn active_descriptors(&self) -> Vec<CameraDescriptor> {
@@ -459,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn invalidation_blocks_old_descriptor_until_authoritative_reconcile() {
+    fn invalidation_blocks_old_descriptor_across_authoritative_reconcile() {
         let mut inventory = CameraInventory::new();
         let camera = observation("/devices/pci/a", Some("A"), &[StreamRole::Rgb]);
         let descriptor = inventory.reconcile(vec![camera.clone()]).unwrap()[0]
@@ -472,8 +521,14 @@ mod tests {
             Err(CameraInventoryError::ContinuityLost)
         );
 
-        assert!(inventory.reconcile(vec![camera]).unwrap().is_empty());
-        assert_eq!(inventory.validate(&descriptor), Ok(()));
+        let refreshed = inventory.reconcile(vec![camera]).unwrap();
+        assert_eq!(refreshed.len(), 1);
+        assert!(refreshed[0].is_changed());
+        assert_eq!(
+            inventory.validate(&descriptor),
+            Err(CameraInventoryError::StaleGeneration)
+        );
+        assert_eq!(inventory.validate(refreshed[0].descriptor()), Ok(()));
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -37,6 +37,7 @@ mod inventory;
 pub mod ir_dark;
 pub mod ir_emitter;
 mod ir_metadata;
+mod lifecycle;
 mod media_graph;
 // Public for exactly one item, `pending_summary`, doctor's read-only view of
 // the store (#429); every record type stays crate-private so no other code

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -4,14 +4,15 @@
 //! Persistent udev lifecycle invalidation for the supervisor inventory.
 //!
 //! Udev messages are deliberately treated only as hints. Every published state
-//! comes from a complete sysfs/udev snapshot taken after the monitor is already
+//! comes from a complete sysfs/media snapshot taken after the monitor is already
 //! listening. Neither enumeration nor monitoring opens a video node.
 
-use std::collections::BTreeMap;
 #[cfg(test)]
 use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::os::fd::AsRawFd as _;
+use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::Mutex;
 use std::sync::Weak;
@@ -22,6 +23,8 @@ use crate::contracts::{BackendKind, CameraCapabilities, PhysicalCameraId};
 use crate::inventory::{CameraInventoryError, CameraInventoryEvent, CameraObservation};
 
 const MAX_QUIET_SNAPSHOT_ATTEMPTS: usize = 4;
+const MAX_COALESCE_POLLS: usize = 16;
+const MAX_EVENTS_PER_POLL: usize = 4096;
 const COALESCE_QUIET: Duration = Duration::from_millis(50);
 const MONITOR_WAIT: Duration = Duration::from_secs(60 * 60);
 
@@ -35,6 +38,7 @@ pub(crate) enum DeviceEventKind {
 pub(crate) struct DeviceEventHint {
     kind: DeviceEventKind,
     devpath: String,
+    affected_topologies: BTreeSet<String>,
 }
 
 impl DeviceEventHint {
@@ -43,14 +47,36 @@ impl DeviceEventHint {
         Self {
             kind,
             devpath: devpath.into(),
+            affected_topologies: BTreeSet::new(),
         }
     }
 
-    fn from_udev(kind: DeviceEventKind, devpath: impl Into<String>) -> Self {
+    fn from_udev(
+        kind: DeviceEventKind,
+        devpath: impl Into<String>,
+        tracked_topologies: &BTreeSet<String>,
+    ) -> Self {
+        let devpath = devpath.into();
+        let affected_topologies = tracked_topologies
+            .iter()
+            .filter(|topology| {
+                devpath == topology.as_str()
+                    || devpath.starts_with(&format!("{topology}/"))
+                    || topology.starts_with(&format!("{devpath}/"))
+            })
+            .cloned()
+            .collect();
         Self {
             kind,
-            devpath: devpath.into(),
+            devpath,
+            affected_topologies,
         }
+    }
+
+    #[cfg(test)]
+    fn with_affected_topology(mut self, topology: impl Into<String>) -> Self {
+        self.affected_topologies.insert(topology.into());
+        self
     }
 
     fn kind(&self) -> DeviceEventKind {
@@ -64,11 +90,15 @@ impl DeviceEventHint {
     fn requires_retirement(&self) -> bool {
         self.kind == DeviceEventKind::ContinuityLost
     }
+
+    fn affected_topologies(&self) -> &BTreeSet<String> {
+        &self.affected_topologies
+    }
 }
 
 fn consume_hints(hints: &[DeviceEventHint]) {
     for hint in hints {
-        let _ = (hint.kind(), hint.devpath());
+        let _ = (hint.kind(), hint.devpath(), hint.affected_topologies());
     }
 }
 
@@ -77,6 +107,7 @@ pub(crate) enum LifecycleError {
     Monitor(String),
     Snapshot(String),
     UnstableSnapshot,
+    EventStorm,
     Inventory(CameraInventoryError),
 }
 
@@ -86,6 +117,7 @@ impl fmt::Display for LifecycleError {
             Self::Monitor(message) => write!(f, "udev monitor failed: {message}"),
             Self::Snapshot(message) => write!(f, "camera snapshot failed: {message}"),
             Self::UnstableSnapshot => f.write_str("camera snapshot never became quiet"),
+            Self::EventStorm => f.write_str("camera lifecycle event storm exceeded bounds"),
             Self::Inventory(error) => write!(f, "camera inventory failed: {error:?}"),
         }
     }
@@ -93,6 +125,10 @@ impl fmt::Display for LifecycleError {
 
 trait DeviceEventSource {
     fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError>;
+
+    fn add_tracked_topologies(&mut self, _topologies: &[String]) {}
+
+    fn commit_tracked_topologies(&mut self, _topologies: &[String]) {}
 }
 
 trait SnapshotSource {
@@ -102,10 +138,28 @@ trait SnapshotSource {
 trait InventorySink {
     fn invalidate_all(&self) -> Result<(), CameraInventoryError>;
 
+    fn invalidate_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<(), CameraInventoryError>;
+
+    fn retire_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
+
     fn reconcile(
         &self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
+
+    fn reconcile_guarded<F>(
+        &self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnMut() -> bool;
 }
 
 impl InventorySink for CameraSupervisor {
@@ -113,11 +167,36 @@ impl InventorySink for CameraSupervisor {
         self.invalidate_inventory()
     }
 
+    fn invalidate_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<(), CameraInventoryError> {
+        self.invalidate_inventory_topologies(topologies)
+    }
+
+    fn retire_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        self.retire_inventory_topologies(topologies)
+    }
+
     fn reconcile(
         &self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
         self.reconcile_inventory(observations)
+    }
+
+    fn reconcile_guarded<F>(
+        &self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnMut() -> bool,
+    {
+        self.reconcile_inventory_guarded(observations, quiet)
     }
 }
 
@@ -155,15 +234,22 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
 
         // A message only invalidates the old view. Drain the burst, then rebuild
         // from one authoritative snapshot; event payloads never mutate inventory.
-        loop {
+        let mut quiet = false;
+        for _ in 0..MAX_COALESCE_POLLS {
             match self.events.poll(COALESCE_QUIET) {
-                Ok(events) if events.is_empty() => break,
+                Ok(events) if events.is_empty() => {
+                    quiet = true;
+                    break;
+                }
                 Ok(events) => {
                     consume_hints(&events);
                     pending.extend(self.prepare_rescan(inventory, &events)?);
                 }
                 Err(error) => return Err(fail_closed(inventory, error)),
             }
+        }
+        if !quiet {
+            return Err(fail_closed(inventory, LifecycleError::EventStorm));
         }
         self.publish_quiet_snapshot(inventory, pending)
     }
@@ -178,11 +264,39 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
                 Ok(observations) => observations,
                 Err(error) => return Err(fail_closed(inventory, error)),
             };
-            match self.events.poll(Duration::ZERO) {
+            let topologies: Vec<String> = observations
+                .iter()
+                .map(|observation| observation.physical_id().topology_path().to_owned())
+                .collect();
+            self.events.add_tracked_topologies(&topologies);
+            match self.events.poll(COALESCE_QUIET) {
                 Ok(events) if events.is_empty() => {
-                    let mut published = inventory
-                        .reconcile(observations)
+                    let mut boundary_events = Vec::new();
+                    let mut boundary_error = None;
+                    let (mut published, committed) = inventory
+                        .reconcile_guarded(observations, || {
+                            match self.events.poll(Duration::ZERO) {
+                                Ok(events) if events.is_empty() => true,
+                                Ok(events) => {
+                                    boundary_events.extend(events);
+                                    false
+                                }
+                                Err(error) => {
+                                    boundary_error = Some(error);
+                                    false
+                                }
+                            }
+                        })
                         .map_err(LifecycleError::Inventory)?;
+                    if let Some(error) = boundary_error {
+                        return Err(fail_closed(inventory, error));
+                    }
+                    if !committed {
+                        consume_hints(&boundary_events);
+                        pending.extend(self.prepare_rescan(inventory, &boundary_events)?);
+                        continue;
+                    }
+                    self.events.commit_tracked_topologies(&topologies);
                     pending.append(&mut published);
                     return Ok(pending);
                 }
@@ -202,15 +316,21 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
         inventory: &impl InventorySink,
         hints: &[DeviceEventHint],
     ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        let affected: BTreeSet<String> = hints
+            .iter()
+            .flat_map(|hint| hint.affected_topologies().iter().cloned())
+            .collect();
         inventory
-            .invalidate_all()
+            .invalidate_topologies(&affected)
             .map_err(LifecycleError::Inventory)?;
-        if hints.iter().any(DeviceEventHint::requires_retirement) {
-            return inventory
-                .reconcile(Vec::new())
-                .map_err(LifecycleError::Inventory);
-        }
-        Ok(Vec::new())
+        let retired: BTreeSet<String> = hints
+            .iter()
+            .filter(|hint| hint.requires_retirement())
+            .flat_map(|hint| hint.affected_topologies().iter().cloned())
+            .collect();
+        inventory
+            .retire_topologies(&retired)
+            .map_err(LifecycleError::Inventory)
     }
 }
 
@@ -223,17 +343,53 @@ fn fail_closed(inventory: &impl InventorySink, error: LifecycleError) -> Lifecyc
 
 struct UdevEventSource {
     socket: udev::MonitorSocket,
+    tracked_topologies: BTreeSet<String>,
 }
 
 impl UdevEventSource {
     fn new() -> Result<Self, LifecycleError> {
         // Do not filter to video4linux: USB parent/interface bind, unbind and
         // reset events are continuity evidence even when no child event exists.
-        let socket = udev::MonitorBuilder::new()
+        // SEQNUM is deliberately not used as loss evidence: it is global across
+        // namespace-targeted uevents and assigned before kernel broadcast order.
+        // Observable socket loss (ENOBUFS/errors/hangup) is the fail-closed signal.
+        let socket = udev::MonitorBuilder::new_kernel()
             .and_then(udev::MonitorBuilder::listen)
             .map_err(|error| LifecycleError::Monitor(error.to_string()))?;
-        Ok(Self { socket })
+        Ok(Self {
+            socket,
+            tracked_topologies: BTreeSet::new(),
+        })
     }
+}
+
+fn classify_kernel_event(
+    subsystem: Option<&str>,
+    interface: Option<&str>,
+    modalias: Option<&str>,
+    devtype: Option<&str>,
+    tracked_usb_parent: bool,
+    event_type: udev::EventType,
+) -> Option<DeviceEventKind> {
+    if subsystem == Some("video4linux") {
+        return Some(if event_type == udev::EventType::Change {
+            DeviceEventKind::DirtyUvc
+        } else {
+            DeviceEventKind::ContinuityLost
+        });
+    }
+    if subsystem != Some("usb") {
+        return None;
+    }
+    let uvc_interface = interface.is_some_and(|value| {
+        value.starts_with("14/") || value.to_ascii_lowercase().starts_with("0e/")
+    }) || modalias
+        .is_some_and(|value| value.to_ascii_lowercase().contains("ic0e"));
+    let usb_parent = devtype == Some("usb_device") && tracked_usb_parent;
+    if !uvc_interface && !usb_parent {
+        return None;
+    }
+    Some(DeviceEventKind::ContinuityLost)
 }
 
 impl DeviceEventSource for UdevEventSource {
@@ -258,32 +414,58 @@ impl DeviceEventSource for UdevEventSource {
         }
 
         let mut hints = Vec::new();
-        for event in self.socket.iter() {
-            let subsystem = event.subsystem().and_then(std::ffi::OsStr::to_str);
-            let is_uvc_usb = subsystem == Some("usb")
-                && (event.driver().and_then(std::ffi::OsStr::to_str) == Some("uvcvideo")
-                    || event
-                        .property_value("ID_USB_DRIVER")
-                        .and_then(std::ffi::OsStr::to_str)
-                        == Some("uvcvideo")
-                    || event
-                        .property_value("ID_USB_INTERFACES")
-                        .and_then(std::ffi::OsStr::to_str)
-                        .is_some_and(|interfaces| interfaces.contains(":0e")));
-            if subsystem != Some("video4linux") && !is_uvc_usb {
-                continue;
+        let mut received = 0;
+        let mut events = self.socket.iter();
+        while let Some(event) = next_monitor_event(&mut events)? {
+            received += 1;
+            if received > MAX_EVENTS_PER_POLL {
+                return Err(LifecycleError::EventStorm);
             }
-            let kind = match event.event_type() {
-                udev::EventType::Change => DeviceEventKind::DirtyUvc,
-                _ => DeviceEventKind::ContinuityLost,
+            let devpath = event.devpath().to_string_lossy();
+            let tracked_usb_parent = self.tracked_topologies.contains(devpath.as_ref());
+            let text = |name| event.property_value(name).and_then(std::ffi::OsStr::to_str);
+            let Some(kind) = classify_kernel_event(
+                event.subsystem().and_then(std::ffi::OsStr::to_str),
+                text("INTERFACE"),
+                text("MODALIAS"),
+                text("DEVTYPE"),
+                tracked_usb_parent,
+                event.event_type(),
+            ) else {
+                continue;
             };
             hints.push(DeviceEventHint::from_udev(
                 kind,
                 event.devpath().to_string_lossy(),
+                &self.tracked_topologies,
             ));
         }
-        ensure_receive_drained(std::io::Error::last_os_error().raw_os_error())?;
         Ok(hints)
+    }
+
+    fn add_tracked_topologies(&mut self, topologies: &[String]) {
+        self.tracked_topologies.extend(topologies.iter().cloned());
+    }
+
+    fn commit_tracked_topologies(&mut self, topologies: &[String]) {
+        self.tracked_topologies = topologies.iter().cloned().collect();
+    }
+}
+
+fn set_errno(errno: i32) {
+    // SAFETY: Linux exposes one thread-local errno cell per calling thread.
+    unsafe { *libc::__errno_location() = errno };
+}
+
+fn next_monitor_event<I: Iterator>(iterator: &mut I) -> Result<Option<I::Item>, LifecycleError> {
+    set_errno(0);
+    match iterator.next() {
+        Some(event) => Ok(Some(event)),
+        None => {
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            ensure_receive_drained(errno)?;
+            Ok(None)
+        }
     }
 }
 
@@ -314,61 +496,81 @@ fn ensure_receive_drained(errno: Option<i32>) -> Result<(), LifecycleError> {
     }
 }
 
-#[derive(Default)]
-struct UdevSnapshotSource;
+struct SysfsSnapshotSource {
+    root: PathBuf,
+}
+
+impl Default for SysfsSnapshotSource {
+    fn default() -> Self {
+        Self {
+            root: PathBuf::from("/sys/class/video4linux"),
+        }
+    }
+}
 
 #[derive(Debug)]
 struct UdevNodeRecord {
     usb_devpath: String,
     serial: Option<String>,
     node_devpath: String,
-    devnode: Option<String>,
+    devnode: String,
     interface_number: Option<String>,
-    v4l_capabilities: Option<String>,
+    capture_node: Option<bool>,
 }
 
-impl SnapshotSource for UdevSnapshotSource {
-    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
-        let mut enumerator =
-            udev::Enumerator::new().map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
-        enumerator
-            .match_subsystem("video4linux")
-            .and_then(|()| enumerator.match_is_initialized())
-            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
-        let devices = enumerator
-            .scan_devices()
-            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+fn read_trimmed(path: impl AsRef<Path>) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
 
+fn devpath(path: &Path) -> String {
+    match path.strip_prefix("/sys") {
+        Ok(relative) => format!("/{}", relative.to_string_lossy()),
+        Err(_) => path.to_string_lossy().into_owned(),
+    }
+}
+
+fn usb_device_parent(interface: &Path) -> Option<&Path> {
+    interface
+        .ancestors()
+        .find(|path| path.join("idVendor").is_file() && path.join("idProduct").is_file())
+}
+
+impl SnapshotSource for SysfsSnapshotSource {
+    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(LifecycleError::Snapshot(error.to_string())),
+        };
         let mut records = Vec::new();
-        for device in devices {
-            if device.property_value("ID_USB_DRIVER") != Some(std::ffi::OsStr::new("uvcvideo")) {
+        for entry in entries {
+            let entry = entry.map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+            let interface = std::fs::canonicalize(entry.path().join("device"))
+                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+            let driver = std::fs::canonicalize(interface.join("driver")).ok();
+            if driver.as_deref().and_then(Path::file_name) != Some(std::ffi::OsStr::new("uvcvideo"))
+            {
                 continue;
             }
-            let usb = device
-                .parent_with_subsystem_devtype("usb", "usb_device")
-                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?
-                .ok_or_else(|| {
-                    LifecycleError::Snapshot(format!(
-                        "{} has uvcvideo but no USB-device parent",
-                        device.devpath().to_string_lossy()
-                    ))
-                })?;
+            let usb = usb_device_parent(&interface).ok_or_else(|| {
+                LifecycleError::Snapshot(format!(
+                    "{} has uvcvideo but no USB-device parent",
+                    interface.display()
+                ))
+            })?;
+            let name = entry.file_name();
+            let devnode = PathBuf::from("/dev").join(&name);
+            let devnode_text = devnode.to_string_lossy().into_owned();
             records.push(UdevNodeRecord {
-                usb_devpath: usb.devpath().to_string_lossy().into_owned(),
-                serial: usb
-                    .attribute_value("serial")
-                    .map(|value| value.to_string_lossy().trim().to_owned())
-                    .filter(|value| !value.is_empty()),
-                node_devpath: device.devpath().to_string_lossy().into_owned(),
-                devnode: device
-                    .devnode()
-                    .map(|path| path.to_string_lossy().into_owned()),
-                interface_number: device
-                    .property_value("ID_USB_INTERFACE_NUM")
-                    .map(|value| value.to_string_lossy().into_owned()),
-                v4l_capabilities: device
-                    .property_value("ID_V4L_CAPABILITIES")
-                    .map(|value| value.to_string_lossy().into_owned()),
+                usb_devpath: devpath(usb),
+                serial: read_trimmed(usb.join("serial")),
+                node_devpath: devpath(&interface),
+                interface_number: read_trimmed(interface.join("bInterfaceNumber")),
+                capture_node: crate::media_graph::node_is_capture(&devnode_text),
+                devnode: devnode_text,
             });
         }
         observations_from_records(records)
@@ -383,9 +585,13 @@ fn observations_from_records(
         let evidence = format!(
             "{}|{}|{}|{}",
             record.node_devpath,
-            record.devnode.as_deref().unwrap_or(""),
+            record.devnode,
             record.interface_number.as_deref().unwrap_or(""),
-            record.v4l_capabilities.as_deref().unwrap_or("")
+            match record.capture_node {
+                Some(true) => "capture",
+                Some(false) => "metadata",
+                None => "unknown",
+            }
         );
         let group = groups
             .entry(record.usb_devpath.clone())
@@ -422,18 +628,33 @@ fn bind_monitor_before_snapshot<S: SnapshotSource, E: DeviceEventSource>(
     Ok(LifecycleCoordinator::new(snapshots(), events))
 }
 
+struct WorkerExitGuard<'a, I: InventorySink>(&'a I);
+
+impl<'a, I: InventorySink> WorkerExitGuard<'a, I> {
+    fn new(inventory: &'a I) -> Self {
+        Self(inventory)
+    }
+}
+
+impl<I: InventorySink> Drop for WorkerExitGuard<'_, I> {
+    fn drop(&mut self) {
+        let _ = self.0.invalidate_all();
+    }
+}
+
 /// Start the production monitor before the first authoritative scan. The thread
 /// owns the monitor socket for the supervisor lifetime; dropping the process is
 /// the only normal shutdown path for this process-scoped inventory.
 pub(crate) fn spawn(supervisor: Weak<CameraSupervisor>) -> Result<(), LifecycleError> {
     let mut coordinator =
-        bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource)?;
+        bind_monitor_before_snapshot(UdevEventSource::new, SysfsSnapshotSource::default)?;
     std::thread::Builder::new()
         .name("irlume-camera-udev".into())
         .spawn(move || {
             let Some(supervisor) = supervisor.upgrade() else {
                 return;
             };
+            let _exit_guard = WorkerExitGuard::new(supervisor.as_ref());
             if let Err(error) = coordinator.initialize(supervisor.as_ref()) {
                 eprintln!("irlume: camera lifecycle monitor stopped: {error}");
                 return;
@@ -476,11 +697,40 @@ mod tests {
             Ok(())
         }
 
+        fn invalidate_topologies(
+            &self,
+            topologies: &BTreeSet<String>,
+        ) -> Result<(), CameraInventoryError> {
+            self.0.lock().unwrap().invalidate_topologies(topologies);
+            Ok(())
+        }
+
+        fn retire_topologies(
+            &self,
+            topologies: &BTreeSet<String>,
+        ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+            Ok(self.0.lock().unwrap().retire_topologies(topologies))
+        }
+
         fn reconcile(
             &self,
             observations: Vec<CameraObservation>,
         ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
             self.0.lock().unwrap().reconcile(observations)
+        }
+
+        fn reconcile_guarded<F>(
+            &self,
+            observations: Vec<CameraObservation>,
+            quiet: F,
+        ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+        where
+            F: FnMut() -> bool,
+        {
+            self.0
+                .lock()
+                .unwrap()
+                .reconcile_guarded(observations, quiet)
         }
     }
 
@@ -501,16 +751,311 @@ mod tests {
     }
 
     fn observation(evidence: &str) -> CameraObservation {
+        observation_at("/devices/pci/usb1/camera", evidence)
+    }
+
+    fn observation_at(topology: &str, evidence: &str) -> CameraObservation {
         CameraObservation::with_lifecycle_evidence(
             BackendKind::UvcV4l2,
-            PhysicalCameraId::new("/devices/pci/usb1/camera", None).unwrap(),
+            PhysicalCameraId::new(topology, None).unwrap(),
             CameraCapabilities::new(vec![StreamRole::Rgb], Default::default(), Vec::new()).unwrap(),
             vec![evidence.into()],
         )
     }
 
     fn hint(kind: DeviceEventKind) -> DeviceEventHint {
-        DeviceEventHint::new(kind, "/devices/pci/usb1/video4linux/video0")
+        DeviceEventHint::new(kind, "/devices/pci/usb1/camera/video4linux/video0")
+            .with_affected_topology("/devices/pci/usb1/camera")
+    }
+
+    #[test]
+    fn iterator_null_preserves_real_receive_error() {
+        let result = next_monitor_event(&mut std::iter::from_fn(|| {
+            set_errno(libc::ENOBUFS);
+            None::<()>
+        }));
+        assert!(matches!(
+            result,
+            Err(LifecycleError::Monitor(message)) if message.contains("overflow")
+        ));
+    }
+
+    #[test]
+    fn usb_uvc_change_and_property_sparse_remove_retire_continuity() {
+        let change = classify_kernel_event(
+            Some("usb"),
+            Some("14/1/0"),
+            None,
+            Some("usb_interface"),
+            false,
+            udev::EventType::Change,
+        );
+        assert_eq!(change, Some(DeviceEventKind::ContinuityLost));
+
+        let remove = classify_kernel_event(
+            Some("usb"),
+            None,
+            Some("usb:v3277p0059d0001dcEFdsc02dp01ic0Eisc01ip00in00"),
+            Some("usb_interface"),
+            false,
+            udev::EventType::Remove,
+        );
+        assert_eq!(remove, Some(DeviceEventKind::ContinuityLost));
+        assert_eq!(
+            classify_kernel_event(
+                Some("video4linux"),
+                None,
+                None,
+                None,
+                false,
+                udev::EventType::Change,
+            ),
+            Some(DeviceEventKind::DirtyUvc)
+        );
+        assert_eq!(
+            classify_kernel_event(
+                Some("usb"),
+                None,
+                None,
+                Some("usb_device"),
+                false,
+                udev::EventType::Remove,
+            ),
+            None
+        );
+        assert_eq!(
+            classify_kernel_event(
+                Some("usb"),
+                None,
+                None,
+                Some("usb_device"),
+                true,
+                udev::EventType::Remove,
+            ),
+            Some(DeviceEventKind::ContinuityLost)
+        );
+    }
+
+    #[test]
+    fn commit_boundary_event_discards_provisional_snapshot_before_unlock() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("provisional")]),
+                Ok(vec![observation("committed")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        coordinator.initialize(&inventory).unwrap();
+        assert!(
+            coordinator.snapshots.0.is_empty(),
+            "event at the guarded post-commit drain must force a fresh snapshot"
+        );
+    }
+
+    #[test]
+    fn sustained_event_storm_is_bounded_and_fail_closed() {
+        let inventory = TestInventory::new();
+        let descriptor = inventory
+            .reconcile(vec![observation("published")])
+            .unwrap()
+            .remove(0)
+            .descriptor()
+            .clone();
+        let mut polls = VecDeque::from([Ok(vec![hint(DeviceEventKind::DirtyUvc)])]);
+        polls.extend((0..MAX_COALESCE_POLLS).map(|_| Ok(vec![hint(DeviceEventKind::DirtyUvc)])));
+        let mut coordinator =
+            LifecycleCoordinator::new(FakeSnapshots(VecDeque::new()), FakeEvents(polls));
+        assert_eq!(
+            coordinator.process_next(&inventory, Duration::ZERO),
+            Err(LifecycleError::EventStorm)
+        );
+        assert!(inventory.validate(&descriptor).is_err());
+    }
+
+    #[test]
+    fn boundary_event_preserves_unaffected_camera_identity_and_events() {
+        let inventory = TestInventory::new();
+        let camera_a = "/devices/pci/usb1/camera-a";
+        let camera_b = "/devices/pci/usb2/camera-b";
+        let seeded = inventory
+            .reconcile(vec![
+                observation_at(camera_a, "a-old"),
+                observation_at(camera_b, "b-stable"),
+            ])
+            .unwrap();
+        let old_a = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_a)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let old_b = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_b)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let dirty_a = DeviceEventHint::new(
+            DeviceEventKind::DirtyUvc,
+            format!("{camera_a}/video4linux/video0"),
+        )
+        .with_affected_topology(camera_a);
+        let loss_a = DeviceEventHint::new(
+            DeviceEventKind::ContinuityLost,
+            format!("{camera_a}/camera-a:1.0"),
+        )
+        .with_affected_topology(camera_a);
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![
+                    observation_at(camera_a, "a-old"),
+                    observation_at(camera_b, "b-stable"),
+                ]),
+                Ok(vec![
+                    observation_at(camera_a, "a-new"),
+                    observation_at(camera_b, "b-stable"),
+                ]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(vec![dirty_a]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(vec![loss_a]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let events = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert!(inventory.validate(&old_a).is_err());
+        assert_eq!(inventory.validate(&old_b), Ok(()));
+        assert!(events.iter().all(|event| event.topology_path() == camera_a));
+        assert_eq!(events.iter().filter(|event| event.is_removed()).count(), 1);
+        assert_eq!(events.iter().filter(|event| event.is_added()).count(), 1);
+    }
+
+    #[test]
+    fn one_camera_continuity_loss_does_not_retire_another_camera() {
+        let inventory = TestInventory::new();
+        let camera_a = "/devices/pci/usb1/camera-a";
+        let camera_b = "/devices/pci/usb2/camera-b";
+        let seeded = inventory
+            .reconcile(vec![
+                observation_at(camera_a, "a-old"),
+                observation_at(camera_b, "b-stable"),
+            ])
+            .unwrap();
+        let old_a = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_a)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let old_b = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_b)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let loss_a = DeviceEventHint::new(
+            DeviceEventKind::ContinuityLost,
+            format!("{camera_a}/camera-a:1.0"),
+        )
+        .with_affected_topology(camera_a);
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([Ok(vec![
+                observation_at(camera_a, "a-new"),
+                observation_at(camera_b, "b-stable"),
+            ])])),
+            FakeEvents(VecDeque::from([
+                Ok(vec![loss_a]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert!(inventory.validate(&old_a).is_err());
+        assert_eq!(inventory.validate(&old_b), Ok(()));
+    }
+
+    #[test]
+    fn empty_startup_inventory_can_discover_a_later_hotplug() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![observation("hotplugged")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(vec![DeviceEventHint::new(
+                    DeviceEventKind::DirtyUvc,
+                    "/devices/pci/usb1/camera/video4linux/video0",
+                )]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        assert!(coordinator.initialize(&inventory).unwrap().is_empty());
+        let events = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_added());
+    }
+
+    #[test]
+    fn missing_video4linux_class_is_an_authoritative_empty_snapshot() {
+        let root =
+            std::env::temp_dir().join(format!("irlume-missing-video4linux-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let mut source = SysfsSnapshotSource { root };
+        assert_eq!(source.snapshot(), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn worker_exit_guard_retires_published_inventory() {
+        let inventory = TestInventory::new();
+        let descriptor = inventory
+            .reconcile(vec![observation("published")])
+            .unwrap()
+            .remove(0)
+            .descriptor()
+            .clone();
+        {
+            let _guard = WorkerExitGuard::new(&inventory);
+        }
+        assert!(inventory.validate(&descriptor).is_err());
+    }
+
+    #[test]
+    fn snapshot_requires_a_real_quiet_interval_before_publish() {
+        struct RecordingEvents(std::sync::Arc<Mutex<Vec<Duration>>>);
+        impl DeviceEventSource for RecordingEvents {
+            fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError> {
+                self.0.lock().unwrap().push(timeout);
+                Ok(Vec::new())
+            }
+        }
+        let waits = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([Ok(vec![observation("quiet")])])),
+            RecordingEvents(waits.clone()),
+        );
+        coordinator.initialize(&TestInventory::new()).unwrap();
+        assert_eq!(*waits.lock().unwrap(), [COALESCE_QUIET, Duration::ZERO]);
     }
 
     #[test]
@@ -559,6 +1104,7 @@ mod tests {
             FakeEvents(VecDeque::from([
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
                 Ok(Vec::new()),
+                Ok(Vec::new()),
             ])),
         );
 
@@ -581,8 +1127,10 @@ mod tests {
             ])),
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
                 Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(Vec::new()),
             ])),
@@ -641,7 +1189,9 @@ mod tests {
             },
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(Vec::new()),
             ])),
@@ -665,8 +1215,10 @@ mod tests {
             ])),
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(Vec::new()),
             ])),
@@ -706,6 +1258,7 @@ mod tests {
             FakeSnapshots(VecDeque::from([Ok(vec![observation("video0")])])),
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Err(LifecycleError::Monitor(message.into())),
             ])),
         );
@@ -729,6 +1282,7 @@ mod tests {
                 Err(LifecycleError::Snapshot("sysfs race".into())),
             ])),
             FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
                 Ok(Vec::new()),
@@ -803,7 +1357,8 @@ mod tests {
 
         let inventory = TestInventory::new();
         let mut coordinator =
-            bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource).unwrap();
+            bind_monitor_before_snapshot(UdevEventSource::new, SysfsSnapshotSource::default)
+                .unwrap();
         let initial = coordinator.initialize(&inventory).unwrap();
         let original = initial
             .iter()
@@ -861,7 +1416,7 @@ mod tests {
     #[test]
     #[ignore = "requires a real initialized UVC camera in udev"]
     fn production_snapshot_matches_shinetech_four_node_topology_without_capture() {
-        let observations = UdevSnapshotSource.snapshot().unwrap();
+        let observations = SysfsSnapshotSource::default().snapshot().unwrap();
         let camera = observations
             .iter()
             .find(|observation| observation.physical_id().serial() == Some("200901010001"))
@@ -871,11 +1426,11 @@ mod tests {
         assert!(camera
             .lifecycle_evidence()
             .iter()
-            .any(|evidence| evidence.contains("video0") && evidence.ends_with(":capture:")));
+            .any(|evidence| evidence.contains("/dev/video0") && evidence.ends_with("|capture")));
         assert!(camera
             .lifecycle_evidence()
             .iter()
-            .any(|evidence| evidence.contains("video3") && evidence.ends_with("|:")));
+            .any(|evidence| evidence.contains("/dev/video3") && evidence.ends_with("|metadata")));
     }
 
     #[test]
@@ -885,17 +1440,17 @@ mod tests {
                 usb_devpath: "/devices/pci/usb1/camera".into(),
                 serial: Some("serial".into()),
                 node_devpath: "/devices/pci/usb1/camera/1.2/video2".into(),
-                devnode: Some("/dev/video2".into()),
+                devnode: "/dev/video2".into(),
                 interface_number: Some("02".into()),
-                v4l_capabilities: Some(":capture:".into()),
+                capture_node: Some(true),
             },
             UdevNodeRecord {
                 usb_devpath: "/devices/pci/usb1/camera".into(),
                 serial: Some("serial".into()),
                 node_devpath: "/devices/pci/usb1/camera/1.0/video0".into(),
-                devnode: Some("/dev/video0".into()),
+                devnode: "/dev/video0".into(),
                 interface_number: Some("00".into()),
-                v4l_capabilities: Some(":capture:".into()),
+                capture_node: Some(true),
             },
         ];
         let observations = observations_from_records(records).unwrap();

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -1,0 +1,909 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Persistent udev lifecycle invalidation for the supervisor inventory.
+//!
+//! Udev messages are deliberately treated only as hints. Every published state
+//! comes from a complete sysfs/udev snapshot taken after the monitor is already
+//! listening. Neither enumeration nor monitoring opens a video node.
+
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::fmt;
+use std::os::fd::AsRawFd as _;
+#[cfg(test)]
+use std::sync::Mutex;
+use std::sync::Weak;
+use std::time::Duration;
+
+use crate::backend::CameraSupervisor;
+use crate::contracts::{BackendKind, CameraCapabilities, PhysicalCameraId};
+use crate::inventory::{CameraInventoryError, CameraInventoryEvent, CameraObservation};
+
+const MAX_QUIET_SNAPSHOT_ATTEMPTS: usize = 4;
+const COALESCE_QUIET: Duration = Duration::from_millis(50);
+const MONITOR_WAIT: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DeviceEventKind {
+    DirtyUvc,
+    ContinuityLost,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DeviceEventHint {
+    kind: DeviceEventKind,
+    devpath: String,
+}
+
+impl DeviceEventHint {
+    #[cfg(test)]
+    fn new(kind: DeviceEventKind, devpath: impl Into<String>) -> Self {
+        Self {
+            kind,
+            devpath: devpath.into(),
+        }
+    }
+
+    fn from_udev(kind: DeviceEventKind, devpath: impl Into<String>) -> Self {
+        Self {
+            kind,
+            devpath: devpath.into(),
+        }
+    }
+
+    fn kind(&self) -> DeviceEventKind {
+        self.kind
+    }
+
+    fn devpath(&self) -> &str {
+        &self.devpath
+    }
+
+    fn requires_retirement(&self) -> bool {
+        self.kind == DeviceEventKind::ContinuityLost
+    }
+}
+
+fn consume_hints(hints: &[DeviceEventHint]) {
+    for hint in hints {
+        let _ = (hint.kind(), hint.devpath());
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum LifecycleError {
+    Monitor(String),
+    Snapshot(String),
+    UnstableSnapshot,
+    Inventory(CameraInventoryError),
+}
+
+impl fmt::Display for LifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Monitor(message) => write!(f, "udev monitor failed: {message}"),
+            Self::Snapshot(message) => write!(f, "camera snapshot failed: {message}"),
+            Self::UnstableSnapshot => f.write_str("camera snapshot never became quiet"),
+            Self::Inventory(error) => write!(f, "camera inventory failed: {error:?}"),
+        }
+    }
+}
+
+trait DeviceEventSource {
+    fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError>;
+}
+
+trait SnapshotSource {
+    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError>;
+}
+
+trait InventorySink {
+    fn invalidate_all(&self) -> Result<(), CameraInventoryError>;
+
+    fn reconcile(
+        &self,
+        observations: Vec<CameraObservation>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
+}
+
+impl InventorySink for CameraSupervisor {
+    fn invalidate_all(&self) -> Result<(), CameraInventoryError> {
+        self.invalidate_inventory()
+    }
+
+    fn reconcile(
+        &self,
+        observations: Vec<CameraObservation>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        self.reconcile_inventory(observations)
+    }
+}
+
+struct LifecycleCoordinator<S, E> {
+    snapshots: S,
+    events: E,
+}
+
+impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
+    fn new(snapshots: S, events: E) -> Self {
+        Self { snapshots, events }
+    }
+
+    fn initialize(
+        &mut self,
+        inventory: &impl InventorySink,
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        self.publish_quiet_snapshot(inventory, Vec::new())
+    }
+
+    fn process_next(
+        &mut self,
+        inventory: &impl InventorySink,
+        wait: Duration,
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        let first = match self.events.poll(wait) {
+            Ok(events) => events,
+            Err(error) => return Err(fail_closed(inventory, error)),
+        };
+        if first.is_empty() {
+            return Ok(Vec::new());
+        }
+        consume_hints(&first);
+        let mut pending = self.prepare_rescan(inventory, &first)?;
+
+        // A message only invalidates the old view. Drain the burst, then rebuild
+        // from one authoritative snapshot; event payloads never mutate inventory.
+        loop {
+            match self.events.poll(COALESCE_QUIET) {
+                Ok(events) if events.is_empty() => break,
+                Ok(events) => {
+                    consume_hints(&events);
+                    pending.extend(self.prepare_rescan(inventory, &events)?);
+                }
+                Err(error) => return Err(fail_closed(inventory, error)),
+            }
+        }
+        self.publish_quiet_snapshot(inventory, pending)
+    }
+
+    fn publish_quiet_snapshot(
+        &mut self,
+        inventory: &impl InventorySink,
+        mut pending: Vec<CameraInventoryEvent>,
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        for _ in 0..MAX_QUIET_SNAPSHOT_ATTEMPTS {
+            let observations = match self.snapshots.snapshot() {
+                Ok(observations) => observations,
+                Err(error) => return Err(fail_closed(inventory, error)),
+            };
+            match self.events.poll(Duration::ZERO) {
+                Ok(events) if events.is_empty() => {
+                    let mut published = inventory
+                        .reconcile(observations)
+                        .map_err(LifecycleError::Inventory)?;
+                    pending.append(&mut published);
+                    return Ok(pending);
+                }
+                Ok(events) => {
+                    consume_hints(&events);
+                    pending.extend(self.prepare_rescan(inventory, &events)?);
+                    continue;
+                }
+                Err(error) => return Err(fail_closed(inventory, error)),
+            }
+        }
+        Err(fail_closed(inventory, LifecycleError::UnstableSnapshot))
+    }
+
+    fn prepare_rescan(
+        &self,
+        inventory: &impl InventorySink,
+        hints: &[DeviceEventHint],
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        inventory
+            .invalidate_all()
+            .map_err(LifecycleError::Inventory)?;
+        if hints.iter().any(DeviceEventHint::requires_retirement) {
+            return inventory
+                .reconcile(Vec::new())
+                .map_err(LifecycleError::Inventory);
+        }
+        Ok(Vec::new())
+    }
+}
+
+fn fail_closed(inventory: &impl InventorySink, error: LifecycleError) -> LifecycleError {
+    match inventory.reconcile(Vec::new()) {
+        Ok(_) => error,
+        Err(inventory_error) => LifecycleError::Inventory(inventory_error),
+    }
+}
+
+struct UdevEventSource {
+    socket: udev::MonitorSocket,
+}
+
+impl UdevEventSource {
+    fn new() -> Result<Self, LifecycleError> {
+        // Do not filter to video4linux: USB parent/interface bind, unbind and
+        // reset events are continuity evidence even when no child event exists.
+        let socket = udev::MonitorBuilder::new()
+            .and_then(udev::MonitorBuilder::listen)
+            .map_err(|error| LifecycleError::Monitor(error.to_string()))?;
+        Ok(Self { socket })
+    }
+}
+
+impl DeviceEventSource for UdevEventSource {
+    fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError> {
+        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        let mut descriptor = libc::pollfd {
+            fd: self.socket.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: descriptor points to one initialized pollfd for the duration
+        // of the call; poll does not retain it.
+        let ready = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
+        if ready < 0 {
+            return Err(LifecycleError::Monitor(
+                std::io::Error::last_os_error().to_string(),
+            ));
+        }
+        ensure_monitor_healthy(descriptor.revents)?;
+        if ready == 0 || descriptor.revents & libc::POLLIN == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut hints = Vec::new();
+        for event in self.socket.iter() {
+            let subsystem = event.subsystem().and_then(std::ffi::OsStr::to_str);
+            let is_uvc_usb = subsystem == Some("usb")
+                && (event.driver().and_then(std::ffi::OsStr::to_str) == Some("uvcvideo")
+                    || event
+                        .property_value("ID_USB_DRIVER")
+                        .and_then(std::ffi::OsStr::to_str)
+                        == Some("uvcvideo")
+                    || event
+                        .property_value("ID_USB_INTERFACES")
+                        .and_then(std::ffi::OsStr::to_str)
+                        .is_some_and(|interfaces| interfaces.contains(":0e")));
+            if subsystem != Some("video4linux") && !is_uvc_usb {
+                continue;
+            }
+            let kind = match event.event_type() {
+                udev::EventType::Change => DeviceEventKind::DirtyUvc,
+                _ => DeviceEventKind::ContinuityLost,
+            };
+            hints.push(DeviceEventHint::from_udev(
+                kind,
+                event.devpath().to_string_lossy(),
+            ));
+        }
+        ensure_receive_drained(std::io::Error::last_os_error().raw_os_error())?;
+        Ok(hints)
+    }
+}
+
+fn ensure_monitor_healthy(revents: libc::c_short) -> Result<(), LifecycleError> {
+    if revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        return Err(LifecycleError::Monitor("udev monitor socket lost".into()));
+    }
+    Ok(())
+}
+
+fn ensure_receive_drained(errno: Option<i32>) -> Result<(), LifecycleError> {
+    if errno == Some(libc::EAGAIN) || errno == Some(libc::EWOULDBLOCK) {
+        return Ok(());
+    }
+    if errno == Some(libc::ENOBUFS) {
+        return Err(LifecycleError::Monitor(
+            "udev monitor receive buffer overflow".into(),
+        ));
+    }
+    match errno {
+        Some(errno) => Err(LifecycleError::Monitor(format!(
+            "udev monitor receive failed: {}",
+            std::io::Error::from_raw_os_error(errno)
+        ))),
+        None => Err(LifecycleError::Monitor(
+            "udev monitor receive failed without errno".into(),
+        )),
+    }
+}
+
+#[derive(Default)]
+struct UdevSnapshotSource;
+
+#[derive(Debug)]
+struct UdevNodeRecord {
+    usb_devpath: String,
+    serial: Option<String>,
+    node_devpath: String,
+    devnode: Option<String>,
+    interface_number: Option<String>,
+    v4l_capabilities: Option<String>,
+}
+
+impl SnapshotSource for UdevSnapshotSource {
+    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+        let mut enumerator =
+            udev::Enumerator::new().map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+        enumerator
+            .match_subsystem("video4linux")
+            .and_then(|()| enumerator.match_is_initialized())
+            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+        let devices = enumerator
+            .scan_devices()
+            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+
+        let mut records = Vec::new();
+        for device in devices {
+            if device.property_value("ID_USB_DRIVER") != Some(std::ffi::OsStr::new("uvcvideo")) {
+                continue;
+            }
+            let usb = device
+                .parent_with_subsystem_devtype("usb", "usb_device")
+                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?
+                .ok_or_else(|| {
+                    LifecycleError::Snapshot(format!(
+                        "{} has uvcvideo but no USB-device parent",
+                        device.devpath().to_string_lossy()
+                    ))
+                })?;
+            records.push(UdevNodeRecord {
+                usb_devpath: usb.devpath().to_string_lossy().into_owned(),
+                serial: usb
+                    .attribute_value("serial")
+                    .map(|value| value.to_string_lossy().trim().to_owned())
+                    .filter(|value| !value.is_empty()),
+                node_devpath: device.devpath().to_string_lossy().into_owned(),
+                devnode: device
+                    .devnode()
+                    .map(|path| path.to_string_lossy().into_owned()),
+                interface_number: device
+                    .property_value("ID_USB_INTERFACE_NUM")
+                    .map(|value| value.to_string_lossy().into_owned()),
+                v4l_capabilities: device
+                    .property_value("ID_V4L_CAPABILITIES")
+                    .map(|value| value.to_string_lossy().into_owned()),
+            });
+        }
+        observations_from_records(records)
+    }
+}
+
+fn observations_from_records(
+    records: Vec<UdevNodeRecord>,
+) -> Result<Vec<CameraObservation>, LifecycleError> {
+    let mut groups: BTreeMap<String, (Option<String>, Vec<String>)> = BTreeMap::new();
+    for record in records {
+        let evidence = format!(
+            "{}|{}|{}|{}",
+            record.node_devpath,
+            record.devnode.as_deref().unwrap_or(""),
+            record.interface_number.as_deref().unwrap_or(""),
+            record.v4l_capabilities.as_deref().unwrap_or("")
+        );
+        let group = groups
+            .entry(record.usb_devpath.clone())
+            .or_insert_with(|| (record.serial.clone(), Vec::new()));
+        if group.0 != record.serial {
+            return Err(LifecycleError::Snapshot(format!(
+                "conflicting serial evidence for {}",
+                record.usb_devpath
+            )));
+        }
+        group.1.push(evidence);
+    }
+
+    groups
+        .into_iter()
+        .map(|(topology_path, (serial, evidence))| {
+            let physical_id = PhysicalCameraId::new(topology_path, serial)
+                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+            Ok(CameraObservation::with_lifecycle_evidence(
+                BackendKind::UvcV4l2,
+                physical_id,
+                CameraCapabilities::default(),
+                evidence,
+            ))
+        })
+        .collect()
+}
+
+fn bind_monitor_before_snapshot<S: SnapshotSource, E: DeviceEventSource>(
+    bind: impl FnOnce() -> Result<E, LifecycleError>,
+    snapshots: impl FnOnce() -> S,
+) -> Result<LifecycleCoordinator<S, E>, LifecycleError> {
+    let events = bind()?;
+    Ok(LifecycleCoordinator::new(snapshots(), events))
+}
+
+/// Start the production monitor before the first authoritative scan. The thread
+/// owns the monitor socket for the supervisor lifetime; dropping the process is
+/// the only normal shutdown path for this process-scoped inventory.
+pub(crate) fn spawn(supervisor: Weak<CameraSupervisor>) -> Result<(), LifecycleError> {
+    let mut coordinator =
+        bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource)?;
+    std::thread::Builder::new()
+        .name("irlume-camera-udev".into())
+        .spawn(move || {
+            let Some(supervisor) = supervisor.upgrade() else {
+                return;
+            };
+            if let Err(error) = coordinator.initialize(supervisor.as_ref()) {
+                eprintln!("irlume: camera lifecycle monitor stopped: {error}");
+                return;
+            }
+            loop {
+                if let Err(error) = coordinator.process_next(supervisor.as_ref(), MONITOR_WAIT) {
+                    eprintln!("irlume: camera lifecycle monitor stopped: {error}");
+                    return;
+                }
+            }
+        })
+        .map_err(|error| LifecycleError::Monitor(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::{CameraGeneration, StreamRole};
+    use crate::inventory::CameraInventory;
+
+    struct TestInventory(Mutex<CameraInventory>);
+
+    impl TestInventory {
+        fn new() -> Self {
+            Self(Mutex::new(CameraInventory::new()))
+        }
+
+        fn validate(
+            &self,
+            descriptor: &crate::contracts::CameraDescriptor,
+        ) -> Result<(), CameraInventoryError> {
+            self.0.lock().unwrap().validate(descriptor)
+        }
+    }
+
+    impl InventorySink for TestInventory {
+        fn invalidate_all(&self) -> Result<(), CameraInventoryError> {
+            self.0.lock().unwrap().invalidate_all();
+            Ok(())
+        }
+
+        fn reconcile(
+            &self,
+            observations: Vec<CameraObservation>,
+        ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+            self.0.lock().unwrap().reconcile(observations)
+        }
+    }
+
+    struct FakeSnapshots(VecDeque<Result<Vec<CameraObservation>, LifecycleError>>);
+
+    impl SnapshotSource for FakeSnapshots {
+        fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+            self.0.pop_front().expect("snapshot fixture exhausted")
+        }
+    }
+
+    struct FakeEvents(VecDeque<Result<Vec<DeviceEventHint>, LifecycleError>>);
+
+    impl DeviceEventSource for FakeEvents {
+        fn poll(&mut self, _: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError> {
+            self.0.pop_front().unwrap_or_else(|| Ok(Vec::new()))
+        }
+    }
+
+    fn observation(evidence: &str) -> CameraObservation {
+        CameraObservation::with_lifecycle_evidence(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new("/devices/pci/usb1/camera", None).unwrap(),
+            CameraCapabilities::new(vec![StreamRole::Rgb], Default::default(), Vec::new()).unwrap(),
+            vec![evidence.into()],
+        )
+    }
+
+    fn hint(kind: DeviceEventKind) -> DeviceEventHint {
+        DeviceEventHint::new(kind, "/devices/pci/usb1/video4linux/video0")
+    }
+
+    #[test]
+    fn monitor_is_bound_before_initial_snapshot() {
+        struct RecordingSnapshot(std::sync::Arc<Mutex<Vec<&'static str>>>);
+        impl SnapshotSource for RecordingSnapshot {
+            fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+                self.0.lock().unwrap().push("scan");
+                Ok(Vec::new())
+            }
+        }
+
+        let order = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let bind_order = order.clone();
+        let snapshot_order = order.clone();
+        let mut coordinator = bind_monitor_before_snapshot(
+            move || {
+                bind_order.lock().unwrap().push("bind");
+                Ok(FakeEvents(VecDeque::from([Ok(Vec::new())])))
+            },
+            move || {
+                snapshot_order.lock().unwrap().push("snapshot-source");
+                RecordingSnapshot(snapshot_order)
+            },
+        )
+        .unwrap();
+        coordinator.initialize(&TestInventory::new()).unwrap();
+        assert_eq!(*order.lock().unwrap(), ["bind", "snapshot-source", "scan"]);
+    }
+
+    #[test]
+    fn event_hints_are_invalidation_only() {
+        let hint = hint(DeviceEventKind::DirtyUvc);
+        assert_eq!(hint.kind(), DeviceEventKind::DirtyUvc);
+        assert!(hint.devpath().ends_with("/video0"));
+    }
+
+    #[test]
+    fn startup_discards_a_scan_if_an_event_arrived_during_it() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("stale")]),
+                Ok(vec![observation("quiet")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+            ])),
+        );
+
+        let events = coordinator.initialize(&inventory).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_added());
+        assert_eq!(
+            events[0].descriptor().generation(),
+            CameraGeneration::INITIAL
+        );
+    }
+
+    #[test]
+    fn remove_add_burst_retires_before_publishing_fresh_instance() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("video0")]),
+                Ok(vec![observation("video2")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let initial = coordinator.initialize(&inventory).unwrap();
+        let old = initial[0].descriptor().clone();
+
+        let changed = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert_eq!(changed.len(), 2);
+        assert!(changed[0].is_removed());
+        assert!(changed[1].is_added());
+        assert_eq!(
+            changed[1].descriptor().generation(),
+            CameraGeneration::INITIAL
+        );
+        assert_ne!(
+            changed[1].descriptor().camera_instance_id(),
+            old.camera_instance_id()
+        );
+        assert_eq!(
+            inventory.validate(&old),
+            Err(CameraInventoryError::ForeignInstance)
+        );
+    }
+
+    #[test]
+    fn old_token_is_unusable_before_soft_rescan_starts() {
+        struct CheckingSnapshots<'a> {
+            inventory: &'a TestInventory,
+            old: Option<crate::contracts::CameraDescriptor>,
+            calls: usize,
+        }
+
+        impl SnapshotSource for CheckingSnapshots<'_> {
+            fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+                self.calls += 1;
+                if self.calls == 2 {
+                    assert_eq!(
+                        self.inventory.validate(self.old.as_ref().unwrap()),
+                        Err(CameraInventoryError::ContinuityLost)
+                    );
+                    return Ok(vec![observation("video2")]);
+                }
+                Ok(vec![observation("video0")])
+            }
+        }
+
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            CheckingSnapshots {
+                inventory: &inventory,
+                old: None,
+                calls: 0,
+            },
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+        coordinator.snapshots.old = Some(old);
+        coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+    }
+
+    #[test]
+    fn change_burst_coalesces_into_one_generation_change() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("video0")]),
+                Ok(vec![observation("video2")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        let changed = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert_eq!(changed.len(), 1);
+        assert!(changed[0].is_changed());
+        assert_eq!(
+            changed[0].descriptor().generation(),
+            CameraGeneration::new(2).unwrap()
+        );
+        assert_eq!(
+            inventory.validate(&old),
+            Err(CameraInventoryError::StaleGeneration)
+        );
+    }
+
+    #[test]
+    fn event_source_disconnect_retires_every_published_descriptor() {
+        assert_monitor_failure_retires("disconnected");
+    }
+
+    #[test]
+    fn monitor_overflow_retires_every_published_descriptor() {
+        assert_monitor_failure_retires("overflow");
+    }
+
+    fn assert_monitor_failure_retires(message: &str) {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([Ok(vec![observation("video0")])])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Err(LifecycleError::Monitor(message.into())),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        assert_eq!(
+            coordinator.process_next(&inventory, Duration::ZERO),
+            Err(LifecycleError::Monitor(message.into()))
+        );
+        assert_eq!(inventory.validate(&old), Err(CameraInventoryError::Removed));
+    }
+
+    #[test]
+    fn scan_failure_retires_every_published_descriptor() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("video0")]),
+                Err(LifecycleError::Snapshot("sysfs race".into())),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        assert_eq!(
+            coordinator.process_next(&inventory, Duration::ZERO),
+            Err(LifecycleError::Snapshot("sysfs race".into()))
+        );
+        assert_eq!(inventory.validate(&old), Err(CameraInventoryError::Removed));
+    }
+
+    #[test]
+    fn an_unstable_startup_snapshot_is_bounded_and_fail_closed() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from_iter(
+                (0..MAX_QUIET_SNAPSHOT_ATTEMPTS).map(|_| Ok(vec![observation("moving")])),
+            )),
+            FakeEvents(VecDeque::from_iter(
+                (0..MAX_QUIET_SNAPSHOT_ATTEMPTS).map(|_| Ok(vec![hint(DeviceEventKind::DirtyUvc)])),
+            )),
+        );
+
+        assert_eq!(
+            coordinator.initialize(&inventory),
+            Err(LifecycleError::UnstableSnapshot)
+        );
+    }
+
+    #[test]
+    fn netlink_error_flags_are_monitor_loss() {
+        assert_eq!(ensure_monitor_healthy(libc::POLLIN), Ok(()));
+        for flag in [libc::POLLERR, libc::POLLHUP, libc::POLLNVAL] {
+            assert_eq!(
+                ensure_monitor_healthy(flag),
+                Err(LifecycleError::Monitor("udev monitor socket lost".into()))
+            );
+        }
+    }
+
+    #[test]
+    fn receive_tail_distinguishes_drained_overflow_and_other_failures() {
+        assert_eq!(ensure_receive_drained(Some(libc::EAGAIN)), Ok(()));
+        assert_eq!(
+            ensure_receive_drained(Some(libc::ENOBUFS)),
+            Err(LifecycleError::Monitor(
+                "udev monitor receive buffer overflow".into()
+            ))
+        );
+        assert!(matches!(
+            ensure_receive_drained(Some(libc::EIO)),
+            Err(LifecycleError::Monitor(message))
+                if message.starts_with("udev monitor receive failed:")
+        ));
+        assert_eq!(
+            ensure_receive_drained(None),
+            Err(LifecycleError::Monitor(
+                "udev monitor receive failed without errno".into()
+            ))
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an operator-controlled UVC interface unbind/rebind"]
+    fn production_monitor_observes_live_uvc_continuity_loss_and_recovery() {
+        use std::io::Write;
+
+        let inventory = TestInventory::new();
+        let mut coordinator =
+            bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource).unwrap();
+        let initial = coordinator.initialize(&inventory).unwrap();
+        let original = initial
+            .iter()
+            .find(|event| event.descriptor().physical_id().serial() == Some("200901010001"))
+            .expect("Shinetech camera is present")
+            .descriptor()
+            .clone();
+
+        println!("IRLUME_UDEV_READY");
+        std::io::stdout().flush().unwrap();
+        let lost_deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            let remaining = lost_deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for old instance retirement"
+            );
+            let events = coordinator.process_next(&inventory, remaining).unwrap();
+            if events.iter().any(|event| {
+                matches!(event, CameraInventoryEvent::Removed(descriptor)
+                    if descriptor.camera_instance_id() == original.camera_instance_id())
+            }) {
+                break;
+            }
+        }
+        println!("IRLUME_UDEV_LOST");
+        std::io::stdout().flush().unwrap();
+
+        let recovered_deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let replacement = loop {
+            let remaining = recovered_deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for replacement instance"
+            );
+            let events = coordinator.process_next(&inventory, remaining).unwrap();
+            if let Some(descriptor) = events.iter().rev().find_map(|event| match event {
+                CameraInventoryEvent::Added(descriptor)
+                    if descriptor.physical_id().serial() == Some("200901010001") =>
+                {
+                    Some(descriptor.clone())
+                }
+                _ => None,
+            }) {
+                break descriptor;
+            }
+        };
+        assert_ne!(
+            replacement.camera_instance_id(),
+            original.camera_instance_id()
+        );
+        println!("IRLUME_UDEV_RECOVERED");
+    }
+
+    #[test]
+    #[ignore = "requires a real initialized UVC camera in udev"]
+    fn production_snapshot_matches_shinetech_four_node_topology_without_capture() {
+        let observations = UdevSnapshotSource.snapshot().unwrap();
+        let camera = observations
+            .iter()
+            .find(|observation| observation.physical_id().serial() == Some("200901010001"))
+            .expect("Shinetech 3277:0059 camera is present");
+        assert!(camera.physical_id().topology_path().ends_with("/usb3/3-5"));
+        assert_eq!(camera.lifecycle_evidence().len(), 4);
+        assert!(camera
+            .lifecycle_evidence()
+            .iter()
+            .any(|evidence| evidence.contains("video0") && evidence.ends_with(":capture:")));
+        assert!(camera
+            .lifecycle_evidence()
+            .iter()
+            .any(|evidence| evidence.contains("video3") && evidence.ends_with("|:")));
+    }
+
+    #[test]
+    fn udev_records_group_one_physical_camera_and_normalize_order() {
+        let records = vec![
+            UdevNodeRecord {
+                usb_devpath: "/devices/pci/usb1/camera".into(),
+                serial: Some("serial".into()),
+                node_devpath: "/devices/pci/usb1/camera/1.2/video2".into(),
+                devnode: Some("/dev/video2".into()),
+                interface_number: Some("02".into()),
+                v4l_capabilities: Some(":capture:".into()),
+            },
+            UdevNodeRecord {
+                usb_devpath: "/devices/pci/usb1/camera".into(),
+                serial: Some("serial".into()),
+                node_devpath: "/devices/pci/usb1/camera/1.0/video0".into(),
+                devnode: Some("/dev/video0".into()),
+                interface_number: Some("00".into()),
+                v4l_capabilities: Some(":capture:".into()),
+            },
+        ];
+        let observations = observations_from_records(records).unwrap();
+        assert_eq!(observations.len(), 1);
+        assert_eq!(
+            observations[0].physical_id().topology_path(),
+            "/devices/pci/usb1/camera"
+        );
+        assert_eq!(observations[0].physical_id().serial(), Some("serial"));
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,7 +83,7 @@ Install the build dependencies, then use `cargo` as usual.
 
 ```sh
 sudo dnf install cargo rust clang-devel pkgconf-pkg-config gcc \
-    pam-devel tpm2-tss-devel kernel-headers curl
+    pam-devel tpm2-tss-devel systemd-devel kernel-headers curl
 ```
 
 **Ubuntu / Debian**: the archive's `rustc` is usually too old (the `ort`
@@ -92,14 +92,14 @@ binding needs Rust ≥ 1.88), so install the toolchain with
 
 ```sh
 sudo apt install build-essential pkg-config clang libclang-dev \
-    libpam0g-dev libtss2-dev curl
+    libpam0g-dev libtss2-dev libudev-dev curl
 rustup toolchain install 1.88.0   # or newer stable
 ```
 
 **Arch**
 
 ```sh
-sudo pacman -S --needed base-devel rust clang tpm2-tss pam onnxruntime-cpu curl
+sudo pacman -S --needed base-devel rust clang tpm2-tss pam systemd onnxruntime-cpu curl
 ```
 
 ### ONNX runtime (non-Nix)

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
           buildInputs = [
             pkgs.tpm2-tss     # TPM 2.0 stack; the tss-esapi crate links tss2-*
             pkgs.linux-pam    # libpam; the pamsm crate links it
+            pkgs.systemd      # libudev for the camera lifecycle adapter
           ];
 
           # bindgen (pulled in transitively by v4l2-sys-mit) dlopens libclang

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,7 @@
   clang,
   tpm2-tss,
   linux-pam,
+  systemd,
   libxcrypt,
   linuxHeaders,
   fetchurl,
@@ -90,6 +91,7 @@ rustPlatform.buildRustPackage {
   buildInputs = [
     tpm2-tss # tss-esapi links tss2-*
     linux-pam # the PAM cdylib links libpam
+    systemd # the udev adapter links libudev
     # irlumed declares #[link(name = "crypt")] for its /etc/shadow fallback.
     # nixpkgs stopped providing libcrypt transitively, and `nix build` failed
     # with "cannot find -lcrypt" at the irlumed link step. CI could not see it:

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -38,6 +38,7 @@ BuildRequires:  rust
 BuildRequires:  gcc
 BuildRequires:  pam-devel
 BuildRequires:  tpm2-tss-devel
+BuildRequires:  systemd-devel
 BuildRequires:  systemd-rpm-macros
 # v4l2-sys-mit generates bindings at build time: bindgen dlopens libclang
 # and parses the kernel's videodev2.h; tss-esapi locates tss2 via pkg-config.

--- a/packaging/ppa/debian/control
+++ b/packaging/ppa/debian/control
@@ -10,6 +10,7 @@ Build-Depends: debhelper-compat (= 13),
                pkg-config,
                libpam0g-dev,
                libtss2-dev,
+               libudev-dev,
                linux-libc-dev
 Standards-Version: 4.6.2
 Homepage: https://github.com/archledger/irlume


### PR DESCRIPTION
## Summary

- bind a process-owned libudev monitor before the initial camera inventory scan
- normalize UVC lifecycle hints, coalesce bursts, and rebuild authoritative sysfs snapshots
- invalidate descriptor-bound inventory references before rescans and permanently retire instances on continuity loss
- fail closed on monitor socket failure, overflow signals, scan failure, and bounded startup instability
- add Fedora, Debian/Ubuntu, Arch, Nix, and CI libudev build dependencies

## Stack / merge order

This PR is intentionally stacked on #458 (`feat/455-camera-inventory-generations`), which is stacked on #453. Merge order:

1. #453
2. #458
3. this PR

The diff does not include the independent optional-provider build fix in #459.

## Security and scope

- udev payloads are invalidation hints only; they never mutate inventory directly
- every accepted hint triggers a complete authoritative snapshot
- capture-node paths are evidence only when bound to `CameraInstanceId` + generation
- no `/dev/video*` node is opened by the lifecycle collector
- no UVC controls, XU writes, emitter behavior, pairing, capture, enrollment, login, or auth behavior changes
- RGB/IR roles remain unset in lifecycle observations because capture roles still require the existing `ENUM_FMT` authority; this adapter does not invent role evidence

## Verification

- `./scripts/run-tests-guarded.sh --min 650 -- cargo test --workspace --locked` — 1,440 passed
- strict default-feature workspace clippy/docs — passed
- strict all-feature `irlume-camera` clippy/docs — passed
- release build + machine API — 36/36 passed
- `cargo deny check advisories bans licenses sources` — passed
- `nix flake check --no-build` — passed
- real `nix build .#packages.x86_64-linux.default --no-link` — passed
- Actionlint 1.7.12 — passed for all workflows
- RPM spec and workflow YAML parsing — passed
- syscall trace of real four-node snapshot — zero `/dev/video*` opens
- Shinetech 3277:0059 snapshot — one physical USB parent, serial `200901010001`, four endpoint records
- controlled live UVC interface unbind/rebind while idle — old instance retired, replacement published with a fresh ID, all four nodes restored
- post-test daemon active; no kernel error/warning; no video-node holders
- sabotage mutations proved fixtures fail if pre-rescan invalidation or monitor-before-scan ordering is removed; socket loss/overflow paths have focused fail-closed fixtures

Workspace `--all-features` clippy on this stack still reproduces #454 in the base branch. The independent fix is green in #459; it is intentionally not duplicated here.

## Rollback

Reverting this commit restores the PR #458 lazy supervisor and removes the libudev thread/dependencies. Existing capture and hardware-control behavior is otherwise unchanged.

Closes #456
