### PR TITLE
feat(camera): establish trusted frame provenance continuity

### DIFF
--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -20,6 +20,153 @@ pub enum TimestampSource {
     StartOfExposure,
 }
 
+/// Why sequence continuity can no longer be represented safely.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SequenceTrackerError {
+    DropCounterOverflow,
+    StreamEpochOverflow,
+    TrackerFailed,
+}
+
+impl std::fmt::Display for SequenceTrackerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DropCounterOverflow => f.write_str("V4L2 sequence drop counter overflowed"),
+            Self::StreamEpochOverflow => f.write_str("V4L2 sequence stream epoch overflowed"),
+            Self::TrackerFailed => f.write_str("V4L2 sequence tracker is permanently failed"),
+        }
+    }
+}
+
+impl std::error::Error for SequenceTrackerError {}
+
+/// Derived continuity facts for one dequeued V4L2 sequence number.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SequenceObservation {
+    raw: u32,
+    gap: u32,
+    cumulative_drops: u64,
+    discontinuity: bool,
+    stream_epoch: u64,
+}
+
+impl SequenceObservation {
+    #[must_use]
+    pub const fn raw(&self) -> u32 {
+        self.raw
+    }
+
+    #[must_use]
+    pub const fn gap(&self) -> u32 {
+        self.gap
+    }
+
+    #[must_use]
+    pub const fn cumulative_drops(&self) -> u64 {
+        self.cumulative_drops
+    }
+
+    #[must_use]
+    pub const fn discontinuity(&self) -> bool {
+        self.discontinuity
+    }
+
+    #[must_use]
+    pub const fn stream_epoch(&self) -> u64 {
+        self.stream_epoch
+    }
+}
+
+/// Stateful RFC-1982 sequence continuity tracker for one logical stream.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SequenceTracker {
+    previous: Option<u32>,
+    cumulative_drops: u64,
+    stream_epoch: u64,
+    pending_discontinuity: bool,
+    failed: bool,
+}
+
+impl SequenceTracker {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            previous: None,
+            cumulative_drops: 0,
+            stream_epoch: 0,
+            pending_discontinuity: false,
+            failed: false,
+        }
+    }
+
+    /// Mark a successfully replaced stream as a new discontinuous epoch.
+    ///
+    /// The marker remains pending until the next observed (delivered) frame, so
+    /// discarded warm-up dequeues cannot consume the recovery evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SequenceTrackerError::StreamEpochOverflow`] and permanently
+    /// fails the tracker when the epoch cannot be represented.
+    pub fn begin_new_epoch(&mut self) -> Result<(), SequenceTrackerError> {
+        if self.failed {
+            return Err(SequenceTrackerError::TrackerFailed);
+        }
+        let Some(stream_epoch) = self.stream_epoch.checked_add(1) else {
+            self.failed = true;
+            return Err(SequenceTrackerError::StreamEpochOverflow);
+        };
+        self.stream_epoch = stream_epoch;
+        self.previous = None;
+        self.pending_discontinuity = true;
+        Ok(())
+    }
+
+    /// Observe one raw sequence value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SequenceTrackerError`] after an unrepresentable counter state.
+    pub fn observe(&mut self, raw: u32) -> Result<SequenceObservation, SequenceTrackerError> {
+        if self.failed {
+            return Err(SequenceTrackerError::TrackerFailed);
+        }
+        let (gap, transition_discontinuity) = self.previous.map_or((0, false), |previous| {
+            let delta = raw.wrapping_sub(previous);
+            if (1..(1_u32 << 31)).contains(&delta) {
+                (delta - 1, false)
+            } else {
+                (0, true)
+            }
+        });
+        if transition_discontinuity {
+            let Some(stream_epoch) = self.stream_epoch.checked_add(1) else {
+                self.failed = true;
+                return Err(SequenceTrackerError::StreamEpochOverflow);
+            };
+            self.stream_epoch = stream_epoch;
+        }
+        if gap != 0 {
+            let Some(cumulative_drops) = self.cumulative_drops.checked_add(u64::from(gap)) else {
+                self.failed = true;
+                return Err(SequenceTrackerError::DropCounterOverflow);
+            };
+            self.cumulative_drops = cumulative_drops;
+        }
+        let discontinuity = transition_discontinuity || self.pending_discontinuity;
+        self.previous = Some(raw);
+        self.pending_discontinuity = false;
+        Ok(SequenceObservation {
+            raw,
+            gap,
+            cumulative_drops: self.cumulative_drops,
+            discontinuity,
+            stream_epoch: self.stream_epoch,
+        })
+    }
+}
+
 /// Why a dequeued buffer cannot enter the trusted decode boundary.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -351,8 +498,181 @@ impl FrameBinding {
 #[cfg(test)]
 mod tests {
     use super::{
-        DequeuedBufferError, DequeuedBufferFacts, PayloadLayout, TimestampClock, TimestampSource,
+        DequeuedBufferError, DequeuedBufferFacts, PayloadLayout, SequenceTracker,
+        SequenceTrackerError, TimestampClock, TimestampSource,
     };
+
+    #[test]
+    fn first_sequence_establishes_a_clean_baseline() {
+        let mut tracker = SequenceTracker::new();
+
+        let observation = tracker.observe(41).expect("first sequence is valid");
+
+        assert_eq!(observation.raw(), 41);
+        assert_eq!(observation.gap(), 0);
+        assert_eq!(observation.cumulative_drops(), 0);
+        assert!(!observation.discontinuity());
+        assert_eq!(observation.stream_epoch(), 0);
+    }
+
+    #[test]
+    fn forward_sequences_count_only_missing_frames() {
+        let mut tracker = SequenceTracker::new();
+        tracker.observe(41).expect("baseline");
+
+        let contiguous = tracker.observe(42).expect("contiguous sequence");
+        assert_eq!(contiguous.gap(), 0);
+        assert_eq!(contiguous.cumulative_drops(), 0);
+        assert!(!contiguous.discontinuity());
+
+        let gap = tracker.observe(45).expect("small forward gap");
+        assert_eq!(gap.gap(), 2);
+        assert_eq!(gap.cumulative_drops(), 2);
+        assert!(!gap.discontinuity());
+        assert_eq!(gap.stream_epoch(), 0);
+    }
+
+    #[test]
+    fn sequence_wrap_is_contiguous() {
+        let mut tracker = SequenceTracker::new();
+        tracker.observe(u32::MAX).expect("baseline");
+
+        let wrapped = tracker.observe(0).expect("serial wrap");
+
+        assert_eq!(wrapped.gap(), 0);
+        assert_eq!(wrapped.cumulative_drops(), 0);
+        assert!(!wrapped.discontinuity());
+        assert_eq!(wrapped.stream_epoch(), 0);
+    }
+
+    #[test]
+    fn non_forward_sequences_start_bounded_discontinuous_epochs() {
+        let mut tracker = SequenceTracker::new();
+        tracker.observe(10).expect("baseline");
+
+        let duplicate = tracker.observe(10).expect("duplicate is represented");
+        assert_eq!(duplicate.gap(), 0);
+        assert_eq!(duplicate.cumulative_drops(), 0);
+        assert!(duplicate.discontinuity());
+        assert_eq!(duplicate.stream_epoch(), 1);
+
+        let backward = tracker.observe(9).expect("backward reset is represented");
+        assert_eq!(backward.gap(), 0);
+        assert_eq!(backward.cumulative_drops(), 0);
+        assert!(backward.discontinuity());
+        assert_eq!(backward.stream_epoch(), 2);
+
+        let ambiguous = tracker
+            .observe(9_u32.wrapping_add(1_u32 << 31))
+            .expect("half-range delta is represented");
+        assert_eq!(ambiguous.gap(), 0);
+        assert_eq!(ambiguous.cumulative_drops(), 0);
+        assert!(ambiguous.discontinuity());
+        assert_eq!(ambiguous.stream_epoch(), 3);
+    }
+
+    #[test]
+    fn explicit_restart_is_sticky_until_the_next_observation() {
+        let mut tracker = SequenceTracker::new();
+        tracker.observe(100).expect("baseline");
+        tracker.begin_new_epoch().expect("representable epoch");
+
+        let restarted = tracker.observe(3).expect("first restarted frame");
+        assert_eq!(restarted.gap(), 0);
+        assert_eq!(restarted.cumulative_drops(), 0);
+        assert!(restarted.discontinuity());
+        assert_eq!(restarted.stream_epoch(), 1);
+
+        let next = tracker.observe(4).expect("new epoch continues");
+        assert!(!next.discontinuity());
+        assert_eq!(next.stream_epoch(), 1);
+    }
+
+    #[test]
+    fn drop_counter_overflow_permanently_fails_the_tracker() {
+        let mut tracker = SequenceTracker {
+            previous: Some(10),
+            cumulative_drops: u64::MAX,
+            stream_epoch: 0,
+            pending_discontinuity: false,
+            failed: false,
+        };
+
+        assert_eq!(
+            tracker.observe(12),
+            Err(SequenceTrackerError::DropCounterOverflow)
+        );
+        assert_eq!(
+            tracker.observe(13),
+            Err(SequenceTrackerError::TrackerFailed)
+        );
+    }
+
+    #[test]
+    fn stream_epoch_overflow_permanently_fails_the_tracker() {
+        let mut tracker = SequenceTracker {
+            previous: Some(10),
+            cumulative_drops: 0,
+            stream_epoch: u64::MAX,
+            pending_discontinuity: false,
+            failed: false,
+        };
+
+        assert_eq!(
+            tracker.observe(10),
+            Err(SequenceTrackerError::StreamEpochOverflow)
+        );
+        assert_eq!(
+            tracker.observe(11),
+            Err(SequenceTrackerError::TrackerFailed)
+        );
+    }
+
+    #[test]
+    fn largest_defined_forward_delta_is_counted_not_ambiguous() {
+        let mut tracker = SequenceTracker::new();
+        tracker.observe(0).expect("baseline");
+
+        let observation = tracker
+            .observe(0x7fff_ffff)
+            .expect("largest RFC-1982 forward delta");
+
+        assert_eq!(observation.gap(), 0x7fff_fffe);
+        assert_eq!(observation.cumulative_drops(), u64::from(0x7fff_fffe_u32));
+        assert!(!observation.discontinuity());
+    }
+
+    #[test]
+    fn wrapped_forward_gap_counts_only_missing_frames() {
+        let mut tracker = SequenceTracker::new();
+        tracker.observe(u32::MAX - 1).expect("baseline");
+
+        let observation = tracker.observe(1).expect("wrapped forward gap");
+
+        assert_eq!(observation.gap(), 2);
+        assert_eq!(observation.cumulative_drops(), 2);
+        assert!(!observation.discontinuity());
+    }
+
+    #[test]
+    fn explicit_epoch_overflow_permanently_fails_the_tracker() {
+        let mut tracker = SequenceTracker {
+            previous: Some(10),
+            cumulative_drops: 0,
+            stream_epoch: u64::MAX,
+            pending_discontinuity: false,
+            failed: false,
+        };
+
+        assert_eq!(
+            tracker.begin_new_epoch(),
+            Err(SequenceTrackerError::StreamEpochOverflow)
+        );
+        assert_eq!(
+            tracker.begin_new_epoch(),
+            Err(SequenceTrackerError::TrackerFailed)
+        );
+    }
 
     #[test]
     fn dequeue_rejects_bytes_used_beyond_the_mapping() {

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Strict runtime evidence bound to one immutable camera lease reference.
+
+use crate::contracts::{CameraGeneration, CameraInstanceId, StreamRole};
+
+/// Immutable camera identity and logical role copied from a validated lease.
+///
+/// This value owns its identity so a dequeued frame never depends on a later
+/// `/dev/videoN` lookup or a mutable inventory observation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FrameBinding {
+    camera_instance_id: CameraInstanceId,
+    generation: CameraGeneration,
+    stream_role: StreamRole,
+}
+
+impl FrameBinding {
+    pub(crate) fn new(
+        camera_instance_id: CameraInstanceId,
+        generation: CameraGeneration,
+        stream_role: StreamRole,
+    ) -> Self {
+        Self {
+            camera_instance_id,
+            generation,
+            stream_role,
+        }
+    }
+
+    /// Process-scoped identity of the physical camera incarnation.
+    #[must_use]
+    pub const fn camera_instance_id(&self) -> &CameraInstanceId {
+        &self.camera_instance_id
+    }
+
+    /// Lifecycle generation validated when the lease was acquired.
+    #[must_use]
+    pub const fn generation(&self) -> CameraGeneration {
+        self.generation
+    }
+
+    /// Logical role of the endpoint producing frames under this binding.
+    #[must_use]
+    pub const fn stream_role(&self) -> StreamRole {
+        self.stream_role
+    }
+}

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -5,6 +5,306 @@
 
 use crate::contracts::{CameraGeneration, CameraInstanceId, StreamRole};
 
+/// Clock domain reported in the known V4L2 timestamp-type bits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TimestampClock {
+    Unknown,
+    Monotonic,
+    Copy,
+}
+
+/// Capture event represented by the V4L2 timestamp.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TimestampSource {
+    EndOfFrame,
+    StartOfExposure,
+}
+
+/// Why a dequeued buffer cannot enter the trusted decode boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DequeuedBufferError {
+    /// V4L2 marked the dequeued payload as corrupt.
+    DriverReportedCorruption,
+    /// The driver returned a timestamp that cannot identify a valid instant.
+    InvalidTimestamp { seconds: i64, microseconds: i64 },
+    /// The known timestamp mask carried a value with no defined semantics.
+    UnsupportedTimestampClock(u32),
+    /// The known timestamp-source mask carried a value with no defined semantics.
+    UnsupportedTimestampSource(u32),
+    /// The negotiated format has no strict payload rule in this boundary.
+    UnsupportedFormat([u8; 4]),
+    /// Zero geometry cannot describe a decodable image payload.
+    InvalidGeometry { width: u32, height: u32 },
+    /// Existing decoders require tightly packed rows.
+    UnsupportedStride { expected: usize, actual: usize },
+    /// Geometry arithmetic exceeded the target address space.
+    PayloadSizeOverflow,
+    /// The initialized payload cannot contain the negotiated image.
+    PayloadTooShort { bytes_used: usize, minimum: usize },
+    /// The driver claims more initialized payload than exists in the mmap slot.
+    PayloadExceedsMapping {
+        bytes_used: usize,
+        mapped_len: usize,
+    },
+    /// The kernel's payload length cannot be represented on this target.
+    PayloadLengthUnsupported(u32),
+}
+
+impl std::fmt::Display for DequeuedBufferError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DriverReportedCorruption => {
+                f.write_str("V4L2 marked the dequeued payload as corrupt")
+            }
+            Self::InvalidTimestamp {
+                seconds,
+                microseconds,
+            } => write!(f, "invalid V4L2 timestamp {seconds}s {microseconds}us"),
+            Self::UnsupportedTimestampClock(bits) => {
+                write!(f, "unsupported V4L2 timestamp clock bits 0x{bits:08x}")
+            }
+            Self::UnsupportedTimestampSource(bits) => {
+                write!(f, "unsupported V4L2 timestamp source bits 0x{bits:08x}")
+            }
+            Self::UnsupportedFormat(fourcc) => write!(
+                f,
+                "unsupported dequeued pixel format {:?}",
+                String::from_utf8_lossy(fourcc)
+            ),
+            Self::InvalidGeometry { width, height } => {
+                write!(f, "invalid dequeued geometry {width}x{height}")
+            }
+            Self::UnsupportedStride { expected, actual } => write!(
+                f,
+                "unsupported row stride {actual}; tight decoder requires {expected}"
+            ),
+            Self::PayloadSizeOverflow => f.write_str("dequeued payload geometry overflows usize"),
+            Self::PayloadTooShort {
+                bytes_used,
+                minimum,
+            } => write!(
+                f,
+                "dequeued payload uses {bytes_used} bytes but format requires at least {minimum}"
+            ),
+            Self::PayloadExceedsMapping {
+                bytes_used,
+                mapped_len,
+            } => write!(
+                f,
+                "dequeued payload uses {bytes_used} bytes but mapping has {mapped_len}"
+            ),
+            Self::PayloadLengthUnsupported(bytes_used) => write!(
+                f,
+                "dequeued payload length {bytes_used} is unsupported on this target"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DequeuedBufferError {}
+
+/// Checked minimum payload for one negotiated, tightly packed image format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PayloadLayout {
+    minimum: usize,
+}
+
+impl PayloadLayout {
+    pub(crate) fn new(
+        fourcc: [u8; 4],
+        width: u32,
+        height: u32,
+        stride: u32,
+    ) -> Result<Self, DequeuedBufferError> {
+        if width == 0 || height == 0 {
+            return Err(DequeuedBufferError::InvalidGeometry { width, height });
+        }
+        if (fourcc == *b"YUYV" && !width.is_multiple_of(2))
+            || (fourcc == *b"NV12" && (!width.is_multiple_of(2) || !height.is_multiple_of(2)))
+        {
+            return Err(DequeuedBufferError::InvalidGeometry { width, height });
+        }
+        let width = usize::try_from(width).map_err(|_| DequeuedBufferError::PayloadSizeOverflow)?;
+        let height =
+            usize::try_from(height).map_err(|_| DequeuedBufferError::PayloadSizeOverflow)?;
+        let actual_stride =
+            usize::try_from(stride).map_err(|_| DequeuedBufferError::PayloadSizeOverflow)?;
+        let expected_stride = match &fourcc {
+            b"GREY" | b"Y8  " | b"Y800" | b"NV12" => width,
+            b"Y16 " | b"Y10 " | b"Y12 " | b"YUYV" => width
+                .checked_mul(2)
+                .ok_or(DequeuedBufferError::PayloadSizeOverflow)?,
+            _ => return Err(DequeuedBufferError::UnsupportedFormat(fourcc)),
+        };
+        if actual_stride != expected_stride {
+            return Err(DequeuedBufferError::UnsupportedStride {
+                expected: expected_stride,
+                actual: actual_stride,
+            });
+        }
+        let image_rows = expected_stride
+            .checked_mul(height)
+            .ok_or(DequeuedBufferError::PayloadSizeOverflow)?;
+        let minimum = if fourcc == *b"NV12" {
+            image_rows
+                .checked_add(image_rows / 2)
+                .ok_or(DequeuedBufferError::PayloadSizeOverflow)?
+        } else {
+            image_rows
+        };
+        Ok(Self { minimum })
+    }
+
+    pub(crate) fn validate(self, facts: &DequeuedBufferFacts) -> Result<(), DequeuedBufferError> {
+        if facts.bytes_used < self.minimum {
+            return Err(DequeuedBufferError::PayloadTooShort {
+                bytes_used: facts.bytes_used,
+                minimum: self.minimum,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Owned kernel facts copied from one reusable V4L2 dequeue slot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DequeuedBufferFacts {
+    bytes_used: usize,
+    known_flags: u32,
+    sequence_raw: u32,
+    timestamp_seconds: i64,
+    timestamp_microseconds: i64,
+    timestamp_micros: i64,
+    timestamp_clock: TimestampClock,
+    timestamp_source: TimestampSource,
+}
+
+fn widen_timestamp_component<T>(value: T) -> i64
+where
+    i64: From<T>,
+{
+    i64::from(value)
+}
+
+impl DequeuedBufferFacts {
+    /// Copy and validate metadata before the ring slot can be reused.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DequeuedBufferError`] when the driver reports corruption,
+    /// malformed timestamp semantics, or a payload outside the mmap boundary.
+    pub(crate) fn from_v4l(
+        metadata: &v4l::buffer::Metadata,
+        mapped_len: usize,
+    ) -> Result<Self, DequeuedBufferError> {
+        let bytes_used = usize::try_from(metadata.bytesused)
+            .map_err(|_| DequeuedBufferError::PayloadLengthUnsupported(metadata.bytesused))?;
+        if bytes_used > mapped_len {
+            return Err(DequeuedBufferError::PayloadExceedsMapping {
+                bytes_used,
+                mapped_len,
+            });
+        }
+        if metadata.flags.contains(v4l::buffer::Flags::ERROR) {
+            return Err(DequeuedBufferError::DriverReportedCorruption);
+        }
+        let timestamp_seconds = widen_timestamp_component(metadata.timestamp.sec);
+        let timestamp_microseconds = widen_timestamp_component(metadata.timestamp.usec);
+        if timestamp_seconds < 0 || !(0..1_000_000).contains(&timestamp_microseconds) {
+            return Err(DequeuedBufferError::InvalidTimestamp {
+                seconds: timestamp_seconds,
+                microseconds: timestamp_microseconds,
+            });
+        }
+        let timestamp_micros = timestamp_seconds
+            .checked_mul(1_000_000)
+            .and_then(|seconds| seconds.checked_add(timestamp_microseconds))
+            .ok_or(DequeuedBufferError::InvalidTimestamp {
+                seconds: timestamp_seconds,
+                microseconds: timestamp_microseconds,
+            })?;
+        let flag_bits = metadata.flags.bits();
+        let clock_bits = flag_bits & v4l::buffer::Flags::TIMESTAMP_MASK.bits();
+        let timestamp_clock = match clock_bits {
+            bits if bits == v4l::buffer::Flags::TIMESTAMP_UNKNOWN.bits() => TimestampClock::Unknown,
+            bits if bits == v4l::buffer::Flags::TIMESTAMP_MONOTONIC.bits() => {
+                TimestampClock::Monotonic
+            }
+            bits if bits == v4l::buffer::Flags::TIMESTAMP_COPY.bits() => TimestampClock::Copy,
+            bits => return Err(DequeuedBufferError::UnsupportedTimestampClock(bits)),
+        };
+        let source_bits = flag_bits & v4l::buffer::Flags::TSTAMP_SRC_MASK.bits();
+        let timestamp_source = match source_bits {
+            bits if bits == v4l::buffer::Flags::TSTAMP_SRC_EOF.bits() => {
+                TimestampSource::EndOfFrame
+            }
+            bits if bits == v4l::buffer::Flags::TSTAMP_SRC_SOE.bits() => {
+                TimestampSource::StartOfExposure
+            }
+            bits => return Err(DequeuedBufferError::UnsupportedTimestampSource(bits)),
+        };
+        Ok(Self {
+            bytes_used,
+            known_flags: flag_bits,
+            sequence_raw: metadata.sequence,
+            timestamp_seconds,
+            timestamp_microseconds,
+            timestamp_micros,
+            timestamp_clock,
+            timestamp_source,
+        })
+    }
+
+    /// Number of initialized payload bytes reported by the driver.
+    #[must_use]
+    pub const fn bytes_used(&self) -> usize {
+        self.bytes_used
+    }
+
+    /// All flag bits preserved by pinned `v4l` 0.14.0.
+    #[must_use]
+    pub const fn known_flags(&self) -> u32 {
+        self.known_flags
+    }
+
+    /// Raw wrapping V4L2 sequence number.
+    #[must_use]
+    pub const fn sequence_raw(&self) -> u32 {
+        self.sequence_raw
+    }
+
+    /// Whole seconds from the V4L2 buffer timestamp.
+    #[must_use]
+    pub const fn timestamp_seconds(&self) -> i64 {
+        self.timestamp_seconds
+    }
+
+    /// Sub-second microseconds from the V4L2 buffer timestamp.
+    #[must_use]
+    pub const fn timestamp_microseconds(&self) -> i64 {
+        self.timestamp_microseconds
+    }
+
+    /// Checked total timestamp in microseconds for same-domain correlation.
+    #[must_use]
+    pub const fn timestamp_micros(&self) -> i64 {
+        self.timestamp_micros
+    }
+
+    /// Clock domain declared by the V4L2 timestamp flags.
+    #[must_use]
+    pub const fn timestamp_clock(&self) -> TimestampClock {
+        self.timestamp_clock
+    }
+
+    /// Capture event declared by the V4L2 timestamp flags.
+    #[must_use]
+    pub const fn timestamp_source(&self) -> TimestampSource {
+        self.timestamp_source
+    }
+}
+
 /// Immutable camera identity and logical role copied from a validated lease.
 ///
 /// This value owns its identity so a dequeued frame never depends on a later
@@ -45,5 +345,208 @@ impl FrameBinding {
     #[must_use]
     pub const fn stream_role(&self) -> StreamRole {
         self.stream_role
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DequeuedBufferError, DequeuedBufferFacts, PayloadLayout, TimestampClock, TimestampSource,
+    };
+
+    #[test]
+    fn dequeue_rejects_bytes_used_beyond_the_mapping() {
+        let metadata = v4l::buffer::Metadata {
+            bytesused: 8,
+            ..v4l::buffer::Metadata::default()
+        };
+
+        assert_eq!(
+            DequeuedBufferFacts::from_v4l(&metadata, 7),
+            Err(DequeuedBufferError::PayloadExceedsMapping {
+                bytes_used: 8,
+                mapped_len: 7,
+            })
+        );
+    }
+
+    #[test]
+    fn dequeue_rejects_driver_error_status() {
+        let metadata = v4l::buffer::Metadata {
+            bytesused: 4,
+            flags: v4l::buffer::Flags::ERROR,
+            ..v4l::buffer::Metadata::default()
+        };
+
+        assert_eq!(
+            DequeuedBufferFacts::from_v4l(&metadata, 4),
+            Err(DequeuedBufferError::DriverReportedCorruption)
+        );
+    }
+
+    #[test]
+    fn dequeue_rejects_out_of_range_timestamp_microseconds() {
+        let metadata = v4l::buffer::Metadata {
+            timestamp: v4l::timestamp::Timestamp::new(7, 1_000_000),
+            ..v4l::buffer::Metadata::default()
+        };
+
+        assert_eq!(
+            DequeuedBufferFacts::from_v4l(&metadata, 0),
+            Err(DequeuedBufferError::InvalidTimestamp {
+                seconds: 7,
+                microseconds: 1_000_000,
+            })
+        );
+    }
+
+    #[test]
+    fn dequeue_rejects_negative_timestamp_seconds() {
+        let metadata = v4l::buffer::Metadata {
+            timestamp: v4l::timestamp::Timestamp::new(-1, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+
+        assert_eq!(
+            DequeuedBufferFacts::from_v4l(&metadata, 0),
+            Err(DequeuedBufferError::InvalidTimestamp {
+                seconds: -1,
+                microseconds: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn dequeue_rejects_timestamp_that_cannot_form_a_microsecond_key() {
+        let metadata = v4l::buffer::Metadata {
+            timestamp: v4l::timestamp::Timestamp::new(i64::MAX, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+
+        assert_eq!(
+            DequeuedBufferFacts::from_v4l(&metadata, 0),
+            Err(DequeuedBufferError::InvalidTimestamp {
+                seconds: i64::MAX,
+                microseconds: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn dequeue_normalizes_monotonic_start_of_exposure_metadata() {
+        let flags = v4l::buffer::Flags::TIMESTAMP_MONOTONIC
+            | v4l::buffer::Flags::TSTAMP_SRC_SOE
+            | v4l::buffer::Flags::KEYFRAME;
+        let metadata = v4l::buffer::Metadata {
+            bytesused: 3,
+            flags,
+            timestamp: v4l::timestamp::Timestamp::new(7, 11),
+            sequence: 42,
+            ..v4l::buffer::Metadata::default()
+        };
+
+        let facts = DequeuedBufferFacts::from_v4l(&metadata, 4).expect("valid metadata");
+        assert_eq!(facts.bytes_used(), 3);
+        assert_eq!(facts.sequence_raw(), 42);
+        assert_eq!(facts.timestamp_seconds(), 7);
+        assert_eq!(facts.timestamp_microseconds(), 11);
+        assert_eq!(facts.timestamp_clock(), TimestampClock::Monotonic);
+        assert_eq!(facts.timestamp_source(), TimestampSource::StartOfExposure);
+        assert_eq!(facts.known_flags(), flags.bits());
+    }
+
+    #[test]
+    fn dequeue_normalizes_monotonic_end_of_frame_metadata() {
+        let metadata = v4l::buffer::Metadata {
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC | v4l::buffer::Flags::TSTAMP_SRC_EOF,
+            timestamp: v4l::timestamp::Timestamp::new(1, 2),
+            ..v4l::buffer::Metadata::default()
+        };
+
+        let facts = DequeuedBufferFacts::from_v4l(&metadata, 0).expect("valid metadata");
+        assert_eq!(facts.timestamp_clock(), TimestampClock::Monotonic);
+        assert_eq!(facts.timestamp_source(), TimestampSource::EndOfFrame);
+    }
+
+    #[test]
+    fn grey_layout_rejects_short_payload() {
+        let layout = PayloadLayout::new(*b"GREY", 4, 3, 4).expect("tight GREY layout");
+        let metadata = v4l::buffer::Metadata {
+            bytesused: 11,
+            ..v4l::buffer::Metadata::default()
+        };
+        let facts = DequeuedBufferFacts::from_v4l(&metadata, 12).expect("bounded metadata");
+
+        assert_eq!(
+            layout.validate(&facts),
+            Err(DequeuedBufferError::PayloadTooShort {
+                bytes_used: 11,
+                minimum: 12,
+            })
+        );
+    }
+
+    #[test]
+    fn every_decoded_format_rejects_a_short_payload() {
+        let cases = [
+            (*b"GREY", 4, 16),
+            (*b"Y8  ", 4, 16),
+            (*b"Y800", 4, 16),
+            (*b"Y16 ", 8, 32),
+            (*b"Y10 ", 8, 32),
+            (*b"Y12 ", 8, 32),
+            (*b"YUYV", 8, 32),
+            (*b"NV12", 4, 24),
+        ];
+
+        for (fourcc, stride, minimum) in cases {
+            let layout = PayloadLayout::new(fourcc, 4, 4, stride).expect("supported layout");
+            let metadata = v4l::buffer::Metadata {
+                bytesused: minimum - 1,
+                ..v4l::buffer::Metadata::default()
+            };
+            let facts = DequeuedBufferFacts::from_v4l(&metadata, minimum as usize)
+                .expect("bounded metadata");
+            assert_eq!(
+                layout.validate(&facts),
+                Err(DequeuedBufferError::PayloadTooShort {
+                    bytes_used: minimum as usize - 1,
+                    minimum: minimum as usize,
+                }),
+                "{}",
+                String::from_utf8_lossy(&fourcc)
+            );
+        }
+    }
+
+    #[test]
+    fn payload_geometry_overflow_is_rejected() {
+        let dimension = u32::MAX - 1;
+        assert_eq!(
+            PayloadLayout::new(*b"NV12", dimension, dimension, dimension),
+            Err(DequeuedBufferError::PayloadSizeOverflow)
+        );
+    }
+
+    #[test]
+    fn padded_stride_is_rejected_until_decoders_support_rows() {
+        assert_eq!(
+            PayloadLayout::new(*b"GREY", 4, 3, 8),
+            Err(DequeuedBufferError::UnsupportedStride {
+                expected: 4,
+                actual: 8,
+            })
+        );
+    }
+
+    #[test]
+    fn yuyv_requires_complete_two_pixel_macropixels() {
+        assert_eq!(
+            PayloadLayout::new(*b"YUYV", 3, 2, 6),
+            Err(DequeuedBufferError::InvalidGeometry {
+                width: 3,
+                height: 2,
+            })
+        );
     }
 }

--- a/crates/irlume-camera/src/lease.rs
+++ b/crates/irlume-camera/src/lease.rs
@@ -14,7 +14,8 @@ use std::{
 };
 
 use crate::{
-    contracts::CameraInstanceId,
+    contracts::{CameraInstanceId, StreamRole},
+    frame_provenance::FrameBinding,
     inventory::{CameraInventory, CameraInventoryRef},
 };
 
@@ -55,6 +56,7 @@ pub enum CameraLeaseError {
     },
     EmptyKey,
     EndpointNotCovered,
+    AmbiguousEndpointBinding,
     InvalidEndpoint(String),
 }
 
@@ -85,6 +87,9 @@ impl std::fmt::Display for CameraLeaseError {
             }
             Self::EndpointNotCovered => {
                 formatter.write_str("camera endpoint is not covered by this operation lease")
+            }
+            Self::AmbiguousEndpointBinding => {
+                formatter.write_str("camera endpoint is covered by multiple lease references")
             }
             Self::InvalidEndpoint(message) => formatter.write_str(message),
         }
@@ -394,6 +399,38 @@ impl CameraLease {
         }
     }
 
+    /// Copy immutable frame identity from the one lease reference covering an endpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns a lifecycle validation error for stale inventory, refuses an
+    /// uncovered endpoint, and fails closed if malformed lease state contains
+    /// more than one reference covering the path.
+    pub fn frame_binding(
+        &self,
+        path: &str,
+        stream_role: StreamRole,
+    ) -> Result<FrameBinding, CameraLeaseError> {
+        self.validate()?;
+        let mut matching = self
+            .inner
+            .references
+            .iter()
+            .filter(|reference| reference.endpoint_paths().iter().any(|known| known == path));
+        let reference = matching
+            .next()
+            .ok_or(CameraLeaseError::EndpointNotCovered)?;
+        if matching.next().is_some() {
+            return Err(CameraLeaseError::AmbiguousEndpointBinding);
+        }
+        let descriptor = reference.descriptor();
+        Ok(FrameBinding::new(
+            descriptor.camera_instance_id().clone(),
+            descriptor.generation(),
+            stream_role,
+        ))
+    }
+
     pub fn state(&self) -> CameraSessionState {
         self.inner
             .state
@@ -687,6 +724,52 @@ mod tests {
         )
         .unwrap();
         (authority, inventory, lease)
+    }
+
+    #[test]
+    fn frame_binding_owns_exact_identity_and_rejects_uncovered_or_stale_endpoints() {
+        let (_authority, inventory, lease) = lease_fixture();
+
+        let binding = lease
+            .frame_binding("/dev/video2", crate::contracts::StreamRole::Ir)
+            .expect("covered current endpoint binds to its immutable descriptor");
+        assert_eq!(binding.camera_instance_id(), &instance('1'));
+        assert_eq!(
+            binding.generation(),
+            crate::contracts::CameraGeneration::INITIAL
+        );
+        assert_eq!(binding.stream_role(), crate::contracts::StreamRole::Ir);
+        assert_eq!(
+            lease.frame_binding("/dev/video9", crate::contracts::StreamRole::Rgb),
+            Err(CameraLeaseError::EndpointNotCovered)
+        );
+
+        inventory.lock().unwrap().invalidate_all();
+        assert_eq!(
+            lease.frame_binding("/dev/video2", crate::contracts::StreamRole::Ir),
+            Err(CameraLeaseError::Stale)
+        );
+    }
+
+    #[test]
+    fn frame_binding_refuses_ambiguous_duplicate_endpoint_coverage() {
+        let (_authority, inventory, lease) = lease_fixture();
+        let reference = lease.inner.references[0].clone();
+        drop(lease);
+        let authority = Arc::new(LeaseAuthority::default());
+        let duplicate = CameraLease::acquire(
+            &authority,
+            inventory,
+            vec![reference.clone(), reference],
+            CameraOperationKind::Authentication,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .unwrap();
+
+        assert_eq!(
+            duplicate.frame_binding("/dev/video0", crate::contracts::StreamRole::Rgb),
+            Err(CameraLeaseError::AmbiguousEndpointBinding)
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -33,6 +33,7 @@ mod backend;
 /// Versioned, backend-neutral camera data contracts.
 pub mod contracts;
 pub mod emitter_journal;
+pub mod frame_provenance;
 mod inventory;
 pub mod ir_dark;
 pub mod ir_emitter;

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -682,6 +682,95 @@ impl<'a> SafeStream<'a> {
     }
 }
 
+trait ValidatedStream {
+    fn next_validated(&mut self)
+        -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)>;
+}
+
+impl ValidatedStream for SafeStream<'_> {
+    fn next_validated(
+        &mut self,
+    ) -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)> {
+        self.next()
+    }
+}
+
+/// Sequence state whose lifetime is independent of its replaceable mmap stream.
+struct TrackedStream<S> {
+    stream: Option<S>,
+    sequence: frame_provenance::SequenceTracker,
+}
+
+impl<S> TrackedStream<S> {
+    fn new(stream: S) -> Self {
+        Self {
+            stream: Some(stream),
+            sequence: frame_provenance::SequenceTracker::new(),
+        }
+    }
+
+    fn stream_mut(&mut self) -> Option<&mut S> {
+        self.stream.as_mut()
+    }
+
+    fn take(&mut self) -> Option<S> {
+        self.stream.take()
+    }
+
+    fn install_recovered(
+        &mut self,
+        stream: S,
+    ) -> Result<(), frame_provenance::SequenceTrackerError> {
+        self.sequence.begin_new_epoch()?;
+        self.stream = Some(stream);
+        Ok(())
+    }
+}
+
+impl<S: ValidatedStream> TrackedStream<S> {
+    fn next(
+        &mut self,
+    ) -> std::io::Result<(
+        &[u8],
+        frame_provenance::DequeuedBufferFacts,
+        frame_provenance::SequenceObservation,
+    )> {
+        let Self { stream, sequence } = self;
+        let (payload, facts) = stream
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
+            .next_validated()?;
+        let observation = sequence
+            .observe(facts.sequence_raw())
+            .map_err(std::io::Error::other)?;
+        Ok((payload, facts, observation))
+    }
+}
+
+fn install_recovered_resources<S, M, G, E>(
+    replacement: S,
+    metadata: M,
+    emitter_guard: G,
+    install: impl FnOnce(S) -> Result<(), E>,
+) -> Result<(M, G), E> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| install(replacement))) {
+        Ok(Ok(())) => Ok((metadata, emitter_guard)),
+        Ok(Err(error)) => {
+            // The replacement is dropped before `install` returns. Stop any
+            // separately-owned metadata queue before restoring the emitter.
+            drop(metadata);
+            drop(emitter_guard);
+            Err(error)
+        }
+        Err(payload) => {
+            // Preserve panic semantics after enforcing the same teardown order.
+            drop(metadata);
+            drop(emitter_guard);
+            std::panic::resume_unwind(payload);
+        }
+    }
+}
+
 impl Drop for SafeStream<'_> {
     fn drop(&mut self) {
         let Some(inner) = self.inner.take() else {
@@ -2044,7 +2133,7 @@ impl RgbCamera {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(RgbSession {
             cam: self,
-            stream: Some(stream),
+            stream: TrackedStream::new(stream),
             warmed: false,
             progress: progress.clone(),
             _blc_restore: blc_restore,
@@ -2229,7 +2318,7 @@ pub struct RgbSession<'a> {
     /// `None` only transiently inside [`Self::recover`]: the broken stream
     /// must be DROPPED (STREAMOFF + buffer release) before its replacement
     /// negotiates, and a plain re-assignment builds the new value first.
-    stream: Option<SafeStream<'a>>,
+    stream: TrackedStream<SafeStream<'a>>,
     warmed: bool,
     /// Per-window heartbeat for the lazy warm-up (#336); owned, not borrowed,
     /// so holding a session never freezes the caller's other borrows.
@@ -2251,7 +2340,7 @@ impl<'a> RgbSession<'a> {
     /// than a panic because this sits in the authentication path.
     fn stream(&mut self) -> irlume_common::Result<&mut SafeStream<'a>> {
         self.stream
-            .as_mut()
+            .stream_mut()
             .ok_or_else(|| Error::Hardware("RGB stream missing after a failed recovery".into()))
     }
 
@@ -2274,17 +2363,23 @@ impl<'a> RgbSession<'a> {
             .lease
             .require_endpoint(&self.cam.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
-        self.stream = None; // drop first: STREAMOFF + buffer release
-        self.stream = Some(SafeStream::open(
+        drop(self.stream.take()); // STREAMOFF + buffer release before replacement
+        let stream = SafeStream::open(
             &self.cam.device,
             &self.cam.dev,
             &self.cam.negotiated,
             self.cam.lease.clone(),
-        )?);
+        )?;
         self.cam
             .lease
             .require_endpoint(&self.cam.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
+        self.stream.install_recovered(stream).map_err(|error| {
+            Error::Hardware(format!(
+                "{}: could not begin the recovered sequence epoch: {error}",
+                self.cam.device
+            ))
+        })?;
         // The fresh stream's auto-exposure starts unsettled, like any new
         // session's.
         self.warmed = false;
@@ -2333,7 +2428,8 @@ impl<'a> RgbSession<'a> {
                 .lease
                 .require_endpoint(&device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, _meta) = self.stream()?.next().map_err(|e| map_io(&device, e))?;
+            let (buf, _meta, _sequence) =
+                self.stream.next().map_err(|error| map_io(&device, error))?;
             let taken = std::time::Instant::now();
             let data = match &chosen {
                 b"NV12" => nv12_to_rgb(buf, w, h),
@@ -3044,7 +3140,7 @@ impl IrCamera {
         warm_up_stream(&self.device, &mut stream, progress)?;
         Ok(IrSession {
             cam: self,
-            stream: Some(stream),
+            stream: TrackedStream::new(stream),
             dec: IrDecoder::new(self.pix, self.quantization),
             lit: mode.lit(),
             _mode: mode,
@@ -3060,7 +3156,7 @@ pub struct IrSession<'a> {
     /// `None` only transiently inside [`Self::recover`]: the broken stream
     /// must be DROPPED (STREAMOFF + buffer release) before its replacement
     /// negotiates, and a plain re-assignment builds the new value first.
-    stream: Option<SafeStream<'a>>,
+    stream: TrackedStream<SafeStream<'a>>,
     dec: IrDecoder,
     lit: bool,
     /// The camera's own per-frame illumination reporting, when it has any.
@@ -3106,10 +3202,12 @@ impl IrSession<'_> {
         // retries the held session. The RGB twin already answers hardware
         // trouble here for the same reason; on the sequential branch the old
         // panic unwound out of the daemon worker.
-        let stream = self
-            .stream
-            .as_mut()
-            .ok_or_else(|| Error::Hardware("IR stream missing after a failed recovery".into()))?;
+        if self.stream.stream_mut().is_none() {
+            return Err(Error::Hardware(
+                "IR stream missing after a failed recovery".into(),
+            ));
+        }
+        let stream = &mut self.stream;
         let dec = &mut self.dec;
         // The emitter may STROBE (pulse), so grab a burst and keep the brightest
         // frame, the lit strobe phase (linhello lesson). Keep every frame so the
@@ -3144,7 +3242,7 @@ impl IrSession<'_> {
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, bmeta) = stream.next().map_err(|e| map_io(device, e))?;
+            let (buf, bmeta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
@@ -3460,7 +3558,7 @@ impl IrSession<'_> {
             .lease
             .require_endpoint(&self.cam.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
-        self.stream = None; // drop first: STREAMOFF + buffer release
+        drop(self.stream.take()); // STREAMOFF + buffer release before replacement
         self.meta = None; // drop the metadata queue
                           // A restore failure PROPAGATES, mirroring the frozen-stream restart:
                           // the guard is spent after one attempt, and an unrecorded write whose
@@ -3490,15 +3588,22 @@ impl IrSession<'_> {
             self.cam.lease.clone(),
         );
         let lit = mode.lit();
-        self.stream = Some(stream);
+        let (meta, mode) = install_recovered_resources(stream, meta, mode, |stream| {
+            self.cam
+                .lease
+                .require_endpoint(&self.cam.device)
+                .map_err(|error| Error::Hardware(error.to_string()))?;
+            self.stream.install_recovered(stream).map_err(|error| {
+                Error::Hardware(format!(
+                    "{}: could not begin the recovered sequence epoch: {error}",
+                    self.cam.device
+                ))
+            })
+        })?;
         self.meta = meta;
         self._mode = mode;
         self.dec = IrDecoder::new(self.cam.pix, self.cam.quantization);
         self.lit = lit;
-        self.cam
-            .lease
-            .require_endpoint(&self.cam.device)
-            .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(())
     }
 }
@@ -3666,14 +3771,15 @@ pub mod ir_probe {
         // buffers; STREAMON happens on the first dequeue, so the set still
         // lands before streaming starts.
         let mode;
-        let mut stream = super::SafeStream::open(device, &dev, &fmt, permit.clone())?;
+        let stream = super::SafeStream::open(device, &dev, &fmt, permit.clone())?;
+        let mut stream = super::TrackedStream::new(stream);
         mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
         // Bound, never read: held for its `Drop`, which restores the control.
         let _ = &mode;
         let mut out = Vec::with_capacity(n);
         let t0 = std::time::Instant::now();
         for _ in 0..n {
-            let (buf, _meta) = stream.next().map_err(|e| map_io(device, e))?;
+            let (buf, _meta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
             let taken = std::time::Instant::now();
             out.push((
                 Frame {
@@ -3774,7 +3880,8 @@ pub fn capture_ir_streaming<B>(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+    let stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+    let mut stream = TrackedStream::new(stream);
     mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
@@ -3807,7 +3914,7 @@ pub fn capture_ir_streaming<B>(
     // user a password fallback. Reading the metadata queue here is how that gets
     // closed, and it is not done.
     for _ in 0..max_frames {
-        let (buf, _meta) = stream.next().map_err(|e| map_io(device, e))?;
+        let (buf, _meta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
         let taken = std::time::Instant::now();
         let data = dec.decode(buf, w, h);
         let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
@@ -3820,33 +3927,44 @@ pub fn capture_ir_streaming<B>(
                 restarts += 1;
                 dead_run = 0;
                 last_sig = None;
-                drop(stream); // stop + release buffers before re-arming
-                              // The OLD guard restores BEFORE the reopen. Its stream is
-                              // already gone, and while the guard lives it holds the
-                              // per-camera stream lock, which would make the fresh `enable`
-                              // refuse to drive the emitter at all — the lock refuses
-                              // contested writes rather than allowing an unrecorded one
-                              // (#188, review round 4). Restoring here cannot write under
-                              // the new stream either, because it happens before the fresh
-                              // apply. Earlier versions kept the old guard armed across the
-                              // reopen and negotiated ownership afterwards; the cost of
-                              // this simpler shape is one restore/apply pair per restart,
-                              // and restarts are the exception, not the path.
-                              // A restore failure PROPAGATES rather than being logged
-                              // over: the guard is spent after one attempt, and an
-                              // UNRECORDED write whose restore failed here would otherwise
-                              // become permanently unowned — the fresh enable finds the
-                              // wanted bytes with no record to claim and leaves them
-                              // forever (review round 12). Surfacing hardware trouble
-                              // beats continuing to authenticate through it.
+                drop(stream.take()); // stop + release buffers before re-arming
+                                     // The OLD guard restores BEFORE the reopen. Its stream is
+                                     // already gone, and while the guard lives it holds the
+                                     // per-camera stream lock, which would make the fresh `enable`
+                                     // refuse to drive the emitter at all — the lock refuses
+                                     // contested writes rather than allowing an unrecorded one
+                                     // (#188, review round 4). Restoring here cannot write under
+                                     // the new stream either, because it happens before the fresh
+                                     // apply. Earlier versions kept the old guard armed across the
+                                     // reopen and negotiated ownership afterwards; the cost of
+                                     // this simpler shape is one restore/apply pair per restart,
+                                     // and restarts are the exception, not the path.
+                                     // A restore failure PROPAGATES rather than being logged
+                                     // over: the guard is spent after one attempt, and an
+                                     // UNRECORDED write whose restore failed here would otherwise
+                                     // become permanently unowned — the fresh enable finds the
+                                     // wanted bytes with no record to claim and leaves them
+                                     // forever (review round 12). Surfacing hardware trouble
+                                     // beats continuing to authenticate through it.
                 mode.restore().map_err(|e| {
                     Error::Hardware(format!(
                         "{device}: could not restore the emitter before restarting \
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
-                mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
+                let replacement = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+                let replacement_mode =
+                    ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
+                let ((), replacement_mode) =
+                    install_recovered_resources(replacement, (), replacement_mode, |replacement| {
+                        stream.install_recovered(replacement)
+                    })
+                    .map_err(|error| {
+                        Error::Hardware(format!(
+                            "{device}: could not begin the recovered sequence epoch: {error}"
+                        ))
+                    })?;
+                mode = replacement_mode;
             }
             continue;
         }
@@ -3881,12 +3999,6 @@ pub fn capture_ir_streaming<B>(
 /// [`capture_ir_streaming`], which delivers raw single frames; the consent
 /// watch uses the streaming core, this stays for the `burst>=2` diagnostic path.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "cannot panic: `stream` is Some from its initialisation, and the one \
-              `take()` on the frozen-restart path reopens it in the same branch; \
-              both failure paths in between return early with `?`"
-)]
 pub fn capture_ir_sequence(
     device: &str,
     samples: usize,
@@ -3924,7 +4036,8 @@ pub fn capture_ir_sequence(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let mut stream = Some(SafeStream::open(device, &dev, &fmt, permit.clone())?);
+    let stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+    let mut stream = TrackedStream::new(stream);
     mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Set once per stream, before it starts, and not per frame (the
     // frozen-stream restart below re-applies on its new stream). This path also carried
@@ -3946,11 +4059,7 @@ pub fn capture_ir_sequence(
         // instant it came from rather than stamping the end of the burst.
         let mut taken = std::time::Instant::now();
         for _ in 0..burst {
-            let (buf, _meta) = stream
-                .as_mut()
-                .expect("IR stream present")
-                .next()
-                .map_err(|e| map_io(device, e))?;
+            let (buf, _meta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
             let at = std::time::Instant::now();
             let data = dec.decode(buf, w, h);
             let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
@@ -3995,8 +4104,19 @@ pub fn capture_ir_sequence(
                          a frozen stream: {e}"
                     ))
                 })?;
-                stream = Some(SafeStream::open(device, &dev, &fmt, permit.clone())?);
-                mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
+                let replacement = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+                let replacement_mode =
+                    ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
+                let ((), replacement_mode) =
+                    install_recovered_resources(replacement, (), replacement_mode, |replacement| {
+                        stream.install_recovered(replacement)
+                    })
+                    .map_err(|error| {
+                        Error::Hardware(format!(
+                            "{device}: could not begin the recovered sequence epoch: {error}"
+                        ))
+                    })?;
+                mode = replacement_mode;
             }
             continue;
         }
@@ -5204,6 +5324,131 @@ mod tests {
 
         assert_eq!(payload, &[1, 2, 3, 4]);
         assert_eq!(facts.bytes_used(), 4);
+    }
+
+    #[test]
+    fn recovery_failure_stops_streams_before_restoring_emitter() {
+        #[derive(Debug)]
+        struct DropMark {
+            name: &'static str,
+            drops: std::rc::Rc<std::cell::RefCell<Vec<&'static str>>>,
+        }
+
+        impl Drop for DropMark {
+            fn drop(&mut self) {
+                self.drops.borrow_mut().push(self.name);
+            }
+        }
+
+        let drops = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mark = |name| DropMark {
+            name,
+            drops: std::rc::Rc::clone(&drops),
+        };
+        let result = install_recovered_resources(
+            mark("image-stream"),
+            mark("metadata-stream"),
+            mark("emitter-restore"),
+            |stream| {
+                drop(stream);
+                Err::<(), _>("install failed")
+            },
+        );
+
+        assert!(matches!(result, Err("install failed")));
+        assert_eq!(
+            drops.borrow().as_slice(),
+            ["image-stream", "metadata-stream", "emitter-restore"]
+        );
+    }
+
+    #[test]
+    fn recovery_panic_stops_streams_before_restoring_emitter() {
+        #[derive(Debug)]
+        struct DropMark {
+            name: &'static str,
+            drops: std::rc::Rc<std::cell::RefCell<Vec<&'static str>>>,
+        }
+
+        impl Drop for DropMark {
+            fn drop(&mut self) {
+                self.drops.borrow_mut().push(self.name);
+            }
+        }
+
+        let drops = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mark = |name| DropMark {
+            name,
+            drops: std::rc::Rc::clone(&drops),
+        };
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = install_recovered_resources(
+                mark("image-stream"),
+                mark("metadata-stream"),
+                mark("emitter-restore"),
+                |stream| -> Result<(), ()> {
+                    drop(stream);
+                    panic!("injected install panic");
+                },
+            );
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(
+            drops.borrow().as_slice(),
+            ["image-stream", "metadata-stream", "emitter-restore"]
+        );
+    }
+
+    #[test]
+    fn recovery_epoch_survives_untracked_warmup_dequeues() {
+        struct SequenceFixture {
+            payload: [u8; 1],
+            sequences: std::collections::VecDeque<u32>,
+        }
+
+        impl ValidatedStream for SequenceFixture {
+            fn next_validated(
+                &mut self,
+            ) -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)> {
+                let sequence = self
+                    .sequences
+                    .pop_front()
+                    .ok_or_else(|| std::io::Error::other("fixture exhausted"))?;
+                let metadata = v4l::buffer::Metadata {
+                    bytesused: 1,
+                    sequence,
+                    ..v4l::buffer::Metadata::default()
+                };
+                let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, 1)
+                    .map_err(std::io::Error::other)?;
+                Ok((&self.payload, facts))
+            }
+        }
+
+        let fixture = |sequences: &[u32]| SequenceFixture {
+            payload: [7],
+            sequences: sequences.iter().copied().collect(),
+        };
+        let mut capture = TrackedStream::new(fixture(&[41]));
+        let (_, _, baseline) = capture.next().expect("baseline delivery");
+        assert!(!baseline.discontinuity());
+
+        capture.take();
+        capture
+            .install_recovered(fixture(&[500, 7]))
+            .expect("representable recovery epoch");
+        capture
+            .stream_mut()
+            .expect("replacement stream")
+            .next_validated()
+            .expect("discarded warm-up dequeue");
+
+        let (_, _, restarted) = capture.next().expect("first delivered recovery frame");
+        assert_eq!(restarted.raw(), 7);
+        assert_eq!(restarted.gap(), 0);
+        assert!(restarted.discontinuity());
+        assert_eq!(restarted.stream_epoch(), 1);
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -114,7 +114,6 @@ pub(crate) mod testenv {
 use irlume_common::Error;
 use v4l::buffer::Type;
 use v4l::format::Quantization;
-use v4l::io::traits::CaptureStream;
 use v4l::video::Capture;
 use v4l::{Device, Format, FourCC};
 
@@ -398,6 +397,39 @@ const FROZEN_RESTART_BUDGET: usize = 4;
 /// 30fps, small enough to be granted by every UVC camera we have seen.
 const MMAP_BUFFERS: u32 = 4;
 
+/// The capture adapter used by the trusted dequeue boundary.
+///
+/// Returning owned metadata is deliberate: v4l reuses its metadata ring, so no
+/// reference may survive another dequeue.
+trait CaptureDequeue {
+    fn dequeue(&mut self) -> std::io::Result<(&[u8], v4l::buffer::Metadata)>;
+}
+
+impl CaptureDequeue for v4l::io::mmap::Stream<'_> {
+    fn dequeue(&mut self) -> std::io::Result<(&[u8], v4l::buffer::Metadata)> {
+        let (mapped, metadata) = v4l::io::traits::CaptureStream::next(self)?;
+        Ok((mapped, *metadata))
+    }
+}
+
+fn dequeue_validated<S, R>(
+    stream: &mut S,
+    layout: frame_provenance::PayloadLayout,
+    mut require_endpoint: R,
+) -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)>
+where
+    S: CaptureDequeue,
+    R: FnMut() -> std::io::Result<()>,
+{
+    require_endpoint()?;
+    let (mapped, metadata) = stream.dequeue()?;
+    require_endpoint()?;
+    let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, mapped.len())
+        .map_err(std::io::Error::other)?;
+    layout.validate(&facts).map_err(std::io::Error::other)?;
+    Ok((&mapped[..facts.bytes_used()], facts))
+}
+
 /// A capture stream whose teardown cannot take the process down.
 ///
 /// v4l 0.14's `Stream::drop` calls `stop()` and PANICS on any failure except
@@ -415,6 +447,7 @@ struct SafeStream<'a> {
     inner: Option<v4l::io::mmap::Stream<'a>>,
     device: String,
     lease: lease::CameraLease,
+    layout: frame_provenance::PayloadLayout,
     lease_started: bool,
 }
 
@@ -579,6 +612,13 @@ impl<'a> SafeStream<'a> {
         lease
             .require_endpoint(device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
+        let layout = frame_provenance::PayloadLayout::new(
+            expect.fourcc.repr,
+            expect.width,
+            expect.height,
+            expect.stride,
+        )
+        .map_err(|error| Error::Hardware(format!("{device}: {error}")))?;
         let mut inner = v4l::io::mmap::Stream::with_buffers(dev, Type::VideoCapture, MMAP_BUFFERS)
             .map_err(|e| map_io(device, e))?;
         inner.set_timeout(STREAM_DEQUEUE_TIMEOUT);
@@ -589,6 +629,7 @@ impl<'a> SafeStream<'a> {
             inner: Some(inner),
             device: device.to_string(),
             lease,
+            layout,
             lease_started: false,
         };
         let now = Capture::format(dev).map_err(|e| map_io(device, e))?;
@@ -621,36 +662,23 @@ impl<'a> SafeStream<'a> {
         Ok(stream)
     }
 
-    fn next(&mut self) -> std::io::Result<(&[u8], &v4l::buffer::Metadata)> {
+    fn next(&mut self) -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)> {
         let Self {
             inner,
             device,
             lease,
+            layout,
             ..
         } = self;
-        lease
-            .require_endpoint(device)
-            .map_err(std::io::Error::other)?;
-        let frame = v4l::io::traits::CaptureStream::next(
+        dequeue_validated(
             inner.as_mut().expect("stream taken only in Drop"),
-        )?;
-        lease
-            .require_endpoint(device)
-            .map_err(std::io::Error::other)?;
-        Ok(frame)
-    }
-}
-
-impl<'a> std::ops::Deref for SafeStream<'a> {
-    type Target = v4l::io::mmap::Stream<'a>;
-    fn deref(&self) -> &Self::Target {
-        self.inner.as_ref().expect("stream taken only in Drop")
-    }
-}
-
-impl std::ops::DerefMut for SafeStream<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.inner.as_mut().expect("stream taken only in Drop")
+            *layout,
+            || {
+                lease
+                    .require_endpoint(device)
+                    .map_err(std::io::Error::other)
+            },
+        )
     }
 }
 
@@ -3120,7 +3148,7 @@ impl IrSession<'_> {
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            stamps.push(bmeta.timestamp.sec * 1_000_000 + bmeta.timestamp.usec);
+            stamps.push(bmeta.timestamp_micros());
             taken.push(std::time::Instant::now());
             // Drain every iteration, not once at the end. The metadata ring is
             // smaller than a burst, so a single drain afterwards silently loses
@@ -5047,7 +5075,7 @@ pub fn nv12_to_rgb(nv12: &[u8], width: u32, height: u32) -> Vec<u8> {
 /// (#141) only starves when a driver call genuinely never returns.
 fn warm_up_stream(
     device: &str,
-    stream: &mut v4l::io::mmap::Stream<'_>,
+    stream: &mut SafeStream<'_>,
     progress: &Progress,
 ) -> irlume_common::Result<()> {
     warm_up_with(
@@ -5107,6 +5135,76 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct SabotagingDequeue {
+        payload: [u8; 4],
+        stale: std::rc::Rc<std::cell::Cell<bool>>,
+    }
+
+    impl CaptureDequeue for SabotagingDequeue {
+        fn dequeue(&mut self) -> std::io::Result<(&[u8], v4l::buffer::Metadata)> {
+            self.stale.set(true);
+            Ok((
+                &self.payload,
+                v4l::buffer::Metadata {
+                    bytesused: 4,
+                    ..v4l::buffer::Metadata::default()
+                },
+            ))
+        }
+    }
+
+    #[test]
+    fn dequeue_refuses_lifecycle_sabotage_after_the_blocking_call() {
+        let stale = std::rc::Rc::new(std::cell::Cell::new(false));
+        let mut stream = SabotagingDequeue {
+            payload: [1, 2, 3, 4],
+            stale: stale.clone(),
+        };
+        let layout =
+            frame_provenance::PayloadLayout::new(*b"GREY", 2, 2, 2).expect("tight GREY layout");
+
+        let error = dequeue_validated(&mut stream, layout, || {
+            if stale.get() {
+                Err(std::io::Error::other("stale camera generation"))
+            } else {
+                Ok(())
+            }
+        })
+        .expect_err("post-dequeue lifecycle sabotage must fail closed");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "stale camera generation");
+    }
+
+    #[test]
+    fn dequeue_returns_only_driver_initialized_payload() {
+        struct FixedDequeue {
+            payload: [u8; 5],
+        }
+
+        impl CaptureDequeue for FixedDequeue {
+            fn dequeue(&mut self) -> std::io::Result<(&[u8], v4l::buffer::Metadata)> {
+                Ok((
+                    &self.payload,
+                    v4l::buffer::Metadata {
+                        bytesused: 4,
+                        ..v4l::buffer::Metadata::default()
+                    },
+                ))
+            }
+        }
+
+        let mut stream = FixedDequeue {
+            payload: [1, 2, 3, 4, 99],
+        };
+        let layout = frame_provenance::PayloadLayout::new(*b"GREY", 2, 2, 2).expect("tight layout");
+        let (payload, facts) =
+            dequeue_validated(&mut stream, layout, || Ok(())).expect("valid dequeue");
+
+        assert_eq!(payload, &[1, 2, 3, 4]);
+        assert_eq!(facts.bytes_used(), 4);
+    }
 
     #[test]
     fn session_slot_is_exclusive_and_reopens_after_drop() {

--- a/crates/irlume-camera/tests/contracts.rs
+++ b/crates/irlume-camera/tests/contracts.rs
@@ -32,38 +32,6 @@ fn capabilities() -> CameraCapabilities {
 }
 
 #[test]
-fn safe_stream_validates_both_sides_of_blocking_dequeue() {
-    let source = include_str!("../src/lib.rs");
-    let start = source
-        .find("    fn next(&mut self) -> std::io::Result<(&[u8], &v4l::buffer::Metadata)> {")
-        .expect("SafeStream::next exists");
-    let body = &source[start
-        ..source[start..]
-            .find(
-                "
-    }
-}
-
-impl<'a> std::ops::Deref",
-            )
-            .map(|end| start + end)
-            .expect("SafeStream::next body ends before Deref")];
-    let dequeue = body
-        .find("CaptureStream::next")
-        .expect("blocking dequeue exists");
-    let checks: Vec<_> = body
-        .match_indices("require_endpoint")
-        .map(|(index, _)| index)
-        .collect();
-    assert_eq!(
-        checks.len(),
-        2,
-        "SafeStream must validate before and after dequeue"
-    );
-    assert!(checks[0] < dequeue && dequeue < checks[1]);
-}
-
-#[test]
 fn camera_descriptor_v1_has_a_stable_wire_shape() {
     let descriptor = CameraDescriptor::new(
         BackendKind::UvcV4l2,


### PR DESCRIPTION
## Summary

Establish the trusted frame-provenance foundation for #462 through sequence continuity:

1. bind frame identity to the immutable camera lease/generation and logical stream role;
2. normalize and validate V4L2 dequeue metadata and payload layout before decode;
3. track RFC-1982-style V4L2 sequence continuity across every frame-producing RGB/IR path and stream recovery.

Refs #462. This PR intentionally does not close the issue; timestamp continuity, public/aggregate provenance, and exact interval negotiation remain in slices 4–7.

## Safety properties

- Identity is copied from the current descriptor-bound lease, never reconstructed from `/dev/videoN`.
- Blocking dequeues revalidate lifecycle state before and after the call.
- Driver error flags, invalid timestamps, `bytesused` beyond the mapping, short payloads, unsupported stride, malformed geometry, and odd YUYV widths fail closed.
- `SafeStream` has no dereference escape hatch around trusted dequeue validation.
- Sequence tracking handles contiguous progress and `u32` wrap, records bounded forward gaps, and starts discontinuous epochs for duplicate/backward/ambiguous half-range transitions.
- Drop/epoch counter overflow permanently poisons the tracker.
- Tracker state lives outside replaceable mmap streams; successful recovery creates a sticky discontinuous epoch that discarded warm-up dequeues cannot consume.
- Every frame-producing RGB/IR path uses the tracked dequeue boundary.
- Recovery error and panic paths stop image streaming, then metadata streaming, before restoring the emitter; the original panic is resumed.

## Test evidence for exact head

Head: `9c782933dbea678dd1e18bd7bd5fb55c6ce029fa`

- Guarded workspace tests: **1,495 passed**.
- Camera: **373 unit tests + 12 contracts passed**; 19 hardware/loopback tests ignored.
- `cargo fmt --all --check`.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`.
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --locked`.
- `cargo build --workspace --release --locked`.
- `cargo deny check` (configured policy passed; existing duplicate/yanked warnings remain).
- `nix flake check`.
- Packaging parity, action-pin policy, machine API (36/36), and script self-tests.
- Sabotage proved hidden recovery and emitter-first cleanup are detected.
- Panic injection proved cleanup order during unwind.
- Two independent final reviews of diff fingerprint `b1dd5d5938488b42c1b5c6a50a7e7759a243116d` found no security concern or logic error; the committed patch matches that fingerprint.

## Hardware coverage

No physical-camera result is claimed for this PR. The 19 ignored hardware/loopback tests remain explicit. Beginning with slice 4, each subsequent slice will be stress-tested at an exact commit on archhost, minihost, thinkpad, and the current device, with per-device evidence recorded separately.

## Follow-up slices

- Slice 4: timestamp continuity within an unchanged clock/source domain.
- Slice 5: attach or safely aggregate provenance on delivered/derived frames without changing schema v1 silently.
- Slices 6–7: exact interval enumeration, negotiation, post-claim/start drift checks, and delivered-rate evidence.
