### PR TITLE
fix: apparmor profiles must allow locking the qualification store (#589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **AppArmor: `camera-tune` could not persist any qualification on
+  enforcing hosts.** The capture-qualification store serializes every
+  save behind a lock file of its own, and the shipped `irlumed` profiles
+  granted `rw` on it but not `flock`'s `k` (camera-tune runs its probe
+  through the daemon), so every `sudo irlume camera-tune` ended in
+  "lock ...: Permission denied" and the pair stayed unmeasured. Found by
+  a 10-iteration tune stress run on the enforcing host; the emitter-stream
+  locks had carried `rwk` all along while this lock, one directory deeper,
+  never did. Both profile variants now carry it, the parity ratchet asserts
+  it, and the fix is hardware-validated by re-running the full stress loop.
+
 ### Added
 
 - **`irlume login status` now lists the lock screen** (and gets its mode

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -124,6 +124,12 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   # permission. Fixing the /run/lock rule above unmasked this one on the
   # same machine, one restart later: locks need naming wherever they live.
   /var/lib/irlume/ir-emitter-stream/*.lock rwk,
+  # The capture-qualification store serializes every save behind a lock file
+  # of its own; flock needs `k` on top of rw, or camera-tune (which runs the
+  # probe through the daemon) cannot persist any qualification on an
+  # enforcing host (found by a 10-iteration tune stress run; issue #589,
+  # the #580 shape one directory deeper).
+  /var/lib/irlume/capture-qualifications/*.lock rwk,
 
   # The deferred template-key loader's per-user flock (same lesson as the
   # emitter rule above: the state tree's ** rule grants rw without the

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -98,6 +98,12 @@ profile irlumed /usr/local/bin/irlumed {
   /run/lock/irlume/irlume-emitter-*.lock rwk,
   /run/lock/irlume-emitter-*.lock rwk,
   /var/lib/irlume/ir-emitter-stream/*.lock rwk,
+  # The capture-qualification store serializes every save behind a lock file
+  # of its own; flock needs `k` on top of rw, or camera-tune (which runs the
+  # probe through the daemon) cannot persist any qualification on an
+  # enforcing host (found by a 10-iteration tune stress run; issue #589,
+  # the #580 shape one directory deeper).
+  /var/lib/irlume/capture-qualifications/*.lock rwk,
 
   /dev/tpmrm[0-9] rw,
   /dev/tpm[0-9] rw,

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -357,6 +357,7 @@ APPARMOR_RUNTIME_RULES=(
   "/run/lock/irlume-emitter-*.lock rwk,"
   "/var/lib/irlume/ir-emitter-stream/*.lock rwk,"
   "/etc/irlume/*.lock rwk,"
+  "/var/lib/irlume/capture-qualifications/*.lock rwk,"
 )
 for profile in "${APPARMOR_PROFILES[@]}"; do
   for rule in "${APPARMOR_RUNTIME_RULES[@]}"; do


### PR DESCRIPTION
Closes #589.

The capture-qualification store serializes every save behind a lock file of its own; the shipped profiles granted `rw` on it but never `flock`'s `k`, and camera-tune runs its probe through the daemon, so on an enforcing host every `sudo irlume camera-tune` ended in `lock ...: Permission denied` and no qualification could ever persist (the pair stays unmeasured, sequential-by-default, forever).

Found by the #586-motivated stress run: 10 tune iterations on the enforcing host, all failing, with one `file_lock` denial per iteration in the kernel audit (`profile="irlumed"`, `denied_mask="k"`, the daemon pid constant across iterations). The emitter-stream locks have carried `rwk` in the profile and the parity ratchet all along; this lock, one directory deeper, never did. Earlier validations missed it because they ran unconfined /tmp binaries against a scratch daemon.

Fix: `rwk` on `/var/lib/irlume/capture-qualifications/*.lock` in both profile variants, asserted by the parity ratchet (entry landed first and was watched to MISS both profiles, test-first). Hardware validation below: live-patch on the enforcing host, then the identical 10-iteration stress loop re-run, every iteration persisting.