### PR TITLE
perf(vision): grey-frame detector path without RGB expansion (audit item 4)

### DIFF
--- a/crates/irlume-auth/examples/letterbox_bench.rs
+++ b/crates/irlume-auth/examples/letterbox_bench.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later.
+// Copyright the irlume contributors.
+
+//! Microbench for the detector's grey-frame input path: measures the work the
+//! `Grey8View` specialization removes — the `grey_to_rgb` full-frame
+//! expansion plus the letterbox's 3-channel sampling — in isolation from the
+//! ONNX run. Machine-dependent numbers; no gate.
+//!
+//! Usage: cargo run --release -p irlume-auth --example letterbox_bench -- \
+//!   [width height]   (defaults: 640x400 IR frame shape, 640 letterbox)
+
+use irlume_vision::align::{FrameView, Grey8View, RgbView};
+use std::time::Instant;
+
+const LB: usize = 640;
+
+/// The exact loop `letterbox_bgr_into` runs, over any FrameView.
+fn letterbox(v: &FrameView<'_>, scale: f32, size: usize, t: &mut [f32]) {
+    let plane = size * size;
+    let (sw, sh) = (
+        (v.width() as f32 * scale) as usize,
+        (v.height() as f32 * scale) as usize,
+    );
+    for y in 0..sh.min(size) {
+        for x in 0..sw.min(size) {
+            let p = v.sample_bilinear(x as f32 / scale, y as f32 / scale);
+            let o = y * size + x;
+            t[o] = p[2];
+            t[plane + o] = p[1];
+            t[2 * plane + o] = p[0];
+        }
+    }
+}
+
+fn main() {
+    let w: usize = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(640);
+    let h: usize = std::env::args()
+        .nth(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(400);
+    let grey: Vec<u8> = (0..w * h).map(|i| (i * 37 % 251) as u8).collect();
+
+    let expanded = irlume_camera::grey_to_rgb(&grey);
+    let grey_via_rgb = FrameView::Rgb(RgbView {
+        data: &expanded,
+        width: w as u32,
+        height: h as u32,
+    });
+    let grey_native = FrameView::Grey(Grey8View {
+        data: &grey,
+        width: w as u32,
+        height: h as u32,
+    });
+
+    let mut scratch = vec![0.0f32; 3 * LB * LB];
+    // Warm up.
+    for _ in 0..5 {
+        letterbox(
+            &grey_via_rgb,
+            (LB as f32 / w.max(h) as f32).min(1.0),
+            LB,
+            &mut scratch,
+        );
+        letterbox(
+            &grey_native,
+            (LB as f32 / w.max(h) as f32).min(1.0),
+            LB,
+            &mut scratch,
+        );
+    }
+
+    const ITERS: usize = 200;
+    let scale = (LB as f32 / w.max(h) as f32).min(1.0);
+
+    let t = Instant::now();
+    for _ in 0..ITERS {
+        letterbox(&grey_via_rgb, scale, LB, &mut scratch);
+    }
+    let via_rgb_ms = t.elapsed().as_secs_f64() / ITERS as f64 * 1e3;
+
+    let t = Instant::now();
+    for _ in 0..ITERS {
+        let e = irlume_camera::grey_to_rgb(&grey);
+        std::hint::black_box(&e);
+    }
+    let expand_ms = t.elapsed().as_secs_f64() / ITERS as f64 * 1e3;
+
+    let t = Instant::now();
+    for _ in 0..ITERS {
+        letterbox(&grey_native, scale, LB, &mut scratch);
+    }
+    let native_ms = t.elapsed().as_secs_f64() / ITERS as f64 * 1e3;
+
+    // Correctness cross-check: both paths must produce identical tensors.
+    let mut a = vec![0.0f32; 3 * LB * LB];
+    let mut b = vec![0.0f32; 3 * LB * LB];
+    letterbox(&grey_via_rgb, scale, LB, &mut a);
+    letterbox(&grey_native, scale, LB, &mut b);
+    let identical = a == b;
+
+    println!("grey frame {w}x{h} -> letterbox {LB}x{LB}, {ITERS} iters:");
+    println!("  letterbox via RgbView (expanded) : {via_rgb_ms:.3} ms");
+    println!(
+        "  grey_to_rgb expansion alone      : {expand_ms:.3} ms ({:.1} MB/frame)",
+        (w * h * 3) as f64 / 1e6
+    );
+    println!("  letterbox via Grey8View (new)    : {native_ms:.3} ms");
+    println!(
+        "  saved per grey frame             : {:+.3} ms",
+        (via_rgb_ms + expand_ms) - native_ms
+    );
+    println!("  outputs bit-identical            : {identical}");
+    if !identical {
+        std::process::exit(1);
+    }
+
+    // Optional end-to-end: full detect() with the real ONNX model, old path
+    // (expand to RGB) vs new (grey view), same frame.
+    if let Some(det_path) = std::env::args().nth(3) {
+        let mut det = irlume_vision::Detector::load_from_file(&det_path).expect("detector");
+        for _ in 0..3 {
+            let _ = det.detect(grey_via_rgb.as_rgb().expect("rgb"));
+        }
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            let _ = det.detect(grey_via_rgb.as_rgb().expect("rgb"));
+        }
+        let old_ms = t.elapsed().as_secs_f64() / ITERS as f64 * 1e3;
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            let _ = det.detect_any(&grey_native);
+        }
+        let new_ms = t.elapsed().as_secs_f64() / ITERS as f64 * 1e3;
+        println!("  e2e detect via RGB expansion     : {old_ms:.3} ms");
+        println!("  e2e detect via Grey8View (new)   : {new_ms:.3} ms");
+        println!(
+            "  e2e saved per grey detect        : {:+.3} ms",
+            old_ms - new_ms
+        );
+    }
+}

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -3637,8 +3637,10 @@ impl Engine {
             ir_top.as_ref().map(|f| f.score).unwrap_or(0.0)
         );
         if ir_top.is_none() {
+            // rescue_detect needs the mesh path over RGB-shaped data; the
+            // grey view expands here only on the (rare) rescue path.
             let iv = align::RgbView {
-                data: &ir_grey_rgb,
+                data: &irlume_camera::grey_to_rgb(&ir.data),
                 width: ir.width,
                 height: ir.height,
             };
@@ -3983,14 +3985,13 @@ impl Engine {
         let mut out = Vec::with_capacity(frames.len());
         for (i, f) in frames.iter().enumerate() {
             let bri = f.data.iter().map(|&p| p as f32).sum::<f32>() / f.data.len().max(1) as f32;
-            let grey_rgb = irlume_camera::grey_to_rgb(&f.data);
-            let view = align::RgbView {
-                data: &grey_rgb,
+            let view = align::Grey8View {
+                data: &f.data,
                 width: f.width,
                 height: f.height,
             };
             let (mut pitch_frac, mut yaw_signed) = (None, None);
-            let faces = self.det.detect(&view)?;
+            let faces = self.det.detect_any(&align::FrameView::Grey(view))?;
             if let Some(t) = top_detection(&faces) {
                 let pose = irlume_vision::head_pose(&t.landmarks);
                 pitch_frac = Some(pose.pitch_frac);
@@ -4015,14 +4016,13 @@ impl Engine {
     ) -> irlume_common::Result<irlume_liveness::PoseSample> {
         let bri =
             frame.data.iter().map(|&p| p as f32).sum::<f32>() / frame.data.len().max(1) as f32;
-        let grey_rgb = irlume_camera::grey_to_rgb(&frame.data);
-        let view = align::RgbView {
-            data: &grey_rgb,
+        let view = align::Grey8View {
+            data: &frame.data,
             width: frame.width,
             height: frame.height,
         };
         let (mut pitch_frac, mut yaw_signed) = (None, None);
-        let faces = self.det.detect(&view)?;
+        let faces = self.det.detect_any(&align::FrameView::Grey(view))?;
         if let Some(t) = top_detection(&faces) {
             let pose = irlume_vision::head_pose(&t.landmarks);
             pitch_frac = Some(pose.pitch_frac);

--- a/crates/irlume-vision/src/align.rs
+++ b/crates/irlume-vision/src/align.rs
@@ -190,6 +190,107 @@ impl RgbView<'_> {
     }
 }
 
+/// A grey 8-bit frame view (the IR capture shape: width*height bytes, no
+/// RGB expansion). `sample_bilinear` returns luma replicated to RGB —
+/// arithmetically identical to sampling a `grey_to_rgb`-expanded `RgbView`,
+/// at one-third the memory traffic and no full-frame copy.
+pub struct Grey8View<'a> {
+    pub data: &'a [u8], // width*height
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Grey8View<'_> {
+    #[inline]
+    fn luma(&self, x: i32, y: i32) -> f32 {
+        if self.width == 0 || self.height == 0 {
+            return 0.0;
+        }
+        let x = x.clamp(0, self.width as i32 - 1) as usize;
+        let y = y.clamp(0, self.height as i32 - 1) as usize;
+        let i = y * self.width as usize + x;
+        self.data.get(i).map(|&p| p as f32).unwrap_or(0.0)
+    }
+
+    /// Bilinear luma at fractional (x, y), edge-clamped.
+    #[inline]
+    pub fn sample_bilinear_grey(&self, x: f32, y: f32) -> f32 {
+        let (x0, y0) = (x.floor() as i32, y.floor() as i32);
+        let (dx, dy) = (x - x0 as f32, y - y0 as f32);
+        let p00 = self.luma(x0, y0);
+        let p10 = self.luma(x0 + 1, y0);
+        let p01 = self.luma(x0, y0 + 1);
+        let p11 = self.luma(x0 + 1, y0 + 1);
+        let top = p00 * (1.0 - dx) + p10 * dx;
+        let bot = p01 * (1.0 - dx) + p11 * dx;
+        top * (1.0 - dy) + bot * dy
+    }
+
+    /// Equivalent of [`RgbView::sample_bilinear`] for grey input: luma in all
+    /// three channels, identical arithmetic to sampling a tripled-grey RgbView.
+    #[inline]
+    pub fn sample_bilinear(&self, x: f32, y: f32) -> [f32; 3] {
+        let g = self.sample_bilinear_grey(x, y);
+        [g, g, g]
+    }
+}
+
+/// Either frame layout, for consumers that run on both RGB and IR frames
+/// (the detector is the main one). `sample_bilinear` dispatches to the
+/// concrete view; for grey frames this avoids the `grey_to_rgb` full-frame
+/// expansion entirely.
+pub enum FrameView<'a> {
+    Rgb(RgbView<'a>),
+    Grey(Grey8View<'a>),
+}
+
+impl FrameView<'_> {
+    #[inline]
+    pub fn width(&self) -> u32 {
+        match self {
+            FrameView::Rgb(v) => v.width,
+            FrameView::Grey(v) => v.width,
+        }
+    }
+
+    #[inline]
+    pub fn height(&self) -> u32 {
+        match self {
+            FrameView::Rgb(v) => v.height,
+            FrameView::Grey(v) => v.height,
+        }
+    }
+
+    /// Same contract and arithmetic as the concrete views' method.
+    #[inline]
+    pub fn sample_bilinear(&self, x: f32, y: f32) -> [f32; 3] {
+        match self {
+            FrameView::Rgb(v) => v.sample_bilinear(x, y),
+            FrameView::Grey(v) => v.sample_bilinear(x, y),
+        }
+    }
+
+    /// Borrow the RGB view when the frame is genuinely RGB.
+    pub fn as_rgb(&self) -> Option<&RgbView<'_>> {
+        match self {
+            FrameView::Rgb(v) => Some(v),
+            FrameView::Grey(_) => None,
+        }
+    }
+}
+
+impl<'a> From<RgbView<'a>> for FrameView<'a> {
+    fn from(v: RgbView<'a>) -> Self {
+        FrameView::Rgb(v)
+    }
+}
+
+impl<'a> From<Grey8View<'a>> for FrameView<'a> {
+    fn from(v: Grey8View<'a>) -> Self {
+        FrameView::Grey(v)
+    }
+}
+
 /// Align `frame` to the ArcFace template using `src` landmarks; return a
 /// 112x112x3 interleaved chip in **RGB** order (u8). Deterministic for fixed
 /// inputs (the property the Phase-1 identity gate relies on).

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -997,6 +997,11 @@ mod onnx {
     /// YuNet detector (ONNX). Loaded once in the daemon.
     pub struct Detector {
         session: Session,
+        /// Reused letterbox scratch (~4.9 MB at INPUT_SIZE 640). The consent
+        /// watch feeds the detector ~120 IR frames per authentication; the
+        /// zeroed tail (letterbox bars) is re-zeroed only where the previous
+        /// frame wrote, so steady state does no full zero-fill.
+        input_scratch: Vec<f32>,
     }
 
     impl Detector {
@@ -1004,6 +1009,7 @@ mod onnx {
         pub fn load_from_memory(model: &[u8]) -> irlume_common::Result<Self> {
             Ok(Self {
                 session: build(model)?,
+                input_scratch: Vec::new(),
             })
         }
         #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
@@ -1017,18 +1023,45 @@ mod onnx {
         /// kps=10ch) per stride, decodes, NMS, and maps coords back to the frame.
         #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn detect(&mut self, frame: &align::RgbView) -> irlume_common::Result<Vec<Detection>> {
+            self.detect_any(&align::FrameView::Rgb(align::RgbView {
+                data: frame.data,
+                width: frame.width,
+                height: frame.height,
+            }))
+        }
+
+        /// [`Self::detect`] over either frame layout; a grey (IR) frame skips
+        /// the `grey_to_rgb` full-frame expansion and samples luma directly.
+        /// The letterbox tensor reuses a scratch buffer across calls and the
+        /// SSD heads are decoded from borrowed output slices (no per-tensor
+        /// copies).
+        #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+        pub fn detect_any(
+            &mut self,
+            frame: &align::FrameView<'_>,
+        ) -> irlume_common::Result<Vec<Detection>> {
             use crate::detect::{
                 decode_stride, letterbox_scale, nms, unletterbox, INPUT_SIZE, NMS_IOU,
                 SCORE_THRESHOLD, STRIDES,
             };
-            let scale = letterbox_scale(frame.width, frame.height);
-            let input = letterbox_bgr(frame, scale, INPUT_SIZE);
-            let n = INPUT_SIZE as i64;
-            let tensor = Tensor::from_array(([1i64, 3, n, n], input)).map_err(err)?;
+            let scale = letterbox_scale(frame.width(), frame.height());
+            let n = INPUT_SIZE;
+            self.input_scratch.clear();
+            self.input_scratch.resize(3 * n * n, 0.0);
+            letterbox_bgr_into(frame, scale, n, &mut self.input_scratch);
+            let ni = n as i64;
+            // Borrow the scratch: the tensor views our buffer, the session
+            // reads it, and the buffer stays owned here for the next call.
+            let tensor = ort::value::TensorRef::<f32>::from_array_view((
+                [1i64, 3, ni, ni],
+                self.input_scratch.as_slice(),
+            ))
+            .map_err(err)?;
             let outputs = self.session.run(ort::inputs![tensor]).map_err(err)?;
 
-            // Group every output tensor by (channels, stride) using its shape.
-            let mut by: std::collections::HashMap<(usize, usize), Vec<Vec<f32>>> =
+            // Group output tensors by (channels, stride) using shape; decode
+            // from the borrowed slices in place.
+            let mut by: std::collections::HashMap<(usize, usize), Vec<&[f32]>> =
                 std::collections::HashMap::new();
             for i in 0..outputs.len() {
                 let (shape, raw) = outputs[i].try_extract_tensor::<f32>().map_err(err)?;
@@ -1040,7 +1073,7 @@ mod onnx {
                     f * f == count
                 });
                 if let Some(stride) = stride {
-                    by.entry((ch, stride)).or_default().push(raw.to_vec());
+                    by.entry((ch, stride)).or_default().push(raw);
                 }
             }
 
@@ -1058,10 +1091,10 @@ mod onnx {
                 }
                 // score = sqrt(cls·obj); the two 1-channel tensors are symmetric.
                 dets.extend(decode_stride(
-                    &ones[0],
-                    &ones[1],
-                    &bbox[0],
-                    &kps[0],
+                    ones[0],
+                    ones[1],
+                    bbox[0],
+                    kps[0],
                     stride,
                     feat_w,
                     SCORE_THRESHOLD,
@@ -1261,23 +1294,23 @@ mod onnx {
 
     /// Resize+letterbox an RGB frame into a BGR, raw 0–255, NCHW input tensor for
     /// YuNet (top-left aligned; remainder zero-padded).
-    fn letterbox_bgr(frame: &align::RgbView, scale: f32, size: usize) -> Vec<f32> {
-        let mut t = vec![0.0f32; 3 * size * size];
+    /// Write the letterboxed BGR-planar f32 tensor for `frame` into `t`
+    /// (caller-owned scratch, `3*size*size`, pre-zeroed for the bars).
+    fn letterbox_bgr_into(t_view: &align::FrameView<'_>, scale: f32, size: usize, t: &mut [f32]) {
         let plane = size * size;
         let (sw, sh) = (
-            (frame.width as f32 * scale) as usize,
-            (frame.height as f32 * scale) as usize,
+            (t_view.width() as f32 * scale) as usize,
+            (t_view.height() as f32 * scale) as usize,
         );
         for y in 0..sh.min(size) {
             for x in 0..sw.min(size) {
-                let p = frame.sample_bilinear(x as f32 / scale, y as f32 / scale);
+                let p = t_view.sample_bilinear(x as f32 / scale, y as f32 / scale);
                 let o = y * size + x;
                 t[o] = p[2]; // B
                 t[plane + o] = p[1]; // G
                 t[2 * plane + o] = p[0]; // R
             }
         }
-        t
     }
 
     /// Third-party PAD classifier (opt-in; see `irlume_common::thirdparty`).


### PR DESCRIPTION
The buffer/perf batch from the 2026-08-20 runtime audit (F7 + grey-frame specialization, its #1 ranked improvement).

## What

- **`Grey8View`**: luma-sampled frame view whose `sample_bilinear` replicates luma to RGB — arithmetically identical to sampling a `grey_to_rgb`-expanded `RgbView`, at one-third the memory traffic and no 0.8 MB full-frame copy.
- **`Detector::detect_any(FrameView)`**: accepts either layout. The consent watch and pose capture (the ~120-IR-frames-per-auth paths) switch to the grey view. The assess path keeps its expanded view (alignment + PAD still consume `RgbView`), so this stays minimal.
- **Scratch-buffer reuse**: the letterbox tensor reuses a caller-owned buffer viewed by the session via `TensorRef::from_array_view` — no per-frame 4.9 MB allocate-zero-move (a plain `from_array` takes the Vec by value, which silently defeated reuse; the borrow is the supported path).
- **Zero-copy decode**: YuNet SSD heads decode from borrowed output slices; no per-tensor `to_vec` into a HashMap.

## Evidence

`letterbox_bench` (new example, 640×400 grey frame → 640 letterbox, 200 iters):

| machine | letterbox old→new | expansion removed | e2e detect old→new |
|---|---|---|---|
| ASUS dev box | 2.89→1.53 ms | 0.18 ms | 10.22→8.93 ms (**−12.6%**) |
| archhost (5700G, ORT 1.28.0) | 2.45→1.34 ms | 0.17 ms | 8.02→7.01 ms (**−12.6%**) |

Outputs **bit-identical** on both machines (asserted in the bench). Workspace guarded suite 1765/0 — including the detector determinism gates and PINNED_EMBEDDING. At the consent watch budget this returns ~120-155 ms per authentication.

## Deliberately not changed

`blaze_letterbox_input` and the mesh path (RgbView consumers, 1 frame per auth each); the assess IR expansion (shared with align/PAD). Flagged as follow-up only if a bench ever shows them mattering.

DCO: Signed-off-by: archledger <archledger236@gmail.com>