### PR TITLE
fix(camera): stop guessing /dev/video2 as the IR node

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -28,7 +28,7 @@ pub use irlume_camera::{camera_rate_diagnostics, list_pairs, privacy_engaged, Ca
 /// so select_pair can survive a udev renumber. Re-exported so the daemon can pick
 /// devices without depending on the camera crate directly. See
 /// [`irlume_camera::select_pair`].
-pub use irlume_camera::{capabilities, device_identity, select_pair};
+pub use irlume_camera::{capabilities, device_identity, select_pair, select_rgb};
 
 /// Loaded models + camera device selection. Build once, reuse per request.
 pub struct Engine {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -3,9 +3,10 @@
 
 //! V4L2 capture for the paired RGB + IR cameras, and active-IR-emitter control.
 //!
-//! Hardware model (Windows-Hello-class module): one RGB sensor (`/dev/video0`)
-//! and one greyscale IR sensor (`/dev/video2`), plus an 850/940nm emitter fired
-//! via a UVC Extension-Unit control write (cf. linux-enable-ir-emitter).
+//! Hardware model (Windows-Hello-class module): one RGB sensor and one
+//! greyscale IR sensor on a single USB device, discovered by topology rather
+//! than assumed node numbers, plus an 850/940nm emitter fired via a UVC
+//! Extension-Unit control write (cf. linux-enable-ir-emitter).
 //!
 //! The auth path captures RGB and IR one at a time unless a measurement says
 //! the module can sustain both: `capture_mode_decision` in irlume-auth answers
@@ -380,6 +381,11 @@ pub struct IrCaptureStats {
     pub saturation_frame: Option<Vec<u8>>,
 }
 
+/// Default `--rgb`/`--ir` flag values for the dev diagnostic tools, and the
+/// engine's pre-`with_devices` placeholder. NOT a discovery fallback: the
+/// discovery path ([`select_pair`]) returns `None` rather than guessing a node
+/// number, because a guessed `/dev/videoN` is wrong the moment udev renumbers
+/// a device and can land a colour node in the IR slot (#385).
 pub const DEFAULT_RGB_DEVICE: &str = "/dev/video0";
 pub const DEFAULT_IR_DEVICE: &str = "/dev/video2";
 const RGB_W: u32 = 640;
@@ -2859,14 +2865,17 @@ pub fn configured_pair_no_probe() -> Option<(String, String)> {
 ///   2. Auto-discovery: a Hello camera is one physical device exposing *both* an
 ///      RGB and an IR node. Ranked: a device matching `IRLUME_CAMERA_PIN` wins,
 ///      else a built-in (`removable=fixed`) wins, else the first pair found.
-///   3. Compiled defaults (`video0`/`video2`).
-pub fn select_pair() -> (String, String) {
+///
+/// `None` when no pair could be established. There is deliberately no
+/// node-number fallback: a guessed `/dev/videoN` is wrong the moment udev
+/// renumbers a device, and can land a colour node in the IR slot (#385).
+pub fn select_pair() -> Option<(String, String)> {
     if let (Ok(r), Ok(i)) = (
         std::env::var("IRLUME_RGB_DEVICE"),
         std::env::var("IRLUME_IR_DEVICE"),
     ) {
         if !r.trim().is_empty() && !i.trim().is_empty() {
-            return (r, i);
+            return Some((r, i));
         }
     }
     // A user-chosen pair persisted via the daemon (TUI Cameras tab) overrides
@@ -2887,7 +2896,7 @@ pub fn select_pair() -> (String, String) {
             if let Some(pair) =
                 resolve_saved_pair(r, i, saved_rgb_id.as_deref(), saved_ir_id.as_deref())
             {
-                return pair;
+                return Some(pair);
             }
         }
     }
@@ -2904,7 +2913,17 @@ pub fn select_pair() -> (String, String) {
             best = Some((p.rgb, p.ir));
         }
     }
-    best.unwrap_or_else(|| (DEFAULT_RGB_DEVICE.into(), DEFAULT_IR_DEVICE.into()))
+    best
+}
+
+/// The first discoverable RGB node, for the convenience tier when no Hello
+/// pair exists. `None` on a camera-less machine. Reads the same discovery
+/// [`select_pair`] does, so it never guesses a node number.
+pub fn select_rgb() -> Option<String> {
+    discover_nodes()
+        .into_iter()
+        .find(|(_, role)| matches!(role, Role::Rgb))
+        .map(|(path, _)| path)
 }
 
 fn device_exists(dev: &str) -> bool {
@@ -10326,7 +10345,7 @@ mod tests {
         let _i = EnvGuard::set("IRLUME_IR_DEVICE", "/dev/irlume-test-ir");
         assert_eq!(
             select_pair(),
-            ("/dev/irlume-test-rgb".into(), "/dev/irlume-test-ir".into())
+            Some(("/dev/irlume-test-rgb".into(), "/dev/irlume-test-ir".into()))
         );
     }
 
@@ -11378,7 +11397,7 @@ mod tests {
     }
 
     #[test]
-    fn select_pair_persisted_conf_and_discovery_fallback() {
+    fn select_pair_persisted_conf_and_discovery() {
         let _lock = env_lock();
         let _rgb_env = EnvGuard::unset("IRLUME_RGB_DEVICE");
         let _ir_env = EnvGuard::unset("IRLUME_IR_DEVICE");
@@ -11388,18 +11407,13 @@ mod tests {
         let _conf = EnvGuard::set("IRLUME_CONFIG_DIR", dir.to_str().unwrap());
 
         // With no env override, no persisted pair and no discoverable Hello
-        // pair, the compiled defaults come back. Loopback nodes can never form
-        // a pair (no USB descriptors in sysfs), so this holds on CI; a dev box
-        // with a real Hello camera legitimately discovers its own pair
-        // instead, so the fallback asserts are skipped there.
+        // pair, there is no node-number fallback: `None`, never a guessed
+        // `/dev/videoN`. Loopback nodes can never form a pair (no USB
+        // descriptors in sysfs), so this holds on CI; a dev box with a real
+        // Hello camera legitimately discovers its own pair instead, so the
+        // fallback assert is skipped there.
         if list_pairs().is_empty() {
-            assert_eq!(
-                select_pair(),
-                (
-                    DEFAULT_RGB_DEVICE.to_string(),
-                    DEFAULT_IR_DEVICE.to_string()
-                )
-            );
+            assert_eq!(select_pair(), None);
         }
 
         // A persisted pair whose nodes are GONE (stale cameras.conf after a
@@ -11410,13 +11424,7 @@ mod tests {
         )
         .unwrap();
         if list_pairs().is_empty() {
-            assert_eq!(
-                select_pair(),
-                (
-                    DEFAULT_RGB_DEVICE.to_string(),
-                    DEFAULT_IR_DEVICE.to_string()
-                )
-            );
+            assert_eq!(select_pair(), None);
         }
 
         // A persisted pair whose nodes EXIST wins over discovery and defaults.
@@ -11425,7 +11433,7 @@ mod tests {
         std::fs::write(dir.join("cameras.conf"), "rgb=/dev/null\nir=/dev/zero\n").unwrap();
         assert_eq!(
             select_pair(),
-            ("/dev/null".to_string(), "/dev/zero".to_string())
+            Some(("/dev/null".to_string(), "/dev/zero".to_string()))
         );
 
         // A blank env override must not shadow the persisted pair...
@@ -11434,7 +11442,7 @@ mod tests {
             let _i = EnvGuard::set("IRLUME_IR_DEVICE", "  ");
             assert_eq!(
                 select_pair(),
-                ("/dev/null".to_string(), "/dev/zero".to_string())
+                Some(("/dev/null".to_string(), "/dev/zero".to_string()))
             );
         }
         // ...but a real one beats it, without an existence check (explicit
@@ -11443,10 +11451,10 @@ mod tests {
         let _i = EnvGuard::set("IRLUME_IR_DEVICE", "/dev/irlume-env-ir");
         assert_eq!(
             select_pair(),
-            (
+            Some((
                 "/dev/irlume-env-rgb".to_string(),
                 "/dev/irlume-env-ir".to_string()
-            )
+            ))
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1926,8 +1926,12 @@ pub(crate) fn camera_pair() -> (String, String) {
                 rgb_dev.unwrap_or_else(|| "none".into()),
                 ir_dev.unwrap_or_else(|| "none".into()),
             ),
-            // Same rule as `caps`: probe only on proven absence.
-            Err(e) if daemon_proven_absent(&e) => irlume_camera::select_pair(), // the one permitted probe
+            // Same rule as `caps`: probe only on proven absence. `None` means
+            // no discoverable pair, reported as "none" rather than a guess.
+            Err(e) if daemon_proven_absent(&e) => {
+                // the one permitted probe
+                irlume_camera::select_pair().unwrap_or_else(|| ("none".into(), "none".into()))
+            }
             _ => irlume_camera::configured_pair_no_probe()
                 .unwrap_or_else(|| ("unknown".into(), "unknown".into())),
         }
@@ -2024,13 +2028,16 @@ fn enrolldev(args: &[String]) -> std::process::ExitCode {
 pub(crate) fn devices_from_flags(
     rgb: Option<&str>,
     ir: Option<&str>,
-    selected: impl FnOnce() -> (String, String),
+    selected: impl FnOnce() -> Option<(String, String)>,
 ) -> Option<(String, String)> {
     match (rgb, ir) {
         (None, None) => None,
         (Some(r), Some(i)) => Some((r.to_string(), i.to_string())),
         (r, i) => {
-            let (sel_r, sel_i) = selected();
+            // One flag alone needs its partner from the selection; with no
+            // discoverable pair there is nothing to guess (no `/dev/videoN`
+            // folklore), so the half-pair is refused rather than invented.
+            let (sel_r, sel_i) = selected()?;
             Some((
                 r.map(str::to_string).unwrap_or(sel_r),
                 i.map(str::to_string).unwrap_or(sel_i),
@@ -4187,6 +4194,14 @@ fn stream_minimum_checks(report: &mut crate::doctor_report::Report, rgb_node: &s
     }
 }
 
+fn selected_stream_minimum_checks(
+    report: &mut crate::doctor_report::Report,
+    pair: Option<(String, String)>,
+) {
+    let (rgb_node, ir_node) = pair.unwrap_or_default();
+    stream_minimum_checks(report, &rgb_node, &ir_node);
+}
+
 /// One pass over the machine. Prints the human report or stays silent and
 /// records, depending on `report`.
 /// `args` carries `--user`, which doctor reports on in eight per-user lines.
@@ -4485,8 +4500,7 @@ fn doctor_run(
         // deliberate camera probe: doctor's job is to inspect the hardware,
         // and negotiating a stream format needs the node open. Foreground and
         // occasional, not a refresh loop, so it is not the #187 shape.
-        let (rgb_node, ir_node) = irlume_camera::select_pair();
-        stream_minimum_checks(report, &rgb_node, &ir_node);
+        selected_stream_minimum_checks(report, irlume_camera::select_pair());
     }
 
     // --- models / runtime --------------------------------------------------
@@ -5367,8 +5381,23 @@ mod tests {
     }
 
     #[test]
+    fn selected_stream_minimum_checks_emit_both_ids_when_selection_finds_no_pair() {
+        let mut report = crate::doctor_report::Report::new(crate::doctor_report::Mode::Collect);
+        selected_stream_minimum_checks(&mut report, None);
+
+        let checks = report.into_checks();
+        for id in ["ir-stream-hello-minimum", "rgb-stream-hello-minimum"] {
+            assert_eq!(
+                checks.iter().filter(|check| check.id == id).count(),
+                1,
+                "{id} must remain present when no camera pair is selected"
+            );
+        }
+    }
+
+    #[test]
     fn devices_from_flags_honors_either_flag_alone() {
-        let sel = || ("/dev/sel-rgb".to_string(), "/dev/sel-ir".to_string());
+        let sel = || Some(("/dev/sel-rgb".to_string(), "/dev/sel-ir".to_string()));
         // No flags: no override, and the selection must not even run.
         assert_eq!(
             devices_from_flags(None, None, || unreachable!("no probe without flags")),

--- a/crates/irlume-cli/tests/camera_authority.rs
+++ b/crates/irlume-cli/tests/camera_authority.rs
@@ -24,7 +24,9 @@ use std::path::Path;
 /// `// the one permitted probe` marks an accessor's daemon-silent fallback;
 /// `// deliberate camera probe:` marks a caller that is about to use the node.
 fn allowed(line: &str, preceding: &str) -> bool {
-    line.contains("// the one permitted probe") || preceding.contains("// deliberate camera probe:")
+    line.contains("// the one permitted probe")
+        || preceding.contains("// deliberate camera probe:")
+        || preceding.contains("// the one permitted probe")
 }
 
 /// Files where a direct probe is the point rather than a mistake.

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -404,21 +404,23 @@ fn main() {
             let mut verified_recognizer =
                 verify_models(&models_to_verify([&det, &model, &mesh, &blaze], &adapter), Some(&model));
             // Auto-select the camera pair: explicit IRLUME_RGB_DEVICE/IR_DEVICE, else a
-            // discovered Hello camera (built-in or external Brio/NexiGo), else defaults.
-            let (rgb_dev, ir_dev) = irlume_auth::select_pair();
-            // Log what is actually usable, not the raw (possibly fallback) selection;
-            // on camera-less or RGB-only hardware the fixed default pair doesn't exist.
-            {
-                let ok = |d: &str| std::path::Path::new(d).exists();
-                match (ok(&rgb_dev), ok(&ir_dev)) {
-                    (true, true) => eprintln!("irlumed: cameras rgb={rgb_dev} ir={ir_dev} (secure tier)"),
-                    (true, false) => eprintln!(
-                        "irlumed: camera rgb={rgb_dev}, no IR node (convenience tier: screen unlock only)"
-                    ),
-                    (false, _) => eprintln!(
-                        "irlumed: no camera found (face auth unavailable; password/fingerprint only)"
-                    ),
-                }
+            // discovered Hello camera (built-in or external Brio/NexiGo). No node-number
+            // fallback: a camera-less or RGB-only machine has no pair, and the
+            // convenience tier falls back to the first discoverable RGB node.
+            let caps = irlume_auth::capabilities();
+            let (rgb_dev, ir_dev) = irlume_auth::select_pair().unwrap_or_else(|| {
+                (irlume_auth::select_rgb().unwrap_or_default(), String::new())
+            });
+            if !ir_dev.is_empty() {
+                eprintln!("irlumed: cameras rgb={rgb_dev} ir={ir_dev} (secure tier)");
+            } else if caps.rgb {
+                eprintln!(
+                    "irlumed: RGB-only camera, no IR pair (convenience tier: screen unlock only)"
+                );
+            } else {
+                eprintln!(
+                    "irlumed: no camera found (face auth unavailable; password/fingerprint only)"
+                );
             }
             // Re-apply the KNOWN emitter control at startup. The emitter is camera
             // hardware state that resets on a USB/power cycle or a daemon restart, so
@@ -2432,7 +2434,11 @@ fn publish_engine_bits(engine: &irlume_auth::Engine) {
     // One probe, at load, on the thread that owns the engine. Every later
     // Health answer reads this copy.
     let caps = irlume_auth::capabilities();
-    let (rgb, ir) = irlume_auth::select_pair();
+    // The Hello pair when one was selected. On a camera-less or RGB-only
+    // machine there is no pair, so the convenience tier falls back to the
+    // first discoverable RGB node (never a guessed `/dev/videoN`).
+    let (rgb, ir) = irlume_auth::select_pair()
+        .unwrap_or_else(|| (irlume_auth::select_rgb().unwrap_or_default(), String::new()));
     let rgb_dev = (caps.rgb && std::path::Path::new(&rgb).exists()).then_some(rgb);
     let ir_dev = (caps.ir_pair && std::path::Path::new(&ir).exists()).then_some(ir);
     let tier = if ir_dev.is_some() {


### PR DESCRIPTION
Part of #341 (item 1 of the camera-support design).

## Problem

`select_pair()` fell back to compiled defaults (`/dev/video0`, `/dev/video2`) when discovery found no Hello pair. Node numbers are not a class invariant: udev can renumber them, and a colour node can land in the IR slot (#385).

## Change

- `select_pair()` now returns `Option<(String, String)>` and yields `None` when no pair can be established—no node-number fallback.
- New `select_rgb()` returns the first discovered RGB node for the RGB-only convenience tier when there is no pair.
- Daemon tier reporting and `Health` publication fall back only to a discovered RGB node.
- CLI device selection refuses a half-pair rather than inventing its partner.
- `DEFAULT_RGB_DEVICE` / `DEFAULT_IR_DEVICE` remain only as documented dev-tool flag defaults.
- Camera-less doctor runs still emit both stable stream-minimum check IDs as informational results. This fixes the original CI contract failure without opening, negotiating, or guessing a camera node.

## Verification

Exact integrated head: `c4c3e115a13c16001c14a386b763925fc2d7c3df`

This head is rebased onto merged #489 and #493.

- RED -> GREEN deterministic regression: `selected_stream_minimum_checks_emit_both_ids_when_selection_finds_no_pair`.
- Machine API contract: `every_doctor_check_id_is_documented_and_every_documented_id_exists` passes with no selected camera pair.
- `cargo test --workspace --all-targets --locked`: PASS.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: PASS.
- `cargo fmt --all --check`: PASS.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --locked`: PASS.
- `git diff --check origin/main...HEAD`: PASS.

Fresh GitHub checks are required on the exact head before merge.
