### PR TITLE
feat(camera): enforce delivered rate and expose diagnostics (#462)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -27,7 +27,7 @@ pub use irlume_camera::{capabilities, device_identity, select_pair};
 /// Enumerate the Hello camera pairs. Re-exported for the daemon's
 /// camera-class `ListCameras` arm: clients must not enumerate for themselves
 /// (#187), so this is the only path to a listing.
-pub use irlume_camera::{list_pairs, privacy_engaged, CameraPair};
+pub use irlume_camera::{camera_rate_diagnostics, list_pairs, privacy_engaged, CameraPair};
 
 /// Loaded models + camera device selection. Build once, reuse per request.
 pub struct Engine {

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -3147,10 +3147,20 @@ impl Engine {
                 // SAFETY: _cams is Some, and _rs/_is borrow from it. _cams is
                 // declared before _rs/_is so it outlives them.
                 let (ref cam_r, ref cam_i) = _cams.as_ref().unwrap();
-                if let (Ok(rs), Ok(is)) = (
+                if let (Ok(mut rs), Ok(mut is)) = (
                     cam_r.session_with_progress(&progress),
                     cam_i.session_with_progress(&progress),
                 ) {
+                    // Establish the delivered-rate windows for the HELD PAIR up
+                    // front, draining both streams concurrently. Best-effort: a
+                    // failure is logged, and the per-frame serial fill in
+                    // `next()` still re-attempts (and fails closed) on capture.
+                    if let Err(error) = irlume_camera::establish_pair_rate(&mut rs, &mut is) {
+                        irlume_common::dlog!(
+                            "auth: held pair could not establish delivered-rate evidence \
+                             ({error}); the per-frame fill will retry"
+                        );
+                    }
                     held_rgb = Some(rs);
                     held_ir = Some(is);
                 }
@@ -3782,6 +3792,16 @@ impl Engine {
                 r.session_with_progress(&progress),
                 i.session_with_progress(&progress),
             ) {
+                // Establish the delivered-rate windows for the HELD PAIR up
+                // front, draining both streams concurrently so neither starves
+                // the other's buffer queue. Best-effort: a failure is logged
+                // and the per-frame serial fill still re-attempts on capture.
+                if let Err(error) = irlume_camera::establish_pair_rate(&mut rs, &mut is) {
+                    irlume_common::dlog!(
+                        "enroll: held pair could not establish delivered-rate evidence \
+                         ({error}); the per-frame fill will retry"
+                    );
+                }
                 return self.capture_scan_loop(
                     want,
                     pitch_neutral,
@@ -3982,6 +4002,15 @@ impl Engine {
             Ok(pair) => pair,
             Err(_) => return false,
         };
+        // Establish the delivered-rate windows for the held pair before the
+        // A/B/A capture, so the serial fill cannot starve one stream and skew
+        // the concurrent mean it measures.
+        if let Err(error) = irlume_camera::establish_pair_rate(&mut rs, &mut is) {
+            irlume_common::dlog!(
+                "enroll: A/B/A check could not establish delivered-rate evidence \
+                 ({error}); the per-frame fill will retry"
+            );
+        }
         let (rgb, ir) = std::thread::scope(|scope| {
             let ir_thread = scope.spawn(|| is.capture_with_stats());
             let rgb = rs.denoised();

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -18,16 +18,16 @@ pub use irlume_camera::{
     no_progress, setup_ir_emitter, store_capture_mode, store_capture_mode_if_absent,
     stored_capture_mode, CaptureMode, ContentionReport, PairSample, Progress, StoreIfAbsent,
 };
+/// Enumerate the Hello camera pairs. Re-exported for the daemon's
+/// camera-class `ListCameras` arm: clients must not enumerate for themselves
+/// (#187), so this is the only path to a listing.
+pub use irlume_camera::{camera_rate_diagnostics, list_pairs, privacy_engaged, CameraPair};
 /// Auto-select the RGB+IR camera pair (built-in or external Hello webcam), plus
 /// the stable per-device identity the daemon records alongside a persisted pair
 /// so select_pair can survive a udev renumber. Re-exported so the daemon can pick
 /// devices without depending on the camera crate directly. See
 /// [`irlume_camera::select_pair`].
 pub use irlume_camera::{capabilities, device_identity, select_pair};
-/// Enumerate the Hello camera pairs. Re-exported for the daemon's
-/// camera-class `ListCameras` arm: clients must not enumerate for themselves
-/// (#187), so this is the only path to a listing.
-pub use irlume_camera::{camera_rate_diagnostics, list_pairs, privacy_engaged, CameraPair};
 
 /// Loaded models + camera device selection. Build once, reuse per request.
 pub struct Engine {

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -1544,6 +1544,14 @@ impl RuntimeFrameProvenance {
             Self::Aggregate(aggregate) => aggregate.contributors[0].format(),
         }
     }
+
+    #[must_use]
+    pub fn rate_evidence(&self) -> DeliveredRateEvidence {
+        match self {
+            Self::Single(single) => single.rate_evidence(),
+            Self::Aggregate(aggregate) => aggregate.rate_evidence(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -1470,7 +1470,7 @@ impl AggregateFrameProvenance {
     /// # Panics
     ///
     /// Panics if the aggregate has no contributors, which is unreachable:
-    /// [`AggregateFrameProvenance::new`] requires at least two.
+    /// construction requires at least two contributors.
     #[must_use]
     pub fn rate_evidence(&self) -> DeliveredRateEvidence {
         self.contributors

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -2163,6 +2163,7 @@ mod tests {
             )
             .expect("valid timestamp");
         let at = std::time::Instant::now();
+        let rate_evidence = test_rate_evidence(&sequence, &timestamp);
 
         let provenance = super::SingleFrameProvenance::begin(
             binding.clone(),
@@ -2171,6 +2172,7 @@ mod tests {
             sequence,
             timestamp,
             CaptureWindow::at(at),
+            rate_evidence,
         )
         .expect("coherent evidence")
         .finalize_illumination(IlluminationProvenance::ActiveIr)
@@ -2234,6 +2236,7 @@ mod tests {
                     )
                     .expect("valid test timestamp");
                 let at = base + Duration::from_micros(micros.unsigned_abs());
+                let rate_evidence = test_rate_evidence(&sequence, &timestamp);
                 super::SingleFrameProvenance::begin(
                     binding.clone(),
                     format.clone(),
@@ -2241,12 +2244,34 @@ mod tests {
                     sequence,
                     timestamp,
                     CaptureWindow::at(at),
+                    rate_evidence,
                 )
                 .expect("coherent test evidence")
                 .finalize_illumination(illumination)
                 .expect("coherent test illumination")
             })
             .collect()
+    }
+
+    /// A fixed, exact rate-evidence value for provenance tests that only assert
+    /// binding/format/domain invariants; the rate fields are irrelevant to them.
+    fn test_rate_evidence(
+        sequence: &super::SequenceObservation,
+        timestamp: &super::TimestampObservation,
+    ) -> super::DeliveredRateEvidence {
+        super::DeliveredRateEvidence::new(
+            crate::contracts::StreamRole::Ir,
+            (1, 15),
+            (1, 15),
+            (15, 1),
+            98,
+            30,
+            2_000_000,
+            (15, 1),
+            true,
+            sequence,
+            timestamp,
+        )
     }
 
     #[test]
@@ -2278,6 +2303,7 @@ mod tests {
             .pop()
             .expect("one single");
         single.facts.sequence_raw = 10;
+        let rate_evidence = test_rate_evidence(&single.sequence, &single.timestamp);
         assert_eq!(
             super::SingleFrameProvenance::begin(
                 single.binding,
@@ -2286,6 +2312,7 @@ mod tests {
                 single.sequence,
                 single.timestamp,
                 single.capture_window,
+                rate_evidence,
             ),
             Err(super::RuntimeProvenanceError::FactsSequenceMismatch)
         );
@@ -2297,6 +2324,7 @@ mod tests {
             .pop()
             .expect("one single");
         single.facts.timestamp_micros += 1;
+        let rate_evidence = test_rate_evidence(&single.sequence, &single.timestamp);
         assert_eq!(
             super::SingleFrameProvenance::begin(
                 single.binding,
@@ -2305,6 +2333,7 @@ mod tests {
                 single.sequence,
                 single.timestamp,
                 single.capture_window,
+                rate_evidence,
             ),
             Err(super::RuntimeProvenanceError::FactsTimestampMismatch)
         );
@@ -2316,6 +2345,7 @@ mod tests {
             .pop()
             .expect("one single");
         corrupt.facts.known_flags |= v4l::buffer::Flags::ERROR.bits();
+        let rate_evidence = test_rate_evidence(&corrupt.sequence, &corrupt.timestamp);
         assert_eq!(
             super::SingleFrameProvenance::begin(
                 corrupt.binding.clone(),
@@ -2324,6 +2354,7 @@ mod tests {
                 corrupt.sequence,
                 corrupt.timestamp,
                 corrupt.capture_window,
+                rate_evidence,
             ),
             Err(super::RuntimeProvenanceError::DriverReportedCorruption)
         );
@@ -2340,6 +2371,7 @@ mod tests {
                     start: corrupt.capture_window.start,
                     end,
                 },
+                rate_evidence,
             ),
             Err(super::RuntimeProvenanceError::SingleWindowMustBePoint)
         );
@@ -2351,6 +2383,7 @@ mod tests {
             .pop()
             .expect("one single");
         single.binding.stream_role = crate::contracts::StreamRole::Rgb;
+        let rate_evidence = test_rate_evidence(&single.sequence, &single.timestamp);
         let pending = super::SingleFrameProvenance::begin(
             single.binding,
             single.format,
@@ -2358,6 +2391,7 @@ mod tests {
             single.sequence,
             single.timestamp,
             single.capture_window,
+            rate_evidence,
         )
         .expect("otherwise coherent");
         assert_eq!(

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -928,6 +928,7 @@ pub enum RuntimeProvenanceError {
     FactsSequenceMismatch,
     FactsTimestampMismatch,
     ContinuityMismatch,
+    RateEvidenceMismatch,
     DriverReportedCorruption,
     SingleWindowMustBePoint,
     ActiveIrRequiresIrStream,
@@ -954,6 +955,7 @@ impl std::fmt::Display for RuntimeProvenanceError {
             Self::FactsSequenceMismatch => "dequeue facts and sequence observation disagree",
             Self::FactsTimestampMismatch => "dequeue facts and timestamp observation disagree",
             Self::ContinuityMismatch => "sequence and timestamp continuity disagree",
+            Self::RateEvidenceMismatch => "delivered-rate evidence disagrees with its timestamp",
             Self::DriverReportedCorruption => "V4L2 marked a provenance contributor corrupt",
             Self::SingleWindowMustBePoint => "single-frame capture window is not a point",
             Self::ActiveIrRequiresIrStream => "active-IR evidence requires an IR stream",
@@ -989,6 +991,150 @@ pub(crate) struct PendingSingleFrameProvenance {
     sequence: SequenceObservation,
     timestamp: TimestampObservation,
     capture_window: CaptureWindow,
+    rate_evidence: DeliveredRateEvidence,
+}
+
+/// Immutable delivered-rate evidence attached to one delivered dequeue.
+///
+/// Constructed from the same [`TimestampObservation`] and
+/// [`SequenceObservation`] that the frame carries, so clock/source/epoch/latest
+/// timestamp are consistent by construction. The delivered rate and floor
+/// verdict are exact reduced integers computed by the rate window.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeliveredRateEvidence {
+    role: StreamRole,
+    requested_num: u32,
+    requested_den: u32,
+    accepted_num: u32,
+    accepted_den: u32,
+    floor_num: u32,
+    floor_den: u32,
+    tolerance_percent: u32,
+    window_count: u32,
+    window_span_us: u64,
+    delivered_num: u64,
+    delivered_den: u64,
+    meets_floor: bool,
+    sequence_gap: u32,
+    cumulative_drops: u64,
+    clock: TimestampClock,
+    source: TimestampSource,
+    latest_timestamp_us: i64,
+    stream_epoch: u64,
+}
+
+impl DeliveredRateEvidence {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        role: StreamRole,
+        requested: (u32, u32),
+        accepted: (u32, u32),
+        floor: (u32, u32),
+        tolerance_percent: u32,
+        window_count: u32,
+        window_span_us: u64,
+        delivered: (u64, u64),
+        meets_floor: bool,
+        sequence: &SequenceObservation,
+        timestamp: &TimestampObservation,
+    ) -> Self {
+        Self {
+            role,
+            requested_num: requested.0,
+            requested_den: requested.1,
+            accepted_num: accepted.0,
+            accepted_den: accepted.1,
+            floor_num: floor.0,
+            floor_den: floor.1,
+            tolerance_percent,
+            window_count,
+            window_span_us,
+            delivered_num: delivered.0,
+            delivered_den: delivered.1,
+            meets_floor,
+            sequence_gap: sequence.gap(),
+            cumulative_drops: sequence.cumulative_drops(),
+            clock: timestamp.clock(),
+            source: timestamp.source(),
+            latest_timestamp_us: timestamp.micros(),
+            stream_epoch: timestamp.stream_epoch(),
+        }
+    }
+
+    #[must_use]
+    pub const fn role(&self) -> StreamRole {
+        self.role
+    }
+
+    #[must_use]
+    pub const fn requested(&self) -> (u32, u32) {
+        (self.requested_num, self.requested_den)
+    }
+
+    #[must_use]
+    pub const fn accepted(&self) -> (u32, u32) {
+        (self.accepted_num, self.accepted_den)
+    }
+
+    #[must_use]
+    pub const fn floor(&self) -> (u32, u32) {
+        (self.floor_num, self.floor_den)
+    }
+
+    #[must_use]
+    pub const fn tolerance_percent(&self) -> u32 {
+        self.tolerance_percent
+    }
+
+    #[must_use]
+    pub const fn window_count(&self) -> u32 {
+        self.window_count
+    }
+
+    #[must_use]
+    pub const fn window_span_us(&self) -> u64 {
+        self.window_span_us
+    }
+
+    #[must_use]
+    pub const fn delivered(&self) -> (u64, u64) {
+        (self.delivered_num, self.delivered_den)
+    }
+
+    #[must_use]
+    pub const fn meets_floor(&self) -> bool {
+        self.meets_floor
+    }
+
+    #[must_use]
+    pub const fn sequence_gap(&self) -> u32 {
+        self.sequence_gap
+    }
+
+    #[must_use]
+    pub const fn cumulative_drops(&self) -> u64 {
+        self.cumulative_drops
+    }
+
+    #[must_use]
+    pub const fn clock(&self) -> TimestampClock {
+        self.clock
+    }
+
+    #[must_use]
+    pub const fn source(&self) -> TimestampSource {
+        self.source
+    }
+
+    #[must_use]
+    pub const fn latest_timestamp_us(&self) -> i64 {
+        self.latest_timestamp_us
+    }
+
+    #[must_use]
+    pub const fn stream_epoch(&self) -> u64 {
+        self.stream_epoch
+    }
 }
 
 /// Complete trusted runtime evidence for one delivered dequeue.
@@ -1001,9 +1147,11 @@ pub struct SingleFrameProvenance {
     timestamp: TimestampObservation,
     capture_window: CaptureWindow,
     illumination: IlluminationProvenance,
+    rate_evidence: DeliveredRateEvidence,
 }
 
 impl SingleFrameProvenance {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn begin(
         binding: FrameBinding,
         format: ValidatedFormatIdentity,
@@ -1011,6 +1159,7 @@ impl SingleFrameProvenance {
         sequence: SequenceObservation,
         timestamp: TimestampObservation,
         capture_window: CaptureWindow,
+        rate_evidence: DeliveredRateEvidence,
     ) -> Result<PendingSingleFrameProvenance, RuntimeProvenanceError> {
         if facts.sequence_raw() != sequence.raw() {
             return Err(RuntimeProvenanceError::FactsSequenceMismatch);
@@ -1026,6 +1175,13 @@ impl SingleFrameProvenance {
         {
             return Err(RuntimeProvenanceError::ContinuityMismatch);
         }
+        if rate_evidence.clock() != timestamp.clock()
+            || rate_evidence.source() != timestamp.source()
+            || rate_evidence.stream_epoch() != timestamp.stream_epoch()
+            || rate_evidence.latest_timestamp_us() != timestamp.micros()
+        {
+            return Err(RuntimeProvenanceError::RateEvidenceMismatch);
+        }
         if facts.driver_reported_corruption() {
             return Err(RuntimeProvenanceError::DriverReportedCorruption);
         }
@@ -1039,6 +1195,7 @@ impl SingleFrameProvenance {
             sequence,
             timestamp,
             capture_window,
+            rate_evidence,
         })
     }
 
@@ -1076,6 +1233,11 @@ impl SingleFrameProvenance {
     pub const fn illumination(&self) -> IlluminationProvenance {
         self.illumination
     }
+
+    #[must_use]
+    pub const fn rate_evidence(&self) -> DeliveredRateEvidence {
+        self.rate_evidence
+    }
 }
 
 impl PendingSingleFrameProvenance {
@@ -1096,6 +1258,7 @@ impl PendingSingleFrameProvenance {
             timestamp: self.timestamp,
             capture_window: self.capture_window,
             illumination,
+            rate_evidence: self.rate_evidence,
         })
     }
 }
@@ -1298,6 +1461,17 @@ impl AggregateFrameProvenance {
     #[must_use]
     pub const fn illumination(&self) -> IlluminationProvenance {
         self.illumination
+    }
+
+    /// The last contributor's delivered-rate evidence. Only reachable after the
+    /// aggregate's binding/format/domain/epoch invariants all pass, so the
+    /// evidence cannot be stale or cross-domain.
+    #[must_use]
+    pub fn rate_evidence(&self) -> DeliveredRateEvidence {
+        self.contributors
+            .last()
+            .expect("aggregate has contributors")
+            .rate_evidence()
     }
 
     #[must_use]

--- a/crates/irlume-camera/src/frame_provenance.rs
+++ b/crates/irlume-camera/src/frame_provenance.rs
@@ -1466,6 +1466,11 @@ impl AggregateFrameProvenance {
     /// The last contributor's delivered-rate evidence. Only reachable after the
     /// aggregate's binding/format/domain/epoch invariants all pass, so the
     /// evidence cannot be stale or cross-domain.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the aggregate has no contributors, which is unreachable:
+    /// [`AggregateFrameProvenance::new`] requires at least two.
     #[must_use]
     pub fn rate_evidence(&self) -> DeliveredRateEvidence {
         self.contributors

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1354,7 +1354,7 @@ impl<S> TrackedStream<S> {
             stream: Some(stream),
             sequence: frame_provenance::SequenceTracker::new(),
             timestamp: frame_provenance::TimestampTracker::new(),
-            rate_window: rate_gate::RateWindow::new(),
+            rate_window: rate_gate::RateWindow::with_capacity(rate_config.policy().window()),
             rate_config,
             observations: 0,
             discarded_observations: 0,
@@ -6485,10 +6485,14 @@ mod tests {
     use super::*;
 
     fn test_rate_config(role: contracts::StreamRole) -> rate_gate::StreamRateConfig {
-        rate_gate::StreamRateConfig::new(
+        // Zero window: a "no gate" config for continuity/provenance fixtures so
+        // the 30-delta delivered-rate fill does not consume the frames those
+        // tests observe. Rate gating is exercised in rate_gate's own unit tests.
+        rate_gate::StreamRateConfig::with_window(
             role,
             frame_interval::FrameInterval::new(1, 15).expect("1/15"),
             frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+            0,
         )
     }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1340,8 +1340,8 @@ fn rate_evidence_to_common(
 }
 
 /// Maximum additional dequeue attempts for the bounded rate-evidence fill in
-/// [`TrackedStream::next`]. Nominal is 30 successful dequeues (~2 s at 15 fps);
-/// 64 gives >2x headroom for timeouts and corrupt frames.
+/// [`TrackedStream::next`]. Nominal is 31 successful dequeues (one seed plus
+/// 30 deltas, ~2 s at 15 fps); 64 gives >2x headroom for timeouts and corrupt frames.
 const MAX_RATE_FILL_ATTEMPTS: usize = 64;
 
 /// Frames discarded before the rate window is measured. The first window after
@@ -1403,6 +1403,16 @@ impl<S> TrackedStream<S> {
         }
         self.stream = Some(stream);
         self.recovery_epoch_pending = true;
+        // Drop the pre-recovery rate window immediately. The recovered stream
+        // has its own STREAMON transient and its timestamps may move to a new
+        // domain (the recovery epoch resets both trackers), so a stale "ready"
+        // window would make `fill_rate_evidence` early-return and skip the
+        // re-establishment — leaving the recovered stream to re-fill serially
+        // on its first `next()` and starve its twin (measured: RGB 5.26 fps,
+        // 236 drops after an IR-only recovery). Clearing it here forces the
+        // fill to re-run, which is where `begin_recovered_continuity_epoch`
+        // then re-seeds the baseline in the new epoch.
+        self.rate_window.reset();
         Ok(())
     }
 }
@@ -1719,6 +1729,93 @@ impl<S: ValidatedStream> TrackedStream<S> {
             rate_evidence,
         ))
     }
+}
+
+/// Establish the delivered-rate window for TWO streams by filling each one on
+/// its own thread, so the two fills run CONCURRENTLY rather than one after the
+/// other.
+///
+/// A single-threaded round-robin throttles the faster stream to the slower
+/// stream's rate: on the ASUS dual the RGB stream runs 30 fps and IR 15 fps,
+/// so a round-robin dequeues RGB at 15 fps, its V4L2 buffer overflows, and the
+/// shared-USB contention drops IR frames, pushing IR's measured rate below the
+/// floor (measured 14.5 Hz vs the 14.7 Hz floor). The 98 % tolerance was
+/// calibrated against a CONCURRENT probe measuring 14.714 Hz (see
+/// `DEFAULT_TOLERANCE_PERCENT`), so the fill must be concurrent — the same
+/// schedule production uses. Each stream's own serial fill is naturally paced
+/// by its frame arrival (a blocking DQBUF cannot outrun the camera), so two
+/// threads filling in parallel cannot starve each other the way one thread
+/// alternating between them does.
+///
+/// After this returns, each stream's `next()` sees a ready window and its own
+/// fill no-ops, so the capture loop measures only the settled rate.
+fn establish_concurrent_rate<A: ValidatedStream + Send, B: ValidatedStream + Send>(
+    primary: &mut TrackedStream<A>,
+    secondary: &mut TrackedStream<B>,
+) -> std::io::Result<()> {
+    if primary.rate_window.ready() && secondary.rate_window.ready() {
+        return Ok(());
+    }
+    let ready_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    std::thread::scope(|scope| {
+        let a = {
+            let count = std::sync::Arc::clone(&ready_count);
+            scope.spawn(move || drain_until_both_ready(primary, &count))
+        };
+        let b = {
+            let count = std::sync::Arc::clone(&ready_count);
+            scope.spawn(move || drain_until_both_ready(secondary, &count))
+        };
+        // A panic in a fill thread is a software defect, never a camera
+        // verdict: re-raise it (mirrors the capture-mode probe's rule, #263).
+        let a = a
+            .join()
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload));
+        let b = b
+            .join()
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload));
+        a?;
+        b?;
+        Ok(())
+    })
+}
+
+/// Fill one stream's delivered-rate window and keep discarding until BOTH
+/// streams are ready. The trailing discards are the point: the faster stream
+/// finishes its own fill first, and if it stopped there it would sit idle
+/// overflowing its V4L2 queue (dropping frames) while the slower twin finishes.
+/// Those dropped frames showed up as a >1 s timestamp gap on the next delivered
+/// frame, tripping the continuity ceiling. So once this stream is ready it
+/// keeps dequeuing (the window merely slides) until the other reports ready.
+fn drain_until_both_ready<S: ValidatedStream>(
+    stream: &mut TrackedStream<S>,
+    ready_count: &std::sync::atomic::AtomicUsize,
+) -> std::io::Result<()> {
+    use std::sync::atomic::Ordering;
+    // Flush the STREAMON transient; its sequence gaps would poison the window.
+    for _ in 0..RATE_STARTUP_FLUSH {
+        stream.next_discarded()?;
+    }
+    stream.rate_window.reset();
+    let mut reported = false;
+    let mut attempts = 0usize;
+    // Fill (bounded) plus the trailing drain while the twin finishes, itself
+    // bounded by the twin's worst-case fill.
+    let budget = MAX_RATE_FILL_ATTEMPTS + MAX_RATE_FILL_ATTEMPTS;
+    while ready_count.load(Ordering::Acquire) < 2 && attempts < budget {
+        stream.next_discarded()?;
+        if !reported && stream.rate_window.ready() {
+            ready_count.fetch_add(1, Ordering::AcqRel);
+            reported = true;
+        }
+        attempts += 1;
+    }
+    if !stream.rate_window.ready() {
+        return Err(std::io::Error::other(
+            "could not establish delivered-rate evidence within the bounded fill",
+        ));
+    }
+    Ok(())
 }
 
 fn install_recovered_resources<S, M, G, E>(
@@ -4767,6 +4864,25 @@ impl IrSession<'_> {
     }
 }
 
+/// Establish the delivered-rate evidence for a held RGB+IR pair by draining
+/// both streams concurrently until each holds a full window. See the
+/// module-level concurrent fill for why the fill must not be serial.
+///
+/// Called once per held session, before the capture loop, so the per-frame
+/// `next()` fills no-op on a ready window. Best-effort by contract: a failure
+/// is reported so the caller can log it, but the session stays usable — the
+/// per-stream serial fill in `next()` re-attempts establishment (and fails
+/// closed) on the first capture, preserving the existing error/retry shape.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+pub fn establish_pair_rate(
+    rgb: &mut RgbSession<'_>,
+    ir: &mut IrSession<'_>,
+) -> irlume_common::Result<()> {
+    let device = rgb.cam.device.clone();
+    establish_concurrent_rate(&mut rgb.stream, &mut ir.stream)
+        .map_err(|error| map_io(&device, error))
+}
+
 /// Ambient-subtraction helpers (Windows-Hello-style illuminated minus ambient).
 /// `subtract` is used by `capture_ir` when `IRLUME_IR_AMBIENT_SUBTRACT=1`
 /// (experimental, off by default); `capture_raw_burst`/`center_border_ratio`
@@ -5809,6 +5925,15 @@ fn held_concurrent_arm<'d>(
                 return Ok(());
             }
         };
+        // Establish the delivered-rate windows before measuring, draining both
+        // streams concurrently so the serial fill cannot starve one and skew
+        // the concurrent brightness this probe exists to measure.
+        if let Err(error) = establish_pair_rate(&mut rs, &mut is) {
+            irlume_common::dlog!(
+                "capture-mode probe: could not establish delivered-rate evidence \
+                 ({error}); the per-frame fill will retry"
+            );
+        }
         for _ in 0..rounds {
             progress();
             let t0 = std::time::Instant::now();
@@ -10603,6 +10728,27 @@ mod tests {
             .transpose()
             .expect("open IR session");
         rgb_session.warm_up().expect("initial RGB warm-up");
+        // Establish the delivered-rate windows for the held pair UP FRONT by
+        // draining both streams concurrently, exactly as the production held
+        // session does before its capture loop. The loop below runs RGB and IR
+        // concurrently too, but the FIRST `next()` on each stream would
+        // otherwise run the serial fill (30 flush + 30 fill) and starve the
+        // twin's V4L2 queue into dropping frames, so the twin's own fill then
+        // measures a false low rate (ping-pong starvation, measured on the ASUS
+        // dual). Establishing both windows first makes every loop `next()`
+        // no-op its fill and measure only the settled rate.
+        if let Some(ir) = ir_session.as_mut() {
+            establish_pair_rate(&mut rgb_session, ir).expect("establish initial pair rate");
+        } else {
+            // RGB-only: establish the single window up front too, so the first
+            // next() does not run a lazy serial fill inside the loop (which
+            // would shift the first delivered frame's timestamp ~5 s and make
+            // the global timestamp span undershoot the measured duration).
+            rgb_session
+                .stream
+                .fill_rate_evidence()
+                .expect("establish initial RGB rate");
+        }
         let started = std::time::Instant::now();
         let deadline = started + std::time::Duration::from_secs(seconds);
         let recovery_at = started + std::time::Duration::from_secs(seconds / 2);
@@ -10613,25 +10759,44 @@ mod tests {
         let mut expect_rgb_discontinuity = false;
         let mut expect_ir_discontinuity = false;
         while std::time::Instant::now() < deadline {
-            let (_, _, sequence, timestamp, _) =
-                rgb_session.stream.next().expect("RGB tracked dequeue");
+            // Concurrent capture, matching production's schedule: IR dequeues
+            // on a worker thread while RGB dequeues on this thread. A
+            // single-threaded round-robin throttles the 30 fps RGB stream to
+            // the 15 fps IR rate, overflowing RGB's queue and dropping IR
+            // frames (measured 14.5 vs 14.7 Hz), so the loop must run both
+            // streams concurrently rather than alternately.
+            let ((rgb_sequence, rgb_timestamp), ir_obs) = std::thread::scope(|scope| {
+                let ir_thread = ir_session.as_mut().map(|session| {
+                    scope.spawn(move || {
+                        let (_, _, sequence, timestamp, _) =
+                            session.stream.next().expect("IR tracked dequeue");
+                        if let Some(log) = session.meta.as_mut() {
+                            log.begin_burst();
+                            log.drain();
+                        }
+                        (sequence, timestamp)
+                    })
+                });
+                let (_, _, rgb_sequence, rgb_timestamp, _) =
+                    rgb_session.stream.next().expect("RGB tracked dequeue");
+                let ir_obs = ir_thread.map(|handle| {
+                    handle
+                        .join()
+                        .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+                });
+                ((rgb_sequence, rgb_timestamp), ir_obs)
+            });
             if expect_rgb_discontinuity {
-                assert!(sequence.discontinuity(), "RGB recovery marker missing");
+                assert!(rgb_sequence.discontinuity(), "RGB recovery marker missing");
                 expect_rgb_discontinuity = false;
             }
-            rgb_stats.record(sequence, timestamp);
-            if let Some(session) = &mut ir_session {
-                let (_, _, sequence, timestamp, _) =
-                    session.stream.next().expect("IR tracked dequeue");
-                if let Some(log) = session.meta.as_mut() {
-                    log.begin_burst();
-                    log.drain();
-                }
+            rgb_stats.record(rgb_sequence, rgb_timestamp);
+            if let Some((ir_sequence, ir_timestamp)) = ir_obs {
                 if expect_ir_discontinuity {
-                    assert!(sequence.discontinuity(), "IR recovery marker missing");
+                    assert!(ir_sequence.discontinuity(), "IR recovery marker missing");
                     expect_ir_discontinuity = false;
                 }
-                ir_stats.record(sequence, timestamp);
+                ir_stats.record(ir_sequence, ir_timestamp);
             }
             if !recovered && std::time::Instant::now() >= recovery_at {
                 let recovery_started = std::time::Instant::now();
@@ -10642,6 +10807,27 @@ mod tests {
                     session.recover().expect("IR recovery");
                     expect_ir_discontinuity = true;
                 }
+                // Re-establish the delivered-rate window(s) up front so the
+                // first post-recovery next() does not add a serial-fill gap
+                // outside the measured recovery duration: concurrently for the
+                // dual pair, serially for an RGB-only camera (single stream,
+                // nothing to starve). The recovery discontinuity markers
+                // survive these discarded dequeues (both trackers re-arm the
+                // pending marker on a discarded observation), so the assertions
+                // above still see them on the next delivered frame.
+                if let Some(ir) = ir_session.as_mut() {
+                    establish_pair_rate(&mut rgb_session, ir)
+                        .expect("re-establish pair rate after recovery");
+                } else {
+                    rgb_session
+                        .stream
+                        .fill_rate_evidence()
+                        .expect("re-establish RGB rate after recovery");
+                }
+                // The recovery duration spans teardown, re-arm, AND the rate
+                // re-establishment, so it matches the timestamp gap the
+                // evidence records between the last pre-recovery and first
+                // post-recovery delivered frame.
                 recovery_duration = Some(recovery_started.elapsed());
                 recovered = true;
             }
@@ -11427,6 +11613,98 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn concurrent_rate_fill_drains_both_streams_in_parallel() {
+        // The fill must drive both streams on two threads SIMULTANEOUSLY. A
+        // serial (round-robin) fill throttles the faster stream to the slower
+        // one's rate, overflowing its V4L2 queue and dropping frames (measured
+        // on the ASUS dual: RGB 30 fps, IR 15 fps). Each fixture rendezvouses
+        // on a barrier on its FIRST dequeue: concurrent threads both arrive and
+        // pass; a serial fill deadlocks on it, which the watchdog below turns
+        // into a clean failure instead of a hung test.
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+        struct RendezvousFixture {
+            payload: [u8; 1],
+            first: bool,
+            next_sequence: u32,
+            next_seconds: i64,
+            barrier: std::sync::Arc<std::sync::Barrier>,
+        }
+
+        impl ValidatedStream for RendezvousFixture {
+            fn next_validated(
+                &mut self,
+            ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>
+            {
+                if self.first {
+                    self.first = false;
+                    self.barrier.wait();
+                }
+                let metadata = v4l::buffer::Metadata {
+                    bytesused: 1,
+                    sequence: self.next_sequence,
+                    flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                    timestamp: v4l::timestamp::Timestamp::new(self.next_seconds, 0),
+                    ..v4l::buffer::Metadata::default()
+                };
+                self.next_sequence += 1;
+                self.next_seconds += 1;
+                let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, 1)
+                    .map_err(ValidatedDequeueError::Facts)?;
+                Ok((&self.payload, facts))
+            }
+        }
+
+        let small = |role| {
+            rate_gate::StreamRateConfig::with_window(
+                role,
+                frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+                frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+                4,
+            )
+        };
+        let mut rgb = TrackedStream::new(
+            RendezvousFixture {
+                payload: [1],
+                first: true,
+                next_sequence: 1,
+                next_seconds: 1,
+                barrier: barrier.clone(),
+            },
+            small(contracts::StreamRole::Rgb),
+        );
+        let mut ir = TrackedStream::new(
+            RendezvousFixture {
+                payload: [2],
+                first: true,
+                next_sequence: 1,
+                next_seconds: 1,
+                barrier: barrier.clone(),
+            },
+            small(contracts::StreamRole::Ir),
+        );
+
+        let (done, ready) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = establish_concurrent_rate(&mut rgb, &mut ir);
+            let _ = done.send(result.map(|()| (rgb.rate_window.ready(), ir.rate_window.ready())));
+        });
+        match ready.recv_timeout(std::time::Duration::from_secs(10)) {
+            Ok(Ok((rgb_ready, ir_ready))) => {
+                assert!(rgb_ready, "rgb window must be ready");
+                assert!(ir_ready, "ir window must be ready");
+            }
+            Ok(Err(error)) => panic!("concurrent fill errored: {error}"),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                panic!("concurrent fill deadlocked (serial fill stuck on the rendezvous)")
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("concurrent fill thread panicked")
+            }
+        }
     }
 }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1642,13 +1642,8 @@ impl<S: ValidatedStream> TrackedStream<S> {
                 return Err(DeliveryError::Io(error.into_io()));
             }
         };
-        begin_recovered_continuity_epoch(
-            recovery_epoch_pending,
-            sequence,
-            timestamp,
-            rate_window,
-        )
-        .map_err(DeliveryError::Io)?;
+        begin_recovered_continuity_epoch(recovery_epoch_pending, sequence, timestamp, rate_window)
+            .map_err(DeliveryError::Io)?;
         let (sequence_observation, timestamp_observation) = observe_continuity_facts(
             sequence,
             timestamp,
@@ -2883,6 +2878,90 @@ pub fn list_pairs() -> Vec<CameraPair> {
     backend::list_pairs()
 }
 
+/// Run one bounded, gated diagnostic capture on an RGB node and return the
+/// exact delivered-rate evidence. The gated session fills its rolling window
+/// before the first delivery, so a single requested frame carries a complete
+/// 30-delta measurement; a stream that cannot fill it fails closed.
+fn diagnose_rgb_rate(
+    device: &str,
+) -> irlume_common::Result<irlume_common::CameraStreamRateEvidence> {
+    let camera = RgbCamera::open(device)?;
+    let mut session = camera.session()?;
+    let frames = session.burst(1)?;
+    let frame = frames
+        .first()
+        .ok_or_else(|| Error::Hardware("diagnostic captured no frame".into()))?;
+    let evidence = frame.provenance().rate_evidence();
+    Ok(rate_evidence_to_common(&evidence))
+}
+
+/// One bounded, gated diagnostic capture on an IR node.
+fn diagnose_ir_rate(
+    device: &str,
+) -> irlume_common::Result<irlume_common::CameraStreamRateEvidence> {
+    let camera = IrCamera::open(device)?;
+    let mut session = camera.session()?;
+    let (frame, _stats) = session.capture_with_stats()?;
+    let evidence = frame.provenance().rate_evidence();
+    Ok(rate_evidence_to_common(&evidence))
+}
+
+fn role_diagnostic(
+    known: bool,
+    result: irlume_common::Result<irlume_common::CameraStreamRateEvidence>,
+) -> irlume_common::CameraRoleDiagnostic {
+    match result {
+        Ok(evidence) => irlume_common::CameraRoleDiagnostic {
+            known,
+            state: if evidence.meets_floor {
+                "measured"
+            } else {
+                "fail"
+            }
+            .into(),
+            evidence: Some(evidence),
+        },
+        Err(_) => irlume_common::CameraRoleDiagnostic {
+            known,
+            state: "unknown".into(),
+            evidence: None,
+        },
+    }
+}
+
+/// Machine-readable delivered-rate diagnostics for a camera pair (issue #462).
+///
+/// Runs the ordinary gated capture session per present role and reports the
+/// measured evidence: an under-rate stream is a measured `fail`, never
+/// degraded to prose. `ir` is `None` on an RGB-only device. No device path,
+/// account identity, or template data is exposed.
+pub fn camera_rate_diagnostics(
+    rgb: &str,
+    ir: Option<&str>,
+) -> irlume_common::Result<irlume_common::CameraDiagnosticsReport> {
+    let rgb_diag = role_diagnostic(true, diagnose_rgb_rate(rgb));
+    let ir_diag = match ir {
+        Some(node) => role_diagnostic(true, diagnose_ir_rate(node)),
+        None => irlume_common::CameraRoleDiagnostic {
+            known: false,
+            state: "missing".into(),
+            evidence: None,
+        },
+    };
+    let skew_us = match (&rgb_diag.evidence, &ir_diag.evidence) {
+        (Some(r), Some(i)) if r.clock == i.clock && r.source == i.source => {
+            Some(i.latest_timestamp_us - r.latest_timestamp_us)
+        }
+        _ => None,
+    };
+    Ok(irlume_common::CameraDiagnosticsReport {
+        rgb: rgb_diag,
+        ir: ir_diag,
+        skew_us,
+        capture_strategy: "burst".into(),
+    })
+}
+
 fn uvc_list_pairs() -> Vec<CameraPair> {
     let mut groups: std::collections::BTreeMap<std::path::PathBuf, (Vec<String>, Vec<String>)> =
         Default::default();
@@ -3401,8 +3480,10 @@ impl<'a> RgbSession<'a> {
                 .lease
                 .require_endpoint(&device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, facts, sequence, timestamp, rate_evidence) =
-                self.stream.next().map_err(|error| map_delivery(&device, error))?;
+            let (buf, facts, sequence, timestamp, rate_evidence) = self
+                .stream
+                .next()
+                .map_err(|error| map_delivery(&device, error))?;
             let taken = std::time::Instant::now();
             let data = match &chosen {
                 b"NV12" => nv12_to_rgb(buf, w, h),
@@ -7353,10 +7434,13 @@ mod tests {
             timestamp: v4l::timestamp::Timestamp::new(2, 0),
             ..v4l::buffer::Metadata::default()
         };
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata,
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata,
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.observations = u64::MAX;
         let sequence_state = capture.sequence.continuity_state_for_test();
         let timestamp_state = capture.timestamp.continuity_state_for_test();
@@ -7449,10 +7533,13 @@ mod tests {
         let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
         let corrupt = continuity_metadata(1, 1, monotonic | v4l::buffer::Flags::ERROR);
         let valid = continuity_metadata(2, 2, monotonic);
-        let mut tracked = TrackedStream::new(QueuedContinuityFixture {
-            payload: [7],
-            metadata: [corrupt, valid].into(),
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut tracked = TrackedStream::new(
+            QueuedContinuityFixture {
+                payload: [7],
+                metadata: [corrupt, valid].into(),
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
 
         warm_up_with(
             "fixture",
@@ -7477,10 +7564,13 @@ mod tests {
         let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
         let corrupt = continuity_metadata(10, 10, monotonic | v4l::buffer::Flags::ERROR);
         let valid = continuity_metadata(11, 11, monotonic);
-        let mut tracked = TrackedStream::new(QueuedContinuityFixture {
-            payload: [9],
-            metadata: [corrupt, valid].into(),
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut tracked = TrackedStream::new(
+            QueuedContinuityFixture {
+                payload: [9],
+                metadata: [corrupt, valid].into(),
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
 
         let error = tracked
             .next()
@@ -7505,10 +7595,13 @@ mod tests {
             ..continuity_metadata(1, 1, monotonic | v4l::buffer::Flags::ERROR)
         };
         let valid = continuity_metadata(2, 2, monotonic);
-        let mut tracked = TrackedStream::new(QueuedContinuityFixture {
-            payload: [3],
-            metadata: [corrupt_invalid, valid].into(),
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut tracked = TrackedStream::new(
+            QueuedContinuityFixture {
+                payload: [3],
+                metadata: [corrupt_invalid, valid].into(),
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
 
         assert!(tracked.next_discarded().is_err());
         assert_eq!(tracked.accounting(), (0, 0, 0));
@@ -7543,10 +7636,13 @@ mod tests {
             let baseline = continuity_metadata(1, 1, monotonic);
             let corrupt = continuity_metadata(sequence, seconds, flags);
             let valid = continuity_metadata(3, 3, monotonic);
-            let mut tracked = TrackedStream::new(QueuedContinuityFixture {
-                payload: [5],
-                metadata: [baseline, corrupt, valid].into(),
-            }, test_rate_config(contracts::StreamRole::Ir));
+            let mut tracked = TrackedStream::new(
+                QueuedContinuityFixture {
+                    payload: [5],
+                    metadata: [baseline, corrupt, valid].into(),
+                },
+                test_rate_config(contracts::StreamRole::Ir),
+            );
 
             tracked.next().expect("baseline delivery");
             assert!(
@@ -7574,13 +7670,16 @@ mod tests {
             timestamp: v4l::timestamp::Timestamp::new(1, 0),
             ..v4l::buffer::Metadata::default()
         };
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: v4l::buffer::Metadata {
-                timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
-                ..valid
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: v4l::buffer::Metadata {
+                    timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
+                    ..valid
+                },
             },
-        }, test_rate_config(contracts::StreamRole::Ir));
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         assert!(capture.next_discarded().is_err());
         capture.stream_mut().expect("stream").metadata = valid;
         assert!(capture.next().is_err(), "discarded invalid evidence healed");
@@ -7612,18 +7711,21 @@ mod tests {
             timestamp: v4l::timestamp::Timestamp::new(2, 0),
             ..v4l::buffer::Metadata::default()
         };
-        let mut tracked = TrackedStream::new(WarmupFixture {
-            payload: [1],
-            metadata: [
-                v4l::buffer::Metadata {
-                    sequence: 1,
-                    timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
-                    ..valid
-                },
-                valid,
-            ]
-            .into(),
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut tracked = TrackedStream::new(
+            WarmupFixture {
+                payload: [1],
+                metadata: [
+                    v4l::buffer::Metadata {
+                        sequence: 1,
+                        timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
+                        ..valid
+                    },
+                    valid,
+                ]
+                .into(),
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         let result = warm_up_with(
             "fixture",
             || tracked.next_discarded(),
@@ -7650,10 +7752,13 @@ mod tests {
                 timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
                 ..v4l::buffer::Metadata::default()
             };
-            let mut capture = TrackedStream::new(ContinuityFixture {
-                payload: [1],
-                metadata: metadata(1, 1, monotonic),
-            }, test_rate_config(contracts::StreamRole::Ir));
+            let mut capture = TrackedStream::new(
+                ContinuityFixture {
+                    payload: [1],
+                    metadata: metadata(1, 1, monotonic),
+                },
+                test_rate_config(contracts::StreamRole::Ir),
+            );
             capture.next().expect("baseline");
             capture.stream_mut().expect("stream").metadata = metadata(2, seconds, flags);
             assert!(capture.next_discarded().is_err());
@@ -7697,7 +7802,8 @@ mod tests {
             payload: [7],
             sequences: sequences.iter().copied().collect(),
         };
-        let mut capture = TrackedStream::new(fixture(&[41]), test_rate_config(contracts::StreamRole::Ir));
+        let mut capture =
+            TrackedStream::new(fixture(&[41]), test_rate_config(contracts::StreamRole::Ir));
         let (_, _, baseline_sequence, baseline_timestamp, _) =
             capture.next().expect("baseline delivery");
         assert!(!baseline_sequence.discontinuity());
@@ -7732,10 +7838,13 @@ mod tests {
             timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
             ..v4l::buffer::Metadata::default()
         };
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: metadata(1, 1),
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: metadata(1, 1),
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.next().expect("baseline");
         let sequence_state = capture.sequence.continuity_state_for_test();
         let timestamp_state = capture.timestamp.continuity_state_for_test();
@@ -7780,10 +7889,13 @@ mod tests {
             timestamp: v4l::timestamp::Timestamp::new(seconds, 0),
             ..v4l::buffer::Metadata::default()
         };
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: metadata(1, 1),
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: metadata(1, 1),
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.next().expect("baseline");
         let sequence_state = capture.sequence.continuity_state_for_test();
         let timestamp_state = capture.timestamp.continuity_state_for_test();
@@ -7827,10 +7939,13 @@ mod tests {
             ..v4l::buffer::Metadata::default()
         };
         let monotonic = v4l::buffer::Flags::TIMESTAMP_MONOTONIC;
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: metadata(1, 1, monotonic),
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: metadata(1, 1, monotonic),
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.next().expect("baseline");
         capture.stream_mut().expect("stream").metadata =
             metadata(5, 2, v4l::buffer::Flags::TIMESTAMP_UNKNOWN);
@@ -7858,7 +7973,8 @@ mod tests {
             calls: calls.clone(),
             fail_validation,
         };
-        let mut capture = TrackedStream::new(fixture(false), test_rate_config(contracts::StreamRole::Ir));
+        let mut capture =
+            TrackedStream::new(fixture(false), test_rate_config(contracts::StreamRole::Ir));
         capture.sequence.force_stream_epoch_overflow_on_recovery();
         assert!(capture.take().is_some());
         capture
@@ -7868,12 +7984,15 @@ mod tests {
         assert_eq!(calls.get(), 1, "replacement was not validated first");
 
         let failed_calls = std::rc::Rc::new(std::cell::Cell::new(0));
-        let mut validation_failure = TrackedStream::new(RecoveryValidationFixture {
-            payload: [1],
-            metadata: v4l::buffer::Metadata::default(),
-            calls: failed_calls.clone(),
-            fail_validation: false,
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut validation_failure = TrackedStream::new(
+            RecoveryValidationFixture {
+                payload: [1],
+                metadata: v4l::buffer::Metadata::default(),
+                calls: failed_calls.clone(),
+                fail_validation: false,
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         let sequence_state = validation_failure.sequence.continuity_state_for_test();
         let timestamp_state = validation_failure.timestamp.continuity_state_for_test();
         assert!(validation_failure.take().is_some());
@@ -7904,7 +8023,8 @@ mod tests {
             metadata: v4l::buffer::Metadata::default(),
         };
 
-        let mut sequence_failure = TrackedStream::new(fixture(), test_rate_config(contracts::StreamRole::Ir));
+        let mut sequence_failure =
+            TrackedStream::new(fixture(), test_rate_config(contracts::StreamRole::Ir));
         sequence_failure
             .sequence
             .force_stream_epoch_overflow_on_recovery();
@@ -7918,7 +8038,8 @@ mod tests {
         assert!(!sequence_failure.timestamp.failed_for_test());
         assert_eq!(sequence_failure.timestamp.stream_epoch_for_test(), 0);
 
-        let mut timestamp_failure = TrackedStream::new(fixture(), test_rate_config(contracts::StreamRole::Ir));
+        let mut timestamp_failure =
+            TrackedStream::new(fixture(), test_rate_config(contracts::StreamRole::Ir));
         timestamp_failure
             .timestamp
             .force_stream_epoch_overflow_on_recovery();
@@ -7935,16 +8056,19 @@ mod tests {
 
     #[test]
     fn discarded_timestamp_failure_does_not_advance_sequence_state() {
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: v4l::buffer::Metadata {
-                bytesused: 1,
-                sequence: 1,
-                flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
-                timestamp: v4l::timestamp::Timestamp::new(1, 0),
-                ..v4l::buffer::Metadata::default()
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: v4l::buffer::Metadata {
+                    bytesused: 1,
+                    sequence: 1,
+                    flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                    timestamp: v4l::timestamp::Timestamp::new(1, 0),
+                    ..v4l::buffer::Metadata::default()
+                },
             },
-        }, test_rate_config(contracts::StreamRole::Ir));
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.next().expect("baseline");
         let stream = capture.stream_mut().expect("stream");
         stream.metadata.sequence = 5;
@@ -7956,16 +8080,19 @@ mod tests {
 
     #[test]
     fn discarded_sequence_failure_does_not_advance_timestamp_state() {
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: v4l::buffer::Metadata {
-                bytesused: 1,
-                sequence: 1,
-                flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
-                timestamp: v4l::timestamp::Timestamp::new(1, 0),
-                ..v4l::buffer::Metadata::default()
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: v4l::buffer::Metadata {
+                    bytesused: 1,
+                    sequence: 1,
+                    flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                    timestamp: v4l::timestamp::Timestamp::new(1, 0),
+                    ..v4l::buffer::Metadata::default()
+                },
             },
-        }, test_rate_config(contracts::StreamRole::Ir));
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.next().expect("baseline");
         capture.sequence.force_drop_overflow_on_next_gap();
         let stream = capture.stream_mut().expect("stream");
@@ -7977,16 +8104,19 @@ mod tests {
 
     #[test]
     fn sequence_failure_does_not_advance_timestamp_state() {
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: v4l::buffer::Metadata {
-                bytesused: 1,
-                sequence: 1,
-                flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
-                timestamp: v4l::timestamp::Timestamp::new(1, 0),
-                ..v4l::buffer::Metadata::default()
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: v4l::buffer::Metadata {
+                    bytesused: 1,
+                    sequence: 1,
+                    flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                    timestamp: v4l::timestamp::Timestamp::new(1, 0),
+                    ..v4l::buffer::Metadata::default()
+                },
             },
-        }, test_rate_config(contracts::StreamRole::Ir));
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.next().expect("baseline");
         capture.sequence.force_drop_overflow_on_next_gap();
         let stream = capture.stream_mut().expect("stream");
@@ -8005,10 +8135,13 @@ mod tests {
             timestamp: v4l::timestamp::Timestamp::new(1, 0),
             ..v4l::buffer::Metadata::default()
         };
-        let mut capture = TrackedStream::new(ContinuityFixture {
-            payload: [1],
-            metadata: valid,
-        }, test_rate_config(contracts::StreamRole::Ir));
+        let mut capture = TrackedStream::new(
+            ContinuityFixture {
+                payload: [1],
+                metadata: valid,
+            },
+            test_rate_config(contracts::StreamRole::Ir),
+        );
         capture.next().expect("baseline");
         let stream = capture.stream_mut().expect("stream");
         stream.metadata.timestamp = v4l::timestamp::Timestamp::new(2, 1_000_000);
@@ -8036,10 +8169,13 @@ mod tests {
                 timestamp: v4l::timestamp::Timestamp::new(1, 0),
                 ..v4l::buffer::Metadata::default()
             };
-            let mut capture = TrackedStream::new(ContinuityFixture {
-                payload: [1],
-                metadata: valid,
-            }, test_rate_config(contracts::StreamRole::Ir));
+            let mut capture = TrackedStream::new(
+                ContinuityFixture {
+                    payload: [1],
+                    metadata: valid,
+                },
+                test_rate_config(contracts::StreamRole::Ir),
+            );
             capture.next().expect("baseline");
             let stream = capture.stream_mut().expect("stream");
             stream.metadata.flags = v4l::buffer::Flags::from_bits_truncate(bits);

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -42,6 +42,7 @@ mod ir_metadata;
 pub mod lease;
 mod lifecycle;
 mod media_graph;
+mod rate_gate;
 // Public for exactly one item, `pending_summary`, doctor's read-only view of
 // the store (#429); every record type stays crate-private so no other code
 // path grows a reader of these files.

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -6409,6 +6409,14 @@ where
 mod tests {
     use super::*;
 
+    fn test_rate_config(role: contracts::StreamRole) -> rate_gate::StreamRateConfig {
+        rate_gate::StreamRateConfig::new(
+            role,
+            frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+            frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+        )
+    }
+
     type CallLog = std::rc::Rc<std::cell::RefCell<Vec<&'static str>>>;
 
     struct FakeClaim {
@@ -7354,7 +7362,7 @@ mod tests {
         let mut capture = TrackedStream::new(ContinuityFixture {
             payload: [1],
             metadata,
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.observations = u64::MAX;
         let sequence_state = capture.sequence.continuity_state_for_test();
         let timestamp_state = capture.timestamp.continuity_state_for_test();
@@ -7450,7 +7458,7 @@ mod tests {
         let mut tracked = TrackedStream::new(QueuedContinuityFixture {
             payload: [7],
             metadata: [corrupt, valid].into(),
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
 
         warm_up_with(
             "fixture",
@@ -7461,7 +7469,7 @@ mod tests {
         .expect("metadata-valid corruption is a discarded warm-up observation");
         assert_eq!(tracked.accounting(), (1, 1, 0));
 
-        let (payload, _, sequence, timestamp) =
+        let (payload, _, sequence, timestamp, _) =
             tracked.next().expect("next payload remains usable");
         assert_eq!(payload, &[7]);
         assert_eq!(sequence.raw(), 2);
@@ -7478,7 +7486,7 @@ mod tests {
         let mut tracked = TrackedStream::new(QueuedContinuityFixture {
             payload: [9],
             metadata: [corrupt, valid].into(),
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
 
         let error = tracked
             .next()
@@ -7486,7 +7494,7 @@ mod tests {
         assert!(error.to_string().contains("corrupt"));
         assert_eq!(tracked.accounting(), (1, 1, 0));
 
-        let (payload, _, sequence, timestamp) =
+        let (payload, _, sequence, timestamp, _) =
             tracked.next().expect("next payload remains usable");
         assert_eq!(payload, &[9]);
         assert_eq!(sequence.raw(), 11);
@@ -7506,7 +7514,7 @@ mod tests {
         let mut tracked = TrackedStream::new(QueuedContinuityFixture {
             payload: [3],
             metadata: [corrupt_invalid, valid].into(),
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
 
         assert!(tracked.next_discarded().is_err());
         assert_eq!(tracked.accounting(), (0, 0, 0));
@@ -7544,7 +7552,7 @@ mod tests {
             let mut tracked = TrackedStream::new(QueuedContinuityFixture {
                 payload: [5],
                 metadata: [baseline, corrupt, valid].into(),
-            });
+            }, test_rate_config(contracts::StreamRole::Ir));
 
             tracked.next().expect("baseline delivery");
             assert!(
@@ -7578,7 +7586,7 @@ mod tests {
                 timestamp: v4l::timestamp::Timestamp::new(1, 1_000_000),
                 ..valid
             },
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         assert!(capture.next_discarded().is_err());
         capture.stream_mut().expect("stream").metadata = valid;
         assert!(capture.next().is_err(), "discarded invalid evidence healed");
@@ -7621,7 +7629,7 @@ mod tests {
                 valid,
             ]
             .into(),
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         let result = warm_up_with(
             "fixture",
             || tracked.next_discarded(),
@@ -7651,7 +7659,7 @@ mod tests {
             let mut capture = TrackedStream::new(ContinuityFixture {
                 payload: [1],
                 metadata: metadata(1, 1, monotonic),
-            });
+            }, test_rate_config(contracts::StreamRole::Ir));
             capture.next().expect("baseline");
             capture.stream_mut().expect("stream").metadata = metadata(2, seconds, flags);
             assert!(capture.next_discarded().is_err());
@@ -7695,8 +7703,8 @@ mod tests {
             payload: [7],
             sequences: sequences.iter().copied().collect(),
         };
-        let mut capture = TrackedStream::new(fixture(&[41]));
-        let (_, _, baseline_sequence, baseline_timestamp) =
+        let mut capture = TrackedStream::new(fixture(&[41]), test_rate_config(contracts::StreamRole::Ir));
+        let (_, _, baseline_sequence, baseline_timestamp, _) =
             capture.next().expect("baseline delivery");
         assert!(!baseline_sequence.discontinuity());
         assert!(!baseline_timestamp.discontinuity());
@@ -7708,7 +7716,7 @@ mod tests {
             .expect("representable recovery epoch");
         capture.next_discarded().expect("discarded warm-up dequeue");
 
-        let (_, _, restarted_sequence, restarted_timestamp) =
+        let (_, _, restarted_sequence, restarted_timestamp, _) =
             capture.next().expect("first delivered recovery frame");
         assert_eq!(restarted_sequence.raw(), 501);
         assert_eq!(restarted_sequence.gap(), 0);
@@ -7733,7 +7741,7 @@ mod tests {
         let mut capture = TrackedStream::new(ContinuityFixture {
             payload: [1],
             metadata: metadata(1, 1),
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.next().expect("baseline");
         let sequence_state = capture.sequence.continuity_state_for_test();
         let timestamp_state = capture.timestamp.continuity_state_for_test();
@@ -7763,7 +7771,7 @@ mod tests {
             .expect("recovery");
         capture.next_discarded().expect("recovered warm-up frame");
         capture.stream_mut().expect("stream").metadata = metadata(11, 11);
-        let (_, _, sequence, timestamp) = capture.next().expect("recovered delivered frame");
+        let (_, _, sequence, timestamp, _) = capture.next().expect("recovered delivered frame");
         assert_eq!(sequence.stream_epoch(), timestamp.stream_epoch());
         assert!(sequence.discontinuity());
         assert!(timestamp.discontinuity());
@@ -7781,7 +7789,7 @@ mod tests {
         let mut capture = TrackedStream::new(ContinuityFixture {
             payload: [1],
             metadata: metadata(1, 1),
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.next().expect("baseline");
         let sequence_state = capture.sequence.continuity_state_for_test();
         let timestamp_state = capture.timestamp.continuity_state_for_test();
@@ -7809,7 +7817,7 @@ mod tests {
                 metadata: metadata(10, 10),
             })
             .expect("recovery");
-        let (_, _, sequence, timestamp) = capture.next().expect("recovered frame");
+        let (_, _, sequence, timestamp, _) = capture.next().expect("recovered frame");
         assert_eq!(sequence.stream_epoch(), timestamp.stream_epoch());
         assert!(sequence.discontinuity());
         assert!(timestamp.discontinuity());
@@ -7828,7 +7836,7 @@ mod tests {
         let mut capture = TrackedStream::new(ContinuityFixture {
             payload: [1],
             metadata: metadata(1, 1, monotonic),
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.next().expect("baseline");
         capture.stream_mut().expect("stream").metadata =
             metadata(5, 2, v4l::buffer::Flags::TIMESTAMP_UNKNOWN);
@@ -7841,7 +7849,7 @@ mod tests {
                 metadata: metadata(10, 1, monotonic),
             })
             .expect("recovery");
-        let (_, _, sequence, timestamp) = capture.next().expect("recovered frame");
+        let (_, _, sequence, timestamp, _) = capture.next().expect("recovered frame");
         assert_eq!(sequence.cumulative_drops(), 0);
         assert!(sequence.discontinuity());
         assert!(timestamp.discontinuity());
@@ -7856,7 +7864,7 @@ mod tests {
             calls: calls.clone(),
             fail_validation,
         };
-        let mut capture = TrackedStream::new(fixture(false));
+        let mut capture = TrackedStream::new(fixture(false), test_rate_config(contracts::StreamRole::Ir));
         capture.sequence.force_stream_epoch_overflow_on_recovery();
         assert!(capture.take().is_some());
         capture
@@ -7871,7 +7879,7 @@ mod tests {
             metadata: v4l::buffer::Metadata::default(),
             calls: failed_calls.clone(),
             fail_validation: false,
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         let sequence_state = validation_failure.sequence.continuity_state_for_test();
         let timestamp_state = validation_failure.timestamp.continuity_state_for_test();
         assert!(validation_failure.take().is_some());
@@ -7902,7 +7910,7 @@ mod tests {
             metadata: v4l::buffer::Metadata::default(),
         };
 
-        let mut sequence_failure = TrackedStream::new(fixture());
+        let mut sequence_failure = TrackedStream::new(fixture(), test_rate_config(contracts::StreamRole::Ir));
         sequence_failure
             .sequence
             .force_stream_epoch_overflow_on_recovery();
@@ -7916,7 +7924,7 @@ mod tests {
         assert!(!sequence_failure.timestamp.failed_for_test());
         assert_eq!(sequence_failure.timestamp.stream_epoch_for_test(), 0);
 
-        let mut timestamp_failure = TrackedStream::new(fixture());
+        let mut timestamp_failure = TrackedStream::new(fixture(), test_rate_config(contracts::StreamRole::Ir));
         timestamp_failure
             .timestamp
             .force_stream_epoch_overflow_on_recovery();
@@ -7942,7 +7950,7 @@ mod tests {
                 timestamp: v4l::timestamp::Timestamp::new(1, 0),
                 ..v4l::buffer::Metadata::default()
             },
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.next().expect("baseline");
         let stream = capture.stream_mut().expect("stream");
         stream.metadata.sequence = 5;
@@ -7963,7 +7971,7 @@ mod tests {
                 timestamp: v4l::timestamp::Timestamp::new(1, 0),
                 ..v4l::buffer::Metadata::default()
             },
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.next().expect("baseline");
         capture.sequence.force_drop_overflow_on_next_gap();
         let stream = capture.stream_mut().expect("stream");
@@ -7984,7 +7992,7 @@ mod tests {
                 timestamp: v4l::timestamp::Timestamp::new(1, 0),
                 ..v4l::buffer::Metadata::default()
             },
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.next().expect("baseline");
         capture.sequence.force_drop_overflow_on_next_gap();
         let stream = capture.stream_mut().expect("stream");
@@ -8006,7 +8014,7 @@ mod tests {
         let mut capture = TrackedStream::new(ContinuityFixture {
             payload: [1],
             metadata: valid,
-        });
+        }, test_rate_config(contracts::StreamRole::Ir));
         capture.next().expect("baseline");
         let stream = capture.stream_mut().expect("stream");
         stream.metadata.timestamp = v4l::timestamp::Timestamp::new(2, 1_000_000);
@@ -8037,7 +8045,7 @@ mod tests {
             let mut capture = TrackedStream::new(ContinuityFixture {
                 payload: [1],
                 metadata: valid,
-            });
+            }, test_rate_config(contracts::StreamRole::Ir));
             capture.next().expect("baseline");
             let stream = capture.stream_mut().expect("stream");
             stream.metadata.flags = v4l::buffer::Flags::from_bits_truncate(bits);
@@ -8452,6 +8460,19 @@ mod tests {
             timestamp,
             at,
             contracts::IlluminationProvenance::Unknown,
+            frame_provenance::DeliveredRateEvidence::new(
+                contracts::StreamRole::Rgb,
+                (15, 2),
+                (15, 2),
+                (15, 2),
+                98,
+                30,
+                2_000_000,
+                (15, 2),
+                true,
+                &sequence,
+                &timestamp,
+            ),
         )
         .expect("test runtime provenance");
         Frame::from_provenance(
@@ -10426,7 +10447,7 @@ mod tests {
         let mut expect_rgb_discontinuity = false;
         let mut expect_ir_discontinuity = false;
         while std::time::Instant::now() < deadline {
-            let (_, _, sequence, timestamp) =
+            let (_, _, sequence, timestamp, _) =
                 rgb_session.stream.next().expect("RGB tracked dequeue");
             if expect_rgb_discontinuity {
                 assert!(sequence.discontinuity(), "RGB recovery marker missing");
@@ -10434,7 +10455,7 @@ mod tests {
             }
             rgb_stats.record(sequence, timestamp);
             if let Some(session) = &mut ir_session {
-                let (_, _, sequence, timestamp) =
+                let (_, _, sequence, timestamp, _) =
                     session.stream.next().expect("IR tracked dequeue");
                 if let Some(log) = session.meta.as_mut() {
                     log.begin_burst();

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -193,6 +193,7 @@ fn checked_single_evidence(
     timestamp: frame_provenance::TimestampObservation,
     taken: std::time::Instant,
     illumination: contracts::IlluminationProvenance,
+    rate_evidence: frame_provenance::DeliveredRateEvidence,
 ) -> irlume_common::Result<frame_provenance::SingleFrameProvenance> {
     frame_provenance::SingleFrameProvenance::begin(
         binding,
@@ -201,6 +202,7 @@ fn checked_single_evidence(
         sequence,
         timestamp,
         CaptureWindow::at(taken),
+        rate_evidence,
     )
     .and_then(|pending| pending.finalize_illumination(illumination))
     .map_err(|error| Error::Hardware(format!("invalid runtime frame provenance: {error}")))
@@ -214,6 +216,7 @@ fn checked_single_provenance(
     timestamp: frame_provenance::TimestampObservation,
     taken: std::time::Instant,
     illumination: contracts::IlluminationProvenance,
+    rate_evidence: frame_provenance::DeliveredRateEvidence,
 ) -> irlume_common::Result<frame_provenance::RuntimeFrameProvenance> {
     checked_single_evidence(
         binding,
@@ -223,6 +226,7 @@ fn checked_single_provenance(
         timestamp,
         taken,
         illumination,
+        rate_evidence,
     )
     .map(frame_provenance::RuntimeFrameProvenance::Single)
 }
@@ -1253,10 +1257,91 @@ impl<S: CameraState> ValidatedStream for CameraStateStream<'_, S> {
 }
 
 /// Continuity state whose lifetime is independent of its replaceable mmap stream.
+/// Typed delivery failure from [`TrackedStream::next`].
+///
+/// Splits the existing dequeue/continuity I/O errors from the new below-floor
+/// refusal, so callers can map the latter to
+/// [`irlume_common::Error::DeliveredRate`] without parsing prose.
+#[derive(Debug)]
+enum DeliveryError {
+    /// Existing dequeue/validation/continuity error (retains current behavior).
+    Io(std::io::Error),
+    /// The measured delivered rate is below the exact floor; carries the
+    /// machine-readable evidence so callers act on the rate, not a message.
+    BelowFloor(Box<irlume_common::CameraStreamRateEvidence>),
+}
+
+impl std::fmt::Display for DeliveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(io) => io.fmt(f),
+            Self::BelowFloor(_) => f.write_str("delivered rate below floor"),
+        }
+    }
+}
+
+/// Map a [`DeliveryError`] to the crate-wide error, preserving the existing
+/// `map_io` behavior for I/O and emitting the typed rate error otherwise.
+fn map_delivery(device: &str, error: DeliveryError) -> Error {
+    match error {
+        DeliveryError::Io(io) => map_io(device, io),
+        DeliveryError::BelowFloor(evidence) => Error::DeliveredRate(evidence),
+    }
+}
+
+/// Convert camera-crate delivered-rate evidence to the common serializable DTO.
+fn rate_evidence_to_common(
+    evidence: &frame_provenance::DeliveredRateEvidence,
+) -> irlume_common::CameraStreamRateEvidence {
+    use frame_provenance::{TimestampClock, TimestampSource};
+    let (requested_num, requested_den) = evidence.requested();
+    let (accepted_num, accepted_den) = evidence.accepted();
+    let (floor_num, floor_den) = evidence.floor();
+    let (delivered_num, delivered_den) = evidence.delivered();
+    irlume_common::CameraStreamRateEvidence {
+        role: match evidence.role() {
+            contracts::StreamRole::Rgb => "rgb".to_string(),
+            contracts::StreamRole::Ir => "ir".to_string(),
+        },
+        requested_num,
+        requested_den,
+        accepted_num,
+        accepted_den,
+        floor_num,
+        floor_den,
+        tolerance_percent: evidence.tolerance_percent(),
+        window_count: evidence.window_count(),
+        window_span_us: evidence.window_span_us(),
+        delivered_num,
+        delivered_den,
+        meets_floor: evidence.meets_floor(),
+        sequence_gap: evidence.sequence_gap(),
+        cumulative_drops: evidence.cumulative_drops(),
+        clock: match evidence.clock() {
+            TimestampClock::Monotonic => "monotonic".to_string(),
+            TimestampClock::Copy => "copy".to_string(),
+            TimestampClock::Unknown => "unknown".to_string(),
+        },
+        source: match evidence.source() {
+            TimestampSource::EndOfFrame => "end_of_frame".to_string(),
+            TimestampSource::StartOfExposure => "start_of_exposure".to_string(),
+        },
+        latest_timestamp_us: evidence.latest_timestamp_us(),
+        stream_epoch: evidence.stream_epoch(),
+    }
+}
+
+/// Maximum additional dequeue attempts for the bounded rate-evidence fill in
+/// [`TrackedStream::next`]. Nominal is 30 successful dequeues (~2 s at 15 fps);
+/// 64 gives >2x headroom for timeouts and corrupt frames.
+const MAX_RATE_FILL_ATTEMPTS: usize = 64;
+
 struct TrackedStream<S> {
     stream: Option<S>,
     sequence: frame_provenance::SequenceTracker,
     timestamp: frame_provenance::TimestampTracker,
+    rate_window: rate_gate::RateWindow,
+    rate_config: rate_gate::StreamRateConfig,
     observations: u64,
     discarded_observations: u64,
     sequence_span_sum: u64,
@@ -1264,11 +1349,13 @@ struct TrackedStream<S> {
 }
 
 impl<S> TrackedStream<S> {
-    fn new(stream: S) -> Self {
+    fn new(stream: S, rate_config: rate_gate::StreamRateConfig) -> Self {
         Self {
             stream: Some(stream),
             sequence: frame_provenance::SequenceTracker::new(),
             timestamp: frame_provenance::TimestampTracker::new(),
+            rate_window: rate_gate::RateWindow::new(),
+            rate_config,
             observations: 0,
             discarded_observations: 0,
             sequence_span_sum: 0,
@@ -1412,6 +1499,7 @@ fn begin_recovered_continuity_epoch(
     pending: &mut bool,
     sequence: &mut frame_provenance::SequenceTracker,
     timestamp: &mut frame_provenance::TimestampTracker,
+    rate_window: &mut rate_gate::RateWindow,
 ) -> std::io::Result<()> {
     if !*pending {
         return Ok(());
@@ -1428,6 +1516,7 @@ fn begin_recovered_continuity_epoch(
     }
     *sequence = next_sequence;
     *timestamp = next_timestamp;
+    rate_window.reset();
     *pending = false;
     Ok(())
 }
@@ -1438,21 +1527,28 @@ impl<S: ValidatedStream> TrackedStream<S> {
             stream,
             sequence,
             timestamp,
+            rate_window,
             observations,
             discarded_observations,
             sequence_span_sum,
             recovery_epoch_pending,
+            ..
         } = self;
         let dequeued = stream
             .as_mut()
             .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
             .next_validated();
-        let facts = match dequeued {
+        let (facts, delivered) = match dequeued {
             Ok((_, facts)) => {
-                begin_recovered_continuity_epoch(recovery_epoch_pending, sequence, timestamp)?;
-                facts
+                begin_recovered_continuity_epoch(
+                    recovery_epoch_pending,
+                    sequence,
+                    timestamp,
+                    rate_window,
+                )?;
+                (facts, true)
             }
-            Err(ValidatedDequeueError::Corrupt(facts)) => facts,
+            Err(ValidatedDequeueError::Corrupt(facts)) => (facts, false),
             Err(error) => {
                 if error.invalidates_timestamp_epoch() {
                     timestamp.fail_current_epoch();
@@ -1469,21 +1565,49 @@ impl<S: ValidatedStream> TrackedStream<S> {
             &facts,
             true,
         )?;
+        if delivered {
+            rate_window
+                .observe_success(facts.timestamp_micros())
+                .map_err(std::io::Error::other)?;
+        }
+        Ok(())
+    }
+
+    /// Boundedly establish the 30-delta window before the next delivered frame.
+    fn fill_rate_evidence(&mut self) -> std::io::Result<()> {
+        let mut attempts = 0;
+        while !self.rate_window.ready() && attempts < MAX_RATE_FILL_ATTEMPTS {
+            self.next_discarded()?;
+            attempts += 1;
+        }
+        if !self.rate_window.ready() {
+            return Err(std::io::Error::other(
+                "could not establish delivered-rate evidence within the bounded fill",
+            ));
+        }
         Ok(())
     }
 
     fn next(
         &mut self,
-    ) -> std::io::Result<(
-        &[u8],
-        frame_provenance::DequeuedBufferFacts,
-        frame_provenance::SequenceObservation,
-        frame_provenance::TimestampObservation,
-    )> {
+    ) -> Result<
+        (
+            &[u8],
+            frame_provenance::DequeuedBufferFacts,
+            frame_provenance::SequenceObservation,
+            frame_provenance::TimestampObservation,
+            frame_provenance::DeliveredRateEvidence,
+        ),
+        DeliveryError,
+    > {
+        self.fill_rate_evidence().map_err(DeliveryError::Io)?;
+
         let Self {
             stream,
             sequence,
             timestamp,
+            rate_window,
+            rate_config,
             observations,
             discarded_observations,
             sequence_span_sum,
@@ -1491,7 +1615,8 @@ impl<S: ValidatedStream> TrackedStream<S> {
         } = self;
         let dequeued = stream
             .as_mut()
-            .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
+            .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))
+            .map_err(DeliveryError::Io)?
             .next_validated();
         let (payload, facts) = match dequeued {
             Ok(frame) => frame,
@@ -1504,17 +1629,26 @@ impl<S: ValidatedStream> TrackedStream<S> {
                     sequence_span_sum,
                     &facts,
                     true,
-                )?;
-                return Err(ValidatedDequeueError::Corrupt(facts).into_io());
+                )
+                .map_err(DeliveryError::Io)?;
+                return Err(DeliveryError::Io(
+                    ValidatedDequeueError::Corrupt(facts).into_io(),
+                ));
             }
             Err(error) => {
                 if error.invalidates_timestamp_epoch() {
                     timestamp.fail_current_epoch();
                 }
-                return Err(error.into_io());
+                return Err(DeliveryError::Io(error.into_io()));
             }
         };
-        begin_recovered_continuity_epoch(recovery_epoch_pending, sequence, timestamp)?;
+        begin_recovered_continuity_epoch(
+            recovery_epoch_pending,
+            sequence,
+            timestamp,
+            rate_window,
+        )
+        .map_err(DeliveryError::Io)?;
         let (sequence_observation, timestamp_observation) = observe_continuity_facts(
             sequence,
             timestamp,
@@ -1523,8 +1657,46 @@ impl<S: ValidatedStream> TrackedStream<S> {
             sequence_span_sum,
             &facts,
             false,
-        )?;
-        Ok((payload, facts, sequence_observation, timestamp_observation))
+        )
+        .map_err(DeliveryError::Io)?;
+
+        rate_window
+            .observe_success(facts.timestamp_micros())
+            .map_err(|error| DeliveryError::Io(std::io::Error::other(error)))?;
+
+        let policy = rate_config.policy();
+        let meets_floor = rate_window.meets_floor(
+            policy.floor_num(),
+            policy.floor_den(),
+            policy.tolerance_percent(),
+        );
+        let (requested_num, requested_den) = rate_config.requested().parts();
+        let (accepted_num, accepted_den) = rate_config.accepted().parts();
+        let rate_evidence = frame_provenance::DeliveredRateEvidence::new(
+            rate_config.role(),
+            (requested_num, requested_den),
+            (accepted_num, accepted_den),
+            (policy.floor_num(), policy.floor_den()),
+            policy.tolerance_percent(),
+            rate_window.count() as u32,
+            rate_window.span_us(),
+            rate_window.delivered_rate(),
+            meets_floor,
+            &sequence_observation,
+            &timestamp_observation,
+        );
+        if !meets_floor {
+            return Err(DeliveryError::BelowFloor(Box::new(
+                rate_evidence_to_common(&rate_evidence),
+            )));
+        }
+        Ok((
+            payload,
+            facts,
+            sequence_observation,
+            timestamp_observation,
+            rate_evidence,
+        ))
     }
 }
 
@@ -2927,7 +3099,14 @@ impl RgbCamera {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         Ok(RgbSession {
             cam: self,
-            stream: TrackedStream::new(stream),
+            stream: TrackedStream::new(
+                stream,
+                rate_gate::StreamRateConfig::new(
+                    contracts::StreamRole::Rgb,
+                    self.requested_interval,
+                    self.accepted_interval,
+                ),
+            ),
             warmed: false,
             progress: progress.clone(),
             _blc_restore: blc_restore,
@@ -3225,8 +3404,8 @@ impl<'a> RgbSession<'a> {
                 .lease
                 .require_endpoint(&device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, facts, sequence, timestamp) =
-                self.stream.next().map_err(|error| map_io(&device, error))?;
+            let (buf, facts, sequence, timestamp, rate_evidence) =
+                self.stream.next().map_err(|error| map_delivery(&device, error))?;
             let taken = std::time::Instant::now();
             let data = match &chosen {
                 b"NV12" => nv12_to_rgb(buf, w, h),
@@ -3244,6 +3423,7 @@ impl<'a> RgbSession<'a> {
                 timestamp,
                 taken,
                 contracts::IlluminationProvenance::Unknown,
+                rate_evidence,
             )?;
             frames.push(Frame::from_provenance(
                 w,
@@ -3915,16 +4095,23 @@ impl IrCamera {
         // restore while the stream was still live, the very mid-stream write
         // this change removes. Assigned further down, once the stream exists.
         let mode;
-        let mut stream = TrackedStream::new(SafeStream::open(
-            V4l2CameraState::with_interval(
+        let mut stream = TrackedStream::new(
+            SafeStream::open(
+                V4l2CameraState::with_interval(
+                    &self.device,
+                    self.lease.clone(),
+                    self.accepted_interval,
+                ),
                 &self.device,
-                self.lease.clone(),
+                &self.dev,
+                &self.negotiated,
+            )?,
+            rate_gate::StreamRateConfig::new(
+                contracts::StreamRole::Ir,
+                self.requested_interval,
                 self.accepted_interval,
             ),
-            &self.device,
-            &self.dev,
-            &self.negotiated,
-        )?);
+        );
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
         // 25s when video went first). `SafeStream::open` only allocates
@@ -4074,15 +4261,15 @@ impl IrSession<'_> {
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
-            let (buf, bmeta, sequence, timestamp) =
-                stream.next().map_err(|error| map_io(device, error))?;
+            let (buf, bmeta, sequence, timestamp, rate_evidence) =
+                stream.next().map_err(|error| map_delivery(device, error))?;
             lease
                 .require_endpoint(device)
                 .map_err(|error| Error::Hardware(error.to_string()))?;
             stamps.push(bmeta.timestamp_micros());
             let frame_taken = std::time::Instant::now();
             taken.push(frame_taken);
-            dequeue_evidence.push((bmeta, sequence, timestamp, frame_taken));
+            dequeue_evidence.push((bmeta, sequence, timestamp, frame_taken, rate_evidence));
             // Drain every iteration, not once at the end. The metadata ring is
             // smaller than a burst, so a single drain afterwards silently loses
             // the earliest frames' records: measured 7 of 10 frames classified
@@ -4346,7 +4533,7 @@ impl IrSession<'_> {
             .into_iter()
             .zip(flags.iter().copied())
             .map(
-                |((facts, sequence, timestamp, frame_taken), illumination)| {
+                |((facts, sequence, timestamp, frame_taken, rate_evidence), illumination)| {
                     let illumination = match illumination {
                         Some(ir_metadata::Illumination::Lit) => {
                             contracts::IlluminationProvenance::ActiveIr
@@ -4364,6 +4551,7 @@ impl IrSession<'_> {
                         timestamp,
                         frame_taken,
                         illumination,
+                        rate_evidence,
                     )
                 },
             )
@@ -4481,7 +4669,8 @@ pub mod ir_probe {
     use super::negotiate_ir_format_and_interval;
     use super::Device;
     use super::{
-        ir_emitter, map_io, privacy_engaged_with_permit, verify_pinned, Error, Frame, Spectrum,
+        ir_emitter, map_delivery, map_io, privacy_engaged_with_permit, verify_pinned, Error, Frame,
+        Spectrum,
     };
 
     /// Mean brightness of an 8-bit greyscale buffer.
@@ -4645,15 +4834,22 @@ pub mod ir_probe {
             &dev,
             &fmt,
         )?;
-        let mut stream = super::TrackedStream::new(stream);
+        let mut stream = super::TrackedStream::new(
+            stream,
+            super::rate_gate::StreamRateConfig::new(
+                super::contracts::StreamRole::Ir,
+                interval.requested,
+                interval.accepted,
+            ),
+        );
         mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
         // Bound, never read: held for its `Drop`, which restores the control.
         let _ = &mode;
         let mut out = Vec::with_capacity(n);
         let t0 = std::time::Instant::now();
         for _ in 0..n {
-            let (buf, facts, sequence, timestamp) =
-                stream.next().map_err(|error| map_io(device, error))?;
+            let (buf, facts, sequence, timestamp, rate_evidence) =
+                stream.next().map_err(|error| map_delivery(device, error))?;
             let taken = std::time::Instant::now();
             let provenance = super::checked_single_provenance(
                 binding.clone(),
@@ -4663,6 +4859,7 @@ pub mod ir_probe {
                 timestamp,
                 taken,
                 super::contracts::IlluminationProvenance::Unknown,
+                rate_evidence,
             )?;
             out.push((
                 Frame::from_provenance(w, h, Spectrum::Ir, dec.decode(buf, w, h), provenance)?,
@@ -4767,7 +4964,14 @@ pub fn capture_ir_streaming<B>(
         &dev,
         &fmt,
     )?;
-    let mut stream = TrackedStream::new(stream);
+    let mut stream = TrackedStream::new(
+        stream,
+        rate_gate::StreamRateConfig::new(
+            contracts::StreamRole::Ir,
+            interval.requested,
+            interval.accepted,
+        ),
+    );
     mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
     // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
@@ -4800,8 +5004,8 @@ pub fn capture_ir_streaming<B>(
     // user a password fallback. Reading the metadata queue here is how that gets
     // closed, and it is not done.
     for _ in 0..max_frames {
-        let (buf, facts, sequence, timestamp) =
-            stream.next().map_err(|error| map_io(device, error))?;
+        let (buf, facts, sequence, timestamp, rate_evidence) =
+            stream.next().map_err(|error| map_delivery(device, error))?;
         let taken = std::time::Instant::now();
         let data = dec.decode(buf, w, h);
         let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
@@ -4872,6 +5076,7 @@ pub fn capture_ir_streaming<B>(
             timestamp,
             taken,
             contracts::IlluminationProvenance::Unknown,
+            rate_evidence,
         )?;
         let frame = Frame::from_provenance(w, h, Spectrum::Ir, data, provenance)?;
         if let std::ops::ControlFlow::Break(b) = on_frame(IrStreamFrame { frame, mean }) {
@@ -4946,7 +5151,14 @@ pub fn capture_ir_sequence(
         &dev,
         &fmt,
     )?;
-    let mut stream = TrackedStream::new(stream);
+    let mut stream = TrackedStream::new(
+        stream,
+        rate_gate::StreamRateConfig::new(
+            contracts::StreamRole::Ir,
+            interval.requested,
+            interval.accepted,
+        ),
+    );
     mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
     // Set once per stream, before it starts, and not per frame (the
     // frozen-stream restart below re-applies on its new stream). This path also carried
@@ -4967,8 +5179,8 @@ pub fn capture_ir_sequence(
         let mut best_index = 0;
         let mut contributors = Vec::with_capacity(burst);
         for _ in 0..burst {
-            let (buf, facts, sequence, timestamp) =
-                stream.next().map_err(|error| map_io(device, error))?;
+            let (buf, facts, sequence, timestamp, rate_evidence) =
+                stream.next().map_err(|error| map_delivery(device, error))?;
             let at = std::time::Instant::now();
             let data = dec.decode(buf, w, h);
             let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
@@ -4980,6 +5192,7 @@ pub fn capture_ir_sequence(
                 timestamp,
                 at,
                 contracts::IlluminationProvenance::Unknown,
+                rate_evidence,
             )?);
             if mean > best_mean {
                 best_mean = mean;

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -185,6 +185,10 @@ impl Frame {
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one immutable runtime-evidence bundle; the args are never confused"
+)]
 fn checked_single_evidence(
     binding: frame_provenance::FrameBinding,
     format: frame_provenance::ValidatedFormatIdentity,
@@ -208,6 +212,10 @@ fn checked_single_evidence(
     .map_err(|error| Error::Hardware(format!("invalid runtime frame provenance: {error}")))
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one immutable runtime-evidence bundle; the args are never confused"
+)]
 fn checked_single_provenance(
     binding: frame_provenance::FrameBinding,
     format: frame_provenance::ValidatedFormatIdentity,
@@ -2935,6 +2943,12 @@ fn role_diagnostic(
 /// measured evidence: an under-rate stream is a measured `fail`, never
 /// degraded to prose. `ir` is `None` on an RGB-only device. No device path,
 /// account identity, or template data is exposed.
+///
+/// # Errors
+///
+/// Returns [`Error::Hardware`] when a role cannot be opened or its bounded
+/// capture cannot establish delivered-rate evidence; the per-role `state` is
+/// then `unknown` rather than the whole request failing.
 pub fn camera_rate_diagnostics(
     rgb: &str,
     ir: Option<&str>,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2969,10 +2969,7 @@ pub struct RgbCamera {
     /// buffers (#427); see `format_moved` for why the geometry alone is not
     /// enough.
     negotiated: v4l::Format,
-    #[expect(
-        dead_code,
-        reason = "immutable negotiation evidence is published by the delivered-rate slice"
-    )]
+    /// Immutable negotiation evidence published by the delivered-rate slice.
     requested_interval: frame_interval::FrameInterval,
     accepted_interval: frame_interval::FrameInterval,
 }
@@ -3982,10 +3979,7 @@ pub struct IrCamera {
     /// buffers (#427); see `format_moved` for why the geometry alone is not
     /// enough.
     negotiated: v4l::Format,
-    #[expect(
-        dead_code,
-        reason = "immutable negotiation evidence is published by the delivered-rate slice"
-    )]
+    /// Immutable negotiation evidence published by the delivered-rate slice.
     requested_interval: frame_interval::FrameInterval,
     accepted_interval: frame_interval::FrameInterval,
     width: u32,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1344,6 +1344,13 @@ fn rate_evidence_to_common(
 /// 64 gives >2x headroom for timeouts and corrupt frames.
 const MAX_RATE_FILL_ATTEMPTS: usize = 64;
 
+/// Frames discarded before the rate window is measured. The first window after
+/// STREAMON spans the driver's initial buffer delivery, whose sequence gaps
+/// make a healthy 15 fps stream read ~7 fps (measured: 32 gaps on the ASUS IR).
+/// Flushing one window's worth of frames before resetting and measuring keeps
+/// the gate from rejecting a settled stream for its startup transient.
+const RATE_STARTUP_FLUSH: usize = 30;
+
 struct TrackedStream<S> {
     stream: Option<S>,
     sequence: frame_provenance::SequenceTracker,
@@ -1583,6 +1590,17 @@ impl<S: ValidatedStream> TrackedStream<S> {
 
     /// Boundedly establish the 30-delta window before the next delivered frame.
     fn fill_rate_evidence(&mut self) -> std::io::Result<()> {
+        if self.rate_window.ready() {
+            return Ok(());
+        }
+        // First fill: flush the STREAMON transient before measuring. The first
+        // window spans the driver's initial buffer delivery, whose sequence
+        // gaps would poison a settled stream's measurement. Reset before
+        // measuring so the startup deltas do not count against the floor.
+        for _ in 0..RATE_STARTUP_FLUSH {
+            self.next_discarded()?;
+        }
+        self.rate_window.reset();
         let mut attempts = 0;
         while !self.rate_window.ready() && attempts < MAX_RATE_FILL_ATTEMPTS {
             self.next_discarded()?;

--- a/crates/irlume-camera/src/rate_gate.rs
+++ b/crates/irlume-camera/src/rate_gate.rs
@@ -79,6 +79,7 @@ const fn gcd_u64(mut left: u64, mut right: u64) -> u64 {
 #[derive(Clone, Debug)]
 pub(crate) struct RateWindow {
     deltas: [u64; RATE_WINDOW_CAPACITY],
+    capacity: usize,
     len: usize,
     head: usize,
     last_successful_timestamp_micros: Option<i64>,
@@ -86,8 +87,16 @@ pub(crate) struct RateWindow {
 
 impl RateWindow {
     pub(crate) const fn new() -> Self {
+        Self::with_capacity(RATE_WINDOW_CAPACITY)
+    }
+
+    /// A window that is "ready" after `capacity` positive deltas (<=
+    /// [`RATE_WINDOW_CAPACITY`]). Production uses the full 30; tests use a small
+    /// capacity so continuity fixtures need not supply a full-rate warm-up.
+    pub(crate) const fn with_capacity(capacity: usize) -> Self {
         Self {
             deltas: [0; RATE_WINDOW_CAPACITY],
+            capacity,
             len: 0,
             head: 0,
             last_successful_timestamp_micros: None,
@@ -123,12 +132,17 @@ impl RateWindow {
     }
 
     fn push(&mut self, delta: u64) {
-        if self.len < RATE_WINDOW_CAPACITY {
+        if self.capacity == 0 {
+            // A zero-capacity window is a test-only "no gate" mode: it is ready
+            // immediately, fills nothing, and never records a delta.
+            return;
+        }
+        if self.len < self.capacity {
             self.deltas[(self.head + self.len) % RATE_WINDOW_CAPACITY] = delta;
             self.len += 1;
         } else {
             self.deltas[self.head] = delta;
-            self.head = (self.head + 1) % RATE_WINDOW_CAPACITY;
+            self.head = (self.head + 1) % self.capacity;
         }
     }
 
@@ -148,17 +162,17 @@ impl RateWindow {
         self.len
     }
 
-    /// Whether the window holds the full [`RATE_WINDOW_CAPACITY`] deltas.
+    /// Whether the window holds its configured number of deltas.
     #[must_use]
     pub(crate) const fn ready(&self) -> bool {
-        self.len == RATE_WINDOW_CAPACITY
+        self.len == self.capacity
     }
 
     /// Sum of the held deltas in microseconds.
     #[must_use]
     pub(crate) fn span_us(&self) -> u64 {
         (0..self.len)
-            .map(|i| self.deltas[(self.head + i) % RATE_WINDOW_CAPACITY])
+            .map(|i| self.deltas[(self.head + i) % self.capacity])
             .sum()
     }
 
@@ -274,6 +288,28 @@ impl StreamRateConfig {
     #[must_use]
     pub(crate) const fn role(&self) -> StreamRole {
         self.role
+    }
+
+    /// The same policy as [`Self::new`] but with a caller-chosen window size.
+    /// Used only by tests (continuity fixtures) so they need not supply a full
+    /// 30-delta warm-up; production always uses the measured 30.
+    #[cfg(test)]
+    pub(crate) const fn with_window(
+        role: StreamRole,
+        requested: FrameInterval,
+        accepted: FrameInterval,
+        window: usize,
+    ) -> Self {
+        let (floor_num, floor_den) = match role {
+            StreamRole::Rgb => (RGB_FLOOR_NUM, RGB_FLOOR_DEN),
+            StreamRole::Ir => (IR_FLOOR_NUM, IR_FLOOR_DEN),
+        };
+        Self {
+            role,
+            policy: RatePolicy::new(floor_num, floor_den, DEFAULT_TOLERANCE_PERCENT, window),
+            requested,
+            accepted,
+        }
     }
 
     #[must_use]

--- a/crates/irlume-camera/src/rate_gate.rs
+++ b/crates/irlume-camera/src/rate_gate.rs
@@ -86,6 +86,7 @@ pub(crate) struct RateWindow {
 }
 
 impl RateWindow {
+    #[cfg(test)]
     pub(crate) const fn new() -> Self {
         Self::with_capacity(RATE_WINDOW_CAPACITY)
     }
@@ -246,7 +247,6 @@ impl RatePolicy {
     }
 
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "used by tests"))]
     pub(crate) const fn window(&self) -> usize {
         self.window
     }

--- a/crates/irlume-camera/src/rate_gate.rs
+++ b/crates/irlume-camera/src/rate_gate.rs
@@ -230,6 +230,12 @@ impl RatePolicy {
     pub(crate) const fn tolerance_percent(&self) -> u32 {
         self.tolerance_percent
     }
+
+    #[must_use]
+    #[cfg_attr(not(test), expect(dead_code, reason = "used by tests"))]
+    pub(crate) const fn window(&self) -> usize {
+        self.window
+    }
 }
 
 /// Immutable per-stream rate configuration threaded through every production

--- a/crates/irlume-camera/src/rate_gate.rs
+++ b/crates/irlume-camera/src/rate_gate.rs
@@ -230,11 +230,6 @@ impl RatePolicy {
     pub(crate) const fn tolerance_percent(&self) -> u32 {
         self.tolerance_percent
     }
-
-    #[must_use]
-    pub(crate) const fn window(&self) -> usize {
-        self.window
-    }
 }
 
 /// Immutable per-stream rate configuration threaded through every production

--- a/crates/irlume-camera/src/rate_gate.rs
+++ b/crates/irlume-camera/src/rate_gate.rs
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Exact delivered-rate enforcement for a single logical capture stream.
+//!
+//! The gate is deliberately independent of the continuity trackers in
+//! [`crate::frame_provenance`]: it owns its own `last_successful_timestamp_micros`
+//! baseline so a corrupt dequeue (which advances the continuity trackers but
+//! delivers no frame) does not advance the rate baseline. The next successful
+//! delta therefore spans the corrupt frame, which is the conservative
+//! (fail-closed) direction.
+//!
+//! All comparisons are exact integer arithmetic. No `f32`/`f64` appears in any
+//! gate path: a floating-point comparison would let a boundary value round the
+//! wrong way and admit a stream that is actually below floor.
+
+use crate::contracts::StreamRole;
+use crate::frame_interval::FrameInterval;
+
+/// Number of positive deltas the window holds and requires before it can judge.
+///
+/// Thirty deltas is approximately two seconds at the binding IR floor (15 fps)
+/// and is above the empirically minimal 25 measured in the concurrent probe;
+/// five/ten-delta enforcement was measured invalid (see the slice-8 design).
+pub(crate) const RATE_WINDOW_CAPACITY: usize = 30;
+
+/// Whole-percent tolerance applied to the floor. 98% is the smallest
+/// whole-percent floor below the measured 14.714 Hz (98.093% of 15 fps) and
+/// rejects 10 Hz.
+pub(crate) const DEFAULT_TOLERANCE_PERCENT: u32 = 98;
+
+/// Exact IR floor: 15 frames per second.
+pub(crate) const IR_FLOOR_NUM: u32 = 15;
+pub(crate) const IR_FLOOR_DEN: u32 = 1;
+
+/// Exact RGB floor: 15/2 = 7.5 frames per second.
+pub(crate) const RGB_FLOOR_NUM: u32 = 15;
+pub(crate) const RGB_FLOOR_DEN: u32 = 2;
+
+/// Why a successful dequeue could not advance the rate window.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RateWindowError {
+    /// The timestamp did not strictly increase past the last successful one.
+    NonIncreasing { previous: i64, current: i64 },
+    /// Checked subtraction overflowed (a negative baseline against a positive
+    /// current, or vice versa).
+    Overflow,
+}
+
+impl std::fmt::Display for RateWindowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonIncreasing { previous, current } => write!(
+                f,
+                "rate timestamp did not increase: previous {previous}us, current {current}us"
+            ),
+            Self::Overflow => f.write_str("rate timestamp delta overflow"),
+        }
+    }
+}
+
+impl std::error::Error for RateWindowError {}
+
+const fn gcd_u64(mut left: u64, mut right: u64) -> u64 {
+    while right != 0 {
+        let remainder = left % right;
+        left = right;
+        right = remainder;
+    }
+    left
+}
+
+/// A fixed-capacity ring of exactly [`RATE_WINDOW_CAPACITY`] positive deltas.
+///
+/// Allocation-free after construction: the ring is a stack array. The window
+/// owns its own `last_successful_timestamp_micros` baseline and never reads
+/// [`crate::frame_provenance::TimestampObservation::delta_micros`], so a corrupt
+/// dequeue cannot advance the rate baseline.
+#[derive(Clone, Debug)]
+pub(crate) struct RateWindow {
+    deltas: [u64; RATE_WINDOW_CAPACITY],
+    len: usize,
+    head: usize,
+    last_successful_timestamp_micros: Option<i64>,
+}
+
+impl RateWindow {
+    pub(crate) const fn new() -> Self {
+        Self {
+            deltas: [0; RATE_WINDOW_CAPACITY],
+            len: 0,
+            head: 0,
+            last_successful_timestamp_micros: None,
+        }
+    }
+
+    /// Record a successful dequeue timestamp.
+    ///
+    /// The first successful timestamp only seeds the baseline and contributes no
+    /// delta. Every later one appends `current - last_successful` as a positive
+    /// `u64` delta and advances the baseline.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RateWindowError::NonIncreasing`] when the timestamp does not
+    /// strictly increase, and [`RateWindowError::Overflow`] when the checked
+    /// subtraction overflows. Both fail closed.
+    pub(crate) fn observe_success(&mut self, timestamp_micros: i64) -> Result<(), RateWindowError> {
+        if let Some(last) = self.last_successful_timestamp_micros {
+            let delta = timestamp_micros
+                .checked_sub(last)
+                .ok_or(RateWindowError::Overflow)?;
+            if delta <= 0 {
+                return Err(RateWindowError::NonIncreasing {
+                    previous: last,
+                    current: timestamp_micros,
+                });
+            }
+            self.push(delta as u64);
+        }
+        self.last_successful_timestamp_micros = Some(timestamp_micros);
+        Ok(())
+    }
+
+    fn push(&mut self, delta: u64) {
+        if self.len < RATE_WINDOW_CAPACITY {
+            self.deltas[(self.head + self.len) % RATE_WINDOW_CAPACITY] = delta;
+            self.len += 1;
+        } else {
+            self.deltas[self.head] = delta;
+            self.head = (self.head + 1) % RATE_WINDOW_CAPACITY;
+        }
+    }
+
+    /// Clear the ring and baseline for recovery. The first post-recovery
+    /// successful timestamp seeds the empty window and contributes no
+    /// cross-epoch delta.
+    pub(crate) fn reset(&mut self) {
+        self.deltas = [0; RATE_WINDOW_CAPACITY];
+        self.len = 0;
+        self.head = 0;
+        self.last_successful_timestamp_micros = None;
+    }
+
+    /// Number of deltas currently held (0..=[`RATE_WINDOW_CAPACITY`]).
+    #[must_use]
+    pub(crate) const fn count(&self) -> usize {
+        self.len
+    }
+
+    /// Whether the window holds the full [`RATE_WINDOW_CAPACITY`] deltas.
+    #[must_use]
+    pub(crate) const fn ready(&self) -> bool {
+        self.len == RATE_WINDOW_CAPACITY
+    }
+
+    /// Sum of the held deltas in microseconds.
+    #[must_use]
+    pub(crate) fn span_us(&self) -> u64 {
+        (0..self.len)
+            .map(|i| self.deltas[(self.head + i) % RATE_WINDOW_CAPACITY])
+            .sum()
+    }
+
+    /// Exact delivered rate as a reduced `(numerator, denominator)` fraction in
+    /// frames per second: `count * 1_000_000 / span_us`, reduced for reporting.
+    #[must_use]
+    pub(crate) fn delivered_rate(&self) -> (u64, u64) {
+        let numerator = self.len as u64 * 1_000_000;
+        let denominator = self.span_us();
+        if denominator == 0 {
+            return (0, 1);
+        }
+        let divisor = gcd_u64(numerator, denominator);
+        (numerator / divisor, denominator / divisor)
+    }
+
+    /// Exact 98%-floor comparison using checked `u128` arithmetic only:
+    /// `count * 1_000_000 * floor_den * 100 >= span_us * floor_num * tolerance`.
+    #[must_use]
+    pub(crate) fn meets_floor(
+        &self,
+        floor_num: u32,
+        floor_den: u32,
+        tolerance_percent: u32,
+    ) -> bool {
+        let count = self.len as u128;
+        let span = self.span_us() as u128;
+        let lhs = count * 1_000_000 * u128::from(floor_den) * 100;
+        let rhs = span * u128::from(floor_num) * u128::from(tolerance_percent);
+        lhs >= rhs
+    }
+}
+
+/// Immutable delivered-rate policy for one stream role.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RatePolicy {
+    floor_num: u32,
+    floor_den: u32,
+    tolerance_percent: u32,
+    window: usize,
+}
+
+impl RatePolicy {
+    pub(crate) const fn new(
+        floor_num: u32,
+        floor_den: u32,
+        tolerance_percent: u32,
+        window: usize,
+    ) -> Self {
+        Self {
+            floor_num,
+            floor_den,
+            tolerance_percent,
+            window,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn floor_num(&self) -> u32 {
+        self.floor_num
+    }
+
+    #[must_use]
+    pub(crate) const fn floor_den(&self) -> u32 {
+        self.floor_den
+    }
+
+    #[must_use]
+    pub(crate) const fn tolerance_percent(&self) -> u32 {
+        self.tolerance_percent
+    }
+
+    #[must_use]
+    pub(crate) const fn window(&self) -> usize {
+        self.window
+    }
+}
+
+/// Immutable per-stream rate configuration threaded through every production
+/// [`crate::TrackedStream`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StreamRateConfig {
+    role: StreamRole,
+    policy: RatePolicy,
+    requested: FrameInterval,
+    accepted: FrameInterval,
+}
+
+impl StreamRateConfig {
+    pub(crate) const fn new(
+        role: StreamRole,
+        requested: FrameInterval,
+        accepted: FrameInterval,
+    ) -> Self {
+        let (floor_num, floor_den) = match role {
+            StreamRole::Rgb => (RGB_FLOOR_NUM, RGB_FLOOR_DEN),
+            StreamRole::Ir => (IR_FLOOR_NUM, IR_FLOOR_DEN),
+        };
+        Self {
+            role,
+            policy: RatePolicy::new(
+                floor_num,
+                floor_den,
+                DEFAULT_TOLERANCE_PERCENT,
+                RATE_WINDOW_CAPACITY,
+            ),
+            requested,
+            accepted,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn role(&self) -> StreamRole {
+        self.role
+    }
+
+    #[must_use]
+    pub(crate) const fn policy(&self) -> RatePolicy {
+        self.policy
+    }
+
+    #[must_use]
+    pub(crate) const fn requested(&self) -> FrameInterval {
+        self.requested
+    }
+
+    #[must_use]
+    pub(crate) const fn accepted(&self) -> FrameInterval {
+        self.accepted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ir_config() -> StreamRateConfig {
+        StreamRateConfig::new(
+            StreamRole::Ir,
+            FrameInterval::new(1, 15).expect("valid requested interval"),
+            FrameInterval::new(1, 15).expect("valid accepted interval"),
+        )
+    }
+
+    #[test]
+    fn first_successful_timestamp_seeds_without_a_delta() {
+        let mut window = RateWindow::new();
+        window.observe_success(1_000_000).expect("first seed");
+        assert_eq!(window.count(), 0);
+        assert!(!window.ready());
+        assert_eq!(window.span_us(), 0);
+    }
+
+    #[test]
+    fn positive_deltas_accumulate_to_capacity() {
+        let mut window = RateWindow::new();
+        for i in 0..=RATE_WINDOW_CAPACITY {
+            window
+                .observe_success(i as i64 * 1_000_000)
+                .expect("monotonic");
+        }
+        assert_eq!(window.count(), RATE_WINDOW_CAPACITY);
+        assert!(window.ready());
+        assert_eq!(window.span_us(), RATE_WINDOW_CAPACITY as u64 * 1_000_000);
+    }
+
+    #[test]
+    fn non_increasing_timestamp_fails_closed() {
+        let mut window = RateWindow::new();
+        window.observe_success(1_000_000).expect("baseline");
+        assert_eq!(
+            window.observe_success(1_000_000),
+            Err(RateWindowError::NonIncreasing {
+                previous: 1_000_000,
+                current: 1_000_000,
+            })
+        );
+        assert_eq!(
+            window.observe_success(999_999),
+            Err(RateWindowError::NonIncreasing {
+                previous: 1_000_000,
+                current: 999_999,
+            })
+        );
+    }
+
+    #[test]
+    fn overflow_fails_closed() {
+        let mut window = RateWindow::new();
+        window.observe_success(i64::MIN).expect("negative baseline");
+        assert_eq!(
+            window.observe_success(i64::MAX),
+            Err(RateWindowError::Overflow)
+        );
+    }
+
+    #[test]
+    fn reset_clears_ring_and_baseline() {
+        let mut window = RateWindow::new();
+        for i in 0..=RATE_WINDOW_CAPACITY {
+            window
+                .observe_success(i as i64 * 1_000_000)
+                .expect("monotonic");
+        }
+        assert!(window.ready());
+        window.reset();
+        assert_eq!(window.count(), 0);
+        assert!(!window.ready());
+        // First post-reset timestamp seeds, no cross-epoch delta.
+        window.observe_success(5_000_000).expect("post-reset seed");
+        assert_eq!(window.count(), 0);
+    }
+
+    #[test]
+    fn ring_stays_exactly_thirty_and_displaces_oldest() {
+        let mut window = RateWindow::new();
+        // Deltas 1..=31 us: seed at 0, then cumulative timestamps.
+        let mut t = 0_i64;
+        window.observe_success(t).expect("seed");
+        for delta in 1..=31_u64 {
+            t += delta as i64;
+            window.observe_success(t).expect("monotonic");
+        }
+        assert_eq!(window.count(), RATE_WINDOW_CAPACITY);
+        // The 31 deltas were 1..=31; the oldest (1) was displaced, so the ring
+        // holds 2..=31, whose sum is (31*32/2) - 1 = 495.
+        assert_eq!(window.span_us(), 495);
+    }
+
+    #[test]
+    fn exact_ir_boundary_passes_and_one_microsecond_fails() {
+        // count 30, floor 15/1, tolerance 98: max passing span is
+        // floor(30 * 1_000_000 * 100 / (15 * 98)) = 2_040_816 us.
+        let mut window = RateWindow::new();
+        // Seed + 30 deltas of equal size summing to the boundary span.
+        let delta = 2_040_816 / RATE_WINDOW_CAPACITY as u64;
+        let mut t = 0_i64;
+        window.observe_success(t).expect("seed");
+        for _ in 0..RATE_WINDOW_CAPACITY {
+            t += delta as i64;
+            window.observe_success(t).expect("monotonic");
+        }
+        // Adjust the last delta so the span is exactly the boundary.
+        // Rebuild precisely instead of approximating.
+        let mut exact = RateWindow::new();
+        let mut t = 0_i64;
+        exact.observe_success(t).expect("seed");
+        for i in 0..RATE_WINDOW_CAPACITY {
+            let step = if i == RATE_WINDOW_CAPACITY - 1 {
+                2_040_816 - (RATE_WINDOW_CAPACITY as u64 - 1) * delta
+            } else {
+                delta
+            };
+            t += step as i64;
+            exact.observe_success(t).expect("monotonic");
+        }
+        assert_eq!(exact.span_us(), 2_040_816);
+        assert!(exact.meets_floor(IR_FLOOR_NUM, IR_FLOOR_DEN, DEFAULT_TOLERANCE_PERCENT));
+
+        // +1 us fails.
+        let mut over = RateWindow::new();
+        let mut t = 0_i64;
+        over.observe_success(t).expect("seed");
+        for i in 0..RATE_WINDOW_CAPACITY {
+            let step = if i == RATE_WINDOW_CAPACITY - 1 {
+                2_040_817 - (RATE_WINDOW_CAPACITY as u64 - 1) * delta
+            } else {
+                delta
+            };
+            t += step as i64;
+            over.observe_success(t).expect("monotonic");
+        }
+        assert_eq!(over.span_us(), 2_040_817);
+        assert!(!over.meets_floor(IR_FLOOR_NUM, IR_FLOOR_DEN, DEFAULT_TOLERANCE_PERCENT));
+    }
+
+    #[test]
+    fn ten_hz_ir_fails_and_rgb_seven_point_five_passes() {
+        // 10 Hz IR: 30 deltas of 100_000 us = 3_000_000 us span.
+        let mut ir = RateWindow::new();
+        let mut t = 0_i64;
+        ir.observe_success(t).expect("seed");
+        for _ in 0..RATE_WINDOW_CAPACITY {
+            t += 100_000;
+            ir.observe_success(t).expect("monotonic");
+        }
+        assert_eq!(ir.span_us(), 3_000_000);
+        assert!(!ir.meets_floor(IR_FLOOR_NUM, IR_FLOOR_DEN, DEFAULT_TOLERANCE_PERCENT));
+
+        // RGB 7.5 fps exact: 30 deltas of 133_333.33... -> use exact 15/2 floor.
+        // 7.5 fps = 1/7.5 s = 133_333.33 us per frame; 30 deltas = 4_000_000 us.
+        let mut rgb = RateWindow::new();
+        let mut t = 0_i64;
+        rgb.observe_success(t).expect("seed");
+        for _ in 0..RATE_WINDOW_CAPACITY {
+            t += 133_333;
+            rgb.observe_success(t).expect("monotonic");
+        }
+        // 30 * 133_333 = 3_999_990 us, slightly faster than 7.5 fps -> passes.
+        assert!(rgb.meets_floor(RGB_FLOOR_NUM, RGB_FLOOR_DEN, DEFAULT_TOLERANCE_PERCENT));
+    }
+
+    #[test]
+    fn delivered_rate_is_reduced() {
+        let mut window = RateWindow::new();
+        let mut t = 0_i64;
+        window.observe_success(t).expect("seed");
+        for _ in 0..RATE_WINDOW_CAPACITY {
+            t += 100_000;
+            window.observe_success(t).expect("monotonic");
+        }
+        // 30 * 1_000_000 / 3_000_000 = 10 fps, reduced to 10/1.
+        assert_eq!(window.delivered_rate(), (10, 1));
+    }
+
+    #[test]
+    fn config_derives_exact_floor_from_role() {
+        let ir = ir_config();
+        assert_eq!(ir.role(), StreamRole::Ir);
+        assert_eq!(ir.policy().floor_num(), IR_FLOOR_NUM);
+        assert_eq!(ir.policy().floor_den(), IR_FLOOR_DEN);
+        assert_eq!(ir.policy().tolerance_percent(), DEFAULT_TOLERANCE_PERCENT);
+        assert_eq!(ir.policy().window(), RATE_WINDOW_CAPACITY);
+
+        let rgb = StreamRateConfig::new(
+            StreamRole::Rgb,
+            FrameInterval::new(1, 7).expect("valid"),
+            FrameInterval::new(1, 7).expect("valid"),
+        );
+        assert_eq!(rgb.policy().floor_num(), RGB_FLOOR_NUM);
+        assert_eq!(rgb.policy().floor_den(), RGB_FLOOR_DEN);
+    }
+}

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -37,6 +37,7 @@ const CAPABILITIES: &[&str] = &[
     "login-plan-json",
     "login-transactions",
     "models-list-json",
+    "camera-diagnostics",
 ];
 
 /// The contract the caller asked for, or the failure to report.
@@ -527,6 +528,58 @@ pub fn doctor(args: &[String]) -> ExitCode {
         &success(COMMAND, json!({ "checks": checks }), contract),
         ExitCode::SUCCESS,
     )
+}
+
+/// `irlume camera diagnostics --json`: machine-readable delivered-rate evidence
+/// for the configured camera pair (issue #462). Runs the ordinary gated capture
+/// session per present role and reports the exact requested/accepted/delivered
+/// rationals, sequence gaps/drops, timestamp clock/source, and same-domain
+/// RGB/IR skew. An under-rate stream is a measured `fail` object, never prose.
+pub fn camera_diagnostics(args: &[String]) -> ExitCode {
+    const COMMAND: &str = "camera.diagnostics";
+    let contract = match negotiate(args) {
+        Contract::Agreed(v) => v,
+        Contract::Malformed => {
+            return emit(
+                &failure(COMMAND, "usage-error", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+        Contract::Unsupported => {
+            return emit(
+                &failure(COMMAND, "unsupported-contract", false, CONTRACT_DEFAULT),
+                ExitCode::from(2),
+            )
+        }
+    };
+    if without_contract(args) != ["camera", "diagnostics", "--json"] {
+        return emit(
+            &failure(COMMAND, "usage-error", false, contract),
+            ExitCode::from(2),
+        );
+    }
+    match crate::daemon_request(&Request::CameraDiagnostics) {
+        Ok(Response::CameraDiagnostics(report)) => emit(
+            &success(COMMAND, json!(report), contract),
+            ExitCode::SUCCESS,
+        ),
+        Ok(Response::OperationError { code, retryable }) => emit(
+            &failure(COMMAND, error_code(code), retryable, contract),
+            ExitCode::FAILURE,
+        ),
+        Ok(Response::Error(_)) => emit(
+            &failure(COMMAND, "operation-failed", false, contract),
+            ExitCode::FAILURE,
+        ),
+        Ok(_) => emit(
+            &failure(COMMAND, "protocol-error", false, contract),
+            ExitCode::FAILURE,
+        ),
+        Err(_) => emit(
+            &failure(COMMAND, "daemon-unavailable", true, contract),
+            ExitCode::FAILURE,
+        ),
+    }
 }
 
 /// `irlume login status --json`: which PAM surfaces carry face auth.
@@ -2296,7 +2349,8 @@ mod tests {
                 "auth-test-events",
                 "login-plan-json",
                 "login-transactions",
-                "models-list-json"
+                "models-list-json",
+                "camera-diagnostics"
             ])
         );
         assert!(document.get("error").is_none());

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -228,6 +228,9 @@ fn main() -> std::process::ExitCode {
         (Some("update"), _) => commands::update(&args),
         (Some("uninstall"), _) => uninstall::run(&args),
         (Some("doctor"), _) if args.iter().any(|arg| arg == "--json") => machine::doctor(&args),
+        (Some("camera"), Some("diagnostics")) if args.iter().any(|arg| arg == "--json") => {
+            machine::camera_diagnostics(&args)
+        }
         (Some("status"), _) if args.iter().any(|arg| arg == "--json") => machine::status(&args),
         (Some("version"), _) if args.iter().any(|arg| arg == "--json") => machine::version(&args),
         (Some("version"), _) | (Some("--version"), _) | (Some("-V"), _) => {

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -32,7 +32,8 @@ fn version_json_is_one_machine_document() {
             "auth-test-events",
             "login-plan-json",
             "login-transactions",
-            "models-list-json"
+            "models-list-json",
+            "camera-diagnostics"
         ])
     );
 }

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -907,7 +907,7 @@ pub enum Response {
     /// A framing-guide sample (`PositionSample`).
     Position(PositionReport),
     /// Delivered-rate diagnostic report (`CameraDiagnostics`).
-    CameraDiagnostics(CameraDiagnosticsReport),
+    CameraDiagnostics(Box<CameraDiagnosticsReport>),
     /// Median eye-aspect-ratio over a capture (`CaptureEarMedian`); `None` if no
     /// eye was detected in any frame.
     EarMedian(Option<f32>),

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -531,6 +531,11 @@ pub enum Request {
     /// must NOT enumerate for themselves; a second opener racing the
     /// daemon's stream is EBUSY on strict UVC modules (#187).
     ListCameras,
+    /// Machine-readable delivered-rate diagnostics for the configured camera
+    /// pair (issue #462). CAMERA-CLASS: runs the normal gated capture session
+    /// per present role and reports the measured evidence; a below-floor stream
+    /// is returned as a measured `fail`, never degraded to English.
+    CameraDiagnostics,
     /// Liveness/health ping.
     Ping,
     /// Daemon self-report: what it actually has loaded and which camera tier it
@@ -901,6 +906,8 @@ pub enum Response {
     },
     /// A framing-guide sample (`PositionSample`).
     Position(PositionReport),
+    /// Delivered-rate diagnostic report (`CameraDiagnostics`).
+    CameraDiagnostics(CameraDiagnosticsReport),
     /// Median eye-aspect-ratio over a capture (`CaptureEarMedian`); `None` if no
     /// eye was detected in any frame.
     EarMedian(Option<f32>),
@@ -1004,6 +1011,76 @@ pub enum Response {
     },
 }
 
+/// One logical stream role's delivered-rate measurement, as a plain serializable
+/// DTO with no camera-crate dependency. Carried by [`Error::DeliveredRate`] and
+/// embedded in [`Response::CameraDiagnostics`] so a caller can act on an
+/// under-rate stream without parsing prose.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CameraStreamRateEvidence {
+    /// `"rgb"` or `"ir"`.
+    pub role: String,
+    /// Requested frame interval, numerator and denominator (reduced).
+    pub requested_num: u32,
+    pub requested_den: u32,
+    /// Accepted (negotiated) frame interval, numerator and denominator (reduced).
+    pub accepted_num: u32,
+    pub accepted_den: u32,
+    /// Exact floor numerator/denominator in frames per second.
+    pub floor_num: u32,
+    pub floor_den: u32,
+    /// Whole-percent tolerance applied to the floor (98).
+    pub tolerance_percent: u32,
+    /// Number of deltas held in the rolling window.
+    pub window_count: u32,
+    /// Sum of the held deltas in microseconds.
+    pub window_span_us: u64,
+    /// Exact delivered rate numerator/denominator in frames per second (reduced).
+    pub delivered_num: u64,
+    pub delivered_den: u64,
+    /// Whether the measured rate clears the exact floor.
+    pub meets_floor: bool,
+    /// Sequence gap of the latest delivered frame.
+    pub sequence_gap: u32,
+    /// Cumulative dropped frames reported by sequence continuity.
+    pub cumulative_drops: u64,
+    /// V4L2 timestamp clock (`"monotonic"`, `"copy"`, `"unknown"`).
+    pub clock: String,
+    /// V4L2 timestamp source (`"end_of_frame"`, `"start_of_exposure"`).
+    pub source: String,
+    /// Latest successful timestamp in microseconds.
+    pub latest_timestamp_us: i64,
+    /// Stream epoch the evidence belongs to.
+    pub stream_epoch: u64,
+}
+
+/// One role's diagnostic result: whether it is known, its state, and the exact
+/// rate evidence when a measurement exists.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CameraRoleDiagnostic {
+    /// Whether this role is present on the machine at all.
+    pub known: bool,
+    /// `"measured"` (floor cleared), `"fail"` (under-rate), `"missing"` (no
+    /// node), or `"unknown"` (open/transport failure).
+    pub state: String,
+    /// Exact evidence, present for `measured` and `fail`, absent otherwise.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub evidence: Option<CameraStreamRateEvidence>,
+}
+
+/// Complete machine diagnostic report for [`Response::CameraDiagnostics`].
+///
+/// Deliberately free of device paths, account identity, and template data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CameraDiagnosticsReport {
+    pub rgb: CameraRoleDiagnostic,
+    pub ir: CameraRoleDiagnostic,
+    /// Same-domain RGB/IR skew in microseconds. `None` means unknown (the two
+    /// latest timestamps do not share clock and source, or a role is missing).
+    pub skew_us: Option<i64>,
+    /// Capture strategy used by the diagnostic (`"burst"`, `"streaming"`, …).
+    pub capture_strategy: String,
+}
+
 /// Crate-wide error type.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -1019,6 +1096,11 @@ pub enum Error {
     Tpm(String),
     #[error("policy: {0}")]
     Policy(String),
+    /// The camera delivered frames below the exact role floor. Carries the
+    /// machine-readable measurement so callers act on the rate, not the prose;
+    /// the message is a fixed, stable string and the evidence rides in the payload.
+    #[error("delivered rate below floor")]
+    DeliveredRate(Box<CameraStreamRateEvidence>),
     /// A long camera operation stopped early because an authentication needed
     /// the camera. Distinct from a failure: nothing went wrong and nothing was
     /// written, so the caller should say "retry", not "it broke".
@@ -1047,6 +1129,72 @@ pub(crate) mod testenv {
 
 #[cfg(test)]
 mod tests {
+
+    /// The delivered-rate DTO is a plain serializable carrier: snake_case JSON
+    /// round-trips every field, and the typed error keeps a stable,
+    /// machine-parseable message with the evidence recoverable from the payload
+    /// rather than parsed from prose (#462).
+    #[test]
+    fn delivered_rate_error_carries_machine_readable_evidence() {
+        use super::{CameraStreamRateEvidence, Error};
+
+        let evidence = CameraStreamRateEvidence {
+            role: "ir".to_string(),
+            requested_num: 1,
+            requested_den: 15,
+            accepted_num: 1,
+            accepted_den: 15,
+            floor_num: 15,
+            floor_den: 1,
+            tolerance_percent: 98,
+            window_count: 30,
+            window_span_us: 2_000_000,
+            delivered_num: 15,
+            delivered_den: 1,
+            meets_floor: true,
+            sequence_gap: 0,
+            cumulative_drops: 0,
+            clock: "monotonic".to_string(),
+            source: "end_of_frame".to_string(),
+            latest_timestamp_us: 123_456_789,
+            stream_epoch: 1,
+        };
+
+        // snake_case JSON round-trips every field exactly.
+        let json = serde_json::to_string(&evidence).expect("serialize");
+        assert!(
+            json.contains("\"requested_num\":1"),
+            "requested_num: {json}"
+        );
+        assert!(
+            json.contains("\"window_span_us\":2000000"),
+            "window_span_us: {json}"
+        );
+        assert!(
+            json.contains("\"delivered_num\":15"),
+            "delivered_num: {json}"
+        );
+        assert!(
+            json.contains("\"tolerance_percent\":98"),
+            "tolerance_percent: {json}"
+        );
+        assert!(
+            json.contains("\"latest_timestamp_us\":123456789"),
+            "latest: {json}"
+        );
+        assert!(json.contains("\"clock\":\"monotonic\""), "clock: {json}");
+        let round: CameraStreamRateEvidence = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(round, evidence);
+
+        // The error message is a fixed, stable prefix; the evidence is carried
+        // in the payload, not logged into the prose.
+        let error = Error::DeliveredRate(Box::new(evidence.clone()));
+        assert_eq!(error.to_string(), "delivered rate below floor");
+        match error {
+            Error::DeliveredRate(inner) => assert_eq!(*inner, evidence),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
 
     /// The digest a `HashedModel` reports must be the digest of the bytes it
     /// carries, because callers skip their own hashing on the strength of it

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -100,6 +100,7 @@ pub fn classify(req: &Request) -> Class {
         | SetupIrEmitter { .. }
         | TuneCaptureMode { .. }
         | SelfTest { .. }
+        | CameraDiagnostics
         // Enumeration OPENS every node, so it belongs to the camera class
         // even though it captures nothing (#187).
         | ListCameras => Class::Camera,

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3736,7 +3736,7 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             let rgb = engine.rgb_device();
             let ir = engine.ir_available().then(|| engine.ir_device());
             match irlume_auth::camera_rate_diagnostics(rgb, ir) {
-                Ok(report) => Response::CameraDiagnostics(report),
+                Ok(report) => Response::CameraDiagnostics(Box::new(report)),
                 Err(error) => Response::Error(error.to_string()),
             }
         }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -5387,6 +5387,7 @@ mod tests {
         ListCameras => Request::ListCameras,
         Ping => Request::Ping,
         Health => Request::Health,
+        CameraDiagnostics => Request::CameraDiagnostics,
         // The user-bearing form, so the traversal walk covers it.
         PositionSample => Request::PositionSample { user: Some(u()) },
         SealPassword => Request::SealPassword {

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2389,7 +2389,7 @@ fn posture(req: &Request) -> RequestPosture<'_> {
             user: user.as_deref(),
             enrollment: Reads,
         },
-        Ping | Health | Identify | ListCameras => RequestPosture {
+        Ping | Health | Identify | ListCameras | CameraDiagnostics => RequestPosture {
             privilege: AnyPeer,
             user: None,
             enrollment: Reads,
@@ -3730,6 +3730,14 @@ fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Resp
             match irlume_core::template_key::forget_recovery(&user) {
                 Ok(()) => Response::Ok(format!("recovery passphrase erased for '{user}'")),
                 Err(e) => Response::Error(e.to_string()),
+            }
+        }
+        Request::CameraDiagnostics => {
+            let rgb = engine.rgb_device();
+            let ir = engine.ir_available().then(|| engine.ir_device());
+            match irlume_auth::camera_rate_diagnostics(rgb, ir) {
+                Ok(report) => Response::CameraDiagnostics(report),
+                Err(error) => Response::Error(error.to_string()),
             }
         }
         Request::ListCameras => Response::Cameras(

--- a/scripts/hardware/test-validate-slice4-hardware.py
+++ b/scripts/hardware/test-validate-slice4-hardware.py
@@ -26,9 +26,9 @@ def valid_record():
             {
                 "role": "rgb",
                 "frames": 100,
-                "observations": 114,
-                "discarded_observations": 14,
-                "sequence_span_sum": 114,
+                "observations": 236,
+                "discarded_observations": 136,
+                "sequence_span_sum": 236,
                 "delivered_hz": 100 / 60.5,
                 "gap_total": 2,
                 "cumulative_drops": 2,
@@ -50,9 +50,9 @@ def valid_record():
             {
                 "role": "ir",
                 "frames": 90,
-                "observations": 91,
-                "discarded_observations": 1,
-                "sequence_span_sum": 89,
+                "observations": 213,
+                "discarded_observations": 123,
+                "sequence_span_sum": 211,
                 "delivered_hz": 90 / 60.5,
                 "gap_total": 0,
                 "cumulative_drops": 0,
@@ -234,8 +234,8 @@ class ValidatorTests(unittest.TestCase):
         def keep_only_three_internally_consistent_rgb_frames(record):
             stream = record["streams"][0]
             stream["frames"] = 3
-            stream["observations"] = 17
-            stream["sequence_span_sum"] = 17
+            stream["observations"] = 139
+            stream["sequence_span_sum"] = 139
             stream["delivered_hz"] = 3 / record["duration_seconds"]
             stream["delta_count"] = 1
             stream["delta_min_us"] = stream["timestamp_span_sum_us"]
@@ -263,10 +263,10 @@ class ValidatorTests(unittest.TestCase):
 
     def test_sequence_observation_accounting_is_exact(self):
         self.assert_rejected(
-            lambda record: record["streams"][0].__setitem__("observations", 113)
+            lambda record: record["streams"][0].__setitem__("observations", 235)
         )
         self.assert_rejected(
-            lambda record: record["streams"][0].__setitem__("sequence_span_sum", 113)
+            lambda record: record["streams"][0].__setitem__("sequence_span_sum", 235)
         )
 
         def omit_rgb_warmup(record):

--- a/scripts/hardware/validate-slice4-hardware.py
+++ b/scripts/hardware/validate-slice4-hardware.py
@@ -167,11 +167,23 @@ def main(argv):
         discarded_observations = bounded_u64(
             stream.get("discarded_observations"), f"{role}: discarded observations"
         )
-        expected_discarded = {"rgb": 14, "ir": 1}[role]
-        if discarded_observations != expected_discarded:
+        # The delivered-rate fill discards a bounded number of frames per
+        # stream on top of the warm-up discards: flush RATE_STARTUP_FLUSH (30)
+        # + fill (1 seed + RATE_WINDOW_CAPACITY deltas = 31) per establishment,
+        # run twice (initial + post-recovery). The faster stream keeps
+        # discarding until its slower twin is ready, so the total is rate-ratio
+        # dependent; assert only the deterministic minimum, and let the
+        # delivered/discarded accounting check above catch inconsistency.
+        minimum_discarded = {
+            # warm-up (14 = 7 initial + 7 recovered; 1 = the IR session warm-up)
+            # + two fill establishments (2 * 61).
+            "rgb": 14 + 2 * 61,
+            "ir": 1 + 2 * 61,
+        }[role]
+        if discarded_observations < minimum_discarded:
             fail(
-                f"{role}: expected {expected_discarded} deterministic warm-up "
-                f"observations, got {discarded_observations}"
+                f"{role}: discarded observations {discarded_observations} below "
+                f"the minimum fill/warm-up {minimum_discarded}"
             )
         if observations != frames + discarded_observations:
             fail(f"{role}: delivered/discarded observation accounting mismatch")


### PR DESCRIPTION
## Summary

Refs #462 — final slice.

Enforces an exact delivered-rate floor on every production capture stream and
exposes machine-readable diagnostics for it, so a camera that advertises a
Windows Hello interval but delivers too slowly is caught and reported, not
assumed adequate.

## What it does

- **Exact 30-delta delivered-rate gate** (`rate_gate::RateWindow`) on
  `TrackedStream::next` — the single dequeue choke point for RGB/IR sessions,
  `capture_raw_burst_timed`, `capture_ir_streaming`, `capture_ir_sequence`, and
  recovery. All integer arithmetic (no `f32`/`f64`). Floors: IR 15/1, RGB 15/2;
  98% tolerance, derived from measured dual-stream hardware (14.714 Hz).
- **Independent rate baseline**: a corrupt dequeue does not advance the rate
  window (the next valid delta spans it, fail-closed). Recovery atomically
  resets the window with the two continuity trackers.
- **Typed failure**: `Error::DeliveredRate(Box<CameraStreamRateEvidence>)`
  carries the exact measurement; the message is a fixed stable string.
- **Per-frame evidence**: immutable `DeliveredRateEvidence` (requested/accepted/
  floor/delivered rationals, gaps, drops, clock/source, epoch) attached to every
  frame's runtime provenance.
- **Machine diagnostics**: `irlume camera diagnostics --json` (contract-1
  additive capability `camera-diagnostics`) → `Request/Response::CameraDiagnostics`
  (boxed report), daemon camera-class handler runs the ordinary gated capture per
  present role and reports requested/accepted/delivered, gaps/drops, clock/source,
  and same-domain RGB/IR skew. No device paths, account identity, or template data.

## Validation

- 1,598 guarded workspace tests green; strict clippy/fmt/docs/release/diff clean.
- 4 compile-valid rate-gate mutants killed and restored (inverted comparison,
  tolerance off-by-one, wrong IR floor, no-op reset).
- Measured basis: single-stream and concurrent dual-stream kernel-timestamp probes
  (`target/rate-probe-evidence/…/analysis.json`); 30-delta window is the smallest
  round window above the measured 25 and clears the 98% floor.

## Scope / non-goals

- No change to interval selection, `S_FMT`/`S_PARM` policy, emitter writes, or
  capture-mode selection. Diagnostics are read-only captures; no device writes.
- `camera diagnostics` opens the camera through the same lease/arbiter as other
  camera-class requests.
