### PR TITLE
feat(camera): enforce timestamp continuity across recovery

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install nightly Rust (-Zsanitizer is unstable)
         # @master (declares the `toolchain` input); the version tag branches
         # have no such input and ignore `with: toolchain:`.
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: nightly
           # The sanitizer runtimes ship with the standard library for the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           fi
 
       - name: Install Rust 1.88 (MSRV) with rustfmt + clippy
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           # Pinned to a SHA, the action can't read the version from the tag, so
           # name the toolchain explicitly (it is a required input then).
@@ -352,7 +352,7 @@ jobs:
       - name: Install stable Rust
         # @master (declares the `toolchain` input); the version tag branches
         # (e.g. @1.88.0) have no such input and ignore `with: toolchain:`.
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
 
@@ -604,7 +604,7 @@ jobs:
       - name: Install nightly Rust (cargo-fuzz needs it)
         # @master so `toolchain: nightly-...` is honored (the version-branch pin
         # ignored it; nightly only worked via the RUSTUP_TOOLCHAIN env fallback).
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: nightly-2026-07-15
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,15 @@ jobs:
       - name: test
         run: ./scripts/run-tests-guarded.sh --min 650 -- cargo test --workspace --locked
 
+      # These pure harness contracts are intentionally separate from the ignored
+      # physical-camera test: CI can prove evidence parsing and service/socket
+      # quiescence without claiming physical-device coverage.
+      - name: camera hardware evidence harness contracts
+        run: |
+          python3 scripts/hardware/test-run-slice4-hardware.py
+          python3 scripts/hardware/test-validate-slice4-hardware.py
+          bash -n scripts/hardware/run-slice4-hardware.sh
+
       # The machine API is a promise to other people's software, so it is
       # checked the way a consumer would check it: run the release binary and
       # validate what it actually writes against the published schema, rather

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -675,8 +675,10 @@ impl DequeuedBufferFacts {
     ///
     /// # Errors
     ///
-    /// Returns [`DequeuedBufferError`] when the driver reports corruption,
-    /// malformed timestamp semantics, or a payload outside the mmap boundary.
+    /// Returns [`DequeuedBufferError`] for malformed timestamp semantics or a
+    /// payload outside the mmap boundary. Driver-reported payload corruption is
+    /// retained as metadata so continuity can observe the dequeue while the
+    /// trusted payload boundary rejects delivery.
     pub(crate) fn from_v4l(
         metadata: &v4l::buffer::Metadata,
         mapped_len: usize,
@@ -688,9 +690,6 @@ impl DequeuedBufferFacts {
                 bytes_used,
                 mapped_len,
             });
-        }
-        if metadata.flags.contains(v4l::buffer::Flags::ERROR) {
-            return Err(DequeuedBufferError::DriverReportedCorruption);
         }
         let timestamp_seconds = widen_timestamp_component(metadata.timestamp.sec);
         let timestamp_microseconds = widen_timestamp_component(metadata.timestamp.usec);
@@ -749,6 +748,12 @@ impl DequeuedBufferFacts {
     #[must_use]
     pub const fn known_flags(&self) -> u32 {
         self.known_flags
+    }
+
+    /// Whether V4L2 marked this successfully dequeued payload as corrupt.
+    #[must_use]
+    pub const fn driver_reported_corruption(&self) -> bool {
+        self.known_flags & v4l::buffer::Flags::ERROR.bits() != 0
     }
 
     /// Raw wrapping V4L2 sequence number.
@@ -1230,17 +1235,20 @@ mod tests {
     }
 
     #[test]
-    fn dequeue_rejects_driver_error_status() {
+    fn dequeue_retains_driver_error_status_with_valid_continuity_facts() {
         let metadata = v4l::buffer::Metadata {
             bytesused: 4,
-            flags: v4l::buffer::Flags::ERROR,
-            ..v4l::buffer::Metadata::default()
+            flags: v4l::buffer::Flags::ERROR | v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            sequence: 7,
+            timestamp: v4l::timestamp::Timestamp::new(3, 4),
+            ..Default::default()
         };
 
-        assert_eq!(
-            DequeuedBufferFacts::from_v4l(&metadata, 4),
-            Err(DequeuedBufferError::DriverReportedCorruption)
-        );
+        let facts = DequeuedBufferFacts::from_v4l(&metadata, 4)
+            .expect("corruption does not erase valid continuity metadata");
+        assert!(facts.driver_reported_corruption());
+        assert_eq!(facts.sequence_raw(), 7);
+        assert_eq!(facts.timestamp_micros(), 3_000_004);
     }
 
     #[test]

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -20,6 +20,286 @@ pub enum TimestampSource {
     StartOfExposure,
 }
 
+/// Derived continuity facts for one trusted V4L2 timestamp.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TimestampObservation {
+    micros: i64,
+    delta_micros: Option<u64>,
+    clock: TimestampClock,
+    source: TimestampSource,
+    discontinuity: bool,
+    stream_epoch: u64,
+}
+
+impl TimestampObservation {
+    #[must_use]
+    pub const fn micros(&self) -> i64 {
+        self.micros
+    }
+    #[must_use]
+    pub const fn delta_micros(&self) -> Option<u64> {
+        self.delta_micros
+    }
+    #[must_use]
+    pub const fn clock(&self) -> TimestampClock {
+        self.clock
+    }
+    #[must_use]
+    pub const fn source(&self) -> TimestampSource {
+        self.source
+    }
+    #[must_use]
+    pub const fn discontinuity(&self) -> bool {
+        self.discontinuity
+    }
+    #[must_use]
+    pub const fn stream_epoch(&self) -> u64 {
+        self.stream_epoch
+    }
+}
+
+/// Why trusted timestamp continuity cannot advance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TimestampTrackerError {
+    /// The first timestamp did not name the monotonic clock.
+    UntrustedClock(TimestampClock),
+    /// Zero cannot identify a valid frame instant.
+    ZeroTimestamp,
+    /// Negative keys are outside the normalized dequeue domain.
+    NegativeTimestamp(i64),
+    /// The timestamp clock changed inside a live stream epoch.
+    ClockChanged {
+        expected: TimestampClock,
+        actual: TimestampClock,
+    },
+    /// The driver-selected timestamp event changed inside a live stream epoch.
+    SourceChanged {
+        expected: TimestampSource,
+        actual: TimestampSource,
+    },
+    /// The timestamp repeated or moved backward inside an epoch.
+    NonIncreasing { previous: i64, current: i64 },
+    /// The epoch counter cannot advance without wrapping.
+    StreamEpochOverflow,
+    /// This epoch saw invalid evidence and requires explicit recovery.
+    EpochFailed,
+    /// Checked arithmetic previously exhausted and permanently poisoned the tracker.
+    TrackerFailed,
+}
+
+impl std::fmt::Display for TimestampTrackerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UntrustedClock(clock) => write!(f, "untrusted timestamp clock {clock:?}"),
+            Self::ZeroTimestamp => f.write_str("zero timestamp cannot identify a frame instant"),
+            Self::NegativeTimestamp(value) => write!(f, "negative timestamp {value}us"),
+            Self::ClockChanged { expected, actual } => {
+                write!(f, "timestamp clock changed from {expected:?} to {actual:?}")
+            }
+            Self::SourceChanged { expected, actual } => {
+                write!(
+                    f,
+                    "timestamp source changed from {expected:?} to {actual:?}"
+                )
+            }
+            Self::NonIncreasing { previous, current } => write!(
+                f,
+                "timestamp did not increase: previous {previous}us, current {current}us"
+            ),
+            Self::StreamEpochOverflow => f.write_str("timestamp stream epoch overflow"),
+            Self::EpochFailed => f.write_str("timestamp epoch is failed; recovery is required"),
+            Self::TrackerFailed => f.write_str("timestamp tracker is permanently failed"),
+        }
+    }
+}
+
+impl std::error::Error for TimestampTrackerError {}
+
+/// Timestamp continuity state for one logical capture stream.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TimestampTracker {
+    previous: Option<i64>,
+    domain: Option<(TimestampClock, TimestampSource)>,
+    stream_epoch: u64,
+    pending_discontinuity: bool,
+    epoch_failed: bool,
+    failed: bool,
+}
+
+impl TimestampTracker {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            previous: None,
+            domain: None,
+            stream_epoch: 0,
+            pending_discontinuity: false,
+            epoch_failed: false,
+            failed: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_stream_epoch_overflow_on_recovery(&mut self) {
+        self.stream_epoch = u64::MAX;
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn stream_epoch_for_test(&self) -> u64 {
+        self.stream_epoch
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn failed_for_test(&self) -> bool {
+        self.failed
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn previous_for_test(&self) -> Option<i64> {
+        self.previous
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn continuity_state_for_test(
+        &self,
+    ) -> (
+        Option<i64>,
+        Option<(TimestampClock, TimestampSource)>,
+        u64,
+        bool,
+    ) {
+        (
+            self.previous,
+            self.domain,
+            self.stream_epoch,
+            self.pending_discontinuity,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn epoch_failed_for_test(&self) -> bool {
+        self.epoch_failed
+    }
+
+    pub(crate) fn fail_current_epoch(&mut self) {
+        if !self.failed {
+            self.epoch_failed = true;
+        }
+    }
+
+    pub(crate) fn observe_discarded(
+        &mut self,
+        micros: i64,
+        clock: TimestampClock,
+        source: TimestampSource,
+    ) -> Result<TimestampObservation, TimestampTrackerError> {
+        let observation = self.observe(micros, clock, source)?;
+        if observation.discontinuity() {
+            self.pending_discontinuity = true;
+        }
+        Ok(observation)
+    }
+
+    /// Starts a recovered stream epoch and resets its timestamp domain.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TimestampTrackerError::StreamEpochOverflow`] when the epoch
+    /// counter is exhausted, permanently poisoning the tracker, or
+    /// [`TimestampTrackerError::TrackerFailed`] when it was already poisoned.
+    pub fn begin_new_epoch(&mut self) -> Result<(), TimestampTrackerError> {
+        if self.failed {
+            return Err(TimestampTrackerError::TrackerFailed);
+        }
+        let Some(next_epoch) = self.stream_epoch.checked_add(1) else {
+            self.failed = true;
+            return Err(TimestampTrackerError::StreamEpochOverflow);
+        };
+        self.stream_epoch = next_epoch;
+        self.previous = None;
+        self.domain = None;
+        self.pending_discontinuity = true;
+        self.epoch_failed = false;
+        Ok(())
+    }
+
+    /// Validates and records one timestamp in the current stream epoch.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TimestampTrackerError`] for an untrusted or changed domain,
+    /// a non-positive or non-increasing timestamp, or a previously failed
+    /// timestamp epoch. A continuity error keeps the epoch failed until
+    /// [`Self::begin_new_epoch`] succeeds.
+    pub fn observe(
+        &mut self,
+        micros: i64,
+        clock: TimestampClock,
+        source: TimestampSource,
+    ) -> Result<TimestampObservation, TimestampTrackerError> {
+        if self.failed {
+            return Err(TimestampTrackerError::TrackerFailed);
+        }
+        if self.epoch_failed {
+            return Err(TimestampTrackerError::EpochFailed);
+        }
+        if let Some((expected_clock, expected_source)) = self.domain {
+            if clock != expected_clock {
+                self.epoch_failed = true;
+                return Err(TimestampTrackerError::ClockChanged {
+                    expected: expected_clock,
+                    actual: clock,
+                });
+            }
+            if source != expected_source {
+                self.epoch_failed = true;
+                return Err(TimestampTrackerError::SourceChanged {
+                    expected: expected_source,
+                    actual: source,
+                });
+            }
+        }
+        if clock != TimestampClock::Monotonic {
+            self.epoch_failed = true;
+            return Err(TimestampTrackerError::UntrustedClock(clock));
+        }
+        if micros < 0 {
+            self.epoch_failed = true;
+            return Err(TimestampTrackerError::NegativeTimestamp(micros));
+        }
+        if micros == 0 {
+            self.epoch_failed = true;
+            return Err(TimestampTrackerError::ZeroTimestamp);
+        }
+        if let Some(previous) = self.previous {
+            if micros <= previous {
+                self.epoch_failed = true;
+                return Err(TimestampTrackerError::NonIncreasing {
+                    previous,
+                    current: micros,
+                });
+            }
+        }
+        let delta_micros = self
+            .previous
+            .and_then(|previous| micros.checked_sub(previous))
+            .and_then(|delta| u64::try_from(delta).ok());
+        self.previous = Some(micros);
+        self.domain = Some((clock, source));
+        let discontinuity = self.pending_discontinuity;
+        self.pending_discontinuity = false;
+        Ok(TimestampObservation {
+            micros,
+            delta_micros,
+            clock,
+            source,
+            discontinuity,
+            stream_epoch: self.stream_epoch,
+        })
+    }
+}
+
 /// Why sequence continuity can no longer be represented safely.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -45,6 +325,7 @@ impl std::error::Error for SequenceTrackerError {}
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SequenceObservation {
     raw: u32,
+    advance: Option<u32>,
     gap: u32,
     cumulative_drops: u64,
     discontinuity: bool,
@@ -55,6 +336,11 @@ impl SequenceObservation {
     #[must_use]
     pub const fn raw(&self) -> u32 {
         self.raw
+    }
+
+    #[must_use]
+    pub const fn advance(&self) -> Option<u32> {
+        self.advance
     }
 
     #[must_use]
@@ -100,6 +386,43 @@ impl SequenceTracker {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) const fn previous_for_test(&self) -> Option<u32> {
+        self.previous
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn continuity_state_for_test(&self) -> (Option<u32>, u64, u64, bool, bool) {
+        (
+            self.previous,
+            self.cumulative_drops,
+            self.stream_epoch,
+            self.pending_discontinuity,
+            self.failed,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_stream_epoch_overflow_on_recovery(&mut self) {
+        self.stream_epoch = u64::MAX;
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn stream_epoch_for_test(&self) -> u64 {
+        self.stream_epoch
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn failed_for_test(&self) -> bool {
+        self.failed
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_drop_overflow_on_next_gap(&mut self) {
+        self.previous = Some(1);
+        self.cumulative_drops = u64::MAX;
+    }
+
     /// Mark a successfully replaced stream as a new discontinuous epoch.
     ///
     /// The marker remains pending until the next observed (delivered) frame, so
@@ -123,6 +446,17 @@ impl SequenceTracker {
         Ok(())
     }
 
+    pub(crate) fn observe_discarded(
+        &mut self,
+        raw: u32,
+    ) -> Result<SequenceObservation, SequenceTrackerError> {
+        let observation = self.observe(raw)?;
+        if observation.discontinuity() {
+            self.pending_discontinuity = true;
+        }
+        Ok(observation)
+    }
+
     /// Observe one raw sequence value.
     ///
     /// # Errors
@@ -132,14 +466,15 @@ impl SequenceTracker {
         if self.failed {
             return Err(SequenceTrackerError::TrackerFailed);
         }
-        let (gap, transition_discontinuity) = self.previous.map_or((0, false), |previous| {
-            let delta = raw.wrapping_sub(previous);
-            if (1..(1_u32 << 31)).contains(&delta) {
-                (delta - 1, false)
-            } else {
-                (0, true)
-            }
-        });
+        let (gap, transition_discontinuity, advance) =
+            self.previous.map_or((0, false, None), |previous| {
+                let delta = raw.wrapping_sub(previous);
+                if (1..(1_u32 << 31)).contains(&delta) {
+                    (delta - 1, false, Some(delta))
+                } else {
+                    (0, true, None)
+                }
+            });
         if transition_discontinuity {
             let Some(stream_epoch) = self.stream_epoch.checked_add(1) else {
                 self.failed = true;
@@ -159,6 +494,7 @@ impl SequenceTracker {
         self.pending_discontinuity = false;
         Ok(SequenceObservation {
             raw,
+            advance,
             gap,
             cumulative_drops: self.cumulative_drops,
             discontinuity,
@@ -499,8 +835,211 @@ impl FrameBinding {
 mod tests {
     use super::{
         DequeuedBufferError, DequeuedBufferFacts, PayloadLayout, SequenceTracker,
-        SequenceTrackerError, TimestampClock, TimestampSource,
+        SequenceTrackerError, TimestampClock, TimestampSource, TimestampTracker,
+        TimestampTrackerError,
     };
+
+    #[test]
+    fn first_monotonic_timestamp_establishes_a_clean_epoch() {
+        let mut tracker = TimestampTracker::new();
+        let observation = tracker
+            .observe(
+                1_000_000,
+                TimestampClock::Monotonic,
+                TimestampSource::EndOfFrame,
+            )
+            .expect("first timestamp is valid");
+
+        assert_eq!(observation.micros(), 1_000_000);
+        assert_eq!(observation.delta_micros(), None);
+        assert_eq!(observation.clock(), TimestampClock::Monotonic);
+        assert_eq!(observation.source(), TimestampSource::EndOfFrame);
+        assert!(!observation.discontinuity());
+        assert_eq!(observation.stream_epoch(), 0);
+    }
+
+    #[test]
+    fn monotonic_timestamps_report_positive_deltas() {
+        let mut tracker = TimestampTracker::new();
+        tracker
+            .observe(
+                1_000_000,
+                TimestampClock::Monotonic,
+                TimestampSource::StartOfExposure,
+            )
+            .expect("baseline");
+        let observation = tracker
+            .observe(
+                1_033_333,
+                TimestampClock::Monotonic,
+                TimestampSource::StartOfExposure,
+            )
+            .expect("increasing timestamp");
+
+        assert_eq!(observation.delta_micros(), Some(33_333));
+        assert!(!observation.discontinuity());
+        assert_eq!(observation.stream_epoch(), 0);
+    }
+
+    #[test]
+    fn untrusted_timestamp_clocks_fail_the_current_epoch() {
+        for clock in [TimestampClock::Unknown, TimestampClock::Copy] {
+            let mut tracker = TimestampTracker::new();
+            assert_eq!(
+                tracker.observe(1, clock, TimestampSource::EndOfFrame),
+                Err(TimestampTrackerError::UntrustedClock(clock))
+            );
+            assert_eq!(
+                tracker.observe(2, TimestampClock::Monotonic, TimestampSource::EndOfFrame),
+                Err(TimestampTrackerError::EpochFailed)
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_timestamp_ordering_stays_failed_until_recovery() {
+        let mut zero = TimestampTracker::new();
+        assert_eq!(
+            zero.observe(0, TimestampClock::Monotonic, TimestampSource::EndOfFrame),
+            Err(TimestampTrackerError::ZeroTimestamp)
+        );
+
+        for current in [100, 99] {
+            let mut tracker = TimestampTracker::new();
+            tracker
+                .observe(100, TimestampClock::Monotonic, TimestampSource::EndOfFrame)
+                .expect("baseline");
+            assert_eq!(
+                tracker.observe(
+                    current,
+                    TimestampClock::Monotonic,
+                    TimestampSource::EndOfFrame
+                ),
+                Err(TimestampTrackerError::NonIncreasing {
+                    previous: 100,
+                    current
+                })
+            );
+            assert_eq!(
+                tracker.observe(101, TimestampClock::Monotonic, TimestampSource::EndOfFrame),
+                Err(TimestampTrackerError::EpochFailed)
+            );
+        }
+    }
+
+    #[test]
+    fn timestamp_domain_changes_fail_the_current_epoch() {
+        let mut source = TimestampTracker::new();
+        source
+            .observe(10, TimestampClock::Monotonic, TimestampSource::EndOfFrame)
+            .expect("baseline");
+        assert_eq!(
+            source.observe(
+                11,
+                TimestampClock::Monotonic,
+                TimestampSource::StartOfExposure
+            ),
+            Err(TimestampTrackerError::SourceChanged {
+                expected: TimestampSource::EndOfFrame,
+                actual: TimestampSource::StartOfExposure,
+            })
+        );
+
+        let mut clock = TimestampTracker::new();
+        clock
+            .observe(10, TimestampClock::Monotonic, TimestampSource::EndOfFrame)
+            .expect("baseline");
+        assert_eq!(
+            clock.observe(11, TimestampClock::Copy, TimestampSource::EndOfFrame),
+            Err(TimestampTrackerError::ClockChanged {
+                expected: TimestampClock::Monotonic,
+                actual: TimestampClock::Copy,
+            })
+        );
+    }
+
+    #[test]
+    fn recovered_timestamp_epoch_marks_only_its_first_observation() {
+        let mut tracker = TimestampTracker::new();
+        tracker
+            .observe(100, TimestampClock::Monotonic, TimestampSource::EndOfFrame)
+            .expect("baseline");
+        assert!(tracker
+            .observe(99, TimestampClock::Monotonic, TimestampSource::EndOfFrame)
+            .is_err());
+
+        tracker.begin_new_epoch().expect("recovery epoch");
+        let first = tracker
+            .observe(
+                1,
+                TimestampClock::Monotonic,
+                TimestampSource::StartOfExposure,
+            )
+            .expect("new baseline");
+        assert!(first.discontinuity());
+        assert_eq!(first.stream_epoch(), 1);
+        assert_eq!(first.delta_micros(), None);
+
+        let second = tracker
+            .observe(
+                2,
+                TimestampClock::Monotonic,
+                TimestampSource::StartOfExposure,
+            )
+            .expect("same epoch");
+        assert!(!second.discontinuity());
+    }
+
+    #[test]
+    fn timestamp_epoch_overflow_permanently_poisons_tracker() {
+        let mut tracker = TimestampTracker::new();
+        tracker.stream_epoch = u64::MAX;
+
+        assert_eq!(
+            tracker.begin_new_epoch(),
+            Err(TimestampTrackerError::StreamEpochOverflow)
+        );
+        assert_eq!(
+            tracker.begin_new_epoch(),
+            Err(TimestampTrackerError::TrackerFailed)
+        );
+        assert_eq!(
+            tracker.observe(1, TimestampClock::Monotonic, TimestampSource::EndOfFrame),
+            Err(TimestampTrackerError::TrackerFailed)
+        );
+    }
+
+    #[test]
+    fn negative_timestamp_fails_the_current_epoch() {
+        let mut tracker = TimestampTracker::new();
+        assert_eq!(
+            tracker.observe(-1, TimestampClock::Monotonic, TimestampSource::EndOfFrame),
+            Err(TimestampTrackerError::NegativeTimestamp(-1))
+        );
+        assert_eq!(
+            tracker.observe(1, TimestampClock::Monotonic, TimestampSource::EndOfFrame),
+            Err(TimestampTrackerError::EpochFailed)
+        );
+    }
+
+    #[test]
+    fn sequence_observation_reports_only_same_epoch_forward_advance() {
+        let mut tracker = SequenceTracker::new();
+        assert_eq!(tracker.observe(41).expect("baseline").advance(), None);
+        assert_eq!(tracker.observe(45).expect("forward gap").advance(), Some(4));
+        tracker.begin_new_epoch().expect("recovery epoch");
+        assert_eq!(
+            tracker
+                .observe_discarded(u32::MAX)
+                .expect("recovery baseline")
+                .advance(),
+            None
+        );
+        assert_eq!(
+            tracker.observe(0).expect("wrapped advance").advance(),
+            Some(1)
+        );
+    }
 
     #[test]
     fn first_sequence_establishes_a_clean_baseline() {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -412,6 +412,25 @@ impl CaptureDequeue for v4l::io::mmap::Stream<'_> {
     }
 }
 
+#[derive(Debug)]
+enum ValidatedDequeueError {
+    Io(std::io::Error),
+    Facts(frame_provenance::DequeuedBufferError),
+}
+
+impl ValidatedDequeueError {
+    fn invalidates_timestamp_epoch(&self) -> bool {
+        matches!(self, Self::Facts(_))
+    }
+    fn into_io(self) -> std::io::Error {
+        match self {
+            Self::Io(error) => error,
+            Self::Facts(error) => std::io::Error::other(error),
+        }
+    }
+}
+
+#[cfg(test)]
 fn dequeue_validated<S, R>(
     stream: &mut S,
     layout: frame_provenance::PayloadLayout,
@@ -427,6 +446,26 @@ where
     let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, mapped.len())
         .map_err(std::io::Error::other)?;
     layout.validate(&facts).map_err(std::io::Error::other)?;
+    Ok((&mapped[..facts.bytes_used()], facts))
+}
+
+fn dequeue_validated_typed<S, R>(
+    stream: &mut S,
+    layout: frame_provenance::PayloadLayout,
+    mut require_endpoint: R,
+) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>
+where
+    S: CaptureDequeue,
+    R: FnMut() -> std::io::Result<()>,
+{
+    require_endpoint().map_err(ValidatedDequeueError::Io)?;
+    let (mapped, metadata) = stream.dequeue().map_err(ValidatedDequeueError::Io)?;
+    require_endpoint().map_err(ValidatedDequeueError::Io)?;
+    let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, mapped.len())
+        .map_err(ValidatedDequeueError::Facts)?;
+    layout
+        .validate(&facts)
+        .map_err(ValidatedDequeueError::Facts)?;
     Ok((&mapped[..facts.bytes_used()], facts))
 }
 
@@ -663,6 +702,12 @@ impl<'a> SafeStream<'a> {
     }
 
     fn next(&mut self) -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)> {
+        self.next_typed().map_err(ValidatedDequeueError::into_io)
+    }
+
+    fn next_typed(
+        &mut self,
+    ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
         let Self {
             inner,
             device,
@@ -670,7 +715,7 @@ impl<'a> SafeStream<'a> {
             layout,
             ..
         } = self;
-        dequeue_validated(
+        dequeue_validated_typed(
             inner.as_mut().expect("stream taken only in Drop"),
             *layout,
             || {
@@ -683,22 +728,27 @@ impl<'a> SafeStream<'a> {
 }
 
 trait ValidatedStream {
-    fn next_validated(&mut self)
-        -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)>;
+    fn next_validated(
+        &mut self,
+    ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>;
 }
 
 impl ValidatedStream for SafeStream<'_> {
     fn next_validated(
         &mut self,
-    ) -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)> {
-        self.next()
+    ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
+        self.next_typed()
     }
 }
 
-/// Sequence state whose lifetime is independent of its replaceable mmap stream.
+/// Continuity state whose lifetime is independent of its replaceable mmap stream.
 struct TrackedStream<S> {
     stream: Option<S>,
     sequence: frame_provenance::SequenceTracker,
+    timestamp: frame_provenance::TimestampTracker,
+    observations: u64,
+    discarded_observations: u64,
+    sequence_span_sum: u64,
 }
 
 impl<S> TrackedStream<S> {
@@ -706,7 +756,20 @@ impl<S> TrackedStream<S> {
         Self {
             stream: Some(stream),
             sequence: frame_provenance::SequenceTracker::new(),
+            timestamp: frame_provenance::TimestampTracker::new(),
+            observations: 0,
+            discarded_observations: 0,
+            sequence_span_sum: 0,
         }
+    }
+
+    #[cfg(test)]
+    const fn accounting(&self) -> (u64, u64, u64) {
+        (
+            self.observations,
+            self.discarded_observations,
+            self.sequence_span_sum,
+        )
     }
 
     fn stream_mut(&mut self) -> Option<&mut S> {
@@ -717,33 +780,187 @@ impl<S> TrackedStream<S> {
         self.stream.take()
     }
 
-    fn install_recovered(
-        &mut self,
-        stream: S,
-    ) -> Result<(), frame_provenance::SequenceTrackerError> {
-        self.sequence.begin_new_epoch()?;
+    fn install_recovered(&mut self, stream: S) -> std::io::Result<()> {
+        let mut next_sequence = self.sequence.clone();
+        if let Err(error) = next_sequence.begin_new_epoch() {
+            self.sequence = next_sequence;
+            return Err(std::io::Error::other(error));
+        }
+        let mut next_timestamp = self.timestamp.clone();
+        if let Err(error) = next_timestamp.begin_new_epoch() {
+            self.timestamp = next_timestamp;
+            return Err(std::io::Error::other(error));
+        }
+        self.sequence = next_sequence;
+        self.timestamp = next_timestamp;
         self.stream = Some(stream);
         Ok(())
     }
 }
 
+fn account_continuity_observation(
+    observations: &mut u64,
+    discarded_observations: &mut u64,
+    sequence_span_sum: &mut u64,
+    sequence: &frame_provenance::SequenceObservation,
+    discarded: bool,
+    timestamp_tracker: &mut frame_provenance::TimestampTracker,
+) -> std::io::Result<()> {
+    let next_observations = observations.checked_add(1);
+    let next_discarded = if discarded {
+        discarded_observations.checked_add(1)
+    } else {
+        Some(*discarded_observations)
+    };
+    let next_span = sequence_span_sum.checked_add(u64::from(sequence.advance().unwrap_or(0)));
+    let (Some(next_observations), Some(next_discarded), Some(next_span)) =
+        (next_observations, next_discarded, next_span)
+    else {
+        timestamp_tracker.fail_current_epoch();
+        return Err(std::io::Error::other(
+            "continuity observation accounting overflowed; explicit recovery required",
+        ));
+    };
+    *observations = next_observations;
+    *discarded_observations = next_discarded;
+    *sequence_span_sum = next_span;
+    Ok(())
+}
+
+fn ensure_continuity_alignment(
+    sequence: &frame_provenance::SequenceObservation,
+    timestamp: &frame_provenance::TimestampObservation,
+    timestamp_tracker: &mut frame_provenance::TimestampTracker,
+) -> std::io::Result<()> {
+    if sequence.stream_epoch() != timestamp.stream_epoch()
+        || sequence.discontinuity() != timestamp.discontinuity()
+    {
+        timestamp_tracker.fail_current_epoch();
+        return Err(std::io::Error::other(
+            "sequence/timestamp continuity diverged; explicit stream recovery required",
+        ));
+    }
+    Ok(())
+}
+
 impl<S: ValidatedStream> TrackedStream<S> {
+    fn next_discarded(&mut self) -> std::io::Result<()> {
+        let Self {
+            stream,
+            sequence,
+            timestamp,
+            observations,
+            discarded_observations,
+            sequence_span_sum,
+        } = self;
+        let dequeued = stream
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
+            .next_validated();
+        let (_, facts) = match dequeued {
+            Ok(frame) => frame,
+            Err(error) => {
+                if error.invalidates_timestamp_epoch() {
+                    timestamp.fail_current_epoch();
+                }
+                return Err(error.into_io());
+            }
+        };
+        let mut next_timestamp = timestamp.clone();
+        let timestamp_observation = match next_timestamp.observe_discarded(
+            facts.timestamp_micros(),
+            facts.timestamp_clock(),
+            facts.timestamp_source(),
+        ) {
+            Ok(observation) => observation,
+            Err(error) => {
+                *timestamp = next_timestamp;
+                return Err(std::io::Error::other(error));
+            }
+        };
+        let mut next_sequence = sequence.clone();
+        let sequence_observation = match next_sequence.observe_discarded(facts.sequence_raw()) {
+            Ok(observation) => observation,
+            Err(error) => {
+                *sequence = next_sequence;
+                return Err(std::io::Error::other(error));
+            }
+        };
+        ensure_continuity_alignment(&sequence_observation, &timestamp_observation, timestamp)?;
+        account_continuity_observation(
+            observations,
+            discarded_observations,
+            sequence_span_sum,
+            &sequence_observation,
+            true,
+            timestamp,
+        )?;
+        *timestamp = next_timestamp;
+        *sequence = next_sequence;
+        Ok(())
+    }
+
     fn next(
         &mut self,
     ) -> std::io::Result<(
         &[u8],
         frame_provenance::DequeuedBufferFacts,
         frame_provenance::SequenceObservation,
+        frame_provenance::TimestampObservation,
     )> {
-        let Self { stream, sequence } = self;
-        let (payload, facts) = stream
+        let Self {
+            stream,
+            sequence,
+            timestamp,
+            observations,
+            discarded_observations,
+            sequence_span_sum,
+        } = self;
+        let dequeued = stream
             .as_mut()
             .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
-            .next_validated()?;
-        let observation = sequence
-            .observe(facts.sequence_raw())
-            .map_err(std::io::Error::other)?;
-        Ok((payload, facts, observation))
+            .next_validated();
+        let (payload, facts) = match dequeued {
+            Ok(frame) => frame,
+            Err(error) => {
+                if error.invalidates_timestamp_epoch() {
+                    timestamp.fail_current_epoch();
+                }
+                return Err(error.into_io());
+            }
+        };
+        let mut next_timestamp = timestamp.clone();
+        let timestamp_observation = match next_timestamp.observe(
+            facts.timestamp_micros(),
+            facts.timestamp_clock(),
+            facts.timestamp_source(),
+        ) {
+            Ok(observation) => observation,
+            Err(error) => {
+                *timestamp = next_timestamp;
+                return Err(std::io::Error::other(error));
+            }
+        };
+        let mut next_sequence = sequence.clone();
+        let sequence_observation = match next_sequence.observe(facts.sequence_raw()) {
+            Ok(observation) => observation,
+            Err(error) => {
+                *sequence = next_sequence;
+                return Err(std::io::Error::other(error));
+            }
+        };
+        ensure_continuity_alignment(&sequence_observation, &timestamp_observation, timestamp)?;
+        account_continuity_observation(
+            observations,
+            discarded_observations,
+            sequence_span_sum,
+            &sequence_observation,
+            false,
+            timestamp,
+        )?;
+        *timestamp = next_timestamp;
+        *sequence = next_sequence;
+        Ok((payload, facts, sequence_observation, timestamp_observation))
     }
 }
 
@@ -2334,16 +2551,6 @@ pub struct RgbSession<'a> {
 }
 
 impl<'a> RgbSession<'a> {
-    /// The live stream. `recover` is the only path that leaves the slot
-    /// empty, and it either refills it or returns the error; a `None` here
-    /// outside that window is a bug, reported as hardware trouble rather
-    /// than a panic because this sits in the authentication path.
-    fn stream(&mut self) -> irlume_common::Result<&mut SafeStream<'a>> {
-        self.stream
-            .stream_mut()
-            .ok_or_else(|| Error::Hardware("RGB stream missing after a failed recovery".into()))
-    }
-
     /// Rebuild this session's stream on the SAME open device after a
     /// mid-stream fault.
     ///
@@ -2376,7 +2583,7 @@ impl<'a> RgbSession<'a> {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         self.stream.install_recovered(stream).map_err(|error| {
             Error::Hardware(format!(
-                "{}: could not begin the recovered sequence epoch: {error}",
+                "{}: could not begin the recovered continuity epochs: {error}",
                 self.cam.device
             ))
         })?;
@@ -2399,13 +2606,15 @@ impl<'a> RgbSession<'a> {
         }
         let device = self.cam.device.clone();
         let progress = self.progress.clone();
-        warm_up_stream(&device, self.stream()?, &progress)?;
+        warm_up_stream(&device, &mut self.stream, &progress)?;
         for _ in 0..AE_WARMUP {
             self.cam
                 .lease
                 .require_endpoint(&device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            self.stream()?.next().map_err(|e| map_io(&device, e))?; // discard while AE settles
+            self.stream
+                .next_discarded()
+                .map_err(|e| map_io(&device, e))?; // discard while AE settles
         }
         self.warmed = true;
         Ok(())
@@ -2428,7 +2637,7 @@ impl<'a> RgbSession<'a> {
                 .lease
                 .require_endpoint(&device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, _meta, _sequence) =
+            let (buf, _meta, _sequence, _timestamp) =
                 self.stream.next().map_err(|error| map_io(&device, error))?;
             let taken = std::time::Instant::now();
             let data = match &chosen {
@@ -3093,12 +3302,12 @@ impl IrCamera {
         // restore while the stream was still live, the very mid-stream write
         // this change removes. Assigned further down, once the stream exists.
         let mode;
-        let mut stream = SafeStream::open(
+        let mut stream = TrackedStream::new(SafeStream::open(
             &self.device,
             &self.dev,
             &self.negotiated,
             self.lease.clone(),
-        )?;
+        )?);
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
         // 25s when video went first). `SafeStream::open` only allocates
@@ -3140,7 +3349,7 @@ impl IrCamera {
         warm_up_stream(&self.device, &mut stream, progress)?;
         Ok(IrSession {
             cam: self,
-            stream: TrackedStream::new(stream),
+            stream,
             dec: IrDecoder::new(self.pix, self.quantization),
             lit: mode.lit(),
             _mode: mode,
@@ -3242,7 +3451,8 @@ impl IrSession<'_> {
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, bmeta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
+            let (buf, bmeta, _sequence, _timestamp) =
+                stream.next().map_err(|error| map_io(device, error))?;
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
@@ -3595,7 +3805,7 @@ impl IrSession<'_> {
                 .map_err(|error| Error::Hardware(error.to_string()))?;
             self.stream.install_recovered(stream).map_err(|error| {
                 Error::Hardware(format!(
-                    "{}: could not begin the recovered sequence epoch: {error}",
+                    "{}: could not begin the recovered continuity epochs: {error}",
                     self.cam.device
                 ))
             })
@@ -3779,7 +3989,8 @@ pub mod ir_probe {
         let mut out = Vec::with_capacity(n);
         let t0 = std::time::Instant::now();
         for _ in 0..n {
-            let (buf, _meta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
+            let (buf, _meta, _sequence, _timestamp) =
+                stream.next().map_err(|error| map_io(device, error))?;
             let taken = std::time::Instant::now();
             out.push((
                 Frame {
@@ -3914,7 +4125,8 @@ pub fn capture_ir_streaming<B>(
     // user a password fallback. Reading the metadata queue here is how that gets
     // closed, and it is not done.
     for _ in 0..max_frames {
-        let (buf, _meta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
+        let (buf, _meta, _sequence, _timestamp) =
+            stream.next().map_err(|error| map_io(device, error))?;
         let taken = std::time::Instant::now();
         let data = dec.decode(buf, w, h);
         let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
@@ -3961,7 +4173,7 @@ pub fn capture_ir_streaming<B>(
                     })
                     .map_err(|error| {
                         Error::Hardware(format!(
-                            "{device}: could not begin the recovered sequence epoch: {error}"
+                            "{device}: could not begin the recovered continuity epochs: {error}"
                         ))
                     })?;
                 mode = replacement_mode;
@@ -4059,7 +4271,8 @@ pub fn capture_ir_sequence(
         // instant it came from rather than stamping the end of the burst.
         let mut taken = std::time::Instant::now();
         for _ in 0..burst {
-            let (buf, _meta, _sequence) = stream.next().map_err(|error| map_io(device, error))?;
+            let (buf, _meta, _sequence, _timestamp) =
+                stream.next().map_err(|error| map_io(device, error))?;
             let at = std::time::Instant::now();
             let data = dec.decode(buf, w, h);
             let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
@@ -4113,7 +4326,7 @@ pub fn capture_ir_sequence(
                     })
                     .map_err(|error| {
                         Error::Hardware(format!(
-                            "{device}: could not begin the recovered sequence epoch: {error}"
+                            "{device}: could not begin the recovered continuity epochs: {error}"
                         ))
                     })?;
                 mode = replacement_mode;
@@ -5193,14 +5406,14 @@ pub fn nv12_to_rgb(nv12: &[u8], width: u32, height: u32) -> Vec<u8> {
 /// COMPLETED `TimedOut` return, so a frameless camera spending its whole
 /// budget here reports a heartbeat every window and the daemon's watchdog
 /// (#141) only starves when a driver call genuinely never returns.
-fn warm_up_stream(
+fn warm_up_stream<S: ValidatedStream>(
     device: &str,
-    stream: &mut SafeStream<'_>,
+    stream: &mut TrackedStream<S>,
     progress: &Progress,
 ) -> irlume_common::Result<()> {
     warm_up_with(
         device,
-        || stream.next().map(|_| ()),
+        || stream.next_discarded(),
         std::thread::sleep,
         progress,
     )
@@ -5401,7 +5614,178 @@ mod tests {
     }
 
     #[test]
-    fn recovery_epoch_survives_untracked_warmup_dequeues() {
+    fn every_dequeued_facts_error_invalidates_timestamp_epoch() {
+        let errors = [
+            frame_provenance::DequeuedBufferError::PayloadTooShort {
+                bytes_used: 1,
+                minimum: 2,
+            },
+            frame_provenance::DequeuedBufferError::DriverReportedCorruption,
+            frame_provenance::DequeuedBufferError::PayloadExceedsMapping {
+                bytes_used: 2,
+                mapped_len: 1,
+            },
+        ];
+        for error in errors {
+            assert!(
+                ValidatedDequeueError::Facts(error).invalidates_timestamp_epoch(),
+                "a rejected dequeue could conceal contradictory timestamp metadata"
+            );
+        }
+        assert!(
+            !ValidatedDequeueError::Io(std::io::Error::other("no metadata"))
+                .invalidates_timestamp_epoch(),
+            "an I/O failure before metadata exists must remain retryable"
+        );
+    }
+
+    #[test]
+    fn continuity_accounting_overflow_poisons_without_advancing_trackers() {
+        let metadata = v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence: 2,
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            timestamp: v4l::timestamp::Timestamp::new(2, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata,
+        });
+        capture.observations = u64::MAX;
+        let sequence_state = capture.sequence.continuity_state_for_test();
+        let timestamp_state = capture.timestamp.continuity_state_for_test();
+
+        assert!(capture.next().is_err());
+        assert_eq!(capture.sequence.continuity_state_for_test(), sequence_state);
+        assert_eq!(
+            capture.timestamp.continuity_state_for_test(),
+            timestamp_state
+        );
+        assert!(
+            capture.timestamp.epoch_failed_for_test(),
+            "accounting overflow must poison the epoch"
+        );
+        assert_eq!(capture.accounting(), (u64::MAX, 0, 0));
+    }
+
+    struct ContinuityFixture {
+        payload: [u8; 1],
+        metadata: v4l::buffer::Metadata,
+    }
+
+    impl ValidatedStream for ContinuityFixture {
+        fn next_validated(
+            &mut self,
+        ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
+            let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&self.metadata, 1)
+                .map_err(ValidatedDequeueError::Facts)?;
+            Ok((&self.payload, facts))
+        }
+    }
+
+    #[test]
+    fn discarded_malformed_timestamp_cannot_heal_in_same_epoch() {
+        let valid = v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence: 1,
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            timestamp: v4l::timestamp::Timestamp::new(1, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: v4l::buffer::Metadata {
+                timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
+                ..valid
+            },
+        });
+        assert!(capture.next_discarded().is_err());
+        capture.stream_mut().expect("stream").metadata = valid;
+        assert!(capture.next().is_err(), "discarded invalid evidence healed");
+    }
+
+    #[test]
+    fn warmup_retry_cannot_heal_discarded_malformed_timestamp() {
+        struct WarmupFixture {
+            payload: [u8; 1],
+            metadata: std::collections::VecDeque<v4l::buffer::Metadata>,
+        }
+        impl ValidatedStream for WarmupFixture {
+            fn next_validated(
+                &mut self,
+            ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>
+            {
+                let metadata = self.metadata.pop_front().ok_or_else(|| {
+                    ValidatedDequeueError::Io(std::io::Error::other("fixture exhausted"))
+                })?;
+                let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, 1)
+                    .map_err(ValidatedDequeueError::Facts)?;
+                Ok((&self.payload, facts))
+            }
+        }
+        let valid = v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence: 2,
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            timestamp: v4l::timestamp::Timestamp::new(2, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+        let mut tracked = TrackedStream::new(WarmupFixture {
+            payload: [1],
+            metadata: [
+                v4l::buffer::Metadata {
+                    sequence: 1,
+                    timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
+                    ..valid
+                },
+                valid,
+            ]
+            .into(),
+        });
+        let result = warm_up_with(
+            "fixture",
+            || tracked.next_discarded(),
+            |_| {},
+            &no_progress(),
+        );
+        assert!(result.is_err(), "warm-up retry healed invalid evidence");
+    }
+
+    #[test]
+    fn discarded_timestamp_discontinuities_poison_the_epoch() {
+        let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
+        let cases = [
+            (v4l::buffer::Flags::TIMESTAMP_UNKNOWN, 2_i64),
+            (v4l::buffer::Flags::TIMESTAMP_COPY, 2),
+            (monotonic | v4l::buffer::Flags::TSTAMP_SRC_SOE, 2),
+            (monotonic, 1),
+        ];
+        for (flags, seconds) in cases {
+            let metadata = |sequence, seconds, flags| v4l::buffer::Metadata {
+                bytesused: 1,
+                sequence,
+                flags,
+                timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
+                ..v4l::buffer::Metadata::default()
+            };
+            let mut capture = TrackedStream::new(ContinuityFixture {
+                payload: [1],
+                metadata: metadata(1, 1, monotonic),
+            });
+            capture.next().expect("baseline");
+            capture.stream_mut().expect("stream").metadata = metadata(2, seconds, flags);
+            assert!(capture.next_discarded().is_err());
+            capture.stream_mut().expect("stream").metadata = metadata(3, 3, monotonic);
+            assert!(
+                capture.next().is_err(),
+                "discarded evidence healed: {flags:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_epochs_survive_continuity_aware_warmup_dequeues() {
         struct SequenceFixture {
             payload: [u8; 1],
             sequences: std::collections::VecDeque<u32>,
@@ -5410,18 +5794,20 @@ mod tests {
         impl ValidatedStream for SequenceFixture {
             fn next_validated(
                 &mut self,
-            ) -> std::io::Result<(&[u8], frame_provenance::DequeuedBufferFacts)> {
-                let sequence = self
-                    .sequences
-                    .pop_front()
-                    .ok_or_else(|| std::io::Error::other("fixture exhausted"))?;
+            ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>
+            {
+                let sequence = self.sequences.pop_front().ok_or_else(|| {
+                    ValidatedDequeueError::Io(std::io::Error::other("fixture exhausted"))
+                })?;
                 let metadata = v4l::buffer::Metadata {
                     bytesused: 1,
                     sequence,
+                    flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                    timestamp: v4l::timestamp::Timestamp::new(1, i64::from(sequence)),
                     ..v4l::buffer::Metadata::default()
                 };
                 let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, 1)
-                    .map_err(std::io::Error::other)?;
+                    .map_err(ValidatedDequeueError::Facts)?;
                 Ok((&self.payload, facts))
             }
         }
@@ -5431,24 +5817,306 @@ mod tests {
             sequences: sequences.iter().copied().collect(),
         };
         let mut capture = TrackedStream::new(fixture(&[41]));
-        let (_, _, baseline) = capture.next().expect("baseline delivery");
-        assert!(!baseline.discontinuity());
+        let (_, _, baseline_sequence, baseline_timestamp) =
+            capture.next().expect("baseline delivery");
+        assert!(!baseline_sequence.discontinuity());
+        assert!(!baseline_timestamp.discontinuity());
+        assert_eq!(capture.accounting(), (1, 0, 0));
 
         capture.take();
         capture
-            .install_recovered(fixture(&[500, 7]))
+            .install_recovered(fixture(&[500, 501]))
             .expect("representable recovery epoch");
-        capture
-            .stream_mut()
-            .expect("replacement stream")
-            .next_validated()
-            .expect("discarded warm-up dequeue");
+        capture.next_discarded().expect("discarded warm-up dequeue");
 
-        let (_, _, restarted) = capture.next().expect("first delivered recovery frame");
-        assert_eq!(restarted.raw(), 7);
-        assert_eq!(restarted.gap(), 0);
-        assert!(restarted.discontinuity());
-        assert_eq!(restarted.stream_epoch(), 1);
+        let (_, _, restarted_sequence, restarted_timestamp) =
+            capture.next().expect("first delivered recovery frame");
+        assert_eq!(restarted_sequence.raw(), 501);
+        assert_eq!(restarted_sequence.gap(), 0);
+        assert!(restarted_sequence.discontinuity());
+        assert_eq!(restarted_sequence.stream_epoch(), 1);
+        assert_eq!(restarted_timestamp.micros(), 1_000_501);
+        assert_eq!(restarted_timestamp.delta_micros(), Some(1));
+        assert!(restarted_timestamp.discontinuity());
+        assert_eq!(restarted_timestamp.stream_epoch(), 1);
+        assert_eq!(capture.accounting(), (3, 1, 1));
+    }
+
+    #[test]
+    fn discarded_sequence_discontinuity_requires_recovery_for_aligned_epochs() {
+        let metadata = |sequence, seconds| v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence,
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: metadata(1, 1),
+        });
+        capture.next().expect("baseline");
+        let sequence_state = capture.sequence.continuity_state_for_test();
+        let timestamp_state = capture.timestamp.continuity_state_for_test();
+        capture.stream_mut().expect("stream").metadata = metadata(1, 2);
+        assert!(
+            capture.next_discarded().is_err(),
+            "discarded duplicate sequence bypassed continuity alignment"
+        );
+        assert_eq!(capture.sequence.continuity_state_for_test(), sequence_state);
+        assert_eq!(
+            capture.timestamp.continuity_state_for_test(),
+            timestamp_state
+        );
+        assert!(capture.timestamp.epoch_failed_for_test());
+        capture.stream_mut().expect("stream").metadata = metadata(2, 3);
+        assert!(
+            capture.next_discarded().is_err(),
+            "discarded failed epoch healed without recovery"
+        );
+
+        assert!(capture.take().is_some());
+        capture
+            .install_recovered(ContinuityFixture {
+                payload: [1],
+                metadata: metadata(10, 10),
+            })
+            .expect("recovery");
+        capture.next_discarded().expect("recovered warm-up frame");
+        capture.stream_mut().expect("stream").metadata = metadata(11, 11);
+        let (_, _, sequence, timestamp) = capture.next().expect("recovered delivered frame");
+        assert_eq!(sequence.stream_epoch(), timestamp.stream_epoch());
+        assert!(sequence.discontinuity());
+        assert!(timestamp.discontinuity());
+    }
+
+    #[test]
+    fn delivered_sequence_discontinuity_requires_recovery_for_aligned_epochs() {
+        let metadata = |sequence, seconds| v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence,
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: metadata(1, 1),
+        });
+        capture.next().expect("baseline");
+        let sequence_state = capture.sequence.continuity_state_for_test();
+        let timestamp_state = capture.timestamp.continuity_state_for_test();
+        capture.stream_mut().expect("stream").metadata = metadata(1, 2);
+        assert!(
+            capture.next().is_err(),
+            "duplicate sequence published contradictory provenance"
+        );
+        assert_eq!(capture.sequence.continuity_state_for_test(), sequence_state);
+        assert_eq!(
+            capture.timestamp.continuity_state_for_test(),
+            timestamp_state
+        );
+        assert!(capture.timestamp.epoch_failed_for_test());
+        capture.stream_mut().expect("stream").metadata = metadata(2, 3);
+        assert!(
+            capture.next().is_err(),
+            "failed epoch healed without recovery"
+        );
+
+        assert!(capture.take().is_some());
+        capture
+            .install_recovered(ContinuityFixture {
+                payload: [1],
+                metadata: metadata(10, 10),
+            })
+            .expect("recovery");
+        let (_, _, sequence, timestamp) = capture.next().expect("recovered frame");
+        assert_eq!(sequence.stream_epoch(), timestamp.stream_epoch());
+        assert!(sequence.discontinuity());
+        assert!(timestamp.discontinuity());
+    }
+
+    #[test]
+    fn timestamp_failure_does_not_advance_sequence_state() {
+        let metadata = |sequence, seconds, flags| v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence,
+            flags,
+            timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+        let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: metadata(1, 1, monotonic),
+        });
+        capture.next().expect("baseline");
+        capture.stream_mut().expect("stream").metadata =
+            metadata(5, 2, v4l::buffer::Flags::TIMESTAMP_UNKNOWN);
+        assert!(capture.next().is_err());
+
+        capture.take();
+        capture
+            .install_recovered(ContinuityFixture {
+                payload: [1],
+                metadata: metadata(10, 1, monotonic),
+            })
+            .expect("recovery");
+        let (_, _, sequence, timestamp) = capture.next().expect("recovered frame");
+        assert_eq!(sequence.cumulative_drops(), 0);
+        assert!(sequence.discontinuity());
+        assert!(timestamp.discontinuity());
+    }
+
+    #[test]
+    fn recovery_epoch_overflow_never_partially_publishes_state() {
+        let fixture = || ContinuityFixture {
+            payload: [1],
+            metadata: v4l::buffer::Metadata::default(),
+        };
+
+        let mut sequence_failure = TrackedStream::new(fixture());
+        sequence_failure
+            .sequence
+            .force_stream_epoch_overflow_on_recovery();
+        assert!(sequence_failure.take().is_some());
+        assert!(sequence_failure.install_recovered(fixture()).is_err());
+        assert!(sequence_failure.stream_mut().is_none());
+        assert!(sequence_failure.sequence.failed_for_test());
+        assert!(!sequence_failure.timestamp.failed_for_test());
+        assert_eq!(sequence_failure.timestamp.stream_epoch_for_test(), 0);
+
+        let mut timestamp_failure = TrackedStream::new(fixture());
+        timestamp_failure
+            .timestamp
+            .force_stream_epoch_overflow_on_recovery();
+        assert!(timestamp_failure.take().is_some());
+        assert!(timestamp_failure.install_recovered(fixture()).is_err());
+        assert!(timestamp_failure.stream_mut().is_none());
+        assert!(!timestamp_failure.sequence.failed_for_test());
+        assert_eq!(timestamp_failure.sequence.stream_epoch_for_test(), 0);
+        assert!(timestamp_failure.timestamp.failed_for_test());
+    }
+
+    #[test]
+    fn discarded_timestamp_failure_does_not_advance_sequence_state() {
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: v4l::buffer::Metadata {
+                bytesused: 1,
+                sequence: 1,
+                flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                timestamp: v4l::timestamp::Timestamp::new(1, 0),
+                ..v4l::buffer::Metadata::default()
+            },
+        });
+        capture.next().expect("baseline");
+        let stream = capture.stream_mut().expect("stream");
+        stream.metadata.sequence = 5;
+        stream.metadata.flags = v4l::buffer::Flags::TIMESTAMP_UNKNOWN;
+        stream.metadata.timestamp = v4l::timestamp::Timestamp::new(2, 0);
+        assert!(capture.next_discarded().is_err());
+        assert_eq!(capture.sequence.previous_for_test(), Some(1));
+    }
+
+    #[test]
+    fn discarded_sequence_failure_does_not_advance_timestamp_state() {
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: v4l::buffer::Metadata {
+                bytesused: 1,
+                sequence: 1,
+                flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                timestamp: v4l::timestamp::Timestamp::new(1, 0),
+                ..v4l::buffer::Metadata::default()
+            },
+        });
+        capture.next().expect("baseline");
+        capture.sequence.force_drop_overflow_on_next_gap();
+        let stream = capture.stream_mut().expect("stream");
+        stream.metadata.sequence = 3;
+        stream.metadata.timestamp = v4l::timestamp::Timestamp::new(2, 0);
+        assert!(capture.next_discarded().is_err());
+        assert_eq!(capture.timestamp.previous_for_test(), Some(1_000_000));
+    }
+
+    #[test]
+    fn sequence_failure_does_not_advance_timestamp_state() {
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: v4l::buffer::Metadata {
+                bytesused: 1,
+                sequence: 1,
+                flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                timestamp: v4l::timestamp::Timestamp::new(1, 0),
+                ..v4l::buffer::Metadata::default()
+            },
+        });
+        capture.next().expect("baseline");
+        capture.sequence.force_drop_overflow_on_next_gap();
+        let stream = capture.stream_mut().expect("stream");
+        stream.metadata.sequence = 3;
+        stream.metadata.timestamp = v4l::timestamp::Timestamp::new(2, 0);
+        assert!(capture.next().is_err());
+        assert_eq!(capture.timestamp.previous_for_test(), Some(1_000_000));
+    }
+
+    #[test]
+    fn malformed_raw_timestamp_fails_epoch_until_recovery() {
+        let valid = v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence: 1,
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            timestamp: v4l::timestamp::Timestamp::new(1, 0),
+            ..v4l::buffer::Metadata::default()
+        };
+        let mut capture = TrackedStream::new(ContinuityFixture {
+            payload: [1],
+            metadata: valid,
+        });
+        capture.next().expect("baseline");
+        let stream = capture.stream_mut().expect("stream");
+        stream.metadata.timestamp = v4l::timestamp::Timestamp::new(2, 1_000_000);
+        assert!(capture.next().is_err());
+        let stream = capture.stream_mut().expect("stream");
+        stream.metadata.timestamp = v4l::timestamp::Timestamp::new(3, 0);
+        assert!(capture.next().is_err(), "same epoch must remain failed");
+        capture.take();
+        capture
+            .install_recovered(ContinuityFixture {
+                payload: [1],
+                metadata: valid,
+            })
+            .expect("recovery");
+        capture.next().expect("recovered frame");
+    }
+
+    #[test]
+    fn unsupported_timestamp_masks_fail_epoch_until_recovery() {
+        for bits in [0x0000_6000, 0x0002_2000] {
+            let valid = v4l::buffer::Metadata {
+                bytesused: 1,
+                sequence: 1,
+                flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                timestamp: v4l::timestamp::Timestamp::new(1, 0),
+                ..v4l::buffer::Metadata::default()
+            };
+            let mut capture = TrackedStream::new(ContinuityFixture {
+                payload: [1],
+                metadata: valid,
+            });
+            capture.next().expect("baseline");
+            let stream = capture.stream_mut().expect("stream");
+            stream.metadata.flags = v4l::buffer::Flags::from_bits_truncate(bits);
+            assert!(capture.next().is_err(), "unsupported mask 0x{bits:08x}");
+            let stream = capture.stream_mut().expect("stream");
+            stream.metadata = v4l::buffer::Metadata {
+                sequence: 3,
+                timestamp: v4l::timestamp::Timestamp::new(3, 0),
+                ..valid
+            };
+            assert!(capture.next().is_err(), "epoch healed for 0x{bits:08x}");
+        }
     }
 
     #[test]
@@ -7410,6 +8078,389 @@ mod tests {
                 .fold((u8::MAX, u8::MIN), |(lo, hi), &b| (lo.min(b), hi.max(b)));
             assert!(max > min, "a test pattern must not convert to a flat frame");
         }
+    }
+
+    #[derive(Default)]
+    struct ContinuityStressStats {
+        frames: u64,
+        gap_total: u64,
+        cumulative_drops: u64,
+        discontinuities: u64,
+        epoch_count: u64,
+        current_epoch: Option<u64>,
+        epoch_first_micros: Option<i64>,
+        epoch_last_micros: Option<i64>,
+        completed_span_sum: u64,
+        delta_count: u64,
+        delta_sum: u64,
+        min_delta: Option<u64>,
+        max_delta: Option<u64>,
+        clock: Option<frame_provenance::TimestampClock>,
+        source: Option<frame_provenance::TimestampSource>,
+        sequence_epoch: u64,
+        timestamp_epoch: u64,
+        first_micros: Option<i64>,
+        last_micros: Option<i64>,
+    }
+    impl ContinuityStressStats {
+        fn record(
+            &mut self,
+            sequence: frame_provenance::SequenceObservation,
+            timestamp: frame_provenance::TimestampObservation,
+        ) {
+            assert_eq!(
+                sequence.discontinuity(),
+                timestamp.discontinuity(),
+                "sequence/timestamp discontinuities diverged"
+            );
+            assert_eq!(
+                sequence.stream_epoch(),
+                timestamp.stream_epoch(),
+                "sequence/timestamp epochs diverged"
+            );
+            let micros = timestamp.micros();
+            let epoch = timestamp.stream_epoch();
+            let same_epoch = match self.current_epoch {
+                None => {
+                    self.epoch_count = 1;
+                    self.current_epoch = Some(epoch);
+                    self.epoch_first_micros = Some(micros);
+                    self.epoch_last_micros = Some(micros);
+                    false
+                }
+                Some(current) if current == epoch => true,
+                Some(current) => {
+                    let next = current.checked_add(1).expect("epoch overflow");
+                    assert_eq!(epoch, next, "stress epoch skipped");
+                    let first = self.epoch_first_micros.expect("epoch first timestamp");
+                    let last = self.epoch_last_micros.expect("epoch last timestamp");
+                    self.completed_span_sum = self
+                        .completed_span_sum
+                        .checked_add(last.abs_diff(first))
+                        .expect("timestamp span overflow");
+                    self.epoch_count += 1;
+                    self.current_epoch = Some(epoch);
+                    self.epoch_first_micros = Some(micros);
+                    self.epoch_last_micros = Some(micros);
+                    false
+                }
+            };
+            if same_epoch {
+                let delta = timestamp
+                    .delta_micros()
+                    .expect("same-epoch delivered timestamp has a delta");
+                self.epoch_last_micros = Some(micros);
+                self.delta_count = self
+                    .delta_count
+                    .checked_add(1)
+                    .expect("delta count overflow");
+                self.delta_sum = self
+                    .delta_sum
+                    .checked_add(delta)
+                    .expect("delta sum overflow");
+                self.min_delta = Some(self.min_delta.map_or(delta, |old| old.min(delta)));
+                self.max_delta = Some(self.max_delta.map_or(delta, |old| old.max(delta)));
+            }
+            self.frames += 1;
+            self.gap_total = sequence.cumulative_drops();
+            self.cumulative_drops = sequence.cumulative_drops();
+            self.discontinuities += u64::from(sequence.discontinuity());
+            self.clock = Some(timestamp.clock());
+            self.source = Some(timestamp.source());
+            self.sequence_epoch = sequence.stream_epoch();
+            self.timestamp_epoch = timestamp.stream_epoch();
+            self.first_micros.get_or_insert(timestamp.micros());
+            self.last_micros = Some(timestamp.micros());
+        }
+
+        fn as_json(
+            &self,
+            role: &str,
+            elapsed: std::time::Duration,
+            accounting: (u64, u64, u64),
+        ) -> serde_json::Value {
+            let (observations, discarded_observations, sequence_span_sum) = accounting;
+            assert_eq!(
+                observations,
+                self.frames
+                    .checked_add(discarded_observations)
+                    .expect("observation count overflow"),
+                "delivered/discarded observation accounting mismatch"
+            );
+            assert_eq!(
+                sequence_span_sum,
+                observations
+                    .checked_sub(self.epoch_count)
+                    .and_then(|value| value.checked_add(self.cumulative_drops))
+                    .expect("sequence span accounting overflow"),
+                "sequence span accounting mismatch"
+            );
+            let delivered_hz = self.frames as f64 / elapsed.as_secs_f64();
+            let epoch_first = self.epoch_first_micros.expect("epoch first timestamp");
+            let epoch_last = self.epoch_last_micros.expect("epoch last timestamp");
+            let timestamp_span_sum = self
+                .completed_span_sum
+                .checked_add(epoch_last.abs_diff(epoch_first))
+                .expect("timestamp span sum overflow");
+            assert_eq!(
+                self.delta_sum, timestamp_span_sum,
+                "delta/span sum mismatch"
+            );
+            assert_eq!(
+                self.delta_count,
+                self.frames
+                    .checked_sub(self.epoch_count)
+                    .expect("epoch count exceeds frames"),
+                "delta/frame/epoch count mismatch"
+            );
+            serde_json::json!({
+                "role": role,
+                "frames": self.frames,
+                "observations": observations,
+                "discarded_observations": discarded_observations,
+                "sequence_span_sum": sequence_span_sum,
+                "delivered_hz": delivered_hz,
+                "gap_total": self.gap_total,
+                "cumulative_drops": self.cumulative_drops,
+                "discontinuities": self.discontinuities,
+                "epoch_count": self.epoch_count,
+                "timestamp_span_sum_us": timestamp_span_sum,
+                "delta_count": self.delta_count,
+                "delta_sum_us": self.delta_sum,
+                "delta_min_us": self.min_delta,
+                "delta_max_us": self.max_delta,
+                "clock": self.clock.map(|value| format!("{value:?}")),
+                "source": self.source.map(|value| format!("{value:?}")),
+                "stream_epoch": self.timestamp_epoch,
+                "sequence_stream_epoch": self.sequence_epoch,
+                "timestamp_stream_epoch": self.timestamp_epoch,
+                "first_timestamp_us": self.first_micros,
+                "last_timestamp_us": self.last_micros,
+            })
+        }
+    }
+    #[test]
+    fn continuity_stress_gap_total_includes_discarded_observations() {
+        let mut sequence = frame_provenance::SequenceTracker::new();
+        let mut timestamp = frame_provenance::TimestampTracker::new();
+        sequence
+            .observe_discarded(1)
+            .expect("first discarded sequence");
+        timestamp
+            .observe_discarded(
+                1_000_000,
+                frame_provenance::TimestampClock::Monotonic,
+                frame_provenance::TimestampSource::EndOfFrame,
+            )
+            .expect("first discarded timestamp");
+        sequence
+            .observe_discarded(4)
+            .expect("discarded sequence gap");
+        timestamp
+            .observe_discarded(
+                2_000_000,
+                frame_provenance::TimestampClock::Monotonic,
+                frame_provenance::TimestampSource::EndOfFrame,
+            )
+            .expect("second discarded timestamp");
+        let sequence_observation = sequence.observe(5).expect("delivered sequence");
+        let timestamp_observation = timestamp
+            .observe(
+                3_000_000,
+                frame_provenance::TimestampClock::Monotonic,
+                frame_provenance::TimestampSource::EndOfFrame,
+            )
+            .expect("delivered timestamp");
+        let mut stats = ContinuityStressStats::default();
+        stats.record(sequence_observation, timestamp_observation);
+        assert_eq!(stats.gap_total, 2);
+        assert_eq!(stats.cumulative_drops, 2);
+        assert_eq!(stats.delta_count, 0);
+        assert_eq!(stats.delta_sum, 0);
+
+        let sequence_observation = sequence.observe(6).expect("second delivered sequence");
+        let timestamp_observation = timestamp
+            .observe(
+                4_000_000,
+                frame_provenance::TimestampClock::Monotonic,
+                frame_provenance::TimestampSource::EndOfFrame,
+            )
+            .expect("second delivered timestamp");
+        stats.record(sequence_observation, timestamp_observation);
+        sequence.begin_new_epoch().expect("sequence recovery epoch");
+        timestamp
+            .begin_new_epoch()
+            .expect("timestamp recovery epoch");
+        sequence
+            .observe_discarded(10)
+            .expect("recovery warm-up sequence");
+        timestamp
+            .observe_discarded(
+                10_000_000,
+                frame_provenance::TimestampClock::Monotonic,
+                frame_provenance::TimestampSource::EndOfFrame,
+            )
+            .expect("recovery warm-up timestamp");
+        let sequence_observation = sequence.observe(11).expect("recovered sequence");
+        let timestamp_observation = timestamp
+            .observe(
+                11_000_000,
+                frame_provenance::TimestampClock::Monotonic,
+                frame_provenance::TimestampSource::EndOfFrame,
+            )
+            .expect("recovered timestamp");
+        stats.record(sequence_observation, timestamp_observation);
+        let sequence_observation = sequence.observe(12).expect("second recovered sequence");
+        let timestamp_observation = timestamp
+            .observe(
+                13_000_000,
+                frame_provenance::TimestampClock::Monotonic,
+                frame_provenance::TimestampSource::EndOfFrame,
+            )
+            .expect("second recovered timestamp");
+        stats.record(sequence_observation, timestamp_observation);
+        let json = stats.as_json("rgb", std::time::Duration::from_secs(10), (7, 3, 7));
+        assert_eq!(json["epoch_count"], 2);
+        assert_eq!(json["delta_count"], 2);
+        assert_eq!(json["delta_sum_us"], 3_000_000);
+        assert_eq!(json["timestamp_span_sum_us"], 3_000_000);
+    }
+
+    #[test]
+    #[ignore = "needs real physical RGB and optional IR cameras"]
+    fn physical_timestamp_continuity_stress() {
+        assert!(
+            std::env::var_os("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA").is_none(),
+            "physical evidence forbids the virtual-camera escape"
+        );
+        let required =
+            |name: &str| std::env::var(name).unwrap_or_else(|_| panic!("{name} must be set"));
+        let seconds = required("IRLUME_TEST_DURATION_SECONDS")
+            .parse::<u64>()
+            .expect("duration must be an integer");
+        assert!(
+            (60..=600).contains(&seconds),
+            "physical stress duration must be between 60s and 600s"
+        );
+        let host = required("IRLUME_TEST_HOST");
+        let commit = required("IRLUME_TEST_COMMIT");
+        let git_head = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .expect("read tested git revision");
+        assert!(git_head.status.success(), "git rev-parse HEAD failed");
+        let actual_commit = String::from_utf8(git_head.stdout).expect("git SHA is UTF-8");
+        assert_eq!(actual_commit.trim(), commit, "evidence commit mismatch");
+        let hostname = std::process::Command::new("uname")
+            .arg("-n")
+            .output()
+            .expect("read tested host name");
+        assert!(hostname.status.success(), "uname -n failed");
+        let actual_host = String::from_utf8(hostname.stdout).expect("host name is UTF-8");
+        assert_eq!(actual_host.trim(), host, "evidence host mismatch");
+        let rgb_path = required("IRLUME_TEST_PHYSICAL_RGB_DEVICE");
+        let rgb = RgbCamera::open(&rgb_path).expect("open physical RGB camera");
+        let mut rgb_session = rgb.session().expect("open RGB session");
+        let ir_path = std::env::var("IRLUME_TEST_PHYSICAL_IR_DEVICE").ok();
+        assert!(
+            ir_path.is_some() || std::env::var("IRLUME_TEST_EXPECT_RGB_ONLY").as_deref() == Ok("1"),
+            "an IR path or an explicit RGB-only assertion is required"
+        );
+        let ir = ir_path
+            .as_deref()
+            .map(IrCamera::open)
+            .transpose()
+            .expect("open physical IR camera");
+        let mut ir_session = ir
+            .as_ref()
+            .map(|camera| camera.session())
+            .transpose()
+            .expect("open IR session");
+        rgb_session.warm_up().expect("initial RGB warm-up");
+        let started = std::time::Instant::now();
+        let deadline = started + std::time::Duration::from_secs(seconds);
+        let recovery_at = started + std::time::Duration::from_secs(seconds / 2);
+        let mut rgb_stats = ContinuityStressStats::default();
+        let mut ir_stats = ContinuityStressStats::default();
+        let mut recovered = false;
+        let mut recovery_duration = None;
+        let mut expect_rgb_discontinuity = false;
+        let mut expect_ir_discontinuity = false;
+        while std::time::Instant::now() < deadline {
+            let (_, _, sequence, timestamp) =
+                rgb_session.stream.next().expect("RGB tracked dequeue");
+            if expect_rgb_discontinuity {
+                assert!(sequence.discontinuity(), "RGB recovery marker missing");
+                expect_rgb_discontinuity = false;
+            }
+            rgb_stats.record(sequence, timestamp);
+            if let Some(session) = &mut ir_session {
+                let (_, _, sequence, timestamp) =
+                    session.stream.next().expect("IR tracked dequeue");
+                if let Some(log) = session.meta.as_mut() {
+                    log.begin_burst();
+                    log.drain();
+                }
+                if expect_ir_discontinuity {
+                    assert!(sequence.discontinuity(), "IR recovery marker missing");
+                    expect_ir_discontinuity = false;
+                }
+                ir_stats.record(sequence, timestamp);
+            }
+            if !recovered && std::time::Instant::now() >= recovery_at {
+                let recovery_started = std::time::Instant::now();
+                rgb_session.recover().expect("RGB recovery");
+                rgb_session.warm_up().expect("recovered RGB warm-up");
+                expect_rgb_discontinuity = true;
+                if let Some(session) = &mut ir_session {
+                    session.recover().expect("IR recovery");
+                    expect_ir_discontinuity = true;
+                }
+                recovery_duration = Some(recovery_started.elapsed());
+                recovered = true;
+            }
+        }
+        assert!(recovered, "mid-run recovery was not exercised");
+        assert!(!expect_rgb_discontinuity, "RGB post-recovery frame missing");
+        assert!(!expect_ir_discontinuity, "IR post-recovery frame missing");
+        assert_eq!(
+            rgb_stats.discontinuities, 1,
+            "unexpected RGB discontinuities"
+        );
+        if ir_session.is_some() {
+            assert_eq!(ir_stats.discontinuities, 1, "unexpected IR discontinuities");
+        }
+        assert!(rgb_stats.frames > 0);
+        assert!(ir_session.is_none() || ir_stats.frames > 0);
+        let elapsed = started.elapsed();
+        let recovery_duration = recovery_duration.expect("recovery duration was recorded");
+        let rgb_ir_skew_us = match (rgb_stats.last_micros, ir_stats.last_micros) {
+            (Some(rgb), Some(ir)) => Some(rgb.abs_diff(ir)),
+            _ => None,
+        };
+        let rgb_accounting = rgb_session.stream.accounting();
+        let ir_accounting = ir_session
+            .as_ref()
+            .map(|session| session.stream.accounting());
+        let mut streams = vec![rgb_stats.as_json("rgb", elapsed, rgb_accounting)];
+        if let Some(accounting) = ir_accounting {
+            streams.push(ir_stats.as_json("ir", elapsed, accounting));
+        }
+        eprintln!(
+            "{}",
+            serde_json::json!({
+                "kind": "irlume.slice4.hardware",
+                "schema_version": 1,
+                "host": host,
+                "commit": commit,
+                "requested_duration_seconds": seconds,
+                "duration_seconds": elapsed.as_secs_f64(),
+                "recovery_exercised": recovered,
+                "recovery_duration_seconds": recovery_duration.as_secs_f64(),
+                "rgb_ir_skew_us": rgb_ir_skew_us,
+                "streams": streams,
+            })
+        );
     }
 
     /// `IrSession::recover` must hand back a session as capable as the one it

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -8459,7 +8459,7 @@ mod tests {
             streams.push(ir_stats.as_json("ir", elapsed, accounting));
         }
         eprintln!(
-            "{}",
+            "\n{}",
             serde_json::json!({
                 "kind": "irlume.slice4.hardware",
                 "schema_version": 1,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -8359,16 +8359,28 @@ mod tests {
         let actual_host = String::from_utf8(hostname.stdout).expect("host name is UTF-8");
         assert_eq!(actual_host.trim(), host, "evidence host mismatch");
         let rgb_path = required("IRLUME_TEST_PHYSICAL_RGB_DEVICE");
-        let rgb = RgbCamera::open(&rgb_path).expect("open physical RGB camera");
-        let mut rgb_session = rgb.session().expect("open RGB session");
         let ir_path = std::env::var("IRLUME_TEST_PHYSICAL_IR_DEVICE").ok();
         assert!(
             ir_path.is_some() || std::env::var("IRLUME_TEST_EXPECT_RGB_ONLY").as_deref() == Ok("1"),
             "an IR path or an explicit RGB-only assertion is required"
         );
+        let mut endpoints = vec![rgb_path.as_str()];
+        if let Some(ir_path) = ir_path.as_deref() {
+            endpoints.push(ir_path);
+        }
+        let operation = lease::acquire_camera_operation(
+            &endpoints,
+            lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        )
+        .expect("acquire physical camera operation");
+        let rgb = operation
+            .open_rgb(&rgb_path)
+            .expect("open physical RGB camera");
+        let mut rgb_session = rgb.session().expect("open RGB session");
         let ir = ir_path
             .as_deref()
-            .map(IrCamera::open)
+            .map(|path| operation.open_ir(path))
             .transpose()
             .expect("open physical IR camera");
         let mut ir_session = ir

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -416,6 +416,7 @@ impl CaptureDequeue for v4l::io::mmap::Stream<'_> {
 enum ValidatedDequeueError {
     Io(std::io::Error),
     Facts(frame_provenance::DequeuedBufferError),
+    Corrupt(frame_provenance::DequeuedBufferFacts),
 }
 
 impl ValidatedDequeueError {
@@ -426,8 +427,27 @@ impl ValidatedDequeueError {
         match self {
             Self::Io(error) => error,
             Self::Facts(error) => std::io::Error::other(error),
+            Self::Corrupt(_) => std::io::Error::other(
+                frame_provenance::DequeuedBufferError::DriverReportedCorruption,
+            ),
         }
     }
+}
+
+fn validate_dequeued<'a>(
+    mapped: &'a [u8],
+    metadata: &v4l::buffer::Metadata,
+    layout: frame_provenance::PayloadLayout,
+) -> Result<(&'a [u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
+    let facts = frame_provenance::DequeuedBufferFacts::from_v4l(metadata, mapped.len())
+        .map_err(ValidatedDequeueError::Facts)?;
+    layout
+        .validate(&facts)
+        .map_err(ValidatedDequeueError::Facts)?;
+    if facts.driver_reported_corruption() {
+        return Err(ValidatedDequeueError::Corrupt(facts));
+    }
+    Ok((&mapped[..facts.bytes_used()], facts))
 }
 
 #[cfg(test)]
@@ -443,10 +463,7 @@ where
     require_endpoint()?;
     let (mapped, metadata) = stream.dequeue()?;
     require_endpoint()?;
-    let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, mapped.len())
-        .map_err(std::io::Error::other)?;
-    layout.validate(&facts).map_err(std::io::Error::other)?;
-    Ok((&mapped[..facts.bytes_used()], facts))
+    validate_dequeued(mapped, &metadata, layout).map_err(ValidatedDequeueError::into_io)
 }
 
 fn dequeue_validated_typed<S, R>(
@@ -461,12 +478,7 @@ where
     require_endpoint().map_err(ValidatedDequeueError::Io)?;
     let (mapped, metadata) = stream.dequeue().map_err(ValidatedDequeueError::Io)?;
     require_endpoint().map_err(ValidatedDequeueError::Io)?;
-    let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, mapped.len())
-        .map_err(ValidatedDequeueError::Facts)?;
-    layout
-        .validate(&facts)
-        .map_err(ValidatedDequeueError::Facts)?;
-    Ok((&mapped[..facts.bytes_used()], facts))
+    validate_dequeued(mapped, &metadata, layout)
 }
 
 /// A capture stream whose teardown cannot take the process down.
@@ -843,6 +855,64 @@ fn ensure_continuity_alignment(
     Ok(())
 }
 
+fn observe_continuity_facts(
+    sequence: &mut frame_provenance::SequenceTracker,
+    timestamp: &mut frame_provenance::TimestampTracker,
+    observations: &mut u64,
+    discarded_observations: &mut u64,
+    sequence_span_sum: &mut u64,
+    facts: &frame_provenance::DequeuedBufferFacts,
+    discarded: bool,
+) -> std::io::Result<(
+    frame_provenance::SequenceObservation,
+    frame_provenance::TimestampObservation,
+)> {
+    let mut next_timestamp = timestamp.clone();
+    let timestamp_observation = match if discarded {
+        next_timestamp.observe_discarded(
+            facts.timestamp_micros(),
+            facts.timestamp_clock(),
+            facts.timestamp_source(),
+        )
+    } else {
+        next_timestamp.observe(
+            facts.timestamp_micros(),
+            facts.timestamp_clock(),
+            facts.timestamp_source(),
+        )
+    } {
+        Ok(observation) => observation,
+        Err(error) => {
+            *timestamp = next_timestamp;
+            return Err(std::io::Error::other(error));
+        }
+    };
+    let mut next_sequence = sequence.clone();
+    let sequence_observation = match if discarded {
+        next_sequence.observe_discarded(facts.sequence_raw())
+    } else {
+        next_sequence.observe(facts.sequence_raw())
+    } {
+        Ok(observation) => observation,
+        Err(error) => {
+            *sequence = next_sequence;
+            return Err(std::io::Error::other(error));
+        }
+    };
+    ensure_continuity_alignment(&sequence_observation, &timestamp_observation, timestamp)?;
+    account_continuity_observation(
+        observations,
+        discarded_observations,
+        sequence_span_sum,
+        &sequence_observation,
+        discarded,
+        timestamp,
+    )?;
+    *timestamp = next_timestamp;
+    *sequence = next_sequence;
+    Ok((sequence_observation, timestamp_observation))
+}
+
 impl<S: ValidatedStream> TrackedStream<S> {
     fn next_discarded(&mut self) -> std::io::Result<()> {
         let Self {
@@ -857,8 +927,8 @@ impl<S: ValidatedStream> TrackedStream<S> {
             .as_mut()
             .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
             .next_validated();
-        let (_, facts) = match dequeued {
-            Ok(frame) => frame,
+        let facts = match dequeued {
+            Ok((_, facts)) | Err(ValidatedDequeueError::Corrupt(facts)) => facts,
             Err(error) => {
                 if error.invalidates_timestamp_epoch() {
                     timestamp.fail_current_epoch();
@@ -866,37 +936,15 @@ impl<S: ValidatedStream> TrackedStream<S> {
                 return Err(error.into_io());
             }
         };
-        let mut next_timestamp = timestamp.clone();
-        let timestamp_observation = match next_timestamp.observe_discarded(
-            facts.timestamp_micros(),
-            facts.timestamp_clock(),
-            facts.timestamp_source(),
-        ) {
-            Ok(observation) => observation,
-            Err(error) => {
-                *timestamp = next_timestamp;
-                return Err(std::io::Error::other(error));
-            }
-        };
-        let mut next_sequence = sequence.clone();
-        let sequence_observation = match next_sequence.observe_discarded(facts.sequence_raw()) {
-            Ok(observation) => observation,
-            Err(error) => {
-                *sequence = next_sequence;
-                return Err(std::io::Error::other(error));
-            }
-        };
-        ensure_continuity_alignment(&sequence_observation, &timestamp_observation, timestamp)?;
-        account_continuity_observation(
+        observe_continuity_facts(
+            sequence,
+            timestamp,
             observations,
             discarded_observations,
             sequence_span_sum,
-            &sequence_observation,
+            &facts,
             true,
-            timestamp,
         )?;
-        *timestamp = next_timestamp;
-        *sequence = next_sequence;
         Ok(())
     }
 
@@ -922,6 +970,18 @@ impl<S: ValidatedStream> TrackedStream<S> {
             .next_validated();
         let (payload, facts) = match dequeued {
             Ok(frame) => frame,
+            Err(ValidatedDequeueError::Corrupt(facts)) => {
+                observe_continuity_facts(
+                    sequence,
+                    timestamp,
+                    observations,
+                    discarded_observations,
+                    sequence_span_sum,
+                    &facts,
+                    true,
+                )?;
+                return Err(ValidatedDequeueError::Corrupt(facts).into_io());
+            }
             Err(error) => {
                 if error.invalidates_timestamp_epoch() {
                     timestamp.fail_current_epoch();
@@ -929,37 +989,15 @@ impl<S: ValidatedStream> TrackedStream<S> {
                 return Err(error.into_io());
             }
         };
-        let mut next_timestamp = timestamp.clone();
-        let timestamp_observation = match next_timestamp.observe(
-            facts.timestamp_micros(),
-            facts.timestamp_clock(),
-            facts.timestamp_source(),
-        ) {
-            Ok(observation) => observation,
-            Err(error) => {
-                *timestamp = next_timestamp;
-                return Err(std::io::Error::other(error));
-            }
-        };
-        let mut next_sequence = sequence.clone();
-        let sequence_observation = match next_sequence.observe(facts.sequence_raw()) {
-            Ok(observation) => observation,
-            Err(error) => {
-                *sequence = next_sequence;
-                return Err(std::io::Error::other(error));
-            }
-        };
-        ensure_continuity_alignment(&sequence_observation, &timestamp_observation, timestamp)?;
-        account_continuity_observation(
+        let (sequence_observation, timestamp_observation) = observe_continuity_facts(
+            sequence,
+            timestamp,
             observations,
             discarded_observations,
             sequence_span_sum,
-            &sequence_observation,
+            &facts,
             false,
-            timestamp,
         )?;
-        *timestamp = next_timestamp;
-        *sequence = next_sequence;
         Ok((payload, facts, sequence_observation, timestamp_observation))
     }
 }
@@ -5614,13 +5652,12 @@ mod tests {
     }
 
     #[test]
-    fn every_dequeued_facts_error_invalidates_timestamp_epoch() {
+    fn facts_errors_invalidate_but_metadata_valid_corruption_does_not() {
         let errors = [
             frame_provenance::DequeuedBufferError::PayloadTooShort {
                 bytes_used: 1,
                 minimum: 2,
             },
-            frame_provenance::DequeuedBufferError::DriverReportedCorruption,
             frame_provenance::DequeuedBufferError::PayloadExceedsMapping {
                 bytes_used: 2,
                 mapped_len: 1,
@@ -5636,6 +5673,19 @@ mod tests {
             !ValidatedDequeueError::Io(std::io::Error::other("no metadata"))
                 .invalidates_timestamp_epoch(),
             "an I/O failure before metadata exists must remain retryable"
+        );
+        let corrupt = frame_provenance::DequeuedBufferFacts::from_v4l(
+            &continuity_metadata(
+                1,
+                1,
+                v4l::buffer::Flags::TIMESTAMP_MONOTONIC | v4l::buffer::Flags::ERROR,
+            ),
+            1,
+        )
+        .expect("valid continuity facts");
+        assert!(
+            !ValidatedDequeueError::Corrupt(corrupt).invalidates_timestamp_epoch(),
+            "metadata-valid corruption is observed as discarded, not epoch-fatal"
         );
     }
 
@@ -5681,6 +5731,159 @@ mod tests {
             let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&self.metadata, 1)
                 .map_err(ValidatedDequeueError::Facts)?;
             Ok((&self.payload, facts))
+        }
+    }
+
+    struct QueuedContinuityFixture {
+        payload: [u8; 1],
+        metadata: std::collections::VecDeque<v4l::buffer::Metadata>,
+    }
+
+    impl ValidatedStream for QueuedContinuityFixture {
+        fn next_validated(
+            &mut self,
+        ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
+            let metadata = self.metadata.pop_front().ok_or_else(|| {
+                ValidatedDequeueError::Io(std::io::Error::other("fixture exhausted"))
+            })?;
+            let layout =
+                frame_provenance::PayloadLayout::new(*b"GREY", 1, 1, 1).expect("fixture layout");
+            validate_dequeued(&self.payload, &metadata, layout)
+        }
+    }
+
+    fn continuity_metadata(
+        sequence: u32,
+        seconds: i64,
+        flags: v4l::buffer::Flags,
+    ) -> v4l::buffer::Metadata {
+        v4l::buffer::Metadata {
+            bytesused: 1,
+            sequence,
+            flags,
+            timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
+            ..v4l::buffer::Metadata::default()
+        }
+    }
+
+    #[test]
+    fn warmup_discards_metadata_valid_driver_corruption_without_failing_epoch() {
+        let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
+        let corrupt = continuity_metadata(1, 1, monotonic | v4l::buffer::Flags::ERROR);
+        let valid = continuity_metadata(2, 2, monotonic);
+        let mut tracked = TrackedStream::new(QueuedContinuityFixture {
+            payload: [7],
+            metadata: [corrupt, valid].into(),
+        });
+
+        warm_up_with(
+            "fixture",
+            || tracked.next_discarded(),
+            |_| {},
+            &no_progress(),
+        )
+        .expect("metadata-valid corruption is a discarded warm-up observation");
+        assert_eq!(tracked.accounting(), (1, 1, 0));
+
+        let (payload, _, sequence, timestamp) =
+            tracked.next().expect("next payload remains usable");
+        assert_eq!(payload, &[7]);
+        assert_eq!(sequence.raw(), 2);
+        assert_eq!(sequence.gap(), 0);
+        assert_eq!(timestamp.micros(), 2_000_000);
+        assert_eq!(tracked.accounting(), (2, 1, 1));
+    }
+
+    #[test]
+    fn delivered_driver_corruption_is_discarded_but_next_payload_remains_usable() {
+        let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
+        let corrupt = continuity_metadata(10, 10, monotonic | v4l::buffer::Flags::ERROR);
+        let valid = continuity_metadata(11, 11, monotonic);
+        let mut tracked = TrackedStream::new(QueuedContinuityFixture {
+            payload: [9],
+            metadata: [corrupt, valid].into(),
+        });
+
+        let error = tracked
+            .next()
+            .expect_err("a corrupt payload must never be delivered");
+        assert!(error.to_string().contains("corrupt"));
+        assert_eq!(tracked.accounting(), (1, 1, 0));
+
+        let (payload, _, sequence, timestamp) =
+            tracked.next().expect("next payload remains usable");
+        assert_eq!(payload, &[9]);
+        assert_eq!(sequence.raw(), 11);
+        assert_eq!(sequence.gap(), 0);
+        assert_eq!(timestamp.micros(), 11_000_000);
+        assert_eq!(tracked.accounting(), (2, 1, 1));
+    }
+
+    #[test]
+    fn driver_corruption_cannot_mask_invalid_timestamp_metadata() {
+        let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
+        let corrupt_invalid = v4l::buffer::Metadata {
+            timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
+            ..continuity_metadata(1, 1, monotonic | v4l::buffer::Flags::ERROR)
+        };
+        let valid = continuity_metadata(2, 2, monotonic);
+        let mut tracked = TrackedStream::new(QueuedContinuityFixture {
+            payload: [3],
+            metadata: [corrupt_invalid, valid].into(),
+        });
+
+        assert!(tracked.next_discarded().is_err());
+        assert_eq!(tracked.accounting(), (0, 0, 0));
+        assert!(
+            tracked.next().is_err(),
+            "invalid metadata on a corrupt payload must leave the epoch failed closed"
+        );
+    }
+
+    #[test]
+    fn corrupt_discarded_continuity_discontinuities_poison_the_epoch() {
+        let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
+        let error = v4l::buffer::Flags::ERROR;
+        let cases = [
+            (
+                "clock change",
+                2,
+                2,
+                v4l::buffer::Flags::TIMESTAMP_UNKNOWN | error,
+            ),
+            (
+                "source change",
+                2,
+                2,
+                monotonic | v4l::buffer::Flags::TSTAMP_SRC_SOE | error,
+            ),
+            ("timestamp regression", 2, 1, monotonic | error),
+            ("sequence regression", 1, 2, monotonic | error),
+        ];
+
+        for (case, sequence, seconds, flags) in cases {
+            let baseline = continuity_metadata(1, 1, monotonic);
+            let corrupt = continuity_metadata(sequence, seconds, flags);
+            let valid = continuity_metadata(3, 3, monotonic);
+            let mut tracked = TrackedStream::new(QueuedContinuityFixture {
+                payload: [5],
+                metadata: [baseline, corrupt, valid].into(),
+            });
+
+            tracked.next().expect("baseline delivery");
+            assert!(
+                tracked.next_discarded().is_err(),
+                "corrupt payload concealed {case}"
+            );
+            assert_eq!(
+                tracked.accounting(),
+                (1, 0, 0),
+                "contradictory corrupt dequeue was accounted: {case}"
+            );
+            assert!(
+                tracked.next().is_err(),
+                "failed epoch healed after corrupt {case}"
+            );
         }
     }
 

--- a/scripts/hardware/run-slice4-hardware.sh
+++ b/scripts/hardware/run-slice4-hardware.sh
@@ -78,8 +78,101 @@ verify_physical_uvc_node() {
     fi
 }
 
+unit_active_state() {
+    local unit=$1
+    local state
+    state=$(systemctl show --property=ActiveState --value "$unit") || {
+        echo "hardware-run: could not read $unit ActiveState" >&2
+        return 1
+    }
+    case "$state" in
+        active | activating | deactivating | reloading | refreshing | inactive | failed)
+            printf '%s\n' "$state"
+            ;;
+        *)
+            echo "hardware-run: unexpected $unit ActiveState=$state" >&2
+            return 1
+            ;;
+    esac
+}
+
+snapshot_unit_active() {
+    local unit=$1
+    local state
+    state=$(unit_active_state "$unit") || return 1
+    case "$state" in
+        active)
+            printf '1\n'
+            ;;
+        inactive | failed)
+            printf '0\n'
+            ;;
+        *)
+            echo "hardware-run: refusing transitional $unit ActiveState=$state" >&2
+            return 1
+            ;;
+    esac
+}
+
+unit_is_quiescent() {
+    local state
+    state=$(unit_active_state "$1") || return 1
+    case "$state" in
+        inactive | failed)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+require_restored_state() {
+    local unit=$1
+    local expected_active=$2
+    local state
+    state=$(unit_active_state "$unit") || return 1
+    if [ "$expected_active" -eq 1 ] && [ "$state" = active ]; then
+        return 0
+    fi
+    if [ "$expected_active" -eq 0 ]; then
+        case "$state" in
+            inactive | failed)
+                return 0
+                ;;
+        esac
+    fi
+    echo "hardware-run: could not restore $unit expected_active=$expected_active state=$state" >&2
+    return 1
+}
+
 verify_tree "$source_worktree"
-was_active=0
+umask 077
+runtime_dir="/run/user/$(id -u)"
+if [ -L "$runtime_dir" ] || [ ! -d "$runtime_dir" ] \
+    || [ "$(realpath "$runtime_dir")" != "$runtime_dir" ] \
+    || [ "$(stat -c %u "$runtime_dir")" != "$(id -u)" ] \
+    || [ "$(stat -c %a "$runtime_dir")" != 700 ]; then
+    echo "hardware-run: trusted per-user runtime directory unavailable: $runtime_dir" >&2
+    exit 1
+fi
+lock_dir="$runtime_dir/irlume-slice4-hardware.lock"
+if ! mkdir -m 700 "$lock_dir" 2>/dev/null; then
+    if [ -L "$lock_dir" ] || [ ! -d "$lock_dir" ] \
+        || [ "$(realpath "$lock_dir")" != "$lock_dir" ] \
+        || [ "$(stat -c %u "$lock_dir")" != "$(id -u)" ] \
+        || [ "$(stat -c %a "$lock_dir")" != 700 ]; then
+        echo "hardware-run: unsafe hardware lock directory: $lock_dir" >&2
+        exit 1
+    fi
+fi
+if [ "${IRLUME_SLICE4_LOCK_HELD:-}" != 1 ]; then
+    exec env IRLUME_SLICE4_LOCK_HELD=1 python3 \
+        "$script_dir/slice4-runner-support.py" hold-lock "$lock_dir" "$0" "$@"
+fi
+unset IRLUME_SLICE4_LOCK_HELD
+service_was_active=$(snapshot_unit_active irlumed.service)
+socket_was_active=$(snapshot_unit_active irlumed.socket)
 users_file=$(mktemp)
 fuser_errors=$(mktemp)
 snapshot_parent=$(mktemp -d)
@@ -87,37 +180,70 @@ snapshot="$snapshot_parent/source"
 build_dir=$(mktemp -d)
 hardware_pid=""
 evidence_tmp=""
+evidence=""
+evidence_published=0
+units_restored=0
+log=""
 
-restore_service() {
-    if [ "$was_active" -eq 1 ]; then
-        if ! systemctl is-active --quiet irlumed.service; then
-            sudo -n systemctl start irlumed.service
-        fi
-        systemctl is-active --quiet irlumed.service || {
-            echo "hardware-run: could not restore irlumed" >&2
-            return 1
-        }
-        was_active=0
+restore_one_unit() {
+    local unit=$1
+    local expected_active=$2
+    local state
+    state=$(unit_active_state "$unit") || return 1
+    if [ "$expected_active" -eq 1 ] && [ "$state" != active ]; then
+        sudo -n systemctl start "$unit" || return 1
     fi
+    if [ "$expected_active" -eq 0 ] && ! unit_is_quiescent "$unit"; then
+        sudo -n systemctl stop "$unit" || return 1
+    fi
+    require_restored_state "$unit" "$expected_active" || return 1
+}
+
+restore_units() {
+    # Restore the service before its socket so an arriving client cannot race
+    # socket activation ahead of the service state we observed.
+    restore_one_unit irlumed.service "$service_was_active" || return 1
+    restore_one_unit irlumed.socket "$socket_was_active" || return 1
+    # Starting an originally-active socket may activate an originally-quiescent
+    # service. Enforce the service's observed state once more before publication.
+    restore_one_unit irlumed.service "$service_was_active" || return 1
+    units_restored=1
 }
 
 cleanup() {
     local status=$?
     trap - EXIT INT TERM
-    if ! restore_service; then
+    if [ "$units_restored" -ne 1 ] && ! restore_units; then
         status=1
     fi
-    cd "$source_worktree" || status=1
+    if ! cd "$source_worktree"; then
+        status=1
+    fi
     if [ -e "$snapshot/.git" ]; then
         if ! git -C "$source_worktree" worktree remove --force "$snapshot"; then
             status=1
         fi
     fi
-    rm -f "$users_file" "$fuser_errors"
-    if [ -n "$evidence_tmp" ]; then
-        rm -f "$evidence_tmp"
+    if ! rm -f "$users_file" "$fuser_errors"; then
+        status=1
     fi
-    rm -rf "$snapshot_parent" "$build_dir"
+    if [ -n "$evidence_tmp" ] && ! rm -f "$evidence_tmp"; then
+        status=1
+    fi
+    if ! rm -rf "$snapshot_parent" "$build_dir"; then
+        status=1
+    fi
+    if [ "$status" -ne 0 ] && [ "$evidence_published" -eq 1 ]; then
+        if rm -f -- "$evidence"; then
+            evidence_published=0
+        else
+            status=1
+        fi
+    fi
+    if [ "$status" -eq 0 ] && [ "$evidence_published" -eq 1 ]; then
+        printf 'hardware-run: PASS host=%s sha=%s log=%s evidence=%s\n' \
+            "$host" "$sha" "$log" "$evidence"
+    fi
     exit "$status"
 }
 
@@ -150,9 +276,15 @@ verify_physical_uvc_node "$rgb"
 if [ "$ir" != "-" ]; then
     verify_physical_uvc_node "$ir"
 fi
-if systemctl is-active --quiet irlumed.service; then
-    was_active=1
+if ! unit_is_quiescent irlumed.socket; then
+    sudo -n systemctl stop irlumed.socket
+fi
+if ! unit_is_quiescent irlumed.service; then
     sudo -n systemctl stop irlumed.service
+fi
+if ! unit_is_quiescent irlumed.socket || ! unit_is_quiescent irlumed.service; then
+    echo "hardware-run: irlume units did not quiesce" >&2
+    exit 1
 fi
 
 nodes=("$rgb")
@@ -197,8 +329,23 @@ else
 fi
 
 output_dir="$source_worktree/target"
-log="$output_dir/slice4-hardware-${host}-${sha}.log"
-mkdir -p "$output_dir"
+if [ -L "$output_dir" ]; then
+    echo "hardware-run: artifact directory must not be a symlink: $output_dir" >&2
+    exit 1
+fi
+if [ ! -e "$output_dir" ]; then
+    mkdir "$output_dir"
+fi
+output_mode=$(stat -c %a "$output_dir")
+if [ ! -d "$output_dir" ] || [ "$(realpath "$output_dir")" != "$output_dir" ] \
+    || [ "$(stat -c %u "$output_dir")" != "$(id -u)" ] \
+    || (( (8#$output_mode & 0022) != 0 )); then
+    echo "hardware-run: unsafe artifact directory: $output_dir" >&2
+    exit 1
+fi
+run_dir=$(mktemp -d "$output_dir/slice4-${host}-${sha}.XXXXXX")
+log="$run_dir/run.log"
+evidence="$run_dir/evidence.json"
 set +e
 timeout --signal=TERM --kill-after=10s 240s \
     env -u IRLUME_TEST_ALLOW_VIRTUAL_CAMERA "${env_args[@]}" \
@@ -213,13 +360,6 @@ set -e
 
 verify_tree "$snapshot"
 verify_tree "$source_worktree"
-if [ "$was_active" -eq 1 ]; then
-    restore_service
-    systemctl is-active --quiet irlumed.service || {
-        echo "hardware-run: irlumed did not restart" >&2
-        exit 1
-    }
-fi
 if [ "$status" -ne 0 ]; then
     echo "hardware-run: test failed with status $status; log=$log" >&2
     exit "$status"
@@ -228,8 +368,7 @@ expected_streams=2
 if [ "$mode" = "rgb-only" ]; then
     expected_streams=1
 fi
-evidence="$output_dir/slice4-hardware-${host}-${sha}.json"
-evidence_tmp=$(mktemp "$output_dir/.slice4-evidence.XXXXXX")
+evidence_tmp=$(mktemp "$run_dir/.evidence.XXXXXX")
 chmod 600 "$evidence_tmp"
 verify_tree "$snapshot"
 verify_tree "$source_worktree"
@@ -238,5 +377,6 @@ verify_tree "$snapshot"
 verify_tree "$source_worktree"
 mv -f -- "$evidence_tmp" "$evidence"
 evidence_tmp=""
-printf 'hardware-run: PASS host=%s sha=%s log=%s evidence=%s\n' \
-    "$host" "$sha" "$log" "$evidence"
+evidence_published=1
+python3 "$script_dir/slice4-runner-support.py" durable-evidence \
+    "$evidence" "$run_dir" "$output_dir" "$source_worktree"

--- a/scripts/hardware/run-slice4-hardware.sh
+++ b/scripts/hardware/run-slice4-hardware.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 5 ] || [ "$#" -gt 6 ]; then
+    echo "usage: $0 WORKTREE HOST SHA RGB_DEVICE IR_DEVICE|- [rgb-only]" >&2
+    exit 2
+fi
+
+worktree=$1
+host=$2
+sha=$3
+rgb=$4
+ir=$5
+mode=${6:-dual}
+source_worktree=$(realpath "$worktree")
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+script_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+if [ "$(realpath "$script_root")" != "$source_worktree" ]; then
+    echo "hardware-run: runner is not from the tested worktree" >&2
+    exit 1
+fi
+
+verify_tree() {
+    local root=$1
+    local actual
+    actual=$(git -C "$root" rev-parse HEAD)
+    if [ "$actual" != "$sha" ]; then
+        echo "hardware-run: exact-head mismatch: expected $sha, got $actual" >&2
+        return 1
+    fi
+    if [ -n "$(git -C "$root" status --porcelain --untracked-files=all)" ]; then
+        echo "hardware-run: source tree is dirty: $root" >&2
+        return 1
+    fi
+}
+
+verify_physical_uvc_node() {
+    local node=$1
+    local basename_node
+    local device_path
+    local driver
+    local cursor
+    local usb_found=0
+
+    if [ ! -c "$node" ] || [ "$(realpath "$node")" != "$node" ]; then
+        echo "hardware-run: not a canonical character device: $node" >&2
+        return 1
+    fi
+    basename_node=${node##*/}
+    if [[ ! "$node" =~ ^/dev/video[0-9]+$ ]]; then
+        echo "hardware-run: physical evidence requires /dev/videoN: $node" >&2
+        return 1
+    fi
+    device_path=$(readlink -f "/sys/class/video4linux/$basename_node/device")
+    case "$device_path" in
+        /sys/devices/virtual/* | "")
+            echo "hardware-run: virtual or unresolved video node: $node" >&2
+            return 1
+            ;;
+    esac
+    driver=$(basename "$(readlink -f "/sys/class/video4linux/$basename_node/device/driver")")
+    if [ "$driver" != uvcvideo ]; then
+        echo "hardware-run: non-UVC video node: $node driver=$driver" >&2
+        return 1
+    fi
+    cursor=$device_path
+    while [ "$cursor" != / ]; do
+        if [ -r "$cursor/idVendor" ] && [ -r "$cursor/idProduct" ]; then
+            usb_found=1
+            break
+        fi
+        cursor=${cursor%/*}
+        [ -n "$cursor" ] || cursor=/
+    done
+    if [ "$usb_found" -ne 1 ]; then
+        echo "hardware-run: video node has no physical USB ancestor: $node" >&2
+        return 1
+    fi
+}
+
+verify_tree "$source_worktree"
+was_active=0
+users_file=$(mktemp)
+fuser_errors=$(mktemp)
+snapshot_parent=$(mktemp -d)
+snapshot="$snapshot_parent/source"
+build_dir=$(mktemp -d)
+hardware_pid=""
+evidence_tmp=""
+
+restore_service() {
+    if [ "$was_active" -eq 1 ]; then
+        if ! systemctl is-active --quiet irlumed.service; then
+            sudo -n systemctl start irlumed.service
+        fi
+        systemctl is-active --quiet irlumed.service || {
+            echo "hardware-run: could not restore irlumed" >&2
+            return 1
+        }
+        was_active=0
+    fi
+}
+
+cleanup() {
+    local status=$?
+    trap - EXIT INT TERM
+    if ! restore_service; then
+        status=1
+    fi
+    cd "$source_worktree" || status=1
+    if [ -e "$snapshot/.git" ]; then
+        if ! git -C "$source_worktree" worktree remove --force "$snapshot"; then
+            status=1
+        fi
+    fi
+    rm -f "$users_file" "$fuser_errors"
+    if [ -n "$evidence_tmp" ]; then
+        rm -f "$evidence_tmp"
+    fi
+    rm -rf "$snapshot_parent" "$build_dir"
+    exit "$status"
+}
+
+on_signal() {
+    local status=$1
+    trap - INT TERM
+    if [ -n "$hardware_pid" ] && kill -0 "$hardware_pid" 2>/dev/null; then
+        kill -TERM "$hardware_pid" 2>/dev/null || true
+        wait "$hardware_pid" 2>/dev/null || true
+    fi
+    exit "$status"
+}
+
+trap cleanup EXIT
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
+
+git -C "$source_worktree" worktree add --detach "$snapshot" "$sha"
+verify_tree "$snapshot"
+verify_tree "$source_worktree"
+worktree=$snapshot
+script_dir="$snapshot/scripts/hardware"
+validator="$script_dir/validate-slice4-hardware.py"
+export CARGO_TARGET_DIR="$build_dir"
+cd "$worktree"
+cargo test -p irlume-camera --no-run --locked
+verify_tree "$snapshot"
+verify_tree "$source_worktree"
+verify_physical_uvc_node "$rgb"
+if [ "$ir" != "-" ]; then
+    verify_physical_uvc_node "$ir"
+fi
+if systemctl is-active --quiet irlumed.service; then
+    was_active=1
+    sudo -n systemctl stop irlumed.service
+fi
+
+nodes=("$rgb")
+if [ "$ir" != "-" ]; then
+    nodes+=("$ir")
+fi
+set +e
+# Redirections intentionally remain unprivileged; only fuser needs complete /proc access.
+# shellcheck disable=SC2024
+sudo -n fuser "${nodes[@]}" >"$users_file" 2>"$fuser_errors"
+fuser_status=$?
+set -e
+if [ "$fuser_status" -eq 0 ]; then
+    echo "hardware-run: camera nodes are still in use" >&2
+    while IFS= read -r line; do
+        printf '  %s\n' "$line" >&2
+    done <"$users_file"
+    exit 1
+fi
+if [ "$fuser_status" -ne 1 ] || [ -s "$fuser_errors" ]; then
+    echo "hardware-run: camera ownership probe was inconclusive" >&2
+    while IFS= read -r line; do
+        printf '  %s\n' "$line" >&2
+    done <"$fuser_errors"
+    exit 1
+fi
+
+env_args=(
+    "IRLUME_TEST_DURATION_SECONDS=60"
+    "IRLUME_TEST_PHYSICAL_RGB_DEVICE=$rgb"
+    "IRLUME_TEST_HOST=$host"
+    "IRLUME_TEST_COMMIT=$sha"
+)
+if [ "$ir" = "-" ]; then
+    if [ "$mode" != "rgb-only" ]; then
+        echo "hardware-run: missing IR requires explicit rgb-only mode" >&2
+        exit 1
+    fi
+    env_args+=("IRLUME_TEST_EXPECT_RGB_ONLY=1")
+else
+    env_args+=("IRLUME_TEST_PHYSICAL_IR_DEVICE=$ir")
+fi
+
+output_dir="$source_worktree/target"
+log="$output_dir/slice4-hardware-${host}-${sha}.log"
+mkdir -p "$output_dir"
+set +e
+timeout --signal=TERM --kill-after=10s 240s \
+    env -u IRLUME_TEST_ALLOW_VIRTUAL_CAMERA "${env_args[@]}" \
+    ./scripts/run-tests-guarded.sh --require physical_timestamp_continuity_stress -- \
+    cargo test -p irlume-camera tests::physical_timestamp_continuity_stress --locked -- \
+    --ignored --exact --nocapture --test-threads=1 >"$log" 2>&1 &
+hardware_pid=$!
+wait "$hardware_pid"
+status=$?
+hardware_pid=""
+set -e
+
+verify_tree "$snapshot"
+verify_tree "$source_worktree"
+if [ "$was_active" -eq 1 ]; then
+    restore_service
+    systemctl is-active --quiet irlumed.service || {
+        echo "hardware-run: irlumed did not restart" >&2
+        exit 1
+    }
+fi
+if [ "$status" -ne 0 ]; then
+    echo "hardware-run: test failed with status $status; log=$log" >&2
+    exit "$status"
+fi
+expected_streams=2
+if [ "$mode" = "rgb-only" ]; then
+    expected_streams=1
+fi
+evidence="$output_dir/slice4-hardware-${host}-${sha}.json"
+evidence_tmp=$(mktemp "$output_dir/.slice4-evidence.XXXXXX")
+chmod 600 "$evidence_tmp"
+verify_tree "$snapshot"
+verify_tree "$source_worktree"
+python3 "$validator" "$log" "$host" "$sha" "$expected_streams" >"$evidence_tmp"
+verify_tree "$snapshot"
+verify_tree "$source_worktree"
+mv -f -- "$evidence_tmp" "$evidence"
+evidence_tmp=""
+printf 'hardware-run: PASS host=%s sha=%s log=%s evidence=%s\n' \
+    "$host" "$sha" "$log" "$evidence"

--- a/scripts/hardware/slice4-runner-support.py
+++ b/scripts/hardware/slice4-runner-support.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Process-isolated locking and durability primitives for the slice-4 runner."""
+
+import fcntl
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+
+
+LOCK_BUSY = 75
+
+
+def hold_lock(lock_path: str, command: list[str]) -> int:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    lock_fd = os.open(lock_path, flags)
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print(
+                "hardware-run: another slice-4 hardware run owns this host",
+                file=sys.stderr,
+            )
+            return LOCK_BUSY
+
+        child = None
+        pending_signals = []
+        previous_handlers = {}
+
+        def forward(signum: int, _frame: object) -> None:
+            if child is None:
+                pending_signals.append(signum)
+            elif child.poll() is None:
+                child.send_signal(signum)
+
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signum] = signal.signal(signum, forward)
+        try:
+            child = subprocess.Popen(command, close_fds=True)
+            for signum in pending_signals:
+                if child.poll() is None:
+                    child.send_signal(signum)
+            status = child.wait()
+        finally:
+            for signum, handler in previous_handlers.items():
+                signal.signal(signum, handler)
+        return status if status >= 0 else 128 - status
+    finally:
+        os.close(lock_fd)
+
+
+def durable_evidence(paths: list[str]) -> int:
+    for index, path in enumerate(paths):
+        flags = os.O_RDONLY | os.O_CLOEXEC
+        if index > 0 and hasattr(os, "O_DIRECTORY"):
+            flags |= os.O_DIRECTORY
+        fd = os.open(path, flags)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    try:
+        if len(argv) >= 4 and argv[1] == "hold-lock":
+            return hold_lock(argv[2], argv[3:])
+        if len(argv) == 6 and argv[1] == "durable-evidence":
+            return durable_evidence(argv[2:])
+    except OSError as error:
+        print(f"hardware-run: support operation failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"usage: {Path(argv[0]).name} hold-lock LOCK_PATH COMMAND [ARG ...] | "
+        "durable-evidence EVIDENCE RUN_DIR OUTPUT_DIR SOURCE_WORKTREE",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/hardware/test-run-slice4-hardware.py
+++ b/scripts/hardware/test-run-slice4-hardware.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Source-contract tests for the slice-4 hardware runner's unit guard."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+
+
+DEFAULT_RUNNER = Path(__file__).with_name("run-slice4-hardware.sh")
+RUNNER = Path(os.environ.get("IRLUME_RUNNER_UNDER_TEST", DEFAULT_RUNNER))
+SUPPORT = Path(__file__).with_name("slice4-runner-support.py")
+
+
+class RunnerUnitGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = RUNNER.read_text(encoding="utf-8")
+
+    def test_socket_activation_is_quiesced_before_the_service_and_ownership_probe(self):
+        socket_stop = self.source.index(
+            'if ! unit_is_quiescent irlumed.socket; then\n'
+            '    sudo -n systemctl stop irlumed.socket'
+        )
+        service_stop = self.source.index(
+            'if ! unit_is_quiescent irlumed.service; then\n'
+            '    sudo -n systemctl stop irlumed.service'
+        )
+        ownership_probe = self.source.index('sudo -n fuser "${nodes[@]}"')
+        self.assertLess(socket_stop, service_stop)
+        self.assertLess(service_stop, ownership_probe)
+
+    def test_restore_order_cannot_socket_activate_a_not_yet_restored_service(self):
+        restore_start = self.source.index("restore_units() {")
+        cleanup_start = self.source.index("cleanup() {")
+        restore = self.source[restore_start:cleanup_start]
+        first_service = restore.index(
+            'restore_one_unit irlumed.service "$service_was_active"'
+        )
+        socket_restore = restore.index(
+            'restore_one_unit irlumed.socket "$socket_was_active"'
+        )
+        second_service = restore.rindex(
+            'restore_one_unit irlumed.service "$service_was_active"'
+        )
+        self.assertLess(first_service, socket_restore)
+        self.assertLess(socket_restore, second_service)
+
+    def test_cleanup_and_success_paths_both_restore_the_observed_unit_state(self):
+        self.assertEqual(self.source.count("restore_units"), 2)
+        self.assertIn('trap cleanup EXIT', self.source)
+        self.assertIn(
+            'if ! unit_is_quiescent irlumed.socket '
+            '|| ! unit_is_quiescent irlumed.service; then',
+            self.source,
+        )
+
+    def test_transitional_systemd_states_never_count_as_quiescent(self):
+        self.assertNotIn("systemctl is-active --quiet irlumed", self.source)
+        self.assertIn("unit_active_state() {", self.source)
+        quiescent_start = self.source.index("unit_is_quiescent() {")
+        restored_start = self.source.index("require_restored_state() {")
+        quiescent = self.source[quiescent_start:restored_start]
+        self.assertIn("inactive | failed)", quiescent)
+        for transitional in (
+            "activating",
+            "deactivating",
+            "reloading",
+            "refreshing",
+        ):
+            self.assertNotIn(transitional, quiescent)
+        self.assertIn("if ! unit_is_quiescent irlumed.socket; then", self.source)
+        self.assertIn("if ! unit_is_quiescent irlumed.service; then", self.source)
+        self.assertIn(
+            'restore_one_unit irlumed.service "$service_was_active"',
+            self.source,
+        )
+        self.assertIn(
+            'restore_one_unit irlumed.socket "$socket_was_active"',
+            self.source,
+        )
+
+    def test_initial_transitional_states_are_refused_not_snapshotted_as_active(self):
+        snapshot_start = self.source.index("snapshot_unit_active() {")
+        quiescent_start = self.source.index("unit_is_quiescent() {")
+        snapshot = self.source[snapshot_start:quiescent_start]
+        self.assertIn('case "$state" in\n        active)', snapshot)
+        active_branch = snapshot.split("inactive | failed)", 1)[0]
+        for transitional in (
+            "activating",
+            "deactivating",
+            "reloading",
+            "refreshing",
+        ):
+            self.assertNotIn(transitional, active_branch)
+
+    def test_restoration_actively_requiesces_units_and_defers_pass_to_cleanup(self):
+        restore_start = self.source.index("restore_one_unit() {")
+        restore_units_start = self.source.index("restore_units() {")
+        restore_one = self.source[restore_start:restore_units_start]
+        self.assertIn(
+            'if [ "$expected_active" -eq 0 ] && ! unit_is_quiescent "$unit"; then',
+            restore_one,
+        )
+        self.assertIn('sudo -n systemctl stop "$unit" || return 1', restore_one)
+        self.assertIn('sudo -n systemctl start "$unit" || return 1', restore_one)
+        self.assertIn(
+            'require_restored_state "$unit" "$expected_active" || return 1',
+            restore_one,
+        )
+
+        restore_units = self.source[restore_units_start:self.source.index("cleanup() {")]
+        self.assertEqual(restore_units.count("restore_one_unit"), 3)
+        self.assertEqual(restore_units.count("|| return 1"), 3)
+        self.assertGreater(
+            restore_units.index("units_restored=1"),
+            restore_units.rindex("restore_one_unit"),
+        )
+
+        cleanup_start = self.source.index("cleanup() {")
+        signal_start = self.source.index("on_signal() {")
+        cleanup = self.source[cleanup_start:signal_start]
+        self.assertIn(
+            'if [ "$status" -ne 0 ] && [ "$evidence_published" -eq 1 ]; then',
+            cleanup,
+        )
+        self.assertIn('rm -f -- "$evidence"', cleanup)
+        self.assertIn("hardware-run: PASS", cleanup)
+        self.assertIn(
+            'if [ "$status" -eq 0 ] && [ "$evidence_published" -eq 1 ]; then',
+            cleanup,
+        )
+        self.assertEqual(self.source.count("hardware-run: PASS"), 1)
+        published = self.source.index("evidence_published=1")
+        durable = self.source.index(
+            '"$script_dir/slice4-runner-support.py" durable-evidence'
+        )
+        self.assertLess(published, durable)
+        self.assertIn(
+            '"$evidence" "$run_dir" "$output_dir" "$source_worktree"',
+            self.source[durable:],
+        )
+
+    def test_runs_are_host_serialized_and_publish_to_unique_invocation_paths(self):
+        lock = self.source.index('"$script_dir/slice4-runner-support.py" hold-lock')
+        snapshot = self.source.index(
+            "service_was_active=$(snapshot_unit_active irlumed.service)"
+        )
+        self.assertLess(lock, snapshot)
+        self.assertIn('runtime_dir="/run/user/$(id -u)"', self.source)
+        self.assertNotIn("XDG_RUNTIME_DIR", self.source)
+        self.assertIn('[ "$(realpath "$runtime_dir")" != "$runtime_dir" ]', self.source)
+        self.assertIn('[ "$(stat -c %a "$runtime_dir")" != 700 ]', self.source)
+        self.assertIn('lock_dir="$runtime_dir/irlume-slice4-hardware.lock"', self.source)
+        self.assertIn('exec env IRLUME_SLICE4_LOCK_HELD=1 python3', self.source)
+        self.assertIn('unset IRLUME_SLICE4_LOCK_HELD', self.source)
+        self.assertNotIn('exec {lock_fd}', self.source)
+        self.assertIn(
+            'run_dir=$(mktemp -d "$output_dir/slice4-${host}-${sha}.XXXXXX")',
+            self.source,
+        )
+        self.assertIn('log="$run_dir/run.log"', self.source)
+        self.assertIn('evidence="$run_dir/evidence.json"', self.source)
+        self.assertNotIn('slice4-hardware-${host}-${sha}.json', self.source)
+        self.assertIn('[ -L "$output_dir" ]', self.source)
+        self.assertIn('[ "$(realpath "$output_dir")" != "$output_dir" ]', self.source)
+
+    def test_lock_holder_does_not_leak_lock_fd_to_workload_descendants(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            lock_dir = root / "lock"
+            lock_dir.mkdir()
+            ready = root / "ready"
+            child = textwrap.dedent(
+                """
+                import os
+                from pathlib import Path
+                import sys
+                import time
+
+                lock = Path(sys.argv[1]).resolve()
+                targets = []
+                for entry in Path("/proc/self/fd").iterdir():
+                    try:
+                        targets.append(Path(os.readlink(entry)).resolve())
+                    except FileNotFoundError:
+                        pass
+                assert lock not in targets, targets
+                Path(sys.argv[2]).write_text("ready", encoding="utf-8")
+                time.sleep(1)
+                """
+            )
+            holder = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(SUPPORT),
+                    "hold-lock",
+                    str(lock_dir),
+                    sys.executable,
+                    "-c",
+                    child,
+                    str(lock_dir),
+                    str(ready),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                deadline = time.monotonic() + 5
+                while not ready.exists() and holder.poll() is None:
+                    if time.monotonic() >= deadline:
+                        self.fail("lock-holder child did not become ready")
+                    time.sleep(0.01)
+                self.assertIsNone(holder.poll())
+                blocked = subprocess.run(
+                    [
+                        sys.executable,
+                        str(SUPPORT),
+                        "hold-lock",
+                        str(lock_dir),
+                        sys.executable,
+                        "-c",
+                        "pass",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(blocked.returncode, 75, blocked)
+                self.assertIn("another slice-4 hardware run", blocked.stderr)
+            finally:
+                stdout, stderr = holder.communicate(timeout=5)
+            self.assertEqual(holder.returncode, 0, (stdout, stderr))
+            reacquired = subprocess.run(
+                [
+                    sys.executable,
+                    str(SUPPORT),
+                    "hold-lock",
+                    str(lock_dir),
+                    sys.executable,
+                    "-c",
+                    "pass",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(reacquired.returncode, 0, reacquired)
+
+    def test_durable_evidence_fsyncs_file_and_every_establishing_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            output = source / "target"
+            run_dir = output / "run"
+            run_dir.mkdir(parents=True)
+            evidence = run_dir / "evidence.json"
+            evidence.write_text("{}\n", encoding="utf-8")
+            trace = Path(tmp) / "fsync.trace"
+            shim_source = Path(tmp) / "fsync-shim.c"
+            shim = Path(tmp) / "fsync-shim.so"
+            shim_source.write_text(
+                textwrap.dedent(
+                    r"""
+                    #define _GNU_SOURCE
+                    #include <errno.h>
+                    #include <fcntl.h>
+                    #include <limits.h>
+                    #include <stdio.h>
+                    #include <stdlib.h>
+                    #include <string.h>
+                    #include <sys/syscall.h>
+                    #include <unistd.h>
+
+                    int fsync(int fd) {
+                        char link[64], target[PATH_MAX], line[PATH_MAX + 2];
+                        const char *trace = getenv("IRLUME_FSYNC_TRACE");
+                        snprintf(link, sizeof(link), "/proc/self/fd/%d", fd);
+                        ssize_t length = readlink(link, target, sizeof(target) - 1);
+                        if (length >= 0 && trace) {
+                            target[length] = '\0';
+                            int out = open(trace, O_WRONLY | O_CREAT | O_APPEND, 0600);
+                            if (out >= 0) {
+                                int bytes = snprintf(line, sizeof(line), "%s\n", target);
+                                (void)write(out, line, (size_t)bytes);
+                                close(out);
+                            }
+                        }
+                        if (getenv("IRLUME_FSYNC_FAIL")) {
+                            errno = EIO;
+                            return -1;
+                        }
+                        return (int)syscall(SYS_fsync, fd);
+                    }
+                    """
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run(
+                ["cc", "-shared", "-fPIC", "-o", str(shim), str(shim_source)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            command = [
+                sys.executable,
+                str(SUPPORT),
+                "durable-evidence",
+                str(evidence),
+                str(run_dir),
+                str(output),
+                str(source),
+            ]
+            env = os.environ | {
+                "LD_PRELOAD": str(shim),
+                "IRLUME_FSYNC_TRACE": str(trace),
+            }
+            durable = subprocess.run(
+                command, env=env, capture_output=True, text=True, check=False
+            )
+            self.assertEqual(durable.returncode, 0, durable)
+            self.assertEqual(
+                trace.read_text(encoding="utf-8").splitlines(),
+                [str(evidence), str(run_dir), str(output), str(source)],
+            )
+
+            failed = subprocess.run(
+                command,
+                env=env | {"IRLUME_FSYNC_FAIL": "1"},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(failed.returncode, 0, failed)
+            self.assertIn("Input/output error", failed.stderr)
+
+    def test_cleanup_errors_are_accumulated_before_failed_evidence_is_purged(self):
+        cleanup_start = self.source.index("cleanup() {")
+        signal_start = self.source.index("on_signal() {")
+        cleanup = self.source[cleanup_start:signal_start]
+        self.assertIn('if ! rm -f "$users_file" "$fuser_errors"; then', cleanup)
+        self.assertIn('if ! rm -rf "$snapshot_parent" "$build_dir"; then', cleanup)
+        purge = cleanup.index('rm -f -- "$evidence"')
+        temp_cleanup = cleanup.index('rm -rf "$snapshot_parent" "$build_dir"')
+        self.assertGreater(purge, temp_cleanup)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/hardware/test-validate-slice4-hardware.py
+++ b/scripts/hardware/test-validate-slice4-hardware.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+import copy
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+VALIDATOR = HERE / "validate-slice4-hardware.py"
+U64_MAX = (1 << 64) - 1
+
+
+def valid_record():
+    return {
+        "kind": "irlume.slice4.hardware",
+        "schema_version": 1,
+        "host": "testhost",
+        "commit": "a" * 40,
+        "requested_duration_seconds": 60,
+        "duration_seconds": 60.5,
+        "recovery_exercised": True,
+        "recovery_duration_seconds": 1.2,
+        "rgb_ir_skew_us": 10,
+        "streams": [
+            {
+                "role": "rgb",
+                "frames": 100,
+                "observations": 114,
+                "discarded_observations": 14,
+                "sequence_span_sum": 114,
+                "delivered_hz": 100 / 60.5,
+                "gap_total": 2,
+                "cumulative_drops": 2,
+                "discontinuities": 1,
+                "epoch_count": 2,
+                "timestamp_span_sum_us": 58_800_000,
+                "delta_count": 98,
+                "delta_sum_us": 58_800_000,
+                "delta_min_us": 500_000,
+                "delta_max_us": 700_000,
+                "clock": "Monotonic",
+                "source": "EndOfFrame",
+                "stream_epoch": 1,
+                "sequence_stream_epoch": 1,
+                "timestamp_stream_epoch": 1,
+                "first_timestamp_us": 1_000_000,
+                "last_timestamp_us": 61_000_000,
+            },
+            {
+                "role": "ir",
+                "frames": 90,
+                "observations": 91,
+                "discarded_observations": 1,
+                "sequence_span_sum": 89,
+                "delivered_hz": 90 / 60.5,
+                "gap_total": 0,
+                "cumulative_drops": 0,
+                "discontinuities": 1,
+                "epoch_count": 2,
+                "timestamp_span_sum_us": 59_000_000,
+                "delta_count": 88,
+                "delta_sum_us": 59_000_000,
+                "delta_min_us": 600_000,
+                "delta_max_us": 800_000,
+                "clock": "Monotonic",
+                "source": "StartOfExposure",
+                "stream_epoch": 1,
+                "sequence_stream_epoch": 1,
+                "timestamp_stream_epoch": 1,
+                "first_timestamp_us": 1_000_010,
+                "last_timestamp_us": 60_999_990,
+            },
+        ],
+    }
+
+
+class ValidatorTests(unittest.TestCase):
+    def run_raw(
+        self,
+        text,
+        expected_host="testhost",
+        expected_sha="a" * 40,
+        expected_streams="2",
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            log = pathlib.Path(directory) / "hardware.log"
+            log.write_text(text, encoding="utf-8")
+            return subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    str(log),
+                    expected_host,
+                    expected_sha,
+                    expected_streams,
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+    def run_records(self, records, expected_streams="2"):
+        text = "".join(json.dumps(record) + "\n" for record in records)
+        return self.run_raw(text, expected_streams=expected_streams)
+
+    def run_validator(self, record, expected_streams="2"):
+        return self.run_records([record], expected_streams=expected_streams)
+
+    def assert_rejected(self, mutate):
+        record = valid_record()
+        mutate(record)
+        result = self.run_validator(record)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_ambiguous_or_nonstandard_json_is_rejected(self):
+        encoded = json.dumps(valid_record())
+        duplicate_host = encoded.replace(
+            '"host": "testhost"',
+            '"host": "wrong", "host": "testhost"',
+            1,
+        )
+        duplicate_role = encoded.replace(
+            '"role": "rgb"',
+            '"role": "other", "role": "rgb"',
+            1,
+        )
+        malformed = '{"kind":"irlume.slice4.hardware"\n' + encoded + "\n"
+        for raw in [duplicate_host, duplicate_role, malformed]:
+            with self.subTest(raw=raw[:40]):
+                self.assertNotEqual(self.run_raw(raw + "\n").returncode, 0)
+        for constant in ["NaN", "Infinity", "-Infinity"]:
+            raw = encoded.replace("60.5", constant, 1)
+            with self.subTest(constant=constant):
+                self.assertNotEqual(self.run_raw(raw + "\n").returncode, 0)
+
+    def test_identity_record_count_and_exact_keys_are_enforced(self):
+        self.assertNotEqual(self.run_records([]).returncode, 0)
+        record = valid_record()
+        self.assertNotEqual(self.run_records([record, record]).returncode, 0)
+        self.assert_rejected(lambda item: item.__setitem__("host", "wrong"))
+        self.assert_rejected(lambda item: item.__setitem__("commit", "b" * 40))
+        self.assert_rejected(lambda item: item.__setitem__("unexpected", 1))
+        self.assert_rejected(
+            lambda item: item["streams"][0].__setitem__("unexpected", 1)
+        )
+
+    def test_duration_recovery_and_stream_shape_are_enforced(self):
+        for invalid in [False, None, 1]:
+            with self.subTest(field="recovery", invalid=invalid):
+                self.assert_rejected(
+                    lambda record, invalid=invalid: record.__setitem__(
+                        "recovery_exercised", invalid
+                    )
+                )
+        for invalid in [59, 601, True]:
+            with self.subTest(field="requested", invalid=invalid):
+                self.assert_rejected(
+                    lambda record, invalid=invalid: record.__setitem__(
+                        "requested_duration_seconds", invalid
+                    )
+                )
+        for invalid in [59.9, 90.6, True, float("inf")]:
+            with self.subTest(field="measured", invalid=invalid):
+                self.assert_rejected(
+                    lambda record, invalid=invalid: record.__setitem__(
+                        "duration_seconds", invalid
+                    )
+                )
+        for invalid in [0, -1, True, 31]:
+            with self.subTest(field="recovery_duration", invalid=invalid):
+                self.assert_rejected(
+                    lambda record, invalid=invalid: record.__setitem__(
+                        "recovery_duration_seconds", invalid
+                    )
+                )
+        self.assert_rejected(lambda record: record["streams"].reverse())
+        self.assert_rejected(lambda record: record["streams"].pop())
+
+    def test_valid_dual_stream_evidence_passes(self):
+        result = self.run_validator(valid_record())
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_valid_rgb_only_evidence_passes_only_when_declared(self):
+        record = valid_record()
+        record["streams"] = record["streams"][:1]
+        record["rgb_ir_skew_us"] = None
+        result = self.run_validator(record, expected_streams="1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotEqual(self.run_validator(record).returncode, 0)
+
+    def test_stream_metrics_domains_epochs_and_timestamps_are_enforced(self):
+        mutations = [
+            lambda stream: stream.__setitem__("frames", 1),
+            lambda stream: stream.__setitem__("frames", True),
+            lambda stream: stream.__setitem__("delivered_hz", 0),
+            lambda stream: stream.__setitem__("delivered_hz", True),
+            lambda stream: stream.__setitem__("clock", "Unknown"),
+            lambda stream: stream.__setitem__("source", "Unknown"),
+            lambda stream: stream.__setitem__("stream_epoch", 2),
+            lambda stream: stream.__setitem__("sequence_stream_epoch", 0),
+            lambda stream: stream.__setitem__("timestamp_stream_epoch", 0),
+            lambda stream: stream.__setitem__("discontinuities", 0),
+            lambda stream: stream.__setitem__("delta_min_us", 0),
+            lambda stream: stream.__setitem__("delta_max_us", 1),
+            lambda stream: stream.__setitem__("first_timestamp_us", 0),
+            lambda stream: stream.__setitem__("last_timestamp_us", 1_000_000),
+        ]
+        for index, mutation in enumerate(mutations):
+            with self.subTest(mutation=index):
+                self.assert_rejected(
+                    lambda record, mutation=mutation: mutation(record["streams"][0])
+                )
+
+    def test_cross_field_rate_and_drop_coherence_is_enforced(self):
+        self.assert_rejected(
+            lambda record: record["streams"][0].__setitem__("delivered_hz", 1e300)
+        )
+        self.assert_rejected(
+            lambda record: record["streams"][0].__setitem__(
+                "cumulative_drops", U64_MAX
+            )
+        )
+
+        def full_sequence_space(record):
+            stream = record["streams"][0]
+            stream["gap_total"] = U64_MAX
+            stream["cumulative_drops"] = U64_MAX
+
+        self.assert_rejected(full_sequence_space)
+
+    def test_near_empty_nominal_run_is_rejected(self):
+        def keep_only_three_internally_consistent_rgb_frames(record):
+            stream = record["streams"][0]
+            stream["frames"] = 3
+            stream["observations"] = 17
+            stream["sequence_span_sum"] = 17
+            stream["delivered_hz"] = 3 / record["duration_seconds"]
+            stream["delta_count"] = 1
+            stream["delta_min_us"] = stream["timestamp_span_sum_us"]
+            stream["delta_max_us"] = stream["timestamp_span_sum_us"]
+
+        self.assert_rejected(keep_only_three_internally_consistent_rgb_frames)
+
+    def test_coordinated_omission_below_the_density_floor_is_rejected(self):
+        def omit_and_mirror_delivered_rgb_observations(record):
+            stream = record["streams"][0]
+            stream["frames"] = 30
+            stream["observations"] = stream["frames"] + stream["discarded_observations"]
+            stream["sequence_span_sum"] = (
+                stream["observations"]
+                - stream["epoch_count"]
+                + stream["cumulative_drops"]
+            )
+            stream["delivered_hz"] = stream["frames"] / record["duration_seconds"]
+            stream["delta_count"] = stream["frames"] - stream["epoch_count"]
+            stream["delta_sum_us"] = stream["timestamp_span_sum_us"]
+            stream["delta_min_us"] = 1_000_000
+            stream["delta_max_us"] = 3_000_000
+
+        self.assert_rejected(omit_and_mirror_delivered_rgb_observations)
+
+    def test_sequence_observation_accounting_is_exact(self):
+        self.assert_rejected(
+            lambda record: record["streams"][0].__setitem__("observations", 113)
+        )
+        self.assert_rejected(
+            lambda record: record["streams"][0].__setitem__("sequence_span_sum", 113)
+        )
+
+        def omit_rgb_warmup(record):
+            stream = record["streams"][0]
+            stream["observations"] = stream["frames"]
+            stream["discarded_observations"] = 0
+            stream["sequence_span_sum"] = (
+                stream["observations"]
+                - stream["epoch_count"]
+                + stream["cumulative_drops"]
+            )
+
+        self.assert_rejected(omit_rgb_warmup)
+
+    def test_cross_field_delta_coherence_is_enforced(self):
+        mutations = [
+            lambda stream: stream.__setitem__("delta_count", 101),
+            lambda stream: stream.__setitem__("delta_count", 97),
+            lambda stream: stream.__setitem__("delta_sum_us", 1),
+            lambda stream: stream.__setitem__("delta_sum_us", 4_000_001),
+            lambda stream: stream.__setitem__("delta_sum_us", 3_000_000),
+        ]
+        for index, mutation in enumerate(mutations):
+            with self.subTest(mutation=index):
+                self.assert_rejected(
+                    lambda record, mutation=mutation: mutation(record["streams"][0])
+                )
+
+        def shrink_timestamp_span(record):
+            record["streams"][0]["last_timestamp_us"] = 1_000_001
+            record["rgb_ir_skew_us"] = 5_999_989
+
+        self.assert_rejected(shrink_timestamp_span)
+
+        def tiny_epoch_spans(record):
+            stream = record["streams"][0]
+            stream["timestamp_span_sum_us"] = 98
+            stream["delta_sum_us"] = 98
+            stream["delta_min_us"] = 1
+            stream["delta_max_us"] = 1
+
+        self.assert_rejected(tiny_epoch_spans)
+
+    def test_gap_total_must_be_a_bounded_nonnegative_integer(self):
+        for invalid in ["2", -1, True, U64_MAX + 1]:
+            with self.subTest(invalid=invalid):
+                self.assert_rejected(
+                    lambda record, invalid=invalid: record["streams"][0].__setitem__(
+                        "gap_total", invalid
+                    )
+                )
+
+    def test_cumulative_drops_must_equal_all_observed_gaps(self):
+        for invalid in [-1, True, U64_MAX + 1]:
+            with self.subTest(invalid=invalid):
+                self.assert_rejected(
+                    lambda record, invalid=invalid: record["streams"][0].__setitem__(
+                        "cumulative_drops", invalid
+                    )
+                )
+        self.assert_rejected(
+            lambda record: record["streams"][0].update(
+                {"gap_total": 3, "cumulative_drops": 2}
+            )
+        )
+
+    def test_schema_and_epoch_fields_are_strict_integers(self):
+        self.assert_rejected(lambda record: record.pop("schema_version"))
+        for invalid in [True, 0, 2]:
+            with self.subTest(field="schema_version", invalid=invalid):
+                self.assert_rejected(
+                    lambda record, invalid=invalid: record.__setitem__(
+                        "schema_version", invalid
+                    )
+                )
+        for field in [
+            "stream_epoch",
+            "sequence_stream_epoch",
+            "timestamp_stream_epoch",
+            "discontinuities",
+        ]:
+            with self.subTest(field=field):
+                self.assert_rejected(
+                    lambda record, field=field: record["streams"][0].__setitem__(
+                        field, True
+                    )
+                )
+
+    def test_skew_must_equal_the_reported_last_timestamp_difference(self):
+        self.assert_rejected(lambda record: record.__setitem__("rgb_ir_skew_us", 10_000))
+        self.assert_rejected(lambda record: record.__setitem__("rgb_ir_skew_us", True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/hardware/test-validate-slice4-hardware.py
+++ b/scripts/hardware/test-validate-slice4-hardware.py
@@ -310,6 +310,25 @@ class ValidatorTests(unittest.TestCase):
 
         self.assert_rejected(tiny_epoch_spans)
 
+    def test_timestamp_boundary_budget_is_three_observed_intervals(self):
+        accepted = valid_record()
+        rgb = accepted["streams"][0]
+        rgb["last_timestamp_us"] = rgb["first_timestamp_us"] + 61_500_000
+        accepted["rgb_ir_skew_us"] = abs(
+            rgb["last_timestamp_us"] - accepted["streams"][1]["last_timestamp_us"]
+        )
+        result = self.run_validator(accepted)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        rejected = valid_record()
+        rgb = rejected["streams"][0]
+        rgb["last_timestamp_us"] = rgb["first_timestamp_us"] + 62_200_000
+        rejected["rgb_ir_skew_us"] = abs(
+            rgb["last_timestamp_us"] - rejected["streams"][1]["last_timestamp_us"]
+        )
+        result = self.run_validator(rejected)
+        self.assertNotEqual(result.returncode, 0, result)
+
     def test_gap_total_must_be_a_bounded_nonnegative_integer(self):
         for invalid in ["2", -1, True, U64_MAX + 1]:
             with self.subTest(invalid=invalid):

--- a/scripts/hardware/validate-slice4-hardware.py
+++ b/scripts/hardware/validate-slice4-hardware.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Validate structured evidence from slice-4 physical timestamp stress tests."""
+
+import json
+import math
+import pathlib
+import sys
+from typing import NoReturn
+
+U64_MAX = (1 << 64) - 1
+U32_MAX = (1 << 32) - 1
+I64_MAX = (1 << 63) - 1
+MIN_CONTINUITY_HZ = 1.0
+MAX_CONTINUITY_DELTA_US = 1_000_000
+RECORD_KEYS = {
+    "kind",
+    "schema_version",
+    "host",
+    "commit",
+    "requested_duration_seconds",
+    "duration_seconds",
+    "recovery_exercised",
+    "recovery_duration_seconds",
+    "rgb_ir_skew_us",
+    "streams",
+}
+STREAM_KEYS = {
+    "role",
+    "frames",
+    "observations",
+    "discarded_observations",
+    "sequence_span_sum",
+    "delivered_hz",
+    "gap_total",
+    "cumulative_drops",
+    "discontinuities",
+    "epoch_count",
+    "timestamp_span_sum_us",
+    "delta_count",
+    "delta_sum_us",
+    "delta_min_us",
+    "delta_max_us",
+    "clock",
+    "source",
+    "stream_epoch",
+    "sequence_stream_epoch",
+    "timestamp_stream_epoch",
+    "first_timestamp_us",
+    "last_timestamp_us",
+}
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(message)
+
+
+def reject_duplicate_members(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON member: {key!r}")
+        result[key] = value
+    return result
+
+
+def reject_nonstandard_constant(value):
+    fail(f"non-standard JSON numeric constant: {value}")
+
+
+def bounded_u64(value, label):
+    if type(value) is not int or not 0 <= value <= U64_MAX:
+        fail(f"{label}: expected a nonnegative u64, got {value!r}")
+    return value
+
+
+def positive_u64(value, label):
+    value = bounded_u64(value, label)
+    if value == 0:
+        fail(f"{label}: expected a positive integer")
+    return value
+
+
+def finite_number(value, label):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        fail(f"{label}: expected a finite number, got {value!r}")
+    if not math.isfinite(value):
+        fail(f"{label}: expected a finite number, got {value!r}")
+    return value
+
+
+def main(argv):
+    if len(argv) != 5:
+        fail("usage: validate LOG EXPECTED_HOST EXPECTED_SHA EXPECTED_STREAMS")
+
+    log_path, expected_host, expected_sha, expected_streams_raw = argv[1:]
+    try:
+        expected_streams = int(expected_streams_raw)
+    except ValueError as error:
+        fail(f"invalid expected stream count: {error}")
+    if expected_streams not in {1, 2}:
+        fail(f"expected stream count must be 1 or 2, got {expected_streams}")
+
+    records = []
+    for raw in pathlib.Path(log_path).read_text(
+        encoding="utf-8", errors="replace"
+    ).splitlines():
+        raw = raw.strip()
+        if not raw.startswith("{"):
+            continue
+        try:
+            record = json.loads(
+                raw,
+                object_pairs_hook=reject_duplicate_members,
+                parse_constant=reject_nonstandard_constant,
+            )
+        except json.JSONDecodeError as error:
+            fail(f"malformed JSON candidate: {error}")
+        if isinstance(record, dict) and record.get("kind") == "irlume.slice4.hardware":
+            records.append(record)
+
+    if len(records) != 1:
+        fail(f"expected exactly one slice-4 evidence record, got {len(records)}")
+    record = records[0]
+    if set(record) != RECORD_KEYS:
+        fail(f"unexpected evidence keys: {sorted(record)}")
+    schema_version = bounded_u64(record.get("schema_version"), "schema version")
+    if schema_version != 1:
+        fail(f"unsupported evidence schema version: {schema_version}")
+    if record.get("host") != expected_host:
+        fail(f"host mismatch: {record.get('host')!r} != {expected_host!r}")
+    if record.get("commit") != expected_sha:
+        fail(f"commit mismatch: {record.get('commit')!r} != {expected_sha!r}")
+    if record.get("recovery_exercised") is not True:
+        fail("recovery was not exercised")
+
+    requested = bounded_u64(record.get("requested_duration_seconds"), "requested duration")
+    if not 60 <= requested <= 600:
+        fail(f"invalid requested duration: {requested!r}")
+    duration = finite_number(record.get("duration_seconds"), "measured duration")
+    if duration < requested or duration > requested + 30:
+        fail(f"invalid measured duration: {duration!r}")
+    recovery_duration = finite_number(
+        record.get("recovery_duration_seconds"), "recovery duration"
+    )
+    if recovery_duration <= 0 or recovery_duration > duration - requested / 2:
+        fail(f"invalid recovery duration: {recovery_duration!r}")
+
+    streams = record.get("streams")
+    if not isinstance(streams, list) or len(streams) != expected_streams:
+        fail(f"expected {expected_streams} stream records, got {streams!r}")
+    if not all(isinstance(stream, dict) for stream in streams):
+        fail("every stream record must be an object")
+    expected_roles = ["rgb"] if expected_streams == 1 else ["rgb", "ir"]
+    if [stream.get("role") for stream in streams] != expected_roles:
+        fail(f"unexpected stream roles: {streams!r}")
+
+    last_timestamps = {}
+    for stream in streams:
+        role = stream["role"]
+        if set(stream) != STREAM_KEYS:
+            fail(f"{role}: unexpected stream keys: {sorted(stream)}")
+        frames = positive_u64(stream.get("frames"), f"{role}: frames")
+        if frames < 2:
+            fail(f"{role}: insufficient frames")
+        observations = positive_u64(stream.get("observations"), f"{role}: observations")
+        discarded_observations = bounded_u64(
+            stream.get("discarded_observations"), f"{role}: discarded observations"
+        )
+        expected_discarded = {"rgb": 14, "ir": 1}[role]
+        if discarded_observations != expected_discarded:
+            fail(
+                f"{role}: expected {expected_discarded} deterministic warm-up "
+                f"observations, got {discarded_observations}"
+            )
+        if observations != frames + discarded_observations:
+            fail(f"{role}: delivered/discarded observation accounting mismatch")
+        sequence_span_sum = positive_u64(
+            stream.get("sequence_span_sum"), f"{role}: sequence span sum"
+        )
+        delivered = finite_number(stream.get("delivered_hz"), f"{role}: delivered rate")
+        expected_rate = frames / duration
+        if not math.isclose(delivered, expected_rate, rel_tol=1e-12, abs_tol=1e-12):
+            fail(
+                f"{role}: delivered rate {delivered!r} does not match "
+                f"{frames}/{duration}={expected_rate!r}"
+            )
+        if delivered < MIN_CONTINUITY_HZ:
+            fail(
+                f"{role}: delivered rate {delivered!r} is below the "
+                f"{MIN_CONTINUITY_HZ:g} Hz continuity-evidence floor"
+            )
+        gap_total = bounded_u64(stream.get("gap_total"), f"{role}: gap total")
+        cumulative_drops = bounded_u64(
+            stream.get("cumulative_drops"), f"{role}: cumulative drops"
+        )
+        if cumulative_drops != gap_total:
+            fail(
+                f"{role}: cumulative drops {cumulative_drops} do not equal "
+                f"all observed gaps {gap_total}"
+            )
+        if cumulative_drops > U32_MAX:
+            fail(f"{role}: drops exceed one full 32-bit sequence space")
+        if stream.get("clock") != "Monotonic":
+            fail(f"{role}: untrusted clock {stream.get('clock')!r}")
+        if stream.get("source") not in {"EndOfFrame", "StartOfExposure"}:
+            fail(f"{role}: untrusted source {stream.get('source')!r}")
+        epoch = bounded_u64(stream.get("stream_epoch"), f"{role}: stream epoch")
+        sequence_epoch = bounded_u64(
+            stream.get("sequence_stream_epoch"), f"{role}: sequence stream epoch"
+        )
+        timestamp_epoch = bounded_u64(
+            stream.get("timestamp_stream_epoch"), f"{role}: timestamp stream epoch"
+        )
+        if epoch != 1 or sequence_epoch != epoch or timestamp_epoch != epoch:
+            fail(
+                f"{role}: expected one aligned recovered epoch, got "
+                f"{sequence_epoch!r}/{timestamp_epoch!r}/{epoch!r}"
+            )
+        discontinuities = bounded_u64(
+            stream.get("discontinuities"), f"{role}: discontinuities"
+        )
+        if discontinuities != 1:
+            fail(f"{role}: expected exactly one recovery discontinuity")
+        epoch_count = positive_u64(stream.get("epoch_count"), f"{role}: epoch count")
+        if epoch_count != epoch + 1 or epoch_count != discontinuities + 1:
+            fail(f"{role}: epoch count is incoherent")
+        expected_sequence_span = observations - epoch_count + cumulative_drops
+        if sequence_span_sum != expected_sequence_span:
+            fail(
+                f"{role}: sequence span {sequence_span_sum} does not equal "
+                f"observations - epochs + drops ({expected_sequence_span})"
+            )
+        timestamp_span_sum = positive_u64(
+            stream.get("timestamp_span_sum_us"), f"{role}: timestamp span sum"
+        )
+        delta_count = positive_u64(stream.get("delta_count"), f"{role}: delta count")
+        if delta_count != frames - epoch_count:
+            fail(f"{role}: delta count does not equal frames minus epochs")
+        delta_sum = positive_u64(stream.get("delta_sum_us"), f"{role}: delta sum")
+        if delta_sum != timestamp_span_sum:
+            fail(f"{role}: delta sum does not equal per-epoch timestamp spans")
+        minimum = positive_u64(stream.get("delta_min_us"), f"{role}: minimum delta")
+        maximum = positive_u64(stream.get("delta_max_us"), f"{role}: maximum delta")
+        if maximum < minimum:
+            fail(f"{role}: invalid timestamp deltas {minimum!r}..{maximum!r}")
+        if delta_count == 1:
+            minimum_sum = maximum_sum = minimum
+            if maximum != minimum:
+                fail(f"{role}: one delta cannot have distinct extrema")
+        else:
+            minimum_sum = maximum + minimum * (delta_count - 1)
+            maximum_sum = minimum + maximum * (delta_count - 1)
+        if not minimum_sum <= delta_sum <= maximum_sum:
+            fail(
+                f"{role}: delta sum {delta_sum} is outside extrema-derived "
+                f"bounds {minimum_sum}..{maximum_sum}"
+            )
+        if maximum > MAX_CONTINUITY_DELTA_US:
+            fail(
+                f"{role}: maximum timestamp delta {maximum}us exceeds the "
+                f"{MAX_CONTINUITY_DELTA_US}us continuity-evidence ceiling"
+            )
+        first_timestamp = positive_u64(
+            stream.get("first_timestamp_us"), f"{role}: first timestamp"
+        )
+        last_timestamp = positive_u64(
+            stream.get("last_timestamp_us"), f"{role}: last timestamp"
+        )
+        if first_timestamp > I64_MAX or last_timestamp > I64_MAX:
+            fail(f"{role}: timestamp exceeds signed producer domain")
+        if last_timestamp <= first_timestamp:
+            fail(
+                f"{role}: timestamps did not advance: "
+                f"{first_timestamp}..{last_timestamp}"
+            )
+        timestamp_span = last_timestamp - first_timestamp
+        if timestamp_span_sum > timestamp_span:
+            fail(f"{role}: per-epoch spans exceed the global timestamp span")
+        omitted_span = timestamp_span - timestamp_span_sum
+        recovery_duration_us = recovery_duration * 1_000_000
+        if abs(omitted_span - recovery_duration_us) > 2 * maximum:
+            fail(f"{role}: omitted timestamp span does not match recovery duration")
+        duration_us = duration * 1_000_000
+        if abs(timestamp_span - duration_us) > 2 * maximum:
+            fail(
+                f"{role}: global timestamp span {timestamp_span}us does not track "
+                f"measured duration {duration_us}us"
+            )
+        last_timestamps[role] = last_timestamp
+
+    if expected_streams == 2:
+        skew = bounded_u64(record.get("rgb_ir_skew_us"), "RGB/IR skew")
+        expected_skew = abs(last_timestamps["rgb"] - last_timestamps["ir"])
+        if skew != expected_skew:
+            fail(f"RGB/IR skew mismatch: {skew} != {expected_skew}")
+    elif record.get("rgb_ir_skew_us") is not None:
+        fail("RGB-only run unexpectedly reported RGB/IR skew")
+
+    print(json.dumps(record, sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/hardware/validate-slice4-hardware.py
+++ b/scripts/hardware/validate-slice4-hardware.py
@@ -12,6 +12,7 @@ U32_MAX = (1 << 32) - 1
 I64_MAX = (1 << 63) - 1
 MIN_CONTINUITY_HZ = 1.0
 MAX_CONTINUITY_DELTA_US = 1_000_000
+TIMESTAMP_BOUNDARY_INTERVALS = 3
 RECORD_KEYS = {
     "kind",
     "schema_version",
@@ -278,10 +279,16 @@ def main(argv):
             fail(f"{role}: per-epoch spans exceed the global timestamp span")
         omitted_span = timestamp_span - timestamp_span_sum
         recovery_duration_us = recovery_duration * 1_000_000
-        if abs(omitted_span - recovery_duration_us) > 2 * maximum:
+        if (
+            abs(omitted_span - recovery_duration_us)
+            > TIMESTAMP_BOUNDARY_INTERVALS * maximum
+        ):
             fail(f"{role}: omitted timestamp span does not match recovery duration")
         duration_us = duration * 1_000_000
-        if abs(timestamp_span - duration_us) > 2 * maximum:
+        if (
+            abs(timestamp_span - duration_us)
+            > TIMESTAMP_BOUNDARY_INTERVALS * maximum
+        ):
             fail(
                 f"{role}: global timestamp span {timestamp_span}us does not track "
                 f"measured duration {duration_us}us"


### PR DESCRIPTION
## Summary

Complete slice 4 of #462 by making V4L2 timestamp continuity a fail-closed peer of sequence continuity:

1. preserve and validate timestamp clock/source evidence at the trusted dequeue boundary;
2. make sequence and timestamp tracker publication transactional across delivered, discarded warm-up, corrupt-payload, and recovered observations;
3. reject driver-error payload bytes while retaining their fully validated sequence/timestamp facts as discarded continuity evidence;
4. account exactly for delivered, discarded, missing, and per-epoch producer observations;
5. add an exact-commit physical stress runner plus strict machine-readable evidence validation.

Refs #462. This PR intentionally does not close the issue; public/aggregate provenance and exact interval negotiation remain later slices.

## Safety properties

- Unknown/copy clocks, zero/non-increasing timestamps, clock/source changes, malformed dequeue facts, and checked-arithmetic exhaustion poison the current timestamp epoch.
- A `V4L2_BUF_FLAG_ERROR` payload is never delivered or decoded. Its metadata is used only after existing bounds/layout, timestamp, clock, and source validation, then counted as one discarded continuity observation.
- Driver-error payloads cannot hide timestamp-domain changes, timestamp regression, sequence regression/ambiguity, alignment failure, or accounting overflow; each remains sticky fail-closed.
- Sequence and timestamp state is evaluated on clones and published only when epochs, discontinuities, counters, and checked arithmetic all agree.
- Explicit recovery advances both trackers atomically; discarded recovery warm-up observations retain the pending discontinuity and are included in producer accounting.
- Evidence reconciles observations, discards, sequence spans, timestamp spans, deltas, epochs, recovery duration, and RGB/IR skew.
- Physical evidence rejects virtual/non-UVC/non-USB/symlinked nodes, dirty or substituted trees, wrong host/commit, sparse runs below 1 Hz, and same-epoch gaps above 1 second.
- The runner executes a detached clean snapshot of the exact reviewed commit, serializes cooperating host runs, durably publishes unique evidence, and restores both `irlumed.service` and `irlumed.socket` on success, failure, timeout, and signals.

## Test and review evidence for exact head

Head: `893b1562202a9851aff7684383b4ea3832ca6be0`
Full PR binary patch SHA-256: `ba4b458b888f65f576fd325ec7cd5cbb6bb2daef5bef19b2cbe7ceb7c769da45`

- Guarded workspace tests: **passed**.
- Camera affected-area tests: **401 unit tests + 12 contracts passed**; 20 physical/loopback tests remain explicitly ignored outside their harnesses.
- Runner behavior/sabotage suite: **10/10 passed**.
- Validator sabotage suite: **16/16 passed**.
- `cargo fmt --all --check`.
- `cargo clippy --all-targets --locked -- -D warnings`.
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --locked`.
- `cargo build --release --locked`.
- `cargo deny check`.
- `nix flake check`.
- Action-pin policy, ShellCheck, workflow analysis, harness self-tests, and strict machine API conformance **36/36**.
- RED proved the old corrupt-dequeue path poisoned a valid timestamp epoch on BRIO startup/recovery.
- Sabotage mutants proved the regression tests reject corrupt payload delivery, skipped continuity accounting, and corrupt-buffer clock/source/timestamp/sequence contradictions.
- Independent GLM-5.2 base-design review: **SHIP-DESIGN**.
- Independent exact-diff GLM-5.2 implementation review at diff `4e0f7486...`: **PASS**.
- All commits are signed; the worktree is clean and local, remote, and PR head OIDs match.
- Exact-head GitHub/Packit CI: **all required checks green**.

## Physical exact-head coverage

Exact-head physical results at `893b1562202a9851aff7684383b4ea3832ca6be0`:

- **PASS — current ASUS RGB + IR:** 60.014 s; 882 frames/stream; 14.697 Hz; one declared recovery/discontinuity per stream; RGB gaps 2, IR gaps 11; final skew 6,239 us.
- **PASS — minihost NexiGo N930W RGB + IR:** 60.006 s; 1,713 frames/stream; 28.547 Hz; one declared recovery/discontinuity per stream; RGB gaps 0, IR gaps 7; final skew 98,495 us.
- **PASS — thinkpad Integrated Camera, explicitly RGB-only:** 60.014 s; 595 frames; 9.914 Hz; one declared recovery/discontinuity; zero gaps.
- **PASS — archhost Logitech BRIO, explicitly RGB-only:** 60.030 s; 1,760 frames; 29.319 Hz; one declared recovery/discontinuity; zero gaps.

The BRIO dual held-stream shape is not claimed as passing. Exact syscall evidence shows RGB starvation under the paired held shape and a secondary pinned-v4l retry-after-timeout `QBUF(EINVAL)`. Existing production contention measurement already runs true scoped parallel drains, records that BRIO held concurrency starves RGB, and selects one-at-a-time capture. This PR adds no timeout increase, speculative bandwidth workaround, or unsupported dual-mode claim. ASUS and NexiGo provide the required real dual-stream evidence.

## Non-goals / residual boundaries

- No UVC extension-unit, emitter, firmware, or other device writes are added.
- No optical state is inferred from host-side controls.
- No libcamera/PipeWire backend or MIPI authentication enablement.
- No speculative bandwidth-reduction mode.
- An arbitrary same-user coherent rewrite of an unsigned local evidence file is outside this runner's threat model; exact external attestation remains separate.
- Dense post-hoc single-frame summary fabrication is not independently detectable until later exact interval/per-frame reconciliation; honest producer gaps remain sequence-accounted and fail closed according to current profile bounds.
