### PR TITLE
feat: doctor recognizes IPU3 and the verified MIPI camera-bridge class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **`doctor` recognizes the IPU3 generation and the verified MIPI camera
+  bridge class.** A cameraless machine now gets an honest explanation for
+  two more classes instead of a bare "no camera": IPU3 CIO2 systems (the
+  single mainline PCI ID 8086:9d32, driver `ipu3-cio2`), and laptops whose
+  camera is a MIPI sensor behind a Synaptics SVP7500 "CVS" bridge (USB
+  06cb:0701, vendor-class I2C tunnel, uvcvideo binds nothing). The bridge
+  table is keyed on the exact vendor:product pair, never the vendor alone:
+  06cb also covers Synaptics fingerprint readers with the same interface
+  shape, and a vendor-only rule would have called the fleet thinkpad's
+  fingerprint reader a camera. Entries carry their evidence (the fix-pack's
+  author-verified machine); a second Dell Pro 14 bridge joins the table
+  when its USB identity is published. The decision function, the PCI ID
+  map, and the sysfs walk are all unit-tested, the walk against fixture
+  trees replicating real sysfs layout (sibling interface entries) including
+  the fingerprint-reader counter-case.
+
 ### Fixed
 
 - **AppArmor: `ir-setup` refused to write the emitter journal on enforcing

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -4158,6 +4158,11 @@ pub fn intel_ipu_present() -> Option<&'static str> {
             "/sys/bus/pci/drivers/intel-ipu6",
             "/sys/module/intel_ipu6",
         ),
+        (
+            "IPU3",
+            "/sys/bus/pci/drivers/ipu3-cio2",
+            "/sys/module/ipu3_cio2",
+        ),
     ] {
         if driver_has_bound_device(drv) || std::path::Path::new(module).exists() {
             return Some(gen);
@@ -4199,15 +4204,126 @@ fn ipu_pci_generation() -> Option<&'static str> {
 /// Map an Intel PCI device ID (as sysfs prints it, e.g. `0x7d19`) to the IPU
 /// generation, or None. IDs from the mainline ipu6/ipu7 drivers.
 fn ipu_generation_for_id(device_id: &str) -> Option<&'static str> {
+    // IPU3 is the single-ID CIO2 (8086:9d32, mainline ipu3-cio2.c's
+    // CIO2_PCI_ID); the camera-facing generations before the ipu6 naming.
+    const IPU3: &[&str] = &["0x9d32"];
     const IPU6: &[&str] = &["0x9a19", "0x4e19", "0x465d", "0x462e", "0xa75d", "0x7d19"];
     const IPU7: &[&str] = &["0x645d", "0xb05d"];
     if IPU7.contains(&device_id) {
         Some("IPU7")
     } else if IPU6.contains(&device_id) {
         Some("IPU6")
+    } else if IPU3.contains(&device_id) {
+        Some("IPU3")
     } else {
         None
     }
+}
+
+/// USB vendor:product pairs of VERIFIED MIPI camera bridges: modules whose
+/// sensor reaches the host over MIPI CSI-2 and whose only USB presence is a
+/// vendor-specific interface carrying an I2C tunnel, so uvcvideo binds
+/// nothing and every UVC-based tool reports "no camera".
+///
+/// Keyed on the exact pair, never the vendor alone. 06cb is Synaptics and also
+/// covers their fingerprint readers (06cb:00f9 ships on fleet thinkpads) with
+/// the same vendor-class, uvc-less shape; a vendor-only rule would call a
+/// fingerprint reader a camera bridge.
+///
+/// Entries need on-device evidence: the SVP7500 "CVS" bridge 06cb:0701 is
+/// author-verified on a Dell XPS 16 (jibsta210/svp7500-camera-fix-pack), with
+/// third-party reports on Dell Pro 14 machines naming a second bridge whose
+/// USB identity is not public yet; it joins this table when someone prints it.
+const MIPI_BRIDGE_IDS: &[(&str, &str)] = &[("06cb", "0701")];
+
+/// Whether `(id_vendor, id_product, interfaces)` is one of the verified MIPI
+/// camera bridges. `interfaces` is `(bInterfaceClass, bound driver name)` per
+/// USB interface of the device.
+///
+/// A uvcvideo-bound interface disqualifies the device however else it matches:
+/// the shape this detects is precisely "no UVC anywhere".
+fn is_vendor_mipi_bridge(
+    id_vendor: &str,
+    id_product: &str,
+    interfaces: &[(u8, Option<&str>)],
+) -> bool {
+    if !MIPI_BRIDGE_IDS
+        .iter()
+        .any(|(vid, pid)| *vid == id_vendor && *pid == id_product)
+    {
+        return false;
+    }
+    interfaces.iter().any(|(class, _)| *class == 0xff)
+        && interfaces
+            .iter()
+            .all(|(_, driver)| driver != &Some("uvcvideo"))
+}
+
+/// The verified MIPI camera bridge on this machine, if one is attached, with
+/// its USB identity for the report. Read from /sys, root-free.
+///
+/// `doctor` uses this to explain a cameraless machine whose camera is really
+/// a MIPI sensor behind an ISP: the bridge is the one USB-visible fact.
+pub fn vendor_mipi_bridge_present() -> Option<String> {
+    bridge_in(std::path::Path::new("/sys/bus/usb/devices"))
+}
+
+/// [`vendor_mipi_bridge_present`] with the sysfs devices root passed in, so a
+/// fixture tree can exercise the whole walk.
+fn bridge_in(devices_root: &std::path::Path) -> Option<String> {
+    let devices = std::fs::read_dir(devices_root).ok()?;
+    // In sysfs, interface entries are SIBLINGS of their device entry in
+    // /sys/bus/usb/devices, named `{device}:{config}.{iface}` (device 5-1.1,
+    // interface 5-1.1:1.0). Collect the whole listing once so each device can
+    // find its own interfaces by prefix.
+    let names: Vec<String> = devices
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    for name in &names {
+        // Devices are `bus-port` / `bus-port.port` (root hubs are `usbN` and
+        // never match a bridge pair anyway); interfaces carry the ':' and are
+        // handled per-device below.
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_digit() || c == '-' || c == '.')
+        {
+            continue;
+        }
+        let dir = devices_root.join(name);
+        let read = |file: &str| {
+            std::fs::read_to_string(dir.join(file))
+                .unwrap_or_default()
+                .trim()
+                .to_ascii_lowercase()
+        };
+        let (vendor, product) = (read("idVendor"), read("idProduct"));
+        let prefix = format!("{name}:");
+        let mut interfaces: Vec<(u8, Option<String>)> = Vec::new();
+        for iname in names.iter().filter(|n| n.starts_with(&prefix)) {
+            let iface = devices_root.join(iname);
+            let class = u8::from_str_radix(
+                std::fs::read_to_string(iface.join("bInterfaceClass"))
+                    .unwrap_or_default()
+                    .trim(),
+                16,
+            )
+            .unwrap_or(0);
+            // The bound driver is the symlink target's final component.
+            let driver = std::fs::read_link(iface.join("driver"))
+                .ok()
+                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()));
+            interfaces.push((class, driver));
+        }
+        let borrowed: Vec<(u8, Option<&str>)> = interfaces
+            .iter()
+            .map(|(class, driver)| (*class, driver.as_deref()))
+            .collect();
+        if is_vendor_mipi_bridge(&vendor, &product, &borrowed) {
+            return Some(format!("{vendor}:{product}"));
+        }
+    }
+    None
 }
 
 /// A node's advertised pixel formats (fourcc), for negotiation and `doctor`.
@@ -12116,6 +12232,114 @@ mod tests {
         assert_eq!(ipu_generation_for_id("0xb05d"), Some("IPU7")); // Panther Lake
         assert_eq!(ipu_generation_for_id("0x1234"), None);
         assert_eq!(ipu_generation_for_id(""), None);
+    }
+
+    /// IPU3's CIO2 has exactly one PCI ID in the mainline table (8086:9d32,
+    /// ipu3-cio2.c's CIO2_PCI_ID), and the machines that carry it are the ones
+    /// whose cameras libcamera owns.
+    #[test]
+    fn ipu3_cio2_pci_id_maps_to_ipu3() {
+        assert_eq!(ipu_generation_for_id("0x9d32"), Some("IPU3"));
+    }
+
+    /// The sysfs walk itself, over a fixture tree with the three devices that
+    /// matter side by side: the verified SVP7500 bridge, a Synaptics
+    /// fingerprint reader with the same vendor and interface shape, and a
+    /// plain UVC camera with uvcvideo bound. Only the bridge may match.
+    #[test]
+    fn bridge_walk_matches_only_the_verified_device_in_sysfs_shape() {
+        let root = std::env::temp_dir().join(format!("irlume-bridge-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+
+        fn device(root: &std::path::Path, name: &str, vendor: &str, product: &str) {
+            let dir = root.join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("idVendor"), vendor).unwrap();
+            std::fs::write(dir.join("idProduct"), product).unwrap();
+        }
+        fn iface(root: &std::path::Path, name: &str, class: &str, driver: Option<&str>) {
+            let dir = root.join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("bInterfaceClass"), class).unwrap();
+            if let Some(d) = driver {
+                let target = root.join("drivers").join(d);
+                std::fs::create_dir_all(&target).unwrap();
+                std::os::unix::fs::symlink(&target, dir.join("driver")).unwrap();
+            }
+        }
+
+        // The verified SVP7500: vendor-class tunnel interface, nothing bound.
+        device(&root, "5-1.1", "06cb", "0701");
+        iface(&root, "5-1.1:1.0", "ff", None);
+        // A Synaptics fingerprint reader: same vendor, same shape, wrong
+        // product. This one is on real fleet hardware.
+        device(&root, "3-2", "06cb", "00f9");
+        iface(&root, "3-2:1.0", "ff", None);
+        // A plain UVC camera with uvcvideo bound.
+        device(&root, "1-4", "046d", "085e");
+        iface(&root, "1-4:1.0", "0e", Some("uvcvideo"));
+
+        assert_eq!(
+            bridge_in(&root).as_deref(),
+            Some("06cb:0701"),
+            "only the verified bridge matches"
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn bridge_walk_reports_none_when_no_verified_bridge_is_attached() {
+        let root = std::env::temp_dir().join(format!("irlume-bridge-none-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        // Only the fingerprint reader: same vendor, wrong product. Interface
+        // entries are siblings of the device entry, as in real sysfs.
+        let dev = root.join("3-2");
+        std::fs::create_dir_all(&dev).unwrap();
+        std::fs::write(dev.join("idVendor"), "06cb").unwrap();
+        std::fs::write(dev.join("idProduct"), "00f9").unwrap();
+        let iface = root.join("3-2:1.0");
+        std::fs::create_dir_all(&iface).unwrap();
+        std::fs::write(iface.join("bInterfaceClass"), "ff").unwrap();
+
+        assert_eq!(bridge_in(&root), None);
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// The vendor-bridge decision. Keyed on the exact USB vendor:product pair,
+    /// never the vendor alone: 06cb is also Synaptics FINGERPRINT readers
+    /// (06cb:00f9 ships on a fleet thinkpad) with the same vendor-class,
+    /// uvc-less interface shape. The only verified camera bridge is the SVP7500
+    /// "CVS" bridge 06cb:0701 (fix-pack author-verified on a Dell XPS 16;
+    /// third-party reports on Dell Pro 14 machines name a different bridge
+    /// whose USB identity is not yet public, so it is deliberately absent).
+    #[test]
+    fn vendor_mipi_bridge_decision() {
+        // The SVP7500 shape: vendor-class interface, nothing bound.
+        assert!(is_vendor_mipi_bridge("06cb", "0701", &[(0xff, None)]));
+        // Same bridge with a second vendor-class interface some other driver
+        // claimed: still no UVC anywhere, still the tunnel shape.
+        assert!(is_vendor_mipi_bridge(
+            "06cb",
+            "0701",
+            &[(0xff, None), (0xff, Some("i2c-tunnel-hid"))]
+        ));
+        // A Synaptics fingerprint reader: same vendor, same shape, WRONG
+        // product. This is the false positive the vendor-only rule would ship.
+        assert!(!is_vendor_mipi_bridge("06cb", "00f9", &[(0xff, None)]));
+        // The bridge pair but a uvcvideo-bound interface: not the tunnel
+        // shape, however it got here.
+        assert!(!is_vendor_mipi_bridge(
+            "06cb",
+            "0701",
+            &[(0x0e, Some("uvcvideo")), (0xff, None)]
+        ));
+        // An ordinary external UVC webcam vendor: never a bridge.
+        assert!(!is_vendor_mipi_bridge("046d", "085e", &[(0xff, None)]));
+        // The bridge pair but no vendor-class interface at all: the shape is
+        // the evidence, the pair alone is not.
+        assert!(!is_vendor_mipi_bridge("06cb", "0701", &[(0x0e, None)]));
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -3702,9 +3702,16 @@ fn doctor_run(
                  - its capture nodes emit raw Bayer, not a directly-openable YUYV/GREY stream;\n     \
                  - the IR (Windows Hello) sensor is not exposed on Linux at all, so IR face\n       \
                  auth and IR liveness are unavailable on this hardware.\n     \
-                 RGB-only webcam use is possible via a libcamera software-ISP + v4l2loopback\n     \
-                 bridge, but irlume needs the IR sensor; an external USB IR camera is the\n     \
+                 RGB-only webcam use is possible via a libcamera software-ISP + v4l2loopback\n       \
+                 bridge, but irlume needs the IR sensor; an external USB IR camera is the\n       \
                  supported path on {gen} machines."
+            );
+        } else if let Some(bridge) = irlume_camera::vendor_mipi_bridge_present() {
+            dout!(report,
+                "  ⚠ this machine has a verified MIPI camera bridge (USB {bridge}) and no UVC\n     \
+                 camera: the sensor is a MIPI module behind an ISP that Linux drives through\n     \
+                 libcamera, so uvcvideo binds nothing and irlume cannot use it. An external\n     \
+                 USB IR camera is the supported path on this machine."
             );
         }
     }


### PR DESCRIPTION
## What & why

Closes #566.

A cameraless machine now explains two more classes honestly instead of printing a bare no-camera:

1. **IPU3 CIO2 systems**: added to `intel_ipu_present` (driver `/sys/bus/pci/drivers/ipu3-cio2`, module `ipu3_cio2`, PCI ID `8086:9d32`), every constant taken from the mainline kernel source (`ipu3-cio2.c` / `ipu3-cio2.h`), not assumed.
2. **Verified MIPI camera bridges**: `vendor_mipi_bridge_present()` walks sysfs for USB devices whose exact vendor:product pair is in the verified table and whose interfaces are vendor-class with no uvcvideo binding. The table carries exactly one entry today, the Synaptics SVP7500 CVS bridge `06cb:0701`, verified from jibsta210/svp7500-camera-fix-pack (author-verified Dell XPS 16; the Dell Pro 14 second bridge joins when its USB identity is published).

The pair-keying is the safety property: `06cb` is also Synaptics fingerprint readers with the same vendor-class, uvc-less shape, and a vendor-only rule would have called the fleet thinkpad's `06cb:00f9` fingerprint reader a camera bridge. That counter-case is a pinned unit test.

Scope note versus the issue text: `detect` remains an install-state probe by contract (its exit codes are consumed by installers); doctor is the surface that explains hardware, and the follow-up camera-census work builds there.

## Verification

- decision function: unit-tested for the bridge, the same-vendor fingerprint reader, the uvcvideo-bound, the wrong-vendor, and the wrong-shape cases
- sysfs walk: fixture-tested against real sysfs layout, where interface entries are SIBLINGS of the device entry; the fixture caught the first walker draft reading them as children (fixed before it could ship)
- PCI ID map: IPU3 `0x9d32` pinned alongside the existing generation tests
- real machine: the worktree binary's `doctor` run on the ASUS (cameras present) confirms no false message and no regression on the populated path
- honest gap: no fleet host is an SVP7500 or IPU3 machine, so the positive message fires first in the wild; the wording is short and the hardware-report template collects the evidence to confirm or correct it

## Testing

- [x] `cargo test --workspace` passes (1757 passed, 0 failed; four new tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs/CHANGELOG updated if user-facing (CHANGELOG Unreleased Added entry)
- [x] Hardware-validated: negative on a real populated machine (above); positive classes have no fleet hardware, covered by fixtures sourced from verified layouts