### PR TITLE
build(ppa): container needs libudev-dev

### DIFF
--- a/packaging/ppa/build-ppa-container.sh
+++ b/packaging/ppa/build-ppa-container.sh
@@ -72,7 +72,7 @@ podman run --rm \
     apt-get install -y -qq --no-install-recommends \
       ca-certificates curl rsync git xz-utils \
       build-essential dpkg-dev debhelper devscripts fakeroot linux-libc-dev \
-      cargo rustc pkg-config clang libclang-dev libtss2-dev libpam0g-dev >/dev/null
+      cargo rustc pkg-config clang libclang-dev libtss2-dev libpam0g-dev libudev-dev >/dev/null
     cd /work
     export BUILDROOT=/work/ppa-build
     bash scripts/build-ppa-source.sh


### PR DESCRIPTION
Same gap #537 fixed in the deb container: the PPA container's apt-get list had every -dev package except libudev's, so libudev-sys's build.rs died at pkg-config while building the 0.11.0 PPA source package.