### PR TITLE
camera: add supervised lifecycle and operation-scoped leases

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -87,7 +87,7 @@ jobs:
           command -v apt-get >/dev/null || { echo "deps preinstalled on the self-hosted runner"; exit 0; }
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev llvm
+            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev llvm
 
       # A leak suppression matches the SYMBOL NAMES in an allocation stack, so
       # without a symbolizer it matches nothing and the deliberate test leak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi
@@ -334,7 +334,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi
@@ -583,7 +583,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libtss2-dev
+              build-essential pkg-config clang libclang-dev libtss2-dev libudev-dev
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,8 +293,9 @@ jobs:
           IRLUME_TEST_IR_DEVICE: /dev/video9
           IRLUME_TEST_SPARE_DEVICE: /dev/video10
           # Loopback nodes have no physical bus; the exact-path escape lets
-          # verify_pinned accept just these (see THREAT_MODEL.md).
-          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9
+          # verify_pinned and the lifecycle inventory accept just these three
+          # harness-owned nodes (see THREAT_MODEL.md).
+          IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9,/dev/video10
         run: |
           ./scripts/run-tests-guarded.sh --min 15 -- cargo test -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 7 -- cargo test -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ All notable changes to irlume are documented here. This project adheres to
   nodes. Monitor loss, overflow, unstable scans, and continuity loss retire stale
   references before replacements become visible; capture and hardware-control behavior
   remain unchanged (#456).
+- **Camera operations now share one descriptor-bound cooperative lease.**
+  Authentication and enrollment acquire RGB+IR atomically by physical camera identity;
+  diagnostics, preview, setup, raw controls, and legacy single-node opens use the same
+  authority. Lifecycle invalidation makes held permits stale before the next dequeue or
+  control, explicit operation scopes cross only opted-in worker threads, and drop/panic
+  paths release leases without path-only identity fallbacks (#461).
 
 ## [0.10.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to irlume are documented here. This project adheres to
   probing, pairing, negotiation, privacy, emitter, and capture behavior remain
   unchanged. A v1 evidence schema now fails closed on unknown versions and
   fields (#452).
+- **The camera supervisor now owns process-scoped lifecycle identity.**
+  Distinct CSPRNG physical-camera identifiers and a transactional inventory keep
+  generations monotonic while continuity is proven; removal retires an incarnation
+  permanently, and rediscovery starts a fresh identifier at generation one. Stale,
+  forged, foreign-instance, duplicate, exhausted, and poisoned states fail closed.
+  Capture and hardware-control behavior remain unchanged (#455).
 
 ## [0.10.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Camera discovery and opens now cross one process-owned backend boundary.**
+  The initial backend remains the existing direct V4L2/UVC implementation, so
+  probing, pairing, negotiation, privacy, emitter, and capture behavior remain
+  unchanged. A v1 evidence schema now fails closed on unknown versions and
+  fields (#452).
+
 ## [0.10.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to irlume are documented here. This project adheres to
   permanently, and rediscovery starts a fresh identifier at generation one. Stale,
   forged, foreign-instance, duplicate, exhausted, and poisoned states fail closed.
   Capture and hardware-control behavior remain unchanged (#455).
+- **Linux camera lifecycle changes now invalidate stale inventory tokens.**
+  A monitor-before-scan libudev adapter coalesces UVC and USB-parent events, detects
+  monitor socket errors, and rebuilds one authoritative sysfs snapshot without opening video
+  nodes. Monitor loss, overflow, unstable scans, and continuity loss retire stale
+  references before replacements become visible; capture and hardware-control behavior
+  remain unchanged (#456).
 
 ## [0.10.0] - 2026-08-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ version = "0.10.0"
 dependencies = [
  "irlume-common",
  "libc",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "v4l",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +987,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "irlume-auth"
 version = "0.10.0"
 dependencies = [
@@ -1002,6 +1019,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
+ "udev",
  "v4l",
 ]
 
@@ -1214,6 +1232,16 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "line-clipping"
@@ -2732,6 +2760,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "udev"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,11 +3086,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3059,7 +3108,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3073,19 +3122,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3095,9 +3165,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3113,9 +3195,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3125,9 +3219,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ argon2     = "0.5"      # Argon2id KDF for the recovery passphrase
 pbkdf2     = { version = "0.13", default-features = false, features = ["hmac"] }  # PBKDF2-HMAC-SHA512: the KDE wallet key ksecretd expects
 rand       = "0.10"      # CSPRNG for template keys, nonces, recovery salts
 libc       = "0.2"      # mlock/madvise (memlock), NSS getpwnam_r, SO_PEERCRED
+udev       = { version = "0.9.3", features = ["send"] } # persistent V4L2 hotplug monitor + sysfs snapshots
 rustfft    = "6"        # 2D FFT for the RGB-only moiré/screen-replay PAD cue
 
 # ONNX inference. `load-dynamic` => libonnxruntime.so is dlopened at runtime, so

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -8868,10 +8868,9 @@ mod engine_tests {
             "the release must clear BOTH session slots"
         );
 
-        // The observation: fresh camera handles and sessions now succeed because
-        // both buffer queues went back when the held sessions dropped.
-        let after_cam = operation.open_ir(&ir).expect("reopen IR after release");
-        let mut after = after_cam.session().expect("open IR session after release");
+        // The observation: the original cameras accept fresh sessions after
+        // release_held drops both owners and their per-camera slots reset.
+        let mut after = cam.session().expect("open IR session after release");
         let after_capture = after.capture_with_stats();
         assert!(
             after_capture.is_ok(),
@@ -8880,11 +8879,8 @@ mod engine_tests {
             after_capture.err()
         );
         drop(after);
-        // The RGB half too: a fresh handle and session on the released node must work.
-        let rgb_after_cam = operation.open_rgb(&rgb).expect("reopen RGB after release");
-        let mut rgb_after = rgb_after_cam
-            .session()
-            .expect("open RGB session after release");
+        // The RGB half too: the original camera's session slot must reopen.
+        let mut rgb_after = rgb_cam.session().expect("open RGB session after release");
         assert!(
             rgb_after.frame().is_ok(),
             "after release an RGB session must be able to capture a frame"

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -3069,6 +3069,23 @@ impl Engine {
                 return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
             }
         }
+        let (rgb_dev, ir_dev) = (self.rgb_dev.clone(), self.ir_dev.clone());
+        let endpoints: Vec<&str> = if self.ir_available {
+            vec![rgb_dev.as_str(), ir_dev.as_str()]
+        } else {
+            vec![rgb_dev.as_str()]
+        };
+        // One authentication owns its physical camera set from the first
+        // consent frame through the final grace-window retry.  Keeping this
+        // lease across sequential fallbacks is deliberate: otherwise another
+        // operation can interleave between consent and matching.
+        let camera_operation = irlume_camera::lease::acquire_camera_operation(
+            &endpoints,
+            irlume_camera::lease::CameraOperationKind::Authentication,
+            std::time::Duration::from_secs(2),
+        )
+        .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+
         // Watch for the consent gesture BEFORE the first capture, so a user who
         // nods when the greeter asks is not ignored for the seconds it takes to
         // capture and match a face. Once per authentication, never per retry: a
@@ -3077,7 +3094,8 @@ impl Engine {
         self.gesture_seen_before_match = false;
         self.gesture_cancelled = false;
         if purpose.demands_gesture(service) {
-            self.gesture_seen_before_match = self.early_consent_watch(&enr)?;
+            self.gesture_seen_before_match =
+                Self::run_camera_operation(&camera_operation, || self.early_consent_watch(&enr))?;
             // A head-shake during the pre-match watch is an explicit decline.
             // Close the request now: do not spend the capture and match only to
             // deny after a second post-match watch, and do not let a later cue
@@ -3103,7 +3121,6 @@ impl Engine {
         // below tries to open the same device again, which is EBUSY on a
         // single-consumer camera and on any v4l2loopback node with a producer
         // attached.
-        let (rgb_dev, ir_dev) = (self.rgb_dev.clone(), self.ir_dev.clone());
         let (sequential, _mode_source) = sequential_capture_selected(&rgb_dev, &ir_dev);
         // Declared in reverse drop order: the sessions borrow from `_cams`, so
         // Rust drops the sessions first and the cameras after.
@@ -3117,50 +3134,41 @@ impl Engine {
         // so the watch's S_FMT and REQBUFS hit EBUSY against this very process:
         // the self-collision #187 diagnosed, reintroduced by #346 and caught by
         // the release audit before it shipped.
-        let mut camera_operation: Option<irlume_camera::lease::CameraOperationSession> = None;
         let mut _cams: Option<(irlume_camera::RgbCamera, irlume_camera::IrCamera)> = None;
         let mut held_rgb: Option<irlume_camera::RgbSession<'_>> = None;
         let mut held_ir: Option<irlume_camera::IrSession<'_>> = None;
         if !sequential && self.ir_available {
-            if let Ok(operation) = irlume_camera::lease::acquire_camera_operation(
-                &[rgb_dev.as_str(), ir_dev.as_str()],
-                irlume_camera::lease::CameraOperationKind::Authentication,
-                std::time::Duration::from_secs(2),
+            if let (Ok(r), Ok(i)) = (
+                camera_operation.open_rgb(&rgb_dev),
+                camera_operation.open_ir(&ir_dev),
             ) {
-                if let (Ok(r), Ok(i)) = (operation.open_rgb(&rgb_dev), operation.open_ir(&ir_dev)) {
-                    camera_operation = Some(operation);
-                    _cams = Some((r, i));
-                    let progress = self.capture_progress();
-                    // SAFETY: _cams is Some, and _rs/_is borrow from it. _cams is
-                    // declared before _rs/_is so it outlives them.
-                    let (ref cam_r, ref cam_i) = _cams.as_ref().unwrap();
-                    if let (Ok(rs), Ok(is)) = (
-                        cam_r.session_with_progress(&progress),
-                        cam_i.session_with_progress(&progress),
-                    ) {
-                        held_rgb = Some(rs);
-                        held_ir = Some(is);
-                    }
+                _cams = Some((r, i));
+                let progress = self.capture_progress();
+                // SAFETY: _cams is Some, and _rs/_is borrow from it. _cams is
+                // declared before _rs/_is so it outlives them.
+                let (ref cam_r, ref cam_i) = _cams.as_ref().unwrap();
+                if let (Ok(rs), Ok(is)) = (
+                    cam_r.session_with_progress(&progress),
+                    cam_i.session_with_progress(&progress),
+                ) {
+                    held_rgb = Some(rs);
+                    held_ir = Some(is);
                 }
             }
         }
         let mut attempt = 0u32;
         let out = loop {
             attempt += 1;
-            let out = if let Some(operation) = camera_operation.as_ref() {
-                Self::run_camera_operation(operation, || {
-                    self.authenticate_once(
-                        &enr,
-                        purpose,
-                        service,
-                        &mut held_rgb,
-                        &mut held_ir,
-                        Some(operation),
-                    )
-                })?
-            } else {
-                self.authenticate_once(&enr, purpose, service, &mut held_rgb, &mut held_ir, None)?
-            };
+            let out = Self::run_camera_operation(&camera_operation, || {
+                self.authenticate_once(
+                    &enr,
+                    purpose,
+                    service,
+                    &mut held_rgb,
+                    &mut held_ir,
+                    Some(&camera_operation),
+                )
+            })?;
             if !presence_retryable(&out) || std::time::Instant::now() >= deadline {
                 if attempt > 1 {
                     irlume_common::dlog!(
@@ -3196,7 +3204,9 @@ impl Engine {
         held_ir: &mut Option<irlume_camera::IrSession<'_>>,
         operation: Option<&irlume_camera::lease::CameraOperationSession>,
     ) -> irlume_common::Result<Outcome> {
-        let a = if let (Some(rs), Some(is), Some(operation)) =
+        let a = if !self.ir_available {
+            self.assess_rgb_only()?
+        } else if let (Some(rs), Some(is), Some(operation)) =
             (held_rgb.as_mut(), held_ir.as_mut(), operation)
         {
             self.assess_full_with(Some((rs, is)), None, operation)?

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1757,16 +1757,40 @@ impl Engine {
         self.mesh.is_some()
     }
 
+    fn run_camera_operation<T>(
+        operation: &irlume_camera::lease::CameraOperationSession,
+        task: impl FnOnce() -> irlume_common::Result<T>,
+    ) -> irlume_common::Result<T> {
+        operation
+            .run(task)
+            .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?
+    }
+
     /// One capture: RGB+IR → liveness verdict + (if a face) its embedding.
     /// Capture + assess, choosing the path from the hardware: full cross-spectrum
     /// (RGB+IR) when an IR camera is present, else RGB-only (convenience).
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn assess(&mut self) -> irlume_common::Result<Assessment> {
-        if self.ir_available {
-            self.assess_full()
+        let endpoints: Vec<&str> = if self.ir_available {
+            vec![self.rgb_dev.as_str(), self.ir_dev.as_str()]
         } else {
-            self.assess_rgb_only()
-        }
+            vec![self.rgb_dev.as_str()]
+        };
+        let operation = irlume_camera::lease::acquire_camera_operation(
+            &endpoints,
+            irlume_camera::lease::CameraOperationKind::Authentication,
+            std::time::Duration::from_secs(2),
+        )
+        .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+        operation
+            .run(|| {
+                if self.ir_available {
+                    self.assess_full(&operation)
+                } else {
+                    self.assess_rgb_only()
+                }
+            })
+            .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?
     }
 
     /// RGB-only capture + algorithmic (no-IR) liveness, the convenience-tier
@@ -1862,8 +1886,11 @@ impl Engine {
     /// held across requests: an idle stream reserves the camera against other
     /// applications, keeps the capture LED lit, and would go stale across a
     /// suspend.
-    fn assess_full(&mut self) -> irlume_common::Result<Assessment> {
-        self.assess_full_with(None, None)
+    fn assess_full(
+        &mut self,
+        operation: &irlume_camera::lease::CameraOperationSession,
+    ) -> irlume_common::Result<Assessment> {
+        self.assess_full_with(None, None, operation)
     }
 
     /// [`Self::assess_full`], optionally reusing already-streaming cameras.
@@ -1874,6 +1901,7 @@ impl Engine {
             &mut irlume_camera::IrSession<'_>,
         )>,
         capture_mode: Option<(bool, &'static str)>,
+        operation: &irlume_camera::lease::CameraOperationSession,
     ) -> irlume_common::Result<Assessment> {
         // Median-denoise the RGB frame so a single blurry/over-exposed frame
         // can't false-reject a genuine user (IR is already brightest-of-burst).
@@ -1980,7 +2008,9 @@ impl Engine {
                 std::thread::scope(|s| {
                     let ir_thread = s.spawn(move || {
                         let t = std::time::Instant::now();
-                        (held_ir_capture(ir_s), t.elapsed().as_millis())
+                        let captured =
+                            Self::run_camera_operation(operation, || held_ir_capture(ir_s));
+                        (captured, t.elapsed().as_millis())
                     });
                     let t = std::time::Instant::now();
                     let rgb = held_rgb_capture(rgb_s);
@@ -2016,10 +2046,10 @@ impl Engine {
                 let ir_progress = progress.clone();
                 let ir_thread = s.spawn(move || {
                     let t = std::time::Instant::now();
-                    (
-                        irlume_camera::capture_ir_with_stats_and_progress(&ir_dev, &ir_progress),
-                        t.elapsed().as_millis(),
-                    )
+                    let captured = Self::run_camera_operation(operation, || {
+                        irlume_camera::capture_ir_with_stats_and_progress(&ir_dev, &ir_progress)
+                    });
+                    (captured, t.elapsed().as_millis())
                 });
                 let t = std::time::Instant::now();
                 let rgb =
@@ -3087,33 +3117,50 @@ impl Engine {
         // so the watch's S_FMT and REQBUFS hit EBUSY against this very process:
         // the self-collision #187 diagnosed, reintroduced by #346 and caught by
         // the release audit before it shipped.
+        let mut camera_operation: Option<irlume_camera::lease::CameraOperationSession> = None;
         let mut _cams: Option<(irlume_camera::RgbCamera, irlume_camera::IrCamera)> = None;
         let mut held_rgb: Option<irlume_camera::RgbSession<'_>> = None;
         let mut held_ir: Option<irlume_camera::IrSession<'_>> = None;
         if !sequential && self.ir_available {
-            if let (Ok(r), Ok(i)) = (
-                irlume_camera::RgbCamera::open(&rgb_dev),
-                irlume_camera::IrCamera::open(&ir_dev),
+            if let Ok(operation) = irlume_camera::lease::acquire_camera_operation(
+                &[rgb_dev.as_str(), ir_dev.as_str()],
+                irlume_camera::lease::CameraOperationKind::Authentication,
+                std::time::Duration::from_secs(2),
             ) {
-                _cams = Some((r, i));
-                let progress = self.capture_progress();
-                // SAFETY: _cams is Some, and _rs/_is borrow from it. _cams is
-                // declared before _rs/_is so it outlives them.
-                let (ref cam_r, ref cam_i) = _cams.as_ref().unwrap();
-                if let (Ok(rs), Ok(is)) = (
-                    cam_r.session_with_progress(&progress),
-                    cam_i.session_with_progress(&progress),
-                ) {
-                    held_rgb = Some(rs);
-                    held_ir = Some(is);
+                if let (Ok(r), Ok(i)) = (operation.open_rgb(&rgb_dev), operation.open_ir(&ir_dev)) {
+                    camera_operation = Some(operation);
+                    _cams = Some((r, i));
+                    let progress = self.capture_progress();
+                    // SAFETY: _cams is Some, and _rs/_is borrow from it. _cams is
+                    // declared before _rs/_is so it outlives them.
+                    let (ref cam_r, ref cam_i) = _cams.as_ref().unwrap();
+                    if let (Ok(rs), Ok(is)) = (
+                        cam_r.session_with_progress(&progress),
+                        cam_i.session_with_progress(&progress),
+                    ) {
+                        held_rgb = Some(rs);
+                        held_ir = Some(is);
+                    }
                 }
             }
         }
         let mut attempt = 0u32;
         let out = loop {
             attempt += 1;
-            let out =
-                self.authenticate_once(&enr, purpose, service, &mut held_rgb, &mut held_ir)?;
+            let out = if let Some(operation) = camera_operation.as_ref() {
+                Self::run_camera_operation(operation, || {
+                    self.authenticate_once(
+                        &enr,
+                        purpose,
+                        service,
+                        &mut held_rgb,
+                        &mut held_ir,
+                        Some(operation),
+                    )
+                })?
+            } else {
+                self.authenticate_once(&enr, purpose, service, &mut held_rgb, &mut held_ir, None)?
+            };
             if !presence_retryable(&out) || std::time::Instant::now() >= deadline {
                 if attempt > 1 {
                     irlume_common::dlog!(
@@ -3147,9 +3194,14 @@ impl Engine {
         // `authenticate_for`.
         held_rgb: &mut Option<irlume_camera::RgbSession<'_>>,
         held_ir: &mut Option<irlume_camera::IrSession<'_>>,
+        operation: Option<&irlume_camera::lease::CameraOperationSession>,
     ) -> irlume_common::Result<Outcome> {
-        let a = if let (Some(rs), Some(is)) = (held_rgb.as_mut(), held_ir.as_mut()) {
-            self.assess_full_with(Some((rs, is)), None)?
+        let a = if let (Some(rs), Some(is), Some(operation)) =
+            (held_rgb.as_mut(), held_ir.as_mut(), operation)
+        {
+            self.assess_full_with(Some((rs, is)), None, operation)?
+        } else if let Some(operation) = operation {
+            self.assess_full_with(None, None, operation)?
         } else {
             self.assess()?
         };
@@ -3677,11 +3729,19 @@ impl Engine {
             ));
         }
         let (rgb_dev, ir_dev) = (self.rgb_dev.clone(), self.ir_dev.clone());
+        let endpoints: Vec<&str> = if self.ir_available {
+            vec![rgb_dev.as_str(), ir_dev.as_str()]
+        } else {
+            vec![rgb_dev.as_str()]
+        };
+        let operation = irlume_camera::lease::acquire_camera_operation(
+            &endpoints,
+            irlume_camera::lease::CameraOperationKind::Enrollment,
+            std::time::Duration::from_secs(2),
+        )
+        .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
         let cams = if self.ir_available {
-            match (
-                irlume_camera::RgbCamera::open(&rgb_dev),
-                irlume_camera::IrCamera::open(&ir_dev),
-            ) {
+            match (operation.open_rgb(&rgb_dev), operation.open_ir(&ir_dev)) {
                 (Ok(r), Ok(i)) => Some((r, i)),
                 _ => None,
             }
@@ -3717,6 +3777,7 @@ impl Engine {
                     pitch_neutral,
                     Some((&mut rs, &mut is)),
                     Some((sequential, mode_source)),
+                    &operation,
                     observed,
                 );
             }
@@ -3741,6 +3802,7 @@ impl Engine {
             pitch_neutral,
             None,
             Some((sequential, mode_source)),
+            &operation,
             observed,
         )
     }
@@ -3760,6 +3822,7 @@ impl Engine {
             &mut irlume_camera::IrSession<'_>,
         )>,
         capture_mode: Option<(bool, &'static str)>,
+        operation: &irlume_camera::lease::CameraOperationSession,
         observed: &mut CaptureShape,
     ) -> irlume_common::Result<Vec<CapturedScan>> {
         let mut out = Vec::new();
@@ -3784,10 +3847,11 @@ impl Engine {
                     "an authentication needed the camera; nothing was saved, please retry".into(),
                 ));
             }
-            let a = match &mut sessions {
-                Some((rs, is)) => self.assess_full_with(Some((rs, is)), capture_mode)?,
-                None => self.assess()?,
-            };
+            let a = Self::run_camera_operation(operation, || match &mut sessions {
+                Some((rs, is)) => self.assess_full_with(Some((rs, is)), capture_mode, operation),
+                None if self.ir_available => self.assess_full_with(None, capture_mode, operation),
+                None => self.assess_rgb_only(),
+            })?;
             observe_attempt(
                 &mut shape,
                 a.embedding.as_ref(),
@@ -3887,10 +3951,15 @@ impl Engine {
         if !self.ir_available {
             return false;
         }
-        let cams = match (
-            irlume_camera::RgbCamera::open(&rgb_dev),
-            irlume_camera::IrCamera::open(&ir_dev),
+        let operation = match irlume_camera::lease::acquire_camera_operation(
+            &[rgb_dev.as_str(), ir_dev.as_str()],
+            irlume_camera::lease::CameraOperationKind::Authentication,
+            std::time::Duration::from_secs(2),
         ) {
+            Ok(operation) => operation,
+            Err(_) => return false,
+        };
+        let cams = match (operation.open_rgb(&rgb_dev), operation.open_ir(&ir_dev)) {
             (Ok(r), Ok(i)) => (r, i),
             _ => return false,
         };

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -8839,8 +8839,14 @@ mod engine_tests {
     fn loopback_release_held_hands_the_camera_back() {
         let (rgb, ir) = loopback_pair();
         let _g = env_guard();
-        let cam = irlume_camera::IrCamera::open(&ir).expect("open the IR node");
-        let rgb_cam = irlume_camera::RgbCamera::open(&rgb).expect("open the RGB node");
+        let operation = irlume_camera::lease::acquire_camera_operation(
+            &[rgb.as_str(), ir.as_str()],
+            irlume_camera::lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        )
+        .expect("acquire one RGB+IR operation");
+        let cam = operation.open_ir(&ir).expect("open the IR node");
+        let rgb_cam = operation.open_rgb(&rgb).expect("open the RGB node");
         let mut held_ir = Some(cam.session().expect("hold an IR session"));
         // BOTH halves must release: the review round noted the test proved
         // only the IR side, and release_held drops two owners.
@@ -8848,11 +8854,11 @@ mod engine_tests {
 
         // Control: with the session alive, a second stream on the same node
         // must be refused. If this passes, the rest proves nothing.
-        let busy =
-            irlume_camera::capture_ir_streaming(&ir, 2, |_| std::ops::ControlFlow::Break::<()>(()));
+        let busy_ir = cam.session();
+        let busy_rgb = rgb_cam.session();
         assert!(
-            busy.is_err(),
-            "control failed: a live IrSession must block a second stream, or this \
+            busy_ir.is_err() && busy_rgb.is_err(),
+            "control failed: live IR and RGB sessions must each block a second stream, or this \
              test cannot distinguish a real release from a camera nobody held"
         );
 
@@ -8862,20 +8868,26 @@ mod engine_tests {
             "the release must clear BOTH session slots"
         );
 
-        // The observation: the same call now succeeds, because the buffer queue
-        // went back when the session dropped.
-        let after =
-            irlume_camera::capture_ir_streaming(&ir, 2, |_| std::ops::ControlFlow::Break::<()>(()));
+        // The observation: fresh camera handles and sessions now succeed because
+        // both buffer queues went back when the held sessions dropped.
+        let after_cam = operation.open_ir(&ir).expect("reopen IR after release");
+        let mut after = after_cam.session().expect("open IR session after release");
+        let after_capture = after.capture_with_stats();
         assert!(
-            after.is_ok(),
-            "after release the consent watch must be able to open its own \
+            after_capture.is_ok(),
+            "after release the consent watch must be able to capture from its own \
              stream, got {:?}",
-            after.err()
+            after_capture.err()
         );
-        // The RGB half too: a fresh capture on the released node must work.
+        drop(after);
+        // The RGB half too: a fresh handle and session on the released node must work.
+        let rgb_after_cam = operation.open_rgb(&rgb).expect("reopen RGB after release");
+        let mut rgb_after = rgb_after_cam
+            .session()
+            .expect("open RGB session after release");
         assert!(
-            irlume_camera::capture_rgb(&rgb).is_ok(),
-            "after release an RGB capture must be able to open the node"
+            rgb_after.frame().is_ok(),
+            "after release an RGB session must be able to capture a frame"
         );
     }
 

--- a/crates/irlume-auth/tests/no_probe_on_the_auth_path.rs
+++ b/crates/irlume-auth/tests/no_probe_on_the_auth_path.rs
@@ -82,3 +82,48 @@ fn the_authentication_path_never_runs_the_capture_mode_probe() {
         offenders.join("\n")
     );
 }
+
+#[test]
+fn one_camera_operation_spans_consent_and_every_authentication_retry() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
+    let text = std::fs::read_to_string(&src).expect("read irlume-auth/src/lib.rs");
+    let start = text
+        .find("    pub fn authenticate_for(")
+        .expect("authenticate_for exists");
+    let end = text[start..]
+        .find("\n    fn authenticate_once(")
+        .map(|offset| start + offset)
+        .expect("authenticate_once follows authenticate_for");
+    let body = &text[start..end];
+
+    let acquire = body
+        .find("acquire_camera_operation(")
+        .expect("authentication acquires a camera operation");
+    let consent = body
+        .find("self.early_consent_watch")
+        .expect("pre-match consent watch exists");
+    let retries = body
+        .find("let out = loop {")
+        .expect("grace retry loop exists");
+
+    assert_eq!(
+        body.matches("acquire_camera_operation(").count(),
+        1,
+        "authenticate_for must acquire exactly one operation"
+    );
+    assert!(acquire < consent && consent < retries);
+    assert!(body.contains("Self::run_camera_operation(&camera_operation"));
+    assert!(body.contains("Some(&camera_operation)"));
+
+    let once_start = text[end..]
+        .find("    fn authenticate_once(")
+        .map(|offset| end + offset)
+        .expect("authenticate_once exists");
+    let once_end = text[once_start..]
+        .find("\n    fn ")
+        .map(|offset| once_start + offset)
+        .expect("another method follows authenticate_once");
+    let once = &text[once_start..once_end];
+    assert!(once.contains("if !self.ir_available"));
+    assert!(once.contains("self.assess_rgb_only()?"));
+}

--- a/crates/irlume-camera/Cargo.toml
+++ b/crates/irlume-camera/Cargo.toml
@@ -12,6 +12,7 @@ serde_json.workspace = true
 # Hello-class hardware, and builds from cache. nokhwa wraps this crate anyway.
 v4l = "0.14"
 libc = "0.2"
+rand.workspace = true
 
 [lints]
 workspace = true

--- a/crates/irlume-camera/Cargo.toml
+++ b/crates/irlume-camera/Cargo.toml
@@ -13,6 +13,7 @@ serde_json.workspace = true
 v4l = "0.14"
 libc = "0.2"
 rand.workspace = true
+udev.workspace = true
 
 [lints]
 workspace = true

--- a/crates/irlume-camera/examples/session_bench.rs
+++ b/crates/irlume-camera/examples/session_bench.rs
@@ -10,8 +10,6 @@
 //!
 //! Usage: cargo run --release -p irlume-camera --example session_bench -- [rgb_dev] [ir_dev] [pairs]
 
-use irlume_camera::{IrCamera, RgbCamera};
-
 fn main() {
     let mut a = std::env::args().skip(1);
     let rgb_dev = a.next().unwrap_or_else(|| "/dev/video0".into());
@@ -30,14 +28,23 @@ fn main() {
     }
     let per_call = t0.elapsed();
 
-    let rgb_cam = match RgbCamera::open(&rgb_dev) {
+    let operation = irlume_camera::lease::acquire_camera_operation(
+        &[rgb_dev.as_str(), ir_dev.as_str()],
+        irlume_camera::lease::CameraOperationKind::Diagnostics,
+        std::time::Duration::from_secs(2),
+    )
+    .unwrap_or_else(|error| {
+        eprintln!("pair lease failed: {error}");
+        std::process::exit(1);
+    });
+    let rgb_cam = match operation.open_rgb(&rgb_dev) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("rgb open failed: {e}");
             std::process::exit(1);
         }
     };
-    let ir_cam = match IrCamera::open(&ir_dev) {
+    let ir_cam = match operation.open_ir(&ir_dev) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("ir open failed: {e}");

--- a/crates/irlume-camera/examples/xu_set.rs
+++ b/crates/irlume-camera/examples/xu_set.rs
@@ -52,6 +52,12 @@ fn run() -> Result<(), String> {
         .parse()
         .map_err(|e| format!("selector {selector}: {e}"))?;
 
+    let operation = irlume_camera::lease::acquire_camera_operation(
+        &[device.as_str()],
+        irlume_camera::lease::CameraOperationKind::Setup,
+        std::time::Duration::from_secs(2),
+    )
+    .map_err(|error| error.to_string())?;
     let dev = v4l::Device::with_path(device).map_err(|e| format!("open {device}: {e}"))?;
     let handle = dev.handle();
     let fd = handle.fd();
@@ -99,6 +105,10 @@ fn run() -> Result<(), String> {
         ));
     }
     eprintln!("xu_set: unit{unit}/sel{selector} before: {before:02x?}");
+    operation
+        .lease()
+        .validate()
+        .map_err(|error| error.to_string())?;
     raw::set_cur(fd, unit, selector, &payload)?;
     let after = raw::get_cur(fd, unit, selector, len)?;
     eprintln!("xu_set: unit{unit}/sel{selector} wrote:  {payload:02x?}");

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -4,10 +4,14 @@
 //! Crate-private capture-backend ownership and operation routing.
 
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Instant;
 
 use crate::contracts::CameraDescriptor;
 use crate::inventory::{
     CameraInventory, CameraInventoryError, CameraInventoryEvent, CameraObservation,
+};
+use crate::lease::{
+    CameraLease, CameraLeaseError, CameraOperationKind, CameraOperationSession, LeaseAuthority,
 };
 use crate::{CameraPair, IrCamera, NodeScan, RgbCamera, Role};
 
@@ -16,8 +20,8 @@ trait CameraBackend: Send + Sync + 'static {
     fn scan_nodes(&self) -> NodeScan;
     fn discover_nodes(&self) -> Vec<(String, Role)>;
     fn list_pairs(&self) -> Vec<CameraPair>;
-    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera>;
-    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera>;
+    fn open_rgb(&self, device: &str, lease: CameraLease) -> irlume_common::Result<RgbCamera>;
+    fn open_ir(&self, device: &str, lease: CameraLease) -> irlume_common::Result<IrCamera>;
 
     #[cfg(test)]
     fn has_exact_production_uvc_delegates(&self) -> bool {
@@ -31,7 +35,8 @@ trait CameraBackend: Send + Sync + 'static {
 /// subscription remain later slices and therefore cannot alter behavior here.
 pub(crate) struct CameraSupervisor {
     backend: Arc<dyn CameraBackend>,
-    inventory: Mutex<CameraInventory>,
+    inventory: Arc<Mutex<CameraInventory>>,
+    leases: Arc<LeaseAuthority>,
 }
 
 impl CameraSupervisor {
@@ -42,7 +47,8 @@ impl CameraSupervisor {
     fn from_arc(backend: Arc<dyn CameraBackend>) -> Self {
         Self {
             backend,
-            inventory: Mutex::new(CameraInventory::new()),
+            inventory: Arc::new(Mutex::new(CameraInventory::new())),
+            leases: Arc::new(LeaseAuthority::default()),
         }
     }
 
@@ -117,6 +123,31 @@ impl CameraSupervisor {
             .validate(descriptor)
     }
 
+    pub(crate) fn acquire_operation(
+        &self,
+        endpoint_paths: &[&str],
+        operation: CameraOperationKind,
+        deadline: Instant,
+    ) -> Result<CameraOperationSession, CameraLeaseError> {
+        let reference = self
+            .inventory
+            .lock()
+            .map_err(|_| CameraLeaseError::Poisoned)?
+            .reference_for_endpoints(endpoint_paths)
+            .map_err(|error| match error {
+                CameraInventoryError::UnknownCamera => CameraLeaseError::UnknownEndpoint,
+                _ => CameraLeaseError::Stale,
+            })?;
+        let lease = CameraLease::acquire(
+            &self.leases,
+            self.inventory.clone(),
+            vec![reference],
+            operation,
+            deadline,
+        )?;
+        Ok(CameraOperationSession::new(lease))
+    }
+
     fn scan_nodes(&self) -> NodeScan {
         self.backend.scan_nodes()
     }
@@ -129,12 +160,12 @@ impl CameraSupervisor {
         self.backend.list_pairs()
     }
 
-    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
-        self.backend.open_rgb(device)
+    fn open_rgb(&self, device: &str, lease: CameraLease) -> irlume_common::Result<RgbCamera> {
+        self.backend.open_rgb(device, lease)
     }
 
-    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
-        self.backend.open_ir(device)
+    fn open_ir(&self, device: &str, lease: CameraLease) -> irlume_common::Result<IrCamera> {
+        self.backend.open_ir(device, lease)
     }
 }
 
@@ -145,8 +176,8 @@ impl CameraSupervisor {
 type ScanNodes = fn() -> NodeScan;
 type DiscoverNodes = fn() -> Vec<(String, Role)>;
 type ListPairs = fn() -> Vec<CameraPair>;
-type OpenRgb = fn(&str) -> irlume_common::Result<RgbCamera>;
-type OpenIr = fn(&str) -> irlume_common::Result<IrCamera>;
+type OpenRgb = fn(&str, CameraLease) -> irlume_common::Result<RgbCamera>;
+type OpenIr = fn(&str, CameraLease) -> irlume_common::Result<IrCamera>;
 
 fn production_scan_nodes() -> NodeScan {
     crate::uvc_scan(true)
@@ -160,12 +191,12 @@ fn production_list_pairs() -> Vec<CameraPair> {
     crate::uvc_list_pairs()
 }
 
-fn production_open_rgb(device: &str) -> irlume_common::Result<RgbCamera> {
-    RgbCamera::open_uvc(device)
+fn production_open_rgb(device: &str, lease: CameraLease) -> irlume_common::Result<RgbCamera> {
+    RgbCamera::open_uvc(device, lease)
 }
 
-fn production_open_ir(device: &str) -> irlume_common::Result<IrCamera> {
-    IrCamera::open_uvc(device)
+fn production_open_ir(device: &str, lease: CameraLease) -> irlume_common::Result<IrCamera> {
+    IrCamera::open_uvc(device, lease)
 }
 
 #[derive(Clone, Copy)]
@@ -202,12 +233,12 @@ impl CameraBackend for UvcV4l2Backend {
         (self.list_pairs)()
     }
 
-    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
-        (self.open_rgb)(device)
+    fn open_rgb(&self, device: &str, lease: CameraLease) -> irlume_common::Result<RgbCamera> {
+        (self.open_rgb)(device, lease)
     }
 
-    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
-        (self.open_ir)(device)
+    fn open_ir(&self, device: &str, lease: CameraLease) -> irlume_common::Result<IrCamera> {
+        (self.open_ir)(device, lease)
     }
 
     #[cfg(test)]
@@ -225,7 +256,7 @@ impl CameraBackend for UvcV4l2Backend {
 
 static DEFAULT_CAMERA_SUPERVISOR: OnceLock<Arc<CameraSupervisor>> = OnceLock::new();
 
-fn default_camera_supervisor() -> &'static CameraSupervisor {
+pub(crate) fn default_camera_supervisor() -> &'static CameraSupervisor {
     DEFAULT_CAMERA_SUPERVISOR
         .get_or_init(|| {
             let supervisor = Arc::new(CameraSupervisor::new(UvcV4l2Backend::default()));
@@ -244,7 +275,7 @@ thread_local! {
 }
 
 /// Route one compatibility operation through the process supervisor.
-fn with_camera_supervisor<T>(operation: impl FnOnce(&CameraSupervisor) -> T) -> T {
+pub(crate) fn with_camera_supervisor<T>(operation: impl FnOnce(&CameraSupervisor) -> T) -> T {
     #[cfg(test)]
     if let Some(supervisor) = TEST_SUPERVISOR.with(|slot| slot.borrow().clone()) {
         return operation(&supervisor);
@@ -265,12 +296,12 @@ pub(crate) fn list_pairs() -> Vec<CameraPair> {
     with_camera_supervisor(CameraSupervisor::list_pairs)
 }
 
-pub(crate) fn open_rgb(device: &str) -> irlume_common::Result<RgbCamera> {
-    with_camera_supervisor(|supervisor| supervisor.open_rgb(device))
+pub(crate) fn open_rgb(device: &str, lease: CameraLease) -> irlume_common::Result<RgbCamera> {
+    with_camera_supervisor(|supervisor| supervisor.open_rgb(device, lease))
 }
 
-pub(crate) fn open_ir(device: &str) -> irlume_common::Result<IrCamera> {
-    with_camera_supervisor(|supervisor| supervisor.open_ir(device))
+pub(crate) fn open_ir(device: &str, lease: CameraLease) -> irlume_common::Result<IrCamera> {
+    with_camera_supervisor(|supervisor| supervisor.open_ir(device, lease))
 }
 
 #[cfg(test)]
@@ -293,6 +324,20 @@ mod tests {
     fn install_test_supervisor(supervisor: Arc<CameraSupervisor>) -> TestBackendGuard {
         let previous = TEST_SUPERVISOR.with(|slot| slot.borrow_mut().replace(supervisor));
         TestBackendGuard(previous)
+    }
+
+    fn seed_test_endpoints(supervisor: &CameraSupervisor, endpoints: &[&str]) {
+        supervisor
+            .reconcile_inventory(vec![
+                CameraObservation::with_lifecycle_evidence_and_endpoints(
+                    crate::contracts::BackendKind::UvcV4l2,
+                    crate::contracts::PhysicalCameraId::new("/devices/test/camera", None).unwrap(),
+                    crate::contracts::CameraCapabilities::default(),
+                    vec!["test-evidence".into()],
+                    endpoints.iter().map(|path| (*path).to_owned()).collect(),
+                ),
+            ])
+            .unwrap();
     }
 
     #[derive(Clone)]
@@ -336,12 +381,12 @@ mod tests {
             }]
         }
 
-        fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
+        fn open_rgb(&self, device: &str, _: CameraLease) -> irlume_common::Result<RgbCamera> {
             self.record(format!("open_rgb:{device}"));
             Err(irlume_common::Error::Hardware("spy RGB refusal".into()))
         }
 
-        fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
+        fn open_ir(&self, device: &str, _: CameraLease) -> irlume_common::Result<IrCamera> {
             self.record(format!("open_ir:{device}"));
             Err(irlume_common::Error::Hardware("spy IR refusal".into()))
         }
@@ -395,11 +440,11 @@ mod tests {
         ]
     }
 
-    fn fixture_open_rgb(_: &str) -> irlume_common::Result<RgbCamera> {
+    fn fixture_open_rgb(_: &str, _: CameraLease) -> irlume_common::Result<RgbCamera> {
         Err(irlume_common::Error::Hardware("fixture RGB".into()))
     }
 
-    fn fixture_open_ir(_: &str) -> irlume_common::Result<IrCamera> {
+    fn fixture_open_ir(_: &str, _: CameraLease) -> irlume_common::Result<IrCamera> {
         Err(irlume_common::Error::Hardware("fixture IR".into()))
     }
 
@@ -409,6 +454,7 @@ mod tests {
         let supervisor = Arc::new(CameraSupervisor::from_arc(Arc::new(RecordingBackend {
             calls: Arc::clone(&calls),
         })));
+        seed_test_endpoints(&supervisor, &["/dev/spy-rgb", "/dev/spy-ir"]);
         let _guard = install_test_supervisor(Arc::clone(&supervisor));
         with_camera_supervisor(|routed| assert!(std::ptr::eq(routed, supervisor.as_ref())));
 
@@ -499,19 +545,21 @@ mod tests {
         assert_eq!(pairs[1].ir, "/dev/usb-ir");
         assert_eq!(pairs[1].id, None);
         assert!(!pairs[1].fixed);
+    }
 
-        assert!(backend
-            .open_rgb("/dev/ignored")
-            .err()
-            .expect("fixture RGB open must refuse")
-            .to_string()
-            .contains("fixture RGB"));
-        assert!(backend
-            .open_ir("/dev/ignored")
-            .err()
-            .expect("fixture IR open must refuse")
-            .to_string()
-            .contains("fixture IR"));
+    #[test]
+    fn known_invalidated_endpoint_cannot_take_the_discovery_bypass() {
+        let supervisor = Arc::new(CameraSupervisor::new(UvcV4l2Backend::default()));
+        seed_test_endpoints(&supervisor, &["/dev/video-test"]);
+        supervisor.invalidate_inventory().unwrap();
+        let _guard = install_test_supervisor(supervisor);
+        assert!(matches!(
+            crate::lease::permit_for_discovery(
+                "/dev/video-test",
+                std::time::Duration::from_millis(5)
+            ),
+            Err(CameraLeaseError::Stale)
+        ));
     }
 
     #[test]

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Crate-private capture-backend ownership and operation routing.
+
+use std::sync::{Arc, OnceLock};
+
+use crate::{CameraPair, IrCamera, NodeScan, RgbCamera, Role};
+
+/// One capture implementation owned by the process camera supervisor.
+trait CameraBackend: Send + Sync + 'static {
+    fn scan_nodes(&self) -> NodeScan;
+    fn discover_nodes(&self) -> Vec<(String, Role)>;
+    fn list_pairs(&self) -> Vec<CameraPair>;
+    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera>;
+    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera>;
+
+    #[cfg(test)]
+    fn has_exact_production_uvc_delegates(&self) -> bool {
+        false
+    }
+}
+
+/// Process component that owns camera backend instances and routes operations.
+///
+/// This foundation deliberately has no mutex, mutable inventory, cache, lease,
+/// or lifecycle generation. Those would alter contention or hotplug behavior.
+struct CameraSupervisor {
+    backend: Arc<dyn CameraBackend>,
+}
+
+impl CameraSupervisor {
+    fn new(backend: impl CameraBackend) -> Self {
+        Self {
+            backend: Arc::new(backend),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_arc(backend: Arc<dyn CameraBackend>) -> Self {
+        Self { backend }
+    }
+
+    fn scan_nodes(&self) -> NodeScan {
+        self.backend.scan_nodes()
+    }
+
+    fn discover_nodes(&self) -> Vec<(String, Role)> {
+        self.backend.discover_nodes()
+    }
+
+    fn list_pairs(&self) -> Vec<CameraPair> {
+        self.backend.list_pairs()
+    }
+
+    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
+        self.backend.open_rgb(device)
+    }
+
+    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
+        self.backend.open_ir(device)
+    }
+}
+
+/// Existing direct V4L2 backend for video-node-centric UVC cameras.
+///
+/// This delegates to the pre-existing direct functions without changing their
+/// probing, pairing, negotiation, privacy, or emitter behavior.
+type ScanNodes = fn() -> NodeScan;
+type DiscoverNodes = fn() -> Vec<(String, Role)>;
+type ListPairs = fn() -> Vec<CameraPair>;
+type OpenRgb = fn(&str) -> irlume_common::Result<RgbCamera>;
+type OpenIr = fn(&str) -> irlume_common::Result<IrCamera>;
+
+fn production_scan_nodes() -> NodeScan {
+    crate::uvc_scan(true)
+}
+
+fn production_discover_nodes() -> Vec<(String, Role)> {
+    crate::uvc_discover_nodes()
+}
+
+fn production_list_pairs() -> Vec<CameraPair> {
+    crate::uvc_list_pairs()
+}
+
+fn production_open_rgb(device: &str) -> irlume_common::Result<RgbCamera> {
+    RgbCamera::open_uvc(device)
+}
+
+fn production_open_ir(device: &str) -> irlume_common::Result<IrCamera> {
+    IrCamera::open_uvc(device)
+}
+
+#[derive(Clone, Copy)]
+struct UvcV4l2Backend {
+    scan_nodes: ScanNodes,
+    discover_nodes: DiscoverNodes,
+    list_pairs: ListPairs,
+    open_rgb: OpenRgb,
+    open_ir: OpenIr,
+}
+
+impl Default for UvcV4l2Backend {
+    fn default() -> Self {
+        Self {
+            scan_nodes: production_scan_nodes,
+            discover_nodes: production_discover_nodes,
+            list_pairs: production_list_pairs,
+            open_rgb: production_open_rgb,
+            open_ir: production_open_ir,
+        }
+    }
+}
+
+impl CameraBackend for UvcV4l2Backend {
+    fn scan_nodes(&self) -> NodeScan {
+        (self.scan_nodes)()
+    }
+
+    fn discover_nodes(&self) -> Vec<(String, Role)> {
+        (self.discover_nodes)()
+    }
+
+    fn list_pairs(&self) -> Vec<CameraPair> {
+        (self.list_pairs)()
+    }
+
+    fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
+        (self.open_rgb)(device)
+    }
+
+    fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
+        (self.open_ir)(device)
+    }
+
+    #[cfg(test)]
+    fn has_exact_production_uvc_delegates(&self) -> bool {
+        std::ptr::fn_addr_eq(self.scan_nodes, production_scan_nodes as ScanNodes)
+            && std::ptr::fn_addr_eq(
+                self.discover_nodes,
+                production_discover_nodes as DiscoverNodes,
+            )
+            && std::ptr::fn_addr_eq(self.list_pairs, production_list_pairs as ListPairs)
+            && std::ptr::fn_addr_eq(self.open_rgb, production_open_rgb as OpenRgb)
+            && std::ptr::fn_addr_eq(self.open_ir, production_open_ir as OpenIr)
+    }
+}
+
+static DEFAULT_CAMERA_SUPERVISOR: OnceLock<CameraSupervisor> = OnceLock::new();
+
+fn default_camera_supervisor() -> &'static CameraSupervisor {
+    DEFAULT_CAMERA_SUPERVISOR.get_or_init(|| CameraSupervisor::new(UvcV4l2Backend::default()))
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_BACKEND: std::cell::RefCell<Option<Arc<dyn CameraBackend>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Route one compatibility operation through the process supervisor.
+fn with_camera_supervisor<T>(operation: impl FnOnce(&CameraSupervisor) -> T) -> T {
+    #[cfg(test)]
+    if let Some(backend) = TEST_BACKEND.with(|slot| slot.borrow().clone()) {
+        return operation(&CameraSupervisor::from_arc(backend));
+    }
+
+    operation(default_camera_supervisor())
+}
+
+pub(crate) fn scan_nodes() -> NodeScan {
+    with_camera_supervisor(CameraSupervisor::scan_nodes)
+}
+
+pub(crate) fn discover_nodes() -> Vec<(String, Role)> {
+    with_camera_supervisor(CameraSupervisor::discover_nodes)
+}
+
+pub(crate) fn list_pairs() -> Vec<CameraPair> {
+    with_camera_supervisor(CameraSupervisor::list_pairs)
+}
+
+pub(crate) fn open_rgb(device: &str) -> irlume_common::Result<RgbCamera> {
+    with_camera_supervisor(|supervisor| supervisor.open_rgb(device))
+}
+
+pub(crate) fn open_ir(device: &str) -> irlume_common::Result<IrCamera> {
+    with_camera_supervisor(|supervisor| supervisor.open_ir(device))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::{FailedAt, McCentric, Unreadable};
+
+    struct TestBackendGuard(Option<Arc<dyn CameraBackend>>);
+
+    impl Drop for TestBackendGuard {
+        fn drop(&mut self) {
+            let previous = self.0.take();
+            TEST_BACKEND.with(|slot| *slot.borrow_mut() = previous);
+        }
+    }
+
+    fn install_test_backend(backend: Arc<dyn CameraBackend>) -> TestBackendGuard {
+        let previous = TEST_BACKEND.with(|slot| slot.borrow_mut().replace(backend));
+        TestBackendGuard(previous)
+    }
+
+    #[derive(Clone)]
+    struct RecordingBackend {
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RecordingBackend {
+        fn record(&self, call: impl Into<String>) {
+            self.calls
+                .lock()
+                .expect("recording lock poisoned")
+                .push(call.into());
+        }
+    }
+
+    impl CameraBackend for RecordingBackend {
+        fn scan_nodes(&self) -> NodeScan {
+            self.record("scan_nodes");
+            NodeScan {
+                classified: vec![("/dev/spy-scan".into(), Role::Rgb)],
+                ..NodeScan::default()
+            }
+        }
+
+        fn discover_nodes(&self) -> Vec<(String, Role)> {
+            self.record("discover_nodes");
+            vec![
+                ("/dev/spy-ir".into(), Role::Ir),
+                ("/dev/spy-rgb".into(), Role::Rgb),
+            ]
+        }
+
+        fn list_pairs(&self) -> Vec<CameraPair> {
+            self.record("list_pairs");
+            vec![CameraPair {
+                rgb: "/dev/spy-rgb".into(),
+                ir: "/dev/spy-ir".into(),
+                id: Some("1234:5678".into()),
+                fixed: true,
+            }]
+        }
+
+        fn open_rgb(&self, device: &str) -> irlume_common::Result<RgbCamera> {
+            self.record(format!("open_rgb:{device}"));
+            Err(irlume_common::Error::Hardware("spy RGB refusal".into()))
+        }
+
+        fn open_ir(&self, device: &str) -> irlume_common::Result<IrCamera> {
+            self.record(format!("open_ir:{device}"));
+            Err(irlume_common::Error::Hardware("spy IR refusal".into()))
+        }
+    }
+
+    fn fixture_scan_nodes() -> NodeScan {
+        NodeScan {
+            classified: vec![
+                ("/dev/fixture-rgb".into(), Role::Rgb),
+                ("/dev/fixture-ir".into(), Role::Ir),
+            ],
+            unreadable: vec![Unreadable {
+                path: "/dev/fixture-busy".into(),
+                at: FailedAt::Open,
+                errno: Some(libc::EBUSY),
+                holder: Some("fixture-holder".into()),
+            }],
+            mc_centric: vec![(
+                "/dev/fixture-mc".into(),
+                McCentric {
+                    driver: "fixture-driver".into(),
+                    io_mc: true,
+                    mplane_only: true,
+                },
+            )],
+            listing_error: Some("fixture listing warning".into()),
+        }
+    }
+
+    fn fixture_discover_nodes() -> Vec<(String, Role)> {
+        vec![
+            ("/dev/fixture-ir".into(), Role::Ir),
+            ("/dev/fixture-rgb".into(), Role::Rgb),
+        ]
+    }
+
+    fn fixture_list_pairs() -> Vec<CameraPair> {
+        vec![
+            CameraPair {
+                rgb: "/dev/fixed-rgb".into(),
+                ir: "/dev/fixed-ir".into(),
+                id: Some("1111:2222".into()),
+                fixed: true,
+            },
+            CameraPair {
+                rgb: "/dev/usb-rgb".into(),
+                ir: "/dev/usb-ir".into(),
+                id: None,
+                fixed: false,
+            },
+        ]
+    }
+
+    fn fixture_open_rgb(_: &str) -> irlume_common::Result<RgbCamera> {
+        Err(irlume_common::Error::Hardware("fixture RGB".into()))
+    }
+
+    fn fixture_open_ir(_: &str) -> irlume_common::Result<IrCamera> {
+        Err(irlume_common::Error::Hardware("fixture IR".into()))
+    }
+
+    #[test]
+    fn public_camera_entrypoints_route_through_one_supervisor_backend() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let _guard = install_test_backend(Arc::new(RecordingBackend {
+            calls: Arc::clone(&calls),
+        }));
+
+        assert_eq!(crate::scan_nodes().classified[0].0, "/dev/spy-scan");
+        assert_eq!(
+            crate::discover_nodes(),
+            vec![
+                ("/dev/spy-ir".into(), Role::Ir),
+                ("/dev/spy-rgb".into(), Role::Rgb),
+            ]
+        );
+        let pairs = crate::list_pairs();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].rgb, "/dev/spy-rgb");
+        assert_eq!(pairs[0].ir, "/dev/spy-ir");
+        assert_eq!(pairs[0].id.as_deref(), Some("1234:5678"));
+        assert!(pairs[0].fixed);
+        assert!(RgbCamera::open("/dev/spy-rgb")
+            .err()
+            .expect("spy RGB open must refuse")
+            .to_string()
+            .contains("spy RGB refusal"));
+        assert!(IrCamera::open("/dev/spy-ir")
+            .err()
+            .expect("spy IR open must refuse")
+            .to_string()
+            .contains("spy IR refusal"));
+
+        assert_eq!(
+            *calls.lock().expect("recording lock poisoned"),
+            [
+                "scan_nodes",
+                "discover_nodes",
+                "list_pairs",
+                "open_rgb:/dev/spy-rgb",
+                "open_ir:/dev/spy-ir",
+            ]
+        );
+    }
+
+    #[test]
+    fn uvc_adapter_preserves_complete_results_and_order() {
+        let backend = UvcV4l2Backend {
+            scan_nodes: fixture_scan_nodes,
+            discover_nodes: fixture_discover_nodes,
+            list_pairs: fixture_list_pairs,
+            open_rgb: fixture_open_rgb,
+            open_ir: fixture_open_ir,
+        };
+
+        let scan = backend.scan_nodes();
+        assert_eq!(
+            scan.classified,
+            vec![
+                ("/dev/fixture-rgb".into(), Role::Rgb),
+                ("/dev/fixture-ir".into(), Role::Ir),
+            ]
+        );
+        assert_eq!(scan.unreadable.len(), 1);
+        assert_eq!(scan.unreadable[0].path, "/dev/fixture-busy");
+        assert_eq!(scan.unreadable[0].at, FailedAt::Open);
+        assert_eq!(scan.unreadable[0].errno, Some(libc::EBUSY));
+        assert_eq!(scan.unreadable[0].holder.as_deref(), Some("fixture-holder"));
+        assert_eq!(
+            scan.mc_centric,
+            vec![(
+                "/dev/fixture-mc".into(),
+                McCentric {
+                    driver: "fixture-driver".into(),
+                    io_mc: true,
+                    mplane_only: true,
+                },
+            )]
+        );
+        assert_eq!(
+            scan.listing_error.as_deref(),
+            Some("fixture listing warning")
+        );
+        assert_eq!(backend.discover_nodes(), fixture_discover_nodes());
+
+        let pairs = backend.list_pairs();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].rgb, "/dev/fixed-rgb");
+        assert_eq!(pairs[0].ir, "/dev/fixed-ir");
+        assert_eq!(pairs[0].id.as_deref(), Some("1111:2222"));
+        assert!(pairs[0].fixed);
+        assert_eq!(pairs[1].rgb, "/dev/usb-rgb");
+        assert_eq!(pairs[1].ir, "/dev/usb-ir");
+        assert_eq!(pairs[1].id, None);
+        assert!(!pairs[1].fixed);
+
+        assert!(backend
+            .open_rgb("/dev/ignored")
+            .err()
+            .expect("fixture RGB open must refuse")
+            .to_string()
+            .contains("fixture RGB"));
+        assert!(backend
+            .open_ir("/dev/ignored")
+            .err()
+            .expect("fixture IR open must refuse")
+            .to_string()
+            .contains("fixture IR"));
+    }
+
+    #[test]
+    fn default_supervisor_is_process_wide_and_uses_exact_uvc_delegates() {
+        assert!(std::ptr::eq(
+            default_camera_supervisor(),
+            default_camera_supervisor()
+        ));
+        assert!(default_camera_supervisor()
+            .backend
+            .has_exact_production_uvc_delegates());
+    }
+}

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -56,12 +56,48 @@ impl CameraSupervisor {
             .reconcile(observations)
     }
 
+    pub(crate) fn reconcile_inventory_guarded<F>(
+        &self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnMut() -> bool,
+    {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .reconcile_guarded(observations, quiet)
+    }
+
     pub(crate) fn invalidate_inventory(&self) -> Result<(), CameraInventoryError> {
         self.inventory
             .lock()
             .map_err(|_| CameraInventoryError::Poisoned)?
             .invalidate_all();
         Ok(())
+    }
+
+    pub(crate) fn invalidate_inventory_topologies(
+        &self,
+        topologies: &std::collections::BTreeSet<String>,
+    ) -> Result<(), CameraInventoryError> {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .invalidate_topologies(topologies);
+        Ok(())
+    }
+
+    pub(crate) fn retire_inventory_topologies(
+        &self,
+        topologies: &std::collections::BTreeSet<String>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        Ok(self
+            .inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .retire_topologies(topologies))
     }
 
     #[cfg_attr(

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -3,8 +3,12 @@
 
 //! Crate-private capture-backend ownership and operation routing.
 
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
+use crate::contracts::CameraDescriptor;
+use crate::inventory::{
+    CameraInventory, CameraInventoryError, CameraInventoryEvent, CameraObservation,
+};
 use crate::{CameraPair, IrCamera, NodeScan, RgbCamera, Role};
 
 /// One capture implementation owned by the process camera supervisor.
@@ -23,22 +27,57 @@ trait CameraBackend: Send + Sync + 'static {
 
 /// Process component that owns camera backend instances and routes operations.
 ///
-/// This foundation deliberately has no mutex, mutable inventory, cache, lease,
-/// or lifecycle generation. Those would alter contention or hotplug behavior.
+/// Inventory mutation is isolated from capture routing. Leases and hotplug event
+/// subscription remain later slices and therefore cannot alter behavior here.
 struct CameraSupervisor {
     backend: Arc<dyn CameraBackend>,
+    inventory: Mutex<CameraInventory>,
 }
 
 impl CameraSupervisor {
     fn new(backend: impl CameraBackend) -> Self {
+        Self::from_arc(Arc::new(backend))
+    }
+
+    fn from_arc(backend: Arc<dyn CameraBackend>) -> Self {
         Self {
-            backend: Arc::new(backend),
+            backend,
+            inventory: Mutex::new(CameraInventory::new()),
         }
     }
 
-    #[cfg(test)]
-    fn from_arc(backend: Arc<dyn CameraBackend>) -> Self {
-        Self { backend }
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the udev adapter will feed inventory observations"
+        )
+    )]
+    fn reconcile_inventory(
+        &self,
+        observations: Vec<CameraObservation>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .reconcile(observations)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "later frame and session slices validate descriptors"
+        )
+    )]
+    fn validate_descriptor(
+        &self,
+        descriptor: &CameraDescriptor,
+    ) -> Result<(), CameraInventoryError> {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .validate(descriptor)
     }
 
     fn scan_nodes(&self) -> NodeScan {
@@ -155,15 +194,15 @@ fn default_camera_supervisor() -> &'static CameraSupervisor {
 
 #[cfg(test)]
 thread_local! {
-    static TEST_BACKEND: std::cell::RefCell<Option<Arc<dyn CameraBackend>>> =
+    static TEST_SUPERVISOR: std::cell::RefCell<Option<Arc<CameraSupervisor>>> =
         const { std::cell::RefCell::new(None) };
 }
 
 /// Route one compatibility operation through the process supervisor.
 fn with_camera_supervisor<T>(operation: impl FnOnce(&CameraSupervisor) -> T) -> T {
     #[cfg(test)]
-    if let Some(backend) = TEST_BACKEND.with(|slot| slot.borrow().clone()) {
-        return operation(&CameraSupervisor::from_arc(backend));
+    if let Some(supervisor) = TEST_SUPERVISOR.with(|slot| slot.borrow().clone()) {
+        return operation(&supervisor);
     }
 
     operation(default_camera_supervisor())
@@ -194,19 +233,20 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
+    use crate::contracts::CameraInstanceId;
     use crate::{FailedAt, McCentric, Unreadable};
 
-    struct TestBackendGuard(Option<Arc<dyn CameraBackend>>);
+    struct TestBackendGuard(Option<Arc<CameraSupervisor>>);
 
     impl Drop for TestBackendGuard {
         fn drop(&mut self) {
             let previous = self.0.take();
-            TEST_BACKEND.with(|slot| *slot.borrow_mut() = previous);
+            TEST_SUPERVISOR.with(|slot| *slot.borrow_mut() = previous);
         }
     }
 
-    fn install_test_backend(backend: Arc<dyn CameraBackend>) -> TestBackendGuard {
-        let previous = TEST_BACKEND.with(|slot| slot.borrow_mut().replace(backend));
+    fn install_test_supervisor(supervisor: Arc<CameraSupervisor>) -> TestBackendGuard {
+        let previous = TEST_SUPERVISOR.with(|slot| slot.borrow_mut().replace(supervisor));
         TestBackendGuard(previous)
     }
 
@@ -321,9 +361,11 @@ mod tests {
     #[test]
     fn public_camera_entrypoints_route_through_one_supervisor_backend() {
         let calls = Arc::new(Mutex::new(Vec::new()));
-        let _guard = install_test_backend(Arc::new(RecordingBackend {
+        let supervisor = Arc::new(CameraSupervisor::from_arc(Arc::new(RecordingBackend {
             calls: Arc::clone(&calls),
-        }));
+        })));
+        let _guard = install_test_supervisor(Arc::clone(&supervisor));
+        with_camera_supervisor(|routed| assert!(std::ptr::eq(routed, supervisor.as_ref())));
 
         assert_eq!(crate::scan_nodes().classified[0].0, "/dev/spy-scan");
         assert_eq!(
@@ -425,6 +467,48 @@ mod tests {
             .expect("fixture IR open must refuse")
             .to_string()
             .contains("fixture IR"));
+    }
+
+    #[test]
+    fn supervisor_owns_and_validates_one_inventory_instance() {
+        let backend = Arc::new(RecordingBackend {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        });
+        let supervisor = CameraSupervisor::from_arc(backend);
+        let observation = CameraObservation::new(
+            crate::contracts::BackendKind::UvcV4l2,
+            crate::contracts::PhysicalCameraId::new("/devices/pci/camera", None).unwrap(),
+            crate::contracts::CameraCapabilities::new(
+                vec![crate::contracts::StreamRole::Rgb],
+                Default::default(),
+                Vec::new(),
+            )
+            .unwrap(),
+        );
+
+        let added = supervisor.reconcile_inventory(vec![observation]).unwrap();
+        assert_eq!(added.len(), 1);
+        assert!(CameraInstanceId::new(added[0].descriptor().camera_instance_id().as_str()).is_ok());
+        assert!(supervisor
+            .validate_descriptor(added[0].descriptor())
+            .is_ok());
+    }
+
+    #[test]
+    fn supervisor_inventory_poison_fails_closed() {
+        let backend = Arc::new(RecordingBackend {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        });
+        let supervisor = CameraSupervisor::from_arc(backend);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = supervisor.inventory.lock().unwrap();
+            panic!("poison inventory fixture");
+        }));
+
+        assert_eq!(
+            supervisor.reconcile_inventory(Vec::new()),
+            Err(CameraInventoryError::Poisoned)
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -29,7 +29,7 @@ trait CameraBackend: Send + Sync + 'static {
 ///
 /// Inventory mutation is isolated from capture routing. Leases and hotplug event
 /// subscription remain later slices and therefore cannot alter behavior here.
-struct CameraSupervisor {
+pub(crate) struct CameraSupervisor {
     backend: Arc<dyn CameraBackend>,
     inventory: Mutex<CameraInventory>,
 }
@@ -46,14 +46,7 @@ impl CameraSupervisor {
         }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the udev adapter will feed inventory observations"
-        )
-    )]
-    fn reconcile_inventory(
+    pub(crate) fn reconcile_inventory(
         &self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
@@ -63,6 +56,14 @@ impl CameraSupervisor {
             .reconcile(observations)
     }
 
+    pub(crate) fn invalidate_inventory(&self) -> Result<(), CameraInventoryError> {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .invalidate_all();
+        Ok(())
+    }
+
     #[cfg_attr(
         not(test),
         expect(
@@ -70,7 +71,7 @@ impl CameraSupervisor {
             reason = "later frame and session slices validate descriptors"
         )
     )]
-    fn validate_descriptor(
+    pub(crate) fn validate_descriptor(
         &self,
         descriptor: &CameraDescriptor,
     ) -> Result<(), CameraInventoryError> {
@@ -186,10 +187,18 @@ impl CameraBackend for UvcV4l2Backend {
     }
 }
 
-static DEFAULT_CAMERA_SUPERVISOR: OnceLock<CameraSupervisor> = OnceLock::new();
+static DEFAULT_CAMERA_SUPERVISOR: OnceLock<Arc<CameraSupervisor>> = OnceLock::new();
 
 fn default_camera_supervisor() -> &'static CameraSupervisor {
-    DEFAULT_CAMERA_SUPERVISOR.get_or_init(|| CameraSupervisor::new(UvcV4l2Backend::default()))
+    DEFAULT_CAMERA_SUPERVISOR
+        .get_or_init(|| {
+            let supervisor = Arc::new(CameraSupervisor::new(UvcV4l2Backend::default()));
+            if let Err(error) = crate::lifecycle::spawn(Arc::downgrade(&supervisor)) {
+                eprintln!("irlume: camera lifecycle monitor unavailable: {error}");
+            }
+            supervisor
+        })
+        .as_ref()
 }
 
 #[cfg(test)]

--- a/crates/irlume-camera/src/contracts.rs
+++ b/crates/irlume-camera/src/contracts.rs
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Versioned, backend-neutral camera evidence contracts.
+//!
+//! Schema v1 is additive and UVC-only. It does not replace any legacy camera,
+//! enrollment, or emitter state. It deliberately permits only ambiguous physical
+//! identity: stronger binding must be introduced by a later schema together with
+//! the trusted evidence producer that proves it.
+
+use std::{collections::BTreeSet, fmt};
+
+use serde::{Deserialize, Serialize};
+
+/// Current camera evidence schema version.
+pub const CAMERA_CONTRACT_SCHEMA_VERSION: u32 = 1;
+/// Largest accepted serialized camera contract.
+///
+/// Both public readers parse a small header before the complete value. This cap
+/// bounds both passes and every string/vector allocation reachable from them.
+pub const MAX_CAMERA_CONTRACT_BYTES: usize = 64 * 1024;
+
+const MAX_TOPOLOGY_PATH_BYTES: usize = 4096;
+const MAX_SERIAL_BYTES: usize = 256;
+const CAMERA_INSTANCE_ID_HEX_BYTES: usize = 32;
+
+/// Capture backend that produced a normalized contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKind {
+    /// Existing direct V4L2 backend for video-node-centric UVC cameras.
+    UvcV4l2,
+}
+
+/// Raw, untrusted identity evidence for a physical camera.
+///
+/// `topology_path` is the canonical sysfs path relative to `/sys`, beginning
+/// with `/devices/`. It is useful for re-enumeration within one host, but schema
+/// v1 never upgrades it into a strong or portable security identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PhysicalCameraId {
+    topology_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    serial: Option<String>,
+}
+
+impl PhysicalCameraId {
+    /// Validate raw physical-camera identity evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-canonical topology path or an empty, control-
+    /// containing, or oversized serial value.
+    pub fn new(
+        topology_path: impl Into<String>,
+        serial: Option<String>,
+    ) -> Result<Self, CameraContractError> {
+        let topology_path = topology_path.into();
+        validate_topology_path(&topology_path)?;
+        validate_serial(serial.as_deref())?;
+        Ok(Self {
+            topology_path,
+            serial,
+        })
+    }
+
+    /// Canonical sysfs path relative to `/sys`.
+    #[must_use]
+    pub fn topology_path(&self) -> &str {
+        &self.topology_path
+    }
+
+    /// Device-declared serial, when present; not by itself a uniqueness proof.
+    #[must_use]
+    pub fn serial(&self) -> Option<&str> {
+        self.serial.as_deref()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PhysicalCameraIdWire {
+    topology_path: String,
+    #[serde(default)]
+    serial: Option<String>,
+}
+
+impl TryFrom<PhysicalCameraIdWire> for PhysicalCameraId {
+    type Error = CameraContractError;
+
+    fn try_from(wire: PhysicalCameraIdWire) -> Result<Self, Self::Error> {
+        Self::new(wire.topology_path, wire.serial)
+    }
+}
+
+/// Strength of a physical-camera identity claim.
+///
+/// Schema v1 exposes only `Ambiguous`. Callers cannot self-assert a stronger
+/// value. A future schema may add stronger variants only with a trusted evidence
+/// producer and explicit migration rules.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityStrength {
+    /// Evidence is insufficient for a durable anti-swap binding.
+    #[default]
+    Ambiguous,
+}
+
+/// Logical stream role established by a capture backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum StreamRole {
+    /// Visible-light color stream.
+    Rgb,
+    /// Near-infrared monochrome stream.
+    Ir,
+}
+
+/// Evidence relating timing across streams.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum SynchronizationProvenance {
+    /// No synchronization claim is supported.
+    #[default]
+    Unknown,
+    /// Streams are known to run independently.
+    Independent,
+    /// Host timestamps correlated at least two streams.
+    HostCorrelated,
+    /// Device metadata correlated at least two streams.
+    DeviceCorrelated,
+    /// Hardware synchronization was qualified for at least two streams.
+    HardwareSynchronized,
+}
+
+/// Evidence that a frame or stream supports a particular illumination state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum IlluminationProvenance {
+    /// No trustworthy illumination evidence exists.
+    #[default]
+    Unknown,
+    /// Ambient-only illumination is known.
+    Ambient,
+    /// Active near-infrared illumination is known.
+    ActiveIr,
+}
+
+/// Process-scoped identity for one physical-camera incarnation.
+///
+/// A supervisor must mint a new nonzero 128-bit identifier after each process
+/// restart and whenever the prior incarnation cannot be proven continuous. A
+/// generation number has meaning only together with this identifier.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct CameraInstanceId(String);
+
+impl CameraInstanceId {
+    /// Validate a lowercase nonzero 128-bit hexadecimal identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraContractError::InvalidCameraInstanceId`] unless the input
+    /// contains exactly 32 lowercase hexadecimal characters and is not all zero.
+    pub fn new(value: impl Into<String>) -> Result<Self, CameraContractError> {
+        let value = value.into();
+        let valid = value.len() == CAMERA_INSTANCE_ID_HEX_BYTES
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            && value.bytes().any(|byte| byte != b'0');
+        if !valid {
+            return Err(CameraContractError::InvalidCameraInstanceId);
+        }
+        Ok(Self(value))
+    }
+
+    /// Lowercase hexadecimal identifier.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Monotonic lifecycle generation within one [`CameraInstanceId`].
+///
+/// Generation zero is reserved. Before incrementing `u64::MAX`, the supervisor
+/// must retire the instance and mint a new camera-instance identifier; wrapping
+/// or saturating would allow stale frames to alias current ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct CameraGeneration(u64);
+
+impl CameraGeneration {
+    /// First generation of a newly minted camera instance.
+    pub const INITIAL: Self = Self(1);
+
+    /// Construct a nonzero generation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraContractError::ZeroGeneration`] for zero.
+    pub const fn new(value: u64) -> Result<Self, CameraContractError> {
+        if value == 0 {
+            Err(CameraContractError::ZeroGeneration)
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Advance without wrapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraContractError::GenerationExhausted`] at `u64::MAX`; the
+    /// caller must mint a new [`CameraInstanceId`] instead.
+    pub const fn next(self) -> Result<Self, CameraContractError> {
+        match self.0.checked_add(1) {
+            Some(value) => Ok(Self(value)),
+            None => Err(CameraContractError::GenerationExhausted),
+        }
+    }
+
+    /// Numeric generation value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Conservative backend capability declaration.
+///
+/// This is a producer claim, not security proof. Deserializing or constructing
+/// it does not establish that the producer measured the claimed synchronization
+/// or illumination behavior. Authentication consumers must accept capabilities
+/// only from a trusted, qualified backend/profile and validate them against the
+/// current camera instance.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct CameraCapabilities {
+    stream_roles: Vec<StreamRole>,
+    synchronization: SynchronizationProvenance,
+    illumination_provenance: Vec<IlluminationProvenance>,
+}
+
+impl CameraCapabilities {
+    /// Construct a coherent capability set.
+    ///
+    /// Empty lists and `Unknown` are valid and make no capability claim.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicates, active-IR support without an IR stream, and any
+    /// cross-stream correlation claim without at least two distinct streams.
+    pub fn new(
+        stream_roles: Vec<StreamRole>,
+        synchronization: SynchronizationProvenance,
+        illumination_provenance: Vec<IlluminationProvenance>,
+    ) -> Result<Self, CameraContractError> {
+        reject_duplicates(&stream_roles, CameraContractError::DuplicateStreamRole)?;
+        reject_duplicates(
+            &illumination_provenance,
+            CameraContractError::DuplicateIllumination,
+        )?;
+        if illumination_provenance.contains(&IlluminationProvenance::ActiveIr)
+            && !stream_roles.contains(&StreamRole::Ir)
+        {
+            return Err(CameraContractError::ActiveIrRequiresIrStream);
+        }
+        if matches!(
+            synchronization,
+            SynchronizationProvenance::HostCorrelated
+                | SynchronizationProvenance::DeviceCorrelated
+                | SynchronizationProvenance::HardwareSynchronized
+        ) && stream_roles.len() < 2
+        {
+            return Err(CameraContractError::SynchronizationRequiresMultipleStreams(
+                synchronization,
+            ));
+        }
+        Ok(Self {
+            stream_roles,
+            synchronization,
+            illumination_provenance,
+        })
+    }
+
+    /// Established logical stream roles.
+    #[must_use]
+    pub fn stream_roles(&self) -> &[StreamRole] {
+        &self.stream_roles
+    }
+
+    /// Established cross-stream timing provenance.
+    #[must_use]
+    pub const fn synchronization(&self) -> SynchronizationProvenance {
+        self.synchronization
+    }
+
+    /// Established illumination evidence mechanisms.
+    #[must_use]
+    pub fn illumination_provenance(&self) -> &[IlluminationProvenance] {
+        &self.illumination_provenance
+    }
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CameraCapabilitiesWire {
+    #[serde(default)]
+    stream_roles: Vec<StreamRole>,
+    #[serde(default)]
+    synchronization: SynchronizationProvenance,
+    #[serde(default)]
+    illumination_provenance: Vec<IlluminationProvenance>,
+}
+
+impl TryFrom<CameraCapabilitiesWire> for CameraCapabilities {
+    type Error = CameraContractError;
+
+    fn try_from(wire: CameraCapabilitiesWire) -> Result<Self, Self::Error> {
+        Self::new(
+            wire.stream_roles,
+            wire.synchronization,
+            wire.illumination_provenance,
+        )
+    }
+}
+
+/// Versioned normalized description of one physical-camera incarnation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CameraDescriptor {
+    schema_version: u32,
+    backend: BackendKind,
+    physical_id: PhysicalCameraId,
+    identity_strength: IdentityStrength,
+    camera_instance_id: CameraInstanceId,
+    generation: CameraGeneration,
+    capabilities: CameraCapabilities,
+}
+
+impl CameraDescriptor {
+    /// Construct a schema-v1 descriptor with fail-closed identity strength.
+    #[must_use]
+    pub fn new(
+        backend: BackendKind,
+        physical_id: PhysicalCameraId,
+        camera_instance_id: CameraInstanceId,
+        generation: CameraGeneration,
+        capabilities: CameraCapabilities,
+    ) -> Self {
+        Self {
+            schema_version: CAMERA_CONTRACT_SCHEMA_VERSION,
+            backend,
+            physical_id,
+            identity_strength: IdentityStrength::Ambiguous,
+            camera_instance_id,
+            generation,
+            capabilities,
+        }
+    }
+
+    /// Parse one bounded schema-v1 descriptor.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized/malformed input, unsupported versions, unknown fields
+    /// or enum variants, invalid identity evidence, contradictory capabilities,
+    /// and self-asserted identity strength.
+    pub fn from_json(input: &str) -> Result<Self, CameraContractReadError> {
+        check_input_size(input)?;
+        require_supported_version(input)?;
+        let wire: CameraDescriptorWire = serde_json::from_str(input)?;
+        Self::try_from(wire).map_err(CameraContractReadError::Invalid)
+    }
+
+    /// Schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Capture backend kind.
+    #[must_use]
+    pub const fn backend(&self) -> BackendKind {
+        self.backend
+    }
+
+    /// Raw physical-camera identity evidence.
+    #[must_use]
+    pub const fn physical_id(&self) -> &PhysicalCameraId {
+        &self.physical_id
+    }
+
+    /// Conservative identity strength; always `Ambiguous` in schema v1.
+    #[must_use]
+    pub const fn identity_strength(&self) -> IdentityStrength {
+        self.identity_strength
+    }
+
+    /// Camera-incarnation scope shared with every frame.
+    #[must_use]
+    pub const fn camera_instance_id(&self) -> &CameraInstanceId {
+        &self.camera_instance_id
+    }
+
+    /// Current generation within the camera instance.
+    #[must_use]
+    pub const fn generation(&self) -> CameraGeneration {
+        self.generation
+    }
+
+    /// Conservative backend capabilities.
+    #[must_use]
+    pub const fn capabilities(&self) -> &CameraCapabilities {
+        &self.capabilities
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CameraDescriptorWire {
+    schema_version: u32,
+    backend: BackendKind,
+    physical_id: PhysicalCameraIdWire,
+    #[serde(default)]
+    identity_strength: IdentityStrength,
+    camera_instance_id: String,
+    generation: u64,
+    #[serde(default)]
+    capabilities: CameraCapabilitiesWire,
+}
+
+impl TryFrom<CameraDescriptorWire> for CameraDescriptor {
+    type Error = CameraContractError;
+
+    fn try_from(wire: CameraDescriptorWire) -> Result<Self, Self::Error> {
+        if wire.schema_version != CAMERA_CONTRACT_SCHEMA_VERSION {
+            return Err(CameraContractError::UnsupportedSchemaVersion(
+                wire.schema_version,
+            ));
+        }
+        match wire.identity_strength {
+            IdentityStrength::Ambiguous => {}
+        }
+        Ok(Self::new(
+            wire.backend,
+            PhysicalCameraId::try_from(wire.physical_id)?,
+            CameraInstanceId::new(wire.camera_instance_id)?,
+            CameraGeneration::new(wire.generation)?,
+            CameraCapabilities::try_from(wire.capabilities)?,
+        ))
+    }
+}
+
+/// Per-frame evidence emitted by a capture backend.
+///
+/// This structure records what a producer claims for one frame; it does not
+/// authenticate that producer or prove hardware synchronization/illumination.
+/// Security-sensitive consumers must bind it to a trusted backend session and
+/// a currently qualified camera profile before treating any field as evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FrameMetadata {
+    schema_version: u32,
+    camera_instance_id: CameraInstanceId,
+    generation: CameraGeneration,
+    stream_role: StreamRole,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sequence: Option<u64>,
+    synchronization: SynchronizationProvenance,
+    illumination: IlluminationProvenance,
+}
+
+impl FrameMetadata {
+    /// Construct coherent metadata from explicit backend evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects active-IR provenance on a non-IR frame.
+    pub fn new(
+        camera_instance_id: CameraInstanceId,
+        generation: CameraGeneration,
+        stream_role: StreamRole,
+        sequence: Option<u64>,
+        synchronization: SynchronizationProvenance,
+        illumination: IlluminationProvenance,
+    ) -> Result<Self, CameraContractError> {
+        if matches!(illumination, IlluminationProvenance::ActiveIr)
+            && matches!(stream_role, StreamRole::Rgb)
+        {
+            return Err(CameraContractError::ActiveIrRequiresIrStream);
+        }
+        Ok(Self {
+            schema_version: CAMERA_CONTRACT_SCHEMA_VERSION,
+            camera_instance_id,
+            generation,
+            stream_role,
+            sequence,
+            synchronization,
+            illumination,
+        })
+    }
+
+    /// Parse one bounded schema-v1 frame metadata value.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized/malformed input, unsupported versions, unknown fields
+    /// or enum variants, invalid instance/generation values, and contradictory
+    /// role/illumination evidence.
+    pub fn from_json(input: &str) -> Result<Self, CameraContractReadError> {
+        check_input_size(input)?;
+        require_supported_version(input)?;
+        let wire: FrameMetadataWire = serde_json::from_str(input)?;
+        Self::try_from(wire).map_err(CameraContractReadError::Invalid)
+    }
+
+    /// Camera-incarnation scope for the generation and sequence.
+    #[must_use]
+    pub const fn camera_instance_id(&self) -> &CameraInstanceId {
+        &self.camera_instance_id
+    }
+
+    /// Camera generation that produced the frame.
+    #[must_use]
+    pub const fn generation(&self) -> CameraGeneration {
+        self.generation
+    }
+
+    /// Logical stream role.
+    #[must_use]
+    pub const fn stream_role(&self) -> StreamRole {
+        self.stream_role
+    }
+
+    /// Backend sequence number, when available.
+    #[must_use]
+    pub const fn sequence(&self) -> Option<u64> {
+        self.sequence
+    }
+
+    /// Proven synchronization relationship.
+    #[must_use]
+    pub const fn synchronization(&self) -> SynchronizationProvenance {
+        self.synchronization
+    }
+
+    /// Per-frame illumination evidence.
+    #[must_use]
+    pub const fn illumination(&self) -> IlluminationProvenance {
+        self.illumination
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FrameMetadataWire {
+    schema_version: u32,
+    camera_instance_id: String,
+    generation: u64,
+    stream_role: StreamRole,
+    #[serde(default)]
+    sequence: Option<u64>,
+    #[serde(default)]
+    synchronization: SynchronizationProvenance,
+    #[serde(default)]
+    illumination: IlluminationProvenance,
+}
+
+impl TryFrom<FrameMetadataWire> for FrameMetadata {
+    type Error = CameraContractError;
+
+    fn try_from(wire: FrameMetadataWire) -> Result<Self, Self::Error> {
+        if wire.schema_version != CAMERA_CONTRACT_SCHEMA_VERSION {
+            return Err(CameraContractError::UnsupportedSchemaVersion(
+                wire.schema_version,
+            ));
+        }
+        Self::new(
+            CameraInstanceId::new(wire.camera_instance_id)?,
+            CameraGeneration::new(wire.generation)?,
+            wire.stream_role,
+            wire.sequence,
+            wire.synchronization,
+            wire.illumination,
+        )
+    }
+}
+
+fn validate_topology_path(value: &str) -> Result<(), CameraContractError> {
+    let canonical = value.starts_with("/devices/")
+        && !value.ends_with('/')
+        && value.len() <= MAX_TOPOLOGY_PATH_BYTES
+        && value.is_ascii()
+        && !value.bytes().any(|byte| byte.is_ascii_control())
+        && value
+            .split('/')
+            .skip(1)
+            .all(|component| !component.is_empty() && component != "." && component != "..");
+    if canonical {
+        Ok(())
+    } else {
+        Err(CameraContractError::InvalidTopologyPath)
+    }
+}
+
+fn validate_serial(value: Option<&str>) -> Result<(), CameraContractError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if value.trim().is_empty() {
+        return Err(CameraContractError::EmptySerial);
+    }
+    if value.len() > MAX_SERIAL_BYTES || value.chars().any(char::is_control) {
+        return Err(CameraContractError::InvalidSerial);
+    }
+    Ok(())
+}
+
+fn reject_duplicates<T: Copy + Ord>(
+    values: &[T],
+    error: impl Fn(T) -> CameraContractError,
+) -> Result<(), CameraContractError> {
+    let mut seen = BTreeSet::new();
+    for &value in values {
+        if !seen.insert(value) {
+            return Err(error(value));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct SchemaHeader {
+    schema_version: u32,
+}
+
+fn check_input_size(input: &str) -> Result<(), CameraContractReadError> {
+    if input.len() > MAX_CAMERA_CONTRACT_BYTES {
+        return Err(CameraContractReadError::Invalid(
+            CameraContractError::InputTooLarge {
+                actual: input.len(),
+                maximum: MAX_CAMERA_CONTRACT_BYTES,
+            },
+        ));
+    }
+    Ok(())
+}
+
+fn require_supported_version(input: &str) -> Result<(), CameraContractReadError> {
+    let header: SchemaHeader = serde_json::from_str(input)?;
+    if header.schema_version != CAMERA_CONTRACT_SCHEMA_VERSION {
+        return Err(CameraContractReadError::Invalid(
+            CameraContractError::UnsupportedSchemaVersion(header.schema_version),
+        ));
+    }
+    Ok(())
+}
+
+/// Semantic camera-contract validation error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CameraContractError {
+    /// Input exceeded the documented parser ceiling.
+    InputTooLarge { actual: usize, maximum: usize },
+    /// Exact schema version is not supported.
+    UnsupportedSchemaVersion(u32),
+    /// Sysfs topology path is not in canonical `/devices/...` form.
+    InvalidTopologyPath,
+    /// A present serial was empty.
+    EmptySerial,
+    /// A serial was oversized or contained control characters.
+    InvalidSerial,
+    /// Camera-instance identifier was malformed or all zero.
+    InvalidCameraInstanceId,
+    /// Generation zero could allow stale and current instances to alias.
+    ZeroGeneration,
+    /// Generation cannot advance without wrapping.
+    GenerationExhausted,
+    /// A logical stream role appeared more than once.
+    DuplicateStreamRole(StreamRole),
+    /// An illumination provenance value appeared more than once.
+    DuplicateIllumination(IlluminationProvenance),
+    /// Active-IR evidence was claimed without an IR stream.
+    ActiveIrRequiresIrStream,
+    /// A cross-stream synchronization claim had fewer than two streams.
+    SynchronizationRequiresMultipleStreams(SynchronizationProvenance),
+}
+
+impl fmt::Display for CameraContractError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InputTooLarge { actual, maximum } => write!(
+                formatter,
+                "camera contract is {actual} bytes; maximum is {maximum} bytes"
+            ),
+            Self::UnsupportedSchemaVersion(version) => write!(
+                formatter,
+                "unsupported camera contract schema version {version}"
+            ),
+            Self::InvalidTopologyPath => formatter
+                .write_str("camera topology path must be canonical ASCII /devices/... form"),
+            Self::EmptySerial => formatter.write_str("camera serial is empty"),
+            Self::InvalidSerial => formatter.write_str("camera serial is invalid"),
+            Self::InvalidCameraInstanceId => formatter
+                .write_str("camera instance id must be nonzero 128-bit lowercase hexadecimal"),
+            Self::ZeroGeneration => formatter.write_str("camera generation must be non-zero"),
+            Self::GenerationExhausted => {
+                formatter.write_str("camera generation exhausted; mint a new camera instance id")
+            }
+            Self::DuplicateStreamRole(role) => {
+                write!(formatter, "camera capabilities repeat stream role {role:?}")
+            }
+            Self::DuplicateIllumination(illumination) => write!(
+                formatter,
+                "camera capabilities repeat illumination provenance {illumination:?}"
+            ),
+            Self::ActiveIrRequiresIrStream => {
+                formatter.write_str("active-IR evidence requires an IR stream")
+            }
+            Self::SynchronizationRequiresMultipleStreams(provenance) => write!(
+                formatter,
+                "synchronization provenance {provenance:?} requires at least two streams"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CameraContractError {}
+
+/// Error returned while decoding a serialized camera contract.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CameraContractReadError {
+    /// JSON syntax, type, duplicate-field, or unknown-field error.
+    Malformed(serde_json::Error),
+    /// Well-formed JSON that violated a semantic contract rule.
+    Invalid(CameraContractError),
+}
+
+impl fmt::Display for CameraContractReadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed(error) => write!(formatter, "malformed camera contract: {error}"),
+            Self::Invalid(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for CameraContractReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Malformed(error) => Some(error),
+            Self::Invalid(error) => Some(error),
+        }
+    }
+}
+
+impl From<serde_json::Error> for CameraContractReadError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Malformed(error)
+    }
+}

--- a/crates/irlume-camera/src/contracts.rs
+++ b/crates/irlume-camera/src/contracts.rs
@@ -161,6 +161,20 @@ pub enum IlluminationProvenance {
 pub struct CameraInstanceId(String);
 
 impl CameraInstanceId {
+    /// Mint a nonzero physical-camera instance identifier for this process.
+    pub(crate) fn generate() -> Self {
+        use rand::Rng;
+
+        loop {
+            let mut bytes = [0_u8; 16];
+            rand::rng().fill_bytes(&mut bytes);
+            if bytes.iter().any(|byte| *byte != 0) {
+                let value = bytes.iter().map(|byte| format!("{byte:02x}")).collect();
+                return Self(value);
+            }
+        }
+    }
+
     /// Validate a lowercase nonzero 128-bit hexadecimal identifier.
     ///
     /// # Errors

--- a/crates/irlume-camera/src/inventory.rs
+++ b/crates/irlume-camera/src/inventory.rs
@@ -23,6 +23,7 @@ pub(crate) struct CameraObservation {
     backend: BackendKind,
     physical_id: PhysicalCameraId,
     capabilities: CameraCapabilities,
+    lifecycle_evidence: Vec<String>,
 }
 
 impl CameraObservation {
@@ -35,11 +36,32 @@ impl CameraObservation {
             backend,
             physical_id,
             capabilities,
+            lifecycle_evidence: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_lifecycle_evidence(
+        backend: BackendKind,
+        physical_id: PhysicalCameraId,
+        capabilities: CameraCapabilities,
+        mut lifecycle_evidence: Vec<String>,
+    ) -> Self {
+        lifecycle_evidence.sort();
+        lifecycle_evidence.dedup();
+        Self {
+            backend,
+            physical_id,
+            capabilities,
+            lifecycle_evidence,
         }
     }
 
     pub(crate) fn physical_id(&self) -> &PhysicalCameraId {
         &self.physical_id
+    }
+
+    pub(crate) fn lifecycle_evidence(&self) -> &[String] {
+        &self.lifecycle_evidence
     }
 
     fn descriptor(
@@ -115,9 +137,26 @@ pub(crate) enum CameraInventoryError {
     UnknownCamera,
     Removed,
     StaleGeneration,
+    ContinuityLost,
     DescriptorMismatch,
     InstanceIdExhausted,
     Poisoned,
+}
+
+/// Descriptor-bound handle for a currently observed backend object.
+///
+/// Endpoint evidence remains private: callers must validate the whole token
+/// rather than treating a `/dev/videoN` path as proof of freshness.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CameraInventoryRef {
+    descriptor: CameraDescriptor,
+    lifecycle_evidence: Vec<String>,
+}
+
+impl CameraInventoryRef {
+    pub(crate) fn descriptor(&self) -> &CameraDescriptor {
+        &self.descriptor
+    }
 }
 
 /// Process-scoped physical-camera lifecycle state.
@@ -128,6 +167,7 @@ pub(crate) struct CameraInventory {
     active: BTreeMap<String, InventoryEntry>,
     tombstones: BTreeSet<String>,
     retired_instance_ids: BTreeSet<CameraInstanceId>,
+    invalidated_instance_ids: BTreeSet<CameraInstanceId>,
     instance_id_source: InstanceIdSource,
 }
 
@@ -141,6 +181,7 @@ impl CameraInventory {
             active: BTreeMap::new(),
             tombstones: BTreeSet::new(),
             retired_instance_ids: BTreeSet::new(),
+            invalidated_instance_ids: BTreeSet::new(),
             instance_id_source,
         }
     }
@@ -248,7 +289,16 @@ impl CameraInventory {
         self.active = next_active;
         self.tombstones = next_tombstones;
         self.retired_instance_ids = next_retired_instance_ids;
+        self.invalidated_instance_ids.clear();
         Ok(events)
+    }
+
+    pub(crate) fn invalidate_all(&mut self) {
+        self.invalidated_instance_ids = self
+            .active
+            .values()
+            .map(|entry| entry.descriptor.camera_instance_id().clone())
+            .collect();
     }
 
     pub(crate) fn active_descriptors(&self) -> Vec<CameraDescriptor> {
@@ -256,6 +306,36 @@ impl CameraInventory {
             .values()
             .map(|entry| entry.descriptor.clone())
             .collect()
+    }
+
+    pub(crate) fn active_references(&self) -> Vec<CameraInventoryRef> {
+        self.active
+            .values()
+            .filter(|entry| {
+                !self
+                    .invalidated_instance_ids
+                    .contains(entry.descriptor.camera_instance_id())
+            })
+            .map(|entry| CameraInventoryRef {
+                descriptor: entry.descriptor.clone(),
+                lifecycle_evidence: entry.observation.lifecycle_evidence.clone(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn validate_reference(
+        &self,
+        reference: &CameraInventoryRef,
+    ) -> Result<(), CameraInventoryError> {
+        self.validate(reference.descriptor())?;
+        let active = self
+            .active
+            .get(reference.descriptor().physical_id().topology_path())
+            .ok_or(CameraInventoryError::UnknownCamera)?;
+        if active.observation.lifecycle_evidence != reference.lifecycle_evidence {
+            return Err(CameraInventoryError::DescriptorMismatch);
+        }
+        Ok(())
     }
 
     pub(crate) fn validate(
@@ -272,6 +352,12 @@ impl CameraInventory {
         };
         if descriptor.camera_instance_id() != active.descriptor.camera_instance_id() {
             return Err(CameraInventoryError::ForeignInstance);
+        }
+        if self
+            .invalidated_instance_ids
+            .contains(descriptor.camera_instance_id())
+        {
+            return Err(CameraInventoryError::ContinuityLost);
         }
         if descriptor.generation() != active.descriptor.generation() {
             return Err(CameraInventoryError::StaleGeneration);
@@ -301,6 +387,7 @@ impl CameraInventory {
             )]),
             tombstones: BTreeSet::new(),
             retired_instance_ids: BTreeSet::new(),
+            invalidated_instance_ids: BTreeSet::new(),
             instance_id_source: Box::new(move || replacement_id.clone()),
         }
     }
@@ -348,6 +435,45 @@ mod tests {
 
     fn generation(event: &CameraInventoryEvent) -> u64 {
         event.descriptor().generation().get()
+    }
+
+    #[test]
+    fn references_are_descriptor_bound_and_hidden_while_invalidated() {
+        let mut inventory = CameraInventory::new();
+        let camera = CameraObservation::with_lifecycle_evidence(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new("/devices/pci/a", Some("A".into())).unwrap(),
+            CameraCapabilities::new(vec![StreamRole::Rgb], Default::default(), Vec::new()).unwrap(),
+            vec!["/devices/pci/a/video4linux/video0".into()],
+        );
+        inventory.reconcile(vec![camera]).unwrap();
+        let reference = inventory.active_references().pop().unwrap();
+        assert_eq!(inventory.validate_reference(&reference), Ok(()));
+
+        inventory.invalidate_all();
+        assert!(inventory.active_references().is_empty());
+        assert_eq!(
+            inventory.validate_reference(&reference),
+            Err(CameraInventoryError::ContinuityLost)
+        );
+    }
+
+    #[test]
+    fn invalidation_blocks_old_descriptor_until_authoritative_reconcile() {
+        let mut inventory = CameraInventory::new();
+        let camera = observation("/devices/pci/a", Some("A"), &[StreamRole::Rgb]);
+        let descriptor = inventory.reconcile(vec![camera.clone()]).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        inventory.invalidate_all();
+        assert_eq!(
+            inventory.validate(&descriptor),
+            Err(CameraInventoryError::ContinuityLost)
+        );
+
+        assert!(inventory.reconcile(vec![camera]).unwrap().is_empty());
+        assert_eq!(inventory.validate(&descriptor), Ok(()));
     }
 
     #[test]

--- a/crates/irlume-camera/src/inventory.rs
+++ b/crates/irlume-camera/src/inventory.rs
@@ -207,6 +207,19 @@ impl CameraInventory {
         &mut self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        let (events, committed) = self.reconcile_guarded(observations, || true)?;
+        debug_assert!(committed);
+        Ok(events)
+    }
+
+    pub(crate) fn reconcile_guarded<F>(
+        &mut self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnOnce() -> bool,
+    {
         let mut incoming = BTreeMap::new();
         for observation in observations {
             let key = observation.physical_id().topology_path().to_owned();
@@ -245,7 +258,11 @@ impl CameraInventory {
                     );
                     events.push(CameraInventoryEvent::Added(descriptor));
                 }
-                (Some(previous), Some(observation)) if previous.observation == observation => {}
+                (Some(previous), Some(observation))
+                    if previous.observation == observation
+                        && !self
+                            .invalidated_instance_ids
+                            .contains(previous.descriptor.camera_instance_id()) => {}
                 (Some(previous), Some(observation)) => {
                     let (instance_id, generation) = match previous.descriptor.generation().next() {
                         Ok(generation) => {
@@ -286,11 +303,15 @@ impl CameraInventory {
                 .then_with(|| left.topology_path().cmp(right.topology_path()))
         });
 
+        if !quiet() {
+            return Ok((Vec::new(), false));
+        }
+
         self.active = next_active;
         self.tombstones = next_tombstones;
         self.retired_instance_ids = next_retired_instance_ids;
         self.invalidated_instance_ids.clear();
-        Ok(events)
+        Ok((events, true))
     }
 
     pub(crate) fn invalidate_all(&mut self) {
@@ -299,6 +320,34 @@ impl CameraInventory {
             .values()
             .map(|entry| entry.descriptor.camera_instance_id().clone())
             .collect();
+    }
+
+    pub(crate) fn invalidate_topologies(&mut self, topologies: &BTreeSet<String>) {
+        self.invalidated_instance_ids.extend(
+            topologies
+                .iter()
+                .filter_map(|topology| self.active.get(topology))
+                .map(|entry| entry.descriptor.camera_instance_id().clone()),
+        );
+    }
+
+    pub(crate) fn retire_topologies(
+        &mut self,
+        topologies: &BTreeSet<String>,
+    ) -> Vec<CameraInventoryEvent> {
+        let mut events = Vec::new();
+        for topology in topologies {
+            let Some(entry) = self.active.remove(topology) else {
+                continue;
+            };
+            self.invalidated_instance_ids
+                .remove(entry.descriptor.camera_instance_id());
+            self.retired_instance_ids
+                .insert(entry.descriptor.camera_instance_id().clone());
+            self.tombstones.insert(topology.clone());
+            events.push(CameraInventoryEvent::Removed(entry.descriptor));
+        }
+        events
     }
 
     pub(crate) fn active_descriptors(&self) -> Vec<CameraDescriptor> {
@@ -459,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn invalidation_blocks_old_descriptor_until_authoritative_reconcile() {
+    fn invalidation_blocks_old_descriptor_across_authoritative_reconcile() {
         let mut inventory = CameraInventory::new();
         let camera = observation("/devices/pci/a", Some("A"), &[StreamRole::Rgb]);
         let descriptor = inventory.reconcile(vec![camera.clone()]).unwrap()[0]
@@ -472,8 +521,14 @@ mod tests {
             Err(CameraInventoryError::ContinuityLost)
         );
 
-        assert!(inventory.reconcile(vec![camera]).unwrap().is_empty());
-        assert_eq!(inventory.validate(&descriptor), Ok(()));
+        let refreshed = inventory.reconcile(vec![camera]).unwrap();
+        assert_eq!(refreshed.len(), 1);
+        assert!(refreshed[0].is_changed());
+        assert_eq!(
+            inventory.validate(&descriptor),
+            Err(CameraInventoryError::StaleGeneration)
+        );
+        assert_eq!(inventory.validate(refreshed[0].descriptor()), Ok(()));
     }
 
     #[test]

--- a/crates/irlume-camera/src/inventory.rs
+++ b/crates/irlume-camera/src/inventory.rs
@@ -1,0 +1,612 @@
+//! Supervisor-owned normalized camera inventory.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the event adapter and frame/session consumers land next"
+    )
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::contracts::{
+    BackendKind, CameraCapabilities, CameraDescriptor, CameraGeneration, CameraInstanceId,
+    PhysicalCameraId,
+};
+
+const MAX_INSTANCE_ID_ATTEMPTS: usize = 64;
+type InstanceIdSource = Box<dyn FnMut() -> CameraInstanceId + Send>;
+
+/// One backend observation before the supervisor assigns lifecycle identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CameraObservation {
+    backend: BackendKind,
+    physical_id: PhysicalCameraId,
+    capabilities: CameraCapabilities,
+}
+
+impl CameraObservation {
+    pub(crate) fn new(
+        backend: BackendKind,
+        physical_id: PhysicalCameraId,
+        capabilities: CameraCapabilities,
+    ) -> Self {
+        Self {
+            backend,
+            physical_id,
+            capabilities,
+        }
+    }
+
+    pub(crate) fn physical_id(&self) -> &PhysicalCameraId {
+        &self.physical_id
+    }
+
+    fn descriptor(
+        &self,
+        instance_id: &CameraInstanceId,
+        generation: CameraGeneration,
+    ) -> CameraDescriptor {
+        CameraDescriptor::new(
+            self.backend,
+            self.physical_id.clone(),
+            instance_id.clone(),
+            generation,
+            self.capabilities.clone(),
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct InventoryEntry {
+    observation: CameraObservation,
+    descriptor: CameraDescriptor,
+}
+
+/// One deterministic inventory transition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CameraInventoryEvent {
+    Added(CameraDescriptor),
+    Changed {
+        previous: CameraDescriptor,
+        current: CameraDescriptor,
+    },
+    Removed(CameraDescriptor),
+}
+
+impl CameraInventoryEvent {
+    pub(crate) fn descriptor(&self) -> &CameraDescriptor {
+        match self {
+            Self::Added(descriptor) | Self::Removed(descriptor) => descriptor,
+            Self::Changed { current, .. } => current,
+        }
+    }
+
+    pub(crate) fn topology_path(&self) -> &str {
+        self.descriptor().physical_id().topology_path()
+    }
+
+    pub(crate) const fn is_added(&self) -> bool {
+        matches!(self, Self::Added(_))
+    }
+
+    pub(crate) const fn is_changed(&self) -> bool {
+        matches!(self, Self::Changed { .. })
+    }
+
+    pub(crate) const fn is_removed(&self) -> bool {
+        matches!(self, Self::Removed(_))
+    }
+
+    const fn phase_rank(&self) -> u8 {
+        match self {
+            Self::Removed(_) => 0,
+            Self::Changed { .. } => 1,
+            Self::Added(_) => 2,
+        }
+    }
+}
+
+/// Fail-closed inventory reconciliation or descriptor validation error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CameraInventoryError {
+    DuplicateObservation(String),
+    ForeignInstance,
+    UnknownCamera,
+    Removed,
+    StaleGeneration,
+    DescriptorMismatch,
+    InstanceIdExhausted,
+    Poisoned,
+}
+
+/// Process-scoped physical-camera lifecycle state.
+///
+/// Reconciliation is transactional: malformed snapshots and instance-ID
+/// exhaustion leave active entries, tombstones, and retired IDs unchanged.
+pub(crate) struct CameraInventory {
+    active: BTreeMap<String, InventoryEntry>,
+    tombstones: BTreeSet<String>,
+    retired_instance_ids: BTreeSet<CameraInstanceId>,
+    instance_id_source: InstanceIdSource,
+}
+
+impl CameraInventory {
+    pub(crate) fn new() -> Self {
+        Self::with_instance_id_source(Box::new(CameraInstanceId::generate))
+    }
+
+    fn with_instance_id_source(instance_id_source: InstanceIdSource) -> Self {
+        Self {
+            active: BTreeMap::new(),
+            tombstones: BTreeSet::new(),
+            retired_instance_ids: BTreeSet::new(),
+            instance_id_source,
+        }
+    }
+
+    fn mint_unique_instance_id(
+        &mut self,
+        active: &BTreeMap<String, InventoryEntry>,
+        retired_instance_ids: &BTreeSet<CameraInstanceId>,
+    ) -> Result<CameraInstanceId, CameraInventoryError> {
+        for _ in 0..MAX_INSTANCE_ID_ATTEMPTS {
+            let candidate = (self.instance_id_source)();
+            let active_collision = active
+                .values()
+                .any(|entry| entry.descriptor.camera_instance_id() == &candidate);
+            if !active_collision && !retired_instance_ids.contains(&candidate) {
+                return Ok(candidate);
+            }
+        }
+        Err(CameraInventoryError::InstanceIdExhausted)
+    }
+
+    pub(crate) fn reconcile(
+        &mut self,
+        observations: Vec<CameraObservation>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        let mut incoming = BTreeMap::new();
+        for observation in observations {
+            let key = observation.physical_id().topology_path().to_owned();
+            if incoming.insert(key.clone(), observation).is_some() {
+                return Err(CameraInventoryError::DuplicateObservation(key));
+            }
+        }
+
+        let mut next_active = self.active.clone();
+        let mut next_tombstones = self.tombstones.clone();
+        let mut next_retired_instance_ids = self.retired_instance_ids.clone();
+        let keys: BTreeSet<_> = next_active.keys().chain(incoming.keys()).cloned().collect();
+        let mut events = Vec::new();
+
+        for key in keys {
+            match (next_active.get(&key).cloned(), incoming.remove(&key)) {
+                (Some(previous), None) => {
+                    next_active.remove(&key);
+                    next_tombstones.insert(key);
+                    next_retired_instance_ids
+                        .insert(previous.descriptor.camera_instance_id().clone());
+                    events.push(CameraInventoryEvent::Removed(previous.descriptor));
+                }
+                (None, Some(observation)) => {
+                    next_tombstones.remove(&key);
+                    let instance_id =
+                        self.mint_unique_instance_id(&next_active, &next_retired_instance_ids)?;
+                    let generation = CameraGeneration::INITIAL;
+                    let descriptor = observation.descriptor(&instance_id, generation);
+                    next_active.insert(
+                        key,
+                        InventoryEntry {
+                            observation,
+                            descriptor: descriptor.clone(),
+                        },
+                    );
+                    events.push(CameraInventoryEvent::Added(descriptor));
+                }
+                (Some(previous), Some(observation)) if previous.observation == observation => {}
+                (Some(previous), Some(observation)) => {
+                    let (instance_id, generation) = match previous.descriptor.generation().next() {
+                        Ok(generation) => {
+                            (previous.descriptor.camera_instance_id().clone(), generation)
+                        }
+                        Err(_) => {
+                            next_retired_instance_ids
+                                .insert(previous.descriptor.camera_instance_id().clone());
+                            (
+                                self.mint_unique_instance_id(
+                                    &next_active,
+                                    &next_retired_instance_ids,
+                                )?,
+                                CameraGeneration::INITIAL,
+                            )
+                        }
+                    };
+                    let descriptor = observation.descriptor(&instance_id, generation);
+                    next_active.insert(
+                        key,
+                        InventoryEntry {
+                            observation,
+                            descriptor: descriptor.clone(),
+                        },
+                    );
+                    events.push(CameraInventoryEvent::Changed {
+                        previous: previous.descriptor,
+                        current: descriptor,
+                    });
+                }
+                (None, None) => unreachable!("key came from the active or incoming inventory"),
+            }
+        }
+
+        events.sort_by(|left, right| {
+            left.phase_rank()
+                .cmp(&right.phase_rank())
+                .then_with(|| left.topology_path().cmp(right.topology_path()))
+        });
+
+        self.active = next_active;
+        self.tombstones = next_tombstones;
+        self.retired_instance_ids = next_retired_instance_ids;
+        Ok(events)
+    }
+
+    pub(crate) fn active_descriptors(&self) -> Vec<CameraDescriptor> {
+        self.active
+            .values()
+            .map(|entry| entry.descriptor.clone())
+            .collect()
+    }
+
+    pub(crate) fn validate(
+        &self,
+        descriptor: &CameraDescriptor,
+    ) -> Result<(), CameraInventoryError> {
+        let key = descriptor.physical_id().topology_path();
+        let Some(active) = self.active.get(key) else {
+            return if self.tombstones.contains(key) {
+                Err(CameraInventoryError::Removed)
+            } else {
+                Err(CameraInventoryError::UnknownCamera)
+            };
+        };
+        if descriptor.camera_instance_id() != active.descriptor.camera_instance_id() {
+            return Err(CameraInventoryError::ForeignInstance);
+        }
+        if descriptor.generation() != active.descriptor.generation() {
+            return Err(CameraInventoryError::StaleGeneration);
+        }
+        if descriptor != &active.descriptor {
+            return Err(CameraInventoryError::DescriptorMismatch);
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn with_active_for_test(
+        observation: CameraObservation,
+        instance_id: CameraInstanceId,
+        generation: CameraGeneration,
+        replacement_id: CameraInstanceId,
+    ) -> Self {
+        let key = observation.physical_id().topology_path().to_owned();
+        let descriptor = observation.descriptor(&instance_id, generation);
+        Self {
+            active: BTreeMap::from([(
+                key,
+                InventoryEntry {
+                    observation,
+                    descriptor,
+                },
+            )]),
+            tombstones: BTreeSet::new(),
+            retired_instance_ids: BTreeSet::new(),
+            instance_id_source: Box::new(move || replacement_id.clone()),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_instance_ids_for_test(ids: Vec<CameraInstanceId>) -> Self {
+        let fallback = ids.last().cloned().expect("at least one fixture ID");
+        let mut ids = ids.into_iter();
+        Self::with_instance_id_source(Box::new(move || {
+            ids.next().unwrap_or_else(|| fallback.clone())
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::{
+        BackendKind, CameraCapabilities, CameraGeneration, CameraInstanceId, PhysicalCameraId,
+        StreamRole,
+    };
+
+    fn instance(hex: char) -> CameraInstanceId {
+        CameraInstanceId::new(hex.to_string().repeat(32)).expect("valid instance")
+    }
+
+    #[test]
+    fn generated_instance_ids_are_valid_nonzero_and_fresh() {
+        let first = CameraInstanceId::generate();
+        let second = CameraInstanceId::generate();
+
+        assert!(CameraInstanceId::new(first.as_str()).is_ok());
+        assert!(CameraInstanceId::new(second.as_str()).is_ok());
+        assert_ne!(first, second);
+    }
+
+    fn observation(path: &str, serial: Option<&str>, roles: &[StreamRole]) -> CameraObservation {
+        CameraObservation::new(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new(path, serial.map(str::to_owned)).expect("valid physical id"),
+            CameraCapabilities::new(roles.to_vec(), Default::default(), Vec::new())
+                .expect("valid capabilities"),
+        )
+    }
+
+    fn generation(event: &CameraInventoryEvent) -> u64 {
+        event.descriptor().generation().get()
+    }
+
+    #[test]
+    fn add_refresh_and_snapshot_reorder_are_deterministic() {
+        let mut inventory = CameraInventory::new();
+        let a = observation("/devices/pci/a", Some("A"), &[StreamRole::Rgb]);
+        let b = observation("/devices/pci/b", None, &[StreamRole::Ir]);
+
+        let first = inventory.reconcile(vec![b.clone(), a.clone()]).unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[0].topology_path(), "/devices/pci/a");
+        assert_eq!(first[1].topology_path(), "/devices/pci/b");
+        assert!(first.iter().all(|event| event.is_added()));
+        assert!(first.iter().all(|event| generation(event) == 1));
+        assert_ne!(
+            first[0].descriptor().camera_instance_id(),
+            first[1].descriptor().camera_instance_id()
+        );
+
+        assert!(inventory.reconcile(vec![a, b]).unwrap().is_empty());
+        assert_eq!(inventory.active_descriptors().len(), 2);
+    }
+
+    #[test]
+    fn remove_readd_retires_instance_and_restarts_generation() {
+        let original_id = instance('1');
+        let replacement_id = instance('2');
+        let mut inventory = CameraInventory::with_instance_ids_for_test(vec![
+            original_id.clone(),
+            original_id.clone(),
+            replacement_id.clone(),
+        ]);
+        let camera = observation("/devices/pci/camera", None, &[StreamRole::Rgb]);
+        let added = inventory.reconcile(vec![camera.clone()]).unwrap();
+        let stale = added[0].descriptor().clone();
+
+        let removed = inventory.reconcile(Vec::new()).unwrap();
+        assert!(removed[0].is_removed());
+        assert_eq!(
+            inventory.validate(&stale),
+            Err(CameraInventoryError::Removed)
+        );
+
+        let readded = inventory.reconcile(vec![camera]).unwrap();
+        assert!(readded[0].is_added());
+        assert_eq!(generation(&readded[0]), 1);
+        assert!(!inventory.tombstones.contains("/devices/pci/camera"));
+        assert_ne!(
+            readded[0].descriptor().camera_instance_id(),
+            stale.camera_instance_id()
+        );
+        assert_eq!(
+            readded[0].descriptor().camera_instance_id(),
+            &replacement_id
+        );
+        assert!(inventory.retired_instance_ids.contains(&original_id));
+        assert_eq!(
+            inventory.validate(&stale),
+            Err(CameraInventoryError::ForeignInstance)
+        );
+        assert!(inventory.validate(readded[0].descriptor()).is_ok());
+    }
+
+    #[test]
+    fn security_relevant_observation_change_advances_generation() {
+        let mut inventory = CameraInventory::new();
+        let old = observation("/devices/pci/camera", None, &[StreamRole::Rgb]);
+        let new = observation("/devices/pci/camera", Some("SERIAL"), &[StreamRole::Rgb]);
+        let old_descriptor = inventory.reconcile(vec![old]).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        let changed = inventory.reconcile(vec![new]).unwrap();
+        assert_eq!(changed.len(), 1);
+        assert!(changed[0].is_changed());
+        assert_eq!(generation(&changed[0]), 2);
+        assert_eq!(
+            changed[0].descriptor().camera_instance_id(),
+            old_descriptor.camera_instance_id()
+        );
+        assert_eq!(
+            inventory.validate(&old_descriptor),
+            Err(CameraInventoryError::StaleGeneration)
+        );
+    }
+
+    #[test]
+    fn topology_move_retires_old_and_adds_new_identity() {
+        let mut inventory = CameraInventory::new();
+        let old = observation("/devices/pci/usb1/z-old", None, &[StreamRole::Rgb]);
+        let new = observation("/devices/pci/usb1/a-new", None, &[StreamRole::Rgb]);
+        let stale = inventory.reconcile(vec![old]).unwrap()[0]
+            .descriptor()
+            .clone();
+        let events = inventory.reconcile(vec![new]).unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert!(events[0].is_removed());
+        assert!(events[1].is_added());
+        assert_eq!(generation(&events[1]), 1);
+        assert_ne!(
+            events[1].descriptor().camera_instance_id(),
+            stale.camera_instance_id()
+        );
+        assert_eq!(
+            inventory.validate(&stale),
+            Err(CameraInventoryError::Removed)
+        );
+    }
+
+    #[test]
+    fn duplicate_snapshot_fails_atomically_instead_of_overwriting() {
+        let mut inventory = CameraInventory::new();
+        let existing = observation("/devices/pci/existing", None, &[StreamRole::Rgb]);
+        inventory.reconcile(vec![existing]).unwrap();
+        let before = inventory.active_descriptors();
+        let duplicate = observation("/devices/pci/duplicate", None, &[StreamRole::Ir]);
+
+        assert!(matches!(
+            inventory.reconcile(vec![duplicate.clone(), duplicate]),
+            Err(CameraInventoryError::DuplicateObservation(_))
+        ));
+        assert_eq!(inventory.active_descriptors(), before);
+    }
+
+    #[test]
+    fn identical_serialless_units_remain_distinct_and_ambiguous() {
+        let mut inventory = CameraInventory::new();
+        let a = observation(
+            "/devices/pci/usb1/1-1",
+            None,
+            &[StreamRole::Rgb, StreamRole::Ir],
+        );
+        let b = observation(
+            "/devices/pci/usb1/1-2",
+            None,
+            &[StreamRole::Rgb, StreamRole::Ir],
+        );
+
+        let events = inventory.reconcile(vec![b, a]).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_ne!(events[0].topology_path(), events[1].topology_path());
+        assert_ne!(
+            events[0].descriptor().camera_instance_id(),
+            events[1].descriptor().camera_instance_id()
+        );
+        assert!(events.iter().all(|event| {
+            event.descriptor().identity_strength() == crate::contracts::IdentityStrength::Ambiguous
+        }));
+    }
+
+    #[test]
+    fn validation_rejects_a_descriptor_from_another_supervisor_instance() {
+        let camera = observation("/devices/pci/camera", None, &[StreamRole::Rgb]);
+        let mut first = CameraInventory::new();
+        let descriptor = first.reconcile(vec![camera.clone()]).unwrap()[0]
+            .descriptor()
+            .clone();
+        let mut second = CameraInventory::new();
+        second.reconcile(vec![camera]).unwrap();
+
+        assert_eq!(
+            second.validate(&descriptor),
+            Err(CameraInventoryError::ForeignInstance)
+        );
+    }
+
+    #[test]
+    fn validation_rejects_forged_evidence_at_the_current_generation() {
+        let camera = observation("/devices/pci/camera", None, &[StreamRole::Rgb]);
+        let mut inventory = CameraInventory::new();
+        let descriptor = inventory.reconcile(vec![camera]).unwrap()[0]
+            .descriptor()
+            .clone();
+        let forged = CameraDescriptor::new(
+            descriptor.backend(),
+            descriptor.physical_id().clone(),
+            descriptor.camera_instance_id().clone(),
+            descriptor.generation(),
+            CameraCapabilities::new(vec![StreamRole::Ir], Default::default(), Vec::new()).unwrap(),
+        );
+
+        assert_eq!(
+            inventory.validate(&forged),
+            Err(CameraInventoryError::DescriptorMismatch)
+        );
+    }
+
+    #[test]
+    fn instance_id_collisions_retry_across_active_cameras() {
+        let first = instance('c');
+        let second = instance('d');
+        let mut inventory = CameraInventory::with_instance_ids_for_test(vec![
+            first.clone(),
+            first.clone(),
+            second.clone(),
+        ]);
+        let a = observation("/devices/a", None, &[StreamRole::Rgb]);
+        let b = observation("/devices/b", None, &[StreamRole::Ir]);
+
+        let events = inventory.reconcile(vec![a, b]).unwrap();
+        assert_eq!(events[0].descriptor().camera_instance_id(), &first);
+        assert_eq!(events[1].descriptor().camera_instance_id(), &second);
+    }
+
+    #[test]
+    fn instance_id_collisions_retry_across_retired_instances() {
+        let removed_id = instance('e');
+        let replacement_id = instance('f');
+        let mut inventory = CameraInventory::with_instance_ids_for_test(vec![
+            removed_id.clone(),
+            removed_id,
+            replacement_id.clone(),
+        ]);
+        inventory
+            .reconcile(vec![observation("/devices/old", None, &[StreamRole::Rgb])])
+            .unwrap();
+        inventory.reconcile(Vec::new()).unwrap();
+
+        let added = inventory
+            .reconcile(vec![observation("/devices/new", None, &[StreamRole::Rgb])])
+            .unwrap();
+        assert_eq!(added[0].descriptor().camera_instance_id(), &replacement_id);
+    }
+
+    #[test]
+    fn instance_id_exhaustion_fails_atomically() {
+        let repeated = instance('c');
+        let mut inventory = CameraInventory::with_instance_ids_for_test(vec![repeated]);
+        let existing = observation("/devices/a", None, &[StreamRole::Rgb]);
+        inventory.reconcile(vec![existing.clone()]).unwrap();
+        let before = inventory.active_descriptors();
+        let new = observation("/devices/b", None, &[StreamRole::Ir]);
+
+        assert_eq!(
+            inventory.reconcile(vec![existing, new]),
+            Err(CameraInventoryError::InstanceIdExhausted)
+        );
+        assert_eq!(inventory.active_descriptors(), before);
+    }
+
+    #[test]
+    fn generation_exhaustion_retires_instance_without_wrap() {
+        let old = observation("/devices/pci/camera", None, &[StreamRole::Rgb]);
+        let changed = observation("/devices/pci/camera", Some("SERIAL"), &[StreamRole::Rgb]);
+        let original_id = instance('8');
+        let replacement_id = instance('9');
+        let mut inventory = CameraInventory::with_active_for_test(
+            old,
+            original_id.clone(),
+            CameraGeneration::new(u64::MAX).unwrap(),
+            replacement_id.clone(),
+        );
+
+        let events = inventory.reconcile(vec![changed]).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_changed());
+        assert_eq!(events[0].descriptor().camera_instance_id(), &replacement_id);
+        assert_eq!(generation(&events[0]), 1);
+        assert!(inventory.retired_instance_ids.contains(&original_id));
+    }
+}

--- a/crates/irlume-camera/src/inventory.rs
+++ b/crates/irlume-camera/src/inventory.rs
@@ -24,6 +24,7 @@ pub(crate) struct CameraObservation {
     physical_id: PhysicalCameraId,
     capabilities: CameraCapabilities,
     lifecycle_evidence: Vec<String>,
+    endpoint_paths: Vec<String>,
 }
 
 impl CameraObservation {
@@ -37,6 +38,7 @@ impl CameraObservation {
             physical_id,
             capabilities,
             lifecycle_evidence: Vec::new(),
+            endpoint_paths: Vec::new(),
         }
     }
 
@@ -44,15 +46,34 @@ impl CameraObservation {
         backend: BackendKind,
         physical_id: PhysicalCameraId,
         capabilities: CameraCapabilities,
+        lifecycle_evidence: Vec<String>,
+    ) -> Self {
+        Self::with_lifecycle_evidence_and_endpoints(
+            backend,
+            physical_id,
+            capabilities,
+            lifecycle_evidence,
+            Vec::new(),
+        )
+    }
+
+    pub(crate) fn with_lifecycle_evidence_and_endpoints(
+        backend: BackendKind,
+        physical_id: PhysicalCameraId,
+        capabilities: CameraCapabilities,
         mut lifecycle_evidence: Vec<String>,
+        mut endpoint_paths: Vec<String>,
     ) -> Self {
         lifecycle_evidence.sort();
         lifecycle_evidence.dedup();
+        endpoint_paths.sort();
+        endpoint_paths.dedup();
         Self {
             backend,
             physical_id,
             capabilities,
             lifecycle_evidence,
+            endpoint_paths,
         }
     }
 
@@ -151,11 +172,16 @@ pub(crate) enum CameraInventoryError {
 pub(crate) struct CameraInventoryRef {
     descriptor: CameraDescriptor,
     lifecycle_evidence: Vec<String>,
+    endpoint_paths: Vec<String>,
 }
 
 impl CameraInventoryRef {
     pub(crate) fn descriptor(&self) -> &CameraDescriptor {
         &self.descriptor
+    }
+
+    pub(crate) fn endpoint_paths(&self) -> &[String] {
+        &self.endpoint_paths
     }
 }
 
@@ -368,8 +394,43 @@ impl CameraInventory {
             .map(|entry| CameraInventoryRef {
                 descriptor: entry.descriptor.clone(),
                 lifecycle_evidence: entry.observation.lifecycle_evidence.clone(),
+                endpoint_paths: entry.observation.endpoint_paths.clone(),
             })
             .collect()
+    }
+
+    pub(crate) fn reference_for_endpoints(
+        &self,
+        endpoint_paths: &[&str],
+    ) -> Result<CameraInventoryRef, CameraInventoryError> {
+        if endpoint_paths.is_empty() {
+            return Err(CameraInventoryError::UnknownCamera);
+        }
+        let requested: BTreeSet<_> = endpoint_paths.iter().copied().collect();
+        let mut matches = self.active.values().filter(|entry| {
+            requested.iter().all(|path| {
+                entry
+                    .observation
+                    .endpoint_paths
+                    .iter()
+                    .any(|known| known == path)
+            })
+        });
+        let entry = matches.next().ok_or(CameraInventoryError::UnknownCamera)?;
+        if matches.next().is_some() {
+            return Err(CameraInventoryError::DescriptorMismatch);
+        }
+        if self
+            .invalidated_instance_ids
+            .contains(entry.descriptor.camera_instance_id())
+        {
+            return Err(CameraInventoryError::ContinuityLost);
+        }
+        Ok(CameraInventoryRef {
+            descriptor: entry.descriptor.clone(),
+            lifecycle_evidence: entry.observation.lifecycle_evidence.clone(),
+            endpoint_paths: entry.observation.endpoint_paths.clone(),
+        })
     }
 
     pub(crate) fn validate_reference(
@@ -382,6 +443,9 @@ impl CameraInventory {
             .get(reference.descriptor().physical_id().topology_path())
             .ok_or(CameraInventoryError::UnknownCamera)?;
         if active.observation.lifecycle_evidence != reference.lifecycle_evidence {
+            return Err(CameraInventoryError::DescriptorMismatch);
+        }
+        if active.observation.endpoint_paths != reference.endpoint_paths {
             return Err(CameraInventoryError::DescriptorMismatch);
         }
         Ok(())
@@ -442,7 +506,7 @@ impl CameraInventory {
     }
 
     #[cfg(test)]
-    fn with_instance_ids_for_test(ids: Vec<CameraInstanceId>) -> Self {
+    pub(crate) fn with_instance_ids_for_test(ids: Vec<CameraInstanceId>) -> Self {
         let fallback = ids.last().cloned().expect("at least one fixture ID");
         let mut ids = ids.into_iter();
         Self::with_instance_id_source(Box::new(move || {
@@ -480,6 +544,49 @@ mod tests {
             CameraCapabilities::new(roles.to_vec(), Default::default(), Vec::new())
                 .expect("valid capabilities"),
         )
+    }
+
+    fn observation_with_endpoints(path: &str, endpoints: &[&str]) -> CameraObservation {
+        CameraObservation::with_lifecycle_evidence_and_endpoints(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new(path, None).expect("valid physical id"),
+            CameraCapabilities::default(),
+            endpoints
+                .iter()
+                .map(|endpoint| format!("evidence:{endpoint}"))
+                .collect(),
+            endpoints
+                .iter()
+                .map(|endpoint| (*endpoint).to_owned())
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn endpoint_lookup_binds_pair_to_one_descriptor_and_rejects_invalidation() {
+        let mut inventory = CameraInventory::with_instance_ids_for_test(vec![instance('1')]);
+        inventory
+            .reconcile(vec![observation_with_endpoints(
+                "/devices/pci/usb1/camera",
+                &["/dev/video0", "/dev/video2"],
+            )])
+            .unwrap();
+
+        let reference = inventory
+            .reference_for_endpoints(&["/dev/video2", "/dev/video0"])
+            .expect("both paths belong to one live camera");
+        assert_eq!(reference.endpoint_paths(), ["/dev/video0", "/dev/video2"]);
+        inventory.validate_reference(&reference).unwrap();
+
+        inventory.invalidate_all();
+        assert_eq!(
+            inventory.reference_for_endpoints(&["/dev/video0"]),
+            Err(CameraInventoryError::ContinuityLost)
+        );
+        assert_eq!(
+            inventory.validate_reference(&reference),
+            Err(CameraInventoryError::ContinuityLost)
+        );
     }
 
     fn generation(event: &CameraInventoryEvent) -> u64 {

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -538,6 +538,10 @@ pub(crate) mod fake_camera {
         static CAMERA: RefCell<Option<Camera>> = const { RefCell::new(None) };
     }
 
+    pub(crate) fn installed() -> bool {
+        CAMERA.with(|camera| camera.borrow().is_some())
+    }
+
     /// Install a fake for the rest of this test, and take it back at the end.
     pub(crate) struct Installed;
 
@@ -736,7 +740,24 @@ fn get_cur(fd: c_int, unit: u8, selector: u8, size: usize) -> XuResult<Vec<u8>> 
 /// including restores. That claim was made once while the logging sat on a
 /// single path and missed the one actually in use, which is exactly the sort of
 /// thing this project can no longer afford to be casual about.
+fn validate_write_lease(fd: c_int) -> XuResult<()> {
+    #[cfg(test)]
+    if fake_camera::installed() {
+        return Ok(());
+    }
+    let endpoint = std::fs::read_link(format!("/proc/self/fd/{fd}"))
+        .map_err(|_| XuError::Unresponsive(libc::ESTALE))?;
+    let endpoint = endpoint
+        .to_str()
+        .ok_or(XuError::Unresponsive(libc::ESTALE))?;
+    match crate::lease::active_permit(endpoint) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) | Err(_) => Err(XuError::Unresponsive(libc::ESTALE)),
+    }
+}
+
 fn set_cur(fd: c_int, unit: u8, selector: u8, payload: &[u8]) -> XuResult<()> {
+    validate_write_lease(fd)?;
     if std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
         eprintln!("irlume: SET_CUR unit{unit}/sel{selector}: {payload:02x?}");
     }
@@ -1364,7 +1385,10 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         None => (None, None, None),
     };
     StreamMode {
-        handle: Some(handle),
+        handle: Some(EmitterHandle {
+            handle,
+            lease: None,
+        }),
         unit,
         selector,
         armed: restore.is_some(),
@@ -1374,6 +1398,19 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         record,
         _lock: lock,
     }
+}
+
+pub(crate) fn enable_with_lease(
+    handle: std::sync::Arc<v4l::device::Handle>,
+    card: &str,
+    device: &str,
+    lease: crate::lease::CameraLease,
+) -> StreamMode {
+    let mut mode = lease.run_active(|| enable(handle, card, device));
+    if let Some(handle) = mode.handle.as_mut() {
+        handle.lease = Some(lease);
+    }
+    mode
 }
 
 /// The face-auth mode held for the lifetime of ONE stream, put back when the
@@ -1398,6 +1435,11 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
 /// `Drop` does the restoring, because the paths that need it most are the ones
 /// no statement covers: an error taken by `?`, a panic in the decoder, a
 /// cancelled request. Same reason the undo record in #183 restores from `Drop`.
+struct EmitterHandle {
+    handle: std::sync::Arc<v4l::device::Handle>,
+    lease: Option<crate::lease::CameraLease>,
+}
+
 #[must_use = "dropping this immediately puts the control back and leaves the stream unlit"]
 pub struct StreamMode {
     /// The open camera the mode was applied through, kept alive for as long as
@@ -1405,7 +1447,7 @@ pub struct StreamMode {
     /// never writes. A raw `c_int` here let a caller drop the `v4l::Device`
     /// first and have the restore land on whatever `open` handed the recycled
     /// number to next (#189); the `Arc` removes that state from the API.
-    handle: Option<std::sync::Arc<v4l::device::Handle>>,
+    handle: Option<EmitterHandle>,
     unit: u8,
     selector: u8,
     /// What the control HELD before irlume touched it, captured before the first
@@ -1492,7 +1534,7 @@ impl StreamMode {
     /// -1 is unreachable from an armed guard: `enable` is the only place that
     /// arms one, and it always installs the handle it wrote through.
     fn fd(&self) -> c_int {
-        self.handle.as_ref().map_or(-1, |h| h.fd())
+        self.handle.as_ref().map_or(-1, |h| h.handle.fd())
     }
 
     /// Whether the emitter control is active for this stream, whoever set it.
@@ -1535,6 +1577,14 @@ impl StreamMode {
     /// all — the mode is still applied, on purpose.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn restore(&mut self) -> std::result::Result<(), RestoreError> {
+        let lease = self.handle.as_ref().and_then(|handle| handle.lease.clone());
+        if let Some(lease) = lease {
+            return lease.run_active(|| self.restore_inner());
+        }
+        self.restore_inner()
+    }
+
+    fn restore_inner(&mut self) -> std::result::Result<(), RestoreError> {
         if !self.armed {
             return Ok(());
         }
@@ -4028,6 +4078,17 @@ pub fn describe_units(device: &str) -> std::io::Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn set_cur_refuses_without_a_current_descriptor_bound_lease() {
+        use std::os::fd::AsRawFd;
+
+        let file = std::fs::File::open("/dev/null").unwrap();
+        assert_eq!(
+            super::set_cur(file.as_raw_fd(), 1, 1, &[0]),
+            Err(super::XuError::Unresponsive(libc::ESTALE))
+        );
+    }
+
     /// The nightly hardware suite greps for this line EXACTLY
     /// (`grep -Fxq` in .github/workflows/hardware-suite.yml), so a reword here
     /// silently turns that gate into one that can never pass, and the camera

--- a/crates/irlume-camera/src/lease.rs
+++ b/crates/irlume-camera/src/lease.rs
@@ -1,0 +1,942 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Process-wide cooperative camera leases and operation lifecycle state.
+
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Condvar, Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+use crate::{
+    contracts::CameraInstanceId,
+    inventory::{CameraInventory, CameraInventoryRef},
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CameraOperationKind {
+    Capture,
+    Authentication,
+    Enrollment,
+    Preview,
+    Diagnostics,
+    Setup,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CameraSessionState {
+    Acquiring,
+    Acquired,
+    Configured,
+    Streaming,
+    Stopping,
+    Released,
+    ContinuityLost,
+    Fault,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CameraLeaseError {
+    DeadlineExpired {
+        current_owner: Option<CameraOperationKind>,
+    },
+    TokenExhausted,
+    Stale,
+    UnknownEndpoint,
+    Poisoned,
+    InvalidTransition {
+        from: CameraSessionState,
+        to: CameraSessionState,
+    },
+    EmptyKey,
+    EndpointNotCovered,
+    InvalidEndpoint(String),
+}
+
+impl std::fmt::Display for CameraLeaseError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DeadlineExpired { current_owner } => match current_owner {
+                Some(owner) => write!(
+                    formatter,
+                    "camera lease deadline expired; current owner: {owner:?}"
+                ),
+                None => formatter.write_str("camera lease deadline expired"),
+            },
+            Self::TokenExhausted => formatter.write_str("camera lease token space exhausted"),
+            Self::Stale => formatter.write_str("camera lifecycle reference is stale"),
+            Self::UnknownEndpoint => {
+                formatter.write_str("camera endpoint is not in the supervisor inventory")
+            }
+            Self::Poisoned => formatter.write_str("camera lease authority is unavailable"),
+            Self::InvalidTransition { from, to } => {
+                write!(
+                    formatter,
+                    "invalid camera session transition from {from:?} to {to:?}"
+                )
+            }
+            Self::EmptyKey => {
+                formatter.write_str("camera lease requires at least one physical camera")
+            }
+            Self::EndpointNotCovered => {
+                formatter.write_str("camera endpoint is not covered by this operation lease")
+            }
+            Self::InvalidEndpoint(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for CameraLeaseError {}
+
+thread_local! {
+    static ACTIVE_OPERATIONS: RefCell<Vec<CameraLease>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn active_permit(endpoint: &str) -> Result<Option<CameraLease>, CameraLeaseError> {
+    ACTIVE_OPERATIONS.with(|operations| {
+        let lease = operations.borrow().last().cloned();
+        if let Some(lease) = lease {
+            lease.require_endpoint(endpoint)?;
+            Ok(Some(lease))
+        } else {
+            Ok(None)
+        }
+    })
+}
+
+pub(crate) fn permit_for_discovery(
+    endpoint: &str,
+    timeout: Duration,
+) -> Result<Option<CameraLease>, CameraLeaseError> {
+    match permit_for_endpoint(endpoint, CameraOperationKind::Diagnostics, timeout) {
+        Ok(permit) => Ok(Some(permit)),
+        Err(CameraLeaseError::UnknownEndpoint | CameraLeaseError::InvalidEndpoint(_)) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn permit_for_endpoint(
+    endpoint: &str,
+    operation: CameraOperationKind,
+    timeout: Duration,
+) -> Result<CameraLease, CameraLeaseError> {
+    if let Some(permit) = active_permit(endpoint)? {
+        return Ok(permit);
+    }
+    let session = acquire_camera_operation(&[endpoint], operation, timeout)?;
+    Ok(session.into_lease())
+}
+
+struct ActiveOperationGuard;
+
+impl Drop for ActiveOperationGuard {
+    fn drop(&mut self) {
+        ACTIVE_OPERATIONS.with(|operations| {
+            operations.borrow_mut().pop();
+        });
+    }
+}
+
+/// Acquire one operation-scoped lease for all supplied endpoints.
+///
+/// RGB and IR endpoints from one physical camera resolve to one atomic key. The
+/// returned session may be moved across threads, but every open must remain
+/// covered by one of its endpoint paths.
+///
+/// # Errors
+///
+/// Returns [`CameraLeaseError::Stale`] when the endpoint set is not one current
+/// physical-camera observation, [`CameraLeaseError::DeadlineExpired`] on
+/// contention, or [`CameraLeaseError::Poisoned`] if supervisor state is unsafe.
+pub fn acquire_camera_operation(
+    endpoint_paths: &[&str],
+    operation: CameraOperationKind,
+    timeout: Duration,
+) -> Result<CameraOperationSession, CameraLeaseError> {
+    let result = crate::backend::with_camera_supervisor(|supervisor| {
+        supervisor.acquire_operation(
+            endpoint_paths,
+            operation,
+            Instant::now()
+                .checked_add(timeout)
+                .ok_or(CameraLeaseError::DeadlineExpired {
+                    current_owner: None,
+                })?,
+        )
+    });
+    if matches!(result, Err(CameraLeaseError::UnknownEndpoint)) {
+        for endpoint in endpoint_paths {
+            crate::verify_pinned(endpoint)
+                .map_err(|error| CameraLeaseError::InvalidEndpoint(error.to_string()))?;
+        }
+    }
+    result
+}
+
+#[derive(Default)]
+struct LeaseState {
+    next_token: u64,
+    next_waiter: u64,
+    active: BTreeMap<CameraInstanceId, ActiveLease>,
+    waiters: BTreeMap<u64, Vec<CameraInstanceId>>,
+}
+
+#[derive(Clone, Copy)]
+struct ActiveLease {
+    token: u64,
+    operation: CameraOperationKind,
+}
+
+#[derive(Default)]
+pub(crate) struct LeaseAuthority {
+    state: Mutex<LeaseState>,
+    changed: Condvar,
+}
+
+impl LeaseAuthority {
+    fn acquire(
+        self: &Arc<Self>,
+        mut keys: Vec<CameraInstanceId>,
+        operation: CameraOperationKind,
+        deadline: Instant,
+    ) -> Result<AuthorityPermit, CameraLeaseError> {
+        keys.sort();
+        keys.dedup();
+        if keys.is_empty() {
+            return Err(CameraLeaseError::EmptyKey);
+        }
+
+        let mut state = self.state.lock().map_err(|_| CameraLeaseError::Poisoned)?;
+        let waiter = state
+            .next_waiter
+            .checked_add(1)
+            .ok_or(CameraLeaseError::TokenExhausted)?;
+        state.next_waiter = waiter;
+        state.waiters.insert(waiter, keys.clone());
+
+        loop {
+            let earlier_conflict = state.waiters.range(..waiter).any(|(_, waiting)| {
+                waiting
+                    .iter()
+                    .any(|waiting_key| keys.binary_search(waiting_key).is_ok())
+            });
+            if !earlier_conflict && keys.iter().all(|key| !state.active.contains_key(key)) {
+                let Some(token) = state.next_token.checked_add(1) else {
+                    state.waiters.remove(&waiter);
+                    self.changed.notify_all();
+                    return Err(CameraLeaseError::TokenExhausted);
+                };
+                state.next_token = token;
+                state.waiters.remove(&waiter);
+                for key in &keys {
+                    state
+                        .active
+                        .insert(key.clone(), ActiveLease { token, operation });
+                }
+                return Ok(AuthorityPermit {
+                    authority: self.clone(),
+                    token,
+                    keys,
+                });
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                let current_owner = keys
+                    .iter()
+                    .find_map(|key| state.active.get(key).map(|active| active.operation));
+                state.waiters.remove(&waiter);
+                self.changed.notify_all();
+                return Err(CameraLeaseError::DeadlineExpired { current_owner });
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let (next, timed_out) = self
+                .changed
+                .wait_timeout(state, remaining)
+                .map_err(|_| CameraLeaseError::Poisoned)?;
+            state = next;
+            if timed_out.timed_out() {
+                let current_owner = keys
+                    .iter()
+                    .find_map(|key| state.active.get(key).map(|active| active.operation));
+                state.waiters.remove(&waiter);
+                self.changed.notify_all();
+                return Err(CameraLeaseError::DeadlineExpired { current_owner });
+            }
+        }
+    }
+}
+
+struct AuthorityPermit {
+    authority: Arc<LeaseAuthority>,
+    token: u64,
+    keys: Vec<CameraInstanceId>,
+}
+
+impl Drop for AuthorityPermit {
+    fn drop(&mut self) {
+        let Ok(mut state) = self.authority.state.lock() else {
+            return;
+        };
+        for key in &self.keys {
+            if state
+                .active
+                .get(key)
+                .is_some_and(|active| active.token == self.token)
+            {
+                state.active.remove(key);
+            }
+        }
+        self.authority.changed.notify_all();
+    }
+}
+
+struct CameraLeaseInner {
+    _permit: AuthorityPermit,
+    inventory: Arc<Mutex<CameraInventory>>,
+    references: Vec<CameraInventoryRef>,
+    operation: CameraOperationKind,
+    state: Mutex<CameraSessionState>,
+    streams: AtomicUsize,
+}
+
+impl Drop for CameraLeaseInner {
+    fn drop(&mut self) {
+        if let Ok(state) = self.state.get_mut() {
+            *state = CameraSessionState::Released;
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CameraLease {
+    inner: Arc<CameraLeaseInner>,
+}
+
+impl CameraLease {
+    pub(crate) fn acquire(
+        authority: &Arc<LeaseAuthority>,
+        inventory: Arc<Mutex<CameraInventory>>,
+        references: Vec<CameraInventoryRef>,
+        operation: CameraOperationKind,
+        deadline: Instant,
+    ) -> Result<Self, CameraLeaseError> {
+        validate_references(&inventory, &references)?;
+        let keys = references
+            .iter()
+            .map(|reference| reference.descriptor().camera_instance_id().clone())
+            .collect();
+        let permit = authority.acquire(keys, operation, deadline)?;
+        let lease = Self {
+            inner: Arc::new(CameraLeaseInner {
+                _permit: permit,
+                inventory,
+                references,
+                operation,
+                state: Mutex::new(CameraSessionState::Acquiring),
+                streams: AtomicUsize::new(0),
+            }),
+        };
+        lease.validate()?;
+        lease.set_state(CameraSessionState::Acquired);
+        Ok(lease)
+    }
+
+    pub(crate) fn run_active<R>(&self, operation: impl FnOnce() -> R) -> R {
+        ACTIVE_OPERATIONS.with(|operations| operations.borrow_mut().push(self.clone()));
+        let _guard = ActiveOperationGuard;
+        operation()
+    }
+
+    pub fn operation(&self) -> CameraOperationKind {
+        self.inner.operation
+    }
+
+    /// Revalidate every descriptor-bound inventory reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraLeaseError::Stale`] after removal, generation change, or
+    /// lifecycle invalidation, and [`CameraLeaseError::Poisoned`] on unsafe state.
+    pub fn validate(&self) -> Result<(), CameraLeaseError> {
+        match self.state() {
+            CameraSessionState::ContinuityLost | CameraSessionState::Released => {
+                return Err(CameraLeaseError::Stale);
+            }
+            CameraSessionState::Fault => return Err(CameraLeaseError::Poisoned),
+            _ => {}
+        }
+        if let Err(error) = validate_references(&self.inner.inventory, &self.inner.references) {
+            self.set_state(CameraSessionState::ContinuityLost);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub fn covers_endpoint(&self, path: &str) -> bool {
+        self.inner
+            .references
+            .iter()
+            .any(|reference| reference.endpoint_paths().iter().any(|known| known == path))
+    }
+
+    pub(crate) fn require_endpoint(&self, path: &str) -> Result<(), CameraLeaseError> {
+        self.validate()?;
+        if self.covers_endpoint(path) {
+            Ok(())
+        } else {
+            Err(CameraLeaseError::EndpointNotCovered)
+        }
+    }
+
+    pub fn state(&self) -> CameraSessionState {
+        self.inner
+            .state
+            .lock()
+            .map(|state| *state)
+            .unwrap_or(CameraSessionState::Fault)
+    }
+
+    pub(crate) fn start_stream(&self) -> Result<(), CameraLeaseError> {
+        self.validate()?;
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| CameraLeaseError::Poisoned)?;
+        let from = *state;
+        if !matches!(
+            from,
+            CameraSessionState::Acquired
+                | CameraSessionState::Configured
+                | CameraSessionState::Streaming
+                | CameraSessionState::Stopping
+        ) {
+            return Err(CameraLeaseError::InvalidTransition {
+                from,
+                to: CameraSessionState::Streaming,
+            });
+        }
+        if matches!(
+            from,
+            CameraSessionState::Acquired | CameraSessionState::Stopping
+        ) {
+            *state = CameraSessionState::Configured;
+        }
+        self.inner.streams.fetch_add(1, Ordering::SeqCst);
+        *state = CameraSessionState::Streaming;
+        Ok(())
+    }
+
+    pub(crate) fn stop_stream(&self) {
+        let previous = self.inner.streams.fetch_sub(1, Ordering::SeqCst);
+        if previous == 0 {
+            self.inner.streams.store(0, Ordering::SeqCst);
+            self.set_state(CameraSessionState::Fault);
+        } else if previous == 1 && self.state() == CameraSessionState::Streaming {
+            self.set_state(CameraSessionState::Stopping);
+        }
+    }
+
+    fn set_state(&self, state: CameraSessionState) {
+        if let Ok(mut current) = self.inner.state.lock() {
+            *current = state;
+        }
+    }
+}
+
+fn validate_references(
+    inventory: &Arc<Mutex<CameraInventory>>,
+    references: &[CameraInventoryRef],
+) -> Result<(), CameraLeaseError> {
+    if references.is_empty() {
+        return Err(CameraLeaseError::EmptyKey);
+    }
+    let inventory = inventory.lock().map_err(|_| CameraLeaseError::Poisoned)?;
+    for reference in references {
+        inventory
+            .validate_reference(reference)
+            .map_err(|_| CameraLeaseError::Stale)?;
+    }
+    Ok(())
+}
+
+pub struct CameraOperationSession {
+    lease: CameraLease,
+    release_on_drop: bool,
+}
+
+impl CameraOperationSession {
+    pub(crate) fn new(lease: CameraLease) -> Self {
+        Self {
+            lease,
+            release_on_drop: true,
+        }
+    }
+
+    pub(crate) fn into_lease(mut self) -> CameraLease {
+        self.release_on_drop = false;
+        self.lease.clone()
+    }
+
+    pub fn lease(&self) -> &CameraLease {
+        &self.lease
+    }
+
+    /// Run work under this operation's explicit re-entrant capability.
+    ///
+    /// The scope is thread-local and panic-safe. A worker thread must call
+    /// `run` itself; capabilities are never inherited or inferred globally.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraLeaseError::Stale`] if lifecycle continuity is lost before
+    /// or during the scope, or [`CameraLeaseError::Poisoned`] if inventory state
+    /// becomes unsafe.
+    pub fn run<R>(&self, operation: impl FnOnce() -> R) -> Result<R, CameraLeaseError> {
+        self.lease.validate()?;
+        ACTIVE_OPERATIONS.with(|operations| operations.borrow_mut().push(self.lease.clone()));
+        let guard = ActiveOperationGuard;
+        let result = operation();
+        drop(guard);
+        self.lease.validate()?;
+        Ok(result)
+    }
+
+    /// Open one RGB endpoint covered by this operation lease.
+    ///
+    /// # Errors
+    ///
+    /// Returns a hardware error for stale or uncovered endpoints and backend
+    /// failures.
+    pub fn open_rgb(&self, endpoint: &str) -> irlume_common::Result<crate::RgbCamera> {
+        self.lease
+            .require_endpoint(endpoint)
+            .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+        self.run(|| crate::backend::open_rgb(endpoint, self.lease.clone()))
+            .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?
+    }
+
+    /// Open one IR endpoint covered by this operation lease.
+    ///
+    /// # Errors
+    ///
+    /// Returns a hardware error for stale or uncovered endpoints and backend
+    /// failures.
+    pub fn open_ir(&self, endpoint: &str) -> irlume_common::Result<crate::IrCamera> {
+        self.lease
+            .require_endpoint(endpoint)
+            .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+        self.run(|| crate::backend::open_ir(endpoint, self.lease.clone()))
+            .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?
+    }
+
+    pub fn state(&self) -> CameraSessionState {
+        self.lease.state()
+    }
+
+    /// Mark successful stream configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraLeaseError::InvalidTransition`] or a validation error.
+    pub fn configure(&mut self) -> Result<(), CameraLeaseError> {
+        self.transition(CameraSessionState::Configured)
+    }
+
+    /// Mark the configured operation as streaming.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraLeaseError::InvalidTransition`] or a validation error.
+    pub fn start(&mut self) -> Result<(), CameraLeaseError> {
+        self.transition(CameraSessionState::Streaming)
+    }
+
+    /// Enter the stopping phase before backend cleanup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraLeaseError::InvalidTransition`] or a validation error.
+    pub fn begin_stop(&mut self) -> Result<(), CameraLeaseError> {
+        self.transition(CameraSessionState::Stopping)
+    }
+
+    /// Mark a non-faulted session released.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CameraLeaseError::InvalidTransition`] or a validation error.
+    pub fn release(&mut self) -> Result<(), CameraLeaseError> {
+        self.transition(CameraSessionState::Released)
+    }
+
+    pub fn fault(&mut self) {
+        self.lease.set_state(CameraSessionState::Fault);
+    }
+
+    fn transition(&mut self, to: CameraSessionState) -> Result<(), CameraLeaseError> {
+        self.lease.validate()?;
+        let mut state = self
+            .lease
+            .inner
+            .state
+            .lock()
+            .map_err(|_| CameraLeaseError::Poisoned)?;
+        let from = *state;
+        let valid = matches!(
+            (from, to),
+            (CameraSessionState::Acquired, CameraSessionState::Configured)
+                | (
+                    CameraSessionState::Configured,
+                    CameraSessionState::Streaming
+                )
+                | (CameraSessionState::Streaming, CameraSessionState::Stopping)
+                | (CameraSessionState::Stopping, CameraSessionState::Released)
+                | (CameraSessionState::Acquired, CameraSessionState::Released)
+                | (CameraSessionState::Configured, CameraSessionState::Released)
+        );
+        if !valid {
+            return Err(CameraLeaseError::InvalidTransition { from, to });
+        }
+        *state = to;
+        Ok(())
+    }
+}
+
+impl Drop for CameraOperationSession {
+    fn drop(&mut self) {
+        if !self.release_on_drop {
+            return;
+        }
+        if !matches!(
+            self.lease.state(),
+            CameraSessionState::Fault
+                | CameraSessionState::ContinuityLost
+                | CameraSessionState::Released
+        ) {
+            self.lease.set_state(CameraSessionState::Released);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{panic::AssertUnwindSafe, time::Duration};
+
+    use super::*;
+    use crate::{
+        contracts::{BackendKind, CameraCapabilities, PhysicalCameraId},
+        inventory::CameraObservation,
+    };
+
+    fn instance(byte: char) -> CameraInstanceId {
+        CameraInstanceId::new(byte.to_string().repeat(32)).unwrap()
+    }
+
+    fn authority_permit(
+        authority: &Arc<LeaseAuthority>,
+        keys: &[CameraInstanceId],
+    ) -> AuthorityPermit {
+        authority
+            .acquire(
+                keys.to_vec(),
+                CameraOperationKind::Capture,
+                Instant::now() + Duration::from_secs(1),
+            )
+            .unwrap()
+    }
+
+    fn lease_fixture() -> (
+        Arc<LeaseAuthority>,
+        Arc<Mutex<CameraInventory>>,
+        CameraLease,
+    ) {
+        let authority = Arc::new(LeaseAuthority::default());
+        let inventory = Arc::new(Mutex::new(CameraInventory::with_instance_ids_for_test(
+            vec![instance('1')],
+        )));
+        let observation = CameraObservation::with_lifecycle_evidence_and_endpoints(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new("/devices/pci/camera", None).unwrap(),
+            CameraCapabilities::default(),
+            vec!["evidence".into()],
+            vec!["/dev/video0".into(), "/dev/video2".into()],
+        );
+        inventory
+            .lock()
+            .unwrap()
+            .reconcile(vec![observation])
+            .unwrap();
+        let reference = inventory
+            .lock()
+            .unwrap()
+            .reference_for_endpoints(&["/dev/video0", "/dev/video2"])
+            .unwrap();
+        let lease = CameraLease::acquire(
+            &authority,
+            inventory.clone(),
+            vec![reference],
+            CameraOperationKind::Authentication,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .unwrap();
+        (authority, inventory, lease)
+    }
+
+    #[test]
+    fn pair_acquisition_is_atomic_and_times_out_without_partial_ownership() {
+        let authority = Arc::new(LeaseAuthority::default());
+        let a = instance('1');
+        let b = instance('2');
+        let held = authority_permit(&authority, std::slice::from_ref(&b));
+
+        assert!(matches!(
+            authority.acquire(
+                vec![a.clone(), b.clone()],
+                CameraOperationKind::Enrollment,
+                Instant::now() + Duration::from_millis(10),
+            ),
+            Err(CameraLeaseError::DeadlineExpired {
+                current_owner: Some(CameraOperationKind::Capture),
+            })
+        ));
+        let independent = authority_permit(&authority, &[a]);
+        drop(independent);
+        drop(held);
+    }
+
+    #[test]
+    fn overlapping_waiters_acquire_fifo() {
+        use std::sync::mpsc;
+
+        let authority = Arc::new(LeaseAuthority::default());
+        let key = instance('1');
+        let held = authority_permit(&authority, std::slice::from_ref(&key));
+        let (order_tx, order_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let first_authority = authority.clone();
+        let first_key = key.clone();
+        let first_tx = order_tx.clone();
+        let first = std::thread::spawn(move || {
+            let permit = first_authority
+                .acquire(
+                    vec![first_key],
+                    CameraOperationKind::Enrollment,
+                    Instant::now() + Duration::from_secs(2),
+                )
+                .unwrap();
+            first_tx.send(1).unwrap();
+            release_rx.recv().unwrap();
+            drop(permit);
+        });
+        while authority.state.lock().unwrap().waiters.is_empty() {
+            std::thread::yield_now();
+        }
+
+        let second_authority = authority.clone();
+        let second_key = key.clone();
+        let second = std::thread::spawn(move || {
+            let permit = second_authority
+                .acquire(
+                    vec![second_key],
+                    CameraOperationKind::Authentication,
+                    Instant::now() + Duration::from_secs(2),
+                )
+                .unwrap();
+            order_tx.send(2).unwrap();
+            drop(permit);
+        });
+        while authority.state.lock().unwrap().waiters.len() < 2 {
+            std::thread::yield_now();
+        }
+
+        drop(held);
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), 1);
+        release_tx.send(()).unwrap();
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), 2);
+        first.join().unwrap();
+        second.join().unwrap();
+    }
+
+    #[test]
+    fn clone_and_panic_keep_lease_until_last_owner_drops() {
+        let authority = Arc::new(LeaseAuthority::default());
+        let key = instance('1');
+        let permit = Arc::new(authority_permit(&authority, std::slice::from_ref(&key)));
+        let clone = permit.clone();
+        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            drop(clone);
+            panic!("operation panic fixture");
+        }));
+        assert!(matches!(
+            authority.acquire(
+                vec![key.clone()],
+                CameraOperationKind::Enrollment,
+                Instant::now() + Duration::from_millis(5),
+            ),
+            Err(CameraLeaseError::DeadlineExpired {
+                current_owner: Some(CameraOperationKind::Capture),
+            })
+        ));
+        drop(permit);
+        drop(authority_permit(&authority, &[key]));
+    }
+
+    #[test]
+    fn stale_lifecycle_reference_invalidates_held_lease() {
+        let (_authority, inventory, lease) = lease_fixture();
+        assert!(lease.covers_endpoint("/dev/video0"));
+        inventory.lock().unwrap().invalidate_all();
+        assert_eq!(lease.validate(), Err(CameraLeaseError::Stale));
+    }
+
+    #[test]
+    #[ignore = "requires the Shinetech four-node UVC camera"]
+    fn production_standalone_rgb_transfers_lease_ownership() {
+        let camera = crate::RgbCamera::open("/dev/video0").expect("standalone RGB open");
+        let _session = camera.session().expect("stream under transferred lease");
+    }
+
+    #[test]
+    #[ignore = "requires the Shinetech four-node UVC camera"]
+    fn production_pair_lease_is_atomic_for_real_rgb_and_ir_endpoints() {
+        let first = acquire_camera_operation(
+            &["/dev/video0", "/dev/video2"],
+            CameraOperationKind::Diagnostics,
+            Duration::from_millis(100),
+        )
+        .expect("real pair resolves to one current physical camera");
+        assert!(first.lease().covers_endpoint("/dev/video0"));
+        assert!(first.lease().covers_endpoint("/dev/video2"));
+        let rgb = first
+            .open_rgb("/dev/video0")
+            .expect("open RGB under pair lease");
+        let ir = first
+            .open_ir("/dev/video2")
+            .expect("open IR under pair lease");
+        assert!(matches!(
+            acquire_camera_operation(
+                &["/dev/video2", "/dev/video0"],
+                CameraOperationKind::Authentication,
+                Duration::from_millis(5),
+            ),
+            Err(CameraLeaseError::DeadlineExpired {
+                current_owner: Some(CameraOperationKind::Diagnostics),
+            })
+        ));
+        drop(rgb);
+        drop(ir);
+        drop(first);
+        acquire_camera_operation(
+            &["/dev/video0", "/dev/video2"],
+            CameraOperationKind::Authentication,
+            Duration::from_millis(100),
+        )
+        .expect("drop releases the physical-camera key");
+    }
+
+    #[test]
+    fn session_ownership_transfer_keeps_standalone_permit_live() {
+        let (authority, _inventory, lease) = lease_fixture();
+        let standalone = CameraOperationSession::new(lease).into_lease();
+        assert_eq!(standalone.state(), CameraSessionState::Acquired);
+        assert_eq!(standalone.validate(), Ok(()));
+        drop(standalone);
+        drop(authority_permit(&authority, &[instance('1')]));
+    }
+
+    #[test]
+    fn active_operation_scope_is_explicit_and_panic_safe() {
+        let (_authority, _inventory, lease) = lease_fixture();
+        let session = CameraOperationSession::new(lease);
+
+        assert!(active_permit("/dev/video0").unwrap().is_none());
+        session
+            .run(|| {
+                assert!(active_permit("/dev/video0").unwrap().is_some());
+                assert!(matches!(
+                    active_permit("/dev/video9"),
+                    Err(CameraLeaseError::EndpointNotCovered)
+                ));
+            })
+            .unwrap();
+        assert!(active_permit("/dev/video0").unwrap().is_none());
+
+        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let _ = session.run(|| panic!("scope panic"));
+        }));
+        assert!(active_permit("/dev/video0").unwrap().is_none());
+    }
+
+    #[test]
+    #[ignore = "requires an operator-controlled UVC interface unbind"]
+    fn production_active_pair_lease_becomes_stale_on_uvc_loss() {
+        use std::io::Write;
+
+        let operation = acquire_camera_operation(
+            &["/dev/video0", "/dev/video2"],
+            CameraOperationKind::Authentication,
+            Duration::from_secs(2),
+        )
+        .expect("acquire real pair");
+        println!("IRLUME_LEASE_READY");
+        std::io::stdout().flush().unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            match operation.lease().validate() {
+                Err(CameraLeaseError::Stale) => break,
+                Ok(()) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                other => panic!("lease did not become stale after UVC loss: {other:?}"),
+            }
+        }
+        println!("IRLUME_LEASE_STALE");
+    }
+
+    #[test]
+    fn stream_lifecycle_is_shared_and_reference_counted() {
+        let (_authority, _inventory, lease) = lease_fixture();
+        let session = CameraOperationSession::new(lease);
+        let lease = session.lease().clone();
+        let observed = lease.clone();
+        assert_eq!(lease.state(), CameraSessionState::Acquired);
+        lease.start_stream().unwrap();
+        lease.start_stream().unwrap();
+        assert_eq!(lease.state(), CameraSessionState::Streaming);
+        lease.stop_stream();
+        assert_eq!(lease.state(), CameraSessionState::Streaming);
+        lease.stop_stream();
+        assert_eq!(lease.state(), CameraSessionState::Stopping);
+        lease.start_stream().unwrap();
+        assert_eq!(lease.state(), CameraSessionState::Streaming);
+        lease.stop_stream();
+        assert_eq!(lease.state(), CameraSessionState::Stopping);
+        drop(session);
+        assert_eq!(observed.state(), CameraSessionState::Released);
+    }
+
+    #[test]
+    fn operation_session_enforces_lifecycle_order() {
+        let (_authority, _inventory, lease) = lease_fixture();
+        let mut session = CameraOperationSession::new(lease);
+        assert_eq!(session.state(), CameraSessionState::Acquired);
+        assert!(matches!(
+            session.start(),
+            Err(CameraLeaseError::InvalidTransition { .. })
+        ));
+        session.configure().unwrap();
+        session.start().unwrap();
+        session.begin_stop().unwrap();
+        session.release().unwrap();
+        assert_eq!(session.state(), CameraSessionState::Released);
+    }
+}

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -33,6 +33,7 @@ mod backend;
 /// Versioned, backend-neutral camera data contracts.
 pub mod contracts;
 pub mod emitter_journal;
+mod inventory;
 pub mod ir_dark;
 pub mod ir_emitter;
 mod ir_metadata;

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1499,6 +1499,12 @@ fn find_attr_dir(start: &std::path::Path, attr: &str) -> Option<std::path::PathB
     }
 }
 
+pub(crate) fn virtual_camera_allowed(device: &str) -> bool {
+    std::env::var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA")
+        .map(|allow| allow.split(',').any(|allowed| allowed.trim() == device))
+        .unwrap_or(false)
+}
+
 /// Camera device-pinning: verify `/dev/videoN` is a real, physically-attached
 /// camera before any frame is read, defeating unprivileged software frame
 /// injection (v4l2loopback / OBS virtual camera). See docs/THREAT_MODEL.md.
@@ -1525,14 +1531,12 @@ pub fn verify_pinned(device: &str) -> irlume_common::Result<()> {
     // daemon's environment is root-controlled via its systemd unit, so an
     // unprivileged local user cannot set this for the auth path; every use is
     // logged loudly. See docs/THREAT_MODEL.md (camera injection).
-    if let Ok(allow) = std::env::var("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA") {
-        if allow.split(',').any(|d| d.trim() == device) {
-            eprintln!(
-                "irlume: WARNING: {device} accepted without a physical-device pin \
-                 (IRLUME_TEST_ALLOW_VIRTUAL_CAMERA)"
-            );
-            return Ok(());
-        }
+    if virtual_camera_allowed(device) {
+        eprintln!(
+            "irlume: WARNING: {device} accepted without a physical-device pin \
+             (IRLUME_TEST_ALLOW_VIRTUAL_CAMERA)"
+        );
+        return Ok(());
     }
     let node = device.strip_prefix("/dev/").unwrap_or(device);
     let link = format!("/sys/class/video4linux/{node}/device");

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1848,6 +1848,31 @@ fn uvc_list_pairs() -> Vec<CameraPair> {
 /// that one blurry / over-exposed / transiently corrupt frame is outvoted.
 const RGB_BURST: usize = 5;
 
+struct SessionSlot<'a>(&'a std::sync::atomic::AtomicBool);
+
+impl<'a> SessionSlot<'a> {
+    fn acquire(
+        active: &'a std::sync::atomic::AtomicBool,
+        device: &str,
+    ) -> irlume_common::Result<Self> {
+        active
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .map_err(|_| Error::Hardware(format!("{device}: camera session already active")))?;
+        Ok(Self(active))
+    }
+}
+
+impl Drop for SessionSlot<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
 /// An opened, format-negotiated RGB camera.
 ///
 /// Exists so a caller that captures REPEATEDLY can pay the open, control write,
@@ -1862,6 +1887,7 @@ const RGB_BURST: usize = 5;
 /// long-lived half and the session is the streaming half.
 pub struct RgbCamera {
     lease: lease::CameraLease,
+    session_active: std::sync::atomic::AtomicBool,
     device: String,
     dev: Device,
     chosen: [u8; 4],
@@ -1930,6 +1956,7 @@ impl RgbCamera {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(Self {
             lease,
+            session_active: std::sync::atomic::AtomicBool::new(false),
             device: device.to_string(),
             dev,
             chosen,
@@ -1959,6 +1986,7 @@ impl RgbCamera {
         self.lease
             .require_endpoint(&self.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
+        let session_slot = SessionSlot::acquire(&self.session_active, &self.device)?;
         // Best-effort backlight/low-light correction: tell auto-exposure to
         // expose for the face, not a bright window behind it (NexiGo N930W:
         // verified face mean 49→124; this machine's ASUS: center mean
@@ -1991,6 +2019,7 @@ impl RgbCamera {
             warmed: false,
             progress: progress.clone(),
             _blc_restore: blc_restore,
+            _session_slot: session_slot,
         })
     }
 
@@ -2182,6 +2211,8 @@ pub struct RgbSession<'a> {
     /// drop order tears the stream down (STREAMOFF) before the control is
     /// put back.
     _blc_restore: Option<BlcRestore<'a>>,
+    /// Reset last, after STREAMOFF and control restoration have completed.
+    _session_slot: SessionSlot<'a>,
 }
 
 impl<'a> RgbSession<'a> {
@@ -2816,6 +2847,7 @@ pub fn capture_ir_with_stats_and_progress(
 /// there for why a device and a session are separate types.
 pub struct IrCamera {
     lease: lease::CameraLease,
+    session_active: std::sync::atomic::AtomicBool,
     device: String,
     dev: Device,
     pix: IrPixel,
@@ -2876,6 +2908,7 @@ impl IrCamera {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(Self {
             lease,
+            session_active: std::sync::atomic::AtomicBool::new(false),
             device: device.to_string(),
             dev,
             pix,
@@ -2928,6 +2961,7 @@ impl IrCamera {
         self.lease
             .require_endpoint(&self.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
+        let session_slot = SessionSlot::acquire(&self.session_active, &self.device)?;
         // DECLARED before the stream so it drops AFTER it. Locals drop in
         // reverse declaration order, and `warm_up_stream` below can fail: with
         // the guard declared second, that `?` dropped it first and sent the
@@ -2986,6 +3020,7 @@ impl IrCamera {
             lit: mode.lit(),
             _mode: mode,
             meta,
+            _session_slot: session_slot,
         })
     }
 }
@@ -3013,6 +3048,8 @@ pub struct IrSession<'a> {
     /// Never read. It is held for its `Drop`, which is the whole point, and the
     /// dead-code lint cannot see that.
     _mode: ir_emitter::StreamMode,
+    /// Reset last, after image/metadata STREAMOFF and emitter restoration.
+    _session_slot: SessionSlot<'a>,
 }
 
 impl IrSession<'_> {
@@ -5069,6 +5106,22 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_slot_is_exclusive_and_reopens_after_drop() {
+        let active = std::sync::atomic::AtomicBool::new(false);
+        let first = SessionSlot::acquire(&active, "/dev/test-camera").unwrap();
+        assert!(SessionSlot::acquire(&active, "/dev/test-camera").is_err());
+        drop(first);
+        assert!(SessionSlot::acquire(&active, "/dev/test-camera").is_ok());
+
+        let active = std::sync::atomic::AtomicBool::new(false);
+        let _ = std::panic::catch_unwind(|| {
+            let _slot = SessionSlot::acquire(&active, "/dev/test-camera").unwrap();
+            panic!("synthetic session panic");
+        });
+        assert!(!active.load(std::sync::atomic::Ordering::Acquire));
+    }
 
     #[test]
     fn a_rate_without_the_timeperframe_capability_is_unknown() {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -29,6 +29,9 @@
 //! RGB8. FOOTGUN: enumerate V4L2 controls defensively; naive control queries
 //! panic on some drivers. Probe, don't assume.
 
+mod backend;
+/// Versioned, backend-neutral camera data contracts.
+pub mod contracts;
 pub mod emitter_journal;
 pub mod ir_dark;
 pub mod ir_emitter;
@@ -1283,7 +1286,7 @@ fn file_node(scan: &mut NodeScan, path: String, outcome: Result<NodeKind, Unread
 /// `with_holders` walks /proc for each busy node to name what holds it. That
 /// is worth a report a person reads and not worth it for the camera-picking
 /// callers, which run on the TUI's refresh path.
-fn scan(with_holders: bool) -> NodeScan {
+fn uvc_scan(with_holders: bool) -> NodeScan {
     let mut scan = NodeScan::default();
     let listing = video_node_paths();
     scan.listing_error = listing.error;
@@ -1299,15 +1302,19 @@ fn scan(with_holders: bool) -> NodeScan {
     scan
 }
 
+fn uvc_discover_nodes() -> Vec<(String, Role)> {
+    uvc_scan(false).classified
+}
+
 /// Classify every video node, keeping the failures and naming what holds a
 /// busy one. For reports; use `discover_nodes` to pick a camera.
 pub fn scan_nodes() -> NodeScan {
-    scan(true)
+    backend::scan_nodes()
 }
 
 /// Scan for each readable capture node, returning (path, role).
 pub fn discover_nodes() -> Vec<(String, Role)> {
-    scan(false).classified
+    backend::discover_nodes()
 }
 
 /// Whether a failed privacy-control read means the camera does not HAVE the
@@ -1724,9 +1731,13 @@ pub struct CameraPair {
 /// Every physical camera that exposes both an RGB and an IR node (a Hello pair),
 /// sorted built-in first. Drives the TUI camera picker.
 pub fn list_pairs() -> Vec<CameraPair> {
+    backend::list_pairs()
+}
+
+fn uvc_list_pairs() -> Vec<CameraPair> {
     let mut groups: std::collections::BTreeMap<std::path::PathBuf, (Vec<String>, Vec<String>)> =
         Default::default();
-    for (path, role) in discover_nodes() {
+    for (path, role) in uvc_discover_nodes() {
         if let Some(id) = physical_device_id(&path) {
             let e = groups.entry(id).or_default();
             match role {
@@ -1789,6 +1800,10 @@ impl RgbCamera {
     /// allocated and the capture LED stays off until a session is opened.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
+        backend::open_rgb(device)
+    }
+
+    fn open_uvc(device: &str) -> irlume_common::Result<Self> {
         verify_pinned(device)?;
         if privacy_engaged(device) {
             return Err(Error::Hardware(format!(
@@ -2666,6 +2681,10 @@ pub struct IrCamera {
 impl IrCamera {
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
+        backend::open_ir(device)
+    }
+
+    fn open_uvc(device: &str) -> irlume_common::Result<Self> {
         verify_pinned(device)?;
         if privacy_engaged(device) {
             return Err(Error::Hardware(format!(

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -37,6 +37,7 @@ mod inventory;
 pub mod ir_dark;
 pub mod ir_emitter;
 mod ir_metadata;
+mod lifecycle;
 mod media_graph;
 // Public for exactly one item, `pending_summary`, doctor's read-only view of
 // the store (#429); every record type stays crate-private so no other code

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -37,6 +37,7 @@ mod inventory;
 pub mod ir_dark;
 pub mod ir_emitter;
 mod ir_metadata;
+pub mod lease;
 mod lifecycle;
 mod media_graph;
 // Public for exactly one item, `pending_summary`, doctor's read-only view of
@@ -331,6 +332,13 @@ impl Drop for BlcRestore<'_> {
         // and must not disturb an authentication's teardown.
         let read = self.cam.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION);
         if let Some(put_back) = blc_restore_decision(self.displaced, read) {
+            if self.cam.lease.require_endpoint(&self.cam.device).is_err() {
+                irlume_common::dlog!(
+                    "{}: skipped backlight-compensation restore after lease invalidation",
+                    self.cam.device
+                );
+                return;
+            }
             let restored = self.cam.dev.set_control(v4l::control::Control {
                 id: V4L2_CID_BACKLIGHT_COMPENSATION,
                 value: v4l::control::Value::Integer(put_back),
@@ -357,6 +365,7 @@ impl Drop for BlcRestore<'_> {
 /// one thing known then is that irlume just changed the control.
 fn apply_blc(cam: &RgbCamera) -> Option<BlcRestore<'_>> {
     let displaced = blc_write_decision(cam.dev.control(V4L2_CID_BACKLIGHT_COMPENSATION))?;
+    cam.lease.require_endpoint(&cam.device).ok()?;
     cam.dev
         .set_control(v4l::control::Control {
             id: V4L2_CID_BACKLIGHT_COMPENSATION,
@@ -367,6 +376,7 @@ fn apply_blc(cam: &RgbCamera) -> Option<BlcRestore<'_>> {
     if blc_restore_decision(displaced, confirm).is_some() {
         Some(BlcRestore { cam, displaced })
     } else {
+        cam.lease.require_endpoint(&cam.device).ok()?;
         let _ = cam.dev.set_control(v4l::control::Control {
             id: V4L2_CID_BACKLIGHT_COMPENSATION,
             value: v4l::control::Value::Integer(displaced),
@@ -403,6 +413,8 @@ const MMAP_BUFFERS: u32 = 4;
 struct SafeStream<'a> {
     inner: Option<v4l::io::mmap::Stream<'a>>,
     device: String,
+    lease: lease::CameraLease,
+    lease_started: bool,
 }
 
 /// How long a single frame dequeue may block.
@@ -557,18 +569,32 @@ impl<'a> SafeStream<'a> {
     /// without erroring blocks the caller indefinitely. That matters most
     /// during emitter setup: a stall there would hang with a control changed and
     /// the restore never reached. Every wait now ends.
-    fn open(device: &str, dev: &'a Device, expect: &v4l::Format) -> irlume_common::Result<Self> {
+    fn open(
+        device: &str,
+        dev: &'a Device,
+        expect: &v4l::Format,
+        lease: lease::CameraLease,
+    ) -> irlume_common::Result<Self> {
+        lease
+            .require_endpoint(device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         let mut inner = v4l::io::mmap::Stream::with_buffers(dev, Type::VideoCapture, MMAP_BUFFERS)
             .map_err(|e| map_io(device, e))?;
         inner.set_timeout(STREAM_DEQUEUE_TIMEOUT);
         // Constructed before the read-back so every error path below releases
         // the queue through the guarded Drop (STREAMOFF + REQBUFS(0)), never
         // through the v4l crate's panicking one.
-        let stream = Self {
+        let mut stream = Self {
             inner: Some(inner),
             device: device.to_string(),
+            lease,
+            lease_started: false,
         };
         let now = Capture::format(dev).map_err(|e| map_io(device, e))?;
+        stream
+            .lease
+            .require_endpoint(device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         if let Some(moved) = format_moved(expect, &now) {
             // Refusing rather than renegotiating, for the same reason the
             // emitter stands down under a foreign consumer (#169): a format
@@ -586,7 +612,21 @@ impl<'a> SafeStream<'a> {
                  this camera{who}; refusing this capture"
             )));
         }
+        stream
+            .lease
+            .start_stream()
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        stream.lease_started = true;
         Ok(stream)
+    }
+
+    fn next(&mut self) -> std::io::Result<(&[u8], &v4l::buffer::Metadata)> {
+        self.lease
+            .require_endpoint(&self.device)
+            .map_err(std::io::Error::other)?;
+        v4l::io::traits::CaptureStream::next(
+            self.inner.as_mut().expect("stream taken only in Drop"),
+        )
     }
 }
 
@@ -611,6 +651,9 @@ impl Drop for SafeStream<'_> {
         let device = self.device.clone();
         if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(inner))).is_err() {
             irlume_common::dlog!("{device}: stream teardown failed (STREAMOFF); frames unaffected");
+        }
+        if self.lease_started {
+            self.lease.stop_stream();
         }
     }
 }
@@ -1030,6 +1073,8 @@ pub fn classify_node(device: &str) -> Result<NodeKind, Unreadable> {
         // isolation does not walk /proc.
         holder: None,
     };
+    let _permit = lease::permit_for_discovery(device, std::time::Duration::from_secs(2))
+        .map_err(|error| unreadable(FailedAt::Open, std::io::Error::other(error)))?;
     let dev = Device::with_path(device).map_err(|e| unreadable(FailedAt::Open, e))?;
     let caps = queried_caps(&dev).map_err(|e| unreadable(FailedAt::QueryCaps, e))?;
     if let Some(mc) = mc_centric_verdict(&caps) {
@@ -1354,6 +1399,17 @@ fn privacy_state(dev: &Device) -> std::io::Result<Option<bool>> {
 /// `setup_ir_emitter` deliberately does NOT use this: it writes to firmware,
 /// where an unknown shutter state must refuse — see `privacy_permits_setup`.
 pub fn privacy_engaged(device: &str) -> bool {
+    let Ok(_permit) = lease::permit_for_endpoint(
+        device,
+        lease::CameraOperationKind::Diagnostics,
+        std::time::Duration::from_secs(2),
+    ) else {
+        return false;
+    };
+    privacy_engaged_with_permit(device)
+}
+
+fn privacy_engaged_with_permit(device: &str) -> bool {
     let Ok(dev) = Device::with_path(device) else {
         return false;
     };
@@ -1399,6 +1455,12 @@ fn backend_from_caps(driver: String, bus: &str) -> (String, bool) {
 /// diagnostic surface has to say "unknown" (#195 review).
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn node_backend(device: &str) -> std::io::Result<(String, bool)> {
+    let _permit = lease::permit_for_endpoint(
+        device,
+        lease::CameraOperationKind::Diagnostics,
+        std::time::Duration::from_secs(2),
+    )
+    .map_err(std::io::Error::other)?;
     let dev = Device::with_path(device)?;
     let caps = dev.query_caps()?;
     Ok(backend_from_caps(caps.driver, &caps.bus))
@@ -1785,6 +1847,7 @@ const RGB_BURST: usize = 5;
 /// device; one struct owning both would be self-referential. The device is the
 /// long-lived half and the session is the streaming half.
 pub struct RgbCamera {
+    lease: lease::CameraLease,
     device: String,
     dev: Device,
     chosen: [u8; 4],
@@ -1802,12 +1865,32 @@ impl RgbCamera {
     /// allocated and the capture LED stays off until a session is opened.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
-        backend::open_rgb(device)
+        if let Some(permit) =
+            lease::active_permit(device).map_err(|error| Error::Hardware(error.to_string()))?
+        {
+            return backend::open_rgb(device, permit);
+        }
+        let operation = match lease::acquire_camera_operation(
+            &[device],
+            lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        ) {
+            Ok(operation) => operation,
+            Err(error @ lease::CameraLeaseError::Stale) => {
+                verify_pinned(device)?;
+                return Err(Error::Hardware(error.to_string()));
+            }
+            Err(error) => return Err(Error::Hardware(error.to_string())),
+        };
+        backend::open_rgb(device, operation.into_lease())
     }
 
-    fn open_uvc(device: &str) -> irlume_common::Result<Self> {
+    fn open_uvc(device: &str, lease: lease::CameraLease) -> irlume_common::Result<Self> {
+        lease
+            .require_endpoint(device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         verify_pinned(device)?;
-        if privacy_engaged(device) {
+        if privacy_engaged_with_permit(device) {
             return Err(Error::Hardware(format!(
                 "{device}: hardware privacy switch is ON"
             )));
@@ -1828,7 +1911,11 @@ impl RgbCamera {
                 fourcc_str(&chosen)
             )));
         }
+        lease
+            .require_endpoint(device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(Self {
+            lease,
             device: device.to_string(),
             dev,
             chosen,
@@ -1855,6 +1942,9 @@ impl RgbCamera {
         &self,
         progress: &Progress,
     ) -> irlume_common::Result<RgbSession<'_>> {
+        self.lease
+            .require_endpoint(&self.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         // Best-effort backlight/low-light correction: tell auto-exposure to
         // expose for the face, not a bright window behind it (NexiGo N930W:
         // verified face mean 49→124; this machine's ASUS: center mean
@@ -1872,7 +1962,15 @@ impl RgbCamera {
         // open that fails below must restore too, and the first version did
         // not (the Codex round's finding 1 on this PR).
         let blc_restore = apply_blc(self);
-        let stream = SafeStream::open(&self.device, &self.dev, &self.negotiated)?;
+        let stream = SafeStream::open(
+            &self.device,
+            &self.dev,
+            &self.negotiated,
+            self.lease.clone(),
+        )?;
+        self.lease
+            .require_endpoint(&self.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(RgbSession {
             cam: self,
             stream: Some(stream),
@@ -2004,7 +2102,13 @@ fn try_format(dev: &Device, fmt: &Format) -> std::io::Result<Format> {
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn negotiated_stream(device: &str, role: Role) -> irlume_common::Result<StreamSpec> {
     verify_pinned(device)?;
-    if privacy_engaged(device) {
+    let _permit = lease::permit_for_endpoint(
+        device,
+        lease::CameraOperationKind::Diagnostics,
+        std::time::Duration::from_secs(2),
+    )
+    .map_err(|error| Error::Hardware(error.to_string()))?;
+    if privacy_engaged_with_permit(device) {
         return Err(Error::Hardware(format!(
             "{device}: hardware privacy switch is ON"
         )));
@@ -2092,12 +2196,21 @@ impl<'a> RgbSession<'a> {
     /// one-shot path.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn recover(&mut self) -> irlume_common::Result<()> {
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         self.stream = None; // drop first: STREAMOFF + buffer release
         self.stream = Some(SafeStream::open(
             &self.cam.device,
             &self.cam.dev,
             &self.cam.negotiated,
+            self.cam.lease.clone(),
         )?);
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         // The fresh stream's auto-exposure starts unsettled, like any new
         // session's.
         self.warmed = false;
@@ -2108,6 +2221,10 @@ impl<'a> RgbSession<'a> {
     /// second capture on the same stream is already settled, and re-running the
     /// warm-up would throw away good frames to no purpose.
     fn warm_up(&mut self) -> irlume_common::Result<()> {
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         if self.warmed {
             return Ok(());
         }
@@ -2115,6 +2232,10 @@ impl<'a> RgbSession<'a> {
         let progress = self.progress.clone();
         warm_up_stream(&device, self.stream()?, &progress)?;
         for _ in 0..AE_WARMUP {
+            self.cam
+                .lease
+                .require_endpoint(&device)
+                .map_err(|error| Error::Hardware(error.to_string()))?;
             self.stream()?.next().map_err(|e| map_io(&device, e))?; // discard while AE settles
         }
         self.warmed = true;
@@ -2124,18 +2245,30 @@ impl<'a> RgbSession<'a> {
     /// Capture `n` (≥1) frames. All share the same dimensions.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn burst(&mut self, n: usize) -> irlume_common::Result<Vec<Frame>> {
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         self.warm_up()?;
         let (w, h) = (self.cam.width, self.cam.height);
         let device = self.cam.device.clone();
         let chosen = self.cam.chosen;
         let mut frames = Vec::with_capacity(n.max(1));
         for _ in 0..n.max(1) {
+            self.cam
+                .lease
+                .require_endpoint(&device)
+                .map_err(|error| Error::Hardware(error.to_string()))?;
             let (buf, _meta) = self.stream()?.next().map_err(|e| map_io(&device, e))?;
             let taken = std::time::Instant::now();
             let data = match &chosen {
                 b"NV12" => nv12_to_rgb(buf, w, h),
                 _ => yuyv_to_rgb(buf, w, h),
             };
+            self.cam
+                .lease
+                .require_endpoint(&device)
+                .map_err(|error| Error::Hardware(error.to_string()))?;
             frames.push(Frame {
                 width: w,
                 height: h,
@@ -2282,6 +2415,13 @@ fn ipu_generation_for_id(device_id: &str) -> Option<&'static str> {
 
 /// A node's advertised pixel formats (fourcc), for negotiation and `doctor`.
 pub fn rgb_node_formats(device: &str) -> Vec<[u8; 4]> {
+    let Ok(_permit) = lease::permit_for_endpoint(
+        device,
+        lease::CameraOperationKind::Diagnostics,
+        std::time::Duration::from_secs(2),
+    ) else {
+        return Vec::new();
+    };
     let Ok(dev) = Device::with_path(device) else {
         return Vec::new();
     };
@@ -2661,6 +2801,7 @@ pub fn capture_ir_with_stats_and_progress(
 /// An opened, format-negotiated IR camera. The companion to [`RgbCamera`]; see
 /// there for why a device and a session are separate types.
 pub struct IrCamera {
+    lease: lease::CameraLease,
     device: String,
     dev: Device,
     pix: IrPixel,
@@ -2683,12 +2824,32 @@ pub struct IrCamera {
 impl IrCamera {
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn open(device: &str) -> irlume_common::Result<Self> {
-        backend::open_ir(device)
+        if let Some(permit) =
+            lease::active_permit(device).map_err(|error| Error::Hardware(error.to_string()))?
+        {
+            return backend::open_ir(device, permit);
+        }
+        let operation = match lease::acquire_camera_operation(
+            &[device],
+            lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        ) {
+            Ok(operation) => operation,
+            Err(error @ lease::CameraLeaseError::Stale) => {
+                verify_pinned(device)?;
+                return Err(Error::Hardware(error.to_string()));
+            }
+            Err(error) => return Err(Error::Hardware(error.to_string())),
+        };
+        backend::open_ir(device, operation.into_lease())
     }
 
-    fn open_uvc(device: &str) -> irlume_common::Result<Self> {
+    fn open_uvc(device: &str, lease: lease::CameraLease) -> irlume_common::Result<Self> {
+        lease
+            .require_endpoint(device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         verify_pinned(device)?;
-        if privacy_engaged(device) {
+        if privacy_engaged_with_permit(device) {
             return Err(Error::Hardware(format!(
                 "{device}: hardware privacy switch is ON"
             )));
@@ -2696,7 +2857,11 @@ impl IrCamera {
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
         let (fmt, pix) = negotiate_ir_format(device, &dev)?;
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
+        lease
+            .require_endpoint(device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(Self {
+            lease,
             device: device.to_string(),
             dev,
             pix,
@@ -2746,13 +2911,21 @@ impl IrCamera {
         &self,
         progress: &Progress,
     ) -> irlume_common::Result<IrSession<'_>> {
+        self.lease
+            .require_endpoint(&self.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         // DECLARED before the stream so it drops AFTER it. Locals drop in
         // reverse declaration order, and `warm_up_stream` below can fail: with
         // the guard declared second, that `?` dropped it first and sent the
         // restore while the stream was still live, the very mid-stream write
         // this change removes. Assigned further down, once the stream exists.
         let mode;
-        let mut stream = SafeStream::open(&self.device, &self.dev, &self.negotiated)?;
+        let mut stream = SafeStream::open(
+            &self.device,
+            &self.dev,
+            &self.negotiated,
+            self.lease.clone(),
+        )?;
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
         // 25s when video went first). `SafeStream::open` only allocates
@@ -2780,7 +2953,15 @@ impl IrCamera {
         // default in the ordinary case, another program's value where one was
         // deliberately set — which is the documented sequence's last step and
         // the half irlume never did.
-        mode = ir_emitter::enable(self.dev.handle(), &self.card, &self.device);
+        self.lease
+            .require_endpoint(&self.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        mode = ir_emitter::enable_with_lease(
+            self.dev.handle(),
+            &self.card,
+            &self.device,
+            self.lease.clone(),
+        );
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
         warm_up_stream(&self.device, &mut stream, progress)?;
@@ -2830,6 +3011,10 @@ impl IrSession<'_> {
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn capture_with_stats(&mut self) -> irlume_common::Result<(Frame, IrCaptureStats)> {
         let device = self.cam.device.as_str();
+        let lease = self.cam.lease.clone();
+        lease
+            .require_endpoint(device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         let (w, h) = (self.cam.width, self.cam.height);
         let card = &self.cam.card;
         let lit = self.lit;
@@ -2876,7 +3061,13 @@ impl IrSession<'_> {
         // camera answers that directly now, per frame, through the illumination
         // metadata added in #167, so the guess is not needed to know the answer.
         for _ in 0..IR_BURST {
+            lease
+                .require_endpoint(device)
+                .map_err(|error| Error::Hardware(error.to_string()))?;
             let (buf, bmeta) = stream.next().map_err(|e| map_io(device, e))?;
+            lease
+                .require_endpoint(device)
+                .map_err(|error| Error::Hardware(error.to_string()))?;
             stamps.push(bmeta.timestamp.sec * 1_000_000 + bmeta.timestamp.usec);
             taken.push(std::time::Instant::now());
             // Drain every iteration, not once at the end. The metadata ring is
@@ -3185,6 +3376,10 @@ impl IrSession<'_> {
     /// grace window returned dark IR frames.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn recover(&mut self) -> irlume_common::Result<()> {
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         self.stream = None; // drop first: STREAMOFF + buffer release
         self.meta = None; // drop the metadata queue
                           // A restore failure PROPAGATES, mirroring the frozen-stream restart:
@@ -3197,15 +3392,33 @@ impl IrSession<'_> {
             ))
         })?;
         self._mode = ir_emitter::StreamMode::inert();
-        let stream = SafeStream::open(&self.cam.device, &self.cam.dev, &self.cam.negotiated)?;
+        let stream = SafeStream::open(
+            &self.cam.device,
+            &self.cam.dev,
+            &self.cam.negotiated,
+            self.cam.lease.clone(),
+        )?;
         let meta = ir_metadata::IlluminationLog::open(&self.cam.device);
-        let mode = ir_emitter::enable(self.cam.dev.handle(), &self.cam.card, &self.cam.device);
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        let mode = ir_emitter::enable_with_lease(
+            self.cam.dev.handle(),
+            &self.cam.card,
+            &self.cam.device,
+            self.cam.lease.clone(),
+        );
         let lit = mode.lit();
         self.stream = Some(stream);
         self.meta = meta;
         self._mode = mode;
         self.dec = IrDecoder::new(self.cam.pix, self.cam.quantization);
         self.lit = lit;
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(())
     }
 }
@@ -3217,8 +3430,10 @@ impl IrSession<'_> {
 /// example and the capture path share one implementation.
 pub mod ir_probe {
     use super::negotiate_ir_format;
-    use super::{ir_emitter, map_io, privacy_engaged, verify_pinned, Error, Frame, Spectrum};
-    use super::{CaptureStream, Device};
+    use super::Device;
+    use super::{
+        ir_emitter, map_io, privacy_engaged_with_permit, verify_pinned, Error, Frame, Spectrum,
+    };
 
     /// Mean brightness of an 8-bit greyscale buffer.
     pub fn mean(data: &[u8]) -> f64 {
@@ -3341,7 +3556,13 @@ pub mod ir_probe {
         n: usize,
     ) -> irlume_common::Result<Vec<(Frame, f64)>> {
         verify_pinned(device)?;
-        if privacy_engaged(device) {
+        let permit = super::lease::permit_for_endpoint(
+            device,
+            super::lease::CameraOperationKind::Diagnostics,
+            std::time::Duration::from_secs(2),
+        )
+        .map_err(|error| Error::Hardware(error.to_string()))?;
+        if privacy_engaged_with_permit(device) {
             return Err(Error::Hardware(format!(
                 "{device}: hardware privacy switch is ON"
             )));
@@ -3365,8 +3586,8 @@ pub mod ir_probe {
         // buffers; STREAMON happens on the first dequeue, so the set still
         // lands before streaming starts.
         let mode;
-        let mut stream = super::SafeStream::open(device, &dev, &fmt)?;
-        mode = ir_emitter::enable(dev.handle(), &card, device);
+        let mut stream = super::SafeStream::open(device, &dev, &fmt, permit.clone())?;
+        mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
         // Bound, never read: held for its `Drop`, which restores the control.
         let _ = &mode;
         let mut out = Vec::with_capacity(n);
@@ -3443,7 +3664,13 @@ pub fn capture_ir_streaming<B>(
     mut on_frame: impl FnMut(IrStreamFrame) -> std::ops::ControlFlow<B>,
 ) -> irlume_common::Result<Option<B>> {
     verify_pinned(device)?;
-    if privacy_engaged(device) {
+    let permit = lease::permit_for_endpoint(
+        device,
+        lease::CameraOperationKind::Preview,
+        std::time::Duration::from_secs(2),
+    )
+    .map_err(|error| Error::Hardware(error.to_string()))?;
+    if privacy_engaged_with_permit(device) {
         return Err(Error::Hardware(format!(
             "{device}: hardware privacy switch is ON"
         )));
@@ -3467,8 +3694,8 @@ pub fn capture_ir_streaming<B>(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = SafeStream::open(device, &dev, &fmt)?;
-    mode = ir_emitter::enable(dev.handle(), &card, device);
+    let mut stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+    mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
     // constant mid-grey for the rest of the window); real sensor noise never
@@ -3538,8 +3765,8 @@ pub fn capture_ir_streaming<B>(
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = SafeStream::open(device, &dev, &fmt)?;
-                mode = ir_emitter::enable(dev.handle(), &card, device);
+                stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+                mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
             }
             continue;
         }
@@ -3586,7 +3813,13 @@ pub fn capture_ir_sequence(
     burst: usize,
 ) -> irlume_common::Result<Vec<Frame>> {
     verify_pinned(device)?;
-    if privacy_engaged(device) {
+    let permit = lease::permit_for_endpoint(
+        device,
+        lease::CameraOperationKind::Diagnostics,
+        std::time::Duration::from_secs(2),
+    )
+    .map_err(|error| Error::Hardware(error.to_string()))?;
+    if privacy_engaged_with_permit(device) {
         return Err(Error::Hardware(format!(
             "{device}: hardware privacy switch is ON"
         )));
@@ -3611,8 +3844,8 @@ pub fn capture_ir_sequence(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = Some(SafeStream::open(device, &dev, &fmt)?);
-    mode = ir_emitter::enable(dev.handle(), &card, device);
+    let mut stream = Some(SafeStream::open(device, &dev, &fmt, permit.clone())?);
+    mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Set once per stream, before it starts, and not per frame (the
     // frozen-stream restart below re-applies on its new stream). This path also carried
     // an every-eighth-frame re-fire; it went for the same reason, and with the
@@ -3682,8 +3915,8 @@ pub fn capture_ir_sequence(
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = Some(SafeStream::open(device, &dev, &fmt)?);
-                mode = ir_emitter::enable(dev.handle(), &card, device);
+                stream = Some(SafeStream::open(device, &dev, &fmt, permit.clone())?);
+                mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
             }
             continue;
         }
@@ -4078,8 +4311,25 @@ fn held_concurrent_arm<'d>(
     ir_dev: &'d str,
 ) -> impl FnOnce(usize, &Progress, &mut PairSample) -> irlume_common::Result<()> + 'd {
     move |rounds, progress, into| {
-        let held = RgbCamera::open(rgb_dev).and_then(|r| IrCamera::open(ir_dev).map(|i| (r, i)));
-        let (rgb_cam, ir_cam) = match held {
+        let operation = lease::acquire_camera_operation(
+            &[rgb_dev, ir_dev],
+            lease::CameraOperationKind::Diagnostics,
+            std::time::Duration::from_secs(2),
+        );
+        let held = operation.and_then(|operation| {
+            operation
+                .open_rgb(rgb_dev)
+                .map_err(|error| lease::CameraLeaseError::InvalidEndpoint(error.to_string()))
+                .and_then(|rgb| {
+                    operation
+                        .open_ir(ir_dev)
+                        .map(|ir| (operation, rgb, ir))
+                        .map_err(|error| {
+                            lease::CameraLeaseError::InvalidEndpoint(error.to_string())
+                        })
+                })
+        });
+        let (_operation, rgb_cam, ir_cam) = match held {
             Ok(pair) => pair,
             Err(e) => {
                 irlume_common::dlog!(
@@ -4515,6 +4765,12 @@ pub fn store_sequential_if_still_concurrent(
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     verify_pinned(device)?;
+    let permit = lease::permit_for_endpoint(
+        device,
+        lease::CameraOperationKind::Setup,
+        std::time::Duration::from_secs(2),
+    )
+    .map_err(|error| Error::Hardware(error.to_string()))?;
     // Open only long enough to read the standard V4L2 privacy control, and
     // refuse before format negotiation, streaming, or any extension-unit
     // write. An engaged shutter blanks the sensor to a flat frame (ASUS
@@ -4541,7 +4797,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
-    let mut stream = SafeStream::open(device, &dev, &fmt)?;
+    let mut stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
     let fd = dev.handle().fd();
     for _ in 0..4 {
         let _ = stream.next(); // let the sensor settle before baseline
@@ -4602,21 +4858,28 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     // SET_CUR, and the operator can engage the E-shutter anywhere in that
     // window (#193 review). The residual race is one syscall wide: V4L2 offers
     // no transaction spanning the privacy read and the extension-unit write.
-    let mut privacy_allows_write = || privacy_permits_setup(privacy_state(&dev));
-    match ir_emitter::discover(fd, &id, &mut measure, &mut privacy_allows_write) {
-        Ok(found) => {
-            let encoded = found.control().encode();
-            // Confirm, publish, release, in that order. The sequence lives in
-            // `finish` rather than here so it is reachable by a test.
-            found.finish(&id).map_err(Error::Hardware)?;
-            Ok(format!(
-                "IR emitter enabled: {encoded} on the camera's Microsoft camera-control unit, \
+    let mut privacy_allows_write = || {
+        permit
+            .require_endpoint(device)
+            .map_err(|error| error.to_string())?;
+        privacy_permits_setup(privacy_state(&dev))
+    };
+    permit.run_active(|| {
+        match ir_emitter::discover(fd, &id, &mut measure, &mut privacy_allows_write) {
+            Ok(found) => {
+                let encoded = found.control().encode();
+                // Confirm, publish, release, in that order. The sequence lives in
+                // `finish` rather than here so it is reachable by a test.
+                found.finish(&id).map_err(Error::Hardware)?;
+                Ok(format!(
+                    "IR emitter enabled: {encoded} on the camera's Microsoft camera-control unit, \
                  using a value built from what the camera reports about that control \
                  (saved; future captures rebuild it the same way)"
-            ))
+                ))
+            }
+            Err(e) => Err(Error::Hardware(e.to_string())),
         }
-        Err(e) => Err(Error::Hardware(e.to_string())),
-    }
+    })
 }
 
 /// What the IR camera's extension units are, for `ir-setup --dry-run`.

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -621,12 +621,22 @@ impl<'a> SafeStream<'a> {
     }
 
     fn next(&mut self) -> std::io::Result<(&[u8], &v4l::buffer::Metadata)> {
-        self.lease
-            .require_endpoint(&self.device)
+        let Self {
+            inner,
+            device,
+            lease,
+            ..
+        } = self;
+        lease
+            .require_endpoint(device)
             .map_err(std::io::Error::other)?;
-        v4l::io::traits::CaptureStream::next(
-            self.inner.as_mut().expect("stream taken only in Drop"),
-        )
+        let frame = v4l::io::traits::CaptureStream::next(
+            inner.as_mut().expect("stream taken only in Drop"),
+        )?;
+        lease
+            .require_endpoint(device)
+            .map_err(std::io::Error::other)?;
+        Ok(frame)
     }
 }
 

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -558,6 +558,32 @@ impl SnapshotSource for SysfsSnapshotSource {
             let name = entry.file_name();
             let devnode = PathBuf::from("/dev").join(&name);
             let devnode_text = devnode.to_string_lossy().into_owned();
+            // v4l2loopback class entries are themselves symlinks into this virtual
+            // subtree and have no UVC-style `videoN/device` child. Both checks are
+            // required: the root-controlled exact-path escape and canonical virtual
+            // ancestry. Production physical/non-UVC nodes still take the path below.
+            let class_target = match std::fs::canonicalize(entry.path()) {
+                Ok(target) => target,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(LifecycleError::Snapshot(error.to_string())),
+            };
+            if crate::virtual_camera_allowed(&devnode_text)
+                && class_target.parent().is_some_and(|parent| {
+                    parent.ends_with(Path::new("devices/virtual/video4linux"))
+                })
+            {
+                let virtual_devpath =
+                    format!("/devices/virtual/video4linux/{}", name.to_string_lossy());
+                records.push(UdevNodeRecord {
+                    usb_devpath: "/devices/virtual/video4linux/irlume-test-camera".to_string(),
+                    serial: None,
+                    node_devpath: virtual_devpath,
+                    interface_number: None,
+                    capture_node: None,
+                    devnode: devnode_text,
+                });
+                continue;
+            }
             let interface = match std::fs::canonicalize(entry.path().join("device")) {
                 Ok(interface) => interface,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
@@ -567,18 +593,6 @@ impl SnapshotSource for SysfsSnapshotSource {
             let is_uvc = driver.as_deref().and_then(Path::file_name)
                 == Some(std::ffi::OsStr::new("uvcvideo"));
             if !is_uvc {
-                if crate::virtual_camera_allowed(&devnode_text) {
-                    let virtual_devpath =
-                        format!("/devices/virtual/video4linux/{}", name.to_string_lossy());
-                    records.push(UdevNodeRecord {
-                        usb_devpath: "/devices/virtual/video4linux/irlume-test-camera".to_string(),
-                        serial: None,
-                        node_devpath: virtual_devpath,
-                        interface_number: None,
-                        capture_node: crate::media_graph::node_is_capture(&devnode_text),
-                        devnode: devnode_text,
-                    });
-                }
                 continue;
             }
             let usb = usb_device_parent(&interface).ok_or_else(|| {
@@ -1093,20 +1107,13 @@ mod tests {
         let rgb = root.join("devices/virtual/video4linux/video8");
         let ir = root.join("devices/virtual/video4linux/video9");
         let excluded = root.join("devices/virtual/video4linux/video10");
-        let driver = root.join("drivers/v4l2loopback");
-        std::fs::create_dir_all(root.join("class/video4linux/video8")).unwrap();
-        std::fs::create_dir_all(root.join("class/video4linux/video9")).unwrap();
-        std::fs::create_dir_all(root.join("class/video4linux/video10")).unwrap();
+        std::fs::create_dir_all(root.join("class/video4linux")).unwrap();
         std::fs::create_dir_all(&rgb).unwrap();
         std::fs::create_dir_all(&ir).unwrap();
         std::fs::create_dir_all(&excluded).unwrap();
-        std::fs::create_dir_all(&driver).unwrap();
-        symlink(&rgb, root.join("class/video4linux/video8/device")).unwrap();
-        symlink(&ir, root.join("class/video4linux/video9/device")).unwrap();
-        symlink(&excluded, root.join("class/video4linux/video10/device")).unwrap();
-        symlink(&driver, rgb.join("driver")).unwrap();
-        symlink(&driver, ir.join("driver")).unwrap();
-        symlink(&driver, excluded.join("driver")).unwrap();
+        symlink(&rgb, root.join("class/video4linux/video8")).unwrap();
+        symlink(&ir, root.join("class/video4linux/video9")).unwrap();
+        symlink(&excluded, root.join("class/video4linux/video10")).unwrap();
         let _allow = crate::testenv::EnvGuard::set(
             "IRLUME_TEST_ALLOW_VIRTUAL_CAMERA",
             "/dev/video8,/dev/video9",

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -4,14 +4,15 @@
 //! Persistent udev lifecycle invalidation for the supervisor inventory.
 //!
 //! Udev messages are deliberately treated only as hints. Every published state
-//! comes from a complete sysfs/udev snapshot taken after the monitor is already
+//! comes from a complete sysfs/media snapshot taken after the monitor is already
 //! listening. Neither enumeration nor monitoring opens a video node.
 
-use std::collections::BTreeMap;
 #[cfg(test)]
 use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::os::fd::AsRawFd as _;
+use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::Mutex;
 use std::sync::Weak;
@@ -22,6 +23,8 @@ use crate::contracts::{BackendKind, CameraCapabilities, PhysicalCameraId};
 use crate::inventory::{CameraInventoryError, CameraInventoryEvent, CameraObservation};
 
 const MAX_QUIET_SNAPSHOT_ATTEMPTS: usize = 4;
+const MAX_COALESCE_POLLS: usize = 16;
+const MAX_EVENTS_PER_POLL: usize = 4096;
 const COALESCE_QUIET: Duration = Duration::from_millis(50);
 const MONITOR_WAIT: Duration = Duration::from_secs(60 * 60);
 
@@ -35,6 +38,7 @@ pub(crate) enum DeviceEventKind {
 pub(crate) struct DeviceEventHint {
     kind: DeviceEventKind,
     devpath: String,
+    affected_topologies: BTreeSet<String>,
 }
 
 impl DeviceEventHint {
@@ -43,14 +47,36 @@ impl DeviceEventHint {
         Self {
             kind,
             devpath: devpath.into(),
+            affected_topologies: BTreeSet::new(),
         }
     }
 
-    fn from_udev(kind: DeviceEventKind, devpath: impl Into<String>) -> Self {
+    fn from_udev(
+        kind: DeviceEventKind,
+        devpath: impl Into<String>,
+        tracked_topologies: &BTreeSet<String>,
+    ) -> Self {
+        let devpath = devpath.into();
+        let affected_topologies = tracked_topologies
+            .iter()
+            .filter(|topology| {
+                devpath == topology.as_str()
+                    || devpath.starts_with(&format!("{topology}/"))
+                    || topology.starts_with(&format!("{devpath}/"))
+            })
+            .cloned()
+            .collect();
         Self {
             kind,
-            devpath: devpath.into(),
+            devpath,
+            affected_topologies,
         }
+    }
+
+    #[cfg(test)]
+    fn with_affected_topology(mut self, topology: impl Into<String>) -> Self {
+        self.affected_topologies.insert(topology.into());
+        self
     }
 
     fn kind(&self) -> DeviceEventKind {
@@ -64,11 +90,15 @@ impl DeviceEventHint {
     fn requires_retirement(&self) -> bool {
         self.kind == DeviceEventKind::ContinuityLost
     }
+
+    fn affected_topologies(&self) -> &BTreeSet<String> {
+        &self.affected_topologies
+    }
 }
 
 fn consume_hints(hints: &[DeviceEventHint]) {
     for hint in hints {
-        let _ = (hint.kind(), hint.devpath());
+        let _ = (hint.kind(), hint.devpath(), hint.affected_topologies());
     }
 }
 
@@ -77,6 +107,7 @@ pub(crate) enum LifecycleError {
     Monitor(String),
     Snapshot(String),
     UnstableSnapshot,
+    EventStorm,
     Inventory(CameraInventoryError),
 }
 
@@ -86,6 +117,7 @@ impl fmt::Display for LifecycleError {
             Self::Monitor(message) => write!(f, "udev monitor failed: {message}"),
             Self::Snapshot(message) => write!(f, "camera snapshot failed: {message}"),
             Self::UnstableSnapshot => f.write_str("camera snapshot never became quiet"),
+            Self::EventStorm => f.write_str("camera lifecycle event storm exceeded bounds"),
             Self::Inventory(error) => write!(f, "camera inventory failed: {error:?}"),
         }
     }
@@ -93,6 +125,10 @@ impl fmt::Display for LifecycleError {
 
 trait DeviceEventSource {
     fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError>;
+
+    fn add_tracked_topologies(&mut self, _topologies: &[String]) {}
+
+    fn commit_tracked_topologies(&mut self, _topologies: &[String]) {}
 }
 
 trait SnapshotSource {
@@ -102,10 +138,28 @@ trait SnapshotSource {
 trait InventorySink {
     fn invalidate_all(&self) -> Result<(), CameraInventoryError>;
 
+    fn invalidate_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<(), CameraInventoryError>;
+
+    fn retire_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
+
     fn reconcile(
         &self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
+
+    fn reconcile_guarded<F>(
+        &self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnMut() -> bool;
 }
 
 impl InventorySink for CameraSupervisor {
@@ -113,11 +167,36 @@ impl InventorySink for CameraSupervisor {
         self.invalidate_inventory()
     }
 
+    fn invalidate_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<(), CameraInventoryError> {
+        self.invalidate_inventory_topologies(topologies)
+    }
+
+    fn retire_topologies(
+        &self,
+        topologies: &BTreeSet<String>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        self.retire_inventory_topologies(topologies)
+    }
+
     fn reconcile(
         &self,
         observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
         self.reconcile_inventory(observations)
+    }
+
+    fn reconcile_guarded<F>(
+        &self,
+        observations: Vec<CameraObservation>,
+        quiet: F,
+    ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+    where
+        F: FnMut() -> bool,
+    {
+        self.reconcile_inventory_guarded(observations, quiet)
     }
 }
 
@@ -155,15 +234,22 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
 
         // A message only invalidates the old view. Drain the burst, then rebuild
         // from one authoritative snapshot; event payloads never mutate inventory.
-        loop {
+        let mut quiet = false;
+        for _ in 0..MAX_COALESCE_POLLS {
             match self.events.poll(COALESCE_QUIET) {
-                Ok(events) if events.is_empty() => break,
+                Ok(events) if events.is_empty() => {
+                    quiet = true;
+                    break;
+                }
                 Ok(events) => {
                     consume_hints(&events);
                     pending.extend(self.prepare_rescan(inventory, &events)?);
                 }
                 Err(error) => return Err(fail_closed(inventory, error)),
             }
+        }
+        if !quiet {
+            return Err(fail_closed(inventory, LifecycleError::EventStorm));
         }
         self.publish_quiet_snapshot(inventory, pending)
     }
@@ -178,11 +264,39 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
                 Ok(observations) => observations,
                 Err(error) => return Err(fail_closed(inventory, error)),
             };
-            match self.events.poll(Duration::ZERO) {
+            let topologies: Vec<String> = observations
+                .iter()
+                .map(|observation| observation.physical_id().topology_path().to_owned())
+                .collect();
+            self.events.add_tracked_topologies(&topologies);
+            match self.events.poll(COALESCE_QUIET) {
                 Ok(events) if events.is_empty() => {
-                    let mut published = inventory
-                        .reconcile(observations)
+                    let mut boundary_events = Vec::new();
+                    let mut boundary_error = None;
+                    let (mut published, committed) = inventory
+                        .reconcile_guarded(observations, || {
+                            match self.events.poll(Duration::ZERO) {
+                                Ok(events) if events.is_empty() => true,
+                                Ok(events) => {
+                                    boundary_events.extend(events);
+                                    false
+                                }
+                                Err(error) => {
+                                    boundary_error = Some(error);
+                                    false
+                                }
+                            }
+                        })
                         .map_err(LifecycleError::Inventory)?;
+                    if let Some(error) = boundary_error {
+                        return Err(fail_closed(inventory, error));
+                    }
+                    if !committed {
+                        consume_hints(&boundary_events);
+                        pending.extend(self.prepare_rescan(inventory, &boundary_events)?);
+                        continue;
+                    }
+                    self.events.commit_tracked_topologies(&topologies);
                     pending.append(&mut published);
                     return Ok(pending);
                 }
@@ -202,15 +316,21 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
         inventory: &impl InventorySink,
         hints: &[DeviceEventHint],
     ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        let affected: BTreeSet<String> = hints
+            .iter()
+            .flat_map(|hint| hint.affected_topologies().iter().cloned())
+            .collect();
         inventory
-            .invalidate_all()
+            .invalidate_topologies(&affected)
             .map_err(LifecycleError::Inventory)?;
-        if hints.iter().any(DeviceEventHint::requires_retirement) {
-            return inventory
-                .reconcile(Vec::new())
-                .map_err(LifecycleError::Inventory);
-        }
-        Ok(Vec::new())
+        let retired: BTreeSet<String> = hints
+            .iter()
+            .filter(|hint| hint.requires_retirement())
+            .flat_map(|hint| hint.affected_topologies().iter().cloned())
+            .collect();
+        inventory
+            .retire_topologies(&retired)
+            .map_err(LifecycleError::Inventory)
     }
 }
 
@@ -223,17 +343,53 @@ fn fail_closed(inventory: &impl InventorySink, error: LifecycleError) -> Lifecyc
 
 struct UdevEventSource {
     socket: udev::MonitorSocket,
+    tracked_topologies: BTreeSet<String>,
 }
 
 impl UdevEventSource {
     fn new() -> Result<Self, LifecycleError> {
         // Do not filter to video4linux: USB parent/interface bind, unbind and
         // reset events are continuity evidence even when no child event exists.
-        let socket = udev::MonitorBuilder::new()
+        // SEQNUM is deliberately not used as loss evidence: it is global across
+        // namespace-targeted uevents and assigned before kernel broadcast order.
+        // Observable socket loss (ENOBUFS/errors/hangup) is the fail-closed signal.
+        let socket = udev::MonitorBuilder::new_kernel()
             .and_then(udev::MonitorBuilder::listen)
             .map_err(|error| LifecycleError::Monitor(error.to_string()))?;
-        Ok(Self { socket })
+        Ok(Self {
+            socket,
+            tracked_topologies: BTreeSet::new(),
+        })
     }
+}
+
+fn classify_kernel_event(
+    subsystem: Option<&str>,
+    interface: Option<&str>,
+    modalias: Option<&str>,
+    devtype: Option<&str>,
+    tracked_usb_parent: bool,
+    event_type: udev::EventType,
+) -> Option<DeviceEventKind> {
+    if subsystem == Some("video4linux") {
+        return Some(if event_type == udev::EventType::Change {
+            DeviceEventKind::DirtyUvc
+        } else {
+            DeviceEventKind::ContinuityLost
+        });
+    }
+    if subsystem != Some("usb") {
+        return None;
+    }
+    let uvc_interface = interface.is_some_and(|value| {
+        value.starts_with("14/") || value.to_ascii_lowercase().starts_with("0e/")
+    }) || modalias
+        .is_some_and(|value| value.to_ascii_lowercase().contains("ic0e"));
+    let usb_parent = devtype == Some("usb_device") && tracked_usb_parent;
+    if !uvc_interface && !usb_parent {
+        return None;
+    }
+    Some(DeviceEventKind::ContinuityLost)
 }
 
 impl DeviceEventSource for UdevEventSource {
@@ -258,32 +414,58 @@ impl DeviceEventSource for UdevEventSource {
         }
 
         let mut hints = Vec::new();
-        for event in self.socket.iter() {
-            let subsystem = event.subsystem().and_then(std::ffi::OsStr::to_str);
-            let is_uvc_usb = subsystem == Some("usb")
-                && (event.driver().and_then(std::ffi::OsStr::to_str) == Some("uvcvideo")
-                    || event
-                        .property_value("ID_USB_DRIVER")
-                        .and_then(std::ffi::OsStr::to_str)
-                        == Some("uvcvideo")
-                    || event
-                        .property_value("ID_USB_INTERFACES")
-                        .and_then(std::ffi::OsStr::to_str)
-                        .is_some_and(|interfaces| interfaces.contains(":0e")));
-            if subsystem != Some("video4linux") && !is_uvc_usb {
-                continue;
+        let mut received = 0;
+        let mut events = self.socket.iter();
+        while let Some(event) = next_monitor_event(&mut events)? {
+            received += 1;
+            if received > MAX_EVENTS_PER_POLL {
+                return Err(LifecycleError::EventStorm);
             }
-            let kind = match event.event_type() {
-                udev::EventType::Change => DeviceEventKind::DirtyUvc,
-                _ => DeviceEventKind::ContinuityLost,
+            let devpath = event.devpath().to_string_lossy();
+            let tracked_usb_parent = self.tracked_topologies.contains(devpath.as_ref());
+            let text = |name| event.property_value(name).and_then(std::ffi::OsStr::to_str);
+            let Some(kind) = classify_kernel_event(
+                event.subsystem().and_then(std::ffi::OsStr::to_str),
+                text("INTERFACE"),
+                text("MODALIAS"),
+                text("DEVTYPE"),
+                tracked_usb_parent,
+                event.event_type(),
+            ) else {
+                continue;
             };
             hints.push(DeviceEventHint::from_udev(
                 kind,
                 event.devpath().to_string_lossy(),
+                &self.tracked_topologies,
             ));
         }
-        ensure_receive_drained(std::io::Error::last_os_error().raw_os_error())?;
         Ok(hints)
+    }
+
+    fn add_tracked_topologies(&mut self, topologies: &[String]) {
+        self.tracked_topologies.extend(topologies.iter().cloned());
+    }
+
+    fn commit_tracked_topologies(&mut self, topologies: &[String]) {
+        self.tracked_topologies = topologies.iter().cloned().collect();
+    }
+}
+
+fn set_errno(errno: i32) {
+    // SAFETY: Linux exposes one thread-local errno cell per calling thread.
+    unsafe { *libc::__errno_location() = errno };
+}
+
+fn next_monitor_event<I: Iterator>(iterator: &mut I) -> Result<Option<I::Item>, LifecycleError> {
+    set_errno(0);
+    match iterator.next() {
+        Some(event) => Ok(Some(event)),
+        None => {
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            ensure_receive_drained(errno)?;
+            Ok(None)
+        }
     }
 }
 
@@ -314,61 +496,81 @@ fn ensure_receive_drained(errno: Option<i32>) -> Result<(), LifecycleError> {
     }
 }
 
-#[derive(Default)]
-struct UdevSnapshotSource;
+struct SysfsSnapshotSource {
+    root: PathBuf,
+}
+
+impl Default for SysfsSnapshotSource {
+    fn default() -> Self {
+        Self {
+            root: PathBuf::from("/sys/class/video4linux"),
+        }
+    }
+}
 
 #[derive(Debug)]
 struct UdevNodeRecord {
     usb_devpath: String,
     serial: Option<String>,
     node_devpath: String,
-    devnode: Option<String>,
+    devnode: String,
     interface_number: Option<String>,
-    v4l_capabilities: Option<String>,
+    capture_node: Option<bool>,
 }
 
-impl SnapshotSource for UdevSnapshotSource {
-    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
-        let mut enumerator =
-            udev::Enumerator::new().map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
-        enumerator
-            .match_subsystem("video4linux")
-            .and_then(|()| enumerator.match_is_initialized())
-            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
-        let devices = enumerator
-            .scan_devices()
-            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+fn read_trimmed(path: impl AsRef<Path>) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
 
+fn devpath(path: &Path) -> String {
+    match path.strip_prefix("/sys") {
+        Ok(relative) => format!("/{}", relative.to_string_lossy()),
+        Err(_) => path.to_string_lossy().into_owned(),
+    }
+}
+
+fn usb_device_parent(interface: &Path) -> Option<&Path> {
+    interface
+        .ancestors()
+        .find(|path| path.join("idVendor").is_file() && path.join("idProduct").is_file())
+}
+
+impl SnapshotSource for SysfsSnapshotSource {
+    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(LifecycleError::Snapshot(error.to_string())),
+        };
         let mut records = Vec::new();
-        for device in devices {
-            if device.property_value("ID_USB_DRIVER") != Some(std::ffi::OsStr::new("uvcvideo")) {
+        for entry in entries {
+            let entry = entry.map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+            let interface = std::fs::canonicalize(entry.path().join("device"))
+                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+            let driver = std::fs::canonicalize(interface.join("driver")).ok();
+            if driver.as_deref().and_then(Path::file_name) != Some(std::ffi::OsStr::new("uvcvideo"))
+            {
                 continue;
             }
-            let usb = device
-                .parent_with_subsystem_devtype("usb", "usb_device")
-                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?
-                .ok_or_else(|| {
-                    LifecycleError::Snapshot(format!(
-                        "{} has uvcvideo but no USB-device parent",
-                        device.devpath().to_string_lossy()
-                    ))
-                })?;
+            let usb = usb_device_parent(&interface).ok_or_else(|| {
+                LifecycleError::Snapshot(format!(
+                    "{} has uvcvideo but no USB-device parent",
+                    interface.display()
+                ))
+            })?;
+            let name = entry.file_name();
+            let devnode = PathBuf::from("/dev").join(&name);
+            let devnode_text = devnode.to_string_lossy().into_owned();
             records.push(UdevNodeRecord {
-                usb_devpath: usb.devpath().to_string_lossy().into_owned(),
-                serial: usb
-                    .attribute_value("serial")
-                    .map(|value| value.to_string_lossy().trim().to_owned())
-                    .filter(|value| !value.is_empty()),
-                node_devpath: device.devpath().to_string_lossy().into_owned(),
-                devnode: device
-                    .devnode()
-                    .map(|path| path.to_string_lossy().into_owned()),
-                interface_number: device
-                    .property_value("ID_USB_INTERFACE_NUM")
-                    .map(|value| value.to_string_lossy().into_owned()),
-                v4l_capabilities: device
-                    .property_value("ID_V4L_CAPABILITIES")
-                    .map(|value| value.to_string_lossy().into_owned()),
+                usb_devpath: devpath(usb),
+                serial: read_trimmed(usb.join("serial")),
+                node_devpath: devpath(&interface),
+                interface_number: read_trimmed(interface.join("bInterfaceNumber")),
+                capture_node: crate::media_graph::node_is_capture(&devnode_text),
+                devnode: devnode_text,
             });
         }
         observations_from_records(records)
@@ -383,9 +585,13 @@ fn observations_from_records(
         let evidence = format!(
             "{}|{}|{}|{}",
             record.node_devpath,
-            record.devnode.as_deref().unwrap_or(""),
+            record.devnode,
             record.interface_number.as_deref().unwrap_or(""),
-            record.v4l_capabilities.as_deref().unwrap_or("")
+            match record.capture_node {
+                Some(true) => "capture",
+                Some(false) => "metadata",
+                None => "unknown",
+            }
         );
         let group = groups
             .entry(record.usb_devpath.clone())
@@ -422,18 +628,33 @@ fn bind_monitor_before_snapshot<S: SnapshotSource, E: DeviceEventSource>(
     Ok(LifecycleCoordinator::new(snapshots(), events))
 }
 
+struct WorkerExitGuard<'a, I: InventorySink>(&'a I);
+
+impl<'a, I: InventorySink> WorkerExitGuard<'a, I> {
+    fn new(inventory: &'a I) -> Self {
+        Self(inventory)
+    }
+}
+
+impl<I: InventorySink> Drop for WorkerExitGuard<'_, I> {
+    fn drop(&mut self) {
+        let _ = self.0.invalidate_all();
+    }
+}
+
 /// Start the production monitor before the first authoritative scan. The thread
 /// owns the monitor socket for the supervisor lifetime; dropping the process is
 /// the only normal shutdown path for this process-scoped inventory.
 pub(crate) fn spawn(supervisor: Weak<CameraSupervisor>) -> Result<(), LifecycleError> {
     let mut coordinator =
-        bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource)?;
+        bind_monitor_before_snapshot(UdevEventSource::new, SysfsSnapshotSource::default)?;
     std::thread::Builder::new()
         .name("irlume-camera-udev".into())
         .spawn(move || {
             let Some(supervisor) = supervisor.upgrade() else {
                 return;
             };
+            let _exit_guard = WorkerExitGuard::new(supervisor.as_ref());
             if let Err(error) = coordinator.initialize(supervisor.as_ref()) {
                 eprintln!("irlume: camera lifecycle monitor stopped: {error}");
                 return;
@@ -476,11 +697,40 @@ mod tests {
             Ok(())
         }
 
+        fn invalidate_topologies(
+            &self,
+            topologies: &BTreeSet<String>,
+        ) -> Result<(), CameraInventoryError> {
+            self.0.lock().unwrap().invalidate_topologies(topologies);
+            Ok(())
+        }
+
+        fn retire_topologies(
+            &self,
+            topologies: &BTreeSet<String>,
+        ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+            Ok(self.0.lock().unwrap().retire_topologies(topologies))
+        }
+
         fn reconcile(
             &self,
             observations: Vec<CameraObservation>,
         ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
             self.0.lock().unwrap().reconcile(observations)
+        }
+
+        fn reconcile_guarded<F>(
+            &self,
+            observations: Vec<CameraObservation>,
+            quiet: F,
+        ) -> Result<(Vec<CameraInventoryEvent>, bool), CameraInventoryError>
+        where
+            F: FnMut() -> bool,
+        {
+            self.0
+                .lock()
+                .unwrap()
+                .reconcile_guarded(observations, quiet)
         }
     }
 
@@ -501,16 +751,311 @@ mod tests {
     }
 
     fn observation(evidence: &str) -> CameraObservation {
+        observation_at("/devices/pci/usb1/camera", evidence)
+    }
+
+    fn observation_at(topology: &str, evidence: &str) -> CameraObservation {
         CameraObservation::with_lifecycle_evidence(
             BackendKind::UvcV4l2,
-            PhysicalCameraId::new("/devices/pci/usb1/camera", None).unwrap(),
+            PhysicalCameraId::new(topology, None).unwrap(),
             CameraCapabilities::new(vec![StreamRole::Rgb], Default::default(), Vec::new()).unwrap(),
             vec![evidence.into()],
         )
     }
 
     fn hint(kind: DeviceEventKind) -> DeviceEventHint {
-        DeviceEventHint::new(kind, "/devices/pci/usb1/video4linux/video0")
+        DeviceEventHint::new(kind, "/devices/pci/usb1/camera/video4linux/video0")
+            .with_affected_topology("/devices/pci/usb1/camera")
+    }
+
+    #[test]
+    fn iterator_null_preserves_real_receive_error() {
+        let result = next_monitor_event(&mut std::iter::from_fn(|| {
+            set_errno(libc::ENOBUFS);
+            None::<()>
+        }));
+        assert!(matches!(
+            result,
+            Err(LifecycleError::Monitor(message)) if message.contains("overflow")
+        ));
+    }
+
+    #[test]
+    fn usb_uvc_change_and_property_sparse_remove_retire_continuity() {
+        let change = classify_kernel_event(
+            Some("usb"),
+            Some("14/1/0"),
+            None,
+            Some("usb_interface"),
+            false,
+            udev::EventType::Change,
+        );
+        assert_eq!(change, Some(DeviceEventKind::ContinuityLost));
+
+        let remove = classify_kernel_event(
+            Some("usb"),
+            None,
+            Some("usb:v3277p0059d0001dcEFdsc02dp01ic0Eisc01ip00in00"),
+            Some("usb_interface"),
+            false,
+            udev::EventType::Remove,
+        );
+        assert_eq!(remove, Some(DeviceEventKind::ContinuityLost));
+        assert_eq!(
+            classify_kernel_event(
+                Some("video4linux"),
+                None,
+                None,
+                None,
+                false,
+                udev::EventType::Change,
+            ),
+            Some(DeviceEventKind::DirtyUvc)
+        );
+        assert_eq!(
+            classify_kernel_event(
+                Some("usb"),
+                None,
+                None,
+                Some("usb_device"),
+                false,
+                udev::EventType::Remove,
+            ),
+            None
+        );
+        assert_eq!(
+            classify_kernel_event(
+                Some("usb"),
+                None,
+                None,
+                Some("usb_device"),
+                true,
+                udev::EventType::Remove,
+            ),
+            Some(DeviceEventKind::ContinuityLost)
+        );
+    }
+
+    #[test]
+    fn commit_boundary_event_discards_provisional_snapshot_before_unlock() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("provisional")]),
+                Ok(vec![observation("committed")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        coordinator.initialize(&inventory).unwrap();
+        assert!(
+            coordinator.snapshots.0.is_empty(),
+            "event at the guarded post-commit drain must force a fresh snapshot"
+        );
+    }
+
+    #[test]
+    fn sustained_event_storm_is_bounded_and_fail_closed() {
+        let inventory = TestInventory::new();
+        let descriptor = inventory
+            .reconcile(vec![observation("published")])
+            .unwrap()
+            .remove(0)
+            .descriptor()
+            .clone();
+        let mut polls = VecDeque::from([Ok(vec![hint(DeviceEventKind::DirtyUvc)])]);
+        polls.extend((0..MAX_COALESCE_POLLS).map(|_| Ok(vec![hint(DeviceEventKind::DirtyUvc)])));
+        let mut coordinator =
+            LifecycleCoordinator::new(FakeSnapshots(VecDeque::new()), FakeEvents(polls));
+        assert_eq!(
+            coordinator.process_next(&inventory, Duration::ZERO),
+            Err(LifecycleError::EventStorm)
+        );
+        assert!(inventory.validate(&descriptor).is_err());
+    }
+
+    #[test]
+    fn boundary_event_preserves_unaffected_camera_identity_and_events() {
+        let inventory = TestInventory::new();
+        let camera_a = "/devices/pci/usb1/camera-a";
+        let camera_b = "/devices/pci/usb2/camera-b";
+        let seeded = inventory
+            .reconcile(vec![
+                observation_at(camera_a, "a-old"),
+                observation_at(camera_b, "b-stable"),
+            ])
+            .unwrap();
+        let old_a = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_a)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let old_b = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_b)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let dirty_a = DeviceEventHint::new(
+            DeviceEventKind::DirtyUvc,
+            format!("{camera_a}/video4linux/video0"),
+        )
+        .with_affected_topology(camera_a);
+        let loss_a = DeviceEventHint::new(
+            DeviceEventKind::ContinuityLost,
+            format!("{camera_a}/camera-a:1.0"),
+        )
+        .with_affected_topology(camera_a);
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![
+                    observation_at(camera_a, "a-old"),
+                    observation_at(camera_b, "b-stable"),
+                ]),
+                Ok(vec![
+                    observation_at(camera_a, "a-new"),
+                    observation_at(camera_b, "b-stable"),
+                ]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(vec![dirty_a]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(vec![loss_a]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let events = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert!(inventory.validate(&old_a).is_err());
+        assert_eq!(inventory.validate(&old_b), Ok(()));
+        assert!(events.iter().all(|event| event.topology_path() == camera_a));
+        assert_eq!(events.iter().filter(|event| event.is_removed()).count(), 1);
+        assert_eq!(events.iter().filter(|event| event.is_added()).count(), 1);
+    }
+
+    #[test]
+    fn one_camera_continuity_loss_does_not_retire_another_camera() {
+        let inventory = TestInventory::new();
+        let camera_a = "/devices/pci/usb1/camera-a";
+        let camera_b = "/devices/pci/usb2/camera-b";
+        let seeded = inventory
+            .reconcile(vec![
+                observation_at(camera_a, "a-old"),
+                observation_at(camera_b, "b-stable"),
+            ])
+            .unwrap();
+        let old_a = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_a)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let old_b = seeded
+            .iter()
+            .find(|event| event.topology_path() == camera_b)
+            .unwrap()
+            .descriptor()
+            .clone();
+        let loss_a = DeviceEventHint::new(
+            DeviceEventKind::ContinuityLost,
+            format!("{camera_a}/camera-a:1.0"),
+        )
+        .with_affected_topology(camera_a);
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([Ok(vec![
+                observation_at(camera_a, "a-new"),
+                observation_at(camera_b, "b-stable"),
+            ])])),
+            FakeEvents(VecDeque::from([
+                Ok(vec![loss_a]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert!(inventory.validate(&old_a).is_err());
+        assert_eq!(inventory.validate(&old_b), Ok(()));
+    }
+
+    #[test]
+    fn empty_startup_inventory_can_discover_a_later_hotplug() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![observation("hotplugged")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(vec![DeviceEventHint::new(
+                    DeviceEventKind::DirtyUvc,
+                    "/devices/pci/usb1/camera/video4linux/video0",
+                )]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        assert!(coordinator.initialize(&inventory).unwrap().is_empty());
+        let events = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_added());
+    }
+
+    #[test]
+    fn missing_video4linux_class_is_an_authoritative_empty_snapshot() {
+        let root =
+            std::env::temp_dir().join(format!("irlume-missing-video4linux-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let mut source = SysfsSnapshotSource { root };
+        assert_eq!(source.snapshot(), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn worker_exit_guard_retires_published_inventory() {
+        let inventory = TestInventory::new();
+        let descriptor = inventory
+            .reconcile(vec![observation("published")])
+            .unwrap()
+            .remove(0)
+            .descriptor()
+            .clone();
+        {
+            let _guard = WorkerExitGuard::new(&inventory);
+        }
+        assert!(inventory.validate(&descriptor).is_err());
+    }
+
+    #[test]
+    fn snapshot_requires_a_real_quiet_interval_before_publish() {
+        struct RecordingEvents(std::sync::Arc<Mutex<Vec<Duration>>>);
+        impl DeviceEventSource for RecordingEvents {
+            fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError> {
+                self.0.lock().unwrap().push(timeout);
+                Ok(Vec::new())
+            }
+        }
+        let waits = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([Ok(vec![observation("quiet")])])),
+            RecordingEvents(waits.clone()),
+        );
+        coordinator.initialize(&TestInventory::new()).unwrap();
+        assert_eq!(*waits.lock().unwrap(), [COALESCE_QUIET, Duration::ZERO]);
     }
 
     #[test]
@@ -559,6 +1104,7 @@ mod tests {
             FakeEvents(VecDeque::from([
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
                 Ok(Vec::new()),
+                Ok(Vec::new()),
             ])),
         );
 
@@ -581,8 +1127,10 @@ mod tests {
             ])),
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
                 Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(Vec::new()),
             ])),
@@ -641,7 +1189,9 @@ mod tests {
             },
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(Vec::new()),
             ])),
@@ -665,8 +1215,10 @@ mod tests {
             ])),
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(Vec::new()),
             ])),
@@ -706,6 +1258,7 @@ mod tests {
             FakeSnapshots(VecDeque::from([Ok(vec![observation("video0")])])),
             FakeEvents(VecDeque::from([
                 Ok(Vec::new()),
+                Ok(Vec::new()),
                 Err(LifecycleError::Monitor(message.into())),
             ])),
         );
@@ -729,6 +1282,7 @@ mod tests {
                 Err(LifecycleError::Snapshot("sysfs race".into())),
             ])),
             FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
                 Ok(Vec::new()),
                 Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
                 Ok(Vec::new()),
@@ -803,7 +1357,8 @@ mod tests {
 
         let inventory = TestInventory::new();
         let mut coordinator =
-            bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource).unwrap();
+            bind_monitor_before_snapshot(UdevEventSource::new, SysfsSnapshotSource::default)
+                .unwrap();
         let initial = coordinator.initialize(&inventory).unwrap();
         let original = initial
             .iter()
@@ -861,7 +1416,7 @@ mod tests {
     #[test]
     #[ignore = "requires a real initialized UVC camera in udev"]
     fn production_snapshot_matches_shinetech_four_node_topology_without_capture() {
-        let observations = UdevSnapshotSource.snapshot().unwrap();
+        let observations = SysfsSnapshotSource::default().snapshot().unwrap();
         let camera = observations
             .iter()
             .find(|observation| observation.physical_id().serial() == Some("200901010001"))
@@ -871,11 +1426,11 @@ mod tests {
         assert!(camera
             .lifecycle_evidence()
             .iter()
-            .any(|evidence| evidence.contains("video0") && evidence.ends_with(":capture:")));
+            .any(|evidence| evidence.contains("/dev/video0") && evidence.ends_with("|capture")));
         assert!(camera
             .lifecycle_evidence()
             .iter()
-            .any(|evidence| evidence.contains("video3") && evidence.ends_with("|:")));
+            .any(|evidence| evidence.contains("/dev/video3") && evidence.ends_with("|metadata")));
     }
 
     #[test]
@@ -885,17 +1440,17 @@ mod tests {
                 usb_devpath: "/devices/pci/usb1/camera".into(),
                 serial: Some("serial".into()),
                 node_devpath: "/devices/pci/usb1/camera/1.2/video2".into(),
-                devnode: Some("/dev/video2".into()),
+                devnode: "/dev/video2".into(),
                 interface_number: Some("02".into()),
-                v4l_capabilities: Some(":capture:".into()),
+                capture_node: Some(true),
             },
             UdevNodeRecord {
                 usb_devpath: "/devices/pci/usb1/camera".into(),
                 serial: Some("serial".into()),
                 node_devpath: "/devices/pci/usb1/camera/1.0/video0".into(),
-                devnode: Some("/dev/video0".into()),
+                devnode: "/dev/video0".into(),
                 interface_number: Some("00".into()),
-                v4l_capabilities: Some(":capture:".into()),
+                capture_node: Some(true),
             },
         ];
         let observations = observations_from_records(records).unwrap();

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -1,0 +1,909 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Persistent udev lifecycle invalidation for the supervisor inventory.
+//!
+//! Udev messages are deliberately treated only as hints. Every published state
+//! comes from a complete sysfs/udev snapshot taken after the monitor is already
+//! listening. Neither enumeration nor monitoring opens a video node.
+
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::fmt;
+use std::os::fd::AsRawFd as _;
+#[cfg(test)]
+use std::sync::Mutex;
+use std::sync::Weak;
+use std::time::Duration;
+
+use crate::backend::CameraSupervisor;
+use crate::contracts::{BackendKind, CameraCapabilities, PhysicalCameraId};
+use crate::inventory::{CameraInventoryError, CameraInventoryEvent, CameraObservation};
+
+const MAX_QUIET_SNAPSHOT_ATTEMPTS: usize = 4;
+const COALESCE_QUIET: Duration = Duration::from_millis(50);
+const MONITOR_WAIT: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DeviceEventKind {
+    DirtyUvc,
+    ContinuityLost,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DeviceEventHint {
+    kind: DeviceEventKind,
+    devpath: String,
+}
+
+impl DeviceEventHint {
+    #[cfg(test)]
+    fn new(kind: DeviceEventKind, devpath: impl Into<String>) -> Self {
+        Self {
+            kind,
+            devpath: devpath.into(),
+        }
+    }
+
+    fn from_udev(kind: DeviceEventKind, devpath: impl Into<String>) -> Self {
+        Self {
+            kind,
+            devpath: devpath.into(),
+        }
+    }
+
+    fn kind(&self) -> DeviceEventKind {
+        self.kind
+    }
+
+    fn devpath(&self) -> &str {
+        &self.devpath
+    }
+
+    fn requires_retirement(&self) -> bool {
+        self.kind == DeviceEventKind::ContinuityLost
+    }
+}
+
+fn consume_hints(hints: &[DeviceEventHint]) {
+    for hint in hints {
+        let _ = (hint.kind(), hint.devpath());
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum LifecycleError {
+    Monitor(String),
+    Snapshot(String),
+    UnstableSnapshot,
+    Inventory(CameraInventoryError),
+}
+
+impl fmt::Display for LifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Monitor(message) => write!(f, "udev monitor failed: {message}"),
+            Self::Snapshot(message) => write!(f, "camera snapshot failed: {message}"),
+            Self::UnstableSnapshot => f.write_str("camera snapshot never became quiet"),
+            Self::Inventory(error) => write!(f, "camera inventory failed: {error:?}"),
+        }
+    }
+}
+
+trait DeviceEventSource {
+    fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError>;
+}
+
+trait SnapshotSource {
+    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError>;
+}
+
+trait InventorySink {
+    fn invalidate_all(&self) -> Result<(), CameraInventoryError>;
+
+    fn reconcile(
+        &self,
+        observations: Vec<CameraObservation>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
+}
+
+impl InventorySink for CameraSupervisor {
+    fn invalidate_all(&self) -> Result<(), CameraInventoryError> {
+        self.invalidate_inventory()
+    }
+
+    fn reconcile(
+        &self,
+        observations: Vec<CameraObservation>,
+    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+        self.reconcile_inventory(observations)
+    }
+}
+
+struct LifecycleCoordinator<S, E> {
+    snapshots: S,
+    events: E,
+}
+
+impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
+    fn new(snapshots: S, events: E) -> Self {
+        Self { snapshots, events }
+    }
+
+    fn initialize(
+        &mut self,
+        inventory: &impl InventorySink,
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        self.publish_quiet_snapshot(inventory, Vec::new())
+    }
+
+    fn process_next(
+        &mut self,
+        inventory: &impl InventorySink,
+        wait: Duration,
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        let first = match self.events.poll(wait) {
+            Ok(events) => events,
+            Err(error) => return Err(fail_closed(inventory, error)),
+        };
+        if first.is_empty() {
+            return Ok(Vec::new());
+        }
+        consume_hints(&first);
+        let mut pending = self.prepare_rescan(inventory, &first)?;
+
+        // A message only invalidates the old view. Drain the burst, then rebuild
+        // from one authoritative snapshot; event payloads never mutate inventory.
+        loop {
+            match self.events.poll(COALESCE_QUIET) {
+                Ok(events) if events.is_empty() => break,
+                Ok(events) => {
+                    consume_hints(&events);
+                    pending.extend(self.prepare_rescan(inventory, &events)?);
+                }
+                Err(error) => return Err(fail_closed(inventory, error)),
+            }
+        }
+        self.publish_quiet_snapshot(inventory, pending)
+    }
+
+    fn publish_quiet_snapshot(
+        &mut self,
+        inventory: &impl InventorySink,
+        mut pending: Vec<CameraInventoryEvent>,
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        for _ in 0..MAX_QUIET_SNAPSHOT_ATTEMPTS {
+            let observations = match self.snapshots.snapshot() {
+                Ok(observations) => observations,
+                Err(error) => return Err(fail_closed(inventory, error)),
+            };
+            match self.events.poll(Duration::ZERO) {
+                Ok(events) if events.is_empty() => {
+                    let mut published = inventory
+                        .reconcile(observations)
+                        .map_err(LifecycleError::Inventory)?;
+                    pending.append(&mut published);
+                    return Ok(pending);
+                }
+                Ok(events) => {
+                    consume_hints(&events);
+                    pending.extend(self.prepare_rescan(inventory, &events)?);
+                    continue;
+                }
+                Err(error) => return Err(fail_closed(inventory, error)),
+            }
+        }
+        Err(fail_closed(inventory, LifecycleError::UnstableSnapshot))
+    }
+
+    fn prepare_rescan(
+        &self,
+        inventory: &impl InventorySink,
+        hints: &[DeviceEventHint],
+    ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        inventory
+            .invalidate_all()
+            .map_err(LifecycleError::Inventory)?;
+        if hints.iter().any(DeviceEventHint::requires_retirement) {
+            return inventory
+                .reconcile(Vec::new())
+                .map_err(LifecycleError::Inventory);
+        }
+        Ok(Vec::new())
+    }
+}
+
+fn fail_closed(inventory: &impl InventorySink, error: LifecycleError) -> LifecycleError {
+    match inventory.reconcile(Vec::new()) {
+        Ok(_) => error,
+        Err(inventory_error) => LifecycleError::Inventory(inventory_error),
+    }
+}
+
+struct UdevEventSource {
+    socket: udev::MonitorSocket,
+}
+
+impl UdevEventSource {
+    fn new() -> Result<Self, LifecycleError> {
+        // Do not filter to video4linux: USB parent/interface bind, unbind and
+        // reset events are continuity evidence even when no child event exists.
+        let socket = udev::MonitorBuilder::new()
+            .and_then(udev::MonitorBuilder::listen)
+            .map_err(|error| LifecycleError::Monitor(error.to_string()))?;
+        Ok(Self { socket })
+    }
+}
+
+impl DeviceEventSource for UdevEventSource {
+    fn poll(&mut self, timeout: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError> {
+        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        let mut descriptor = libc::pollfd {
+            fd: self.socket.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: descriptor points to one initialized pollfd for the duration
+        // of the call; poll does not retain it.
+        let ready = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
+        if ready < 0 {
+            return Err(LifecycleError::Monitor(
+                std::io::Error::last_os_error().to_string(),
+            ));
+        }
+        ensure_monitor_healthy(descriptor.revents)?;
+        if ready == 0 || descriptor.revents & libc::POLLIN == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut hints = Vec::new();
+        for event in self.socket.iter() {
+            let subsystem = event.subsystem().and_then(std::ffi::OsStr::to_str);
+            let is_uvc_usb = subsystem == Some("usb")
+                && (event.driver().and_then(std::ffi::OsStr::to_str) == Some("uvcvideo")
+                    || event
+                        .property_value("ID_USB_DRIVER")
+                        .and_then(std::ffi::OsStr::to_str)
+                        == Some("uvcvideo")
+                    || event
+                        .property_value("ID_USB_INTERFACES")
+                        .and_then(std::ffi::OsStr::to_str)
+                        .is_some_and(|interfaces| interfaces.contains(":0e")));
+            if subsystem != Some("video4linux") && !is_uvc_usb {
+                continue;
+            }
+            let kind = match event.event_type() {
+                udev::EventType::Change => DeviceEventKind::DirtyUvc,
+                _ => DeviceEventKind::ContinuityLost,
+            };
+            hints.push(DeviceEventHint::from_udev(
+                kind,
+                event.devpath().to_string_lossy(),
+            ));
+        }
+        ensure_receive_drained(std::io::Error::last_os_error().raw_os_error())?;
+        Ok(hints)
+    }
+}
+
+fn ensure_monitor_healthy(revents: libc::c_short) -> Result<(), LifecycleError> {
+    if revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        return Err(LifecycleError::Monitor("udev monitor socket lost".into()));
+    }
+    Ok(())
+}
+
+fn ensure_receive_drained(errno: Option<i32>) -> Result<(), LifecycleError> {
+    if errno == Some(libc::EAGAIN) || errno == Some(libc::EWOULDBLOCK) {
+        return Ok(());
+    }
+    if errno == Some(libc::ENOBUFS) {
+        return Err(LifecycleError::Monitor(
+            "udev monitor receive buffer overflow".into(),
+        ));
+    }
+    match errno {
+        Some(errno) => Err(LifecycleError::Monitor(format!(
+            "udev monitor receive failed: {}",
+            std::io::Error::from_raw_os_error(errno)
+        ))),
+        None => Err(LifecycleError::Monitor(
+            "udev monitor receive failed without errno".into(),
+        )),
+    }
+}
+
+#[derive(Default)]
+struct UdevSnapshotSource;
+
+#[derive(Debug)]
+struct UdevNodeRecord {
+    usb_devpath: String,
+    serial: Option<String>,
+    node_devpath: String,
+    devnode: Option<String>,
+    interface_number: Option<String>,
+    v4l_capabilities: Option<String>,
+}
+
+impl SnapshotSource for UdevSnapshotSource {
+    fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+        let mut enumerator =
+            udev::Enumerator::new().map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+        enumerator
+            .match_subsystem("video4linux")
+            .and_then(|()| enumerator.match_is_initialized())
+            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+        let devices = enumerator
+            .scan_devices()
+            .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+
+        let mut records = Vec::new();
+        for device in devices {
+            if device.property_value("ID_USB_DRIVER") != Some(std::ffi::OsStr::new("uvcvideo")) {
+                continue;
+            }
+            let usb = device
+                .parent_with_subsystem_devtype("usb", "usb_device")
+                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?
+                .ok_or_else(|| {
+                    LifecycleError::Snapshot(format!(
+                        "{} has uvcvideo but no USB-device parent",
+                        device.devpath().to_string_lossy()
+                    ))
+                })?;
+            records.push(UdevNodeRecord {
+                usb_devpath: usb.devpath().to_string_lossy().into_owned(),
+                serial: usb
+                    .attribute_value("serial")
+                    .map(|value| value.to_string_lossy().trim().to_owned())
+                    .filter(|value| !value.is_empty()),
+                node_devpath: device.devpath().to_string_lossy().into_owned(),
+                devnode: device
+                    .devnode()
+                    .map(|path| path.to_string_lossy().into_owned()),
+                interface_number: device
+                    .property_value("ID_USB_INTERFACE_NUM")
+                    .map(|value| value.to_string_lossy().into_owned()),
+                v4l_capabilities: device
+                    .property_value("ID_V4L_CAPABILITIES")
+                    .map(|value| value.to_string_lossy().into_owned()),
+            });
+        }
+        observations_from_records(records)
+    }
+}
+
+fn observations_from_records(
+    records: Vec<UdevNodeRecord>,
+) -> Result<Vec<CameraObservation>, LifecycleError> {
+    let mut groups: BTreeMap<String, (Option<String>, Vec<String>)> = BTreeMap::new();
+    for record in records {
+        let evidence = format!(
+            "{}|{}|{}|{}",
+            record.node_devpath,
+            record.devnode.as_deref().unwrap_or(""),
+            record.interface_number.as_deref().unwrap_or(""),
+            record.v4l_capabilities.as_deref().unwrap_or("")
+        );
+        let group = groups
+            .entry(record.usb_devpath.clone())
+            .or_insert_with(|| (record.serial.clone(), Vec::new()));
+        if group.0 != record.serial {
+            return Err(LifecycleError::Snapshot(format!(
+                "conflicting serial evidence for {}",
+                record.usb_devpath
+            )));
+        }
+        group.1.push(evidence);
+    }
+
+    groups
+        .into_iter()
+        .map(|(topology_path, (serial, evidence))| {
+            let physical_id = PhysicalCameraId::new(topology_path, serial)
+                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+            Ok(CameraObservation::with_lifecycle_evidence(
+                BackendKind::UvcV4l2,
+                physical_id,
+                CameraCapabilities::default(),
+                evidence,
+            ))
+        })
+        .collect()
+}
+
+fn bind_monitor_before_snapshot<S: SnapshotSource, E: DeviceEventSource>(
+    bind: impl FnOnce() -> Result<E, LifecycleError>,
+    snapshots: impl FnOnce() -> S,
+) -> Result<LifecycleCoordinator<S, E>, LifecycleError> {
+    let events = bind()?;
+    Ok(LifecycleCoordinator::new(snapshots(), events))
+}
+
+/// Start the production monitor before the first authoritative scan. The thread
+/// owns the monitor socket for the supervisor lifetime; dropping the process is
+/// the only normal shutdown path for this process-scoped inventory.
+pub(crate) fn spawn(supervisor: Weak<CameraSupervisor>) -> Result<(), LifecycleError> {
+    let mut coordinator =
+        bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource)?;
+    std::thread::Builder::new()
+        .name("irlume-camera-udev".into())
+        .spawn(move || {
+            let Some(supervisor) = supervisor.upgrade() else {
+                return;
+            };
+            if let Err(error) = coordinator.initialize(supervisor.as_ref()) {
+                eprintln!("irlume: camera lifecycle monitor stopped: {error}");
+                return;
+            }
+            loop {
+                if let Err(error) = coordinator.process_next(supervisor.as_ref(), MONITOR_WAIT) {
+                    eprintln!("irlume: camera lifecycle monitor stopped: {error}");
+                    return;
+                }
+            }
+        })
+        .map_err(|error| LifecycleError::Monitor(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::{CameraGeneration, StreamRole};
+    use crate::inventory::CameraInventory;
+
+    struct TestInventory(Mutex<CameraInventory>);
+
+    impl TestInventory {
+        fn new() -> Self {
+            Self(Mutex::new(CameraInventory::new()))
+        }
+
+        fn validate(
+            &self,
+            descriptor: &crate::contracts::CameraDescriptor,
+        ) -> Result<(), CameraInventoryError> {
+            self.0.lock().unwrap().validate(descriptor)
+        }
+    }
+
+    impl InventorySink for TestInventory {
+        fn invalidate_all(&self) -> Result<(), CameraInventoryError> {
+            self.0.lock().unwrap().invalidate_all();
+            Ok(())
+        }
+
+        fn reconcile(
+            &self,
+            observations: Vec<CameraObservation>,
+        ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+            self.0.lock().unwrap().reconcile(observations)
+        }
+    }
+
+    struct FakeSnapshots(VecDeque<Result<Vec<CameraObservation>, LifecycleError>>);
+
+    impl SnapshotSource for FakeSnapshots {
+        fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+            self.0.pop_front().expect("snapshot fixture exhausted")
+        }
+    }
+
+    struct FakeEvents(VecDeque<Result<Vec<DeviceEventHint>, LifecycleError>>);
+
+    impl DeviceEventSource for FakeEvents {
+        fn poll(&mut self, _: Duration) -> Result<Vec<DeviceEventHint>, LifecycleError> {
+            self.0.pop_front().unwrap_or_else(|| Ok(Vec::new()))
+        }
+    }
+
+    fn observation(evidence: &str) -> CameraObservation {
+        CameraObservation::with_lifecycle_evidence(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new("/devices/pci/usb1/camera", None).unwrap(),
+            CameraCapabilities::new(vec![StreamRole::Rgb], Default::default(), Vec::new()).unwrap(),
+            vec![evidence.into()],
+        )
+    }
+
+    fn hint(kind: DeviceEventKind) -> DeviceEventHint {
+        DeviceEventHint::new(kind, "/devices/pci/usb1/video4linux/video0")
+    }
+
+    #[test]
+    fn monitor_is_bound_before_initial_snapshot() {
+        struct RecordingSnapshot(std::sync::Arc<Mutex<Vec<&'static str>>>);
+        impl SnapshotSource for RecordingSnapshot {
+            fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+                self.0.lock().unwrap().push("scan");
+                Ok(Vec::new())
+            }
+        }
+
+        let order = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let bind_order = order.clone();
+        let snapshot_order = order.clone();
+        let mut coordinator = bind_monitor_before_snapshot(
+            move || {
+                bind_order.lock().unwrap().push("bind");
+                Ok(FakeEvents(VecDeque::from([Ok(Vec::new())])))
+            },
+            move || {
+                snapshot_order.lock().unwrap().push("snapshot-source");
+                RecordingSnapshot(snapshot_order)
+            },
+        )
+        .unwrap();
+        coordinator.initialize(&TestInventory::new()).unwrap();
+        assert_eq!(*order.lock().unwrap(), ["bind", "snapshot-source", "scan"]);
+    }
+
+    #[test]
+    fn event_hints_are_invalidation_only() {
+        let hint = hint(DeviceEventKind::DirtyUvc);
+        assert_eq!(hint.kind(), DeviceEventKind::DirtyUvc);
+        assert!(hint.devpath().ends_with("/video0"));
+    }
+
+    #[test]
+    fn startup_discards_a_scan_if_an_event_arrived_during_it() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("stale")]),
+                Ok(vec![observation("quiet")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+            ])),
+        );
+
+        let events = coordinator.initialize(&inventory).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_added());
+        assert_eq!(
+            events[0].descriptor().generation(),
+            CameraGeneration::INITIAL
+        );
+    }
+
+    #[test]
+    fn remove_add_burst_retires_before_publishing_fresh_instance() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("video0")]),
+                Ok(vec![observation("video2")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(vec![hint(DeviceEventKind::ContinuityLost)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let initial = coordinator.initialize(&inventory).unwrap();
+        let old = initial[0].descriptor().clone();
+
+        let changed = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert_eq!(changed.len(), 2);
+        assert!(changed[0].is_removed());
+        assert!(changed[1].is_added());
+        assert_eq!(
+            changed[1].descriptor().generation(),
+            CameraGeneration::INITIAL
+        );
+        assert_ne!(
+            changed[1].descriptor().camera_instance_id(),
+            old.camera_instance_id()
+        );
+        assert_eq!(
+            inventory.validate(&old),
+            Err(CameraInventoryError::ForeignInstance)
+        );
+    }
+
+    #[test]
+    fn old_token_is_unusable_before_soft_rescan_starts() {
+        struct CheckingSnapshots<'a> {
+            inventory: &'a TestInventory,
+            old: Option<crate::contracts::CameraDescriptor>,
+            calls: usize,
+        }
+
+        impl SnapshotSource for CheckingSnapshots<'_> {
+            fn snapshot(&mut self) -> Result<Vec<CameraObservation>, LifecycleError> {
+                self.calls += 1;
+                if self.calls == 2 {
+                    assert_eq!(
+                        self.inventory.validate(self.old.as_ref().unwrap()),
+                        Err(CameraInventoryError::ContinuityLost)
+                    );
+                    return Ok(vec![observation("video2")]);
+                }
+                Ok(vec![observation("video0")])
+            }
+        }
+
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            CheckingSnapshots {
+                inventory: &inventory,
+                old: None,
+                calls: 0,
+            },
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+        coordinator.snapshots.old = Some(old);
+        coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+    }
+
+    #[test]
+    fn change_burst_coalesces_into_one_generation_change() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("video0")]),
+                Ok(vec![observation("video2")]),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+                Ok(Vec::new()),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        let changed = coordinator
+            .process_next(&inventory, Duration::ZERO)
+            .unwrap();
+        assert_eq!(changed.len(), 1);
+        assert!(changed[0].is_changed());
+        assert_eq!(
+            changed[0].descriptor().generation(),
+            CameraGeneration::new(2).unwrap()
+        );
+        assert_eq!(
+            inventory.validate(&old),
+            Err(CameraInventoryError::StaleGeneration)
+        );
+    }
+
+    #[test]
+    fn event_source_disconnect_retires_every_published_descriptor() {
+        assert_monitor_failure_retires("disconnected");
+    }
+
+    #[test]
+    fn monitor_overflow_retires_every_published_descriptor() {
+        assert_monitor_failure_retires("overflow");
+    }
+
+    fn assert_monitor_failure_retires(message: &str) {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([Ok(vec![observation("video0")])])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Err(LifecycleError::Monitor(message.into())),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        assert_eq!(
+            coordinator.process_next(&inventory, Duration::ZERO),
+            Err(LifecycleError::Monitor(message.into()))
+        );
+        assert_eq!(inventory.validate(&old), Err(CameraInventoryError::Removed));
+    }
+
+    #[test]
+    fn scan_failure_retires_every_published_descriptor() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from([
+                Ok(vec![observation("video0")]),
+                Err(LifecycleError::Snapshot("sysfs race".into())),
+            ])),
+            FakeEvents(VecDeque::from([
+                Ok(Vec::new()),
+                Ok(vec![hint(DeviceEventKind::DirtyUvc)]),
+                Ok(Vec::new()),
+            ])),
+        );
+        let old = coordinator.initialize(&inventory).unwrap()[0]
+            .descriptor()
+            .clone();
+
+        assert_eq!(
+            coordinator.process_next(&inventory, Duration::ZERO),
+            Err(LifecycleError::Snapshot("sysfs race".into()))
+        );
+        assert_eq!(inventory.validate(&old), Err(CameraInventoryError::Removed));
+    }
+
+    #[test]
+    fn an_unstable_startup_snapshot_is_bounded_and_fail_closed() {
+        let inventory = TestInventory::new();
+        let mut coordinator = LifecycleCoordinator::new(
+            FakeSnapshots(VecDeque::from_iter(
+                (0..MAX_QUIET_SNAPSHOT_ATTEMPTS).map(|_| Ok(vec![observation("moving")])),
+            )),
+            FakeEvents(VecDeque::from_iter(
+                (0..MAX_QUIET_SNAPSHOT_ATTEMPTS).map(|_| Ok(vec![hint(DeviceEventKind::DirtyUvc)])),
+            )),
+        );
+
+        assert_eq!(
+            coordinator.initialize(&inventory),
+            Err(LifecycleError::UnstableSnapshot)
+        );
+    }
+
+    #[test]
+    fn netlink_error_flags_are_monitor_loss() {
+        assert_eq!(ensure_monitor_healthy(libc::POLLIN), Ok(()));
+        for flag in [libc::POLLERR, libc::POLLHUP, libc::POLLNVAL] {
+            assert_eq!(
+                ensure_monitor_healthy(flag),
+                Err(LifecycleError::Monitor("udev monitor socket lost".into()))
+            );
+        }
+    }
+
+    #[test]
+    fn receive_tail_distinguishes_drained_overflow_and_other_failures() {
+        assert_eq!(ensure_receive_drained(Some(libc::EAGAIN)), Ok(()));
+        assert_eq!(
+            ensure_receive_drained(Some(libc::ENOBUFS)),
+            Err(LifecycleError::Monitor(
+                "udev monitor receive buffer overflow".into()
+            ))
+        );
+        assert!(matches!(
+            ensure_receive_drained(Some(libc::EIO)),
+            Err(LifecycleError::Monitor(message))
+                if message.starts_with("udev monitor receive failed:")
+        ));
+        assert_eq!(
+            ensure_receive_drained(None),
+            Err(LifecycleError::Monitor(
+                "udev monitor receive failed without errno".into()
+            ))
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an operator-controlled UVC interface unbind/rebind"]
+    fn production_monitor_observes_live_uvc_continuity_loss_and_recovery() {
+        use std::io::Write;
+
+        let inventory = TestInventory::new();
+        let mut coordinator =
+            bind_monitor_before_snapshot(UdevEventSource::new, || UdevSnapshotSource).unwrap();
+        let initial = coordinator.initialize(&inventory).unwrap();
+        let original = initial
+            .iter()
+            .find(|event| event.descriptor().physical_id().serial() == Some("200901010001"))
+            .expect("Shinetech camera is present")
+            .descriptor()
+            .clone();
+
+        println!("IRLUME_UDEV_READY");
+        std::io::stdout().flush().unwrap();
+        let lost_deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            let remaining = lost_deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for old instance retirement"
+            );
+            let events = coordinator.process_next(&inventory, remaining).unwrap();
+            if events.iter().any(|event| {
+                matches!(event, CameraInventoryEvent::Removed(descriptor)
+                    if descriptor.camera_instance_id() == original.camera_instance_id())
+            }) {
+                break;
+            }
+        }
+        println!("IRLUME_UDEV_LOST");
+        std::io::stdout().flush().unwrap();
+
+        let recovered_deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let replacement = loop {
+            let remaining = recovered_deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for replacement instance"
+            );
+            let events = coordinator.process_next(&inventory, remaining).unwrap();
+            if let Some(descriptor) = events.iter().rev().find_map(|event| match event {
+                CameraInventoryEvent::Added(descriptor)
+                    if descriptor.physical_id().serial() == Some("200901010001") =>
+                {
+                    Some(descriptor.clone())
+                }
+                _ => None,
+            }) {
+                break descriptor;
+            }
+        };
+        assert_ne!(
+            replacement.camera_instance_id(),
+            original.camera_instance_id()
+        );
+        println!("IRLUME_UDEV_RECOVERED");
+    }
+
+    #[test]
+    #[ignore = "requires a real initialized UVC camera in udev"]
+    fn production_snapshot_matches_shinetech_four_node_topology_without_capture() {
+        let observations = UdevSnapshotSource.snapshot().unwrap();
+        let camera = observations
+            .iter()
+            .find(|observation| observation.physical_id().serial() == Some("200901010001"))
+            .expect("Shinetech 3277:0059 camera is present");
+        assert!(camera.physical_id().topology_path().ends_with("/usb3/3-5"));
+        assert_eq!(camera.lifecycle_evidence().len(), 4);
+        assert!(camera
+            .lifecycle_evidence()
+            .iter()
+            .any(|evidence| evidence.contains("video0") && evidence.ends_with(":capture:")));
+        assert!(camera
+            .lifecycle_evidence()
+            .iter()
+            .any(|evidence| evidence.contains("video3") && evidence.ends_with("|:")));
+    }
+
+    #[test]
+    fn udev_records_group_one_physical_camera_and_normalize_order() {
+        let records = vec![
+            UdevNodeRecord {
+                usb_devpath: "/devices/pci/usb1/camera".into(),
+                serial: Some("serial".into()),
+                node_devpath: "/devices/pci/usb1/camera/1.2/video2".into(),
+                devnode: Some("/dev/video2".into()),
+                interface_number: Some("02".into()),
+                v4l_capabilities: Some(":capture:".into()),
+            },
+            UdevNodeRecord {
+                usb_devpath: "/devices/pci/usb1/camera".into(),
+                serial: Some("serial".into()),
+                node_devpath: "/devices/pci/usb1/camera/1.0/video0".into(),
+                devnode: Some("/dev/video0".into()),
+                interface_number: Some("00".into()),
+                v4l_capabilities: Some(":capture:".into()),
+            },
+        ];
+        let observations = observations_from_records(records).unwrap();
+        assert_eq!(observations.len(), 1);
+        assert_eq!(
+            observations[0].physical_id().topology_path(),
+            "/devices/pci/usb1/camera"
+        );
+        assert_eq!(observations[0].physical_id().serial(), Some("serial"));
+    }
+}

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -555,11 +555,30 @@ impl SnapshotSource for SysfsSnapshotSource {
         let mut records = Vec::new();
         for entry in entries {
             let entry = entry.map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
-            let interface = std::fs::canonicalize(entry.path().join("device"))
-                .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
+            let name = entry.file_name();
+            let devnode = PathBuf::from("/dev").join(&name);
+            let devnode_text = devnode.to_string_lossy().into_owned();
+            let interface = match std::fs::canonicalize(entry.path().join("device")) {
+                Ok(interface) => interface,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(LifecycleError::Snapshot(error.to_string())),
+            };
             let driver = std::fs::canonicalize(interface.join("driver")).ok();
-            if driver.as_deref().and_then(Path::file_name) != Some(std::ffi::OsStr::new("uvcvideo"))
-            {
+            let is_uvc = driver.as_deref().and_then(Path::file_name)
+                == Some(std::ffi::OsStr::new("uvcvideo"));
+            if !is_uvc {
+                if crate::virtual_camera_allowed(&devnode_text) {
+                    let virtual_devpath =
+                        format!("/devices/virtual/video4linux/{}", name.to_string_lossy());
+                    records.push(UdevNodeRecord {
+                        usb_devpath: "/devices/virtual/video4linux/irlume-test-camera".to_string(),
+                        serial: None,
+                        node_devpath: virtual_devpath,
+                        interface_number: None,
+                        capture_node: crate::media_graph::node_is_capture(&devnode_text),
+                        devnode: devnode_text,
+                    });
+                }
                 continue;
             }
             let usb = usb_device_parent(&interface).ok_or_else(|| {
@@ -568,9 +587,6 @@ impl SnapshotSource for SysfsSnapshotSource {
                     interface.display()
                 ))
             })?;
-            let name = entry.file_name();
-            let devnode = PathBuf::from("/dev").join(&name);
-            let devnode_text = devnode.to_string_lossy().into_owned();
             records.push(UdevNodeRecord {
                 usb_devpath: devpath(usb),
                 serial: read_trimmed(usb.join("serial")),
@@ -1050,6 +1066,72 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         let mut source = SysfsSnapshotSource { root };
         assert_eq!(source.snapshot(), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn vanished_video_class_entry_does_not_abort_snapshot() {
+        let root = std::env::temp_dir().join(format!(
+            "irlume-vanished-video4linux-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("video10")).unwrap();
+        let mut source = SysfsSnapshotSource { root: root.clone() };
+        assert_eq!(source.snapshot(), Ok(Vec::new()));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_allowlisted_virtual_camera_is_present_in_test_inventory() {
+        use std::os::unix::fs::symlink;
+
+        let _guard = crate::testenv::env_lock();
+        let root =
+            std::env::temp_dir().join(format!("irlume-virtual-video4linux-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let rgb = root.join("devices/virtual/video4linux/video8");
+        let ir = root.join("devices/virtual/video4linux/video9");
+        let excluded = root.join("devices/virtual/video4linux/video10");
+        let driver = root.join("drivers/v4l2loopback");
+        std::fs::create_dir_all(root.join("class/video4linux/video8")).unwrap();
+        std::fs::create_dir_all(root.join("class/video4linux/video9")).unwrap();
+        std::fs::create_dir_all(root.join("class/video4linux/video10")).unwrap();
+        std::fs::create_dir_all(&rgb).unwrap();
+        std::fs::create_dir_all(&ir).unwrap();
+        std::fs::create_dir_all(&excluded).unwrap();
+        std::fs::create_dir_all(&driver).unwrap();
+        symlink(&rgb, root.join("class/video4linux/video8/device")).unwrap();
+        symlink(&ir, root.join("class/video4linux/video9/device")).unwrap();
+        symlink(&excluded, root.join("class/video4linux/video10/device")).unwrap();
+        symlink(&driver, rgb.join("driver")).unwrap();
+        symlink(&driver, ir.join("driver")).unwrap();
+        symlink(&driver, excluded.join("driver")).unwrap();
+        let _allow = crate::testenv::EnvGuard::set(
+            "IRLUME_TEST_ALLOW_VIRTUAL_CAMERA",
+            "/dev/video8,/dev/video9",
+        );
+
+        let mut source = SysfsSnapshotSource {
+            root: root.join("class/video4linux"),
+        };
+        let observations = source.snapshot().unwrap();
+        assert_eq!(observations.len(), 1);
+        let evidence = observations[0].lifecycle_evidence();
+        assert!(evidence.iter().any(|item| item.contains("/dev/video8")));
+        assert!(evidence.iter().any(|item| item.contains("/dev/video9")));
+        assert!(!evidence.iter().any(|item| item.contains("/dev/video10")));
+
+        let mut inventory = CameraInventory::new();
+        inventory.reconcile(observations).unwrap();
+        assert!(inventory
+            .reference_for_endpoints(&["/dev/video8", "/dev/video9"])
+            .is_ok());
+        assert!(matches!(
+            inventory.reference_for_endpoints(&["/dev/video10"]),
+            Err(CameraInventoryError::UnknownCamera)
+        ));
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -525,6 +525,13 @@ fn read_trimmed(path: impl AsRef<Path>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+#[derive(Default)]
+struct UdevCameraGroup {
+    serial: Option<String>,
+    evidence: Vec<String>,
+    endpoints: Vec<String>,
+}
+
 fn devpath(path: &Path) -> String {
     match path.strip_prefix("/sys") {
         Ok(relative) => format!("/{}", relative.to_string_lossy()),
@@ -580,8 +587,9 @@ impl SnapshotSource for SysfsSnapshotSource {
 fn observations_from_records(
     records: Vec<UdevNodeRecord>,
 ) -> Result<Vec<CameraObservation>, LifecycleError> {
-    let mut groups: BTreeMap<String, (Option<String>, Vec<String>)> = BTreeMap::new();
+    let mut groups: BTreeMap<String, UdevCameraGroup> = BTreeMap::new();
     for record in records {
+        let endpoint = record.devnode.clone();
         let evidence = format!(
             "{}|{}|{}|{}",
             record.node_devpath,
@@ -595,26 +603,31 @@ fn observations_from_records(
         );
         let group = groups
             .entry(record.usb_devpath.clone())
-            .or_insert_with(|| (record.serial.clone(), Vec::new()));
-        if group.0 != record.serial {
+            .or_insert_with(|| UdevCameraGroup {
+                serial: record.serial.clone(),
+                ..UdevCameraGroup::default()
+            });
+        if group.serial != record.serial {
             return Err(LifecycleError::Snapshot(format!(
                 "conflicting serial evidence for {}",
                 record.usb_devpath
             )));
         }
-        group.1.push(evidence);
+        group.evidence.push(evidence);
+        group.endpoints.push(endpoint);
     }
 
     groups
         .into_iter()
-        .map(|(topology_path, (serial, evidence))| {
-            let physical_id = PhysicalCameraId::new(topology_path, serial)
+        .map(|(topology_path, group)| {
+            let physical_id = PhysicalCameraId::new(topology_path, group.serial)
                 .map_err(|error| LifecycleError::Snapshot(error.to_string()))?;
-            Ok(CameraObservation::with_lifecycle_evidence(
+            Ok(CameraObservation::with_lifecycle_evidence_and_endpoints(
                 BackendKind::UvcV4l2,
                 physical_id,
                 CameraCapabilities::default(),
-                evidence,
+                group.evidence,
+                group.endpoints,
             ))
         })
         .collect()
@@ -648,26 +661,40 @@ impl<I: InventorySink> Drop for WorkerExitGuard<'_, I> {
 pub(crate) fn spawn(supervisor: Weak<CameraSupervisor>) -> Result<(), LifecycleError> {
     let mut coordinator =
         bind_monitor_before_snapshot(UdevEventSource::new, SysfsSnapshotSource::default)?;
-    std::thread::Builder::new()
+    let Some(supervisor) = supervisor.upgrade() else {
+        return Ok(());
+    };
+    coordinator.initialize(supervisor.as_ref())?;
+    let worker_supervisor = supervisor.clone();
+    let spawned = std::thread::Builder::new()
         .name("irlume-camera-udev".into())
         .spawn(move || {
-            let Some(supervisor) = supervisor.upgrade() else {
-                return;
-            };
-            let _exit_guard = WorkerExitGuard::new(supervisor.as_ref());
-            if let Err(error) = coordinator.initialize(supervisor.as_ref()) {
-                eprintln!("irlume: camera lifecycle monitor stopped: {error}");
-                return;
-            }
+            let _exit_guard = WorkerExitGuard::new(worker_supervisor.as_ref());
             loop {
-                if let Err(error) = coordinator.process_next(supervisor.as_ref(), MONITOR_WAIT) {
+                if let Err(error) =
+                    coordinator.process_next(worker_supervisor.as_ref(), MONITOR_WAIT)
+                {
                     eprintln!("irlume: camera lifecycle monitor stopped: {error}");
                     return;
                 }
             }
-        })
-        .map_err(|error| LifecycleError::Monitor(error.to_string()))?;
-    Ok(())
+        });
+    finish_spawn(supervisor.as_ref(), spawned)
+}
+
+fn finish_spawn<I: InventorySink>(
+    inventory: &I,
+    spawned: std::io::Result<std::thread::JoinHandle<()>>,
+) -> Result<(), LifecycleError> {
+    match spawned {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            inventory
+                .invalidate_all()
+                .map_err(LifecycleError::Inventory)?;
+            Err(LifecycleError::Monitor(error.to_string()))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1023,6 +1050,31 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         let mut source = SysfsSnapshotSource { root };
         assert_eq!(source.snapshot(), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn thread_spawn_failure_invalidates_published_inventory() {
+        let inventory = TestInventory::new();
+        let descriptor = inventory
+            .reconcile(vec![observation("published")])
+            .unwrap()
+            .into_iter()
+            .find_map(|event| match event {
+                CameraInventoryEvent::Added(descriptor) => Some(descriptor),
+                _ => None,
+            })
+            .unwrap();
+        let spawned: std::io::Result<std::thread::JoinHandle<()>> =
+            Err(std::io::Error::other("synthetic spawn failure"));
+
+        assert!(matches!(
+            finish_spawn(&inventory, spawned),
+            Err(LifecycleError::Monitor(_))
+        ));
+        assert!(matches!(
+            inventory.validate(&descriptor),
+            Err(CameraInventoryError::ContinuityLost)
+        ));
     }
 
     #[test]

--- a/crates/irlume-camera/tests/contracts.rs
+++ b/crates/irlume-camera/tests/contracts.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use irlume_camera::contracts::{
+    BackendKind, CameraCapabilities, CameraDescriptor, CameraGeneration, CameraInstanceId,
+    FrameMetadata, IdentityStrength, IlluminationProvenance, PhysicalCameraId, StreamRole,
+    SynchronizationProvenance, MAX_CAMERA_CONTRACT_BYTES,
+};
+
+const TOPOLOGY: &str = "/devices/pci0000:00/usb1/1-2/1-2.1";
+const INSTANCE_ID: &str = "00000000000000000000000000000001";
+
+fn physical_id() -> PhysicalCameraId {
+    PhysicalCameraId::new(TOPOLOGY, Some("200901010001".into()))
+        .expect("valid raw identity evidence")
+}
+
+fn instance_id() -> CameraInstanceId {
+    CameraInstanceId::new(INSTANCE_ID).expect("valid process camera-instance id")
+}
+
+fn capabilities() -> CameraCapabilities {
+    CameraCapabilities::new(
+        vec![StreamRole::Rgb, StreamRole::Ir],
+        SynchronizationProvenance::HostCorrelated,
+        vec![
+            IlluminationProvenance::Ambient,
+            IlluminationProvenance::ActiveIr,
+        ],
+    )
+    .expect("coherent capability evidence")
+}
+
+#[test]
+fn camera_descriptor_v1_has_a_stable_wire_shape() {
+    let descriptor = CameraDescriptor::new(
+        BackendKind::UvcV4l2,
+        physical_id(),
+        instance_id(),
+        CameraGeneration::new(7).expect("non-zero generation"),
+        capabilities(),
+    );
+
+    let wire = serde_json::to_string(&descriptor).expect("serialize descriptor");
+    assert_eq!(
+        wire,
+        r#"{"schema_version":1,"backend":"uvc_v4l2","physical_id":{"topology_path":"/devices/pci0000:00/usb1/1-2/1-2.1","serial":"200901010001"},"identity_strength":"ambiguous","camera_instance_id":"00000000000000000000000000000001","generation":7,"capabilities":{"stream_roles":["rgb","ir"],"synchronization":"host_correlated","illumination_provenance":["ambient","active_ir"]}}"#
+    );
+    assert_eq!(
+        CameraDescriptor::from_json(&wire).expect("parse supported descriptor"),
+        descriptor
+    );
+}
+
+#[test]
+fn conservative_camera_fields_default_to_no_claim() {
+    let wire = format!(
+        r#"{{"schema_version":1,"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let descriptor = CameraDescriptor::from_json(&wire).expect("parse conservative descriptor");
+
+    assert_eq!(descriptor.identity_strength(), IdentityStrength::Ambiguous);
+    assert_eq!(descriptor.capabilities(), &CameraCapabilities::default());
+    assert_eq!(descriptor.physical_id().serial(), None);
+}
+
+#[test]
+fn frame_metadata_v1_has_a_stable_wire_shape() {
+    let metadata = FrameMetadata::new(
+        instance_id(),
+        CameraGeneration::new(7).expect("non-zero generation"),
+        StreamRole::Ir,
+        Some(42),
+        SynchronizationProvenance::HostCorrelated,
+        IlluminationProvenance::ActiveIr,
+    )
+    .expect("active IR is valid for an IR frame");
+
+    let wire = serde_json::to_string(&metadata).expect("serialize frame metadata");
+    assert_eq!(
+        wire,
+        r#"{"schema_version":1,"camera_instance_id":"00000000000000000000000000000001","generation":7,"stream_role":"ir","sequence":42,"synchronization":"host_correlated","illumination":"active_ir"}"#
+    );
+    assert_eq!(
+        FrameMetadata::from_json(&wire).expect("parse supported frame metadata"),
+        metadata
+    );
+}
+
+#[test]
+fn frame_generation_is_scoped_by_the_same_camera_instance_as_the_descriptor() {
+    let descriptor = CameraDescriptor::new(
+        BackendKind::UvcV4l2,
+        physical_id(),
+        instance_id(),
+        CameraGeneration::INITIAL,
+        CameraCapabilities::default(),
+    );
+    let metadata = FrameMetadata::new(
+        instance_id(),
+        CameraGeneration::INITIAL,
+        StreamRole::Ir,
+        None,
+        SynchronizationProvenance::Unknown,
+        IlluminationProvenance::Unknown,
+    )
+    .expect("unknown evidence is conservative");
+
+    assert_eq!(
+        metadata.camera_instance_id(),
+        descriptor.camera_instance_id()
+    );
+}
+
+#[test]
+fn missing_frame_evidence_defaults_to_unknown_not_proven() {
+    let wire = format!(
+        r#"{{"schema_version":1,"camera_instance_id":"{INSTANCE_ID}","generation":7,"stream_role":"ir"}}"#
+    );
+    let metadata = FrameMetadata::from_json(&wire).expect("parse conservative frame metadata");
+
+    assert_eq!(metadata.sequence(), None);
+    assert_eq!(
+        metadata.synchronization(),
+        SynchronizationProvenance::Unknown
+    );
+    assert_eq!(metadata.illumination(), IlluminationProvenance::Unknown);
+}
+
+#[test]
+fn both_roots_reject_old_and_new_schema_versions() {
+    for version in [0, 2] {
+        let descriptor = format!(
+            r#"{{"schema_version":{version},"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+        );
+        let frame = format!(
+            r#"{{"schema_version":{version},"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"ir"}}"#
+        );
+
+        assert!(CameraDescriptor::from_json(&descriptor)
+            .expect_err("unsupported descriptor schema must fail")
+            .to_string()
+            .contains(&format!(
+                "unsupported camera contract schema version {version}"
+            )));
+        assert!(FrameMetadata::from_json(&frame)
+            .expect_err("unsupported frame schema must fail")
+            .to_string()
+            .contains(&format!(
+                "unsupported camera contract schema version {version}"
+            )));
+    }
+}
+
+#[test]
+fn identity_evidence_is_canonical_and_never_self_upgrades_strength() {
+    for topology in ["", "x", "/devices/", "/devices/a//b", "/devices/a/../b"] {
+        assert!(PhysicalCameraId::new(topology, None).is_err());
+    }
+    assert!(PhysicalCameraId::new(TOPOLOGY, Some(String::new())).is_err());
+
+    let self_asserted = format!(
+        r#"{{"schema_version":1,"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"identity_strength":"topology_bound","camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    assert!(CameraDescriptor::from_json(&self_asserted).is_err());
+}
+
+#[test]
+fn instance_and_generation_identifiers_reject_zero_or_malformed_values() {
+    assert!(CameraGeneration::new(0).is_err());
+    assert!(CameraGeneration::new(u64::MAX)
+        .expect("maximum is a valid current generation")
+        .next()
+        .is_err());
+    for id in [
+        "",
+        "00000000000000000000000000000000",
+        "0000000000000000000000000000000g",
+        "000000000000000000000000000000001",
+    ] {
+        assert!(CameraInstanceId::new(id).is_err());
+    }
+}
+
+#[test]
+fn contradictory_and_duplicate_capability_claims_are_rejected() {
+    assert!(CameraCapabilities::new(
+        vec![StreamRole::Rgb, StreamRole::Rgb],
+        SynchronizationProvenance::Unknown,
+        Vec::new(),
+    )
+    .is_err());
+    assert!(CameraCapabilities::new(
+        vec![StreamRole::Rgb],
+        SynchronizationProvenance::Unknown,
+        vec![IlluminationProvenance::ActiveIr],
+    )
+    .is_err());
+    assert!(CameraCapabilities::new(
+        vec![StreamRole::Rgb],
+        SynchronizationProvenance::HardwareSynchronized,
+        Vec::new(),
+    )
+    .is_err());
+    assert!(CameraCapabilities::new(
+        Vec::new(),
+        SynchronizationProvenance::Unknown,
+        vec![
+            IlluminationProvenance::Ambient,
+            IlluminationProvenance::Ambient,
+        ],
+    )
+    .is_err());
+}
+
+#[test]
+fn active_ir_is_rejected_on_an_rgb_frame() {
+    assert!(FrameMetadata::new(
+        instance_id(),
+        CameraGeneration::INITIAL,
+        StreamRole::Rgb,
+        None,
+        SynchronizationProvenance::Unknown,
+        IlluminationProvenance::ActiveIr,
+    )
+    .is_err());
+}
+
+#[test]
+fn malformed_duplicate_unknown_and_oversized_inputs_fail_closed() {
+    let duplicate_version = format!(
+        r#"{{"schema_version":1,"schema_version":1,"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let unknown_backend = format!(
+        r#"{{"schema_version":1,"backend":"libcamera","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let unknown_role = format!(
+        r#"{{"schema_version":1,"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"depth"}}"#
+    );
+    let unknown_field = format!(
+        r#"{{"schema_version":1,"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"ir","future":true}}"#
+    );
+    let oversized = "x".repeat(MAX_CAMERA_CONTRACT_BYTES + 1);
+
+    assert!(CameraDescriptor::from_json(&duplicate_version).is_err());
+    assert!(CameraDescriptor::from_json(&unknown_backend).is_err());
+    assert!(FrameMetadata::from_json(&unknown_role).is_err());
+    assert!(FrameMetadata::from_json(&unknown_field).is_err());
+    assert!(CameraDescriptor::from_json(&oversized).is_err());
+    assert!(FrameMetadata::from_json(&oversized).is_err());
+}
+
+#[test]
+fn missing_schema_version_is_rejected() {
+    let descriptor = format!(
+        r#"{{"backend":"uvc_v4l2","physical_id":{{"topology_path":"{TOPOLOGY}"}},"camera_instance_id":"{INSTANCE_ID}","generation":1}}"#
+    );
+    let frame =
+        format!(r#"{{"camera_instance_id":"{INSTANCE_ID}","generation":1,"stream_role":"ir"}}"#);
+    assert!(CameraDescriptor::from_json(&descriptor).is_err());
+    assert!(FrameMetadata::from_json(&frame).is_err());
+}

--- a/crates/irlume-camera/tests/contracts.rs
+++ b/crates/irlume-camera/tests/contracts.rs
@@ -32,6 +32,38 @@ fn capabilities() -> CameraCapabilities {
 }
 
 #[test]
+fn safe_stream_validates_both_sides_of_blocking_dequeue() {
+    let source = include_str!("../src/lib.rs");
+    let start = source
+        .find("    fn next(&mut self) -> std::io::Result<(&[u8], &v4l::buffer::Metadata)> {")
+        .expect("SafeStream::next exists");
+    let body = &source[start
+        ..source[start..]
+            .find(
+                "
+    }
+}
+
+impl<'a> std::ops::Deref",
+            )
+            .map(|end| start + end)
+            .expect("SafeStream::next body ends before Deref")];
+    let dequeue = body
+        .find("CaptureStream::next")
+        .expect("blocking dequeue exists");
+    let checks: Vec<_> = body
+        .match_indices("require_endpoint")
+        .map(|(index, _)| index)
+        .collect();
+    assert_eq!(
+        checks.len(),
+        2,
+        "SafeStream must validate before and after dequeue"
+    );
+    assert!(checks[0] < dequeue && dequeue < checks[1]);
+}
+
+#[test]
 fn camera_descriptor_v1_has_a_stable_wire_shape() {
     let descriptor = CameraDescriptor::new(
         BackendKind::UvcV4l2,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,7 +83,7 @@ Install the build dependencies, then use `cargo` as usual.
 
 ```sh
 sudo dnf install cargo rust clang-devel pkgconf-pkg-config gcc \
-    pam-devel tpm2-tss-devel kernel-headers curl
+    pam-devel tpm2-tss-devel systemd-devel kernel-headers curl
 ```
 
 **Ubuntu / Debian**: the archive's `rustc` is usually too old (the `ort`
@@ -92,14 +92,14 @@ binding needs Rust ≥ 1.88), so install the toolchain with
 
 ```sh
 sudo apt install build-essential pkg-config clang libclang-dev \
-    libpam0g-dev libtss2-dev curl
+    libpam0g-dev libtss2-dev libudev-dev curl
 rustup toolchain install 1.88.0   # or newer stable
 ```
 
 **Arch**
 
 ```sh
-sudo pacman -S --needed base-devel rust clang tpm2-tss pam onnxruntime-cpu curl
+sudo pacman -S --needed base-devel rust clang tpm2-tss pam systemd onnxruntime-cpu curl
 ```
 
 ### ONNX runtime (non-Nix)

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
           buildInputs = [
             pkgs.tpm2-tss     # TPM 2.0 stack; the tss-esapi crate links tss2-*
             pkgs.linux-pam    # libpam; the pamsm crate links it
+            pkgs.systemd      # libudev for the camera lifecycle adapter
           ];
 
           # bindgen (pulled in transitively by v4l2-sys-mit) dlopens libclang

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,7 @@
   clang,
   tpm2-tss,
   linux-pam,
+  systemd,
   libxcrypt,
   linuxHeaders,
   fetchurl,
@@ -90,6 +91,7 @@ rustPlatform.buildRustPackage {
   buildInputs = [
     tpm2-tss # tss-esapi links tss2-*
     linux-pam # the PAM cdylib links libpam
+    systemd # the udev adapter links libudev
     # irlumed declares #[link(name = "crypt")] for its /etc/shadow fallback.
     # nixpkgs stopped providing libcrypt transitively, and `nix build` failed
     # with "cannot find -lcrypt" at the irlumed link step. CI could not see it:

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -38,6 +38,7 @@ BuildRequires:  rust
 BuildRequires:  gcc
 BuildRequires:  pam-devel
 BuildRequires:  tpm2-tss-devel
+BuildRequires:  systemd-devel
 BuildRequires:  systemd-rpm-macros
 # v4l2-sys-mit generates bindings at build time: bindgen dlopens libclang
 # and parses the kernel's videodev2.h; tss-esapi locates tss2 via pkg-config.

--- a/packaging/ppa/debian/control
+++ b/packaging/ppa/debian/control
@@ -10,6 +10,7 @@ Build-Depends: debhelper-compat (= 13),
                pkg-config,
                libpam0g-dev,
                libtss2-dev,
+               libudev-dev,
                linux-libc-dev
 Standards-Version: 4.6.2
 Homepage: https://github.com/archledger/irlume


### PR DESCRIPTION
Closes #452.
Closes #455.
Closes #456.
Closes #461.

## Summary
- add the process-wide camera supervisor foundation and descriptor-bound inventory generations
- monitor udev lifecycle changes with monitor-before-scan ordering, bounded SEQNUM reordering, quiet coalescing, and fail-closed worker supervision
- add process-wide cooperative operation leases with atomic RGB+IR acquisition, FIFO contention, bounded deadlines, and re-entrant operation scopes
- bind leases to immutable inventory references and reject stale, foreign, removed, or unknown endpoints
- validate active leases before stream dequeue and immediately before camera-control writes and restores
- retain one camera operation across authentication retries and consent handling
- enforce one live session per opened camera object even on permissive V4L2 drivers

## Safety
- no new emitter payloads or speculative XU probes
- emitter SET_CUR remains centralized behind live fd-to-endpoint lease validation
- lifecycle monitoring never opens video nodes
- paired RGB+IR acquisition is all-or-nothing
- stale continuity invalidates active leases before further frame or control use
- virtual test cameras require both an exact root-controlled allowlist and canonical virtual-video ancestry

## Verification
- 1,466 workspace tests passed; one unrelated PAM fork/flock flake passed immediately in isolation
- v4l2loopback authentication, enrollment, held-session release, and paired lease tests passed in CI
- strict workspace clippy and rustdoc passed
- release build passed
- cargo-deny passed under existing policy
- Nix flake evaluation and Fedora 43/44 RPM builds passed
- ASan, fuzz, stable Rust, systemd, hardware, and real-TPM CI passed
- real hardware validated standalone RGB ownership, atomic paired RGB+IR contention, and continuity loss/recovery across UVC unbind/rebind
- independent final reviews found no blocking or non-blocking issues

## Stack integration
This PR now targets `main` and contains the exact cumulative, fully tested heads previously reviewed as #453, #458, #460, and #463. The lower stack PRs are superseded by this squash-only integration because the repository does not permit ancestry-preserving merge commits.
