### PR TITLE
fix(tui): drop the head-gesture line from Overview; record the enrollment N-sweep

### DIFF
--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -5490,7 +5490,7 @@ impl App {
         } else if self.enrolled_known() == Some(true) {
             (
                 "Face unlock is ready",
-                "Keep nodding to approve; shake your head to decline.",
+                "Face confirmed with your keyboard at the prompt.",
                 th().ok,
             )
         } else {
@@ -11214,8 +11214,9 @@ mod tests {
         let text = draw_text(&app);
         assert!(text.contains("Face unlock is ready"));
         assert!(
-            text.contains("Keep nodding to approve; shake your head to decline."),
-            "the ready state must explain head approval and decline: {text}"
+            !text.contains("Keep nodding to approve"),
+            "Overview must not carry the head-gesture line (default-off, \
+             configured in Settings): {text}"
         );
 
         // Keyring: keyring_armed is already tri-state.

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -30,7 +30,15 @@ pub const MAX_PROFILES: usize = 3;
 /// [`crate::scaled_threshold`] (+0.074 at 30, under the +0.10 cap).
 pub const MAX_SCANS_PER_PROFILE: usize = 30;
 /// Scans captured by a fresh enrollment to bootstrap solid recognition and a
-/// usable first calibration fit.
+/// usable first calibration fit. 10 is the measured knee, not a round number:
+/// the 2026-07-15 calibrated cross-condition sweep improves FRR steeply from
+/// 5 scans (25%) through ~10 and plateaus by 15 (17%); the 2026-08-23 CBSR
+/// deployment-shaped OR-arm N-sweep (dark-path bars, within-session split)
+/// is N-insensitive from 5-13 (FAR 3.5-4.0e-4, FRR 0.5-0.7% — noise), so the
+/// binding constraint is CROSS-CONDITION coverage + the per-user calibration
+/// fit (k=5 fit pairs beat k=3, ADR-0004 Tufts arm), which need headroom
+/// above the MIN_FIT_PAIRS floor. Lowering to 5 buys ~15s of enrollment time
+/// and costs ~7-8pp of hard-condition FRR; do not.
 pub const DEFAULT_ENROLL_SCANS: usize = 10;
 /// Scans added per improve-recognition round.
 pub const IMPROVE_SCANS: usize = 5;


### PR DESCRIPTION
## What

- Overview's ready-state subtitle no longer shows `Keep nodding to approve; shake your head to decline.` — head gestures are default-off and the Settings screen already documents approve/decline where the gesture is actually configured. Overview now says `Face confirmed with your keyboard at the prompt.` Test inverted to pin the absence.
- `DEFAULT_ENROLL_SCANS` doc now records the 2026-08-23 CBSR deployment-shaped OR-arm N-sweep (N ∈ {3,5,7,9,11,13,15}, dark bars 0.60/0.635): within-session FAR/FRR are N-insensitive from 5-13 (3.5-4.0e-4 / 0.5-0.7%), so the enrollment default stands on the calibrated cross-condition knee (25%→17% FRR from 5→15 scans) and the k=5 calibration-fit floor. **No constant change: 10 stays.**

Text-only code change (one string + one test + one doc comment); no camera-path, daemon, or auth-path change.