### PR TITLE
fix: login status lists the lock screen; docs for the Mint detour and the PPA coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **`irlume login status` now lists the lock screen** (and gets its mode
+  right): the report had kept the static KDE row after the lock surface
+  became environment-aware, so no desktop ever saw its lock listed, and
+  the Omarchy lock's consent line reported as a keyring line. The lock
+  row now follows the exact surface `login enable` wires, and the mode
+  naming (verify / on-demand / keyring / face-first) is one pure, tested
+  decision shared by the human report, `login status --json`, and the TUI.
+- **Docs: the Mint/Cinnamon fingerprint detour and the PPA's release
+  coverage.** The FAQ explains why typing anything at a Cinnamon lock
+  reaches the fingerprint prompt first (stock Debian-lane ordering; the
+  password is honored after the reader timeout) and that face there stays
+  on the empty-field Enter. The README's PPA line now says which Ubuntu
+  releases the PPA builds for and routes 22.04/24.04 derivatives (Mint,
+  Pop!_OS, Zorin, elementary) to the universal .deb, instead of leaving
+  them at "Unable to locate package".
+
+
 - **Cinnamon lock screen support (Linux Mint and friends).** The Cinnamon
   screensaver's `cinnamon-screensaver` PAM service is now classified as a
   screen unlock and wired with the on-demand recipe: empty-field Enter arms

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -fsSL https://raw.githubusercontent.com/archledger/irlume/main/scripts/inst
 
 ```sh
 sudo dnf copr enable archledger/irlume && sudo dnf install irlume   # Fedora
-sudo add-apt-repository ppa:archledger/irlume && sudo apt install irlume   # Ubuntu
+sudo add-apt-repository ppa:archledger/irlume && sudo apt install irlume   # Ubuntu 26.04; on 22.04/24.04 and derivatives (Mint, Pop!_OS, Zorin, elementary) the PPA serves no build: use the universal .deb from the latest release
 yay -S irlume                                                       # Arch
 sudo apt install ./irlume_*.deb                                     # Debian 12+, from Releases
 ```

--- a/crates/irlume-cli/src/pamwire/report.rs
+++ b/crates/irlume-cli/src/pamwire/report.rs
@@ -48,20 +48,7 @@ pub(super) fn surface_fact(
         .and_then(|p| std::fs::read_to_string(p).ok())
         .unwrap_or_default();
     let wired = content_has_module(&content);
-    // Name HOW face fires on this service: on-demand (the consent model) is
-    // invisible in the PAM file to a reader, and a keyring-only line is the
-    // fingerprint unlock rather than face at all.
-    let mode = if !wired {
-        None
-    } else if role == ROLE_SUDO || role == ROLE_POLKIT {
-        Some("verify")
-    } else if !content.contains("unseal") {
-        Some("keyring")
-    } else if content.contains("ondemand") {
-        Some("on-demand")
-    } else {
-        Some("face-first")
-    };
+    let mode = wiring_mode(role, &content);
     SurfaceFact {
         id: service_name(etc),
         role,
@@ -72,11 +59,47 @@ pub(super) fn surface_fact(
     }
 }
 
+/// Name HOW face fires on a wired service, from its content. Pure: the same
+/// decision feeds the human report, `login status --json`, and the TUI.
+/// `verify` is the plain consent line (sudo, polkit, and the Omarchy lock,
+/// whose polkit-recipe line carries no `unseal`); a keyring-only line is the
+/// fingerprint unlock rather than face at all, and locks never carry one.
+fn wiring_mode(role: &str, content: &str) -> Option<&'static str> {
+    if !content_has_module(content) {
+        return None;
+    }
+    if role == ROLE_SUDO
+        || role == ROLE_POLKIT
+        || (role == ROLE_LOCK && !content.contains("unseal"))
+    {
+        return Some("verify");
+    }
+    if !content.contains("unseal") {
+        return Some("keyring");
+    }
+    if content.contains("ondemand") {
+        return Some("on-demand");
+    }
+    Some("face-first")
+}
+
 /// Every surface irlume can wire, present or not, in the order the human report
 /// prints them. Absent services are kept in the list with `present: false`: a
 /// consumer must be able to read an id it knows and cannot find as "this engine
 /// does not wire that service" rather than as "not wired here".
 pub(crate) fn surface_facts() -> Vec<SurfaceFact> {
+    surface_facts_with(
+        irlume_common::platform::omarchy_present(),
+        std::path::Path::new("/etc/pam.d/cinnamon-screensaver").exists(),
+    )
+}
+
+/// Testable core of [`surface_facts`]: the lock row follows the SAME dynamic
+/// lock surface the wiring uses, so what `login status` reports can never
+/// drift from what `login enable` wires (#584/#585 made the lock surface
+/// environment-aware; the report had kept the static KDE row, which is why
+/// no desktop ever saw its lock listed).
+fn surface_facts_with(omarchy: bool, cinnamon: bool) -> Vec<SurfaceFact> {
     let mut out: Vec<SurfaceFact> = GREETERS
         .iter()
         .map(|s| surface_fact(s.etc, s.vendor, ROLE_LOGIN))
@@ -86,7 +109,8 @@ pub(crate) fn surface_facts() -> Vec<SurfaceFact> {
                 .map(|s| surface_fact(s.etc, s.vendor, ROLE_LOGIN_FP)),
         )
         .collect();
-    out.push(surface_fact(LOCKSCREEN.etc, LOCKSCREEN.vendor, ROLE_LOCK));
+    let (lock_svc, _) = lock_surface_for(omarchy, cinnamon);
+    out.push(surface_fact(lock_svc.etc, lock_svc.vendor, ROLE_LOCK));
     out.push(surface_fact(SUDO, None, ROLE_SUDO));
     out.push(surface_fact(POLKIT.etc, POLKIT.vendor, ROLE_POLKIT));
     out
@@ -279,4 +303,57 @@ pub(super) fn status() -> ExitCode {
         );
     }
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #584/#585 made the lock surface environment-aware; the status report
+    /// must follow the SAME surface the wiring writes, or `login status`
+    /// silently omits a wired lock (which is exactly what shipped: no desktop
+    /// ever saw a lock row). The lock row's path tracks the chosen surface,
+    /// including the Omarchy-beats-Cinnamon precedence.
+    #[test]
+    fn wiring_mode_names_each_shape_correctly() {
+        // The Omarchy lock's polkit-recipe line: a consent keyword, not
+        // keyring, not on-demand.
+        let omarchy_lock = "auth       [success=done new_authtok_reqd=done abort=die default=ignore]   pam_irlume.so\n@include common-auth\n";
+        assert_eq!(wiring_mode(ROLE_LOCK, omarchy_lock), Some("verify"));
+        // The KDE/Cinnamon on-demand line.
+        let ondemand =
+            "auth       sufficient   pam_irlume.so unseal ondemand\n@include common-auth\n";
+        assert_eq!(wiring_mode(ROLE_LOCK, ondemand), Some("on-demand"));
+        // A keyring-only line on a greeter is the fingerprint unlock
+        // (stanzas.rs KEYRING_UNSEAL's exact shape, no `unseal` token).
+        let keyring = "auth       optional                     pam_irlume.so keyring\n";
+        assert_eq!(wiring_mode(ROLE_LOGIN_FP, keyring), Some("keyring"));
+        // Nothing wired says nothing.
+        assert_eq!(wiring_mode(ROLE_LOCK, "#%PAM-1.0\n"), None);
+    }
+
+    #[test]
+    fn surface_facts_lock_row_follows_the_dynamic_lock_surface() {
+        let lock_row = |omarchy: bool, cinnamon: bool| {
+            surface_facts_with(omarchy, cinnamon)
+                .into_iter()
+                .find(|f| f.role == ROLE_LOCK)
+                .expect("exactly one lock row")
+        };
+        assert_eq!(
+            lock_row(true, true).id,
+            "omarchy-lock-password",
+            "omarchy wins when both signals exist"
+        );
+        assert_eq!(
+            lock_row(false, true).id,
+            "cinnamon-screensaver",
+            "Cinnamon's lock is reported when its service file exists"
+        );
+        assert_eq!(
+            lock_row(false, false).id,
+            "kde",
+            "KDE remains the default lock row"
+        );
+    }
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -77,6 +77,19 @@ are all in the repo, reproducible regardless of what tools wrote them.
 </details>
 
 <details>
+<summary><b>On Linux Mint/Cinnamon, why does typing at the lock screen ask for my fingerprint first?</b></summary>
+
+That is the stock Debian-lane ordering, not irlume: enabling fingerprint
+places `pam_fprintd` before the password in `common-auth`, and Cinnamon's
+lock uses one PAM conversation for every factor, so ANY submitted text
+reaches the fingerprint prompt first. Your password is held and honored
+the moment the reader gives up (about ten seconds); touching the reader
+unlocks instantly. Face on the Cinnamon lock stays on the empty-field
+Enter gesture (press Enter on the empty password field), and typed input
+never triggers the camera on any lock.
+</details>
+
+<details>
 <summary><b>Can I verify these claims myself?</b></summary>
 
 That's the point of [`docs/VERIFY.md`](VERIFY.md). Each claim maps to a


### PR DESCRIPTION
## What

Three small items from the Mint validation round:

1. **`login status` lock row** (code): the report still pushed the static KDE row after #584/#585 made the lock surface environment-aware, so no desktop ever listed its lock (observed on Mint, Omarchy, and KDE alike); the Omarchy lock's polkit-recipe line also reported mode `keyring`. The lock row now follows the exact surface `login enable` wires (same chooser, precedence Omarchy over Cinnamon over KDE), and the mode naming is one pure, tested function (`verify`/`on-demand`/`keyring`/`face-first`) shared by the human report, `login status --json`, and the TUI. Mutation-verified RED on the dynamic-row test; the mode test pins each line shape including the real `KEYRING_UNSEAL` bytes.
2. **FAQ**: why typing anything at a Cinnamon lock reaches the fingerprint prompt first (stock Debian-lane ordering; password held and honored after the ~10s reader timeout; face stays on the empty-field Enter) - recorded per the Mint live session.
3. **README**: the PPA line now states it builds for Ubuntu 26.04 and routes 22.04/24.04 derivatives (Mint, Pop!_OS, Zorin, elementary) to the universal .deb, replacing the silent "Unable to locate package" dead end a fresh Mint user hits today.

Gates: fmt/clippy/doc clean, workspace 1795/0. Live check of the status row on the Mint box follows below.