### PR TITLE
fix(camera): mirror the device's access control onto the emitter lock

### DIFF
--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -42,6 +42,7 @@
 
 use crate::uvc_descriptor::CameraIdentity;
 use serde::{Deserialize, Serialize};
+use std::os::raw::c_int;
 use std::path::PathBuf;
 
 /// The record format this build writes and is willing to act on.
@@ -638,7 +639,7 @@ fn lock_path(id: &CameraIdentity) -> PathBuf {
 /// every stream open during authentication; waiting behind a discovery run that
 /// takes tens of seconds would stall a login. A camera whose lock is held is a
 /// camera somebody else is already looking after.
-pub(crate) fn lock_camera(id: &CameraIdentity) -> Result<Option<CameraLock>, String> {
+pub(crate) fn lock_camera(fd: c_int, id: &CameraIdentity) -> Result<Option<CameraLock>, String> {
     use std::os::unix::io::AsRawFd as _;
     let path = lock_path(id);
     if let Some(dir) = path.parent() {
@@ -650,82 +651,11 @@ pub(crate) fn lock_camera(id: &CameraIdentity) -> Result<Option<CameraLock>, Str
         .truncate(false)
         .open(&path)
         .map_err(|e| format!("open {}: {e}", path.display()))?;
-    // /dev/video* is root:video 0660, so the lock guarding that capability
-    // matches rather than being root-only. Without this a non-root caller in
-    // the video group (the nightly CI runner, ir-setup, camera-tune) can open
-    // the camera but not the lock, and ir-setup declines to drive the emitter
-    // with "passwordless sudo is required" even though the caller already owns
-    // the device it is trying to configure.
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        let mut perms = file
-            .metadata()
-            .map_err(|e| format!("stat {}: {e}", path.display()))?
-            .permissions();
-        // Fix the mode only when it is wrong AND this process can: fchmod on
-        // a root-owned file from a non-root caller is EPERM no matter what
-        // mode is requested, and failing the LOCK on it disabled the emitter
-        // for exactly the caller #392 exists to serve (the lock already
-        // exists as root:video 0660 after the daemon's first run, the video
-        // group member opens it through the group bit, and then the
-        // unconditional chmod errored). A wrong mode that cannot be fixed is
-        // reported by whoever cannot OPEN the file, with a better message
-        // than EPERM here.
-        let mode = perms.mode() & 0o777;
-        if mode != 0o660 {
-            perms.set_mode(0o660);
-            if let Err(e) = file.set_permissions(perms) {
-                // Whether an unfixable wrong mode is tolerable depends on
-                // WHICH way it is wrong. flock takes the lock on a read-only
-                // open, so any other-accessible bit lets an unprivileged
-                // process hold this camera's lock and keep the emitter dark
-                // for everyone; a lock that permissive cannot be trusted and
-                // the caller must refuse rather than authenticate behind it.
-                // A merely over-restrictive mode adds no holder who was not
-                // already root or group, so it degrades to a log the way the
-                // root-owned-0660 case does (the #392 caller this branch
-                // exists for).
-                if mode & 0o007 != 0 {
-                    return Err(format!(
-                        "emitter lock {} has mode {mode:o}, which any local user can \
-                         flock, and this process cannot correct it ({e}); refusing to \
-                         trust the lock. Fix it as root: chmod 660 {}",
-                        path.display(),
-                        path.display()
-                    ));
-                }
-                irlume_common::dlog!(
-                    "emitter lock {}: mode {mode:o} left as-is ({e}); a non-owner cannot chmod",
-                    path.display()
-                );
-            }
-        }
-    }
-    // Set the group to video so the lock is reachable by the same group that
-    // already owns /dev/video*. The caller is root (the daemon), so fchown
-    // succeeds. If the group does not exist on this system the mode alone is
-    // still an improvement: the lock was 0640 root:root and is now 0660, so a
-    // non-root caller whose primary group is video can open it.
-    //
-    // SAFETY: getgrnam_r reads /etc/group (or the nsswitch equivalent). The
-    // C string is a literal null-terminated byte string.
-    unsafe {
-        let mut grp: libc::group = std::mem::zeroed();
-        let mut buf = vec![0u8; 2048];
-        let mut result: *mut libc::group = std::ptr::null_mut();
-        let name = b"video\0";
-        if libc::getgrnam_r(
-            name.as_ptr().cast(),
-            &mut grp,
-            buf.as_mut_ptr().cast(),
-            buf.len(),
-            &mut result,
-        ) == 0
-            && !result.is_null()
-        {
-            let _ = libc::fchown(file.as_raw_fd(), u32::MAX, grp.gr_gid);
-        }
-    }
+    // Mirror the device's access control (group, mode, extended ACL) onto the
+    // lock, so the lock opens to exactly the callers the device opens to, not
+    // to a hardcoded video group (#487). A -1 fd (tests) or an unreadable
+    // device skips the mirror and leaves the lock at its creation default.
+    mirror_device_access(fd, &file, &path)?;
     // SAFETY: `fd` is owned by `file`, which outlives the call and the guard.
     if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
         let err = std::io::Error::last_os_error();
@@ -735,6 +665,107 @@ pub(crate) fn lock_camera(id: &CameraIdentity) -> Result<Option<CameraLock>, Str
         };
     }
     Ok(Some(CameraLock { _file: file }))
+}
+
+/// Mirror the device's access control (group, extended ACL, mode) onto the
+/// lock, so the lock opens to exactly the callers the device opens to, rather
+/// than a hardcoded `video`/`0660`. On an ACL-managed host the camera is
+/// reachable through a per-user uaccess ACL and a non-standard group, and a
+/// lock that mirrors neither stays closed to the exact callers it exists to
+/// serve (#487).
+///
+/// A `fstat` failure (a `-1` test fd, or an already-closed device) is a no-op:
+/// there is no device to mirror, so the lock keeps its creation default.
+fn mirror_device_access(
+    fd: c_int,
+    file: &std::fs::File,
+    path: &std::path::Path,
+) -> Result<(), String> {
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // SAFETY: libc::stat is a plain C struct of integers, so all-zero is a
+    // valid value; fstat overwrites it next.
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: fstat reads the caller's device fd into `st`.
+    if unsafe { libc::fstat(fd, &mut st) } != 0 {
+        return Ok(());
+    }
+    let lock_fd = file.as_raw_fd();
+
+    // Group first so the mode and ACL land on the device's group. uid -1
+    // leaves the owner alone. A non-root caller who is not in the device's
+    // group cannot chown to it, and that is exactly the case where the lock
+    // cannot be made to match, so the best-effort attempt is silent.
+    // SAFETY: fchown sets only the group on an owned fd.
+    let _ = unsafe { libc::fchown(lock_fd, u32::MAX, st.st_gid) };
+
+    // Copy the extended ACL, the part that grants a per-user uaccess caller.
+    // A device with none (the common case) leaves the lock a plain mode/group
+    // file.
+    copy_access_acl(fd, lock_fd);
+
+    // Mode last. The ACL mask (if any) already fixed the group bits; without
+    // an ACL the mode must be set to the device's exactly. Preserve the
+    // world-accessible refusal: a lock any local user can flock cannot be
+    // trusted, and one this process cannot correct must refuse rather than
+    // authenticate behind it.
+    let mode = st.st_mode & 0o777;
+    let mut perms = file
+        .metadata()
+        .map_err(|e| format!("stat {}: {e}", path.display()))?
+        .permissions();
+    let current = perms.mode() & 0o777;
+    if current != mode {
+        perms.set_mode(mode);
+        if let Err(e) = file.set_permissions(perms) {
+            if current & 0o007 != 0 {
+                return Err(format!(
+                    "emitter lock {} has mode {current:o}, which any local user can \
+                     flock, and this process cannot correct it ({e}); refusing to \
+                     trust the lock. Fix it as root: chmod {mode:o} {}",
+                    path.display(),
+                    path.display()
+                ));
+            }
+            irlume_common::dlog!(
+                "emitter lock {}: mode {current:o} left as-is ({e}); a non-owner cannot chmod",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Copy the device's extended POSIX ACL (the `system.posix_acl_access` xattr)
+/// onto the lock, byte-for-byte, so no parsing of the wire format is needed.
+/// Absence on the device (the ordinary case) and any read or write failure are
+/// a no-op: the lock then carries no extended ACL, which is still correct for
+/// a device that has none.
+fn copy_access_acl(from: c_int, to: c_int) {
+    const NAME: &[u8] = b"system.posix_acl_access\0";
+    // SAFETY: the name is a null-terminated literal; a null buffer with size 0
+    // asks the kernel for the required size.
+    let size = unsafe { libc::fgetxattr(from, NAME.as_ptr().cast(), std::ptr::null_mut(), 0) };
+    if size < 0 {
+        return;
+    }
+    let mut buf = vec![0u8; size as usize];
+    // SAFETY: buf is size bytes; the name is null-terminated.
+    let got = unsafe {
+        libc::fgetxattr(
+            from,
+            NAME.as_ptr().cast(),
+            buf.as_mut_ptr().cast(),
+            buf.len(),
+        )
+    };
+    if got < 0 || got as usize != buf.len() {
+        return;
+    }
+    // SAFETY: buf holds exactly the bytes read; writing the same xattr onto
+    // the lock makes its access match the device's. Flags 0 (no replace).
+    let _ = unsafe { libc::fsetxattr(to, NAME.as_ptr().cast(), buf.as_ptr().cast(), buf.len(), 0) };
 }
 
 /// What the store has to say about the camera in front of us.
@@ -1035,7 +1066,8 @@ mod tests {
     #[test]
     #[ignore = "needs a root-owned pre-created lock; set IRLUME_EMITTER_LOCK_DIR and pre-create the lock file as root:<caller-group> 0660"]
     fn lock_succeeds_on_a_preexisting_lock_this_process_cannot_chmod() {
-        use std::os::unix::fs::MetadataExt as _;
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
         let _env = env_lock();
         let dir = std::env::var_os("IRLUME_EMITTER_LOCK_DIR")
             .expect("IRLUME_EMITTER_LOCK_DIR is unset; this test is a request for the harness");
@@ -1050,7 +1082,15 @@ mod tests {
             me,
             "the pre-created lock must belong to another uid or this test proves nothing"
         );
-        let lock = lock_camera(&id).expect("a lock this process can open must be takeable");
+        // A stand-in device whose mode the mirror reads; it must not make a
+        // root-owned lock this process can open (but not chmod) refuse.
+        let device = std::env::temp_dir().join("irlume-lock-mirror-device");
+        let device_file = std::fs::File::create(&device).expect("device file");
+        device_file
+            .set_permissions(std::fs::Permissions::from_mode(0o660))
+            .expect("device mode");
+        let fd = device_file.as_raw_fd();
+        let lock = lock_camera(fd, &id).expect("a lock this process can open must be takeable");
         assert!(lock.is_some(), "nobody else holds it in this harness");
     }
 
@@ -1063,8 +1103,8 @@ mod tests {
     #[test]
     #[ignore = "needs a root-owned 0666 pre-created lock; set IRLUME_EMITTER_LOCK_DIR and pre-create the lock file as root 0666"]
     fn lock_refuses_an_other_accessible_lock_it_cannot_fix() {
-        use std::os::unix::fs::MetadataExt as _;
-        use std::os::unix::fs::PermissionsExt as _;
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
         let _env = env_lock();
         let dir = std::env::var_os("IRLUME_EMITTER_LOCK_DIR")
             .expect("IRLUME_EMITTER_LOCK_DIR is unset; this test is a request for the harness");
@@ -1080,12 +1120,145 @@ mod tests {
             0o006,
             "the harness pre-creates the lock world-accessible"
         );
-        let err = lock_camera(&id)
+        // A stand-in device whose mode the mirror reads; it must not make a
+        // root-owned lock this process can open (but not chmod) refuse.
+        let device = std::env::temp_dir().join("irlume-lock-mirror-device");
+        let device_file = std::fs::File::create(&device).expect("device file");
+        device_file
+            .set_permissions(std::fs::Permissions::from_mode(0o660))
+            .expect("device mode");
+        let fd = device_file.as_raw_fd();
+        let err = lock_camera(fd, &id)
             .expect_err("a world-accessible lock this process cannot fix must refuse");
         assert!(
             err.contains("any local user can") && err.contains("chmod 660"),
             "the refusal must say why and how to fix it: {err}"
         );
+    }
+
+    /// The lock must mirror the device's access control, not a hardcoded
+    /// `video`/`0660`. On an ACL-managed host the camera is reachable through
+    /// a per-user uaccess ACL, so the lock guarding it must open to exactly
+    /// the same callers. A stand-in device with a distinctive mode must
+    /// produce a lock with that mode, not 0660.
+    #[test]
+    fn lock_mirrors_the_device_mode() {
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-lock-mirror-mode");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let device = dir.join("device");
+        let device_file = std::fs::File::create(&device).expect("device file");
+        device_file
+            .set_permissions(std::fs::Permissions::from_mode(0o640))
+            .expect("set the device mode");
+        let fd = device_file.as_raw_fd();
+
+        let id = identity();
+        let lock = lock_camera(fd, &id)
+            .expect("take the lock")
+            .expect("not busy");
+        let meta = std::fs::metadata(lock_path(&id)).expect("lock stat");
+        assert_eq!(
+            meta.permissions().mode() & 0o777,
+            0o640,
+            "the lock inherits the device mode, not the hardcoded 0660"
+        );
+        drop(lock);
+    }
+
+    /// The extended ACL is the part that grants a per-user uaccess caller, so
+    /// the lock must carry the device's ACL byte-for-byte. A named-user entry
+    /// written to the stand-in device must appear on the lock.
+    #[test]
+    fn lock_mirrors_the_device_acl() {
+        use std::os::fd::AsRawFd as _;
+
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-lock-mirror-acl");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let device = dir.join("device");
+        let device_file = std::fs::File::create(&device).expect("device file");
+        let fd = device_file.as_raw_fd();
+
+        // SAFETY: geteuid reads this process's own credentials and cannot fail.
+        let me = unsafe { libc::geteuid() };
+        let acl = named_user_acl(me, 0o6);
+        set_access_acl(fd, &acl);
+
+        let id = identity();
+        let lock = lock_camera(fd, &id)
+            .expect("take the lock")
+            .expect("not busy");
+        let lock_file = std::fs::File::open(lock_path(&id)).expect("open the lock");
+        assert_eq!(
+            get_access_acl(lock_file.as_raw_fd()),
+            Some(acl),
+            "the lock inherits the device ACL byte-for-byte"
+        );
+        drop(lock);
+    }
+
+    /// A named-user POSIX ACL in the kernel's `system.posix_acl_access` wire
+    /// format: a version header then `posix_acl_xattr_entry` records sorted by
+    /// tag, with the id undefined for the object/mask/other entries.
+    fn named_user_acl(uid: u32, perm: u16) -> Vec<u8> {
+        const VERSION: u32 = 0x0002;
+        const USER_OBJ: u16 = 0x01;
+        const USER: u16 = 0x02;
+        const GROUP_OBJ: u16 = 0x04;
+        const MASK: u16 = 0x10;
+        const OTHER: u16 = 0x20;
+        const UNDEFINED_ID: u32 = 0xFFFF_FFFF;
+
+        let mut out = Vec::with_capacity(4 + 5 * 8);
+        out.extend_from_slice(&VERSION.to_le_bytes());
+        let mut push = |tag: u16, p: u16, id: u32| {
+            out.extend_from_slice(&tag.to_le_bytes());
+            out.extend_from_slice(&p.to_le_bytes());
+            out.extend_from_slice(&id.to_le_bytes());
+        };
+        push(USER_OBJ, 0o6, UNDEFINED_ID);
+        push(USER, perm, uid);
+        push(GROUP_OBJ, 0o4, UNDEFINED_ID);
+        push(MASK, 0o6, UNDEFINED_ID);
+        push(OTHER, 0o0, UNDEFINED_ID);
+        out
+    }
+
+    fn set_access_acl(fd: c_int, acl: &[u8]) {
+        const NAME: &[u8] = b"system.posix_acl_access\0";
+        // SAFETY: name is a null-terminated literal; acl points at acl.len()
+        // valid bytes.
+        let rc =
+            unsafe { libc::fsetxattr(fd, NAME.as_ptr().cast(), acl.as_ptr().cast(), acl.len(), 0) };
+        assert_eq!(rc, 0, "set the stand-in device ACL");
+    }
+
+    fn get_access_acl(fd: c_int) -> Option<Vec<u8>> {
+        const NAME: &[u8] = b"system.posix_acl_access\0";
+        // SAFETY: null buffer with size 0 asks the kernel for the required size.
+        let size = unsafe { libc::fgetxattr(fd, NAME.as_ptr().cast(), std::ptr::null_mut(), 0) };
+        if size < 0 {
+            return None;
+        }
+        let mut buf = vec![0u8; size as usize];
+        // SAFETY: buf is size bytes.
+        let got = unsafe {
+            libc::fgetxattr(fd, NAME.as_ptr().cast(), buf.as_mut_ptr().cast(), buf.len())
+        };
+        if got < 0 || got as usize != buf.len() {
+            return None;
+        }
+        Some(buf)
     }
 
     /// A camera identity backed by the real ASUS descriptor bytes, so these
@@ -1555,7 +1728,9 @@ mod tests {
         let id = identity();
         let path = lock_path(&id);
 
-        let held = lock_camera(&id).expect("take the lock").expect("not busy");
+        let held = lock_camera(-1, &id)
+            .expect("take the lock")
+            .expect("not busy");
 
         // `flock -n` exits 1 when the lock is held; the shell is a separate
         // process, which is the whole point.
@@ -1762,7 +1937,7 @@ mod tests {
             "one camera, one lock"
         );
 
-        let held = lock_camera(&with_serial)
+        let held = lock_camera(-1, &with_serial)
             .expect("take the lock")
             .expect("not busy");
         let path = lock_path(&without_serial);

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -639,7 +639,11 @@ fn lock_path(id: &CameraIdentity) -> PathBuf {
 /// every stream open during authentication; waiting behind a discovery run that
 /// takes tens of seconds would stall a login. A camera whose lock is held is a
 /// camera somebody else is already looking after.
-pub(crate) fn lock_camera(fd: c_int, id: &CameraIdentity) -> Result<Option<CameraLock>, String> {
+pub(crate) fn lock_camera(
+    device_fd: Option<c_int>,
+    id: &CameraIdentity,
+) -> Result<Option<CameraLock>, String> {
+    use std::os::unix::fs::OpenOptionsExt as _;
     use std::os::unix::io::AsRawFd as _;
     let path = lock_path(id);
     if let Some(dir) = path.parent() {
@@ -649,13 +653,18 @@ pub(crate) fn lock_camera(fd: c_int, id: &CameraIdentity) -> Result<Option<Camer
         .write(true)
         .create(true)
         .truncate(false)
+        // A permissive process umask must not create a briefly world-open lock
+        // before the device ACL is applied.
+        .mode(0o600)
         .open(&path)
         .map_err(|e| format!("open {}: {e}", path.display()))?;
     // Mirror the device's access control (group, mode, extended ACL) onto the
     // lock, so the lock opens to exactly the callers the device opens to, not
-    // to a hardcoded video group (#487). A -1 fd (tests) or an unreadable
-    // device skips the mirror and leaves the lock at its creation default.
-    mirror_device_access(fd, &file, &path)?;
+    // to a hardcoded video group (#487). Tests that exercise only exclusion
+    // pass `None`; production always supplies the already-open device fd.
+    if let Some(fd) = device_fd {
+        mirror_device_access(fd, &file, &path)?;
+    }
     // SAFETY: `fd` is owned by `file`, which outlives the call and the guard.
     if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
         let err = std::io::Error::last_os_error();
@@ -674,43 +683,66 @@ pub(crate) fn lock_camera(fd: c_int, id: &CameraIdentity) -> Result<Option<Camer
 /// lock that mirrors neither stays closed to the exact callers it exists to
 /// serve (#487).
 ///
-/// A `fstat` failure (a `-1` test fd, or an already-closed device) is a no-op:
-/// there is no device to mirror, so the lock keeps its creation default.
 fn mirror_device_access(
     fd: c_int,
     file: &std::fs::File,
     path: &std::path::Path,
 ) -> Result<(), String> {
     use std::os::fd::AsRawFd as _;
-    use std::os::unix::fs::PermissionsExt as _;
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 
-    // SAFETY: libc::stat is a plain C struct of integers, so all-zero is a
-    // valid value; fstat overwrites it next.
-    let mut st: libc::stat = unsafe { std::mem::zeroed() };
-    // SAFETY: fstat reads the caller's device fd into `st`.
-    if unsafe { libc::fstat(fd, &mut st) } != 0 {
-        return Ok(());
+    let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `st` points to enough writable memory for fstat. It is assumed
+    // initialized only after fstat reports success.
+    if unsafe { libc::fstat(fd, st.as_mut_ptr()) } != 0 {
+        return Err(format!(
+            "stat camera device fd {fd}: {}",
+            std::io::Error::last_os_error()
+        ));
     }
+    // SAFETY: the successful fstat initialized the whole stat value.
+    let st = unsafe { st.assume_init() };
     let lock_fd = file.as_raw_fd();
+    let mode = st.st_mode & 0o777;
+
+    if mode & 0o007 != 0 {
+        return Err(format!(
+            "camera device fd {fd} has mode {mode:o}, which would let any local user flock \
+             the emitter lock {}; refusing to trust a world-accessible lock",
+            path.display()
+        ));
+    }
 
     // Group first so the mode and ACL land on the device's group. uid -1
-    // leaves the owner alone. A non-root caller who is not in the device's
-    // group cannot chown to it, and that is exactly the case where the lock
-    // cannot be made to match, so the best-effort attempt is silent.
-    // SAFETY: fchown sets only the group on an owned fd.
-    let _ = unsafe { libc::fchown(lock_fd, u32::MAX, st.st_gid) };
+    // leaves the owner alone. Do not silently accept a failed correction: the
+    // old group may grant the lock to callers who cannot open the device.
+    let lock_meta = file
+        .metadata()
+        .map_err(|e| format!("stat emitter lock {}: {e}", path.display()))?;
+    if lock_meta.gid() != st.st_gid {
+        // SAFETY: fchown sets only the group on an owned fd.
+        if unsafe { libc::fchown(lock_fd, u32::MAX, st.st_gid) } != 0 {
+            return Err(format!(
+                "set emitter lock {} group to {}: {}",
+                path.display(),
+                st.st_gid,
+                std::io::Error::last_os_error()
+            ));
+        }
+    }
 
-    // Copy the extended ACL, the part that grants a per-user uaccess caller.
-    // A device with none (the common case) leaves the lock a plain mode/group
-    // file.
-    copy_access_acl(fd, lock_fd);
+    // Copy the extended ACL, the part that grants a per-user uaccess caller. A
+    // device with none must REMOVE an ACL left by an earlier session; leaving
+    // stale named-user entries would grant callers who lost device access.
+    let device_acl =
+        read_access_acl(fd).map_err(|e| format!("read camera device fd {fd} access ACL: {e}"))?;
+    replace_access_acl(lock_fd, device_acl.as_deref(), path)?;
 
     // Mode last. The ACL mask (if any) already fixed the group bits; without
     // an ACL the mode must be set to the device's exactly. Preserve the
     // world-accessible refusal: a lock any local user can flock cannot be
     // trusted, and one this process cannot correct must refuse rather than
     // authenticate behind it.
-    let mode = st.st_mode & 0o777;
     let mut perms = file
         .metadata()
         .map_err(|e| format!("stat {}: {e}", path.display()))?
@@ -728,44 +760,98 @@ fn mirror_device_access(
                     path.display()
                 ));
             }
-            irlume_common::dlog!(
-                "emitter lock {}: mode {current:o} left as-is ({e}); a non-owner cannot chmod",
+            return Err(format!(
+                "set emitter lock {} mode from {current:o} to {mode:o}: {e}",
                 path.display()
-            );
+            ));
         }
+    }
+
+    let final_meta = file
+        .metadata()
+        .map_err(|e| format!("re-stat emitter lock {}: {e}", path.display()))?;
+    let final_mode = final_meta.permissions().mode() & 0o777;
+    if final_meta.gid() != st.st_gid || final_mode != mode {
+        return Err(format!(
+            "emitter lock {} access changed while mirroring it (wanted group {} mode \
+             {mode:o}, found group {} mode {final_mode:o})",
+            path.display(),
+            st.st_gid,
+            final_meta.gid()
+        ));
+    }
+    let final_acl = read_access_acl(lock_fd)
+        .map_err(|e| format!("verify emitter lock {} access ACL: {e}", path.display()))?;
+    if final_acl != device_acl {
+        return Err(format!(
+            "emitter lock {} access ACL changed while mirroring it",
+            path.display()
+        ));
     }
     Ok(())
 }
 
-/// Copy the device's extended POSIX ACL (the `system.posix_acl_access` xattr)
-/// onto the lock, byte-for-byte, so no parsing of the wire format is needed.
-/// Absence on the device (the ordinary case) and any read or write failure are
-/// a no-op: the lock then carries no extended ACL, which is still correct for
-/// a device that has none.
-fn copy_access_acl(from: c_int, to: c_int) {
+/// Read a file descriptor's extended POSIX ACL without parsing its kernel wire
+/// format. `None` means the file has only its ordinary mode entries.
+fn read_access_acl(fd: c_int) -> std::io::Result<Option<Vec<u8>>> {
     const NAME: &[u8] = b"system.posix_acl_access\0";
     // SAFETY: the name is a null-terminated literal; a null buffer with size 0
     // asks the kernel for the required size.
-    let size = unsafe { libc::fgetxattr(from, NAME.as_ptr().cast(), std::ptr::null_mut(), 0) };
+    let size = unsafe { libc::fgetxattr(fd, NAME.as_ptr().cast(), std::ptr::null_mut(), 0) };
     if size < 0 {
-        return;
+        let error = std::io::Error::last_os_error();
+        return if error.raw_os_error() == Some(libc::ENODATA) {
+            Ok(None)
+        } else {
+            Err(error)
+        };
     }
     let mut buf = vec![0u8; size as usize];
     // SAFETY: buf is size bytes; the name is null-terminated.
-    let got = unsafe {
-        libc::fgetxattr(
-            from,
-            NAME.as_ptr().cast(),
-            buf.as_mut_ptr().cast(),
-            buf.len(),
-        )
-    };
-    if got < 0 || got as usize != buf.len() {
-        return;
+    let got =
+        unsafe { libc::fgetxattr(fd, NAME.as_ptr().cast(), buf.as_mut_ptr().cast(), buf.len()) };
+    if got < 0 {
+        return Err(std::io::Error::last_os_error());
     }
-    // SAFETY: buf holds exactly the bytes read; writing the same xattr onto
-    // the lock makes its access match the device's. Flags 0 (no replace).
-    let _ = unsafe { libc::fsetxattr(to, NAME.as_ptr().cast(), buf.as_ptr().cast(), buf.len(), 0) };
+    buf.truncate(got as usize);
+    Ok(Some(buf))
+}
+
+/// Make `fd` carry exactly `wanted`, including removing a stale named-user ACL
+/// when the device has none. Avoid rewriting an already-correct ACL so a
+/// non-owner who can legitimately open a root-owned lock does not hit EPERM.
+fn replace_access_acl(
+    fd: c_int,
+    wanted: Option<&[u8]>,
+    path: &std::path::Path,
+) -> Result<(), String> {
+    const NAME: &[u8] = b"system.posix_acl_access\0";
+    let current = read_access_acl(fd)
+        .map_err(|e| format!("read emitter lock {} access ACL: {e}", path.display()))?;
+    if current.as_deref() == wanted {
+        return Ok(());
+    }
+
+    let rc = match wanted {
+        Some(acl) => {
+            // SAFETY: the name is null-terminated and `acl` points to exactly
+            // acl.len() initialized bytes copied from the device.
+            unsafe { libc::fsetxattr(fd, NAME.as_ptr().cast(), acl.as_ptr().cast(), acl.len(), 0) }
+        }
+        None => {
+            // SAFETY: the name is a valid null-terminated xattr name.
+            unsafe { libc::fremovexattr(fd, NAME.as_ptr().cast()) }
+        }
+    };
+    if rc != 0 {
+        return Err(format!(
+            "{} emitter lock {} access ACL: {}",
+            if wanted.is_some() { "set" } else { "remove" },
+            path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
 }
 
 /// What the store has to say about the camera in front of us.
@@ -1090,7 +1176,8 @@ mod tests {
             .set_permissions(std::fs::Permissions::from_mode(0o660))
             .expect("device mode");
         let fd = device_file.as_raw_fd();
-        let lock = lock_camera(fd, &id).expect("a lock this process can open must be takeable");
+        let lock =
+            lock_camera(Some(fd), &id).expect("a lock this process can open must be takeable");
         assert!(lock.is_some(), "nobody else holds it in this harness");
     }
 
@@ -1128,7 +1215,7 @@ mod tests {
             .set_permissions(std::fs::Permissions::from_mode(0o660))
             .expect("device mode");
         let fd = device_file.as_raw_fd();
-        let err = lock_camera(fd, &id)
+        let err = lock_camera(Some(fd), &id)
             .expect_err("a world-accessible lock this process cannot fix must refuse");
         assert!(
             err.contains("any local user can") && err.contains("chmod 660"),
@@ -1160,7 +1247,7 @@ mod tests {
         let fd = device_file.as_raw_fd();
 
         let id = identity();
-        let lock = lock_camera(fd, &id)
+        let lock = lock_camera(Some(fd), &id)
             .expect("take the lock")
             .expect("not busy");
         let meta = std::fs::metadata(lock_path(&id)).expect("lock stat");
@@ -1195,7 +1282,7 @@ mod tests {
         set_access_acl(fd, &acl);
 
         let id = identity();
-        let lock = lock_camera(fd, &id)
+        let lock = lock_camera(Some(fd), &id)
             .expect("take the lock")
             .expect("not busy");
         let lock_file = std::fs::File::open(lock_path(&id)).expect("open the lock");
@@ -1205,6 +1292,139 @@ mod tests {
             "the lock inherits the device ACL byte-for-byte"
         );
         drop(lock);
+    }
+
+    /// The lock name is stable across sessions, while logind's uaccess ACL is
+    /// not. If the device no longer has a named-user ACL, the lock must remove
+    /// the old one rather than retaining access for a user whose session ended.
+    #[test]
+    fn lock_removes_an_acl_the_device_no_longer_has() {
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-lock-remove-stale-acl");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let device = dir.join("device");
+        let device_file = std::fs::File::create(&device).expect("device file");
+        device_file
+            .set_permissions(std::fs::Permissions::from_mode(0o640))
+            .expect("set the device mode");
+
+        let id = identity();
+        let lock_path = lock_path(&id);
+        let stale_lock = std::fs::File::create(&lock_path).expect("stale lock");
+        // SAFETY: geteuid reads this process's own credentials and cannot fail.
+        let me = unsafe { libc::geteuid() };
+        set_access_acl(stale_lock.as_raw_fd(), &named_user_acl(me, 0o6));
+        assert!(
+            get_access_acl(stale_lock.as_raw_fd()).is_some(),
+            "the harness planted a stale ACL"
+        );
+        drop(stale_lock);
+
+        let held = lock_camera(Some(device_file.as_raw_fd()), &id)
+            .expect("take the lock")
+            .expect("not busy");
+        let lock_file = std::fs::File::open(lock_path).expect("open the lock");
+        assert_eq!(
+            get_access_acl(lock_file.as_raw_fd()),
+            None,
+            "an ACL absent from the device must be absent from the lock"
+        );
+        drop(held);
+    }
+
+    /// Mirroring a world-accessible device mode would defeat the lock's
+    /// denial-of-service boundary: any local user could open and hold it. The
+    /// existing refusal therefore applies to the source mode as well as stale
+    /// lock modes that cannot be corrected.
+    #[test]
+    fn lock_refuses_a_world_accessible_device_mode() {
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-lock-world-device");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let device = dir.join("device");
+        let device_file = std::fs::File::create(&device).expect("device file");
+        device_file
+            .set_permissions(std::fs::Permissions::from_mode(0o666))
+            .expect("set the device mode");
+
+        let err = lock_camera(Some(device_file.as_raw_fd()), &identity())
+            .expect_err("a world-accessible lock cannot be trusted");
+        assert!(
+            err.contains("any local user") && err.contains("world-accessible"),
+            "the refusal must explain the trust boundary: {err}"
+        );
+    }
+
+    /// Production passes an already-open camera descriptor. If that descriptor
+    /// cannot be inspected, silently keeping the lock's old access would make
+    /// the mirror claim false, so the operation must fail closed.
+    #[test]
+    fn lock_refuses_an_invalid_device_fd() {
+        let _lock = env_lock();
+        let dir = std::env::temp_dir().join("irlume-journal-lock-invalid-device-fd");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let _env = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+
+        let err = lock_camera(Some(-1), &identity()).expect_err("an invalid fd must fail closed");
+        assert!(
+            err.contains("stat camera device fd -1"),
+            "the error must identify the failed device inspection: {err}"
+        );
+    }
+
+    /// Real-device acceptance for the ACL-only fleet case. Run once as root to
+    /// model the upgraded daemon repairing a stale lock, then as the ordinary
+    /// device ACL user to prove that the repaired lock can be opened without
+    /// privilege. This test performs no camera ioctl or emitter write.
+    #[test]
+    #[ignore = "needs a real UVC node; set IRLUME_TEST_EMITTER_LOCK_DEVICE"]
+    fn lock_mirrors_real_device_access() {
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+        let _env = env_lock();
+        let device_path = std::env::var("IRLUME_TEST_EMITTER_LOCK_DEVICE").expect(
+            "IRLUME_TEST_EMITTER_LOCK_DEVICE is unset; running an ignored test requests the harness",
+        );
+        let device = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&device_path)
+            .expect("open the real device read/write");
+        let fd = device.as_raw_fd();
+        let id = crate::uvc_descriptor::identity_from_fd(fd).expect("identify the real UVC device");
+
+        let held = lock_camera(Some(fd), &id)
+            .expect("mirror and take the real device lock")
+            .expect("no other process holds the real device lock");
+        let lock = std::fs::File::open(lock_path(&id)).expect("open the mirrored lock for review");
+        let device_meta = device.metadata().expect("stat the real device");
+        let lock_meta = lock.metadata().expect("stat the mirrored lock");
+        assert_eq!(lock_meta.gid(), device_meta.gid(), "group must match");
+        assert_eq!(
+            lock_meta.permissions().mode() & 0o777,
+            device_meta.permissions().mode() & 0o777,
+            "mode must match"
+        );
+        assert_eq!(
+            get_access_acl(lock.as_raw_fd()),
+            get_access_acl(fd),
+            "extended access ACL must match byte-for-byte"
+        );
+        drop(held);
     }
 
     /// A named-user POSIX ACL in the kernel's `system.posix_acl_access` wire
@@ -1728,7 +1948,7 @@ mod tests {
         let id = identity();
         let path = lock_path(&id);
 
-        let held = lock_camera(-1, &id)
+        let held = lock_camera(None, &id)
             .expect("take the lock")
             .expect("not busy");
 
@@ -1937,7 +2157,7 @@ mod tests {
             "one camera, one lock"
         );
 
-        let held = lock_camera(-1, &with_serial)
+        let held = lock_camera(None, &with_serial)
             .expect("take the lock")
             .expect("not busy");
         let path = lock_path(&without_serial);

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2824,7 +2824,7 @@ pub(crate) fn recover_pending_write(
     // the record read at the start was removed at the end without being looked
     // at again, so a second process that resolved it and saved a new one in
     // between had its live record deleted.
-    match crate::emitter_journal::lock_camera(fd, id) {
+    match crate::emitter_journal::lock_camera(lock_device_fd(fd), id) {
         Ok(Some(lock)) => {
             let outcome = recover_pending_write_locked(fd, id);
             drop(lock);
@@ -3394,7 +3394,7 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     // then again for the writes would leave a gap in which another process could
     // resolve this camera and start its own setup, and the record this run then
     // wrote would be filed over the top of that one.
-    let lock = match crate::emitter_journal::lock_camera(fd, id) {
+    let lock = match crate::emitter_journal::lock_camera(lock_device_fd(fd), id) {
         Ok(Some(lock)) => lock,
         Ok(None) => return Err(DiscoveryError::CameraBusy),
         Err(why) => return Err(DiscoveryError::JournalUnwritable(why)),
@@ -3468,6 +3468,17 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
         unit: ms.unit_id,
         tried,
     })
+}
+
+/// Production always mirrors the real device descriptor. Unit tests that stop
+/// before any ioctl traditionally use `-1`; let those exercise the surrounding
+/// journal state machine without pretending that sentinel is a camera.
+fn lock_device_fd(fd: c_int) -> Option<c_int> {
+    #[cfg(test)]
+    if fd < 0 {
+        return None;
+    }
+    Some(fd)
 }
 
 /// A discovery run that has left the camera lit, and the undo record that stays
@@ -4734,7 +4745,7 @@ mod tests {
                 payload: vec![1, 3, 2],
             },
             pending,
-            _lock: crate::emitter_journal::lock_camera(-1, &id)
+            _lock: crate::emitter_journal::lock_camera(None, &id)
                 .expect("lock")
                 .expect("not busy"),
         };
@@ -4792,7 +4803,7 @@ mod tests {
                 payload: vec![1, 3, 2],
             },
             pending,
-            _lock: crate::emitter_journal::lock_camera(-1, &id)
+            _lock: crate::emitter_journal::lock_camera(None, &id)
                 .expect("lock")
                 .expect("not busy"),
         };
@@ -4994,7 +5005,7 @@ mod tests {
                 payload: vec![1, 3, 2],
             },
             pending,
-            _lock: crate::emitter_journal::lock_camera(-1, &id)
+            _lock: crate::emitter_journal::lock_camera(None, &id)
                 .expect("lock")
                 .expect("not busy"),
         };
@@ -5350,7 +5361,7 @@ mod tests {
 
         let id = identity(0x3277, 0x0059);
         // Create the store and the lock path the same way production does.
-        let held = crate::emitter_journal::lock_camera(-1, &id)
+        let held = crate::emitter_journal::lock_camera(None, &id)
             .expect("take the lock")
             .expect("not busy");
         // Asked for by the same code the daemon uses, not rebuilt from the

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2824,7 +2824,7 @@ pub(crate) fn recover_pending_write(
     // the record read at the start was removed at the end without being looked
     // at again, so a second process that resolved it and saved a new one in
     // between had its live record deleted.
-    match crate::emitter_journal::lock_camera(id) {
+    match crate::emitter_journal::lock_camera(fd, id) {
         Ok(Some(lock)) => {
             let outcome = recover_pending_write_locked(fd, id);
             drop(lock);
@@ -3394,7 +3394,7 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     // then again for the writes would leave a gap in which another process could
     // resolve this camera and start its own setup, and the record this run then
     // wrote would be filed over the top of that one.
-    let lock = match crate::emitter_journal::lock_camera(id) {
+    let lock = match crate::emitter_journal::lock_camera(fd, id) {
         Ok(Some(lock)) => lock,
         Ok(None) => return Err(DiscoveryError::CameraBusy),
         Err(why) => return Err(DiscoveryError::JournalUnwritable(why)),
@@ -4734,7 +4734,7 @@ mod tests {
                 payload: vec![1, 3, 2],
             },
             pending,
-            _lock: crate::emitter_journal::lock_camera(&id)
+            _lock: crate::emitter_journal::lock_camera(-1, &id)
                 .expect("lock")
                 .expect("not busy"),
         };
@@ -4792,7 +4792,7 @@ mod tests {
                 payload: vec![1, 3, 2],
             },
             pending,
-            _lock: crate::emitter_journal::lock_camera(&id)
+            _lock: crate::emitter_journal::lock_camera(-1, &id)
                 .expect("lock")
                 .expect("not busy"),
         };
@@ -4994,7 +4994,7 @@ mod tests {
                 payload: vec![1, 3, 2],
             },
             pending,
-            _lock: crate::emitter_journal::lock_camera(&id)
+            _lock: crate::emitter_journal::lock_camera(-1, &id)
                 .expect("lock")
                 .expect("not busy"),
         };
@@ -5350,7 +5350,7 @@ mod tests {
 
         let id = identity(0x3277, 0x0059);
         // Create the store and the lock path the same way production does.
-        let held = crate::emitter_journal::lock_camera(&id)
+        let held = crate::emitter_journal::lock_camera(-1, &id)
             .expect("take the lock")
             .expect("not busy");
         // Asked for by the same code the daemon uses, not rebuilt from the


### PR DESCRIPTION
## What

`lock_camera` hardcoded the `video` group and mode `0660`, and never copied the device's extended POSIX ACL. On a host whose camera is reachable through a per-user uaccess ACL (systemd-logind), the lock stayed `root:root 0640` and the emitter failed closed for exactly the caller it guards.

This change passes the already-open device fd into `lock_camera` and mirrors the device's actual access control onto the stable per-camera lock:

- `fstat` supplies the device group and mode;
- `fchown`/`fchmod` make the lock match;
- `system.posix_acl_access` is copied byte-for-byte without a new dependency;
- an ACL absent from the device removes any stale ACL from an earlier login session;
- ACL/group/mode failures and invalid production fds fail closed instead of silently claiming a match;
- new locks start at `0600`, independent of a permissive umask, and the world-accessible refusal remains enforced;
- the final group, mode, and ACL are re-read and verified before `flock` is trusted.

The stable lock file is retained rather than flocking the device fd directly: one physical camera can expose multiple video-node inodes, and the synchronization key deliberately remains stable across node/replug churn.

Fixes #487.

## Verification

### Automated

- New ordinary tests:
  - `lock_mirrors_the_device_mode`
  - `lock_mirrors_the_device_acl`
  - `lock_removes_an_acl_the_device_no_longer_has`
  - `lock_refuses_a_world_accessible_device_mode`
  - `lock_refuses_an_invalid_device_fd`
- New operator-invoked acceptance test: `lock_mirrors_real_device_access`.
- PR head `708b52ad80c8d5dbc426049501ebe719936170f4`: all GitHub checks green (full CI/stable tests, Clippy/fmt/build, ASan, CodeQL, fuzz, Nix, cargo-deny, self-hosted hardware checks, Fedora 43/44 package builds).

### Real-device ACL transition (root once, then ordinary user)

The same exact-head binary repaired/took the lock as root, then took and verified it again as the ordinary device user:

- ASUS `/dev/video2`: ACL-only user (`wisbfime` is not in `video`) — PASS; lock `root:video 0660` with `user:wisbfime:rw-`.
- ThinkPad `/dev/video0`: ACL-only user (`fimerlwi` is not in `video`) — PASS; lock `root:video 0660` with `user:fimerlwi:rw-`.
- BRIO `/dev/video2`: `video` member plus named-user ACL — PASS.
- NexiGo `/dev/video2`: plain `root:video 0660`, no extended ACL — PASS.

All four daemon/socket pairs were restored active afterward.

### Emitter-driving evidence

- ASUS: non-root exact-head `burst_dump` completed the emitter write and restore, captured 6 × 640×400 IR frames, brightness spread **63.7** — PASS.
- NexiGo: non-root exact-head `burst_dump` completed the emitter write and restore, captured 6 × 640×360 IR frames, brightness spread **7.6** (required floor 5) — PASS.
- BRIO optical/default-D1 path: after a USB reset, Microsoft XU unit 12 selector 6 read `01 02 02 00 00 00 00 00 00`; with an empty irlume state directory, 6 x 340x340 frames alternated means **81.9 / 0.6** (spread **81.3**) -- PASS. No `SET_CUR` was sent or needed: this dedicated IR interface resets directly into D1 alternating illumination. The obsolete live config (`4:6:01,03,02,...`) was preserved and disabled because both its unit and interface byte are wrong for this BRIO.
- ThinkPad is RGB-only.

### Exact-head 60-second physical stress

- ASUS dual RGB+IR: PASS — 819 frames/stream, 13.645 Hz, recovery exercised.
- NexiGo dual RGB+IR: PASS — 1,654 frames/stream, 27.554 Hz, recovery exercised.
- BRIO measured RGB-only policy: PASS — 822 frames, 13.692 Hz, recovery exercised.
- ThinkPad RGB-only: PASS — 1,721 frames, 28.675 Hz, recovery exercised.

Each guarded runner verified the clean exact commit, restored the original systemd unit state, and published durable evidence.

## Deployment transition

Mirroring necessarily happens after the lock is opened. An ordinary user therefore cannot repair an already-existing `root:root 0640` lock that denies the initial open. The upgraded root daemon repairs that lock on its first emitter drive; reboot also clears `/run` locks. Upgrade/restart the daemon before invoking non-root camera tooling during the transition.

Do **not** put a user default ACL on the global `/run/lock`: it would affect unrelated services' newly-created locks, and a static default ACL does not track logind's dynamic active-session uaccess ACL. If packaging later needs pre-created policy, use a dedicated irlume runtime-lock directory and review that separately.
