### PR TITLE
feat(tui): remove the Face Model tab (single shipped model focus)

### DIFF
--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -136,7 +136,7 @@ fn enabled_name_for(key: &str) -> Option<String> {
 /// that None as "disabled" told a user whose anti-spoof model IS enabled that
 /// none was, which invites them to re-run enable or to believe the PAD layer is
 /// off. `models list --json` already reports `enabled: {known: false}` here; the
-/// human list has to say the same thing. pub(crate) since #331: the TUI models
+/// human list has to say the same thing. pub(crate) since #331: the TUI Settings
 /// screen renders the same tri-state.
 pub(crate) fn enabled_state_readable() -> bool {
     use irlume_common::config::KvObservation;
@@ -218,7 +218,7 @@ fn file_state(m: &ThirdPartyModel) -> &'static str {
 
 /// The state tag the listing shows for one catalog entry: enabled (with the
 /// weight-file verdict), disabled, or unknown when settings.conf is root-only
-/// and this process cannot read it. Shared with the TUI models screen (#331)
+/// and this process cannot read it. Shared with the TUI Settings section (#331)
 /// so the two surfaces cannot describe the same entry differently.
 pub(crate) fn entry_state_label(m: &ThirdPartyModel) -> String {
     let enabled_here =
@@ -235,7 +235,7 @@ pub(crate) fn entry_state_label(m: &ThirdPartyModel) -> String {
 /// How this entry gets onto the machine, with the exact command: irlume
 /// fetches an entry whose licence permits that; a bring-your-own entry's file
 /// is the user's to obtain (`url: None` is a licence statement, not a gap).
-/// Shared with the TUI models screen (#331): the command spelling has one home.
+/// Shared with the TUI Settings section (#331): the command spelling has one home.
 pub(crate) fn obtain_line(m: &ThirdPartyModel) -> String {
     match m.url {
         Some(_) => format!("irlume fetches it: sudo irlume models enable {}", m.name),
@@ -293,7 +293,7 @@ fn list() -> ExitCode {
 }
 
 /// One line saying what enabling this entry DOES, per stage. Shown in the
-/// listing, in the consent prompts, and on the TUI models screen (#331),
+/// listing, in the consent prompts, and in the TUI Settings section (#331),
 /// because "what happens when I say yes" is the one thing those must not be
 /// vague about.
 pub(crate) fn role_line(m: &ThirdPartyModel) -> String {

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -88,7 +88,7 @@ fn selected_style() -> Style {
 }
 
 const SPIN: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-const SCREENS: [&str; 12] = [
+const SCREENS: [&str; 11] = [
     "Overview",
     "Diagnostics",
     "Cameras",
@@ -99,7 +99,6 @@ const SCREENS: [&str; 12] = [
     "Fingerprint",
     "Login & Apps",
     "Preferences",
-    "Face Model",
     "Setup Status",
 ];
 // Screen indices (keep in sync with SCREENS).
@@ -113,11 +112,10 @@ const SC_RECOVERY: usize = 6;
 const SC_FINGERPRINT: usize = 7;
 const SC_PAM: usize = 8;
 const SC_SETTINGS: usize = 9;
-const SC_MODELS: usize = 10;
-const SC_DONE: usize = 11;
+const SC_DONE: usize = 10;
 /// User-facing navigation order. Group headings in the sidebar use this same
 /// order, so Tab never walks a different information architecture than the eye.
-const NAV_ORDER: [usize; 11] = [
+const NAV_ORDER: [usize; 10] = [
     SC_WELCOME,
     SC_PROFILES,
     SC_FINGERPRINT,
@@ -128,7 +126,6 @@ const NAV_ORDER: [usize; 11] = [
     SC_CAMERAS,
     SC_IDENTIFY,
     SC_SETTINGS,
-    SC_MODELS,
 ];
 const ACT_H: usize = 5; // visible rows in the expanded Activity panel
 const ACTIVITY_COLLAPSED_ROWS: u16 = 3;
@@ -634,14 +631,6 @@ struct App {
     /// Disable repeating motion while preserving static status/progress.
     /// Set by `IRLUME_REDUCE_MOTION` for terminals or users that prefer it.
     reduce_motion: bool,
-    /// Models-tab catalog states, copied from the landed probe sweep; `None`
-    /// until the first sweep lands (draw then says the state is loading
-    /// instead of asserting either direction). See [`ModelsStatus`] for why
-    /// this is cached rather than computed in draw.
-    models_status: Option<ModelsStatus>,
-    /// Models-tab scroll offset in wrapped rows (↑/↓); clamped to the content
-    /// height in `draw_models`, reset on entering the tab.
-    models_scroll: u16,
     /// Hardware-adaptive: the subset of screen indices to show (Tab walks these).
     /// e.g. a fingerprint-only desktop hides the camera/face screens entirely.
     visible: Vec<usize>,
@@ -761,40 +750,6 @@ struct Probes {
     secureboot: (bool, bool, bool),
     /// Firmware boot mode label (UEFI/legacy), from efivars.
     boot_mode: String,
-    /// Third-party catalog states for the Models tab; `None` until gathered
-    /// (the derived default), so draw asserts nothing before the first sweep.
-    models: Option<ModelsStatus>,
-}
-
-/// Cached per-entry state for the Models tab, one label per
-/// `thirdparty::CATALOG` entry in catalog order.
-///
-/// Gathered on the probe worker, never in draw (#334 review): the ENABLED and
-/// root-only labels hash the on-disk weights (`entry_state_label` →
-/// `weight_state`), the main loop redraws every 100ms, and rendered inline an
-/// installed recognizer was reread and re-hashed about ten times a second on
-/// the UI thread for as long as the tab stayed open.
-#[derive(Clone)]
-struct ModelsStatus {
-    /// `models::entry_state_label` per catalog entry, catalog order.
-    labels: Vec<String>,
-    /// Whether settings.conf was readable; root-only when not, and the
-    /// listing then names the sudo command for the authoritative answer.
-    readable: bool,
-}
-
-impl ModelsStatus {
-    /// The one computation source (the probe worker and the tests both call
-    /// it): exactly the labels the CLI listing prints.
-    fn gather() -> Self {
-        ModelsStatus {
-            labels: irlume_common::thirdparty::CATALOG
-                .iter()
-                .map(crate::models::entry_state_label)
-                .collect(),
-            readable: crate::models::enabled_state_readable(),
-        }
-    }
 }
 
 impl Probes {
@@ -858,7 +813,6 @@ impl Probes {
                 secureboot::is_setup_mode(),
             ),
             boot_mode: secureboot::detect_boot_mode().as_str().to_string(),
-            models: Some(ModelsStatus::gather()),
         }
     }
 }
@@ -1101,8 +1055,6 @@ impl App {
             activity_open: false,
             reduce_motion: std::env::var_os("IRLUME_REDUCE_MOTION")
                 .is_some_and(|v| !v.is_empty() && v != "0"),
-            models_status: None,
-            models_scroll: 0,
             visible,
             caps,
             fp_present,
@@ -1147,10 +1099,7 @@ impl App {
                 // third-party models), not diagnostics, so it is always
                 // reachable; hiding config behind "advanced" both buries it and
                 // creates dead-end pointers (a Repair fix references Settings).
-                // Models (#331) is reachable for the same reason: the measured
-                // catalog is the surface the issue exists to expose, and the
-                // Settings third-party section points at it.
-                SC_SETTINGS | SC_MODELS => true,
+                SC_SETTINGS => true,
                 // Diagnostics is stable navigation; its badge carries live state.
                 SC_REPAIR => true,
                 // Keyring unlock: an IR camera (face releases the credential) OR a
@@ -1158,7 +1107,7 @@ impl App {
                 SC_KEYRING => caps.ir_pair || fp_present,
                 // Fingerprint screen only if a reader exists.
                 SC_FINGERPRINT => fp_present,
-                // Overview / Login & Apps / Preferences / Face Model: always.
+                // Overview / Login & Apps / Preferences: always.
                 _ => true,
             })
             .collect()
@@ -1448,11 +1397,6 @@ impl App {
             self.fp = self.probes.fp.clone();
             self.pam_cache = self.probes.pam_cache.clone();
             self.fp_coverage = self.probes.fp_coverage.clone();
-            // The Models-tab cache (#334 review): only ever replaced by a
-            // gathered value, so a landed sweep can never blank it.
-            if let Some(models) = self.probes.models.clone() {
-                self.models_status = Some(models);
-            }
         }
         self.run_checks();
         // Visibility is state-driven (Repair appears when something fails);
@@ -3279,32 +3223,10 @@ impl App {
             self.refresh_diagnostics();
         } else if self.screen == SC_PROFILES {
             self.refresh_profiles();
-        } else if self.screen == SC_MODELS {
-            // Fresh entry starts at the top, so the re-enroll warning is met
-            // before any switch command (#331), and the state cache refreshes
-            // via the probe worker (idempotent while one is in flight).
-            self.models_scroll = 0;
-            self.request_probes();
         }
     }
 
     fn move_sel(&mut self, d: i32) {
-        // The Models tab is a read-only text panel: ↑↓ (and j/k) scroll the
-        // catalog (#334 review: at 80×24 the body shows ~7 rows and ratatui
-        // clips the rest, hiding whole entries and their commands) instead of
-        // moving a selection nothing on that screen has. The offset is
-        // clamped HERE, not just in draw: an unclamped store kept counting
-        // past the end, and every wasted ↓ then cost an ↑ before the view
-        // moved again.
-        if self.screen == SC_MODELS {
-            let max = self.models_lines().len().saturating_sub(1) as u16;
-            self.models_scroll = if d > 0 {
-                self.models_scroll.saturating_add(d as u16).min(max)
-            } else {
-                self.models_scroll.saturating_sub(d.unsigned_abs() as u16)
-            };
-            return;
-        }
         // The Settings tab has no profile/scan list; ↑/↓ pick the per-service
         // consent-gesture row that [c] toggles.
         if self.screen == SC_SETTINGS {
@@ -4356,7 +4278,7 @@ impl App {
                 ],
             ),
             ("System", &[SC_REPAIR, SC_CAMERAS]),
-            ("Advanced", &[SC_IDENTIFY, SC_SETTINGS, SC_MODELS]),
+            ("Advanced", &[SC_IDENTIFY, SC_SETTINGS]),
         ];
         let mut rows: Vec<SidebarRow> = Vec::new();
         for (name, members) in groups {
@@ -4607,7 +4529,6 @@ impl App {
                     None => "Checking login, lock-screen, and application integration.",
                 },
                 SC_SETTINGS => "Security preferences and per-service consent behavior.",
-                SC_MODELS => "Measured model options; changing recognition requires re-enrollment.",
                 SC_DONE => "Legacy setup summary; Overview now carries completion status.",
                 _ => "",
             }
@@ -4646,7 +4567,6 @@ impl App {
             SC_FINGERPRINT => self.draw_fingerprint(f, inner),
             SC_PAM => self.draw_pam(f, inner),
             SC_SETTINGS => self.draw_settings(f, inner),
-            SC_MODELS => self.draw_models(f, inner),
             _ => self.draw_done(f, inner),
         }
     }
@@ -5149,10 +5069,12 @@ impl App {
                     "  Opt-in, measured models by pipeline stage: PAD adds a deny-only cue,",
                     Style::new().dim(),
                 )),
-                // Points at the Models tab (#331) so the full listing is one
-                // Tab away, not a CLI command the user has to know about.
                 Line::from(Span::styled(
-                    "  recognition replaces RGB matching. Licenses + measurements: Face Model.",
+                    "  recognition replaces RGB matching. Licenses + measurements:",
+                    Style::new().dim(),
+                )),
+                Line::from(Span::styled(
+                    "  irlume models list",
                     Style::new().dim(),
                 )),
                 Line::from(vec![
@@ -5174,142 +5096,6 @@ impl App {
             .wrap(Wrap { trim: false }),
             area,
         );
-    }
-
-    /// The measured model choices (#331). Every catalog entry renders with
-    /// the license line, measurement summary, and effect line the CLI listing
-    /// prints, all read from the one catalog in `irlume_common::thirdparty`
-    /// (via `crate::models`), so nothing unmeasured can appear and the two
-    /// surfaces cannot drift. Provenance is deliberately omitted: the
-    /// provenance rows pushed the root-only note off a 50-row terminal, and
-    /// the CLI consent flow prints provenance before any enable can proceed.
-    /// The re-enrollment consequence is a section ABOVE the entries, so it is
-    /// met before any switch command (#288: templates are per recognizer, and
-    /// on a one-user machine a stranded enrollment is a lockout path if the
-    /// camera then misbehaves). Display and guidance only: a state change
-    /// goes through the CLI's own sudo + license flow, so the screen shows
-    /// the exact command instead of wrapping it, and root-gating stays where
-    /// the CLI already enforces it.
-    ///
-    /// A PURE RENDER of `self.models_status` (#334 review): the per-entry
-    /// state hashes weight files, so it is gathered on the probe worker and
-    /// cached; the content builder must never call back into `crate::models`
-    /// state readers. `↑/↓` scroll by LOGICAL line (`models_scroll` skips
-    /// leading entries of [`Self::models_lines`]): exact and clampable, where
-    /// a wrapped-row offset needs the renderer's private line count and every
-    /// estimate of it risks clamping the tail commands out of reach.
-    fn draw_models(&self, f: &mut Frame, area: Rect) {
-        let lines = self.models_lines();
-        // Clamp so the LAST content line can top the viewport but the view
-        // can never run away into blank space; models_lines ends on content
-        // (trailing blanks popped), so even fully scrolled the tail command
-        // or root-only note stays on screen.
-        let start = (self.models_scroll as usize).min(lines.len().saturating_sub(1));
-        f.render_widget(
-            Paragraph::new(lines[start..].to_vec()).wrap(Wrap { trim: false }),
-            area,
-        );
-    }
-
-    /// The Models tab's full content, top to bottom; see [`Self::draw_models`]
-    /// for the contract. Split out so the ↑/↓ handler can clamp the scroll
-    /// offset against the same list the renderer slices.
-    fn models_lines(&self) -> Vec<Line<'static>> {
-        use irlume_common::thirdparty::CATALOG;
-        let kv = |k: &str, v: &str| {
-            Line::from(vec![
-                Span::styled(format!("    {k:<12}"), Style::new().dim()),
-                Span::raw(v.to_string()),
-            ])
-        };
-        let mut lines: Vec<Line> = vec![
-            Line::from(Span::styled(
-                "  Models irlume measured on real hardware but does not ship or warrant.",
-                Style::new().dim(),
-            )),
-            Line::from(Span::styled(
-                "  Only measured entries appear (ADR-0001): the same catalog, numbers and",
-                Style::new().dim(),
-            )),
-            Line::from(Span::styled(
-                "  license lines `irlume models` prints.",
-                Style::new().dim(),
-            )),
-            Line::raw(""),
-            section("Switching the recognizer means re-enrolling"),
-            Line::from(Span::styled(
-                "  Templates are stored per recognizer (#288): scans enrolled under one do",
-                Style::new().fg(th().warn),
-            )),
-            Line::from(Span::styled(
-                "  not match under another. After a switch, face login stays off until you",
-                Style::new().fg(th().warn),
-            )),
-            Line::from(Span::styled(
-                "  re-enroll; until then only your password works.",
-                Style::new().fg(th().warn),
-            )),
-            Line::raw(""),
-        ];
-        for (i, m) in CATALOG.iter().enumerate() {
-            // From the cache, never a live read: `entry_state_label` hashes
-            // the weight file, and this runs per frame. Before the first
-            // sweep lands the answer is not known, and the tri-state rule
-            // says say so rather than claim "disabled".
-            let state = self
-                .models_status
-                .as_ref()
-                .and_then(|s| s.labels.get(i).cloned())
-                .unwrap_or_else(|| "state loading".into());
-            let enabled = state.starts_with("ENABLED");
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {}", m.name),
-                    Style::new().add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!("  ({} stage)  [{state}]", m.stage.as_str()),
-                    Style::new().dim(),
-                ),
-            ]));
-            lines.push(kv("license:", m.license));
-            lines.push(kv("measured:", m.summary));
-            lines.push(kv("effect:", &crate::models::role_line(m)));
-            lines.push(kv("obtain:", &crate::models::obtain_line(m)));
-            if enabled {
-                lines.push(kv(
-                    "disable:",
-                    &format!("sudo irlume models disable {}", m.name),
-                ));
-            }
-            lines.push(Line::raw(""));
-        }
-        // Root-gated like the CLI: settings.conf is 0600 root-only, so an
-        // unprivileged TUI cannot read the enabled flags and must say so
-        // rather than render "disabled" (the same tri-state rule the Settings
-        // sections follow). The commands above are the way to act either way.
-        // Keyed off the CACHED observation; before the first sweep neither
-        // direction is asserted.
-        if self.models_status.as_ref().is_some_and(|s| !s.readable) {
-            lines.push(Line::from(Span::styled(
-                "  settings.conf is root-only, so the enabled states above are unknown;",
-                Style::new().fg(th().warn),
-            )));
-            lines.push(Line::from(Span::styled(
-                "  the authoritative answer: sudo irlume models list",
-                Style::new().fg(th().warn),
-            )));
-        }
-        // End on content, never a blank: the scroll clamp lets the last line
-        // top the viewport, and a trailing blank there would render a page
-        // holding nothing.
-        while lines
-            .last()
-            .is_some_and(|l| l.spans.iter().all(|s| s.content.trim().is_empty()))
-        {
-            lines.pop();
-        }
-        lines
     }
 
     fn draw_cameras(&self, f: &mut Frame, area: Rect) {
@@ -6724,10 +6510,6 @@ impl App {
                 ("b", "Biopolicy…"),
                 ("m", "Third-Party Model…"),
             ],
-            // Read-only by design (#331): a model change goes through the
-            // CLI's own sudo + license flow, and the screen prints the exact
-            // command for it, so the only key to advertise is the scroll.
-            SC_MODELS => &[("↑/↓", "Scroll Catalog")],
             // [w] only while wiring is OBSERVED missing: the body hides its
             // [w] line on a wired box, and a footer still offering it invites
             // a needless `sudo irlume login enable --apply` re-run. Unknown
@@ -7587,7 +7369,7 @@ mod tests {
         let wide = draw_text(&app);
         let wide_hdr = row_with(&wide, "irlume");
         assert!(
-            !wide_hdr.contains("2/5"),
+            !wide_hdr.contains("2/4"),
             "wide header must not show the step counter, got: {wide_hdr}"
         );
         // Narrow: sidebar collapsed, so the header carries position.
@@ -7596,7 +7378,7 @@ mod tests {
         let narrow = rendered(&term);
         let narrow_hdr = row_with(&narrow, "irlume");
         assert!(
-            narrow_hdr.contains("2/5 · Login & Apps"),
+            narrow_hdr.contains("2/4 · Login & Apps"),
             "narrow header must show the step counter, got: {narrow_hdr}"
         );
     }
@@ -7963,8 +7745,6 @@ mod tests {
             act_scroll: 0,
             activity_open: false,
             reduce_motion: false,
-            models_status: None,
-            models_scroll: 0,
             visible: App::compute_visible(&caps, VisibilityInputs::default(), &[]),
             advanced: false,
             caps,
@@ -9042,7 +8822,7 @@ mod tests {
         // No biometric hardware: only stable system destinations.
         assert_eq!(
             App::compute_visible(&none, basic, &[]),
-            vec![SC_WELCOME, SC_PAM, SC_REPAIR, SC_SETTINGS, SC_MODELS]
+            vec![SC_WELCOME, SC_PAM, SC_REPAIR, SC_SETTINGS]
         );
         // RGB-only adds Faces + Recovery, not Password Wallet.
         assert_eq!(
@@ -9053,8 +8833,7 @@ mod tests {
                 SC_RECOVERY,
                 SC_PAM,
                 SC_REPAIR,
-                SC_SETTINGS,
-                SC_MODELS
+                SC_SETTINGS
             ]
         );
         // An IR pair earns Password Wallet.
@@ -9067,8 +8846,7 @@ mod tests {
                 SC_RECOVERY,
                 SC_PAM,
                 SC_REPAIR,
-                SC_SETTINGS,
-                SC_MODELS
+                SC_SETTINGS
             ]
         );
         // A fingerprint-only box gets Fingerprint + Password Wallet, no face tabs.
@@ -9087,8 +8865,7 @@ mod tests {
                 SC_KEYRING,
                 SC_PAM,
                 SC_REPAIR,
-                SC_SETTINGS,
-                SC_MODELS
+                SC_SETTINGS
             ]
         );
         // Advanced view on full hardware shows every user-facing destination in
@@ -9134,7 +8911,7 @@ mod tests {
         assert_eq!(app.screen, SC_WELCOME);
         app.on_key(KeyCode::BackTab);
         assert_eq!(
-            app.screen, SC_MODELS,
+            app.screen, SC_SETTINGS,
             "BackTab from Overview wraps to the final visible destination"
         );
         app.on_key(KeyCode::Tab);
@@ -11023,287 +10800,6 @@ mod tests {
     /// back (#334 review): restored only on return, a panicking test left the
     /// process env pointing into its deleted sandbox and later tests failed
     /// against the wrong configuration, burying the original failure.
-    struct ModelsEnvGuard {
-        root: std::path::PathBuf,
-        old_cfg: Option<std::ffi::OsString>,
-        old_state: Option<std::ffi::OsString>,
-    }
-
-    impl Drop for ModelsEnvGuard {
-        fn drop(&mut self) {
-            // Restored independently: a paired match would drop whichever var
-            // existed alone before the test.
-            match self.old_cfg.take() {
-                Some(v) => std::env::set_var("IRLUME_CONFIG_DIR", v),
-                None => std::env::remove_var("IRLUME_CONFIG_DIR"),
-            }
-            match self.old_state.take() {
-                Some(v) => std::env::set_var("IRLUME_STATE_DIR", v),
-                None => std::env::remove_var("IRLUME_STATE_DIR"),
-            }
-            let _ = std::fs::remove_dir_all(&self.root);
-        }
-    }
-
-    /// Sandbox the config + state dirs for a Models-screen draw and restore
-    /// them after, panic or not. The screen's state cache reads settings.conf
-    /// and the weights dir through `crate::models`; without the sandbox a dev
-    /// box with a real (0600) /etc/irlume/settings.conf renders "root-only
-    /// unknown" and the tests assert on that machine's state instead of the
-    /// state they set up. Caller must hold ENV_LOCK.
-    fn with_models_sandbox<R>(tag: &str, body: impl FnOnce(&std::path::Path) -> R) -> R {
-        let root = std::env::temp_dir().join(format!("irlume-tui-{tag}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
-        let (cfg, state) = (root.join("cfg"), root.join("state"));
-        std::fs::create_dir_all(&cfg).unwrap();
-        std::fs::create_dir_all(&state).unwrap();
-        let _guard = ModelsEnvGuard {
-            root,
-            old_cfg: std::env::var_os("IRLUME_CONFIG_DIR"),
-            old_state: std::env::var_os("IRLUME_STATE_DIR"),
-        };
-        std::env::set_var("IRLUME_CONFIG_DIR", &cfg);
-        std::env::set_var("IRLUME_STATE_DIR", &state);
-        body(&cfg)
-    }
-
-    /// A test App on the Models tab with the state cache gathered from the
-    /// CURRENT (sandboxed) environment, the way `poll()` lands a probe sweep.
-    /// Draw itself must never read the environment (#334 review), so every
-    /// draw test populates the cache through the same `ModelsStatus::gather`
-    /// the probe worker runs.
-    fn models_app() -> App {
-        let mut app = test_app();
-        app.screen = SC_MODELS;
-        app.models_status = Some(ModelsStatus::gather());
-        app
-    }
-
-    #[test]
-    fn models_screen_lists_each_catalog_entry_with_license_and_measurement() {
-        // The listing is the CATALOG rendered, nothing else (#331): each
-        // entry's name, license line, measurement summary, and obtain command
-        // come from the same `crate::models` helpers the CLI listing uses.
-        // Iterates the live catalog so this keeps holding as entries land.
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let text = with_models_sandbox("mlist", |_| draw_text(&models_app()));
-        // Compared WHOLE, normalized: the rendered lines word-wrap at the
-        // panel width, so collapsing all whitespace on both sides lets the
-        // full license and summary text be asserted, not just its first
-        // words (#334 review: a renderer truncating after the opening words
-        // used to pass). The block border glyphs land between wrapped
-        // segments in the flattened frame, so they normalize to spaces too.
-        let flat = |s: &str| {
-            s.replace('│', " ")
-                .split_whitespace()
-                .collect::<Vec<_>>()
-                .join(" ")
-        };
-        let flat_text = flat(&text);
-        for m in irlume_common::thirdparty::CATALOG {
-            row_with(&text, m.name);
-            assert!(
-                flat_text.contains(&flat(m.license)),
-                "full license line for '{}' missing:\n{text}",
-                m.name
-            );
-            assert!(
-                flat_text.contains(&flat(m.summary)),
-                "full measurement summary for '{}' missing:\n{text}",
-                m.name
-            );
-            // The obtain line is short enough to sit on one rendered row, so
-            // it is asserted whole: the exact sudo command is the point.
-            assert!(
-                text.contains(&crate::models::obtain_line(m)),
-                "obtain command for '{}' missing:\n{text}",
-                m.name
-            );
-        }
-        // An enabled entry earns the one extra row: its exact disable command
-        // (still under the same ENV_LOCK guard).
-        let enabled = with_models_sandbox("mlist-on", |cfg| {
-            std::fs::write(cfg.join("settings.conf"), "third_party_pad=flir\n").unwrap();
-            draw_text(&models_app())
-        });
-        assert!(
-            enabled.contains("ENABLED"),
-            "the enabled tag must show:\n{enabled}"
-        );
-        assert!(
-            enabled.contains("sudo irlume models disable flir"),
-            "an enabled entry must name its disable command:\n{enabled}"
-        );
-    }
-
-    #[test]
-    fn models_screen_states_the_reenroll_consequence_before_any_switch_command() {
-        // #331's ordering policy: templates are per recognizer (#288), so the
-        // cost of switching renders ABOVE every switch command, and a reader
-        // meets it before the offer. Byte order in the flattened frame is
-        // render order (rows top to bottom).
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let text = with_models_sandbox("morder", |_| draw_text(&models_app()));
-        let warn = text
-            .find("Templates are stored per recognizer")
-            .unwrap_or_else(|| panic!("no re-enroll warning:\n{text}"));
-        let cmd = text
-            .find("sudo irlume models")
-            .unwrap_or_else(|| panic!("no switch command:\n{text}"));
-        assert!(
-            warn < cmd,
-            "the re-enroll consequence must render before the first switch command:\n{text}"
-        );
-    }
-
-    #[test]
-    fn models_screen_unprivileged_shows_unknown_state_and_the_sudo_commands() {
-        // Root-gated like the CLI: settings.conf unreadable (0600 root-only in
-        // the field, chmod 000 here) must render as unknown state, never as
-        // "disabled", with the sudo commands as the only way to act. FAILS
-        // (never silently skips) under root (#334 review): root reads any
-        // mode, so the chmod fixture proves nothing there, and an early
-        // return recorded a test that observed nothing as passed on root-run
-        // package builders.
-        assert!(
-            !crate::is_root(),
-            "this test needs a non-root job: under root the chmod-000 fixture is \
-             readable and none of the assertions below observe anything"
-        );
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let text = with_models_sandbox("mroot", |cfg| {
-            use std::os::unix::fs::PermissionsExt;
-            let conf = cfg.join("settings.conf");
-            std::fs::write(&conf, "third_party_pad=flir\n").unwrap();
-            std::fs::set_permissions(&conf, std::fs::Permissions::from_mode(0o000)).unwrap();
-            draw_text(&models_app())
-        });
-        assert!(
-            text.contains("enabled state unknown, root-only"),
-            "unreadable settings must not claim disabled:\n{text}"
-        );
-        assert!(
-            text.contains("sudo irlume models list"),
-            "the authoritative sudo listing must be named:\n{text}"
-        );
-        // The state-changing commands render read-only for everyone; the
-        // unprivileged case is where they are the ONLY path.
-        assert!(
-            text.contains("sudo irlume models enable flir"),
-            "the fetchable entry's enable command must show:\n{text}"
-        );
-        assert!(
-            text.contains("sudo irlume models add buffalo"),
-            "the bring-your-own entry's add command must show:\n{text}"
-        );
-    }
-
-    #[test]
-    fn models_screen_renders_the_cached_state_never_a_fresh_probe() {
-        // The #334 review's HIGH finding: drawing this tab used to call
-        // entry_state_label per entry per frame, and its ENABLED/root-only
-        // branches read and hash the whole weight file, ~10x/s on the UI
-        // thread. Draw must be a pure render of App.models_status. A sentinel
-        // label no gather could produce proves it: if draw recomputed from
-        // the environment the sentinel could not reach the frame.
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let (fresh, cached) = with_models_sandbox("mcache", |_| {
-            let mut app = test_app();
-            app.screen = SC_MODELS;
-            let fresh = draw_text(&app); // cache still None
-            app.models_status = Some(ModelsStatus {
-                labels: irlume_common::thirdparty::CATALOG
-                    .iter()
-                    .map(|_| "SENTINEL-CACHED-STATE".into())
-                    .collect(),
-                readable: true,
-            });
-            (fresh, draw_text(&app))
-        });
-        // Before the first sweep lands the state is not yet known, and the
-        // tri-state rule says say so rather than claim either direction.
-        assert!(
-            fresh.contains("state loading"),
-            "an unlanded cache must render as loading:\n{fresh}"
-        );
-        // The state TAG specifically: "disabled" also appears in prose (the
-        // recognizer effect line names the disabled IR paths), so only the
-        // bracketed tag would be a false claim.
-        assert!(
-            !fresh.contains("[disabled]"),
-            "an unlanded cache must not claim a disabled state:\n{fresh}"
-        );
-        assert!(
-            cached.contains("SENTINEL-CACHED-STATE"),
-            "draw must render the cache verbatim:\n{cached}"
-        );
-    }
-
-    #[test]
-    fn models_screen_scrolls_to_reach_every_command_on_a_short_terminal() {
-        // The #334 review's MEDIUM finding: at 80x24 the body shows about
-        // seven rows and ratatui clips the rest, so without scrolling the
-        // entries and their commands were unreachable. ↑/↓ (move_sel's
-        // SC_MODELS branch) must bring the LAST command into view, and the
-        // re-enroll warning must sit at the unscrolled top so it is met
-        // before any command.
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        with_models_sandbox("mscroll", |_| {
-            let mut app = models_app();
-            let render = |app: &App| {
-                let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
-                term.draw(|f| app.draw(f)).unwrap();
-                rendered(&term)
-            };
-            let top = render(&app);
-            assert!(
-                top.contains("Templates are stored per recognizer"),
-                "the warning heads the unscrolled view:\n{top}"
-            );
-            let last_cmd = "sudo irlume models add buffalo";
-            assert!(
-                !top.contains(last_cmd),
-                "at 80x24 the last command must genuinely start off-screen, or \
-                 the scroll assertions below prove nothing:\n{top}"
-            );
-            // ↓ one logical line at a time until the LAST command scrolls in.
-            let budget = app.models_lines().len();
-            let mut found = false;
-            for _ in 0..budget {
-                app.on_key(KeyCode::Down);
-                if render(&app).contains(last_cmd) {
-                    found = true;
-                    break;
-                }
-            }
-            assert!(
-                found,
-                "the last catalog command never scrolled into view:\n{}",
-                render(&app)
-            );
-            // The clamp (#334 review): extra presses cannot run past the end
-            // into blank space; the content's last line still tops the view.
-            for _ in 0..100 {
-                app.on_key(KeyCode::Down);
-            }
-            let clamped = render(&app);
-            assert!(
-                clamped.contains(last_cmd),
-                "over-scrolling must clamp at the content end:\n{clamped}"
-            );
-            // And ↑ returns to the warning-first top without re-walking the
-            // wasted presses (the store itself is clamped, not just the view).
-            for _ in 0..budget {
-                app.on_key(KeyCode::Up);
-            }
-            let back = render(&app);
-            assert!(
-                back.contains("Templates are stored per recognizer"),
-                "scrolling back up must restore the warning-first view:\n{back}"
-            );
-        });
-    }
-
     #[test]
     fn done_screen_status_line_matches_setup_state() {
         let mut app = test_app();
@@ -11442,15 +10938,15 @@ mod tests {
 
     #[test]
     fn header_counts_steps_over_visible_screens_only() {
-        let mut app = test_app(); // Overview, Login & Apps, Diagnostics, Preferences, Face Model
+        let mut app = test_app(); // Overview, Login & Apps, Diagnostics, Preferences
         app.screen = SC_PAM;
         // The step counter only appears on a narrow terminal (sidebar collapsed);
-        // there it must track VISIBLE tabs, so Login wiring is 2 of 5.
+        // there it must track VISIBLE tabs, so Login wiring is 2 of 4.
         let mut term = Terminal::new(TestBackend::new(80, 30)).unwrap();
         term.draw(|f| app.draw(f)).unwrap();
         let text = rendered(&term);
         assert!(
-            text.contains("2/5 · Login & Apps"),
+            text.contains("2/4 · Login & Apps"),
             "the step counter must track visible tabs, got:\n{text}"
         );
         assert!(text.contains("testuser"), "the managed user is shown");


### PR DESCRIPTION
## Why

Product decision: focus on maintaining and improving the one model irlume ships. The Face Model tab existed for the bring-your-own third-party model lane (#331); external recognizer pursuit is not happening (InsightFace licensing/legal makes it improbable), so the catalog no longer deserves a first-class navigation tab.

The thirdparty lane itself stays available where it already enforces its own safety: the CLI (`irlume models list/enable/disable`, sudo + license consent flow) and the Settings `[m]` toggle. Nothing about the daemon machinery changes.

## What was removed

- `SC_MODELS` screen + all navigation/sidebar/footer/help/status entries; `SC_DONE` renumbered
- The catalog state cache (`ModelsStatus`, its probe-worker gather, cache landing) and scroll handling
- `draw_models`/`models_lines` and the five Models-screen tests
- Settings' third-party section now points at `irlume models list`

529 deletions, 25 insertions. No camera-path code touched.

## Audit finding surfaced alongside (fixed on PR #518, noted here for the record)

The TUI **"Identify me" has been broken on every dual-camera sequential host since the delivered-rate gate landed**: one-shot identify resolves a sequential capture whose machinery gap (~4.4s) exceeded the 3s concurrent skew limit, structurally discarding the RGB embedding identify is RGB-primary on. Reproduced live on the ASUS: `no RGB face: RGB and IR frames are 4416ms apart (limit 3000ms)`. #518's role-aware startup flush + ADR-0014's sequential pairing budget fix it (verified live: identify completes the full gate at a 3095ms gap).

## Validation

- workspace 1771/0, clippy -D warnings all-targets, fmt, rustdoc
- Live TUI smoke test in a pty: render, full tab cycle incl. wrap and advanced toggle, no Face Model anywhere