### PR TITLE
feat: name the accepted face-authentication mode in ir-setup evidence

### DIFF
--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -4853,6 +4853,55 @@ pub(crate) fn face_auth_payload(def: &[u8], max: &[u8]) -> std::result::Result<V
     Ok(out)
 }
 
+/// Read a Face Authentication `SET_CUR` payload back as promotion evidence.
+///
+/// The `ir-setup` transcript is the evidence chain for adding a USB ID to the
+/// built-in table: descriptor, on-device write, read-back, optical output,
+/// restoration. The raw bytes leave the reader to decode the accepted mode by
+/// hand; this names each streaming interface and the mode it was set to, in the
+/// specification's own vocabulary, so a transcript can be filed as-is.
+///
+/// It interprets, never guesses. Every shape rule the builder enforces is a
+/// `None` here rather than a best effort, because evidence that might be wrong
+/// is worse than evidence that admits it read nothing.
+pub(crate) fn face_auth_mode_evidence(payload: &[u8]) -> Option<String> {
+    const D0_GENERAL: u8 = 1 << 0;
+    const D1_ALTERNATIVE_ILLUMINATION: u8 = 1 << 1;
+    const D2_BACKGROUND_SUBTRACTION: u8 = 1 << 2;
+    const DEFINED: u8 = D0_GENERAL | D1_ALTERNATIVE_ILLUMINATION | D2_BACKGROUND_SUBTRACTION;
+
+    let len = payload.len();
+    if len < 3 || !(len - 1).is_multiple_of(2) {
+        return None;
+    }
+    let entries = usize::from(payload[0]);
+    let capacity = (len - 1) / 2;
+    if entries == 0 || entries > capacity {
+        return None;
+    }
+    let tail = 1 + entries * 2;
+    if payload[tail..].iter().any(|&b| b != 0) {
+        return None;
+    }
+    let mut parts = Vec::with_capacity(entries);
+    for i in 0..entries {
+        let at = 1 + i * 2;
+        let interface = payload[at];
+        let flags = payload[at + 1];
+        if flags & !DEFINED != 0 || flags.count_ones() != 1 {
+            return None;
+        }
+        let mode = match flags {
+            D0_GENERAL => "D0 (general purpose)",
+            D1_ALTERNATIVE_ILLUMINATION => "D1 (alternative illumination)",
+            D2_BACKGROUND_SUBTRACTION => "D2 (background subtraction)",
+            _ => return None,
+        };
+        parts.push(format!("interface 0x{interface:02x} set to {mode}"));
+    }
+    Some(parts.join(", "))
+}
+
 /// Whether an IR Torch `GET_DEF` value is one the specification says may be
 /// written back.
 ///
@@ -10271,6 +10320,51 @@ mod tests {
         assert!(face_auth_payload(&[1, 3, 1], &[1, 3, 3, 0]).is_err());
         // A length that cannot hold whole entries.
         assert!(face_auth_payload(&[1, 3], &[1, 3]).is_err());
+    }
+
+    /// The payload validated on both built-in cameras reads back as the
+    /// mode and interface the USB-ID promotion evidence chain needs.
+    #[test]
+    fn evidence_names_the_mode_the_camera_accepted() {
+        let evidence = face_auth_mode_evidence(&[1, 3, 2, 0, 0, 0, 0, 0, 0])
+            .expect("the validated payload is well-formed");
+        assert!(evidence.contains("0x03"), "names the interface: {evidence}");
+        assert!(evidence.contains("D1"), "names the mode: {evidence}");
+        assert!(
+            evidence.contains("alternative illumination"),
+            "spells the mode out: {evidence}"
+        );
+    }
+
+    /// A multi-interface payload names each interface and its own mode.
+    #[test]
+    fn evidence_names_each_interface_and_mode() {
+        let evidence = face_auth_mode_evidence(&[2, 3, 2, 5, 4, 0, 0, 0, 0])
+            .expect("two whole entries, zero tail");
+        assert!(
+            evidence.contains("0x03") && evidence.contains("0x05"),
+            "{evidence}"
+        );
+        assert!(
+            evidence.contains("D1") && evidence.contains("D2"),
+            "{evidence}"
+        );
+        assert!(evidence.contains("background subtraction"), "{evidence}");
+    }
+
+    /// The reader interprets, it never guesses: anything that is not the
+    /// layout the builder produces yields no evidence at all.
+    #[test]
+    fn malformed_payloads_yield_no_evidence() {
+        assert!(face_auth_mode_evidence(&[]).is_none());
+        assert!(face_auth_mode_evidence(&[1, 3]).is_none());
+        assert!(face_auth_mode_evidence(&[2, 3, 2, 5]).is_none());
+        assert!(face_auth_mode_evidence(&[1, 3, 2, 9]).is_none());
+        assert!(face_auth_mode_evidence(&[0, 0, 0, 0, 0, 0, 0, 0, 0]).is_none());
+        // Undefined flag bits are not a mode.
+        assert!(face_auth_mode_evidence(&[1, 3, 0b1000, 0, 0, 0, 0, 0, 0]).is_none());
+        // More than one mode bit set is not a mode.
+        assert!(face_auth_mode_evidence(&[1, 3, 0b011, 0, 0, 0, 0, 0, 0]).is_none());
     }
 
     /// Nothing is invented: the output names only interfaces the camera listed,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -7927,16 +7927,23 @@ pub fn store_sequential_if_still_concurrent(
 /// anything changed can be undone.
 fn active_by_device_default_message(control: &ir_emitter::EmitterControl) -> String {
     let encoded = control.encode();
-    let mode = if control.selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION {
-        "Face Authentication D1"
-    } else {
-        "IR Torch active mode"
-    };
-    format!(
-        "IR emitter mode active by device default: {encoded} on the camera's Microsoft \
-         camera-control unit; GET_CUR and GET_DEF both report the validated {mode} value \
-         (no camera write or saved config was needed)"
-    )
+    if control.selector == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION {
+        // The accepted mode is read out of the payload rather than assumed, so
+        // the transcript states what THIS camera reported (#565). A default
+        // that does not parse still works; it just cannot be described beyond
+        // its control name.
+        let evidence = ir_emitter::face_auth_mode_evidence(&control.payload)
+            .unwrap_or_else(|| "an uninterpretable face-authentication value".to_string());
+        return format!(
+            "IR emitter mode active by device default: {encoded} on the camera's Microsoft \
+             camera-control unit; GET_CUR and GET_DEF both report the validated Face \
+             Authentication value, {evidence} (no camera write or saved config was needed)"
+        );
+    }
+    "IR emitter mode active by device default: {encoded} on the camera's Microsoft \
+     camera-control unit; GET_CUR and GET_DEF both report the validated IR Torch active \
+     mode value (no camera write or saved config was needed)"
+        .replace("{encoded}", &encoded)
 }
 
 fn setup_measurement_from_burst(
@@ -8118,13 +8125,26 @@ pub fn setup_ir_emitter(device: &str) -> irlume_common::Result<String> {
         ) {
             Ok(ir_emitter::DiscoveryOutcome::Applied(found)) => {
                 let encoded = found.control().encode();
+                // The accepted mode rides along for the USB-ID promotion
+                // evidence chain (#565): descriptor, write, read-back, optical
+                // output, restoration, and now WHICH face-authentication mode
+                // the camera took. IR Torch has no per-interface modes to name.
+                let accepted = if found.control().selector
+                    == crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION
+                {
+                    ir_emitter::face_auth_mode_evidence(&found.control().payload)
+                        .map(|evidence| format!("; accepted: {evidence}"))
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                };
                 // Confirm, publish, release, in that order. The sequence lives in
                 // `finish` rather than here so it is reachable by a test.
                 found.finish(&id).map_err(Error::Hardware)?;
                 Ok(format!(
                     "IR emitter enabled: {encoded} on the camera's Microsoft camera-control unit, \
                  using a value built from what the camera reports about that control \
-                    (saved; future captures rebuild it the same way)"
+                     (saved; future captures rebuild it the same way){accepted}"
                 ))
             }
             Ok(ir_emitter::DiscoveryOutcome::ActiveByDeviceDefault(control)) => {
@@ -8318,7 +8338,12 @@ mod tests {
         });
 
         assert!(message.contains("active by device default"), "{message}");
-        assert!(message.contains("Face Authentication D1"), "{message}");
+        assert!(message.contains("Face Authentication"), "{message}");
+        assert!(
+            message.contains("D1 (alternative illumination)"),
+            "the accepted mode is read from the payload: {message}"
+        );
+        assert!(message.contains("interface 0x02"), "{message}");
         assert!(message.contains("GET_CUR and GET_DEF"), "{message}");
         assert!(
             message.contains("no camera write or saved config was needed"),


### PR DESCRIPTION
## What & why

Closes #565.

Reading the issue against the code first: the spec-driven payload construction from GET_MAX answers already exists (`face_auth_payload` in ir_emitter.rs, with every structural contradiction a refusal and D2 background-subtraction refused rather than driven, per the existing tests). What was missing is the evidence half of the issue: the ir-setup transcript carried the accepted mode as raw bytes, so the USB-ID promotion chain (descriptor, write, read-back, optical output, restoration) could not be filed without hand-decoding.

This adds `face_auth_mode_evidence`: a pure reader that turns a Face Authentication SET_CUR payload into one clause per streaming interface in the specification's vocabulary. It interprets, never guesses: every shape rule the builder enforces is a None rather than a best effort. Both transcripts now carry it:

- applied control: appends "accepted: interface 0xNN set to D1 (alternative illumination)"
- active by device default: names what GET_CUR and GET_DEF report per interface, instead of assuming D1

## Testing

- [x] `cargo test --workspace` passes (1753 passed, 0 failed; three new tests for the reader, one existing message test updated to the richer wording)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs/CHANGELOG updated if user-facing (message wording only; no CHANGELOG entry)
- [ ] Hardware-validated (if it touches PAM, the daemon, or capture): NOT yet run on hardware this session; the message path is string-level and unit-tested, the fleet BRIO is default-active so a live `sudo irlume ir-setup` on it would exercise the rewritten default-active message. Can run on the thinkpad before merge on request, and the #449 reporter's eventual transcript will carry the new clause on real discovery hardware.