### PR TITLE
ci: exclude CodeQL's two cfg(test)-blind Rust queries

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,39 @@
+# CodeQL configuration: the default suite, minus the two Rust queries that
+# cannot see inline `#[cfg(test)] mod tests` blocks.
+#
+# CodeQL's Rust extractor does not evaluate `cfg` attributes, so unit-test
+# code that compiles only under `cfg(test)` is analyzed as production code.
+# These two queries then fire on test fixtures and on every `panic!` or
+# `assert!` message that interpolates one:
+#
+# - `rust/cleartext-logging`: 119 of 119 alerts were false positives.
+#   116 were `panic!`/`assert!` messages inside `mod tests` printing enum
+#   Debug output or a numeric uid; 3 were production lines logging a
+#   refused caller's uid, which is public account metadata logged
+#   deliberately for field diagnostics (the unseal-refusal journal line
+#   exists because a silent refusal once cost hours of investigation).
+# - `rust/hard-coded-cryptographic-value`: 20 of 20 alerts were false
+#   positives: test fixtures (`b"correct horse battery staple"`,
+#   `vec![0x5a; SALT_LEN]`), key-length-rejection asserts over zero-filled
+#   arrays, and a public NIST CAVP known-answer vector.
+#
+# The same classes were manually dismissed on 2026-07-05, 2026-08-03, and
+# 2026-08-04, and they regenerate with new alert numbers whenever test lines
+# drift, which buries real findings under noise. Excluding the queries is
+# surgical: every other query in the default code-scanning suite still runs
+# for all three languages, and the `id` filters are no-ops for the actions
+# and python matrix legs.
+#
+# Trade-off, accepted with eyes open: a future REAL regression of these two
+# classes in production code would not be caught by CodeQL. Re-include a
+# query by deleting its filter when CodeQL gains `cfg(test)` modeling for
+# Rust (the queries live in the `codeql/rust-queries` pack:
+# CWE-312/CleartextLogging.ql and CWE-798/HardcodedCryptographicValue.ql).
+
+name: "irlume CodeQL configuration"
+
+query-filters:
+  - exclude:
+      id: rust/cleartext-logging
+  - exclude:
+      id: rust/hard-coded-cryptographic-value

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,6 +73,13 @@ jobs:
           # same suite the default setup used. `queries: default` is not a
           # suite name; it fatal-errors with "Query pack default cannot be
           # found".
+          #
+          # The config file keeps that default suite and only applies two
+          # `query-filters` excluding the Rust queries that cannot see inline
+          # `#[cfg(test)] mod tests` code (139/139 false-positive alerts,
+          # regenerating on every test-line drift; rationale in the config
+          # file). The filters are no-ops for the actions and python legs.
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,21 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **Code scanning no longer buries real alerts under test-fixture noise.**
+  CodeQL's Rust extractor does not evaluate `cfg` attributes, so its two
+  fixture-sensitive queries (`rust/cleartext-logging`,
+  `rust/hard-coded-cryptographic-value`) fired on inline
+  `#[cfg(test)] mod tests` code: 139 false-positive alerts in one run
+  (test passwords like `b"correct horse battery staple"`, salt and
+  key-length fixtures, a public NIST vector, and `panic!` messages
+  printing enum Debug output), regenerating with new alert numbers every
+  time test lines drift. The checked-in CodeQL workflow now applies two
+  `query-filters` that exclude exactly those two queries while every
+  other default-suite query keeps running for all three languages, and
+  the 139 standing alerts were dismissed with per-alert reasoning. The
+  rationale and the re-enable condition live in
+  `.github/codeql/codeql-config.yml`.
+
 - **`ir-setup` evidence names the accepted face-authentication mode (#572).**
   The undo record's evidence now states which D1/D2 mode the camera actually
   accepted (for example "D1 (alternative illumination)"), not just that a


### PR DESCRIPTION
## What

The 2026-08-27 CodeQL run opened 139 security alerts (20 critical, 119 high). Triage found **139 of 139 are false positives**, all from one root cause: CodeQL's Rust extractor does not evaluate `cfg` attributes, so inline `#[cfg(test)] mod tests` code is analyzed as production code.

## Triage detail

`rust/hard-coded-cryptographic-value` (critical, 20 alerts): all inside `mod tests`. Test fixtures (`b"correct horse battery staple"`, `vec![0x5a; SALT_LEN]`), zero-filled key-length-rejection asserts, and the public NIST CAVP known-answer vector in `crypto.rs`.

`rust/cleartext-logging` (high, 119 alerts): 116 are `panic!`/`assert!` messages inside `mod tests` printing enum Debug output or a uid (the query's log-injection sink model includes panic message formatting). 3 are production lines logging a refused caller's numeric uid (`note_unseal_password_refusal`, the pamwire marker check), which is public account metadata logged deliberately for field diagnostics: the unseal-refusal journal line exists precisely because a silent refusal once cost hours of investigation.

Evidence this is a treadmill, not a one-off: the same classes were dismissed as "used in tests" on 2026-07-05, 2026-08-03, and 2026-08-04, and they regenerate with new alert numbers whenever test lines drift (fingerprint = provenance), burying real findings.

## Fix

`.github/codeql/codeql-config.yml` keeps the entire default code-scanning suite and applies two `query-filters` excluding exactly these two query ids (a first-class feature of the codeql-action config). The workflow passes it via `config-file:`. The filters are no-ops for the actions and python matrix legs. Every other default-suite query keeps running unchanged.

The 139 standing alerts are dismissed in the same pass with per-alert reasoning (136 `used in tests`, 3 `false positive`).

## Trade-off

A future real regression of these two classes in production Rust code would not be caught by CodeQL. Accepted with eyes open: 100 percent false-positive rate on this codebase so far, and the exclusion is two deletions to revert (re-enable conditions documented in the config file).

## Verification

- YAML validated locally; actionlint runs in CI as usual
- The PR's own CodeQL run is the live test: it must complete green with the config in place
- After merge, the main-branch run must open zero new alerts from these two rules