### PR TITLE
feat: face authentication on the stock Omarchy lock screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **Omarchy: face authentication on the stock lock screen.** Omarchy boots
+  with autologin by default, so the lock screen, not the greeter, is where
+  a cold boot actually asks for credentials, and the stock lock's
+  `omarchy-lock-password` PAM lane carried no pam_irlume (only the sddm,
+  sudo, and polkit-1 lanes were wired): face worked at pkexec and the
+  logout greeter but never at the lock. The lock surface is now
+  environment-aware: on Omarchy, `irlume login enable` wires the stock lock
+  lane with the same polkit-style consent line the polkit agent already
+  carries (type `yes` in the lock's field to fire the camera; validated
+  live on Omarchy 4.0.1), self-heal reconcile watches that file, and the
+  service classifies as ScreenUnlock so biopolicy treats it as an unlock
+  surface. Non-Omarchy machines keep the KDE lock lane and its on-demand
+  shape byte-for-byte.
 - **Omarchy: `irlume fingerprint enable` now wires the distro's own
   fingerprint layout.** Omarchy (Arch underneath) owns an opinionated
   fingerprint contract its lock and scripts depend on: a clamshell gate

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -105,6 +105,35 @@ const LOCKSCREEN: Svc = Svc {
     // screen because /etc/pam.d/kde doesn't exist yet.
     vendor: Some("/usr/lib/pam.d/kde"),
 };
+
+/// The stock Omarchy lock's password lane. Face rides the polkit-style
+/// verify line, NOT the KDE on-demand block: the Omarchy lock dialog submits
+/// a typed value (the same type-`yes` consent its polkit agent already
+/// carries), and that exact line was live-validated on Omarchy 4.0.1. Its
+/// fingerprint sibling lane (`omarchy-lock-fingerprint`) belongs to
+/// `irlume fingerprint`, never to this wiring.
+const OMARCHY_LOCKSCREEN: Svc = Svc {
+    etc: "/etc/pam.d/omarchy-lock-password",
+    vendor: None,
+};
+
+/// The lock surface for THIS machine. Omarchy's stock lock replaces KDE's:
+/// with the distro's autologin default, the lock is where a cold boot
+/// actually prompts, so wiring it is not optional there.
+type LockSurface = (&'static Svc, fn(&str) -> (String, bool));
+
+fn lock_surface() -> LockSurface {
+    lock_surface_for(irlume_common::platform::omarchy_present())
+}
+
+/// Testable core of [`lock_surface`].
+fn lock_surface_for(omarchy: bool) -> LockSurface {
+    if omarchy {
+        (&OMARCHY_LOCKSCREEN, wire_polkit_service)
+    } else {
+        (&LOCKSCREEN, wire_lock)
+    }
+}
 /// GDM uses a SEPARATE PAM service for fingerprint logins (`gdm-fingerprint`),
 /// distinct from `gdm-password` (password/face). It runs pam_fprintd then
 /// pam_gnome_keyring, which finds no password and leaves the wallet locked. We
@@ -265,8 +294,9 @@ fn reconcile() -> ExitCode {
         // Record the lock screen as ours only if the /etc override actually
         // carries the module now (it was wired), not merely because the vendor
         // file exists.
+        let (lock_svc, _) = lock_surface();
         let with_lock =
-            Path::new(LOCKSCREEN.etc).exists() && file_has_module(Path::new(LOCKSCREEN.etc));
+            Path::new(lock_svc.etc).exists() && file_has_module(Path::new(lock_svc.etc));
         write_wired_marker(true, with_sudo, with_polkit, with_lock);
         eprintln!(
             "[login] adopted the existing face-login wiring into the self-heal marker \
@@ -328,7 +358,8 @@ fn reconcile() -> ExitCode {
 /// WIRED rather than what was asked for: writing `with_lock=true` on a host that
 /// wires no lock screen makes reconcile chase a surface that was never there.
 pub(crate) fn lock_wired() -> bool {
-    Path::new(LOCKSCREEN.etc).exists() && file_has_module(Path::new(LOCKSCREEN.etc))
+    let (svc, _) = lock_surface();
+    Path::new(svc.etc).exists() && file_has_module(Path::new(svc.etc))
 }
 
 pub(crate) fn active_login_wired() -> bool {
@@ -358,7 +389,8 @@ fn lockscreen_regressed(with_lock: bool) -> bool {
     if !with_lock {
         return false;
     }
-    lock_regressed(Path::new(LOCKSCREEN.etc), LOCKSCREEN.vendor.map(Path::new))
+    let (svc, _) = lock_surface();
+    lock_regressed(Path::new(svc.etc), svc.vendor.map(Path::new))
 }
 
 /// Testable core of [`lockscreen_regressed`]: the /etc override was stripped in
@@ -460,10 +492,11 @@ pub(crate) fn reconcile_needed() -> bool {
 }
 
 pub(crate) fn login_wired() -> bool {
+    let (lock_svc, _) = lock_surface();
     for s in GREETERS
         .iter()
         .chain(FP_GREETERS.iter())
-        .chain(std::iter::once(&LOCKSCREEN))
+        .chain(std::iter::once(lock_svc))
     {
         if let Some(p) = service_present(s) {
             if file_has_module(&p) {
@@ -859,7 +892,8 @@ fn walk_surfaces(enable: bool, with_sudo: bool, with_polkit: bool, visit: &mut S
         let fp_wire = |c: &str| wire_fp_keyring(c, service_name(s.etc));
         visit(s, ROLE_LOGIN_FP, &fp_wire, fp_keyring);
     }
-    visit(&LOCKSCREEN, ROLE_LOCK, &wire_lock, face_lock);
+    let (lock_svc, lock_wire) = lock_surface();
+    visit(lock_svc, ROLE_LOCK, &lock_wire, face_lock);
     if sudo_in_scope(enable, with_sudo) {
         visit(
             &Svc {
@@ -1372,7 +1406,8 @@ fn act_holding_lock(enable: bool, apply: bool, with_sudo: bool, with_polkit: boo
     }
     // A separate lock service (KDE `kde`) is a WARM screen unlock: the module
     // short-circuits (no `kr`), so the keyring (already open) isn't re-touched.
-    do_svc(&LOCKSCREEN, &wire_lock, want_face_lock);
+    let (lock_svc, lock_wire) = lock_surface();
+    do_svc(lock_svc, &lock_wire, want_face_lock);
     if sudo_in_scope(enable, with_sudo) {
         match wire_service(
             &Svc {
@@ -2486,9 +2521,47 @@ mod tests {
     fn fedora_substack_still_uses_the_jump_form() {
         // Regression guard: a Fedora `substack` is atomic for jump counting, so
         // it must keep the [success=1] jump, not switch to sufficient.
-        let fedora = "#%PAM-1.0\nauth       substack     password-auth\nauth       optional     pam_permit.so\n";
+        let fedora = "#%PAM-1.0\nauth       substack     password-auth\nauth        optional     pam_permit.so\n";
         let (l, _) = wire_lock(fedora);
         assert!(l.contains("[success=1 default=ignore]   pam_irlume.so unseal ondemand"));
+    }
+
+    /// #583-era research, live-validated on a fresh Omarchy thinkpad: the
+    /// stock lock's password lane carries the polkit-style consent line
+    /// (type `yes` in the lock's field fires the camera), the KDE on-demand
+    /// shape does not apply there, and the line lands ABOVE the whole auth
+    /// stack because the first auth directive is the faillock preauth.
+    #[test]
+    fn omarchy_lock_surface_uses_the_stock_lane_with_the_polkit_recipe() {
+        let (svc, wire) = lock_surface_for(true);
+        assert_eq!(svc.etc, "/etc/pam.d/omarchy-lock-password");
+        assert!(svc.vendor.is_none(), "omarchy ships a real /etc file");
+
+        // Byte-for-byte the stock file from a fresh Omarchy 4.0.1 install.
+        let stock = "#%PAM-1.0\nauth       required                    pam_faillock.so preauth silent deny=10 unlock_time=120\n-auth      [success=2 default=ignore]  pam_systemd_home.so\nauth       [success=1 default=bad]     pam_unix.so try_first_pass nullok\nauth       [default=die]               pam_faillock.so authfail deny=10 unlock_time=120\nauth       optional                    pam_permit.so\nauth       required                    pam_env.so\nauth       required                    pam_faillock.so authsucc\naccount    include                     system-local-login\n";
+        let (wired, changed) = wire(stock);
+        assert!(changed);
+        let face_at = wired
+            .find("auth       [success=done new_authtok_reqd=done abort=die default=ignore]   pam_irlume.so")
+            .expect("the exact line the live experiment validated");
+        let first_auth = wired
+            .find("pam_faillock.so")
+            .expect("the stack's first auth line");
+        assert!(
+            face_at < first_auth,
+            "the face line must precede the whole auth stack: {wired}"
+        );
+        // Idempotent: the module present means a second pass changes nothing.
+        let (_, again) = wire(&wired);
+        assert!(!again);
+
+        // Non-omarchy keeps the KDE lane and its own recipe, untouched.
+        let (kde_svc, kde_wire) = lock_surface_for(false);
+        assert_eq!(kde_svc.etc, "/etc/pam.d/kde");
+        let kde_stock = "#%PAM-1.0\nauth       include     system-local-login\naccount    include     system-local-login\n";
+        let (w, changed) = kde_wire(kde_stock);
+        assert!(changed);
+        assert!(w.contains("ondemand"), "KDE keeps the on-demand shape");
     }
 
     #[test]

--- a/crates/irlume-common/src/pam_service.rs
+++ b/crates/irlume-common/src/pam_service.rs
@@ -63,6 +63,10 @@ pub const SERVICES: &[(&str, ServiceKind)] = &[
     ("i3lock", ServiceKind::ScreenUnlock),
     ("hyprlock", ServiceKind::ScreenUnlock),
     ("omarchy-lock-face", ServiceKind::ScreenUnlock),
+    // The stock Omarchy lock's password lane: with the distro's autologin
+    // default, this is where a cold boot actually prompts, and pam_irlume
+    // wires into it with the polkit-style consent line.
+    ("omarchy-lock-password", ServiceKind::ScreenUnlock),
     // Display-manager greeters (cold login), including GDM's separate
     // fingerprint login service, same login class.
     ("sddm", ServiceKind::Greeter),
@@ -173,6 +177,18 @@ mod tests {
     fn omarchy_face_lock_is_screen_unlock() {
         assert_eq!(
             classify("omarchy-lock-face"),
+            Some(ServiceKind::ScreenUnlock)
+        );
+    }
+
+    /// The stock Omarchy lock's PASSWORD lane: with autologin as the distro
+    /// default, this lane (not the greeter) is where a cold boot actually
+    /// asks for credentials, so it classifies as ScreenUnlock exactly like
+    /// the dedicated face service.
+    #[test]
+    fn omarchy_stock_lock_password_lane_is_screen_unlock() {
+        assert_eq!(
+            classify("omarchy-lock-password"),
             Some(ServiceKind::ScreenUnlock)
         );
     }


### PR DESCRIPTION
## What

On a fresh Omarchy install, face worked at pkexec and the logout greeter but never at the lock screen, which made "cold login" feel broken. The investigation told the whole story: Omarchy boots with **autologin by default** (`/etc/sddm.conf.d/autologin.conf`), so the lock screen, not the greeter, is where a cold boot actually asks for credentials, and the stock lock's `omarchy-lock-password` PAM lane carried no pam_irlume (only sddm, sudo, and polkit-1 were wired).

Before writing any code, the fix shape was validated live on the machine: manually inserting the polkit-style verify line into `omarchy-lock-password` made the stock lock's own dialog carry the full consent flow (type `yes` in the password field, camera fires, unlock). This PR turns that experiment into the product:

- the lock surface is environment-aware (`lock_surface()`): on Omarchy it targets `/etc/pam.d/omarchy-lock-password` with the polkit recipe; every consumer (wiring, plan, adopt-marker, `lock_wired`, self-heal regression tracking, `login_wired`) now follows the dynamic surface
- `omarchy-lock-password` classifies as `ScreenUnlock` (biopolicy treats it as an unlock surface; the fingerprint sibling lane stays with `irlume fingerprint`, untouched)
- non-Omarchy machines keep the KDE lock lane and its on-demand shape byte-for-byte (the omarchy arm is behind the same probe as #583)
- TDD: classification RED first; the surface-selection test pins the stock Omarchy lock file byte-for-byte, asserts the exact line the live experiment validated lands above the whole auth stack, idempotence, and that the KDE arm is unchanged

## Evidence

- Local gates: fmt clean, clippy `--workspace --all-targets -D warnings` clean, `cargo doc -D warnings` clean, workspace 1791/0.
- The manual experiment (already on the thinkpad): lock screen, type `yes` + Enter, camera fires, unlock succeeds.
- Live validation of the patched binary follows below: fresh wiring via `login enable`, lock screen face, and a cold reboot (autologin + lock engage, face unlocks the lock).

Out of scope, unchanged: upstream omarchy#7935 (their native lock-face UI), SDDM fingerprint (upstream parity rule from #583).