### PR TITLE
perf(auth): overlap the TPM enrollment unseal with camera setup (~2.5s off every encrypted auth)

### DIFF
--- a/crates/irlume-auth/examples/auth_timing.rs
+++ b/crates/irlume-auth/examples/auth_timing.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! One full `Engine::authenticate_for` with wall-clock stage timings, for
+//! latency work: prints total elapsed plus the stage timings (camera open /
+//! stream arm / rate establishment) and the enrollment-load overlap line
+//! (IRLUME_LOG=debug), so the TPM-unseal-vs-camera-setup overlap is visible
+//! in one run.
+//!
+//! Usage: IRLUME_LOG=debug cargo run --release -p irlume-auth \
+//!   --example auth_timing -- <user> <det.onnx> <model.onnx> [rgb] [ir]
+//! Look at the camera when it runs.
+
+use irlume_common::diagnostics::{DiagnosticSink, TraceEventKind};
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct StageSink {
+    stages: Mutex<Vec<(TraceEventKind, std::time::Instant)>>,
+}
+
+impl DiagnosticSink for StageSink {
+    fn emit_trace(&self, kind: TraceEventKind) {
+        if matches!(kind, TraceEventKind::StageTiming { .. }) {
+            self.stages
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((kind, std::time::Instant::now()));
+        }
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let user = args.next().expect("user");
+    let det = args.next().expect("det.onnx");
+    let model = args.next().expect("model.onnx");
+    let rgb = args.next().unwrap_or_else(|| "/dev/video0".into());
+    let ir = args.next().unwrap_or_else(|| "/dev/video2".into());
+
+    let mut engine = irlume_auth::Engine::load(&det, &model)
+        .expect("load engine")
+        .with_devices(&rgb, &ir);
+    let sink = StageSink::default();
+    let t0 = std::time::Instant::now();
+    let outcome = engine
+        .authenticate_for_with_diagnostics(
+            &user,
+            Some("sudo"),
+            irlume_auth::AuthenticationPurpose::Verify,
+            &sink,
+        )
+        .expect("authenticate");
+    println!(
+        "outcome: granted={} live={} reason={}",
+        outcome.granted, outcome.live, outcome.reason
+    );
+    println!("TOTAL authenticate_for: {:.2?}", t0.elapsed());
+    for (kind, at) in sink.stages.lock().unwrap_or_else(|e| e.into_inner()).iter() {
+        if let TraceEventKind::StageTiming { stage, elapsed_us } = kind {
+            println!(
+                "  +{:.2}s  stage {stage:?}: {:.0} ms",
+                at.duration_since(t0).as_secs_f64(),
+                *elapsed_us as f64 / 1000.0
+            );
+        }
+    }
+}

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -591,6 +591,67 @@ impl AuthenticationPurpose {
     }
 }
 
+/// The deferred enrollment load's result, as sent by the loader thread in
+/// [`Engine::authenticate_for_with_diagnostics`].
+type EnrollmentLoad = irlume_common::Result<Option<irlume_core::storage::Enrollment>>;
+
+/// Wait out a still-running deferred enrollment load on an early exit, so the
+/// user-state flock and the TPM are free before this request returns. An
+/// immediate retry (decline, then a fallback attempt) would otherwise block
+/// on the orphaned loader's locks — the one way this overlap could make a
+/// retry SLOWER than the serial load it replaced. The exits that can still be
+/// waiting are rare deny/error paths (consent-policy refusal, camera-lease
+/// failure); the post-watch exits arrive seconds after the spawn, by which
+/// time the load has long finished.
+fn finish_loader(loader: &mut Option<std::sync::mpsc::Receiver<EnrollmentLoad>>) {
+    if let Some(rx) = loader.take() {
+        // The loader always sends or drops its sender (a panic drops it), so
+        // this returns as soon as the load — not the whole thread — is done.
+        let _ = rx.recv();
+    }
+}
+
+/// How a deferred enrollment load ended when it did not produce an
+/// enrollment the request can use.
+#[derive(Debug)]
+enum LoaderExit {
+    /// The store vanished between the pre-check and the read: the same
+    /// "not enrolled" deny as the pre-check.
+    NotEnrolled,
+    /// The request must fail closed to the password: the load errored, the
+    /// deadline expired before it finished, or the loader panicked.
+    Fallback(irlume_common::Error),
+}
+
+/// Resolve the deferred loader's channel result into the enrollment (or the
+/// request-ending fallback). Pure, so every arm of the fail-closed mapping
+/// is unit-testable without camera hardware; the join in
+/// [`Engine::authenticate_for_with_diagnostics`] is exactly this mapping.
+fn resolve_loader(
+    recv: Result<EnrollmentLoad, std::sync::mpsc::RecvTimeoutError>,
+) -> Result<irlume_core::storage::Enrollment, LoaderExit> {
+    match recv {
+        Ok(Ok(Some(enr))) => Ok(enr),
+        Ok(Ok(None)) => Err(LoaderExit::NotEnrolled),
+        Ok(Err(e)) => Err(LoaderExit::Fallback(e)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            Err(LoaderExit::Fallback(irlume_common::Error::Protocol(
+                "enrollment load exceeded the authentication deadline; \
+                 falling back to password"
+                    .into(),
+            )))
+        }
+        // The sender is gone without a result: the loader panicked.
+        // Contained by the thread boundary; the request fails closed rather
+        // than crashing the daemon over an enrollment read.
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err(LoaderExit::Fallback(irlume_common::Error::Protocol(
+                "enrollment loader failed; falling back to password".into(),
+            )))
+        }
+    }
+}
+
 fn blocking_head_consent_policy(
     purpose: AuthenticationPurpose,
     service: Option<&str>,
@@ -4428,7 +4489,7 @@ impl Engine {
         // user-visible outcome is unchanged. A panic inside the loader maps
         // to an error (password fallback), never a daemon crash.
         let load_started = std::time::Instant::now();
-        let loader = match irlume_core::storage::store_is_encrypted(user) {
+        let mut loader = match irlume_core::storage::store_is_encrypted(user)? {
             // No file at all: the instant deny, before anything else wakes.
             None => {
                 return Ok(Outcome::deny(
@@ -4439,13 +4500,20 @@ impl Engine {
             // Plaintext: cheap JSON load, synchronous, old precedence.
             Some(false) => None,
             // Encrypted: the TPM unseal is the expensive part — defer it
-            // into the overlap window.
+            // into the overlap window. A channel, not a JoinHandle: the
+            // receiver can wait with a timeout at the join (a wedged unseal
+            // must not pin the camera lease past the auth deadline), and a
+            // dropped sender reports a loader panic as a disconnect.
             Some(true) => Some({
                 let loader_user = user.to_string();
+                let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
                 std::thread::Builder::new()
                     .name("irlume-enrollment-load".into())
-                    .spawn(move || irlume_core::storage::load(&loader_user))
-                    .map_err(|e| irlume_common::Error::Io(e.to_string()))?
+                    .spawn(move || {
+                        let _ = tx.send(irlume_core::storage::load(&loader_user));
+                    })
+                    .map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+                rx
             }),
         };
         // The synchronous-path enrollment (plaintext stores). The encrypted
@@ -4453,7 +4521,7 @@ impl Engine {
         let loader_was_async = loader.is_some();
         let sync_enr = if loader.is_none() {
             match irlume_core::storage::load(user)? {
-                Some(enr) => match self.enrollment_policy_refusal(&enr) {
+                Some(enr) => match self.enrollment_policy_refusal(user, &enr) {
                     Some(outcome) => return Ok(outcome),
                     None => Some(enr),
                 },
@@ -4468,6 +4536,7 @@ impl Engine {
             None
         };
         if let Some(policy) = blocking_head_consent_policy(purpose, service) {
+            finish_loader(&mut loader);
             return Ok(Outcome::deny(
                 OutcomeKind::OtherDeny,
                 policy.instruction("approve"),
@@ -4483,12 +4552,17 @@ impl Engine {
         // consent frame through the final grace-window retry.  Keeping this
         // lease across sequential fallbacks is deliberate: otherwise another
         // operation can interleave between consent and matching.
-        let camera_operation = irlume_camera::lease::acquire_camera_operation(
+        let camera_operation = match irlume_camera::lease::acquire_camera_operation(
             &endpoints,
             irlume_camera::lease::CameraOperationKind::Authentication,
             std::time::Duration::from_secs(2),
-        )
-        .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+        ) {
+            Ok(op) => op,
+            Err(error) => {
+                finish_loader(&mut loader);
+                return Err(irlume_common::Error::Hardware(error.to_string()));
+            }
+        };
 
         // Watch for the consent gesture BEFORE the first capture, so a user who
         // nods when the greeter asks is not ignored for the seconds it takes to
@@ -4496,8 +4570,16 @@ impl Engine {
         // grace window can hold several attempts and none of them should re-ask
         // for a gesture already given.
         if purpose.demands_gesture(service) {
-            self.head_consent_before_match =
-                Self::run_camera_operation(&camera_operation, || self.early_consent_watch())?;
+            let verdict = match Self::run_camera_operation(&camera_operation, || {
+                self.early_consent_watch()
+            }) {
+                Ok(v) => v,
+                Err(e) => {
+                    finish_loader(&mut loader);
+                    return Err(e);
+                }
+            };
+            self.head_consent_before_match = verdict;
             // A head-shake during the pre-match watch is an explicit decline.
             // Close the request now: do not spend the capture and match only to
             // deny after a second post-match watch, and do not let a later cue
@@ -4506,6 +4588,7 @@ impl Engine {
                 irlume_common::dlog!("consent: head shake before the match cancelled the request");
                 // A pre-match shake never reached matching: no live face, no score.
                 self.head_consent_before_match = HeadConsentVerdict::NoGesture;
+                finish_loader(&mut loader);
                 return Ok(Outcome::gesture_declined(false, 0.0));
             }
         }
@@ -4620,27 +4703,27 @@ impl Engine {
         // on every measured host that window exceeds the unseal (2.7s quiet),
         // so the load costs the auth path nothing. First enrollment-dependent
         // decision happens after this join, before any capture is spent.
-        // The Ok(None) arm (file vanished between the check and the read)
-        // keeps the same deny as the pre-check.
-        let enr = match loader {
-            Some(handle) => match handle.join() {
-                Ok(Ok(Some(enr))) => enr,
-                Ok(Ok(None)) => {
-                    return Ok(Outcome::deny(
-                        OutcomeKind::OtherDeny,
-                        format!("'{user}' is not enrolled"),
-                    ));
+        // The wait is bounded by the authentication deadline: a wedged unseal
+        // (stuck tpmrm, or a user-state flock held by a wedged sibling) must
+        // not pin the camera lease forever — on timeout the auth fails closed
+        // to the password and the detached loader releases its locks whenever
+        // it finishes. A ready result is returned even at zero remaining
+        // time, so a healthy load that already finished is never mistaken
+        // for a timeout. The arms live in [`resolve_loader`].
+        let enr = match loader.take() {
+            Some(rx) => {
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                match resolve_loader(rx.recv_timeout(remaining)) {
+                    Ok(enr) => enr,
+                    Err(LoaderExit::NotEnrolled) => {
+                        return Ok(Outcome::deny(
+                            OutcomeKind::OtherDeny,
+                            format!("'{user}' is not enrolled"),
+                        ));
+                    }
+                    Err(LoaderExit::Fallback(e)) => return Err(e),
                 }
-                Ok(Err(e)) => return Err(e),
-                Err(_) => {
-                    // The loader panicked: contained by the thread boundary.
-                    // Report failure so PAM cascades to the password rather
-                    // than crashing the daemon over an enrollment read.
-                    return Err(irlume_common::Error::Protocol(
-                        "enrollment loader failed; falling back to password".into(),
-                    ));
-                }
-            },
+            }
             None => match sync_enr {
                 Some(enr) => enr,
                 // Unreachable by construction (the sync path resolves
@@ -4664,7 +4747,7 @@ impl Engine {
             }
         );
         if loader_was_async {
-            if let Some(outcome) = self.enrollment_policy_refusal(&enr) {
+            if let Some(outcome) = self.enrollment_policy_refusal(user, &enr) {
                 return Ok(outcome);
             }
         }
@@ -6038,9 +6121,6 @@ impl Engine {
         }
     }
 
-    /// If the live cameras no longer match the enrolled binding, return a reason
-    /// to refuse (anti-swap). A bound device that now reads differently, or an
-    /// enrolled IR camera that's gone, fails; an unbound side is not checked.
     /// The enrollment-dependent policy refusals that gate an authentication
     /// before any capture is spent: retired-eye-policy migration, the
     /// empty-profile refuse, and the anti-swap camera binding. A pure
@@ -6048,14 +6128,18 @@ impl Engine {
     /// binding); runs synchronously for plaintext stores (before the camera)
     /// and at the loader join for encrypted stores (see
     /// `authenticate_for_with_diagnostics` for the precedence note).
-    fn enrollment_policy_refusal(&self, enr: &irlume_core::storage::Enrollment) -> Option<Outcome> {
+    fn enrollment_policy_refusal(
+        &self,
+        user: &str,
+        enr: &irlume_core::storage::Enrollment,
+    ) -> Option<Outcome> {
         if let Err(reason) = legacy_eye_policy(enr) {
             return Some(Outcome::deny(OutcomeKind::OtherDeny, reason));
         }
         if enr.profiles.iter().all(|p| p.scans.is_empty()) {
             return Some(Outcome::deny(
                 OutcomeKind::OtherDeny,
-                format!("'{}' has no face scans enrolled", enr.user),
+                format!("'{user}' has no face scans enrolled"),
             ));
         }
         if let Some(bind) = &enr.camera_binding {
@@ -6066,6 +6150,9 @@ impl Engine {
         None
     }
 
+    /// If the live cameras no longer match the enrolled binding, return a reason
+    /// to refuse (anti-swap). A bound device that now reads differently, or an
+    /// enrolled IR camera that's gone, fails; an unbound side is not checked.
     fn binding_mismatch(&self, bind: &irlume_core::storage::CameraBinding) -> Option<String> {
         if let Some(want) = &bind.rgb {
             if irlume_camera::device_identity(&self.rgb_dev).as_ref() != Some(want) {
@@ -10801,5 +10888,60 @@ mod engine_tests {
             })
             .collect();
         assert!(!completed_consent_take_hit(false, true, &poses));
+    }
+
+    #[test]
+    fn deferred_loader_resolution_fails_closed_on_every_arm() {
+        // Every way the deferred enrollment load can end, through a real
+        // channel; the join in authenticate_for_with_diagnostics is exactly
+        // this mapping, so its fail-closed contract is pinned here without
+        // camera hardware.
+        // A finished load passes through, even at zero remaining deadline.
+        let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
+        tx.send(Ok(Some(Enrollment::new("u")))).unwrap();
+        drop(tx);
+        assert!(resolve_loader(rx.recv_timeout(std::time::Duration::ZERO)).is_ok());
+
+        // A store that vanished between the pre-check and the read is the
+        // not-enrolled deny, not an error.
+        let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
+        tx.send(Ok(None)).unwrap();
+        drop(tx);
+        assert!(matches!(
+            resolve_loader(rx.recv_timeout(std::time::Duration::ZERO)),
+            Err(LoaderExit::NotEnrolled)
+        ));
+
+        // A load error is the fallback, propagated verbatim.
+        let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
+        tx.send(Err(irlume_common::Error::Io("unreadable".into())))
+            .unwrap();
+        drop(tx);
+        assert!(matches!(
+            resolve_loader(rx.recv_timeout(std::time::Duration::ZERO)),
+            Err(LoaderExit::Fallback(irlume_common::Error::Io(_)))
+        ));
+
+        // A load that outlives the authentication deadline fails closed.
+        let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
+        let resolved = resolve_loader(rx.recv_timeout(std::time::Duration::from_millis(1)));
+        match resolved {
+            Err(LoaderExit::Fallback(irlume_common::Error::Protocol(msg))) => {
+                assert!(msg.contains("deadline"), "{msg}");
+            }
+            other => panic!("deadline expiry must fail closed to the password: {other:?}"),
+        }
+        drop(tx);
+
+        // A sender dropped without a result (the loader panicked) fails
+        // closed with its own reason, distinct from the deadline.
+        let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
+        drop(tx);
+        match resolve_loader(rx.recv_timeout(std::time::Duration::from_secs(1))) {
+            Err(LoaderExit::Fallback(irlume_common::Error::Protocol(msg))) => {
+                assert!(msg.contains("loader failed"), "{msg}");
+            }
+            other => panic!("a panicked loader must fail closed: {other:?}"),
+        }
     }
 }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -4411,28 +4411,62 @@ impl Engine {
         // entirely. The key is dropped inside load; only the decrypted
         // Enrollment is held, which is already plaintext in memory during
         // each authenticate_once today.
-        let Some(enr) = irlume_core::storage::load(user)? else {
-            return Ok(Outcome::deny(
-                OutcomeKind::OtherDeny,
-                format!("'{user}' is not enrolled"),
-            ));
-        };
-        if let Err(reason) = legacy_eye_policy(&enr) {
-            return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
-        }
-        if enr.profiles.iter().all(|p| p.scans.is_empty()) {
-            return Ok(Outcome::deny(
-                OutcomeKind::OtherDeny,
-                format!("'{user}' has no face scans enrolled"),
-            ));
-        }
-        // Anti-swap: refuse if the live camera no longer matches the one this
-        // user enrolled on (only enforced once an enrollment carries a binding).
-        if let Some(bind) = &enr.camera_binding {
-            if let Some(reason) = self.binding_mismatch(bind) {
-                return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
+        //
+        // It leaves the critical path HERE, for the case that has a critical
+        // path to leave: an ENCRYPTED store, whose unseal costs 2.7s quiet /
+        // 18.97s contended on a discrete TPM. A plaintext store loads with no
+        // TPM at all, so it stays synchronous and keeps the historical
+        // deny-before-camera precedence for every policy check below (tests
+        // and plaintext hosts see identical behavior to before). For an
+        // encrypted store the full load runs on a helper thread CONCURRENTLY
+        // with the camera lease, stream arming, delivered-rate establishment
+        // and the consent watch below (>=5s of camera-bound work in
+        // concurrent mode), joined before the first enrollment-dependent
+        // decision. The one precedence change: on an encrypted store whose
+        // camera path ALSO fails hard, the hardware error now precedes the
+        // empty-scans/binding deny lines — both end at the password, so the
+        // user-visible outcome is unchanged. A panic inside the loader maps
+        // to an error (password fallback), never a daemon crash.
+        let load_started = std::time::Instant::now();
+        let loader = match irlume_core::storage::store_is_encrypted(user) {
+            // No file at all: the instant deny, before anything else wakes.
+            None => {
+                return Ok(Outcome::deny(
+                    OutcomeKind::OtherDeny,
+                    format!("'{user}' is not enrolled"),
+                ));
             }
-        }
+            // Plaintext: cheap JSON load, synchronous, old precedence.
+            Some(false) => None,
+            // Encrypted: the TPM unseal is the expensive part — defer it
+            // into the overlap window.
+            Some(true) => Some({
+                let loader_user = user.to_string();
+                std::thread::Builder::new()
+                    .name("irlume-enrollment-load".into())
+                    .spawn(move || irlume_core::storage::load(&loader_user))
+                    .map_err(|e| irlume_common::Error::Io(e.to_string()))?
+            }),
+        };
+        // The synchronous-path enrollment (plaintext stores). The encrypted
+        // path resolves `enr` at the join below, after camera setup.
+        let loader_was_async = loader.is_some();
+        let sync_enr = if loader.is_none() {
+            match irlume_core::storage::load(user)? {
+                Some(enr) => match self.enrollment_policy_refusal(&enr) {
+                    Some(outcome) => return Ok(outcome),
+                    None => Some(enr),
+                },
+                None => {
+                    return Ok(Outcome::deny(
+                        OutcomeKind::OtherDeny,
+                        format!("'{user}' is not enrolled"),
+                    ));
+                }
+            }
+        } else {
+            None
+        };
         if let Some(policy) = blocking_head_consent_policy(purpose, service) {
             return Ok(Outcome::deny(
                 OutcomeKind::OtherDeny,
@@ -4578,6 +4612,60 @@ impl Engine {
                     emit_capture_fallback(RuntimeDegradation::PairArmFailure, diagnostics);
                     demote_after_pair_arm_failure(&mut capture_mode);
                 }
+            }
+        }
+        // Join the enrollment loader. Everything between the spawn and HERE —
+        // camera lease, consent watch, stream arming, delivered-rate
+        // establishment — is the overlap window the TPM unseal ran inside;
+        // on every measured host that window exceeds the unseal (2.7s quiet),
+        // so the load costs the auth path nothing. First enrollment-dependent
+        // decision happens after this join, before any capture is spent.
+        // The Ok(None) arm (file vanished between the check and the read)
+        // keeps the same deny as the pre-check.
+        let enr = match loader {
+            Some(handle) => match handle.join() {
+                Ok(Ok(Some(enr))) => enr,
+                Ok(Ok(None)) => {
+                    return Ok(Outcome::deny(
+                        OutcomeKind::OtherDeny,
+                        format!("'{user}' is not enrolled"),
+                    ));
+                }
+                Ok(Err(e)) => return Err(e),
+                Err(_) => {
+                    // The loader panicked: contained by the thread boundary.
+                    // Report failure so PAM cascades to the password rather
+                    // than crashing the daemon over an enrollment read.
+                    return Err(irlume_common::Error::Protocol(
+                        "enrollment loader failed; falling back to password".into(),
+                    ));
+                }
+            },
+            None => match sync_enr {
+                Some(enr) => enr,
+                // Unreachable by construction (the sync path resolves
+                // sync_enr or returns early); a deny rather than a panic so
+                // a future edit cannot crash the daemon here.
+                None => {
+                    return Ok(Outcome::deny(
+                        OutcomeKind::OtherDeny,
+                        format!("'{user}' is not enrolled"),
+                    ));
+                }
+            },
+        };
+        irlume_common::dlog!(
+            "auth: enrollment load took {:?} ({})",
+            load_started.elapsed(),
+            if loader_was_async {
+                "overlapped with camera setup"
+            } else {
+                "plaintext, synchronous"
+            }
+        );
+        if loader_was_async {
+            if let Some(outcome) = self.enrollment_policy_refusal(&enr) {
+                return Ok(outcome);
             }
         }
         if held_rgb.is_none() || held_ir.is_none() {
@@ -5953,6 +6041,31 @@ impl Engine {
     /// If the live cameras no longer match the enrolled binding, return a reason
     /// to refuse (anti-swap). A bound device that now reads differently, or an
     /// enrolled IR camera that's gone, fails; an unbound side is not checked.
+    /// The enrollment-dependent policy refusals that gate an authentication
+    /// before any capture is spent: retired-eye-policy migration, the
+    /// empty-profile refuse, and the anti-swap camera binding. A pure
+    /// decision over the loaded enrollment (plus sysfs identities for the
+    /// binding); runs synchronously for plaintext stores (before the camera)
+    /// and at the loader join for encrypted stores (see
+    /// `authenticate_for_with_diagnostics` for the precedence note).
+    fn enrollment_policy_refusal(&self, enr: &irlume_core::storage::Enrollment) -> Option<Outcome> {
+        if let Err(reason) = legacy_eye_policy(enr) {
+            return Some(Outcome::deny(OutcomeKind::OtherDeny, reason));
+        }
+        if enr.profiles.iter().all(|p| p.scans.is_empty()) {
+            return Some(Outcome::deny(
+                OutcomeKind::OtherDeny,
+                format!("'{}' has no face scans enrolled", enr.user),
+            ));
+        }
+        if let Some(bind) = &enr.camera_binding {
+            if let Some(reason) = self.binding_mismatch(bind) {
+                return Some(Outcome::deny(OutcomeKind::OtherDeny, reason));
+            }
+        }
+        None
+    }
+
     fn binding_mismatch(&self, bind: &irlume_core::storage::CameraBinding) -> Option<String> {
         if let Some(want) = &bind.rgb {
             if irlume_camera::device_identity(&self.rgb_dev).as_ref() != Some(want) {

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -641,8 +641,8 @@ pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
     deserialize_enrollment(&data, key.as_ref().map(|k| k.as_slice())).map(Some)
 }
 
-/// Whether the on-disk store for `user` is encrypted, or `None` when there is
-/// no store at all.
+/// Whether the on-disk store for `user` is encrypted, `Ok(None)` when there
+/// is no store at all, and `Err` when a store exists but cannot be read.
 ///
 /// Read from the file's own `enc` envelope, NOT from whether a template key
 /// exists. Those two answers disagree in exactly one state, and it is the state
@@ -650,14 +650,25 @@ pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
 /// Reporting that as "plaintext at rest" both understates the privacy posture
 /// and hides the data loss, and it points the user at `recovery setup` when the
 /// only remaining move is to re-enroll.
-pub fn store_is_encrypted(user: &str) -> Option<bool> {
+///
+/// An unreadable store is NOT the same as an absent one: collapsing it to
+/// `None` would deny "not enrolled" where the caller's full load reports an
+/// error (and the password fallback). Unparseable bytes read as plaintext so
+/// that full load surfaces the real parse error instead of this probe.
+///
+/// # Errors
+/// `Io` when a store exists but cannot be read.
+pub fn store_is_encrypted(user: &str) -> irlume_common::Result<Option<bool>> {
     let path = profile_path(user);
-    let data = fs::read(&path).ok()?;
-    Some(
-        serde_json::from_slice::<serde_json::Value>(&data)
-            .map(|v| v.get("enc").is_some())
-            .unwrap_or(false),
-    )
+    match fs::read(&path) {
+        Ok(data) => Ok(Some(
+            serde_json::from_slice::<serde_json::Value>(&data)
+                .map(|v| v.get("enc").is_some())
+                .unwrap_or(false),
+        )),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(irlume_common::Error::Io(e.to_string())),
+    }
 }
 
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
@@ -1465,5 +1476,43 @@ mod tests {
             ..ir_scan("rgb-only", None)
         });
         assert_eq!(e.usable_ir_scans("raw"), 0);
+    }
+
+    #[test]
+    fn store_is_encrypted_distinguishes_absent_shape_and_unreadable() {
+        // Held across the whole test: every assertion reads a path derived
+        // from IRLUME_STATE_DIR (same pattern as the retag-marker test).
+        let _g = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!("irlume-enc-probe-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+
+        // Absent: Ok(None), the "not enrolled" answer.
+        assert_eq!(store_is_encrypted("absent").unwrap(), None);
+
+        // Plaintext JSON: Ok(Some(false)) — the synchronous pre-camera path.
+        fs::write(dir.join("plain.json"), br#"{"user":"plain"}"#).unwrap();
+        assert_eq!(store_is_encrypted("plain").unwrap(), Some(false));
+
+        // Encrypted envelope: Ok(Some(true)) — detection is the `enc` field.
+        fs::write(dir.join("sealed.json"), br#"{"version":3,"enc":"AAAA"}"#).unwrap();
+        assert_eq!(store_is_encrypted("sealed").unwrap(), Some(true));
+
+        // Unparseable bytes read as plaintext so the FULL load reports the
+        // real parse error instead of this probe.
+        fs::write(dir.join("garbage.json"), b"\x00not json").unwrap();
+        assert_eq!(store_is_encrypted("garbage").unwrap(), Some(false));
+
+        // A store that exists but cannot be read is an ERROR, not "absent":
+        // collapsing it to None would deny "not enrolled" where the
+        // caller's load reports an error (and the password fallback).
+        fs::create_dir(dir.join("locked.json")).unwrap();
+        assert!(store_is_encrypted("locked").is_err());
+
+        std::env::remove_var("IRLUME_STATE_DIR");
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2942,7 +2942,14 @@ fn dispatch_status_with_diagnostics(
                 // The store's own shape, not the key's presence: those differ
                 // exactly when the key is gone, and that case has to be
                 // reportable rather than collapsed into "plaintext".
-                encrypted: irlume_core::storage::store_is_encrypted(user).unwrap_or(false),
+                // Ok(Some(true)) is the only "encrypted" answer; absent and
+                // unreadable stores both report as not-encrypted here (a
+                // status read, not an auth decision — the auth path
+                // propagates the read error instead).
+                encrypted: matches!(
+                    irlume_core::storage::store_is_encrypted(user),
+                    Ok(Some(true))
+                ),
                 recovery_set: irlume_core::template_key::has_recovery(user),
                 tpm_present: irlume_core::template_key::tpm_available(),
                 key_present: irlume_core::template_key::has_key(user),


### PR DESCRIPTION
## What

The template-key TPM unseal (2.7s quiet / 18.97s contended on a discrete TPM) previously ran **serially before the camera lease** on every authentication of an encrypted store. It now runs on a helper thread **concurrently with the camera lease, consent watch, stream arming and delivered-rate establishment** (≥5s of camera-bound work in concurrent mode), joined before the first enrollment-dependent decision.

**Measured live** (ASUS, encrypted store, TPM 2.0, new `auth_timing` example): enrollment load 258ms wall inside a 10.6s auth — was ~2.7s of critical path.

## Precedence preserved (deny-before-camera)

- Absent store: one file-stat, instant deny, nothing wakes (unchanged)
- Plaintext store: synchronous load, every policy refusal before the camera — the existing `authenticate_refuses_before_the_camera_on_state_and_policy` test passes **unchanged**
- Encrypted store only defers, and its refusals still precede any capture
- Loader panic is contained by the thread boundary → error → PAM password cascade, never a daemon crash
- Clippy forced the one `expect` out of the path; a future edit cannot crash the daemon there

## Measured in the same session, deliberately NOT changed here

This host's capture qualification re-measured `sequential_required / invalid_provenance`: 4 of 6 concurrent rounds fail the zero-sequence-gap continuity bar under dual load (the module keeps 100% RGB brightness but drops sequence numbers when both interfaces stream). The ~9.4s concurrent-mode saving stays gated on hardware measurement, not code. The remaining big latency items (sequential-schedule skew discard, rate-window cost) are slice-8/qualification territory needing their own fleet measurement.

## Gates

fmt, clippy -D warnings, workspace **1766/0**. Signed commit `73b456c5`, DCO present.