### PR TITLE
chore: bump the ONNX Runtime pin 1.24.4 → 1.28.1

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
         run: |
-          ver=1.24.4
+          ver=1.28.1
           curl -fsSLO "https://github.com/microsoft/onnxruntime/releases/download/v${ver}/onnxruntime-linux-x64-${ver}.tgz"
           tar xzf "onnxruntime-linux-x64-${ver}.tgz"
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
         run: |
-          ver=1.24.4
+          ver=1.28.1
           curl -fsSLO "https://github.com/microsoft/onnxruntime/releases/download/v${ver}/onnxruntime-linux-x64-${ver}.tgz"
           tar xzf "onnxruntime-linux-x64-${ver}.tgz"
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
@@ -381,7 +381,7 @@ jobs:
 
       - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
         run: |
-          ver=1.24.4
+          ver=1.28.1
           curl -fsSLO "https://github.com/microsoft/onnxruntime/releases/download/v${ver}/onnxruntime-linux-x64-${ver}.tgz"
           tar xzf "onnxruntime-linux-x64-${ver}.tgz"
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Fetch the ONNX runtime (ort loads it dynamically at runtime)
         run: |
-          ver=1.24.4
+          ver=1.28.1
           curl -fsSLO "https://github.com/microsoft/onnxruntime/releases/download/v${ver}/onnxruntime-linux-x64-${ver}.tgz"
           tar xzf "onnxruntime-linux-x64-${ver}.tgz"
           echo "ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-${ver}/lib/libonnxruntime.so" >> "$GITHUB_ENV"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ Everything irlume's messy build needs, so you don't hunt distro packages:
 | `clang` + `libclang` (`LIBCLANG_PATH`) | `v4l2-sys-mit`'s bindgen needs it |
 | kernel headers (`BINDGEN_EXTRA_CLANG_ARGS`) | bindgen parses `<linux/videodev2.h>` |
 | `linux-pam` | the `pamsm` crate links `libpam`; `pamsm` itself comes from the irlume-maintained fork [`archledger/pam_sm_rust`](https://github.com/archledger/pam_sm_rust), pinned by exact commit in `Cargo.toml`/`Cargo.lock` (ADR-0012). Offline builds vendor it like any other git dependency: `cargo vendor --locked vendor` then `--offline` builds resolve it from the vendor dir. |
-| onnxruntime **1.24.4** (`ORT_DYLIB_PATH`) | irlume needs the `api-24` ABI; nixpkgs' is older |
+| onnxruntime **1.28.1** (`ORT_DYLIB_PATH`) | irlume needs the `api-24` ABI; nixpkgs' is older |
 
 To bump the toolchain or nixpkgs later: edit the version string in `flake.nix`
 or run `nix flake update`, then commit the changed `flake.lock`.
@@ -110,9 +110,9 @@ distro build is older, so fetch the upstream release and point `ORT_DYLIB_PATH`
 at it:
 
 ```sh
-curl -fsSLO https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-1.24.4.tgz
-tar xzf onnxruntime-linux-x64-1.24.4.tgz
-export ORT_DYLIB_PATH="$PWD/onnxruntime-linux-x64-1.24.4/lib/libonnxruntime.so"
+curl -fsSLO https://github.com/microsoft/onnxruntime/releases/download/v1.28.1/onnxruntime-linux-x64-1.28.1.tgz
+tar xzf onnxruntime-linux-x64-1.28.1.tgz
+export ORT_DYLIB_PATH="$PWD/onnxruntime-linux-x64-1.28.1/lib/libonnxruntime.so"
 ```
 
 ## Option C: Container (Podman/Docker)
@@ -266,7 +266,7 @@ CLI tools, they open the camera directly and hold no privileged path.
 The `irlume-auth` examples load ONNX models, so they need `ORT_DYLIB_PATH`
 set (see the ONNX runtime section above; on an installed Fedora/RPM box,
 `/usr/share/irlume/onnxruntime/lib/libonnxruntime.so` works, on a Debian/PPA
-box `/opt/irlume/onnxruntime/lib/libonnxruntime.so.1.24.4`). Without it the
+box `/opt/irlume/onnxruntime/lib/libonnxruntime.so.1.28.1`). Without it the
 process hangs instead of erroring: an upstream `ort` bug where building the
 load-failure message re-enters the API lock being initialized.
 

--- a/flake.nix
+++ b/flake.nix
@@ -47,13 +47,13 @@
         # irlume needs onnxruntime >= 1.24 (the api-24 ABI). nixpkgs ships an
         # older build, so we pin the exact upstream release the RPM/.deb bundle.
         # `ort` uses load-dynamic, so this is only needed to RUN, not to build.
-        ortVersion = "1.24.4";
+        ortVersion = "1.28.1";
         onnxruntime-bin = pkgs.stdenv.mkDerivation {
           pname = "onnxruntime-linux-x64";
           version = ortVersion;
           src = pkgs.fetchurl {
             url = "https://github.com/microsoft/onnxruntime/releases/download/v${ortVersion}/onnxruntime-linux-x64-${ortVersion}.tgz";
-            hash = "sha256-OiEfvqJSweZikGWPG3NbdyBWFJ8oMh5xwwiULNtUt0c=";
+            hash = "sha256-JSmu+WjQrQYDNlBUvEbr76fw/jvBLyjF9ynJnd/+KoE=";
           };
           # A prebuilt binary: unpack it and expose just the shared library.
           # autoPatchelf fixes its library paths so it also runs on NixOS.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -86,13 +86,13 @@ let
   # already does it. Written out three times, a bump could change the derivation
   # label while still fetching the old archive, and the parity check in
   # scripts/check-packaging-parity.sh reads the label (#411).
-  ortVersion = "1.24.4";
+  ortVersion = "1.28.1";
   onnxruntime-bin = pkgs.stdenv.mkDerivation {
     pname = "onnxruntime-linux-x64";
     version = ortVersion;
     src = pkgs.fetchurl {
       url = "https://github.com/microsoft/onnxruntime/releases/download/v${ortVersion}/onnxruntime-linux-x64-${ortVersion}.tgz";
-      hash = "sha256-OiEfvqJSweZikGWPG3NbdyBWFJ8oMh5xwwiULNtUt0c=";
+      hash = "sha256-JSmu+WjQrQYDNlBUvEbr76fw/jvBLyjF9ynJnd/+KoE=";
     };
     nativeBuildInputs = [ pkgs.autoPatchelfHook ];
     buildInputs = [ pkgs.stdenv.cc.cc.lib ];

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 ORT_VER="${ORT_VER:-1.28.1}"
 # sha256 of onnxruntime-linux-x64-${ORT_VER}.tgz (bundled .so runs in the
 # privileged daemon); verify rather than trusting HTTPS. Update with ORT_VER.
-ORT_SHA256="${ORT_SHA256:-3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747}"
+ORT_SHA256="${ORT_SHA256:-2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81}"
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 STAGE="$REPO/.deb-staging"
 cd "$REPO"

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -5,7 +5,7 @@
 #   bash packaging/debian/build-deb.sh
 set -euo pipefail
 
-ORT_VER="${ORT_VER:-1.24.4}"
+ORT_VER="${ORT_VER:-1.28.1}"
 # sha256 of onnxruntime-linux-x64-${ORT_VER}.tgz (bundled .so runs in the
 # privileged daemon); verify rather than trusting HTTPS. Update with ORT_VER.
 ORT_SHA256="${ORT_SHA256:-3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747}"
@@ -73,7 +73,7 @@ EOF
 
 cd "$REPO/packaging/debian"
 # Name the artifact after the irlume version (from nfpm.yaml), NOT the bundled
-# onnxruntime version; irlume_1.24.4.deb read like irlume itself was 1.24.4.
+# onnxruntime version; irlume_1.28.1.deb read like irlume itself was 1.28.1.
 PKG_VER="$(sed -n 's/^version:[[:space:]]*v\{0,1\}\([0-9][^[:space:]]*\).*/\1/p' nfpm.yaml)"
 nfpm package --packager deb --target "$REPO/irlume_${PKG_VER}_amd64.deb"
 echo "built irlume_${PKG_VER}_amd64.deb in $REPO"

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -84,7 +84,7 @@ daemon socket. Only needed on SELinux-enforcing systems (Fedora default).
 # Verify the bundled onnxruntime (Source1) before unpacking: the .so runs in
 # the privileged daemon, and Copr fetches remote sources without the Fedora
 # lookaside's own integrity check. Update the digest together with ort_ver.
-echo '3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747  %{SOURCE1}' | sha256sum -c -
+echo '2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81  %{SOURCE1}' | sha256sum -c -
 # Unpack the bundled onnxruntime (Source1) next to the source tree; installed
 # below into %{_datadir}/%{name}/onnxruntime.
 tar -xzf %{SOURCE1}

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -1,5 +1,5 @@
 %global tflite_ver v2.19.0
-%global ort_ver 1.24.4
+%global ort_ver 1.28.1
 
 Name:           irlume
 Version:        0.10.0

--- a/scripts/build-ppa-source.sh
+++ b/scripts/build-ppa-source.sh
@@ -19,13 +19,13 @@
 #   dput ppa:archledger/irlume "$HOME/ppa-build/irlume_"*"~resolute1_source.changes"
 # (The deterministic orig below still lets a NEW LTS be added cleanly later.)
 #
-# Env knobs: SERIES (default resolute), PPAREV (0ppa1), ORT_VER (1.24.4),
+# Env knobs: SERIES (default resolute), PPAREV (0ppa1), ORT_VER (1.28.1),
 # BUILDROOT (~/ppa-build), SKIP_BUILD_CHECK=1 to skip the offline test build.
 set -euo pipefail
 
 SERIES="${SERIES:-resolute}"
 PPAREV="${PPAREV:-0ppa1}"
-ORT_VER="${ORT_VER:-1.24.4}"
+ORT_VER="${ORT_VER:-1.28.1}"
 # sha256 of onnxruntime-linux-x64-${ORT_VER}.tgz; the bundled .so runs in the
 # privileged daemon, so verify it rather than trusting HTTPS alone. Update
 # together with ORT_VER.

--- a/scripts/build-ppa-source.sh
+++ b/scripts/build-ppa-source.sh
@@ -29,7 +29,7 @@ ORT_VER="${ORT_VER:-1.28.1}"
 # sha256 of onnxruntime-linux-x64-${ORT_VER}.tgz; the bundled .so runs in the
 # privileged daemon, so verify it rather than trusting HTTPS alone. Update
 # together with ORT_VER.
-ORT_SHA256="${ORT_SHA256:-3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747}"
+ORT_SHA256="${ORT_SHA256:-2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81}"
 BUILDROOT="${BUILDROOT:-$HOME/ppa-build}"
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
From the 2026-08-20 runtime audit. **Motivation is hardening hygiene, not a CVE**: the onnxruntime repo has zero published advisories; the adjacent protobuf CVE-2026-0994 is Python-only and outside the bundled 21.12 range; the ORT-shape CVE-2026-14647 is neutralized by the pinned-trusted-models threat model. The 1.28 line carries a memory-safety hardening batch (FlatBuffer loader, bind_input type confusion, kernel OOB/overflow fixes) worth having as defense-in-depth.

## What

- All eight pin sites move together (parity-script enforced): ci.yml ×2, asan.yml, install-matrix.yml, flake.nix + nix/module.nix (fetchurl hash recomputed from the actual fetch), fedora spec, deb + PPA scripts, DEVELOPMENT.md copy-paste commands.
- Binding unchanged: `ort =2.0.0-rc.13` with `api-24` — the C API is append-only, GetApi(24) against the 1.28.1 runtime is the documented supported path (rc.13 supports runtimes 1.17-1.28). Latest stable ORT is 1.29.0; 1.28.1 (2026-08-18) chosen as the mature patched line.

## Local evidence at the bumped runtime

With `ORT_DYLIB_PATH` pointed at the 1.28.1 tarball lib: vision lib 66/66 incl. every determinism gate (PINNED_EMBEDDING, detector, blaze), pinned TFLite mesh test green (XNNPACK engaged), full workspace guarded 1765/0, `nix build .#irlume` green with the recomputed hash, packaging parity OK.

## Follow-up (per the camera-change rule)

Four-host fleet revalidation before release cut (ASUS done implicitly here on the dev box; archhost/minihost/thinkpad next), bundled with the F2 normalization A/B bench on archhost.

DCO: Signed-off-by: archledger <archledger236@gmail.com>