### PR TITLE
fix(camera): share the emitter lock with non-root tools under the sandboxed daemon (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ All notable changes to irlume are documented here. This project adheres to
   Authentication was never affected (fail-closed direction); upgrading
   from an older version and back again during one boot mixes lock paths
   for the transition window, disclosed here.
+- **An unexaminable emitter journal no longer reports a phantom pending
+  change.** With non-root tools reaching the journal read for the first
+  time (they used to stop at the lock), a permission failure reading the
+  root-owned store was reported as "an emitter control ... was left
+  changed ... and has not been put back" — asserting a record that was
+  never observed. The store-read failure now reports "could not check"
+  (same fail-closed refusal, honest wording), matching the lock-side
+  #210 contract.
 
 ## [0.11.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,14 @@ All notable changes to irlume are documented here. This project adheres to
   bounding set), and the lock moves to a dedicated setgid
   `/run/lock/irlume` directory (tmpfiles.d, `root:video` 2751) so
   daemon-created locks inherit the camera group at creation — the only
-  capability-free fix for hosts whose cameras carry no per-user ACL.
-  Authentication was never affected (fail-closed direction); upgrading
-  from an older version and back again during one boot mixes lock paths
-  for the transition window, disclosed here.
+  capability-free fix for hosts whose cameras carry no per-user ACL. When
+  the group still cannot be corrected (a camera group no tmpfiles override
+  covers), the mirror now strips every group-class grant from the lock
+  instead of granting the wrong group, so the lock never opens to callers
+  the camera itself would refuse. Authentication was never affected
+  (fail-closed direction); upgrading from an older version and back again
+  during one boot mixes lock paths for the transition window, disclosed
+  here.
 - **An unexaminable emitter journal no longer reports a phantom pending
   change.** With non-root tools reaching the journal read for the first
   time (they used to stop at the lock), a permission failure reading the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
-- Nothing yet.
+### Fixed
+
+- **Non-root camera tools can open the IR-emitter lock again (#542).** The
+  daemon's systemd unit deliberately excludes `CAP_CHOWN`, so the lock it
+  creates on a clean boot could not be re-grouped to the camera's group;
+  the #534 tolerance then returned early, skipping the ACL copy and mode
+  set as well, leaving the lock `root:root 0600` with no ACL — unopenable
+  by `camera-tune`, user-context `ir-setup`, and the hardware stress
+  runner on every host. Two halves fix it: the tolerated mirror failure
+  now continues to the ACL and mode steps (which work under the daemon's
+  bounding set), and the lock moves to a dedicated setgid
+  `/run/lock/irlume` directory (tmpfiles.d, `root:video` 2751) so
+  daemon-created locks inherit the camera group at creation — the only
+  capability-free fix for hosts whose cameras carry no per-user ACL.
+  Authentication was never affected (fail-closed direction); upgrading
+  from an older version and back again during one boot mixes lock paths
+  for the transition window, disclosed here.
 
 ## [0.11.0] - 2026-08-23
 

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -660,6 +660,30 @@ pub(crate) fn lock_camera(
     let path = lock_path(id);
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+        // create_dir_all follows symlinks, and /run/lock is writable by root
+        // only — but the lock directory is created by tmpfiles.d at boot in
+        // the packaged lanes, and a silently-failed rule plus a pre-planted
+        // symlink must not turn the root daemon into a file-creation oracle
+        // inside an attacker-chosen directory. Refuse anything that is not a
+        // real directory (symlink_metadata: the symlink itself, not its
+        // target).
+        match std::fs::symlink_metadata(dir) {
+            Ok(m) if m.is_dir() => {}
+            Ok(_) => {
+                return Err(format!(
+                    "emitter lock directory {} is not a directory; refusing to create \
+                     locks through it (packaged installs: systemd-tmpfiles --create \
+                     irlume.conf repairs it)",
+                    dir.display()
+                ))
+            }
+            Err(e) => {
+                return Err(format!(
+                    "stat emitter lock directory {}: {e}",
+                    dir.display()
+                ))
+            }
+        }
     }
     let file = std::fs::OpenOptions::new()
         .write(true)
@@ -777,54 +801,90 @@ fn mirror_device_access(
         }
     }
 
-    // Copy the extended ACL, the part that grants a per-user uaccess caller. A
-    // device with none must REMOVE an ACL left by an earlier session; leaving
-    // stale named-user entries would grant callers who lost device access.
-    let device_acl =
-        read_access_acl(fd).map_err(|e| format!("read camera device fd {fd} access ACL: {e}"))?;
-    if let Err(e) = replace_access_acl(lock_fd, device_acl.as_deref(), path) {
-        if !secure_fallback {
-            return Err(e);
+    // When the group could not be corrected, every group-class grant below
+    // would land on the WRONG group (this process's own, typically the
+    // setgid directory's `video`), handing members of that group a lock for
+    // a camera they cannot open — a lock the module's own invariant says
+    // must open to exactly the device's callers. So a degraded group strips
+    // the group bits from the applied mode and skips the ACL copy entirely
+    // (an ACL's GROUP_OBJ/MASK entries carry the device's group perms onto
+    // the same wrong group). The lock then opens to its owner alone:
+    // stricter than the device, which is the fail-closed direction and
+    // exactly the pre-#542 status quo on such hosts. Hosts whose camera
+    // group is not `video` get the full mirror by shipping the documented
+    // /etc/tmpfiles.d override for the lock directory.
+    let effective_mode = if degraded.contains(&"group") {
+        mode & !0o070
+    } else {
+        mode
+    };
+    let device_acl = if degraded.contains(&"group") {
+        // No copy — but a stale ACL from an earlier session must not survive
+        // either: its named entries may reference callers who lost device
+        // access, and its GROUP_OBJ/MASK would re-grant the wrong group the
+        // mode below just stripped.
+        if let Err(e) = replace_access_acl(lock_fd, None, path) {
+            if !secure_fallback {
+                return Err(e);
+            }
+            degraded.push("ACL");
+            irlume_common::dlog!(
+                "emitter lock {}: cannot strip a stale ACL ({}); continuing",
+                path.display(),
+                e
+            );
         }
-        degraded.push("ACL");
-        irlume_common::dlog!(
-            "emitter lock {}: cannot mirror the device ACL ({}); continuing without it",
-            path.display(),
-            e
-        );
-    }
+        None
+    } else {
+        let acl = read_access_acl(fd)
+            .map_err(|e| format!("read camera device fd {fd} access ACL: {e}"))?;
+        if let Err(e) = replace_access_acl(lock_fd, acl.as_deref(), path) {
+            if !secure_fallback {
+                return Err(e);
+            }
+            degraded.push("ACL");
+            irlume_common::dlog!(
+                "emitter lock {}: cannot mirror the device ACL ({}); continuing without it",
+                path.display(),
+                e
+            );
+        }
+        acl
+    };
 
     // Mode last. The ACL mask (if any) already fixed the group bits; without
-    // an ACL the mode must be set to the device's exactly. Preserve the
-    // world-accessible refusal: a lock any local user can flock cannot be
-    // trusted, and one this process cannot correct must refuse rather than
-    // authenticate behind it.
+    // an ACL the mode must be set to the device's exactly — unless the group
+    // is degraded, where `effective_mode` carries the stripped group bits so
+    // no grant lands on the wrong group. Preserve the world-accessible
+    // refusal: a lock any local user can flock cannot be trusted, and one
+    // this process cannot correct must refuse rather than authenticate
+    // behind it.
     let mut perms = file
         .metadata()
         .map_err(|e| format!("stat {}: {e}", path.display()))?
         .permissions();
     let current = perms.mode() & 0o777;
-    if current != mode {
-        perms.set_mode(mode);
+    if current != effective_mode {
+        perms.set_mode(effective_mode);
         if let Err(e) = file.set_permissions(perms) {
             if current & 0o007 != 0 {
                 return Err(format!(
                     "emitter lock {} has mode {current:o}, which any local user can \
                      flock, and this process cannot correct it ({e}); refusing to \
-                     trust the lock. Fix it as root: chmod {mode:o} {}",
+                     trust the lock. Fix it as root: chmod {effective_mode:o} {}",
                     path.display(),
                     path.display()
                 ));
             }
             if !secure_fallback {
                 return Err(format!(
-                    "set emitter lock {} mode from {current:o} to {mode:o}: {e}",
+                    "set emitter lock {} mode from {current:o} to {effective_mode:o}: {e}",
                     path.display()
                 ));
             }
             degraded.push("mode");
             irlume_common::dlog!(
-                "emitter lock {}: cannot set mode {mode:o} ({}); continuing on the \
+                "emitter lock {}: cannot set mode {effective_mode:o} ({}); continuing on the \
                  already-restricted mode {current:o}",
                 path.display(),
                 e
@@ -859,9 +919,9 @@ fn mirror_device_access(
             final_meta.gid()
         ));
     }
-    if !degraded.contains(&"mode") && final_mode != mode {
+    if !degraded.contains(&"mode") && final_mode != effective_mode {
         return Err(format!(
-            "emitter lock {} access changed while mirroring it (wanted mode {mode:o}, found {final_mode:o})",
+            "emitter lock {} access changed while mirroring it (wanted mode {effective_mode:o}, found {final_mode:o})",
             path.display()
         ));
     }
@@ -877,19 +937,24 @@ fn mirror_device_access(
         // Once per process, not per capture: the packaged daemon holds this
         // lock on every stream open, and the fleet journals showed the
         // silent form of this exact defect is what kept #542 hidden through
-        // a release. The message names the consequence (non-root camera
-        // tools blocked) because that is the operational signal, not the
-        // syscall.
+        // a release. The remedy is named only for the group case, where it
+        // is true; an ACL or mode degradation alone does not block tools on
+        // ACL-granted hosts.
         static DEGRADED_MIRROR: std::sync::Once = std::sync::Once::new();
         DEGRADED_MIRROR.call_once(|| {
+            let group_note = if degraded.contains(&"group") {
+                " non-root camera tools will be unable to open this lock until the \
+                 camera group is inherited at creation (packaged installs: check \
+                 the irlume tmpfiles.d rule for /run/lock/irlume);"
+            } else {
+                ""
+            };
             eprintln!(
-                "irlume: emitter lock {} could not mirror: {}; non-root camera tools \
-                 (camera-tune, ir-setup from a user context, the hardware stress \
-                 runner) will be unable to open this lock until the camera group is \
-                 restored (packaged installs: check the irlume tmpfiles.d rule for \
-                 /run/lock/irlume); authentication itself is unaffected",
+                "irlume: emitter lock {} could not mirror: {};{} authentication \
+                 itself is unaffected",
                 path.display(),
-                degraded.join(", ")
+                degraded.join(", "),
+                group_note
             );
         });
     }
@@ -985,14 +1050,16 @@ pub(crate) enum Situation {
     SameModelElsewhere(Box<PendingWrite>),
 }
 
-/// Prefix `load` puts on errors that mean "the store could not be examined"
-/// (an unreadable directory or record), as opposed to a record that exists
-/// and is damaged. The recovery path maps these to `Unchecked` ("could not
-/// check whether a change is pending") rather than `Unresolved` ("a change
-/// is recorded"): an unreadable store must refuse writes without claiming a
-/// pending change that may not exist. Same contract as the lock-side
-/// #210 fix; the read side resurfaced once #542 let unprivileged tools get
-/// past the lock to the store at all (#542 fleet validation, minihost).
+/// Prefix `load` and `all_records` put on errors that mean "the store could
+/// not be examined" (an unreadable directory or record), as opposed to a
+/// record that exists and is damaged. The recovery path maps these to
+/// `Unchecked` ("could not check whether a change is pending") rather than
+/// `Unresolved` ("a change is recorded"): an unreadable store must refuse
+/// writes without claiming a pending change that may not exist. Same
+/// contract as the lock-side #210 fix; the read side resurfaced once #542
+/// let unprivileged tools get past the lock to the store at all (#542 fleet
+/// validation, minihost). Any NEW error path added to either function must
+/// decide explicitly which class it belongs to — this prefix is the contract.
 pub(crate) const STORE_UNEXAMINABLE: &str = "cannot examine the store: ";
 
 /// Classify the store against this camera.

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -606,16 +606,28 @@ fn synchronization_key(id: &CameraIdentity) -> String {
 
 /// Where a camera's lock file lives.
 ///
-/// `/run/lock`, not beside the records, for the same reason `pamwire` puts its
-/// lock there: a lock's lifetime is a boot, not the machine's. Under the store it
-/// would create `/var/lib/irlume/ir-emitter-journal/` on every machine that ever
-/// opens a camera, including the overwhelming majority that never run `ir-setup`
-/// and have nothing to record, and leave a lock file behind for each camera
+/// `/run/lock/irlume`, not beside the records, for the same reason `pamwire`
+/// puts its lock under `/run/lock`: a lock's lifetime is a boot, not the
+/// machine's. Under the store it would create
+/// `/var/lib/irlume/ir-emitter-journal/` on every machine that ever opens a
+/// camera, including the overwhelming majority that never run `ir-setup` and
+/// have nothing to record, and leave a lock file behind for each camera
 /// forever. `IRLUME_EMITTER_LOCK_DIR` moves it for tests and containers.
+///
+/// The dedicated SUBDIRECTORY is the capability-free half of the #542 fix.
+/// The daemon's unit deliberately excludes `CAP_CHOWN`, so a lock the root
+/// daemon creates under its own umask cannot be re-grouped to the camera's
+/// group in-process. The directory ships as a tmpfiles.d rule (`root:video`,
+/// setgid, mode 2751) so every lock INHERITS the camera group at creation,
+/// which is the only way group-permission hosts (camera node with no uaccess
+/// ACL, tools granted through `video` membership) can share the lock with
+/// non-root camera tools. `mirror_device_access` still applies mode and ACL
+/// at runtime, and tolerates a group it cannot correct on a lock already
+/// restricted to this process.
 fn lock_path(id: &CameraIdentity) -> PathBuf {
     std::env::var_os("IRLUME_EMITTER_LOCK_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/run/lock"))
+        .unwrap_or_else(|| PathBuf::from("/run/lock/irlume"))
         .join(format!("irlume-emitter-{}.lock", synchronization_key(id)))
 }
 
@@ -718,7 +730,7 @@ fn mirror_device_access(
     // lock is not already locked down to this process: the packaged daemon
     // runs under CapabilityBoundingSet without CAP_CHOWN (the unit documents
     // "nothing chowns"), so on a clean install it CREATES the lock root:root
-    // 0600 and cannot widen it to the device's group/ACL — a root-only lock
+    // 0600 and cannot widen it to the device's group — a root-only lock
     // excludes strictly MORE callers than the mirror target, which is safe
     // for authentication (the mirror exists so user-context dev tools can
     // share the lock, #487; a privileged tool re-runs ir-setup, which
@@ -726,12 +738,23 @@ fn mirror_device_access(
     // still refuses, unchanged. This restores the contract the ignored
     // harness test documents: "it must not make a root-owned lock this
     // process can open (but not chmod) refuse".
+    //
+    // A tolerated failure now CONTINUES to the ACL and mode steps below
+    // instead of returning early (#542): the early return left the lock at
+    // 0600 root:root with no ACL, which no non-root camera tool can open on
+    // any host class. The ACL copy and the mode set both work under the
+    // daemon's bounding set (CAP_FOWNER is present), so a group the process
+    // cannot correct costs only the group bit — the device's uaccess callers
+    // still reach the lock through the copied ACL. Group-only hosts (no ACL
+    // on the camera node) need the group and are covered by the setgid lock
+    // directory from tmpfiles.d, which makes this fchown a no-op skip.
     let lock_meta = file
         .metadata()
         .map_err(|e| format!("stat emitter lock {}: {e}", path.display()))?;
     // SAFETY: geteuid reads this process's own credentials and cannot fail.
     let secure_fallback =
         lock_meta.uid() == unsafe { libc::geteuid() } && lock_meta.mode() & 0o007 == 0;
+    let mut degraded: Vec<&'static str> = Vec::new();
     if lock_meta.gid() != st.st_gid {
         // SAFETY: fchown sets only the group on an owned fd.
         if unsafe { libc::fchown(lock_fd, u32::MAX, st.st_gid) } != 0 {
@@ -744,13 +767,13 @@ fn mirror_device_access(
                     e
                 ));
             }
+            degraded.push("group");
             irlume_common::dlog!(
-                "emitter lock {}: cannot set group {} ({}); proceeding on the                  already-restricted root-owned lock (no world access)",
+                "emitter lock {}: cannot set group {} ({}); continuing without the group bit",
                 path.display(),
                 st.st_gid,
                 e
             );
-            return Ok(());
         }
     }
 
@@ -763,12 +786,12 @@ fn mirror_device_access(
         if !secure_fallback {
             return Err(e);
         }
+        degraded.push("ACL");
         irlume_common::dlog!(
-            "emitter lock {}: cannot mirror the device ACL ({}); proceeding on              the already-restricted root-owned lock",
+            "emitter lock {}: cannot mirror the device ACL ({}); continuing without it",
             path.display(),
             e
         );
-        return Ok(());
     }
 
     // Mode last. The ACL mask (if any) already fixed the group bits; without
@@ -793,10 +816,19 @@ fn mirror_device_access(
                     path.display()
                 ));
             }
-            return Err(format!(
-                "set emitter lock {} mode from {current:o} to {mode:o}: {e}",
-                path.display()
-            ));
+            if !secure_fallback {
+                return Err(format!(
+                    "set emitter lock {} mode from {current:o} to {mode:o}: {e}",
+                    path.display()
+                ));
+            }
+            degraded.push("mode");
+            irlume_common::dlog!(
+                "emitter lock {}: cannot set mode {mode:o} ({}); continuing on the \
+                 already-restricted mode {current:o}",
+                path.display(),
+                e
+            );
         }
     }
 
@@ -804,22 +836,62 @@ fn mirror_device_access(
         .metadata()
         .map_err(|e| format!("re-stat emitter lock {}: {e}", path.display()))?;
     let final_mode = final_meta.permissions().mode() & 0o777;
-    if final_meta.gid() != st.st_gid || final_mode != mode {
+    // The unconditional floor of every tolerated failure above: whatever else
+    // could not be mirrored, a lock this process cannot restrict to
+    // non-world access is a lock any local user can flock, and it refuses.
+    if final_mode & 0o007 != 0 {
         return Err(format!(
-            "emitter lock {} access changed while mirroring it (wanted group {} mode \
-             {mode:o}, found group {} mode {final_mode:o})",
+            "emitter lock {} ended at mode {final_mode:o}, which any local user can \
+             flock; refusing to trust the lock. Fix it as root: chmod {mode:o} {}",
+            path.display(),
+            path.display()
+        ));
+    }
+    // Assert only what was supposed to be achieved, so a RACE (someone
+    // changing the lock underneath the mirror) is still caught on every
+    // dimension this process could set, while a tolerated step does not fail
+    // the lock for the state it never reached.
+    if !degraded.contains(&"group") && final_meta.gid() != st.st_gid {
+        return Err(format!(
+            "emitter lock {} access changed while mirroring it (wanted group {}, found {})",
             path.display(),
             st.st_gid,
             final_meta.gid()
         ));
     }
+    if !degraded.contains(&"mode") && final_mode != mode {
+        return Err(format!(
+            "emitter lock {} access changed while mirroring it (wanted mode {mode:o}, found {final_mode:o})",
+            path.display()
+        ));
+    }
     let final_acl = read_access_acl(lock_fd)
         .map_err(|e| format!("verify emitter lock {} access ACL: {e}", path.display()))?;
-    if final_acl != device_acl {
+    if !degraded.contains(&"ACL") && final_acl != device_acl {
         return Err(format!(
             "emitter lock {} access ACL changed while mirroring it",
             path.display()
         ));
+    }
+    if !degraded.is_empty() {
+        // Once per process, not per capture: the packaged daemon holds this
+        // lock on every stream open, and the fleet journals showed the
+        // silent form of this exact defect is what kept #542 hidden through
+        // a release. The message names the consequence (non-root camera
+        // tools blocked) because that is the operational signal, not the
+        // syscall.
+        static DEGRADED_MIRROR: std::sync::Once = std::sync::Once::new();
+        DEGRADED_MIRROR.call_once(|| {
+            eprintln!(
+                "irlume: emitter lock {} could not mirror: {}; non-root camera tools \
+                 (camera-tune, ir-setup from a user context, the hardware stress \
+                 runner) will be unable to open this lock until the camera group is \
+                 restored (packaged installs: check the irlume tmpfiles.d rule for \
+                 /run/lock/irlume); authentication itself is unaffected",
+                path.display(),
+                degraded.join(", ")
+            );
+        });
     }
     Ok(())
 }
@@ -1253,6 +1325,23 @@ mod tests {
         assert!(
             err.contains("any local user can") && err.contains("chmod 660"),
             "the refusal must say why and how to fix it: {err}"
+        );
+    }
+
+    /// The lock lives in the dedicated setgid directory (#542): the default
+    /// path must be `/run/lock/irlume/`, the directory the tmpfiles.d rule
+    /// creates `root:video` 2751 so daemon-created locks inherit the camera
+    /// group at creation (the daemon's bounding set has no CAP_CHOWN and
+    /// cannot re-group them in-process).
+    #[test]
+    fn lock_path_defaults_to_the_setgid_lock_directory() {
+        let _env = env_lock();
+        let _guard = EnvGuard::unset("IRLUME_EMITTER_LOCK_DIR");
+        let path = lock_path_for_test(&identity());
+        assert_eq!(
+            path.parent(),
+            Some(std::path::Path::new("/run/lock/irlume")),
+            "the default lock directory is the tmpfiles.d-managed setgid dir"
         );
     }
 

--- a/crates/irlume-camera/src/emitter_journal.rs
+++ b/crates/irlume-camera/src/emitter_journal.rs
@@ -985,6 +985,16 @@ pub(crate) enum Situation {
     SameModelElsewhere(Box<PendingWrite>),
 }
 
+/// Prefix `load` puts on errors that mean "the store could not be examined"
+/// (an unreadable directory or record), as opposed to a record that exists
+/// and is damaged. The recovery path maps these to `Unchecked` ("could not
+/// check whether a change is pending") rather than `Unresolved` ("a change
+/// is recorded"): an unreadable store must refuse writes without claiming a
+/// pending change that may not exist. Same contract as the lock-side
+/// #210 fix; the read side resurfaced once #542 let unprivileged tools get
+/// past the lock to the store at all (#542 fleet validation, minihost).
+pub(crate) const STORE_UNEXAMINABLE: &str = "cannot examine the store: ";
+
 /// Classify the store against this camera.
 ///
 /// The exact record is tried first, by name, so the ordinary case costs one
@@ -1040,7 +1050,7 @@ pub(crate) fn load(id: &CameraIdentity) -> Result<Situation, String> {
             });
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(format!("read {}: {e}", path.display())),
+        Err(e) => return Err(format!("{STORE_UNEXAMINABLE}read {}: {e}", path.display())),
     }
 
     // EVERY same-model record is examined, not the first one `read_dir` happens
@@ -1081,18 +1091,18 @@ fn all_records() -> Result<Vec<(PathBuf, PendingWrite)>, String> {
     let entries = match std::fs::read_dir(&dir) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(format!("list {}: {e}", dir.display())),
+        Err(e) => return Err(format!("{STORE_UNEXAMINABLE}list {}: {e}", dir.display())),
     };
     let mut records = Vec::new();
     for entry in entries {
         let path = entry
-            .map_err(|e| format!("list {}: {e}", dir.display()))?
+            .map_err(|e| format!("{STORE_UNEXAMINABLE}list {}: {e}", dir.display()))?
             .path();
         if path.extension().is_none_or(|e| e != "json") {
             continue;
         }
-        let body =
-            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let body = std::fs::read_to_string(&path)
+            .map_err(|e| format!("{STORE_UNEXAMINABLE}read {}: {e}", path.display()))?;
         let record =
             serde_json::from_str(&body).map_err(|e| format!("parse {}: {e}", path.display()))?;
         records.push((path, record));

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -3662,8 +3662,19 @@ fn recover_pending_write_locked(
             }
         }
         // A store that cannot be read may be hiding a change to THIS camera, so
-        // it is unresolved rather than "nothing pending".
-        Err(why) => return RecoveryOutcome::Unresolved(why),
+        // it is unresolved rather than "nothing pending" — UNLESS the store
+        // simply could not be examined (permission, IO), which must refuse
+        // with the honest "could not check" wording instead of asserting a
+        // recorded change that may not exist. Same refusal either way
+        // (#210 contract; the unprivileged read side of it surfaced during
+        // the #542 fleet validation).
+        Err(why) => {
+            return if why.starts_with(journal::STORE_UNEXAMINABLE) {
+                RecoveryOutcome::Unchecked(why)
+            } else {
+                RecoveryOutcome::Unresolved(why)
+            }
+        }
     };
     if let Err(mismatch) = journal::record_applies(&record, id) {
         use journal::Mismatch;
@@ -6117,9 +6128,9 @@ mod tests {
             !msg.contains("recorded original"),
             "the message must not claim a record exists: {msg}"
         );
-        // And no unsupported assurance in the other direction: nothing here
-        // knows whether any other process checked or recovered anything, and
-        // the daemon itself can land here (EROFS, ENOSPC, a bad lock path).
+        // The daemon knows nothing was checked, so it must not claim the
+        // process itself will sort it out; that wording predates the shared
+        // lock and reads as "ignore this" today.
         assert!(!msg.contains("checks and recovers on its own"), "{msg}");
         assert!(!msg.contains("expected and harmless"), "{msg}");
         assert!(
@@ -6128,6 +6139,64 @@ mod tests {
         );
         assert!(outcome.blocks_discovery());
         std::fs::remove_file(&dir).expect("remove blocking file");
+    }
+
+    /// The read-side twin of the test above: a store that cannot be examined
+    /// (an unprivileged tool hitting the 0700 root journal directory, made
+    /// reachable once #542 let such tools past the lock) must report
+    /// "could not check", never fabricate a recorded change. The blocking
+    /// fixture is a regular FILE where the journal directory belongs: ENOTDIR
+    /// stops root and CAP_DAC_OVERRIDE exactly like an unprivileged uid, so
+    /// this test has no privileged skip arm.
+    #[test]
+    fn an_unexaminable_store_reports_unchecked_never_a_phantom_record() {
+        let _lock = crate::testenv::env_lock();
+        let state =
+            std::env::temp_dir().join(format!("irlume-unreadable-store-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&state);
+        std::fs::create_dir_all(&state).expect("scratch state dir");
+        std::fs::write(state.join("ir-emitter-journal"), b"not a directory")
+            .expect("blocking file where the journal dir belongs");
+        let _statedir = EnvGuard::set("IRLUME_STATE_DIR", &state);
+        let lockdir = std::env::temp_dir().join(format!(
+            "irlume-unreadable-store-locks-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&lockdir);
+        std::fs::create_dir_all(&lockdir).expect("scratch lock dir");
+        let _lockdir = EnvGuard::set("IRLUME_EMITTER_LOCK_DIR", &lockdir);
+        let id = identity(0x3277, 0x0059);
+        use std::os::unix::fs::PermissionsExt as _;
+        use std::os::unix::io::AsRawFd as _;
+        let device = std::env::temp_dir().join(format!(
+            "irlume-unreadable-store-device-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&device);
+        let device_file = std::fs::File::create(&device).expect("device stand-in");
+        device_file
+            .set_permissions(std::fs::Permissions::from_mode(0o660))
+            .expect("device mode");
+        let fd = device_file.as_raw_fd();
+        let outcome = recover_pending_write(fd, &id);
+        assert!(
+            matches!(outcome, RecoveryOutcome::Unchecked(_)),
+            "an unreadable store is a failure to OBSERVE, got {outcome:?}"
+        );
+        let msg = outcome.message().expect("unchecked is loud");
+        assert!(msg.contains("could not check"), "{msg}");
+        assert!(msg.contains("cannot examine the store"), "{msg}");
+        assert!(
+            !msg.contains("was left changed"),
+            "the message must not claim a record was observed: {msg}"
+        );
+        assert!(
+            !outcome.permits_capture_write(),
+            "refusing is the safe half"
+        );
+        assert!(outcome.blocks_discovery());
+        let _ = std::fs::remove_dir_all(&state);
+        let _ = std::fs::remove_dir_all(&lockdir);
     }
 
     /// A camera that says "yes" to the final write but holds something else

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -204,7 +204,10 @@ in
     # Setgid root:video directory for the IR-emitter exclusion locks (#542).
     # The service below mirrors the packaged unit's bounding set (no
     # CAP_CHOWN), so a lock the daemon creates cannot be re-grouped
-    # in-process; the group must be inherited at creation.
+    # in-process; the group must be inherited at creation. Keep this rule in
+    # step with packaging/tmpfiles.d/irlume.conf — the conf shipped inside
+    # the package is documentation here; THIS line is the operative one on
+    # NixOS (nothing scans $out/lib/tmpfiles.d).
     systemd.tmpfiles.rules = [
       "d /run/lock/irlume 2751 root video -"
     ];

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -201,6 +201,14 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
+    # Setgid root:video directory for the IR-emitter exclusion locks (#542).
+    # The service below mirrors the packaged unit's bounding set (no
+    # CAP_CHOWN), so a lock the daemon creates cannot be re-grouped
+    # in-process; the group must be inherited at creation.
+    systemd.tmpfiles.rules = [
+      "d /run/lock/irlume 2751 root video -"
+    ];
+
     # systemd owns the socket, so it exists from sockets.target onward rather
     # than only once irlumed has finished loading models. Greeters authenticate
     # well before that, and a PAM client with nothing to connect to loses the

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -169,6 +169,11 @@ rustPlatform.buildRustPackage {
     # speaks.
     install -Dm0644 schemas/machine-api-v1.schema.json \
       "$out/share/irlume/schemas/machine-api-v1.schema.json"
+
+    # tmpfiles.d rule for the setgid root:video emitter-lock directory (#542);
+    # the NixOS module applies it via systemd.tmpfiles.rules.
+    install -Dm0644 packaging/tmpfiles.d/irlume.conf \
+      "$out/lib/tmpfiles.d/irlume.conf"
   '';
 
   meta = {

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -96,14 +96,19 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   /run/irlume.sock rw,
 
   # The emitter undo-journal's per-camera lock (flock over the whole
-  # check/act window; emitter_journal.rs). Lives under /run/lock because a
-  # lock's lifetime is a boot. 'k' is the flock permission; without this
-  # rule the daemon refuses to drive the IR emitter and logs the #283
+  # check/act window; emitter_journal.rs). Lives under /run/lock/irlume, the
+  # setgid root:video directory from the tmpfiles.d rule (#542), because a
+  # lock's lifetime is a boot and its group must be inherited at creation
+  # (the bounding set has no CAP_CHOWN). 'k' is the flock permission; without
+  # this rule the daemon refuses to drive the IR emitter and logs the #283
   # warning on every start. The profile's 2026-07-09 soak predates the
-  # journal (0.8.x), which is how the gap shipped. No rule on the /run/lock
+  # journal (0.8.x), which is how the gap shipped. No rule on the lock
   # directory itself: creation is authorized on the new file's pathname, the
   # recorded denials named only the file path, and enumerate/modify authority
   # over every service's lock is nothing this daemon needs.
+  /run/lock/irlume/irlume-emitter-*.lock rwk,
+  # Pre-0.11.1 flat-path locks (kept one release so a still-running old
+  # binary stays confined during an upgrade's restart window).
   /run/lock/irlume-emitter-*.lock rwk,
 
   # The per-stream emitter bookkeeping lock is a flock too, and it lives

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -86,9 +86,11 @@ profile irlumed /usr/local/bin/irlumed {
   /run/irlume.sock rw,
 
   # TPM (template-key sealing, keyring unlock).
-  # Emitter locks: the undo-journal per-camera flock under /run/lock, and
-  # the per-stream bookkeeping flock, whose 'k' the state-dir ** rule does
-  # not grant (#283).
+  # Emitter locks: the undo-journal per-camera flock under the setgid
+  # /run/lock/irlume directory (#542), and the per-stream bookkeeping flock,
+  # whose 'k' the state-dir ** rule does not grant (#283). The flat-path rule
+  # is kept one release for a still-running old binary at upgrade time.
+  /run/lock/irlume/irlume-emitter-*.lock rwk,
   /run/lock/irlume-emitter-*.lock rwk,
   /var/lib/irlume/ir-emitter-stream/*.lock rwk,
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -106,6 +106,11 @@ package() {
     install -Dm0644 packaging/systemd/irlume-reconcile.path "$pkgdir/usr/lib/systemd/system/irlume-reconcile.path"
     install -Dm0644 packaging/systemd/irlume-reconcile.service "$pkgdir/usr/lib/systemd/system/irlume-reconcile.service"
     install -Dm0644 packaging/systemd/irlume-reconcile.timer "$pkgdir/usr/lib/systemd/system/irlume-reconcile.timer"
+    # tmpfiles.d: the setgid root:video lock directory for the IR-emitter
+    # exclusion locks (#542). The daemon's bounding set has no CAP_CHOWN, so
+    # the group must be inherited at creation, not corrected in-process.
+    # irlume.install applies it before any daemon start.
+    install -Dm0644 packaging/tmpfiles.d/irlume.conf "$pkgdir/usr/lib/tmpfiles.d/irlume.conf"
     # AppArmor profile for the daemon. Arch does not run AppArmor by default, so
     # it sits inert unless the user boots with `lsm=...,apparmor`; irlume.install
     # loads it only when apparmor_parser is present. The profile confines the

--- a/packaging/arch/irlume.install
+++ b/packaging/arch/irlume.install
@@ -1,5 +1,9 @@
 post_install() {
     systemctl daemon-reload
+    # Create the setgid lock directory (#542) BEFORE the daemon starts: the
+    # first lock the daemon creates sets the group it will keep, and a fresh
+    # install has had no boot to apply the tmpfiles.d rule yet.
+    systemd-tmpfiles --create irlume.conf &>/dev/null || true
     # Load the AppArmor profile before the daemon starts, but only if this box
     # actually runs AppArmor (Arch does not by default). apparmor_parser is
     # absent unless the user opted in, so this is a no-op on a stock install.
@@ -31,6 +35,9 @@ EOF
 
 post_upgrade() {
     systemctl daemon-reload
+    # Apply the tmpfiles.d rule on upgrade too (#542): the dir may not exist
+    # yet, and the restarted daemon below must find it group-video setgid.
+    systemd-tmpfiles --create irlume.conf &>/dev/null || true
     if command -v apparmor_parser >/dev/null 2>&1; then
         apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
     fi

--- a/packaging/arch/irlume.install
+++ b/packaging/arch/irlume.install
@@ -3,7 +3,7 @@ post_install() {
     # Create the setgid lock directory (#542) BEFORE the daemon starts: the
     # first lock the daemon creates sets the group it will keep, and a fresh
     # install has had no boot to apply the tmpfiles.d rule yet.
-    systemd-tmpfiles --create irlume.conf &>/dev/null || true
+    systemd-tmpfiles --create irlume.conf || true
     # Load the AppArmor profile before the daemon starts, but only if this box
     # actually runs AppArmor (Arch does not by default). apparmor_parser is
     # absent unless the user opted in, so this is a no-op on a stock install.
@@ -37,7 +37,7 @@ post_upgrade() {
     systemctl daemon-reload
     # Apply the tmpfiles.d rule on upgrade too (#542): the dir may not exist
     # yet, and the restarted daemon below must find it group-video setgid.
-    systemd-tmpfiles --create irlume.conf &>/dev/null || true
+    systemd-tmpfiles --create irlume.conf || true
     if command -v apparmor_parser >/dev/null 2>&1; then
         apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
     fi

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -98,6 +98,11 @@ contents:
     dst: /usr/lib/systemd/system/irlume-reconcile.service
   - src: ../systemd/irlume-reconcile.timer
     dst: /usr/lib/systemd/system/irlume-reconcile.timer
+  # tmpfiles.d: setgid root:video lock directory for the IR-emitter exclusion
+  # locks (#542); the daemon's bounding set has no CAP_CHOWN, so the group
+  # must be inherited at creation.
+  - src: ../tmpfiles.d/irlume.conf
+    dst: /usr/lib/tmpfiles.d/irlume.conf
   # AppArmor profile (enforces by default; see the profile header)
   - src: ../apparmor/usr.bin.irlumed
     dst: /etc/apparmor.d/usr.bin.irlumed

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -17,6 +17,10 @@ if command -v apparmor_parser >/dev/null 2>&1; then
     fi
 fi
 systemctl daemon-reload 2>/dev/null || true
+# Create the setgid lock directory (#542) BEFORE any daemon start below: the
+# first lock the daemon creates sets the group it will keep, and a fresh
+# install has had no boot to apply the tmpfiles.d rule yet.
+systemd-tmpfiles --create irlume.conf 2>/dev/null || true
 # Enable + start ONLY on first install ($2 empty). On an upgrade, re-enabling
 # would override a unit the user deliberately disabled; try-restart below picks
 # up the new binary/unit for a running daemon and is a no-op for a stopped one.

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -20,7 +20,7 @@ systemctl daemon-reload 2>/dev/null || true
 # Create the setgid lock directory (#542) BEFORE any daemon start below: the
 # first lock the daemon creates sets the group it will keep, and a fresh
 # install has had no boot to apply the tmpfiles.d rule yet.
-systemd-tmpfiles --create irlume.conf 2>/dev/null || true
+systemd-tmpfiles --create irlume.conf || true
 # Enable + start ONLY on first install ($2 empty). On an upgrade, re-enabling
 # would override a unit the user deliberately disabled; try-restart below picks
 # up the new binary/unit for a running daemon and is a no-op for a stopped one.

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -166,7 +166,7 @@ install -Dm0644 schemas/machine-api-v1.schema.json %{buildroot}%{_datadir}/%{nam
 # Create the setgid lock directory (#542) BEFORE the daemon starts below: on
 # a fresh install there has been no boot to apply the tmpfiles.d rule yet,
 # and the first lock the daemon creates sets the group it will keep.
-systemd-tmpfiles --create irlume.conf &>/dev/null || :
+systemd-tmpfiles --create irlume.conf || :
 # %%systemd_post honours our shipped preset → enables irlumed + the PAM-wiring
 # self-heal path unit on first install.
 %systemd_post irlumed.socket irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -149,6 +149,10 @@ install -m0644 libtensorflowlite_c-%{tflite_ver}-linux-x64/PROVENANCE %{buildroo
 # (MPL-2.0), XNNPACK, ruy and others. Name them beside the library.
 install -m0644 packaging/licenses/THIRD-PARTY-NOTICES.tflite %{buildroot}%{_datadir}/%{name}/tflite/THIRD-PARTY-NOTICES
 install -Dm0644 packaging/fedora/10-ort.conf %{buildroot}%{_unitdir}/irlumed.service.d/10-ort.conf
+# tmpfiles.d: the setgid root:video lock directory for the IR-emitter
+# exclusion locks (#542). The daemon's bounding set has no CAP_CHOWN, so the
+# group must be inherited at creation, not corrected in-process.
+install -Dm0644 packaging/tmpfiles.d/irlume.conf %{buildroot}%{_tmpfilesdir}/irlume.conf
 install -Dm0644 packaging/selinux/irlume.pp %{buildroot}%{_datadir}/selinux/packages/irlume.pp
 # Preset: the daemon is enabled on install (see %%post); it only serves a local
 # socket and auth stays opt-in, so "installed" should mean "works".
@@ -159,6 +163,10 @@ install -Dm0644 packaging/fedora/90-irlume.preset %{buildroot}%{_presetdir}/90-i
 install -Dm0644 schemas/machine-api-v1.schema.json %{buildroot}%{_datadir}/%{name}/schemas/machine-api-v1.schema.json
 
 %post
+# Create the setgid lock directory (#542) BEFORE the daemon starts below: on
+# a fresh install there has been no boot to apply the tmpfiles.d rule yet,
+# and the first lock the daemon creates sets the group it will keep.
+systemd-tmpfiles --create irlume.conf &>/dev/null || :
 # %%systemd_post honours our shipped preset → enables irlumed + the PAM-wiring
 # self-heal path unit on first install.
 %systemd_post irlumed.socket irlumed.service irlume-reconcile.path irlume-reconcile.timer irlume-reconcile.service
@@ -250,6 +258,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_unitdir}/irlume-reconcile.service
 %{_unitdir}/irlume-reconcile.timer
 %{_presetdir}/90-irlume.preset
+%{_tmpfilesdir}/irlume.conf
 
 %files selinux
 %{_datadir}/selinux/packages/irlume.pp

--- a/packaging/ppa/debian/postinst
+++ b/packaging/ppa/debian/postinst
@@ -7,7 +7,7 @@ case "$1" in
         # restarts the unit below: the first lock the daemon creates sets the
         # group it will keep, and a fresh install has had no boot to apply the
         # tmpfiles.d rule yet.
-        systemd-tmpfiles --create irlume.conf 2>/dev/null || true
+        systemd-tmpfiles --create irlume.conf || true
         # Load the AppArmor profile (enforces, soak-validated - see the profile
         # header). Runs before the debhelper-inserted section starts or restarts
         # the unit, so the daemon is confined at exec time on both fresh install

--- a/packaging/ppa/debian/postinst
+++ b/packaging/ppa/debian/postinst
@@ -3,6 +3,11 @@ set -e
 
 case "$1" in
     configure)
+        # Create the setgid lock directory (#542) BEFORE debhelper starts or
+        # restarts the unit below: the first lock the daemon creates sets the
+        # group it will keep, and a fresh install has had no boot to apply the
+        # tmpfiles.d rule yet.
+        systemd-tmpfiles --create irlume.conf 2>/dev/null || true
         # Load the AppArmor profile (enforces, soak-validated - see the profile
         # header). Runs before the debhelper-inserted section starts or restarts
         # the unit, so the daemon is confined at exec time on both fresh install

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -90,6 +90,11 @@ override_dh_auto_install:
 # failure it was built for.
 	install -D -m0644 packaging/systemd/irlume-reconcile.timer \
 		debian/irlume/usr/lib/systemd/system/irlume-reconcile.timer
+# tmpfiles.d: the setgid root:video lock directory for the IR-emitter
+# exclusion locks (#542). The daemon's bounding set has no CAP_CHOWN, so the
+# group must be inherited at creation; postinst creates it before any start.
+	install -D -m0644 packaging/tmpfiles.d/irlume.conf \
+		debian/irlume/usr/lib/tmpfiles.d/irlume.conf
 	install -D -m0644 packaging/apparmor/usr.bin.irlumed \
 		debian/irlume/etc/apparmor.d/usr.bin.irlumed
 

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -122,7 +122,12 @@ SystemCallArchitectures=native
 # chowns. The old comment here claimed the daemon "chowns enrolled files to the
 # target user", which was never implemented; enrollment files are created by the
 # root daemon and left root-owned at mode 0600. The capability's one real user
-# was the socket's `root:irlume` chown, and that is gone.
+# was the socket's `root:irlume` chown, and that is gone. The emitter lock's
+# group mirror DOES attempt an fchown and deliberately tolerates its EPERM
+# here (#542): the lock directory created by the irlume tmpfiles.d rule
+# (setgid root:video /run/lock/irlume) gives locks the camera group at
+# creation, so no chown capability is needed. Do not "fix" the tolerated
+# fchown failure by adding CAP_CHOWN or removing the fchown call.
 #
 # Do not delete this directive to "simplify" it. For a uid-0 service systemd
 # clears everything not listed before exec, and the root exec rule then makes

--- a/packaging/tmpfiles.d/irlume.conf
+++ b/packaging/tmpfiles.d/irlume.conf
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+
+# Dedicated setgid directory for irlume's IR-emitter exclusion locks (#542).
+#
+# The daemon's systemd unit deliberately excludes CAP_CHOWN (see the
+# CapabilityBoundingSet note in irlumed.service), so a lock the root daemon
+# creates cannot be re-grouped to the camera's group in-process. A setgid
+# root:video directory makes every lock inherit that group at creation, which
+# is the only capability-free way group-permission hosts (camera node with no
+# uaccess ACL, camera tools granted through `video` membership) can share the
+# lock with non-root camera tools.
+#
+# Mode 2751: setgid (group inheritance) + group read/traverse + other
+# traverse only. ACL-granted callers must be able to traverse to open the lock
+# file itself; nobody but root can create or delete locks, exactly like the
+# previous flat /run/lock behaviour where creation was root-only in practice.
+#
+# Hosts whose camera group is not `video` (nonstandard udev rules) should
+# drop a matching override in /etc/tmpfiles.d.
+d /run/lock/irlume 2751 root video -

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -350,6 +350,7 @@ APPARMOR_RUNTIME_RULES=(
   "/var/lib/systemd/pcrlock.json r,"
   "deny capability sys_ptrace,"
   "/dev/ r,"
+  "/run/lock/irlume/irlume-emitter-*.lock rwk,"
   "/run/lock/irlume-emitter-*.lock rwk,"
   "/var/lib/irlume/ir-emitter-stream/*.lock rwk,"
 )
@@ -362,6 +363,47 @@ for profile in "${APPARMOR_PROFILES[@]}"; do
       fail=1
     fi
   done
+done
+
+echo
+echo "== tmpfiles.d setgid lock dir shipped and applied in every lane (#542) =="
+# The setgid lock directory must exist BEFORE the daemon creates its first
+# lock. Every lane needs BOTH halves: the file shipped to
+# /usr/lib/tmpfiles.d, and a scriptlet that applies it ahead of any daemon
+# start (a fresh install has had no boot to apply it). The NixOS module has
+# no package scriptlets; its equivalent is the tmpfiles rule inline.
+TMPFILES_SHIP_MARKERS=(
+  "packaging/fedora/irlume.spec|%{_tmpfilesdir}/irlume.conf"
+  "packaging/arch/PKGBUILD|usr/lib/tmpfiles.d/irlume.conf"
+  "packaging/debian/nfpm.yaml|/usr/lib/tmpfiles.d/irlume.conf"
+  "packaging/ppa/debian/rules|usr/lib/tmpfiles.d/irlume.conf"
+)
+for marker in "${TMPFILES_SHIP_MARKERS[@]}"; do
+  lane="${marker%%|*}"
+  needle="${marker#*|}"
+  if uncommented "$lane" | grep -F -- "$needle" >/dev/null; then
+    printf '  ok    %-34s %s\n' "tmpfiles.d/irlume.conf" "$lane"
+  else
+    printf '  MISS  %-34s %s\n' "tmpfiles.d/irlume.conf" "$lane"
+    fail=1
+  fi
+done
+TMPFILES_APPLY_MARKERS=(
+  "packaging/fedora/irlume.spec|systemd-tmpfiles --create irlume.conf"
+  "packaging/arch/irlume.install|systemd-tmpfiles --create irlume.conf"
+  "packaging/debian/postinstall.sh|systemd-tmpfiles --create irlume.conf"
+  "packaging/ppa/debian/postinst|systemd-tmpfiles --create irlume.conf"
+  "nix/module.nix|d /run/lock/irlume 2751 root video -"
+)
+for marker in "${TMPFILES_APPLY_MARKERS[@]}"; do
+  lane="${marker%%|*}"
+  needle="${marker#*|}"
+  if uncommented "$lane" | grep -F -- "$needle" >/dev/null; then
+    printf '  ok    %-34s %s\n' "apply before daemon start" "$lane"
+  else
+    printf '  MISS  %-34s %s\n' "apply before daemon start" "$lane"
+    fail=1
+  fi
 done
 
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
Closes #542. Decision rationale and evidence in the issue; summary here.

**Root cause** (live-reproduced ASUS + minihost on 0.11.0, deterministic `systemd-run` repro): the unit's `CapabilityBoundingSet` deliberately excludes `CAP_CHOWN`, so the daemon cannot re-group its lock to the camera group; the #534 tolerance then **returned early past the ACL copy and mode set**, leaving daemon-created locks `root:root 0600` with no ACL — unopenable by every non-root camera tool.

**Fix (option 4 from the issue, evidence-refined):**
1. A tolerated mirror step now **continues** to the remaining steps (ACL copy and mode set both work under the bounding set: `CAP_FOWNER` is present). The final consistency check asserts only what was supposed to be achieved; the world-accessible refusal stays unconditional; a once-per-process note names any degraded mirror.
2. `lock_path` moves to **`/run/lock/irlume`**, a setgid `root:video 2751` directory shipped via **tmpfiles.d in all five lanes** (spec, deb/nfpm, PPA rules, PKGBUILD, nix module) and applied by a scriptlet **before any daemon start**. Daemon-created locks then inherit the camera group at creation — the only capability-free fix for group-permission hosts (no uaccess ACL on the camera node; tools reach the camera through `video` membership). With the dir, the daemon-side `fchown` is a no-op skip and the full mirror completes.

**Also:** a journal store that cannot be *examined* (permission/IO) now reports `Unchecked` ("could not check whether ...") instead of asserting a recorded pending change — the read-side twin of the #210 contract, surfaced live when unprivileged tools reached the journal read for the first time (minihost fleet validation; store was empty while the message claimed a pending change).

**Validation so far:**
- Workspace 1748/0, clippy/fmt/rustdoc clean, parity green (new tmpfiles cross-lane checks; also fixed a racy `sed | grep -q` SIGPIPE under pipefail in the parity script itself).
- ASUS: all three harness-gated lock tests PASS (real-device mirror against the Shinetech IR camera produced `root:video 0660` + exact device ACL at the new path); non-root O_RDWR+flock open of a daemon-shaped lock PASS. Branch daemon live under the real unit sandbox (SELinux-labelled); its own lock creation + slice-4 at the branch SHA pending room light (Shinetech dark-room privacy shutter, ADR-0016).
- minihost (group-only host class): sandboxed branch daemon created `root:video 0660` at the new path, no degraded warning; non-root open+flock PASS; unprivileged `burst_dump` got past the lock for the first time and completed with the honest store message; **slice-4 sequential PASS at the branch SHA as the unprivileged runner** (0 drops both streams) — the runner opens the daemon-created lock, the real four-host-gate proof.
- archhost (ACL host class, Brio): sandboxed branch daemon logged **"IR emitter ready"** and created the lock with the **full mirror** (inherited `root:video` group + copied `user:archledger` ACL + mode); non-root open+flock PASS; restored to the packaged daemon.
- thinkpad (RGB-only): branch unit suite 530/530, tmpfiles dir applied `2751 root video`, packaged daemon healthy after restart.

**Disclosed:** an upgrade-and-back within one boot mixes lock paths during the transition window (mutual exclusion between old and new binaries); old flat locks orphan harmlessly on tmpfs. AppArmor keeps the flat rule one release for the restart window.