### PR TITLE
feat: add shadow closure calibration selector

### DIFF
--- a/crates/irlume-cli/src/blinkcap.rs
+++ b/crates/irlume-cli/src/blinkcap.rs
@@ -17,6 +17,23 @@
 //!
 //!   replay:  `IRLUME_DEV=1 irlume blinkcap replay data/`   (a file or a directory)
 //!
+//!   selector shadow:
+//!   `IRLUME_DEV=1 irlume blinkcap select --profiles profiles.json \
+//!      --attempts attempts/ --prefix-frames 6`
+//!
+//! The selector manifest names repeated open/closed blinkcap recordings for
+//! each condition. Paths are relative to the manifest unless absolute:
+//!
+//! ```json
+//! {"profiles":[{"name":"desk-glasses",
+//!   "open":["open-1.jsonl","open-2.jsonl"],
+//!   "closed":["closed-1.jsonl","closed-2.jsonl"]}]}
+//! ```
+//!
+//! Selector output is evidence only. It never reaches the daemon, enrollment,
+//! or authorization outcome, and the prefix length is deliberately explicit
+//! because no production value has been qualified.
+//!
 //! Labels are free text; the replay summary groups by them. The suggested set
 //! for the consent-gesture campaign: `held-closure` (genuine deliberate closes),
 //! `natural-blink` (passive spontaneous blinks, must NOT pass), `ae-settle`
@@ -25,9 +42,10 @@
 
 use crate::{engine, flag};
 use irlume_liveness::{
-    detect_blink, detect_deliberate_closure, BlinkResult, ClosureCalibration, EarSample,
+    detect_blink, detect_deliberate_closure, select_closure_profile, BlinkResult,
+    ClosureCalibration, ClosureProfileRange, ClosureProfileSelection, EarSample,
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 /// Derive a [`ClosureCalibration`] from a pool of samples: open = the 75th
@@ -94,11 +112,13 @@ pub fn run(args: &[String]) -> ExitCode {
     match args.get(1).map(String::as_str) {
         Some("capture") => capture(args),
         Some("replay") => replay(args),
+        Some("select") => selector(args),
         _ => {
             eprintln!(
-                "usage: irlume blinkcap <capture|replay>\n  \
+                "usage: irlume blinkcap <capture|replay|select>\n  \
                  capture --label L --det <y.onnx> --model <g.onnx> --mesh <fl.onnx> --out F.jsonl [--ir DEV] [--n 75]\n  \
-                 replay <file.jsonl | dir>   (runs the detectors + sweeps the closure threshold)"
+                 replay <file.jsonl | dir>   (runs the detectors + sweeps the closure threshold)\n  \
+                 select --profiles P.json --attempts <file.jsonl | dir> --prefix-frames N"
             );
             ExitCode::from(2)
         }
@@ -242,6 +262,337 @@ struct Recording {
     file: String,
     label: String,
     samples: Vec<EarSample>,
+}
+
+const SELECTOR_MANIFEST_MAX_BYTES: u64 = 64 * 1024;
+const SELECTOR_RECORDING_MAX_BYTES: u64 = 8 * 1024 * 1024;
+const SELECTOR_MAX_PROFILES: usize = 16;
+const SELECTOR_MAX_RECORDINGS_PER_PHASE: usize = 64;
+const SELECTOR_MAX_ATTEMPTS: usize = 512;
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SelectorManifest {
+    profiles: Vec<SelectorProfileSpec>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SelectorProfileSpec {
+    name: String,
+    open: Vec<String>,
+    closed: Vec<String>,
+}
+
+fn read_bounded(path: &Path, max: u64, kind: &str) -> Result<String, String> {
+    let len = std::fs::metadata(path)
+        .map_err(|error| format!("{}: {error}", path.display()))?
+        .len();
+    if len > max {
+        return Err(format!(
+            "{}: {kind} is {len} bytes; limit is {max}",
+            path.display()
+        ));
+    }
+    std::fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+fn load_recording_strict(path: &Path) -> Result<Recording, String> {
+    let text = read_bounded(path, SELECTOR_RECORDING_MAX_BYTES, "blink recording")?;
+    let mut lines = text.lines();
+    let header: serde_json::Value = serde_json::from_str(
+        lines
+            .next()
+            .ok_or_else(|| format!("{}: empty recording", path.display()))?,
+    )
+    .map_err(|error| format!("{}: invalid blinkcap header: {error}", path.display()))?;
+    if header.get("blinkcap").and_then(serde_json::Value::as_bool) != Some(true) {
+        return Err(format!("{}: not a blinkcap recording", path.display()));
+    }
+    let expected = header
+        .get("frames")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|count| usize::try_from(count).ok())
+        .ok_or_else(|| format!("{}: header has no valid frame count", path.display()))?;
+    let label = header
+        .get("label")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unlabeled")
+        .to_owned();
+    let mut samples = Vec::new();
+    for (line_index, line) in lines.enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: RecordedSample = serde_json::from_str(line).map_err(|error| {
+            format!(
+                "{}:{}: invalid blink record: {error}",
+                path.display(),
+                line_index + 2
+            )
+        })?;
+        let sample = EarSample::from(&record);
+        if sample.ear.is_some_and(|ear| !ear.is_finite() || ear < 0.0) {
+            return Err(format!(
+                "{}:{}: EAR must be finite and non-negative",
+                path.display(),
+                line_index + 2
+            ));
+        }
+        samples.push(sample);
+    }
+    if samples.len() != expected {
+        return Err(format!(
+            "{}: header declares {expected} frames but {} were read",
+            path.display(),
+            samples.len()
+        ));
+    }
+    Ok(Recording {
+        file: path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+        label,
+        samples,
+    })
+}
+
+fn median(values: &mut [f32]) -> f32 {
+    values.sort_by(f32::total_cmp);
+    let middle = values.len() / 2;
+    if values.len().is_multiple_of(2) {
+        (values[middle - 1] + values[middle]) / 2.0
+    } else {
+        values[middle]
+    }
+}
+
+fn recording_median(path: &Path) -> Result<f32, String> {
+    let recording = load_recording_strict(path)?;
+    let mut ears: Vec<f32> = recording
+        .samples
+        .iter()
+        .filter_map(|sample| sample.ear)
+        .collect();
+    if ears.is_empty() {
+        return Err(format!(
+            "{}: recording contains no EAR samples",
+            path.display()
+        ));
+    }
+    Ok(median(&mut ears))
+}
+
+fn resolve_recording(manifest_path: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else {
+        manifest_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(path)
+    }
+}
+
+fn phase_medians(manifest_path: &Path, files: &[String]) -> Result<Vec<f32>, String> {
+    files
+        .iter()
+        .map(|file| recording_median(&resolve_recording(manifest_path, file)))
+        .collect()
+}
+
+fn load_selector_profiles(
+    manifest_path: &Path,
+) -> Result<Vec<(String, ClosureProfileRange, ClosureCalibration)>, String> {
+    let text = read_bounded(
+        manifest_path,
+        SELECTOR_MANIFEST_MAX_BYTES,
+        "selector manifest",
+    )?;
+    let manifest: SelectorManifest = serde_json::from_str(&text).map_err(|error| {
+        format!(
+            "{}: invalid selector manifest: {error}",
+            manifest_path.display()
+        )
+    })?;
+    if !(1..=SELECTOR_MAX_PROFILES).contains(&manifest.profiles.len()) {
+        return Err(format!(
+            "selector manifest needs 1..={SELECTOR_MAX_PROFILES} profiles"
+        ));
+    }
+    let mut names = std::collections::BTreeSet::new();
+    for spec in &manifest.profiles {
+        if spec.name.is_empty() || spec.name.len() > 64 || spec.name.trim() != spec.name {
+            return Err("profile names must be 1..=64 characters without outer whitespace".into());
+        }
+        if !names.insert(spec.name.clone()) {
+            return Err(format!("duplicate profile name '{}'", spec.name));
+        }
+        for (phase, files) in [("open", &spec.open), ("closed", &spec.closed)] {
+            if !(2..=SELECTOR_MAX_RECORDINGS_PER_PHASE).contains(&files.len()) {
+                return Err(format!(
+                    "profile '{}' {phase} phase needs 2..={SELECTOR_MAX_RECORDINGS_PER_PHASE} recordings",
+                    spec.name
+                ));
+            }
+            if files.iter().any(|file| file.trim().is_empty()) {
+                return Err(format!("profile '{}' has an empty {phase} path", spec.name));
+            }
+        }
+    }
+
+    let mut profiles = Vec::with_capacity(manifest.profiles.len());
+    for spec in manifest.profiles {
+        let mut open = phase_medians(manifest_path, &spec.open)?;
+        let mut closed = phase_medians(manifest_path, &spec.closed)?;
+        open.sort_by(f32::total_cmp);
+        closed.sort_by(f32::total_cmp);
+        let range = ClosureProfileRange {
+            open_min: open[0],
+            open_max: open[open.len() - 1],
+            closed_min: closed[0],
+            closed_max: closed[closed.len() - 1],
+        };
+        let calibration = ClosureCalibration {
+            ear_open: median(&mut open),
+            ear_closed: median(&mut closed),
+        };
+        if !range.is_valid() || !calibration.is_usable() {
+            return Err(format!(
+                "profile '{}': open and closed evidence is not cleanly separated",
+                spec.name
+            ));
+        }
+        profiles.push((spec.name, range, calibration));
+    }
+    Ok(profiles)
+}
+
+fn selector_attempt_files(path: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut files = if path.is_dir() {
+        std::fs::read_dir(path)
+            .map_err(|error| format!("{}: {error}", path.display()))?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| format!("{}: {error}", path.display()))?
+            .into_iter()
+            .filter(|path| {
+                path.extension()
+                    .is_some_and(|extension| extension == "jsonl")
+            })
+            .collect()
+    } else {
+        vec![path.to_path_buf()]
+    };
+    files.sort();
+    if files.is_empty() || files.len() > SELECTOR_MAX_ATTEMPTS {
+        return Err(format!(
+            "{}: expected 1..={SELECTOR_MAX_ATTEMPTS} JSONL attempts",
+            path.display()
+        ));
+    }
+    Ok(files)
+}
+
+fn split_selector_prefix(
+    samples: &[EarSample],
+    required: usize,
+) -> Option<(Vec<f32>, &[EarSample])> {
+    let mut prefix = Vec::with_capacity(required);
+    for (index, sample) in samples.iter().enumerate() {
+        if let Some(ear) = sample.ear {
+            prefix.push(ear);
+            if prefix.len() == required {
+                return Some((prefix, &samples[index + 1..]));
+            }
+        }
+    }
+    None
+}
+
+fn escaped(value: &str) -> String {
+    value.chars().flat_map(char::escape_default).collect()
+}
+
+fn evaluate_selector(
+    attempts: &Path,
+    prefix_frames: usize,
+    profiles: &[(String, ClosureProfileRange, ClosureCalibration)],
+) -> Result<(), String> {
+    let ranges: Vec<ClosureProfileRange> = profiles.iter().map(|(_, range, _)| *range).collect();
+    println!("== closure profile selector (SHADOW ONLY; never authorizes) ==");
+    for path in selector_attempt_files(attempts)? {
+        let recording = load_recording_strict(&path)?;
+        let file = escaped(&recording.file);
+        let label = escaped(&recording.label);
+        let Some((prefix, remaining)) = split_selector_prefix(&recording.samples, prefix_frames)
+        else {
+            let observed = recording
+                .samples
+                .iter()
+                .filter(|sample| sample.ear.is_some())
+                .count();
+            println!(
+                "  {file} label={label} prefix={observed} remaining=0 selector=out-of-range shadow-consent=not-run"
+            );
+            continue;
+        };
+        let selection = select_closure_profile(&prefix, &ranges);
+        match selection {
+            ClosureProfileSelection::Unique(index) => {
+                let profile = escaped(&profiles[index].0);
+                let verdict = detect_deliberate_closure(remaining, &profiles[index].2);
+                println!(
+                    "  {file} label={label} prefix={} remaining={} selector=unique:{profile} shadow-consent={verdict:?}",
+                    prefix.len(),
+                    remaining.len()
+                );
+            }
+            ClosureProfileSelection::Ambiguous => println!(
+                "  {file} label={label} prefix={} remaining={} selector=ambiguous shadow-consent=not-run",
+                prefix.len(),
+                remaining.len()
+            ),
+            ClosureProfileSelection::OutOfRange => println!(
+                "  {file} label={label} prefix={} remaining={} selector=out-of-range shadow-consent=not-run",
+                prefix.len(),
+                remaining.len()
+            ),
+        }
+    }
+    Ok(())
+}
+
+fn selector(args: &[String]) -> ExitCode {
+    let (Some(manifest), Some(attempts), Some(prefix)) = (
+        flag(args, "--profiles"),
+        flag(args, "--attempts"),
+        flag(args, "--prefix-frames"),
+    ) else {
+        eprintln!(
+            "usage: irlume blinkcap select --profiles P.json --attempts <file.jsonl | dir> --prefix-frames N"
+        );
+        return ExitCode::from(2);
+    };
+    let prefix = match prefix.parse::<usize>() {
+        Ok(value) if (1..=120).contains(&value) => value,
+        _ => {
+            eprintln!("[blinkcap] --prefix-frames requires a number from 1 to 120");
+            return ExitCode::from(2);
+        }
+    };
+    match load_selector_profiles(Path::new(manifest))
+        .and_then(|profiles| evaluate_selector(Path::new(attempts), prefix, &profiles))
+    {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("[blinkcap] {error}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
 fn load_recording(path: &Path) -> Option<Recording> {

--- a/crates/irlume-cli/src/blinkcap.rs
+++ b/crates/irlume-cli/src/blinkcap.rs
@@ -284,54 +284,126 @@ struct SelectorProfileSpec {
     closed: Vec<String>,
 }
 
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SelectorRecordingHeader {
+    blinkcap: bool,
+    label: String,
+    frames: usize,
+    #[serde(default, rename = "host")]
+    _host: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SelectorRecordedSample {
+    idx: usize,
+    ear: serde_json::Value,
+    bri: f32,
+    cx: f32,
+    cy: f32,
+    fsize: f32,
+    contrast: f32,
+}
+
 fn read_bounded(path: &Path, max: u64, kind: &str) -> Result<String, String> {
-    let len = std::fs::metadata(path)
-        .map_err(|error| format!("{}: {error}", path.display()))?
-        .len();
-    if len > max {
+    use std::io::Read as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        return Err(format!("{}: {kind} must be a regular file", path.display()));
+    }
+    let mut text = String::new();
+    file.take(max + 1)
+        .read_to_string(&mut text)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    if text.len() as u64 > max {
         return Err(format!(
-            "{}: {kind} is {len} bytes; limit is {max}",
+            "{}: {kind} exceeds the {max}-byte limit",
             path.display()
         ));
     }
-    std::fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))
+    Ok(text)
 }
 
 fn load_recording_strict(path: &Path) -> Result<Recording, String> {
     let text = read_bounded(path, SELECTOR_RECORDING_MAX_BYTES, "blink recording")?;
     let mut lines = text.lines();
-    let header: serde_json::Value = serde_json::from_str(
+    let header: SelectorRecordingHeader = serde_json::from_str(
         lines
             .next()
             .ok_or_else(|| format!("{}: empty recording", path.display()))?,
     )
     .map_err(|error| format!("{}: invalid blinkcap header: {error}", path.display()))?;
-    if header.get("blinkcap").and_then(serde_json::Value::as_bool) != Some(true) {
+    if !header.blinkcap {
         return Err(format!("{}: not a blinkcap recording", path.display()));
     }
-    let expected = header
-        .get("frames")
-        .and_then(serde_json::Value::as_u64)
-        .and_then(|count| usize::try_from(count).ok())
-        .ok_or_else(|| format!("{}: header has no valid frame count", path.display()))?;
-    let label = header
-        .get("label")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("unlabeled")
-        .to_owned();
     let mut samples = Vec::new();
     for (line_index, line) in lines.enumerate() {
         if line.trim().is_empty() {
             continue;
         }
-        let record: RecordedSample = serde_json::from_str(line).map_err(|error| {
+        let record: SelectorRecordedSample = serde_json::from_str(line).map_err(|error| {
             format!(
                 "{}:{}: invalid blink record: {error}",
                 path.display(),
                 line_index + 2
             )
         })?;
-        let sample = EarSample::from(&record);
+        let expected_index = samples.len();
+        if record.idx != expected_index {
+            return Err(format!(
+                "{}:{}: expected frame index {expected_index}, got {}",
+                path.display(),
+                line_index + 2,
+                record.idx
+            ));
+        }
+        let ear = match &record.ear {
+            serde_json::Value::Null => None,
+            serde_json::Value::Number(number) => number.as_f64().map(|value| value as f32),
+            _ => None,
+        };
+        if !record.ear.is_null() && ear.is_none() {
+            return Err(format!(
+                "{}:{}: EAR must be a number or null",
+                path.display(),
+                line_index + 2
+            ));
+        }
+        let sample = EarSample {
+            idx: record.idx,
+            ear,
+            bri: record.bri,
+            cx: record.cx,
+            cy: record.cy,
+            fsize: record.fsize,
+            contrast: record.contrast,
+        };
+        if [
+            sample.bri,
+            sample.cx,
+            sample.cy,
+            sample.fsize,
+            sample.contrast,
+        ]
+        .into_iter()
+        .any(|value| !value.is_finite())
+        {
+            return Err(format!(
+                "{}:{}: sample fields must be finite",
+                path.display(),
+                line_index + 2
+            ));
+        }
         if sample.ear.is_some_and(|ear| !ear.is_finite() || ear < 0.0) {
             return Err(format!(
                 "{}:{}: EAR must be finite and non-negative",
@@ -341,10 +413,11 @@ fn load_recording_strict(path: &Path) -> Result<Recording, String> {
         }
         samples.push(sample);
     }
-    if samples.len() != expected {
+    if samples.len() != header.frames {
         return Err(format!(
-            "{}: header declares {expected} frames but {} were read",
+            "{}: header declares {} frames but {} were read",
             path.display(),
+            header.frames,
             samples.len()
         ));
     }
@@ -354,7 +427,7 @@ fn load_recording_strict(path: &Path) -> Result<Recording, String> {
             .unwrap_or_default()
             .to_string_lossy()
             .into_owned(),
-        label,
+        label: header.label,
         samples,
     })
 }
@@ -444,6 +517,21 @@ fn load_selector_profiles(
         }
     }
 
+    for spec in &manifest.profiles {
+        let mut paths = std::collections::BTreeSet::new();
+        for file in spec.open.iter().chain(&spec.closed) {
+            let path = resolve_recording(manifest_path, file);
+            let canonical = std::fs::canonicalize(&path)
+                .map_err(|error| format!("{}: {error}", path.display()))?;
+            if !paths.insert(canonical) {
+                return Err(format!(
+                    "profile '{}' requires distinct recording files",
+                    spec.name
+                ));
+            }
+        }
+    }
+
     let mut profiles = Vec::with_capacity(manifest.profiles.len());
     for spec in manifest.profiles {
         let mut open = phase_medians(manifest_path, &spec.open)?;
@@ -523,9 +611,12 @@ fn evaluate_selector(
     profiles: &[(String, ClosureProfileRange, ClosureCalibration)],
 ) -> Result<(), String> {
     let ranges: Vec<ClosureProfileRange> = profiles.iter().map(|(_, range, _)| *range).collect();
+    let recordings = selector_attempt_files(attempts)?
+        .iter()
+        .map(|path| load_recording_strict(path))
+        .collect::<Result<Vec<_>, _>>()?;
     println!("== closure profile selector (SHADOW ONLY; never authorizes) ==");
-    for path in selector_attempt_files(attempts)? {
-        let recording = load_recording_strict(&path)?;
+    for recording in recordings {
         let file = escaped(&recording.file);
         let label = escaped(&recording.label);
         let Some((prefix, remaining)) = split_selector_prefix(&recording.samples, prefix_frames)

--- a/crates/irlume-cli/src/blinkcap.rs
+++ b/crates/irlume-cli/src/blinkcap.rs
@@ -269,6 +269,7 @@ const SELECTOR_RECORDING_MAX_BYTES: u64 = 8 * 1024 * 1024;
 const SELECTOR_MAX_PROFILES: usize = 16;
 const SELECTOR_MAX_RECORDINGS_PER_PHASE: usize = 64;
 const SELECTOR_MAX_ATTEMPTS: usize = 512;
+const SELECTOR_MAX_LABEL_BYTES: usize = 256;
 
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -345,6 +346,12 @@ fn load_recording_strict(path: &Path) -> Result<Recording, String> {
     .map_err(|error| format!("{}: invalid blinkcap header: {error}", path.display()))?;
     if !header.blinkcap {
         return Err(format!("{}: not a blinkcap recording", path.display()));
+    }
+    if header.label.is_empty() || header.label.len() > SELECTOR_MAX_LABEL_BYTES {
+        return Err(format!(
+            "{}: label must be 1..={SELECTOR_MAX_LABEL_BYTES} bytes",
+            path.display()
+        ));
     }
     let mut samples = Vec::new();
     for (line_index, line) in lines.enumerate() {

--- a/crates/irlume-cli/src/blinkcap.rs
+++ b/crates/irlume-cli/src/blinkcap.rs
@@ -611,48 +611,51 @@ fn evaluate_selector(
     profiles: &[(String, ClosureProfileRange, ClosureCalibration)],
 ) -> Result<(), String> {
     let ranges: Vec<ClosureProfileRange> = profiles.iter().map(|(_, range, _)| *range).collect();
-    let recordings = selector_attempt_files(attempts)?
+    let rows = selector_attempt_files(attempts)?
         .iter()
-        .map(|path| load_recording_strict(path))
-        .collect::<Result<Vec<_>, _>>()?;
-    println!("== closure profile selector (SHADOW ONLY; never authorizes) ==");
-    for recording in recordings {
-        let file = escaped(&recording.file);
-        let label = escaped(&recording.label);
-        let Some((prefix, remaining)) = split_selector_prefix(&recording.samples, prefix_frames)
-        else {
-            let observed = recording
-                .samples
-                .iter()
-                .filter(|sample| sample.ear.is_some())
-                .count();
-            println!(
-                "  {file} label={label} prefix={observed} remaining=0 selector=out-of-range shadow-consent=not-run"
-            );
-            continue;
-        };
-        let selection = select_closure_profile(&prefix, &ranges);
-        match selection {
-            ClosureProfileSelection::Unique(index) => {
-                let profile = escaped(&profiles[index].0);
-                let verdict = detect_deliberate_closure(remaining, &profiles[index].2);
-                println!(
-                    "  {file} label={label} prefix={} remaining={} selector=unique:{profile} shadow-consent={verdict:?}",
+        .map(|path| -> Result<String, String> {
+            let recording = load_recording_strict(path)?;
+            let file = escaped(&recording.file);
+            let label = escaped(&recording.label);
+            let Some((prefix, remaining)) =
+                split_selector_prefix(&recording.samples, prefix_frames)
+            else {
+                let observed = recording
+                    .samples
+                    .iter()
+                    .filter(|sample| sample.ear.is_some())
+                    .count();
+                return Ok(format!(
+                    "{file} label={label} prefix={observed} remaining=0 selector=out-of-range shadow-consent=not-run"
+                ));
+            };
+            let row = match select_closure_profile(&prefix, &ranges) {
+                ClosureProfileSelection::Unique(index) => {
+                    let profile = escaped(&profiles[index].0);
+                    let verdict = detect_deliberate_closure(remaining, &profiles[index].2);
+                    format!(
+                        "{file} label={label} prefix={} remaining={} selector=unique:{profile} shadow-consent={verdict:?}",
+                        prefix.len(),
+                        remaining.len()
+                    )
+                }
+                ClosureProfileSelection::Ambiguous => format!(
+                    "{file} label={label} prefix={} remaining={} selector=ambiguous shadow-consent=not-run",
                     prefix.len(),
                     remaining.len()
-                );
-            }
-            ClosureProfileSelection::Ambiguous => println!(
-                "  {file} label={label} prefix={} remaining={} selector=ambiguous shadow-consent=not-run",
-                prefix.len(),
-                remaining.len()
-            ),
-            ClosureProfileSelection::OutOfRange => println!(
-                "  {file} label={label} prefix={} remaining={} selector=out-of-range shadow-consent=not-run",
-                prefix.len(),
-                remaining.len()
-            ),
-        }
+                ),
+                ClosureProfileSelection::OutOfRange => format!(
+                    "{file} label={label} prefix={} remaining={} selector=out-of-range shadow-consent=not-run",
+                    prefix.len(),
+                    remaining.len()
+                ),
+            };
+            Ok(row)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    println!("== closure profile selector (SHADOW ONLY; never authorizes) ==");
+    for row in rows {
+        println!("  {row}");
     }
     Ok(())
 }

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -2366,6 +2366,14 @@ fn blinkcap_selector_strictly_validates_attempt_headers_records_and_indices() {
         ),
         (
             format!(
+                "{{\"blinkcap\":true,\"label\":\"{}\",\"frames\":1}}\n{}",
+                "x".repeat(257),
+                record(0, "\"ear\":0.25,", "")
+            ),
+            "label must be 1..=256 bytes",
+        ),
+        (
+            format!(
                 "{{\"blinkcap\":true,\"label\":\"attempt\",\"frames\":2}}\n{}{}",
                 record(0, "\"ear\":0.25,", ""),
                 record(0, "\"ear\":0.25,", "")

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -2032,6 +2032,214 @@ fn write_pose_recording(path: &std::path::Path, label: &str, pitches: &[f32]) {
     std::fs::write(path, s).unwrap();
 }
 
+/// A blink recording exactly as `blinkcap capture` writes it.
+fn write_blink_recording(path: &std::path::Path, label: &str, ears: &[f32]) {
+    let mut s = format!(
+        "{{\"blinkcap\":true,\"label\":\"{label}\",\"frames\":{}}}\n",
+        ears.len()
+    );
+    for (i, ear) in ears.iter().enumerate() {
+        s.push_str(&format!(
+            "{{\"idx\":{i},\"ear\":{ear},\"bri\":60.0,\"cx\":100.0,\"cy\":100.0,\"fsize\":100.0,\"contrast\":50.0}}\n"
+        ));
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+fn write_selector_manifest(path: &std::path::Path, profiles: serde_json::Value) {
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&serde_json::json!({ "profiles": profiles })).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn blinkcap_selector_locks_one_profile_and_discards_the_prefix() {
+    let sb = Sandbox::new("bc-selector-unique");
+    let dir = sb.path("work");
+    for (file, label, ears) in [
+        ("bare-open-1.jsonl", "bare-open", vec![0.24; 3]),
+        ("bare-open-2.jsonl", "bare-open", vec![0.25; 3]),
+        ("bare-closed-1.jsonl", "bare-closed", vec![0.02; 3]),
+        ("bare-closed-2.jsonl", "bare-closed", vec![0.03; 3]),
+        ("glasses-open-1.jsonl", "glasses-open", vec![0.27; 3]),
+        ("glasses-open-2.jsonl", "glasses-open", vec![0.29; 3]),
+        ("glasses-closed-1.jsonl", "glasses-closed", vec![0.10; 3]),
+        ("glasses-closed-2.jsonl", "glasses-closed", vec![0.12; 3]),
+    ] {
+        write_blink_recording(&dir.join(file), label, &ears);
+    }
+    let manifest = dir.join("profiles.json");
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([
+            {
+                "name": "bare",
+                "open": ["bare-open-1.jsonl", "bare-open-2.jsonl"],
+                "closed": ["bare-closed-1.jsonl", "bare-closed-2.jsonl"]
+            },
+            {
+                "name": "glasses",
+                "open": ["glasses-open-1.jsonl", "glasses-open-2.jsonl"],
+                "closed": ["glasses-closed-1.jsonl", "glasses-closed-2.jsonl"]
+            }
+        ]),
+    );
+    let mut attempt = vec![0.28, 0.281, 0.279];
+    attempt.extend([0.11; 11]);
+    attempt.extend([0.28; 4]);
+    let attempt_file = dir.join("attempt.jsonl");
+    write_blink_recording(&attempt_file, "held-closure-glasses", &attempt);
+
+    let (code, out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "select",
+            "--profiles",
+            manifest.to_str().unwrap(),
+            "--attempts",
+            attempt_file.to_str().unwrap(),
+            "--prefix-frames",
+            "3",
+        ])
+        .env("IRLUME_DEV", "1"));
+
+    assert_eq!(code, 0, "stderr: {err}");
+    assert!(out.contains("SHADOW ONLY"), "{out}");
+    assert!(out.contains("selector=unique:glasses"), "{out}");
+    assert!(out.contains("prefix=3 remaining=15"), "{out}");
+    assert!(out.contains("shadow-consent=Blinked"), "{out}");
+}
+
+#[test]
+fn blinkcap_selector_never_runs_consent_for_ambiguous_or_closed_like_prefixes() {
+    let sb = Sandbox::new("bc-selector-refuse");
+    let dir = sb.path("work");
+    for (file, label, ears) in [
+        ("a-open-1.jsonl", "a-open", vec![0.24; 3]),
+        ("a-open-2.jsonl", "a-open", vec![0.28; 3]),
+        ("a-closed-1.jsonl", "a-closed", vec![0.02; 3]),
+        ("a-closed-2.jsonl", "a-closed", vec![0.03; 3]),
+        ("b-open-1.jsonl", "b-open", vec![0.25; 3]),
+        ("b-open-2.jsonl", "b-open", vec![0.29; 3]),
+        ("b-closed-1.jsonl", "b-closed", vec![0.10; 3]),
+        ("b-closed-2.jsonl", "b-closed", vec![0.12; 3]),
+    ] {
+        write_blink_recording(&dir.join(file), label, &ears);
+    }
+    let manifest = dir.join("profiles.json");
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([
+            {
+                "name": "a",
+                "open": ["a-open-1.jsonl", "a-open-2.jsonl"],
+                "closed": ["a-closed-1.jsonl", "a-closed-2.jsonl"]
+            },
+            {
+                "name": "b",
+                "open": ["b-open-1.jsonl", "b-open-2.jsonl"],
+                "closed": ["b-closed-1.jsonl", "b-closed-2.jsonl"]
+            }
+        ]),
+    );
+    let attempts = dir.join("attempts");
+    std::fs::create_dir(&attempts).unwrap();
+    write_blink_recording(&attempts.join("ambiguous.jsonl"), "ambiguous", &[0.26; 6]);
+    write_blink_recording(
+        &attempts.join("closed-first.jsonl"),
+        "closed-first",
+        &[0.11; 6],
+    );
+
+    let (code, out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "select",
+            "--profiles",
+            manifest.to_str().unwrap(),
+            "--attempts",
+            attempts.to_str().unwrap(),
+            "--prefix-frames",
+            "3",
+        ])
+        .env("IRLUME_DEV", "1"));
+
+    assert_eq!(code, 0, "stderr: {err}");
+    assert!(
+        out.contains("ambiguous.jsonl label=ambiguous prefix=3 remaining=3 selector=ambiguous shadow-consent=not-run"),
+        "{out}"
+    );
+    assert!(
+        out.contains("closed-first.jsonl label=closed-first prefix=3 remaining=3 selector=out-of-range shadow-consent=not-run"),
+        "{out}"
+    );
+}
+
+#[test]
+fn blinkcap_selector_rejects_duplicate_profiles_and_partial_recordings() {
+    let sb = Sandbox::new("bc-selector-invalid");
+    let dir = sb.path("work");
+    let manifest = dir.join("profiles.json");
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([
+            {"name": "same", "open": ["x", "y"], "closed": ["z", "q"]},
+            {"name": "same", "open": ["x", "y"], "closed": ["z", "q"]}
+        ]),
+    );
+    let attempt = dir.join("attempt.jsonl");
+    write_blink_recording(&attempt, "attempt", &[0.25; 6]);
+
+    let (code, _out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "select",
+            "--profiles",
+            manifest.to_str().unwrap(),
+            "--attempts",
+            attempt.to_str().unwrap(),
+            "--prefix-frames",
+            "3",
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("duplicate profile name 'same'"), "{err}");
+
+    write_blink_recording(&dir.join("open-1.jsonl"), "open", &[0.24; 3]);
+    write_blink_recording(&dir.join("open-2.jsonl"), "open", &[0.25; 3]);
+    write_blink_recording(&dir.join("closed-1.jsonl"), "closed", &[0.02; 3]);
+    std::fs::write(
+        dir.join("closed-2.jsonl"),
+        "{\"blinkcap\":true,\"label\":\"closed\",\"frames\":2}\n\
+         {\"idx\":0,\"ear\":0.03,\"bri\":60.0,\"cx\":100.0,\"cy\":100.0,\"fsize\":100.0,\"contrast\":50.0}\n",
+    )
+    .unwrap();
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([{
+            "name": "profile",
+            "open": ["open-1.jsonl", "open-2.jsonl"],
+            "closed": ["closed-1.jsonl", "closed-2.jsonl"]
+        }]),
+    );
+    let (code, _out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "select",
+            "--profiles",
+            manifest.to_str().unwrap(),
+            "--attempts",
+            attempt.to_str().unwrap(),
+            "--prefix-frames",
+            "3",
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("declares 2 frames but 1 were read"), "{err}");
+}
+
 #[test]
 fn blinkcap_replay_accepts_a_single_pose_file_and_a_pose_only_dir() {
     let sb = Sandbox::new("bc-pose-ok");

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -2113,6 +2113,57 @@ fn blinkcap_selector_locks_one_profile_and_discards_the_prefix() {
 }
 
 #[test]
+fn blinkcap_selector_prefix_cannot_supply_closure_frames() {
+    let sb = Sandbox::new("bc-selector-prefix-discard");
+    let dir = sb.path("work");
+    for (file, label, ears) in [
+        ("open-low.jsonl", "open", vec![0.10; 3]),
+        ("open-high-1.jsonl", "open", vec![0.30; 3]),
+        ("open-high-2.jsonl", "open", vec![0.30; 3]),
+        ("closed-1.jsonl", "closed", vec![0.04; 3]),
+        ("closed-2.jsonl", "closed", vec![0.05; 3]),
+    ] {
+        write_blink_recording(&dir.join(file), label, &ears);
+    }
+    let manifest = dir.join("profiles.json");
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([{
+            "name": "wide-open-range",
+            "open": ["open-low.jsonl", "open-high-1.jsonl", "open-high-2.jsonl"],
+            "closed": ["closed-1.jsonl", "closed-2.jsonl"]
+        }]),
+    );
+    // Derived calibration: open 0.30, closed 0.045, threshold 0.1215. The
+    // prefix at 0.11 is closure-like to the detector while remaining inside
+    // the observed open selector range. If it leaks into detection, 3 + 8
+    // frames reaches the 11-frame consent floor; discarding it leaves only 8.
+    let mut attempt = vec![0.11; 3];
+    attempt.extend([0.11; 8]);
+    attempt.extend([0.30; 4]);
+    let attempt_file = dir.join("attempt.jsonl");
+    write_blink_recording(&attempt_file, "prefix-sabotage", &attempt);
+
+    let (code, out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "select",
+            "--profiles",
+            manifest.to_str().unwrap(),
+            "--attempts",
+            attempt_file.to_str().unwrap(),
+            "--prefix-frames",
+            "3",
+        ])
+        .env("IRLUME_DEV", "1"));
+
+    assert_eq!(code, 0, "stderr: {err}");
+    assert!(out.contains("selector=unique:wide-open-range"), "{out}");
+    assert!(out.contains("prefix=3 remaining=12"), "{out}");
+    assert!(out.contains("shadow-consent=NoBlink"), "{out}");
+}
+
+#[test]
 fn blinkcap_selector_never_runs_consent_for_ambiguous_or_closed_like_prefixes() {
     let sb = Sandbox::new("bc-selector-refuse");
     let dir = sb.path("work");
@@ -2210,6 +2261,30 @@ fn blinkcap_selector_rejects_duplicate_profiles_and_partial_recordings() {
     write_blink_recording(&dir.join("open-1.jsonl"), "open", &[0.24; 3]);
     write_blink_recording(&dir.join("open-2.jsonl"), "open", &[0.25; 3]);
     write_blink_recording(&dir.join("closed-1.jsonl"), "closed", &[0.02; 3]);
+    write_blink_recording(&dir.join("closed-2.jsonl"), "closed", &[0.03; 3]);
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([{
+            "name": "profile",
+            "open": ["open-1.jsonl", "./open-1.jsonl"],
+            "closed": ["closed-1.jsonl", "closed-2.jsonl"]
+        }]),
+    );
+    let (code, _out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "select",
+            "--profiles",
+            manifest.to_str().unwrap(),
+            "--attempts",
+            attempt.to_str().unwrap(),
+            "--prefix-frames",
+            "3",
+        ])
+        .env("IRLUME_DEV", "1"));
+    assert_eq!(code, 1);
+    assert!(err.contains("distinct recording files"), "{err}");
+
     std::fs::write(
         dir.join("closed-2.jsonl"),
         "{\"blinkcap\":true,\"label\":\"closed\",\"frames\":2}\n\
@@ -2237,6 +2312,141 @@ fn blinkcap_selector_rejects_duplicate_profiles_and_partial_recordings() {
         ])
         .env("IRLUME_DEV", "1"));
     assert_eq!(code, 1);
+    assert!(err.contains("declares 2 frames but 1 were read"), "{err}");
+}
+
+#[test]
+fn blinkcap_selector_strictly_validates_attempt_headers_records_and_indices() {
+    let sb = Sandbox::new("bc-selector-strict-attempt");
+    let dir = sb.path("work");
+    for (file, label, ears) in [
+        ("open-1.jsonl", "open", vec![0.24; 3]),
+        ("open-2.jsonl", "open", vec![0.25; 3]),
+        ("closed-1.jsonl", "closed", vec![0.02; 3]),
+        ("closed-2.jsonl", "closed", vec![0.03; 3]),
+    ] {
+        write_blink_recording(&dir.join(file), label, &ears);
+    }
+    let manifest = dir.join("profiles.json");
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([{
+            "name": "profile",
+            "open": ["open-1.jsonl", "open-2.jsonl"],
+            "closed": ["closed-1.jsonl", "closed-2.jsonl"]
+        }]),
+    );
+    let attempt = dir.join("attempt.jsonl");
+    let record = |idx: usize, ear_field: &str, extra: &str| {
+        format!(
+            "{{\"idx\":{idx},{ear_field}\"bri\":60.0,\"cx\":100.0,\"cy\":100.0,\"fsize\":100.0,\"contrast\":50.0{extra}}}\n"
+        )
+    };
+    let cases = [
+        (
+            format!(
+                "{{\"blinkcap\":true,\"label\":\"attempt\",\"frames\":1}}\n{}",
+                record(0, "\"ear\":0.25,", ",\"extra\":true")
+            ),
+            "unknown field",
+        ),
+        (
+            format!(
+                "{{\"blinkcap\":true,\"label\":\"attempt\",\"frames\":1}}\n{}",
+                record(0, "", "")
+            ),
+            "missing field `ear`",
+        ),
+        (
+            format!(
+                "{{\"blinkcap\":true,\"label\":7,\"frames\":1}}\n{}",
+                record(0, "\"ear\":0.25,", "")
+            ),
+            "invalid blinkcap header",
+        ),
+        (
+            format!(
+                "{{\"blinkcap\":true,\"label\":\"attempt\",\"frames\":2}}\n{}{}",
+                record(0, "\"ear\":0.25,", ""),
+                record(0, "\"ear\":0.25,", "")
+            ),
+            "expected frame index 1",
+        ),
+        (
+            format!(
+                "{{\"blinkcap\":true,\"label\":\"attempt\",\"frames\":2}}\n{}{}",
+                record(0, "\"ear\":0.25,", ""),
+                record(2, "\"ear\":0.25,", "")
+            ),
+            "expected frame index 1",
+        ),
+    ];
+
+    for (contents, expected) in cases {
+        std::fs::write(&attempt, contents).unwrap();
+        let (code, _out, err) = run(sb
+            .cmd(&[
+                "blinkcap",
+                "select",
+                "--profiles",
+                manifest.to_str().unwrap(),
+                "--attempts",
+                attempt.to_str().unwrap(),
+                "--prefix-frames",
+                "1",
+            ])
+            .env("IRLUME_DEV", "1"));
+        assert_eq!(code, 1, "expected {expected}; stderr: {err}");
+        assert!(err.contains(expected), "expected {expected}; stderr: {err}");
+    }
+}
+
+#[test]
+fn blinkcap_selector_emits_no_partial_report_when_a_later_attempt_is_damaged() {
+    let sb = Sandbox::new("bc-selector-atomic-report");
+    let dir = sb.path("work");
+    for (file, label, ears) in [
+        ("open-1.jsonl", "open", vec![0.24; 3]),
+        ("open-2.jsonl", "open", vec![0.25; 3]),
+        ("closed-1.jsonl", "closed", vec![0.02; 3]),
+        ("closed-2.jsonl", "closed", vec![0.03; 3]),
+    ] {
+        write_blink_recording(&dir.join(file), label, &ears);
+    }
+    let manifest = dir.join("profiles.json");
+    write_selector_manifest(
+        &manifest,
+        serde_json::json!([{
+            "name": "profile",
+            "open": ["open-1.jsonl", "open-2.jsonl"],
+            "closed": ["closed-1.jsonl", "closed-2.jsonl"]
+        }]),
+    );
+    let attempts = dir.join("attempts");
+    std::fs::create_dir(&attempts).unwrap();
+    write_blink_recording(&attempts.join("a-valid.jsonl"), "valid", &[0.25; 3]);
+    std::fs::write(
+        attempts.join("z-damaged.jsonl"),
+        "{\"blinkcap\":true,\"label\":\"damaged\",\"frames\":2}\n\
+         {\"idx\":0,\"ear\":0.25,\"bri\":60.0,\"cx\":100.0,\"cy\":100.0,\"fsize\":100.0,\"contrast\":50.0}\n",
+    )
+    .unwrap();
+
+    let (code, out, err) = run(sb
+        .cmd(&[
+            "blinkcap",
+            "select",
+            "--profiles",
+            manifest.to_str().unwrap(),
+            "--attempts",
+            attempts.to_str().unwrap(),
+            "--prefix-frames",
+            "1",
+        ])
+        .env("IRLUME_DEV", "1"));
+
+    assert_eq!(code, 1);
+    assert!(out.is_empty(), "partial report leaked to stdout: {out}");
     assert!(err.contains("declares 2 frames but 1 were read"), "{err}");
 }
 

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1829,31 +1829,6 @@ pub fn detect_blink(samples: &[EarSample]) -> BlinkResult {
     }
 }
 
-/// Per-user eye-closure calibration: the enrolled open-eye and closed-eye EAR
-/// medians. Set once from an enrollment calibration (a few open frames, then a
-/// held closure), NOT from the gesture window itself.
-///
-/// The consent gesture is measured against an ABSOLUTE, per-user threshold, not
-/// a running-median baseline. That is deliberate: a running median is polluted
-/// by the very closure being detected (once the eyes are shut for most of the
-/// window the median drops to the closed value and the closure vanishes into the
-/// "baseline"), a documented failure mode of relative EAR gating. Capturing the
-/// open/closed extremes offline and comparing at a fixed midpoint (the
-/// Modified-EAR method, PeerJ CS-943 / PMC9044337) avoids it, and validated
-/// cleanly on real captures (a deliberate hold reads a 18-35 frame sub-threshold
-/// run; spontaneous blinks and squints read ≤5).
-///
-/// KNOWN COST OF THAT CHOICE, measured 2026-07-27, one user, 20 readings: absolute
-/// values move with the LIGHT. The same seated position gave a median open EAR of
-/// 0.109 at an ambient of 22-42 and 0.166 at an ambient of 1, a 52% shift, with
-/// the closed values rising too. No single calibration spans both sessions:
-/// registering the deepest closure (0.0894) and the shallowest reopen (0.0984)
-/// requires `(CLOSURE_REOPEN_FRACTION - CLOSURE_DEEP_FRACTION) * gap <= 0.0090`,
-/// so `gap <= 0.030`, while [`MIN_CALIBRATION_SEPARATION`] demands 0.05. Each
-/// session calibrates fine alone; the pair cannot. A calibration therefore
-/// describes one lighting condition, which `calibrate-closure` and `doctor` both
-/// now say out loud. [`detect_nod`] is pose-defined and carries none of this,
-/// which is why it is the default and the only gesture the prompts name.
 /// Observed open- and closed-eye EAR ranges for one shadow calibration profile.
 ///
 /// This is evidence-tooling input, not persisted enrollment state. The selector
@@ -1932,6 +1907,31 @@ pub fn select_closure_profile(
     }
 }
 
+/// Per-user eye-closure calibration: the enrolled open-eye and closed-eye EAR
+/// medians. Set once from an enrollment calibration (a few open frames, then a
+/// held closure), NOT from the gesture window itself.
+///
+/// The consent gesture is measured against an ABSOLUTE, per-user threshold, not
+/// a running-median baseline. That is deliberate: a running median is polluted
+/// by the very closure being detected (once the eyes are shut for most of the
+/// window the median drops to the closed value and the closure vanishes into the
+/// "baseline"), a documented failure mode of relative EAR gating. Capturing the
+/// open/closed extremes offline and comparing at a fixed midpoint (the
+/// Modified-EAR method, PeerJ CS-943 / PMC9044337) avoids it, and validated
+/// cleanly on real captures (a deliberate hold reads a 18-35 frame sub-threshold
+/// run; spontaneous blinks and squints read ≤5).
+///
+/// KNOWN COST OF THAT CHOICE, measured 2026-07-27, one user, 20 readings: absolute
+/// values move with the LIGHT. The same seated position gave a median open EAR of
+/// 0.109 at an ambient of 22-42 and 0.166 at an ambient of 1, a 52% shift, with
+/// the closed values rising too. No single calibration spans both sessions:
+/// registering the deepest closure (0.0894) and the shallowest reopen (0.0984)
+/// requires `(CLOSURE_REOPEN_FRACTION - CLOSURE_DEEP_FRACTION) * gap <= 0.0090`,
+/// so `gap <= 0.030`, while [`MIN_CALIBRATION_SEPARATION`] demands 0.05. Each
+/// session calibrates fine alone; the pair cannot. A calibration therefore
+/// describes one lighting condition, which `calibrate-closure` and `doctor` both
+/// now say out loud. [`detect_nod`] is pose-defined and carries none of this,
+/// which is why it is the default and the only gesture the prompts name.
 #[derive(Debug, Clone, Copy)]
 pub struct ClosureCalibration {
     /// Median EAR with the eyes open (the smaller eye, as [`EarSample::ear`]).

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1868,7 +1868,9 @@ pub struct ClosureProfileRange {
 }
 
 impl ClosureProfileRange {
-    fn is_valid(self) -> bool {
+    /// Whether every bound is finite, ordered, non-negative, and the observed
+    /// closed range stays strictly below the observed open range.
+    pub fn is_valid(self) -> bool {
         [
             self.open_min,
             self.open_max,

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -1854,6 +1854,82 @@ pub fn detect_blink(samples: &[EarSample]) -> BlinkResult {
 /// describes one lighting condition, which `calibrate-closure` and `doctor` both
 /// now say out loud. [`detect_nod`] is pose-defined and carries none of this,
 /// which is why it is the default and the only gesture the prompts name.
+/// Observed open- and closed-eye EAR ranges for one shadow calibration profile.
+///
+/// This is evidence-tooling input, not persisted enrollment state. The selector
+/// below returns the slice index so profile names and serialization stay outside
+/// the liveness crate.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClosureProfileRange {
+    pub open_min: f32,
+    pub open_max: f32,
+    pub closed_min: f32,
+    pub closed_max: f32,
+}
+
+impl ClosureProfileRange {
+    fn is_valid(self) -> bool {
+        [
+            self.open_min,
+            self.open_max,
+            self.closed_min,
+            self.closed_max,
+        ]
+        .into_iter()
+        .all(|value| value.is_finite() && value >= 0.0)
+            && self.open_min <= self.open_max
+            && self.closed_min <= self.closed_max
+            && self.closed_max < self.open_min
+    }
+}
+
+/// Non-authoritative result of classifying a pre-gesture open-eye prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClosureProfileSelection {
+    /// Exactly one profile contains every prefix observation.
+    Unique(usize),
+    /// More than one profile contains the complete prefix; no tie is broken.
+    Ambiguous,
+    /// Evidence is absent, invalid, closed-like, or outside every open range.
+    OutOfRange,
+}
+
+/// Classify a pre-gesture EAR prefix against explicit observed profile ranges.
+///
+/// No nearest-profile fallback exists. If any prefix observation is compatible
+/// with any stored closed range, the whole prefix is refused before open-range
+/// classification so one profile's closure cannot become another profile's
+/// open evidence.
+pub fn select_closure_profile(
+    prefix: &[f32],
+    profiles: &[ClosureProfileRange],
+) -> ClosureProfileSelection {
+    if prefix.is_empty()
+        || profiles.is_empty()
+        || prefix.iter().any(|value| !value.is_finite())
+        || profiles.iter().any(|profile| !profile.is_valid())
+        || prefix.iter().any(|value| {
+            profiles
+                .iter()
+                .any(|profile| (profile.closed_min..=profile.closed_max).contains(value))
+        })
+    {
+        return ClosureProfileSelection::OutOfRange;
+    }
+
+    let mut candidates = profiles.iter().enumerate().filter_map(|(index, profile)| {
+        prefix
+            .iter()
+            .all(|value| (profile.open_min..=profile.open_max).contains(value))
+            .then_some(index)
+    });
+    match (candidates.next(), candidates.next()) {
+        (Some(index), None) => ClosureProfileSelection::Unique(index),
+        (Some(_), Some(_)) => ClosureProfileSelection::Ambiguous,
+        (None, _) => ClosureProfileSelection::OutOfRange,
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ClosureCalibration {
     /// Median EAR with the eyes open (the smaller eye, as [`EarSample::ear`]).
@@ -2980,6 +3056,78 @@ mod tests {
         ClosureCalibration {
             ear_open: 0.24,
             ear_closed: 0.05,
+        }
+    }
+
+    fn profile(
+        open_min: f32,
+        open_max: f32,
+        closed_min: f32,
+        closed_max: f32,
+    ) -> ClosureProfileRange {
+        ClosureProfileRange {
+            open_min,
+            open_max,
+            closed_min,
+            closed_max,
+        }
+    }
+
+    #[test]
+    fn closure_profile_selector_locks_only_the_unique_open_range() {
+        let profiles = [
+            profile(0.24, 0.26, 0.01, 0.04),
+            profile(0.27, 0.30, 0.10, 0.14),
+        ];
+
+        assert_eq!(
+            select_closure_profile(&[0.281, 0.276, 0.289], &profiles),
+            ClosureProfileSelection::Unique(1)
+        );
+    }
+
+    #[test]
+    fn closure_profile_selector_never_breaks_an_open_range_tie() {
+        let profiles = [
+            profile(0.24, 0.28, 0.01, 0.04),
+            profile(0.26, 0.30, 0.10, 0.14),
+        ];
+
+        assert_eq!(
+            select_closure_profile(&[0.271, 0.274], &profiles),
+            ClosureProfileSelection::Ambiguous
+        );
+    }
+
+    #[test]
+    fn closure_profile_selector_refuses_a_prefix_closed_under_any_profile() {
+        let profiles = [
+            profile(0.24, 0.26, 0.10, 0.13),
+            profile(0.10, 0.14, 0.05, 0.09),
+        ];
+
+        assert_eq!(
+            select_closure_profile(&[0.11, 0.12], &profiles),
+            ClosureProfileSelection::OutOfRange,
+            "one profile's closed evidence must not become another profile's open prefix"
+        );
+    }
+
+    #[test]
+    fn closure_profile_selector_fails_closed_on_bad_or_missing_evidence() {
+        let valid = [profile(0.24, 0.26, 0.01, 0.04)];
+        let invalid = [profile(0.26, 0.24, 0.01, 0.04)];
+
+        for (prefix, profiles) in [
+            (&[][..], &valid[..]),
+            (&[f32::NAN][..], &valid[..]),
+            (&[0.20][..], &valid[..]),
+            (&[0.25][..], &invalid[..]),
+        ] {
+            assert_eq!(
+                select_closure_profile(prefix, profiles),
+                ClosureProfileSelection::OutOfRange
+            );
         }
     }
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -88,6 +88,22 @@ Each prints its own usage line when run without arguments. `padcapture` /
 [PAD_SELFTEST.md](PAD_SELFTEST.md); `suncal` is the outdoor/sunlight
 calibration analyzer.
 
+`blinkcap select` evaluates the issue #173 multi-calibration selector without
+changing authentication or enrollment:
+
+```console
+IRLUME_DEV=1 irlume blinkcap select \
+  --profiles profiles.json --attempts attempts/ --prefix-frames 6
+```
+
+The manifest contains one or more named profiles, each referencing at least two
+existing blinkcap JSONL recordings for its `open` phase and two for its `closed`
+phase. Relative paths resolve beside the manifest. The command derives observed
+ranges from per-recording medians, classifies only the explicit prefix, discards
+that prefix, and runs the existing detector only when exactly one profile is
+eligible. Its output is marked `SHADOW ONLY`; ambiguous, closed-like,
+out-of-range, malformed, or incomplete evidence can never become consent.
+
 ## Where to go next
 
 - First-time setup, step by step: [SETUP.md](SETUP.md)

--- a/docs/research/2026-08-18-issue-173-closure-calibration-profiles.md
+++ b/docs/research/2026-08-18-issue-173-closure-calibration-profiles.md
@@ -1,0 +1,565 @@
+# Issue #173: closure-calibration profiles without widening consent
+
+Date: 2026-08-18
+
+Issue: [#173 — Closure calibration is one snapshot per user, but glasses change
+the eye it measured](https://github.com/archledger/irlume/issues/173)
+
+## Decision
+
+Support more than one closure calibration, but **never accept a gesture against
+every stored calibration**. The production target should be a fail-closed,
+two-stage state machine:
+
+1. While closure acceptance is disarmed, collect a clean, frontal, stable
+   open-eye prefix.
+2. Select exactly one calibration whose enrolled open range uniquely contains
+   that prefix and whose enrolled closed range does not overlap it.
+3. Lock that calibration for the entire authorization attempt, discard the
+   selection prefix from the gesture samples, and only then arm the existing
+   bounded close-and-reopen detector.
+4. If the prefix is missing, out of range, consistent with a closed state, or
+   consistent with more than one profile, do not select a nearest fallback.
+   Closure remains unavailable; `Either` mode can still accept a nod and
+   `Closure` mode falls back to the password.
+
+This is a safety-engineering conclusion, not an algorithm already validated by
+the literature. The primary literature establishes condition and subject
+variation, gaze/squint confounding, and the danger of contaminated or
+unsupervised adaptation. It does **not** establish automatic selection among
+multiple stored closure calibrations. The current project evidence is one
+subject on one camera. Therefore the smallest safe first implementation is an
+evidence-only slice: record the would-be selector inputs and verdicts without
+changing authorization, then collect a held-out matrix of genuine closures,
+downward gaze, squint, ambiguity, glasses, and lighting conditions. Storage and
+the production selector should follow only after the selector rule and margins
+are fixed from that evidence.
+
+## Scope and pinned artifacts
+
+This note audits GitHub `main` at
+[`f1e20e9e5270a4791737fa618bf24f4aa921463d`](https://github.com/archledger/irlume/commit/f1e20e9e5270a4791737fa618bf24f4aa921463d).
+It changes no code and repeats no hardware measurement.
+
+| Artifact | Git blob |
+|---|---|
+| `crates/irlume-core/src/storage.rs` | `b51f28225bbacc430a1497a6543bcfd5a8e15163` |
+| `crates/irlume-common/src/lib.rs` | `e46dc06d9281020091b2f963d5f172d46f761d38` |
+| `crates/irlume-liveness/src/lib.rs` | `dced31b7699024041aabc4c05bf2fe6271cb6bfe` |
+| `crates/irlume-auth/src/lib.rs` | `f14596d582b28045e255ba4b091d7b15711e9289` |
+| `crates/irlume-cli/src/main.rs` | `711525eb5df1af13f02b80c26d8cf4b69542a09b` |
+
+Repository measurements are treated as project evidence reported by the issue
+or checked-in measurement notes, not as independently reproduced results.
+External sources are original papers, author/institution repositories, and
+official platform or serialization documentation.
+
+## What the current system actually does
+
+The on-disk `Enrollment` has one
+[`Option<(f32, f32)>`](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-core/src/storage.rs#L176-L195),
+representing the median open and closed EAR. `calibrate-closure` captures three
+open/closed rounds by default, takes each median, verifies a minimum `0.05` gap,
+and reports how many of the enrollment readings would pass the resulting
+thresholds. It then sends the single
+[`SetClosureCalibration`](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-common/src/lib.rs#L505-L516)
+request, whose daemon handler replaces the tuple.
+
+At authentication, a usable tuple becomes one runtime `ClosureCalibration`.
+The detector classifies a closure below
+
+```text
+closed + 0.30 * (open - closed)
+```
+
+for 11–25 face frames, then requires a reopen above
+
+```text
+closed + 0.60 * (open - closed)
+```
+
+within four frames. These are an enrolled absolute threshold and a bounded
+temporal shape, not a per-attempt relative baseline; see the
+[`ClosureCalibration` and detector contract](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-liveness/src/lib.rs#L1832-L1980).
+
+The same authorization may watch twice: an early pre-match watch exists so a
+gesture made when the PAM prompt appears is not missed, and a post-match watch
+uses the remaining budget. The current watch begins evaluating the accumulated
+EAR sequence every six frames as soon as frames arrive; it has no profile
+selection phase. The relevant flow is
+[`early_consent_watch`](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-auth/src/lib.rs#L4216-L4249)
+and
+[`consent_watch`](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-auth/src/lib.rs#L4281-L4358).
+Any selector must therefore work before an early gesture, and its lock must
+survive the transition from the early watch through matching to the post-match
+watch. Selecting afresh in each watch would let one authorization be tested
+under two thresholds.
+
+## Evidence that drives the design
+
+### The effect is condition-dependent, not a uniform offset
+
+Issue #173 reports five captures in each state from one subject on the ASUS FHD
+IR module:
+
+| State | Observed range | Median |
+|---|---:|---:|
+| glasses off, open | 0.2460–0.2541 | 0.2527 |
+| glasses off, closed | 0.0162–0.0267 | 0.0178 |
+| glasses on, open | 0.2598–0.2885 | 0.2710 |
+| glasses on, closed | 0.1065–0.1303 | 0.1128 |
+
+The open median moved by 0.0183, while the closed median moved by 0.0950
+(6.3×). A bare-eyed calibration yields a closed threshold of 0.0883 and
+registered 0/5 glasses-on closures. A glasses-on calibration yields 0.1603 and
+registered all captured closures in both states. Those figures come directly
+from the issue's
+[`2026-08-04 measurement comment`](https://github.com/archledger/irlume/issues/173#issuecomment-5175356292).
+
+That apparent one-profile workaround has a safety cost already documented in
+the shipped CLI. An excluded “open” run while the operator looked down at the
+terminal read 0.07–0.16. The glasses-on threshold classifies that entire band as
+closed; a roughly one-second glance down followed by looking back at the camera
+can have the same below-threshold-run-plus-reopen shape as the consent gesture.
+The exact concern and arithmetic are preserved in
+[`closure_calibration_intro`](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-cli/src/main.rs#L720-L770).
+
+Independent primary evidence supports treating this as a real confound rather
+than an odd local trace. Frigerio et al.'s controlled 24-participant IR sensor
+study reported false blink detections during 46.5% of downward gaze changes,
+versus 6.3% lateral and 10.4% upward, and reported disruption from substantial
+squinting ([JAMA Facial Plastic Surgery, DOI
+10.1001/jamafacial.2014.1](https://pubmed.ncbi.nlm.nih.gov/24699708/)). Its
+wearable beam sensor is not EAR, so the percentages cannot be transferred to
+irlume; what transfers is the demonstrated ambiguity between eyelid closure,
+downward gaze, and squint in an IR eye signal. BlinkLinMulT also treats head
+pose, lighting, reflection, appearance, and temporal features as jointly
+relevant and reports condition-stratified performance differences
+([Fodor et al. 2023](https://doi.org/10.3390/jimaging9100196)).
+
+### Multiple enrollment conditions are reasonable; their decision rule matters
+
+Microsoft's official Windows Hello documentation describes enrollment as a set
+of representations and specifically recommends additional enrollment for
+occasional glasses and high ambient near-IR environments. It also performs a
+head-orientation check before its decision
+([Windows Hello face authentication](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/windows-hello-face-authentication)).
+That supports representing condition diversity; it does not specify how an EAR
+consent gesture should choose a calibration.
+
+Personalized thresholds have empirical support. A 2026 study reports fixed
+EAR/MAR thresholds failing to generalize across facial structure, illumination,
+and driving conditions, with a 2–3 percentage-point accuracy improvement from
+driver-specific calibration
+([Ersoy et al., arXiv:2604.22479](https://arxiv.org/abs/2604.22479)). The
+original EAR work likewise notes that a low EAR can be an intentional closure,
+expression, or landmark error rather than a blink and finds temporal modeling
+more reliable than a fixed threshold
+([Soukupová 2016 thesis](https://cmp.felk.cvut.cz/ftp/articles/cech/Soukupova-TR-2016-05.pdf),
+building on the original
+[CVWW paper](https://vision.fe.uni-lj.si/cvww2016/proceedings/papers/05.pdf)).
+These sources justify subject/condition calibration and temporal checks, but
+none validates a multi-profile selector for a credential-release gesture.
+
+### A mutable baseline is not the same as a clean prefix
+
+The current source deliberately rejects a running median: once a deliberate
+closure occupies most of the window, it pulls the “open” median toward the
+closed value and can make itself disappear. This follows directly from the
+11–25-frame held-closure contract and is stated in the
+[`ClosureCalibration` documentation](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-liveness/src/lib.rs#L1832-L1856).
+
+Related primary evidence points in the same direction. Mathôt et al. show that
+blink/data-loss samples in a pupil baseline can materially distort baseline
+correction and recommend rejecting contaminated baseline trials
+([Behavior Research Methods 2018](https://pubmed.ncbi.nlm.nih.gov/29330763/)).
+That is pupil size rather than EAR, so applying it here is an arithmetic and
+safety inference, not a direct replication. Soukupová's adaptive HMM learned a
+half-open squint as the new open state and then made symmetric errors when the
+squint ended; adaptation can normalize the adversarial state it is supposed to
+distinguish. At the stored-template level, Lovisotto et al. demonstrate that
+unsupervised biometric updates can be poisoned and distinguish them from
+supervised updates with independent identity assurance
+([EuroS&P 2020](https://conferences.computer.org/eurosp/pdfs/EuroSP2020-2psedXWK6U4prXdo7t91Gm/508700a184/508700a184.pdf)).
+
+Consequently:
+
+- a pre-gesture prefix that is validated once and frozen is defensible;
+- a statistic that continues moving after the gesture can start is not; and
+- normal authentication must never modify stored calibration profiles.
+
+## Threat model and invariants
+
+This gesture authorizes polkit actions and release of a reusable keyring secret
+after a face match. Availability failures fall back to another gesture or the
+password; false acceptance weakens an explicit-consent boundary. The design
+must therefore prefer a visible refusal over extrapolation.
+
+The relevant adversarial or confused inputs are:
+
+- a real matched user looking down at a keyboard or prompt without intending
+  consent;
+- a held or timed squint followed by reopening;
+- a user beginning the capture already closed, before any clean open prefix;
+- a lighting/glasses condition outside every enrolled profile;
+- a prefix equally compatible with two profiles;
+- transient landmark errors or exposure settling; and
+- a presentation attack that produces a closure-like EAR trace. Profile
+  selection is not PAD and must not be credited as one.
+
+The non-negotiable invariants are:
+
+1. At most one closure profile can contribute to one authorization decision.
+2. No closure sample can contribute to profile selection or baseline update.
+3. The detector remains disarmed until selection is complete.
+4. Selection never chooses the nearest profile outside an enrolled acceptance
+   region and never breaks a tie.
+5. A locked profile cannot change across early watch, face matching, retries,
+   or post-match watch.
+6. A shake decline stays terminal and cannot be reinterpreted by closure logic.
+7. Missing, invalid, ambiguous, or out-of-range evidence cannot enable closure.
+8. Authentication never writes profile state.
+
+## Comparison of the five candidate designs
+
+| Design | Availability | False-accept effect | Verdict |
+|---|---|---|---|
+| Accept against any stored calibration | Highest | The effective accepted set is the union of every profile; a permissive condition can authorize a trace rejected by the correct condition | Reject |
+| Named/manual active profile | Predictable when the user switches correctly | No union, but stale/wrong selection can retain a permissive threshold and is easy to forget at a PAM prompt | Useful management/fallback, not the automatic default |
+| Select from pre-gesture open frames, then lock | Can cover conditions without user interaction | Safe only with bounded, unique selection and a clean prefix; forced-nearest is unsafe | Recommended target |
+| Within-burst adaptive baseline | Smooth when the starting state is clean | Closure/squint can pollute or become the baseline; behavior changes during the decision | Reject for production consent |
+| Ambiguous/out-of-range fail closed | More password/nod fallbacks | Does not widen the accepted set | Mandatory policy around every design |
+
+### 1. Accepting against any calibration
+
+Running `detect_deliberate_closure(samples, cal)` for every profile and OR-ing
+the results is compact but wrong. In #173's measured pair, the glasses profile's
+0.1603 closed threshold admits the full 0.07–0.16 downward-looking band that the
+bare profile mostly rejects. Adding that profile would broaden consent even
+when the live user is bare-eyed.
+
+This is the same direction as the general biometric OR rule: it reduces false
+rejects while increasing false accepts. Daugman's primary analysis gives the
+independent-test formula and explains the operating-point tradeoff
+([University of Cambridge Technical Report 482](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-482.html)).
+Closure profiles are correlated, so its numerical formula must not be applied
+to them; set inclusion is sufficient here—the union cannot have fewer false
+accepts than either member.
+
+### 2. Named/manual active profiles
+
+Names such as `desk-glasses` and `night-no-glasses` help users understand and
+replace data. An explicit active profile also guarantees one threshold rather
+than a union. However, a user cannot reasonably switch persistent state every
+time a polkit prompt appears. Selecting a stale glasses profile while bare-eyed
+retains the exact downward-gaze exposure above. Manual selection is therefore
+appropriate for diagnostics, an operator-controlled fallback, or a first data
+collection tool—not sufficient as the unattended runtime policy. A live
+out-of-range guard is still required.
+
+Names must remain labels, not a glasses classifier. The underlying variation is
+continuous across lens reflections, light, gaze, distance, and landmark error;
+the machine decision must use measured enrollment ranges, not the string.
+
+### 3. Pre-gesture selection and lock
+
+This is the only candidate that represents multiple conditions without unioning
+their closure thresholds or trusting a persistent manual switch. “Nearest” must
+mean **the only eligible profile**, not the least-distant profile among all
+profiles.
+
+The selector needs repeated enrollment observations, not just two medians. For
+each profile it needs at least an enrolled open acceptance region and a closed
+exclusion region derived from explicitly prompted, quality-gated rounds. At
+runtime it should:
+
+1. Start in `Selecting`, with closure detection disabled.
+2. Gather a stable prefix after rejecting non-finite landmarks, bad framing,
+   out-of-policy head pose, and exposure/transient failures.
+3. Refuse selection if the prefix is compatible with any enrolled closed
+   region. This prevents one condition's closed eye from serving as another
+   condition's “open” baseline.
+4. Find profiles whose open region contains the complete observed prefix under
+   a prevalidated margin.
+5. Lock only if exactly one remains and it has required clearance from the next
+   candidate. Zero or multiple candidates produce `Unavailable`, never a
+   nearest fallback.
+6. Clear the selection samples, enter `Armed(locked_profile)`, and begin the
+   existing bounded close-and-reopen detector at frame zero.
+7. Carry the lock across both consent watches. If later quality/context leaves
+   the validated envelope, make closure unavailable; do not switch profiles.
+
+The required prefix length, stability statistic, pose envelope, and margins are
+not established by current evidence and must come from the evidence-only slice.
+Hard-coding them from five captures would turn measurement noise into policy.
+The instruction also needs to become sequential—“look at the camera, then close
+your eyes”—because a user who starts closed cannot provide a selectable open
+prefix and must safely miss rather than be guessed through.
+
+### 4. Within-burst adaptive baselines
+
+A rolling median over the whole watch is directly incompatible with a gesture
+whose closed portion deliberately lasts 11–25 frames. Updating only on samples
+classified as open is circular when the mutable baseline is what classifies
+them, and Soukupová's squint adaptation demonstrates the failure shape. Using a
+maximum or upper quantile may resist closure pollution but becomes sensitive to
+landmark spikes and has no project validation.
+
+If “adaptive” is narrowed to a clean prefix that is frozen before any gesture
+sample, it is no longer this option; it is option 3. No stored profile should be
+updated from successful authentication samples.
+
+### 5. Ambiguity and out-of-range handling
+
+This is not a separate convenience feature. It is the condition that makes
+option 3 safe:
+
+- no face/eyes or insufficient valid prefix → unavailable;
+- prefix begins in a closed-like region → unavailable;
+- no open region contains the prefix → unavailable;
+- two open regions contain it or clearance is insufficient → unavailable;
+- quality/pose changes after lock → unavailable, without reselection; and
+- exactly one eligible profile → lock it once.
+
+The fallback already exists. In `Either`, the nod is independent of closure
+calibration. In `Closure`, the password is the safe result. The UI and journal
+should distinguish “profile ambiguous/out of range” from “gesture not seen”
+without logging raw EAR values or user-chosen condition names by default.
+
+## Backward-compatible storage and IPC migration
+
+### On-disk representation
+
+The current encrypted payload is ordinary JSON serialized from `Enrollment`;
+old plaintext and encrypted forms converge through the same deserializer
+([storage serialization](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-core/src/storage.rs#L528-L595)).
+The least disruptive new shape is additive:
+
+```rust
+struct ClosureCalibrationProfile {
+    name: String,
+    ear_open: f32,
+    ear_closed: f32,
+    open_observed_min: f32,
+    open_observed_max: f32,
+    closed_observed_min: f32,
+    closed_observed_max: f32,
+    // Any later selector context is additive and defaults absent.
+}
+
+struct Enrollment {
+    // Existing field retained exactly for old data and downgrade behavior.
+    closure_calibration: Option<(f32, f32)>,
+    #[serde(default)]
+    closure_calibrations: Vec<ClosureCalibrationProfile>,
+}
+```
+
+The exact persisted statistics may change after the evidence slice; the
+important properties are that selection bounds come from repeated raw rounds,
+not reconstructed from the two medians, and every numeric field is finite,
+ordered, and validated on load and write.
+
+Effective behavior should be explicit:
+
+- empty vector + legacy tuple: use the exact legacy single-profile behavior;
+- empty vector + no tuple: closure unavailable;
+- nonempty vector: use the new selector and **do not also OR the legacy tuple**;
+- legacy tuples have no observed range, so they cannot silently become
+  auto-selectable multi-profile entries; enrolling the first multi-profile set
+  must explain that the legacy calibration needs a fresh repeated capture.
+
+Serde's official contract says `#[serde(default)]` fills a missing field and,
+unless `deny_unknown_fields` is used, JSON ignores fields unknown to an older
+struct ([field attributes](https://serde.rs/field-attrs.html),
+[container attributes](https://serde.rs/container-attrs.html)). That gives
+new-reader/old-file compatibility and lets an older binary read the retained
+legacy tuple. It does **not** provide lossless downgrade round-tripping: an old
+daemon that loads and re-saves the enrollment will discard the unknown vector.
+That risk must be documented and tested with an old-shape fixture. It cannot be
+fixed by bumping the current envelope's `version`, because the source explicitly
+treats that number as informational and detects the envelope by `enc`.
+
+Do not mirror the “most permissive” new profile into the legacy tuple. A
+downgrade would then inherit the widest threshold without the new selector. The
+legacy tuple should remain the pre-migration calibration until the user
+explicitly replaces legacy mode. A separate sidecar could avoid unknown-field
+loss on downgrade, but it would duplicate encryption, atomicity, deletion, and
+template-key lifecycle; that is not the smallest safe design.
+
+### Wire contract
+
+Keep `SetClosureCalibration` with its current replace-one semantics for old
+clients. Add distinct privileged requests for profile add/replace/delete rather
+than optional fields that an old daemon would ignore and misinterpret as a
+legacy overwrite. Add a default-false capability field to the existing
+`Response::Health` and require a new client to check it before sending a profile
+request. A new client meeting an old daemon can then ask the user to restart the
+daemon after upgrade instead of turning the old daemon's generic `bad request`
+response into ambiguous UX. If a request nevertheless reaches an old daemon,
+deserialization fails before dispatch and no enrollment state changes.
+
+Extend the existing `Response::Enrollment` with a defaulted list of closure
+profile summaries. Old clients ignore the field; new clients meeting an old
+daemon see an empty list plus the existing `closure_calibrated` boolean and can
+identify legacy mode. Do not add a new response variant unless the client first
+opts in: the repository's own wire comments note that an unknown response
+variant fails deserialization while unknown fields can be ignored
+([upgrade contract](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-common/src/lib.rs#L451-L467)).
+
+A new daemon receiving the old `SetClosureCalibration` while profiles exist
+must not leave the profile vector silently active, because the old CLI would
+report a successful replacement that authentication ignores. Treat the old
+request as an explicit return to legacy single-profile mode and clear the new
+vector, using the old CLI's existing destructive replacement confirmation.
+
+## Measurable acceptance criteria
+
+### Evidence gate before authorization changes
+
+Collect separate enrollment and held-out authorization sessions, not validation
+on the samples that created each profile. The matrix must include:
+
+- glasses on/off;
+- at least the materially different lighting sessions already observed;
+- frontal open, genuine close-and-reopen, downward gaze-and-return at several
+  durations, timed squint-and-release, natural blink, and initially closed;
+- ambiguous open states near profile boundaries and wholly out-of-range states;
+- normal stream start/exposure settling; and
+- each available project camera whose IR/landmark behavior differs.
+
+For every attempt, record without raw images: candidate count, selected/ambiguous/
+out-of-range result, quality/pose rejection category, lock frame, whether any
+profile would have accepted under OR, and the final shadow detector verdict.
+Raw EAR traces are biometric measurements and should remain in the same
+restricted research handling as existing corpora, not ordinary journals.
+
+Report these denominators separately:
+
+1. unique-selection rate for each genuine condition;
+2. genuine close-and-reopen acceptance after unique selection;
+3. ambiguity and out-of-range fallback rates;
+4. false closure accepts for downward gaze, squint, natural blink, and initially
+   closed;
+5. how often OR-any would accept when locked selection refuses; and
+6. selection changes that would have occurred if the lock were absent.
+
+The safety gate is zero observed grants on the adversarial/confused corpus,
+including the exact 0.07–0.16 downward-gaze band, plus deterministic unit tests
+for every invariant. Zero events in a small corpus is not proof of a production
+false-accept rate; the report must give the denominator and must not claim a FAR
+the sample size cannot support. A production threshold should not be chosen
+until the project states the acceptable false-consent bound and gathers enough
+trials to measure it.
+
+### Deterministic code criteria for the later production slice
+
+- Legacy JSON with only `closure_calibration` loads and behaves byte-for-value
+  like the current detector.
+- New JSON round-trips under both plaintext and encrypted enrollment paths.
+- Missing/defaulted new fields never enable closure.
+- Invalid, non-finite, inverted, or duplicate-name profiles are rejected on
+  write and fail closed on load. Overlapping but otherwise valid measurements
+  may be retained for diagnostics/manual management, but are never
+  auto-selectable while the required clearance is absent.
+- OR-any sabotage: a trace accepted only by the wrong/permissive profile is
+  refused by the locked selector.
+- Selection-prefix sabotage: prefix frames can never contribute to the
+  11–25-frame closure run.
+- Closed-first, downward-gaze, timed-squint, ambiguous, and out-of-range traces
+  never lock or grant.
+- Once locked, a later closer profile cannot replace the first one; the same
+  lock is used across early and post-match watches.
+- Shake decline remains terminal.
+- Normal authentication performs no enrollment write.
+- `Either` continues accepting a valid nod when closure selection fails;
+  `Closure` returns a password fallback.
+- Old request/new daemon and new request/old daemon behavior is covered, and an
+  old-shape deserialize/reserialize fixture demonstrates the documented
+  downgrade-loss risk rather than hiding it.
+
+## Smallest safe first implementation slice
+
+Do **not** begin with the storage vector or production OR/selector behavior.
+Begin with a shadow selector probe that cannot affect `Outcome`:
+
+1. Extend the existing measurement tooling to capture repeated labelled open
+   and closed ranges for named conditions while retaining the current stored
+   tuple.
+2. Add a pure candidate-classification function over explicit profile fixtures
+   and a pre-gesture prefix. Its output is only `Unique(id)`, `Ambiguous`, or
+   `OutOfRange`; it must have no nearest fallback.
+3. Run that function in offline tooling or shadow diagnostics against the matrix
+   above. Do not call it from the grant path yet.
+4. Use the held-out results to fix the prefix length, stability/pose filters,
+   range construction, and separation margin.
+5. Only then add profile storage/IPC and wire the proven selector into the
+   consent state machine, with exact-head hardware replay and adversarial tests.
+
+This slice is deliberately small: it answers the remaining design questions
+without widening a credential-release gate or committing an on-disk schema to
+statistics that five samples cannot justify.
+
+## Missing evidence and open decisions
+
+- The #173 ranges are one subject, one camera, one day, five captures per state.
+  They establish a real failure, not population bounds.
+- No primary paper found here validates automatic selection among multiple
+  stored EAR closure profiles for consent or liveness.
+- The open-glasses ranges in #173 are separated by only 0.0057 at their closest
+  observed points. It is unknown whether that separation survives another day,
+  head position, lens reflection, or another subject.
+- The repository has evidence that lighting can shift open EAR from 0.109 to
+  0.166 and that the paired sessions cannot share one usable calibration, but
+  there is not yet a labelled multi-condition selector corpus.
+- Head pose is available, but downward **eye gaze** can change lid opening while
+  the head remains frontal. Pose gating reduces risk; it cannot be assumed to
+  solve it.
+- The UX cost of an open-prefix phase has not been measured. Because the early
+  watch exists specifically to honor a gesture made immediately at the PAM
+  prompt, the prompt and arming timing must be tested together.
+- A profile-count cap, selection margin, and production false-consent target
+  need evidence or a stated policy; they should not be invented in the schema.
+
+## Primary sources
+
+### Project sources
+
+- [Issue #173 body and measurement discussion](https://github.com/archledger/irlume/issues/173)
+- [Enrollment storage at the pinned commit](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-core/src/storage.rs)
+- [Daemon wire types at the pinned commit](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-common/src/lib.rs)
+- [Closure detector at the pinned commit](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-liveness/src/lib.rs)
+- [Consent watch at the pinned commit](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-auth/src/lib.rs)
+- [Calibration CLI at the pinned commit](https://github.com/archledger/irlume/blob/f1e20e9e5270a4791737fa618bf24f4aa921463d/crates/irlume-cli/src/main.rs)
+- [Checked-in blink corpus, one subject/camera](../pad-results/2026-08-07-blink-corpus.md)
+
+### External primary sources and official documentation
+
+- Soukupová, T. and Čech, J., [*Real-Time Eye Blink Detection using Facial
+  Landmarks*](https://vision.fe.uni-lj.si/cvww2016/proceedings/papers/05.pdf),
+  CVWW 2016; extended primary analysis in
+  [Soukupová's thesis](https://cmp.felk.cvut.cz/ftp/articles/cech/Soukupova-TR-2016-05.pdf).
+- Dewi et al., [*Adjusting eye aspect ratio for strong eye blink detection based
+  on facial landmarks*](https://pmc.ncbi.nlm.nih.gov/articles/PMC9044337/),
+  PeerJ Computer Science 2022, DOI 10.7717/peerj-cs.943.
+- Frigerio et al., [*Infrared-based blink-detecting glasses for facial pacing:
+  toward a bionic blink*](https://pubmed.ncbi.nlm.nih.gov/24699708/), JAMA
+  Facial Plastic Surgery 2014, DOI 10.1001/jamafacial.2014.1.
+- Fodor, Fenech, and Lőrincz,
+  [*BlinkLinMulT: Transformer-Based Eye Blink Detection*](https://doi.org/10.3390/jimaging9100196),
+  Journal of Imaging 2023.
+- Ersoy et al., [*Improving Driver Drowsiness Detection via Personalized EAR/MAR
+  Thresholds and CNN-Based Classification*](https://arxiv.org/abs/2604.22479),
+  arXiv:2604.22479, 2026.
+- Mathôt et al., [*Safe and sensible preprocessing and baseline correction of
+  pupil-size data*](https://pubmed.ncbi.nlm.nih.gov/29330763/), Behavior
+  Research Methods 2018, DOI 10.3758/s13428-017-1007-2.
+- Lovisotto, Eberz, and Martinovic,
+  [*Biometric Backdoors: A Poisoning Attack Against Unsupervised Template
+  Updating*](https://conferences.computer.org/eurosp/pdfs/EuroSP2020-2psedXWK6U4prXdo7t91Gm/508700a184/508700a184.pdf),
+  IEEE EuroS&P 2020, DOI 10.1109/EuroSP48549.2020.00020.
+- Daugman, J., [*Biometric decision landscapes*](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-482.html),
+  University of Cambridge Computer Laboratory Technical Report 482, 2000.
+- Microsoft, [*Windows Hello face authentication*](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/windows-hello-face-authentication).
+- Serde, [field attributes](https://serde.rs/field-attrs.html) and
+  [container attributes](https://serde.rs/container-attrs.html).


### PR DESCRIPTION
## What & why

Advances #173 with the evidence-only slice recommended by the deep-dive research. Glasses and lighting can move eye-closure EAR enough that one stored calibration misses genuine closures, but accepting against every calibration would widen the consent gate.

This PR deliberately does **not** change authentication, enrollment storage, daemon IPC, PAM, or any authorization outcome.

## What changed

- adds a primary-source deep dive covering safe multi-calibration selection and the missing evidence
- adds a pure fail-closed selector returning only `Unique`, `Ambiguous`, or `OutOfRange`
- adds developer-only `IRLUME_DEV=1 irlume blinkcap select` shadow replay
- derives explicit profile ranges from repeated open/closed recording medians
- requires an explicit pre-gesture prefix length, discards that prefix, and runs the existing detector only for a unique profile
- strictly validates bounded regular-file JSON/JSONL evidence, distinct capture paths, labels, frame counts, required fields, and consecutive indices
- validates every attempt before printing, and retains only one parsed trace at a time
- documents the manifest and developer workflow

## Safety boundary

- no nearest-profile fallback
- no OR-across-profiles behavior
- ambiguous, closed-like, out-of-range, malformed, or incomplete evidence produces `shadow-consent=not-run`
- output is marked `SHADOW ONLY; never authorizes`
- selector symbols have no callers in auth, daemon, storage, common IPC, or PAM crates
- no new dependencies or lockfile changes

This is instrumentation for building the held-out adversarial corpus. It does not close #173 and does not commit to a production profile schema or selector threshold.

## Validation

Exact head: `4edf283`

- `cargo test --workspace` — pass, zero runnable failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- `rustup run 1.88.0 cargo check -p irlume-cli` — pass
- prefix-discard regression verified red under deliberate full-sequence sabotage, then green after restoration
- independent exact-head review: no Critical, Important, or Minor findings; Ready to merge
