### PR TITLE
Evaluate ModelScope FRIR as the IR recognizer — rejected

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -65,6 +65,7 @@ weights derived from these sets (see `models/README.md` and ADR-0004).
 | `bench_cascade.py` | `results-cascade.json`, `results-cascade.log` | Per-environment detection rate (YuNet vs BlazeFace vs cascade) and the 468-vs-478 mesh eye-NME |
 | `bench_mp_results` (via `bench_cascade.py`/mediapipe harness) | `results-mp_results.json` | Detector eye-NME and standalone 468-vs-478 landmarker NME |
 | `bench_insightface.py` | n/a | Full AuraFace-vs-InsightFace comparison across all sets |
+| FRIR eval (2026-08-21, ad-hoc over these same protocols) | `results-frir.json`, `results-frir.log` | ModelScope `iic/cv_manual_face-recognition_frir` vs AuraFace on CBSR + Tufts under irlume's pipeline; see `docs/research/2026-08-21-frir-ir-recognizer-evaluation.md` |
 | `blaze_parity.py` | n/a | BlazeFace ONNX decode parity vs the official MediaPipe runtime (IoU, keypoint px error) |
 
 ## The headline numbers and where to read them
@@ -75,6 +76,12 @@ weights derived from these sets (see `models/README.md` and ADR-0004).
   InsightFace buffalo scores 99.4% (`results-lfw.json`), higher, but its weights
   are non-commercial, which is why irlume ships AuraFace instead. This is a
   deliberate license-over-peak-accuracy tradeoff, stated plainly.
+- **IR recognizer candidate FRIR: rejected** (`results-frir.json`). ModelScope's
+  IR-native FRIR loses to the shipped AuraFace even on active-NIR CBSR
+  (EER 1.50% vs 0.77%) and collapses on Tufts NIR↔NIR (15.1% vs 1.43%) and
+  RGB↔RGB (15.2% vs 0.40%) under irlume's own detection/alignment. The
+  dedicated-IR-recognizer bar (beat AuraFace-on-IR publicly, then live) stays
+  open with no current candidate.
 - **IR adapter overfit: Tufts NIR→NIR EER 1.43% (raw) vs 1.53% (+v3 adapter)**
   (`results-nir_results.json`, `tufts.nir_nir`). On CBSR, the adapter's own
   training data, it instead improved (0.77% → 0.37%, `cbsr_nir`). Helping the

--- a/benchmarks/results-frir.json
+++ b/benchmarks/results-frir.json
@@ -1,0 +1,105 @@
+{
+  "ort": "1.27.0",
+  "latency_ms": {
+    "auraface": 37.98,
+    "frir": 1.93
+  },
+  "cbsr_nir": {
+    "detection": {
+      "images": 3940,
+      "detect_rate": 1.0,
+      "gt_eyes_in_box_rate": 1.0,
+      "gt_align_fallbacks": 0,
+      "eye_nme_mean": 0.05295662727480854,
+      "eye_nme_p95": 0.09428756614418426
+    },
+    "auraface": {
+      "verification": {
+        "eer": 0.007666666666666688,
+        "auc": 0.9994966666666667,
+        "tar@far0.01": 0.993,
+        "tar@far0.001": 0.983,
+        "pairs_used": 6000
+      },
+      "rank1_ident": {
+        "acc": 1.0,
+        "probes": 2364,
+        "gallery_ids": 197
+      }
+    },
+    "frir": {
+      "verification": {
+        "eer": 0.015000000000000006,
+        "auc": 0.9963237777777778,
+        "tar@far0.01": 0.9843333333333333,
+        "tar@far0.001": 0.974,
+        "pairs_used": 6000
+      },
+      "rank1_ident": {
+        "acc": 0.9978849407783418,
+        "probes": 2364,
+        "gallery_ids": 197
+      }
+    }
+  },
+  "tufts": {
+    "detection": {
+      "rgb": {
+        "images": 3234,
+        "detected": 3234,
+        "detect_rate": 1.0
+      },
+      "nir": {
+        "images": 3234,
+        "detected": 3211,
+        "detect_rate": 0.9928880643166358
+      }
+    },
+    "nir_nir": {
+      "auraface": {
+        "eer": 0.014333333333333321,
+        "auc": 0.9987338888888889,
+        "tar@far0.01": 0.9833333333333333,
+        "tar@far0.001": 0.9363333333333334,
+        "pairs_used": 6000
+      },
+      "frir": {
+        "eer": 0.15100000000000002,
+        "auc": 0.9202018888888889,
+        "tar@far0.01": 0.541,
+        "tar@far0.001": 0.304,
+        "pairs_used": 6000
+      }
+    },
+    "rgb_rgb": {
+      "auraface": {
+        "eer": 0.004000000000000002,
+        "auc": 0.9998744444444445,
+        "tar@far0.01": 0.9983333333333333,
+        "tar@far0.001": 0.984,
+        "pairs_used": 6000
+      },
+      "frir": {
+        "eer": 0.15200000000000002,
+        "auc": 0.9233193333333334,
+        "tar@far0.01": 0.4856666666666667,
+        "tar@far0.001": 0.34,
+        "pairs_used": 6000
+      }
+    },
+    "cross_spectral_same_model_rgb_enroll_nir_verify": {
+      "auraface": {
+        "eer": 0.009031454375583938,
+        "auc": 0.9996803653278046,
+        "tar@far0.01": 0.9915914045468701,
+        "tar@far0.001": 0.9744627841793834
+      },
+      "frir": {
+        "eer": 0.10246029274369353,
+        "auc": 0.959849545915284,
+        "tar@far0.01": 0.6982248520710059,
+        "tar@far0.001": 0.4456555590158829
+      }
+    }
+  }
+}

--- a/benchmarks/results-frir.log
+++ b/benchmarks/results-frir.log
@@ -1,0 +1,13 @@
+[ WARN:0@0.025] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
+latency_ms: {'auraface': 37.98, 'frir': 1.93}
+[CBSR det] detect=1.0000 eyes_in_box=1.0000 eye_nme=0.0530 fallbacks=0
+[CBSR] auraface: EER=0.0077 TAR@1e-3=0.9830 rank1=1.0000
+[CBSR] frir: EER=0.0150 TAR@1e-3=0.9740 rank1=0.9979
+[Tufts det] rgb=1.0000 nir=0.9929
+[Tufts nir_nir] auraface: EER=0.0143 TAR@1e-3=0.9363
+[Tufts nir_nir] frir: EER=0.1510 TAR@1e-3=0.3040
+[Tufts rgb_rgb] auraface: EER=0.0040 TAR@1e-3=0.9840
+[Tufts rgb_rgb] frir: EER=0.1520 TAR@1e-3=0.3400
+[Tufts xspec1model] auraface: EER=0.0090 TAR@1e-3=0.9745
+[Tufts xspec1model] frir: EER=0.1025 TAR@1e-3=0.4457
+wrote /tmp/frir-bench/results_frir_bench.json

--- a/docs/research/2026-08-21-frir-ir-recognizer-evaluation.md
+++ b/docs/research/2026-08-21-frir-ir-recognizer-evaluation.md
@@ -1,0 +1,87 @@
+# FRIR (iic/cv_manual_face-recognition_frir) evaluation — rejected as the IR recognizer
+
+Date: 2026-08-21 · Agent: opencode · Host: archhost (Ryzen 7 5700G, CPU, ORT 1.27.0)
+
+## Question
+
+`IR_MATCH_THRESHOLD`'s docblock (`crates/irlume-core/src/lib.rs`) records that
+dark-mode IR matching is convenience-grade because AuraFace is an RGB-trained
+recognizer applied to IR, and that high-assurance dark needs "a dedicated
+IR-trained recognizer (proven, not speculation)". ModelScope's FRIR
+(`iic/cv_manual_face-recognition_frir`, DAMO academy, MIT) is marketed as
+exactly that: a residual network trained for IR face features for "low-cost IR
+camera access control". This evaluation asks whether FRIR should replace
+AuraFace-on-IR, retiring the RGB-model-on-IR workaround.
+
+## Model facts (primary source: the download itself + modelscope 1.39.1 pipeline code)
+
+- `modelscope download --model iic/cv_manual_face-recognition_frir` works
+  (modelscope-hub 0.2.0); 6 files, 12.6 MB total, `model.onnx` is the weights.
+- ONNX: opset 11, dynamic batch, input `3×112×112` float, output `1×512`
+  float. Raw FC+BN head, **no baked preprocessing or L2 norm** (same shape
+  convention as glintr100). 3.16M float parameters (AuraFace glintr100: ~65M).
+- Vendor preprocessing (`face_recognition_onnx_ir_pipeline.py`): aligned
+  112×112 BGR chip → RGB → `(px/255 - 0.5)/0.5` → external L2 norm. That is
+  `(px-127.5)/127.5` on RGB, i.e. the standard ArcFace convention.
+- License: MIT (README front-matter).
+- Vendor claim: "私有数据集下，100人底库，1e-5的误识率下，通过率97%" — 97% TAR at
+  1e-5 FAR on a private 100-person gallery, vendor pipeline.
+
+## Method
+
+Repo bench harness (`benchmarks/bench_faceid.py` + `bench_nir_ext.py`
+protocols) run unmodified on archhost, both recognizers under irlume's
+production pipeline: YuNet detection → ArcFace 5-point similarity warp to
+112×112 → embed (std 127.5 for FRIR, matching the vendor formula). CBSR
+active-NIR 850 nm (197 ids, 3940 faces) is the fleet IR cameras' physics
+class; Tufts td-a paired RGB/NIR (110 ids, 3234+3234) adds passive NIR and
+clean RGB controls.
+
+Faithfulness control: the vendor README's own same-person demo pair
+(`ir_face_recognition_1/2.png`) scores **0.7166 cosine** through this
+embedding path — a healthy genuine score, proving the irlume-side
+preprocessing matches the vendor's intent. The bench measures model quality,
+not an integration bug.
+
+## Results (archhost, CPU, 6000 seeded pairs per cell)
+
+| protocol | AuraFace EER / TAR@1e-3 | FRIR EER / TAR@1e-3 | verdict |
+|---|---|---|---|
+| CBSR active-NIR verify | **0.77% / 98.3%** | 1.50% / 97.4% | FRIR 2× worse EER |
+| CBSR rank-1 (197 ids) | **100.0%** | 99.79% | FRIR worse |
+| Tufts NIR↔NIR | **1.43% / 93.6%** | 15.10% / 30.4% | FRIR 10× worse |
+| Tufts RGB↔RGB (control) | **0.40% / 98.4%** | 15.20% / 34.0% | FRIR 38× worse |
+| Tufts RGB-enroll→NIR-verify | **0.90% / 97.4%** | 10.25% / 44.6% | FRIR 11× worse |
+| embed latency | 37.98 ms | **1.93 ms** | FRIR 20× faster |
+
+Full numbers: `benchmarks/results-frir.json`, run log
+`benchmarks/results-frir.log`.
+
+## Verdict
+
+**Reject FRIR; keep AuraFace-on-IR.** FRIR loses to the shipped RGB recognizer
+on FRIR's own home domain (active NIR) and collapses everywhere else. The
+RGB↔RGB control is decisive: a generalizable recognizer does not degrade to
+15% EER on clean studio RGB under a faithful pipeline, so this is model
+quality, not alignment mismatch. The vendor's private 100-person claim does
+not transfer to public data under irlume's pipeline. The 20× latency win is
+irrelevant while accuracy gates authentication, and the IR embed is not the
+dark-path bottleneck (detection dominates).
+
+"AuraFace-on-IR retirement" stays open as a goal with no candidate: the bar
+remains a dedicated IR recognizer that measurably beats AuraFace-on-IR on
+public NIR corpora under irlume's pipeline before any live-camera trial.
+
+## Scope notes
+
+- No fleet camera testing was run: a single-user live trial cannot overturn a
+  2–10× EER deficit measured over 197+110 identities, and nothing was shipped
+  for the daemon to load. Per the hardware rule, tests that cannot change the
+  decision are not run.
+- The vendor's integrated RetinaFace+landmark pipeline was not run to
+  completion (mmcv dependency chain unavailable for py3.14); the demo-pair
+  faithfulness control bounds that gap: both pipelines use InsightFace-family
+  5-point similarity warps, and FRIR's chips are the same geometry family.
+- archhost `~/ort-venv` gained `modelscope`, CPU torch, `datasets`,
+  `scikit-image`, `pillow` for the vendor-pipeline attempt; `/tmp/frir-bench`
+  staging was removed after the run (results pulled to this repo).


### PR DESCRIPTION
## What

Evaluates `iic/cv_manual_face-recognition_frir` (ModelScope, DAMO, MIT) as a
replacement dedicated IR recognizer, with the goal of retiring AuraFace-on-IR
(the RGB model reused in the dark path, documented as convenience-grade in
`IR_MATCH_THRESHOLD`).

## How

- `modelscope download --model iic/cv_manual_face-recognition_frir`: works,
  12.6 MB ONNX, opset 11, 3×112×112 → 512-D, no baked preprocessing,
  vendor formula `(px-127.5)/127.5` RGB + external L2 (verified against the
  modelscope 1.39.1 pipeline source, not docs).
- Bench on archhost (5700G, ORT 1.27 CPU) with the repo's own
  `bench_faceid`/`bench_nir_ext` protocols: YuNet → ArcFace 5-pt warp →
  embed, both recognizers identically.
- Faithfulness control: the vendor README's own same-person demo pair scores
  0.7166 cosine through this path.

## Results

| protocol | AuraFace EER / TAR@1e-3 | FRIR EER / TAR@1e-3 |
|---|---|---|
| CBSR active-NIR (fleet physics) | **0.77% / 98.3%** | 1.50% / 97.4% |
| CBSR rank-1 (197 ids) | **100.0%** | 99.79% |
| Tufts NIR↔NIR | **1.43% / 93.6%** | 15.10% / 30.4% |
| Tufts RGB↔RGB (control) | **0.40% / 98.4%** | 15.20% / 34.0% |
| Tufts RGB-enroll→NIR-verify | **0.90% / 97.4%** | 10.25% / 44.6% |
| embed latency | 37.98 ms | **1.93 ms** |

## Verdict

**Reject.** FRIR loses on its home domain (active NIR) and collapses on the
RGB control, which bounds the deficit to model quality, not our alignment.
The 20× latency win does not gate auth (detection dominates the dark path).
No daemon code changed; no fleet camera run — a single-user live trial cannot
overturn a 2–10× EER deficit over 300+ identities. AuraFace-on-IR stays; the
dedicated-IR-recognizer bar remains open with no current candidate.

Docs-only PR: research note + benchmark results + README row. Workspace gate
green locally (1766/0, fmt, clippy -D warnings).

Signed commit `ac383aac`, DCO present.