### PR TITLE
docs: enforce zero em dashes across this session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@ All notable changes to irlume are documented here. This project adheres to
   daemon's systemd unit deliberately excludes `CAP_CHOWN`, so the lock it
   creates on a clean boot could not be re-grouped to the camera's group;
   the #534 tolerance then returned early, skipping the ACL copy and mode
-  set as well, leaving the lock `root:root 0600` with no ACL — unopenable
+  set as well, leaving the lock `root:root 0600` with no ACL, unopenable
   by `camera-tune`, user-context `ir-setup`, and the hardware stress
   runner on every host. Two halves fix it: the tolerated mirror failure
   now continues to the ACL and mode steps (which work under the daemon's
   bounding set), and the lock moves to a dedicated setgid
   `/run/lock/irlume` directory (tmpfiles.d, `root:video` 2751) so
-  daemon-created locks inherit the camera group at creation — the only
-  capability-free fix for hosts whose cameras carry no per-user ACL. When
+  daemon-created locks inherit the camera group at creation. That is the
+  only capability-free fix for hosts whose cameras carry no per-user ACL. When
   the group still cannot be corrected (a camera group no tmpfiles override
   covers), the mirror now strips every group-class grant from the lock
   instead of granting the wrong group, so the lock never opens to callers
@@ -34,7 +34,7 @@ All notable changes to irlume are documented here. This project adheres to
   change.** With non-root tools reaching the journal read for the first
   time (they used to stop at the lock), a permission failure reading the
   root-owned store was reported as "an emitter control ... was left
-  changed ... and has not been put back" — asserting a record that was
+  changed ... and has not been put back", asserting a record that was
   never observed. The store-read failure now reports "could not check"
   (same fail-closed refusal, honest wording), matching the lock-side
   #210 contract.
@@ -51,7 +51,7 @@ All notable changes to irlume are documented here. This project adheres to
   visible light could choose the lowest-evidence path on purpose. The
   pure-dark match threshold rises 0.55 → 0.60 (CBSR NIR: FAR 1.3e-3 →
   2.7e-4 for +1.3% FRR), ending the inversion where the dim-light
-  fallback — which verifies an RGB face first — demanded a stricter bar
+  fallback (which verifies an RGB face first) demanded a stricter bar
   than pure darkness. Per-user IR calibration, FLIR PAD, IR physics, and
   the per-user center/edge floor are unchanged. **Stage 2 (2026-08-23):**
   the live dark session ran (30 true-dark auths, minihost NexiGo; genuine
@@ -64,7 +64,7 @@ All notable changes to irlume are documented here. This project adheres to
   that host, failing closed), and an occluded RGB lens in a lit room reads
   ~18 and routes to the dark path (no in-stream discriminator exists; the
   occlusion attacker still faces the 0.635-effective IR identity bar, FLIR
-  — whose lit-room-via-IR margin thins to p_fake 0.80 — and the per-user
+  (whose lit-room-via-IR margin thins to p_fake 0.80), and the per-user
   floor). Multi-frame consistency stays gated on the next session's
   in-burst pair-cosine measurement.
 
@@ -91,7 +91,7 @@ All notable changes to irlume are documented here. This project adheres to
   measured operating points: ViT m96 crop, 0.55, 5-frame-median vote per
   authentication (catches the print/banner species at 100% across two
   qualification sessions, 0/180 genuine false-fires; does NOT stop a phone
-  at login distance — disclosed in the startup line, IR covers that
+  at login distance (disclosed in the startup line; IR covers that
   species); FLIR 0.9 on lit IR frames. Kill switches: `IRLUME_PAD_VIT=0` /
   `pad_vit=0` and `IRLUME_PAD_IR=0` / `pad_ir=0`. The opt-in catalog keeps
   both provenance records; `flir` selections in existing settings.conf keep
@@ -112,7 +112,7 @@ All notable changes to irlume are documented here. This project adheres to
   per-service defaults are unchanged; passive PAD remains mandatory.
 - **Capture-path latency and pairing (ADR-0014, PR #518).** The rate-gate
   startup flush is role-aware (IR 10 dequeues, RGB 0; was 30/30) from fleet
-  measurement — lit authentication on sequential-schedule dual hosts drops
+  measurement: lit authentication on sequential-schedule dual hosts drops
   from ~10.4 s to ~7.0 s. The cross-spectrum pairing budget is
   schedule-aware: concurrent captures keep the 3 s ceiling, sequential
   one-shot captures (and concurrent attempts that degraded to their
@@ -164,14 +164,14 @@ All notable changes to irlume are documented here. This project adheres to
 - **Clean installs keep IR face authentication (P0).** The packaged daemon
   creates the emitter lock root-owned, then the #487 access-mirror rework
   hard-failed the group correction under the unit's deliberately
-  CAP_CHOWN-less bounding set — IR auth was dead on every clean install
+  CAP_CHOWN-less bounding set, so IR auth was dead on every clean install
   (existing hosts only worked via leftover dev-run locks, which /run
   clears at reboot). A lock owned by the process with no world bits is
   strictly tighter than the mirror target and now proceeds; a
   world-accessible uncorrectable lock still refuses.
 - **AppArmor profile gaps (enforce-mode installs):** the deferred
   template-key loader's flocks and camera classification's media-graph
-  reads were both denied under enforcement — the first broke every
+  reads were both denied under enforcement. The first broke every
   enrollment read, the second silently regressed the no-open
   classification to the privacy-LED open probe. Both rules added; a
   complain-mode audit across the full exercise battery confirmed no

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ IR camera. Stored as an embedding, never an image. Password always works.
 | 🔓 **Unlocks everything** | Login, lock screen, `sudo`, polkit prompts |
 | 🗝️ **Opens your wallet** | A face match TPM-unseals your keyring secret |
 | 🧬 **No face images** | 512-D embeddings, AES-256-GCM under a TPM-sealed key |
-| 🙋 **Consent before camera** | `yes` for a face attempt; typing your password never starts a scan, and both work in the same prompt — no waiting for one to time out (the field accepts either) |
+| 🙋 **Consent before camera** | `yes` for a face attempt; typing your password never starts a scan, and both work in the same prompt (the field accepts either, so you never wait for one path to time out) |
 | 🛡️ **Refuses photos and screens** | Two anti-spoofing models run by default: print attacks on RGB, screens/phones on IR (Howdy's own README warns a printed photo can defeat it) |
 | 🔁 **Survives real life** | Suspend/resume verified on hardware; a failed scan or a crashed component falls back to your password, never a lockout |
-| 📦 **Installs boring** | One Rust binary per package, no Python, no dlib, no pip — the class of install breakage that dominates other face-unlock trackers does not exist here |
+| 📦 **Installs boring** | One Rust binary per package, no Python, no dlib, no pip. The class of install breakage that dominates other face-unlock trackers does not exist here |
 | 🩺 **Repairs itself** | A live TUI fixes faults; PAM wiring survives updates |
 
 </div>

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -8,7 +8,7 @@
 
 Howdy-class install pain (54% of its open issues) does not exist here:
 no interpreter, no pip, no dlib. If your camera is not listed, irlume
-still runs — the RGB path needs any UVC camera, and unknown IR emitters
+still runs: the RGB path needs any UVC camera, and unknown IR emitters
 take `sudo irlume ir-setup` (it measures, warns, and undoes; it never
 blind-writes). Hardware reports are the most useful contribution:
 open an issue with `irlume status`, `sudo irlume doctor --probe`, and
@@ -20,10 +20,10 @@ open an issue with `irlume status`, `sudo irlume doctor --probe`, and
 ### ASUS Zenbook S 14 (UX5406S)
 
 - **Module:** Shinetech ASUS FHD webcam + IR (`3277:0059`)
-- **RGB:** `/dev/video0` — MJPG 1280x720@30 (also YUYV) (RGB primary)
-- **IR:** `/dev/video2` — GREY 640x400@15
-- **Capture mode:** sequential — measured (camera-tune qualification); concurrent dims both sensors
-- **IR emitter:** MS-XU unit 14 selector 0x06 (face authentication), D1 alternative-frame illumination — validated (write, read-back, optical output, restoration). firmware privacy shutter auto-engages in darkness (reads its own RGB); fail-closed refusal, disclosed in ADR-0016; no ALS on the host
+- **RGB:** `/dev/video0`: MJPG 1280x720@30 (also YUYV) (RGB primary)
+- **IR:** `/dev/video2`: GREY 640x400@15
+- **Capture mode:** sequential: measured (camera-tune qualification); concurrent dims both sensors
+- **IR emitter:** MS-XU unit 14 selector 0x06 (face authentication), D1 alternative-frame illumination: validated (write, read-back, optical output, restoration). firmware privacy shutter auto-engages in darkness (reads its own RGB); fail-closed refusal, disclosed in ADR-0016; no ALS on the host
 - **Anti-spoofing:** ViT RGB + FLIR IR qualified
 - **Evidence (irlume 0.11.1-1.fc44):**
   - slice4: sequential PASS (2026-08-24, sha a9c410e0: 0 drops both streams, recovery 2.1-2.9s)
@@ -33,10 +33,10 @@ open an issue with `irlume status`, `sudo irlume doctor --probe`, and
 ### HP Arch Linux gaming desktop + Logitech Brio 4K
 
 - **Module:** Logitech BRIO 4K (`046d:085e`)
-- **RGB:** `/dev/video0` — YUYV 640x480@30 (RGB primary)
-- **IR:** `/dev/video2` — GREY 340x340 (metadata node video1)
-- **Capture mode:** sequential — measured; RGB+IR concurrent fails QBUF EINVAL (dual-stream incapable); IR emitter strobes on USB3 only
-- **IR emitter:** MS-XU unit 12 selector 0x06 present — qualified through camera-tune; strobe alternates frames on USB3 link. MSXU probe finding recorded 2026-08-22 (Brio is a third dual-capable host, not RGB-only)
+- **RGB:** `/dev/video0`: YUYV 640x480@30 (RGB primary)
+- **IR:** `/dev/video2`: GREY 340x340 (metadata node video1)
+- **Capture mode:** sequential: measured; RGB+IR concurrent fails QBUF EINVAL (dual-stream incapable); IR emitter strobes on USB3 only
+- **IR emitter:** MS-XU unit 12 selector 0x06 present: qualified through camera-tune; strobe alternates frames on USB3 link. MSXU probe finding recorded 2026-08-22 (Brio is a third dual-capable host, not RGB-only)
 - **Anti-spoofing:** FLIR IR qualified; ViT weights not installed on this host's package (open package follow-up)
 - **Evidence (irlume 0.11.1-1 (Arch)):**
   - suspend: 3x S3 cycles, daemon active zero-anomaly, GRANTED t+4s post-resume (2026-08-24)
@@ -45,10 +45,10 @@ open an issue with `irlume status`, `sudo irlume doctor --probe`, and
 ### minihost (headless N100)
 
 - **Module:** NexiGo HelloCam N930W (`3443:c803`)
-- **RGB:** `/dev/video0` — MJPG 1280x720@30 (RGB primary)
-- **IR:** `/dev/video2` — GREY 640x360, strobe ~2.4fps burst / ~15fps delivered lit frames
-- **Capture mode:** sequential — measured (capture_mode.3443:c803+3443:c803=sequential persisted)
-- **IR emitter:** MS-XU unit 4 selector 0x06 (face authentication), D1 alternative-frame illumination — validated (write, read-back, optical output via burst_dump PGM evidence, restoration); 3443:930d deliberately NOT in the table (identity ambiguous, see ir_emitter.rs). steady-state delivered-rate margin ~1.2% over floor (tolerance 97%)
+- **RGB:** `/dev/video0`: MJPG 1280x720@30 (RGB primary)
+- **IR:** `/dev/video2`: GREY 640x360, strobe ~2.4fps burst / ~15fps delivered lit frames
+- **Capture mode:** sequential: measured (capture_mode.3443:c803+3443:c803=sequential persisted)
+- **IR emitter:** MS-XU unit 4 selector 0x06 (face authentication), D1 alternative-frame illumination: validated (write, read-back, optical output via burst_dump PGM evidence, restoration); 3443:930d deliberately NOT in the table (identity ambiguous, see ir_emitter.rs). steady-state delivered-rate margin ~1.2% over floor (tolerance 97%)
 - **Anti-spoofing:** ViT RGB + FLIR IR qualified; SecureDark stage 2+3 measured on this host
 - **Evidence (irlume 0.11.1-1 (Arch)):**
   - slice4: sequential PASS as unprivileged runner (2026-08-24, sha a9c410e0: 0 drops)
@@ -58,9 +58,9 @@ open an issue with `irlume status`, `sudo irlume doctor --probe`, and
 ### ThinkPad X13 Yoga Gen 4
 
 - **Module:** Chicony Integrated Camera (`04f2:b7bf`)
-- **RGB:** `/dev/video0` — MJPG 1080p/720p@30 (RGB-only host)
+- **RGB:** `/dev/video0`: MJPG 1080p/720p@30 (RGB-only host)
 - **IR:** none (RGB-only host; convenience tier only)
-- **Capture mode:** rgb-only — single camera; policy denies face for privileged surfaces on RGB-only hosts (convenience tier only)
+- **Capture mode:** rgb-only: single camera; policy denies face for privileged surfaces on RGB-only hosts (convenience tier only)
 - **Anti-spoofing:** ViT RGB (print species) on the RGB-only tier
 - **Evidence (irlume 0.11.0-0ppa1 (suspend-tested build; 0.11.1 PPA publication pending index at test time)):**
   - slice4: thinkpad-validated release lane (rc4 == final content)
@@ -70,7 +70,7 @@ open an issue with `irlume status`, `sudo irlume doctor --probe`, and
 
 Read from source at generation time. These are the modules whose emitter payload was validated end to end (write, read-back, optical output, restoration). Everything else uses `irlume ir-setup`.
 
-- `3277:0059` MS-XU unit 14, selector 0x06 (face authentication) — Shinetech "ASUS FHD webcam" in the Zenbook S 14; MS-XU is unit 14.
-- `3443:c803` MS-XU unit 4, selector 0x06 (face authentication) — NexiGo HelloCam N930W; MS-XU is unit 4.
+- `3277:0059` MS-XU unit 14, selector 0x06 (face authentication) (Shinetech "ASUS FHD webcam" in the Zenbook S 14; MS-XU is unit 14.)
+- `3443:c803` MS-XU unit 4, selector 0x06 (face authentication) (NexiGo HelloCam N930W; MS-XU is unit 4.)
 
 <!-- generated: schema 1; inputs: docs/hardware/fleet-evidence.json + ir_emitter.rs known_control; regenerate with scripts/generate-hardware-matrix.py -->

--- a/docs/research/2026-08-24-suspend-resume-auth-test.md
+++ b/docs/research/2026-08-24-suspend-resume-auth-test.md
@@ -18,27 +18,27 @@ panic/watchdog) across each resume boundary.
 | Host | Irlume | Suspend type | Cycles | Daemon | Post-resume auth |
 |---|---|---|---|---|---|
 | archhost (Brio dual) | 0.11.1-1 | S3 deep (mem) | 3 | `active` throughout, zero restarts, zero journal anomalies | **Granted at t+4 s after resume cycle 3** (`archledger 0.674 ✅`); other probes honest environmental denials (no face / yaw-pitch while user was angled away) |
-| minihost (NexiGo dual) | 0.11.1-1 | S3 deep (mem) | 3 | `active` throughout, zero restarts, zero journal anomalies | Unattended headless camera: honest denials only (no face in RGB / Spoof: no face in IR — nobody present). Camera paths reopened cleanly after every cycle |
+| minihost (NexiGo dual) | 0.11.1-1 | S3 deep (mem) | 3 | `active` throughout, zero restarts, zero journal anomalies | Unattended headless camera: honest denials only (no face in RGB / Spoof: no face in IR; nobody present). Camera paths reopened cleanly after every cycle |
 | thinkpad (RGB-only) | 0.11.0-0ppa1 (PPA index lag at test time; same daemon lineage) | s2idle | 3 | `active` throughout, zero anomalies | Unattended: honest "no face" denials; camera reopened every cycle |
-| ASUS dev box | 0.11.1-1.fc44 | — | — | — | **Skipped by owner instruction** (daily driver in active use); the same daemon build is validated on the other three hosts |
+| ASUS dev box | 0.11.1-1.fc44 | none | none | none | **Skipped by owner instruction** (daily driver in active use); the same daemon build is validated on the other three hosts |
 
 Kernel evidence for every cycle: `PM: suspend entry (deep)` /
 `suspend exit` (and s2idle equivalents on thinkpad) in the system
 journal, plus resume-delta timestamps on the probe log (22-34 s gaps).
 rtcwake ran as root; the first pass silently failed unprivileged
 (`rtcwake: /dev/rtc0: Permission denied`, 0 real cycles) and was
-discarded — recorded below as a test-harness lesson.
+discarded, recorded below as a test-harness lesson.
 
 ## Why the wall-clock failure mode cannot occur here
 
 Static sweep (this session): every timeout, deadline, rate window,
 timestamp-continuity and skew measurement in irlume-camera and
 irlume-auth uses `std::time::Instant` (CLOCK_MONOTONIC, suspend-
-excluding) — the slice-4 evidence schema literally records
+excluding); the slice-4 evidence schema literally records
 `clock: "monotonic"`. The only `SystemTime` (wall-clock) uses in the
 crates are: the capture-qualification record's persisted
 `measured_at_unix` metadata (camera/lib.rs:6713), diagnostic epoch
-stamps, and CLI support-report headers — none feed any auth decision,
+stamps, and CLI support-report headers. None feed any auth decision,
 timeout, or rate computation. Howdy's #1131 class (a wall-clock jump
 across suspend inflating a timeout) has no code path to live in.
 
@@ -48,7 +48,7 @@ visage #26's shape is a daemon holding a camera fd across hibernate
 that wedges on resume. irlume's daemon opens and drops the camera per
 request under the lease supervisor; no capture spans the suspend. The
 3x3 real cycles above show zero `camera busy`, zero EBUSY, zero
-watchdog, and a full grant at t+4 s after one resume — the camera
+watchdog, and a full grant at t+4 s after one resume, so the camera
 subsystem re-acquires cleanly.
 
 ## Residuals
@@ -60,7 +60,7 @@ subsystem re-acquires cleanly.
 - ASUS was not cycled (owner instruction). If a user report ever
   implicates suspend on the Shinetech module, the follow-up is a cycle
   on this class of hardware with a user present.
-- `mem` (S3) and `s2idle` covered; `disk` (hibernate) was not tested —
+- `mem` (S3) and `s2idle` covered; `disk` (hibernate) was not tested:
   no fleet host hibernates in normal use. Hibernate's extra variable is
   the restore path, not the clock; the wall-clock immunity argument
   covers it, but a real hibernate cycle remains untested.
@@ -75,7 +75,7 @@ post-resume grant within 4 s. No code change needed.
 ## Harness lessons (recorded)
 
 1. Unprivileged `rtcwake` fails with "unable to find device: Permission
-   denied" and returns 0 while suspending NOTHING — a run whose log
+   denied" and returns 0 while suspending NOTHING; a run whose log
    lacks `PM: suspend entry` did not test suspend. Root rtcwake or it
    did not happen; verify against the kernel journal, never the script's
    own resume line.

--- a/scripts/generate-hardware-matrix.py
+++ b/scripts/generate-hardware-matrix.py
@@ -10,10 +10,10 @@ pages rotted within months because they were maintained by hand. This
 generator is the countermeasure: the matrix is RENDERED from two inputs
 that already have review pressure on them:
 
-1. docs/hardware/fleet-evidence.json — one record per validated host,
+1. docs/hardware/fleet-evidence.json: one record per validated host,
    each row citing the irlume version and the measurement that produced
    it. A camera without evidence does not get a row.
-2. crates/irlume-camera/src/ir_emitter.rs — the `known_control` match
+2. crates/irlume-camera/src/ir_emitter.rs: the `known_control` match
    arms, read straight from source so the emitter-control table in the
    docs can never drift from the code that applies it.
 
@@ -49,7 +49,7 @@ HEADER = """\
 
 Howdy-class install pain (54% of its open issues) does not exist here:
 no interpreter, no pip, no dlib. If your camera is not listed, irlume
-still runs — the RGB path needs any UVC camera, and unknown IR emitters
+still runs: the RGB path needs any UVC camera, and unknown IR emitters
 take `sudo irlume ir-setup` (it measures, warns, and undoes; it never
 blind-writes). Hardware reports are the most useful contribution:
 open an issue with `irlume status`, `sudo irlume doctor --probe`, and
@@ -128,18 +128,18 @@ def render_host(h: dict) -> list[str]:
     rgb = h.get("rgb")
     if rgb:
         lines.append(
-            f"- **RGB:** `/dev/{rgb['node']}` — {rgb['format']} ({rgb['role']})"
+            f"- **RGB:** `/dev/{rgb['node']}`: {rgb['format']} ({rgb['role']})"
         )
     ir = h.get("ir")
     if ir:
-        lines.append(f"- **IR:** `/dev/{ir['node']}` — {ir['format']}")
+        lines.append(f"- **IR:** `/dev/{ir['node']}`: {ir['format']}")
     else:
         lines.append("- **IR:** none (RGB-only host; convenience tier only)")
-    lines.append(f"- **Capture mode:** {h['capture_mode']} — {h['capture_mode_source']}")
+    lines.append(f"- **Capture mode:** {h['capture_mode']}: {h['capture_mode_source']}")
     em = h.get("emitter")
     if em:
         lines.append(
-            f"- **IR emitter:** {em['control']} — {em['status']}"
+            f"- **IR emitter:** {em['control']}: {em['status']}"
             + (f". {em['notes']}" if em.get("notes") else "")
         )
     if h.get("pad"):
@@ -170,7 +170,7 @@ def main() -> int:
         " output, restoration). Everything else uses `irlume ir-setup`.\n"
     )
     for e in known_control_entries():
-        note = f" — {e['comment']}" if e["comment"] else ""
+        note = f" ({e['comment']})" if e["comment"] else ""
         out.append(
             f"- `{e['vid']}:{e['pid']}` MS-XU unit {e['unit']}, selector 0x06"
             f" (face authentication){note}"


### PR DESCRIPTION
The no_ai_slop writing rule is binding and was violated repeatedly this session. Sweep of everything written today: README hero table (2), CHANGELOG 0.11.1 and 0.11.0 entries (9), hardware-matrix generator template (8; HARDWARE.md regenerated clean), suspend/resume research doc (8). Em dashes became commas, periods, or parentheses. Copr storefront text re-published clean and verified by read-back; PPA draft updated for the pending browser step.