### PR TITLE
fix(vision): runtime quick-fixes from the model-runtime audit

### DIFF
--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -5,7 +5,8 @@
 //!
 //! Commercially-clean, GPL-3.0-compatible bill of materials (all permissive):
 //!   * Detection:   YuNet  (MIT)      `face_detection_yunet_2023mar.onnx`
-//!     bbox + 5 landmarks; ~1.6 ms @320x320 on a laptop CPU.
+//!     bbox + 5 landmarks; runs at the fixed 640x640 letterbox (INPUT_SIZE in
+//!     detect.rs); see `examples/mp_latency_bench.rs` for current numbers.
 //!   * Recognition: AuraFace (Apache) `glintr100.onnx`, ResNet100/ArcFace,
 //!     512-D embedding, 112x112 input, standard 5-point alignment.
 //!
@@ -244,6 +245,13 @@ mod onnx {
     use crate::align;
     use ort::session::{builder::GraphOptimizationLevel, Session};
     use ort::value::Tensor;
+
+    /// Intra-op threads per ONNX session. 2 matches the measured TFLite
+    /// XNNPACK knee for these small single-image models, and the ONNX
+    /// determinism notes (by the PINNED_EMBEDDING gate) found counts 1-8
+    /// bit-identical, so a small fixed cap only removes idle-pool contention
+    /// with capture threads.
+    const ORT_INTRA_THREADS: usize = 2;
 
     fn err<E: std::fmt::Display>(e: E) -> irlume_common::Error {
         irlume_common::Error::Hardware(format!("onnx: {e}"))
@@ -523,7 +531,29 @@ mod onnx {
                 .with_execution_providers([ort::ep::OpenVINO::default().build()])
                 .map_err(err)?;
         }
-        b.with_optimization_level(GraphOptimizationLevel::Level3)
+        #[cfg(feature = "tensorrt")]
+        {
+            b = b
+                .with_execution_providers([ort::ep::TensorRT::default().build()])
+                .map_err(err)?;
+        }
+        #[cfg(feature = "coreml")]
+        {
+            b = b
+                .with_execution_providers([ort::ep::CoreML::default().build()])
+                .map_err(err)?;
+        }
+        // Cap the intra-op pool explicitly. The runtime default sizes one pool
+        // per session to the physical-core count; this daemon holds up to four
+        // ONNX sessions plus a TFLite session, and idle pools contend with the
+        // capture and consent-watch threads inside the seconds-scale auth
+        // budget. The repo's own measurement (see the determinism notes by the
+        // PINNED_EMBEDDING gate) found intra-op thread counts 1, 2, 4 and 8
+        // bit-identical for the embedder, so capping costs nothing and removes
+        // the contention.
+        b.with_intra_threads(ORT_INTRA_THREADS)
+            .map_err(err)?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
             .map_err(err)?
             .commit_from_memory(model)
             .map_err(err)

--- a/crates/irlume-vision/src/moire.rs
+++ b/crates/irlume-vision/src/moire.rs
@@ -14,8 +14,9 @@
 //! camera show weak moiré, and very sharp natural texture can read high, so this
 //! is one cue layered onto lit + frontal + glare, used only in convenience tier.
 
-use rustfft::{num_complex::Complex, FftPlanner};
+use rustfft::{num_complex::Complex, Fft, FftPlanner};
 use std::f32::consts::PI;
+use std::sync::OnceLock;
 
 /// Analysis grid size (square). Power-of-two keeps the FFT fast; the caller
 /// nearest-resamples the face crop to this (nearest, not bilinear, to preserve
@@ -43,8 +44,12 @@ pub fn moire_score(gray: &[u8]) -> f32 {
         }
     }
 
-    let mut planner = FftPlanner::new();
-    let fft = planner.plan_fft_forward(N);
+    // rustfft planners cache twiddle tables per length; N is a fixed constant,
+    // so the plan is built once per process instead of per score call (the
+    // convenience path runs this on every capture).
+    static PLAN: OnceLock<std::sync::Arc<dyn Fft<f32>>> = OnceLock::new();
+    let fft =
+        PLAN.get_or_init(|| std::sync::Arc::clone(&FftPlanner::<f32>::new().plan_fft_forward(N)));
     // Rows, then columns = 2D FFT.
     for y in 0..N {
         fft.process(&mut buf[y * N..(y + 1) * N]);


### PR DESCRIPTION
First batch from the 2026-08-20 ONNX/TFLite runtime audit (code-audit verdict: sound and fail-closed; these are the actionable small findings).

- **Dead EP features wired**: `tensorrt` and `coreml` compiled (CI checks them) but were never registered in `build()` — builds with those features silently ran CPU while the adjacent comment claimed registration. Now registered following the existing cuda/openvino pattern; both feature-combos verified to compile.
- **Intra-op thread cap = 2**: the repo's own determinism notes (PINNED_EMBEDDING gate) measured intra-op counts 1-8 bit-identical, so the default physical-core-sized pool per session is pure contention against capture/consent-watch threads; four ONNX sessions in one daemon made that 4 idle pools. 2 matches the measured TFLite XNNPACK knee.
- **rustfft plan cached**: `moire_score` rebuilt an `FftPlanner` (twiddle tables) on every call, once per capture on the convenience path; the plan for the fixed N=128 is now a `OnceLock`.
- **Doc fix**: crate header claimed YuNet ~1.6ms@320x320; actual INPUT_SIZE is 640 (detect.rs). Stale by 4x pixels for anyone budgeting latency.

## Evidence

Workspace guarded suite 1765/0 (all determinism gates pass with the new thread cap — empirically re-confirming the bit-identical claim), fmt/clippy `-D warnings` clean, `--features tensorrt` and `--features coreml` compile green.

Next batches (separate PRs): normalization /128-vs-/127.5 A/B bench (needs hardware measurement; archhost), grey-frame/buffer perf work, ORT 1.24.4→1.28.1 pin bump with fleet validation.

DCO: Signed-off-by: archledger <archledger236@gmail.com>