### PR TITLE
release: 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to irlume are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.11.3] - 2026-08-29
 
 ### Added
 
@@ -3165,7 +3165,8 @@ is always the fallback: no lockout, ever.
   credentials).
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
-[Unreleased]: https://github.com/archledger/irlume/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/archledger/irlume/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/archledger/irlume/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/archledger/irlume/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/archledger/irlume/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/archledger/irlume/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "image",
  "irlume-auth",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "libc",
  "serde",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "irlume-auth",
  "irlume-common",
@@ -1095,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.11.2"
+version = "0.11.3"
 
 [[package]]
 name = "irlume-gkr-unlock"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-kwallet-init"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-liveness"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "irlume-common",
  "irlume-vision",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "edgefirst-tflite",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ unlock · **fingerprint** → companion factor.
 
 ## Status
 
-**v0.11.2**, working on real hardware across Fedora, Ubuntu and Arch. Self-tested
+**v0.11.3**, working on real hardware across Fedora, Ubuntu and Arch. Self-tested
 against ISO/IEC 30107-3, not lab-certified. Interfaces may shift before 1.0.
 Validated cameras are listed in [Hardware compatibility](docs/HARDWARE.md)
 (generated from measured evidence, never hand-edited).

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.11.2
+pkgver=0.11.3
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux: IR cameras, consent-gated, photo-spoofing resistant, TPM-sealed, password always works"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.11.2
+version: 0.11.3
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -2,7 +2,7 @@
 %global ort_ver 1.28.1
 
 Name:           irlume
-Version:        0.11.2
+Version:        0.11.3
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 
@@ -274,6 +274,23 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %{_datadir}/selinux/packages/irlume.pp
 
 %changelog
+* Sat Aug 29 2026 archledger <archledger236@gmail.com> - 0.11.3-1
+- AppArmor: emitter-journal ancestor-fsync reads and the qualification-store
+  file lock are granted in both profiles (set-cameras persist, camera-tune and
+  ir-setup work on enforcing hosts) (#573/#582/#590)
+- Omarchy: fingerprint wiring honors upstream's contract; face unlock on the
+  stock lock screen (#583/#584); Cinnamon lock screen face (#585)
+- camera-tune reports the persisted verdict and names the continuity fact that
+  failed (#588/#591/#592); TUI shows capture qualification state
+- proactive concurrent degradation and background auto-requalification after a
+  camera-context change (#594)
+- security audit batch: atomic mode-preserving PAM edits, atomic method-file
+  writes, sanitized journal service strings (#597); CodeQL noise fix (#595)
+- forbid_external_cameras policy for high-security deployments (#577-era)
+- docs: census/machine diagnostics grounding, far-range dark-path sweep,
+  XFCE-lock unsupported note, calibration campaign foundations (#578/#579/#581/
+  #593/#596)
+
 * Tue Aug 25 2026 archledger <archledger236@gmail.com> - 0.11.2-1
 - rpm-ostree: %post survives the scriptlet sandbox (touch instead of `: >`,
   guarded mkdir); layering was impossible on Silverblue/Kinoite before this


### PR DESCRIPTION
Version bump in Cargo.toml (+lock), nfpm.yaml, PKGBUILD, spec (+%changelog); CHANGELOG stamped; README status line.

Carries the full 0.11.3 vehicle (#577-#597 + #596): AppArmor enforcing-host fixes (journal ancestor fsync #573, config lock #582, qualification-store lock #590), Omarchy fingerprint wiring (#583) + stock lock face (#584), Cinnamon lock face (#585) + polish (#587), camera-tune persisted verdict + named continuity facts (#588/#591/#592), TUI capture qualification display + proactive degradation + background auto-requalification (#594), forbid_external_cameras policy, docs grounding (census/machine diagnostics #578/#579, far-range dark sweep #581, XFCE lock note #593), the security audit hardening batch with its committed report (#597), the CodeQL cfg(test)-noise fix (#595), and the model calibration campaign Phase 0 foundations (#596).

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>