### PR TITLE
fix(tpm): salt policy sessions so unseal returns the sealed secret

### DIFF
--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -178,12 +178,23 @@ fn read_pcr_values(ctx: &mut Context, pcrs: &[u32]) -> Result<Vec<PcrValue>> {
 /// regardless of whether `body` succeeded.
 fn with_session<T>(
     ctx: &mut Context,
+    salt: Option<KeyHandle>,
     kind: SessionType,
     body: impl FnOnce(&mut Context, AuthSession) -> Result<T>,
 ) -> Result<T> {
+    // `salt` is load-bearing, not decoration. ESYS parameter encryption derives
+    // its key from the session key, and an UNSALTED, UNBOUND session has an
+    // EMPTY session key: the TPM then returns the response parameter in the
+    // clear while ESYS still "decrypts" it, so `unseal` hands back plausible
+    // garbage instead of the sealed secret. The sealed object is fine; only the
+    // response is mangled, which is why a tpm2-tools unseal of the very same
+    // object succeeds. Salting against the SRK gives both sides the same key,
+    // so the secret is genuinely protected on the bus AND comes back intact.
+    // Trial sessions pass `None`: they carry no secret, and turning encryption
+    // off there keeps them correct without a salt.
     let session = ctx
         .start_auth_session(
-            None,
+            salt,
             None,
             None,
             kind,
@@ -192,9 +203,10 @@ fn with_session<T>(
         )
         .map_err(tpm_err)?
         .ok_or_else(|| Error::Tpm("start_auth_session returned None".into()))?;
+    let encrypted = salt.is_some();
     let (attrs, mask) = SessionAttributesBuilder::new()
-        .with_decrypt(true)
-        .with_encrypt(true)
+        .with_decrypt(encrypted)
+        .with_encrypt(encrypted)
         .build();
     if let Err(e) = ctx.tr_sess_set_attributes(session, attrs, mask) {
         let _ = ctx.flush_context(SessionHandle::from(session).into());
@@ -209,7 +221,7 @@ fn with_session<T>(
 /// Compute the PolicyPCR digest for a given PCR selection using a trial session.
 /// The digest is what the sealed object commits to.
 fn compute_policy_digest(ctx: &mut Context, pcrs: Option<&PcrSelectionList>) -> Result<Digest> {
-    with_session(ctx, SessionType::Trial, |ctx, session| {
+    with_session(ctx, None, SessionType::Trial, |ctx, session| {
         if let Some(sel) = pcrs {
             let policy = PolicySession::try_from(session).map_err(tpm_err)?;
             ctx.policy_pcr(policy, Digest::default(), sel.clone())
@@ -624,7 +636,7 @@ fn unseal_literal(env: &SealedEnvelope) -> Result<Zeroizing<Vec<u8>>> {
 
         // Scoped fallible region so the loaded object is flushed on every exit.
         let result: Result<Zeroizing<Vec<u8>>> = (|| {
-            with_session(ctx, SessionType::Policy, |ctx, session| {
+            with_session(ctx, Some(*srk), SessionType::Policy, |ctx, session| {
                 if !env.pcrs.is_empty() {
                     let sel = pcr_selection(&env.pcrs)?;
                     let policy = PolicySession::try_from(session).map_err(tpm_err)?;
@@ -718,7 +730,7 @@ fn unseal_authorized(
             .map_err(tpm_err)?;
 
         let result: Result<Zeroizing<Vec<u8>>> = (|| {
-            with_session(ctx, SessionType::Policy, |ctx, session| {
+            with_session(ctx, Some(*srk), SessionType::Policy, |ctx, session| {
                 let policy_session = PolicySession::try_from(session).map_err(tpm_err)?;
 
                 // 1. Fold the current PCR state in and read the resulting policy
@@ -1103,7 +1115,7 @@ fn software_replay(steps: &[PolicyStep]) -> Result<Digest> {
 /// has to say so explicitly.
 #[cfg(test)]
 fn trial_replay(ctx: &mut Context, steps: &[PolicyStep]) -> Result<Digest> {
-    with_session(ctx, SessionType::Trial, |ctx, session| {
+    with_session(ctx, None, SessionType::Trial, |ctx, session| {
         let policy = PolicySession::try_from(session).map_err(tpm_err)?;
         for step in steps {
             match step {
@@ -1214,7 +1226,7 @@ fn build_super_pcr(plock: &PcrlockJson) -> Result<SuperPcr> {
 /// index) using a trial session. The index's Name (WRITTEN bit set once
 /// make-policy has written it) fully determines the digest; the TPM reads it.
 fn pcrlock_auth_policy(ctx: &mut Context, nv: NvIndexHandle) -> Result<Digest> {
-    with_session(ctx, SessionType::Trial, |ctx, session| {
+    with_session(ctx, None, SessionType::Trial, |ctx, session| {
         let policy = PolicySession::try_from(session).map_err(tpm_err)?;
         ctx.execute_with_session(Some(AuthSession::Password), |ctx| {
             ctx.policy_authorize_nv(policy, NvAuth::Owner, nv)
@@ -1276,7 +1288,7 @@ fn unseal_pcrlock(env: &SealedEnvelope, nv_index: u32) -> Result<Zeroizing<Vec<u
             .map_err(tpm_err)?;
 
         let result: Result<Zeroizing<Vec<u8>>> = (|| {
-            with_session(ctx, SessionType::Policy, |ctx, session| {
+            with_session(ctx, Some(*srk), SessionType::Policy, |ctx, session| {
                 let policy = PolicySession::try_from(session).map_err(tpm_err)?;
 
                 // Super-PCR replay against LIVE PCRs (empty digest => the TPM
@@ -1765,7 +1777,7 @@ pub(crate) mod tests {
             // what the live unseal session presents when PolicyAuthorizeNV
             // compares it against the NV content.
             let composite: [u8; 32] = Sha256::digest(&pcr7.value).into();
-            let policy_digest = with_session(&mut ctx, SessionType::Trial, |ctx, session| {
+            let policy_digest = with_session(&mut ctx, None, SessionType::Trial, |ctx, session| {
                 let policy = PolicySession::try_from(session).map_err(tpm_err)?;
                 ctx.policy_pcr(
                     policy,


### PR DESCRIPTION
Fixes the root cause behind #472 (and, I believe, #448): on this machine every TPM unseal returned plausible-looking garbage, so enrollment was encrypted with a key the envelope could never yield.

## The bug

`with_session()` turns on ESYS parameter encryption:

```rust
let session = ctx.start_auth_session(
    None,   // tpm_key  (salt)
    None,   // bind
    None, kind, SymmetricDefinition::AES_128_CFB, HashingAlgorithm::Sha256)?;
let (attrs, mask) = SessionAttributesBuilder::new()
    .with_decrypt(true)
    .with_encrypt(true)
    .build();
```

The session is started **unsalted and unbound**, so its session key is empty. ESYS still applies response-parameter decryption to the value coming back from `TPM2_Unseal`, using a key the TPM never encrypted with. The result is 32 well-formed, wrong, different-every-run bytes.

## Why it looked like a storage bug

The sealed object is perfectly fine. Unsealing the *same* envelope with tpm2-tools, under the same SRK (`0x81010002`) and the same PCR-7 policy, returns the exact secret:

```
sealed         : 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
tpm2_unseal    : 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f   <- correct
irlume unseal(): e10425f3ec9623f02b4516a514405c31e6fcbb87e5baa1c060b65429daaa7452   <- garbage
```

Only the ESYS response path is affected, and only where a real secret is returned. `seal()` is untouched because `create` runs under `execute_with_nullauth_session`. So the failure surfaces one layer later, as `decryption failed (wrong key or tampered data)` on read-back, or — after #450 — as `new template key failed persisted TPM round-trip`.

Worth noting: #450's round-trip guard is doing exactly its job here. It correctly refuses to write an enrollment it cannot read back, which turned silent corruption into a clean refusal. It just couldn't fix the cause, so on this host enrollment cannot complete at all.

## The fix

Salt the three policy sessions against the SRK, so both sides derive the same session key. Parameter encryption then does what it was written to do — protect the unsealed secret on the bus — instead of corrupting it. Trial sessions pass `None` and turn the attributes off: they carry no secret and need no salt.

I chose salting over simply dropping `with_encrypt`/`with_decrypt` because the attributes are clearly deliberate, and an unsealed login password or template key is exactly the thing worth encrypting on the bus. Dropping them also fixes the corruption, if you'd prefer the smaller change.

## Verification

Your own `tpm::tests::seal_unseal_roundtrip_real_tpm`, on real hardware (Lenovo 83KF fTPM, tpm2-tss 4.2.0, `/dev/tpmrm0`, run as root):

**Before**
```
test tpm::tests::seal_unseal_roundtrip_real_tpm ... FAILED
assertion `left == right` failed: round-trip must match
  left:  [112, 213, 59, 99, 97, 212, 227, 195, ...]
  right: [105, 114, 108, 117, 109, 101, 45, 107, ...]   // b"irlume-keyring-secret-roundtrip!"
```

**After**
```
test tpm::tests::seal_unseal_roundtrip_real_tpm ... ok
```

Full suite after the change: `124 passed; 0 failed; 26 ignored`.

That test already exists and is `#[ignore]`-gated with "CI does this" via swtpm, so it's worth checking whether swtpm tolerates parameter encryption on an unsalted session where this fTPM does not — that would explain how this reached a release.

A pleasant side effect: with unseal working, `seal()`'s tier ladder stops falling back. Before, every attempt logged `pcrlock seal round-trip mismatch; falling back to literal PCR seal`, because the round-trip check was being defeated by this same corruption. After, a pcrlock host seals at Tier 2 as intended:

```
policy : PcrlockNv { nv_index: 27697224 }   pcrs [15]
MATCH  : yes
```

So this may also be why Tier 1/Tier 2 seals appeared unusable on hosts that had them provisioned.

Happy to split the trial-session part out, add a dedicated regression test, or adjust anything to fit your conventions.
