### PR TITLE
fix(cli): report both TPM seals in diag (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **`irlume diag` reports the keyring and face-template seals separately.** A
+  healthy keyring credential envelope can no longer hide a missing, unreadable,
+  or PCR-drifted template-key envelope behind one generic seal status; each row
+  now names the secret it protects and gives its own recovery action (#472).
 - **CUDA and OpenVINO feature builds compile against pinned `ort` rc.13 again.**
   The dependency update removed deprecated execution-provider aliases while these
   two optional paths still referenced them. CI now compiles every supported ONNX

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -995,9 +995,75 @@ pub fn identify(_args: &[String]) -> ExitCode {
     }
 }
 
+/// Print one root-readable TPM seal and its PCR-drift diagnosis. Missing and
+/// permission-denied paths return false so the caller can use a daemon summary;
+/// malformed or other unreadable files are reported here and return true.
+fn print_seal_diagnostics(
+    label: &str,
+    path: &std::path::Path,
+    healthy: &str,
+    drift_fix: &str,
+    corrupt_fix: &str,
+) -> bool {
+    let serialized = match std::fs::read_to_string(path) {
+        Ok(serialized) => serialized,
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            return false;
+        }
+        Err(error) => {
+            println!(
+                "  {label:<14}: UNREADABLE {NO} (I/O error {:?}; seal health is unknown)",
+                error.kind()
+            );
+            return true;
+        }
+    };
+    let env = match serde_json::from_str::<irlume_core::envelope::SealedEnvelope>(&serialized) {
+        Ok(env) => env,
+        Err(_) => {
+            println!("  {label:<14}: CORRUPT {NO} (envelope JSON is malformed; {corrupt_fix})");
+            return true;
+        }
+    };
+    println!("  {label:<14}: {} {OK}", path.display());
+    println!(
+        "    policy      : {}, bound PCRs {:?}",
+        env.policy.describe(),
+        env.pcrs
+    );
+    if env.pcr_values.is_empty() {
+        println!(
+            "    PCR drift   : unknown {WARN} (envelope has no recorded PCR snapshot; unseal was not tested)"
+        );
+        return true;
+    }
+    match irlume_core::tpm::diagnose_pcrs(&env) {
+        Ok(drifted) if drifted.is_empty() => {
+            println!("    PCR drift   : none {OK} ({healthy})");
+        }
+        Ok(drifted) => {
+            println!(
+                "    PCR drift   : DRIFTED at {drifted:?} {WARN}; unseal will FAIL; {drift_fix}"
+            );
+        }
+        Err(error) => {
+            println!(
+                "    PCR drift   : could not replay PCRs ({error}); need TPM access (tss group / root)"
+            );
+        }
+    }
+    true
+}
+
 /// `irlume diag`: TPM seal / PCR-drift diagnostics (the dbx/firmware debugger).
-/// Needs root + TPM access to read the root-only envelope and replay PCRs; falls
-/// back to a daemon-only summary otherwise.
+/// The keyring credential and face-template key are independent seals and are
+/// always reported separately. Needs root + TPM access to read their root-only
+/// envelopes and replay PCRs; falls back to daemon summaries otherwise.
 pub fn diag(args: &[String]) -> ExitCode {
     use irlume_common::secureboot;
     let user = user_arg(args);
@@ -1038,28 +1104,73 @@ pub fn diag(args: &[String]) -> ExitCode {
         ),
     }
 
-    // Keyring envelope: policy kind, bound PCRs, drift (root + TPM only).
-    let path = irlume_core::keyring::envelope_path(&user);
-    match irlume_core::envelope::SealedEnvelope::load(&path) {
-        Ok(env) => {
-            let kind = env.policy.describe();
-            println!("  seal envelope : {} {OK}", path.display());
-            println!("  seal policy   : {kind}, bound PCRs {:?}", env.pcrs);
-            match irlume_core::tpm::diagnose_pcrs(&env) {
-                Ok(d) if d.is_empty() => println!("  PCR drift     : none {OK} (the seal still satisfies; face unlock will release the password)"),
-                Ok(d) => println!("  PCR drift     : DRIFTED at {d:?} {WARN}; unseal will FAIL until you `irlume keyring arm` (or `irlume recovery restore`)"),
-                Err(e) => println!("  PCR drift     : could not replay PCRs ({e}); need TPM access (tss group / root)"),
+    // These envelopes protect different things and can drift independently. A
+    // healthy keyring seal says nothing about the template key that face auth
+    // must unseal, which is the misleading single-row diagnosis #472 exposed.
+    let keyring_path = irlume_core::keyring::envelope_path(&user);
+    if !print_seal_diagnostics(
+        "keyring seal",
+        &keyring_path,
+        "the keyring credential can unseal",
+        "run `irlume keyring arm` or log in with the typed password to recover and re-bind it",
+        "preserve the file and do not force-forget it",
+    ) {
+        match daemon_request(&Request::HasSealedPassword { user: user.clone() }) {
+            Ok(Response::HasPassword(true)) => println!(
+                "  keyring seal  : armed, but not readable here; run `sudo irlume diag` for PCR-drift detail"
+            ),
+            Ok(Response::HasPassword(false)) => {
+                println!("  keyring seal  : not armed (run `irlume keyring arm`)")
             }
+            Ok(_) => println!(
+                "  keyring seal  : unknown (daemon returned an unexpected response)"
+            ),
+            Err(_) => println!("  keyring seal  : unknown (daemon unreachable)"),
         }
-        Err(_) => {
-            // No readable envelope: either not armed, or not root.
-            match daemon_request(&Request::HasSealedPassword { user: user.clone() }) {
-                Ok(Response::HasPassword(true)) =>
-                    println!("  seal envelope : armed, but not readable here; run `sudo irlume diag` for PCR-drift detail"),
-                Ok(Response::HasPassword(false)) =>
-                    println!("  seal envelope : not armed (run `irlume keyring arm`)"),
-                _ => println!("  seal envelope : unknown (daemon unreachable)"),
-            }
+    }
+
+    let template_path = irlume_core::template_key::key_path(&user);
+    if !print_seal_diagnostics(
+        "template seal",
+        &template_path,
+        "the face-template key can unseal",
+        "run `irlume recovery restore`; without a recovery passphrase, re-enroll",
+        "preserve the file; run `irlume recovery restore` if a recovery passphrase was set, otherwise re-enroll",
+    ) {
+        match daemon_request(&Request::RecoveryStatus { user: user.clone() }) {
+            Ok(Response::RecoveryStatus {
+                encrypted: true,
+                key_present: false,
+                recovery_set: true,
+                ..
+            }) => println!(
+                "  template seal : MISSING {WARN} (recoverable: run `irlume recovery restore`)"
+            ),
+            Ok(Response::RecoveryStatus {
+                encrypted: true,
+                key_present: false,
+                recovery_set: false,
+                ..
+            }) => println!(
+                "  template seal : MISSING {NO} (encrypted templates cannot be opened; re-enroll)"
+            ),
+            Ok(Response::RecoveryStatus {
+                encrypted: true,
+                recovery_set,
+                ..
+            }) => println!(
+                "  template seal : sealed, but not readable here; recovery passphrase {}; run `sudo irlume diag` for PCR-drift detail",
+                if recovery_set { "set" } else { "NOT SET" }
+            ),
+            Ok(Response::RecoveryStatus {
+                encrypted: false, ..
+            }) => println!(
+                "  template seal : not present (templates are plaintext at rest)"
+            ),
+            Ok(_) => println!(
+                "  template seal : unknown (daemon returned an unexpected response)"
+            ),
+            Err(_) => println!("  template seal : unknown (daemon unreachable)"),
         }
     }
     ExitCode::SUCCESS

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -762,9 +762,15 @@ fn diag_falls_back_to_the_daemon_summary_and_reports_unknown() {
     let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]));
     assert_eq!(code, 0);
     assert!(out.contains("irlume diag for 'tester'"), "{out}");
-    // No envelope in the sandboxed keyring dir + dead socket:
+    // Neither envelope exists in the sandbox + dead socket. They must stay
+    // distinct: a generic seal summary can hide the broken template key behind
+    // a healthy keyring credential (#472).
     assert!(
-        out.contains("seal envelope : unknown (daemon unreachable)"),
+        out.contains("keyring seal  : unknown (daemon unreachable)"),
+        "{out}"
+    );
+    assert!(
+        out.contains("template seal : unknown (daemon unreachable)"),
         "{out}"
     );
 }

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -207,6 +207,23 @@ fn one_profile() -> Vec<ProfileSummary> {
     }]
 }
 
+fn write_test_seal_without_pcr_snapshot(path: &Path) {
+    use irlume_core::envelope::{PolicyKind, SealedEnvelope, SecretKind, CURRENT_VERSION};
+
+    std::fs::create_dir_all(path.parent().expect("test seal has a parent")).unwrap();
+    let envelope = SealedEnvelope {
+        version: CURRENT_VERSION,
+        policy: PolicyKind::PcrLiteral,
+        secret: SecretKind::LoginPassword,
+        pcrs: vec![7],
+        public: vec![1, 2, 3],
+        private: vec![4, 5, 6],
+        pcr_values: Vec::new(),
+        password_wrap: None,
+    };
+    std::fs::write(path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+}
+
 // ---------------------------------------------------------------- status arms
 
 // status renders one arm per daemon answer; cli.rs pins the all-green dashboard,
@@ -421,26 +438,218 @@ fn identify_no_live_face_and_daemon_error() {
 
 // ------------------------------------------------------------------- diag arms
 
-// With no readable envelope in the sandbox keyring dir but a reachable daemon,
-// diag reports the sealed state from HasSealedPassword: armed-but-unreadable,
-// and not-armed. cli.rs only reaches the dead-socket "unknown" arm.
+// With neither root-only envelope readable in the sandbox but a reachable
+// daemon, diag must name the keyring and template-key seals independently.
+// Collapsing them back into one generic "seal envelope" row recreates #472:
+// a healthy keyring seal can hide the broken template seal that face auth uses.
 #[test]
-fn diag_reports_sealed_state_from_daemon_when_envelope_unreadable() {
+fn diag_reports_both_seals_from_daemon_when_envelopes_are_unreadable() {
     let sb = Sandbox::new("diagarmed");
-    serve(&sb.sock(), |_| Response::HasPassword(true));
+    serve(&sb.sock(), |request| match request {
+        Request::HasSealedPassword { .. } => Response::HasPassword(true),
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: true,
+            tpm_present: true,
+            key_present: true,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
     let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]), "diag");
     assert_eq!(code, 0);
     assert!(out.contains("irlume diag for 'tester'"), "{out}");
     assert!(
-        out.contains("seal envelope : armed, but not readable here"),
+        out.contains("keyring seal  : armed, but not readable here"),
+        "{out}"
+    );
+    assert!(
+        out.contains("template seal : sealed, but not readable here"),
         "{out}"
     );
 
     let sb2 = Sandbox::new("diagunarmed");
-    serve(&sb2.sock(), |_| Response::HasPassword(false));
+    serve(&sb2.sock(), |request| match request {
+        Request::HasSealedPassword { .. } => Response::HasPassword(false),
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: false,
+            recovery_set: false,
+            tpm_present: true,
+            key_present: false,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
     let (code, out, _) = run(&mut sb2.cmd(&["diag", "--user", "tester"]), "diag");
     assert_eq!(code, 0);
-    assert!(out.contains("seal envelope : not armed"), "{out}");
+    assert!(out.contains("keyring seal  : not armed"), "{out}");
+    assert!(
+        out.contains("template seal : not present (templates are plaintext at rest)"),
+        "{out}"
+    );
+}
+
+#[test]
+fn diag_reports_keyring_and_template_states_independently() {
+    let armed_keyring = Sandbox::new("diag-keyring-only");
+    serve(&armed_keyring.sock(), |request| match request {
+        Request::HasSealedPassword { .. } => Response::HasPassword(true),
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: false,
+            tpm_present: true,
+            key_present: false,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+    let (code, out, _) = run(
+        &mut armed_keyring.cmd(&["diag", "--user", "tester"]),
+        "diag",
+    );
+    assert_eq!(code, 0);
+    assert!(out.contains("keyring seal  : armed"), "{out}");
+    assert!(out.contains("template seal : MISSING ✗"), "{out}");
+
+    let sealed_template = Sandbox::new("diag-template-only");
+    serve(&sealed_template.sock(), |request| match request {
+        Request::HasSealedPassword { .. } => Response::HasPassword(false),
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: true,
+            tpm_present: true,
+            key_present: true,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+    let (code, out, _) = run(
+        &mut sealed_template.cmd(&["diag", "--user", "tester"]),
+        "diag",
+    );
+    assert_eq!(code, 0);
+    assert!(out.contains("keyring seal  : not armed"), "{out}");
+    assert!(
+        out.contains("template seal : sealed, but not readable here"),
+        "{out}"
+    );
+}
+
+#[test]
+fn diag_does_not_call_a_seal_healthy_without_a_recorded_pcr_snapshot() {
+    let sb = Sandbox::new("diag-no-pcr-snapshot");
+    write_test_seal_without_pcr_snapshot(&sb.path("keyring/tester.json"));
+    write_test_seal_without_pcr_snapshot(&sb.path("state/template-keys/tester.json"));
+
+    let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]), "diag");
+
+    assert_eq!(code, 0);
+    assert!(out.contains("keyring seal  :"), "{out}");
+    assert!(out.contains("template seal :"), "{out}");
+    assert_eq!(
+        out.matches(
+            "PCR drift   : unknown ⚠ (envelope has no recorded PCR snapshot; unseal was not tested)"
+        )
+        .count(),
+        2,
+        "{out}"
+    );
+    assert!(!out.contains("can unseal"), "{out}");
+}
+
+#[test]
+fn diag_reports_malformed_envelopes_as_corrupt_instead_of_falling_back() {
+    let sb = Sandbox::new("diag-corrupt-envelopes");
+    std::fs::write(sb.path("keyring/tester.json"), b"{not-json").unwrap();
+    std::fs::create_dir_all(sb.path("state/template-keys")).unwrap();
+    std::fs::write(
+        sb.path("state/template-keys/tester.json"),
+        b"{also-not-json",
+    )
+    .unwrap();
+
+    let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]), "diag");
+
+    assert_eq!(code, 0);
+    assert!(
+        out.contains(
+            "keyring seal  : CORRUPT ✗ (envelope JSON is malformed; preserve the file and do not force-forget it)"
+        ),
+        "{out}"
+    );
+    assert!(
+        out.contains(
+            "template seal : CORRUPT ✗ (envelope JSON is malformed; preserve the file; run `irlume recovery restore` if a recovery passphrase was set, otherwise re-enroll)"
+        ),
+        "{out}"
+    );
+    assert!(!out.contains("daemon unreachable"), "{out}");
+}
+
+#[test]
+fn diag_reports_an_encrypted_store_with_no_template_key_as_unrecoverable() {
+    let sb = Sandbox::new("diag-missing-template-key");
+    serve(&sb.sock(), |request| match request {
+        Request::HasSealedPassword { .. } => Response::HasPassword(false),
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: false,
+            tpm_present: true,
+            key_present: false,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]), "diag");
+
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("template seal : MISSING ✗ (encrypted templates cannot be opened; re-enroll)"),
+        "{out}"
+    );
+    assert!(
+        !out.contains("template seal : sealed, but not readable here"),
+        "{out}"
+    );
+}
+
+#[test]
+fn diag_reports_a_missing_template_key_as_recoverable_when_a_recovery_wrap_exists() {
+    let sb = Sandbox::new("diag-recoverable-template-key");
+    serve(&sb.sock(), |request| match request {
+        Request::HasSealedPassword { .. } => Response::HasPassword(false),
+        Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+            encrypted: true,
+            recovery_set: true,
+            tpm_present: true,
+            key_present: false,
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]), "diag");
+
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("template seal : MISSING ⚠ (recoverable: run `irlume recovery restore`)"),
+        "{out}"
+    );
+    assert!(!out.contains("re-enroll"), "{out}");
+}
+
+#[test]
+fn diag_does_not_call_a_reachable_daemon_unreachable_when_its_reply_is_unexpected() {
+    let sb = Sandbox::new("diag-unexpected-reply");
+    serve(&sb.sock(), |_| Response::Pong);
+
+    let (code, out, _) = run(&mut sb.cmd(&["diag", "--user", "tester"]), "diag");
+
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("keyring seal  : unknown (daemon returned an unexpected response)"),
+        "{out}"
+    );
+    assert!(
+        out.contains("template seal : unknown (daemon returned an unexpected response)"),
+        "{out}"
+    );
+    assert!(!out.contains("daemon unreachable"), "{out}");
 }
 
 // ---------------------------------------------------------------- selinux load

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -47,7 +47,7 @@ Conventions that apply everywhere:
 | `irlume keyring <arm\|status\|forget>` | TPM-sealed secret so a login also unlocks the wallet/keyring. What is sealed depends on the backend: the login password, the KDE wallet key, or a random token this re-keys a GNOME keyring to. `status` names which; `forget` re-keys a token back and takes `--force` to skip that |
 | `irlume reseal` | re-bind the sealed secret to the current PCRs after a firmware or kernel update; prompts for the password, safe to re-run. A GNOME keyring token re-binds itself on the next password login, so this reports that and does nothing |
 | `irlume recovery <status\|setup\|restore\|forget>` | recovery passphrase + profile encryption |
-| `irlume diag` | TPM seal + PCR-drift diagnostics; run with `sudo` for full detail |
+| `irlume diag` | Separate keyring-credential and face-template-key seal/PCR-drift diagnostics; run with `sudo` for full detail |
 
 ## System integration
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -130,7 +130,7 @@ release are identical.
 ```sh
 irlume doctor          # platform, TPM, Secure Boot, cameras, models, install origin
 irlume login status    # per-service wiring + face trigger mode (on-demand / face-first)
-irlume diag            # TPM seal + PCR drift (sudo for detail)
+irlume diag            # both TPM seals + PCR drift (sudo for detail)
 irlume status          # daemon + enrollment state
 ```
 


### PR DESCRIPTION
## Summary

- report the keyring-credential and face-template-key TPM seals independently in `irlume diag`
- distinguish missing, permission-limited, malformed, legacy-without-PCR-snapshot, drifted, and healthy states without overclaiming
- give recovery guidance specific to the affected secret
- preserve the existing random GNOME token design, whose password wrap recovers the same token after seal loss

## Why

#472 showed that the old single `seal envelope` row could declare health for the keyring envelope while the template-key envelope that face authentication needs was broken. It also raised the broader concern that a random GNOME token was unrecoverable after TPM seal loss. The implementation already keeps a password-wrapped copy and the real-TPM regression tests confirm it recovers and re-seals the same token.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --quiet`
- `keyring::tests::rearming_reuses_the_existing_token_rather_than_minting` on TPM
- `keyring::tests::a_token_envelope_heals_from_whichever_half_survives` on TPM
- live root `irlume diag --user wisbfime`: both pcrlock Tier-2 envelopes reported independently with no PCR drift
- independent code review: no remaining findings

## Four-device hardware regression

| Device | Real-TPM token recovery | Live `irlume diag` result |
|---|---|---|
| Zenbook | both recovery tests pass | keyring Tier 2 and template Tier 2 reported separately; no drift |
| archhost | both recovery tests pass | keyring Tier 2 and template Tier 1 reported separately; no drift |
| ThinkPad X13 Yoga | both recovery tests pass under root | keyring Tier 2 and template Tier 2 reported separately; no drift |
| minihost | both recovery tests pass | correctly reports keyring not armed and templates plaintext |

The ESYS load errors printed by the recovery tests are expected: each test deliberately damages a test-only sealed blob to prove recovery uses the password wrap and preserves the original token.

Closes #472
