### PR TITLE
fix: apparmor profiles must allow locking the config lock file (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **AppArmor: `set-cameras` could not persist the camera pair.** Config
+  writes serialize on a lock file beside the config (`cameras.conf.lock`),
+  and the shipped `irlumed` profiles granted the lock file's create and
+  write but not `flock`'s `k`, so on an enforcing host `set-cameras`
+  switched the running daemon live, reported success with a persist
+  warning, and the next daemon restart silently reverted the pair. Both
+  profile variants now carry `rwk` on `/etc/irlume/*.lock`, the packaging
+  parity ratchet asserts the rule so the gap cannot re-ship, and the fix is
+  hardware-validated (live patch on the enforcing Arch host completed a
+  persisting `set-cameras` immediately after; issue #580).
+
 ### Added
 
 - **Camera triage docs: the kernel quirk table, first.** DEBUGGING.md gains

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -152,6 +152,13 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   # Config + state: enrollments (per-user), template keys, recovery blobs.
   /etc/irlume/ r,
   /etc/irlume/** rw,
+  # Config writes serialize on a lock file beside the config (config.rs
+  # lock_exclusive). The broad rw rule above grants the lock file's create
+  # and write; flock additionally needs `k`, without which set-cameras
+  # switched the running daemon live but silently failed to persist the pair,
+  # and the next restart reverted it (found enforcing on Arch, 2026-08-28;
+  # issue #580).
+  /etc/irlume/*.lock rwk,
   /home/*/.local/share/irlume/ rw,
   /home/*/.local/share/irlume/** rw,
   /var/lib/irlume/ rw,

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -117,6 +117,10 @@ profile irlumed /usr/local/bin/irlumed {
   # Config + state: enrollments (per-user), template keys, recovery blobs.
   /etc/irlume/ r,
   /etc/irlume/** rw,
+  # Config writes serialize on a lock file beside the config (config.rs
+  # lock_exclusive); flock needs `k` on top of the broad rw rule above, or
+  # set-cameras switches live but never persists (issue #580).
+  /etc/irlume/*.lock rwk,
   /home/*/.local/share/irlume/ rw,
   /home/*/.local/share/irlume/** rw,
   /var/lib/irlume/ rw,

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -356,6 +356,7 @@ APPARMOR_RUNTIME_RULES=(
   "/run/lock/irlume/irlume-emitter-*.lock rwk,"
   "/run/lock/irlume-emitter-*.lock rwk,"
   "/var/lib/irlume/ir-emitter-stream/*.lock rwk,"
+  "/etc/irlume/*.lock rwk,"
 )
 for profile in "${APPARMOR_PROFILES[@]}"; do
   for rule in "${APPARMOR_RUNTIME_RULES[@]}"; do


### PR DESCRIPTION
Closes #580.

Config writes serialize on a lock file beside the config (`config.rs lock_exclusive`). The shipped `irlumed` profiles granted the lock file's create and write through the broad `/etc/irlume/** rw` rule but not `flock`'s `k`, so on an enforcing host `set-cameras` switched the running daemon live, printed the "live only; could not persist" warning, and the next daemon restart silently reverted the pair. Same class as #573: a confinement gap only the enforcing host can hit.

Fix: `rwk` on `/etc/irlume/*.lock` in both profile variants, asserted by the packaging parity ratchet (the ratchet entry landed first and was watched to MISS both profiles before the profile change, test-first). Found enforcing on Arch during the far-range dark-path sweep; the audit denial line is in the issue.

Hardware validation follows below: live patch on the enforcing Arch host, then a persisting `set-cameras` including across a daemon restart.