### PR TITLE
release: irlume 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+- Nothing yet.
+
+## [0.11.1] - 2026-08-24
+
 ### Fixed
 
 - **Non-root camera tools can open the IR-emitter lock again (#542).** The
@@ -2869,7 +2873,8 @@ is always the fallback: no lockout, ever.
   credentials).
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
-[Unreleased]: https://github.com/archledger/irlume/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/archledger/irlume/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/archledger/irlume/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/archledger/irlume/compare/v0.10.0...v0.11.0
 [0.9.0]: https://github.com/archledger/irlume/releases/tag/v0.9.0
 [0.8.1]: https://github.com/archledger/irlume/releases/tag/v0.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "image",
  "irlume-auth",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "libc",
  "serde",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -1095,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.11.0"
+version = "0.11.1"
 
 [[package]]
 name = "irlume-gkr-unlock"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-kwallet-init"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-liveness"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "irlume-common",
  "irlume-vision",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "edgefirst-tflite",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.11.0
+pkgver=0.11.1
 pkgrel=1
 pkgdesc="Face authentication for Linux with head-gesture consent and passive PAD"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.11.0
+version: 0.11.1
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -2,7 +2,7 @@
 %global ort_ver 1.28.1
 
 Name:           irlume
-Version:        0.11.0
+Version:        0.11.1
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -264,6 +264,11 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Mon Aug 24 2026 archledger <archledger236@gmail.com> - 0.11.1-1
+- IR emitter lock: shared with non-root camera tools under the sandboxed daemon (#542)
+- IR emitter lock: setgid /run/lock/irlume via tmpfiles.d, group-strip hardening
+- Emitter journal: an unexaminable store reports "could not check", not a phantom record
+
 * Sun Aug 23 2026 archledger <archledger236@gmail.com> - 0.11.0-1
 - SecureDark: scene gate + 0.635 dark threshold (ADR-0016)
 - Capture-path: role-aware flush (-3.3s/auth), schedule-aware pairing (ADR-0014)


### PR DESCRIPTION
Version bump for the #542 emitter-lock fix.

Carries: emitter-lock sharing with non-root camera tools under the sandboxed daemon (mirror fall-through, group-strip hardening, setgid /run/lock/irlume via tmpfiles.d in all five lanes), the unexaminable-store honesty fix, and housekeeping (#543 stray file, #544 stage-3 docs).

Surface walk done pre-PR on the branch build: read-only CLI lane deterministic (12 commands x2, `models` exit 2 = intended removal notice), 0.11.0 CLI against 0.11.1 daemon cross-version OK, TUI renders, --version and engine_version both 0.11.1, daemon created its lock at /run/lock/irlume with "IR emitter ready" under the real unit sandbox.