### PR TITLE
fix(camera): classify weak IR setup evidence as inconclusive

### DIFF
--- a/crates/irlume-camera/examples/xu_set.rs
+++ b/crates/irlume-camera/examples/xu_set.rs
@@ -24,14 +24,19 @@
 //!
 //! Usage:
 //!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> get
+//!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> snapshot
+//!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> identity
 //!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> def
 //!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> <b0,b1,...>
+//!   cargo run -p irlume-camera --example xu_set -- <video-dev> <unit> <selector> \
+//!       <b0,b1,...> --expect-camera <identity-token>
 //!
 //! `get` reads GET_CUR and writes nothing at all. Bytes are decimal or 0x-hex,
 //! comma-separated, and must match GET_LEN.
 
 use irlume_camera::ir_emitter::raw;
 use irlume_camera::uvc_descriptor;
+use std::os::unix::fs::MetadataExt;
 
 fn parse_byte(s: &str) -> Result<u8, String> {
     let s = s.trim();
@@ -42,10 +47,57 @@ fn parse_byte(s: &str) -> Result<u8, String> {
     }
 }
 
+fn identity_token(id: &uvc_descriptor::CameraIdentity, sysfs_instance: (u64, u64)) -> String {
+    let descriptor_sha256 = irlume_common::sha256_hex(&id.descriptors);
+    let serial = id.serial.as_deref().unwrap_or("");
+    irlume_common::sha256_hex(
+        format!(
+            "descriptors:{descriptor_sha256}|interface:{}|serial:{}:{serial}|devpath:{}:{}|sysfs:{}:{}",
+            id.interface_number,
+            serial.len(),
+            id.usb_devpath.len(),
+            id.usb_devpath,
+            sysfs_instance.0,
+            sysfs_instance.1,
+        )
+        .as_bytes(),
+    )
+}
+
+fn live_identity_token(id: &uvc_descriptor::CameraIdentity) -> Result<String, String> {
+    let path = format!("/sys{}", id.usb_devpath);
+    let metadata = std::fs::metadata(&path)
+        .map_err(|error| format!("inspect current camera incarnation at {path}: {error}"))?;
+    Ok(identity_token(id, (metadata.dev(), metadata.ino())))
+}
+
+fn snapshot_line(
+    id: &uvc_descriptor::CameraIdentity,
+    token: &str,
+    unit: u8,
+    selector: u8,
+    bytes: &[u8],
+) -> String {
+    let bytes = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
+    format!(
+        "{token} {} {} {unit} {selector} {bytes}",
+        id.usb_id(),
+        id.interface_number,
+    )
+}
+
 fn run() -> Result<(), String> {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    let [device, unit, selector, value] = args.as_slice() else {
-        return Err("usage: xu_set <video-dev> <unit> <selector> <get|def|b0,b1,...>".to_string());
+    let (device, unit, selector, value, expected_camera) = match args.as_slice() {
+        [device, unit, selector, value] => (device, unit, selector, value, None),
+        [device, unit, selector, value, flag, expected] if flag == "--expect-camera" => {
+            (device, unit, selector, value, Some(expected.as_str()))
+        }
+        _ => {
+            return Err("usage: xu_set <video-dev> <unit> <selector> \
+                 <get|snapshot|identity|def|b0,b1,...> [--expect-camera <identity-token>]"
+                .to_string());
+        }
     };
     let unit: u8 = unit.parse().map_err(|e| format!("unit {unit}: {e}"))?;
     let selector: u8 = selector
@@ -76,9 +128,34 @@ fn run() -> Result<(), String> {
             id.usb_id()
         ));
     }
+    let current_camera = live_identity_token(&id)?;
+    if value == "identity" {
+        if expected_camera.is_some() {
+            return Err("identity does not accept --expect-camera".to_string());
+        }
+        println!("{current_camera}");
+        return Ok(());
+    }
+    if let Some(expected) = expected_camera {
+        if current_camera != expected {
+            return Err(format!(
+                "camera identity changed: expected {expected}, found {current_camera}; nothing was sent"
+            ));
+        }
+    }
 
     let len = raw::get_len(fd, unit, selector)?;
     let before = raw::get_cur(fd, unit, selector, len)?;
+    if value == "snapshot" {
+        if expected_camera.is_some() {
+            return Err("snapshot does not accept --expect-camera".to_string());
+        }
+        println!(
+            "{}",
+            snapshot_line(&id, &current_camera, unit, selector, &before)
+        );
+        return Ok(());
+    }
     if value == "get" {
         // Read-only: the one line a harness parses, and no ioctl but GETs.
         println!(
@@ -129,5 +206,44 @@ fn main() {
     if let Err(why) = run() {
         eprintln!("xu_set: {why}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> irlume_camera::uvc_descriptor::CameraIdentity {
+        irlume_camera::uvc_descriptor::CameraIdentity {
+            descriptors: vec![1, 2, 3, 4],
+            interface_number: 1,
+            vid: 0x3277,
+            pid: 0x0059,
+            serial: Some("camera-a".into()),
+            usb_devpath: "/devices/pci/usb/camera".into(),
+        }
+    }
+
+    #[test]
+    fn expected_camera_token_binds_the_current_sysfs_incarnation() {
+        let id = identity();
+        assert_eq!(identity_token(&id, (7, 11)), identity_token(&id, (7, 11)));
+        assert_ne!(identity_token(&id, (7, 11)), identity_token(&id, (7, 12)));
+
+        let mut replacement = identity();
+        replacement.serial = Some("camera-b".into());
+        assert_ne!(
+            identity_token(&id, (7, 11)),
+            identity_token(&replacement, (7, 11))
+        );
+    }
+
+    #[test]
+    fn snapshot_line_binds_control_bytes_to_descriptor_identity() {
+        let id = identity();
+        assert_eq!(
+            snapshot_line(&id, "identity-token", 14, 6, &[1, 3, 1]),
+            "identity-token 3277:0059 1 14 6 010301"
+        );
     }
 }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -98,6 +98,107 @@ pub(crate) const IR_LIT_MEAN: f32 = 40.0;
 /// calls a control a success; filters ambient flicker and exposure drift.
 const AUTOCONF_MIN_LIFT: f32 = 20.0;
 
+/// Camera-reported illumination observations from one setup burst.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct D1MetadataEvidence {
+    total: usize,
+    lit: usize,
+    dark: usize,
+    parity_consistent_pairs: usize,
+    parity_conflicts: usize,
+}
+
+impl D1MetadataEvidence {
+    pub(crate) fn from_lit_flags(flags: &[Option<bool>]) -> Self {
+        let mut previous = None;
+        let mut parity_consistent_pairs = 0;
+        let mut parity_conflicts = 0;
+        for (index, flag) in flags.iter().copied().enumerate() {
+            let Some(lit) = flag else {
+                continue;
+            };
+            if let Some((previous_index, previous_lit)) = previous {
+                let even_gap = (index - previous_index) % 2 == 0;
+                if (lit == previous_lit) == even_gap {
+                    parity_consistent_pairs += 1;
+                } else {
+                    parity_conflicts += 1;
+                }
+            }
+            previous = Some((index, lit));
+        }
+        Self {
+            total: flags.len(),
+            lit: flags.iter().filter(|flag| **flag == Some(true)).count(),
+            dark: flags.iter().filter(|flag| **flag == Some(false)).count(),
+            parity_consistent_pairs,
+            parity_conflicts,
+        }
+    }
+
+    const fn classified(self) -> usize {
+        self.lit + self.dark
+    }
+
+    const fn missing(self) -> usize {
+        self.total - self.classified()
+    }
+
+    const fn proves_d1(self) -> bool {
+        self.classified() >= 4
+            && self.lit >= 2
+            && self.dark >= 2
+            && self.parity_consistent_pairs >= 3
+            && self.parity_conflicts == 0
+    }
+
+    const fn contradicts_d1(self) -> bool {
+        self.classified() >= 4 && self.parity_conflicts > 0
+    }
+}
+
+/// One setup burst, keeping optical and camera-reported evidence separate.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct SetupMeasurement {
+    brightness: f32,
+    d1_metadata: Option<D1MetadataEvidence>,
+}
+
+impl SetupMeasurement {
+    pub(crate) const fn optical(brightness: f32) -> Self {
+        Self {
+            brightness,
+            d1_metadata: None,
+        }
+    }
+
+    pub(crate) const fn with_d1_metadata(brightness: f32, evidence: D1MetadataEvidence) -> Self {
+        Self {
+            brightness,
+            d1_metadata: Some(evidence),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn brightness(self) -> f32 {
+        self.brightness
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn metadata_proves_d1(self) -> bool {
+        match self.d1_metadata {
+            Some(evidence) => evidence.proves_d1(),
+            None => false,
+        }
+    }
+}
+
+impl From<f32> for SetupMeasurement {
+    fn from(brightness: f32) -> Self {
+        Self::optical(brightness)
+    }
+}
+
 /// Built-in table, keyed on USB `idVendor:idProduct`. Verified on-hardware.
 ///
 /// This used to match a substring of the V4L card name, so every camera whose
@@ -2474,9 +2575,13 @@ pub enum DiscoveryError {
     /// The camera has no Microsoft-XU, so irlume has no documented control to
     /// address on it.
     NoMicrosoftXu { seen: Vec<u8> },
-    /// The Microsoft-XU is present but advertises no control irlume can use, or
-    /// the ones it advertises did not light anything.
+    /// The Microsoft-XU is present but advertises no control whose documented
+    /// capability and value contract irlume can safely use.
     NoUsableControl { unit: u8, tried: Vec<String> },
+    /// A documented control was accepted, read back, and exactly restored, but
+    /// the available frame evidence could not prove that it affected the IR
+    /// stream. This is an observation gap, not an unsupported control.
+    Inconclusive { unit: u8, tried: Vec<String> },
     /// The camera stopped answering. Discovery is abandoned immediately.
     Unresponsive {
         unit: u8,
@@ -2529,6 +2634,14 @@ impl std::fmt::Display for DiscoveryError {
             Self::NoUsableControl { unit, tried } => write!(
                 f,
                 "unit {unit} advertises no usable emitter control ({})",
+                tried.join("; ")
+            ),
+            Self::Inconclusive { unit, tried } => write!(
+                f,
+                "IR emitter setup was inconclusive at unit {unit} ({}). This does not show that \
+                 the control is unsupported or unusable. Put a nearby subject in the IR camera's \
+                 view, keep the scene still, make sure the privacy shutter is open, and retry \
+                 `sudo irlume ir-setup`",
                 tried.join("; ")
             ),
             // Two different situations reach here, and calling a refusal
@@ -3502,6 +3615,19 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     // check-to-write window is one syscall, not the whole discovery pipeline.
     before_forward_write: &mut G,
 ) -> std::result::Result<DiscoveryOutcome, DiscoveryError> {
+    let mut measure_with_evidence = || measure().map(SetupMeasurement::optical);
+    discover_with_measurements(fd, id, &mut measure_with_evidence, before_forward_write)
+}
+
+pub(crate) fn discover_with_measurements<
+    F: FnMut() -> Option<SetupMeasurement>,
+    G: FnMut() -> Result<(), String>,
+>(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    measure: &mut F,
+    before_forward_write: &mut G,
+) -> std::result::Result<DiscoveryOutcome, DiscoveryError> {
     let ms = id
         .microsoft_xu()
         .ok_or_else(|| DiscoveryError::NoMicrosoftXu {
@@ -3532,6 +3658,7 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
     }
 
     let mut tried = Vec::new();
+    let mut inconclusive = Vec::new();
 
     for selector in [
         crate::uvc_descriptor::MSXU_IR_TORCH,
@@ -3558,6 +3685,9 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
             Ok(Attempt::AlreadyApplied) => tried.push(format!(
                 "selector {selector:#04x} is already set to the value setup would apply"
             )),
+            Ok(Attempt::Inconclusive(why)) => {
+                inconclusive.push(format!("selector {selector:#04x}: {why}"));
+            }
             Ok(Attempt::NotUsable(why)) => tried.push(format!("selector {selector:#04x}: {why}")),
             Err(TryFailure::Measurement) => return Err(DiscoveryError::MeasurementFailed),
             Err(TryFailure::Restore(err)) => {
@@ -3586,10 +3716,17 @@ pub fn discover<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
         }
     }
 
-    Err(DiscoveryError::NoUsableControl {
-        unit: ms.unit_id,
-        tried,
-    })
+    if inconclusive.is_empty() {
+        Err(DiscoveryError::NoUsableControl {
+            unit: ms.unit_id,
+            tried,
+        })
+    } else {
+        Err(DiscoveryError::Inconclusive {
+            unit: ms.unit_id,
+            tried: inconclusive,
+        })
+    }
 }
 
 /// Production always mirrors the real device descriptor. Unit tests that stop
@@ -3714,8 +3851,11 @@ enum Attempt {
     /// again could not demonstrate anything, but it is not the device default
     /// and may be transient state owned by another client.
     AlreadyApplied,
-    /// Usable but it did not brighten the image, or its default failed the
-    /// checks the specification allows. The control was left as it was found.
+    /// The documented control transaction was safe, but the available frame
+    /// evidence could not establish a functional effect.
+    Inconclusive(String),
+    /// The control's documented capability or value contract failed validation.
+    /// The control was left as it was found.
     NotUsable(String),
 }
 
@@ -3743,7 +3883,10 @@ impl From<XuError> for TryFailure {
 
 /// Try one advertised, documented control, leaving it as it was found unless it
 /// worked.
-fn try_documented_control<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), String>>(
+fn try_documented_control<
+    F: FnMut() -> Option<SetupMeasurement>,
+    G: FnMut() -> Result<(), String>,
+>(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     unit: u8,
@@ -3890,11 +4033,35 @@ fn try_documented_control<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), St
     // Those are different questions; conflating them made success depend on room
     // lighting, and the same camera here has measured 38 to 168 depending only
     // on what was in front of it.
-    if lit < before + AUTOCONF_MIN_LIFT {
+    let metadata_proves_d1 = selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION
+        && lit.d1_metadata.is_some_and(D1MetadataEvidence::proves_d1);
+    let contradictory_metadata = if selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION {
+        lit.d1_metadata.filter(|evidence| evidence.contradicts_d1())
+    } else {
+        None
+    };
+    if let Some(evidence) = contradictory_metadata {
         pending.restore_once().map_err(TryFailure::Restore)?;
         pending.confirm_restored().map_err(TryFailure::Journal)?;
-        return Ok(Attempt::NotUsable(format!(
-            "the image did not brighten (before {before:.0}, after {lit:.0}, needs +{AUTOCONF_MIN_LIFT:.0})"
+        return Ok(Attempt::Inconclusive(format!(
+            "the camera supplied {} classified illumination records ({} lit, {} dark, {} missing), \
+             but their frame parity contradicted D1 alternation; the exact original value was \
+             restored and verified, and no configuration was saved",
+            evidence.classified(),
+            evidence.lit,
+            evidence.dark,
+            evidence.missing()
+        )));
+    }
+    if !metadata_proves_d1 && lit.brightness < before.brightness + AUTOCONF_MIN_LIFT {
+        pending.restore_once().map_err(TryFailure::Restore)?;
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
+        return Ok(Attempt::Inconclusive(format!(
+            "the camera accepted and read back the device-derived value, but the optical change \
+             was too weak to classify (before {:.0}, after {:.0}, needs \
+             +{AUTOCONF_MIN_LIFT:.0}); the exact original value was restored and verified, and \
+             no configuration was saved",
+            before.brightness, lit.brightness
         )));
     }
 
@@ -3903,20 +4070,24 @@ fn try_documented_control<F: FnMut() -> Option<f32>, G: FnMut() -> Result<(), St
     // illuminator. Put the control back and require the brightness to fall with
     // it: a change that does not follow the control is not caused by it.
     pending.restore_once().map_err(TryFailure::Restore)?;
-    let Some(after_restore) = measure() else {
-        return Err(TryFailure::Measurement);
-    };
-    if after_restore >= lit - AUTOCONF_MIN_LIFT {
-        // Restored above, and this branch writes nothing further, so the record
-        // is resolvable here. The read-back is what resolves it: the restoring
-        // `set_cur` returning success says the ioctl was accepted, not that the
-        // control holds those bytes.
-        pending.confirm_restored().map_err(TryFailure::Journal)?;
-        return Ok(Attempt::NotUsable(format!(
-            "the image brightened but stayed bright when the control was put back \
-             ({before:.0} before, {lit:.0} with it set, {after_restore:.0} after undoing it), \
-             so the change did not come from this control"
-        )));
+    if !metadata_proves_d1 {
+        let Some(after_restore) = measure() else {
+            return Err(TryFailure::Measurement);
+        };
+        if after_restore.brightness >= lit.brightness - AUTOCONF_MIN_LIFT {
+            // Restored above, and this branch writes nothing further, so the record
+            // is resolvable here. The read-back is what resolves it: the restoring
+            // `set_cur` returning success says the ioctl was accepted, not that the
+            // control holds those bytes.
+            pending.confirm_restored().map_err(TryFailure::Journal)?;
+            return Ok(Attempt::Inconclusive(format!(
+                "the image brightened but stayed bright when the control was put back \
+                 ({:.0} before, {:.0} with it set, {:.0} after undoing it), \
+                 so the change could not be assigned to this control; the exact original value \
+                 was restored and verified, and no configuration was saved",
+                before.brightness, lit.brightness, after_restore.brightness
+            )));
+        }
     }
 
     // It followed the control both ways. Apply it and report it.
@@ -4631,10 +4802,10 @@ mod tests {
     /// Returns the ordered request log and the value the control ends up
     /// holding. `IRLUME_STATE_DIR` points at a scratch directory so the undo
     /// record is real.
-    fn run_discovery(
+    fn run_discovery<M: Into<SetupMeasurement>>(
         camera: fake_camera::Camera,
         tag: &str,
-        measure: impl FnMut() -> Option<f32>,
+        measure: impl FnMut() -> Option<M>,
     ) -> (
         std::result::Result<Attempt, TryFailure>,
         Vec<fake_camera::Request>,
@@ -4644,10 +4815,10 @@ mod tests {
         run_discovery_guarded(camera, tag, measure, || Ok(()))
     }
 
-    fn run_discovery_guarded(
+    fn run_discovery_guarded<M: Into<SetupMeasurement>>(
         camera: fake_camera::Camera,
         tag: &str,
-        mut measure: impl FnMut() -> Option<f32>,
+        mut measure: impl FnMut() -> Option<M>,
         mut guard: impl FnMut() -> Result<(), String>,
     ) -> (
         std::result::Result<Attempt, TryFailure>,
@@ -4669,8 +4840,15 @@ mod tests {
         .find(|s| ms.advertises(*s))
         .expect("fixture advertises an emitter selector");
         // fd is never reached: the fake intercepts before the ioctl.
-        let outcome =
-            try_documented_control(-1, &id, ms.unit_id, selector, &mut measure, &mut guard);
+        let mut measure_with_evidence = || measure().map(Into::into);
+        let outcome = try_documented_control(
+            -1,
+            &id,
+            ms.unit_id,
+            selector,
+            &mut measure_with_evidence,
+            &mut guard,
+        );
         (outcome, fake_camera::log(), fake_camera::current(), dir)
     }
 
@@ -4690,6 +4868,178 @@ mod tests {
             res: vec![1, 1, 1],
             ..Default::default()
         }
+    }
+
+    /// A weak scene is an observation gap, not evidence that a documented D1
+    /// control is unusable. This reproduces the ASUS setup result from #492:
+    /// the device-derived value is accepted, read back, and exactly restored,
+    /// but the short optical window moves only four brightness points.
+    #[test]
+    fn weak_reflection_is_inconclusive_not_no_usable_control() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "irlume-discovery-weak-reflection-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let _fake = fake_camera::install(a_working_camera());
+        let id = identity(0x3277, 0x0059);
+        let mut readings = [48.0, 52.0].into_iter();
+        let mut permit = || Ok(());
+
+        let error = discover(-1, &id, &mut || readings.next(), &mut permit)
+            .expect_err("weak optical evidence must not publish a configuration");
+
+        assert!(
+            !matches!(error, DiscoveryError::NoUsableControl { .. }),
+            "a scene-dependent miss must not classify the advertised control as unusable: {error}"
+        );
+        let message = error.to_string();
+        assert!(message.contains("inconclusive"), "{message}");
+        assert!(!message.contains("no usable emitter control"), "{message}");
+        assert_eq!(
+            fake_camera::current(),
+            vec![1, 3, 1],
+            "the exact original value must be restored"
+        );
+        let sets = fake_camera::log()
+            .iter()
+            .filter(|request| matches!(request, fake_camera::Request::Set { .. }))
+            .count();
+        assert_eq!(
+            sets, 2,
+            "only exploratory apply and exact restore may be sent"
+        );
+        let records = std::fs::read_dir(dir.join("ir-emitter-journal"))
+            .map(|entries| entries.flatten().count())
+            .unwrap_or(0);
+        assert_eq!(records, 0, "a confirmed restore must clear the journal");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Brightening that does not reverse with the control is compatible with
+    /// ambient or exposure drift. It must neither prove D1 nor condemn a
+    /// documented control that was safely restored.
+    #[test]
+    fn independent_brightness_drift_is_inconclusive_not_unusable() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "irlume-discovery-independent-drift-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let _fake = fake_camera::install(a_working_camera());
+        let id = identity(0x3277, 0x0059);
+        let mut readings = [10.0, 40.0, 35.0].into_iter();
+        let mut permit = || Ok(());
+
+        let error = discover(-1, &id, &mut || readings.next(), &mut permit)
+            .expect_err("a change independent of the control must not be published");
+
+        assert!(
+            matches!(error, DiscoveryError::Inconclusive { .. }),
+            "ambient or exposure drift is an evidence gap, not an unusable control: {error}"
+        );
+        let message = error.to_string();
+        assert!(message.contains("stayed bright"), "{message}");
+        assert_eq!(fake_camera::current(), vec![1, 3, 1]);
+        let sets = fake_camera::log()
+            .iter()
+            .filter(|request| matches!(request, fake_camera::Request::Set { .. }))
+            .count();
+        assert_eq!(sets, 2, "drift permits only exploratory apply and restore");
+        let records = std::fs::read_dir(dir.join("ir-emitter-journal"))
+            .map(|entries| entries.flatten().count())
+            .unwrap_or(0);
+        assert_eq!(records, 0, "a confirmed restore clears the journal");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Microsoft D1 metadata can prove the alternating mode even when the
+    /// scene is too weak for the optical heuristic. The proof remains labelled
+    /// as metadata evidence; it does not claim to have measured photons.
+    #[test]
+    fn d1_metadata_proves_setup_when_optical_lift_is_weak() {
+        let _lock = crate::testenv::env_lock();
+        let evidence = D1MetadataEvidence::from_lit_flags(&[
+            Some(false),
+            Some(true),
+            None,
+            Some(true),
+            Some(false),
+            Some(true),
+        ]);
+        let mut measurements = [
+            SetupMeasurement::optical(48.0),
+            SetupMeasurement::with_d1_metadata(52.0, evidence),
+        ]
+        .into_iter();
+
+        let (outcome, log, current, dir) =
+            run_discovery(a_working_camera(), "metadata-proves-weak-optical", || {
+                measurements.next()
+            });
+
+        assert!(matches!(outcome, Ok(Attempt::Lit(..))), "{outcome:?}");
+        assert_eq!(current, vec![1, 3, 2], "proven D1 is left applied");
+        let sets = log
+            .iter()
+            .filter(|request| matches!(request, fake_camera::Request::Set { .. }))
+            .count();
+        assert_eq!(
+            sets, 3,
+            "metadata proof still performs exploratory apply, exact restore, and final apply"
+        );
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Once the camera supplies enough metadata to contradict D1, a reversible
+    /// brightness swing cannot erase that contradiction. The result needs a
+    /// better observation, not a persisted mode with dishonest provenance.
+    #[test]
+    fn contradictory_d1_metadata_cannot_be_overridden_by_optical_lift() {
+        let _lock = crate::testenv::env_lock();
+        let contradictory = D1MetadataEvidence::from_lit_flags(&[
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+        ]);
+        let mut measurements = [
+            SetupMeasurement::optical(10.0),
+            SetupMeasurement::with_d1_metadata(40.0, contradictory),
+            SetupMeasurement::optical(10.0),
+        ]
+        .into_iter();
+
+        let (outcome, log, current, dir) =
+            run_discovery(a_working_camera(), "metadata-contradicts-optical", || {
+                measurements.next()
+            });
+
+        assert!(
+            matches!(outcome, Ok(Attempt::Inconclusive(_))),
+            "{outcome:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1], "the exact original is restored");
+        let sets = log
+            .iter()
+            .filter(|request| matches!(request, fake_camera::Request::Set { .. }))
+            .count();
+        assert_eq!(sets, 2, "a contradiction may only apply and restore");
+        let records = std::fs::read_dir(dir.join("ir-emitter-journal"))
+            .map(|entries| entries.flatten().count())
+            .unwrap_or(0);
+        assert_eq!(records, 0, "the confirmed restore clears the journal");
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Microsoft's Face Authentication control permits a dedicated IR
@@ -8931,6 +9281,25 @@ mod tests {
         // Ambient infrared with no real change must still be rejected.
         let bright_ambient = 120.0f32;
         assert!(bright_ambient + 5.0 < bright_ambient + AUTOCONF_MIN_LIFT);
+    }
+
+    /// One absent metadata record is an observation gap, not a dark frame.
+    /// The remaining records still prove D1 when their states agree with frame
+    /// parity and include both phases more than once.
+    #[test]
+    fn d1_metadata_alternation_tolerates_one_missing_record() {
+        let evidence = D1MetadataEvidence::from_lit_flags(&[
+            Some(false),
+            Some(true),
+            None,
+            Some(true),
+            Some(false),
+            Some(true),
+        ]);
+
+        assert!(evidence.proves_d1(), "{evidence:?}");
+        assert_eq!(evidence.classified(), 5);
+        assert_eq!(evidence.missing(), 1);
     }
 
     // --- round 6 ---------------------------------------------------------

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -97,6 +97,9 @@ pub(crate) const IR_LIT_MEAN: f32 = 40.0;
 /// Minimum mean lift over the emitter-off baseline before [`discover`]
 /// calls a control a success; filters ambient flicker and exposure drift.
 const AUTOCONF_MIN_LIFT: f32 = 20.0;
+/// One lost image or illumination record does not erase a burst, but a burst
+/// cannot bridge arbitrary capture discontinuities and remain one observation.
+const MAX_D1_MISSING_SEQUENCE_FRAMES: u32 = 1;
 
 /// Phase-locked optical evidence from one D1 setup burst.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -104,6 +107,8 @@ pub(crate) struct D1OpticalEvidence {
     even_frames: usize,
     odd_frames: usize,
     phase_delta: f32,
+    bright_phase_support: usize,
+    dark_phase_support: usize,
     consistent_pairs: usize,
     conflicting_pairs: usize,
     invalid_sequence_steps: usize,
@@ -135,9 +140,23 @@ impl D1OpticalEvidence {
         let even_median = median(&even).unwrap_or(0.0);
         let odd_median = median(&odd).unwrap_or(0.0);
         let bright_even = even_median > odd_median;
+        let (bright_phase, bright_median, dark_phase, dark_median) = if bright_even {
+            (&even, even_median, &odd, odd_median)
+        } else {
+            (&odd, odd_median, &even, even_median)
+        };
+        let bright_phase_support = bright_phase
+            .iter()
+            .filter(|mean| **mean >= dark_median + AUTOCONF_MIN_LIFT)
+            .count();
+        let dark_phase_support = dark_phase
+            .iter()
+            .filter(|mean| **mean <= bright_median - AUTOCONF_MIN_LIFT)
+            .count();
         let mut consistent_pairs = 0;
         let mut conflicting_pairs = 0;
         let mut invalid_sequence_steps = usize::from(!valid);
+        let mut missing_sequence_frames = 0u32;
         for pair in observations.windows(2) {
             let [(first_sequence, first_mean), (second_sequence, second_mean)] = pair else {
                 unreachable!("windows(2) always has two entries")
@@ -147,6 +166,13 @@ impl D1OpticalEvidence {
                 invalid_sequence_steps += 1;
                 continue;
             }
+            missing_sequence_frames = match missing_sequence_frames.checked_add(gap - 1) {
+                Some(missing) if missing <= MAX_D1_MISSING_SEQUENCE_FRAMES => missing,
+                _ => {
+                    invalid_sequence_steps += 1;
+                    continue;
+                }
+            };
             if gap != 1 {
                 continue;
             }
@@ -166,6 +192,8 @@ impl D1OpticalEvidence {
             even_frames: even.len(),
             odd_frames: odd.len(),
             phase_delta: (even_median - odd_median).abs(),
+            bright_phase_support,
+            dark_phase_support,
             consistent_pairs,
             conflicting_pairs,
             invalid_sequence_steps,
@@ -176,6 +204,8 @@ impl D1OpticalEvidence {
         self.even_frames >= 3
             && self.odd_frames >= 3
             && self.phase_delta >= AUTOCONF_MIN_LIFT
+            && self.bright_phase_support >= 3
+            && self.dark_phase_support >= 3
             && self.consistent_pairs >= 3
             && self.conflicting_pairs == 0
             && self.invalid_sequence_steps == 0
@@ -208,6 +238,7 @@ impl D1MetadataEvidence {
         let mut previous = None;
         let mut parity_consistent_pairs = 0;
         let mut parity_conflicts = 0;
+        let mut missing_sequence_frames = 0u32;
         for (sequence, flag) in observations.iter().copied() {
             let Some(lit) = flag else {
                 continue;
@@ -218,10 +249,20 @@ impl D1MetadataEvidence {
                 // Natural u32 wrap remains a small positive delta.
                 if gap == 0 || gap > i32::MAX as u32 {
                     parity_conflicts += 1;
-                } else if (lit == previous_lit) == (gap % 2 == 0) {
-                    parity_consistent_pairs += 1;
                 } else {
-                    parity_conflicts += 1;
+                    missing_sequence_frames = match missing_sequence_frames.checked_add(gap - 1) {
+                        Some(missing) if missing <= MAX_D1_MISSING_SEQUENCE_FRAMES => missing,
+                        _ => {
+                            parity_conflicts += 1;
+                            previous = Some((sequence, lit));
+                            continue;
+                        }
+                    };
+                    if (lit == previous_lit) == (gap % 2 == 0) {
+                        parity_consistent_pairs += 1;
+                    } else {
+                        parity_conflicts += 1;
+                    }
                 }
             }
             previous = Some((sequence, lit));
@@ -9717,6 +9758,36 @@ mod tests {
         assert_eq!(evidence.parity_conflicts, 0, "{evidence:?}");
     }
 
+    /// Parity survives any even gap mathematically, but evidence continuity
+    /// does not. Setup may tolerate one missing frame; it may not join two
+    /// unrelated capture epochs across an unbounded driver drop.
+    #[test]
+    fn d1_evidence_rejects_an_unbounded_forward_sequence_gap() {
+        let metadata = D1MetadataEvidence::from_sequence_flags(&[
+            (10, Some(false)),
+            (11, Some(true)),
+            (12, Some(false)),
+            (13, Some(true)),
+            (10_014, Some(false)),
+            (10_015, Some(true)),
+            (10_016, Some(false)),
+            (10_017, Some(true)),
+        ]);
+        let optical = D1OpticalEvidence::from_sequence_means(&[
+            (10, 10.0),
+            (11, 40.0),
+            (12, 10.0),
+            (13, 40.0),
+            (10_014, 10.0),
+            (10_015, 40.0),
+            (10_016, 10.0),
+            (10_017, 40.0),
+        ]);
+
+        assert!(!metadata.proves_d1(), "{metadata:?}");
+        assert!(!optical.proves_d1(), "{optical:?}");
+    }
+
     /// The metadata-absent fallback looks for the physical signature D1
     /// defines: a stable bright/dark phase keyed to raw frame parity. A smooth
     /// exposure excursion can move the burst maximum just as far, but cannot
@@ -9743,9 +9814,23 @@ mod tests {
             (16, 20.0),
             (17, 10.0),
         ]);
+        let two_spikes = D1OpticalEvidence::from_sequence_means(&[
+            (10, 0.0),
+            (11, 40.0),
+            (12, 0.0),
+            (13, 40.0),
+            (14, 0.0),
+            (15, 0.0),
+            (16, 0.0),
+            (17, 0.0),
+        ]);
 
         assert!(periodic.proves_d1(), "{periodic:?}");
         assert!(!exposure_drift.proves_d1(), "{exposure_drift:?}");
+        assert!(
+            !two_spikes.proves_d1(),
+            "two transient spikes are not stable phase support: {two_spikes:?}"
+        );
     }
 
     // --- round 6 ---------------------------------------------------------

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -97,6 +97,11 @@ pub(crate) const IR_LIT_MEAN: f32 = 40.0;
 /// Minimum mean lift over the emitter-off baseline before [`discover`]
 /// calls a control a success; filters ambient flicker and exposure drift.
 const AUTOCONF_MIN_LIFT: f32 = 20.0;
+/// A baseline/restored burst is affirmative D1-off evidence only when the two
+/// raw-sequence phases differ by no more than one decoded 8-bit mean point.
+/// Anything above that noise-sized band is ambiguous rather than the negation
+/// of the much stronger D1 proof threshold.
+const AUTOCONF_MAX_OFF_PHASE_DELTA: f32 = 1.0;
 /// One lost image or illumination record does not erase a burst, but a burst
 /// cannot bridge arbitrary capture discontinuities and remain one observation.
 const MAX_D1_MISSING_SEQUENCE_FRAMES: u32 = 1;
@@ -112,6 +117,13 @@ pub(crate) struct D1OpticalEvidence {
     consistent_pairs: usize,
     conflicting_pairs: usize,
     invalid_sequence_steps: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpticalD1Verdict {
+    Proven,
+    Refuted,
+    Inconclusive,
 }
 
 impl D1OpticalEvidence {
@@ -200,14 +212,31 @@ impl D1OpticalEvidence {
         }
     }
 
-    const fn proves_d1(self) -> bool {
-        self.valid_for_causality()
-            && self.phase_delta >= AUTOCONF_MIN_LIFT
+    const fn verdict(self) -> OpticalD1Verdict {
+        if !self.valid_for_causality() {
+            return OpticalD1Verdict::Inconclusive;
+        }
+        if self.phase_delta >= AUTOCONF_MIN_LIFT
             && self.bright_phase_support >= 3
             && self.dark_phase_support >= 3
             && self.consistent_pairs >= 3
             && self.conflicting_pairs == 0
-            && self.invalid_sequence_steps == 0
+        {
+            return OpticalD1Verdict::Proven;
+        }
+        if self.phase_delta <= AUTOCONF_MAX_OFF_PHASE_DELTA
+            && self.bright_phase_support == 0
+            && self.dark_phase_support == 0
+            && self.consistent_pairs == 0
+            && self.conflicting_pairs == 0
+        {
+            return OpticalD1Verdict::Refuted;
+        }
+        OpticalD1Verdict::Inconclusive
+    }
+
+    const fn proves_d1(self) -> bool {
+        matches!(self.verdict(), OpticalD1Verdict::Proven)
     }
 
     const fn valid_for_causality(self) -> bool {
@@ -215,7 +244,7 @@ impl D1OpticalEvidence {
     }
 
     const fn refutes_d1(self) -> bool {
-        self.valid_for_causality() && !self.proves_d1()
+        matches!(self.verdict(), OpticalD1Verdict::Refuted)
     }
 }
 
@@ -5353,6 +5382,31 @@ mod tests {
 
         let (outcome, _log, current, dir) =
             run_discovery(a_working_camera(), "optical-invalid-baseline", || {
+                measurements.next()
+            });
+
+        assert!(
+            matches!(outcome, Ok(Attempt::Inconclusive(_))),
+            "{outcome:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1]);
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn subthreshold_periodicity_is_ambiguous_not_affirmative_d1_off() {
+        let _lock = crate::testenv::env_lock();
+        let weak_periodic = optical_burst(&[10.0, 29.0, 10.0, 29.0, 10.0, 29.0, 10.0, 29.0]);
+        let mut measurements = [
+            weak_periodic,
+            optical_burst(&[10.0, 40.0, 10.0, 40.0, 10.0, 40.0, 10.0, 40.0]),
+            weak_periodic,
+        ]
+        .into_iter();
+
+        let (outcome, _log, current, dir) =
+            run_discovery(a_working_camera(), "optical-ambiguous-baseline", || {
                 measurements.next()
             });
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -201,14 +201,21 @@ impl D1OpticalEvidence {
     }
 
     const fn proves_d1(self) -> bool {
-        self.even_frames >= 3
-            && self.odd_frames >= 3
+        self.valid_for_causality()
             && self.phase_delta >= AUTOCONF_MIN_LIFT
             && self.bright_phase_support >= 3
             && self.dark_phase_support >= 3
             && self.consistent_pairs >= 3
             && self.conflicting_pairs == 0
             && self.invalid_sequence_steps == 0
+    }
+
+    const fn valid_for_causality(self) -> bool {
+        self.even_frames >= 3 && self.odd_frames >= 3 && self.invalid_sequence_steps == 0
+    }
+
+    const fn refutes_d1(self) -> bool {
+        self.valid_for_causality() && !self.proves_d1()
     }
 }
 
@@ -220,6 +227,7 @@ pub(crate) struct D1MetadataEvidence {
     dark: usize,
     parity_consistent_pairs: usize,
     parity_conflicts: usize,
+    invalid_sequence_steps: usize,
 }
 
 impl D1MetadataEvidence {
@@ -238,6 +246,7 @@ impl D1MetadataEvidence {
         let mut previous = None;
         let mut parity_consistent_pairs = 0;
         let mut parity_conflicts = 0;
+        let mut invalid_sequence_steps = 0;
         let mut missing_sequence_frames = 0u32;
         for (sequence, flag) in observations.iter().copied() {
             let Some(lit) = flag else {
@@ -248,12 +257,12 @@ impl D1MetadataEvidence {
                 // A zero or reverse/ambiguous delta cannot establish parity.
                 // Natural u32 wrap remains a small positive delta.
                 if gap == 0 || gap > i32::MAX as u32 {
-                    parity_conflicts += 1;
+                    invalid_sequence_steps += 1;
                 } else {
                     missing_sequence_frames = match missing_sequence_frames.checked_add(gap - 1) {
                         Some(missing) if missing <= MAX_D1_MISSING_SEQUENCE_FRAMES => missing,
                         _ => {
-                            parity_conflicts += 1;
+                            invalid_sequence_steps += 1;
                             previous = Some((sequence, lit));
                             continue;
                         }
@@ -279,6 +288,7 @@ impl D1MetadataEvidence {
                 .count(),
             parity_consistent_pairs,
             parity_conflicts,
+            invalid_sequence_steps,
         }
     }
 
@@ -291,7 +301,8 @@ impl D1MetadataEvidence {
     }
 
     const fn proves_d1(self) -> bool {
-        self.classified() >= 4
+        self.invalid_sequence_steps == 0
+            && self.classified() >= 4
             && self.lit >= 2
             && self.dark >= 2
             && self.parity_consistent_pairs >= 3
@@ -299,7 +310,7 @@ impl D1MetadataEvidence {
     }
 
     const fn contradicts_d1(self) -> bool {
-        self.classified() >= 4 && self.parity_conflicts > 0
+        self.invalid_sequence_steps == 0 && self.classified() >= 4 && self.parity_conflicts > 0
     }
 }
 
@@ -4273,12 +4284,10 @@ fn try_documented_control<
             .is_some_and(D1MetadataEvidence::contradicts_d1);
     let optical_proves_d1 = face_auth
         && lit.d1_optical.is_some_and(D1OpticalEvidence::proves_d1)
-        && before
-            .d1_optical
-            .is_some_and(|evidence| !evidence.proves_d1())
+        && before.d1_optical.is_some_and(D1OpticalEvidence::refutes_d1)
         && after_restore
             .d1_optical
-            .is_some_and(|evidence| !evidence.proves_d1());
+            .is_some_and(D1OpticalEvidence::refutes_d1);
     if face_auth
         && lit.d1_metadata.is_some_and(D1MetadataEvidence::proves_d1)
         && (before
@@ -5310,6 +5319,96 @@ mod tests {
             3,
             "proof still uses exploratory apply, exact restore, and final apply"
         );
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// "Did not prove D1" includes malformed observations and therefore cannot
+    /// stand in for positive evidence that D1 was absent. Both sides of the
+    /// transition must be continuous before an applied burst can be called
+    /// control-correlated.
+    #[test]
+    fn discontinuous_optical_baseline_cannot_prove_control_correlation() {
+        let _lock = crate::testenv::env_lock();
+        let invalid_baseline = SetupMeasurement::with_d1_evidence(
+            10.0,
+            D1OpticalEvidence::from_sequence_means(&[
+                (10, 10.0),
+                (11, 10.0),
+                (12, 10.0),
+                (13, 10.0),
+                (10_014, 10.0),
+                (10_015, 10.0),
+                (10_016, 10.0),
+                (10_017, 10.0),
+            ]),
+            None,
+        );
+        let mut measurements = [
+            invalid_baseline,
+            optical_burst(&[10.0, 40.0, 11.0, 41.0, 9.0, 39.0, 10.0, 40.0]),
+            optical_burst(&[10.0; 8]),
+        ]
+        .into_iter();
+
+        let (outcome, _log, current, dir) =
+            run_discovery(a_working_camera(), "optical-invalid-baseline", || {
+                measurements.next()
+            });
+
+        assert!(
+            matches!(outcome, Ok(Attempt::Inconclusive(_))),
+            "{outcome:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1]);
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discontinuous_metadata_baseline_cannot_prove_control_correlation() {
+        let _lock = crate::testenv::env_lock();
+        let invalid_d0 = D1MetadataEvidence::from_sequence_flags(&[
+            (10, Some(false)),
+            (11, Some(false)),
+            (12, Some(false)),
+            (13, Some(false)),
+            (10_014, Some(false)),
+            (10_015, Some(false)),
+        ]);
+        let d1 = D1MetadataEvidence::from_lit_flags(&[
+            Some(false),
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(false),
+            Some(true),
+        ]);
+        let d0 = D1MetadataEvidence::from_lit_flags(&[
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+        ]);
+        let mut measurements = [
+            SetupMeasurement::with_d1_metadata(10.0, invalid_d0),
+            SetupMeasurement::with_d1_metadata(40.0, d1),
+            SetupMeasurement::with_d1_metadata(10.0, d0),
+        ]
+        .into_iter();
+
+        let (outcome, _log, current, dir) =
+            run_discovery(a_working_camera(), "metadata-invalid-baseline", || {
+                measurements.next()
+            });
+
+        assert!(
+            matches!(outcome, Ok(Attempt::Inconclusive(_))),
+            "{outcome:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1]);
         drop(outcome);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -98,6 +98,90 @@ pub(crate) const IR_LIT_MEAN: f32 = 40.0;
 /// calls a control a success; filters ambient flicker and exposure drift.
 const AUTOCONF_MIN_LIFT: f32 = 20.0;
 
+/// Phase-locked optical evidence from one D1 setup burst.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct D1OpticalEvidence {
+    even_frames: usize,
+    odd_frames: usize,
+    phase_delta: f32,
+    consistent_pairs: usize,
+    conflicting_pairs: usize,
+    invalid_sequence_steps: usize,
+}
+
+impl D1OpticalEvidence {
+    pub(crate) fn from_sequence_means(observations: &[(u32, f32)]) -> Self {
+        let valid = observations
+            .iter()
+            .all(|(_, mean)| mean.is_finite() && *mean >= 0.0);
+        let mut even: Vec<f32> = observations
+            .iter()
+            .filter_map(|(sequence, mean)| (sequence % 2 == 0).then_some(*mean))
+            .collect();
+        let mut odd: Vec<f32> = observations
+            .iter()
+            .filter_map(|(sequence, mean)| (sequence % 2 == 1).then_some(*mean))
+            .collect();
+        even.sort_by(f32::total_cmp);
+        odd.sort_by(f32::total_cmp);
+        let median = |values: &[f32]| -> Option<f32> {
+            let middle = values.len() / 2;
+            match values.len() {
+                0 => None,
+                len if len % 2 == 0 => Some((values[middle - 1] + values[middle]) / 2.0),
+                _ => Some(values[middle]),
+            }
+        };
+        let even_median = median(&even).unwrap_or(0.0);
+        let odd_median = median(&odd).unwrap_or(0.0);
+        let bright_even = even_median > odd_median;
+        let mut consistent_pairs = 0;
+        let mut conflicting_pairs = 0;
+        let mut invalid_sequence_steps = usize::from(!valid);
+        for pair in observations.windows(2) {
+            let [(first_sequence, first_mean), (second_sequence, second_mean)] = pair else {
+                unreachable!("windows(2) always has two entries")
+            };
+            let gap = second_sequence.wrapping_sub(*first_sequence);
+            if gap == 0 || gap > i32::MAX as u32 {
+                invalid_sequence_steps += 1;
+                continue;
+            }
+            if gap != 1 {
+                continue;
+            }
+            let (bright, dark) = if (*first_sequence % 2 == 0) == bright_even {
+                (*first_mean, *second_mean)
+            } else {
+                (*second_mean, *first_mean)
+            };
+            let difference = bright - dark;
+            if difference >= AUTOCONF_MIN_LIFT {
+                consistent_pairs += 1;
+            } else if difference <= -AUTOCONF_MIN_LIFT {
+                conflicting_pairs += 1;
+            }
+        }
+        Self {
+            even_frames: even.len(),
+            odd_frames: odd.len(),
+            phase_delta: (even_median - odd_median).abs(),
+            consistent_pairs,
+            conflicting_pairs,
+            invalid_sequence_steps,
+        }
+    }
+
+    const fn proves_d1(self) -> bool {
+        self.even_frames >= 3
+            && self.odd_frames >= 3
+            && self.phase_delta >= AUTOCONF_MIN_LIFT
+            && self.consistent_pairs >= 3
+            && self.conflicting_pairs == 0
+            && self.invalid_sequence_steps == 0
+    }
+}
+
 /// Camera-reported illumination observations from one setup burst.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct D1MetadataEvidence {
@@ -109,28 +193,49 @@ pub(crate) struct D1MetadataEvidence {
 }
 
 impl D1MetadataEvidence {
+    #[cfg(test)]
     pub(crate) fn from_lit_flags(flags: &[Option<bool>]) -> Self {
+        let observations: Vec<(u32, Option<bool>)> = flags
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(sequence, lit)| (sequence as u32, lit))
+            .collect();
+        Self::from_sequence_flags(&observations)
+    }
+
+    pub(crate) fn from_sequence_flags(observations: &[(u32, Option<bool>)]) -> Self {
         let mut previous = None;
         let mut parity_consistent_pairs = 0;
         let mut parity_conflicts = 0;
-        for (index, flag) in flags.iter().copied().enumerate() {
+        for (sequence, flag) in observations.iter().copied() {
             let Some(lit) = flag else {
                 continue;
             };
-            if let Some((previous_index, previous_lit)) = previous {
-                let even_gap = (index - previous_index) % 2 == 0;
-                if (lit == previous_lit) == even_gap {
+            if let Some((previous_sequence, previous_lit)) = previous {
+                let gap = sequence.wrapping_sub(previous_sequence);
+                // A zero or reverse/ambiguous delta cannot establish parity.
+                // Natural u32 wrap remains a small positive delta.
+                if gap == 0 || gap > i32::MAX as u32 {
+                    parity_conflicts += 1;
+                } else if (lit == previous_lit) == (gap % 2 == 0) {
                     parity_consistent_pairs += 1;
                 } else {
                     parity_conflicts += 1;
                 }
             }
-            previous = Some((index, lit));
+            previous = Some((sequence, lit));
         }
         Self {
-            total: flags.len(),
-            lit: flags.iter().filter(|flag| **flag == Some(true)).count(),
-            dark: flags.iter().filter(|flag| **flag == Some(false)).count(),
+            total: observations.len(),
+            lit: observations
+                .iter()
+                .filter(|(_, flag)| *flag == Some(true))
+                .count(),
+            dark: observations
+                .iter()
+                .filter(|(_, flag)| *flag == Some(false))
+                .count(),
             parity_consistent_pairs,
             parity_conflicts,
         }
@@ -161,6 +266,7 @@ impl D1MetadataEvidence {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct SetupMeasurement {
     brightness: f32,
+    d1_optical: Option<D1OpticalEvidence>,
     d1_metadata: Option<D1MetadataEvidence>,
 }
 
@@ -168,14 +274,29 @@ impl SetupMeasurement {
     pub(crate) const fn optical(brightness: f32) -> Self {
         Self {
             brightness,
+            d1_optical: None,
             d1_metadata: None,
         }
     }
 
+    #[cfg(test)]
     pub(crate) const fn with_d1_metadata(brightness: f32, evidence: D1MetadataEvidence) -> Self {
         Self {
             brightness,
+            d1_optical: None,
             d1_metadata: Some(evidence),
+        }
+    }
+
+    pub(crate) const fn with_d1_evidence(
+        brightness: f32,
+        optical: D1OpticalEvidence,
+        metadata: Option<D1MetadataEvidence>,
+    ) -> Self {
+        Self {
+            brightness,
+            d1_optical: Some(optical),
+            d1_metadata: metadata,
         }
     }
 
@@ -187,6 +308,14 @@ impl SetupMeasurement {
     #[cfg(test)]
     pub(crate) const fn metadata_proves_d1(self) -> bool {
         match self.d1_metadata {
+            Some(evidence) => evidence.proves_d1(),
+            None => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn optical_proves_d1(self) -> bool {
+        match self.d1_optical {
             Some(evidence) => evidence.proves_d1(),
             None => false,
         }
@@ -620,6 +749,12 @@ pub(crate) mod fake_camera {
         pub(crate) gets_seen: usize,
         /// `SET_CUR`s seen so far, so `fail_set_from` can count.
         pub(crate) sets_seen: usize,
+        /// Accept this numbered `SET_CUR` without changing `current`.
+        ///
+        /// Some firmware acknowledges a request but clamps or ignores its
+        /// payload. Discovery must prove the exploratory value with GET_CUR
+        /// before interpreting any subsequent frames as D1 evidence.
+        pub(crate) ignore_set_at: Option<usize>,
         /// Run at the instant the first `SET_CUR` is intercepted, before it is
         /// recorded or applied.
         ///
@@ -726,6 +861,7 @@ pub(crate) mod fake_camera {
                         Some((from, errno)) if cam.sets_seen >= from => {
                             Err(XuError::from_errno(errno))
                         }
+                        _ if cam.ignore_set_at == Some(cam.sets_seen) => Ok(()),
                         _ => {
                             // An accepted write changes what the control holds,
                             // so a read-back sees it. A fake whose GET_CUR never
@@ -2953,7 +3089,7 @@ impl ExploratoryWrite {
     /// returning success says the ioctl was accepted, not that the control now
     /// holds those bytes, and assuming the two are the same thing is what left
     /// the camera changed in the first place.
-    fn confirm_restored(&mut self) -> Result<(), String> {
+    fn verify_restored(&mut self) -> Result<(), String> {
         let now = get_cur(self.fd, self.unit, self.selector, self.original.len())
             .map_err(|e| format!("read the control back: {e}"))?;
         crate::emitter_journal::trace(&format!("read back {now:02x?}"));
@@ -2963,6 +3099,11 @@ impl ExploratoryWrite {
                 now, self.original
             ));
         }
+        Ok(())
+    }
+
+    fn confirm_restored(&mut self) -> Result<(), String> {
+        self.verify_restored()?;
         crate::emitter_journal::clear(&self.record_path)?;
         self.resolved = true;
         Ok(())
@@ -2997,15 +3138,22 @@ impl ExploratoryWrite {
     /// and this module's rule is that nothing further is sent to a camera in
     /// that state. A value mismatch does NOT disarm it, because there the camera
     /// is answering fine and the control genuinely needs putting back.
-    fn confirm_applied(&mut self) -> Result<(), String> {
+    fn read_applied(&mut self) -> XuResult<Vec<u8>> {
         let now = match get_cur(self.fd, self.unit, self.selector, self.attempted.len()) {
             Ok(now) => now,
             Err(e) => {
                 self.exploratory_value_is_live = false;
-                return Err(format!("read the applied control back: {e}"));
+                return Err(e);
             }
         };
         crate::emitter_journal::trace(&format!("read back applied {now:02x?}"));
+        Ok(now)
+    }
+
+    fn confirm_applied(&mut self) -> Result<(), String> {
+        let now = self
+            .read_applied()
+            .map_err(|e| format!("read the applied control back: {e}"))?;
         if now != self.attempted {
             return Err(format!(
                 "the control reads {now:02x?} after being set to {:02x?}",
@@ -3658,7 +3806,7 @@ pub(crate) fn discover_with_measurements<
     }
 
     let mut tried = Vec::new();
-    let mut inconclusive = Vec::new();
+    let mut saw_inconclusive = false;
 
     for selector in [
         crate::uvc_descriptor::MSXU_IR_TORCH,
@@ -3686,7 +3834,8 @@ pub(crate) fn discover_with_measurements<
                 "selector {selector:#04x} is already set to the value setup would apply"
             )),
             Ok(Attempt::Inconclusive(why)) => {
-                inconclusive.push(format!("selector {selector:#04x}: {why}"));
+                saw_inconclusive = true;
+                tried.push(format!("selector {selector:#04x}: {why}"));
             }
             Ok(Attempt::NotUsable(why)) => tried.push(format!("selector {selector:#04x}: {why}")),
             Err(TryFailure::Measurement) => return Err(DiscoveryError::MeasurementFailed),
@@ -3716,16 +3865,14 @@ pub(crate) fn discover_with_measurements<
         }
     }
 
-    if inconclusive.is_empty() {
-        Err(DiscoveryError::NoUsableControl {
-            unit: ms.unit_id,
-            tried,
-        })
+    Err(exhausted_discovery(ms.unit_id, tried, saw_inconclusive))
+}
+
+fn exhausted_discovery(unit: u8, tried: Vec<String>, saw_inconclusive: bool) -> DiscoveryError {
+    if saw_inconclusive {
+        DiscoveryError::Inconclusive { unit, tried }
     } else {
-        Err(DiscoveryError::Inconclusive {
-            unit: ms.unit_id,
-            tried: inconclusive,
-        })
+        DiscoveryError::NoUsableControl { unit, tried }
     }
 }
 
@@ -4019,6 +4166,15 @@ fn try_documented_control<
         return Err(TryFailure::Guard(why));
     }
     pending.apply_exploratory(&wanted)?;
+    let applied = pending.read_applied()?;
+    if applied != wanted {
+        pending.restore_once().map_err(TryFailure::Restore)?;
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
+        return Ok(Attempt::NotUsable(format!(
+            "the camera accepted the device-derived value {wanted:02x?} but immediately read back \
+             {applied:02x?}; the exact original value was restored and verified"
+        )));
+    }
     let Some(lit) = measure() else {
         // The stream died after the control was changed. Aborting without
         // putting it back would leave the camera altered by a run that
@@ -4033,9 +4189,8 @@ fn try_documented_control<
     // Those are different questions; conflating them made success depend on room
     // lighting, and the same camera here has measured 38 to 168 depending only
     // on what was in front of it.
-    let metadata_proves_d1 = selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION
-        && lit.d1_metadata.is_some_and(D1MetadataEvidence::proves_d1);
-    let contradictory_metadata = if selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION {
+    let face_auth = selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION;
+    let contradictory_metadata = if face_auth {
         lit.d1_metadata.filter(|evidence| evidence.contradicts_d1())
     } else {
         None
@@ -4053,8 +4208,56 @@ fn try_documented_control<
             evidence.missing()
         )));
     }
-    if !metadata_proves_d1 && lit.brightness < before.brightness + AUTOCONF_MIN_LIFT {
-        pending.restore_once().map_err(TryFailure::Restore)?;
+    // A single before-and-after pair is not evidence. Someone moving, a cloud,
+    // or an exposure transition produces the same twenty points as a working
+    // illuminator. Put the control back and require the brightness to fall with
+    // it: a change that does not follow the control is not caused by it.
+    pending.restore_once().map_err(TryFailure::Restore)?;
+    // Prove the restore before treating the next frames as the restored phase.
+    // Keep the record open because a successful run still has one final,
+    // guarded application to make after the evidence decision.
+    pending.verify_restored().map_err(TryFailure::Journal)?;
+    let Some(after_restore) = measure() else {
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
+        return Err(TryFailure::Measurement);
+    };
+
+    let metadata_proves_d1 = face_auth
+        && lit.d1_metadata.is_some_and(D1MetadataEvidence::proves_d1)
+        && before
+            .d1_metadata
+            .is_some_and(D1MetadataEvidence::contradicts_d1)
+        && after_restore
+            .d1_metadata
+            .is_some_and(D1MetadataEvidence::contradicts_d1);
+    let optical_proves_d1 = face_auth
+        && lit.d1_optical.is_some_and(D1OpticalEvidence::proves_d1)
+        && before
+            .d1_optical
+            .is_some_and(|evidence| !evidence.proves_d1())
+        && after_restore
+            .d1_optical
+            .is_some_and(|evidence| !evidence.proves_d1());
+    if face_auth
+        && lit.d1_metadata.is_some_and(D1MetadataEvidence::proves_d1)
+        && (before
+            .d1_metadata
+            .is_some_and(D1MetadataEvidence::proves_d1)
+            || after_restore
+                .d1_metadata
+                .is_some_and(D1MetadataEvidence::proves_d1))
+    {
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
+        return Ok(Attempt::Inconclusive(
+            "D1 illumination metadata was present after the write but did not begin and end with \
+             the control transition; the exact original value was restored and verified, and no \
+             configuration was saved"
+                .into(),
+        ));
+    }
+
+    let d1_proven = metadata_proves_d1 || optical_proves_d1;
+    if !d1_proven && lit.brightness < before.brightness + AUTOCONF_MIN_LIFT {
         pending.confirm_restored().map_err(TryFailure::Journal)?;
         return Ok(Attempt::Inconclusive(format!(
             "the camera accepted and read back the device-derived value, but the optical change \
@@ -4064,30 +4267,24 @@ fn try_documented_control<
             before.brightness, lit.brightness
         )));
     }
-
-    // A single before-and-after pair is not evidence. Someone moving, a cloud,
-    // or an exposure transition produces the same twenty points as a working
-    // illuminator. Put the control back and require the brightness to fall with
-    // it: a change that does not follow the control is not caused by it.
-    pending.restore_once().map_err(TryFailure::Restore)?;
-    if !metadata_proves_d1 {
-        let Some(after_restore) = measure() else {
-            return Err(TryFailure::Measurement);
-        };
-        if after_restore.brightness >= lit.brightness - AUTOCONF_MIN_LIFT {
-            // Restored above, and this branch writes nothing further, so the record
-            // is resolvable here. The read-back is what resolves it: the restoring
-            // `set_cur` returning success says the ioctl was accepted, not that the
-            // control holds those bytes.
-            pending.confirm_restored().map_err(TryFailure::Journal)?;
-            return Ok(Attempt::Inconclusive(format!(
-                "the image brightened but stayed bright when the control was put back \
-                 ({:.0} before, {:.0} with it set, {:.0} after undoing it), \
-                 so the change could not be assigned to this control; the exact original value \
-                 was restored and verified, and no configuration was saved",
-                before.brightness, lit.brightness, after_restore.brightness
-            )));
-        }
+    if !d1_proven && after_restore.brightness >= lit.brightness - AUTOCONF_MIN_LIFT {
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
+        return Ok(Attempt::Inconclusive(format!(
+            "the image brightened but stayed bright when the control was put back \
+             ({:.0} before, {:.0} with it set, {:.0} after undoing it), \
+             so the change could not be assigned to this control; the exact original value \
+             was restored and verified, and no configuration was saved",
+            before.brightness, lit.brightness, after_restore.brightness
+        )));
+    }
+    if face_auth && !d1_proven {
+        pending.confirm_restored().map_err(TryFailure::Journal)?;
+        return Ok(Attempt::Inconclusive(
+            "the reversible brightness change did not contain control-correlated alternating-frame \
+             D1 evidence; the exact original value was restored and verified, and no configuration \
+             was saved"
+                .into(),
+        ));
     }
 
     // It followed the control both ways. Apply it and report it.
@@ -4870,6 +5067,23 @@ mod tests {
         }
     }
 
+    fn optical_burst(means: &[f32]) -> SetupMeasurement {
+        let observations: Vec<(u32, f32)> = (10u32..).zip(means.iter().copied()).collect();
+        SetupMeasurement::with_d1_evidence(
+            means.iter().copied().reduce(f32::max).expect("non-empty"),
+            D1OpticalEvidence::from_sequence_means(&observations),
+            None,
+        )
+    }
+
+    fn optically_proven_d1_triplet() -> [SetupMeasurement; 3] {
+        [
+            optical_burst(&[10.0; 8]),
+            optical_burst(&[10.0, 40.0, 11.0, 41.0, 9.0, 39.0, 10.0, 40.0]),
+            optical_burst(&[10.0; 8]),
+        ]
+    }
+
     /// A weak scene is an observation gap, not evidence that a documented D1
     /// control is unusable. This reproduces the ASUS setup result from #492:
     /// the device-derived value is accepted, read back, and exactly restored,
@@ -4886,7 +5100,7 @@ mod tests {
         let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
         let _fake = fake_camera::install(a_working_camera());
         let id = identity(0x3277, 0x0059);
-        let mut readings = [48.0, 52.0].into_iter();
+        let mut readings = [48.0, 52.0, 48.0].into_iter();
         let mut permit = || Ok(());
 
         let error = discover(-1, &id, &mut || readings.next(), &mut permit)
@@ -4916,6 +5130,46 @@ mod tests {
             .map(|entries| entries.flatten().count())
             .unwrap_or(0);
         assert_eq!(records, 0, "a confirmed restore must clear the journal");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An accepted SET_CUR is not proof that D1 became current. No frame
+    /// captured after a write the camera ignored may be interpreted as D1
+    /// evidence, and the exact pre-test value still has to be verified before
+    /// the undo record is cleared.
+    #[test]
+    fn exploratory_d1_is_read_back_before_any_d1_measurement() {
+        let _lock = crate::testenv::env_lock();
+        let mut camera = a_working_camera();
+        camera.ignore_set_at = Some(1);
+        let mut measurements: usize = 0;
+
+        let (outcome, log, current, dir) = run_discovery(camera, "exploratory-readback", || {
+            measurements += 1;
+            Some([10.0, 40.0, 10.0][measurements.saturating_sub(1).min(2)])
+        });
+
+        assert!(matches!(outcome, Ok(Attempt::NotUsable(_))), "{outcome:?}");
+        assert_eq!(
+            measurements, 1,
+            "only the pre-write baseline may be measured when D1 was not retained"
+        );
+        assert_eq!(current, vec![1, 3, 1], "the exact original remains active");
+        assert!(
+            log.windows(2).any(|requests| matches!(
+                requests,
+                [
+                    fake_camera::Request::Set(value),
+                    fake_camera::Request::Get { query: UVC_GET_CUR, .. }
+                ] if value == &[1, 3, 2]
+            )),
+            "the exploratory write must be read back immediately: {log:?}"
+        );
+        let records = std::fs::read_dir(dir.join("ir-emitter-journal"))
+            .map(|entries| entries.flatten().count())
+            .unwrap_or(0);
+        assert_eq!(records, 0, "the unchanged original resolves the journal");
+        drop(outcome);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -4959,13 +5213,73 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Even a reversible max-brightness triplet can be an exposure transient.
+    /// Face Authentication D1 has a stronger optical signature available:
+    /// alternative-frame periodicity. Without that within-burst evidence the
+    /// safe result is inconclusive, not a persisted control.
+    #[test]
+    fn one_reversible_brightness_triplet_does_not_prove_d1() {
+        let _lock = crate::testenv::env_lock();
+        let mut brightness = [10.0f32, 40.0, 10.0].into_iter();
+
+        let (outcome, log, current, dir) =
+            run_discovery(a_working_camera(), "one-triplet", || brightness.next());
+
+        assert!(
+            matches!(outcome, Ok(Attempt::Inconclusive(_))),
+            "a triplet without alternating-frame evidence must not prove D1: {outcome:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1], "the exact original is restored");
+        assert_eq!(
+            log.iter()
+                .filter(|request| matches!(request, fake_camera::Request::Set { .. }))
+                .count(),
+            2,
+            "an inconclusive run does not perform the final application"
+        );
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A weak change in the burst maximum can still contain strong, stable D1
+    /// phase contrast. This is the metadata-absent success path requested by
+    /// #492: the phase appears only while the read-back-confirmed D1 value is
+    /// active and disappears after the exact original is restored.
+    #[test]
+    fn control_correlated_optical_periodicity_proves_d1_without_metadata() {
+        let _lock = crate::testenv::env_lock();
+        let mut measurements = [
+            optical_burst(&[48.0; 8]),
+            optical_burst(&[30.0, 55.0, 29.0, 54.0, 31.0, 56.0, 30.0, 55.0]),
+            optical_burst(&[48.0; 8]),
+        ]
+        .into_iter();
+
+        let (outcome, log, current, dir) =
+            run_discovery(a_working_camera(), "optical-periodicity", || {
+                measurements.next()
+            });
+
+        assert!(matches!(outcome, Ok(Attempt::Lit(..))), "{outcome:?}");
+        assert_eq!(current, vec![1, 3, 2], "proven D1 remains applied");
+        assert_eq!(
+            log.iter()
+                .filter(|request| matches!(request, fake_camera::Request::Set { .. }))
+                .count(),
+            3,
+            "proof still uses exploratory apply, exact restore, and final apply"
+        );
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// Microsoft D1 metadata can prove the alternating mode even when the
     /// scene is too weak for the optical heuristic. The proof remains labelled
     /// as metadata evidence; it does not claim to have measured photons.
     #[test]
     fn d1_metadata_proves_setup_when_optical_lift_is_weak() {
         let _lock = crate::testenv::env_lock();
-        let evidence = D1MetadataEvidence::from_lit_flags(&[
+        let d1 = D1MetadataEvidence::from_lit_flags(&[
             Some(false),
             Some(true),
             None,
@@ -4973,9 +5287,18 @@ mod tests {
             Some(false),
             Some(true),
         ]);
+        let d0 = D1MetadataEvidence::from_lit_flags(&[
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+        ]);
         let mut measurements = [
-            SetupMeasurement::optical(48.0),
-            SetupMeasurement::with_d1_metadata(52.0, evidence),
+            SetupMeasurement::with_d1_metadata(48.0, d0),
+            SetupMeasurement::with_d1_metadata(52.0, d1),
+            SetupMeasurement::with_d1_metadata(48.0, d0),
         ]
         .into_iter();
 
@@ -4985,6 +5308,11 @@ mod tests {
             });
 
         assert!(matches!(outcome, Ok(Attempt::Lit(..))), "{outcome:?}");
+        assert_eq!(
+            measurements.len(),
+            0,
+            "metadata success must observe baseline, applied D1, and exact restore"
+        );
         assert_eq!(current, vec![1, 3, 2], "proven D1 is left applied");
         let sets = log
             .iter()
@@ -4994,6 +5322,55 @@ mod tests {
             sets, 3,
             "metadata proof still performs exploratory apply, exact restore, and final apply"
         );
+        drop(outcome);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An alternating metadata stream that predates the exploratory write is
+    /// not evidence that this selector caused D1. This can happen when another
+    /// interface or firmware-owned mode is already producing illumination
+    /// records while the queried control reports a different value.
+    #[test]
+    fn metadata_alternation_must_begin_with_the_control_transition() {
+        let _lock = crate::testenv::env_lock();
+        let d1 = D1MetadataEvidence::from_lit_flags(&[
+            Some(false),
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(false),
+            Some(true),
+        ]);
+        let d0 = D1MetadataEvidence::from_lit_flags(&[
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+        ]);
+        let mut measurements = [
+            SetupMeasurement::with_d1_metadata(48.0, d1),
+            SetupMeasurement::with_d1_metadata(52.0, d1),
+            SetupMeasurement::with_d1_metadata(48.0, d0),
+        ]
+        .into_iter();
+
+        let (outcome, log, current, dir) =
+            run_discovery(a_working_camera(), "metadata-predates-control", || {
+                measurements.next()
+            });
+
+        assert!(
+            matches!(outcome, Ok(Attempt::Inconclusive(_))),
+            "pre-existing alternation cannot prove this selector: {outcome:?}"
+        );
+        assert_eq!(current, vec![1, 3, 1], "the exact original is restored");
+        let sets = log
+            .iter()
+            .filter(|request| matches!(request, fake_camera::Request::Set { .. }))
+            .count();
+        assert_eq!(sets, 2, "inconclusive metadata may only apply and restore");
         drop(outcome);
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -5182,7 +5559,7 @@ mod tests {
             Ok(())
         }));
 
-        let mut brightness = [10.0f32, 90.0, 10.0].into_iter();
+        let mut brightness = optically_proven_d1_triplet().into_iter();
         let (outcome, log, _current, dir) =
             run_discovery(camera, "record-first", move || brightness.next());
 
@@ -7813,7 +8190,7 @@ mod tests {
     #[test]
     fn a_guard_refusal_before_the_final_write_leaves_the_control_restored() {
         let _lock = crate::testenv::env_lock();
-        let mut readings = [10.0, 40.0, 10.0].into_iter();
+        let mut readings = optically_proven_d1_triplet().into_iter();
         let mut calls = 0;
         let (outcome, log, current, dir) = run_discovery_guarded(
             a_working_camera(),
@@ -8547,6 +8924,25 @@ mod tests {
             err: XuError::Unsupported,
         };
         assert!(stuck.to_string().contains("could not be restored"));
+    }
+
+    #[test]
+    fn inconclusive_discovery_keeps_every_selector_diagnostic() {
+        let error = exhausted_discovery(
+            14,
+            vec![
+                "selector 0x08: advertised range is malformed".into(),
+                "selector 0x06: optical evidence was inconclusive".into(),
+            ],
+            true,
+        );
+
+        let DiscoveryError::Inconclusive { tried, .. } = error else {
+            panic!("an evidence gap must dominate the aggregate outcome: {error:?}");
+        };
+        assert_eq!(tried.len(), 2);
+        assert!(tried[0].contains("malformed"), "{tried:?}");
+        assert!(tried[1].contains("inconclusive"), "{tried:?}");
     }
 
     // --- IR Torch value checking ------------------------------------------
@@ -9300,6 +9696,56 @@ mod tests {
         assert!(evidence.proves_d1(), "{evidence:?}");
         assert_eq!(evidence.classified(), 5);
         assert_eq!(evidence.missing(), 1);
+    }
+
+    /// Image buffers can be dropped without losing the metadata record's frame
+    /// identity. Alternation follows the device's wrapping V4L2 sequence, not
+    /// the position at which userspace happened to retain an observation.
+    #[test]
+    fn d1_metadata_parity_uses_raw_frame_sequence_across_a_drop() {
+        let evidence = D1MetadataEvidence::from_sequence_flags(&[
+            (10, Some(false)),
+            (11, Some(true)),
+            // Sequence 12 was dropped. Sequence 13 therefore has the same
+            // illumination phase as 11 even though these entries are adjacent.
+            (13, Some(true)),
+            (14, Some(false)),
+            (15, Some(true)),
+        ]);
+
+        assert!(evidence.proves_d1(), "{evidence:?}");
+        assert_eq!(evidence.parity_conflicts, 0, "{evidence:?}");
+    }
+
+    /// The metadata-absent fallback looks for the physical signature D1
+    /// defines: a stable bright/dark phase keyed to raw frame parity. A smooth
+    /// exposure excursion can move the burst maximum just as far, but cannot
+    /// supply that phase-locked periodicity.
+    #[test]
+    fn optical_d1_evidence_separates_periodicity_from_exposure_drift() {
+        let periodic = D1OpticalEvidence::from_sequence_means(&[
+            (10, 10.0),
+            (11, 41.0),
+            (12, 11.0),
+            (13, 40.0),
+            (14, 9.0),
+            (15, 42.0),
+            (16, 10.0),
+            (17, 41.0),
+        ]);
+        let exposure_drift = D1OpticalEvidence::from_sequence_means(&[
+            (10, 10.0),
+            (11, 20.0),
+            (12, 30.0),
+            (13, 40.0),
+            (14, 35.0),
+            (15, 30.0),
+            (16, 20.0),
+            (17, 10.0),
+        ]);
+
+        assert!(periodic.proves_d1(), "{periodic:?}");
+        assert!(!exposure_drift.proves_d1(), "{exposure_drift:?}");
     }
 
     // --- round 6 ---------------------------------------------------------

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -7425,6 +7425,28 @@ fn active_by_device_default_message(control: &ir_emitter::EmitterControl) -> Str
     )
 }
 
+fn setup_measurement_from_burst(
+    means: &[f32],
+    flags: &[Option<ir_metadata::Illumination>],
+) -> Option<ir_emitter::SetupMeasurement> {
+    let brightness = means.iter().copied().reduce(f32::max)?;
+    if means.len() != flags.len() || !flags.iter().any(Option::is_some) {
+        return Some(ir_emitter::SetupMeasurement::optical(brightness));
+    }
+    let lit_flags: Vec<Option<bool>> = flags
+        .iter()
+        .map(|flag| match flag {
+            Some(ir_metadata::Illumination::Lit) => Some(true),
+            Some(ir_metadata::Illumination::Dark) => Some(false),
+            None => None,
+        })
+        .collect();
+    Some(ir_emitter::SetupMeasurement::with_d1_metadata(
+        brightness,
+        ir_emitter::D1MetadataEvidence::from_lit_flags(&lit_flags),
+    ))
+}
+
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     verify_pinned(device)?;
@@ -7467,8 +7489,14 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
         &fmt,
     )?;
     let fd = dev.handle().fd();
+    // Start the metadata queue before the image queue's first dequeue. uvcvideo
+    // otherwise produces no metadata for this stream at all.
+    let mut meta = ir_metadata::IlluminationLog::open(device);
     for _ in 0..4 {
         let _ = stream.next(); // let the sensor settle before baseline
+        if let Some(log) = meta.as_mut() {
+            log.drain();
+        }
     }
     // Mean IR brightness over a short burst (catches a strobed emitter's lit
     // phase). Measured on the DECODED 8-bit frame so the brightness scale is
@@ -7481,7 +7509,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     // exactly the daemon's watchdog deadline, so a stall during setup could get
     // the daemon killed before the control it changed was restored. A fix for a
     // hang is not worth a race with systemd.
-    let mut measure = || -> Option<f32> {
+    let mut measure = || -> Option<ir_emitter::SetupMeasurement> {
         // A stop signal aborts through the same path a dead stream does, which
         // is the path that puts the control back.
         //
@@ -7496,6 +7524,9 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
         if ir_emitter::abort_requested() {
             return None;
         }
+        if let Some(log) = meta.as_mut() {
+            log.begin_burst();
+        }
         // Frames already in flight were captured before the control changed, and
         // taking the brightest of the burst makes one stale frame decide the
         // answer. Discard a stream's worth before believing anything.
@@ -7504,18 +7535,38 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
                 return None;
             }
             stream.next().ok()?;
+            if let Some(log) = meta.as_mut() {
+                log.drain();
+            }
         }
-        let mut best: Option<f32> = None;
+        let mut means = Vec::with_capacity(8);
+        let mut stamps = Vec::with_capacity(8);
         for _ in 0..8 {
             if ir_emitter::abort_requested() {
                 return None;
             }
-            let (buf, _) = stream.next().ok()?;
+            let (buf, facts) = stream.next().ok()?;
+            stamps.push(facts.timestamp_micros());
+            if let Some(log) = meta.as_mut() {
+                log.drain();
+            }
             let data = dec.decode(buf, w, h);
             let m = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
-            best = Some(best.map_or(m as f32, |b: f32| b.max(m as f32)));
+            means.push(m as f32);
         }
-        best
+        let flags = match meta.as_mut() {
+            Some(log) => {
+                // The final image's metadata buffer can arrive just after its
+                // image buffer, as in the production capture path.
+                log.drain();
+                stamps
+                    .iter()
+                    .map(|&timestamp| log.illumination_at(timestamp))
+                    .collect::<Vec<_>>()
+            }
+            None => vec![None; means.len()],
+        };
+        setup_measurement_from_burst(&means, &flags)
     };
 
     let id = crate::uvc_descriptor::identity_from_fd(fd)
@@ -7533,7 +7584,12 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
         privacy_permits_setup(privacy_state(&dev))
     };
     permit.run_active(|| {
-        match ir_emitter::discover(fd, &id, &mut measure, &mut privacy_allows_write) {
+        match ir_emitter::discover_with_measurements(
+            fd,
+            &id,
+            &mut measure,
+            &mut privacy_allows_write,
+        ) {
             Ok(ir_emitter::DiscoveryOutcome::Applied(found)) => {
                 let encoded = found.control().encode();
                 // Confirm, publish, release, in that order. The sequence lives in
@@ -7742,6 +7798,27 @@ mod tests {
             message.contains("no camera write or saved config was needed"),
             "{message}"
         );
+    }
+
+    #[test]
+    fn setup_burst_keeps_brightness_and_d1_metadata_as_separate_evidence() {
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        let measurement = setup_measurement_from_burst(
+            &[48.0, 52.0, 49.0, 51.0, 48.0, 52.0],
+            &[
+                Some(Dark),
+                Some(Lit),
+                None,
+                Some(Lit),
+                Some(Dark),
+                Some(Lit),
+            ],
+        )
+        .expect("a non-empty decoded burst is measurable");
+
+        assert_eq!(measurement.brightness(), 52.0);
+        assert!(measurement.metadata_proves_d1(), "{measurement:?}");
     }
 
     fn test_rate_config(role: contracts::StreamRole) -> rate_gate::StreamRateConfig {

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -7427,23 +7427,33 @@ fn active_by_device_default_message(control: &ir_emitter::EmitterControl) -> Str
 
 fn setup_measurement_from_burst(
     means: &[f32],
+    sequences: &[u32],
     flags: &[Option<ir_metadata::Illumination>],
 ) -> Option<ir_emitter::SetupMeasurement> {
     let brightness = means.iter().copied().reduce(f32::max)?;
-    if means.len() != flags.len() || !flags.iter().any(Option::is_some) {
+    if means.len() != sequences.len() || means.len() != flags.len() {
         return Some(ir_emitter::SetupMeasurement::optical(brightness));
     }
-    let lit_flags: Vec<Option<bool>> = flags
+    let optical_observations: Vec<(u32, f32)> = sequences
         .iter()
-        .map(|flag| match flag {
-            Some(ir_metadata::Illumination::Lit) => Some(true),
-            Some(ir_metadata::Illumination::Dark) => Some(false),
-            None => None,
-        })
+        .copied()
+        .zip(means.iter().copied())
         .collect();
-    Some(ir_emitter::SetupMeasurement::with_d1_metadata(
-        brightness,
-        ir_emitter::D1MetadataEvidence::from_lit_flags(&lit_flags),
+    let optical = ir_emitter::D1OpticalEvidence::from_sequence_means(&optical_observations);
+    let metadata = flags.iter().any(Option::is_some).then(|| {
+        let observations: Vec<(u32, Option<bool>)> = sequences
+            .iter()
+            .copied()
+            .zip(flags.iter().map(|flag| match flag {
+                Some(ir_metadata::Illumination::Lit) => Some(true),
+                Some(ir_metadata::Illumination::Dark) => Some(false),
+                None => None,
+            }))
+            .collect();
+        ir_emitter::D1MetadataEvidence::from_sequence_flags(&observations)
+    });
+    Some(ir_emitter::SetupMeasurement::with_d1_evidence(
+        brightness, optical, metadata,
     ))
 }
 
@@ -7541,12 +7551,14 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
         }
         let mut means = Vec::with_capacity(8);
         let mut stamps = Vec::with_capacity(8);
+        let mut sequences = Vec::with_capacity(8);
         for _ in 0..8 {
             if ir_emitter::abort_requested() {
                 return None;
             }
             let (buf, facts) = stream.next().ok()?;
             stamps.push(facts.timestamp_micros());
+            sequences.push(facts.sequence_raw());
             if let Some(log) = meta.as_mut() {
                 log.drain();
             }
@@ -7566,7 +7578,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
             }
             None => vec![None; means.len()],
         };
-        setup_measurement_from_burst(&means, &flags)
+        setup_measurement_from_burst(&means, &sequences, &flags)
     };
 
     let id = crate::uvc_descriptor::identity_from_fd(fd)
@@ -7805,20 +7817,28 @@ mod tests {
         use ir_metadata::Illumination::{Dark, Lit};
 
         let measurement = setup_measurement_from_burst(
-            &[48.0, 52.0, 49.0, 51.0, 48.0, 52.0],
-            &[
-                Some(Dark),
-                Some(Lit),
-                None,
-                Some(Lit),
-                Some(Dark),
-                Some(Lit),
-            ],
+            &[48.0, 52.0, 51.0, 48.0, 52.0],
+            &[10, 11, 13, 14, 15],
+            &[Some(Dark), Some(Lit), Some(Lit), Some(Dark), Some(Lit)],
         )
         .expect("a non-empty decoded burst is measurable");
 
         assert_eq!(measurement.brightness(), 52.0);
         assert!(measurement.metadata_proves_d1(), "{measurement:?}");
+    }
+
+    #[test]
+    fn setup_burst_retains_sequence_locked_optical_evidence_without_metadata() {
+        let measurement = setup_measurement_from_burst(
+            &[10.0, 41.0, 11.0, 40.0, 9.0, 42.0, 10.0, 41.0],
+            &[10, 11, 12, 13, 14, 15, 16, 17],
+            &[None, None, None, None, None, None, None, None],
+        )
+        .expect("a non-empty decoded burst is measurable");
+
+        assert_eq!(measurement.brightness(), 42.0);
+        assert!(measurement.optical_proves_d1(), "{measurement:?}");
+        assert!(!measurement.metadata_proves_d1(), "{measurement:?}");
     }
 
     fn test_rate_config(role: contracts::StreamRole) -> rate_gate::StreamRateConfig {

--- a/docs/research/2026-08-18-ir-setup-evidence-hardware.md
+++ b/docs/research/2026-08-18-ir-setup-evidence-hardware.md
@@ -1,0 +1,102 @@
+# Issue #492: four-device IR setup evidence
+
+Date: 2026-08-18  
+Tested commit: `5f38c745a390452e389dbb922dc8c61e8b631c4b`  
+Harness: `scripts/hardware/ir-setup-evidence-hardware-test.sh`
+
+## Purpose
+
+This is the physical acceptance record for the evidence semantics introduced
+for issue #492. It tests three distinct claims:
+
+1. Microsoft Face Authentication D1 may be accepted only when its alternating
+   frame behavior is tied to the control transition.
+2. Weak or absent optical evidence is `Inconclusive`, not proof that a control
+   is unsupported or unusable.
+3. Every exploratory write is exactly recoverable, and a failed recovery must
+   preserve its durable record and keep normal service stopped.
+
+The transition harness atomically snapshots the camera identity and current
+control bytes from one open descriptor. Its identity token binds the descriptor
+hash, interface, serial when present, USB device path, and live sysfs inode.
+Every direct test write revalidates that token on the same descriptor that will
+receive the ioctl. The exact initial bytes are fsynced under `/var/lib` before
+the first write. Cleanup deletes that record and restarts the packaged daemon
+only after exact read-back succeeds.
+
+## Artifact identity
+
+The Fedora-built artifacts used on the local ASUS, Arch BRIO, and CachyOS
+NexiGo hosts had these SHA-256 values on every machine:
+
+| Artifact | SHA-256 |
+|---|---|
+| `irlume` | `cc876d2835673e2ee342126e38c456c398c1e474aaf06fffff5f1cad3b6a9b90` |
+| `irlumed` | `c7484f3597ba432c59faca8cb9d2bdb7055712099ab547b3d20becc51946374c` |
+| `xu_set` | `5ee76866d4bbed1e98bcb25dfdbf1daf21d87182fcf4bd5053e3c36835c63b34` |
+| hardware harness | `c0209fb8c430d07978723d9ce0199eaecb8e00bdaa53f4cb0328a4e8a7e89152` |
+
+The Ubuntu ThinkPad could not load the Fedora binary because Ubuntu lacked
+`libcrypt.so.2`. It therefore built the same complete-history bundle and exact
+commit natively, with `TMPDIR` and `CARGO_TARGET_DIR` on its home filesystem.
+
+## Results
+
+| Host / camera | Hardware class | Result | Final control / state |
+|---|---|---|---|
+| UX5406S Fedora, Shinetech ASUS `3277:0059` | transition, unit 14 selector 6 | 8 passed, 0 failed | exact pre-test `010301000000000000`; daemon active |
+| Arch host, Logitech BRIO `046d:085e` | device default, unit 12 selector 6 | 8 passed, 0 failed | unchanged D1 `010202000000000000`; daemon active |
+| CachyOS mini host, NexiGo N930W `3443:c803` | transition, unit 4 selector 6 | 8 passed, 0 failed | exact pre-test `010301000000000000`; daemon active |
+| Ubuntu ThinkPad, Integrated Camera | no usable emitter XU | 3 passed, 0 failed | no XU write and no persisted state; daemon active |
+
+No host retained a `/var/lib/irlume-492.*` recovery directory after its
+successful exact-restoration audit.
+
+### ASUS transition camera
+
+With UVCM metadata available, setup proved D1, persisted `3277:0059 14:6`,
+left exactly `010302000000000000` applied until harness cleanup, and left no
+undo record. With metadata forcibly disabled, the optical observation was too
+weak (`before 91`, `after 89`, threshold `+20`), so setup returned typed
+`Inconclusive`, saved no config, and restored the parked value exactly.
+
+Transcript directory: `/tmp/irlume-492-evidence.lDz7sA`
+
+### BRIO device-default camera
+
+Both metadata modes recognized the validated Face Authentication D1 default
+`010202000000000000`. Neither mode emitted `SET_CUR`, neither persisted a
+configuration or undo record, and both left the exact control unchanged.
+
+Transcript directory: `/tmp/irlume-492-evidence.Van31D`
+
+### NexiGo transition camera
+
+With UVCM metadata available, setup proved D1, persisted `3443:c803 4:6`, left
+exactly `010302000000000000` applied until cleanup, and left no undo record.
+With metadata disabled, the weak optical observation (`before 0`, `after 7`,
+threshold `+20`) returned typed `Inconclusive`, saved no config, and restored
+the parked value exactly.
+
+Transcript directory: `/tmp/irlume-492-evidence.ljXEb3`
+
+### ThinkPad RGB-only camera
+
+The camera's Microsoft unit advertised selectors `0x02`, `0x03`, and `0x09`,
+but neither Face Authentication `0x06` nor IR Torch `0x0a`. Setup therefore
+reported no usable emitter control, emitted no XU write, and persisted neither
+configuration nor undo state.
+
+Transcript directory: `/tmp/irlume-492-evidence.LR7r6h`
+
+## Conclusion
+
+The physical matrix supports the typed three-state design. Contract-level
+metadata established D1 on both transition cameras. Removing that observation
+did not produce strong control-correlated optical evidence on either device,
+so both correctly became `Inconclusive` rather than false success or a claim of
+incompatibility. The BRIO remained a read-only device-default success, and the
+RGB-only ThinkPad remained a definitive no-control result without writes.
+
+Most importantly, all exploratory paths ended with exact control read-back,
+no recovery residue, and the packaged daemon active.

--- a/docs/research/2026-08-18-ir-setup-inconclusive-semantics.md
+++ b/docs/research/2026-08-18-ir-setup-inconclusive-semantics.md
@@ -1,0 +1,596 @@
+# `ir-setup`: semantics when D1 is accepted but functional proof is inconclusive
+
+Date: 2026-08-18
+
+Issue: [#492](https://github.com/archledger/irlume/issues/492)
+
+## Decision
+
+When the camera advertises Microsoft Face Authentication D1, accepts a
+standards-derived D1 `SET_CUR`, returns that exact value from `GET_CUR`, and is
+then restored to its exact original value, but neither per-frame metadata nor
+the optical experiment establishes that D1 took functional effect, the result
+must be **inconclusive**.
+
+It is not `unsupported`: the camera advertised D1 and accepted the D1 state. It
+is not `unusable`: the observation did not establish a negative result. It is
+not success: `ir-setup` has not established a configuration safe to persist and
+reuse. The camera's compatibility state remains **unproven**.
+
+The human CLI should:
+
+- say which protocol facts succeeded;
+- say that exact restoration was verified and no configuration was saved;
+- say why the functional evidence was insufficient;
+- explicitly say that this is not evidence that the control is unsupported or
+  unusable;
+- give a scene-specific retry instruction; and
+- return nonzero status **1**.
+
+Status 0 would tell shells and service automation that setup accomplished its
+goal when it did not. Status 1 keeps the ordinary success predicate honest and
+preserves irlume's current `0 = established`, `1 = not established`, `2 = bad
+invocation` convention. The structured daemon/machine result—not a new process
+status—is where `inconclusive` must remain distinct from an operational error.
+
+## Scope and pinned artifacts
+
+This is source and contract research, not a hardware run. The repository
+behavior audited here is GitHub `main` at
+[`715fd170983c9500e5fa25ff6374663909bcccb1`](https://github.com/archledger/irlume/commit/715fd170983c9500e5fa25ff6374663909bcccb1),
+queried on 2026-08-18. Relevant Git blob IDs are:
+
+| Artifact | Git blob |
+|---|---|
+| `crates/irlume-camera/src/ir_emitter.rs` | `9236123e03fad370265584b8226d410fc0fdc819` |
+| `crates/irlume-camera/src/lib.rs` | `a5015a5d70c09858e5df31672a3ac066f253a86c` |
+| `crates/irlume-camera/src/ir_metadata.rs` | `c08907cadd7412bfe4064dda48033eb8b36b7e29` |
+| `crates/irlume-cli/src/main.rs` | `711525eb5df1af13f02b80c26d8cf4b69542a09b` |
+
+Issue #492 had no comments when inspected. Its hardware measurements are
+treated as project evidence reported by the issue, not as measurements repeated
+for this note.
+
+Primary external sources were restricted to Microsoft's camera contracts and
+bring-up documentation, Linux kernel documentation and upstream source, POSIX,
+and the GNU project's own CLI manual. The Microsoft UVC extension page was last
+updated 2024-05-22; the face-auth DDI page was last updated 2023-02-27; the
+public Hello bring-up guide was last updated 2021-12-15. Linux source links are
+to upstream `master` as observed on the date above.
+
+## Terminology verdict
+
+| Term | Authority | What it establishes | What it does not establish |
+|---|---|---|---|
+| Face Authentication D1 | Microsoft-defined control mode | Alternative-frame illumination is the selected mode for a named IR streaming interface | That Linux received usable metadata, that photons reached the scene, or that irlume can authenticate |
+| Successful `SET_CUR` | UVC control transaction | The request completed without an ioctl/device error | That the requested state became current or affected frames |
+| Exact D1 `GET_CUR` readback | Microsoft control contract | The camera reports D1 as the current selected mode | Optical output, metadata delivery to Linux, or useful reflected signal |
+| `MetadataId_FrameIllumination` | Microsoft standard-format frame metadata | The camera reports whether active illumination was on for that captured frame | Measured irradiance, reflected signal strength, emitter health, or scene suitability |
+| `UVCM` | Linux V4L2 metadata format | Userspace can receive the complete Microsoft-style UVC payload metadata rather than only the standard UVC header | That every Microsoft camera embeds illumination metadata, that every kernel exposes it, or that every queued record arrives |
+| Optical proof | irlume policy/experiment | Pixel observations changed in a repeatable way correlated with control state | Microsoft/USB conformance by itself |
+| Inconclusive | irlume operation result | The safe experiment ended without enough evidence for success or a definitive negative | Permanent device incompatibility |
+
+The important correction is grammatical as much as technical: **the operation
+is inconclusive; the control is not thereby unusable**.
+
+## The standards and OS layers are different contracts
+
+The relevant path is:
+
+```text
+Microsoft FaceAuth XU capability and mode selection
+        -> USB control transfer (SET_CUR / GET_CUR)
+        -> camera firmware and IR streaming interface
+        -> optional embedded Microsoft frame metadata
+        -> Linux uvcvideo UVCM metadata node
+        -> irlume timestamp/sequence correlation
+        -> contract-level or optical proof policy
+```
+
+Windows has another possible path: a vendor Device MFT can attach the required
+illumination metadata in the Windows capture stack. Linux cannot observe a
+Windows Device MFT. Microsoft explicitly describes both a Device MFT and
+firmware-carried metadata as ways to provide the illumination attribute in the
+[UVC extensions](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/uvc-extensions-1-5#22210-ir-torch-control).
+Consequently, lack of an embedded record visible through Linux is not, by
+itself, proof that a Windows Hello camera violates its Windows integration
+contract.
+
+This layer boundary rules out two tempting but incorrect conclusions:
+
+1. A successful control write cannot be promoted to optical success.
+2. Missing Linux metadata cannot be promoted to control failure.
+
+## What Microsoft's D1 contract actually proves
+
+### Capability and state
+
+Microsoft assigns Face Authentication selector `0x06` to the Microsoft camera
+control extension unit. For each IR streaming interface, `GET_MAX` identifies
+whether D1 or D2 is supported; `GET_DEF`, `GET_CUR`, and `SET_CUR` select exactly
+one of D0, D1, or D2. The control must not be implemented by a camera that is
+not capable of face authentication. These are normative device declarations,
+not scene measurements. See [Microsoft UVC Extensions, Face Authentication
+Control](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/uvc-extensions-1-5#2226-face-authentication-control).
+
+Therefore, after irlume has validated the descriptor, the payload shape, D1
+support, interface identities, and then obtained exact D1 readback, it may
+truthfully report:
+
+> The camera advertised D1 and reports D1 selected.
+
+It may not replace that sentence with:
+
+> The IR emitter works.
+
+The first is device-reported control state. The second is a claim about
+functional or physical effect that needs additional evidence.
+
+### Expected streaming behavior
+
+Microsoft's face-authentication DDI defines alternative-frame illumination as
+a mode in which the IR strobe is expected to alternate off and on for captured
+frames, with the mode represented on each sample. The alternative mode and the
+background-subtraction mode are mutually exclusive. See
+[`KSPROPERTY_CAMERACONTROL_EXTENDED_FACEAUTH_MODE`](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-faceauth-mode).
+
+The public Windows Hello bring-up procedure follows that contract. It selects
+the FaceAuth IR stream, sets the supported face-auth property, starts streaming,
+and for alternative illumination checks illuminated/unilluminated frame-pair
+metadata at the required delivered rate. It then stops streaming and unsets the
+control. The procedure does **not** prescribe a fixed increase in mean image
+brightness. See [Windows Hello Camera Driver Bring Up
+Guide](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/windows-hello-camera-driver-bring-up-guide#hlk-tests-for-kscategory_sensor_camera-to-assist-driver-testing).
+
+This does not prove that Microsoft's private certification contains no optical
+tests. It proves only what the public guide contracts: the published bring-up
+gate is mode, stream, rate, timestamp, and per-frame metadata oriented. There
+is no primary-source basis for treating irlume's `+20` mean threshold as a
+Microsoft requirement.
+
+### What illumination metadata says
+
+Microsoft defines a 16-byte `MetadataId_FrameIllumination` item. Bit 0 is set
+when a frame was captured with illumination on and clear otherwise. The
+corresponding Media Foundation attribute likewise says whether active IR
+illumination was on for the frame. See the [standard-format metadata
+definition](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/uvc-extensions-1-5#222344-metadataid_frameillumination)
+and
+[`MF_CAPTURE_METADATA_FRAME_ILLUMINATION`](https://learn.microsoft.com/en-us/windows/win32/medfound/mf-capture-metadata-frame-illumination).
+
+That is strong contract evidence when correlated with the correct video frame:
+it can establish that the camera reports the expected D1 off/on pattern. It is
+not a photodiode reading. A firmware defect could report `ON` while an LED is
+failed, blocked, or too weak at the subject. Irlume's own runtime diagnosis
+already preserves this distinction: its `LitButDark` arm says metadata reports
+state, not optical output.
+
+For user-facing wording, the honest proof labels are therefore:
+
+- `contract-proven` for a control-correlated D1 metadata pattern;
+- `optically-proven` for a sufficiently strong pixel-domain experiment; and
+- `unproven` when neither is conclusive.
+
+Do not call metadata-only evidence `optically proven`.
+
+## What Linux can and cannot observe
+
+### The usable path
+
+The Linux metadata interface exposes non-image data on metadata capture nodes.
+A supporting node reports `V4L2_CAP_META_CAPTURE`, and the buffer layout is
+bound to a negotiated metadata format. See the [V4L2 Metadata
+Interface](https://docs.kernel.org/userspace-api/media/v4l/dev-meta.html).
+
+Ordinary `V4L2_META_FMT_UVC` (`UVCH`) retains only the standard 2--12-byte UVC
+payload header. `V4L2_META_FMT_UVC_MSXU_1_5` (`UVCM`) uses the same V4L2 block
+layout but retains all payload metadata, which is what makes the appended
+Microsoft illumination item observable. See the kernel documentation for
+[`UVCH`](https://docs.kernel.org/userspace-api/media/v4l/metafmt-uvc.html) and
+[`UVCM`](https://docs.kernel.org/userspace-api/media/v4l/metafmt-uvc-msxu-1-5.html).
+
+Current upstream `uvcvideo` looks for the Microsoft XU GUID, queries Microsoft
+metadata selector 9, enables metadata when possible, and advertises `UVCM` only
+when that detection succeeds. It still advertises `UVCH`. See
+[`uvc_metadata.c`](https://github.com/torvalds/linux/blob/master/drivers/media/usb/uvc/uvc_metadata.c#L197-L266).
+
+The repository already has an implementation of the userspace half. At the
+pinned revision,
+[`ir_metadata.rs`](https://github.com/archledger/irlume/blob/715fd170983c9500e5fa25ff6374663909bcccb1/crates/irlume-camera/src/ir_metadata.rs)
+finds the paired metadata node, negotiates `UVCM`, parses
+`MetadataId_FrameIllumination`, and correlates metadata to image timestamps.
+The ordinary authentication capture path uses it. `ir-setup` does not: its
+measurement closure still returns only the maximum decoded mean of eight
+frames.
+
+### Absence is not a negative result
+
+There are several independent reasons for no usable illumination record:
+
+- the distribution kernel predates `UVCM` support;
+- the camera exposes no metadata node;
+- the Microsoft metadata control is absent, disabled, or unavailable to the
+  current kernel;
+- the Windows integration supplies the attribute through a Device MFT rather
+  than the USB payload;
+- the camera embeds metadata but the userspace queue loses or cannot correlate
+  a record; or
+- the camera emits other Microsoft metadata but not the illumination item.
+
+The kernel's `UVCH` documentation also permits dropping UVC header records for
+buffer-space, usefulness, or rate-limiting reasons. A proof algorithm must use
+sequence/timestamp correlation and tolerate a bounded number of missing
+records; it must not treat one missing buffer as an `OFF` frame or as a device
+failure.
+
+Linux 6.17 documentation contains `UVCM`; older deployed kernels cannot be
+assumed to do so. The portability rule is therefore:
+
+> Metadata present and correlated can be positive evidence. Metadata absent,
+> uncorrelated, or unavailable is an evidence gap.
+
+## Current irlume behavior and the classification bug
+
+At `715fd170`, setup computes the brightest decoded mean from a short burst. It
+requires `after >= before + 20`, restores, and then requires the brightness to
+fall by 20. The reversible transition is a useful causal structure, but the
+fixed effect-size threshold is scene dependent. See
+[`ir_emitter.rs` lines 3893--3923](https://github.com/archledger/irlume/blob/715fd170983c9500e5fa25ff6374663909bcccb1/crates/irlume-camera/src/ir_emitter.rs#L3893-L3923).
+
+If the first delta is smaller than 20, setup returns `Attempt::NotUsable`. The
+outer discovery loop folds that into `DiscoveryError::NoUsableControl`, whose
+text says the unit advertises no usable emitter control. See
+[`DiscoveryError`](https://github.com/archledger/irlume/blob/715fd170983c9500e5fa25ff6374663909bcccb1/crates/irlume-camera/src/ir_emitter.rs#L2469-L2533).
+The daemon turns the error into `Response::Error`; `report_ok_response` prints
+it to stderr and returns `ExitCode::FAILURE` (1). See
+[`setup_ir_emitter`](https://github.com/archledger/irlume/blob/715fd170983c9500e5fa25ff6374663909bcccb1/crates/irlume-camera/src/lib.rs#L7429-L7561)
+and the [CLI response mapping](https://github.com/archledger/irlume/blob/715fd170983c9500e5fa25ff6374663909bcccb1/crates/irlume-cli/src/main.rs#L608-L638).
+
+The exit status is already safe. The classification and message are not. The
+code turns `did not cross this scene-dependent threshold` into `the control is
+not usable`, losing the stronger protocol facts it had just established.
+
+### Four-device evidence and what it does—and does not—calibrate
+
+The project's physical matrix contains four materially different cases:
+
+| Device | Relevant evidence | Semantic consequence |
+|---|---|---|
+| ASUS 3277:0059 RGB/IR | Issue #492 reports correct derived D1 write and exact restoration, but setup measured only `48 -> 52` (`+4`). The configured production path then wrote/read D1 and delivered 120 frames with a much wider observed range. The repository's metadata reader also records this model as supplying per-frame illumination records. | The `+20` miss is inconclusive, not unusable. Metadata should be attempted before optical fallback. |
+| NexiGo 3443:c803 RGB/IR | Issue #492 reports correct D1 write/restore with `2 -> 9` (`+7`); the production path wrote/read D1 and delivered 120 frames. The mostly empty/distant scene remained dim. The metadata reader records this model as supplying illumination records. | A weak/empty scene can hide a working transition; lowering the threshold blindly would trade false negatives for false positives. |
+| Logitech BRIO 046d:085e RGB/IR | A 21-burst campaign measured a stable paired lit-minus-ambient differential around 36 after two warm-up bursts, with uncontrolled ambient light and one underpowered post-idle arm. See [the pinned BRIO cadence note](https://github.com/archledger/irlume/blob/715fd170983c9500e5fa25ff6374663909bcccb1/docs/research/2026-08-12-brio-emitter-cadence.md). | Alternating within-burst structure is more informative than one absolute before/after mean. The study is not a universal threshold calibration. |
+| ThinkPad RGB-only camera | The #491/#496 hardware matrix found no Microsoft XU and no IR member on this device. See [PR #496](https://github.com/archledger/irlume/pull/496). | This is `Unsupported` from capability evidence; no optical experiment should run. |
+
+The first two are direct counterexamples to `small delta => unusable`. The
+BRIO run shows that warm-up and paired phase structure matter. The ThinkPad
+shows why unsupported must remain a separate, pre-write result.
+
+This is not enough data to choose a new universal numeric cutoff. It spans
+only three IR implementations, scenes were not standardized, and the ASUS and
+NexiGo issue measurements intentionally demonstrate poor optical targets.
+
+## Evidence model: keep five axes separate
+
+A single success/error boolean cannot express this operation safely. Preserve
+these facts independently:
+
+1. **Capability provenance**: Microsoft XU and selector advertised; D1 listed
+   for the correct IR interface; payload structurally derived from current
+   device answers.
+2. **Control transaction**: original captured; D1 write completed; exact D1
+   `GET_CUR` readback matched.
+3. **Functional observation**: metadata pattern, optical correlation, negative
+   evidence, or insufficient evidence.
+4. **Restoration**: exact original read back, not merely a successful restore
+   ioctl.
+5. **Publication**: configuration durably saved, intentionally unnecessary, or
+   not saved.
+
+The scenario in this note is:
+
+```text
+capability = advertised_d1
+transaction = accepted_and_read_back
+functional_observation = insufficient
+restoration = exact_original_confirmed
+publication = not_saved
+```
+
+The only honest disposition is `Inconclusive`.
+
+## Recommended typed contract
+
+The names below are illustrative Rust, not an implementation requirement. The
+important property is that the axes survive across the daemon protocol rather
+than being formatted into one string too early.
+
+```rust
+enum IrSetupDisposition {
+    Ready {
+        control: EmitterControlRef,
+        proof: D1Proof,
+        publication: Publication,
+    },
+    Inconclusive {
+        control: EmitterControlRef,
+        protocol: ProtocolAcceptance,
+        evidence_gap: EvidenceGap,
+        restoration: Restoration,
+        retry: RetryGuidance,
+    },
+    Unsupported {
+        reason: UnsupportedReason,
+    },
+    Unusable {
+        control: EmitterControlRef,
+        reason: ConclusiveNegative,
+        restoration: Restoration,
+    },
+    Failed {
+        stage: SetupStage,
+        error: SetupFailure,
+        restoration: Restoration,
+    },
+}
+
+enum D1Proof {
+    DeviceDeclaredActiveDefault,
+    MetadataAlternation {
+        correlated: usize,
+        lit: usize,
+        dark: usize,
+        missing: usize,
+    },
+    OpticalControlCorrelation {
+        transitions: usize,
+        effect_summary: RobustEffectSummary,
+    },
+}
+
+enum EvidenceGap {
+    MetadataUnavailableAndOpticalEffectTooWeak,
+    MetadataInsufficient { correlated: usize, missing: usize },
+    SceneUnsuitable(SceneReason),
+    ExposureOrWarmupUnsettled,
+    ConflictingMetadataAndPixels,
+}
+
+enum Restoration {
+    NotNeeded,
+    ExactOriginalConfirmed,
+    PendingRecovery,
+    Failed,
+}
+
+enum Publication {
+    SavedDurably,
+    NotNeededDeviceDefault,
+}
+```
+
+`Ready` is the only ordinary configuration success. The existing
+`ActiveByDeviceDefault` result fits `Ready` with
+`DeviceDeclaredActiveDefault` and `NotNeededDeviceDefault`; this note does not
+reopen the deliberate #490 policy for a device whose validated active value is
+already its own default.
+
+`Inconclusive` is allowed only when exact restoration is confirmed and no
+configuration was published. If restoration cannot be verified, the result is
+`Failed`, the durable recovery record remains authoritative, and retry guidance
+must concern recovery—not scene positioning.
+
+### Classification rules
+
+| Observation | Disposition | Persist? | Exit |
+|---|---|---:|---:|
+| No Microsoft XU, selector absent, D1 not advertised, or only D2 is offered | `Unsupported` | no | 1 |
+| D1 advertised; write/readback/restoration succeeded; metadata and optical evidence insufficient | `Inconclusive` | no | 1 |
+| D1 advertised, but a properly powered experiment obtains affirmative, repeatable contradictory evidence under established prerequisites | `Unusable` | no | 1 |
+| D1 proof obtained; final applied value read back; config committed | `Ready` | yes | 0 |
+| Validated active device default, unchanged | `Ready` | unnecessary | 0 |
+| Busy, privacy refusal, journal failure, query failure, stream failure, or unconfirmed restore | `Failed` | no | 1 |
+| Invalid CLI invocation | usage error | no | 2 |
+
+`Unusable` should be rare. A query transport failure is not conclusive proof of
+permanent unusability; it belongs under `Failed`. Missing metadata is not
+conclusive. A weak scene is not conclusive. Reserve `Unusable` for a defined,
+repeatable contradiction after the test has first established that its
+prerequisites and observation channel are adequate.
+
+## CLI exit status and automation semantics
+
+POSIX's process model uses zero to conventionally report successful
+termination and warns applications not to return zero when they terminate
+unsuccessfully. See POSIX
+[`_Exit`/`_exit`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/_exit.html).
+An inconclusive `ir-setup` has not achieved the requested postcondition: there
+is no established reusable control and no saved configuration. Returning 0
+would make all of these common patterns wrong:
+
+```sh
+sudo irlume ir-setup && sudo irlume login enable
+if sudo irlume ir-setup; then enable_face_login; fi
+set -e
+sudo irlume ir-setup
+```
+
+Nonzero does not have to assert a permanent error. GNU `grep`, for example,
+uses 1 for the valid negative outcome “no selected lines” and 2 for an actual
+error. See the [GNU grep exit-status
+contract](https://www.gnu.org/s/grep/manual/html_node/Exit-Status.html). The
+material analogy is predicate semantics: status 0 means the requested predicate
+was established; status 1 means it was not.
+
+For irlume now:
+
+- **0**: setup established `Ready`.
+- **1**: setup did not establish `Ready`, including `Inconclusive`,
+  `Unsupported`, `Unusable`, and `Failed`.
+- **2**: malformed invocation.
+
+Do not add an undocumented status 3 merely to encode `Inconclusive`. Existing
+shell callers need only the success predicate, and a second nonzero number does
+not carry the restoration, evidence, or retry facts automation actually needs.
+Expose those through a typed daemon response and, if/when a stable machine CLI
+is added, a versioned object such as:
+
+```json
+{
+  "outcome": "inconclusive",
+  "ready": false,
+  "retryable": true,
+  "protocol": "d1-accepted-readback",
+  "restoration": "exact-original-confirmed",
+  "configuration_saved": false,
+  "evidence_gap": "metadata-unavailable-optical-effect-too-weak"
+}
+```
+
+Automation must branch on `outcome`, not parse localized prose. A generic
+shell sees nonzero and safely stops. An interactive installer can recognize
+`inconclusive`, show positioning instructions, and offer one user-directed
+retry. A headless service should not busy-loop: the missing prerequisite is
+often a human/scene change, and repeating the same firmware transaction against
+the same empty view adds risk without adding information.
+
+## Operator message
+
+The message must lead with the disposition and then state the safe facts. A
+calibrated example is:
+
+```text
+[ir-setup] inconclusive: this camera advertised Microsoft Face Authentication
+D1, accepted the device-derived D1 value, and read it back exactly. irlume then
+restored the exact original value and verified the restoration. The available
+frame metadata and image changes did not prove D1 illumination, so no emitter
+configuration was saved. This does not show that the control is unsupported or
+unusable. Put a nearby subject in the IR camera's view, keep the scene still,
+make sure the privacy shutter is open, and retry `sudo irlume ir-setup`.
+```
+
+When known, replace the generic evidence sentence with a specific one:
+
+- `Linux exposed no UVCM illumination metadata, and the optical change was too
+  weak to classify.`
+- `Only 2 of 16 video frames had correlated metadata; that is not enough to
+  verify the D1 pattern.`
+- `The scene was saturated/flat before the write, so brightness could not
+  measure an additional reflection.`
+- `Exposure was still changing across the reversal, so the observed delta
+  could not be assigned to the control.`
+
+The retry instruction intentionally gives no universal distance or brightness
+number. None of the primary sources specifies one, and the local devices have
+already shown wide scene-dependent means. Distance and optical thresholds must
+come from a controlled empirical calibration, not from the Microsoft mode
+number.
+
+Ideally, scene guidance appears **before** the first optical measurement as
+well as after an inconclusive result. Requiring an undocumented target and then
+blaming the control when it is absent is the compatibility defect in #492.
+
+## Calibrated limits for the optical fallback
+
+The metadata-first path should not become metadata-only policy. When correlated
+UVCM illumination records are unavailable, an optical fallback remains useful,
+but it must answer a narrower question and preserve an inconclusive arm.
+
+The following are engineering deductions from the contracts and the four-device
+evidence, not requirements stated by Microsoft:
+
+1. **Preflight the observation channel.** Refuse to classify a flat,
+   near-black, saturated, empty/distant, or still-settling scene as a negative
+   control result. Prompt for a nearby subject and a still scene first.
+2. **Discard warm-up and in-flight frames.** The BRIO's first two bursts differed
+   from its later stable paired differential. The current setup already drains
+   frames after transitions; retain that invariant and calibrate the count per
+   delivered-frame behavior rather than wall-clock sleep alone.
+3. **Use repeated reversible transitions.** One `off -> D1 -> restore` triplet
+   rejects some ambient drift but is still vulnerable to exposure movement.
+   Multiple balanced transitions allow a median paired effect and a sign/
+   consistency check.
+4. **Prefer within-burst D1 periodicity.** D1 is an alternating-frame mode. A
+   stable alternating component correlated with the selected mode is more
+   specific than comparing only the maximum of two bursts.
+5. **Use robust effects, not one absolute mean delta.** Record paired effect,
+   dispersion, transition count, classified/missing metadata counts, exposure
+   stability when available, and scene dynamic range. Do not silently lower
+   `+20` to fit the ASUS and NexiGo examples.
+6. **Require positive evidence for success, adequate prerequisites for a
+   negative.** If the effect is below the success bound and the test lacks power
+   to reject scene/exposure explanations, return `Inconclusive`. Only a
+   separately calibrated negative test may return `Unusable`.
+7. **Calibrate and validate out of sample.** Use all three IR cameras across
+   controlled distances, targets, ambient levels, exposure states, and warm-up
+   conditions; keep one session/device condition out of threshold selection.
+   The RGB-only ThinkPad remains the no-write `Unsupported` control.
+
+This policy preserves the existing safety invariants: journal before write,
+re-read before forward write, stop on the first failed query/dequeue, exact
+readback after every write, restore even when privacy changes, and publish only
+after proof. Statistical sophistication must not weaken any of them.
+
+## Known gaps and unresolved tensions
+
+- **Metadata is device testimony.** Microsoft defines what it means, but it
+  does not independently measure emitted or reflected power. Runtime dark-frame
+  policy must continue to distinguish `metadata-lit` from `optically useful`.
+- **Windows and Linux observability differ.** A Windows Device MFT can supply
+  metadata Linux never sees. The public contracts do not provide a portable way
+  for Linux to execute that transform.
+- **Kernel version and queue behavior matter.** `UVCM` is recent relative to
+  supported distributions, and metadata capture is a separate queue. Missing
+  records need correlation and bounded-loss policy.
+- **The public Hello guide is not the complete private HLK implementation.** It
+  supports a metadata-oriented bring-up model and does not support the `+20`
+  rule; it cannot prove that no unpublished optical certification exists.
+- **No universal optical threshold is sourced.** The present device/scene data
+  refutes the current classification but is insufficient to choose replacement
+  constants.
+- **`ActiveByDeviceDefault` has different assurance.** It is a deliberate
+  device-declared ready state from #490, not metadata or optical proof. The
+  typed result must retain that proof provenance rather than merging every
+  status-0 path into “optically verified.”
+
+## Implementation acceptance implied by the research
+
+This note does not implement #492, but an implementation conforming to the
+decision should demonstrate:
+
+- a typed `Inconclusive` path retains D1 support, exact D1 readback, evidence
+  gap, exact restoration, and `configuration_saved = false`;
+- the path cannot render `unsupported`, `unusable`, `enabled`, or `saved`;
+- human CLI output is on stderr and returns 1;
+- structured consumers can distinguish inconclusive from unsupported,
+  conclusive negative, and operational failure without parsing text;
+- status 0 is impossible until the ready-state postcondition is established;
+- metadata-present fixtures verify correlated D1 lit/dark behavior, tolerate a
+  bounded missing first/occasional record, and reject mismatched stream
+  provenance;
+- metadata-absent fixtures fall back to optical evidence without treating
+  absence as dark or unsupported;
+- exposure/ambient drift and unsuitable-scene fixtures return inconclusive, not
+  success or unusable;
+- restore failure overrides inconclusive and retains the recovery journal;
+- the physical matrix covers ASUS and NexiGo metadata and weak-scene cases,
+  BRIO alternating behavior and warm-up, and the ThinkPad no-XU unsupported
+  case.
+
+## Final answer to the narrow question
+
+For the exact scenario posed:
+
+- **Device classification:** `D1 advertised and control-accepted; functional
+  compatibility unproven`.
+- **Operation outcome:** `Inconclusive`, retryable after an operator changes the
+  scene; exact restoration verified; nothing saved.
+- **Operator message:** report the successful D1 derivation/write/readback and
+  exact restore, name the evidence gap, explicitly deny the inference
+  “unusable,” and instruct the operator to put a nearby subject in view and
+  retry.
+- **CLI exit:** **1**, not 0. Keep 2 for invocation errors. Preserve the richer
+  distinction in a typed daemon/machine response.
+
+That contract is simultaneously honest about Microsoft's standard, Linux's
+limited observation channel, the successful safety transaction, and the fact
+that `ir-setup` did not actually establish a reusable configuration.

--- a/scripts/hardware/ir-setup-evidence-hardware-test.sh
+++ b/scripts/hardware/ir-setup-evidence-hardware-test.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Physical acceptance gate for #492.
+#
+#   sudo bash scripts/hardware/ir-setup-evidence-hardware-test.sh \
+#       <worktree> <ir-node> <rgb-node> <transition|device-default|no-xu>
+#
+# `transition` is restricted to the ASUS 3277:0059 and NexiGo 3443:c803
+# modules already validated with a device-derived Face Authentication payload.
+# It parks selector 6 at this camera's own GET_DEF, then runs setup once with
+# UVCM metadata enabled and once with it forcibly disabled. Success and the
+# explicit Inconclusive result are both valid functional outcomes; every result
+# is checked against its persistence, journal, read-back, and restoration rules.
+#
+# `device-default` is the read-only Logitech BRIO case: its validated Face
+# Authentication D1 value is already GET_CUR == GET_DEF, so setup must report
+# that state without a SET_CUR or saved config, with and without metadata.
+#
+# `no-xu` is the RGB-only negative gate: setup must fail without any extension-
+# unit write, config, or journal.
+set -uo pipefail
+
+TREE=${1:?usage: $0 <worktree> <ir-node> <rgb-node> <transition|device-default|no-xu>}
+IR=${2:?missing IR/camera node}
+RGB=${3:?missing RGB node}
+CLASS=${4:?missing hardware class}
+
+CLI="$TREE/target/release/irlume"
+DAEMON="$TREE/target/release/irlumed"
+XU_SET="$TREE/target/release/examples/xu_set"
+MODELS=${IRLUME_MODEL_DIR:-/usr/share/irlume/models}
+SOCK="/run/irlume-492-$$.sock"
+STATE=$(mktemp -d /var/lib/irlume-492.XXXXXX)
+OUT=$(mktemp -d /tmp/irlume-492-evidence.XXXXXX)
+CONF="$STATE/ir_emitter.conf"
+LOCKS="$STATE/locks"
+STORE="$STATE/ir-emitter-journal"
+ORT=${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
+    sed -n 's/^Environment="\?ORT_DYLIB_PATH=\([^"]*\)"\?$/\1/p' | head -1)}
+
+daemon_pid=""
+unit=""
+control_needs_restore=no
+pass=0
+fail=0
+
+ok() { pass=$((pass + 1)); echo "  ok      $1"; }
+bad() { fail=$((fail + 1)); echo "  FAILED  $1"; echo "            $2"; }
+
+stop_private() {
+    if [ -n "$daemon_pid" ]; then
+        kill -TERM "$daemon_pid" 2>/dev/null || true
+        wait "$daemon_pid" 2>/dev/null || true
+        daemon_pid=""
+    fi
+    rm -f "$SOCK"
+}
+
+restore_default() {
+    if [ "$control_needs_restore" = yes ] && [ -n "$unit" ] && [ -e "$IR" ]; then
+        stop_private
+        if "$XU_SET" "$IR" "$unit" 6 def >"$OUT/cleanup-restore.out" 2>&1; then
+            control_needs_restore=no
+        else
+            echo "  WARNING: cleanup could not restore the device default" >&2
+            sed 's/^/    /' "$OUT/cleanup-restore.out" >&2
+        fi
+    fi
+}
+
+packaged_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
+cleanup() {
+    stop_private
+    restore_default
+    rm -f "$SOCK"
+    case "$STATE" in
+        /var/lib/irlume-492.*) rm -rf "$STATE" ;;
+        *) echo "refusing to remove unexpected state path $STATE" >&2 ;;
+    esac
+    if [ "$packaged_was_active" = active ]; then
+        systemctl start irlumed 2>/dev/null || true
+        echo "  (packaged irlumed: $(systemctl is-active irlumed 2>/dev/null || true))"
+    fi
+}
+trap cleanup EXIT
+
+[ "$(id -u)" -eq 0 ] || { echo "refusing: physical camera gate requires root"; exit 2; }
+[ -x "$CLI" ] && [ -x "$DAEMON" ] && [ -x "$XU_SET" ] || {
+    echo "refusing: release irlume, irlumed, or xu_set is missing under $TREE/target/release"
+    exit 2
+}
+[ -e "$IR" ] && [ -e "$RGB" ] || { echo "refusing: camera node is absent"; exit 2; }
+case "$CLASS" in transition|device-default|no-xu) ;; *) echo "unknown class: $CLASS"; exit 2 ;; esac
+
+mkdir -p "$LOCKS"
+if [ -d /var/lib/irlume/models-thirdparty ]; then
+    ln -s /var/lib/irlume/models-thirdparty "$STATE/models-thirdparty"
+fi
+systemctl stop irlumed 2>/dev/null || true
+
+start_private() { # tag, metadata-disabled(0|1)
+    local tag=$1 no_meta=$2
+    local -a extra=()
+    stop_private
+    [ "$no_meta" = 1 ] && extra+=(IRLUME_NO_ILLUM_META=1)
+    env IRLUME_SOCKET="$SOCK" \
+        IRLUME_STATE_DIR="$STATE" \
+        IRLUME_IR_EMITTER_CONF="$CONF" \
+        IRLUME_EMITTER_LOCK_DIR="$LOCKS" \
+        IRLUME_RGB_DEVICE="$RGB" \
+        IRLUME_IR_DEVICE="$IR" \
+        IRLUME_IR_EMITTER=off \
+        IRLUME_LOG_EMITTER_WRITES=1 \
+        IRLUME_DET_MODEL="$MODELS/face_detection_yunet_2023mar.onnx" \
+        IRLUME_MODEL="$MODELS/glintr100.onnx" \
+        IRLUME_MESH_MODEL="$MODELS/face_landmark.onnx" \
+        IRLUME_BLAZE_MODEL="$MODELS/blaze_face_short_range.onnx" \
+        ${ORT:+ORT_DYLIB_PATH="$ORT"} "${extra[@]}" \
+        "$DAEMON" >"$OUT/daemon-$tag.log" 2>&1 &
+    daemon_pid=$!
+    for _ in $(seq 1 1800); do
+        [ -S "$SOCK" ] && return 0
+        kill -0 "$daemon_pid" 2>/dev/null || {
+            tail -20 "$OUT/daemon-$tag.log"
+            return 1
+        }
+        sleep 0.1
+    done
+    echo "private daemon did not open $SOCK"
+    return 1
+}
+
+run_cli() { IRLUME_SOCKET="$SOCK" "$CLI" ir-setup "$@"; }
+records() { find "$STORE" -name '*.json' -print 2>/dev/null; }
+
+start_private probe 0 || exit 2
+run_cli --dry-run >"$OUT/dry-run.out" 2>&1
+stop_private
+sed 's/^/    /' "$OUT/dry-run.out"
+unit=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$OUT/dry-run.out" | head -1)
+
+run_transition_case() { # tag, metadata-disabled
+    local tag=$1 no_meta=$2 rc current default
+    rm -f "$CONF"
+    rm -rf "$STORE"
+    "$XU_SET" "$IR" "$unit" 6 def >"$OUT/$tag-park.out" 2>&1 || return 2
+    control_needs_restore=yes
+    default=$("$XU_SET" "$IR" "$unit" 6 get)
+    start_private "$tag" "$no_meta" || return 2
+    run_cli >"$OUT/$tag.out" 2>&1
+    rc=$?
+    stop_private
+    current=$("$XU_SET" "$IR" "$unit" 6 get)
+    sed 's/^/    /' "$OUT/$tag.out"
+
+    if [ "$rc" -eq 0 ]; then
+        grep -q "IR emitter enabled" "$OUT/$tag.out" && ok "$tag reports proven success" ||
+            bad "$tag success is explicitly labelled" "unexpected output"
+        [ -f "$CONF" ] && ok "$tag saves the proven control" ||
+            bad "$tag saves the proven control" "no $CONF"
+    elif [ "$rc" -eq 1 ] && grep -qi "inconclusive" "$OUT/$tag.out"; then
+        ok "$tag reports the typed inconclusive outcome"
+        [ ! -e "$CONF" ] && ok "$tag saves no inconclusive control" ||
+            bad "$tag saves no inconclusive control" "config exists"
+        [ "$current" = "$default" ] && ok "$tag exactly restores the original" ||
+            bad "$tag exactly restores the original" "$current != $default"
+    else
+        bad "$tag returns success or typed inconclusive" "exit $rc"
+    fi
+
+    [ -z "$(records)" ] && ok "$tag leaves no undo record" ||
+        bad "$tag leaves no undo record" "$(records)"
+    "$XU_SET" "$IR" "$unit" 6 def >"$OUT/$tag-final-restore.out" 2>&1 || return 2
+    control_needs_restore=no
+    current=$("$XU_SET" "$IR" "$unit" 6 get)
+    [ "$current" = "$default" ] && ok "$tag finishes at the device default" ||
+        bad "$tag finishes at the device default" "$current != $default"
+}
+
+case "$CLASS" in
+    transition)
+        grep -q "unit $unit (Microsoft camera control): advertises \[.*0x06" "$OUT/dry-run.out" || {
+            echo "refusing: target does not advertise Face Authentication selector 6"
+            exit 2
+        }
+        devpath=$(udevadm info -q path -n "$IR" 2>/dev/null | sed 's,/video4linux.*,,' | sed 's,/[^/]*$,,')
+        vid=$(cat "/sys$devpath/idVendor" 2>/dev/null || true)
+        pid=$(cat "/sys$devpath/idProduct" 2>/dev/null || true)
+        case "$vid:$pid" in 3277:0059|3443:c803) ;; *)
+            echo "refusing: transition parking is validated only on ASUS and NexiGo, got $vid:$pid"
+            exit 2
+        esac
+        run_transition_case metadata-present 0 || exit 2
+        run_transition_case metadata-absent 1 || exit 2
+        ;;
+    device-default)
+        [ -n "$unit" ] || { echo "refusing: no Microsoft XU"; exit 2; }
+        before=$("$XU_SET" "$IR" "$unit" 6 get)
+        for mode in metadata-present metadata-absent; do
+            disabled=0; [ "$mode" = metadata-absent ] && disabled=1
+            rm -f "$CONF"; rm -rf "$STORE"
+            start_private "$mode" "$disabled" || exit 2
+            run_cli >"$OUT/$mode.out" 2>&1; rc=$?
+            stop_private
+            sed 's/^/    /' "$OUT/$mode.out"
+            [ "$rc" -eq 0 ] && grep -q "active by device default" "$OUT/$mode.out" &&
+                ok "$mode recognizes device-default D1 without a write" ||
+                bad "$mode recognizes device-default D1 without a write" "exit $rc"
+            ! grep -q "SET_CUR unit$unit/sel6" "$OUT/daemon-$mode.log" &&
+                ok "$mode sends no Face Authentication write" ||
+                bad "$mode sends no Face Authentication write" "SET_CUR found"
+            [ ! -e "$CONF" ] && [ -z "$(records)" ] && ok "$mode persists nothing" ||
+                bad "$mode persists nothing" "config or journal exists"
+            after=$("$XU_SET" "$IR" "$unit" 6 get)
+            [ "$after" = "$before" ] && ok "$mode leaves the exact control unchanged" ||
+                bad "$mode leaves the exact control unchanged" "$after != $before"
+        done
+        ;;
+    no-xu)
+        rm -f "$CONF"; rm -rf "$STORE"
+        start_private no-xu 0 || exit 2
+        run_cli >"$OUT/no-xu.out" 2>&1; rc=$?
+        stop_private
+        sed 's/^/    /' "$OUT/no-xu.out"
+        [ "$rc" -ne 0 ] && ok "RGB-only hardware is not reported ready" ||
+            bad "RGB-only hardware is not reported ready" "exit 0"
+        ! grep -q "SET_CUR" "$OUT/daemon-no-xu.log" && ok "RGB-only hardware receives no XU write" ||
+            bad "RGB-only hardware receives no XU write" "SET_CUR found"
+        [ ! -e "$CONF" ] && [ -z "$(records)" ] && ok "RGB-only hardware persists nothing" ||
+            bad "RGB-only hardware persists nothing" "config or journal exists"
+        ;;
+esac
+
+echo
+echo "$pass passed, $fail failed"
+echo "transcripts: $OUT"
+[ "$fail" -eq 0 ]

--- a/scripts/hardware/ir-setup-evidence-hardware-test.sh
+++ b/scripts/hardware/ir-setup-evidence-hardware-test.sh
@@ -6,7 +6,8 @@
 #
 # `transition` is restricted to the ASUS 3277:0059 and NexiGo 3443:c803
 # modules already validated with a device-derived Face Authentication payload.
-# It parks selector 6 at this camera's own GET_DEF, then runs setup once with
+# It durably records selector 6's exact GET_CUR, parks the selector at this
+# camera's own GET_DEF, then runs setup once with
 # UVCM metadata enabled and once with it forcibly disabled. Success and the
 # explicit Inconclusive result are both valid functional outcomes; every result
 # is checked against its persistence, journal, read-back, and restoration rules.
@@ -29,8 +30,8 @@ DAEMON="$TREE/target/release/irlumed"
 XU_SET="$TREE/target/release/examples/xu_set"
 MODELS=${IRLUME_MODEL_DIR:-/usr/share/irlume/models}
 SOCK="/run/irlume-492-$$.sock"
-STATE=$(mktemp -d /var/lib/irlume-492.XXXXXX)
-OUT=$(mktemp -d /tmp/irlume-492-evidence.XXXXXX)
+STATE=""
+OUT=""
 CONF="$STATE/ir_emitter.conf"
 LOCKS="$STATE/locks"
 STORE="$STATE/ir-emitter-journal"
@@ -40,6 +41,10 @@ ORT=${ORT_DYLIB_PATH:-$(systemctl cat irlumed 2>/dev/null |
 daemon_pid=""
 unit=""
 control_needs_restore=no
+initial_cur=""
+initial_payload=""
+initial_identity=""
+expected_d1=""
 pass=0
 fail=0
 
@@ -55,35 +60,93 @@ stop_private() {
     rm -f "$SOCK"
 }
 
-restore_default() {
-    if [ "$control_needs_restore" = yes ] && [ -n "$unit" ] && [ -e "$IR" ]; then
-        stop_private
-        if "$XU_SET" "$IR" "$unit" 6 def >"$OUT/cleanup-restore.out" 2>&1; then
-            control_needs_restore=no
+read_cur() { # diagnostic tag
+    local tag=$1 value
+    if ! value=$("$XU_SET" "$IR" "$unit" 6 get 2>"$OUT/get-$tag.err"); then
+        echo "GET_CUR failed ($tag)" >&2
+        sed 's/^/    /' "$OUT/get-$tag.err" >&2
+        return 1
+    fi
+    if [[ ! "$value" =~ ^([0-9a-fA-F][0-9a-fA-F])+$ ]]; then
+        echo "GET_CUR returned malformed bytes ($tag): $value" >&2
+        return 1
+    fi
+    printf '%s\n' "${value,,}"
+}
+
+hex_to_payload() {
+    local value=$1 result="" byte
+    while [ -n "$value" ]; do
+        byte=${value:0:2}
+        value=${value:2}
+        result="${result:+$result,}0x$byte"
+    done
+    printf '%s\n' "$result"
+}
+
+restore_initial() {
+    local restored
+    [ "$control_needs_restore" = yes ] || return 0
+    stop_private
+    if [ -z "$unit" ] || [ -z "$initial_cur" ] || [ -z "$initial_payload" ] \
+        || [ -z "$initial_identity" ] || [ ! -e "$IR" ]; then
+        echo "cannot restore: initial control identity or camera node is unavailable" >&2
+        return 1
+    fi
+    if ! "$XU_SET" "$IR" "$unit" 6 "$initial_payload" \
+        --expect-camera "$initial_identity" >"$OUT/cleanup-restore.out" 2>&1; then
+        sed 's/^/    /' "$OUT/cleanup-restore.out" >&2
+        return 1
+    fi
+    if ! restored=$(read_cur cleanup); then
+        return 1
+    fi
+    if [ "$restored" != "$initial_cur" ]; then
+        echo "restore verification failed: $restored != $initial_cur" >&2
+        return 1
+    fi
+    control_needs_restore=no
+}
+
+cleanup() {
+    local original_status=$? cleanup_status=0
+    trap - EXIT INT TERM HUP
+    stop_private
+    if ! restore_initial; then
+        cleanup_status=1
+        echo "CRITICAL: exact control restoration failed." >&2
+        echo "Recovery state is preserved at $STATE; transcripts are at $OUT." >&2
+        echo "The packaged daemon will NOT be restarted while the camera may be altered." >&2
+    fi
+    rm -f "$SOCK"
+    if [ "$cleanup_status" -eq 0 ]; then
+        case "$STATE" in
+            /var/lib/irlume-492.*) rm -rf "$STATE" ;;
+            *) echo "refusing to remove unexpected state path $STATE" >&2; cleanup_status=1 ;;
+        esac
+    fi
+    if [ "$cleanup_status" -eq 0 ] && [ "$packaged_was_active" = active ]; then
+        if systemctl start irlumed && systemctl is-active --quiet irlumed; then
+            echo "  (packaged irlumed: active)"
         else
-            echo "  WARNING: cleanup could not restore the device default" >&2
-            sed 's/^/    /' "$OUT/cleanup-restore.out" >&2
+            echo "FAILED: packaged irlumed did not restart" >&2
+            cleanup_status=1
         fi
     fi
+    [ "$cleanup_status" -eq 0 ] || exit 1
+    exit "$original_status"
 }
-
-packaged_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
-cleanup() {
-    stop_private
-    restore_default
-    rm -f "$SOCK"
-    case "$STATE" in
-        /var/lib/irlume-492.*) rm -rf "$STATE" ;;
-        *) echo "refusing to remove unexpected state path $STATE" >&2 ;;
-    esac
-    if [ "$packaged_was_active" = active ]; then
-        systemctl start irlumed 2>/dev/null || true
-        echo "  (packaged irlumed: $(systemctl is-active irlumed 2>/dev/null || true))"
-    fi
-}
-trap cleanup EXIT
 
 [ "$(id -u)" -eq 0 ] || { echo "refusing: physical camera gate requires root"; exit 2; }
+STATE=$(mktemp -d /var/lib/irlume-492.XXXXXX) || exit 2
+OUT=$(mktemp -d /tmp/irlume-492-evidence.XXXXXX) || exit 2
+CONF="$STATE/ir_emitter.conf"
+LOCKS="$STATE/locks"
+STORE="$STATE/ir-emitter-journal"
+packaged_was_active=$(systemctl is-active irlumed 2>/dev/null || true)
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
 [ -x "$CLI" ] && [ -x "$DAEMON" ] && [ -x "$XU_SET" ] || {
     echo "refusing: release irlume, irlumed, or xu_set is missing under $TREE/target/release"
     exit 2
@@ -95,7 +158,14 @@ mkdir -p "$LOCKS"
 if [ -d /var/lib/irlume/models-thirdparty ]; then
     ln -s /var/lib/irlume/models-thirdparty "$STATE/models-thirdparty"
 fi
-systemctl stop irlumed 2>/dev/null || true
+if ! systemctl stop irlumed; then
+    echo "refusing: failed to stop packaged irlumed"
+    exit 2
+fi
+if systemctl is-active --quiet irlumed; then
+    echo "refusing: packaged irlumed is still active"
+    exit 2
+fi
 
 start_private() { # tag, metadata-disabled(0|1)
     local tag=$1 no_meta=$2
@@ -118,7 +188,10 @@ start_private() { # tag, metadata-disabled(0|1)
         "$DAEMON" >"$OUT/daemon-$tag.log" 2>&1 &
     daemon_pid=$!
     for _ in $(seq 1 1800); do
-        [ -S "$SOCK" ] && return 0
+        if [ -S "$SOCK" ] \
+            && IRLUME_SOCKET="$SOCK" "$CLI" ir-setup --dry-run >/dev/null 2>&1; then
+            return 0
+        fi
         kill -0 "$daemon_pid" 2>/dev/null || {
             tail -20 "$OUT/daemon-$tag.log"
             return 1
@@ -139,62 +212,100 @@ sed 's/^/    /' "$OUT/dry-run.out"
 unit=$(sed -n 's/.*unit \([0-9]*\) (Microsoft camera control).*/\1/p' "$OUT/dry-run.out" | head -1)
 
 run_transition_case() { # tag, metadata-disabled
-    local tag=$1 no_meta=$2 rc current default
+    local tag=$1 no_meta=$2 rc current parked_default
     rm -f "$CONF"
     rm -rf "$STORE"
-    "$XU_SET" "$IR" "$unit" 6 def >"$OUT/$tag-park.out" 2>&1 || return 2
     control_needs_restore=yes
-    default=$("$XU_SET" "$IR" "$unit" 6 get)
+    "$XU_SET" "$IR" "$unit" 6 def --expect-camera "$initial_identity" \
+        >"$OUT/$tag-park.out" 2>&1 || return 2
+    if ! parked_default=$(read_cur "$tag-parked"); then return 2; fi
     start_private "$tag" "$no_meta" || return 2
     run_cli >"$OUT/$tag.out" 2>&1
     rc=$?
     stop_private
-    current=$("$XU_SET" "$IR" "$unit" 6 get)
+    if ! current=$(read_cur "$tag-result"); then return 2; fi
     sed 's/^/    /' "$OUT/$tag.out"
 
     if [ "$rc" -eq 0 ]; then
         grep -q "IR emitter enabled" "$OUT/$tag.out" && ok "$tag reports proven success" ||
             bad "$tag success is explicitly labelled" "unexpected output"
-        [ -f "$CONF" ] && ok "$tag saves the proven control" ||
-            bad "$tag saves the proven control" "no $CONF"
+        [ "$(sed -n '1p' "$CONF" 2>/dev/null)" = "$vid:$pid $unit:6" ] \
+            && ok "$tag saves the proven control for this camera" ||
+            bad "$tag saves the proven control for this camera" "unexpected or absent $CONF"
+        [ "$current" = "$expected_d1" ] && ok "$tag leaves exactly the proven D1 value applied" ||
+            bad "$tag leaves exactly the proven D1 value applied" "$current != $expected_d1"
     elif [ "$rc" -eq 1 ] && grep -qi "inconclusive" "$OUT/$tag.out"; then
         ok "$tag reports the typed inconclusive outcome"
         [ ! -e "$CONF" ] && ok "$tag saves no inconclusive control" ||
             bad "$tag saves no inconclusive control" "config exists"
-        [ "$current" = "$default" ] && ok "$tag exactly restores the original" ||
-            bad "$tag exactly restores the original" "$current != $default"
+        [ "$current" = "$parked_default" ] && ok "$tag exactly restores the parked value" ||
+            bad "$tag exactly restores the parked value" "$current != $parked_default"
     else
         bad "$tag returns success or typed inconclusive" "exit $rc"
     fi
 
     [ -z "$(records)" ] && ok "$tag leaves no undo record" ||
         bad "$tag leaves no undo record" "$(records)"
-    "$XU_SET" "$IR" "$unit" 6 def >"$OUT/$tag-final-restore.out" 2>&1 || return 2
-    control_needs_restore=no
-    current=$("$XU_SET" "$IR" "$unit" 6 get)
-    [ "$current" = "$default" ] && ok "$tag finishes at the device default" ||
-        bad "$tag finishes at the device default" "$current != $default"
 }
 
 case "$CLASS" in
     transition)
-        grep -q "unit $unit (Microsoft camera control): advertises \[.*0x06" "$OUT/dry-run.out" || {
-            echo "refusing: target does not advertise Face Authentication selector 6"
+        if ! snapshot=$("$XU_SET" "$IR" "$unit" 6 snapshot 2>"$OUT/get-initial.err"); then
+            echo "refusing: could not atomically capture camera identity and GET_CUR"
+            sed 's/^/    /' "$OUT/get-initial.err" >&2
             exit 2
-        }
-        devpath=$(udevadm info -q path -n "$IR" 2>/dev/null | sed 's,/video4linux.*,,' | sed 's,/[^/]*$,,')
-        vid=$(cat "/sys$devpath/idVendor" 2>/dev/null || true)
-        pid=$(cat "/sys$devpath/idProduct" 2>/dev/null || true)
-        case "$vid:$pid" in 3277:0059|3443:c803) ;; *)
-            echo "refusing: transition parking is validated only on ASUS and NexiGo, got $vid:$pid"
+        fi
+        snapshot_extra=""
+        read -r initial_identity snapshot_usb_id snapshot_interface snapshot_unit \
+            snapshot_selector initial_cur snapshot_extra <<<"$snapshot"
+        if [[ ! "$initial_identity" =~ ^[0-9a-f]{64}$ ]] \
+            || [[ ! "$snapshot_usb_id" =~ ^[0-9a-f]{4}:[0-9a-f]{4}$ ]] \
+            || [[ ! "$snapshot_interface" =~ ^[0-9]+$ ]] \
+            || [[ ! "$snapshot_unit" =~ ^[0-9]+$ ]] \
+            || [ "$snapshot_selector" != 6 ] \
+            || [[ ! "$initial_cur" =~ ^([0-9a-f][0-9a-f])+$ ]] \
+            || [ -n "$snapshot_extra" ]; then
+            echo "refusing: malformed camera snapshot: $snapshot"
             exit 2
+        fi
+        case "$snapshot_usb_id" in
+            3277:0059) expected_unit=14 ;;
+            3443:c803) expected_unit=4 ;;
+            *)
+                echo "refusing: transition parking is validated only on ASUS and NexiGo, got $snapshot_usb_id"
+                exit 2
+                ;;
         esac
+        if [ "$snapshot_unit" != "$expected_unit" ]; then
+            echo "refusing: $snapshot_usb_id reported unexpected Microsoft unit $snapshot_unit"
+            exit 2
+        fi
+        unit=$snapshot_unit
+        vid=${snapshot_usb_id%:*}
+        pid=${snapshot_usb_id#*:}
+        expected_d1=010302000000000000
+        initial_payload=$(hex_to_payload "$initial_cur")
+        recovery="$STATE/pretest-control"
+        {
+            printf 'device=%s\n' "$IR"
+            printf 'usb_id=%s\ninterface=%s\n' "$snapshot_usb_id" "$snapshot_interface"
+            printf 'unit=%s\nselector=%s\n' "$unit" "$snapshot_selector"
+            printf 'initial_cur=%s\n' "$initial_cur"
+            printf 'camera_identity=%s\n' "$initial_identity"
+            printf 'restore_payload=%s\n' "$initial_payload"
+            printf 'transcripts=%s\n' "$OUT"
+        } >"$recovery"
+        chmod 600 "$recovery"
+        if ! sync -f "$recovery" || ! sync -f "$STATE"; then
+            echo "refusing: could not durably record the pre-test control"
+            exit 2
+        fi
         run_transition_case metadata-present 0 || exit 2
         run_transition_case metadata-absent 1 || exit 2
         ;;
     device-default)
         [ -n "$unit" ] || { echo "refusing: no Microsoft XU"; exit 2; }
-        before=$("$XU_SET" "$IR" "$unit" 6 get)
+        if ! before=$(read_cur device-default-before); then exit 2; fi
         for mode in metadata-present metadata-absent; do
             disabled=0; [ "$mode" = metadata-absent ] && disabled=1
             rm -f "$CONF"; rm -rf "$STORE"
@@ -210,7 +321,7 @@ case "$CLASS" in
                 bad "$mode sends no Face Authentication write" "SET_CUR found"
             [ ! -e "$CONF" ] && [ -z "$(records)" ] && ok "$mode persists nothing" ||
                 bad "$mode persists nothing" "config or journal exists"
-            after=$("$XU_SET" "$IR" "$unit" 6 get)
+            if ! after=$(read_cur "$mode-after"); then exit 2; fi
             [ "$after" = "$before" ] && ok "$mode leaves the exact control unchanged" ||
                 bad "$mode leaves the exact control unchanged" "$after != $before"
         done


### PR DESCRIPTION
## Summary

- add a typed Inconclusive discovery outcome: exit 1, save no configuration, verify exact restoration, and explicitly avoid calling the control unsupported or unusable
- verify Face Authentication D1 from frame-illumination metadata when available; otherwise require robust alternating-frame optical evidence that appears only while the control is active
- make metadata and optical evidence sequence-aware, gap-bounded, and tri-state so weak or discontinuous observations cannot become affirmative proof
- add a fail-closed physical gate with an atomic camera/CUR snapshot, durable exact recovery record, same-fd identity checks before every direct SET, and no daemon restart after failed restoration
- record the standards/Linux analysis and the complete four-device acceptance matrix

## Verification

- host-environment workspace gate: 1,724 passed
- camera crate: 514 passed, 22 declared hardware-only ignores; 13 contract tests passed
- emitter-focused suite: 122 passed
- xu_set identity/snapshot tests: 2 passed
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- bash -n hardware harness

## Physical matrix

- ASUS 3277:0059 transition: 8/8; metadata proves D1, metadata-disabled is typed Inconclusive; exact D0 restored
- Logitech BRIO 046d:085e device default: 8/8; no SET, no persistence, exact D1 unchanged
- NexiGo 3443:c803 transition: 8/8; metadata proves D1, metadata-disabled is typed Inconclusive; exact D0 restored
- ThinkPad Integrated Camera no usable emitter XU: 3/3; no XU write and no persistence
- packaged daemon active and no recovery residue on every host after the audit

Closes #492