### PR TITLE
fix(camera): enter active permit for xu_set writes

### DIFF
--- a/crates/irlume-camera/examples/xu_set.rs
+++ b/crates/irlume-camera/examples/xu_set.rs
@@ -109,7 +109,7 @@ fn run() -> Result<(), String> {
         .lease()
         .validate()
         .map_err(|error| error.to_string())?;
-    raw::set_cur(fd, unit, selector, &payload)?;
+    raw::set_cur(&operation, fd, unit, selector, &payload)?;
     let after = raw::get_cur(fd, unit, selector, len)?;
     eprintln!("xu_set: unit{unit}/sel{selector} wrote:  {payload:02x?}");
     eprintln!("xu_set: unit{unit}/sel{selector} after:  {after:02x?}");

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -811,6 +811,7 @@ pub(crate) fn info_allows_set(info: u8) -> bool {
 #[doc(hidden)]
 pub mod raw {
     use super::c_int;
+    use crate::lease::CameraOperationSession;
 
     /// `GET_LEN` for a control, as the device reports it.
     pub fn get_len(fd: c_int, unit: u8, selector: u8) -> Result<usize, String> {
@@ -827,9 +828,24 @@ pub mod raw {
         super::get_of(fd, unit, selector, super::UVC_GET_DEF, len).map_err(|e| e.to_string())
     }
 
-    /// ONE `SET_CUR`, owned by no guard, recorded in no journal.
-    pub fn set_cur(fd: c_int, unit: u8, selector: u8, payload: &[u8]) -> Result<(), String> {
-        super::set_cur(fd, unit, selector, payload).map_err(|e| e.to_string())
+    /// ONE `SET_CUR` under a current camera operation, owned by no restore
+    /// guard and recorded in no journal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the operation is stale or does not cover the open
+    /// endpoint, or when the camera refuses or does not answer the write.
+    pub fn set_cur(
+        operation: &CameraOperationSession,
+        fd: c_int,
+        unit: u8,
+        selector: u8,
+        payload: &[u8],
+    ) -> Result<(), String> {
+        operation
+            .lease()
+            .run_active(|| super::set_cur(fd, unit, selector, payload))
+            .map_err(|error| error.to_string())
     }
 }
 

--- a/crates/irlume-camera/src/lease.rs
+++ b/crates/irlume-camera/src/lease.rs
@@ -959,6 +959,45 @@ mod tests {
     }
 
     #[test]
+    fn raw_set_cur_enters_the_acquired_operations_active_scope() {
+        let (_authority, _inventory, lease) = lease_fixture();
+        let session = CameraOperationSession::new(lease);
+        let _camera =
+            crate::ir_emitter::fake_camera::install(crate::ir_emitter::fake_camera::Camera {
+                at_first_write: Some(Box::new(|| match active_permit("/dev/video0") {
+                    Ok(Some(_)) => Ok(()),
+                    Ok(None) => Err("SET_CUR had no current operation".into()),
+                    Err(error) => Err(format!("SET_CUR operation was invalid: {error}")),
+                })),
+                ..Default::default()
+            });
+
+        assert_eq!(
+            crate::ir_emitter::raw::set_cur(&session, -1_i32, 1, 1, &[7]),
+            Ok(())
+        );
+        assert_eq!(
+            crate::ir_emitter::fake_camera::log(),
+            vec![crate::ir_emitter::fake_camera::Request::Set(vec![7])]
+        );
+    }
+
+    #[test]
+    fn raw_set_cur_keeps_a_stale_operation_fail_closed_as_estale() {
+        use std::os::fd::AsRawFd;
+
+        let (_authority, inventory, lease) = lease_fixture();
+        let session = CameraOperationSession::new(lease);
+        inventory.lock().unwrap().invalidate_all();
+        let file = std::fs::File::open("/dev/null").unwrap();
+
+        let error = crate::ir_emitter::raw::set_cur(&session, file.as_raw_fd(), 1, 1, &[7])
+            .expect_err("a stale operation must not reach SET_CUR");
+        assert!(error.starts_with("camera did not answer ("));
+        assert!(error.ends_with(&format!("(os error {}))", libc::ESTALE)));
+    }
+
+    #[test]
     #[ignore = "requires an operator-controlled UVC interface unbind"]
     fn production_active_pair_lease_becomes_stale_on_uvc_loss() {
         use std::io::Write;


### PR DESCRIPTION
Closes #491.

## Why

`xu_set` acquired and validated a `CameraOperationSession`, but its `SET_CUR`
write ran outside that operation's active permit. The common write gate therefore
rejected the request with `ESTALE` before the ioctl.

## What changed

- Require the acquired operation at the example-only raw `SET_CUR` boundary.
- Enter the lease's production active scope immediately around the existing
  write path.
- Pass the already-acquired operation from `xu_set`.
- Add regressions proving a valid operation is active at the fake camera's first
  write and a stale operation remains fail-closed with `ESTALE`.

## Safety invariants preserved

- Endpoint/descriptor publication checks and immediate pre-write validation are
  unchanged.
- `GET_LEN`, payload length validation, and readback verification are unchanged.
- `xu_get` remains read-only.
- Missing and stale permits remain fail-closed with `ESTALE`.

## Verification

Verified at `382774ee84256ee1144e967250e06abcdb526579`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --locked`
- `cargo build --workspace --release --locked`
- `cargo deny check advisories bans licenses sources`
- Mutation check: bypassing the active scope makes the new first-write permit
  regression fail; restoring the production scope passes it.
- Independent safety review: ready to merge, with no blocking findings.

## Physical hardware matrix

The guarded physical matrix passed on the exact PR commit. Each lane exercised
capture recovery and restored `irlumed.service` and `irlumed.socket` to active:

- ASUS FHD/IR (`3277:0059`): sequential RGB 13.72 Hz and IR 13.95 Hz,
  zero cumulative drops. Idempotent `SET_CUR`/readback passed on Microsoft XU
  unit 14, selector 6.
- Logitech BRIO (`046d:085e`): sequential RGB 13.61 Hz (one cumulative drop)
  and IR 28.53 Hz (zero drops). Idempotent `SET_CUR`/readback passed on unit 12,
  selector 6.
- ThinkPad Chicony (`04f2:b7bf`): explicit RGB-only 28.68 Hz, zero cumulative
  drops. No Microsoft emitter XU is present, so the write check is not
  applicable.
- NexiGo N930W (`3443:c803`): sequential RGB 27.83 Hz and IR 28.56 Hz,
  zero cumulative drops. Idempotent `SET_CUR`/readback passed on unit 4,
  selector 6.

Every XU check wrote only the exact current nine bytes reported by that device,
then confirmed byte-for-byte readback, so it exercised the real ioctl without
changing emitter state.
