### PR TITLE
docs(readme): lead with the features face-unlock users vote for — survey action item 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ IR camera. Stored as an embedding, never an image. Password always works.
 | 🔓 **Unlocks everything** | Login, lock screen, `sudo`, polkit prompts |
 | 🗝️ **Opens your wallet** | A face match TPM-unseals your keyring secret |
 | 🧬 **No face images** | 512-D embeddings, AES-256-GCM under a TPM-sealed key |
-| 🙋 **Only when you ask** | Empty password + Enter. Typing never starts a scan |
+| 🙋 **Consent before camera** | `yes` for a face attempt; typing your password never starts a scan, and both work in the same prompt — no waiting for one to time out (the field accepts either) |
+| 🛡️ **Refuses photos and screens** | Two anti-spoofing models run by default: print attacks on RGB, screens/phones on IR (Howdy's own README warns a printed photo can defeat it) |
+| 🔁 **Survives real life** | Suspend/resume verified on hardware; a failed scan or a crashed component falls back to your password, never a lockout |
+| 📦 **Installs boring** | One Rust binary per package, no Python, no dlib, no pip — the class of install breakage that dominates other face-unlock trackers does not exist here |
 | 🩺 **Repairs itself** | A live TUI fixes faults; PAM wiring survives updates |
 
 </div>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=irlume
 pkgver=0.11.1
 pkgrel=1
-pkgdesc="Face authentication for Linux with head-gesture consent and passive PAD"
+pkgdesc="Windows Hello-style face login for Linux: IR cameras, consent-gated, photo-spoofing resistant, TPM-sealed, password always works"
 arch=('x86_64')
 url="https://github.com/archledger/irlume"
 license=('GPL-3.0-or-later')


### PR DESCRIPTION
From the competitor survey: Howdy users have requested, for years, features irlume ships as defaults. This makes the README hero table say so, with mechanisms:

- Consent gate (#218 +13, #1079 +8): the shipped `yes` field — and fixes the stale "Empty password + Enter" line that described the retired pre-ADR-0011 flow.
- Password+face in one prompt (#9, +21, their most-reacted issue ever): one hidden field accepts either; pam_unix consumes the password via PAM_AUTHTOK (ADR-0011).
- Photo/screen resistance: the default-on PAD pair (their README warns a printed photo can defeat them).
- Suspend/resume reliability (#1131): verified on hardware this cycle (#550).
- No-interpreter installs: 54% of their open issues are install churn that cannot exist here.

AUR `pkgdesc` updated to drop the retired "head-gesture consent" wording (PR #502). Copr storefront updated in the same sitting and verified by read-back; PPA description draft recorded for the browser step.