### PR TITLE
docs: accuracy sweep after 0.11.0 (23 findings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ IR camera. Stored as an embedding, never an image. Password always works.
 ---
 
 > [!IMPORTANT]
-> **A printed photograph of an enrolled face passes the built-in liveness gate**
-> (accepted in 69 of 70 measured presentations). `irlume setup` offers a trained
-> cue that refuses it. Read **[Limits](docs/LIMITATIONS.md)** before wiring this
+> **A printed photograph of an enrolled face passes the algorithmic IR gate
+> alone** (accepted in 69 of 70 measured presentations). The shipped PAD pair
+> (ViT RGB + FLIR IR) refuses it, runs default-on, and verifies against signed
+> checksums at startup; kill switches: `IRLUME_PAD_VIT=0`, `IRLUME_PAD_IR=0`.
+> Read **[Limits](docs/LIMITATIONS.md)** before wiring this
 > into anything that matters.
 
 <br>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,8 +49,9 @@ Full detail in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). Primary concerns:
   release manifest (`models/SHA256SUMS`, embedded at build time) and logs a
   loud warning on any mismatch; `IRLUME_MODELS_STRICT=1` turns both a
   mismatch and an unreadable/deleted model into a startup refusal. Warn-first
-  is the default so operators can run self-trained weights without being
-  locked out.
+  is the default so a recoverable mis-packaging (or a deliberately overridden
+  model path via the unit's `IRLUME_*_MODEL` variables) degrades to a loud
+  warning instead of bricking face login; strict is the hardened choice.
 
 ## Reporting a vulnerability
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 - [Privilege separation](#privilege-separation): who is trusted, and the one
   socket everything crosses
 - [Authentication flow](#authentication-flow): what happens on a login attempt
-- [Model stack](#model-stack): the five bundled models, and what is
+- [Model stack](#model-stack): the seven bundled models, and what is
   deliberately not a model
 - [IR capture: strobe and ambient subtraction](#ir-capture-strobe-and-ambient-subtraction)
 - [Face login → keyring unlock](#face-login--keyring-unlock): the
@@ -81,7 +81,8 @@ flowchart LR
 
 ## Model stack
 
-Five model files ship with every package, loaded once by `irlumed` at startup
+Seven model files ship with every package (five recognizers/landmarkers plus
+the two PAD models below), loaded once by `irlumed` at startup
 and checksum-verified against a built-in manifest (a mismatch warns;
 `IRLUME_MODELS_STRICT=1` refuses to start instead). Four are ONNX; the
 landmark mesh is Google's published `.tflite`, run on the TFLite C runtime the
@@ -133,8 +134,10 @@ physics (cross-spectrum co-location, center/edge brightness falloff, corneal gli
 and the matcher is a fixed cosine threshold; both are plain, auditable
 algorithms. Per-user IR calibration is fitted on-device from the user's own
 enrollment scans ([ADR-0004](adr/0004-per-enrollment-ir-adapter.md); it
-replaced a retired, dataset-trained IR adapter). No learned anti-spoof model
-ships; the acceptance bar one would have to clear is in
+replaced a retired, dataset-trained IR adapter). Two learned anti-spoof
+models ship default-on as deny-only cues
+([ADR-0013](adr/0013-ship-pad-models-default-on.md)); the acceptance bar a
+grant-capable model would have to clear is in
 [ADR-0001](adr/0001-liveness-pad-strategy.md).
 
 Per-model provenance, license verification notes, and the models this project

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -69,7 +69,7 @@ Conventions that apply everywhere:
 | `irlume camera-mode` | no | ask the daemon which schedule is active for its exact open pair. Reports qualified concurrent, measured sequential and its reason, no authority, changed/unreadable context, an environment override, or generation-scoped runtime degradation and its cause. It also prints the exact requested/accepted stream and USB context used by v2. RGB-only hosts report `no_ir_pair` without trying to open IR. The CLI does not read legacy `capture_mode.*` entries from `cameras.conf` or open cameras itself |
 | `irlume models …` | — | removed (ADR-0015): third-party/bring-your-own model support is gone; irlume ships its full model set and the command answers with a notice. Check installed weights with `irlume doctor` |
 | `irlume update [--check]` | for install | update via the channel irlume was installed from (Copr/PPA: runs it; .deb/pkg/source: shows the steps); `--check` only reports |
-| `irlume uninstall [--keep-data] [--yes]` | yes | un-wire PAM first (lockout-safe order), stop the daemon, wipe enrolled data unless `--keep-data`, then print the package-removal command |
+| `irlume uninstall [--keep-data] [--yes]` | yes | un-wire PAM first (lockout-safe order), stop the daemon, sweep the stale socket, the `/etc/systemd/system` unit copies and enabled timer, the kernel-loaded AppArmor profile, and per-user XDG state; wipe enrolled data unless `--keep-data`, then print the package-removal command |
 
 ## Developer and benchmark tools
 

--- a/docs/CREDITS.md
+++ b/docs/CREDITS.md
@@ -8,6 +8,8 @@ The bundled models:
 - **[YuNet](https://github.com/opencv/opencv_zoo)** (OpenCV Zoo, MIT) detects faces in both streams.
 - **[AuraFace](https://huggingface.co/fal/AuraFace-v1)** by fal (Apache-2.0) is the 512-D ArcFace recognizer; irlume ships only its `glintr100.onnx`.
 - **[MediaPipe FaceLandmarker](https://ai.google.dev/edge/mediapipe/solutions/vision/face_landmarker)** and **[BlazeFace short-range](https://ai.google.dev/edge/mediapipe/solutions/vision/face_detector)** (Google, Apache-2.0) supply dense landmarks and the detection-rescue stage for saturated frames; FaceLandmarker refines BlazeFace rescue boxes for alignment.
+- **[ViT liveness](https://github.com/Adedev-W/LivenessModels-ONNX)** (Adedev-W, MIT) is the shipped RGB PAD cue (`liveness_vit.onnx`), default-on per ADR-0013.
+- **[FLIR liveness](https://modelscope.cn/models/iic/cv_manual_face-liveness_flir)** (Alibaba DAMO Academy on ModelScope, MIT) is the shipped IR PAD cue (`flir.onnx`), default-on per ADR-0013.
 
 The TPM and camera code builds on:
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -30,7 +30,7 @@ irlume status --json --contract 1
 Call `irlume version --json` once at startup:
 
 ```json
-{ "contract_version": 1, "engine_version": "0.8.1", "command": "version", "ok": true,
+{ "contract_version": 1, "engine_version": "0.11.0", "command": "version", "ok": true,
   "data": { "capabilities": ["version-json", "profiles-list-json", "status-json",
                              "doctor-json", "login-status-json", "auth-test-events",
                              "login-plan-json", "login-transactions", "models-list-json"],

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -8,11 +8,13 @@ summary lives on the [README](../README.md); this is the detail.
   accepted a life-size vinyl print in 69 of 70 presentations. The cue is a
   brightness ratio on a 2D infrared sensor, and a print held at an angle produces
   the same falloff a face does, so no threshold accepts the user and rejects the
-  print. `irlume setup` offers a trained deny-only cue (`flir`) that refused the
+  print. The shipped default-on PAD pair (ADR-0013) refused the
   same print at p_fake 0.941 to 1.000, including when it was enhanced with an
-  infrared-absorbing patch. irlume does not ship or warrant those weights,
-  because their publisher documents neither the training data nor a way to
-  reproduce the model ([ADR-0001](adr/0001-liveness-pad-strategy.md)).
+  infrared-absorbing patch. The weights are bundled, checksummed, and verified
+  at daemon startup; their publishers document neither the training data nor a
+  way to reproduce the models, which is disclosed at startup and in
+  [models/README.md](../models/README.md) ([ADR-0001](adr/0001-liveness-pad-strategy.md),
+  amended by ADR-0013).
   Every miss falls safely to the password.
 - **Bright infrared behind you rejects a genuine face.** The gate infers shape
   from how the emitter's light falls, and open sky or a hot lamp floods it. In a

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -146,7 +146,8 @@ headless SPICE host.
 
 ## Model weights and building from a remote flake
 
-The four ONNX model files are fetched by the flake from the `models-v1` GitHub
+The six ONNX model files plus the TFLite mesh are
+fetched by the flake from the `models-v1` GitHub
 release as hash-pinned `fetchurl` inputs, and the package installs them into
 `$out/share/irlume/models/`. Because they are fixed-output fetches keyed by
 sha256 (not Git LFS), `nix build github:archledger/irlume` gets the real weights

--- a/docs/PAD_SELFTEST.md
+++ b/docs/PAD_SELFTEST.md
@@ -1,7 +1,9 @@
 # IR liveness PAD self-test (ISO/IEC 30107-3)
 
-**Status:** V1.0 methodology · **Applies to:** the credential-releasing IR liveness
-gate (`irlume_liveness::LivenessGate`)
+**Status:** V1.0 methodology · **Applies to:** the algorithmic credential-releasing
+IR liveness gate (`irlume_liveness::LivenessGate`). The shipped deny-only PAD
+models (ViT RGB + FLIR IR, ADR-0013) run alongside this gate on the credential
+path and are out of scope here; see `docs/pad-results/`.
 
 This document defines how irlume's presentation-attack-detection (PAD) gate is
 self-tested against the methodology of **ISO/IEC 30107-3** (*Biometric presentation
@@ -36,7 +38,8 @@ overstate what it is trusted to do, so it is excluded from the PAD claim. Its
 screen/glare/moiré cues are documented in the source, not certified here.
 
 The gate is a **hard AND of physically-grounded cues** (any single failure
-rejects); there is no learned model and no score fusion in the liveness decision.
+rejects); there is no learned model and no score fusion in this gate's decision
+(the shipped PAD cues are separate, deny-only stages).
 See [`adr/0001-liveness-pad-strategy.md`](adr/0001-liveness-pad-strategy.md) for why
 (clean-BOM constraint + the rPPG latency paradox).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,31 +6,19 @@ not promises, and the order can change when hardware reports or security
 findings say it should. Dated snapshots of what shipped live in
 [CHANGELOG.md](../CHANGELOG.md).
 
-## Next: a security-focused 0.3.x
+## Done from the original audit backlog
 
-The audit backlog, in rough order:
+Shipped since this list was written: the consecutive-failure throttle (0.4.0;
+the NIST SP 800-63B-4 3.2.3 hard requirement), panic containment at the PAM
+entry points, the hardening passes (constant-time checks, zeroization), the
+sandboxed systemd unit (validated on real logins), and the anti-spoof
+decision: both PAD models ship default-on and bundled, verified at startup
+([ADR-0013](adr/0013-ship-pad-models-default-on.md)); the third-party model
+lane was later removed outright
+([ADR-0015](adr/0015-remove-thirdparty-model-lane.md)).
 
-- Consecutive-failure lockout in the daemon: disable face auth for a user
-  after repeated failed verifications and fall back to password. This is the
-  one hard requirement from NIST SP 800-63B-4 section 3.2.3 that irlume
-  lacks, and it bounds spoof-retry attacks.
-- `catch_unwind` at the PAM entry points plus `forbid(unsafe_code)` and
-  panic-lint denies on the crates that already have no unsafe, so a panic
-  can never take down the host greeter.
-- Constant-time comparison (`subtle`) for the sealed-password check, a
-  manual `Clone` for `SecretBytes` that keeps the mlock guarantee, and
-  zeroization of the remaining error-path copies.
-- systemd unit sandboxing (NoNewPrivileges, ProtectSystem, SystemCallFilter,
-  device allow-listing) layered under the existing SELinux/AppArmor
-  policies, validated on real logins before shipping.
-- `PR_SET_DUMPABLE` and core-dump limits for the daemon.
+## Still open: footprint
 
-## Then: anti-spoof and footprint (0.4 direction)
-
-- Decide whether the qualified third-party IR PAD model becomes a default
-  deny-only cue instead of an opt-in. It closes the one demonstrated
-  presentation-attack breach (life-size glossy print); the open question is
-  UX for offline installs, since the model is fetched, not bundled.
 - Convert the recognizer model to external-data ONNX so onnxruntime maps it
   from disk instead of copying it; the daemon currently holds about 617 MB
   resident for 260 MB of weights.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -419,10 +419,10 @@ with none of these checks ([#179]).
 [#159]: https://github.com/archledger/irlume/issues/159
 [#179]: https://github.com/archledger/irlume/issues/179
 
-## Third-party models: optional, and recommended
+## Anti-spoofing (PAD) models: shipped default-on
 
-**Enable one if a printed photograph of you should not unlock your machine.**
-The built-in gate does not stop a life-size print. Measured twice on the same
+The shipped PAD pair refuses a life-size print.
+The algorithmic gate alone does not stop one. Measured twice on the same
 hardware, on 2026-06-30 and again on 2026-08-02, an angled vinyl print of the
 enrolled user's face produces the same centre-to-edge infrared falloff a real
 face does, so no threshold separates them and the gate accepts the print. The
@@ -453,7 +453,7 @@ live in them; sealed envelopes are stored separately (see
 
 | File | Holds | Written by |
 |---|---|---|
-| `/etc/irlume/settings.conf` | `credential_release_challenge=1` opts IN to a head gesture before the login-keyring credential is released (default off); every `service_gesture.<service>` also defaults off, with `=1` adding an experimental gesture after mandatory privileged keyboard confirmation; the legacy `polkit_gesture=1` switch remains an explicit polkit opt-in. `enforce_biopolicy=1` opts into operation-class gating; `third_party_pad=<name>` and `third_party_recognizer=<name>` select enabled third-party models. During the migration window, `consent_gesture=closure` or malformed values block only a gesture-gated request until removed or changed to `nod` | TUI Settings; `sudo irlume credential-release-challenge [<service>] on\|off`; `sudo irlume models enable/add/disable` |
+| `/etc/irlume/settings.conf` | `credential_release_challenge=1` opts IN to a head gesture before the login-keyring credential is released (default off); every `service_gesture.<service>` also defaults off, with `=1` adding an experimental gesture after mandatory privileged keyboard confirmation; the legacy `polkit_gesture=1` switch remains an explicit polkit opt-in. `enforce_biopolicy=1` opts into operation-class gating; the legacy `third_party_pad` / `third_party_recognizer` keys are ignored with a startup notice (the third-party lane was removed, ADR-0015). During the migration window, `consent_gesture=closure` or malformed values block only a gesture-gated request until removed or changed to `nod` | TUI Settings; `sudo irlume credential-release-challenge [<service>] on\|off` |
 | `/etc/irlume/cameras.conf` | `rgb=` / `ir=` device nodes of the active camera pair | TUI camera picker, or `sudo irlume set-cameras <rgb> <ir>` |
 | `/etc/irlume/method` | one line: the active auth method (`auto`, `face`, `fingerprint`, or `both` = face OR fingerprint) | `irlume fingerprint enable/disable` |
 | `/var/lib/irlume/ir_emitter.conf` | the UVC extension-unit control that lights the emitter | `irlume ir-setup` |

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -17,7 +17,7 @@ not on this page.
 
 | Standard / bar | What it covers | irlume today |
 |---|---|---|
-| [ISO/IEC 30107-3](#isoiec-30107-3-presentation-attack-detection) | spoof testing and reporting | methodology adopted, self-tested; one attack class published as unsolved |
+| [ISO/IEC 30107-3](#isoiec-30107-3-presentation-attack-detection) | spoof testing and reporting | methodology adopted, self-tested; the vinyl-print class is denied by the shipped PAD pair |
 | [ISO/IEC 19795-1](#isoiec-19795-1-measuring-and-reporting-accuracy) | accuracy measurement and reporting | benchmark protocols with committed raw results |
 | [ISO/IEC 24745](#isoiec-24745-template-protection) | biometric template protection | encryption and TPM key custody, live-audited |
 | [Windows Hello requirements](#the-windows-hello-bar) | consumer face-login bar (FAR, TAR) | not demonstrated at the required confidence; measured points published |
@@ -60,12 +60,13 @@ irlume adopted the methodology rather than the certificate:
   shake decline remain experimental and separate from passive PAD
   ([ADR-0010](adr/0010-conventional-face-intent-confirmation.md)).
 
-What that adds up to, stated plainly: in the default configuration the
-credential-releasing gate is single-frame IR physics. It stopped every emissive
+What that adds up to, stated plainly: the algorithmic credential-releasing
+gate is single-frame IR physics. It stopped every emissive
 screen and matte print tested; a large IR-reflective flat print of the enrolled
-user defeats it, and that is an accepted, documented residual risk
-([ADR-0001](adr/0001-liveness-pad-strategy.md), and the README's honest
-limitations). Level 2 instruments (3D masks) have never been tested and no
+user defeats the algorithmic layer alone, and the default-on shipped PAD pair
+denies it (ADR-0013), leaving the print breach open only in kill-switch
+configurations ([ADR-0001](adr/0001-liveness-pad-strategy.md), and the
+README's honest limitations). Level 2 instruments (3D masks) have never been tested and no
 resistance is claimed. Scene-level IR flooding (open sky, sun) fails closed with
 an explanatory message rather than degrading the cues silently
 (`IR_AMBIENT_FLOOD` in `crates/irlume-liveness/src/lib.rs`).
@@ -177,7 +178,8 @@ shape as per-species APCER, and irlume's spoof results read directly in those
 terms. From the published self-tests under the default configuration: SAR 0%
 (n=20 each, CI upper bound 16.8%) for phone-screen, laptop-screen, and
 matte-print instruments; SAR 98.6% for the life-size vinyl-print instrument
-that remains the documented open breach.
+against the algorithmic layer alone (the shipped PAD pair denies it; see
+[ADR-0013](adr/0013-ship-pad-models-default-on.md)).
 
 ## Standards that do not apply to irlume
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -160,9 +160,11 @@ here is a claim about those.
 [ms-ess]: https://learn.microsoft.com/windows-hardware/design/device-experiences/windows-hello-enhanced-sign-in-security
 [ms-xu]: https://learn.microsoft.com/windows-hardware/drivers/stream/device-requirements-for-usb-video-class-extension-units
 
-## Liveness: algorithmic single-frame gate (no trained weights)
+## Liveness: algorithmic gate plus shipped deny-only PAD models
 
-The default PAD gate uses no trained weights. MediaPipe FaceMesh remains a
+The algorithmic gate uses no trained weights; the default configuration's PAD
+stack additionally runs two shipped deny-only models (ViT RGB + FLIR IR,
+ADR-0013). MediaPipe FaceMesh remains a
 dense landmarker for BlazeFace rescue alignment, not a spoof classifier or a
 consent detector; it is Apache-2.0, so the clean-BOM claim holds.
 
@@ -200,21 +202,18 @@ brightness-ratio cue (banner center/edge 1.02–1.58 *overlaps and exceeds* genu
 were still fully rejected. This is a demonstrated instance of the accepted
 IR-approximating-spoof residual risk.
 
-One mitigation exists and it is not automatic. The **trained `flir` cue** has
+The mitigation is automatic. The **shipped FLIR PAD cue** (default-on since
+ADR-0013, verified against `models/SHA256SUMS` at daemon startup) has
 refused this print in every measured session, including one enhanced with an
 infrared-absorbing patch that carries the centre/edge ratio into the genuine
-range while the built-in gate still returns `Live`; since 2026-08-04
-`irlume setup` offers it as a recommended step with the license and provenance
-on screen ([ADR-0001](adr/0001-liveness-pad-strategy.md)), though the weights
-are neither shipped nor fetched without consent. The passive-blink gate that
+range while the built-in gate still returns `Live`. The passive-blink gate that
 once closed this breach in validation was retired for field non-response
 ([ADR-0002](adr/0002-challenge-response-liveness.md), superseded); the nod and
 head-shake gestures that replaced it prove intent, not liveness, and do not
 stand between a print and a grant. Measurements:
 [docs/pad-results/](pad-results/).
 
-A user who declines both, or who never runs setup, still carries this gap in
-full.
+A user who sets the kill switch (`IRLUME_PAD_IR=0`) carries this gap in full.
 Full write-up: [`pad-results/2026-06-30-ir-liveness-selftest.md`](pad-results/2026-06-30-ir-liveness-selftest.md).
 
 ## Storage
@@ -326,7 +325,7 @@ with a fabricated print.
   of a live person and must not be read as an anti-spoofing figure.
 
   No printed attempt was ever granted. Every one was refused by cross-spectrum
-  liveness and the third-party PAD cue, at `p_fake` 0.996-1.000; the gesture was
+  liveness and the FLIR PAD cue (shipped since ADR-0013), at `p_fake` 0.996-1.000; the gesture was
   never the layer standing between the print and a credential.
 
   The gate's own separation was then measured directly, with the daemon

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -77,7 +77,7 @@ cd irlume && bash scripts/fetch-models.sh
 cargo test --workspace
 ```
 
-Around 150 tests pass; the fifteen or so that need camera or TPM hardware are
+Around 1,700 tests pass; the ones that need camera or TPM hardware are
 marked `ignored`.
 
 ## 4. The liveness gate is self-tested against ISO/IEC 30107-3 · deeper (needs your own spoofs)

--- a/docs/adr/0006-third-party-model-stage-policy.md
+++ b/docs/adr/0006-third-party-model-stage-policy.md
@@ -1,6 +1,6 @@
 # ADR-0006: Which pipeline stages accept third-party models, and on what evidence
 
-**Status:** Accepted
+**Status:** Accepted; the lane this governs was removed by [ADR-0015](0015-remove-thirdparty-model-lane.md)
 **Date:** 2026-08-12
 
 ## Context

--- a/docs/adr/0007-context-bound-capture-qualification.md
+++ b/docs/adr/0007-context-bound-capture-qualification.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-17
 
-Status: Proposed
+Status: Accepted; implemented (context-bound qualification-v2 and runtime degradation shipped)
 
 ## Context
 


### PR DESCRIPTION
Full-repo docs audit after the 0.11.0 campaign. Every finding listed with its fix in the commit message; highlights:

**Wrong instructions removed:** SETUP/README/THREAT_MODEL/LIMITATIONS told users to enable third-party models via the removed setup offer and `models enable` commands, and described the print-defense weights as unshipped. All four now state the shipped reality: the ViT+FLIR PAD pair is default-on, checksummed at startup, with documented kill switches and the disclosed-training-data caveat.

**Stale facts corrected:** model count (7 not 5), CREDITS gains both PAD models, NixOS fetch count, the uninstall row gains the full teardown, PAD_SELFTEST scopes itself beside the shipped PAD layer, VERIFY's test count (~1,700 not ~150), SECURITY's warn-first rationale re-anchored (the external-weights lane it cited is gone), ROADMAP's shipped items marked done, two ADR status lines corrected.

**Scoping fix:** the STANDARDS vinyl-print SAR 98.6% figure is now scoped to the algorithmic layer alone, since the default-on PAD pair denies that print.