### PR TITLE
Recognize Omarchy face lock PAM service

### DIFF
--- a/crates/irlume-common/src/pam_service.rs
+++ b/crates/irlume-common/src/pam_service.rs
@@ -62,6 +62,7 @@ pub const SERVICES: &[(&str, ServiceKind)] = &[
     ("swaylock", ServiceKind::ScreenUnlock),
     ("i3lock", ServiceKind::ScreenUnlock),
     ("hyprlock", ServiceKind::ScreenUnlock),
+    ("omarchy-lock-face", ServiceKind::ScreenUnlock),
     // Display-manager greeters (cold login), including GDM's separate
     // fingerprint login service, same login class.
     ("sddm", ServiceKind::Greeter),
@@ -164,6 +165,16 @@ mod tests {
         for probe in ["SUDO", " sudo ", "Sudo"] {
             assert_eq!(classify(probe), Some(ServiceKind::Elevation), "{probe}");
         }
+    }
+
+    /// Omarchy's lock shell drives face auth through a dedicated PAM service.
+    /// It is a live-session screen unlock, not a cold-login greeter.
+    #[test]
+    fn omarchy_face_lock_is_screen_unlock() {
+        assert_eq!(
+            classify("omarchy-lock-face"),
+            Some(ServiceKind::ScreenUnlock)
+        );
     }
 
     /// The divergence that prompted this: doas was Elevation for the policy and


### PR DESCRIPTION
## Summary

Recognize Omarchy's dedicated `omarchy-lock-face` PAM service as a live-session `ScreenUnlock` service.

This keeps Irlume's existing fail-closed behavior for unknown PAM service names while allowing Omarchy's face lock integration to work when biopolicy is enabled.

## Why

Omarchy's Quickshell lock screen is adding a dedicated face-auth PAM lane (`/etc/pam.d/omarchy-lock-face`) so face authentication remains separate from the password stack. I tested Irlume 0.11.2 with that architecture on a 2026 Dell XPS 13 with an RGB + IR Windows-Hello-style camera.

The integration works for:

- automatic face unlock
- failed face attempt with password fallback
- blank -> wake -> fresh face attempt
- suspend/resume

With Irlume's biopolicy off (the default), the service works today. With biopolicy enforcing, the unrecognized service would classify as unknown and fail closed. Since this is a known local live-session lock service, adding it to the shared service table as `ScreenUnlock` is the narrow compatibility fix.

## Change

- add `("omarchy-lock-face", ServiceKind::ScreenUnlock)` to the shared PAM service table
- add a regression test asserting that classification

No behavior for other or unknown PAM service names is changed.

Related Omarchy face-auth work: basecamp/omarchy#7935.