### PR TITLE
fix(hardware): widen global timestamp-span tolerance for concurrent dual captures

### DIFF
--- a/scripts/hardware/validate-slice4-hardware.py
+++ b/scripts/hardware/validate-slice4-hardware.py
@@ -13,6 +13,14 @@ I64_MAX = (1 << 63) - 1
 MIN_CONTINUITY_HZ = 1.0
 MAX_CONTINUITY_DELTA_US = 1_000_000
 TIMESTAMP_BOUNDARY_INTERVALS = 3
+# The global timestamp span (first delivered frame to last) may legitimately
+# undershoot the measured duration by the capture loop's start and end slack:
+# the first frame lands up to ~one interval after the loop starts, and the last
+# frame of the slower stream in a concurrent pair lands up to ~three intervals
+# before the loop's deadline (measured ~201 ms of end lag on the ASUS IR at
+# 15 fps). A real stall collapses the span by whole seconds, so a separate,
+# wider budget here keeps that signal while not flaking on clean timing.
+GLOBAL_SPAN_BOUNDARY_INTERVALS = 6
 RECORD_KEYS = {
     "kind",
     "schema_version",
@@ -299,7 +307,7 @@ def main(argv):
         duration_us = duration * 1_000_000
         if (
             abs(timestamp_span - duration_us)
-            > TIMESTAMP_BOUNDARY_INTERVALS * maximum
+            > GLOBAL_SPAN_BOUNDARY_INTERVALS * maximum
         ):
             fail(
                 f"{role}: global timestamp span {timestamp_span}us does not track "


### PR DESCRIPTION
## Problem

The slice-4 hardware stress test (`physical_timestamp_continuity_stress`) fails intermittently on the ASUS dual with:

```
ir: global timestamp span ~59.75s does not track measured duration ~60.0s
```

**It is not a code regression.** The failing head `2fe5b920` and the last passing head `3a4eb9e` have byte-identical Rust camera code — they differ only in a test fixture.

## Root cause

The IR stream's `global timestamp span` (first→last delivered timestamp) undershoots the measured wall-clock duration by ~270 ms, dominated by ~201 ms of **end lag**: the IR stream (15 fps) delivers its last frame ~3 frame-intervals before the capture loop's deadline, while RGB (30 fps) ends cleanly.

The validator budgeted `3 × max_delta` for this check. The `3a4eb9e` pass happened to have `max_delta = 104 ms` → 312 ms budget (absorbed the 270 ms). Cleaner runs have `max_delta = 68 ms` → 204 ms budget, which flakes. So the check was tightest exactly when the timing was cleanest.

## Fix

A dedicated `GLOBAL_SPAN_BOUNDARY_INTERVALS = 6` budget for the global-span check, leaving the recovery-gap check at 3 intervals. A genuine stall still collapses the span by whole seconds, so the check keeps its purpose — it just no longer flakes on the slower stream's natural end-lag.

## Verification

- `python3 scripts/hardware/test-validate-slice4-hardware.py` → 16 pass.
- Hardware re-run on the ASUS dual at the fixed head → **PASS** (was failing consistently before).