### PR TITLE
feat: face authentication on the Cinnamon lock screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **Cinnamon lock screen support (Linux Mint and friends).** The Cinnamon
+  screensaver's `cinnamon-screensaver` PAM service is now classified as a
+  screen unlock and wired with the on-demand recipe: empty-field Enter arms
+  the camera, exactly like KDE's lock, because live validation on Mint 22.3
+  showed the Cinnamon dialog submits empty fields (the best lock UX irlume
+  ships; no `yes` keyword needed). Typed input still never triggers the
+  camera on any lock: on Mint it flows to the stock pam_fprintd-then-
+  password order in common-auth. Surfaces on a fresh Mint install now cover
+  greeter face (lightdm on-demand), lock face, lock fingerprint, polkit
+  face, and sudo.
+
+
 - **Omarchy: face authentication on the stock lock screen.** Omarchy boots
   with autologin by default, so the lock screen, not the greeter, is where
   a cold boot actually asks for credentials, and the stock lock's

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -123,13 +123,29 @@ const OMARCHY_LOCKSCREEN: Svc = Svc {
 type LockSurface = (&'static Svc, fn(&str) -> (String, bool));
 
 fn lock_surface() -> LockSurface {
-    lock_surface_for(irlume_common::platform::omarchy_present())
+    lock_surface_for(
+        irlume_common::platform::omarchy_present(),
+        std::path::Path::new(CINNAMON_LOCKSCREEN.etc).exists(),
+    )
 }
 
 /// Testable core of [`lock_surface`].
-fn lock_surface_for(omarchy: bool) -> LockSurface {
+/// The stock Cinnamon screensaver's service (Linux Mint, and any Cinnamon
+/// desktop): Debian include-layout, so the KDE on-demand recipe applies, and
+/// live-validated on Mint 22.3 the dialog DOES submit empty fields, which is
+/// what the on-demand empty-Enter camera arm needs. Typed input never reaches
+/// the camera here (by design); it goes to whatever the includes carry, which
+/// on Mint is pam_fprintd then the password.
+const CINNAMON_LOCKSCREEN: Svc = Svc {
+    etc: "/etc/pam.d/cinnamon-screensaver",
+    vendor: None,
+};
+
+fn lock_surface_for(omarchy: bool, cinnamon: bool) -> LockSurface {
     if omarchy {
         (&OMARCHY_LOCKSCREEN, wire_polkit_service)
+    } else if cinnamon {
+        (&CINNAMON_LOCKSCREEN, wire_lock)
     } else {
         (&LOCKSCREEN, wire_lock)
     }
@@ -2533,7 +2549,7 @@ mod tests {
     /// stack because the first auth directive is the faillock preauth.
     #[test]
     fn omarchy_lock_surface_uses_the_stock_lane_with_the_polkit_recipe() {
-        let (svc, wire) = lock_surface_for(true);
+        let (svc, wire) = lock_surface_for(true, false);
         assert_eq!(svc.etc, "/etc/pam.d/omarchy-lock-password");
         assert!(svc.vendor.is_none(), "omarchy ships a real /etc file");
 
@@ -2556,12 +2572,41 @@ mod tests {
         assert!(!again);
 
         // Non-omarchy keeps the KDE lane and its own recipe, untouched.
-        let (kde_svc, kde_wire) = lock_surface_for(false);
+        let (kde_svc, kde_wire) = lock_surface_for(false, false);
         assert_eq!(kde_svc.etc, "/etc/pam.d/kde");
         let kde_stock = "#%PAM-1.0\nauth       include     system-local-login\naccount    include     system-local-login\n";
         let (w, changed) = kde_wire(kde_stock);
         assert!(changed);
         assert!(w.contains("ondemand"), "KDE keeps the on-demand shape");
+    }
+
+    /// Live-validated on Mint 22.3 (#585-era): the Cinnamon screensaver's
+    /// Debian include-layout takes the SAME on-demand recipe as KDE, and its
+    /// dialog submits empty fields, so empty-Enter arms the camera there.
+    /// Omarchy, when present, still wins the lock.
+    #[test]
+    fn cinnamon_lock_surface_takes_the_kde_recipe_when_present() {
+        let (svc, wire) = lock_surface_for(false, true);
+        assert_eq!(svc.etc, "/etc/pam.d/cinnamon-screensaver");
+
+        // Byte-for-byte the stock file from a Mint 22.3 install.
+        let stock = "@include common-auth\nauth optional pam_gnome_keyring.so\n";
+        let (wired, changed) = wire(stock);
+        assert!(changed);
+        assert!(
+            wired.contains("sufficient   pam_irlume.so unseal ondemand"),
+            "the on-demand line the live experiment validated: {wired}"
+        );
+        let face_at = wired.find("pam_irlume.so").expect("face line");
+        let inc_at = wired.find("@include common-auth").expect("the include");
+        assert!(face_at < inc_at, "face line leads the include");
+        // Idempotent.
+        let (_, again) = wire(&wired);
+        assert!(!again);
+
+        // Omarchy outranks Cinnamon when both signals somehow exist.
+        let (omarchy_svc, _) = lock_surface_for(true, true);
+        assert_eq!(omarchy_svc.etc, "/etc/pam.d/omarchy-lock-password");
     }
 
     #[test]

--- a/crates/irlume-common/src/pam_service.rs
+++ b/crates/irlume-common/src/pam_service.rs
@@ -67,6 +67,11 @@ pub const SERVICES: &[(&str, ServiceKind)] = &[
     // default, this is where a cold boot actually prompts, and pam_irlume
     // wires into it with the polkit-style consent line.
     ("omarchy-lock-password", ServiceKind::ScreenUnlock),
+    // Cinnamon's screensaver (Linux Mint and friends): a live-session screen
+    // unlock. Live-validated on Mint 22.3: the dialog submits empty fields,
+    // so the on-demand empty-Enter camera arm works there, the best lock UX
+    // irlume has.
+    ("cinnamon-screensaver", ServiceKind::ScreenUnlock),
     // Display-manager greeters (cold login), including GDM's separate
     // fingerprint login service, same login class.
     ("sddm", ServiceKind::Greeter),
@@ -189,6 +194,16 @@ mod tests {
     fn omarchy_stock_lock_password_lane_is_screen_unlock() {
         assert_eq!(
             classify("omarchy-lock-password"),
+            Some(ServiceKind::ScreenUnlock)
+        );
+    }
+
+    /// Cinnamon's screensaver service (Mint): a live-session unlock, wired
+    /// with the on-demand empty-Enter face arm.
+    #[test]
+    fn cinnamon_screensaver_is_screen_unlock() {
+        assert_eq!(
+            classify("cinnamon-screensaver"),
             Some(ServiceKind::ScreenUnlock)
         );
     }


### PR DESCRIPTION
## What

Fresh-install validation on Linux Mint 22.3 (universal .deb lane; the PPA builds only for Ubuntu 26.04, separate docs fix queued) found face working at the lightdm greeter, pkexec, and sudo, but never at the lock screen, the primary surface on a desktop distro: `cinnamon-screensaver` was neither classified nor wired.

The fix follows the Omarchy pattern (#584) with a better outcome: live validation on Mint 22.3 showed the Cinnamon dialog **submits empty fields**, so the lock takes the KDE **on-demand** recipe (empty-field Enter arms the camera, no consent keyword). Typed input never triggers the camera anywhere; on Mint it flows to the stock `pam_fprintd`-then-password order in common-auth.

- `cinnamon-screensaver` classified `ScreenUnlock` (classification test mutation-verified RED)
- `lock_surface_for` gains a Cinnamon arm keyed on the service file's presence; Omarchy still wins when both signals exist (arm test mutation-verified RED; the pinned fixture is the byte-exact stock Mint file, asserting the on-demand line leads the include and idempotence)
- `login enable` now wires it with the KDE recipe; self-heal, `lock_wired`, `login_wired` follow the dynamic surface (machinery from #584)

## Mint lane findings recorded alongside (not this PR)

- The PPA add on noble-based Mint succeeds but serves no package ("Unable to locate package"); only the PPA description mentions the universal-.deb fallback. README caveat queued as a docs fix.
- Fingerprint works at the lock via common-auth but not at pkexec: fprintd's D-Bus policy refuses verification from the polkit helper context (stock Ubuntu-family behavior, not an irlume regression; face works through the same stack).

## Evidence

- Live on Mint 22.3, with the exact line this PR ships manually inserted: empty-field Enter at the Cinnamon lock engaged the camera and unlocked; `yes` and password inputs flowed to pam_fprintd then pam_unix exactly as the stock ordering predicts.
- Gates: fmt clean, clippy `--workspace --all-targets -D warnings` clean, `cargo doc -D warnings` clean, workspace 1793/0.
- Live validation of the product path (sed line removed, patched `login enable`) follows below.