### PR TITLE
fix(cli,tui): walkthrough findings — SELinux absence, update skew note, TUI parity actions

### DIFF
--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -1199,9 +1199,19 @@ pub fn diag(args: &[String]) -> ExitCode {
 /// exists or the tooling is installed. Neither being true (plain Arch, most
 /// minimal containers) means the module questions have no meaningful answer.
 fn selinux_present() -> bool {
-    std::path::Path::new("/sys/fs/selinux").exists()
-        || std::path::Path::new("/usr/sbin/semodule").exists()
-        || std::path::Path::new("/usr/bin/semodule").exists()
+    if std::path::Path::new("/sys/fs/selinux").exists() {
+        return true;
+    }
+    // Honor PATH (the integration tests inject a fake `semodule` there; a
+    // real SELinux box also may not have it in the fixed /usr slots).
+    if let Ok(path) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path) {
+            if dir.join("semodule").exists() {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// `irlume selinux <status|load>`: manage the policy module that lets the

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -18,6 +18,12 @@ use std::process::ExitCode;
 /// matching manual steps, plus a pointer to the dedicated repo where one
 /// exists for the family. `--check` reports without running anything. No
 /// network library is bundled; we shell out to curl and degrade gracefully.
+/// The upstream-version part of a package version string ("0.10.0-1.fc44" →
+/// "0.10.0"), for comparing the running binary against the package.
+fn version_base(v: &str) -> &str {
+    v.split(['-', '+']).next().unwrap_or(v)
+}
+
 pub fn update(args: &[String]) -> ExitCode {
     let check_only = args.iter().any(|a| a == "--check" || a == "-n");
     let origin = install_origin();
@@ -27,6 +33,16 @@ pub fn update(args: &[String]) -> ExitCode {
     let current = installed_version(&origin);
     println!("[update] installed: {current}");
     println!("[update] install method: {}", origin.describe());
+    // A hand-installed/overlaid build (dev box) can run a binary newer than
+    // the package. `installed:` above stays the package truth — it is what
+    // the update replaces — but say so instead of letting the two versions
+    // silently disagree (doctor's install-hygiene check has the detail).
+    let bin = env!("CARGO_PKG_VERSION");
+    if version_base(&current) != bin {
+        println!(
+            "[update] note: the running binary is {bin}, not the packaged {current}; the package version above is what updating replaces (see `irlume doctor`)"
+        );
+    }
 
     let release = latest_release();
     let latest = &release.tag;
@@ -1179,9 +1195,37 @@ pub fn diag(args: &[String]) -> ExitCode {
     ExitCode::SUCCESS
 }
 
+/// True when this system plausibly runs SELinux: the policy mountpoint
+/// exists or the tooling is installed. Neither being true (plain Arch, most
+/// minimal containers) means the module questions have no meaningful answer.
+fn selinux_present() -> bool {
+    std::path::Path::new("/sys/fs/selinux").exists()
+        || std::path::Path::new("/usr/sbin/semodule").exists()
+        || std::path::Path::new("/usr/bin/semodule").exists()
+}
+
 /// `irlume selinux <status|load>`: manage the policy module that lets the
 /// confined greeter (`xdm_t`) reach the daemon socket at login.
 pub fn selinux(sub: Option<&str>, _args: &[String]) -> ExitCode {
+    // Arch and most non-Fedora distros ship no SELinux at all: there is no
+    // policy store and no semodule. On those hosts the old output ("unknown,
+    // semodule needs root" plus a bare `ls -Z` filename with no label) read
+    // like a broken setup instead of an inapplicable feature.
+    if !selinux_present() {
+        match sub {
+            None | Some("status") => {
+                println!("[selinux] SELinux is not present on this system; nothing to manage.");
+                return ExitCode::SUCCESS;
+            }
+            Some("load") => {
+                eprintln!(
+                    "[selinux] SELinux is not present on this system; there is no policy to load."
+                );
+                return ExitCode::FAILURE;
+            }
+            _ => {}
+        }
+    }
     match sub {
         None | Some("status") => {
             // `semodule -l` needs root; as a normal user it returns nothing, so
@@ -1215,7 +1259,9 @@ pub fn selinux(sub: Option<&str>, _args: &[String]) -> ExitCode {
                 format!("not loaded {WARN} (run `sudo irlume selinux load`)")
             };
             println!("[selinux] module 'irlume': {state}");
-            if !label.is_empty() {
+            // `ls -Z` on a non-SELinux coreutils prints just the filename
+            // (or "? path"); only a real label (contains ':') is information.
+            if label.contains(':') {
                 print!("[selinux] socket label: {label}");
             }
             ExitCode::SUCCESS
@@ -2239,6 +2285,7 @@ mod reach_tests {
 #[cfg(test)]
 mod origin_tests {
     use super::ort_on_disk;
+    use super::version_base;
 
     /// A packaged install puts onnxruntime somewhere no distro path covers and
     /// exports ORT_DYLIB_PATH to the daemon only, so with irlumed stopped `deps`
@@ -2368,6 +2415,17 @@ mod origin_tests {
     // overlaid install; (b) ppa_serves must be true only when the Packages
     // index lists irlume, false on an empty index or HTTP 404; (c) a network
     // failure must be None (unknown), never "not served".
+    #[test]
+    fn version_base_strips_release_suffixes() {
+        assert_eq!(version_base("0.10.0"), "0.10.0");
+        assert_eq!(version_base("0.10.0-1.fc44"), "0.10.0");
+        assert_eq!(version_base("0.10.0-0ppa1~resolute1"), "0.10.0");
+        assert_eq!(version_base("0.7.0-2"), "0.7.0");
+        // A distro "+" revision suffix also strips, so a 0.10.0+r1 local
+        // package does not read as skewing from a 0.10.0 binary.
+        assert_eq!(version_base("0.10.0+g1"), "0.10.0");
+    }
+
     #[test]
     fn update_probes_query_the_package_manager_and_the_ppa_index() {
         // No PATH mutation, no FAKE_CURL_MODE, no ENV_LOCK, and no files: each

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -290,6 +290,9 @@ enum Suspend {
     /// Origin-aware updater; runs unprivileged (it invokes sudo itself for
     /// the package-manager step when one is needed).
     Update,
+    /// `irlume diag` in the cooked terminal: TPM seal + PCR-drift summary.
+    /// Unprivileged (sudo adds envelope detail; the summary is useful alone).
+    Diag,
     /// The full `irlume doctor` text readout in the cooked terminal: the
     /// complete authoritative dump (incl. the info-only lines the Repair
     /// checklist omits), copy-pasteable for a bug report.
@@ -557,6 +560,10 @@ struct App {
     /// contradicted the active-pair line right under it on a daemon that
     /// predates the request.
     pairs_known: bool,
+    /// Current capture schedule from the daemon (`CaptureModeStatus`), for
+    /// the Cameras info block — e.g. "sequential (source: measured; …)".
+    /// `None` = not fetched / daemon refused: drawn as unknown, never blank.
+    capture_mode: Option<String>,
     activity: Vec<(char, String)>,
     input: Option<(String, String, Pending)>,
     confirm: Option<Confirm>,
@@ -1063,6 +1070,7 @@ impl App {
             nodes: Vec::new(),
             pairs: Vec::new(),
             pairs_known: false,
+            capture_mode: None,
             activity: Vec::new(),
             input: None,
             confirm: None,
@@ -1282,6 +1290,24 @@ impl App {
             if self.cam_sel >= n {
                 self.cam_sel = n - 1;
             }
+        }
+        // The same camera-class slot as the listing above: the arbiter
+        // serializes this against captures, and it is refreshed on screen
+        // entry (not per frame). A refusal or older daemon leaves the last
+        // answer in place — unknown is not "default".
+        if let Ok(Response::CaptureModeStatus {
+            mode,
+            source,
+            runtime_degradation,
+            ..
+        }) = crate::daemon_poll(&Request::CaptureModeStatus)
+        {
+            let mut text = format!("{mode} (source: {source})");
+            if let Some(why) = runtime_degradation {
+                text.push_str("; degraded: ");
+                text.push_str(&why);
+            }
+            self.capture_mode = Some(text);
         }
     }
 
@@ -2936,6 +2962,9 @@ impl App {
             Suspend::Update => {
                 crate::commands::update(&none);
             }
+            Suspend::Diag => {
+                let _ = crate::commands::diag(&["--user".to_string(), self.user.clone()]);
+            }
             Suspend::Doctor => {
                 // The TUI already knows its target account; pass it so doctor
                 // reports on the same user the rest of the screen does.
@@ -3394,6 +3423,20 @@ impl App {
             // including the info-only lines the Repair checklist omits, for a
             // bug report. Runs as the user (no sudo prompt); root-only lines
             // say so.
+            (SC_REPAIR, KeyCode::Char('a')) => {
+                self.log('→', "irlume diag: TPM seal + PCR-drift readout (sudo adds envelope detail)");
+                self.suspend = Some(Suspend::Diag);
+            }
+            (SC_REPAIR, KeyCode::Char('v')) => {
+                // Trace RECORD is root-only and lasts the full window, so it
+                // runs cooked under sudo; the command itself prints the
+                // output path and the `irlume trace explain` follow-up.
+                self.log('→', "irlume trace record: 60s privileged diagnostic (no frames or credentials recorded)");
+                self.sudo_step(
+                    "record a 60-second diagnostic trace",
+                    &["irlume", "trace", "record", "--duration", "60s"],
+                );
+            }
             (SC_REPAIR, KeyCode::Char('d')) => {
                 self.log('→', "irlume doctor: the complete platform readout (copy-pasteable)");
                 self.suspend = Some(Suspend::Doctor);
@@ -3811,6 +3854,10 @@ impl App {
                 self.suspend = Some(Suspend::LogsDebug(!on));
             }
             // Origin-aware updater, from the dashboard.
+            (SC_WELCOME, KeyCode::Char('u')) => {
+                self.log('→', "irlume update: checks the release feed and updates via the channel this install came from");
+                self.suspend = Some(Suspend::Update);
+            }
             (SC_DONE, KeyCode::Char('u')) => {
                 self.log('→', "irlume update: checks the release feed and updates via the channel this install came from");
                 self.suspend = Some(Suspend::Update);
@@ -5439,6 +5486,21 @@ impl App {
                 ]));
             }
         }
+        // Capture schedule in force (the `irlume camera-mode` answer): a
+        // user deciding whether to run [t] tune wants the current verdict
+        // without leaving the screen. Not-fetched draws as unknown, never
+        // as the default schedule.
+        let capture = match &self.capture_mode {
+            Some(text) => Span::raw(text.clone()),
+            None => Span::styled(
+                "unknown (daemon not answering)".to_string(),
+                Style::new().dim(),
+            ),
+        };
+        lines.push(Line::from(vec![
+            Span::styled("  capture  ", Style::new().dim()),
+            capture,
+        ]));
         lines.push(Line::raw(""));
         lines.push(section("IR emitter (850nm)"));
         lines.push(Line::from(Span::styled(
@@ -6555,6 +6617,7 @@ impl App {
                 "d" => &[
                     ("d", "Open Diagnostics"),
                     ("e", "Enroll Face"),
+                    ("u", "Update…"),
                     ("r", "Refresh Status"),
                     ("enter", "Open Selected Section"),
                     ("U", "Uninstall…"),
@@ -6562,6 +6625,7 @@ impl App {
                 "e" => &[
                     ("e", "Enroll Face"),
                     ("i", "Test Recognition"),
+                    ("u", "Update…"),
                     ("r", "Refresh Status"),
                     ("enter", "Open Selected Section"),
                     ("U", "Uninstall…"),
@@ -6569,6 +6633,7 @@ impl App {
                 "w" => &[
                     ("w", "Connect Login…"),
                     ("i", "Test Recognition"),
+                    ("u", "Update…"),
                     ("r", "Refresh Status"),
                     ("enter", "Open Selected Section"),
                     ("U", "Uninstall…"),
@@ -6576,11 +6641,13 @@ impl App {
                 "i" => &[
                     ("i", "Test Recognition"),
                     ("e", "Enroll Face"),
+                    ("u", "Update…"),
                     ("r", "Refresh Status"),
                     ("enter", "Open Selected Section"),
                     ("U", "Uninstall…"),
                 ],
                 _ => &[
+                    ("u", "Update…"),
                     ("r", "Refresh Status"),
                     ("enter", "Open Selected Section"),
                     ("U", "Uninstall…"),
@@ -6590,6 +6657,8 @@ impl App {
                 ("f", "Fix Selected Issue…"),
                 ("r", "Recheck"),
                 ("d", "Full Diagnostics"),
+                ("a", "TPM Diagnostics"),
+                ("v", "Record Trace (60s)"),
                 ("s", "Create Support Report"),
                 ("l", "Test Infrared Camera"),
                 ("g", "Show Logs"),
@@ -7864,6 +7933,7 @@ mod tests {
             nodes: Vec::new(),
             pairs: Vec::new(),
             pairs_known: false,
+            capture_mode: None,
             activity: Vec::new(),
             input: None,
             confirm: None,

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -812,7 +812,11 @@ fn selinux_load_handles_missing_module_and_semodule_outcomes() {
     // No irlume.pp anywhere reachable: the not-found guard fires. Pin the
     // lookup with the env override so a host that really has the packaged
     // .pp installed (/usr/share/selinux/packages) cannot satisfy it.
-    let mut miss = sb.cmd(&["selinux", "load"]);
+    // A semodule fake keeps the SELinux-absence probe (which otherwise
+    // short-circuits `load` on hosts without SELinux) out of the way, so
+    // this still tests the .pp lookup path it was written for.
+    sb.fake_tool("semodule", "exit 0");
+    let mut miss = sb.cmd_with_fakes(&["selinux", "load"]);
     miss.env("IRLUME_SELINUX_PP", sb.path("does-not-exist.pp"));
     let (code, _, err) = run(&mut miss, "selinux load");
     assert_eq!(code, 1);


### PR DESCRIPTION
From the systematic CLI+TUI walkthrough on archhost (RGB-only, 0.9.0 binary over 0.7.0 package) and minihost (dual RGB+IR, 0.10.0): every public command exercised read-only, the full TUI driven through tmux on both hosts (basic + advanced views, help overlays, headless refusal), plus the JSON contract lanes.

## CLI accuracy fixes

- **`selinux status|load` on non-SELinux hosts** (plain Arch): previously printed "unknown ⚠ semodule needs root" plus a meaningless `? /run/irlume.sock` label line — read like a broken setup on a system where the feature simply does not apply. Now detects SELinux absence (`/sys/fs/selinux` + `semodule` both missing) and answers "SELinux is not present on this system"; `load` refuses cleanly (exit 1). The socket-label line only prints when a real label exists.
- **`update --check` skew note**: on a dev/overlaid box (running binary ≠ installed package) the "installed:" line alone let the two versions silently disagree. A note now states what the running binary is and that the package version is what updating replaces. Verified live on archhost's 0.9.0-over-0.7.0 state.

## TUI parity (CLI → TUI)

- **`u` Update on Overview** — the only Update action lived on a legacy screen outside navigation, making `irlume update` unreachable from the TUI.
- **`a` TPM Diagnostics on Diagnostics** (`irlume diag`) and **`v` Record Trace (60s)** (root-only `trace record` via the existing sudo suspend) — both were CLI-only.
- **Cameras shows the capture schedule in force** (the `irlume camera-mode` answer): fetched on screen entry alongside the camera listing (same camera-class arbiter slot), drawn as "unknown (daemon not answering)" against a daemon that cannot answer rather than implying the default.

Verified live on archhost via tmux: Overview/Diagnostics overlays list the new actions; Cameras capture line is honest against the 0.9.0 daemon and matches `irlume camera-mode` verbatim ("sequential (source: default)") against a current daemon on the ASUS.

## Deliberately left CLI-only

`trace explain` (file-oriented follow-up; the recorder prints the path), `profiles forget-model` (niche migration tool), machine lanes (`auth test`, login transactions). The existing meta-tests (`every_advertised_key_does_something_on_its_screen`, footer listing) automatically cover the new keys.

## Evidence

Workspace guarded 1766/0 (incl. the new `version_base` suffix test and the key-parity meta-tests), fmt/clippy clean. Live runs on both hosts recorded in the session.

DCO: Signed-off-by: archledger <archledger236@gmail.com>