### PR TITLE
fix: security audit hardening batch (atomic privileged writes, journal sanitization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,21 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- **Security audit hardening batch (full report:
+  `docs/research/2026-08-29-security-audit.md`).** A workspace-wide audit
+  (context dossiers, adversarial verification, semgrep, 101M-execution fuzz
+  campaigns) confirmed the standing threat model held; four discipline
+  gaps it found are closed here. `write_pam_edit` is now an atomic
+  temp+rename+fsync write that preserves the existing file mode instead of
+  a truncate-in-place write that forced 0644 (a crash could truncate a PAM
+  stack; a 0600 stack file came back world-readable). `set_method` writes
+  `/etc/irlume/method` atomically (a truncated file parses as face-on,
+  silently undoing an operator's fingerprint choice). Peer-supplied PAM
+  service strings are sanitized (control characters replaced, length
+  clamped) before reaching the journal, so a local peer can no longer
+  forge `irlumed:` lines via embedded newlines. A failed socket `chmod` is
+  now reported instead of silently discarded.
+
 - **Code scanning no longer buries real alerts under test-fixture noise.**
   CodeQL's Rust extractor does not evaluate `cfg` attributes, so its two
   fixture-sensitive queries (`rust/cleartext-logging`,

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -405,17 +405,20 @@ fn unwire_omarchy() -> bool {
 }
 
 /// One PAM edit with the same discipline pamwire uses: back the original up
-/// once beside the file, write the new content, keep mode 0644.
+/// once beside the file, write the new content ATOMICALLY (temp + rename +
+/// fsync, so a crash or full disk mid-edit leaves the previous bytes intact
+/// instead of a truncated auth stack), and preserve the existing file's mode
+/// rather than forcing 0644 (2026-08-29 audit: a 0600 stack file came back
+/// world-readable).
 fn write_pam_edit(path: &str, next: &str) -> bool {
-    use std::os::unix::fs::PermissionsExt;
     let backup = format!("{path}.pre-irlume");
     if !std::path::Path::new(&backup).exists() {
         if let Ok(current) = std::fs::read_to_string(path) {
             let _ = std::fs::write(&backup, current);
         }
     }
-    std::fs::write(path, next).is_ok()
-        && std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).is_ok()
+    irlume_common::write_atomic_preserving(std::path::Path::new(path), next.as_bytes(), 0o644)
+        .is_ok()
 }
 
 fn enable(user: &str, args: &[String]) -> ExitCode {
@@ -1158,6 +1161,32 @@ fn run_cmd(cmd: &str, args: &[&str]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn write_pam_edit_preserves_a_tighter_existing_mode_and_replaces_content() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = std::env::temp_dir().join(format!(
+            "irlume-pamedit-mode-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "auth include system-auth\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(write_pam_edit(
+            path.to_str().unwrap(),
+            "auth sufficient pam_fprintd.so\nauth include system-auth\n"
+        ));
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "a rewrite of a 0600 PAM file must not widen it to 0644"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "auth sufficient pam_fprintd.so\nauth include system-auth\n"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
 
     #[test]
     fn omarchy_wire_inserts_the_pair_at_the_top_of_a_bare_stack() {

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -303,6 +303,33 @@ pub fn write_atomic_mode(path: &std::path::Path, bytes: &[u8], mode: u32) -> std
     }
 }
 
+/// [`write_atomic_mode`] that keeps the mode of an EXISTING file and only uses
+/// `default_mode` when creating one.
+///
+/// For rewrite-in-place surfaces whose current mode is the deployed truth: a
+/// PAM stack a distro shipped 0600 must not come back 0644 because our edit
+/// replaced the file (2026-08-29 audit; `write_pam_edit` used to force 0644).
+/// The umask ceiling note of [`write_atomic_mode`] applies, so the replacement
+/// can only come out EQUAL OR TIGHTER than the mode being preserved, never
+/// wider.
+#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
+pub fn write_atomic_preserving(
+    path: &std::path::Path,
+    bytes: &[u8],
+    default_mode: u32,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path)
+            .map(|m| m.permissions().mode() & 0o777)
+            .unwrap_or(default_mode);
+        write_atomic_mode(path, bytes, mode)
+    }
+    #[cfg(not(unix))]
+    write_atomic_mode(path, bytes, default_mode)
+}
+
 /// How far an atomic write got.
 ///
 /// "It returned an error" and "nothing became visible" are not the same thing,

--- a/crates/irlume-core/src/policy.rs
+++ b/crates/irlume-core/src/policy.rs
@@ -66,13 +66,17 @@ pub fn method() -> Method {
 }
 
 /// Persist the active method (creates `/etc/irlume` if needed; needs root).
+/// Atomic: a crash or full disk mid-write must not leave a truncated file,
+/// because a truncated/empty method parses as `Auto` (face on), silently
+/// undoing an operator's `fingerprint` choice (2026-08-29 audit).
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn set_method(m: Method) -> irlume_common::Result<()> {
     let p = path();
     if let Some(dir) = p.parent() {
         std::fs::create_dir_all(dir).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
     }
-    std::fs::write(&p, m.as_str()).map_err(|e| irlume_common::Error::Io(e.to_string()))
+    irlume_common::write_atomic_preserving(&p, m.as_str().as_bytes(), 0o644)
+        .map_err(|e| irlume_common::Error::Io(e.to_string()))
 }
 
 #[cfg(test)]
@@ -156,6 +160,16 @@ mod tests {
         set_method(Method::Auto).unwrap();
         assert_eq!(std::fs::read_to_string(&f).unwrap(), "auto");
         assert_eq!(method(), Method::Auto);
+
+        // A rewrite of an existing TIGHT file must not come back wider: the
+        // atomic write preserves the deployed mode (2026-08-29 audit).
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o600)).unwrap();
+            set_method(Method::Face).unwrap();
+            let mode = std::fs::metadata(&f).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "method rewrite must preserve a 0600 mode");
+        }
 
         std::env::remove_var("IRLUME_METHOD_CONF");
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -327,7 +327,12 @@ fn main() {
     // from SocketMode= in the unit, and chmod'ing systemd's socket behind its
     // back would drift from what the unit says.
     if !socket_activated() {
-        set_mode(&socket, DAEMON_SOCKET_MODE);
+        if let Err(e) = set_mode(&socket, DAEMON_SOCKET_MODE) {
+            // Silent failure here would leave the socket at the umask mode
+            // with no trace, and face auth would just stop working for part
+            // of the fleet (2026-08-29 audit: the error was discarded).
+            eprintln!("irlumed: WARNING: could not set {DAEMON_SOCKET_MODE:o} on {socket}: {e}");
+        }
     }
     eprintln!("irlumed: socket ready at {socket}; requests queue while startup finishes");
 
@@ -2044,7 +2049,7 @@ fn unseal_keyring(user: &str, service: Option<&str>, have_password: bool, peer: 
         if !matches!(class, OperationClass::ScreenUnlock | OperationClass::Login) {
             eprintln!(
                 "irlumed: UnsealKeyring refused for service '{}' ({class:?})",
-                service.as_deref().unwrap_or("?")
+                journal_safe(service.as_deref().unwrap_or("?"))
             );
             return Response::Error(format!("keyring unseal not allowed for {class:?}"));
         }
@@ -3626,7 +3631,10 @@ fn dispatch_scoped(
                     .unwrap_or(SessionState::Cold);
                 let class = classify(service.as_deref().unwrap_or(""), session);
                 if class != OperationClass::ScreenUnlock {
-                    eprintln!("irlumed: convenience(RGB-only) denies face for '{}' ({class:?}) -> password", service.as_deref().unwrap_or("?"));
+                    eprintln!(
+                        "irlumed: convenience(RGB-only) denies face for '{}' ({class:?}) -> password",
+                        journal_safe(service.as_deref().unwrap_or("?"))
+                    );
                     return Response::AuthResult {
                         granted: false,
                         score: 0.0,
@@ -3651,7 +3659,10 @@ fn dispatch_scoped(
                 use irlume_core::biopolicy::{classify, decide, Action, SessionState, Tier};
                 let svc = service.as_deref().unwrap_or("");
                 if decide(classify(svc, SessionState::Cold), Tier::Secure) == Action::Deny {
-                    eprintln!("irlumed: biopolicy denies verify for service '{svc}' -> password");
+                    eprintln!(
+                        "irlumed: biopolicy denies verify for service '{}' -> password",
+                        journal_safe(svc)
+                    );
                     return Response::AuthResult {
                         granted: false,
                         score: 0.0,
@@ -4074,7 +4085,10 @@ fn dispatch_scoped(
                 use irlume_core::biopolicy::{classify, OperationClass, SessionState};
                 let svc = service.as_deref().unwrap_or("");
                 if classify(svc, SessionState::Cold) == OperationClass::AppConsent {
-                    eprintln!("irlumed: UnsealPassword refused for polkit service '{svc}' (verify-only class)");
+                    eprintln!(
+                    "irlumed: UnsealPassword refused for polkit service '{}' (verify-only class)",
+                    journal_safe(svc)
+                );
                     return Response::Error(format!(
                         "'{svc}' is verify-only: a polkit prompt never releases the credential"
                     ));
@@ -4106,7 +4120,10 @@ fn dispatch_scoped(
                 // is Secure tier.
                 let action = decide(classify(svc, SessionState::Cold), Tier::Secure);
                 if action != Action::Unseal {
-                    eprintln!("irlumed: biopolicy denies unseal for service '{svc}' ({action:?}) -> password");
+                    eprintln!(
+                    "irlumed: biopolicy denies unseal for service '{}' ({action:?}) -> password",
+                    journal_safe(svc)
+                );
                     return Response::Error(format!(
                         "biopolicy: '{svc}' may not release the credential"
                     ));
@@ -4771,9 +4788,34 @@ fn respond(mut stream: UnixStream, resp: &Response) -> std::io::Result<()> {
 /// group-restricted mode was removed rather than repaired.
 const DAEMON_SOCKET_MODE: u32 = 0o666;
 
-fn set_mode(path: &str, mode: u32) {
+fn set_mode(path: &str, mode: u32) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
-    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+}
+
+/// Peer-supplied text (the PAM service string) must never reach the journal
+/// raw: a local peer could otherwise forge `irlumed:` lines by embedding
+/// newlines in its service name (2026-08-29 audit). Newlines and tabs become
+/// spaces, other control characters become `?`, and the result is clamped.
+fn journal_safe(s: &str) -> String {
+    const MAX: usize = 64;
+    let mut out = String::with_capacity(s.len().min(MAX + 3));
+    let mut clamped = false;
+    for c in s.chars() {
+        if out.chars().count() >= MAX {
+            clamped = true;
+            break;
+        }
+        match c {
+            '\n' | '\r' | '\t' => out.push(' '),
+            c if (c as u32) < 0x20 || c as u32 == 0x7f => out.push('?'),
+            c => out.push(c),
+        }
+    }
+    if clamped {
+        out.push_str("...");
+    }
+    out
 }
 
 #[cfg(test)]
@@ -8068,12 +8110,33 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let f = dir.join("sock-standin");
         std::fs::write(&f, b"").unwrap();
-        set_mode(f.to_str().unwrap(), 0o660);
+        set_mode(f.to_str().unwrap(), 0o660).unwrap();
         let mode = std::fs::metadata(&f).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o660);
-        // Best-effort on a missing path: must not panic.
-        set_mode("/nonexistent/irlume-test/sock", 0o666);
+        // A missing path is now a REPORTED error, not a silently discarded
+        // one: the caller (the socket setup) journal-warns on it.
+        assert!(
+            set_mode("/nonexistent/irlume-test/sock", 0o666).is_err(),
+            "a failed chmod must surface so the socket mode is never silently wrong"
+        );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn journal_safe_strips_forging_characters_and_clamps() {
+        // A local peer controls its service string; embedded newlines must not
+        // reach the journal or they forge additional `irlumed:` lines.
+        assert_eq!(
+            journal_safe("sddm\nirlumed: face granted for alice"),
+            "sddm irlumed: face granted for alice"
+        );
+        assert_eq!(journal_safe("a\tb\rc"), "a b c");
+        assert_eq!(journal_safe("ctl\x01\x7f"), "ctl??");
+        assert_eq!(journal_safe("plain-sddm"), "plain-sddm");
+        let long = "x".repeat(200);
+        let out = journal_safe(&long);
+        assert_eq!(out.len(), 64 + 3, "clamped to 64 plus an ellipsis marker");
+        assert!(out.ends_with("..."));
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -8153,7 +8153,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("irlume.sock");
         let _listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
-        set_mode(path.to_str().unwrap(), DAEMON_SOCKET_MODE);
+        set_mode(path.to_str().unwrap(), DAEMON_SOCKET_MODE).unwrap();
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o666, "every local uid must be able to connect");

--- a/docs/research/2026-08-29-security-audit.md
+++ b/docs/research/2026-08-29-security-audit.md
@@ -1,0 +1,176 @@
+# Security audit, 2026-08-29
+
+A full code-grounded security audit of the irlume workspace at `65460762`,
+covering all twelve crates, the packaging units, and the PAM wiring surfaces.
+Method: context-building dossiers (per-function assumptions with citations),
+structural review of the authorization matrix, adversarial verification of
+every candidate finding to a TRUE/FALSE verdict, scanner passes, and fuzz
+campaigns over the untrusted-input parsers.
+
+## Scope and attacker classes
+
+In scope, in decreasing order of attention:
+
+1. Unprivileged local process (any uid): the Unix socket peer, the PAM
+   conversation input, sysfs/proc readers, `/tmp` and `/run` tenants.
+2. Physical / presentation attacker: prints, screens, masks, IR reflectors.
+3. Malicious camera device or hostile kernel-supplied descriptors.
+4. Crash / power-loss windows in privileged writers (integrity class).
+5. Supply chain (model files, packaging scriptlets).
+
+Out of scope, per the standing threat model
+([THREAT_MODEL.md](../THREAT_MODEL.md)): a root attacker, and cryptographic
+camera attestation against malicious hardware.
+
+## What held (verified controls)
+
+Every control below was traced source-to-sink with file:line evidence and
+survived adversarial reading:
+
+- **Socket authorization matrix.** `SO_PEERCRED` is captured before any
+  parse; every `Request` arm carries an explicit `RequestPosture`
+  (`main.rs` L2364-2615), `SetCameras`/`UnsealPassword`/`UnsealKeyring` are
+  `RootOnly` with tests pinning refusal (`main.rs` L9986, L10000), and the
+  unseal paths add envelope-existence, biopolicy class, and intent gates.
+- **Request framing.** `take(64 KiB)` precedes any allocation or parse
+  (`main.rs` L1313, L2335); the wire type is a closed Rust enum with no
+  untyped `Value`; `serde_json` never disables the recursion limit anywhere
+  in the workspace.
+- **PAM module env trust.** `secure_getenv` suppresses every
+  secret-relevant `IRLUME_*` override in all setuid contexts
+  (`client.rs` L47-65); remote-session markers only ever force deny; the
+  helper binaries that receive the TPM-released secret on stdin are
+  reachable only from root-daemon greeter lanes (wiring is verify-only for
+  sudo/polkit), and their argv/envp are constants plus NSS values. No
+  unprivileged env reaches a privileged sink.
+- **Username path safety.** `valid_username` (`main.rs` L2356-2362) rejects
+  empty, over-64, leading `-`/`.`, and every byte outside
+  `[A-Za-z0-9_.$-]`: no `/`, no NUL, no traversal into the
+  `format!("{user}.json")` joins.
+- **Matching math.** Every shipped embedding is L2-normalized in Rust
+  (`vision.rs` L612, L662) before the fixed 0.55 cosine comparison
+  (`auth.rs` L5263-5276); enroll and auth share one path; a swapped
+  recognizer changes the `embed:<sha256>` space tag and fails closed for
+  every stored scan (`main.rs` L163-166).
+- **Liveness fallbacks.** The saturation-frame fallback reads the raw (not
+  differenced) frame (`camera` L391, L5358); the only unmeasurable corner
+  is refused before any grant (`liveness.rs` L807-816). Degenerate
+  landmarks that default FRONTAL only skip a permissive gate and destroy
+  the identity chip simultaneously (`align.rs` L298-325).
+- **Helpers.** `drop_privileges` does initgroups-setgid-setuid with a
+  four-ID verify and refuses uid 0; wallet keys ride a private pipe, never
+  argv/env/socket; `/run/user/<uid>` is 0700 and the GKR socket checks
+  `SO_PASSCRED` peer uid.
+- **At-rest storage.** Secret-bearing files are 0600 from creation
+  (create_new + explicit mode, no chmod window); daemon dirs 0750 via
+  `UMask=0027`; template spaces are digest-pinned (`storage.rs` L206-223).
+- **Panic firewall.** All four PAM entry points wrap their bodies; no
+  reachable panic on untrusted input in the module's production spans.
+
+Scanner and dynamic evidence: semgrep (default ruleset) over all crates:
+0 findings. CodeQL default suite via CI: clean (the two
+`cfg(test)`-blind queries excluded 2026-08-29, PR #595, after 139/139
+verified false positives). `cargo test --workspace`: green. Fuzz campaigns
+over the four untrusted-input parsers (`ipc_request`, `sealed_envelope`,
+`pcr_signature`, `uvc_illumination`): 101,286,310 executions, zero crashes,
+zero OOMs, zero timeouts.
+
+## Findings fixed by this audit batch
+
+1. **`write_pam_edit` was a truncate-in-place write of a PAM file**
+   (`fingerprint.rs` L409): a crash, full disk, or power loss mid-write
+   could leave a truncated `/etc/pam.d` file, and the forced 0644 clobbered
+   any tighter existing mode. Now: one-shot backup, atomic temp-rename with
+   directory fsync via the shared helper, and the existing file mode is
+   preserved.
+2. **`policy::set_method` was a non-atomic truncate write** (`policy.rs`
+   L70): same crash-window class for `/etc/irlume/method`; a truncated file
+   parses to `Auto` (face on). Now atomic via the same helper. The
+   fail-open parse itself stays: it is the documented anti-lockout default
+   and the atomic write removes the crash path that could silently flip it.
+3. **Peer-supplied service strings reached the journal unsanitized**
+   (`main.rs` L2046, L3629, L3654, L4077, L4109): a local peer could forge
+   `irlumed:` journal lines via embedded newlines. Now sanitized (control
+   characters replaced, length clamped) before any journal write.
+4. **`set_mode` ignored chmod errors** (`main.rs` L4774): a silent failure
+   would leave the socket mode unset with no trace. Now checked, with a
+   loud journal warning on failure.
+
+## Hardening backlog (verified, not fixed here)
+
+Ordered by value; each was confirmed real in code but sits inside the root
+trust boundary, hardens a fail-closed path, or is cosmetic:
+
+1. **Pin absolute paths for binaries spawned as root.** `loginctl`
+   (`platform.rs` L115), `systemctl`/`restorecon`/`semodule`
+   (`pamwire.rs` L1841-1888), `authselect`/`pam-auth-update`
+   (`fingerprint.rs` L1143), `gnome-shell` (`pamwire.rs` L612), `busctl`
+   (`secrets.rs` L33), package-manager detection (`uninstall.rs`). All are
+   root-invoked with root-controlled env today; pinning removes the class.
+2. **`IRLUME_MODELS_STRICT` defaults off, and the post-panic engine rebuild
+   reopens model paths without re-verifying digests** (`main.rs` L150-172,
+   in-code comment is honest about it). Ship `=1` in the daemon unit and
+   re-verify on rebuild when strict is on.
+3. **Envelope/version fields are never checked on load**
+   (`envelope.rs` L128, `storage.rs` L566, `recovery.rs` L46); unknown
+   versions should be rejected rather than best-effort parsed (root-only
+   files, so integrity-of-format hardening).
+4. **Rate-limit strikes are keyed by username, not uid** (`main.rs`
+   L1004-1080): NSS aliases multiply the 5-strike budget; keying by uid
+   closes it. The throttle is documented as a throttle with password
+   fallback, so impact is bounded.
+5. **`/var/lib/irlume` is 0755 from packaging scriptlets** (umask 022):
+   enrolled usernames are listable. One mechanism creating it 0750 (tmpfiles
+   or scriptlet with explicit mode) closes the listing.
+6. **Secret hygiene gaps:** `SecretBytes` clones are not memlocked
+   (`common/lib.rs` L35); mlock failure is warn-and-continue and nothing
+   ever munlocks (`memlock.rs` L14-46); the kwallet PBKDF2 output is not
+   memlocked (`kwallet.rs` L154). Swap/dump exposure only, root process.
+7. **`kwallet read_salt` walks user-controlled intermediate symlinks**
+   (`kwallet.rs` L75; leaf is the fixed `kdewallet.salt`): an openat2
+   `RESOLVE_BENEATH`/`NO_SYMLINKS` walk removes the residual
+   existence/size oracle from error text.
+8. **`Adapter::apply` returns un-normalized output and its doc comment
+   claims otherwise** (`vision.rs` L692-700): opt-in, root-only path;
+   normalize and fix the doc.
+9. **`IRLUME_GRACE_MS` parses unvalidated and
+   `IRLUME_SHAKE_MIN_CROSSINGS` bypasses the `env_override` range/report
+   chain** (`auth.rs` L541-546, `liveness.rs` L1258-1263): route both
+   through the existing override discipline (operator-controlled env only,
+   but the validation asymmetry invites mistakes).
+10. **Per-recognizer threshold remains the shipped constant 0.55**
+    (`auth.rs` L2635, `core` L91): safe today because non-default weights
+    change the space tag and fail closed; #276 tracks the ROC-derived
+    threshold.
+11. **Omarchy fingerprint unwire uses raw substring matching**
+    (`fingerprint.rs` L601-643): drift in upstream lines could delete
+    foreign content; match on the pinned byte-constants instead.
+12. **Uninstall wildcard deletion** (`uninstall.rs` L340-352): `*irlume*`
+    glob in five root dirs; narrow to the exact packaged file list.
+13. **Daemon `set_devices`/cameras.conf values are format-unvalidated**
+    (`main.rs` L3751-3777, root-only writers): a `/dev/videoN`-shape check
+    would make misconfiguration loud instead of weird.
+14. **Stale unit comment**: `irlumed.service` L26-27 describes per-user
+    `$HOME` state that the daemon (no HOME, writes `/var/lib/irlume`) does
+    not have.
+
+## Threat model delta
+
+The standing [THREAT_MODEL.md](../THREAT_MODEL.md) validated against the
+code: the camera-pinning conditions, the posture table, the sealing-tier
+ladder, the fingerprint-tier residual (ADR-0003), and the score-exposure
+rules all match their implementations. Two additions from this audit:
+
+- **Journal forging** (fixed in this batch): a local peer could forge
+  journal lines via newlines in service strings; treat daemon journal lines
+  as attacker-influensible input in investigations no longer needed.
+- **Model tamper gate is opt-in and one-shot**: the strict manifest check
+  is honest about its own limits; until it defaults on and re-verifies on
+  rebuild, treat verified-model status as a startup-time property only.
+
+Assumptions that materially shaped the verdicts: single-user workstations
+and laptops (no multi-tenant hosts where uid boundaries matter differently);
+packaged deployment (systemd unit env is root-owned; LSM profiles active
+where the distro enforces them); the maintainer fleet tests on enforcing
+hosts. If any deployment shares a host between mutually distrusting users,
+revisit backlog items 4 and 5 first.


### PR DESCRIPTION
## What

Full workspace security audit at 65460762, delivered with the fixes it justifies. Report committed at `docs/research/2026-08-29-security-audit.md`.

## Audit summary

- Method: per-function context dossiers across all twelve crates (~90 unenforced assumptions collected), adversarial verification of every candidate to TRUE/FALSE verdict, scanner passes, fuzz campaigns.
- Verdict: the standing threat model HELD under adversarial reading (posture table, SO_PEERCRED matrix, camera pinning, sealing tiers, helper drop-privileges, matching math normalization, request framing caps, PAM env hardening all verified source-to-sink).
- Scanners/dynamic: semgrep default ruleset 0 findings; CodeQL default suite clean; cargo test workspace green; 101,286,310 fuzz executions over the four untrusted-input parsers, zero crashes/OOMs/timeouts.

## Fixed in this PR (the four verified discipline gaps)

1. `write_pam_edit` (fingerprint.rs): was a truncate-in-place write of a PAM file with forced 0644. Crash/ENOSPC mid-write could truncate an auth stack; a 0600 stack file came back world-readable. Now atomic (temp+rename+fsync via the shared helper) and mode-preserving via a new `irlume_common::write_atomic_preserving`. RED-first test (watched fail on the mode-widening behavior).
2. `policy::set_method`: was a non-atomic write of `/etc/irlume/method`; a truncated file parses as Auto (face on), silently undoing an operator's fingerprint choice. Now atomic.
3. `journal_safe`: peer-supplied PAM service strings reached the journal raw; embedded newlines let a local peer forge irlumed: lines. Sanitized (control chars replaced, 64-char clamp) at all five journal sites. Mutation-checked.
4. `set_mode`: failed socket chmod silently discarded; now journal-warns.

## Hardening backlog

14 verified items documented in the report (absolute-path pinning for root-spawned binaries, IRLUME_MODELS_STRICT default, envelope version rejection, uid-keyed throttle, /var/lib/irlume 0750, secret memlock gaps, kwallet openat2 walk, adapter normalization, env override routing, per-recognizer threshold, omarchy unwire constants, uninstall glob narrowing, set_devices validation, stale unit comment). None are attacker-reachable without root or are documented residuals; each carries file:line and a suggested action.

## Testing

- RED-first for the mode fix; mutation check for journal_safe
- cargo test --workspace: 33 batches green (engine tests needed the staged model weights, the known fresh-worktree trap)
- cargo fmt + clippy clean