### PR TITLE
release: irlume 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+- Nothing yet.
+
+## [0.11.0] - 2026-08-23
+
 ### Security
 
 - **SecureDark stage 1 (ADR-0016): the pure-dark (IR-only) path hardens.**
@@ -63,6 +67,14 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Changed
 
+- **Diagnostics finds AND fixes.** Rows can open the exact fixing flow
+  in-TUI (`Fix::Goto`): no-face-enrolled and template-key-missing start
+  enrollment, a missing recovery passphrase opens its prompt, a new
+  keyring-not-armed check opens the arm flow, and the daemon-down row
+  runs the sudo fix it used to merely describe. Diagnosis rows are
+  click-to-select then click-to-fix; the IR-test and Support lines and
+  every footer chip are click targets; the diagnosis box breathes with
+  proper spacing.
 - Eye-based user challenges are retired. Gesture-gated requests now use only
   repeated head nodding to approve and a head shake to decline. Existing
   per-service defaults are unchanged; passive PAD remains mandatory.
@@ -117,6 +129,50 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **Clean installs keep IR face authentication (P0).** The packaged daemon
+  creates the emitter lock root-owned, then the #487 access-mirror rework
+  hard-failed the group correction under the unit's deliberately
+  CAP_CHOWN-less bounding set — IR auth was dead on every clean install
+  (existing hosts only worked via leftover dev-run locks, which /run
+  clears at reboot). A lock owned by the process with no world bits is
+  strictly tighter than the mirror target and now proceeds; a
+  world-accessible uncorrectable lock still refuses.
+- **AppArmor profile gaps (enforce-mode installs):** the deferred
+  template-key loader's flocks and camera classification's media-graph
+  reads were both denied under enforcement — the first broke every
+  enrollment read, the second silently regressed the no-open
+  classification to the privacy-LED open probe. Both rules added; a
+  complain-mode audit across the full exercise battery confirmed no
+  other denial class remains.
+- **TUI could not be exited discoverably:** `q` was documented only in the
+  `?` overlay and bare `Esc` exited the whole app without confirmation.
+  Every screen's header now carries a clickable `✕ Exit (q)` chip; Esc
+  returns to Overview instead of quitting (it remains the escape hatch
+  during a stalled camera probe); the Cameras sudo action confirms
+  before running.
+- **`[s] Create Support Report` appeared broken:** the report ran silently
+  during the terminal suspend, showing a blank screen. The outcome now
+  prints with the absolute path on the suspended terminal (failure
+  included), and the file lands findably in the TUI's working directory.
+- **`sudo irlume` no longer writes user state into the invoking user's
+  HOME** (a root-owned `~/.local/share/irlume/<user>.json` survived
+  until now); privileged processes resolve to the system state dir
+  whenever $HOME is foreign.
+- **Uninstall leaves nothing behind:** the stale `/run/irlume.sock`, the
+  kernel-loaded AppArmor profile, `systemctl enable`'s unit copies in
+  `/etc/systemd/system/` (with a still-enabled timer), and per-user
+  `~/.local/share/irlume` state are all swept.
+- **install.sh:** verified channel fallbacks (Copr/PPA outage →
+  checksum+signature-verified release packages, upgrade-only: no
+  downgrades or lane flip-flop; `IRLUME_UPDATE=1` updates an installed
+  system from the release lane when the distro lane is down;
+  `IRLUME_RELEASE_PKG=1` opts Arch into the release package), plus
+  audit fixes: the PPA purge no longer defeats the no-downgrade guard,
+  asset matching is anchored with exactly-one-match, and the RPM path
+  uses `dnf install` (upgrade cannot fresh-install). Tampered sums,
+  stripped signatures, and reruns are container-verified fail-closed.
+- **The universal .deb container build** installs `libudev-dev` and
+  accepts docker as a podman fallback.
 - **`irlume diag` reports the keyring and face-template seals separately.** A
   healthy keyring credential envelope can no longer hide a missing, unreadable,
   or PCR-drifted template-key envelope behind one generic seal status; each row
@@ -2785,7 +2841,8 @@ is always the fallback: no lockout, ever.
   credentials).
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
-[Unreleased]: https://github.com/archledger/irlume/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/archledger/irlume/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/archledger/irlume/compare/v0.10.0...v0.11.0
 [0.9.0]: https://github.com/archledger/irlume/releases/tag/v0.9.0
 [0.8.1]: https://github.com/archledger/irlume/releases/tag/v0.8.1
 [0.8.0]: https://github.com/archledger/irlume/releases/tag/v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "image",
  "irlume-auth",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "libc",
  "serde",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -1095,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "irlume-gkr-unlock"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-kwallet-init"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-liveness"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "irlume-common",
  "irlume-vision",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "edgefirst-tflite",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.10.0
+pkgver=0.11.0
 pkgrel=1
 pkgdesc="Face authentication for Linux with head-gesture consent and passive PAD"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.10.0
+version: 0.11.0
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -2,7 +2,7 @@
 %global ort_ver 1.28.1
 
 Name:           irlume
-Version:        0.10.0
+Version:        0.11.0
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -255,6 +255,15 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Sun Aug 23 2026 archledger <archledger236@gmail.com> - 0.11.0-1
+- SecureDark: scene gate + 0.635 dark threshold (ADR-0016)
+- Capture-path: role-aware flush (-3.3s/auth), schedule-aware pairing (ADR-0014)
+- IR emitter lock: clean installs keep IR auth under confinement
+- AppArmor: template-key locks + media-controller reads
+- TUI: Diagnostics fixes issues in-app; visible support report; exit chip
+- install.sh: verified channel fallbacks for Copr/PPA outages
+- uninstall: socket, units, AppArmor profile, user XDG state swept
+
 * Wed Aug 12 2026 archledger <archledger236@gmail.com> - 0.10.0-1
 - Per-service consent gestures with a head-shake decline; elevation and polkit prompts require a nod by default
 - The keyring-release gesture default changed from ON to OFF; opt back in with irlume credential-release-challenge credential_release on


### PR DESCRIPTION
Version bump (Cargo/lock, PKGBUILD, spec + %changelog, nfpm), CHANGELOG stamp, packaging parity OK.

Validated as RC4 fleet-wide (archhost clean-install + P0 re-test, minihost + thinkpad upgrades, ASUS TUI/stress), final stress + TUI-CLI parity pass clean, all blockers merged (#518, #521-#522, #530-#537). Full campaign record in shared memory.