### PR TITLE
fix(uninstall): remove systemctl-enable's /etc unit copies + stale enabled timer

### DIFF
--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -538,6 +538,29 @@ pub fn perform_teardown(keep_data: bool) -> TeardownReport {
             let _ = std::fs::remove_file(sock);
         }
     }
+    // `systemctl enable` copies units into /etc/systemd/system/ (Arch's
+    // systemd does this for units with [Install] aliases) — files pacman/apt
+    // do not own, so package removal leaves them behind as the second
+    // RC2 audit finding (4 files + a still-enabled timer). Remove exactly the
+    // irlume-named units from /etc; package-owned /usr/lib copies are the
+    // package manager's business.
+    for unit in [
+        "irlume-runner-prune.timer",
+        "irlume-runner-prune.service",
+        "irlume-reconcile.path",
+        "irlume-reconcile.timer",
+        "irlume-reconcile.service",
+        "irlumed.socket",
+        "irlumed.service",
+    ] {
+        let _ = systemctl(&["reset-failed", unit]);
+        let p = std::path::Path::new("/etc/systemd/system").join(unit);
+        if p.exists() {
+            let _ = std::fs::remove_file(&p);
+        }
+    }
+    // Reload so a later `systemctl list-unit-files` reflects the removal.
+    let _ = systemctl(&["daemon-reload"]);
     // AppArmor: removing the package deletes /etc/apparmor.d/usr.bin.irlumed
     // but does NOT unload the profile from the kernel — the daemon binary is
     // gone, so the residual profile can only cause confusion (and would


### PR DESCRIPTION
RC2 uninstall re-audit finding: 4 irlume unit files remained in `/etc/systemd/system/` (irlumed.service/.socket, runner-prune .service/.timer) with the prune timer still ENABLED after `irlume uninstall --yes`. `systemctl enable` had copied them into /etc (Arch/systemd behavior); the package owns only the /usr/lib originals, so package removal leaves the copies.

Teardown now disables (existing), then removes exactly the irlume-named units from /etc, reset-failed each, and daemon-reloads. Verified on archhost: RC1 leftovers were 3 residues -> #531 fixed those; RC2 left these 4 unit files -> this PR. Re-audit after merge will re-run the full residue scan.