### PR TITLE
fix(ppa): forward PPAREV into the build container

### DIFF
--- a/packaging/ppa/build-ppa-container.sh
+++ b/packaging/ppa/build-ppa-container.sh
@@ -63,7 +63,7 @@ cp "$REPO"/models/*.onnx "$WORK/models/"
 echo "==> building PPA source in $BASE (SERIES=$SERIES, SOURCE_DATE_EPOCH=$SDE)"
 podman run --rm \
   -v "$WORK:/work:z" \
-  -e "SOURCE_DATE_EPOCH=$SDE" -e "SERIES=$SERIES" \
+  -e "SOURCE_DATE_EPOCH=$SDE" -e "SERIES=$SERIES" -e "PPAREV=${PPAREV:-0ppa1}" \
   "$BASE" bash -euc '
     export DEBIAN_FRONTEND=noninteractive HOME=/work CARGO_HOME=/work/.cargo-home
     apt-get update -qq >/dev/null


### PR DESCRIPTION
One-line: the wrapper documented `PPAREV` as the revision knob but only forwarded `SERIES` and `SOURCE_DATE_EPOCH` into the podman run, so `PPAREV=0ppa2` on the host silently rebuilt `0ppa1`. Hit live during the 0.11.1 cut (builder-side failure needed a bumped re-upload; the first 0ppa2 attempt produced 0ppa1 artifacts).