### PR TITLE
feat(camera): negotiate exact frame intervals

### DIFF
--- a/crates/irlume-camera/src/frame_interval.rs
+++ b/crates/irlume-camera/src/frame_interval.rs
@@ -480,6 +480,20 @@ struct DirectSource {
     file: File,
 }
 
+struct BorrowedFdSource {
+    fd: std::os::fd::RawFd,
+}
+
+impl RecordSource for BorrowedFdSource {
+    fn record(
+        &mut self,
+        query: FrameIntervalQuery,
+        index: u32,
+    ) -> Result<RawRecord, std::io::Error> {
+        direct_record(self.fd, query, index)
+    }
+}
+
 impl RecordSource for DirectSource {
     fn record(
         &mut self,
@@ -575,6 +589,22 @@ fn direct_record(
         reserved: raw.reserved,
         kind,
     })
+}
+
+/// Enumerates exact frame intervals on a caller-owned, already authorized fd.
+///
+/// This crate-private entrypoint performs no open, lease acquisition, endpoint
+/// lookup, or device-state mutation. The caller owns those lifecycle checks.
+pub(crate) fn frame_interval_capabilities_for_fd(
+    device: &str,
+    fd: std::os::fd::RawFd,
+    fourcc: [u8; 4],
+    width: u32,
+    height: u32,
+) -> Result<FrameIntervalDomain, FrameIntervalError> {
+    let query = FrameIntervalQuery::new(fourcc, width, height)?;
+    let mut source = BorrowedFdSource { fd };
+    enumerate_via(query, &mut source).map_err(|error| error.with_device(device))
 }
 
 /// Enumerates exact frame-interval capabilities without changing device state.
@@ -710,6 +740,24 @@ mod tests {
 
     fn errno(code: i32) -> std::io::Error {
         std::io::Error::from_raw_os_error(code)
+    }
+
+    #[test]
+    fn same_fd_entrypoint_borrows_descriptor_and_retains_device_context() {
+        let file = File::open("/dev/null").expect("test fd");
+        let error = frame_interval_capabilities_for_fd(
+            "/dev/fake-owned-by-caller",
+            file.as_raw_fd(),
+            *b"YUYV",
+            640,
+            480,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("/dev/fake-owned-by-caller"));
+        assert!(
+            file.metadata().is_ok(),
+            "same-fd enumeration closed caller fd"
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -517,6 +517,77 @@ impl CaptureDequeue for v4l::io::mmap::Stream<'_> {
     }
 }
 
+/// Existing camera-state operations used while negotiating and claiming a
+/// capture stream. This protocol stays crate-private: it is an injected test
+/// seam, not new public API.
+trait CameraState {
+    type Device: 'static;
+    type Claim<'a>: CaptureDequeue;
+    type EndpointError: std::error::Error + Send + Sync + 'static;
+
+    fn set_format(&self, dev: &Self::Device, requested: &Format) -> std::io::Result<Format>;
+    fn require_endpoint(&self) -> Result<(), Self::EndpointError>;
+    fn compare_format(&self, expected: &Format, current: &Format) -> Option<String>;
+    fn claim_buffers<'a>(&self, dev: &'a Self::Device) -> std::io::Result<Self::Claim<'a>>;
+    fn current_format(&self, dev: &Self::Device) -> std::io::Result<Format>;
+    fn start_stream(&self) -> irlume_common::Result<()>;
+    fn stop_stream(&self);
+}
+
+#[derive(Clone)]
+struct V4l2CameraState {
+    device: String,
+    lease: lease::CameraLease,
+}
+
+impl V4l2CameraState {
+    fn new(device: &str, lease: lease::CameraLease) -> Self {
+        Self {
+            device: device.to_owned(),
+            lease,
+        }
+    }
+}
+
+impl CameraState for V4l2CameraState {
+    type Device = Device;
+    type Claim<'a> = v4l::io::mmap::Stream<'a>;
+    type EndpointError = lease::CameraLeaseError;
+
+    fn set_format(&self, dev: &Device, requested: &Format) -> std::io::Result<Format> {
+        Capture::set_format(dev, requested)
+    }
+
+    fn require_endpoint(&self) -> Result<(), Self::EndpointError> {
+        self.lease.require_endpoint(&self.device)
+    }
+
+    fn compare_format(&self, expected: &Format, current: &Format) -> Option<String> {
+        format_moved(expected, current)
+    }
+
+    fn claim_buffers<'a>(&self, dev: &'a Device) -> std::io::Result<Self::Claim<'a>> {
+        let mut stream =
+            v4l::io::mmap::Stream::with_buffers(dev, Type::VideoCapture, MMAP_BUFFERS)?;
+        stream.set_timeout(STREAM_DEQUEUE_TIMEOUT);
+        Ok(stream)
+    }
+
+    fn current_format(&self, dev: &Device) -> std::io::Result<Format> {
+        Capture::format(dev)
+    }
+
+    fn start_stream(&self) -> irlume_common::Result<()> {
+        self.lease
+            .start_stream()
+            .map_err(|error| Error::Hardware(error.to_string()))
+    }
+
+    fn stop_stream(&self) {
+        self.lease.stop_stream();
+    }
+}
+
 #[derive(Debug)]
 enum ValidatedDequeueError {
     Io(std::io::Error),
@@ -599,13 +670,15 @@ where
 /// Wrapping (rather than calling a "drop it safely" helper at each success
 /// path) is deliberate: every `?` early return drops the stream too, and those
 /// are exactly the paths a failing camera takes.
-struct SafeStream<'a> {
-    inner: Option<v4l::io::mmap::Stream<'a>>,
+struct CameraStateStream<'a, S: CameraState> {
+    inner: Option<S::Claim<'a>>,
+    state: S,
     device: String,
-    lease: lease::CameraLease,
     layout: frame_provenance::PayloadLayout,
-    lease_started: bool,
+    state_started: bool,
 }
+
+type SafeStream<'a> = CameraStateStream<'a, V4l2CameraState>;
 
 /// How long a single frame dequeue may block.
 ///
@@ -737,7 +810,7 @@ fn format_moved(expect: &v4l::Format, now: &v4l::Format) -> Option<String> {
     None
 }
 
-impl<'a> SafeStream<'a> {
+impl<'a, S: CameraState> CameraStateStream<'a, S> {
     /// Open a stream on `dev` with the standard buffer ring, and verify the
     /// device still holds the format the caller negotiated.
     ///
@@ -760,14 +833,19 @@ impl<'a> SafeStream<'a> {
     /// during emitter setup: a stall there would hang with a control changed and
     /// the restore never reached. Every wait now ends.
     fn open(
+        state: S,
         device: &str,
-        dev: &'a Device,
+        dev: &'a S::Device,
         expect: &v4l::Format,
-        lease: lease::CameraLease,
     ) -> irlume_common::Result<Self> {
-        lease
-            .require_endpoint(device)
+        state
+            .require_endpoint()
             .map_err(|error| Error::Hardware(error.to_string()))?;
+        // Record the complete driver-echoed S_FMT identity at the existing
+        // pre-claim validation boundary. The self-comparison is infallible and
+        // has no observable production effect; the post-REQBUFS G_FMT identity
+        // must still compare equal to this same value.
+        let _ = state.compare_format(expect, expect);
         let layout = frame_provenance::PayloadLayout::new(
             expect.fourcc.repr,
             expect.width,
@@ -775,25 +853,26 @@ impl<'a> SafeStream<'a> {
             expect.stride,
         )
         .map_err(|error| Error::Hardware(format!("{device}: {error}")))?;
-        let mut inner = v4l::io::mmap::Stream::with_buffers(dev, Type::VideoCapture, MMAP_BUFFERS)
-            .map_err(|e| map_io(device, e))?;
-        inner.set_timeout(STREAM_DEQUEUE_TIMEOUT);
+        let inner = state.claim_buffers(dev).map_err(|e| map_io(device, e))?;
         // Constructed before the read-back so every error path below releases
         // the queue through the guarded Drop (STREAMOFF + REQBUFS(0)), never
         // through the v4l crate's panicking one.
         let mut stream = Self {
             inner: Some(inner),
+            state,
             device: device.to_string(),
-            lease,
             layout,
-            lease_started: false,
+            state_started: false,
         };
-        let now = Capture::format(dev).map_err(|e| map_io(device, e))?;
+        let now = stream
+            .state
+            .current_format(dev)
+            .map_err(|e| map_io(device, e))?;
         stream
-            .lease
-            .require_endpoint(device)
+            .state
+            .require_endpoint()
             .map_err(|error| Error::Hardware(error.to_string()))?;
-        if let Some(moved) = format_moved(expect, &now) {
+        if let Some(moved) = stream.state.compare_format(expect, &now) {
             // Refusing rather than renegotiating, for the same reason the
             // emitter stands down under a foreign consumer (#169): a format
             // that moved means another application is actively configuring
@@ -810,11 +889,8 @@ impl<'a> SafeStream<'a> {
                  this camera{who}; refusing this capture"
             )));
         }
-        stream
-            .lease
-            .start_stream()
-            .map_err(|error| Error::Hardware(error.to_string()))?;
-        stream.lease_started = true;
+        stream.state.start_stream()?;
+        stream.state_started = true;
         Ok(stream)
     }
 
@@ -827,19 +903,14 @@ impl<'a> SafeStream<'a> {
     ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
         let Self {
             inner,
-            device,
-            lease,
+            state,
             layout,
             ..
         } = self;
         dequeue_validated_typed(
             inner.as_mut().expect("stream taken only in Drop"),
             *layout,
-            || {
-                lease
-                    .require_endpoint(device)
-                    .map_err(std::io::Error::other)
-            },
+            || state.require_endpoint().map_err(std::io::Error::other),
         )
     }
 }
@@ -850,7 +921,7 @@ trait ValidatedStream {
     ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>;
 }
 
-impl ValidatedStream for SafeStream<'_> {
+impl<S: CameraState> ValidatedStream for CameraStateStream<'_, S> {
     fn next_validated(
         &mut self,
     ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
@@ -1131,7 +1202,7 @@ fn install_recovered_resources<S, M, G, E>(
     }
 }
 
-impl Drop for SafeStream<'_> {
+impl<S: CameraState> Drop for CameraStateStream<'_, S> {
     fn drop(&mut self) {
         let Some(inner) = self.inner.take() else {
             return;
@@ -1140,8 +1211,8 @@ impl Drop for SafeStream<'_> {
         if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(inner))).is_err() {
             irlume_common::dlog!("{device}: stream teardown failed (STREAMOFF); frames unaffected");
         }
-        if self.lease_started {
-            self.lease.stop_stream();
+        if self.state_started {
+            self.state.stop_stream();
         }
     }
 }
@@ -2404,8 +2475,9 @@ impl RgbCamera {
     }
 
     fn open_uvc(device: &str, lease: lease::CameraLease) -> irlume_common::Result<Self> {
-        lease
-            .require_endpoint(device)
+        let state = V4l2CameraState::new(device, lease.clone());
+        state
+            .require_endpoint()
             .map_err(|error| Error::Hardware(error.to_string()))?;
         verify_pinned(device)?;
         if privacy_engaged_with_permit(device) {
@@ -2421,7 +2493,9 @@ impl RgbCamera {
         // is preferred; NV12 is the common uncompressed fallback.
         let chosen = negotiate_rgb_format(device, &dev)?;
         let fmt = Format::new(RGB_W, RGB_H, FourCC::new(&chosen));
-        let fmt = Capture::set_format(&dev, &fmt).map_err(|e| map_io(device, e))?;
+        let fmt = state
+            .set_format(&dev, &fmt)
+            .map_err(|e| map_io(device, e))?;
         if fmt.fourcc.repr != chosen {
             return Err(Error::Hardware(format!(
                 "{device}: driver gave {}, expected {}",
@@ -2429,8 +2503,8 @@ impl RgbCamera {
                 fourcc_str(&chosen)
             )));
         }
-        lease
-            .require_endpoint(device)
+        state
+            .require_endpoint()
             .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(Self {
             lease,
@@ -2483,10 +2557,10 @@ impl RgbCamera {
         // not (the Codex round's finding 1 on this PR).
         let blc_restore = apply_blc(self);
         let stream = SafeStream::open(
+            V4l2CameraState::new(&self.device, self.lease.clone()),
             &self.device,
             &self.dev,
             &self.negotiated,
-            self.lease.clone(),
         )?;
         self.lease
             .require_endpoint(&self.device)
@@ -2715,10 +2789,10 @@ impl<'a> RgbSession<'a> {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         drop(self.stream.take()); // STREAMOFF + buffer release before replacement
         let stream = SafeStream::open(
+            V4l2CameraState::new(&self.cam.device, self.cam.lease.clone()),
             &self.cam.device,
             &self.cam.dev,
             &self.cam.negotiated,
-            self.cam.lease.clone(),
         )?;
         self.cam
             .lease
@@ -3035,6 +3109,14 @@ const IR_CANDIDATES: [(&[u8; 4], IrPixel); 8] = [
 /// one the driver echoes back, and fail with a message naming what it offers.
 fn negotiate_ir_format(device: &str, dev: &Device) -> irlume_common::Result<(Format, IrPixel)> {
     negotiate_ir_format_via(device, dev, Capture::set_format)
+}
+
+fn negotiate_ir_format_state<S: CameraState<Device = Device>>(
+    device: &str,
+    dev: &Device,
+    state: &S,
+) -> irlume_common::Result<(Format, IrPixel)> {
+    negotiate_ir_format_via(device, dev, |dev, fmt| state.set_format(dev, fmt))
 }
 
 /// The IR candidate walk with the format ioctl injected: capture applies it
@@ -3380,8 +3462,9 @@ impl IrCamera {
     }
 
     fn open_uvc(device: &str, lease: lease::CameraLease) -> irlume_common::Result<Self> {
-        lease
-            .require_endpoint(device)
+        let state = V4l2CameraState::new(device, lease.clone());
+        state
+            .require_endpoint()
             .map_err(|error| Error::Hardware(error.to_string()))?;
         verify_pinned(device)?;
         if privacy_engaged_with_permit(device) {
@@ -3390,10 +3473,10 @@ impl IrCamera {
             )));
         }
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
-        let (fmt, pix) = negotiate_ir_format(device, &dev)?;
+        let (fmt, pix) = negotiate_ir_format_state(device, &dev, &state)?;
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-        lease
-            .require_endpoint(device)
+        state
+            .require_endpoint()
             .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(Self {
             lease,
@@ -3458,10 +3541,10 @@ impl IrCamera {
         // this change removes. Assigned further down, once the stream exists.
         let mode;
         let mut stream = TrackedStream::new(SafeStream::open(
+            V4l2CameraState::new(&self.device, self.lease.clone()),
             &self.device,
             &self.dev,
             &self.negotiated,
-            self.lease.clone(),
         )?);
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
@@ -3969,10 +4052,10 @@ impl IrSession<'_> {
         })?;
         self._mode = ir_emitter::StreamMode::inert();
         let stream = SafeStream::open(
+            V4l2CameraState::new(&self.cam.device, self.cam.lease.clone()),
             &self.cam.device,
             &self.cam.dev,
             &self.cam.negotiated,
-            self.cam.lease.clone(),
         )?;
         let meta = ir_metadata::IlluminationLog::open(&self.cam.device);
         self.cam
@@ -4173,7 +4256,12 @@ pub mod ir_probe {
         // buffers; STREAMON happens on the first dequeue, so the set still
         // lands before streaming starts.
         let mode;
-        let stream = super::SafeStream::open(device, &dev, &fmt, permit.clone())?;
+        let stream = super::SafeStream::open(
+            super::V4l2CameraState::new(device, permit.clone()),
+            device,
+            &dev,
+            &fmt,
+        )?;
         let mut stream = super::TrackedStream::new(stream);
         mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
         // Bound, never read: held for its `Drop`, which restores the control.
@@ -4290,7 +4378,12 @@ pub fn capture_ir_streaming<B>(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+    let stream = SafeStream::open(
+        V4l2CameraState::new(device, permit.clone()),
+        device,
+        &dev,
+        &fmt,
+    )?;
     let mut stream = TrackedStream::new(stream);
     mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
@@ -4363,7 +4456,12 @@ pub fn capture_ir_streaming<B>(
                          a frozen stream: {e}"
                     ))
                 })?;
-                let replacement = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+                let replacement = SafeStream::open(
+                    V4l2CameraState::new(device, permit.clone()),
+                    device,
+                    &dev,
+                    &fmt,
+                )?;
                 let replacement_mode =
                     ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
                 let ((), replacement_mode) =
@@ -4459,7 +4557,12 @@ pub fn capture_ir_sequence(
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
     let mut mode;
-    let stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+    let stream = SafeStream::open(
+        V4l2CameraState::new(device, permit.clone()),
+        device,
+        &dev,
+        &fmt,
+    )?;
     let mut stream = TrackedStream::new(stream);
     mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Set once per stream, before it starts, and not per frame (the
@@ -4536,7 +4639,12 @@ pub fn capture_ir_sequence(
                          a frozen stream: {e}"
                     ))
                 })?;
-                let replacement = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+                let replacement = SafeStream::open(
+                    V4l2CameraState::new(device, permit.clone()),
+                    device,
+                    &dev,
+                    &fmt,
+                )?;
                 let replacement_mode =
                     ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
                 let ((), replacement_mode) =
@@ -5441,7 +5549,12 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     let (fmt, pix) = negotiate_ir_format(device, &dev)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
-    let mut stream = SafeStream::open(device, &dev, &fmt, permit.clone())?;
+    let mut stream = SafeStream::open(
+        V4l2CameraState::new(device, permit.clone()),
+        device,
+        &dev,
+        &fmt,
+    )?;
     let fd = dev.handle().fd();
     for _ in 0..4 {
         let _ = stream.next(); // let the sensor settle before baseline
@@ -5699,6 +5812,328 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    type CallLog = std::rc::Rc<std::cell::RefCell<Vec<&'static str>>>;
+
+    struct FakeClaim {
+        calls: CallLog,
+        payload: Vec<u8>,
+        fail_dequeue: bool,
+    }
+
+    impl CaptureDequeue for FakeClaim {
+        fn dequeue(&mut self) -> std::io::Result<(&[u8], v4l::buffer::Metadata)> {
+            self.calls.borrow_mut().push("dequeue");
+            if self.fail_dequeue {
+                return Err(std::io::Error::other("dequeue failure"));
+            }
+            Ok((
+                &self.payload,
+                v4l::buffer::Metadata {
+                    bytesused: self.payload.len() as u32,
+                    ..v4l::buffer::Metadata::default()
+                },
+            ))
+        }
+    }
+
+    impl Drop for FakeClaim {
+        fn drop(&mut self) {
+            self.calls.borrow_mut().push("cleanup");
+        }
+    }
+
+    struct FakeCameraState {
+        calls: CallLog,
+        echoed: Format,
+        current: Format,
+        endpoint_calls: std::cell::Cell<usize>,
+        fail_set: bool,
+        fail_endpoint_at: Option<usize>,
+        fail_claim: bool,
+        fail_dequeue: bool,
+    }
+
+    impl FakeCameraState {
+        fn new(format: Format) -> (Self, CallLog) {
+            let calls = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+            (
+                Self {
+                    calls: calls.clone(),
+                    echoed: format,
+                    current: format,
+                    endpoint_calls: std::cell::Cell::new(0),
+                    fail_set: false,
+                    fail_endpoint_at: None,
+                    fail_claim: false,
+                    fail_dequeue: false,
+                },
+                calls,
+            )
+        }
+    }
+
+    impl CameraState for FakeCameraState {
+        type Device = ();
+        type Claim<'a> = FakeClaim;
+        type EndpointError = std::io::Error;
+
+        fn set_format(&self, _dev: &(), _requested: &Format) -> std::io::Result<Format> {
+            self.calls.borrow_mut().push("set_format");
+            if self.fail_set {
+                Err(std::io::Error::other("set format failure"))
+            } else {
+                Ok(self.echoed)
+            }
+        }
+
+        fn require_endpoint(&self) -> Result<(), Self::EndpointError> {
+            self.calls.borrow_mut().push("endpoint");
+            let call = self.endpoint_calls.get() + 1;
+            self.endpoint_calls.set(call);
+            if self.fail_endpoint_at == Some(call) {
+                Err(std::io::Error::other("endpoint failure"))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn compare_format(&self, expected: &Format, current: &Format) -> Option<String> {
+            self.calls.borrow_mut().push("check_format");
+            format_moved(expected, current)
+        }
+
+        fn claim_buffers<'a>(&self, _dev: &'a ()) -> std::io::Result<Self::Claim<'a>> {
+            self.calls.borrow_mut().push("reqbufs");
+            if self.fail_claim {
+                return Err(std::io::Error::other("buffer claim failure"));
+            }
+            Ok(FakeClaim {
+                calls: self.calls.clone(),
+                payload: vec![0; self.echoed.size as usize],
+                fail_dequeue: self.fail_dequeue,
+            })
+        }
+
+        fn current_format(&self, _dev: &()) -> std::io::Result<Format> {
+            self.calls.borrow_mut().push("g_fmt");
+            Ok(self.current)
+        }
+
+        fn start_stream(&self) -> irlume_common::Result<()> {
+            self.calls.borrow_mut().push("start");
+            Ok(())
+        }
+
+        fn stop_stream(&self) {
+            self.calls.borrow_mut().push("stop");
+        }
+    }
+
+    fn fake_format(fourcc: &[u8; 4]) -> Format {
+        let mut format = Format::new(2, 2, FourCC::new(fourcc));
+        format.stride = if fourcc == b"YUYV" { 4 } else { 2 };
+        format.size = format.stride * format.height;
+        format.field_order = v4l::format::FieldOrder::Progressive;
+        format.colorspace = v4l::format::Colorspace::SRGB;
+        format.quantization = v4l::format::Quantization::FullRange;
+        format.transfer = v4l::format::TransferFunction::SRGB;
+        format.flags = v4l::format::Flags::PREMUL_ALPHA;
+        format
+    }
+
+    fn exercise_fake_happy_path(format: Format) -> Vec<&'static str> {
+        let (state, calls) = FakeCameraState::new(format);
+        let echoed = state.set_format(&(), &format).expect("S_FMT");
+        state.require_endpoint().expect("endpoint after S_FMT");
+        let mut stream = CameraStateStream::open(state, "/dev/fake", &(), &echoed)
+            .expect("buffer claim orchestration");
+        stream.next().expect("first dequeue");
+        drop(stream);
+        let recorded = calls.borrow().clone();
+        recorded
+    }
+
+    #[test]
+    fn camera_state_seam_records_rgb_and_ir_happy_path_order() {
+        let expected = vec![
+            "set_format",
+            "endpoint",
+            "endpoint",
+            "check_format",
+            "reqbufs",
+            "g_fmt",
+            "endpoint",
+            "check_format",
+            "start",
+            "endpoint",
+            "dequeue",
+            "endpoint",
+            "cleanup",
+            "stop",
+        ];
+        assert_eq!(exercise_fake_happy_path(fake_format(b"YUYV")), expected);
+        assert_eq!(exercise_fake_happy_path(fake_format(b"GREY")), expected);
+    }
+
+    #[test]
+    fn camera_state_seam_preserves_setup_and_dequeue_error_cleanup() {
+        let format = fake_format(b"GREY");
+
+        let (mut state, calls) = FakeCameraState::new(format);
+        state.fail_set = true;
+        assert!(state.set_format(&(), &format).is_err());
+        assert_eq!(&*calls.borrow(), &["set_format"]);
+
+        let (mut state, calls) = FakeCameraState::new(format);
+        state.fail_endpoint_at = Some(1);
+        assert!(state.set_format(&(), &format).is_ok());
+        assert!(state.require_endpoint().is_err());
+        assert_eq!(&*calls.borrow(), &["set_format", "endpoint"]);
+
+        let (mut state, calls) = FakeCameraState::new(format);
+        state.fail_claim = true;
+        assert!(CameraStateStream::open(state, "/dev/fake", &(), &format).is_err());
+        assert_eq!(&*calls.borrow(), &["endpoint", "check_format", "reqbufs"]);
+
+        let (mut state, calls) = FakeCameraState::new(format);
+        state.fail_endpoint_at = Some(2);
+        assert!(CameraStateStream::open(state, "/dev/fake", &(), &format).is_err());
+        assert_eq!(
+            &*calls.borrow(),
+            &[
+                "endpoint",
+                "check_format",
+                "reqbufs",
+                "g_fmt",
+                "endpoint",
+                "cleanup"
+            ]
+        );
+
+        let (mut state, calls) = FakeCameraState::new(format);
+        state.fail_dequeue = true;
+        let mut stream = CameraStateStream::open(state, "/dev/fake", &(), &format).unwrap();
+        assert!(stream.next().is_err());
+        drop(stream);
+        assert_eq!(
+            &*calls.borrow(),
+            &[
+                "endpoint",
+                "check_format",
+                "reqbufs",
+                "g_fmt",
+                "endpoint",
+                "check_format",
+                "start",
+                "endpoint",
+                "dequeue",
+                "cleanup",
+                "stop",
+            ]
+        );
+    }
+
+    #[test]
+    fn camera_state_seam_preserves_raw_endpoint_error_during_dequeue() {
+        let format = fake_format(b"GREY");
+
+        let (mut setup_state, setup_calls) = FakeCameraState::new(format);
+        setup_state.fail_endpoint_at = Some(1);
+        let setup_error = match CameraStateStream::open(setup_state, "/dev/fake", &(), &format) {
+            Ok(_) => panic!("stale endpoint must fail stream setup"),
+            Err(error) => error,
+        };
+        assert_eq!(setup_error.to_string(), "hardware: endpoint failure");
+        assert_eq!(&*setup_calls.borrow(), &["endpoint"]);
+
+        let (mut state, calls) = FakeCameraState::new(format);
+        // `open` performs two endpoint validations; fail the pre-dequeue one.
+        state.fail_endpoint_at = Some(3);
+        let mut stream =
+            CameraStateStream::open(state, "/dev/fake", &(), &format).expect("stream open");
+
+        let error = match stream.next() {
+            Ok(_) => panic!("stale endpoint must fail before dequeue"),
+            Err(error) => error,
+        };
+        assert_eq!(error.to_string(), "endpoint failure");
+        drop(stream);
+        assert_eq!(
+            &*calls.borrow(),
+            &[
+                "endpoint",
+                "check_format",
+                "reqbufs",
+                "g_fmt",
+                "endpoint",
+                "check_format",
+                "start",
+                "endpoint",
+                "cleanup",
+                "stop",
+            ]
+        );
+    }
+
+    #[test]
+    fn camera_state_seam_compares_every_driver_echoed_format_field() {
+        let expected = fake_format(b"GREY");
+        let mut changed = Vec::new();
+
+        let mut value = expected;
+        value.fourcc = FourCC::new(b"YUYV");
+        changed.push(value);
+        let mut value = expected;
+        value.width += 1;
+        changed.push(value);
+        let mut value = expected;
+        value.height += 1;
+        changed.push(value);
+        let mut value = expected;
+        value.stride += 1;
+        changed.push(value);
+        let mut value = expected;
+        value.size += 1;
+        changed.push(value);
+        let mut value = expected;
+        value.field_order = v4l::format::FieldOrder::Interlaced;
+        changed.push(value);
+        let mut value = expected;
+        value.colorspace = v4l::format::Colorspace::Rec709;
+        changed.push(value);
+        let mut value = expected;
+        value.quantization = v4l::format::Quantization::LimitedRange;
+        changed.push(value);
+        let mut value = expected;
+        value.transfer = v4l::format::TransferFunction::Rec709;
+        changed.push(value);
+        let mut value = expected;
+        value.flags = v4l::format::Flags::empty();
+        changed.push(value);
+
+        for current in changed {
+            let (mut state, calls) = FakeCameraState::new(expected);
+            state.current = current;
+            let error = match CameraStateStream::open(state, "/dev/fake", &(), &expected) {
+                Ok(_) => panic!("every full-format drift must fail closed"),
+                Err(error) => error,
+            };
+            assert!(error.to_string().contains("stream format changed"));
+            assert_eq!(
+                &*calls.borrow(),
+                &[
+                    "endpoint",
+                    "check_format",
+                    "reqbufs",
+                    "g_fmt",
+                    "endpoint",
+                    "check_format",
+                    "cleanup"
+                ]
+            );
+        }
+    }
 
     struct SabotagingDequeue {
         payload: [u8; 4],

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -526,10 +526,29 @@ trait CameraState {
     type EndpointError: std::error::Error + Send + Sync + 'static;
 
     fn set_format(&self, dev: &Self::Device, requested: &Format) -> std::io::Result<Format>;
+    fn interval_domain(
+        &self,
+        dev: &Self::Device,
+        format: &Format,
+    ) -> irlume_common::Result<frame_interval::FrameIntervalDomain>;
+    fn set_interval(
+        &self,
+        dev: &Self::Device,
+        query: frame_interval::FrameIntervalQuery,
+        requested: frame_interval::FrameInterval,
+        stage: &'static str,
+    ) -> irlume_common::Result<frame_interval::FrameInterval>;
     fn require_endpoint(&self) -> Result<(), Self::EndpointError>;
     fn compare_format(&self, expected: &Format, current: &Format) -> Option<String>;
     fn claim_buffers<'a>(&self, dev: &'a Self::Device) -> std::io::Result<Self::Claim<'a>>;
+    fn accepted_interval(&self) -> Option<frame_interval::FrameInterval>;
     fn current_format(&self, dev: &Self::Device) -> std::io::Result<Format>;
+    fn current_interval(
+        &self,
+        dev: &Self::Device,
+        query: frame_interval::FrameIntervalQuery,
+        stage: &'static str,
+    ) -> irlume_common::Result<frame_interval::FrameInterval>;
     fn start_stream(&self) -> irlume_common::Result<()>;
     fn stop_stream(&self);
 }
@@ -538,6 +557,7 @@ trait CameraState {
 struct V4l2CameraState {
     device: String,
     lease: lease::CameraLease,
+    accepted_interval: Option<frame_interval::FrameInterval>,
 }
 
 impl V4l2CameraState {
@@ -545,6 +565,19 @@ impl V4l2CameraState {
         Self {
             device: device.to_owned(),
             lease,
+            accepted_interval: None,
+        }
+    }
+
+    fn with_interval(
+        device: &str,
+        lease: lease::CameraLease,
+        accepted_interval: frame_interval::FrameInterval,
+    ) -> Self {
+        Self {
+            device: device.to_owned(),
+            lease,
+            accepted_interval: Some(accepted_interval),
         }
     }
 }
@@ -556,6 +589,31 @@ impl CameraState for V4l2CameraState {
 
     fn set_format(&self, dev: &Device, requested: &Format) -> std::io::Result<Format> {
         Capture::set_format(dev, requested)
+    }
+
+    fn interval_domain(
+        &self,
+        dev: &Device,
+        format: &Format,
+    ) -> irlume_common::Result<frame_interval::FrameIntervalDomain> {
+        frame_interval::frame_interval_capabilities_for_fd(
+            &self.device,
+            dev.handle().fd(),
+            format.fourcc.repr,
+            format.width,
+            format.height,
+        )
+        .map_err(|error| Error::Hardware(error.to_string()))
+    }
+
+    fn set_interval(
+        &self,
+        dev: &Device,
+        query: frame_interval::FrameIntervalQuery,
+        requested: frame_interval::FrameInterval,
+        stage: &'static str,
+    ) -> irlume_common::Result<frame_interval::FrameInterval> {
+        set_stream_interval(&self.device, dev, query, requested, stage)
     }
 
     fn require_endpoint(&self) -> Result<(), Self::EndpointError> {
@@ -573,8 +631,21 @@ impl CameraState for V4l2CameraState {
         Ok(stream)
     }
 
+    fn accepted_interval(&self) -> Option<frame_interval::FrameInterval> {
+        self.accepted_interval
+    }
+
     fn current_format(&self, dev: &Device) -> std::io::Result<Format> {
         Capture::format(dev)
+    }
+
+    fn current_interval(
+        &self,
+        dev: &Device,
+        query: frame_interval::FrameIntervalQuery,
+        stage: &'static str,
+    ) -> irlume_common::Result<frame_interval::FrameInterval> {
+        read_stream_interval(&self.device, dev, query, stage)
     }
 
     fn start_stream(&self) -> irlume_common::Result<()> {
@@ -586,6 +657,136 @@ impl CameraState for V4l2CameraState {
     fn stop_stream(&self) {
         self.lease.stop_stream();
     }
+}
+
+fn streamparm_request(
+    interval: Option<frame_interval::FrameInterval>,
+) -> v4l::v4l_sys::v4l2_streamparm {
+    // SAFETY: `v4l2_streamparm` is a plain kernel C ABI object for which an
+    // all-zero value is valid; `type_` and the optional active capture fields
+    // are initialized immediately below before the ioctl.
+    let mut wire: v4l::v4l_sys::v4l2_streamparm = unsafe { std::mem::zeroed() };
+    wire.type_ = Type::VideoCapture as u32;
+    if let Some(interval) = interval {
+        let (numerator, denominator) = interval.parts();
+        wire.parm.capture.timeperframe.numerator = numerator;
+        wire.parm.capture.timeperframe.denominator = denominator;
+    }
+    wire
+}
+
+fn validate_streamparm_response(
+    device: &str,
+    query: frame_interval::FrameIntervalQuery,
+    stage: &'static str,
+    wire: &v4l::v4l_sys::v4l2_streamparm,
+) -> irlume_common::Result<frame_interval::FrameInterval> {
+    if wire.type_ != Type::VideoCapture as u32 {
+        return Err(Error::Hardware(format!(
+            "{device}: {query:?}: {stage} returned type {}, expected video capture",
+            wire.type_
+        )));
+    }
+    // SAFETY: the validated type selects the capture union arm. Copy it
+    // immediately so no reference to union storage escapes this boundary.
+    let capture = unsafe { wire.parm.capture };
+    if capture.capability & v4l::v4l_sys::V4L2_CAP_TIMEPERFRAME == 0 {
+        return Err(Error::Hardware(format!(
+            "{device}: {query:?}: {stage} lacks V4L2_CAP_TIMEPERFRAME"
+        )));
+    }
+    if capture.extendedmode != 0 {
+        return Err(Error::Hardware(format!(
+            "{device}: {query:?}: {stage} returned unsupported extendedmode {}",
+            capture.extendedmode
+        )));
+    }
+    if capture.reserved != [0; 4] {
+        return Err(Error::Hardware(format!(
+            "{device}: {query:?}: {stage} returned nonzero reserved fields"
+        )));
+    }
+    frame_interval::FrameInterval::new(
+        capture.timeperframe.numerator,
+        capture.timeperframe.denominator,
+    )
+    .map_err(|error| {
+        Error::Hardware(format!(
+            "{device}: {query:?}: {stage} returned malformed timeperframe: {error}"
+        ))
+    })
+}
+
+fn streamparm_transaction(
+    device: &str,
+    query: frame_interval::FrameIntervalQuery,
+    stage: &'static str,
+    operation: &'static str,
+    requested: Option<frame_interval::FrameInterval>,
+    ioctl: impl FnOnce(&mut v4l::v4l_sys::v4l2_streamparm) -> std::io::Result<()>,
+) -> irlume_common::Result<frame_interval::FrameInterval> {
+    let mut wire = streamparm_request(requested);
+    ioctl(&mut wire).map_err(|error| {
+        Error::Hardware(format!(
+            "{device}: {query:?}: {stage} {operation} failed: {error}"
+        ))
+    })?;
+    validate_streamparm_response(device, query, stage, &wire)
+}
+
+fn read_stream_interval(
+    device: &str,
+    dev: &Device,
+    query: frame_interval::FrameIntervalQuery,
+    stage: &'static str,
+) -> irlume_common::Result<frame_interval::FrameInterval> {
+    streamparm_transaction(device, query, stage, "VIDIOC_G_PARM", None, |wire| {
+        // SAFETY: `dev` owns the fd and `wire` is a fully initialized exact ABI object.
+        let rc = unsafe {
+            libc::ioctl(
+                dev.handle().fd(),
+                v4l::v4l2::vidioc::VIDIOC_G_PARM,
+                wire as *mut _ as *mut libc::c_void,
+            )
+        };
+        if rc < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    })
+}
+
+fn set_stream_interval(
+    device: &str,
+    dev: &Device,
+    query: frame_interval::FrameIntervalQuery,
+    requested: frame_interval::FrameInterval,
+    stage: &'static str,
+) -> irlume_common::Result<frame_interval::FrameInterval> {
+    streamparm_transaction(
+        device,
+        query,
+        stage,
+        "VIDIOC_S_PARM",
+        Some(requested),
+        |wire| {
+            // SAFETY: same initialized ABI boundary as G_PARM; the response is
+            // validated before union data is used.
+            let rc = unsafe {
+                libc::ioctl(
+                    dev.handle().fd(),
+                    v4l::v4l2::vidioc::VIDIOC_S_PARM,
+                    wire as *mut _ as *mut libc::c_void,
+                )
+            };
+            if rc < 0 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        },
+    )
 }
 
 #[derive(Debug)]
@@ -657,6 +858,113 @@ where
     validate_dequeued(mapped, &metadata, layout)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct NegotiatedInterval {
+    requested: frame_interval::FrameInterval,
+    accepted: frame_interval::FrameInterval,
+}
+
+fn negotiate_interval_after_format<S: CameraState>(
+    state: &S,
+    device: &str,
+    dev: &S::Device,
+    accepted_format: &Format,
+) -> irlume_common::Result<NegotiatedInterval> {
+    state
+        .require_endpoint()
+        .map_err(|error| Error::Hardware(error.to_string()))?;
+    let domain = state.interval_domain(dev, accepted_format)?;
+    let query = frame_interval::FrameIntervalQuery::new(
+        accepted_format.fourcc.repr,
+        accepted_format.width,
+        accepted_format.height,
+    )
+    .map_err(|error| Error::Hardware(format!("{device}: {error}")))?;
+    let requested = state.current_interval(dev, query, "factory default")?;
+    if !domain.contains(requested) {
+        let (numerator, denominator) = requested.parts();
+        return Err(Error::Hardware(format!(
+            "{device}: {query:?}: driver default {numerator}/{denominator} is outside the \
+             enumerated interval domain"
+        )));
+    }
+    let accepted = state.set_interval(dev, query, requested, "factory request")?;
+    if !domain.contains(accepted) {
+        let (numerator, denominator) = accepted.parts();
+        return Err(Error::Hardware(format!(
+            "{device}: {query:?}: driver accepted {numerator}/{denominator} outside the \
+             enumerated interval domain"
+        )));
+    }
+    verify_stream_state(
+        state,
+        device,
+        dev,
+        accepted_format,
+        accepted,
+        "after interval negotiation",
+    )?;
+    Ok(NegotiatedInterval {
+        requested,
+        accepted,
+    })
+}
+
+fn verify_stream_state<S: CameraState>(
+    state: &S,
+    device: &str,
+    dev: &S::Device,
+    expected_format: &Format,
+    expected_interval: frame_interval::FrameInterval,
+    stage: &'static str,
+) -> irlume_common::Result<()> {
+    state
+        .require_endpoint()
+        .map_err(|error| Error::Hardware(error.to_string()))?;
+    verify_stream_snapshot(
+        state,
+        device,
+        dev,
+        expected_format,
+        expected_interval,
+        stage,
+    )
+}
+
+fn verify_stream_snapshot<S: CameraState>(
+    state: &S,
+    device: &str,
+    dev: &S::Device,
+    expected_format: &Format,
+    expected_interval: frame_interval::FrameInterval,
+    stage: &'static str,
+) -> irlume_common::Result<()> {
+    let current_format = state
+        .current_format(dev)
+        .map_err(|error| map_io(device, error))?;
+    if let Some(moved) = state.compare_format(expected_format, &current_format) {
+        return Err(Error::Hardware(format!(
+            "{device}: stream state drift at {stage}: {moved}; refusing this capture"
+        )));
+    }
+    let query = frame_interval::FrameIntervalQuery::new(
+        expected_format.fourcc.repr,
+        expected_format.width,
+        expected_format.height,
+    )
+    .map_err(|error| Error::Hardware(format!("{device}: {stage}: {error}")))?;
+    let current_interval = state.current_interval(dev, query, stage)?;
+    if current_interval != expected_interval {
+        let (current_num, current_den) = current_interval.parts();
+        let (expected_num, expected_den) = expected_interval.parts();
+        return Err(Error::Hardware(format!(
+            "{device}: stream interval drift at {stage}: now {current_num}/{current_den}, \
+             accepted {expected_num}/{expected_den}; refusing this capture"
+        )));
+    }
+    Ok(())
+}
+
 /// A capture stream whose teardown cannot take the process down.
 ///
 /// v4l 0.14's `Stream::drop` calls `stop()` and PANICS on any failure except
@@ -674,8 +982,12 @@ struct CameraStateStream<'a, S: CameraState> {
     inner: Option<S::Claim<'a>>,
     state: S,
     device: String,
+    dev: &'a S::Device,
+    expected_format: Format,
+    expected_interval: frame_interval::FrameInterval,
     layout: frame_provenance::PayloadLayout,
     state_started: bool,
+    stream_started_validated: bool,
 }
 
 type SafeStream<'a> = CameraStateStream<'a, V4l2CameraState>;
@@ -819,13 +1131,13 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
     /// streaming struct gated only on buffer ownership, and ownership begins
     /// at REQBUFS, not at open (#427; the audit in
     /// docs/research/2026-08-12-camera-handling-audit.md, Q3). Between the
-    /// caller's S_FMT and the REQBUFS here, any other process can retarget
-    /// the device, and the capture would then decode frames against stale
-    /// width, height and fourcc assumptions. Once `with_buffers` returns,
-    /// this handle owns the queue and S_FMT answers EBUSY to everyone, so a
-    /// G_FMT read taken HERE is stable for the stream's whole life; the same
-    /// window recurs at every reopen (recover, the frozen-stream restarts),
-    /// which is why the check lives in the one function they all call.
+    /// caller's S_FMT/S_PARM and the REQBUFS here, any other process can retarget
+    /// the device, and the capture would then decode frames against a stale full
+    /// format or interval. Read-only G_FMT/G_PARM checks therefore run before and
+    /// after buffer claim. The first successful dequeue is the first proof that
+    /// STREAMON delivered a frame, so its existing post-DQBUF endpoint check is
+    /// followed by one final full-tuple snapshot. Every reopen uses the immutable
+    /// factory-accepted interval and repeats the same checks without S_PARM.
     ///
     /// A dequeue timeout is set explicitly. v4l leaves it unset, which polls
     /// with -1 and waits forever, so a camera that stops delivering frames
@@ -838,14 +1150,19 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
         dev: &'a S::Device,
         expect: &v4l::Format,
     ) -> irlume_common::Result<Self> {
-        state
-            .require_endpoint()
-            .map_err(|error| Error::Hardware(error.to_string()))?;
-        // Record the complete driver-echoed S_FMT identity at the existing
-        // pre-claim validation boundary. The self-comparison is infallible and
-        // has no observable production effect; the post-REQBUFS G_FMT identity
-        // must still compare equal to this same value.
-        let _ = state.compare_format(expect, expect);
+        let expected_interval = state.accepted_interval().ok_or_else(|| {
+            Error::Hardware(format!(
+                "{device}: no accepted stream interval is bound to this capture state"
+            ))
+        })?;
+        verify_stream_state(
+            &state,
+            device,
+            dev,
+            expect,
+            expected_interval,
+            "before buffer claim",
+        )?;
         let layout = frame_provenance::PayloadLayout::new(
             expect.fourcc.repr,
             expect.width,
@@ -861,34 +1178,21 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
             inner: Some(inner),
             state,
             device: device.to_string(),
+            dev,
+            expected_format: *expect,
+            expected_interval,
             layout,
             state_started: false,
+            stream_started_validated: false,
         };
-        let now = stream
-            .state
-            .current_format(dev)
-            .map_err(|e| map_io(device, e))?;
-        stream
-            .state
-            .require_endpoint()
-            .map_err(|error| Error::Hardware(error.to_string()))?;
-        if let Some(moved) = stream.state.compare_format(expect, &now) {
-            // Refusing rather than renegotiating, for the same reason the
-            // emitter stands down under a foreign consumer (#169): a format
-            // that moved means another application is actively configuring
-            // this camera, and fighting it over shared state serves nobody.
-            // The cost is one refused capture, which degrades toward the
-            // password prompt.
-            let who = match camera_holder(device) {
-                Some(h) => format!(", likely {h}"),
-                None => String::new(),
-            };
-            return Err(Error::Hardware(format!(
-                "{device}: the stream format changed between negotiation and \
-                 buffer claim ({moved}). Another application is configuring \
-                 this camera{who}; refusing this capture"
-            )));
-        }
+        verify_stream_state(
+            &stream.state,
+            device,
+            dev,
+            expect,
+            expected_interval,
+            "after buffer claim",
+        )?;
         stream.state.start_stream()?;
         stream.state_started = true;
         Ok(stream)
@@ -904,14 +1208,32 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
         let Self {
             inner,
             state,
+            device,
+            dev,
+            expected_format,
+            expected_interval,
             layout,
+            stream_started_validated,
             ..
         } = self;
-        dequeue_validated_typed(
+        let dequeued = dequeue_validated_typed(
             inner.as_mut().expect("stream taken only in Drop"),
             *layout,
             || state.require_endpoint().map_err(std::io::Error::other),
-        )
+        )?;
+        if !*stream_started_validated {
+            verify_stream_snapshot(
+                state,
+                device,
+                dev,
+                expected_format,
+                *expected_interval,
+                "after first dequeue",
+            )
+            .map_err(|error| ValidatedDequeueError::Io(std::io::Error::other(error)))?;
+            *stream_started_validated = true;
+        }
+        Ok(dequeued)
     }
 }
 
@@ -937,6 +1259,7 @@ struct TrackedStream<S> {
     observations: u64,
     discarded_observations: u64,
     sequence_span_sum: u64,
+    recovery_epoch_pending: bool,
 }
 
 impl<S> TrackedStream<S> {
@@ -948,6 +1271,7 @@ impl<S> TrackedStream<S> {
             observations: 0,
             discarded_observations: 0,
             sequence_span_sum: 0,
+            recovery_epoch_pending: false,
         }
     }
 
@@ -969,19 +1293,13 @@ impl<S> TrackedStream<S> {
     }
 
     fn install_recovered(&mut self, stream: S) -> std::io::Result<()> {
-        let mut next_sequence = self.sequence.clone();
-        if let Err(error) = next_sequence.begin_new_epoch() {
-            self.sequence = next_sequence;
-            return Err(std::io::Error::other(error));
+        if self.stream.is_some() {
+            return Err(std::io::Error::other(
+                "replacement capture installed before the old stream was removed",
+            ));
         }
-        let mut next_timestamp = self.timestamp.clone();
-        if let Err(error) = next_timestamp.begin_new_epoch() {
-            self.timestamp = next_timestamp;
-            return Err(std::io::Error::other(error));
-        }
-        self.sequence = next_sequence;
-        self.timestamp = next_timestamp;
         self.stream = Some(stream);
+        self.recovery_epoch_pending = true;
         Ok(())
     }
 }
@@ -1089,6 +1407,30 @@ fn observe_continuity_facts(
     Ok((sequence_observation, timestamp_observation))
 }
 
+fn begin_recovered_continuity_epoch(
+    pending: &mut bool,
+    sequence: &mut frame_provenance::SequenceTracker,
+    timestamp: &mut frame_provenance::TimestampTracker,
+) -> std::io::Result<()> {
+    if !*pending {
+        return Ok(());
+    }
+    let mut next_sequence = sequence.clone();
+    if let Err(error) = next_sequence.begin_new_epoch() {
+        *sequence = next_sequence;
+        return Err(std::io::Error::other(error));
+    }
+    let mut next_timestamp = timestamp.clone();
+    if let Err(error) = next_timestamp.begin_new_epoch() {
+        *timestamp = next_timestamp;
+        return Err(std::io::Error::other(error));
+    }
+    *sequence = next_sequence;
+    *timestamp = next_timestamp;
+    *pending = false;
+    Ok(())
+}
+
 impl<S: ValidatedStream> TrackedStream<S> {
     fn next_discarded(&mut self) -> std::io::Result<()> {
         let Self {
@@ -1098,13 +1440,18 @@ impl<S: ValidatedStream> TrackedStream<S> {
             observations,
             discarded_observations,
             sequence_span_sum,
+            recovery_epoch_pending,
         } = self;
         let dequeued = stream
             .as_mut()
             .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
             .next_validated();
         let facts = match dequeued {
-            Ok((_, facts)) | Err(ValidatedDequeueError::Corrupt(facts)) => facts,
+            Ok((_, facts)) => {
+                begin_recovered_continuity_epoch(recovery_epoch_pending, sequence, timestamp)?;
+                facts
+            }
+            Err(ValidatedDequeueError::Corrupt(facts)) => facts,
             Err(error) => {
                 if error.invalidates_timestamp_epoch() {
                     timestamp.fail_current_epoch();
@@ -1139,6 +1486,7 @@ impl<S: ValidatedStream> TrackedStream<S> {
             observations,
             discarded_observations,
             sequence_span_sum,
+            recovery_epoch_pending,
         } = self;
         let dequeued = stream
             .as_mut()
@@ -1165,6 +1513,7 @@ impl<S: ValidatedStream> TrackedStream<S> {
                 return Err(error.into_io());
             }
         };
+        begin_recovered_continuity_epoch(recovery_epoch_pending, sequence, timestamp)?;
         let (sequence_observation, timestamp_observation) = observe_continuity_facts(
             sequence,
             timestamp,
@@ -2447,6 +2796,12 @@ pub struct RgbCamera {
     /// buffers (#427); see `format_moved` for why the geometry alone is not
     /// enough.
     negotiated: v4l::Format,
+    #[expect(
+        dead_code,
+        reason = "immutable negotiation evidence is published by the delivered-rate slice"
+    )]
+    requested_interval: frame_interval::FrameInterval,
+    accepted_interval: frame_interval::FrameInterval,
 }
 
 impl RgbCamera {
@@ -2503,9 +2858,7 @@ impl RgbCamera {
                 fourcc_str(&chosen)
             )));
         }
-        state
-            .require_endpoint()
-            .map_err(|error| Error::Hardware(error.to_string()))?;
+        let interval = negotiate_interval_after_format(&state, device, &dev, &fmt)?;
         Ok(Self {
             lease,
             session_active: std::sync::atomic::AtomicBool::new(false),
@@ -2515,6 +2868,8 @@ impl RgbCamera {
             width: fmt.width,
             height: fmt.height,
             negotiated: fmt,
+            requested_interval: interval.requested,
+            accepted_interval: interval.accepted,
         })
     }
 
@@ -2557,7 +2912,11 @@ impl RgbCamera {
         // not (the Codex round's finding 1 on this PR).
         let blc_restore = apply_blc(self);
         let stream = SafeStream::open(
-            V4l2CameraState::new(&self.device, self.lease.clone()),
+            V4l2CameraState::with_interval(
+                &self.device,
+                self.lease.clone(),
+                self.accepted_interval,
+            ),
             &self.device,
             &self.dev,
             &self.negotiated,
@@ -2789,7 +3148,11 @@ impl<'a> RgbSession<'a> {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         drop(self.stream.take()); // STREAMOFF + buffer release before replacement
         let stream = SafeStream::open(
-            V4l2CameraState::new(&self.cam.device, self.cam.lease.clone()),
+            V4l2CameraState::with_interval(
+                &self.cam.device,
+                self.cam.lease.clone(),
+                self.cam.accepted_interval,
+            ),
             &self.cam.device,
             &self.cam.dev,
             &self.cam.negotiated,
@@ -2800,7 +3163,7 @@ impl<'a> RgbSession<'a> {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         self.stream.install_recovered(stream).map_err(|error| {
             Error::Hardware(format!(
-                "{}: could not begin the recovered continuity epochs: {error}",
+                "{}: could not install the recovered stream: {error}",
                 self.cam.device
             ))
         })?;
@@ -3104,13 +3467,7 @@ const IR_CANDIDATES: [(&[u8; 4], IrPixel); 8] = [
     (b"YUYV", IrPixel::YuyvLuma),
 ];
 
-/// Negotiate an IR-decodable format on `dev`, mirroring [`negotiate_rgb_format`]:
-/// walk [`IR_CANDIDATES`] against what the driver advertises, accept the first
-/// one the driver echoes back, and fail with a message naming what it offers.
-fn negotiate_ir_format(device: &str, dev: &Device) -> irlume_common::Result<(Format, IrPixel)> {
-    negotiate_ir_format_via(device, dev, Capture::set_format)
-}
-
+/// Negotiate an IR-decodable format through the injected camera state.
 fn negotiate_ir_format_state<S: CameraState<Device = Device>>(
     device: &str,
     dev: &Device,
@@ -3119,8 +3476,19 @@ fn negotiate_ir_format_state<S: CameraState<Device = Device>>(
     negotiate_ir_format_via(device, dev, |dev, fmt| state.set_format(dev, fmt))
 }
 
+fn negotiate_ir_format_and_interval(
+    device: &str,
+    dev: &Device,
+    lease: &lease::CameraLease,
+) -> irlume_common::Result<(Format, IrPixel, NegotiatedInterval)> {
+    let state = V4l2CameraState::new(device, lease.clone());
+    let (format, pixel) = negotiate_ir_format_state(device, dev, &state)?;
+    let interval = negotiate_interval_after_format(&state, device, dev, &format)?;
+    Ok((format, pixel, interval))
+}
+
 /// The IR candidate walk with the format ioctl injected: capture applies it
-/// through `VIDIOC_S_FMT` ([`negotiate_ir_format`]) while the doctor's
+/// through `VIDIOC_S_FMT` while the doctor's
 /// read-only probe applies the SAME walk through `VIDIOC_TRY_FMT`
 /// ([`negotiated_stream`]). One walk, two ioctls, so the probe cannot drift
 /// from what capture negotiates.
@@ -3433,6 +3801,12 @@ pub struct IrCamera {
     /// buffers (#427); see `format_moved` for why the geometry alone is not
     /// enough.
     negotiated: v4l::Format,
+    #[expect(
+        dead_code,
+        reason = "immutable negotiation evidence is published by the delivered-rate slice"
+    )]
+    requested_interval: frame_interval::FrameInterval,
+    accepted_interval: frame_interval::FrameInterval,
     width: u32,
     height: u32,
     card: String,
@@ -3474,10 +3848,8 @@ impl IrCamera {
         }
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
         let (fmt, pix) = negotiate_ir_format_state(device, &dev, &state)?;
+        let interval = negotiate_interval_after_format(&state, device, &dev, &fmt)?;
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
-        state
-            .require_endpoint()
-            .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(Self {
             lease,
             session_active: std::sync::atomic::AtomicBool::new(false),
@@ -3487,6 +3859,8 @@ impl IrCamera {
             quantization: fmt.quantization,
             fourcc: fourcc_str(&fmt.fourcc.repr),
             negotiated: fmt,
+            requested_interval: interval.requested,
+            accepted_interval: interval.accepted,
             width: fmt.width,
             height: fmt.height,
             card,
@@ -3541,7 +3915,11 @@ impl IrCamera {
         // this change removes. Assigned further down, once the stream exists.
         let mode;
         let mut stream = TrackedStream::new(SafeStream::open(
-            V4l2CameraState::new(&self.device, self.lease.clone()),
+            V4l2CameraState::with_interval(
+                &self.device,
+                self.lease.clone(),
+                self.accepted_interval,
+            ),
             &self.device,
             &self.dev,
             &self.negotiated,
@@ -4052,7 +4430,11 @@ impl IrSession<'_> {
         })?;
         self._mode = ir_emitter::StreamMode::inert();
         let stream = SafeStream::open(
-            V4l2CameraState::new(&self.cam.device, self.cam.lease.clone()),
+            V4l2CameraState::with_interval(
+                &self.cam.device,
+                self.cam.lease.clone(),
+                self.cam.accepted_interval,
+            ),
             &self.cam.device,
             &self.cam.dev,
             &self.cam.negotiated,
@@ -4076,7 +4458,7 @@ impl IrSession<'_> {
                 .map_err(|error| Error::Hardware(error.to_string()))?;
             self.stream.install_recovered(stream).map_err(|error| {
                 Error::Hardware(format!(
-                    "{}: could not begin the recovered continuity epochs: {error}",
+                    "{}: could not install the recovered stream: {error}",
                     self.cam.device
                 ))
             })
@@ -4095,7 +4477,7 @@ impl IrSession<'_> {
 /// are diagnostics for the strobe-probe example. Kept in the crate so the
 /// example and the capture path share one implementation.
 pub mod ir_probe {
-    use super::negotiate_ir_format;
+    use super::negotiate_ir_format_and_interval;
     use super::Device;
     use super::{
         ir_emitter, map_io, privacy_engaged_with_permit, verify_pinned, Error, Frame, Spectrum,
@@ -4234,7 +4616,7 @@ pub mod ir_probe {
             )));
         }
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
-        let (fmt, pix) = negotiate_ir_format(device, &dev)?;
+        let (fmt, pix, interval) = negotiate_ir_format_and_interval(device, &dev, &permit)?;
         let mut dec = super::IrDecoder::new(pix, fmt.quantization);
         let (w, h) = (fmt.width, fmt.height);
         let binding = permit
@@ -4257,7 +4639,7 @@ pub mod ir_probe {
         // lands before streaming starts.
         let mode;
         let stream = super::SafeStream::open(
-            super::V4l2CameraState::new(device, permit.clone()),
+            super::V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
             device,
             &dev,
             &fmt,
@@ -4356,7 +4738,7 @@ pub fn capture_ir_streaming<B>(
         )));
     }
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
-    let (fmt, pix) = negotiate_ir_format(device, &dev)?;
+    let (fmt, pix, interval) = negotiate_ir_format_and_interval(device, &dev, &permit)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
     let binding = permit
@@ -4379,7 +4761,7 @@ pub fn capture_ir_streaming<B>(
     // lands before streaming starts.
     let mut mode;
     let stream = SafeStream::open(
-        V4l2CameraState::new(device, permit.clone()),
+        V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
         device,
         &dev,
         &fmt,
@@ -4457,7 +4839,7 @@ pub fn capture_ir_streaming<B>(
                     ))
                 })?;
                 let replacement = SafeStream::open(
-                    V4l2CameraState::new(device, permit.clone()),
+                    V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
                     device,
                     &dev,
                     &fmt,
@@ -4470,7 +4852,7 @@ pub fn capture_ir_streaming<B>(
                     })
                     .map_err(|error| {
                         Error::Hardware(format!(
-                            "{device}: could not begin the recovered continuity epochs: {error}"
+                            "{device}: could not install the recovered stream: {error}"
                         ))
                     })?;
                 mode = replacement_mode;
@@ -4535,7 +4917,7 @@ pub fn capture_ir_sequence(
         )));
     }
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
-    let (fmt, pix) = negotiate_ir_format(device, &dev)?;
+    let (fmt, pix, interval) = negotiate_ir_format_and_interval(device, &dev, &permit)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
     let binding = permit
@@ -4558,7 +4940,7 @@ pub fn capture_ir_sequence(
     // lands before streaming starts.
     let mut mode;
     let stream = SafeStream::open(
-        V4l2CameraState::new(device, permit.clone()),
+        V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
         device,
         &dev,
         &fmt,
@@ -4640,7 +5022,7 @@ pub fn capture_ir_sequence(
                     ))
                 })?;
                 let replacement = SafeStream::open(
-                    V4l2CameraState::new(device, permit.clone()),
+                    V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
                     device,
                     &dev,
                     &fmt,
@@ -4653,7 +5035,7 @@ pub fn capture_ir_sequence(
                     })
                     .map_err(|error| {
                         Error::Hardware(format!(
-                            "{device}: could not begin the recovered continuity epochs: {error}"
+                            "{device}: could not install the recovered stream: {error}"
                         ))
                     })?;
                 mode = replacement_mode;
@@ -5546,11 +5928,11 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     // `found` on the success path) and has to finish before this re-raises the
     // signal that stops the process.
     let _abort_orderly = ir_emitter::AbortOnSignal::install();
-    let (fmt, pix) = negotiate_ir_format(device, &dev)?;
+    let (fmt, pix, interval) = negotiate_ir_format_and_interval(device, &dev, &permit)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
     let mut stream = SafeStream::open(
-        V4l2CameraState::new(device, permit.clone()),
+        V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
         device,
         &dev,
         &fmt,
@@ -5847,6 +6229,13 @@ mod tests {
         calls: CallLog,
         echoed: Format,
         current: Format,
+        format_reads: std::cell::RefCell<std::collections::VecDeque<Format>>,
+        accepted_interval: frame_interval::FrameInterval,
+        current_interval: frame_interval::FrameInterval,
+        interval_reads:
+            std::cell::RefCell<std::collections::VecDeque<frame_interval::FrameInterval>>,
+        interval_domain: frame_interval::FrameIntervalDomain,
+        set_interval_response: frame_interval::FrameInterval,
         endpoint_calls: std::cell::Cell<usize>,
         fail_set: bool,
         fail_endpoint_at: Option<usize>,
@@ -5857,11 +6246,20 @@ mod tests {
     impl FakeCameraState {
         fn new(format: Format) -> (Self, CallLog) {
             let calls = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+            let interval =
+                frame_interval::FrameInterval::new(1, 30).expect("valid fixture interval");
             (
                 Self {
                     calls: calls.clone(),
                     echoed: format,
                     current: format,
+                    format_reads: std::cell::RefCell::new(std::collections::VecDeque::new()),
+                    accepted_interval: interval,
+                    current_interval: interval,
+                    interval_reads: std::cell::RefCell::new(std::collections::VecDeque::new()),
+                    interval_domain: frame_interval::FrameIntervalDomain::discrete(vec![interval])
+                        .expect("valid fixture domain"),
+                    set_interval_response: interval,
                     endpoint_calls: std::cell::Cell::new(0),
                     fail_set: false,
                     fail_endpoint_at: None,
@@ -5885,6 +6283,26 @@ mod tests {
             } else {
                 Ok(self.echoed)
             }
+        }
+
+        fn interval_domain(
+            &self,
+            _dev: &(),
+            _format: &Format,
+        ) -> irlume_common::Result<frame_interval::FrameIntervalDomain> {
+            self.calls.borrow_mut().push("enum_intervals");
+            Ok(self.interval_domain.clone())
+        }
+
+        fn set_interval(
+            &self,
+            _dev: &(),
+            _query: frame_interval::FrameIntervalQuery,
+            _requested: frame_interval::FrameInterval,
+            _stage: &'static str,
+        ) -> irlume_common::Result<frame_interval::FrameInterval> {
+            self.calls.borrow_mut().push("set_interval");
+            Ok(self.set_interval_response)
         }
 
         fn require_endpoint(&self) -> Result<(), Self::EndpointError> {
@@ -5915,9 +6333,31 @@ mod tests {
             })
         }
 
+        fn accepted_interval(&self) -> Option<frame_interval::FrameInterval> {
+            Some(self.accepted_interval)
+        }
+
         fn current_format(&self, _dev: &()) -> std::io::Result<Format> {
             self.calls.borrow_mut().push("g_fmt");
-            Ok(self.current)
+            Ok(self
+                .format_reads
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or(self.current))
+        }
+
+        fn current_interval(
+            &self,
+            _dev: &(),
+            _query: frame_interval::FrameIntervalQuery,
+            _stage: &'static str,
+        ) -> irlume_common::Result<frame_interval::FrameInterval> {
+            self.calls.borrow_mut().push("get_interval");
+            Ok(self
+                .interval_reads
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or(self.current_interval))
         }
 
         fn start_stream(&self) -> irlume_common::Result<()> {
@@ -5942,10 +6382,28 @@ mod tests {
         format
     }
 
+    fn interval(numerator: u32, denominator: u32) -> frame_interval::FrameInterval {
+        frame_interval::FrameInterval::new(numerator, denominator).expect("valid test interval")
+    }
+
+    fn fake_query() -> frame_interval::FrameIntervalQuery {
+        frame_interval::FrameIntervalQuery::new(*b"GREY", 640, 480).expect("valid query")
+    }
+
+    fn streamparm_response(numerator: u32, denominator: u32) -> v4l::v4l_sys::v4l2_streamparm {
+        let mut wire = streamparm_request(None);
+        wire.parm.capture.capability = v4l::v4l_sys::V4L2_CAP_TIMEPERFRAME;
+        wire.parm.capture.timeperframe.numerator = numerator;
+        wire.parm.capture.timeperframe.denominator = denominator;
+        wire
+    }
+
     fn exercise_fake_happy_path(format: Format) -> Vec<&'static str> {
-        let (state, calls) = FakeCameraState::new(format);
+        let (mut state, calls) = FakeCameraState::new(format);
         let echoed = state.set_format(&(), &format).expect("S_FMT");
-        state.require_endpoint().expect("endpoint after S_FMT");
+        let negotiated = negotiate_interval_after_format(&state, "/dev/fake", &(), &echoed)
+            .expect("interval negotiation");
+        state.accepted_interval = negotiated.accepted;
         let mut stream = CameraStateStream::open(state, "/dev/fake", &(), &echoed)
             .expect("buffer claim orchestration");
         stream.next().expect("first dequeue");
@@ -5959,21 +6417,369 @@ mod tests {
         let expected = vec![
             "set_format",
             "endpoint",
+            "enum_intervals",
+            "get_interval",
+            "set_interval",
             "endpoint",
-            "check_format",
-            "reqbufs",
             "g_fmt",
-            "endpoint",
             "check_format",
+            "get_interval",
+            "endpoint",
+            "g_fmt",
+            "check_format",
+            "get_interval",
+            "reqbufs",
+            "endpoint",
+            "g_fmt",
+            "check_format",
+            "get_interval",
             "start",
             "endpoint",
             "dequeue",
             "endpoint",
+            "g_fmt",
+            "check_format",
+            "get_interval",
             "cleanup",
             "stop",
         ];
         assert_eq!(exercise_fake_happy_path(fake_format(b"YUYV")), expected);
         assert_eq!(exercise_fake_happy_path(fake_format(b"GREY")), expected);
+    }
+
+    #[test]
+    fn streamparm_adapter_zeroes_full_request_and_reduces_exact_response() {
+        let requested = interval(2, 60);
+        let request = streamparm_request(Some(requested));
+        assert_eq!(std::mem::size_of_val(&request), 204);
+        assert_eq!(request.type_, Type::VideoCapture as u32);
+        // SAFETY: `streamparm_request` set VideoCapture and initialized the
+        // capture arm before this fixture reads its scalar fields.
+        let capture = unsafe { request.parm.capture };
+        assert_eq!(capture.capability, 0);
+        assert_eq!(capture.capturemode, 0);
+        assert_eq!(capture.timeperframe.numerator, 1);
+        assert_eq!(capture.timeperframe.denominator, 30);
+        assert_eq!(capture.extendedmode, 0);
+        assert_eq!(capture.readbuffers, 0);
+        assert_eq!(capture.reserved, [0; 4]);
+        // SAFETY: every byte of the union was zero-initialized before only the
+        // timeperframe subrange was written; raw inspection is fixture-only.
+        let raw = unsafe { request.parm.raw_data };
+        assert!(raw[..8].iter().all(|byte| *byte == 0));
+        assert!(raw[16..].iter().all(|byte| *byte == 0));
+
+        let mut response = streamparm_response(2, 60);
+        response.parm.capture.readbuffers = u32::MAX;
+        assert_eq!(
+            validate_streamparm_response("/dev/fake", fake_query(), "test", &response)
+                .expect("unreduced equivalent response"),
+            interval(1, 30)
+        );
+    }
+
+    #[test]
+    fn streamparm_adapter_rejects_malformed_responses_and_errno() {
+        let base = streamparm_response(1, 30);
+
+        let mut wrong_type = base;
+        wrong_type.type_ = Type::VideoOutput as u32;
+        assert!(
+            validate_streamparm_response("/dev/fake", fake_query(), "wrong type", &wrong_type)
+                .unwrap_err()
+                .to_string()
+                .contains("returned type")
+        );
+
+        let mut no_capability = base;
+        no_capability.parm.capture.capability = 0;
+        assert!(validate_streamparm_response(
+            "/dev/fake",
+            fake_query(),
+            "no capability",
+            &no_capability,
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("V4L2_CAP_TIMEPERFRAME"));
+
+        for (numerator, denominator, needle) in [(0, 30, "numerator"), (1, 0, "denominator")] {
+            let malformed = streamparm_response(numerator, denominator);
+            assert!(validate_streamparm_response(
+                "/dev/fake",
+                fake_query(),
+                "zero rational",
+                &malformed,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains(needle));
+        }
+
+        let mut extended = base;
+        extended.parm.capture.extendedmode = 1;
+        assert!(
+            validate_streamparm_response("/dev/fake", fake_query(), "extended", &extended)
+                .unwrap_err()
+                .to_string()
+                .contains("extendedmode")
+        );
+
+        let mut reserved = base;
+        // SAFETY: the fixture was initialized with the capture arm and keeps
+        // `type_` set to VideoCapture while corrupting one response field.
+        unsafe {
+            reserved.parm.capture.reserved[3] = 1;
+        }
+        assert!(
+            validate_streamparm_response("/dev/fake", fake_query(), "reserved", &reserved)
+                .unwrap_err()
+                .to_string()
+                .contains("reserved")
+        );
+
+        let error = streamparm_transaction(
+            "/dev/fake",
+            fake_query(),
+            "errno stage",
+            "VIDIOC_G_PARM",
+            None,
+            |_| Err(std::io::Error::from_raw_os_error(libc::EIO)),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("/dev/fake"));
+        assert!(error.contains("errno stage"));
+        assert!(error.contains("VIDIOC_G_PARM"));
+        assert!(error.contains("Input/output error"));
+    }
+
+    #[test]
+    fn streamparm_set_transaction_sends_only_type_and_timeperframe() {
+        let accepted = streamparm_transaction(
+            "/dev/fake",
+            fake_query(),
+            "set stage",
+            "VIDIOC_S_PARM",
+            Some(interval(1, 30)),
+            |wire| {
+                assert_eq!(wire.type_, Type::VideoCapture as u32);
+                // SAFETY: the transaction constructed the VideoCapture request
+                // and initialized this active union arm before invoking the fixture.
+                let capture = unsafe { wire.parm.capture };
+                assert_eq!(capture.capability, 0);
+                assert_eq!(capture.capturemode, 0);
+                assert_eq!(capture.timeperframe.numerator, 1);
+                assert_eq!(capture.timeperframe.denominator, 30);
+                assert_eq!(capture.extendedmode, 0);
+                assert_eq!(capture.readbuffers, 0);
+                assert_eq!(capture.reserved, [0; 4]);
+                // SAFETY: the request union was fully zeroed before only its
+                // timeperframe bytes were written; raw inspection is fixture-only.
+                let raw = unsafe { wire.parm.raw_data };
+                assert!(raw[..8].iter().all(|byte| *byte == 0));
+                assert!(raw[16..].iter().all(|byte| *byte == 0));
+                *wire = streamparm_response(2, 60);
+                Ok(())
+            },
+        )
+        .expect("valid adjusted response");
+        assert_eq!(accepted, interval(1, 30));
+    }
+
+    #[test]
+    fn factory_interval_negotiation_requires_domain_membership_and_stores_exact_evidence() {
+        let format = fake_format(b"GREY");
+        let (mut state, _) = FakeCameraState::new(format);
+        state.interval_domain =
+            frame_interval::FrameIntervalDomain::discrete(vec![interval(1, 30), interval(1, 15)])
+                .unwrap();
+        state.set_interval_response = interval(1, 15);
+        state
+            .interval_reads
+            .borrow_mut()
+            .extend([interval(1, 30), interval(1, 15)]);
+        let evidence = negotiate_interval_after_format(&state, "/dev/fake", &(), &format)
+            .expect("declared adjusted interval");
+        assert_eq!(evidence.requested, interval(1, 30));
+        assert_eq!(evidence.accepted, interval(1, 15));
+
+        let (mut outside_default, calls) = FakeCameraState::new(format);
+        outside_default.current_interval = interval(1, 25);
+        assert!(
+            negotiate_interval_after_format(&outside_default, "/dev/fake", &(), &format)
+                .unwrap_err()
+                .to_string()
+                .contains("driver default")
+        );
+        assert!(!calls.borrow().contains(&"set_interval"));
+
+        let domains = [
+            frame_interval::FrameIntervalDomain::discrete(vec![interval(1, 30)]).unwrap(),
+            frame_interval::FrameIntervalDomain::continuous(interval(1, 60), interval(1, 15))
+                .unwrap(),
+            frame_interval::FrameIntervalDomain::stepwise(
+                interval(1, 60),
+                interval(1, 30),
+                interval(1, 180),
+            )
+            .unwrap(),
+        ];
+        let rejected = [interval(1, 25), interval(1, 10), interval(1, 50)];
+        for (domain, adjusted) in domains.into_iter().zip(rejected) {
+            let (mut state, _) = FakeCameraState::new(format);
+            state.interval_domain = domain;
+            state.set_interval_response = adjusted;
+            assert!(
+                negotiate_interval_after_format(&state, "/dev/fake", &(), &format)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("driver accepted")
+            );
+        }
+    }
+
+    #[test]
+    fn factory_post_set_readback_detects_every_full_format_field() {
+        let format = fake_format(b"GREY");
+        let mut moved = Vec::new();
+        let mut value = format;
+        value.fourcc = FourCC::new(b"YUYV");
+        moved.push(value);
+        let mut value = format;
+        value.width += 1;
+        moved.push(value);
+        let mut value = format;
+        value.height += 1;
+        moved.push(value);
+        let mut value = format;
+        value.stride += 1;
+        moved.push(value);
+        let mut value = format;
+        value.size += 1;
+        moved.push(value);
+        let mut value = format;
+        value.field_order = v4l::format::FieldOrder::Interlaced;
+        moved.push(value);
+        let mut value = format;
+        value.colorspace = v4l::format::Colorspace::Rec709;
+        moved.push(value);
+        let mut value = format;
+        value.quantization = v4l::format::Quantization::LimitedRange;
+        moved.push(value);
+        let mut value = format;
+        value.transfer = v4l::format::TransferFunction::Rec709;
+        moved.push(value);
+        let mut value = format;
+        value.flags = v4l::format::Flags::empty();
+        moved.push(value);
+
+        for current in moved {
+            let (mut state, _) = FakeCameraState::new(format);
+            state.current = current;
+            assert!(
+                negotiate_interval_after_format(&state, "/dev/fake", &(), &format)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("stream state drift")
+            );
+        }
+    }
+
+    #[test]
+    fn first_dequeue_refuses_format_or_interval_drift_and_validates_only_once() {
+        let format = fake_format(b"GREY");
+        let accepted = interval(1, 30);
+
+        let (state, calls) = FakeCameraState::new(format);
+        let mut changed = format;
+        changed.stride += 1;
+        state
+            .format_reads
+            .borrow_mut()
+            .extend([format, format, changed]);
+        let mut stream = CameraStateStream::open(state, "/dev/fake", &(), &format).unwrap();
+        assert!(stream
+            .next()
+            .unwrap_err()
+            .to_string()
+            .contains("stream state drift"));
+        drop(stream);
+        assert!(calls.borrow().ends_with(&["cleanup", "stop"]));
+
+        let (state, calls) = FakeCameraState::new(format);
+        state
+            .interval_reads
+            .borrow_mut()
+            .extend([accepted, accepted, interval(1, 25)]);
+        let mut stream = CameraStateStream::open(state, "/dev/fake", &(), &format).unwrap();
+        assert!(stream
+            .next()
+            .unwrap_err()
+            .to_string()
+            .contains("stream interval drift"));
+        drop(stream);
+        assert!(calls.borrow().ends_with(&["cleanup", "stop"]));
+
+        let (state, calls) = FakeCameraState::new(format);
+        let mut stream = CameraStateStream::open(state, "/dev/fake", &(), &format).unwrap();
+        stream.next().expect("first frame");
+        stream.next().expect("second frame");
+        drop(stream);
+        assert_eq!(
+            calls
+                .borrow()
+                .iter()
+                .filter(|call| **call == "get_interval")
+                .count(),
+            3
+        );
+    }
+
+    #[test]
+    fn every_stream_endpoint_boundary_fails_closed_and_tears_down() {
+        let format = fake_format(b"GREY");
+        for fail_at in 1..=4 {
+            let (mut state, calls) = FakeCameraState::new(format);
+            state.fail_endpoint_at = Some(fail_at);
+            match CameraStateStream::open(state, "/dev/fake", &(), &format) {
+                Err(_) if fail_at <= 2 => {}
+                Ok(mut stream) if fail_at > 2 => {
+                    assert!(
+                        stream.next().is_err(),
+                        "boundary {fail_at} returned a frame"
+                    );
+                    drop(stream);
+                }
+                Ok(_) => panic!("boundary {fail_at} should fail during open"),
+                Err(error) => panic!("boundary {fail_at} failed too early: {error}"),
+            }
+            let calls = calls.borrow();
+            if fail_at == 1 {
+                assert!(!calls.contains(&"cleanup"));
+            } else {
+                assert!(calls.contains(&"cleanup"));
+            }
+            if fail_at > 2 {
+                assert!(calls.ends_with(&["cleanup", "stop"]));
+            }
+        }
+    }
+
+    #[test]
+    fn recovery_open_uses_immutable_accepted_interval_and_never_sets_it() {
+        let format = fake_format(b"GREY");
+        let (mut state, calls) = FakeCameraState::new(format);
+        state.accepted_interval = interval(1, 30);
+        state.current_interval = interval(1, 25);
+        let error = match CameraStateStream::open(state, "/dev/fake", &(), &format) {
+            Ok(_) => panic!("recovery must refuse accepted-interval drift"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("accepted 1/30"));
+        let calls = calls.borrow();
+        assert!(!calls.contains(&"set_interval"));
+        assert!(!calls.contains(&"reqbufs"));
     }
 
     #[test]
@@ -5994,7 +6800,16 @@ mod tests {
         let (mut state, calls) = FakeCameraState::new(format);
         state.fail_claim = true;
         assert!(CameraStateStream::open(state, "/dev/fake", &(), &format).is_err());
-        assert_eq!(&*calls.borrow(), &["endpoint", "check_format", "reqbufs"]);
+        assert_eq!(
+            &*calls.borrow(),
+            &[
+                "endpoint",
+                "g_fmt",
+                "check_format",
+                "get_interval",
+                "reqbufs"
+            ]
+        );
 
         let (mut state, calls) = FakeCameraState::new(format);
         state.fail_endpoint_at = Some(2);
@@ -6003,9 +6818,10 @@ mod tests {
             &*calls.borrow(),
             &[
                 "endpoint",
-                "check_format",
-                "reqbufs",
                 "g_fmt",
+                "check_format",
+                "get_interval",
+                "reqbufs",
                 "endpoint",
                 "cleanup"
             ]
@@ -6020,11 +6836,14 @@ mod tests {
             &*calls.borrow(),
             &[
                 "endpoint",
-                "check_format",
-                "reqbufs",
                 "g_fmt",
-                "endpoint",
                 "check_format",
+                "get_interval",
+                "reqbufs",
+                "endpoint",
+                "g_fmt",
+                "check_format",
+                "get_interval",
                 "start",
                 "endpoint",
                 "dequeue",
@@ -6063,11 +6882,14 @@ mod tests {
             &*calls.borrow(),
             &[
                 "endpoint",
-                "check_format",
-                "reqbufs",
                 "g_fmt",
-                "endpoint",
                 "check_format",
+                "get_interval",
+                "reqbufs",
+                "endpoint",
+                "g_fmt",
+                "check_format",
+                "get_interval",
                 "start",
                 "endpoint",
                 "cleanup",
@@ -6119,19 +6941,8 @@ mod tests {
                 Ok(_) => panic!("every full-format drift must fail closed"),
                 Err(error) => error,
             };
-            assert!(error.to_string().contains("stream format changed"));
-            assert_eq!(
-                &*calls.borrow(),
-                &[
-                    "endpoint",
-                    "check_format",
-                    "reqbufs",
-                    "g_fmt",
-                    "endpoint",
-                    "check_format",
-                    "cleanup"
-                ]
-            );
+            assert!(error.to_string().contains("stream state drift"));
+            assert_eq!(&*calls.borrow(), &["endpoint", "g_fmt", "check_format"]);
         }
     }
 
@@ -6347,9 +7158,32 @@ mod tests {
         assert_eq!(capture.accounting(), (u64::MAX, 0, 0));
     }
 
+    struct RecoveryValidationFixture {
+        payload: [u8; 1],
+        metadata: v4l::buffer::Metadata,
+        calls: std::rc::Rc<std::cell::Cell<usize>>,
+        fail_validation: bool,
+    }
+
     struct ContinuityFixture {
         payload: [u8; 1],
         metadata: v4l::buffer::Metadata,
+    }
+
+    impl ValidatedStream for RecoveryValidationFixture {
+        fn next_validated(
+            &mut self,
+        ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
+            self.calls.set(self.calls.get() + 1);
+            if self.fail_validation {
+                return Err(ValidatedDequeueError::Io(std::io::Error::other(
+                    "replacement validation failed",
+                )));
+            }
+            let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&self.metadata, 1)
+                .map_err(ValidatedDequeueError::Facts)?;
+            Ok((&self.payload, facts))
+        }
     }
 
     impl ValidatedStream for ContinuityFixture {
@@ -6800,6 +7634,54 @@ mod tests {
     }
 
     #[test]
+    fn recovered_stream_validates_before_continuity_epoch_installation() {
+        let calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        let fixture = |fail_validation| RecoveryValidationFixture {
+            payload: [1],
+            metadata: v4l::buffer::Metadata::default(),
+            calls: calls.clone(),
+            fail_validation,
+        };
+        let mut capture = TrackedStream::new(fixture(false));
+        capture.sequence.force_stream_epoch_overflow_on_recovery();
+        assert!(capture.take().is_some());
+        capture
+            .install_recovered(fixture(false))
+            .expect("replacement installation is lazy");
+        assert!(capture.next_discarded().is_err());
+        assert_eq!(calls.get(), 1, "replacement was not validated first");
+
+        let failed_calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        let mut validation_failure = TrackedStream::new(RecoveryValidationFixture {
+            payload: [1],
+            metadata: v4l::buffer::Metadata::default(),
+            calls: failed_calls.clone(),
+            fail_validation: false,
+        });
+        let sequence_state = validation_failure.sequence.continuity_state_for_test();
+        let timestamp_state = validation_failure.timestamp.continuity_state_for_test();
+        assert!(validation_failure.take().is_some());
+        validation_failure
+            .install_recovered(RecoveryValidationFixture {
+                payload: [1],
+                metadata: v4l::buffer::Metadata::default(),
+                calls: failed_calls.clone(),
+                fail_validation: true,
+            })
+            .expect("replacement installation is lazy");
+        assert!(validation_failure.next().is_err());
+        assert_eq!(failed_calls.get(), 1);
+        assert_eq!(
+            validation_failure.sequence.continuity_state_for_test(),
+            sequence_state
+        );
+        assert_eq!(
+            validation_failure.timestamp.continuity_state_for_test(),
+            timestamp_state
+        );
+    }
+
+    #[test]
     fn recovery_epoch_overflow_never_partially_publishes_state() {
         let fixture = || ContinuityFixture {
             payload: [1],
@@ -6811,8 +7693,11 @@ mod tests {
             .sequence
             .force_stream_epoch_overflow_on_recovery();
         assert!(sequence_failure.take().is_some());
-        assert!(sequence_failure.install_recovered(fixture()).is_err());
-        assert!(sequence_failure.stream_mut().is_none());
+        sequence_failure
+            .install_recovered(fixture())
+            .expect("replacement installation is lazy");
+        assert!(sequence_failure.next().is_err());
+        assert!(sequence_failure.stream_mut().is_some());
         assert!(sequence_failure.sequence.failed_for_test());
         assert!(!sequence_failure.timestamp.failed_for_test());
         assert_eq!(sequence_failure.timestamp.stream_epoch_for_test(), 0);
@@ -6822,8 +7707,11 @@ mod tests {
             .timestamp
             .force_stream_epoch_overflow_on_recovery();
         assert!(timestamp_failure.take().is_some());
-        assert!(timestamp_failure.install_recovered(fixture()).is_err());
-        assert!(timestamp_failure.stream_mut().is_none());
+        timestamp_failure
+            .install_recovered(fixture())
+            .expect("replacement installation is lazy");
+        assert!(timestamp_failure.next().is_err());
+        assert!(timestamp_failure.stream_mut().is_some());
         assert!(!timestamp_failure.sequence.failed_for_test());
         assert_eq!(timestamp_failure.sequence.stream_epoch_for_test(), 0);
         assert!(timestamp_failure.timestamp.failed_for_test());


### PR DESCRIPTION
## Summary

Refs #462.

Completes the stateful interval-negotiation slice without conflating configured kernel state with delivered-rate policy:

- reuses the exact same-fd frame-interval capability domain;
- performs one default-preserving raw `VIDIOC_S_PARM` after accepted `S_FMT`;
- stores exact reduced requested/accepted rationals;
- requires exact domain membership for default and adjusted responses;
- revalidates endpoint + full `G_FMT` + exact `G_PARM` before/after `REQBUFS` and after first successful dequeue;
- recovery performs zero `S_PARM`, uses immutable accepted state, and validates the replacement before continuity epoch installation or frame delivery.

No `Capture::set_params`, f64 FPS, schema, authentication policy, bandwidth policy, control, or emitter behavior changes. Delivered-rate enforcement remains the next bounded slice.

## Safety / TDD evidence

Three genuine behavioral REDs covered missing boundary ordering, missing factory enum/G/S/readback, and eager recovery epoch installation. All are GREEN.

17 compile-valid sabotage variants were killed and restored: omitted/extra S_PARM, four G_PARM boundaries, four G_FMT boundaries, one omitted full-format field, all three domain forms, stale recovery adoption, omitted first-dequeue snapshot, and eager recovery epoch installation.

An initial independent audit found the recovery epoch-order blocker. The corrected diff and final exact head both received independent GLM-5.2 SHIP verdicts with no blockers.

## Exact identity

- head: `072e36cccb6dbca0f6fc18745d5f550384ff7e6b`
- base: `e6bb3c52de9b06dc770906f66c9960dab57074fc`
- Phase-B signed commit: `7929bd0b5f768d70293996603952c7b45f0b5c46`
- final delta SHA-256: `25e2f536f8f2f1e1cd9eaea454e1f2f850080d7f542208d69c9f7d316dc80b08`

## Local gates

Exact head passed:

- `cargo fmt --all --check`
- strict all-target clippy with `-D warnings`
- workspace docs with `RUSTDOCFLAGS=-D warnings`
- release build
- 1,587 guarded workspace tests
- all 51 action pins
- clean diff/status

Camera package: 450 unit tests passed, 20 intentional hardware-only ignores, 12 contracts passed.

## Physical + stress matrix

Exact head, hardened runner, >=60 seconds, recovery exercised, durable evidence, services restored active, no holders:

| Host / device | Mode | Result | Frames | Observed rate |
|---|---:|---:|---:|---:|
| local ASUS FHD | RGB + IR | PASS | 883 / stream | 14.714 Hz |
| archhost Logitech BRIO | RGB-only measured policy | PASS | 1,024 | 17.052 Hz |
| minihost NexiGo N930W | RGB + IR | PASS | 1,716 / stream | 28.596 Hz |
| thinkpad Integrated Camera | RGB-only | PASS | 595 | 9.913 Hz |

Observed-rate policy is intentionally not enforced in this slice; these numeric windows feed the next delivered-rate slice.

## Exclusions

- delivered-rate windowing/enforcement and diagnostics
- f64/schema changes
- format-selection or bandwidth-policy changes
- camera control/emitter changes
