### PR TITLE
feat(camera): attach runtime frame provenance

### DIFF
--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -3,7 +3,8 @@
 
 //! Strict runtime evidence bound to one immutable camera lease reference.
 
-use crate::contracts::{CameraGeneration, CameraInstanceId, StreamRole};
+use crate::contracts::{CameraGeneration, CameraInstanceId, IlluminationProvenance, StreamRole};
+use crate::CaptureWindow;
 
 /// Clock domain reported in the known V4L2 timestamp-type bits.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -836,6 +837,541 @@ impl FrameBinding {
     }
 }
 
+/// Complete identity of the format proven stable after the V4L2 buffer claim.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ValidatedFormatIdentity {
+    fourcc: [u8; 4],
+    width: u32,
+    height: u32,
+    stride: u32,
+    image_size: u32,
+    field_order: u32,
+    colorspace: u32,
+    quantization: u32,
+    transfer: u32,
+    flags: u32,
+}
+
+impl ValidatedFormatIdentity {
+    /// Copy every field category compared by the post-claim format check.
+    #[must_use]
+    pub(crate) fn from_stable_format(format: &v4l::Format) -> Self {
+        Self {
+            fourcc: format.fourcc.repr,
+            width: format.width,
+            height: format.height,
+            stride: format.stride,
+            image_size: format.size,
+            field_order: format.field_order as u32,
+            colorspace: format.colorspace as u32,
+            quantization: format.quantization as u32,
+            transfer: format.transfer as u32,
+            flags: format.flags.bits(),
+        }
+    }
+
+    #[must_use]
+    pub const fn fourcc(&self) -> [u8; 4] {
+        self.fourcc
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> u32 {
+        self.width
+    }
+
+    #[must_use]
+    pub const fn height(&self) -> u32 {
+        self.height
+    }
+
+    #[must_use]
+    pub const fn stride(&self) -> u32 {
+        self.stride
+    }
+
+    #[must_use]
+    pub const fn image_size(&self) -> u32 {
+        self.image_size
+    }
+
+    #[must_use]
+    pub const fn field_order(&self) -> u32 {
+        self.field_order
+    }
+
+    #[must_use]
+    pub const fn colorspace(&self) -> u32 {
+        self.colorspace
+    }
+
+    #[must_use]
+    pub const fn quantization(&self) -> u32 {
+        self.quantization
+    }
+
+    #[must_use]
+    pub const fn transfer(&self) -> u32 {
+        self.transfer
+    }
+
+    #[must_use]
+    pub const fn flags(&self) -> u32 {
+        self.flags
+    }
+}
+
+/// Why captured evidence cannot be published as runtime frame provenance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RuntimeProvenanceError {
+    FactsSequenceMismatch,
+    FactsTimestampMismatch,
+    ContinuityMismatch,
+    DriverReportedCorruption,
+    SingleWindowMustBePoint,
+    ActiveIrRequiresIrStream,
+    TooFewContributors,
+    TooManyContributors,
+    InvalidSelection,
+    EqualSubtractionIndices,
+    MixedBinding,
+    MixedFormat,
+    MixedRole,
+    MixedTimestampDomain,
+    MixedContinuityEpoch,
+    ContributorDiscontinuity,
+    NonIncreasingTimestamp,
+    NonConsecutiveSequence,
+    TimestampDeltaMismatch,
+    CounterUnderflow,
+    TimestampSpanOverflow,
+}
+
+impl std::fmt::Display for RuntimeProvenanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::FactsSequenceMismatch => "dequeue facts and sequence observation disagree",
+            Self::FactsTimestampMismatch => "dequeue facts and timestamp observation disagree",
+            Self::ContinuityMismatch => "sequence and timestamp continuity disagree",
+            Self::DriverReportedCorruption => "V4L2 marked a provenance contributor corrupt",
+            Self::SingleWindowMustBePoint => "single-frame capture window is not a point",
+            Self::ActiveIrRequiresIrStream => "active-IR evidence requires an IR stream",
+            Self::TooFewContributors => "aggregate provenance requires at least two contributors",
+            Self::TooManyContributors => "aggregate provenance exceeds 64 contributors",
+            Self::InvalidSelection => "aggregate contributor selection is out of bounds",
+            Self::EqualSubtractionIndices => "subtraction contributors must be distinct",
+            Self::MixedBinding => "aggregate contributors have mixed camera bindings",
+            Self::MixedFormat => "aggregate contributors have mixed validated formats",
+            Self::MixedRole => "aggregate contributors have mixed stream roles",
+            Self::MixedTimestampDomain => "aggregate contributors have mixed timestamp domains",
+            Self::MixedContinuityEpoch => "aggregate contributors have mixed continuity epochs",
+            Self::ContributorDiscontinuity => "aggregate contributor reports a discontinuity",
+            Self::NonIncreasingTimestamp => "aggregate timestamps are not strictly increasing",
+            Self::NonConsecutiveSequence => "aggregate sequence observations are not consecutive",
+            Self::TimestampDeltaMismatch => {
+                "aggregate timestamp delta disagrees with its observation"
+            }
+            Self::CounterUnderflow => "aggregate cumulative drop counter moved backward",
+            Self::TimestampSpanOverflow => "aggregate timestamp span cannot be represented",
+        })
+    }
+}
+
+impl std::error::Error for RuntimeProvenanceError {}
+
+/// Validated evidence awaiting an explicit, consuming illumination decision.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PendingSingleFrameProvenance {
+    binding: FrameBinding,
+    format: ValidatedFormatIdentity,
+    facts: DequeuedBufferFacts,
+    sequence: SequenceObservation,
+    timestamp: TimestampObservation,
+    capture_window: CaptureWindow,
+}
+
+/// Complete trusted runtime evidence for one delivered dequeue.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SingleFrameProvenance {
+    binding: FrameBinding,
+    format: ValidatedFormatIdentity,
+    facts: DequeuedBufferFacts,
+    sequence: SequenceObservation,
+    timestamp: TimestampObservation,
+    capture_window: CaptureWindow,
+    illumination: IlluminationProvenance,
+}
+
+impl SingleFrameProvenance {
+    pub(crate) fn begin(
+        binding: FrameBinding,
+        format: ValidatedFormatIdentity,
+        facts: DequeuedBufferFacts,
+        sequence: SequenceObservation,
+        timestamp: TimestampObservation,
+        capture_window: CaptureWindow,
+    ) -> Result<PendingSingleFrameProvenance, RuntimeProvenanceError> {
+        if facts.sequence_raw() != sequence.raw() {
+            return Err(RuntimeProvenanceError::FactsSequenceMismatch);
+        }
+        if facts.timestamp_micros() != timestamp.micros()
+            || facts.timestamp_clock() != timestamp.clock()
+            || facts.timestamp_source() != timestamp.source()
+        {
+            return Err(RuntimeProvenanceError::FactsTimestampMismatch);
+        }
+        if sequence.stream_epoch() != timestamp.stream_epoch()
+            || sequence.discontinuity() != timestamp.discontinuity()
+        {
+            return Err(RuntimeProvenanceError::ContinuityMismatch);
+        }
+        if facts.driver_reported_corruption() {
+            return Err(RuntimeProvenanceError::DriverReportedCorruption);
+        }
+        if capture_window.start != capture_window.end {
+            return Err(RuntimeProvenanceError::SingleWindowMustBePoint);
+        }
+        Ok(PendingSingleFrameProvenance {
+            binding,
+            format,
+            facts,
+            sequence,
+            timestamp,
+            capture_window,
+        })
+    }
+
+    #[must_use]
+    pub const fn binding(&self) -> &FrameBinding {
+        &self.binding
+    }
+
+    #[must_use]
+    pub const fn format(&self) -> &ValidatedFormatIdentity {
+        &self.format
+    }
+
+    #[must_use]
+    pub const fn facts(&self) -> &DequeuedBufferFacts {
+        &self.facts
+    }
+
+    #[must_use]
+    pub const fn sequence(&self) -> &SequenceObservation {
+        &self.sequence
+    }
+
+    #[must_use]
+    pub const fn timestamp(&self) -> &TimestampObservation {
+        &self.timestamp
+    }
+
+    #[must_use]
+    pub const fn capture_window(&self) -> CaptureWindow {
+        self.capture_window
+    }
+
+    #[must_use]
+    pub const fn illumination(&self) -> IlluminationProvenance {
+        self.illumination
+    }
+}
+
+impl PendingSingleFrameProvenance {
+    pub(crate) fn finalize_illumination(
+        self,
+        illumination: IlluminationProvenance,
+    ) -> Result<SingleFrameProvenance, RuntimeProvenanceError> {
+        if illumination == IlluminationProvenance::ActiveIr
+            && self.binding.stream_role() != StreamRole::Ir
+        {
+            return Err(RuntimeProvenanceError::ActiveIrRequiresIrStream);
+        }
+        Ok(SingleFrameProvenance {
+            binding: self.binding,
+            format: self.format,
+            facts: self.facts,
+            sequence: self.sequence,
+            timestamp: self.timestamp,
+            capture_window: self.capture_window,
+            illumination,
+        })
+    }
+}
+
+/// How contributors influenced a derived frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContributorSelection {
+    Selected {
+        index: usize,
+    },
+    ReducedOverAll,
+    Subtracted {
+        lit_index: usize,
+        ambient_index: usize,
+    },
+}
+
+/// Validated provenance for a frame derived from multiple single dequeues.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AggregateFrameProvenance {
+    contributors: Vec<SingleFrameProvenance>,
+    selection: ContributorSelection,
+    capture_window: CaptureWindow,
+    illumination: IlluminationProvenance,
+    cumulative_drops_start: u64,
+    cumulative_drops_end: u64,
+    drops_within: u64,
+    worst_gap: u32,
+    worst_delta_micros: Option<u64>,
+    timestamp_span_micros: u64,
+}
+
+impl AggregateFrameProvenance {
+    pub(crate) fn new(
+        contributors: Vec<SingleFrameProvenance>,
+        selection: ContributorSelection,
+    ) -> Result<Self, RuntimeProvenanceError> {
+        if contributors.len() < 2 {
+            return Err(RuntimeProvenanceError::TooFewContributors);
+        }
+        if contributors.len() > 64 {
+            return Err(RuntimeProvenanceError::TooManyContributors);
+        }
+        let len = contributors.len();
+        let illumination = match selection {
+            ContributorSelection::Selected { index } => contributors
+                .get(index)
+                .ok_or(RuntimeProvenanceError::InvalidSelection)?
+                .illumination(),
+            ContributorSelection::ReducedOverAll => {
+                let first = contributors[0].illumination();
+                if contributors
+                    .iter()
+                    .all(|contributor| contributor.illumination() == first)
+                {
+                    first
+                } else {
+                    IlluminationProvenance::Unknown
+                }
+            }
+            ContributorSelection::Subtracted {
+                lit_index,
+                ambient_index,
+            } => {
+                if lit_index == ambient_index {
+                    return Err(RuntimeProvenanceError::EqualSubtractionIndices);
+                }
+                let lit = contributors
+                    .get(lit_index)
+                    .ok_or(RuntimeProvenanceError::InvalidSelection)?;
+                let ambient = contributors
+                    .get(ambient_index)
+                    .ok_or(RuntimeProvenanceError::InvalidSelection)?;
+                if lit.illumination() == IlluminationProvenance::ActiveIr
+                    && ambient.illumination() == IlluminationProvenance::Ambient
+                {
+                    IlluminationProvenance::ActiveIr
+                } else {
+                    IlluminationProvenance::Unknown
+                }
+            }
+        };
+        debug_assert!(len >= 2);
+        let first = &contributors[0];
+        if contributors
+            .iter()
+            .any(|contributor| contributor.binding().stream_role() != first.binding().stream_role())
+        {
+            return Err(RuntimeProvenanceError::MixedRole);
+        }
+        if contributors.iter().any(|contributor| {
+            contributor.binding().camera_instance_id() != first.binding().camera_instance_id()
+                || contributor.binding().generation() != first.binding().generation()
+        }) {
+            return Err(RuntimeProvenanceError::MixedBinding);
+        }
+        if contributors
+            .iter()
+            .any(|contributor| contributor.format() != first.format())
+        {
+            return Err(RuntimeProvenanceError::MixedFormat);
+        }
+        if contributors.iter().any(|contributor| {
+            contributor.timestamp().clock() != first.timestamp().clock()
+                || contributor.timestamp().source() != first.timestamp().source()
+        }) {
+            return Err(RuntimeProvenanceError::MixedTimestampDomain);
+        }
+        if contributors.iter().any(|contributor| {
+            contributor.sequence().stream_epoch() != first.sequence().stream_epoch()
+                || contributor.timestamp().stream_epoch() != first.timestamp().stream_epoch()
+        }) {
+            return Err(RuntimeProvenanceError::MixedContinuityEpoch);
+        }
+        if contributors.iter().any(|contributor| {
+            contributor.facts().driver_reported_corruption()
+                || contributor.sequence().discontinuity()
+                || contributor.timestamp().discontinuity()
+        }) {
+            return Err(RuntimeProvenanceError::ContributorDiscontinuity);
+        }
+        for pair in contributors.windows(2) {
+            let previous = &pair[0];
+            let current = &pair[1];
+            let Some(timestamp_delta) = current
+                .timestamp()
+                .micros()
+                .checked_sub(previous.timestamp().micros())
+            else {
+                return Err(RuntimeProvenanceError::TimestampSpanOverflow);
+            };
+            if timestamp_delta <= 0 {
+                return Err(RuntimeProvenanceError::NonIncreasingTimestamp);
+            }
+            let Some(advance) = current.sequence().advance() else {
+                return Err(RuntimeProvenanceError::NonConsecutiveSequence);
+            };
+            if current.sequence().raw() != previous.sequence().raw().wrapping_add(advance) {
+                return Err(RuntimeProvenanceError::NonConsecutiveSequence);
+            }
+            if u64::try_from(timestamp_delta).ok() != current.timestamp().delta_micros() {
+                return Err(RuntimeProvenanceError::TimestampDeltaMismatch);
+            }
+        }
+        let last = contributors.last().expect("aggregate has contributors");
+        let cumulative_drops_start = first.sequence().cumulative_drops();
+        let cumulative_drops_end = last.sequence().cumulative_drops();
+        let drops_within = cumulative_drops_end
+            .checked_sub(cumulative_drops_start)
+            .ok_or(RuntimeProvenanceError::CounterUnderflow)?;
+        let timestamp_span = last
+            .timestamp()
+            .micros()
+            .checked_sub(first.timestamp().micros())
+            .and_then(|span| u64::try_from(span).ok())
+            .ok_or(RuntimeProvenanceError::TimestampSpanOverflow)?;
+        let capture_window = contributors
+            .iter()
+            .map(SingleFrameProvenance::capture_window)
+            .reduce(CaptureWindow::union)
+            .expect("aggregate has contributors");
+        let worst_gap = contributors
+            .iter()
+            .map(|contributor| contributor.sequence().gap())
+            .max()
+            .expect("aggregate has contributors");
+        let worst_delta_micros = contributors
+            .iter()
+            .filter_map(|contributor| contributor.timestamp().delta_micros())
+            .max();
+        Ok(Self {
+            contributors,
+            selection,
+            capture_window,
+            illumination,
+            cumulative_drops_start,
+            cumulative_drops_end,
+            drops_within,
+            worst_gap,
+            worst_delta_micros,
+            timestamp_span_micros: timestamp_span,
+        })
+    }
+
+    #[must_use]
+    pub fn contributors(&self) -> &[SingleFrameProvenance] {
+        &self.contributors
+    }
+
+    #[must_use]
+    pub const fn selection(&self) -> ContributorSelection {
+        self.selection
+    }
+
+    #[must_use]
+    pub const fn capture_window(&self) -> CaptureWindow {
+        self.capture_window
+    }
+
+    #[must_use]
+    pub const fn illumination(&self) -> IlluminationProvenance {
+        self.illumination
+    }
+
+    #[must_use]
+    pub const fn cumulative_drops_start(&self) -> u64 {
+        self.cumulative_drops_start
+    }
+
+    #[must_use]
+    pub const fn cumulative_drops_end(&self) -> u64 {
+        self.cumulative_drops_end
+    }
+
+    #[must_use]
+    pub const fn drops_within(&self) -> u64 {
+        self.drops_within
+    }
+
+    #[must_use]
+    pub const fn worst_gap(&self) -> u32 {
+        self.worst_gap
+    }
+
+    #[must_use]
+    pub const fn worst_delta_micros(&self) -> Option<u64> {
+        self.worst_delta_micros
+    }
+
+    #[must_use]
+    pub const fn timestamp_span_micros(&self) -> u64 {
+        self.timestamp_span_micros
+    }
+}
+
+/// Mandatory runtime evidence owned by every frame.
+#[derive(Clone, Debug)]
+pub enum RuntimeFrameProvenance {
+    Single(SingleFrameProvenance),
+    Aggregate(AggregateFrameProvenance),
+}
+
+impl RuntimeFrameProvenance {
+    #[must_use]
+    pub const fn capture_window(&self) -> CaptureWindow {
+        match self {
+            Self::Single(single) => single.capture_window(),
+            Self::Aggregate(aggregate) => aggregate.capture_window(),
+        }
+    }
+
+    #[must_use]
+    pub const fn illumination(&self) -> IlluminationProvenance {
+        match self {
+            Self::Single(single) => single.illumination(),
+            Self::Aggregate(aggregate) => aggregate.illumination(),
+        }
+    }
+
+    #[must_use]
+    pub fn stream_role(&self) -> StreamRole {
+        match self {
+            Self::Single(single) => single.binding().stream_role(),
+            Self::Aggregate(aggregate) => aggregate.contributors[0].binding().stream_role(),
+        }
+    }
+
+    #[must_use]
+    pub fn format(&self) -> &ValidatedFormatIdentity {
+        match self {
+            Self::Single(single) => single.format(),
+            Self::Aggregate(aggregate) => aggregate.contributors[0].format(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -843,6 +1379,7 @@ mod tests {
         SequenceTrackerError, TimestampClock, TimestampSource, TimestampTracker,
         TimestampTrackerError,
     };
+    use crate::contracts::IlluminationProvenance;
 
     #[test]
     fn first_monotonic_timestamp_establishes_a_clean_epoch() {
@@ -1414,6 +1951,469 @@ mod tests {
                 width: 3,
                 height: 2,
             })
+        );
+    }
+
+    #[test]
+    fn single_runtime_provenance_echoes_complete_evidence() {
+        use crate::contracts::{
+            CameraGeneration, CameraInstanceId, IlluminationProvenance, StreamRole,
+        };
+        use crate::CaptureWindow;
+
+        let binding = super::FrameBinding::new(
+            CameraInstanceId::new("11111111111111111111111111111111").expect("test identity"),
+            CameraGeneration::INITIAL,
+            StreamRole::Ir,
+        );
+        let format = v4l::Format::new(4, 3, v4l::FourCC::new(b"GREY"));
+        let format = super::ValidatedFormatIdentity::from_stable_format(&format);
+        let metadata = v4l::buffer::Metadata {
+            bytesused: 12,
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC
+                | v4l::buffer::Flags::TSTAMP_SRC_SOE
+                | v4l::buffer::Flags::KEYFRAME,
+            sequence: 7,
+            timestamp: v4l::timestamp::Timestamp::new(3, 4),
+            ..Default::default()
+        };
+        let facts = super::DequeuedBufferFacts::from_v4l(&metadata, 12).expect("valid facts");
+        let sequence = super::SequenceTracker::new()
+            .observe(7)
+            .expect("valid sequence");
+        let timestamp = super::TimestampTracker::new()
+            .observe(
+                3_000_004,
+                super::TimestampClock::Monotonic,
+                super::TimestampSource::StartOfExposure,
+            )
+            .expect("valid timestamp");
+        let at = std::time::Instant::now();
+
+        let provenance = super::SingleFrameProvenance::begin(
+            binding.clone(),
+            format.clone(),
+            facts.clone(),
+            sequence,
+            timestamp,
+            CaptureWindow::at(at),
+        )
+        .expect("coherent evidence")
+        .finalize_illumination(IlluminationProvenance::ActiveIr)
+        .expect("IR may carry authoritative active illumination");
+
+        assert_eq!(provenance.binding(), &binding);
+        assert_eq!(provenance.format(), &format);
+        assert_eq!(provenance.facts(), &facts);
+        assert_eq!(provenance.sequence(), &sequence);
+        assert_eq!(provenance.timestamp(), &timestamp);
+        assert_eq!(provenance.capture_window(), CaptureWindow::at(at));
+        assert_eq!(provenance.illumination(), IlluminationProvenance::ActiveIr);
+    }
+
+    fn runtime_series(
+        raws: &[u32],
+        micros: &[i64],
+        illumination: &[IlluminationProvenance],
+    ) -> Vec<super::SingleFrameProvenance> {
+        use crate::contracts::{CameraGeneration, CameraInstanceId, StreamRole};
+        use crate::CaptureWindow;
+        use std::time::{Duration, Instant};
+
+        let binding = super::FrameBinding::new(
+            CameraInstanceId::new("33333333333333333333333333333333").expect("test identity"),
+            CameraGeneration::INITIAL,
+            StreamRole::Ir,
+        );
+        let mut stable = v4l::Format::new(8, 6, v4l::FourCC::new(b"GREY"));
+        stable.stride = 8;
+        stable.size = 48;
+        stable.field_order = v4l::format::FieldOrder::Progressive;
+        stable.colorspace = v4l::format::Colorspace::SRGB;
+        stable.flags = v4l::format::Flags::PREMUL_ALPHA;
+        stable.quantization = v4l::format::Quantization::FullRange;
+        stable.transfer = v4l::format::TransferFunction::SRGB;
+        let format = super::ValidatedFormatIdentity::from_stable_format(&stable);
+        let mut sequence_tracker = super::SequenceTracker::new();
+        let mut timestamp_tracker = super::TimestampTracker::new();
+        let base = Instant::now();
+
+        raws.iter()
+            .zip(micros)
+            .zip(illumination)
+            .map(|((&raw, &micros), &illumination)| {
+                let metadata = v4l::buffer::Metadata {
+                    bytesused: 48,
+                    sequence: raw,
+                    timestamp: v4l::timestamp::Timestamp::new(0, micros),
+                    flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                    ..Default::default()
+                };
+                let facts =
+                    super::DequeuedBufferFacts::from_v4l(&metadata, 48).expect("valid test facts");
+                let sequence = sequence_tracker.observe(raw).expect("valid test sequence");
+                let timestamp = timestamp_tracker
+                    .observe(
+                        micros,
+                        super::TimestampClock::Monotonic,
+                        super::TimestampSource::EndOfFrame,
+                    )
+                    .expect("valid test timestamp");
+                let at = base + Duration::from_micros(micros.unsigned_abs());
+                super::SingleFrameProvenance::begin(
+                    binding.clone(),
+                    format.clone(),
+                    facts,
+                    sequence,
+                    timestamp,
+                    CaptureWindow::at(at),
+                )
+                .expect("coherent test evidence")
+                .finalize_illumination(illumination)
+                .expect("coherent test illumination")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn validated_format_identity_retains_every_discriminant() {
+        let mut format = v4l::Format::new(640, 400, v4l::FourCC::new(b"GREY"));
+        format.stride = 672;
+        format.size = 268_800;
+        format.field_order = v4l::format::FieldOrder::Interlaced;
+        format.colorspace = v4l::format::Colorspace::Rec709;
+        format.flags = v4l::format::Flags::PREMUL_ALPHA;
+        format.quantization = v4l::format::Quantization::LimitedRange;
+        format.transfer = v4l::format::TransferFunction::Rec709;
+        let identity = super::ValidatedFormatIdentity::from_stable_format(&format);
+        assert_eq!(identity.width(), 640);
+        assert_eq!(identity.height(), 400);
+        assert_eq!(identity.fourcc(), *b"GREY");
+        assert_eq!(identity.stride(), 672);
+        assert_eq!(identity.image_size(), 268_800);
+        assert_eq!(identity.field_order(), format.field_order as u32);
+        assert_eq!(identity.colorspace(), format.colorspace as u32);
+        assert_eq!(identity.flags(), format.flags.bits());
+        assert_eq!(identity.quantization(), format.quantization as u32);
+        assert_eq!(identity.transfer(), format.transfer as u32);
+    }
+
+    #[test]
+    fn single_rejects_raw_metadata_and_observation_disagreement() {
+        let mut single = runtime_series(&[9], &[1_000], &[IlluminationProvenance::Unknown])
+            .pop()
+            .expect("one single");
+        single.facts.sequence_raw = 10;
+        assert_eq!(
+            super::SingleFrameProvenance::begin(
+                single.binding,
+                single.format,
+                single.facts,
+                single.sequence,
+                single.timestamp,
+                single.capture_window,
+            ),
+            Err(super::RuntimeProvenanceError::FactsSequenceMismatch)
+        );
+    }
+
+    #[test]
+    fn single_rejects_timestamp_facts_and_observation_disagreement() {
+        let mut single = runtime_series(&[9], &[1_000], &[IlluminationProvenance::Unknown])
+            .pop()
+            .expect("one single");
+        single.facts.timestamp_micros += 1;
+        assert_eq!(
+            super::SingleFrameProvenance::begin(
+                single.binding,
+                single.format,
+                single.facts,
+                single.sequence,
+                single.timestamp,
+                single.capture_window,
+            ),
+            Err(super::RuntimeProvenanceError::FactsTimestampMismatch)
+        );
+    }
+
+    #[test]
+    fn single_rejects_corrupt_buffers_and_non_point_capture_windows() {
+        let mut corrupt = runtime_series(&[9], &[1_000], &[IlluminationProvenance::Unknown])
+            .pop()
+            .expect("one single");
+        corrupt.facts.known_flags |= v4l::buffer::Flags::ERROR.bits();
+        assert_eq!(
+            super::SingleFrameProvenance::begin(
+                corrupt.binding.clone(),
+                corrupt.format.clone(),
+                corrupt.facts.clone(),
+                corrupt.sequence,
+                corrupt.timestamp,
+                corrupt.capture_window,
+            ),
+            Err(super::RuntimeProvenanceError::DriverReportedCorruption)
+        );
+        corrupt.facts.known_flags &= !v4l::buffer::Flags::ERROR.bits();
+        let end = corrupt.capture_window.end + std::time::Duration::from_millis(1);
+        assert_eq!(
+            super::SingleFrameProvenance::begin(
+                corrupt.binding,
+                corrupt.format,
+                corrupt.facts,
+                corrupt.sequence,
+                corrupt.timestamp,
+                crate::CaptureWindow {
+                    start: corrupt.capture_window.start,
+                    end,
+                },
+            ),
+            Err(super::RuntimeProvenanceError::SingleWindowMustBePoint)
+        );
+    }
+
+    #[test]
+    fn illumination_finalization_rejects_active_ir_on_rgb() {
+        let mut single = runtime_series(&[1], &[1], &[IlluminationProvenance::Unknown])
+            .pop()
+            .expect("one single");
+        single.binding.stream_role = crate::contracts::StreamRole::Rgb;
+        let pending = super::SingleFrameProvenance::begin(
+            single.binding,
+            single.format,
+            single.facts,
+            single.sequence,
+            single.timestamp,
+            single.capture_window,
+        )
+        .expect("otherwise coherent");
+        assert_eq!(
+            pending.finalize_illumination(IlluminationProvenance::ActiveIr),
+            Err(super::RuntimeProvenanceError::ActiveIrRequiresIrStream)
+        );
+    }
+
+    #[test]
+    fn aggregate_accumulates_drop_span_gap_delta_and_union() {
+        let contributors = runtime_series(
+            &[10, 13, 17],
+            &[100, 200, 500],
+            &[
+                IlluminationProvenance::Unknown,
+                IlluminationProvenance::Ambient,
+                IlluminationProvenance::ActiveIr,
+            ],
+        );
+        let expected_start = contributors[0].capture_window().start;
+        let expected_end = contributors[2].capture_window().end;
+        let aggregate = super::AggregateFrameProvenance::new(
+            contributors,
+            super::ContributorSelection::Selected { index: 2 },
+        )
+        .expect("coherent aggregate");
+        assert_eq!(aggregate.drops_within(), 5);
+        assert_eq!(aggregate.timestamp_span_micros(), 400);
+        assert_eq!(aggregate.worst_gap(), 3);
+        assert_eq!(aggregate.worst_delta_micros(), Some(300));
+        assert_eq!(aggregate.capture_window().start, expected_start);
+        assert_eq!(aggregate.capture_window().end, expected_end);
+        assert_eq!(aggregate.illumination(), IlluminationProvenance::ActiveIr);
+    }
+
+    #[test]
+    fn aggregate_accepts_checked_u32_wrap_continuity() {
+        let aggregate = super::AggregateFrameProvenance::new(
+            runtime_series(
+                &[u32::MAX - 1, u32::MAX, 0],
+                &[100, 200, 300],
+                &[IlluminationProvenance::Unknown; 3],
+            ),
+            super::ContributorSelection::ReducedOverAll,
+        )
+        .expect("wrap is consecutive");
+        assert_eq!(aggregate.drops_within(), 0);
+        assert_eq!(aggregate.worst_gap(), 0);
+    }
+
+    #[test]
+    fn aggregate_enforces_contributor_bounds_and_selection_indices() {
+        let one = runtime_series(&[1], &[1], &[IlluminationProvenance::Unknown]);
+        assert_eq!(
+            super::AggregateFrameProvenance::new(one, super::ContributorSelection::ReducedOverAll),
+            Err(super::RuntimeProvenanceError::TooFewContributors)
+        );
+        let too_many = runtime_series(
+            &(1..=65).collect::<Vec<_>>(),
+            &(1..=65).map(i64::from).collect::<Vec<_>>(),
+            &[IlluminationProvenance::Unknown; 65],
+        );
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                too_many,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::TooManyContributors)
+        );
+        let two = runtime_series(&[1, 2], &[1, 2], &[IlluminationProvenance::Unknown; 2]);
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                two,
+                super::ContributorSelection::Selected { index: 2 }
+            ),
+            Err(super::RuntimeProvenanceError::InvalidSelection)
+        );
+    }
+
+    #[test]
+    fn aggregate_rejects_mixed_binding_role_format_and_timestamp_domain() {
+        let base = runtime_series(&[1, 2], &[100, 200], &[IlluminationProvenance::Unknown; 2]);
+        let mut mixed = base.clone();
+        mixed[1].binding.generation =
+            crate::contracts::CameraGeneration::new(2).expect("generation");
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                mixed,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::MixedBinding)
+        );
+        let mut mixed = base.clone();
+        mixed[1].binding.stream_role = crate::contracts::StreamRole::Rgb;
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                mixed,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::MixedRole)
+        );
+        let mut mixed = base.clone();
+        mixed[1].format.flags ^= 1;
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                mixed,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::MixedFormat)
+        );
+        let mut mixed = base;
+        mixed[1].timestamp.source = super::TimestampSource::StartOfExposure;
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                mixed,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::MixedTimestampDomain)
+        );
+    }
+
+    #[test]
+    fn aggregate_rejects_discontinuity_nonconsecutive_and_counter_underflow() {
+        let base = runtime_series(&[5, 6], &[100, 200], &[IlluminationProvenance::Unknown; 2]);
+        let mut broken = base.clone();
+        broken[1].sequence.discontinuity = true;
+        broken[1].timestamp.discontinuity = true;
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                broken,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::ContributorDiscontinuity)
+        );
+        let mut broken = base.clone();
+        broken[1].facts.known_flags |= v4l::buffer::Flags::ERROR.bits();
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                broken,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::ContributorDiscontinuity)
+        );
+        let mut broken = base.clone();
+        broken[1].sequence.advance = Some(2);
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                broken,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::NonConsecutiveSequence)
+        );
+        let mut broken = base;
+        broken[1].sequence.cumulative_drops = 0;
+        broken[0].sequence.cumulative_drops = 1;
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                broken,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::CounterUnderflow)
+        );
+    }
+
+    #[test]
+    fn aggregate_rejects_mixed_continuity_epoch() {
+        let mut broken =
+            runtime_series(&[5, 6], &[100, 200], &[IlluminationProvenance::Unknown; 2]);
+        broken[1].sequence.stream_epoch = 1;
+        broken[1].timestamp.stream_epoch = 1;
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                broken,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::MixedContinuityEpoch)
+        );
+    }
+
+    #[test]
+    fn aggregate_rejects_non_increasing_or_inconsistent_timestamps() {
+        let base = runtime_series(&[1, 2], &[100, 200], &[IlluminationProvenance::Unknown; 2]);
+        let mut broken = base.clone();
+        broken[1].timestamp.micros = 100;
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                broken,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::NonIncreasingTimestamp)
+        );
+        let mut broken = base;
+        broken[1].timestamp.delta_micros = Some(99);
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                broken,
+                super::ContributorSelection::ReducedOverAll
+            ),
+            Err(super::RuntimeProvenanceError::TimestampDeltaMismatch)
+        );
+    }
+
+    #[test]
+    fn aggregate_subtraction_requires_distinct_lit_and_ambient_evidence() {
+        let contributors = runtime_series(
+            &[1, 2],
+            &[100, 200],
+            &[
+                IlluminationProvenance::ActiveIr,
+                IlluminationProvenance::Ambient,
+            ],
+        );
+        let aggregate = super::AggregateFrameProvenance::new(
+            contributors.clone(),
+            super::ContributorSelection::Subtracted {
+                lit_index: 0,
+                ambient_index: 1,
+            },
+        )
+        .expect("valid subtraction");
+        assert_eq!(aggregate.illumination(), IlluminationProvenance::ActiveIr);
+        assert_eq!(
+            super::AggregateFrameProvenance::new(
+                contributors,
+                super::ContributorSelection::Subtracted {
+                    lit_index: 0,
+                    ambient_index: 0,
+                },
+            ),
+            Err(super::RuntimeProvenanceError::EqualSubtractionIndices)
         );
     }
 }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -128,6 +128,110 @@ pub struct Frame {
     /// BOTH sensors need this: the RGB and IR frames of one decision come from
     /// separate streams that can drift apart without it.
     pub captured: CaptureWindow,
+    provenance: frame_provenance::RuntimeFrameProvenance,
+}
+
+impl Frame {
+    fn from_provenance(
+        width: u32,
+        height: u32,
+        spectrum: Spectrum,
+        data: Vec<u8>,
+        provenance: frame_provenance::RuntimeFrameProvenance,
+    ) -> irlume_common::Result<Self> {
+        let expected_role = match spectrum {
+            Spectrum::Rgb => contracts::StreamRole::Rgb,
+            Spectrum::Ir => contracts::StreamRole::Ir,
+        };
+        if provenance.stream_role() != expected_role {
+            return Err(Error::Hardware(
+                "frame spectrum disagrees with runtime provenance role".into(),
+            ));
+        }
+        if (provenance.format().width(), provenance.format().height()) != (width, height) {
+            return Err(Error::Hardware(
+                "frame geometry disagrees with validated runtime format".into(),
+            ));
+        }
+        let captured = provenance.capture_window();
+        Ok(Self {
+            width,
+            height,
+            spectrum,
+            data,
+            captured,
+            provenance,
+        })
+    }
+
+    /// Trusted runtime evidence transactionally attached to this frame.
+    #[must_use]
+    pub const fn provenance(&self) -> &frame_provenance::RuntimeFrameProvenance {
+        &self.provenance
+    }
+
+    fn into_single_provenance(
+        self,
+    ) -> Result<frame_provenance::SingleFrameProvenance, frame_provenance::RuntimeProvenanceError>
+    {
+        match self.provenance {
+            frame_provenance::RuntimeFrameProvenance::Single(single) => Ok(single),
+            frame_provenance::RuntimeFrameProvenance::Aggregate(_) => {
+                Err(frame_provenance::RuntimeProvenanceError::InvalidSelection)
+            }
+        }
+    }
+}
+
+fn checked_single_evidence(
+    binding: frame_provenance::FrameBinding,
+    format: frame_provenance::ValidatedFormatIdentity,
+    facts: frame_provenance::DequeuedBufferFacts,
+    sequence: frame_provenance::SequenceObservation,
+    timestamp: frame_provenance::TimestampObservation,
+    taken: std::time::Instant,
+    illumination: contracts::IlluminationProvenance,
+) -> irlume_common::Result<frame_provenance::SingleFrameProvenance> {
+    frame_provenance::SingleFrameProvenance::begin(
+        binding,
+        format,
+        facts,
+        sequence,
+        timestamp,
+        CaptureWindow::at(taken),
+    )
+    .and_then(|pending| pending.finalize_illumination(illumination))
+    .map_err(|error| Error::Hardware(format!("invalid runtime frame provenance: {error}")))
+}
+
+fn checked_single_provenance(
+    binding: frame_provenance::FrameBinding,
+    format: frame_provenance::ValidatedFormatIdentity,
+    facts: frame_provenance::DequeuedBufferFacts,
+    sequence: frame_provenance::SequenceObservation,
+    timestamp: frame_provenance::TimestampObservation,
+    taken: std::time::Instant,
+    illumination: contracts::IlluminationProvenance,
+) -> irlume_common::Result<frame_provenance::RuntimeFrameProvenance> {
+    checked_single_evidence(
+        binding,
+        format,
+        facts,
+        sequence,
+        timestamp,
+        taken,
+        illumination,
+    )
+    .map(frame_provenance::RuntimeFrameProvenance::Single)
+}
+
+fn checked_aggregate_provenance(
+    contributors: Vec<frame_provenance::SingleFrameProvenance>,
+    selection: frame_provenance::ContributorSelection,
+) -> irlume_common::Result<frame_provenance::RuntimeFrameProvenance> {
+    frame_provenance::AggregateFrameProvenance::new(contributors, selection)
+        .map(frame_provenance::RuntimeFrameProvenance::Aggregate)
+        .map_err(|error| Error::Hardware(format!("invalid aggregate frame provenance: {error}")))
 }
 
 /// The span of time a frame's pixels came from, on the monotonic clock.
@@ -137,7 +241,7 @@ pub struct Frame {
 /// a burst, so their contents belong to a stretch of time rather than an instant.
 /// Keeping the stretch (instead of stamping "now" at return) is what lets
 /// [`CaptureWindow::gap_to`] state a real bound rather than a flattering one.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CaptureWindow {
     pub start: std::time::Instant,
     pub end: std::time::Instant,
@@ -2669,13 +2773,20 @@ impl<'a> RgbSession<'a> {
         let (w, h) = (self.cam.width, self.cam.height);
         let device = self.cam.device.clone();
         let chosen = self.cam.chosen;
+        let binding = self
+            .cam
+            .lease
+            .frame_binding(&device, contracts::StreamRole::Rgb)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        let format =
+            frame_provenance::ValidatedFormatIdentity::from_stable_format(&self.cam.negotiated);
         let mut frames = Vec::with_capacity(n.max(1));
         for _ in 0..n.max(1) {
             self.cam
                 .lease
                 .require_endpoint(&device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, _meta, _sequence, _timestamp) =
+            let (buf, facts, sequence, timestamp) =
                 self.stream.next().map_err(|error| map_io(&device, error))?;
             let taken = std::time::Instant::now();
             let data = match &chosen {
@@ -2686,13 +2797,22 @@ impl<'a> RgbSession<'a> {
                 .lease
                 .require_endpoint(&device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            frames.push(Frame {
-                width: w,
-                height: h,
-                spectrum: Spectrum::Rgb,
+            let provenance = checked_single_provenance(
+                binding.clone(),
+                format.clone(),
+                facts,
+                sequence,
+                timestamp,
+                taken,
+                contracts::IlluminationProvenance::Unknown,
+            )?;
+            frames.push(Frame::from_provenance(
+                w,
+                h,
+                Spectrum::Rgb,
                 data,
-                captured: CaptureWindow::at(taken),
-            });
+                provenance,
+            )?);
         }
         Ok(frames)
     }
@@ -2709,7 +2829,7 @@ impl<'a> RgbSession<'a> {
     /// the burst, so one blurry or over-exposed frame cannot decide a match.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn denoised(&mut self) -> irlume_common::Result<Frame> {
-        Ok(median_frame(self.burst(RGB_BURST)?))
+        median_frame(self.burst(RGB_BURST)?)
     }
 }
 
@@ -3105,9 +3225,9 @@ pub fn capture_rgb_denoised_with_progress(
     device: &str,
     progress: &Progress,
 ) -> irlume_common::Result<Frame> {
-    Ok(median_frame(capture_rgb_burst_with_progress(
+    median_frame(capture_rgb_burst_with_progress(
         device, RGB_BURST, progress,
-    )?))
+    )?)
 }
 
 /// Per-pixel temporal median across same-sized frames (sorts each byte position
@@ -3115,16 +3235,11 @@ pub fn capture_rgb_denoised_with_progress(
 /// for a degenerate burst. Private on purpose: callers must pass at least one
 /// frame (`capture_rgb_burst` clamps to n.max(1)), and keeping it crate-local
 /// keeps that invariant next to the only code that must uphold it.
-fn median_frame(mut frames: Vec<Frame>) -> Frame {
+fn median_frame(mut frames: Vec<Frame>) -> irlume_common::Result<Frame> {
     if frames.len() <= 1 {
-        return frames.pop().expect("median_frame: empty burst");
+        return Ok(frames.pop().expect("median_frame: empty burst"));
     }
     let (w, h, spectrum) = (frames[0].width, frames[0].height, frames[0].spectrum);
-    let window = frames
-        .iter()
-        .map(|f| f.captured)
-        .reduce(CaptureWindow::union)
-        .unwrap_or_else(|| CaptureWindow::at(std::time::Instant::now()));
     let len = frames.iter().map(|f| f.data.len()).min().unwrap_or(0);
     let mut out = vec![0u8; len];
     let mut col = vec![0u8; frames.len()];
@@ -3135,15 +3250,16 @@ fn median_frame(mut frames: Vec<Frame>) -> Frame {
         col.sort_unstable();
         *o = col[col.len() / 2];
     }
-    Frame {
-        width: w,
-        height: h,
-        spectrum,
-        data: out,
-        // A median pixel can come from any frame in the burst, so the result
-        // belongs to the whole span, not to any one dequeue.
-        captured: window,
-    }
+    let contributors = frames
+        .into_iter()
+        .map(Frame::into_single_provenance)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| Error::Hardware(format!("invalid median contributors: {error}")))?;
+    let provenance = checked_aggregate_provenance(
+        contributors,
+        frame_provenance::ContributorSelection::ReducedOverAll,
+    )?;
+    Frame::from_provenance(w, h, spectrum, out, provenance)
 }
 
 const IR_W: u32 = 640;
@@ -3442,6 +3558,11 @@ impl IrSession<'_> {
         let card = &self.cam.card;
         let lit = self.lit;
         let white_level = self.dec.white_level();
+        let binding = lease
+            .frame_binding(device, contracts::StreamRole::Ir)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        let format =
+            frame_provenance::ValidatedFormatIdentity::from_stable_format(&self.cam.negotiated);
         // The state is NOT impossible, which is why this is an error and not
         // the expect it used to be: a failed `recover` (its reopen can lose a
         // format race with another application, #427, or hit transient
@@ -3465,6 +3586,7 @@ impl IrSession<'_> {
         let mut frames: Vec<Vec<u8>> = Vec::with_capacity(IR_BURST);
         let mut means: Vec<f64> = Vec::with_capacity(IR_BURST);
         let mut taken: Vec<std::time::Instant> = Vec::with_capacity(IR_BURST);
+        let mut dequeue_evidence = Vec::with_capacity(IR_BURST);
         // Each frame's V4L2 buffer timestamp, the key that ties it to the
         // camera's illumination record. Measured identical across the image and
         // metadata queues for every frame of a 24-frame run; dequeue order is
@@ -3489,13 +3611,15 @@ impl IrSession<'_> {
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, bmeta, _sequence, _timestamp) =
+            let (buf, bmeta, sequence, timestamp) =
                 stream.next().map_err(|error| map_io(device, error))?;
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
             stamps.push(bmeta.timestamp_micros());
-            taken.push(std::time::Instant::now());
+            let frame_taken = std::time::Instant::now();
+            taken.push(frame_taken);
+            dequeue_evidence.push((bmeta, sequence, timestamp, frame_taken));
             // Drain every iteration, not once at the end. The metadata ring is
             // smaller than a burst, so a single drain afterwards silently loses
             // the earliest frames' records: measured 7 of 10 frames classified
@@ -3572,7 +3696,6 @@ impl IrSession<'_> {
         let best_i =
             ir_metadata::best_gate_frame(&means, &flags, clipped_fracs.as_deref()).unwrap_or(0);
         let mut best = Some(frames[best_i].clone());
-        let mut ir_window = CaptureWindow::at(taken[best_i]);
 
         // Windows-Hello-style ambient subtraction. EXPERIMENTAL, opt-in. On a
         // strobing emitter the frame adjacent to the brightest is an emitter-OFF
@@ -3603,6 +3726,7 @@ impl IrSession<'_> {
         let debug_ir = std::env::var("IRLUME_DEBUG_IR").is_ok();
         // Stays None unless the returned pixels stop being the raw gate frame.
         let mut saturation_frame: Option<Vec<u8>> = None;
+        let mut ambient_used = None;
         if subtract {
             // An adjacent frame the camera flagged dark, else the darker
             // neighbour as before. Adjacency still bounds auto-exposure drift
@@ -3629,8 +3753,8 @@ impl IrSession<'_> {
                         // the raw ones.
                         saturation_frame = white_level.map(|_| frames[best_i].clone());
                         best = Some(sub);
+                        ambient_used = Some(ai);
                         // The result now carries pixels from BOTH frames.
-                        ir_window = ir_window.union(CaptureWindow::at(taken[ai]));
                     }
                     if debug_ir {
                         // Reads the same ceiling the gate-frame selection above
@@ -3755,17 +3879,42 @@ impl IrSession<'_> {
             }
         }
         let grey = best.ok_or_else(|| Error::Hardware("no IR frames captured".into()))?;
-        Ok((
-            Frame {
-                width: w,
-                height: h,
-                spectrum: Spectrum::Ir,
-                data: grey,
-                // The returned pixels are the chosen burst frame's, so the window is
-                // that dequeue. Ambient subtraction mixes in an ADJACENT frame, so
-                // it widens to cover both.
-                captured: ir_window,
+        let contributors = dequeue_evidence
+            .into_iter()
+            .zip(flags.iter().copied())
+            .map(
+                |((facts, sequence, timestamp, frame_taken), illumination)| {
+                    let illumination = match illumination {
+                        Some(ir_metadata::Illumination::Lit) => {
+                            contracts::IlluminationProvenance::ActiveIr
+                        }
+                        Some(ir_metadata::Illumination::Dark) => {
+                            contracts::IlluminationProvenance::Ambient
+                        }
+                        None => contracts::IlluminationProvenance::Unknown,
+                    };
+                    checked_single_evidence(
+                        binding.clone(),
+                        format.clone(),
+                        facts,
+                        sequence,
+                        timestamp,
+                        frame_taken,
+                        illumination,
+                    )
+                },
+            )
+            .collect::<irlume_common::Result<Vec<_>>>()?;
+        let selection = ambient_used.map_or(
+            frame_provenance::ContributorSelection::Selected { index: best_i },
+            |ambient_index| frame_provenance::ContributorSelection::Subtracted {
+                lit_index: best_i,
+                ambient_index,
             },
+        );
+        let provenance = checked_aggregate_provenance(contributors, selection)?;
+        Ok((
+            Frame::from_provenance(w, h, Spectrum::Ir, grey, provenance)?,
             IrCaptureStats {
                 saturation_frame,
                 lit_mean: lit_level as f32,
@@ -4004,6 +4153,10 @@ pub mod ir_probe {
         let (fmt, pix) = negotiate_ir_format(device, &dev)?;
         let mut dec = super::IrDecoder::new(pix, fmt.quantization);
         let (w, h) = (fmt.width, fmt.height);
+        let binding = permit
+            .frame_binding(device, super::contracts::StreamRole::Ir)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        let format = super::frame_provenance::ValidatedFormatIdentity::from_stable_format(&fmt);
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
         // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
         // reverse declaration order, so `stream` drops first and stops the
@@ -4027,17 +4180,20 @@ pub mod ir_probe {
         let mut out = Vec::with_capacity(n);
         let t0 = std::time::Instant::now();
         for _ in 0..n {
-            let (buf, _meta, _sequence, _timestamp) =
+            let (buf, facts, sequence, timestamp) =
                 stream.next().map_err(|error| map_io(device, error))?;
             let taken = std::time::Instant::now();
+            let provenance = super::checked_single_provenance(
+                binding.clone(),
+                format.clone(),
+                facts,
+                sequence,
+                timestamp,
+                taken,
+                super::contracts::IlluminationProvenance::Unknown,
+            )?;
             out.push((
-                Frame {
-                    width: w,
-                    height: h,
-                    spectrum: Spectrum::Ir,
-                    data: dec.decode(buf, w, h),
-                    captured: super::CaptureWindow::at(taken),
-                },
+                Frame::from_provenance(w, h, Spectrum::Ir, dec.decode(buf, w, h), provenance)?,
                 t0.elapsed().as_secs_f64() * 1000.0,
             ));
         }
@@ -4114,6 +4270,10 @@ pub fn capture_ir_streaming<B>(
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
+    let binding = permit
+        .frame_binding(device, contracts::StreamRole::Ir)
+        .map_err(|error| Error::Hardware(error.to_string()))?;
+    let format = frame_provenance::ValidatedFormatIdentity::from_stable_format(&fmt);
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
     // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
     // reverse declaration order, so `stream` drops first and stops the
@@ -4163,7 +4323,7 @@ pub fn capture_ir_streaming<B>(
     // user a password fallback. Reading the metadata queue here is how that gets
     // closed, and it is not done.
     for _ in 0..max_frames {
-        let (buf, _meta, _sequence, _timestamp) =
+        let (buf, facts, sequence, timestamp) =
             stream.next().map_err(|error| map_io(device, error))?;
         let taken = std::time::Instant::now();
         let data = dec.decode(buf, w, h);
@@ -4222,13 +4382,16 @@ pub fn capture_ir_streaming<B>(
         if mean >= IR_BLOWN_MEAN {
             continue;
         }
-        let frame = Frame {
-            width: w,
-            height: h,
-            spectrum: Spectrum::Ir,
-            data,
-            captured: CaptureWindow::at(taken),
-        };
+        let provenance = checked_single_provenance(
+            binding.clone(),
+            format.clone(),
+            facts,
+            sequence,
+            timestamp,
+            taken,
+            contracts::IlluminationProvenance::Unknown,
+        )?;
+        let frame = Frame::from_provenance(w, h, Spectrum::Ir, data, provenance)?;
         if let std::ops::ControlFlow::Break(b) = on_frame(IrStreamFrame { frame, mean }) {
             return Ok(Some(b));
         }
@@ -4254,6 +4417,12 @@ pub fn capture_ir_sequence(
     samples: usize,
     burst: usize,
 ) -> irlume_common::Result<Vec<Frame>> {
+    let burst = burst.max(1);
+    if burst > 64 {
+        return Err(Error::Hardware(
+            "IR mini-burst exceeds the 64-contributor provenance cap".into(),
+        ));
+    }
     verify_pinned(device)?;
     let permit = lease::permit_for_endpoint(
         device,
@@ -4266,11 +4435,14 @@ pub fn capture_ir_sequence(
             "{device}: hardware privacy switch is ON"
         )));
     }
-    let burst = burst.max(1);
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
+    let binding = permit
+        .frame_binding(device, contracts::StreamRole::Ir)
+        .map_err(|error| Error::Hardware(error.to_string()))?;
+    let format = frame_provenance::ValidatedFormatIdentity::from_stable_format(&fmt);
     let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
     // DECLARED before the stream, ASSIGNED after it opens. Locals drop in
     // reverse declaration order, so `stream` drops first and stops the
@@ -4305,19 +4477,27 @@ pub fn capture_ir_sequence(
         }
         let mut best: Option<Vec<u8>> = None;
         let mut best_mean = -1.0f64;
-        // The kept frame is one dequeue out of the mini-burst, so remember WHICH
-        // instant it came from rather than stamping the end of the burst.
-        let mut taken = std::time::Instant::now();
+        let mut best_index = 0;
+        let mut contributors = Vec::with_capacity(burst);
         for _ in 0..burst {
-            let (buf, _meta, _sequence, _timestamp) =
+            let (buf, facts, sequence, timestamp) =
                 stream.next().map_err(|error| map_io(device, error))?;
             let at = std::time::Instant::now();
             let data = dec.decode(buf, w, h);
             let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
+            contributors.push(checked_single_evidence(
+                binding.clone(),
+                format.clone(),
+                facts,
+                sequence,
+                timestamp,
+                at,
+                contracts::IlluminationProvenance::Unknown,
+            )?);
             if mean > best_mean {
                 best_mean = mean;
                 best = Some(data);
-                taken = at;
+                best_index = contributors.len() - 1;
             }
         }
         let Some(data) = best else { continue };
@@ -4375,13 +4555,25 @@ pub fn capture_ir_sequence(
         if best_mean >= IR_BLOWN_MEAN {
             continue;
         }
-        frames.push(Frame {
-            width: w,
-            height: h,
-            spectrum: Spectrum::Ir,
+        let provenance = if contributors.len() == 1 {
+            frame_provenance::RuntimeFrameProvenance::Single(
+                contributors.into_iter().next().ok_or_else(|| {
+                    Error::Hardware("mini-burst produced no provenance contributor".into())
+                })?,
+            )
+        } else {
+            checked_aggregate_provenance(
+                contributors,
+                frame_provenance::ContributorSelection::Selected { index: best_index },
+            )?
+        };
+        frames.push(Frame::from_provenance(
+            w,
+            h,
+            Spectrum::Ir,
             data,
-            captured: CaptureWindow::at(taken),
-        });
+            provenance,
+        )?);
     }
     // A short return is a CAPTURE fault, not a quiet fact about the scene: the
     // attempt budget ran out because frames arrived frozen, blown out, or too
@@ -4810,7 +5002,7 @@ fn held_concurrent_arm<'d>(
             let t0 = std::time::Instant::now();
             let (rgb, ir) = std::thread::scope(|scope| {
                 let ir_thread = scope.spawn(|| is.capture_with_stats());
-                let rgb = rs.burst(RGB_BURST).map(median_frame);
+                let rgb = rs.burst(RGB_BURST).and_then(median_frame);
                 let ir = match ir_thread.join() {
                     Ok(result) => result,
                     // Re-raise into the composer's catch_unwind: a panic is a
@@ -6669,14 +6861,73 @@ mod tests {
         assert!(why.contains("could not be listed"), "{why}");
     }
 
+    thread_local! {
+        static TEST_SEQUENCE: std::cell::RefCell<frame_provenance::SequenceTracker> =
+            const { std::cell::RefCell::new(frame_provenance::SequenceTracker::new()) };
+        static TEST_TIMESTAMP: std::cell::RefCell<frame_provenance::TimestampTracker> =
+            const { std::cell::RefCell::new(frame_provenance::TimestampTracker::new()) };
+    }
+
+    fn frame_at(data: &[u8], at: std::time::Instant) -> Frame {
+        static NEXT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
+        let raw = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let micros = i64::from(raw) * 1_000;
+        let metadata = v4l::buffer::Metadata {
+            bytesused: data.len() as u32,
+            sequence: raw,
+            timestamp: v4l::timestamp::Timestamp::new(0, micros),
+            flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+            ..Default::default()
+        };
+        let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, data.len())
+            .expect("test buffer facts");
+        let sequence = TEST_SEQUENCE.with(|tracker| {
+            tracker
+                .borrow_mut()
+                .observe(raw)
+                .expect("test sequence observation")
+        });
+        let timestamp = TEST_TIMESTAMP.with(|tracker| {
+            tracker
+                .borrow_mut()
+                .observe(
+                    micros,
+                    frame_provenance::TimestampClock::Monotonic,
+                    frame_provenance::TimestampSource::EndOfFrame,
+                )
+                .expect("test timestamp observation")
+        });
+        let binding = frame_provenance::FrameBinding::new(
+            contracts::CameraInstanceId::new("22222222222222222222222222222222")
+                .expect("test camera identity"),
+            contracts::CameraGeneration::INITIAL,
+            contracts::StreamRole::Rgb,
+        );
+        let format = frame_provenance::ValidatedFormatIdentity::from_stable_format(
+            &v4l::Format::new(data.len() as u32, 1, v4l::FourCC::new(b"RGB3")),
+        );
+        let provenance = checked_single_provenance(
+            binding,
+            format,
+            facts,
+            sequence,
+            timestamp,
+            at,
+            contracts::IlluminationProvenance::Unknown,
+        )
+        .expect("test runtime provenance");
+        Frame::from_provenance(
+            data.len() as u32,
+            1,
+            Spectrum::Rgb,
+            data.to_vec(),
+            provenance,
+        )
+        .expect("test frame")
+    }
+
     fn frame(data: &[u8]) -> Frame {
-        Frame {
-            width: data.len() as u32,
-            height: 1,
-            spectrum: Spectrum::Rgb,
-            data: data.to_vec(),
-            captured: CaptureWindow::at(std::time::Instant::now()),
-        }
+        frame_at(data, std::time::Instant::now())
     }
 
     // The decision the probe exists to make, checked against the two modules we
@@ -7171,16 +7422,30 @@ mod tests {
     fn median_frame_window_spans_the_whole_burst() {
         use std::time::{Duration, Instant};
         let t0 = Instant::now();
-        let mut frames = vec![frame(&[10, 10]), frame(&[20, 20]), frame(&[30, 30])];
-        for (i, f) in frames.iter_mut().enumerate() {
-            f.captured = CaptureWindow::at(t0 + Duration::from_millis(100 * i as u64));
-        }
+        let frames = vec![
+            frame_at(&[10, 10], t0),
+            frame_at(&[20, 20], t0 + Duration::from_millis(100)),
+            frame_at(&[30, 30], t0 + Duration::from_millis(200)),
+        ];
         // A median pixel may come from any frame, so the result cannot claim a
         // single instant: it must cover first-to-last dequeue.
-        let m = median_frame(frames);
+        let m = median_frame(frames).expect("coherent median provenance");
         assert_eq!(m.captured.start, t0);
         assert_eq!(m.captured.end, t0 + Duration::from_millis(200));
         assert_eq!(m.data, vec![20, 20]);
+        match m.provenance() {
+            frame_provenance::RuntimeFrameProvenance::Aggregate(aggregate) => {
+                assert_eq!(aggregate.contributors().len(), 3);
+                assert_eq!(
+                    aggregate.selection(),
+                    frame_provenance::ContributorSelection::ReducedOverAll
+                );
+                assert_eq!(aggregate.capture_window(), m.captured);
+            }
+            frame_provenance::RuntimeFrameProvenance::Single(_) => {
+                panic!("a multi-frame median must retain all contributors")
+            }
+        }
     }
 
     #[test]
@@ -7194,14 +7459,33 @@ mod tests {
             frame(&[99, 51, 199]),
             frame(&[100, 50, 200]),
         ];
-        let m = median_frame(frames);
+        let m = median_frame(frames).expect("coherent median provenance");
         assert_eq!(m.data, vec![100, 50, 200]);
     }
 
     #[test]
+    fn oversized_ir_sequence_burst_fails_before_device_access() {
+        let error = match capture_ir_sequence("/definitely/missing/video", 1, 65) {
+            Ok(_) => panic!("oversized provenance aggregate must be refused"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("64-contributor"), "{error}");
+    }
+
+    #[test]
+    fn frame_storage_is_mandatory_runtime_provenance() {
+        let frame = frame(&[1]);
+        let _: &frame_provenance::RuntimeFrameProvenance = &frame.provenance;
+    }
+
+    #[test]
     fn median_frame_passes_lone_frame_through() {
-        let m = median_frame(vec![frame(&[1, 2, 3])]);
+        let m = median_frame(vec![frame(&[1, 2, 3])]).expect("lone frame passes through");
         assert_eq!(m.data, vec![1, 2, 3]);
+        assert!(matches!(
+            m.provenance(),
+            frame_provenance::RuntimeFrameProvenance::Single(_)
+        ));
     }
 
     #[test]
@@ -7514,16 +7798,18 @@ mod tests {
     }
 
     #[test]
-    fn median_frame_even_burst_takes_upper_middle_and_min_length() {
+    fn median_frame_even_burst_takes_upper_middle_and_rejects_mixed_formats() {
         // Even burst: sorted [1,2,3,4] -> index 4/2 = 2 -> 3 (upper middle).
         let frames = vec![frame(&[1]), frame(&[4]), frame(&[2]), frame(&[3])];
-        assert_eq!(median_frame(frames).data, vec![3]);
-        // Mixed-length burst: output truncates to the shortest frame, and the
-        // dimensions/spectrum come from the first frame.
+        assert_eq!(
+            median_frame(frames)
+                .expect("coherent median provenance")
+                .data,
+            vec![3]
+        );
+        // A reduction may not silently combine different validated formats.
         let frames = vec![frame(&[9, 9, 9]), frame(&[5, 5]), frame(&[7, 7, 7])];
-        let m = median_frame(frames);
-        assert_eq!(m.data, vec![7, 7]);
-        assert_eq!((m.width, m.height, m.spectrum), (3, 1, Spectrum::Rgb));
+        assert!(median_frame(frames).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implement issue #462 slice 5 by attaching mandatory trusted runtime provenance to every delivered `irlume-camera::Frame` while leaving frozen wire `FrameMetadata` schema v1 unchanged.

- add full post-buffer-claim `ValidatedFormatIdentity` covering every field already protected by `format_moved`;
- add mandatory private `RuntimeFrameProvenance::{Single, Aggregate}` with complete dequeue facts, immutable lease binding, sequence/timestamp observations, capture window, and conservative illumination;
- migrate RGB burst/median, IR gated capture, raw IR burst, IR streaming, and IR sequence producers plus their delegating wrappers;
- aggregate bounded derivation evidence (2..=64 contributors) with selection/subtraction semantics, wrap-aware continuity, checked counters/spans, union-all host windows, and fail-closed identity/domain/epoch/status checks;
- keep exact interval negotiation, hardware controls, emitter policy, and wire schema changes out of this slice.

## Fail-closed properties

- no `None` or `Unavailable` provenance state;
- no nested aggregate or arbitrary metadata borrowing;
- corrupt status, facts/observation mismatch, mixed binding/role/format/timestamp domain/epoch, discontinuity, non-consecutive sequence, inconsistent timestamps, counter underflow, invalid selection, and contributor-cap violations reject before Frame publication;
- RGB never self-upgrades to `ActiveIr`; subtraction claims `ActiveIr` only from authoritative ActiveIr + Ambient evidence;
- aggregate capture windows conservatively cover every derivation contributor.

## Verification completed before push

Exact signed head: `8605af4863a453b87bc88eea197f0cf890908a89`

Reviewed full branch diff SHA-256:
`8431c65bf1e3e9604a4f8c76695b0f774d010bbad46d778f0f0170bcb5f6dfe3`

- genuine RED on missing runtime provenance types;
- 10 restored sabotage mutants killed (mandatory storage, full format identity, corrupt status, mixed format, drop accounting, illumination, union window, cumulative-counter sum, wrap ordering, facts timestamp alignment);
- complete `irlume-camera` suite and 12 contract tests pass; 20 hardware/loopback tests remain intentionally ignored in that lane;
- strict camera and workspace clippy, warnings-as-errors docs, release build, guarded workspace tests (650+ discovery floor), and 36 strict machine-API checks pass;
- cargo-deny passes (existing yanked `spin 0.9.8` warning), Nix flake evaluation passes, all 51 action refs are pinned, and all 26 slice-4 runner/validator harness tests pass;
- independent GLM-5.2 full review and bounded delta review both PASS.

## Exact-head physical evidence

All runs used signed commit `8605af4863a453b87bc88eea197f0cf890908a89`, exercised recovery, and restored `irlumed.service` and `.socket` active:

- local ASUS dual: PASS, 60.018s, 882 frames/stream, 6,056 µs RGB/IR skew;
- archhost Logitech BRIO RGB-only under its measured sequential policy: PASS, 60.009s, 879 RGB frames, zero gaps;
- minihost NexiGo N930W dual: PASS, 60.003s, 1,714 frames/stream, 101,889 µs skew;
- thinkpad Integrated Camera RGB-only: PASS, 60.093s, 596 RGB frames, zero gaps.

Exact-head GitHub CI and Fedora 43/44 Packit are fully green. This PR advances but does not close #462.

Refs #462
