### PR TITLE
ci: bump codeql-action init+analyze to 4.37.7 (combined)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -75,6 +75,6 @@ jobs:
           # found".
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Replaces the closed #527/#528: dependabot split the init/analyze pair across two branches, so each PR alone mixed action versions inside one workflow run (`Loaded a configuration file for version '4.37.4', but running version '4.37.7'`) and could never pass. This bumps both refs in codeql.yml together, matching the merged upload-sarif 4.37.7 (#526) and the repo's one-codeql-action-version rule. SHA-pinned to the 4.37.7 tag commit, same as #526's.