### PR TITLE
release: 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to irlume are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.11.2] - 2026-08-25
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "image",
  "irlume-auth",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "libc",
  "serde",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -1095,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.11.1"
+version = "0.11.2"
 
 [[package]]
 name = "irlume-gkr-unlock"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-kwallet-init"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-liveness"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "irlume-common",
  "irlume-vision",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "edgefirst-tflite",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.11.1
+pkgver=0.11.2
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux: IR cameras, consent-gated, photo-spoofing resistant, TPM-sealed, password always works"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.11.1
+version: 0.11.2
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -2,7 +2,7 @@
 %global ort_ver 1.28.1
 
 Name:           irlume
-Version:        0.11.1
+Version:        0.11.2
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -274,6 +274,11 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Tue Aug 25 2026 archledger <archledger236@gmail.com> - 0.11.2-1
+- rpm-ostree: %post survives the scriptlet sandbox (touch instead of `: >`,
+  guarded mkdir); layering was impossible on Silverblue/Kinoite before this
+- docs: one page for turning irlume off (docs/DISABLE.md)
+
 * Mon Aug 24 2026 archledger <archledger236@gmail.com> - 0.11.1-1
 - IR emitter lock: shared with non-root camera tools under the sandboxed daemon (#542)
 - IR emitter lock: setgid /run/lock/irlume via tmpfiles.d, group-strip hardening


### PR DESCRIPTION
Version bump for the 0.11.2 cut. Contains, relative to 0.11.1:

- Fixed: rpm-ostree installs now work (#555). The Fedora `%post` scriptlet wrote the reconcile-timer marker with `: >`, which aborts under rpm-ostree's read-only /var sandbox; it uses `touch` plus a guarded mkdir. Verified on a Silverblue 44 VM.
- Added: docs/DISABLE.md, one page covering every off-switch and cancel path (#556).

Vehicle rationale: the scriptlet fix is install-fatal for rpm-ostree users; a -2 respin would reach no storefront text and no changelog on any other lane.

## Verification

- packaging parity: OK (Cargo.toml source of truth; nfpm.yaml/PKGBUILD/spec hand-bumped)
- Gate on this tree: fmt OK, clippy -D warnings clean, workspace tests 1749/0
- Surface walk on the release build: read-only CLI battery deterministic x2 (status, keyring status, doctor, login status, recovery status, fingerprint status, --version), all rc=0 against the installed 0.11.1 daemon (old-daemon path exercised); version agreement: --version = machine API engine_version = 0.11.2; TUI renders clean
- Commit GPG-signed + DCO signed-off