### PR TITLE
fix(apparmor): grant media-controller reads — classification's no-open path regressed under enforce

### DIFF
--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -80,6 +80,14 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   # engine mis-tiers (found enforcing on Arch, 2026-08-05; issues #281/#283).
   /dev/ r,
   /dev/video[0-9]* rw,
+  # Media-controller nodes: camera classification's no-open path (#428) reads
+  # the media graph to decide a video node's role WITHOUT opening it (a video
+  # open powers the camera up pre-6.16 = privacy-LED blink per scan, and the
+  # udev lifecycle thread re-reads the graph on every hot-plug event). Under
+  # enforce without this rule the read fails and classification silently
+  # falls back to the legacy open probe — found by the 0.11.0rc3 complain-mode
+  # audit: the ONLY denial class across a full exercise battery.
+  /dev/media[0-9]* r,
   /sys/class/video4linux/ r,
   /sys/class/video4linux/** r,
   /sys/devices/** r,


### PR DESCRIPTION
## From the deep LSM investigation (0.11.0rc3 campaign)

Complain-mode AppArmor audit on the RC3 clean install, exercising status / profiles / keyring / recovery / doctor / deps / identify / 2x dark auths / ir-setup / camera diagnostics / a live udev hot-plug trigger, found **exactly one denial class**: `/dev/media0` opens (`r`) from the `irlume-startup` and `irlume-camera-u` (udev) threads.

## Why it matters

That read is camera classification's no-open path (#428): classify a video node's role from the media graph instead of opening it, because a video-node open powers the camera up on pre-6.16 kernels — a privacy-LED blink per scan. Under enforce, the denied read silently falls back to the legacy open probe: **every AppArmor-confining install (Arch pkg, Ubuntu deb — both load this profile) regressed to privacy-LED blinks per classification**, plus denial-log noise on every udev hot-plug re-enumeration.

## The fix

One rule: `/dev/media[0-9]* r,` (glob-consistent with the video rule), with the reasoning in a comment.

## Investigation negatives worth recording (no code)

- **The udev netlink monitor needs no network rule**: `abstractions/base` has zero network rules, yet the kernel-netlink monitor thread received a synthetic udev trigger live — this kernel/profile combination does not mediate those socket families. Empirical, verified by event delivery.
- **SELinux deliberately leaves irlumed unconfined** (Fedora lane): `irlume.te` v1.1.0 is documented greeter-reach glue (xdm_t/policykit_auth_t → socket); no daemon domain, no AVCs possible, nothing broken. A real SELinux domain is future hardening work, not a defect.
- The deb lane ships AND enforces this same profile (postinst `apparmor_parser -r`) — thinkpad's irlumed is confined by it right now, so this fix lands on all three lanes' confinement story.