### PR TITLE
fix(camera): fail closed on live IR privacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
           # harness-owned nodes (see THREAT_MODEL.md).
           IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9,/dev/video10
         run: |
-          ./scripts/run-tests-guarded.sh --min 17 -- cargo test -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
+          ./scripts/run-tests-guarded.sh --min 19 -- cargo test -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 7 -- cargo test -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 5 -- cargo test -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 1 -- cargo test -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
           # harness-owned nodes (see THREAT_MODEL.md).
           IRLUME_TEST_ALLOW_VIRTUAL_CAMERA: /dev/video8,/dev/video9,/dev/video10
         run: |
-          ./scripts/run-tests-guarded.sh --min 15 -- cargo test -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
+          ./scripts/run-tests-guarded.sh --min 17 -- cargo test -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 7 -- cargo test -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 5 -- cargo test -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 1 -- cargo test -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1520,6 +1520,36 @@ fn foreign_consumers(proc_root: &std::path::Path, dev: &str, self_pid: u32) -> C
     scan
 }
 
+fn apply_capture_action_guarded(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    action: CaptureAction,
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<(Option<CaptureWrite>, Vec<u8>), String> {
+    match action {
+        CaptureAction::Nothing => Ok((None, Vec::new())),
+        CaptureAction::Override(ctrl) => {
+            let payload = ctrl.payload.clone();
+            apply_override_guarded(fd, id, &ctrl, before_forward_write)
+                .map(|write| (Some(write), payload))
+        }
+        CaptureAction::DeviceDefault { unit, selector } => {
+            match apply_device_default_guarded(fd, id, unit, selector, before_forward_write) {
+                Ok((write, sent)) => Ok((Some(write), sent)),
+                Err(GuardedApplyError::Apply(_)) => Ok((None, Vec::new())),
+                Err(GuardedApplyError::Guard(why)) => Err(why),
+            }
+        }
+        CaptureAction::KnownPayload(ctrl) => {
+            match apply_known_payload_guarded(fd, id, &ctrl, before_forward_write) {
+                Ok(write) => Ok((Some(write), ctrl.payload)),
+                Err(GuardedApplyError::Apply(_)) => Ok((None, Vec::new())),
+                Err(GuardedApplyError::Guard(why)) => Err(why),
+            }
+        }
+    }
+}
+
 /// Light the emitter on the open `fd` for `device`, if a control is configured.
 /// Returns whether a `SET_CUR` succeeded. Best-effort.
 ///
@@ -1699,35 +1729,7 @@ fn enable_guarded(
     // user about their infrared. A control that already held the wanted value
     // is active and not irlume's to undo, and collapsing the pair reported it
     // dark.
-    let (write, applied) = match action {
-        CaptureAction::Nothing => (None, Vec::new()),
-        CaptureAction::Override(ctrl) => {
-            let payload = ctrl.payload.clone();
-            (
-                Some(apply_override_guarded(
-                    fd,
-                    &id,
-                    &ctrl,
-                    before_forward_write,
-                )?),
-                payload,
-            )
-        }
-        CaptureAction::DeviceDefault { unit, selector } => {
-            match apply_device_default_guarded(fd, &id, unit, selector, before_forward_write) {
-                Ok((w, sent)) => (Some(w), sent),
-                Err(GuardedApplyError::Apply(_)) => (None, Vec::new()),
-                Err(GuardedApplyError::Guard(why)) => return Err(why),
-            }
-        }
-        CaptureAction::KnownPayload(ctrl) => {
-            match apply_known_payload_guarded(fd, &id, &ctrl, before_forward_write) {
-                Ok(w) => (Some(w), ctrl.payload),
-                Err(GuardedApplyError::Apply(_)) => (None, Vec::new()),
-                Err(GuardedApplyError::Guard(why)) => return Err(why),
-            }
-        }
-    };
+    let (write, applied) = apply_capture_action_guarded(fd, &id, action, before_forward_write)?;
     let active = write
         .as_ref()
         .is_some_and(|w| w.outcome != Applied::Nothing);
@@ -8434,6 +8436,47 @@ mod tests {
                 .any(|request| matches!(request, fake_camera::Request::Set(_))),
             "the degraded unrecorded path still sends nothing"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn every_capture_action_arm_propagates_the_late_guard_refusal() {
+        use std::os::fd::AsRawFd as _;
+
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "irlume-capture-action-guard-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let file = std::fs::File::open("/dev/null").expect("stable fake fd");
+        let id = identity(0x3277, 0x0059);
+        let control = || ctrl(14, 6, vec![1, 3, 2]);
+        let actions = [
+            CaptureAction::Override(control()),
+            CaptureAction::DeviceDefault {
+                unit: 14,
+                selector: 6,
+            },
+            CaptureAction::KnownPayload(control()),
+        ];
+
+        for action in actions {
+            let _fake = fake_camera::install(a_working_camera());
+            let error = apply_capture_action_guarded(file.as_raw_fd(), &id, action, &mut || {
+                Err("late privacy refusal".into())
+            })
+            .expect_err("every forward-write action must propagate the guard");
+            assert!(error.contains("privacy refusal"), "{error}");
+            assert!(
+                !fake_camera::log()
+                    .iter()
+                    .any(|request| matches!(request, fake_camera::Request::Set(_))),
+                "no action arm may degrade the refusal into best-effort apply"
+            );
+        }
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2155,6 +2155,38 @@ impl EmitterBackend for InertBackend {
     fn attach_lease(&mut self, _lease: crate::lease::CameraLease) {}
 }
 
+#[cfg(test)]
+struct SentinelBackend {
+    events: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    lit: bool,
+    owns_restore: bool,
+}
+
+#[cfg(test)]
+impl EmitterBackend for SentinelBackend {
+    fn lit(&self) -> bool {
+        self.lit
+    }
+
+    fn owns_restore(&self) -> bool {
+        self.owns_restore
+    }
+
+    fn restore(&mut self) -> std::result::Result<(), RestoreError> {
+        if self.owns_restore {
+            self.events
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push("emitter-restore");
+            self.owns_restore = false;
+            self.lit = false;
+        }
+        Ok(())
+    }
+
+    fn attach_lease(&mut self, _lease: crate::lease::CameraLease) {}
+}
+
 /// The face-auth emitter guard, held for the lifetime of ONE stream and put
 /// back when the stream ends. Backend-agnostic: it wraps an `EmitterBackend`,
 /// so the UVC extension-unit write and a future LED-class or V4L2-control
@@ -2176,6 +2208,17 @@ impl StreamMode {
     /// A guard over nothing: no control was applied, so `Drop` writes nothing.
     pub(crate) fn inert() -> Self {
         StreamMode::new(Box::new(InertBackend))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_sentinel(
+        events: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    ) -> Self {
+        StreamMode::new(Box::new(SentinelBackend {
+            events,
+            lit: true,
+            owns_restore: true,
+        }))
     }
 
     /// Whether the emitter control is active for this stream, whoever set it.

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2160,6 +2160,7 @@ struct SentinelBackend {
     events: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
     lit: bool,
     owns_restore: bool,
+    restore_failure: Option<String>,
 }
 
 #[cfg(test)]
@@ -2180,6 +2181,9 @@ impl EmitterBackend for SentinelBackend {
                 .push("emitter-restore");
             self.owns_restore = false;
             self.lit = false;
+            if let Some(why) = self.restore_failure.take() {
+                return Err(RestoreError::Bookkeeping(why));
+            }
         }
         Ok(())
     }
@@ -2218,6 +2222,19 @@ impl StreamMode {
             events,
             lit: true,
             owns_restore: true,
+            restore_failure: None,
+        }))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_failing_sentinel(
+        events: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    ) -> Self {
+        StreamMode::new(Box::new(SentinelBackend {
+            events,
+            lit: true,
+            owns_restore: true,
+            restore_failure: Some("sentinel restore failure".into()),
         }))
     }
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1251,14 +1251,45 @@ impl CaptureWrite {
 /// a busy lock into IR authentication going dark. The cost of proceeding
 /// unrecorded is that a kill mid-stream leaves a leftover no later session
 /// can claim, which is exactly the pre-#188 status quo.
-fn write_if_different(
+#[derive(Debug, PartialEq)]
+enum CaptureWriteError {
+    Hardware(XuError),
+    Guard(String),
+}
+
+#[derive(Debug)]
+enum GuardedApplyError<E> {
+    Apply(E),
+    Guard(String),
+}
+
+impl From<XuError> for CaptureWriteError {
+    fn from(error: XuError) -> Self {
+        Self::Hardware(error)
+    }
+}
+
+fn write_if_different_guarded(
     fd: c_int,
     unit: u8,
     selector: u8,
     len: usize,
     wanted: &[u8],
     id: &crate::uvc_descriptor::CameraIdentity,
-) -> XuResult<CaptureWrite> {
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<CaptureWrite, CaptureWriteError> {
+    write_if_different_inner(fd, unit, selector, len, wanted, id, before_forward_write)
+}
+
+fn write_if_different_inner(
+    fd: c_int,
+    unit: u8,
+    selector: u8,
+    len: usize,
+    wanted: &[u8],
+    id: &crate::uvc_descriptor::CameraIdentity,
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<CaptureWrite, CaptureWriteError> {
     let lock = match crate::stream_record::acquire(id) {
         Ok(lock) => Some(lock),
         // A LIVE irlume guard owns this camera. Writing anyway — even
@@ -1344,6 +1375,14 @@ fn write_if_different(
         // bookkeeping or exclusion — there is nothing left to hold.
         None => (None, None),
     };
+    if let Err(why) = before_forward_write() {
+        if let Some(record) = record {
+            if let Err(error) = record.resolve() {
+                eprintln!("irlume: {error}");
+            }
+        }
+        return Err(CaptureWriteError::Guard(why));
+    }
     if set_cur(fd, unit, selector, wanted).is_ok() {
         // Confirm only after the camera accepted. A failure here leaves the
         // record PREPARED on disk — the write happened, but a crash from this
@@ -1517,11 +1556,21 @@ fn foreign_consumers(proc_root: &std::path::Path, dev: &str, self_pid: u32) -> C
 /// prevent it (#189). Holding the `Arc` makes the descriptor outlive the guard
 /// by construction.
 pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &str) -> StreamMode {
+    enable_guarded(handle, card, device, &mut || Ok(()))
+        .unwrap_or_else(|_| unreachable!("the unguarded path cannot refuse"))
+}
+
+fn enable_guarded(
+    handle: std::sync::Arc<v4l::device::Handle>,
+    card: &str,
+    device: &str,
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<StreamMode, String> {
     let _ = card;
     let fd = handle.fd();
     let setting = override_setting(std::env::var("IRLUME_IR_EMITTER"));
     let wanted = match setting {
-        OverrideSetting::Disabled => return StreamMode::inert(),
+        OverrideSetting::Disabled => return Ok(StreamMode::inert()),
         // A value that is set but cannot be read as a control is NOT the same as
         // no value. Treating it as absent fell through to the built-in table, so
         // one mistyped byte in an override meant to replace that payload made
@@ -1529,7 +1578,7 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         // variable is consent to the control named in it and to nothing else.
         OverrideSetting::Malformed(why) => {
             eprintln!("irlume: refusing to drive the IR emitter: IRLUME_IR_EMITTER {why}");
-            return StreamMode::inert();
+            return Ok(StreamMode::inert());
         }
         OverrideSetting::Absent => None,
         OverrideSetting::Control(ctrl) => Some(ctrl),
@@ -1562,7 +1611,7 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
              camera ({}); its configuration is left untouched",
             who.join(", ")
         );
-        return StreamMode::inert();
+        return Ok(StreamMode::inert());
     }
     if scan.permission_denied {
         // Once per process, not per capture: under the packaged capability
@@ -1604,7 +1653,7 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
                     ctrl.selector
                 );
             }
-            return StreamMode::inert();
+            return Ok(StreamMode::inert());
         }
     };
 
@@ -1632,7 +1681,7 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
     // its coordinates; every read of the control itself happens inside the
     // apply path, on the same pass that decides whether to write.
     let Some((unit, selector)) = action.coordinates() else {
-        return StreamMode::inert();
+        return Ok(StreamMode::inert());
     };
 
     // Armed only when irlume actually CHANGED the control, and the guard's
@@ -1654,18 +1703,30 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         CaptureAction::Nothing => (None, Vec::new()),
         CaptureAction::Override(ctrl) => {
             let payload = ctrl.payload.clone();
-            (Some(apply_override(fd, &id, &ctrl)), payload)
+            (
+                Some(apply_override_guarded(
+                    fd,
+                    &id,
+                    &ctrl,
+                    before_forward_write,
+                )?),
+                payload,
+            )
         }
         CaptureAction::DeviceDefault { unit, selector } => {
-            match apply_device_default(fd, &id, unit, selector) {
+            match apply_device_default_guarded(fd, &id, unit, selector, before_forward_write) {
                 Ok((w, sent)) => (Some(w), sent),
-                Err(_) => (None, Vec::new()),
+                Err(GuardedApplyError::Apply(_)) => (None, Vec::new()),
+                Err(GuardedApplyError::Guard(why)) => return Err(why),
             }
         }
-        CaptureAction::KnownPayload(ctrl) => match apply_known_payload(fd, &id, &ctrl) {
-            Ok(w) => (Some(w), ctrl.payload),
-            Err(_) => (None, Vec::new()),
-        },
+        CaptureAction::KnownPayload(ctrl) => {
+            match apply_known_payload_guarded(fd, &id, &ctrl, before_forward_write) {
+                Ok(w) => (Some(w), ctrl.payload),
+                Err(GuardedApplyError::Apply(_)) => (None, Vec::new()),
+                Err(GuardedApplyError::Guard(why)) => return Err(why),
+            }
+        }
     };
     let active = write
         .as_ref()
@@ -1718,7 +1779,7 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         },
         None => (None, None, None),
     };
-    StreamMode::new(Box::new(UvcMode {
+    Ok(StreamMode::new(Box::new(UvcMode {
         handle: Some(EmitterHandle {
             handle,
             lease: None,
@@ -1731,18 +1792,20 @@ pub fn enable(handle: std::sync::Arc<v4l::device::Handle>, card: &str, device: &
         applied,
         record,
         _lock: lock,
-    }))
+    })))
 }
 
-pub(crate) fn enable_with_lease(
+pub(crate) fn enable_with_lease_guarded(
     handle: std::sync::Arc<v4l::device::Handle>,
     card: &str,
     device: &str,
     lease: crate::lease::CameraLease,
-) -> StreamMode {
-    let mut mode = lease.run_active(|| enable(handle, card, device));
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<StreamMode, String> {
+    let mut mode =
+        lease.run_active(|| enable_guarded(handle, card, device, before_forward_write))?;
     mode.attach_lease(lease);
-    mode
+    Ok(mode)
 }
 
 /// The face-auth mode held for the lifetime of ONE stream, put back when the
@@ -2475,11 +2538,22 @@ enum Applied {
 /// put the control back. It is read because a control that cannot be read is not
 /// demonstrably the control the documentation described, and because a control
 /// already holding the payload needs no write at all.
+#[cfg(test)]
 fn apply_override(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
 ) -> CaptureWrite {
+    apply_override_guarded(fd, id, ctrl, &mut || Ok(()))
+        .unwrap_or_else(|_| unreachable!("the unguarded path cannot refuse"))
+}
+
+fn apply_override_guarded(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    ctrl: &EmitterControl,
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<CaptureWrite, String> {
     let key = match override_key(fd, id, ctrl) {
         Ok(key) => key,
         Err(err) => {
@@ -2488,7 +2562,7 @@ fn apply_override(
                  so irlume cannot tell whether this was already applied",
                 ctrl.encode()
             );
-            return CaptureWrite::refused();
+            return Ok(CaptureWrite::refused());
         }
     };
 
@@ -2513,14 +2587,14 @@ fn apply_override(
                  after a panic, so irlume cannot tell whether this was already applied",
                 ctrl.encode()
             );
-            return CaptureWrite::refused();
+            return Ok(CaptureWrite::refused());
         }
     };
     match reuse(memo.get(&key), &ctrl.payload) {
         // A remembered refusal stands: re-running the checks every capture is
         // the traffic the record exists to stop, and the answer is "no" either
         // way.
-        Reuse::Answer(false) => return CaptureWrite::refused(),
+        Reuse::Answer(false) => return Ok(CaptureWrite::refused()),
         // A remembered SUCCESS says this payload was checked against this
         // camera's descriptors and accepted. It does NOT say the control still
         // holds it, and since the mode is now restored when each stream ends it
@@ -2537,15 +2611,16 @@ fn apply_override(
         // applied again for this stream. That is one write per stream, which is
         // the documented sequence, not the repeated writing this change removes.
         Reuse::Answer(true) => {
-            return match check_and_apply_override(fd, id, ctrl) {
-                Ok(write) => write,
-                Err(why) => {
+            return match check_and_apply_override_guarded(fd, id, ctrl, before_forward_write) {
+                Ok(write) => Ok(write),
+                Err(GuardedApplyError::Apply(why)) => {
                     eprintln!(
                         "irlume: refusing IRLUME_IR_EMITTER={}: {why}",
                         ctrl.encode()
                     );
-                    CaptureWrite::refused()
+                    Ok(CaptureWrite::refused())
                 }
+                Err(GuardedApplyError::Guard(why)) => Err(why),
             }
         }
         Reuse::RefuseChanged => {
@@ -2557,13 +2632,13 @@ fn apply_override(
                 ctrl.unit,
                 ctrl.selector
             );
-            return CaptureWrite::refused();
+            return Ok(CaptureWrite::refused());
         }
         Reuse::Decide => {}
     }
-    let write = match check_and_apply_override(fd, id, ctrl) {
+    let write = match check_and_apply_override_guarded(fd, id, ctrl, before_forward_write) {
         Ok(write) => write,
-        Err(why) => {
+        Err(GuardedApplyError::Apply(why)) => {
             // Silence here would read as "the value was applied and the camera
             // is simply dark", which is the reading that sends someone back to
             // try another unit and selector.
@@ -2573,6 +2648,7 @@ fn apply_override(
             );
             CaptureWrite::refused()
         }
+        Err(GuardedApplyError::Guard(why)) => return Err(why),
     };
     memo.insert(
         key,
@@ -2583,7 +2659,7 @@ fn apply_override(
             applied: write.outcome != Applied::Nothing,
         },
     );
-    write
+    Ok(write)
 }
 
 /// Test-only: hold a caller inside the gate so another thread can observe what
@@ -2627,17 +2703,31 @@ fn test_park() -> &'static TestPark {
 
 /// The gate itself, separated from the memo and the message so a test can assert
 /// on the reason rather than on a bare `false`.
+#[cfg(test)]
 fn check_and_apply_override(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
 ) -> std::result::Result<CaptureWrite, OverrideRefusal> {
+    match check_and_apply_override_guarded(fd, id, ctrl, &mut || Ok(())) {
+        Ok(write) => Ok(write),
+        Err(GuardedApplyError::Apply(error)) => Err(error),
+        Err(GuardedApplyError::Guard(_)) => unreachable!("the unguarded path cannot refuse"),
+    }
+}
+
+fn check_and_apply_override_guarded(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    ctrl: &EmitterControl,
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> std::result::Result<CaptureWrite, GuardedApplyError<OverrideRefusal>> {
     #[cfg(test)]
     park_inside_for_test();
 
     // First, and before the fd is touched at all: a unit this camera does not
     // publish is refused without a single ioctl reaching the device.
-    override_is_published(id, ctrl)?;
+    override_is_published(id, ctrl).map_err(GuardedApplyError::Apply)?;
 
     let (unit, selector) = (ctrl.unit, ctrl.selector);
     // Every query failure below is reported the same way for the reason
@@ -2645,37 +2735,53 @@ fn check_and_apply_override(
     // just confirmed as advertised, so a failure is the camera contradicting its
     // own descriptor, and uvcvideo's errnos cannot separate a healthy refusal
     // from a device in trouble. Either way nothing further is sent.
-    let info = get_info(fd, unit, selector).map_err(|err| OverrideRefusal::Unreadable {
-        unit,
-        selector,
-        err,
-    })?;
-    if !info_allows_set(info) {
-        return Err(OverrideRefusal::WriteNotAccepted {
+    let info = get_info(fd, unit, selector).map_err(|err| {
+        GuardedApplyError::Apply(OverrideRefusal::Unreadable {
             unit,
             selector,
-            info,
-        });
+            err,
+        })
+    })?;
+    if !info_allows_set(info) {
+        return Err(GuardedApplyError::Apply(
+            OverrideRefusal::WriteNotAccepted {
+                unit,
+                selector,
+                info,
+            },
+        ));
     }
-    let len = get_len(fd, unit, selector).map_err(|err| OverrideRefusal::Unreadable {
-        unit,
-        selector,
-        err,
+    let len = get_len(fd, unit, selector).map_err(|err| {
+        GuardedApplyError::Apply(OverrideRefusal::Unreadable {
+            unit,
+            selector,
+            err,
+        })
     })?;
     if len != ctrl.payload.len() {
-        return Err(OverrideRefusal::WrongLength {
+        return Err(GuardedApplyError::Apply(OverrideRefusal::WrongLength {
             unit,
             selector,
             wants: len,
             given: ctrl.payload.len(),
-        });
+        }));
     }
-    write_if_different(fd, unit, selector, len, &ctrl.payload, id).map_err(|err| {
-        OverrideRefusal::Unreadable {
+    write_if_different_guarded(
+        fd,
+        unit,
+        selector,
+        len,
+        &ctrl.payload,
+        id,
+        before_forward_write,
+    )
+    .map_err(|error| match error {
+        CaptureWriteError::Hardware(err) => GuardedApplyError::Apply(OverrideRefusal::Unreadable {
             unit,
             selector,
             err,
-        }
+        }),
+        CaptureWriteError::Guard(why) => GuardedApplyError::Guard(why),
     })
 }
 
@@ -2687,19 +2793,45 @@ fn check_and_apply_override(
 /// that size right now. Writing a nine-byte payload to a control the camera has
 /// just reported as disabled, or as a different length, is not something a
 /// validated VID:PID should buy.
+#[cfg(test)]
 fn apply_known_payload(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     ctrl: &EmitterControl,
 ) -> XuResult<CaptureWrite> {
-    if !info_allows_set(get_info(fd, ctrl.unit, ctrl.selector)?) {
-        return Err(XuError::Unsupported);
+    match apply_known_payload_guarded(fd, id, ctrl, &mut || Ok(())) {
+        Ok(write) => Ok(write),
+        Err(GuardedApplyError::Apply(error)) => Err(error),
+        Err(GuardedApplyError::Guard(_)) => unreachable!("the unguarded path cannot refuse"),
     }
-    let len = get_len(fd, ctrl.unit, ctrl.selector)?;
+}
+
+fn apply_known_payload_guarded(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    ctrl: &EmitterControl,
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<CaptureWrite, GuardedApplyError<XuError>> {
+    if !info_allows_set(get_info(fd, ctrl.unit, ctrl.selector).map_err(GuardedApplyError::Apply)?) {
+        return Err(GuardedApplyError::Apply(XuError::Unsupported));
+    }
+    let len = get_len(fd, ctrl.unit, ctrl.selector).map_err(GuardedApplyError::Apply)?;
     if len != ctrl.payload.len() {
-        return Err(XuError::Unsupported);
+        return Err(GuardedApplyError::Apply(XuError::Unsupported));
     }
-    write_if_different(fd, ctrl.unit, ctrl.selector, len, &ctrl.payload, id)
+    write_if_different_guarded(
+        fd,
+        ctrl.unit,
+        ctrl.selector,
+        len,
+        &ctrl.payload,
+        id,
+        before_forward_write,
+    )
+    .map_err(|error| match error {
+        CaptureWriteError::Hardware(error) => GuardedApplyError::Apply(error),
+        CaptureWriteError::Guard(why) => GuardedApplyError::Guard(why),
+    })
 }
 
 /// The bytes to write for one documented control, or why the camera has not
@@ -2766,21 +2898,42 @@ fn intended_value(
 /// this function derives them and the caller needs them: `enable` records what
 /// the guard APPLIED, which for IR Torch is the camera's own default rather
 /// than anything the caller named.
+#[cfg(test)]
 fn apply_device_default(
     fd: c_int,
     id: &crate::uvc_descriptor::CameraIdentity,
     unit: u8,
     selector: u8,
 ) -> XuResult<(CaptureWrite, Vec<u8>)> {
-    if !info_allows_set(get_info(fd, unit, selector)?) {
-        return Err(XuError::Unsupported);
+    match apply_device_default_guarded(fd, id, unit, selector, &mut || Ok(())) {
+        Ok(write) => Ok(write),
+        Err(GuardedApplyError::Apply(error)) => Err(error),
+        Err(GuardedApplyError::Guard(_)) => unreachable!("the unguarded path cannot refuse"),
     }
-    let len = get_len(fd, unit, selector)?;
-    let Ok(intended) = intended_value(fd, unit, selector, len)? else {
-        return Err(XuError::Unsupported);
+}
+
+fn apply_device_default_guarded(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+    unit: u8,
+    selector: u8,
+    before_forward_write: &mut dyn FnMut() -> Result<(), String>,
+) -> Result<(CaptureWrite, Vec<u8>), GuardedApplyError<XuError>> {
+    if !info_allows_set(get_info(fd, unit, selector).map_err(GuardedApplyError::Apply)?) {
+        return Err(GuardedApplyError::Apply(XuError::Unsupported));
+    }
+    let len = get_len(fd, unit, selector).map_err(GuardedApplyError::Apply)?;
+    let Ok(intended) = intended_value(fd, unit, selector, len).map_err(GuardedApplyError::Apply)?
+    else {
+        return Err(GuardedApplyError::Apply(XuError::Unsupported));
     };
     let wanted = intended.payload;
-    let write = write_if_different(fd, unit, selector, len, &wanted, id)?;
+    let write =
+        write_if_different_guarded(fd, unit, selector, len, &wanted, id, before_forward_write)
+            .map_err(|error| match error {
+                CaptureWriteError::Hardware(error) => GuardedApplyError::Apply(error),
+                CaptureWriteError::Guard(why) => GuardedApplyError::Guard(why),
+            })?;
     Ok((write, wanted))
 }
 
@@ -8203,6 +8356,83 @@ mod tests {
             stream_store_state(&dir).0,
             0,
             "a record must not describe a write the camera refused"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_late_capture_guard_refusal_sends_nothing_and_resolves_its_record() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "irlume-capture-guard-recorded-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &dir);
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &dir);
+        let _fake = fake_camera::install(a_working_camera());
+        let id = identity(0x3277, 0x0059);
+        let calls = std::cell::Cell::new(0usize);
+
+        let error = write_if_different_guarded(-1, 14, 6, 3, &[1, 3, 2], &id, &mut || {
+            calls.set(calls.get() + 1);
+            Err("privacy engaged after initial authorization".into())
+        })
+        .expect_err("the late privacy boundary must refuse the forward write");
+
+        assert!(
+            matches!(error, CaptureWriteError::Guard(ref why) if why.contains("privacy engaged")),
+            "{error:?}"
+        );
+        assert_eq!(
+            calls.get(),
+            1,
+            "the guard runs exactly at the write boundary"
+        );
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|request| matches!(request, fake_camera::Request::Set(_))),
+            "no SET_CUR may follow the refusal: {:?}",
+            fake_camera::log()
+        );
+        assert_eq!(
+            stream_store_state(&dir).0,
+            0,
+            "the prepared no-write record must be removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_late_capture_guard_also_blocks_an_unrecorded_write() {
+        let _lock = crate::testenv::env_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "irlume-capture-guard-unrecorded-{}",
+            std::process::id()
+        ));
+        let lock_path = dir.join("not-a-directory");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch directory");
+        std::fs::write(&lock_path, b"block lock directory creation").expect("blocking file");
+        let _env = EnvGuard::set("IRLUME_STATE_DIR", &lock_path);
+        let _fake = fake_camera::install(a_working_camera());
+        let id = identity(0x3277, 0x0059);
+        let calls = std::cell::Cell::new(0usize);
+
+        let error = write_if_different_guarded(-1, 14, 6, 3, &[1, 3, 2], &id, &mut || {
+            calls.set(calls.get() + 1);
+            Err("privacy became unreadable".into())
+        })
+        .expect_err("journal degradation must not bypass the privacy boundary");
+
+        assert!(matches!(error, CaptureWriteError::Guard(_)), "{error:?}");
+        assert_eq!(calls.get(), 1);
+        assert!(
+            !fake_camera::log()
+                .iter()
+                .any(|request| matches!(request, fake_camera::Request::Set(_))),
+            "the degraded unrecorded path still sends nothing"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-camera/src/ir_metadata.rs
+++ b/crates/irlume-camera/src/ir_metadata.rs
@@ -454,6 +454,8 @@ pub(crate) struct IlluminationLog {
     /// changed for the next process to open this camera.
     restore_format: u32,
     streaming: bool,
+    #[cfg(test)]
+    sentinel_events: Option<std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>>,
 }
 
 impl IlluminationLog {
@@ -483,6 +485,8 @@ impl IlluminationLog {
             by_timestamp: std::collections::HashMap::new(),
             restore_format: UVCH,
             streaming: false,
+            #[cfg(test)]
+            sentinel_events: None,
         };
         match log.start() {
             Ok(()) => Some(log),
@@ -597,6 +601,13 @@ impl IlluminationLog {
     /// would grow for the life of the session. Called once before a burst
     /// rather than inside `drain`, which runs per frame.
     pub(crate) fn begin_burst(&mut self) {
+        #[cfg(test)]
+        if let Some(events) = &self.sentinel_events {
+            events
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push("metadata-begin-burst");
+        }
         self.by_timestamp.clear();
     }
 
@@ -606,6 +617,14 @@ impl IlluminationLog {
     /// queues advance together, so a drain per image frame keeps up, and a
     /// missed record costs one frame's classification rather than a stall.
     pub(crate) fn drain(&mut self) {
+        #[cfg(test)]
+        if let Some(events) = &self.sentinel_events {
+            events
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push("metadata-drain");
+            return;
+        }
         if !self.streaming {
             return;
         }
@@ -674,10 +693,33 @@ impl IlluminationLog {
             std::io::Error::last_os_error()
         ))
     }
+
+    #[cfg(test)]
+    pub(crate) fn test_sentinel(
+        events: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    ) -> Self {
+        Self {
+            fd: -1,
+            device: "test-metadata".into(),
+            buffers: Vec::new(),
+            by_timestamp: std::collections::HashMap::new(),
+            restore_format: 0,
+            streaming: false,
+            sentinel_events: Some(events),
+        }
+    }
 }
 
 impl Drop for IlluminationLog {
     fn drop(&mut self) {
+        #[cfg(test)]
+        if let Some(events) = &self.sentinel_events {
+            events
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push("metadata-drop");
+            return;
+        }
         if self.streaming {
             let mut kind = META_CAPTURE as c_int;
             let _ = self.ioctl(

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -610,6 +610,8 @@ struct V4l2CameraState {
     privacy_boundary: PrivacyBoundary,
     #[cfg(test)]
     privacy_refusal_countdown: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    #[cfg(test)]
+    delivery_failure_countdown: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl V4l2CameraState {
@@ -621,6 +623,8 @@ impl V4l2CameraState {
             privacy_boundary: PrivacyBoundary::LeaseOnly,
             #[cfg(test)]
             privacy_refusal_countdown: Default::default(),
+            #[cfg(test)]
+            delivery_failure_countdown: Default::default(),
         }
     }
 
@@ -636,6 +640,8 @@ impl V4l2CameraState {
             privacy_boundary: PrivacyBoundary::LeaseOnly,
             #[cfg(test)]
             privacy_refusal_countdown: Default::default(),
+            #[cfg(test)]
+            delivery_failure_countdown: Default::default(),
         }
     }
 
@@ -651,6 +657,8 @@ impl V4l2CameraState {
             privacy_boundary: PrivacyBoundary::RequireReleased,
             #[cfg(test)]
             privacy_refusal_countdown: Default::default(),
+            #[cfg(test)]
+            delivery_failure_countdown: Default::default(),
         }
     }
 }
@@ -695,6 +703,19 @@ impl CameraState for V4l2CameraState {
 
     fn require_dequeue_boundary(&self, dev: &Device) -> std::io::Result<()> {
         self.require_endpoint().map_err(std::io::Error::other)?;
+        #[cfg(test)]
+        {
+            use std::sync::atomic::Ordering;
+            let failed = self
+                .delivery_failure_countdown
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok_and(|remaining| remaining == 1);
+            if failed {
+                return Err(std::io::Error::other("injected delivery failure"));
+            }
+        }
         if self.privacy_boundary == PrivacyBoundary::RequireReleased {
             #[cfg(test)]
             {
@@ -1094,6 +1115,12 @@ impl CameraStateStream<'_, V4l2CameraState> {
     fn refuse_privacy_after(&self, boundaries: usize) {
         self.state
             .privacy_refusal_countdown
+            .store(boundaries, std::sync::atomic::Ordering::Release);
+    }
+
+    fn fail_delivery_after(&self, boundaries: usize) {
+        self.state
+            .delivery_failure_countdown
             .store(boundaries, std::sync::atomic::Ordering::Release);
     }
 }
@@ -1553,6 +1580,14 @@ impl TrackedStream<SafeStream<'_>> {
             .as_ref()
             .expect("test sabotage requires a live stream")
             .refuse_privacy_after(boundaries);
+    }
+
+    #[cfg(test)]
+    fn fail_delivery_after(&self, boundaries: usize) {
+        self.stream
+            .as_ref()
+            .expect("test sabotage requires a live stream")
+            .fail_delivery_after(boundaries);
     }
 
     fn privacy_refused(&self) -> bool {
@@ -13535,6 +13570,12 @@ mod tests {
         .expect("acquire IR operation");
         let camera = operation.open_ir(&ir_path).expect("open IR camera");
         let mut session = camera.session().expect("open IR session");
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        session.meta = Some(ir_metadata::IlluminationLog::test_sentinel(events.clone()));
+        session._mode = ir_emitter::StreamMode::test_sentinel(events.clone());
+        session.lit = session._mode.lit();
+        assert!(session.meta.is_some());
+        assert!(session.lit && session._mode.owns_restore());
         session.stream.refuse_privacy_after(1);
 
         let error = match session.capture_with_stats() {
@@ -13561,6 +13602,16 @@ mod tests {
             !session._mode.owns_restore(),
             "the restore is no longer live"
         );
+        let events = events.lock().unwrap_or_else(|error| error.into_inner());
+        let metadata_drop = events
+            .iter()
+            .position(|event| *event == "metadata-drop")
+            .expect("metadata sentinel must be dropped");
+        let emitter_restore = events
+            .iter()
+            .position(|event| *event == "emitter-restore")
+            .expect("owned emitter sentinel must be restored");
+        assert!(metadata_drop < emitter_restore, "{events:?}");
     }
 
     #[test]
@@ -13577,6 +13628,12 @@ mod tests {
         let ir_camera = operation.open_ir(&ir_path).expect("open IR camera");
         let mut rgb = rgb_camera.session().expect("open RGB session");
         let mut ir = ir_camera.session().expect("open IR session");
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        ir.meta = Some(ir_metadata::IlluminationLog::test_sentinel(events.clone()));
+        ir._mode = ir_emitter::StreamMode::test_sentinel(events.clone());
+        ir.lit = ir._mode.lit();
+        assert!(ir.meta.is_some());
+        assert!(ir.lit && ir._mode.owns_restore());
         rgb.stream.rate_window.reset();
         ir.stream.rate_window.reset();
         let rgb_before = rgb.stream.accounting().0;
@@ -13601,6 +13658,81 @@ mod tests {
         assert!(
             rgb.stream.accounting().0.saturating_sub(rgb_before) <= 1,
             "RGB may finish one in-flight dequeue, never the bounded fill"
+        );
+        assert_eq!(
+            events
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .as_slice(),
+            ["metadata-drop", "emitter-restore"],
+            "privacy skips metadata drain and tears down before restore"
+        );
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_recovered_fill_drains_metadata_before_the_exposed_burst() {
+        let (_, ir_path) = loopback_pair();
+        let operation = lease::acquire_camera_operation(
+            &[ir_path.as_str()],
+            lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        )
+        .expect("acquire IR operation");
+        let camera = operation.open_ir(&ir_path).expect("open IR camera");
+        let mut session = camera.session().expect("open IR session");
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        session.meta = Some(ir_metadata::IlluminationLog::test_sentinel(events.clone()));
+        session.stream.rate_window.reset();
+
+        session
+            .capture_with_stats()
+            .expect("recovered-shape serial fill and capture succeed");
+
+        let events = events.lock().unwrap_or_else(|error| error.into_inner());
+        assert_eq!(
+            events.get(..2),
+            Some(["metadata-drain", "metadata-begin-burst"].as_slice()),
+            "the hidden fill must requeue metadata before any exposed burst"
+        );
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_pair_rate_ordinary_error_drains_metadata_without_teardown() {
+        let (rgb_path, ir_path) = loopback_pair();
+        let operation = lease::acquire_camera_operation(
+            &[rgb_path.as_str(), ir_path.as_str()],
+            lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        )
+        .expect("acquire pair operation");
+        let rgb_camera = operation.open_rgb(&rgb_path).expect("open RGB camera");
+        let ir_camera = operation.open_ir(&ir_path).expect("open IR camera");
+        let mut rgb = rgb_camera.session().expect("open RGB session");
+        let mut ir = ir_camera.session().expect("open IR session");
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        ir.meta = Some(ir_metadata::IlluminationLog::test_sentinel(events.clone()));
+        ir._mode = ir_emitter::StreamMode::test_sentinel(events.clone());
+        ir.lit = ir._mode.lit();
+        rgb.stream.rate_window.reset();
+        ir.stream.rate_window.reset();
+        ir.stream.fail_delivery_after(1);
+
+        let error = establish_pair_rate(&mut rgb, &mut ir)
+            .expect_err("ordinary injected delivery failure must be reported");
+
+        assert!(error.to_string().contains("injected delivery failure"));
+        assert!(ir.stream.stream.is_some(), "ordinary error stays reusable");
+        assert!(ir.meta.is_some(), "ordinary error keeps metadata open");
+        assert!(ir.lit && ir._mode.owns_restore());
+        assert_eq!(
+            events
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .as_slice(),
+            ["metadata-drain"],
+            "ordinary failure requeues metadata and performs no teardown"
         );
     }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2704,6 +2704,7 @@ fn privacy_permits_ir_capture(observed: std::io::Result<Option<bool>>) -> Result
     }
 }
 
+#[cfg(test)]
 fn with_released_ir_privacy<T>(
     observed: std::io::Result<Option<bool>>,
     action: impl FnOnce() -> T,
@@ -2728,9 +2729,22 @@ fn enable_ir_emitter_privacy_bounded(
     permit: lease::CameraLease,
     stage: &'static str,
 ) -> irlume_common::Result<ir_emitter::StreamMode> {
-    with_released_ir_privacy(privacy_state(dev), || {
-        ir_emitter::enable_with_lease(dev.handle(), card, device, permit)
-    })
+    privacy_permits_ir_capture(privacy_state(dev))
+        .map_err(|why| Error::Hardware(format!("{device}: {stage}: {why}")))?;
+    let write_permit = permit.clone();
+    let mut before_forward_write = || {
+        write_permit
+            .require_endpoint(device)
+            .map_err(|error| error.to_string())?;
+        privacy_permits_ir_capture(privacy_state(dev))
+    };
+    ir_emitter::enable_with_lease_guarded(
+        dev.handle(),
+        card,
+        device,
+        permit,
+        &mut before_forward_write,
+    )
     .map_err(|why| Error::Hardware(format!("{device}: {stage}: {why}")))
 }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -608,6 +608,8 @@ struct V4l2CameraState {
     lease: lease::CameraLease,
     accepted_interval: Option<frame_interval::FrameInterval>,
     privacy_boundary: PrivacyBoundary,
+    #[cfg(test)]
+    privacy_refusal_countdown: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl V4l2CameraState {
@@ -617,6 +619,8 @@ impl V4l2CameraState {
             lease,
             accepted_interval: None,
             privacy_boundary: PrivacyBoundary::LeaseOnly,
+            #[cfg(test)]
+            privacy_refusal_countdown: Default::default(),
         }
     }
 
@@ -630,6 +634,8 @@ impl V4l2CameraState {
             lease,
             accepted_interval: Some(accepted_interval),
             privacy_boundary: PrivacyBoundary::LeaseOnly,
+            #[cfg(test)]
+            privacy_refusal_countdown: Default::default(),
         }
     }
 
@@ -643,6 +649,8 @@ impl V4l2CameraState {
             lease,
             accepted_interval: Some(accepted_interval),
             privacy_boundary: PrivacyBoundary::RequireReleased,
+            #[cfg(test)]
+            privacy_refusal_countdown: Default::default(),
         }
     }
 }
@@ -688,6 +696,21 @@ impl CameraState for V4l2CameraState {
     fn require_dequeue_boundary(&self, dev: &Device) -> std::io::Result<()> {
         self.require_endpoint().map_err(std::io::Error::other)?;
         if self.privacy_boundary == PrivacyBoundary::RequireReleased {
+            #[cfg(test)]
+            {
+                use std::sync::atomic::Ordering;
+                let refused = self
+                    .privacy_refusal_countdown
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok_and(|remaining| remaining == 1);
+                if refused {
+                    return Err(privacy_boundary_error(
+                        "injected privacy boundary failure".into(),
+                    ));
+                }
+            }
             privacy_permits_ir_capture(privacy_state(dev)).map_err(privacy_boundary_error)?;
         }
         Ok(())
@@ -1065,6 +1088,15 @@ struct CameraStateStream<'a, S: CameraState> {
 }
 
 type SafeStream<'a> = CameraStateStream<'a, V4l2CameraState>;
+
+#[cfg(test)]
+impl CameraStateStream<'_, V4l2CameraState> {
+    fn refuse_privacy_after(&self, boundaries: usize) {
+        self.state
+            .privacy_refusal_countdown
+            .store(boundaries, std::sync::atomic::Ordering::Release);
+    }
+}
 
 /// How long a single frame dequeue may block.
 ///
@@ -1515,6 +1547,14 @@ impl<S> TrackedStream<S> {
 }
 
 impl TrackedStream<SafeStream<'_>> {
+    #[cfg(test)]
+    fn refuse_privacy_after(&self, boundaries: usize) {
+        self.stream
+            .as_ref()
+            .expect("test sabotage requires a live stream")
+            .refuse_privacy_after(boundaries);
+    }
+
     fn privacy_refused(&self) -> bool {
         self.stream
             .as_ref()
@@ -13480,6 +13520,87 @@ mod tests {
         for f in &seq {
             assert!(f.data.len() >= (IR_W * IR_H) as usize);
         }
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_privacy_refusal_tears_down_the_reusable_ir_session() {
+        let (_, ir_path) = loopback_pair();
+        let operation = lease::acquire_camera_operation(
+            &[ir_path.as_str()],
+            lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        )
+        .expect("acquire IR operation");
+        let camera = operation.open_ir(&ir_path).expect("open IR camera");
+        let mut session = camera.session().expect("open IR session");
+        session.stream.refuse_privacy_after(1);
+
+        let error = match session.capture_with_stats() {
+            Ok(_) => panic!("the injected live privacy boundary must refuse"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("injected privacy boundary failure"),
+            "{error}"
+        );
+        assert!(
+            session.stream.stream.is_none(),
+            "the image queue must be stopped before the refusal returns"
+        );
+        assert!(
+            session.meta.is_none(),
+            "the metadata queue must be stopped before emitter restoration"
+        );
+        assert!(!session.lit, "a privacy-stopped session is inert");
+        assert!(
+            !session._mode.owns_restore(),
+            "the restore is no longer live"
+        );
+    }
+
+    #[test]
+    #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
+    fn loopback_pair_rate_privacy_refusal_stops_only_ir_and_cancels_rgb() {
+        let (rgb_path, ir_path) = loopback_pair();
+        let operation = lease::acquire_camera_operation(
+            &[rgb_path.as_str(), ir_path.as_str()],
+            lease::CameraOperationKind::Capture,
+            std::time::Duration::from_secs(2),
+        )
+        .expect("acquire pair operation");
+        let rgb_camera = operation.open_rgb(&rgb_path).expect("open RGB camera");
+        let ir_camera = operation.open_ir(&ir_path).expect("open IR camera");
+        let mut rgb = rgb_camera.session().expect("open RGB session");
+        let mut ir = ir_camera.session().expect("open IR session");
+        rgb.stream.rate_window.reset();
+        ir.stream.rate_window.reset();
+        let rgb_before = rgb.stream.accounting().0;
+        ir.stream.refuse_privacy_after(1);
+
+        let error = establish_pair_rate(&mut rgb, &mut ir)
+            .expect_err("the injected IR privacy boundary must refuse paired fill");
+
+        assert!(
+            error
+                .to_string()
+                .contains("injected privacy boundary failure"),
+            "{error}"
+        );
+        assert!(ir.stream.stream.is_none(), "IR image queue must stop");
+        assert!(ir.meta.is_none(), "IR metadata queue must stop");
+        assert!(!ir.lit && !ir._mode.owns_restore());
+        assert!(
+            rgb.stream.stream.is_some(),
+            "the companion remains reusable after cancellation"
+        );
+        assert!(
+            rgb.stream.accounting().0.saturating_sub(rgb_before) <= 1,
+            "RGB may finish one in-flight dequeue, never the bounded fill"
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1983,6 +1983,7 @@ fn establish_concurrent_rate_with_cancel<A: ValidatedStream + Send, B: Validated
             .unwrap_or_else(|payload| std::panic::resume_unwind(payload));
         match (a, b) {
             (Ok(()), Ok(())) => Ok(()),
+            (Err(_), Err(b)) if is_privacy_boundary_error(&b) => Err(b),
             (Err(a), Err(b)) if paired_rate_fill_cancelled(&a) => Err(b),
             (Err(a), _) => Err(a),
             (_, Err(b)) => Err(b),
@@ -14412,6 +14413,58 @@ mod tests {
             calls.load(std::sync::atomic::Ordering::SeqCst) <= 1,
             "the companion may finish one in-flight dequeue, never the bounded fill"
         );
+    }
+
+    #[test]
+    fn simultaneous_pair_errors_preserve_the_ir_privacy_refusal() {
+        struct BarrierFailure {
+            barrier: std::sync::Arc<std::sync::Barrier>,
+            privacy: bool,
+        }
+
+        impl ValidatedStream for BarrierFailure {
+            fn next_validated(
+                &mut self,
+            ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>
+            {
+                self.barrier.wait();
+                let error = if self.privacy {
+                    privacy_boundary_error("IR privacy refusal".into())
+                } else {
+                    std::io::Error::other("RGB delivery failure")
+                };
+                Err(ValidatedDequeueError::Io(error))
+            }
+        }
+
+        let config = |role| {
+            rate_gate::StreamRateConfig::with_window(
+                role,
+                frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+                frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+                4,
+            )
+        };
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let mut rgb = TrackedStream::new(
+            BarrierFailure {
+                barrier: barrier.clone(),
+                privacy: false,
+            },
+            config(contracts::StreamRole::Rgb),
+        );
+        let mut ir = TrackedStream::new(
+            BarrierFailure {
+                barrier,
+                privacy: true,
+            },
+            config(contracts::StreamRole::Ir),
+        );
+
+        let error = establish_concurrent_rate(&mut rgb, &mut ir)
+            .expect_err("both members fail, but privacy is the safety authority");
+
+        assert!(error.to_string().contains("IR privacy refusal"), "{error}");
     }
 }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -510,13 +510,6 @@ fn apply_blc(cam: &RgbCamera) -> Option<BlcRestore<'_>> {
     }
 }
 
-/// Frozen-stream recovery for burst captures: after this many consecutive
-/// identical frames the stream is torn down and re-opened, at most
-/// `FROZEN_RESTART_BUDGET` times per burst (a fully static feed therefore
-/// yields 1 + budget frames instead of hanging).
-const FROZEN_RUN_BEFORE_RESTART: usize = 2;
-const FROZEN_RESTART_BUDGET: usize = 4;
-
 /// mmap ring size for every V4L2 capture stream. Four buffers is the classic
 /// quad-buffer: enough that the driver never stalls waiting for a dequeue at
 /// 30fps, small enough to be granted by every UVC camera we have seen.
@@ -559,6 +552,14 @@ trait CameraState {
         stage: &'static str,
     ) -> irlume_common::Result<frame_interval::FrameInterval>;
     fn require_endpoint(&self) -> Result<(), Self::EndpointError>;
+    /// Revalidate every invariant that can change while a dequeue blocks.
+    ///
+    /// The default preserves the lease-only behavior used by RGB and injected
+    /// test states. IR V4L2 streams additionally require a freshly released
+    /// privacy state on the same open device before and after every dequeue.
+    fn require_dequeue_boundary(&self, _dev: &Self::Device) -> std::io::Result<()> {
+        self.require_endpoint().map_err(std::io::Error::other)
+    }
     fn compare_format(&self, expected: &Format, current: &Format) -> Option<String>;
     fn claim_buffers<'a>(&self, dev: &'a Self::Device) -> std::io::Result<Self::Claim<'a>>;
     fn accepted_interval(&self) -> Option<frame_interval::FrameInterval>;
@@ -573,11 +574,18 @@ trait CameraState {
     fn stop_stream(&self);
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PrivacyBoundary {
+    LeaseOnly,
+    RequireReleased,
+}
+
 #[derive(Clone)]
 struct V4l2CameraState {
     device: String,
     lease: lease::CameraLease,
     accepted_interval: Option<frame_interval::FrameInterval>,
+    privacy_boundary: PrivacyBoundary,
 }
 
 impl V4l2CameraState {
@@ -586,6 +594,7 @@ impl V4l2CameraState {
             device: device.to_owned(),
             lease,
             accepted_interval: None,
+            privacy_boundary: PrivacyBoundary::LeaseOnly,
         }
     }
 
@@ -598,6 +607,20 @@ impl V4l2CameraState {
             device: device.to_owned(),
             lease,
             accepted_interval: Some(accepted_interval),
+            privacy_boundary: PrivacyBoundary::LeaseOnly,
+        }
+    }
+
+    fn with_ir_interval(
+        device: &str,
+        lease: lease::CameraLease,
+        accepted_interval: frame_interval::FrameInterval,
+    ) -> Self {
+        Self {
+            device: device.to_owned(),
+            lease,
+            accepted_interval: Some(accepted_interval),
+            privacy_boundary: PrivacyBoundary::RequireReleased,
         }
     }
 }
@@ -638,6 +661,14 @@ impl CameraState for V4l2CameraState {
 
     fn require_endpoint(&self) -> Result<(), Self::EndpointError> {
         self.lease.require_endpoint(&self.device)
+    }
+
+    fn require_dequeue_boundary(&self, dev: &Device) -> std::io::Result<()> {
+        self.require_endpoint().map_err(std::io::Error::other)?;
+        if self.privacy_boundary == PrivacyBoundary::RequireReleased {
+            privacy_permits_ir_capture(privacy_state(dev)).map_err(std::io::Error::other)?;
+        }
+        Ok(())
     }
 
     fn compare_format(&self, expected: &Format, current: &Format) -> Option<String> {
@@ -1239,7 +1270,7 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
         let dequeued = dequeue_validated_typed(
             inner.as_mut().expect("stream taken only in Drop"),
             *layout,
-            || state.require_endpoint().map_err(std::io::Error::other),
+            || state.require_dequeue_boundary(dev),
         )?;
         if !*stream_started_validated {
             verify_stream_snapshot(
@@ -1736,6 +1767,15 @@ impl<S: ValidatedStream> TrackedStream<S> {
             rate_evidence,
         ))
     }
+}
+
+fn fill_rate_then_drain_metadata<E>(
+    fill_rate: impl FnOnce() -> Result<(), E>,
+    drain_metadata: impl FnOnce(),
+) -> Result<(), E> {
+    fill_rate()?;
+    drain_metadata();
+    Ok(())
 }
 
 /// Establish the delivered-rate window for TWO streams by filling each one on
@@ -2641,6 +2681,57 @@ fn privacy_permits_setup(observed: std::io::Result<Option<bool>>) -> Result<(), 
              to camera firmware while the shutter state is unknown"
         )),
     }
+}
+
+/// Fail-closed privacy decision for IR capture and forward emitter writes.
+///
+/// A camera without the control preserves existing portability. Once a device
+/// publishes privacy, however, both an engaged state and a failed observation
+/// refuse the frame/write boundary: "could not read" is never evidence that a
+/// physical shutter is released.
+fn privacy_permits_ir_capture(observed: std::io::Result<Option<bool>>) -> Result<(), String> {
+    match observed {
+        Ok(Some(true)) => Err(
+            "the hardware privacy shutter is engaged (the `privacy` control reads 1); \
+             refusing IR capture and any forward emitter write"
+                .into(),
+        ),
+        Ok(Some(false)) | Ok(None) => Ok(()),
+        Err(error) => Err(format!(
+            "could not read the hardware privacy control ({error}); refusing IR capture \
+             and any forward emitter write while the shutter state is unknown"
+        )),
+    }
+}
+
+fn with_released_ir_privacy<T>(
+    observed: std::io::Result<Option<bool>>,
+    action: impl FnOnce() -> T,
+) -> Result<T, String> {
+    privacy_permits_ir_capture(observed)?;
+    Ok(action())
+}
+
+fn require_ir_privacy_released(
+    device: &str,
+    dev: &Device,
+    stage: &'static str,
+) -> irlume_common::Result<()> {
+    privacy_permits_ir_capture(privacy_state(dev))
+        .map_err(|why| Error::Hardware(format!("{device}: {stage}: {why}")))
+}
+
+fn enable_ir_emitter_privacy_bounded(
+    device: &str,
+    dev: &Device,
+    card: &str,
+    permit: lease::CameraLease,
+    stage: &'static str,
+) -> irlume_common::Result<ir_emitter::StreamMode> {
+    with_released_ir_privacy(privacy_state(dev), || {
+        ir_emitter::enable_with_lease(dev.handle(), card, device, permit)
+    })
+    .map_err(|why| Error::Hardware(format!("{device}: {stage}: {why}")))
 }
 
 /// The backend classification from a `VIDIOC_QUERYCAP` answer. The V4L2
@@ -3600,8 +3691,7 @@ impl<'a> RgbSession<'a> {
     /// EBUSY at .269393, and no close ran in between. Dropping the stream
     /// first releases the queue, and the replacement renegotiates on the fd
     /// this session already holds, so nothing new opens and nothing collides.
-    /// Same drop-then-reopen shape as the frozen-stream restart in the IR
-    /// one-shot path.
+    /// Same drop-then-reopen shape as explicit IR session recovery.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn recover(&mut self) -> irlume_common::Result<()> {
         self.cam
@@ -4303,12 +4393,8 @@ impl IrCamera {
             .require_endpoint()
             .map_err(|error| Error::Hardware(error.to_string()))?;
         verify_pinned(device)?;
-        if privacy_engaged_with_permit(device) {
-            return Err(Error::Hardware(format!(
-                "{device}: hardware privacy switch is ON"
-            )));
-        }
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
+        require_ir_privacy_released(device, &dev, "before IR negotiation")?;
         let (fmt, pix) = negotiate_ir_format_state(device, &dev, &state)?;
         let interval = negotiate_interval_after_format(&state, device, &dev, &fmt)?;
         let card = dev.query_caps().map(|c| c.card).unwrap_or_default();
@@ -4375,18 +4461,16 @@ impl IrCamera {
 
     /// Start streaming and fire the emitter.
     ///
-    /// Holding the session across several captures is safe on the modules we
-    /// measured: after ONE control write the emitter stayed lit for 30s of
-    /// continuous streaming on both (ASUS built-in at a flat level of 144, NexiGo
-    /// N930W at ~37), and the control survives even stream close and process
-    /// exit. See `examples/ir_refire_probe.rs`.
+    /// One guard owns one stream: it applies the documented face-auth mode once
+    /// before the first image dequeue and restores the displaced value after
+    /// image and metadata STREAMOFF.
     ///
     /// The per-capture re-fires that used to sit below are gone (#168): they are
-    /// not part of the sequence Microsoft documents, and on a module that DOES
-    /// self-clear the illumination metadata from #167 now reports the dark
-    /// frames rather than leaving brightness to guess. The residual risk is a
-    /// module nobody here has seen going dark for a window, which costs the user
-    /// a password fallback rather than the hardware.
+    /// not part of the sequence Microsoft documents. The earlier claim that
+    /// self-clear was measured false on both cameras was incorrect: the harness
+    /// read after guard restoration and explicitly did not observe in-stream
+    /// `GET_CUR`. Illumination metadata now supplies frame evidence where the
+    /// camera reports it; absence stays Unknown rather than licensing re-fire.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn session(&self) -> irlume_common::Result<IrSession<'_>> {
         self.session_with_progress(&no_progress())
@@ -4412,7 +4496,7 @@ impl IrCamera {
         let mode;
         let mut stream = TrackedStream::new(
             SafeStream::open(
-                V4l2CameraState::with_interval(
+                V4l2CameraState::with_ir_interval(
                     &self.device,
                     self.lease.clone(),
                     self.accepted_interval,
@@ -4432,7 +4516,7 @@ impl IrCamera {
         // 25s when video went first). `SafeStream::open` only allocates
         // buffers; STREAMON happens on the first dequeue, which is inside
         // `warm_up_stream` below. This is the window, and it is the only one.
-        let meta = ir_metadata::IlluminationLog::open(&self.device);
+        let mut meta = ir_metadata::IlluminationLog::open(&self.device);
         // BEFORE the warm-up, because the warm-up's first dequeue is STREAMON.
         // Microsoft's sequence sets the property and THEN starts streaming, and
         // this ran the other way round: every authentication set the mode under
@@ -4444,10 +4528,10 @@ impl IrCamera {
         // the image queue is load-bearing and measured.
         //
         // The comment this replaces said the write had to happen "while
-        // streaming" because Hello modules reset the control per open. The reset
-        // is on DEVICE open, which happened in `IrCamera::open`, not here; and
-        // the record above says the control survives stream close and process
-        // exit on both cameras measured, so it is not stream-scoped.
+        // streaming" because Hello modules reset the control per open. No
+        // in-stream measurement established that claim. The published sequence
+        // is still unambiguous: set the mode before image STREAMON and restore
+        // the displaced value after STREAMOFF.
         //
         // Held for the session rather than just applied: dropping `IrSession`
         // puts back the value the capture write displaced — the camera's
@@ -4457,15 +4541,28 @@ impl IrCamera {
         self.lease
             .require_endpoint(&self.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
-        mode = ir_emitter::enable_with_lease(
-            self.dev.handle(),
-            &self.card,
+        mode = enable_ir_emitter_privacy_bounded(
             &self.device,
+            &self.dev,
+            &self.card,
             self.lease.clone(),
-        );
+            "before Face Authentication D1",
+        )?;
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
         warm_up_stream(&self.device, &mut stream, progress)?;
+        // Rate establishment internally discards more frames than the metadata
+        // ring can hold. Drain those records now, after the fill, so buffers are
+        // requeued before the first frame a caller can observe.
+        fill_rate_then_drain_metadata(
+            || stream.fill_rate_evidence(),
+            || {
+                if let Some(log) = meta.as_mut() {
+                    log.drain();
+                }
+            },
+        )
+        .map_err(|error| map_io(&self.device, error))?;
         Ok(IrSession {
             cam: self,
             stream,
@@ -4849,15 +4946,7 @@ impl IrSession<'_> {
             .zip(flags.iter().copied())
             .map(
                 |((facts, sequence, timestamp, frame_taken, rate_evidence), illumination)| {
-                    let illumination = match illumination {
-                        Some(ir_metadata::Illumination::Lit) => {
-                            contracts::IlluminationProvenance::ActiveIr
-                        }
-                        Some(ir_metadata::Illumination::Dark) => {
-                            contracts::IlluminationProvenance::Ambient
-                        }
-                        None => contracts::IlluminationProvenance::Unknown,
-                    };
+                    let illumination = illumination_provenance(illumination);
                     checked_single_evidence(
                         binding.clone(),
                         format.clone(),
@@ -4906,9 +4995,8 @@ impl IrSession<'_> {
     /// and the decoder is reset to its initial state. No new device open, so
     /// no EBUSY from a double-open-rejecting camera.
     ///
-    /// The old guard MUST go before the fresh `enable`, the same order the
-    /// frozen-stream restarts in `capture_ir_streaming` and
-    /// `capture_ir_sequence` use: while it lives it holds the per-camera
+    /// The old guard MUST go before the fresh `enable`: while it lives it holds
+    /// the per-camera
     /// stream lock, and `flock` excludes per open file description, so the
     /// fresh enable in this same process answered Busy, refused to drive the
     /// emitter, and the assignment below then dropped the old guard, whose
@@ -4923,7 +5011,7 @@ impl IrSession<'_> {
             .map_err(|error| Error::Hardware(error.to_string()))?;
         drop(self.stream.take()); // STREAMOFF + buffer release before replacement
         self.meta = None; // drop the metadata queue
-                          // A restore failure PROPAGATES, mirroring the frozen-stream restart:
+                          // A restore failure PROPAGATES before any replacement write:
                           // the guard is spent after one attempt, and an unrecorded write whose
                           // restore failed would otherwise become permanently unowned.
         self._mode.restore().map_err(|e| {
@@ -4934,7 +5022,7 @@ impl IrSession<'_> {
         })?;
         self._mode = ir_emitter::StreamMode::inert();
         let stream = SafeStream::open(
-            V4l2CameraState::with_interval(
+            V4l2CameraState::with_ir_interval(
                 &self.cam.device,
                 self.cam.lease.clone(),
                 self.cam.accepted_interval,
@@ -4948,12 +5036,13 @@ impl IrSession<'_> {
             .lease
             .require_endpoint(&self.cam.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
-        let mode = ir_emitter::enable_with_lease(
-            self.cam.dev.handle(),
-            &self.cam.card,
+        let mode = enable_ir_emitter_privacy_bounded(
             &self.cam.device,
+            &self.cam.dev,
+            &self.cam.card,
             self.cam.lease.clone(),
-        );
+            "before recovered Face Authentication D1",
+        )?;
         let lit = mode.lit();
         let (meta, mode) = install_recovered_resources(stream, meta, mode, |stream| {
             self.cam
@@ -5002,10 +5091,7 @@ pub fn establish_pair_rate(
 pub mod ir_probe {
     use super::negotiate_ir_format_and_interval;
     use super::Device;
-    use super::{
-        ir_emitter, map_delivery, map_io, privacy_engaged_with_permit, verify_pinned, Error, Frame,
-        Spectrum,
-    };
+    use super::{map_delivery, map_io, verify_pinned, Error, Frame, Spectrum};
 
     /// Mean brightness of an 8-bit greyscale buffer.
     pub fn mean(data: &[u8]) -> f64 {
@@ -5134,12 +5220,8 @@ pub mod ir_probe {
             std::time::Duration::from_secs(2),
         )
         .map_err(|error| Error::Hardware(error.to_string()))?;
-        if privacy_engaged_with_permit(device) {
-            return Err(Error::Hardware(format!(
-                "{device}: hardware privacy switch is ON"
-            )));
-        }
         let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
+        super::require_ir_privacy_released(device, &dev, "before IR negotiation")?;
         let (fmt, pix, interval) = negotiate_ir_format_and_interval(device, &dev, &permit)?;
         let mut dec = super::IrDecoder::new(pix, fmt.quantization);
         let (w, h) = (fmt.width, fmt.height);
@@ -5163,7 +5245,7 @@ pub mod ir_probe {
         // lands before streaming starts.
         let mode;
         let stream = super::SafeStream::open(
-            super::V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
+            super::V4l2CameraState::with_ir_interval(device, permit.clone(), interval.accepted),
             device,
             &dev,
             &fmt,
@@ -5176,7 +5258,13 @@ pub mod ir_probe {
                 interval.accepted,
             ),
         );
-        mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
+        mode = super::enable_ir_emitter_privacy_bounded(
+            device,
+            &dev,
+            &card,
+            permit.clone(),
+            "before Face Authentication D1",
+        )?;
         // Bound, never read: held for its `Drop`, which restores the control.
         let _ = &mode;
         let mut out = Vec::with_capacity(n);
@@ -5204,28 +5292,41 @@ pub mod ir_probe {
     }
 }
 
-/// Sparse content signature for the frozen-stream detector: up to 64 bytes
-/// sampled at a fixed stride across the frame. Verbatim extraction from
-/// [`capture_ir_sequence`] (the former `sig_of` closure) so the pure logic is
-/// unit-testable without a camera; zero behavior change.
-pub(crate) fn frame_signature(data: &[u8]) -> Vec<u8> {
-    let stride = (data.len() / 64).max(1);
-    data.iter().step_by(stride).take(64).copied().collect()
-}
-
-/// Frozen-stream predicate: BIT-IDENTICAL consecutive signatures on a frame
-/// whose mean sits in the normal exposure band (saturated / near-black frames
-/// are optical states, not a stall). Verbatim extraction of the `frozen`
-/// expression in [`capture_ir_sequence`] as a test seam; zero behavior change.
-pub(crate) fn frame_frozen(best_mean: f64, sig: &[u8], last_sig: Option<&[u8]>) -> bool {
-    (10.0..245.0).contains(&best_mean) && last_sig == Some(sig)
-}
-
 /// Mean IR value at/above which a decoded frame is treated as an exposure
 /// blow-out: a saturated frame carries no detectable face, so a streaming
-/// consumer skips it rather than spend a window slot on it. Matches the upper
-/// bound of [`frame_frozen`]'s normal-exposure band.
+/// consumer skips it rather than spend a window slot on it.
 const IR_BLOWN_MEAN: f64 = 245.0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IrFrameDisposition {
+    Deliver,
+    SkipBlown,
+}
+
+/// Classify only the optical usability of one delivered IR frame.
+///
+/// Transport health is established by the validated dequeue, sequence,
+/// timestamp, and delivered-rate boundaries before this function is called.
+/// Pixel equality is intentionally not an input: privacy firmware may deliver
+/// an advancing constant placeholder, and content can never license a stream
+/// restart or another emitter write.
+fn ir_frame_disposition(mean: f64) -> IrFrameDisposition {
+    if mean >= IR_BLOWN_MEAN {
+        IrFrameDisposition::SkipBlown
+    } else {
+        IrFrameDisposition::Deliver
+    }
+}
+
+fn illumination_provenance(
+    illumination: Option<ir_metadata::Illumination>,
+) -> contracts::IlluminationProvenance {
+    match illumination {
+        Some(ir_metadata::Illumination::Lit) => contracts::IlluminationProvenance::ActiveIr,
+        Some(ir_metadata::Illumination::Dark) => contracts::IlluminationProvenance::Ambient,
+        None => contracts::IlluminationProvenance::Unknown,
+    }
+}
 
 /// One usable IR frame delivered to a [`capture_ir_streaming`] consumer, with
 /// the decoded mean the caller would otherwise recompute (the strobe phase and
@@ -5236,21 +5337,21 @@ pub struct IrStreamFrame {
     pub mean: f64,
 }
 
-/// Drive a single held-open IR stream, invoking `on_frame` for each USABLE frame
-/// (non-frozen, non-blown) until the consumer returns [`std::ops::ControlFlow::Break`] or
+/// Drive a single held-open IR stream, invoking `on_frame` for each usable frame
+/// (non-blown) until the consumer returns [`std::ops::ControlFlow::Break`] or
 /// the `max_frames` attempt budget is spent. Returns the break value, or `None`
 /// if the budget ran out first.
 ///
 /// This is the rolling-capture core the burst helpers and the live consumers
-/// share: it owns the device, the V4L2 mmap stream, the emitter re-fire, and the
-/// frozen-stream restart, so a consumer only decides what to do with each frame
+/// share: it owns the device, the V4L2 mmap stream, and the emitter guard, so a
+/// consumer only decides what to do with each frame
 /// and when to stop. The consent watch can therefore return the instant it
 /// sees an accepted gesture instead of always draining a fixed window, and a
-/// preview can pull frames continuously; both get the same black/blown/frozen filtering.
+/// preview can pull frames continuously; both get the same blown-frame filtering.
 ///
 /// Usable = the same set [`capture_ir_sequence`] historically kept: emitter-off
 /// (dark) frames ARE delivered, because a consumer classifying the strobe needs
-/// them; only frozen and blown frames are dropped.
+/// them; only blown frames are dropped.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn capture_ir_streaming<B>(
     device: &str,
@@ -5264,12 +5365,8 @@ pub fn capture_ir_streaming<B>(
         std::time::Duration::from_secs(2),
     )
     .map_err(|error| Error::Hardware(error.to_string()))?;
-    if privacy_engaged_with_permit(device) {
-        return Err(Error::Hardware(format!(
-            "{device}: hardware privacy switch is ON"
-        )));
-    }
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
+    require_ir_privacy_released(device, &dev, "before IR negotiation")?;
     let (fmt, pix, interval) = negotiate_ir_format_and_interval(device, &dev, &permit)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
@@ -5291,9 +5388,9 @@ pub fn capture_ir_streaming<B>(
     // other process's live stream. `SafeStream::open` only allocates
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
-    let mut mode;
+    let _mode;
     let stream = SafeStream::open(
-        V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
+        V4l2CameraState::with_ir_interval(device, permit.clone(), interval.accepted),
         device,
         &dev,
         &fmt,
@@ -5306,100 +5403,60 @@ pub fn capture_ir_streaming<B>(
             interval.accepted,
         ),
     );
-    mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
-    // Sparse content signature: BIT-IDENTICAL consecutive frames mean the stream
-    // has FROZEN (measured live 2026-07-01 in dark rooms: frames lock to a
-    // constant mid-grey for the rest of the window); real sensor noise never
-    // repeats exactly. Saturated and near-black frames are excluded from the
-    // check: those are optical states (exposure blow-out / emitter-off phase),
-    // not a stall, and restarting mid-settle only prolongs the settle.
-    // (Signature + predicate live in `frame_signature` / `frame_frozen`.)
-    let (mut dead_run, mut restarts) = (0usize, 0usize);
-    let mut last_sig: Option<Vec<u8>> = None;
-    // Set once per stream, before it starts, and not per frame; the
-    // frozen-stream restart below opens a new stream and applies it again,
-    // which is the only re-apply left.
+    // Metadata must STREAMON before the image queue's first dequeue.
+    let mut meta = ir_metadata::IlluminationLog::open(device);
+    _mode = enable_ir_emitter_privacy_bounded(
+        device,
+        &dev,
+        &card,
+        permit.clone(),
+        "before Face Authentication D1",
+    )?;
+    if max_frames > 0 {
+        fill_rate_then_drain_metadata(
+            || stream.fill_rate_evidence(),
+            || {
+                if let Some(log) = meta.as_mut() {
+                    log.drain();
+                }
+            },
+        )
+        .map_err(|error| map_io(device, error))?;
+    }
+    // Set once per stream, before it starts, and not per frame.
     //
     // This used to re-apply the control every eighth frame on the theory that
     // "some controls self-clear". At the default consent budget that is ten more
     // writes to camera firmware per watch, and `enable` is not a bare ioctl: each
     // call re-reads the USB descriptors from sysfs and takes a lock to scan the
     // undo journal on disk. Ten of those sit in the authentication path for a
-    // hypothesis this project MEASURED and found false: the record in
-    // `IrCamera::session` says the control survives stream close and process
-    // exit on both cameras here, so there was nothing self-clearing to re-arm
-    // against.
+    // hypothesis the project did not actually measure in-stream on the ASUS.
+    // Repeating a hardware write without that evidence remains unjustified;
+    // timestamp-correlated metadata below observes the frame result instead.
     //
-    // NOT justified by the illumination metadata from #167. `capture_with_stats`
-    // classifies its frames with that; this function never opens the metadata
-    // queue, and an earlier version of this comment claimed the evidence anyway.
-    // The residual risk is a module nobody here has seen whose control does
-    // self-clear mid stream: this path would go dark for the window and cost the
-    // user a password fallback. Reading the metadata queue here is how that gets
-    // closed, and it is not done.
+    // The metadata queue classifies each timestamp-correlated frame where the
+    // camera reports illumination. Missing records remain Unknown; host control
+    // readback is never promoted to optical provenance.
+    //
+    // Content equality is deliberately absent. The ASUS privacy shutter emits
+    // advancing, byte-identical 0x90 frames; those are live deliveries with
+    // substituted pixels, not a stalled transport. Dequeue timeout, corrupt
+    // metadata, or sequence/timestamp discontinuity already fails through the
+    // validated stream boundary without issuing another hardware write.
     for _ in 0..max_frames {
         let (buf, facts, sequence, timestamp, rate_evidence) =
             stream.next().map_err(|error| map_delivery(device, error))?;
         let taken = std::time::Instant::now();
+        let illumination = match meta.as_mut() {
+            Some(log) => {
+                log.drain();
+                log.illumination_at(facts.timestamp_micros())
+            }
+            None => None,
+        };
         let data = dec.decode(buf, w, h);
         let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
-        let sig = frame_signature(&data);
-        let frozen = frame_frozen(mean, &sig, last_sig.as_deref());
-        last_sig = Some(sig);
-        if frozen {
-            dead_run += 1;
-            if dead_run >= FROZEN_RUN_BEFORE_RESTART && restarts < FROZEN_RESTART_BUDGET {
-                restarts += 1;
-                dead_run = 0;
-                last_sig = None;
-                drop(stream.take()); // stop + release buffers before re-arming
-                                     // The OLD guard restores BEFORE the reopen. Its stream is
-                                     // already gone, and while the guard lives it holds the
-                                     // per-camera stream lock, which would make the fresh `enable`
-                                     // refuse to drive the emitter at all — the lock refuses
-                                     // contested writes rather than allowing an unrecorded one
-                                     // (#188, review round 4). Restoring here cannot write under
-                                     // the new stream either, because it happens before the fresh
-                                     // apply. Earlier versions kept the old guard armed across the
-                                     // reopen and negotiated ownership afterwards; the cost of
-                                     // this simpler shape is one restore/apply pair per restart,
-                                     // and restarts are the exception, not the path.
-                                     // A restore failure PROPAGATES rather than being logged
-                                     // over: the guard is spent after one attempt, and an
-                                     // UNRECORDED write whose restore failed here would otherwise
-                                     // become permanently unowned — the fresh enable finds the
-                                     // wanted bytes with no record to claim and leaves them
-                                     // forever (review round 12). Surfacing hardware trouble
-                                     // beats continuing to authenticate through it.
-                mode.restore().map_err(|e| {
-                    Error::Hardware(format!(
-                        "{device}: could not restore the emitter before restarting \
-                         a frozen stream: {e}"
-                    ))
-                })?;
-                let replacement = SafeStream::open(
-                    V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
-                    device,
-                    &dev,
-                    &fmt,
-                )?;
-                let replacement_mode =
-                    ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
-                let ((), replacement_mode) =
-                    install_recovered_resources(replacement, (), replacement_mode, |replacement| {
-                        stream.install_recovered(replacement)
-                    })
-                    .map_err(|error| {
-                        Error::Hardware(format!(
-                            "{device}: could not install the recovered stream: {error}"
-                        ))
-                    })?;
-                mode = replacement_mode;
-            }
-            continue;
-        }
-        dead_run = 0;
-        if mean >= IR_BLOWN_MEAN {
+        if ir_frame_disposition(mean) == IrFrameDisposition::SkipBlown {
             continue;
         }
         let provenance = checked_single_provenance(
@@ -5409,7 +5466,7 @@ pub fn capture_ir_streaming<B>(
             sequence,
             timestamp,
             taken,
-            contracts::IlluminationProvenance::Unknown,
+            illumination_provenance(illumination),
             rate_evidence,
         )?;
         let frame = Frame::from_provenance(w, h, Spectrum::Ir, data, provenance)?;
@@ -5451,12 +5508,8 @@ pub fn capture_ir_sequence(
         std::time::Duration::from_secs(2),
     )
     .map_err(|error| Error::Hardware(error.to_string()))?;
-    if privacy_engaged_with_permit(device) {
-        return Err(Error::Hardware(format!(
-            "{device}: hardware privacy switch is ON"
-        )));
-    }
     let dev = Device::with_path(device).map_err(|e| map_io(device, e))?;
+    require_ir_privacy_released(device, &dev, "before IR negotiation")?;
     let (fmt, pix, interval) = negotiate_ir_format_and_interval(device, &dev, &permit)?;
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
@@ -5478,9 +5531,9 @@ pub fn capture_ir_sequence(
     // other process's live stream. `SafeStream::open` only allocates
     // buffers; STREAMON happens on the first dequeue, so the set still
     // lands before streaming starts.
-    let mut mode;
+    let _mode;
     let stream = SafeStream::open(
-        V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
+        V4l2CameraState::with_ir_interval(device, permit.clone(), interval.accepted),
         device,
         &dev,
         &fmt,
@@ -5493,17 +5546,33 @@ pub fn capture_ir_sequence(
             interval.accepted,
         ),
     );
-    mode = ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
-    // Set once per stream, before it starts, and not per frame (the
-    // frozen-stream restart below re-applies on its new stream). This path also carried
-    // an every-eighth-frame re-fire; it went for the same reason, and with the
-    // same caveat: the justification is the MEASURED record in
-    // `IrCamera::session` that the control survives streaming, not the
-    // illumination metadata, which this function does not read either.
+    // Metadata must STREAMON before the image queue's first dequeue.
+    let mut meta = ir_metadata::IlluminationLog::open(device);
+    _mode = enable_ir_emitter_privacy_bounded(
+        device,
+        &dev,
+        &card,
+        permit.clone(),
+        "before Face Authentication D1",
+    )?;
+    if samples > 0 {
+        fill_rate_then_drain_metadata(
+            || stream.fill_rate_evidence(),
+            || {
+                if let Some(log) = meta.as_mut() {
+                    log.drain();
+                }
+            },
+        )
+        .map_err(|error| map_io(device, error))?;
+    }
+    // Set once per stream, before it starts, and not per frame. This path also
+    // carried an every-eighth-frame re-fire; it went for the same reason, and
+    // with the same caveat: one host-side readback does not prove optical
+    // output. The metadata queue above now supplies per-frame provenance where
+    // the camera reports it; absence remains Unknown.
     let mut frames = Vec::with_capacity(samples);
     let max_attempts = samples * 2 + 30;
-    let (mut dead_run, mut restarts) = (0usize, 0usize);
-    let mut last_sig: Option<Vec<u8>> = None;
     for _ in 0..max_attempts {
         if frames.len() >= samples {
             break;
@@ -5511,87 +5580,58 @@ pub fn capture_ir_sequence(
         let mut best: Option<Vec<u8>> = None;
         let mut best_mean = -1.0f64;
         let mut best_index = 0;
-        let mut contributors = Vec::with_capacity(burst);
+        let mut observations = Vec::with_capacity(burst);
+        let mut stamps = Vec::with_capacity(burst);
+        if let Some(log) = meta.as_mut() {
+            log.begin_burst();
+        }
         for _ in 0..burst {
             let (buf, facts, sequence, timestamp, rate_evidence) =
                 stream.next().map_err(|error| map_delivery(device, error))?;
             let at = std::time::Instant::now();
+            stamps.push(facts.timestamp_micros());
+            observations.push((facts, sequence, timestamp, at, rate_evidence));
+            if let Some(log) = meta.as_mut() {
+                log.drain();
+            }
             let data = dec.decode(buf, w, h);
             let mean = data.iter().map(|&p| p as f64).sum::<f64>() / data.len().max(1) as f64;
-            contributors.push(checked_single_evidence(
-                binding.clone(),
-                format.clone(),
-                facts,
-                sequence,
-                timestamp,
-                at,
-                contracts::IlluminationProvenance::Unknown,
-                rate_evidence,
-            )?);
             if mean > best_mean {
                 best_mean = mean;
                 best = Some(data);
-                best_index = contributors.len() - 1;
+                best_index = observations.len() - 1;
             }
         }
+        let flags = match meta.as_mut() {
+            Some(log) => {
+                log.drain();
+                stamps
+                    .iter()
+                    .map(|timestamp| log.illumination_at(*timestamp))
+                    .collect::<Vec<_>>()
+            }
+            None => vec![None; observations.len()],
+        };
+        let contributors = observations
+            .into_iter()
+            .zip(flags)
+            .map(
+                |((facts, sequence, timestamp, at, rate_evidence), illumination)| {
+                    checked_single_evidence(
+                        binding.clone(),
+                        format.clone(),
+                        facts,
+                        sequence,
+                        timestamp,
+                        at,
+                        illumination_provenance(illumination),
+                        rate_evidence,
+                    )
+                },
+            )
+            .collect::<irlume_common::Result<Vec<_>>>()?;
         let Some(data) = best else { continue };
-        let sig = frame_signature(&data);
-        let frozen = frame_frozen(best_mean, &sig, last_sig.as_deref());
-        last_sig = Some(sig);
-        if frozen {
-            dead_run += 1;
-            if dead_run >= FROZEN_RUN_BEFORE_RESTART && restarts < FROZEN_RESTART_BUDGET {
-                restarts += 1;
-                dead_run = 0;
-                last_sig = None;
-                drop(stream.take()); // stop + release buffers before re-arming
-                                     // The OLD guard restores BEFORE the reopen. Its stream is
-                                     // already gone, and while the guard lives it holds the
-                                     // per-camera stream lock, which would make the fresh `enable`
-                                     // refuse to drive the emitter at all — the lock refuses
-                                     // contested writes rather than allowing an unrecorded one
-                                     // (#188, review round 4). Restoring here cannot write under
-                                     // the new stream either, because it happens before the fresh
-                                     // apply. Earlier versions kept the old guard armed across the
-                                     // reopen and negotiated ownership afterwards; the cost of
-                                     // this simpler shape is one restore/apply pair per restart,
-                                     // and restarts are the exception, not the path.
-                                     // A restore failure PROPAGATES rather than being logged
-                                     // over: the guard is spent after one attempt, and an
-                                     // UNRECORDED write whose restore failed here would otherwise
-                                     // become permanently unowned — the fresh enable finds the
-                                     // wanted bytes with no record to claim and leaves them
-                                     // forever (review round 12). Surfacing hardware trouble
-                                     // beats continuing to authenticate through it.
-                mode.restore().map_err(|e| {
-                    Error::Hardware(format!(
-                        "{device}: could not restore the emitter before restarting \
-                         a frozen stream: {e}"
-                    ))
-                })?;
-                let replacement = SafeStream::open(
-                    V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
-                    device,
-                    &dev,
-                    &fmt,
-                )?;
-                let replacement_mode =
-                    ir_emitter::enable_with_lease(dev.handle(), &card, device, permit.clone());
-                let ((), replacement_mode) =
-                    install_recovered_resources(replacement, (), replacement_mode, |replacement| {
-                        stream.install_recovered(replacement)
-                    })
-                    .map_err(|error| {
-                        Error::Hardware(format!(
-                            "{device}: could not install the recovered stream: {error}"
-                        ))
-                    })?;
-                mode = replacement_mode;
-            }
-            continue;
-        }
-        dead_run = 0;
-        if best_mean >= IR_BLOWN_MEAN {
+        if ir_frame_disposition(best_mean) == IrFrameDisposition::SkipBlown {
             continue;
         }
         let provenance = if contributors.len() == 1 {
@@ -5615,15 +5655,15 @@ pub fn capture_ir_sequence(
         )?);
     }
     // A short return is a CAPTURE fault, not a quiet fact about the scene: the
-    // attempt budget ran out because frames arrived frozen, blown out, or too
+    // attempt budget ran out because frames arrived blown out or too
     // slowly. Callers read this sequence as temporal evidence, so a silent
     // shortfall reads downstream as "the user did not blink" when the truth is
     // "the camera did not deliver a window to look at". Say so; the caller
     // decides whether a partial window is still worth judging.
     if frames.len() < samples {
         irlume_common::dlog!(
-            "{device}: IR sequence delivered {}/{samples} frames in {max_attempts} attempts \
-             ({restarts} stream restarts); temporal evidence is incomplete",
+            "{device}: IR sequence delivered {}/{samples} frames in {max_attempts} attempts; \
+             temporal evidence is incomplete",
             frames.len()
         );
     }
@@ -7493,7 +7533,7 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
     let mut dec = IrDecoder::new(pix, fmt.quantization);
     let (w, h) = (fmt.width, fmt.height);
     let mut stream = SafeStream::open(
-        V4l2CameraState::with_interval(device, permit.clone(), interval.accepted),
+        V4l2CameraState::with_ir_interval(device, permit.clone(), interval.accepted),
         device,
         &dev,
         &fmt,
@@ -7828,6 +7868,31 @@ mod tests {
     }
 
     #[test]
+    fn illumination_metadata_maps_to_frame_provenance_without_brightness_guessing() {
+        use contracts::IlluminationProvenance::{ActiveIr, Ambient, Unknown};
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        assert_eq!(illumination_provenance(Some(Lit)), ActiveIr);
+        assert_eq!(illumination_provenance(Some(Dark)), Ambient);
+        assert_eq!(illumination_provenance(None), Unknown);
+    }
+
+    #[test]
+    fn hidden_rate_fill_completes_before_metadata_is_drained_for_exposed_frames() {
+        let calls = std::cell::RefCell::new(Vec::new());
+        fill_rate_then_drain_metadata(
+            || {
+                calls.borrow_mut().push("fill-rate");
+                Ok::<(), std::io::Error>(())
+            },
+            || calls.borrow_mut().push("drain-metadata"),
+        )
+        .expect("fixture fill succeeds");
+
+        assert_eq!(*calls.borrow(), ["fill-rate", "drain-metadata"]);
+    }
+
+    #[test]
     fn setup_burst_retains_sequence_locked_optical_evidence_without_metadata() {
         let measurement = setup_measurement_from_burst(
             &[10.0, 41.0, 11.0, 40.0, 9.0, 42.0, 10.0, 41.0],
@@ -7895,8 +7960,10 @@ mod tests {
         interval_domain: frame_interval::FrameIntervalDomain,
         set_interval_response: frame_interval::FrameInterval,
         endpoint_calls: std::cell::Cell<usize>,
+        dequeue_boundary_calls: std::cell::Cell<usize>,
         fail_set: bool,
         fail_endpoint_at: Option<usize>,
+        fail_dequeue_boundary_at: Option<usize>,
         fail_claim: bool,
         fail_dequeue: bool,
     }
@@ -7919,8 +7986,10 @@ mod tests {
                         .expect("valid fixture domain"),
                     set_interval_response: interval,
                     endpoint_calls: std::cell::Cell::new(0),
+                    dequeue_boundary_calls: std::cell::Cell::new(0),
                     fail_set: false,
                     fail_endpoint_at: None,
+                    fail_dequeue_boundary_at: None,
                     fail_claim: false,
                     fail_dequeue: false,
                 },
@@ -7972,6 +8041,16 @@ mod tests {
             } else {
                 Ok(())
             }
+        }
+
+        fn require_dequeue_boundary(&self, _dev: &()) -> std::io::Result<()> {
+            let call = self.dequeue_boundary_calls.get() + 1;
+            self.dequeue_boundary_calls.set(call);
+            if self.fail_dequeue_boundary_at == Some(call) {
+                self.calls.borrow_mut().push("privacy_refusal");
+                return Err(std::io::Error::other("privacy boundary failure"));
+            }
+            self.require_endpoint()
         }
 
         fn compare_format(&self, expected: &Format, current: &Format) -> Option<String> {
@@ -8103,6 +8182,39 @@ mod tests {
         ];
         assert_eq!(exercise_fake_happy_path(fake_format(b"YUYV")), expected);
         assert_eq!(exercise_fake_happy_path(fake_format(b"GREY")), expected);
+    }
+
+    #[test]
+    fn dequeue_refuses_privacy_transition_after_the_blocking_call() {
+        let format = fake_format(b"GREY");
+        let (mut state, calls) = FakeCameraState::new(format);
+        state.fail_dequeue_boundary_at = Some(2);
+        let mut stream = CameraStateStream::open(state, "/dev/fake-ir", &(), &format)
+            .expect("stream opens before the simulated privacy transition");
+
+        let error = stream
+            .next()
+            .expect_err("post-dequeue privacy engagement must reject the frame");
+        assert!(
+            error.to_string().contains("privacy boundary failure"),
+            "{error}"
+        );
+        drop(stream);
+
+        let calls = calls.borrow();
+        let dequeue = calls
+            .iter()
+            .position(|call| *call == "dequeue")
+            .expect("the blocking dequeue ran");
+        let refusal = calls
+            .iter()
+            .position(|call| *call == "privacy_refusal")
+            .expect("the post-dequeue privacy boundary ran");
+        let cleanup = calls
+            .iter()
+            .position(|call| *call == "cleanup")
+            .expect("the rejected frame tears down its stream");
+        assert!(dequeue < refusal && refusal < cleanup, "{calls:?}");
     }
 
     #[test]
@@ -11623,39 +11735,15 @@ mod tests {
     }
 
     #[test]
-    fn frame_signature_is_sparse_and_content_sensitive() {
-        // Short frames: the whole content is the signature.
-        assert_eq!(frame_signature(&[1, 2, 3]), vec![1, 2, 3]);
-        // Long frames: capped at 64 sampled bytes.
-        let long = vec![7u8; 640 * 400];
-        let sig = frame_signature(&long);
-        assert_eq!(sig.len(), 64);
-        assert!(sig.iter().all(|&b| b == 7));
-        // Identical content -> identical signature; a change at a sampled
-        // position (index 0 is always sampled) -> different signature.
-        let mut changed = long.clone();
-        changed[0] = 8;
-        assert_eq!(frame_signature(&long), sig);
-        assert_ne!(frame_signature(&changed), sig);
-    }
-
-    #[test]
-    fn frozen_detector_fires_only_on_repeated_normal_exposure_frames() {
-        let sig = frame_signature(&[99u8; 1024]);
-        // First frame of a window (no previous signature): never frozen.
-        assert!(!frame_frozen(99.0, &sig, None));
-        // Bit-identical consecutive mid-grey frames: frozen.
-        assert!(frame_frozen(99.0, &sig, Some(&sig)));
-        // Same signature but saturated / near-black mean: optical state, not a
-        // stall (exposure blow-out or the emitter-off strobe phase).
-        assert!(!frame_frozen(250.0, &sig, Some(&sig)));
-        assert!(!frame_frozen(245.0, &sig, Some(&sig)));
-        assert!(!frame_frozen(5.0, &sig, Some(&sig)));
-        // Boundary means inside the band still count.
-        assert!(frame_frozen(10.0, &sig, Some(&sig)));
-        // Different content -> live stream.
-        let other = frame_signature(&[98u8; 1024]);
-        assert!(!frame_frozen(99.0, &sig, Some(&other)));
+    fn constant_content_is_deliverable_not_a_recovery_signal() {
+        // Repeated calls model a byte-identical advancing feed. Content is not
+        // part of this decision, so the exact ASUS privacy placeholder remains
+        // a delivered frame and can never authorize another emitter write.
+        assert_eq!(ir_frame_disposition(144.0), IrFrameDisposition::Deliver);
+        assert_eq!(ir_frame_disposition(144.0), IrFrameDisposition::Deliver);
+        assert_eq!(ir_frame_disposition(10.0), IrFrameDisposition::Deliver);
+        assert_eq!(ir_frame_disposition(244.9), IrFrameDisposition::Deliver);
+        assert_eq!(ir_frame_disposition(245.0), IrFrameDisposition::SkipBlown);
     }
 
     #[test]
@@ -12128,6 +12216,40 @@ mod tests {
         assert!(privacy_permits_setup(Ok(None)).is_ok());
     }
 
+    #[test]
+    fn privacy_capture_decision_blocks_forward_d1_on_engaged_or_unknown_state() {
+        let engaged = privacy_permits_ir_capture(Ok(Some(true)))
+            .expect_err("an engaged shutter must block capture and the D1 write");
+        assert!(engaged.contains("shutter is engaged"), "{engaged}");
+
+        let unreadable =
+            privacy_permits_ir_capture(Err(std::io::Error::from_raw_os_error(libc::EIO)))
+                .expect_err("an unreadable shutter must not authorize D1");
+        assert!(unreadable.contains("could not read"), "{unreadable}");
+
+        assert!(privacy_permits_ir_capture(Ok(Some(false))).is_ok());
+        assert!(privacy_permits_ir_capture(Ok(None)).is_ok());
+    }
+
+    #[test]
+    fn privacy_gate_never_invokes_forward_write_on_engaged_or_unknown_state() {
+        let writes = std::cell::Cell::new(0usize);
+        let write = || writes.set(writes.get() + 1);
+
+        assert!(with_released_ir_privacy(Ok(Some(true)), write).is_err());
+        assert_eq!(writes.get(), 0);
+        assert!(
+            with_released_ir_privacy(Err(std::io::Error::from_raw_os_error(libc::EIO)), write,)
+                .is_err()
+        );
+        assert_eq!(writes.get(), 0);
+
+        with_released_ir_privacy(Ok(Some(false)), write).expect("released privacy authorizes D1");
+        with_released_ir_privacy(Ok(None), write)
+            .expect("an absent privacy control preserves support");
+        assert_eq!(writes.get(), 2);
+    }
+
     /// The two backlight-compensation decisions (#426), every arm. The write
     /// only fires on an answered control holding something other than the
     /// wanted value, so an unreadable or absent control is never written
@@ -12226,7 +12348,7 @@ mod tests {
     // patterns (YUYV 640x480 / GREY 640x400), and exports the two vars.
     // Without them the tests return immediately (and are #[ignore]d anyway).
     // A THIRD node, IRLUME_TEST_SPARE_DEVICE, has NO CI-side feeder: tests
-    // that need a specific pattern (static for the frozen-stream detector,
+    // that need a specific pattern (static for constant-content capture,
     // alternating for strobe pairing) spawn their own ffmpeg against it and
     // kill the child on drop. Spare-node tests own that node exclusively;
     // CI runs the gated suite with --test-threads=1.
@@ -13258,37 +13380,28 @@ mod tests {
 
     #[test]
     #[ignore = "needs an unfed v4l2loopback node; set IRLUME_TEST_SPARE_DEVICE (CI does this)"]
-    fn loopback_frozen_static_feed_starves_the_sequence_window() {
-        // A bit-identical feed simulates the stalled-sensor failure the
-        // detector was built for (streams observed locking to a constant
-        // mid-grey). Expected arithmetic, from capture_ir_sequence: the first
-        // frame is accepted (no previous signature), every repeat is frozen,
-        // two frozen frames trigger a stream restart (budget 4), and each
-        // restart clears last_sig so exactly one more frame is accepted. A
-        // 6-sample window on a fully static feed therefore returns Ok with
-        // exactly 1 + 4 = 5 frames: a SHORT window, never an error.
+    fn loopback_advancing_static_feed_fills_the_sequence_without_recovery() {
+        // A bit-identical feed is valid content while V4L2 sequence and
+        // timestamps advance. It must fill the requested window without a
+        // content-triggered restart; privacy firmware can produce this exact
+        // shape, and another emitter write cannot repair it.
         let _lock = env_lock();
         let spare = spare_device();
         let _sub = EnvGuard::unset("IRLUME_IR_AMBIENT_SUBTRACT");
         let _esc = allow_virtual(&spare);
         let _feeder = FfmpegFeeder::spawn(&spare, "color=c=gray:size=640x400:rate=15");
 
-        // The single-shot path has no frozen gate: a static feed still yields
-        // a frame (this also blocks until the feeder's frames actually flow).
+        // The single-shot path also accepts static content (this blocks until
+        // the feeder's frames actually flow).
         let (frame, _) = capture_ir_with_stats(&spare).expect("static feed single capture");
         let mean = ir_probe::mean(&frame.data);
         assert!(
             (10.0..245.0).contains(&mean),
-            "harness: the static gray feed must sit inside the frozen \
-             detector's normal-exposure band, got mean {mean:.1}"
+            "harness: the static gray feed must be usable, got mean {mean:.1}"
         );
 
         let seq = capture_ir_sequence(&spare, 6, 1).expect("sequence returns Ok, not Err");
-        assert_eq!(
-            seq.len(),
-            5,
-            "static feed: 1 initial accept + 1 per stream restart (budget 4)"
-        );
+        assert_eq!(seq.len(), 6, "advancing static frames fill the window");
         for f in &seq {
             assert_eq!((f.width, f.height), (IR_W, IR_H));
             assert_eq!(f.spectrum, Spectrum::Ir);

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -580,6 +580,28 @@ enum PrivacyBoundary {
     RequireReleased,
 }
 
+#[derive(Debug)]
+struct PrivacyBoundaryRefusal(String);
+
+impl std::fmt::Display for PrivacyBoundaryRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for PrivacyBoundaryRefusal {}
+
+fn privacy_boundary_error(why: String) -> std::io::Error {
+    std::io::Error::other(PrivacyBoundaryRefusal(why))
+}
+
+fn is_privacy_boundary_error(error: &std::io::Error) -> bool {
+    error
+        .get_ref()
+        .and_then(|inner| inner.downcast_ref::<PrivacyBoundaryRefusal>())
+        .is_some()
+}
+
 #[derive(Clone)]
 struct V4l2CameraState {
     device: String,
@@ -666,7 +688,7 @@ impl CameraState for V4l2CameraState {
     fn require_dequeue_boundary(&self, dev: &Device) -> std::io::Result<()> {
         self.require_endpoint().map_err(std::io::Error::other)?;
         if self.privacy_boundary == PrivacyBoundary::RequireReleased {
-            privacy_permits_ir_capture(privacy_state(dev)).map_err(std::io::Error::other)?;
+            privacy_permits_ir_capture(privacy_state(dev)).map_err(privacy_boundary_error)?;
         }
         Ok(())
     }
@@ -1039,6 +1061,7 @@ struct CameraStateStream<'a, S: CameraState> {
     layout: frame_provenance::PayloadLayout,
     state_started: bool,
     stream_started_validated: bool,
+    privacy_refused: bool,
 }
 
 type SafeStream<'a> = CameraStateStream<'a, V4l2CameraState>;
@@ -1235,6 +1258,7 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
             layout,
             state_started: false,
             stream_started_validated: false,
+            privacy_refused: false,
         };
         verify_stream_state(
             &stream.state,
@@ -1265,13 +1289,26 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
             expected_interval,
             layout,
             stream_started_validated,
+            privacy_refused,
             ..
         } = self;
-        let dequeued = dequeue_validated_typed(
-            inner.as_mut().expect("stream taken only in Drop"),
-            *layout,
-            || state.require_dequeue_boundary(dev),
-        )?;
+        let inner = inner.as_mut().ok_or_else(|| {
+            ValidatedDequeueError::Io(std::io::Error::other(
+                "capture stream stopped after privacy refusal",
+            ))
+        })?;
+        let dequeued = match dequeue_validated_typed(inner, *layout, || {
+            state.require_dequeue_boundary(dev)
+        }) {
+            Ok(dequeued) => dequeued,
+            Err(error) => {
+                if matches!(&error, ValidatedDequeueError::Io(io) if is_privacy_boundary_error(io))
+                {
+                    *privacy_refused = true;
+                }
+                return Err(error);
+            }
+        };
         if !*stream_started_validated {
             verify_stream_snapshot(
                 state,
@@ -1285,6 +1322,24 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
             *stream_started_validated = true;
         }
         Ok(dequeued)
+    }
+
+    fn take_privacy_refusal(&mut self) -> bool {
+        std::mem::take(&mut self.privacy_refused)
+    }
+
+    fn stop(&mut self) {
+        let Some(inner) = self.inner.take() else {
+            return;
+        };
+        let device = self.device.clone();
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(inner))).is_err() {
+            irlume_common::dlog!("{device}: stream teardown failed (STREAMOFF); frames unaffected");
+        }
+        if self.state_started {
+            self.state.stop_stream();
+            self.state_started = false;
+        }
     }
 }
 
@@ -1452,6 +1507,14 @@ impl<S> TrackedStream<S> {
         // then re-seeds the baseline in the new epoch.
         self.rate_window.reset();
         Ok(())
+    }
+}
+
+impl TrackedStream<SafeStream<'_>> {
+    fn take_privacy_refusal(&mut self) -> bool {
+        self.stream
+            .as_mut()
+            .is_some_and(CameraStateStream::take_privacy_refusal)
     }
 }
 
@@ -1889,18 +1952,28 @@ fn install_recovered_resources<S, M, G, E>(
     }
 }
 
+fn teardown_ir_after_privacy_refusal<S, M, E>(
+    stream: &mut Option<S>,
+    metadata: &mut Option<M>,
+    restore_emitter: impl FnOnce() -> Result<(), E>,
+) -> Result<(), E> {
+    drop(stream.take());
+    drop(metadata.take());
+    restore_emitter()
+}
+
+fn finish_privacy_teardown<E: std::fmt::Display>(refusal: Error, restore: Result<(), E>) -> Error {
+    match restore {
+        Ok(()) => refusal,
+        Err(restore) => Error::Hardware(format!(
+            "{refusal}; additionally could not restore the emitter after the privacy refusal: {restore}"
+        )),
+    }
+}
+
 impl<S: CameraState> Drop for CameraStateStream<'_, S> {
     fn drop(&mut self) {
-        let Some(inner) = self.inner.take() else {
-            return;
-        };
-        let device = self.device.clone();
-        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(inner))).is_err() {
-            irlume_common::dlog!("{device}: stream teardown failed (STREAMOFF); frames unaffected");
-        }
-        if self.state_started {
-            self.state.stop_stream();
-        }
+        self.stop();
     }
 }
 
@@ -4625,6 +4698,30 @@ impl IrSession<'_> {
     /// (#221).
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn capture_with_stats(&mut self) -> irlume_common::Result<(Frame, IrCaptureStats)> {
+        let result = self.capture_with_stats_inner();
+        if !self.stream.take_privacy_refusal() {
+            return result;
+        }
+        let refusal = result.err().unwrap_or_else(|| {
+            Error::Hardware(format!(
+                "{}: privacy boundary refused a capture after it produced a frame",
+                self.cam.device
+            ))
+        });
+        Err(self.stop_after_privacy_refusal(refusal))
+    }
+
+    fn stop_after_privacy_refusal(&mut self, refusal: Error) -> Error {
+        let restore =
+            teardown_ir_after_privacy_refusal(&mut self.stream.stream, &mut self.meta, || {
+                self._mode.restore()
+            });
+        self._mode = ir_emitter::StreamMode::inert();
+        self.lit = false;
+        finish_privacy_teardown(refusal, restore)
+    }
+
+    fn capture_with_stats_inner(&mut self) -> irlume_common::Result<(Frame, IrCaptureStats)> {
         let device = self.cam.device.as_str();
         let lease = self.cam.lease.clone();
         lease
@@ -5093,8 +5190,20 @@ pub fn establish_pair_rate(
     ir: &mut IrSession<'_>,
 ) -> irlume_common::Result<()> {
     let device = rgb.cam.device.clone();
-    establish_concurrent_rate(&mut rgb.stream, &mut ir.stream)
-        .map_err(|error| map_io(&device, error))
+    let result = establish_concurrent_rate(&mut rgb.stream, &mut ir.stream);
+    if ir.stream.take_privacy_refusal() {
+        let refusal = result
+            .err()
+            .map(|error| map_io(&ir.cam.device, error))
+            .unwrap_or_else(|| {
+                Error::Hardware(format!(
+                    "{}: privacy boundary refused paired rate establishment",
+                    ir.cam.device
+                ))
+            });
+        return Err(ir.stop_after_privacy_refusal(refusal));
+    }
+    result.map_err(|error| map_io(&device, error))
 }
 
 /// Ambient-subtraction helpers (Windows-Hello-style illuminated minus ambient).
@@ -8062,7 +8171,7 @@ mod tests {
             self.dequeue_boundary_calls.set(call);
             if self.fail_dequeue_boundary_at == Some(call) {
                 self.calls.borrow_mut().push("privacy_refusal");
-                return Err(std::io::Error::other("privacy boundary failure"));
+                return Err(privacy_boundary_error("privacy boundary failure".into()));
             }
             self.require_endpoint()
         }
@@ -8213,6 +8322,10 @@ mod tests {
             error.to_string().contains("privacy boundary failure"),
             "{error}"
         );
+        assert!(
+            stream.take_privacy_refusal(),
+            "the session boundary must retain the typed refusal for teardown"
+        );
         drop(stream);
 
         let calls = calls.borrow();
@@ -8227,7 +8340,7 @@ mod tests {
         let cleanup = calls
             .iter()
             .position(|call| *call == "cleanup")
-            .expect("the rejected frame tears down its stream");
+            .expect("the rejected frame tears down when its owner responds to the marker");
         assert!(dequeue < refusal && refusal < cleanup, "{calls:?}");
     }
 
@@ -8798,6 +8911,51 @@ mod tests {
 
         assert_eq!(payload, &[1, 2, 3, 4]);
         assert_eq!(facts.bytes_used(), 4);
+    }
+
+    #[test]
+    fn privacy_refusal_stops_image_and_metadata_before_emitter_restore() {
+        #[derive(Debug)]
+        struct DropMark {
+            name: &'static str,
+            drops: std::rc::Rc<std::cell::RefCell<Vec<&'static str>>>,
+        }
+
+        impl Drop for DropMark {
+            fn drop(&mut self) {
+                self.drops.borrow_mut().push(self.name);
+            }
+        }
+
+        let drops = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mark = |name| DropMark {
+            name,
+            drops: std::rc::Rc::clone(&drops),
+        };
+        let mut image = Some(mark("image-stream"));
+        let mut metadata = Some(mark("metadata-stream"));
+
+        teardown_ir_after_privacy_refusal(&mut image, &mut metadata, || {
+            drops.borrow_mut().push("emitter-restore");
+            Ok::<(), &str>(())
+        })
+        .expect("restore succeeds");
+
+        assert_eq!(
+            drops.borrow().as_slice(),
+            ["image-stream", "metadata-stream", "emitter-restore"]
+        );
+    }
+
+    #[test]
+    fn privacy_cleanup_reports_both_refusal_and_restore_failure() {
+        let error = finish_privacy_teardown(
+            Error::Hardware("privacy boundary failure".into()),
+            Err::<(), _>("restore failed"),
+        );
+        let message = error.to_string();
+        assert!(message.contains("privacy boundary failure"), "{message}");
+        assert!(message.contains("restore failed"), "{message}");
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1328,6 +1328,10 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
         std::mem::take(&mut self.privacy_refused)
     }
 
+    fn privacy_refused(&self) -> bool {
+        self.privacy_refused
+    }
+
     fn stop(&mut self) {
         let Some(inner) = self.inner.take() else {
             return;
@@ -1511,6 +1515,12 @@ impl<S> TrackedStream<S> {
 }
 
 impl TrackedStream<SafeStream<'_>> {
+    fn privacy_refused(&self) -> bool {
+        self.stream
+            .as_ref()
+            .is_some_and(CameraStateStream::privacy_refused)
+    }
+
     fn take_privacy_refusal(&mut self) -> bool {
         self.stream
             .as_mut()
@@ -1839,6 +1849,17 @@ fn fill_rate_then_drain_metadata<E>(
     fill_rate()?;
     drain_metadata();
     Ok(())
+}
+
+fn finish_hidden_rate_fill<E>(
+    result: Result<(), E>,
+    privacy_refused: bool,
+    drain_metadata: impl FnOnce(),
+) -> Result<(), E> {
+    if !privacy_refused {
+        drain_metadata();
+    }
+    result
 }
 
 /// Establish the delivered-rate window for TWO streams by filling each one on
@@ -4748,6 +4769,14 @@ impl IrSession<'_> {
                 "IR stream missing after a failed recovery".into(),
             ));
         }
+        let rate_fill = self.stream.fill_rate_evidence();
+        let privacy_refused = self.stream.privacy_refused();
+        finish_hidden_rate_fill(rate_fill, privacy_refused, || {
+            if let Some(log) = self.meta.as_mut() {
+                log.drain();
+            }
+        })
+        .map_err(|error| map_io(device, error))?;
         let stream = &mut self.stream;
         let dec = &mut self.dec;
         // The emitter may STROBE (pulse), so grab a burst and keep the brightest
@@ -5191,6 +5220,12 @@ pub fn establish_pair_rate(
 ) -> irlume_common::Result<()> {
     let device = rgb.cam.device.clone();
     let result = establish_concurrent_rate(&mut rgb.stream, &mut ir.stream);
+    let privacy_refused = ir.stream.privacy_refused();
+    let result = finish_hidden_rate_fill(result, privacy_refused, || {
+        if let Some(log) = ir.meta.as_mut() {
+            log.drain();
+        }
+    });
     if ir.stream.take_privacy_refusal() {
         let refusal = result
             .err()
@@ -8011,8 +8046,39 @@ mod tests {
             || calls.borrow_mut().push("drain-metadata"),
         )
         .expect("fixture fill succeeds");
+        calls.borrow_mut().push("begin-burst");
+        calls.borrow_mut().push("exposed-dequeue");
 
-        assert_eq!(*calls.borrow(), ["fill-rate", "drain-metadata"]);
+        assert_eq!(
+            *calls.borrow(),
+            [
+                "fill-rate",
+                "drain-metadata",
+                "begin-burst",
+                "exposed-dequeue"
+            ]
+        );
+    }
+
+    #[test]
+    fn reusable_rate_fill_errors_requeue_metadata_but_privacy_refusals_do_not() {
+        let calls = std::cell::RefCell::new(Vec::new());
+        let result =
+            finish_hidden_rate_fill(Err::<(), _>("ordinary delivery error"), false, || {
+                calls.borrow_mut().push("drain-metadata")
+            });
+        assert_eq!(result, Err("ordinary delivery error"));
+        assert_eq!(*calls.borrow(), ["drain-metadata"]);
+
+        calls.borrow_mut().clear();
+        let result = finish_hidden_rate_fill(Err::<(), _>("privacy refusal"), true, || {
+            calls.borrow_mut().push("must-not-drain")
+        });
+        assert_eq!(result, Err("privacy refusal"));
+        assert!(
+            calls.borrow().is_empty(),
+            "privacy refusal must proceed directly to teardown"
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -1887,15 +1887,51 @@ fn establish_concurrent_rate<A: ValidatedStream + Send, B: ValidatedStream + Sen
     if primary.rate_window.ready() && secondary.rate_window.ready() {
         return Ok(());
     }
+    establish_concurrent_rate_with_cancel(
+        primary,
+        secondary,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+}
+
+#[derive(Debug)]
+struct PairedRateFillCancelled;
+
+impl std::fmt::Display for PairedRateFillCancelled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("paired rate fill cancelled after companion failure")
+    }
+}
+
+impl std::error::Error for PairedRateFillCancelled {}
+
+fn paired_rate_fill_cancelled(error: &std::io::Error) -> bool {
+    error
+        .get_ref()
+        .and_then(|inner| inner.downcast_ref::<PairedRateFillCancelled>())
+        .is_some()
+}
+
+fn paired_rate_cancel_error() -> std::io::Error {
+    std::io::Error::other(PairedRateFillCancelled)
+}
+
+fn establish_concurrent_rate_with_cancel<A: ValidatedStream + Send, B: ValidatedStream + Send>(
+    primary: &mut TrackedStream<A>,
+    secondary: &mut TrackedStream<B>,
+    cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> std::io::Result<()> {
     let ready_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     std::thread::scope(|scope| {
         let a = {
             let count = std::sync::Arc::clone(&ready_count);
-            scope.spawn(move || drain_until_both_ready(primary, &count))
+            let cancelled = std::sync::Arc::clone(&cancelled);
+            scope.spawn(move || drain_until_both_ready(primary, &count, &cancelled))
         };
         let b = {
             let count = std::sync::Arc::clone(&ready_count);
-            scope.spawn(move || drain_until_both_ready(secondary, &count))
+            let cancelled = std::sync::Arc::clone(&cancelled);
+            scope.spawn(move || drain_until_both_ready(secondary, &count, &cancelled))
         };
         // A panic in a fill thread is a software defect, never a camera
         // verdict: re-raise it (mirrors the capture-mode probe's rule, #263).
@@ -1905,9 +1941,12 @@ fn establish_concurrent_rate<A: ValidatedStream + Send, B: ValidatedStream + Sen
         let b = b
             .join()
             .unwrap_or_else(|payload| std::panic::resume_unwind(payload));
-        a?;
-        b?;
-        Ok(())
+        match (a, b) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(a), Err(b)) if paired_rate_fill_cancelled(&a) => Err(b),
+            (Err(a), _) => Err(a),
+            (_, Err(b)) => Err(b),
+        }
     })
 }
 
@@ -1921,11 +1960,18 @@ fn establish_concurrent_rate<A: ValidatedStream + Send, B: ValidatedStream + Sen
 fn drain_until_both_ready<S: ValidatedStream>(
     stream: &mut TrackedStream<S>,
     ready_count: &std::sync::atomic::AtomicUsize,
+    cancelled: &std::sync::atomic::AtomicBool,
 ) -> std::io::Result<()> {
     use std::sync::atomic::Ordering;
     // Flush the STREAMON transient; its sequence gaps would poison the window.
     for _ in 0..RATE_STARTUP_FLUSH {
-        stream.next_discarded()?;
+        if cancelled.load(Ordering::Acquire) {
+            return Err(paired_rate_cancel_error());
+        }
+        if let Err(error) = stream.next_discarded() {
+            cancelled.store(true, Ordering::Release);
+            return Err(error);
+        }
     }
     stream.rate_window.reset();
     let mut reported = false;
@@ -1934,7 +1980,13 @@ fn drain_until_both_ready<S: ValidatedStream>(
     // bounded by the twin's worst-case fill.
     let budget = MAX_RATE_FILL_ATTEMPTS + MAX_RATE_FILL_ATTEMPTS;
     while ready_count.load(Ordering::Acquire) < 2 && attempts < budget {
-        stream.next_discarded()?;
+        if cancelled.load(Ordering::Acquire) {
+            return Err(paired_rate_cancel_error());
+        }
+        if let Err(error) = stream.next_discarded() {
+            cancelled.store(true, Ordering::Release);
+            return Err(error);
+        }
         if !reported && stream.rate_window.ready() {
             ready_count.fetch_add(1, Ordering::AcqRel);
             reported = true;
@@ -4686,9 +4738,9 @@ impl IrCamera {
 /// A running IR stream with its emitter lit.
 pub struct IrSession<'a> {
     cam: &'a IrCamera,
-    /// `None` only transiently inside [`Self::recover`]: the broken stream
-    /// must be DROPPED (STREAMOFF + buffer release) before its replacement
-    /// negotiates, and a plain re-assignment builds the new value first.
+    /// `None` while [`Self::recover`] replaces a broken stream, after a failed
+    /// recovery, or after a privacy refusal deliberately tears the session
+    /// down. Recovery must open a fresh stream before capture can resume.
     stream: TrackedStream<SafeStream<'a>>,
     dec: IrDecoder,
     lit: bool,
@@ -5209,10 +5261,10 @@ impl IrSession<'_> {
 /// module-level concurrent fill for why the fill must not be serial.
 ///
 /// Called once per held session, before the capture loop, so the per-frame
-/// `next()` fills no-op on a ready window. Best-effort by contract: a failure
-/// is reported so the caller can log it, but the session stays usable — the
-/// per-stream serial fill in `next()` re-attempts establishment (and fails
-/// closed) on the first capture, preserving the existing error/retry shape.
+/// `next()` fills no-op on a ready window. An ordinary failure is reported but
+/// leaves both sessions reusable, so `next()` may retry its serial fill. A
+/// privacy refusal is different: the IR stream and metadata queue are stopped,
+/// D1 is restored, and that session remains inert until explicit recovery.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn establish_pair_rate(
     rgb: &mut RgbSession<'_>,
@@ -14165,6 +14217,80 @@ mod tests {
                 panic!("concurrent fill thread panicked")
             }
         }
+    }
+
+    #[test]
+    fn paired_rate_failure_cancels_the_companion_fill_without_spending_its_budget() {
+        struct ImmediateFailure;
+
+        impl ValidatedStream for ImmediateFailure {
+            fn next_validated(
+                &mut self,
+            ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>
+            {
+                Err(ValidatedDequeueError::Io(std::io::Error::other(
+                    "privacy refusal",
+                )))
+            }
+        }
+
+        struct CancelAwareFixture {
+            payload: [u8; 1],
+            calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+            cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+
+        impl ValidatedStream for CancelAwareFixture {
+            fn next_validated(
+                &mut self,
+            ) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError>
+            {
+                use std::sync::atomic::Ordering;
+                let call = self.calls.fetch_add(1, Ordering::SeqCst);
+                while !self.cancelled.load(Ordering::Acquire) {
+                    std::thread::yield_now();
+                }
+                let metadata = v4l::buffer::Metadata {
+                    bytesused: 1,
+                    sequence: call as u32,
+                    flags: v4l::buffer::Flags::TIMESTAMP_MONOTONIC,
+                    timestamp: v4l::timestamp::Timestamp::new(call as i64 + 1, 0),
+                    ..v4l::buffer::Metadata::default()
+                };
+                let facts = frame_provenance::DequeuedBufferFacts::from_v4l(&metadata, 1)
+                    .map_err(ValidatedDequeueError::Facts)?;
+                Ok((&self.payload, facts))
+            }
+        }
+
+        let config = |role| {
+            rate_gate::StreamRateConfig::with_window(
+                role,
+                frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+                frame_interval::FrameInterval::new(1, 15).expect("1/15"),
+                4,
+            )
+        };
+        let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut rgb = TrackedStream::new(
+            CancelAwareFixture {
+                payload: [1],
+                calls: calls.clone(),
+                cancelled: cancelled.clone(),
+            },
+            config(contracts::StreamRole::Rgb),
+        );
+        let mut ir = TrackedStream::new(ImmediateFailure, config(contracts::StreamRole::Ir));
+
+        let error = establish_concurrent_rate_with_cancel(&mut rgb, &mut ir, cancelled)
+            .expect_err("the IR refusal must remain the paired result");
+
+        assert!(error.to_string().contains("privacy refusal"), "{error}");
+        assert!(
+            calls.load(std::sync::atomic::Ordering::SeqCst) <= 1,
+            "the companion may finish one in-flight dequeue, never the bounded fill"
+        );
     }
 }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -13572,7 +13572,7 @@ mod tests {
         let mut session = camera.session().expect("open IR session");
         let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         session.meta = Some(ir_metadata::IlluminationLog::test_sentinel(events.clone()));
-        session._mode = ir_emitter::StreamMode::test_sentinel(events.clone());
+        session._mode = ir_emitter::StreamMode::test_failing_sentinel(events.clone());
         session.lit = session._mode.lit();
         assert!(session.meta.is_some());
         assert!(session.lit && session._mode.owns_restore());
@@ -13588,6 +13588,10 @@ mod tests {
                 .to_string()
                 .contains("injected privacy boundary failure"),
             "{error}"
+        );
+        assert!(
+            error.to_string().contains("sentinel restore failure"),
+            "the explicit restore failure must be combined with privacy: {error}"
         );
         assert!(
             session.stream.stream.is_none(),

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -612,6 +612,10 @@ struct V4l2CameraState {
     privacy_refusal_countdown: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     #[cfg(test)]
     delivery_failure_countdown: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    #[cfg(test)]
+    boundary_barrier: Option<std::sync::Arc<std::sync::Barrier>>,
+    #[cfg(test)]
+    boundary_barrier_used: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl V4l2CameraState {
@@ -625,6 +629,10 @@ impl V4l2CameraState {
             privacy_refusal_countdown: Default::default(),
             #[cfg(test)]
             delivery_failure_countdown: Default::default(),
+            #[cfg(test)]
+            boundary_barrier: None,
+            #[cfg(test)]
+            boundary_barrier_used: Default::default(),
         }
     }
 
@@ -642,6 +650,10 @@ impl V4l2CameraState {
             privacy_refusal_countdown: Default::default(),
             #[cfg(test)]
             delivery_failure_countdown: Default::default(),
+            #[cfg(test)]
+            boundary_barrier: None,
+            #[cfg(test)]
+            boundary_barrier_used: Default::default(),
         }
     }
 
@@ -659,6 +671,10 @@ impl V4l2CameraState {
             privacy_refusal_countdown: Default::default(),
             #[cfg(test)]
             delivery_failure_countdown: Default::default(),
+            #[cfg(test)]
+            boundary_barrier: None,
+            #[cfg(test)]
+            boundary_barrier_used: Default::default(),
         }
     }
 }
@@ -706,6 +722,11 @@ impl CameraState for V4l2CameraState {
         #[cfg(test)]
         {
             use std::sync::atomic::Ordering;
+            if !self.boundary_barrier_used.swap(true, Ordering::AcqRel) {
+                if let Some(barrier) = &self.boundary_barrier {
+                    barrier.wait();
+                }
+            }
             let failed = self
                 .delivery_failure_countdown
                 .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
@@ -1122,6 +1143,13 @@ impl CameraStateStream<'_, V4l2CameraState> {
         self.state
             .delivery_failure_countdown
             .store(boundaries, std::sync::atomic::Ordering::Release);
+    }
+
+    fn synchronize_next_boundary(&mut self, barrier: std::sync::Arc<std::sync::Barrier>) {
+        self.state.boundary_barrier = Some(barrier);
+        self.state
+            .boundary_barrier_used
+            .store(false, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -1588,6 +1616,14 @@ impl TrackedStream<SafeStream<'_>> {
             .as_ref()
             .expect("test sabotage requires a live stream")
             .fail_delivery_after(boundaries);
+    }
+
+    #[cfg(test)]
+    fn synchronize_next_boundary(&mut self, barrier: std::sync::Arc<std::sync::Barrier>) {
+        self.stream
+            .as_mut()
+            .expect("test synchronization requires a live stream")
+            .synchronize_next_boundary(barrier);
     }
 
     fn privacy_refused(&self) -> bool {
@@ -13641,6 +13677,9 @@ mod tests {
         rgb.stream.rate_window.reset();
         ir.stream.rate_window.reset();
         let rgb_before = rgb.stream.accounting().0;
+        let boundary = std::sync::Arc::new(std::sync::Barrier::new(2));
+        rgb.stream.synchronize_next_boundary(boundary.clone());
+        ir.stream.synchronize_next_boundary(boundary);
         ir.stream.refuse_privacy_after(1);
 
         let error = establish_pair_rate(&mut rgb, &mut ir)


### PR DESCRIPTION
## What changed

- make IR capture preserve the three privacy outcomes and fail closed when the hardware privacy state is engaged or unreadable
- revalidate privacy before and after every blocking IR dequeue and at the actual forward Face Authentication D1 `SET_CUR` boundary
- stop reusable IR image/metadata queues and restore the emitter immediately after a live privacy refusal
- cancel the companion rate-fill worker after one member fails, preserving a typed IR privacy error if both members fail
- remove content-only "frozen stream" recovery, so advancing constant frames cannot trigger four stream restarts and repeated D1 writes
- attach timestamp-correlated UVC illumination metadata to streaming and temporal IR frame provenance
- drain/requeue metadata after serial and paired hidden delivered-rate fills before exposing frames
- add concrete loopback sabotage/sentinel coverage for drain, drop, restore, restore failure, and paired cancellation
- correct stale comments that claimed ASUS in-stream self-clear behavior had been measured

## Root cause

The ASUS privacy shutter can deliver advancing, byte-identical GREY frames at value 144. The old capture loop interpreted matching pixels as a transport freeze and reopened the stream four times, reapplying D1 on each replacement. Privacy was sampled only once before streaming, and the streaming paths did not consume the camera's illumination metadata.

The first review also found three later safety windows: capture enablement sampled privacy before lengthy setup rather than at `SET_CUR`; reusable sessions retained streams/D1 after privacy refusal; and recovered/paired rate fills could exhaust the smaller metadata ring before the first exposed frame.

## Impact

A mid-stream privacy transition now stops capture, cancels paired warm-up, tears down image and metadata queues, restores the exact displaced control value, and leaves no pending recovery record. Constant content remains a delivered frame rather than write authorization. Cameras without a privacy control retain support, and RGB-only devices never enter the emitter path.

This unblocks safe continuation of the #440 hardware corpus; it does not by itself complete or close #440.

## Validation

Current DCO-signed head: `7db8c181d4e4dcf8af994b043eb69fb2c8f9778a`.

- independent exact-head safety review: SHIP, no Critical, Important, or Minor findings
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- release build of `irlume-daemon` and `irlume-cli`
- deterministic red/green regressions for late recorded/unrecorded write refusal, public-session teardown, paired cancellation, simultaneous errors, restore failure, metadata provenance, and hidden-fill ordering
- CI loopback lane raised to require all 19 guarded camera/auth/daemon tests, including four public-path privacy/metadata sentinels

### Physical evidence boundary

The four-device camera matrix and operator-controlled shutter transcript were recorded at the pre-review commit `59f42563cf02d07fd7a51d1bdbcd57af64d03905`. The current head retains that behavior and adds safety guards/tests; those later code changes have exact-head local/review/CI evidence, not a repeated four-device physical matrix.

- ASUS `3277:0059`: RGB 13.72 Hz, IR 13.95 Hz, zero drops
- Logitech BRIO `046d:085e`: RGB 13.80 Hz, IR 28.53 Hz
- NexiGo `3443:c803`: RGB 27.86 Hz, IR 28.56 Hz, zero drops
- ThinkPad Chicony `04f2:b7bf`: RGB-only 15.56 Hz, zero emitter path
- root emitter/metadata probes:
  - ASUS: 30 ActiveIr / 30 Ambient / 0 Unknown; real scene range 10.6..69.6
  - BRIO: 9/10 frames classified; lit 76.3 / ambient 12.7
  - NexiGo: 10/10 classified; lit 14.4 / ambient 2.2
- operator-controlled ASUS mid-stream shutter transition stopped on `privacy=1`, performed no restart/reapply, restored selector 6 to D0 `010301000000000000`, and left no pending JSON record
- live candidate face assessment detected one RGB face (`0.71`) and one IR face (`0.94`); the attempt denied on the separate sequential-skew limit (`4393 ms` > `3000 ms`)
