### PR TITLE
fix(camera): accept FaceAuth D1 device defaults

### DIFF
--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2288,12 +2288,19 @@ fn apply_known_payload(
 /// `ir-setup` recorded is re-derived exactly as it was found. Persisting only
 /// coordinates is coherent because of that: the camera is the authority at both
 /// moments, and nothing is replayed out of a file.
+struct IntendedValue {
+    payload: Vec<u8>,
+    /// The value is not merely supported: it is also what `GET_DEF` says this
+    /// camera chooses without a host write.
+    is_device_default: bool,
+}
+
 fn intended_value(
     fd: c_int,
     unit: u8,
     selector: u8,
     len: usize,
-) -> XuResult<std::result::Result<Vec<u8>, String>> {
+) -> XuResult<std::result::Result<IntendedValue, String>> {
     let def = get_of(fd, unit, selector, UVC_GET_DEF, len)?;
     if selector == crate::uvc_descriptor::MSXU_IR_TORCH {
         // Microsoft specifies IR Torch's GET_INFO as exactly 3: a synchronous
@@ -2312,12 +2319,20 @@ fn intended_value(
         let min = get_of(fd, unit, selector, UVC_GET_MIN, len)?;
         let max = get_of(fd, unit, selector, UVC_GET_MAX, len)?;
         let res = get_of(fd, unit, selector, UVC_GET_RES, len)?;
-        return Ok(ir_torch_default_is_usable(&def, &min, &max, &res).map(|()| def));
+        return Ok(
+            ir_torch_default_is_usable(&def, &min, &max, &res).map(|()| IntendedValue {
+                payload: def,
+                is_device_default: true,
+            }),
+        );
     }
     // Face Authentication's default is general-purpose mode on a dual-purpose
     // interface, so it is derived from the camera's advertised capabilities.
     let max = get_of(fd, unit, selector, UVC_GET_MAX, len)?;
-    Ok(face_auth_payload(&def, &max))
+    Ok(face_auth_payload(&def, &max).map(|payload| IntendedValue {
+        is_device_default: payload == def,
+        payload,
+    }))
 }
 
 /// Apply a control's own default, with the checks discovery makes.
@@ -2340,9 +2355,10 @@ fn apply_device_default(
         return Err(XuError::Unsupported);
     }
     let len = get_len(fd, unit, selector)?;
-    let Ok(wanted) = intended_value(fd, unit, selector, len)? else {
+    let Ok(intended) = intended_value(fd, unit, selector, len)? else {
         return Err(XuError::Unsupported);
     };
+    let wanted = intended.payload;
     let write = write_if_different(fd, unit, selector, len, &wanted, id)?;
     Ok((write, wanted))
 }
@@ -3382,7 +3398,7 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     // The caller supplies the privacy-shutter re-check through this, so the
     // check-to-write window is one syscall, not the whole discovery pipeline.
     before_forward_write: &mut G,
-) -> std::result::Result<Discovered, DiscoveryError> {
+) -> std::result::Result<DiscoveryOutcome, DiscoveryError> {
     let ms = id
         .microsoft_xu()
         .ok_or_else(|| DiscoveryError::NoMicrosoftXu {
@@ -3427,11 +3443,14 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
             // the configuration naming the applied control is durable, so nothing
             // else can file a record over this one in between.
             Ok(Attempt::Lit(control, pending)) => {
-                return Ok(Discovered {
+                return Ok(DiscoveryOutcome::Applied(Discovered {
                     control,
                     pending,
                     _lock: lock,
-                })
+                }))
+            }
+            Ok(Attempt::ActiveByDeviceDefault(control)) => {
+                return Ok(DiscoveryOutcome::ActiveByDeviceDefault(control))
             }
             Ok(Attempt::AlreadyApplied) => tried.push(format!(
                 "selector {selector:#04x} is already set to the value setup would apply"
@@ -3479,6 +3498,18 @@ fn lock_device_fd(fd: c_int) -> Option<c_int> {
         return None;
     }
     Some(fd)
+}
+
+/// What standards-based emitter discovery established.
+///
+/// `Applied` owns a camera change until its configuration is committed.
+/// `ActiveByDeviceDefault` is a read-only result: the camera reports the same
+/// validated active value in both `GET_CUR` and `GET_DEF`, so no write or
+/// persistence is needed to reproduce its declared power-on behaviour.
+#[derive(Debug)]
+pub enum DiscoveryOutcome {
+    Applied(Discovered),
+    ActiveByDeviceDefault(EmitterControl),
 }
 
 /// A discovery run that has left the camera lit, and the undo record that stays
@@ -3573,8 +3604,12 @@ impl Discovered {
 enum Attempt {
     /// Lit, and still holding the applied value, with its undo record open.
     Lit(EmitterControl, ExploratoryWrite),
+    /// The validated active value is both current and the device's own default.
+    /// Nothing was written, measured, journalled, or claimed by irlume.
+    ActiveByDeviceDefault(EmitterControl),
     /// The control is already set to the value setup would apply, so writing it
-    /// again could not demonstrate anything.
+    /// again could not demonstrate anything, but it is not the device default
+    /// and may be transient state owned by another client.
     AlreadyApplied,
     /// Usable but it did not brighten the image, or its default failed the
     /// checks the specification allows. The control was left as it was found.
@@ -3628,10 +3663,11 @@ fn try_documented_control<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), St
 
     // The same derivation every later capture will use, so what is recorded is
     // reproducible rather than a value that only existed during setup.
-    let wanted = match intended_value(fd, unit, selector, len)? {
+    let intended = match intended_value(fd, unit, selector, len)? {
         Ok(v) => v,
         Err(why) => return Ok(Attempt::NotUsable(why)),
     };
+    let wanted = intended.payload;
 
     // Nothing here assumes what "off" looks like.
     //
@@ -3647,6 +3683,25 @@ fn try_documented_control<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), St
     // learn from writing it again, and saying so is more honest than measuring
     // a difference that cannot exist.
     if original == wanted {
+        // The validation queries above are several USB round trips. Re-read at
+        // the decision point so a client that moved the control during them is
+        // not reported as a ready camera. UVC has no compare-and-get, so this
+        // narrows the unavoidable observation window to one request.
+        let now = get_cur(fd, unit, selector, len)?;
+        if now != original {
+            return Ok(Attempt::NotUsable(format!(
+                "the control changed while setup was validating it: it held {original:02x?} \
+                 when discovery began and {now:02x?} before the ready-state decision; \
+                 nothing was sent"
+            )));
+        }
+        if intended.is_device_default {
+            return Ok(Attempt::ActiveByDeviceDefault(EmitterControl {
+                unit,
+                selector,
+                payload: wanted,
+            }));
+        }
         return Ok(Attempt::AlreadyApplied);
     }
 
@@ -4532,6 +4587,111 @@ mod tests {
             res: vec![1, 1, 1],
             ..Default::default()
         }
+    }
+
+    /// Microsoft's Face Authentication control permits a dedicated IR
+    /// interface to declare D1 as its default. The BRIO 046d:085e does exactly
+    /// that after a USB reset: interface 2 is already in alternative-frame
+    /// illumination mode before the host sends anything.
+    ///
+    /// Setup must recognise that documented ready state without manufacturing
+    /// evidence by rewriting the same bytes. In particular, measurement,
+    /// `SET_CUR`, and the undo journal all belong only to an exploratory change.
+    #[test]
+    fn a_face_auth_d1_device_default_is_already_active_without_a_write() {
+        let _lock = crate::testenv::env_lock();
+        let camera = fake_camera::Camera {
+            current: vec![1, 2, 0b010],
+            len: 3,
+            info: 0b0000_0011,
+            def: vec![1, 2, 0b010],
+            max: vec![1, 2, 0b011],
+            ..Default::default()
+        };
+        let mut measurements = 0;
+        let (outcome, log, current, dir) = run_discovery(camera, "d1-default", || {
+            measurements += 1;
+            Some(50.0)
+        });
+
+        assert!(matches!(
+            outcome,
+            Ok(Attempt::ActiveByDeviceDefault(EmitterControl {
+                unit: 14,
+                selector: 6,
+                payload,
+            })) if payload == vec![1, 2, 0b010]
+        ));
+        assert_eq!(
+            measurements, 0,
+            "an unchanged device default needs no optical experiment"
+        );
+        assert_eq!(current, vec![1, 2, 0b010]);
+        assert_eq!(
+            log,
+            vec![
+                fake_camera::Request::Get {
+                    query: UVC_GET_INFO,
+                    size: 1,
+                },
+                fake_camera::Request::Get {
+                    query: UVC_GET_LEN,
+                    size: 2,
+                },
+                fake_camera::Request::Get {
+                    query: UVC_GET_CUR,
+                    size: 3,
+                },
+                fake_camera::Request::Get {
+                    query: UVC_GET_DEF,
+                    size: 3,
+                },
+                fake_camera::Request::Get {
+                    query: UVC_GET_MAX,
+                    size: 3,
+                },
+                fake_camera::Request::Get {
+                    query: UVC_GET_CUR,
+                    size: 3,
+                },
+            ],
+            "the ready path must contain reads only"
+        );
+        assert!(
+            !dir.exists(),
+            "a path that changed nothing must not create an undo journal"
+        );
+    }
+
+    /// A dual-purpose interface defaults to D0. If its current value is D1,
+    /// another client may own that transient state; matching the value setup
+    /// would choose does not make it irlume's device-default success.
+    #[test]
+    fn a_transient_face_auth_d1_is_not_promoted_to_device_default_success() {
+        let _lock = crate::testenv::env_lock();
+        let camera = fake_camera::Camera {
+            current: vec![1, 3, 0b010],
+            len: 3,
+            info: 0b0000_0011,
+            def: vec![1, 3, 0b001],
+            max: vec![1, 3, 0b011],
+            ..Default::default()
+        };
+        let mut measurements = 0;
+        let (outcome, log, current, dir) = run_discovery(camera, "transient-d1", || {
+            measurements += 1;
+            Some(50.0)
+        });
+
+        assert!(matches!(outcome, Ok(Attempt::AlreadyApplied)));
+        assert_eq!(measurements, 0);
+        assert_eq!(current, vec![1, 3, 0b010]);
+        assert!(
+            log.iter()
+                .all(|request| !matches!(request, fake_camera::Request::Set(_))),
+            "another client's matching value must not be rewritten"
+        );
+        assert!(!dir.exists());
     }
 
     /// The undo record is on disk, complete and correct, AT THE MOMENT the first

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -6434,6 +6434,20 @@ pub fn store_sequential_if_still_concurrent(
 ///
 /// A control is only written when its current value could be read back first, so
 /// anything changed can be undone.
+fn active_by_device_default_message(control: &ir_emitter::EmitterControl) -> String {
+    let encoded = control.encode();
+    let mode = if control.selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION {
+        "Face Authentication D1"
+    } else {
+        "IR Torch active mode"
+    };
+    format!(
+        "IR emitter mode active by device default: {encoded} on the camera's Microsoft \
+         camera-control unit; GET_CUR and GET_DEF both report the validated {mode} value \
+         (no camera write or saved config was needed)"
+    )
+}
+
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     verify_pinned(device)?;
@@ -6543,7 +6557,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     };
     permit.run_active(|| {
         match ir_emitter::discover(fd, &id, &mut measure, &mut privacy_allows_write) {
-            Ok(found) => {
+            Ok(ir_emitter::DiscoveryOutcome::Applied(found)) => {
                 let encoded = found.control().encode();
                 // Confirm, publish, release, in that order. The sequence lives in
                 // `finish` rather than here so it is reachable by a test.
@@ -6551,8 +6565,11 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
                 Ok(format!(
                     "IR emitter enabled: {encoded} on the camera's Microsoft camera-control unit, \
                  using a value built from what the camera reports about that control \
-                 (saved; future captures rebuild it the same way)"
+                    (saved; future captures rebuild it the same way)"
                 ))
+            }
+            Ok(ir_emitter::DiscoveryOutcome::ActiveByDeviceDefault(control)) => {
+                Ok(active_by_device_default_message(&control))
             }
             Err(e) => Err(Error::Hardware(e.to_string())),
         }
@@ -6732,6 +6749,23 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_device_default_d1_message_reports_evidence_and_absence_of_writes() {
+        let message = active_by_device_default_message(&ir_emitter::EmitterControl {
+            unit: 12,
+            selector: crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION,
+            payload: vec![1, 2, 0b010],
+        });
+
+        assert!(message.contains("active by device default"), "{message}");
+        assert!(message.contains("Face Authentication D1"), "{message}");
+        assert!(message.contains("GET_CUR and GET_DEF"), "{message}");
+        assert!(
+            message.contains("no camera write or saved config was needed"),
+            "{message}"
+        );
+    }
 
     fn test_rate_config(role: contracts::StreamRole) -> rate_gate::StreamRateConfig {
         // Zero window: a "no gate" config for continuity/provenance fixtures so


### PR DESCRIPTION
Closes #490.

## Why

Microsoft's Face Authentication XU permits a dedicated IR interface to choose D1 Alternative Frame Illumination as its device default. On such a camera, `GET_CUR` can already equal the validated D1 value before the host writes anything.

irlume already derived D1 from the camera's `GET_DEF` / `GET_MAX` data, but folded that state into `NoUsableControl` as `AlreadyApplied`. That made the Logitech BRIO's standards-valid power-on state look like failed discovery even though the camera was already producing alternating lit/ambient IR frames.

Contract sources:

- Microsoft Face Authentication Control (D0/D1/D2, `GET_DEF`, `GET_CUR`, `GET_MAX`): https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/uvc-extensions-1-5#2226-face-authentication-control
- Windows Hello camera bring-up and frame-illumination contract: https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/windows-hello-camera-driver-bring-up-guide
- Linux UVCM exposure of Microsoft UVC 1.5 payload metadata: https://www.kernel.org/doc/html/next/userspace-api/media/v4l/metafmt-uvc-msxu-1-5.html

## What changed

- `IntendedValue` now carries both the device-derived payload and whether it exactly matches `GET_DEF`.
- Discovery has a typed `ActiveByDeviceDefault` outcome, distinct from an exploratory write that irlume owns.
- Read-only success requires the existing descriptor, `GET_INFO`, length, and Microsoft payload checks, plus `GET_CUR == derived D1`, `GET_DEF == derived D1`, and a final `GET_CUR` re-read at the decision point.
- Setup reports that no camera write or config was needed.
- A transient D1 current value with D0 as the device default remains `AlreadyApplied` and is not claimed or persisted.

This path performs no brightness measurement, `SET_CUR`, undo-journal creation, or emitter-config save.

## Integrated verification

Exact head: `256ae5cf30846a0225a7b866cb9609653e6c4445`

This head was rebased onto merged #489. The conflict resolution preserves both #489's device-fd ACL lock mirroring and this PR's typed device-default discovery outcome.

- Microsoft-layout fake-camera regression asserts the exact read sequence and zero measurements, writes, or journal creation.
- Counterexample keeps `GET_CUR=D1`, `GET_DEF=D0` out of device-default success.
- User-facing regression requires the D1/default/read-only evidence.
- `cargo test -p irlume-camera`: 470 passed, 22 ignored.
- `cargo test --workspace --all-targets --locked`: PASS.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: PASS.
- `cargo fmt --all --check`: PASS.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --locked`: PASS.
- Fresh GitHub CI, ASan, CodeQL, self-hosted hardware, stable tests, dependency policy, fuzzing, Nix, systemd, and Fedora 43/44 builds all passed on this exact head.

## Hardware evidence

Manual four-host testing was performed on the predecessor feature head `a9761b49e6bdb2d1ff4163b5abdfe29cdd592b68`; #489's lock behavior was separately tested before the mechanical rebase. Fresh self-hosted hardware CI passed on the combined exact head above.

| Host / camera | Result |
|---|---|
| Archhost / Logitech BRIO 046d:085e | After `usbreset`, FaceAuth unit 12 selector 6 stayed at `01 02 02 00 00 00 00 00 00`; setup reported `active by device default`, created no emitter config/journal, and a 36-frame native 340x340 burst delivered 9.6 fps with alternating scene means. |
| Local / ASUS 3277:0059 | Weak-scene setup safely restored D0. The configured production path derived/wrote D1, captured 120 frames at 640x400 / 9.8 fps, restored D0, and cleared its journal. |
| Minihost / NexiGo N930W 3443:c803 | Configured production path derived/wrote D1, captured 120 frames at 640x360 / 9.0 fps, restored D0, and left no journal. |
| ThinkPad / Chicony 04f2:b7bf | Descriptor report found Microsoft selectors 0x02, 0x03, 0x09 but no FaceAuth 0x06; candidate captured 120 frames at 640x360 / 19.1 fps with the emitter off and zero emitter writes. |

## Follow-ups

- #491 tracks the `xu_set` example's write modes not entering the active camera-permit scope.
- #492 tracks setup's scene-dependent optical proof and metadata/periodicity/inconclusive handling.

Neither is folded into this PR; this change stays limited to the standards-valid, read-only D1 device-default state.
