### PR TITLE
docs: the XFCE lock screen is unsupported for face unlock, with the measured reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- **Docs: the XFCE lock screen is recorded as unsupported for face unlock,
+  with the measured reason.** xfce4-screensaver pre-starts its PAM
+  conversation at lock-open and auto-answers module prompts, so a
+  consent-gated module fires the camera with zero user action (any typed
+  submit included, correct password among them), never displays prompt
+  text, and refuses empty-field submits; the privacy rule cannot hold
+  there, so no recipe ships for it. Every other XFCE surface works
+  (LightDM greeter, sudo, polkit). Reported upstream; any prompt-based
+  PAM module misfires the same way on this dialog.
+
 - **Per-round continuity facts: a failing concurrent qualification now says
   WHICH condition fired (#586).** The round-continuity verdict is four
   nameable conditions (a within-round stream break on either sensor, and

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -3,6 +3,21 @@
 What irlume does not do, and the measurements behind each statement. The
 summary lives on the [README](../README.md); this is the detail.
 
+- **Face unlock does not work on the XFCE lock screen (xfce4-screensaver),
+  by design.** The screensaver pre-starts its PAM conversation the moment
+  the lock engages and auto-answers module prompts without user action, so
+  a consent-gated module like pam_irlume fires the camera the instant the
+  lock opens, with no keystroke and with any typed input, correct password
+  included; the dialog also never displays the module's prompt text, and it
+  refuses to submit an empty field, which rules out the on-demand
+  empty-Enter gesture too. Measured on Manjaro XFCE with instrumented
+  runs: the face attempt starts at lock-open, denies cleanly when the
+  camera is covered (the password then unlocks), and the privacy rule
+  "typing your password never triggers a camera" cannot be upheld on this
+  dialog. Every other surface on XFCE works (LightDM greeter on-demand,
+  `sudo`, polkit). The screensaver inherits its conversation style from
+  GNOME-screensaver; any prompt-based PAM module (challenge-response, one
+  time codes) misfires the same way there, which is reported upstream.
 - **A glossy printed photo defeats the built-in gate.** The
   [2026-06-30 self-test](pad-results/2026-06-30-ir-liveness-selftest.md)
   accepted a life-size vinyl print in 69 of 70 presentations. The cue is a


### PR DESCRIPTION
## What

Records the Manjaro-XFCE lane's one red outcome. Everything else on the lane works (LightDM greeter face on-demand, sudo, polkit; validated live on Manjaro 22.x-era install with the BRIO pair), but the XFCE lock screen cannot carry face unlock, and the reason is measured, not assumed:

xfce4-screensaver pre-starts its PAM conversation the moment the lock engages and auto-answers module prompts with zero user action. Instrumented runs (journal-corroborated) show:

- the face attempt fires at lock-open, before any keystroke
- every submit (wrong password, correct password, anything) re-triggers the camera
- the dialog never displays the consent prompt text
- empty-field submits are refused locally, so the on-demand empty-Enter gesture cannot work either

The privacy rule ("typing your password never triggers a camera") therefore cannot be upheld on this dialog, so no recipe ships. Fail-closed held throughout: with the camera covered the face attempt denied cleanly and the password unlocked. The upstream report is drafted for Xfce's GitLab (their GitHub mirror takes no issues); any prompt-based PAM module (challenge-response, OTP) misfires the same way on this conversation style, which is the upstream angle.

LIMITATIONS.md carries the entry with the measurements; CHANGELOG records it.

(The lane also survived one operator-error incident during the experiment: a pair of line-number sed undos across two messages removed the stack's auth include, briefly leaving a no-auth lock. The fix discipline going forward, now in the docs PR too: PAM experiments restore via full canonical file writes, never line surgery.)