### PR TITLE
bench: calibration Phase 1, detection and landmarks tracks

### DIFF
--- a/benchmarks/bench_detection_ir.py
+++ b/benchmarks/bench_detection_ir.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""YuNet IR-grey detection benchmark on CBSR NIR and Oulu-CASIA NIR.
+
+No ground truth boxes are scored: the bench reports YuNet detection
+rate and score distribution at the irlume operating point (640 square
+letterbox, score_threshold 0.6) on near-infrared frames. The decode
+matches bench_detection_wider --ap: detector rows are x,y,w,h plus 5
+landmarks with the score at column 14.
+
+CBSR NIR is walked over sorted .bmp files; the mirror nests the frames
+one level under NIR_face_dataset and subjects are encoded in filename
+prefixes, so the walk is flat in practice and the gallery groundtruth
+file is ignored. Oulu-CASIA NIR is walked recursively under NI only and
+grouped by lighting directory name; the VL/ RGB counterpart is ignored.
+Each dataset is capped at 4000 frames via stride sampling over the
+sorted recursive file list; the stride and counts land in the notes.
+"""
+
+import argparse
+import json
+import math
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from letterbox import letterbox_image
+
+OP_INPUT = 640
+OP_SCORE = 0.6
+FRAME_CAP = 4000
+YUNET_MODEL = "face_detection_yunet_2023mar.onnx"
+
+
+def collect_files(root: Path, exts: tuple[str, ...]) -> list[Path]:
+    return sorted(
+        p for p in root.rglob("*")
+        if p.is_file() and p.suffix.lower() in exts
+    )
+
+
+def stride_sample(items: list[Path], target: int) -> tuple[list[Path], int]:
+    stride = max(1, math.ceil(len(items) / target))
+    return items[::stride], stride
+
+
+def yunet_detector(model_path: Path, size: int, score_threshold: float):
+    return cv2.FaceDetectorYN_create(
+        str(model_path), "", (size, size), score_threshold=score_threshold
+    )
+
+
+def detect_scores(det, img, target: int) -> list[float]:
+    """YuNet scores on the letterbox canvas: rows are x,y,w,h plus 5
+    landmarks with the score at column 14, same decode as the wider
+    bench --ap mode."""
+    canvas, _ = letterbox_image(img, target)
+    _, faces = det.detect(canvas)
+    if faces is None:
+        return []
+    return [float(f[14]) for f in faces]
+
+
+def score_stats(scores: list[float]) -> tuple[float, float]:
+    if not scores:
+        return 0.0, 0.0
+    arr = np.asarray(scores, dtype=np.float64)
+    return float(np.percentile(arr, 50)), float(np.percentile(arr, 10))
+
+
+def _read_progress(i: int, total: int, tag: str) -> None:
+    if i % 500 == 0:
+        print(f"[{tag}] {i}/{total} frames", flush=True)
+
+
+def run_group(det, files: list[Path], tag: str) -> tuple[dict, list[float], int]:
+    frames = detected = read_failures = 0
+    scores: list[float] = []
+    t0 = time.time()
+    for i, path in enumerate(files, 1):
+        img = cv2.imread(str(path))
+        if img is None:
+            read_failures += 1
+        else:
+            frames += 1
+            found = detect_scores(det, img, OP_INPUT)
+            if found:
+                detected += 1
+                scores.extend(found)
+        _read_progress(i, len(files), tag)
+    p50, p10 = score_stats(scores)
+    section = {
+        "frames": frames,
+        "detected": detected,
+        "rate": detected / frames if frames else 0.0,
+        "score_p50": p50,
+        "score_p10": p10,
+    }
+    print(
+        f"[{tag}] {detected}/{frames} frames with a face "
+        f"({section['rate']:.4f}) in {time.time() - t0:.1f}s",
+        flush=True,
+    )
+    return section, scores, read_failures
+
+
+def run_cbsr(det, root: Path) -> tuple[dict, list[str]]:
+    all_files = collect_files(root, (".bmp",))
+    if not all_files:
+        raise SystemExit(f"error: no .bmp frames under {root}")
+    sample, stride = stride_sample(all_files, FRAME_CAP)
+    section, scores, failures = run_group(det, sample, "cbsr")
+    notes = [
+        (
+            f"cbsr run: {len(sample)} of {len(all_files)} bmp frames "
+            f"(stride {stride}, nearest stride-integer approximation of "
+            f"the {FRAME_CAP}-frame cap) in one flat sorted walk; the "
+            "gallery groundtruth file is not consulted."
+        ),
+    ]
+    if failures:
+        notes.append(f"cbsr: {failures} unreadable frames skipped.")
+    return section, notes
+
+
+def run_oulu(det, root: Path) -> tuple[dict, list[str]]:
+    ni = root / "NI"
+    if not ni.is_dir():
+        raise SystemExit(f"error: missing NI/ under {root}")
+    all_files = collect_files(ni, (".jpg", ".jpeg"))
+    if not all_files:
+        raise SystemExit(f"error: no jpg frames under {ni}")
+    sample, stride = stride_sample(all_files, FRAME_CAP)
+    by_lighting: dict[str, list[Path]] = {}
+    for p in sample:
+        by_lighting.setdefault(p.relative_to(ni).parts[0], []).append(p)
+    per_lighting = []
+    tot_frames = tot_detected = tot_failures = 0
+    all_scores: list[float] = []
+    for lighting in sorted(by_lighting):
+        section, scores, failures = run_group(
+            det, by_lighting[lighting], f"oulu-{lighting}"
+        )
+        per_lighting.append(
+            {
+                "lighting": lighting,
+                "frames": section["frames"],
+                "rate": section["rate"],
+            }
+        )
+        tot_frames += section["frames"]
+        tot_detected += section["detected"]
+        tot_failures += failures
+        all_scores.extend(scores)
+    p50, p10 = score_stats(all_scores)
+    overall = {
+        "frames": tot_frames,
+        "detected": tot_detected,
+        "rate": tot_detected / tot_frames if tot_frames else 0.0,
+        "score_p50": p50,
+        "score_p10": p10,
+    }
+    notes = [
+        (
+            f"oulu run: {len(sample)} of {len(all_files)} jpg frames under "
+            f"NI (stride {stride}, nearest stride-integer approximation of "
+            f"the {FRAME_CAP}-frame cap) in one sorted recursive walk, "
+            "grouped by lighting directory name; the VL/ RGB counterpart "
+            "is not walked."
+        ),
+    ]
+    if tot_failures:
+        notes.append(f"oulu: {tot_failures} unreadable frames skipped.")
+    return {"per_lighting": per_lighting, "overall": overall}, notes
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models-dir", type=Path, required=True)
+    ap.add_argument("--cbsr-root", type=Path, required=True)
+    ap.add_argument("--oulu-root", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args(argv)
+
+    det = yunet_detector(args.models_dir / YUNET_MODEL, OP_INPUT, OP_SCORE)
+    cbsr, cbsr_notes = run_cbsr(det, args.cbsr_root)
+    oulu, oulu_notes = run_oulu(det, args.oulu_root)
+    result = {
+        "runtime": {
+            "cv2_version": cv2.__version__,
+            "yunet": YUNET_MODEL,
+            "input": OP_INPUT,
+            "score_threshold": OP_SCORE,
+        },
+        "cbsr": cbsr,
+        "oulu": oulu,
+        "notes": cbsr_notes + oulu_notes,
+    }
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result["oulu"]["overall"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_detection_wider.py
+++ b/benchmarks/bench_detection_wider.py
@@ -8,8 +8,11 @@ dataset, OpenCV YuNet) end to end.
 
 --ap: full WIDER FACE val AP at the operating point (640 square letterbox,
 score_threshold 0.6) using the official-protocol evaluator in wider_ap.py.
-Easy/medium/hard follow the standard GT height bands (easy >= 50, medium
->= 20, hard = all); predictions are unchanged across bands.
+Difficulty tiers use official-approximation tier cuts (h>50/h>30/h>=10),
+off-tier predictions discarded: each prediction is first matched to its
+best-IoU GT among all valid boxes of its image, and predictions whose
+best-overlap GT is outside the tier are dropped (neither tp nor fp);
+invalid-flag GT boxes stay excluded everywhere.
 
 --sweep: stratified val sample (every k-th image of the sorted list, nearest
 stride-integer approximation of a 2000-image target) across input sizes
@@ -37,7 +40,7 @@ import numpy as np
 import onnxruntime as ort
 
 from letterbox import letterbox_image, restore_boxes
-from wider_ap import _match, evaluate as ap_evaluate, parse_val_gt, voc_ap
+from wider_ap import _match, evaluate_tier, parse_val_gt, voc_ap
 
 OP_INPUT = 640
 OP_SCORE = 0.6
@@ -47,7 +50,8 @@ SWEEP_TARGET = 2000
 CASCADE_TRAIN_TARGET = 4000
 IOU_THR = 0.5
 EASY_MIN_H = 50.0
-MEDIUM_MIN_H = 20.0
+MEDIUM_MIN_H = 30.0
+HARD_MIN_H = 10.0
 YUNET_MODEL = "face_detection_yunet_2023mar.onnx"
 BLAZE_MODEL = "blaze_face_short_range.onnx"
 
@@ -100,13 +104,6 @@ def detect_letterbox(det, img, target: int) -> list[tuple[float, list[float]]]:
     return [(s, b) for (s, _), b in zip(raw, boxes)]
 
 
-def filter_gt_by_height(gt_by_image: dict, min_h: float) -> dict:
-    out = {}
-    for key, boxes in gt_by_image.items():
-        out[key] = [b for b in boxes if (b["box"][3] - b["box"][1]) >= min_h]
-    return out
-
-
 def _read_progress(i: int, total: int, tag: str) -> None:
     if i % 200 == 0:
         print(f"[{tag}] {i}/{total} images", flush=True)
@@ -131,11 +128,11 @@ def run_ap(args) -> dict:
             continue
         preds_by_image[rel] = detect_letterbox(det, img, OP_INPUT)
         _read_progress(i, len(vals), "ap")
-    hard = ap_evaluate(preds_by_image, gt_all)
-    medium = ap_evaluate(
-        preds_by_image, filter_gt_by_height(gt_all, MEDIUM_MIN_H)
+    hard = evaluate_tier(preds_by_image, gt_all, HARD_MIN_H, strict=False)
+    medium = evaluate_tier(
+        preds_by_image, gt_all, MEDIUM_MIN_H, strict=True
     )
-    easy = ap_evaluate(preds_by_image, filter_gt_by_height(gt_all, EASY_MIN_H))
+    easy = evaluate_tier(preds_by_image, gt_all, EASY_MIN_H, strict=True)
     elapsed = time.time() - t0
     section = {
         "easy": easy["ap"],
@@ -146,12 +143,23 @@ def run_ap(args) -> dict:
         "n_gt": hard["n_gt"],
         "images": len(vals),
     }
-    notes = (
-        f"ap run: {len(vals)} val images in {elapsed:.1f}s at the operating "
-        f"point (letterbox {OP_INPUT}, score {OP_SCORE}); easy/medium/hard "
-        f"use GT height bands >= {EASY_MIN_H:g} / >= {MEDIUM_MIN_H:g} / all "
-        "with predictions unchanged; tp/fp/n_gt are the hard-band totals."
-    )
+    notes = [
+        (
+            f"ap run: {len(vals)} val images in {elapsed:.1f}s at the "
+            f"operating point (letterbox {OP_INPUT}, score {OP_SCORE}); "
+            "official-approximation tier cuts (h>50/h>30/h>=10), off-tier "
+            "predictions discarded (best-overlap valid GT outside the tier "
+            "drops the prediction; zero-overlap predictions stay fp "
+            "candidates); invalid-flag GT boxes excluded everywhere; "
+            "tp/fp/n_gt are the hard-tier totals."
+        ),
+        (
+            "height-band approximation run superseded by tier semantics: "
+            "the earlier h>=50/h>=20/all-valid bands scored easy "
+            "0.6859 / medium 0.6866 / hard 0.3964 (tp 15826, fp 2366, "
+            "n_gt 39123)."
+        ),
+    ]
     return section, notes
 
 
@@ -245,8 +253,9 @@ def _gen_anchors() -> np.ndarray:
 
 class BlazeRescue:
     """Single-face rescue mirroring the shipped Rust decode: bottom-right
-    square pad, 128x128 input, sigmoid scores over 896+64=960 anchors,
-    argmax anchor, box restored in original image coords and clipped."""
+    square pad, 128x128 input, sigmoid scores over 16x16x2 + 8x8x6 = 896
+    anchors, argmax anchor, box restored in original image coords and
+    clipped."""
 
     def __init__(self, model_path: Path):
         self.sess = ort.InferenceSession(
@@ -432,15 +441,15 @@ def main(argv: list[str] | None = None) -> int:
     result["runtime"] = runtime
     result["operating_point"] = {"input": OP_INPUT, "score_threshold": OP_SCORE}
     if args.ap:
-        section, note = run_ap(args)
+        section, new_notes = run_ap(args)
         result["ap"] = section
     elif args.sweep:
-        section, note = run_sweep(args)
+        section, new_notes = run_sweep(args)
         result["sweep"] = section
     else:
-        section, note = run_cascade(args)
+        section, new_notes = run_cascade(args)
         result["cascade"] = section
-    notes.append(note)
+    notes.extend(new_notes if isinstance(new_notes, list) else [new_notes])
     result["notes"] = notes
     args.out.write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(section))

--- a/benchmarks/bench_detection_wider.py
+++ b/benchmarks/bench_detection_wider.py
@@ -5,24 +5,356 @@
 at irlume operating scale and write per-image counts. Full AP evaluation is a
 later phase; this smoke run exists to prove the chain (venv, CUDA, models,
 dataset, OpenCV YuNet) end to end.
+
+--ap: full WIDER FACE val AP at the operating point (640 square letterbox,
+score_threshold 0.6) using the official-protocol evaluator in wider_ap.py.
+Easy/medium/hard follow the standard GT height bands (easy >= 50, medium
+>= 20, hard = all); predictions are unchanged across bands.
+
+--sweep: stratified val sample (every k-th image of the sorted list, nearest
+stride-integer approximation of a 2000-image target) across input sizes
+{320, 448, 640} x score thresholds {0.3, 0.45, 0.6, 0.7}. Decoders run at
+the lowest sweep threshold and rows post-filter scores, so per-input FPPI
+curves support recall_at_op_fppi (recall at the 640/0.6 row's FPPI).
+
+--cascade: recall with and without the BlazeFace short-range rescue on
+YuNet misses at the operating point, on full val plus a stride-sampled
+train split (nearest stride-integer approximation of 4000 images).
+
+All non-smoke modes merge their section into the shared results JSON so
+successive runs build one artifact.
 """
 
 import argparse
 import json
+import math
 import sys
+import time
 from pathlib import Path
 
 import cv2
+import numpy as np
 import onnxruntime as ort
+
+from letterbox import letterbox_image, restore_boxes
+from wider_ap import _match, evaluate as ap_evaluate, parse_val_gt, voc_ap
+
+OP_INPUT = 640
+OP_SCORE = 0.6
+SWEEP_INPUTS = (320, 448, 640)
+SWEEP_THRESHOLDS = (0.3, 0.45, 0.6, 0.7)
+SWEEP_TARGET = 2000
+CASCADE_TRAIN_TARGET = 4000
+IOU_THR = 0.5
+EASY_MIN_H = 50.0
+MEDIUM_MIN_H = 20.0
+YUNET_MODEL = "face_detection_yunet_2023mar.onnx"
+BLAZE_MODEL = "blaze_face_short_range.onnx"
 
 
 def val_image_list(wider_root: Path) -> list[str]:
     gt = wider_root / "wider_face_split" / "wider_face_val_bbx_gt.txt"
+    return gt_image_list(gt)
+
+
+def gt_image_list(gt_path: Path) -> list[str]:
     out = []
-    for line in gt.read_text().splitlines():
+    for line in gt_path.read_text().splitlines():
         if line.endswith(".jpg"):
             out.append(line.strip())
     return out
+
+
+def stride_sample(items: list[str], target: int) -> tuple[list[str], int]:
+    stride = max(1, math.ceil(len(items) / target))
+    return items[::stride], stride
+
+
+def yunet_detector(model_path: Path, size: int, score_threshold: float):
+    return cv2.FaceDetectorYN_create(
+        str(model_path), "", (size, size), score_threshold=score_threshold
+    )
+
+
+def detect_letterbox(det, img, target: int) -> list[tuple[float, list[float]]]:
+    """Decode YuNet rows [x, y, w, h, 5 landmarks, score] on the letterbox
+    canvas into (score, [x1, y1, x2, y2]) in original image coordinates."""
+    canvas, params = letterbox_image(img, target)
+    _, faces = det.detect(canvas)
+    if faces is None:
+        return []
+    h, w = img.shape[:2]
+    raw = [
+        (
+            float(f[14]),
+            [
+                float(f[0]),
+                float(f[1]),
+                float(f[0] + f[2]),
+                float(f[1] + f[3]),
+            ],
+        )
+        for f in faces
+    ]
+    boxes = restore_boxes([b for _, b in raw], params, w, h)
+    return [(s, b) for (s, _), b in zip(raw, boxes)]
+
+
+def filter_gt_by_height(gt_by_image: dict, min_h: float) -> dict:
+    out = {}
+    for key, boxes in gt_by_image.items():
+        out[key] = [b for b in boxes if (b["box"][3] - b["box"][1]) >= min_h]
+    return out
+
+
+def _read_progress(i: int, total: int, tag: str) -> None:
+    if i % 200 == 0:
+        print(f"[{tag}] {i}/{total} images", flush=True)
+
+
+def _load_img(wider_root: Path, split: str, rel: str):
+    return cv2.imread(str(wider_root / split / "images" / rel))
+
+
+def run_ap(args) -> dict:
+    vals = sorted(val_image_list(args.wider_root))
+    gt_all = parse_val_gt(
+        args.wider_root / "wider_face_split" / "wider_face_val_bbx_gt.txt"
+    )
+    det = yunet_detector(args.models_dir / YUNET_MODEL, OP_INPUT, OP_SCORE)
+    preds_by_image = {}
+    t0 = time.time()
+    for i, rel in enumerate(vals, 1):
+        img = _load_img(args.wider_root, "WIDER_val", rel)
+        if img is None:
+            preds_by_image[rel] = []
+            continue
+        preds_by_image[rel] = detect_letterbox(det, img, OP_INPUT)
+        _read_progress(i, len(vals), "ap")
+    hard = ap_evaluate(preds_by_image, gt_all)
+    medium = ap_evaluate(
+        preds_by_image, filter_gt_by_height(gt_all, MEDIUM_MIN_H)
+    )
+    easy = ap_evaluate(preds_by_image, filter_gt_by_height(gt_all, EASY_MIN_H))
+    elapsed = time.time() - t0
+    section = {
+        "easy": easy["ap"],
+        "medium": medium["ap"],
+        "hard": hard["ap"],
+        "tp": hard["tp"],
+        "fp": hard["fp"],
+        "n_gt": hard["n_gt"],
+        "images": len(vals),
+    }
+    notes = (
+        f"ap run: {len(vals)} val images in {elapsed:.1f}s at the operating "
+        f"point (letterbox {OP_INPUT}, score {OP_SCORE}); easy/medium/hard "
+        f"use GT height bands >= {EASY_MIN_H:g} / >= {MEDIUM_MIN_H:g} / all "
+        "with predictions unchanged; tp/fp/n_gt are the hard-band totals."
+    )
+    return section, notes
+
+
+def run_sweep(args) -> dict:
+    vals = sorted(val_image_list(args.wider_root))
+    sample, stride = stride_sample(vals, SWEEP_TARGET)
+    gt_all = parse_val_gt(
+        args.wider_root / "wider_face_split" / "wider_face_val_bbx_gt.txt"
+    )
+    gt_sample = {k: gt_all[k] for k in sample if k in gt_all}
+    n_gt_sample = sum(
+        1 for boxes in gt_sample.values() for b in boxes if not b["invalid"]
+    )
+    dets = {
+        s: yunet_detector(args.models_dir / YUNET_MODEL, s, min(SWEEP_THRESHOLDS))
+        for s in SWEEP_INPUTS
+    }
+    decoded = {s: {} for s in SWEEP_INPUTS}
+    t0 = time.time()
+    for i, rel in enumerate(sample, 1):
+        img = _load_img(args.wider_root, "WIDER_val", rel)
+        for s in SWEEP_INPUTS:
+            decoded[s][rel] = (
+                detect_letterbox(dets[s], img, s) if img is not None else []
+            )
+        _read_progress(i, len(sample), "sweep")
+    flags_by_input = {}
+    for s in SWEEP_INPUTS:
+        pairs: list[tuple[float, int]] = []
+        for rel in sample:
+            preds = sorted(
+                decoded[s][rel], key=lambda p: p[0], reverse=True
+            )
+            flags = _match(preds, gt_sample.get(rel, []), IOU_THR)
+            pairs.extend(
+                (preds[j][0], 1 if f else 0) for j, f in enumerate(flags)
+            )
+        pairs.sort(key=lambda p: p[0], reverse=True)
+        flags_by_input[s] = pairs
+    op_pairs = [
+        p for p in flags_by_input[OP_INPUT] if p[0] >= OP_SCORE
+    ]
+    op_fp = sum(1 for _, tp in op_pairs if not tp)
+    op_fppi = op_fp / len(sample)
+    rows = []
+    for s in SWEEP_INPUTS:
+        pairs = flags_by_input[s]
+        for thr in SWEEP_THRESHOLDS:
+            filt = [p for p in pairs if p[0] >= thr]
+            scores = [p[0] for p in filt]
+            tps = [p[1] for p in filt]
+            recall = 0.0
+            cum_tp = cum_fp = 0
+            for _, tp in filt:
+                if tp:
+                    cum_tp += 1
+                else:
+                    cum_fp += 1
+                if n_gt_sample > 0 and cum_fp / len(sample) <= op_fppi:
+                    recall = cum_tp / n_gt_sample
+            rows.append(
+                {
+                    "input": s,
+                    "score_threshold": thr,
+                    "ap_hard": voc_ap(scores, tps, n_gt_sample),
+                    "recall_at_op_fppi": recall,
+                }
+            )
+    elapsed = time.time() - t0
+    notes = (
+        f"sweep run: {len(sample)} of {len(vals)} val images (stride "
+        f"{stride}, nearest stride-integer approximation of the "
+        f"{SWEEP_TARGET}-image target) in {elapsed:.1f}s; decoders run at "
+        f"the lowest sweep threshold {min(SWEEP_THRESHOLDS)} and rows "
+        f"post-filter scores; recall_at_op_fppi uses this sample's "
+        f"operating-point FPPI {op_fppi:.4f} (640/0.6 row); ap_hard and "
+        "recall use all valid val GT faces (hard band)."
+    )
+    return rows, notes
+
+
+def _gen_anchors() -> np.ndarray:
+    anchors = []
+    for cells, per in ((16, 2), (8, 6)):
+        for r in range(cells):
+            for c in range(cells):
+                for _ in range(per):
+                    anchors.append(((c + 0.5) / cells, (r + 0.5) / cells))
+    return np.array(anchors, np.float32)
+
+
+class BlazeRescue:
+    """Single-face rescue mirroring the shipped Rust decode: bottom-right
+    square pad, 128x128 input, sigmoid scores over 896+64=960 anchors,
+    argmax anchor, box restored in original image coords and clipped."""
+
+    def __init__(self, model_path: Path):
+        self.sess = ort.InferenceSession(
+            str(model_path), providers=["CPUExecutionProvider"]
+        )
+        self.input_name = self.sess.get_inputs()[0].name
+        self.anchors = _gen_anchors()
+
+    def detect(self, bgr, thr: float = 0.5) -> list[float] | None:
+        h, w = bgr.shape[:2]
+        side = max(h, w)
+        pad = np.zeros((side, side, 3), np.uint8)
+        pad[:h, :w] = bgr
+        rgb = cv2.cvtColor(cv2.resize(pad, (128, 128)), cv2.COLOR_BGR2RGB)
+        x = (rgb.astype(np.float32) - 127.5) / 127.5
+        reg, cls = self.sess.run(None, {self.input_name: x[None]})
+        scores = 1.0 / (1.0 + np.exp(-np.clip(cls[0, :, 0], -100, 100)))
+        i = int(np.argmax(scores))
+        if scores[i] < thr:
+            return None
+        r = reg[0, i]
+        ax, ay = self.anchors[i]
+        cx, cy = ax + r[0] / 128.0, ay + r[1] / 128.0
+        bw, bh = r[2] / 128.0, r[3] / 128.0
+        x1 = float(np.clip((cx - bw / 2) * side, 0.0, float(w)))
+        y1 = float(np.clip((cy - bh / 2) * side, 0.0, float(h)))
+        x2 = float(np.clip((cx + bw / 2) * side, 0.0, float(w)))
+        y2 = float(np.clip((cy + bh / 2) * side, 0.0, float(h)))
+        return [x1, y1, x2, y2]
+
+
+def _matched_count(preds, gt_boxes) -> int:
+    return sum(1 for f in _match(preds, gt_boxes, IOU_THR) if f)
+
+
+def _cascade_counts(
+    wider_root: Path, split_dir: str, items, gt_all, det, blaze
+) -> dict:
+    yunet_matched = cascade_matched = n_gt = 0
+    yunet_empty = rescue_boxes = rescue_fired = 0
+    t0 = time.time()
+    for i, rel in enumerate(items, 1):
+        boxes = [b for b in gt_all.get(rel, []) if not b["invalid"]]
+        n_gt += len(boxes)
+        img = _load_img(wider_root, split_dir, rel)
+        if img is not None:
+            preds = detect_letterbox(det, img, OP_INPUT)
+            ym = _matched_count(preds, boxes)
+            yunet_matched += ym
+            if preds:
+                cascade_matched += ym
+            else:
+                yunet_empty += 1
+                rescue_fired += 1
+                box = blaze.detect(img)
+                if box is not None:
+                    rescue_boxes += 1
+                    cascade_matched += _matched_count([(1.0, box)], boxes)
+        _read_progress(i, len(items), f"cascade-{split_dir}")
+    return {
+        "yunet_recall": yunet_matched / n_gt if n_gt else 0.0,
+        "cascade_recall": cascade_matched / n_gt if n_gt else 0.0,
+        "rescues": cascade_matched - yunet_matched,
+        "n_gt": n_gt,
+        "images": len(items),
+        "yunet_empty_images": yunet_empty,
+        "rescue_fired": rescue_fired,
+        "rescue_boxes": rescue_boxes,
+        "elapsed_s": round(time.time() - t0, 1),
+    }
+
+
+def run_cascade(args) -> dict:
+    val_list = sorted(val_image_list(args.wider_root))
+    train_list_all = sorted(
+        gt_image_list(
+            args.wider_root
+            / "wider_face_split"
+            / "wider_face_train_bbx_gt.txt"
+        )
+    )
+    train_list, train_stride = stride_sample(
+        train_list_all, CASCADE_TRAIN_TARGET
+    )
+    gt_val = parse_val_gt(
+        args.wider_root / "wider_face_split" / "wider_face_val_bbx_gt.txt"
+    )
+    gt_train = parse_val_gt(
+        args.wider_root / "wider_face_split" / "wider_face_train_bbx_gt.txt"
+    )
+    det = yunet_detector(args.models_dir / YUNET_MODEL, OP_INPUT, OP_SCORE)
+    blaze = BlazeRescue(args.models_dir / BLAZE_MODEL)
+    val_counts = _cascade_counts(
+        args.wider_root, "WIDER_val", val_list, gt_val, det, blaze
+    )
+    train_counts = _cascade_counts(
+        args.wider_root, "WIDER_train", train_list, gt_train, det, blaze
+    )
+    train_counts["stride"] = train_stride
+    section = {"val": val_counts, "train_sample": train_counts}
+    notes = (
+        "cascade run: YuNet at the operating point, BlazeFace short-range "
+        "rescue only on YuNet-empty images (rescue score 0.5, shipped "
+        "anchor decode); recall is valid-GT faces matched at IoU 0.5; "
+        f"train sample is {len(train_list)} of {len(train_list_all)} train "
+        f"images at stride {train_stride}."
+    )
+    return section, notes
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -30,55 +362,88 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--models-dir", type=Path, required=True)
     ap.add_argument("--wider-root", type=Path, required=True)
     ap.add_argument("--out", type=Path, required=True)
-    ap.add_argument("--smoke", action="store_true")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--smoke", action="store_true")
+    mode.add_argument("--ap", action="store_true")
+    mode.add_argument("--sweep", action="store_true")
+    mode.add_argument("--cascade", action="store_true")
     ap.add_argument("--n", type=int, default=32, help="smoke image count")
     args = ap.parse_args(argv)
 
-    det = cv2.FaceDetectorYN_create(
-        str(args.models_dir / "face_detection_yunet_2023mar.onnx"),
-        "",
-        (320, 240),
-        score_threshold=0.6,
-    )
-    vals = val_image_list(args.wider_root)
-    images = vals[: args.n] if args.smoke else vals
-    per_image = []
-    for rel in images:
-        img = cv2.imread(str(args.wider_root / "WIDER_val" / "images" / rel))
-        if img is None:
-            per_image.append({"file": rel, "n_faces": -1, "max_score": 0.0})
-            continue
-        h, w = img.shape[:2]
-        det.setInputSize((w, h))
-        ret, faces = det.detect(img)
-        if faces is None:
-            n, mx = 0, 0.0
-        else:
-            n = int(faces.shape[0])
-            mx = float(faces[:, 14].max())
-        per_image.append({"file": rel, "n_faces": n, "max_score": round(mx, 4)})
-
-    ok = [p for p in per_image if p["n_faces"] >= 0]
-    result = {
-        "runtime": {
-            "ort_version": ort.__version__,
-            "providers": ort.get_available_providers(),
-            "cv2_version": cv2.__version__,
-        },
-        "protocol": {
-            "smoke": bool(args.smoke),
-            "n": len(images),
-            "source": "wider_face val, first N images of the sorted bbox ground truth",
-        },
-        "per_image": per_image,
-        "summary": {
-            "images": len(ok),
-            "total_faces": sum(p["n_faces"] for p in ok),
-            "images_with_zero_faces": sum(1 for p in ok if p["n_faces"] == 0),
-        },
+    result: dict = {}
+    if args.out.exists():
+        try:
+            result = json.loads(args.out.read_text())
+        except json.JSONDecodeError:
+            result = {}
+    notes = list(result.get("notes", []))
+    runtime = {
+        "ort_version": ort.__version__,
+        "providers": ort.get_available_providers(),
+        "cv2_version": cv2.__version__,
     }
+
+    if args.smoke or not (
+        args.ap or args.sweep or args.cascade
+    ):
+        det = cv2.FaceDetectorYN_create(
+            str(args.models_dir / "face_detection_yunet_2023mar.onnx"),
+            "",
+            (320, 240),
+            score_threshold=0.6,
+        )
+        vals = val_image_list(args.wider_root)
+        images = vals[: args.n] if args.smoke else vals
+        per_image = []
+        for rel in images:
+            img = cv2.imread(str(args.wider_root / "WIDER_val" / "images" / rel))
+            if img is None:
+                per_image.append({"file": rel, "n_faces": -1, "max_score": 0.0})
+                continue
+            h, w = img.shape[:2]
+            det.setInputSize((w, h))
+            ret, faces = det.detect(img)
+            if faces is None:
+                n, mx = 0, 0.0
+            else:
+                n = int(faces.shape[0])
+                mx = float(faces[:, 14].max())
+            per_image.append({"file": rel, "n_faces": n, "max_score": round(mx, 4)})
+
+        ok = [p for p in per_image if p["n_faces"] >= 0]
+        result = {
+            "runtime": runtime,
+            "protocol": {
+                "smoke": bool(args.smoke),
+                "n": len(images),
+                "source": "wider_face val, first N images of the sorted bbox ground truth",
+            },
+            "per_image": per_image,
+            "summary": {
+                "images": len(ok),
+                "total_faces": sum(p["n_faces"] for p in ok),
+                "images_with_zero_faces": sum(1 for p in ok if p["n_faces"] == 0),
+            },
+        }
+        args.out.write_text(json.dumps(result, indent=2) + "\n")
+        print(json.dumps(result["summary"]))
+        return 0
+
+    result["runtime"] = runtime
+    result["operating_point"] = {"input": OP_INPUT, "score_threshold": OP_SCORE}
+    if args.ap:
+        section, note = run_ap(args)
+        result["ap"] = section
+    elif args.sweep:
+        section, note = run_sweep(args)
+        result["sweep"] = section
+    else:
+        section, note = run_cascade(args)
+        result["cascade"] = section
+    notes.append(note)
+    result["notes"] = notes
     args.out.write_text(json.dumps(result, indent=2) + "\n")
-    print(json.dumps(result["summary"]))
+    print(json.dumps(section))
     return 0
 
 

--- a/benchmarks/bench_landmarks.py
+++ b/benchmarks/bench_landmarks.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Landmark bench: the 478-point face mesh vs sparse GT landmarks.
 
-Datasets: WFLW test split (2,500 annotation rows over 2,118 images, 98-pt)
-and the 300W common test subset (600 png+pts pairs, 68-pt). AFLW2000 stays
-deferred: scoring its MATLAB mat files needs scipy, which the pinned bench
-venv does not carry and this script will not install.
+Datasets: WFLW test split (2,500 annotation rows over 2,118 images, 98-pt),
+the 300W common test subset (600 png+pts pairs, 68-pt), and AFLW2000
+(2,000 jpg+mat pairs, 68-pt read from the mat's pt3d_68 x/y, which the
+controller approved scipy 1.18.1 in the bench venv for; pinned in
+requirements-bench.txt).
 
 Protocol per row: YuNet at the operating point (640 square letterbox, score
 threshold 0.6) proposes faces; the best detection by IoU against the GT face
@@ -213,11 +214,32 @@ def load_300w(root: Path):
 
 
 def load_aflw2000(root: Path):
-    raise RuntimeError(
-        "aflw2000 deferred: reading its MATLAB mat files needs scipy, "
-        "which the pinned bench venv does not carry; installing it "
-        "requires controller approval"
-    )
+    """2,000 annotation mats at the dataset root (flat glob only: the
+    mirror's Code/ tree holds unrelated morphology mats under rglob).
+
+    68-pt GT comes from pt3d_68 (3x68, x/y rows in image pixel space; zero
+    NaNs across all 2,000 mats, 3 mats have landmarks at the image edge).
+    The mat's roi is a loose detection region (landmark centroid outside it
+    on 885 of the first-pass check), so it is ignored: the GT face box is
+    the tight landmark bounds, the shared convention across all three sets.
+    """
+    try:
+        from scipy.io import loadmat
+    except ImportError as e:
+        raise RuntimeError(
+            "aflw2000 needs scipy (pinned in requirements-bench.txt)"
+        ) from e
+    rows = []
+    for p in sorted(root.glob("*.mat")):
+        img = p.with_suffix(".jpg")
+        if not img.exists():
+            raise FileNotFoundError(f"mat without jpg: {p}")
+        m = loadmat(str(p))
+        if "pt3d_68" not in m:
+            raise KeyError(f"no pt3d_68 in {p}")
+        pts = np.array(m["pt3d_68"][:2].T, float)
+        rows.append((img, pts))
+    return rows, "pts68"
 
 
 LOADERS = {
@@ -395,15 +417,22 @@ def main(argv: list[str] | None = None) -> int:
             "68-pt scheme scores 6 anchors (its topology has no separate "
             "inner-corner points for mesh 133/362), wflw98 scores 8."
         ),
-        (
-            "aflw2000 deferred: its MATLAB mat files need scipy, which the "
-            "pinned bench venv lacks; installing requires controller "
-            "approval (dataset present on archhost: 2,000 jpg+mat pairs)."
-        ),
     ]
     for name, root in enabled:
         loader, _ = LOADERS[name]
         rows, scheme = loader(root)
+        if name == "aflw2000":
+            import scipy
+
+            notes.append(
+                "aflw2000 gt: 68-pt from mat pt3d_68 x/y in image pixel "
+                f"space (flat glob of 2,000 mats; the mirror's Code/ tree "
+                "holds unrelated mats, excluded); roi ignored as a loose "
+                "detection region, tight landmark bounds per the shared "
+                f"convention; parsed with scipy {scipy.__version__}; pts68 "
+                "eye/anchor constants reused, geometry re-verified over "
+                "the first 20 mats (two tight clusters above the mouth)."
+            )
         section, audit = score_dataset(
             name, rows, scheme, det, mesh, args.limit
         )

--- a/benchmarks/bench_landmarks.py
+++ b/benchmarks/bench_landmarks.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Landmark bench: the 478-point face mesh vs sparse GT landmarks.
+
+Datasets: WFLW test split (2,500 annotation rows over 2,118 images, 98-pt)
+and the 300W common test subset (600 png+pts pairs, 68-pt). AFLW2000 stays
+deferred: scoring its MATLAB mat files needs scipy, which the pinned bench
+venv does not carry and this script will not install.
+
+Protocol per row: YuNet at the operating point (640 square letterbox, score
+threshold 0.6) proposes faces; the best detection by IoU against the GT face
+box must reach MATCH_IOU or the row counts a pipeline failure. Matched and
+standalone paths crop a square of CROP_SCALE x the box side, centered on the
+box, edge-replicated at the frame border (the shipped Rust mesh samples its
+crop square with edge clamping; the copyMakeBorder crop reproduces that
+without rescaling), resize to 256, and run the mesh ([1,256,256,3] RGB in
+[0,1]; output [1,1,1434] = 478 x,y,z in input space). Mapped-back points are
+gated by the same plausibility rule as the runtime (>=half the points within
+the crop plus 25% slop, central 80% span >= 2px on both axes) before scoring.
+
+GT face box: the tight bounds of the GT landmarks. WFLW's shipped rect is a
+loose region (2.1-5.4x the landmark extent wide on the first test rows), too
+loose for a meaningful IoU-0.3 match or a face-scale mesh crop; the landmark
+bounds are the face. 300W ships no box at all, so the landmark bounds are the
+only shared convention across both sets.
+
+GT eye-index sets are pinned by geometry (per-index mean positions over the
+first 20 annotations per dataset; evidence in the task report):
+  WFLW98: left eye 60-67 (outer 60, inner 64), right eye 68-75 (inner 68,
+    outer 72), mouth corners 76/82, nose tip 57, chin 16.
+  300W68: left eye 36-41 (outer 36, inner 39), right eye 42-47 (inner 42,
+    outer 45), mouth corners 48/54, nose tip 30, chin 8.
+Both verified as two tight clusters straddling the face midline, above the
+mouth. Eye centers are corner means; the 68-pt scheme drops the two
+inner-corner mesh anchors (133/362) that its topology cannot name.
+
+--limit N caps rows per dataset (validation only; full runs omit it).
+"""
+
+import argparse
+import json
+import math
+import sys
+import time
+from collections import OrderedDict
+from pathlib import Path
+
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+from landmark_score import (
+    iou,
+    mesh_eye_centers,
+    nme,
+    point_bounds,
+)
+from letterbox import letterbox_image, restore_boxes
+
+OP_INPUT = 640
+OP_SCORE = 0.6
+YUNET_MODEL = "face_detection_yunet_2023mar.onnx"
+MESH_MODEL = "face_landmark.onnx"
+MESH_INPUT = 256
+MESH_OUT = 478 * 3
+CROP_SCALE = 1.25
+MATCH_IOU = 0.3
+
+# mesh anchor indices in correspondence order per scheme (see module
+# docstring for the pinned GT evidence).
+SCHEMES = {
+    "wflw98": {
+        "eye_corners": ((60, 64), (68, 72)),
+        "anchors_mesh": [33, 133, 362, 263, 61, 291, 1, 152],
+        "anchors_gt": [60, 64, 68, 72, 76, 82, 57, 16],
+    },
+    "pts68": {
+        "eye_corners": ((36, 39), (42, 45)),
+        "anchors_mesh": [33, 263, 61, 291, 1, 152],
+        "anchors_gt": [36, 45, 48, 54, 30, 8],
+    },
+}
+
+
+def yunet_detector(model_path: Path):
+    return cv2.FaceDetectorYN_create(
+        str(model_path), "", (OP_INPUT, OP_INPUT), score_threshold=OP_SCORE
+    )
+
+
+def detect_letterbox(det, img) -> list[tuple[float, list[float]]]:
+    """YuNet on the 640 letterbox canvas, decoded to (score, xyxy) in
+    original image coordinates (the bench_detection_wider convention)."""
+    canvas, params = letterbox_image(img, OP_INPUT)
+    _, faces = det.detect(canvas)
+    if faces is None:
+        return []
+    h, w = img.shape[:2]
+    raw = [
+        (
+            float(f[14]),
+            [float(f[0]), float(f[1]), float(f[0] + f[2]), float(f[1] + f[3])],
+        )
+        for f in faces
+    ]
+    boxes = restore_boxes([b for _, b in raw], params, w, h)
+    return [(s, b) for (s, _), b in zip(raw, boxes)]
+
+
+class MeshRunner:
+    def __init__(self, model_path: Path):
+        self.sess = ort.InferenceSession(
+            str(model_path), providers=["CPUExecutionProvider"]
+        )
+        self.input_name = self.sess.get_inputs()[0].name
+
+    def run(self, crop_bgr):
+        """RGB [0,1] NHWC into the mesh; returns 478 (x, y) pairs in input
+        space (0..256), or None when no 1434-value output comes back."""
+        rgb = cv2.cvtColor(crop_bgr, cv2.COLOR_BGR2RGB)
+        x = rgb.astype(np.float32) / 255.0
+        outs = self.sess.run(None, {self.input_name: x[None]})
+        for o in outs:
+            if o.size == MESH_OUT:
+                return o.reshape(478, 3)[:, :2]
+        return None
+
+
+def crop_square(img, box, scale: float):
+    """Square CROP_SCALE-x-side crop centered on `box`, edge-replicated at
+    the frame border. Returns (crop, win) where win = (x, y, w, h) is the
+    exact sampled window in original coordinates for mapping mesh output
+    back."""
+    h, w = img.shape[:2]
+    x1, y1, x2, y2 = box
+    cx, cy = (x1 + x2) / 2, (y1 + y2) / 2
+    side = max(x2 - x1, y2 - y1) * scale
+    wx0, wy0 = cx - side / 2, cy - side / 2
+    xi0, yi0 = math.floor(wx0), math.floor(wy0)
+    xi1, yi1 = math.ceil(wx0 + side), math.ceil(wy0 + side)
+    pad_l, pad_t = max(0, -xi0), max(0, -yi0)
+    pad_r, pad_b = max(0, xi1 - w), max(0, yi1 - h)
+    if pad_l or pad_t or pad_r or pad_b:
+        img = cv2.copyMakeBorder(
+            img, pad_t, pad_b, pad_l, pad_r, cv2.BORDER_REPLICATE
+        )
+    win = img[yi0 + pad_t : yi1 + pad_t, xi0 + pad_l : xi1 + pad_l]
+    crop = cv2.resize(win, (MESH_INPUT, MESH_INPUT))
+    return crop, (float(xi0), float(yi0), float(xi1 - xi0), float(yi1 - yi0))
+
+
+def map_mesh(pts2d, win) -> np.ndarray:
+    """Input-space points into original image coordinates via the sampled
+    window."""
+    x0, y0, w, h = win
+    return pts2d / MESH_INPUT * np.array([w, h]) + np.array([x0, y0])
+
+
+def mesh_plausible(pts: np.ndarray, win) -> bool:
+    """The runtime's mesh_output_plausible, ported: at least half the
+    points inside the sampled window plus a 25% slop margin, and a central
+    80% span of at least 2px on both axes."""
+    x0, y0, w, h = win
+    sx, sy = w * 0.25, h * 0.25
+    inside = int(
+        (
+            (pts[:, 0] >= x0 - sx)
+            & (pts[:, 0] <= x0 + w + sx)
+            & (pts[:, 1] >= y0 - sy)
+            & (pts[:, 1] <= y0 + h + sy)
+        ).sum()
+    )
+    if inside * 2 < len(pts):
+        return False
+
+    def central_span(v):
+        v = np.sort(v)
+        lo = len(v) // 10
+        hi = len(v) - 1 - lo
+        return v[hi] - v[lo] if hi > lo else 0.0
+
+    return central_span(pts[:, 0]) >= 2.0 and central_span(pts[:, 1]) >= 2.0
+
+
+def parse_pts(path: Path) -> np.ndarray:
+    lines = path.read_text().splitlines()
+    n = int([l for l in lines if l.startswith("n_points")][0].split(":")[1])
+    start = lines.index("{") + 1
+    return np.array([lines[start + i].split() for i in range(n)], float)
+
+
+def load_wflw(root: Path):
+    txt = (
+        root
+        / "WFLW_annotations/list_98pt_rect_attr_train_test/list_98pt_rect_attr_test.txt"
+    )
+    rows = []
+    for line in txt.read_text().splitlines():
+        f = line.split()
+        pts = np.array(f[:196], float).reshape(98, 2)
+        rows.append((root / "WFLW_images" / f[-1], pts))
+    return rows, "wflw98"
+
+
+def load_300w(root: Path):
+    base = root / "300w_extracted" / "300W"
+    rows = []
+    for p in sorted(base.rglob("*.pts")):
+        img = p.with_suffix(".png")
+        if not img.exists():
+            raise FileNotFoundError(f"pts without png: {p}")
+        rows.append((img, parse_pts(p)))
+    return rows, "pts68"
+
+
+def load_aflw2000(root: Path):
+    raise RuntimeError(
+        "aflw2000 deferred: reading its MATLAB mat files needs scipy, "
+        "which the pinned bench venv does not carry; installing it "
+        "requires controller approval"
+    )
+
+
+LOADERS = {
+    "wflw_test": (load_wflw, "wflw_root"),
+    "300w_test": (load_300w, "w300_root"),
+    "aflw2000": (load_aflw2000, "aflw_root"),
+}
+
+
+def gt_eye_centers(pts, scheme) -> tuple[tuple, tuple]:
+    (lo, li), (ri, ro) = SCHEMES[scheme]["eye_corners"]
+    left = (
+        (float(pts[lo][0]) + float(pts[li][0])) / 2,
+        (float(pts[lo][1]) + float(pts[li][1])) / 2,
+    )
+    right = (
+        (float(pts[ri][0]) + float(pts[ro][0])) / 2,
+        (float(pts[ri][1]) + float(pts[ro][1])) / 2,
+    )
+    return left, right
+
+
+def score_dataset(tag, rows, scheme, det, mesh, limit):
+    sch = SCHEMES[scheme]
+    if limit:
+        rows = rows[:limit]
+    by_img: OrderedDict[Path, list] = OrderedDict()
+    for path, pts in rows:
+        by_img.setdefault(path, []).append(pts)
+
+    counts = {
+        "rows": len(rows),
+        "mesh_ok": 0,
+        "n_fail_yunet": 0,
+        "n_fail_mesh": 0,
+        "n_standalone_mesh_fail": 0,
+        "n_zero_iod": 0,
+        "n_unreadable": 0,
+    }
+    eye_nmes, standalone_nmes, anchor_nmes, iou_gains = [], [], [], []
+    t0 = time.time()
+    done = 0
+    mark = {"bucket": -1}
+    for path, pts_list in by_img.items():
+        img = cv2.imread(str(path))
+        if img is None:
+            counts["n_unreadable"] += len(pts_list)
+            done += len(pts_list)
+            continue
+        dets = detect_letterbox(det, img)
+        for pts in pts_list:
+            done += 1
+            gt_box = point_bounds(pts)
+            gt_l, gt_r = gt_eye_centers(pts, scheme)
+            iod = math.hypot(gt_r[0] - gt_l[0], gt_r[1] - gt_l[1])
+            if iod <= 0.0:
+                counts["n_zero_iod"] += 1
+                _progress(done, counts["rows"], tag, mark)
+                continue
+            best = None
+            if dets:
+                best = max(dets, key=lambda d: iou(d[1], gt_box))
+            if best is None or iou(best[1], gt_box) < MATCH_IOU:
+                counts["n_fail_yunet"] += 1
+            else:
+                det_box = best[1]
+                crop, win = crop_square(img, det_box, CROP_SCALE)
+                raw = mesh.run(crop)
+                if raw is None or not mesh_plausible(map_mesh(raw, win), win):
+                    counts["n_fail_mesh"] += 1
+                else:
+                    frame_pts = map_mesh(raw, win)
+                    counts["mesh_ok"] += 1
+                    le, re = mesh_eye_centers(frame_pts.tolist())
+                    eye_nmes.append(nme((le, re), gt_l, gt_r, [], []))
+                    anchors_pred = [frame_pts[i] for i in sch["anchors_mesh"]]
+                    anchors_gt = [pts[i] for i in sch["anchors_gt"]]
+                    anchor_nmes.append(
+                        nme(None, gt_l, gt_r, anchors_pred, anchors_gt)
+                    )
+                    refined = point_bounds(frame_pts)
+                    iou_gains.append(
+                        iou(refined, gt_box) - iou(det_box, gt_box)
+                    )
+            crop, win = crop_square(img, gt_box, CROP_SCALE)
+            raw = mesh.run(crop)
+            if raw is None or not mesh_plausible(map_mesh(raw, win), win):
+                counts["n_standalone_mesh_fail"] += 1
+            else:
+                le, re = mesh_eye_centers(map_mesh(raw, win).tolist())
+                standalone_nmes.append(nme((le, re), gt_l, gt_r, [], []))
+            _progress(done, counts["rows"], tag, mark)
+
+    section = {
+        "images": counts["rows"],
+        "mesh_ok": counts["mesh_ok"],
+        "eye_nme_mean": _mean(eye_nmes),
+        "eye_nme_p90": _p90(eye_nmes),
+        "eye_nme_standalone_mean": _mean(standalone_nmes),
+        "anchor_nme_mean": _mean(anchor_nmes),
+        "align_iou_gain_mean": _mean(iou_gains),
+        "n_fail_yunet": counts["n_fail_yunet"],
+        "n_fail_mesh": counts["n_fail_mesh"],
+    }
+    audit = {
+        "rows": counts["rows"],
+        "unique_images": len(by_img),
+        "eye_nme_n": len(eye_nmes),
+        "standalone_n": len(standalone_nmes),
+        "n_standalone_mesh_fail": counts["n_standalone_mesh_fail"],
+        "n_zero_iod": counts["n_zero_iod"],
+        "n_unreadable": counts["n_unreadable"],
+        "elapsed_s": round(time.time() - t0, 1),
+    }
+    return section, audit
+
+
+def _mean(v):
+    return float(np.mean(v)) if v else 0.0
+
+
+def _p90(v):
+    return float(np.percentile(v, 90)) if v else 0.0
+
+
+def _progress(done, total, tag, mark):
+    bucket = done // 200
+    if bucket > mark["bucket"]:
+        mark["bucket"] = bucket
+        print(f"[{tag}] {done}/{total} rows", flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models-dir", type=Path, required=True)
+    ap.add_argument("--wflw-root", type=Path)
+    ap.add_argument("--w300-root", type=Path)
+    ap.add_argument("--aflw-root", type=Path)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--limit", type=int)
+    args = ap.parse_args(argv)
+
+    enabled = [
+        (name, getattr(args, arg))
+        for name, (_, arg) in LOADERS.items()
+        if getattr(args, arg)
+    ]
+    if not enabled:
+        ap.error("at least one dataset root is required")
+
+    det = yunet_detector(args.models_dir / YUNET_MODEL)
+    mesh = MeshRunner(args.models_dir / MESH_MODEL)
+
+    per_dataset = {}
+    notes = [
+        (
+            "pipeline: YuNet at the operating point (640 square letterbox, "
+            f"score {OP_SCORE}); best detection matched to the GT face box "
+            f"at IoU >= {MATCH_IOU}; matched and standalone paths crop a "
+            f"{CROP_SCALE}x-side square centered on the box, edge-"
+            "replicated at the frame border, resized to "
+            f"{MESH_INPUT}; mesh output gated by the runtime plausibility "
+            "rule before scoring."
+        ),
+        (
+            "gt face box = tight bounds of the GT landmarks: WFLW's shipped "
+            "rect is a loose region (2.1-5.4x the landmark extent wide on "
+            "the first test rows), unusable for IoU-0.3 matching or "
+            "face-scale crops; 300W ships no box. Eye indices pinned by "
+            "geometry over the first 20 annotations per dataset (evidence "
+            "in the task report): wflw98 left 60-67/right 68-75 with "
+            "corners 60/64/68/72, mouth 76/82, nose tip 57, chin 16; "
+            "pts68 left 36-41/right 42-47 with corners 36/39/42/45, mouth "
+            "48/54, nose tip 30, chin 8; eye centers are corner means; the "
+            "68-pt scheme scores 6 anchors (its topology has no separate "
+            "inner-corner points for mesh 133/362), wflw98 scores 8."
+        ),
+        (
+            "aflw2000 deferred: its MATLAB mat files need scipy, which the "
+            "pinned bench venv lacks; installing requires controller "
+            "approval (dataset present on archhost: 2,000 jpg+mat pairs)."
+        ),
+    ]
+    for name, root in enabled:
+        loader, _ = LOADERS[name]
+        rows, scheme = loader(root)
+        section, audit = score_dataset(
+            name, rows, scheme, det, mesh, args.limit
+        )
+        per_dataset[name] = section
+        notes.append(f"{name} audit: {json.dumps(audit, sort_keys=True)}")
+        print(f"[{name}] {json.dumps(section)}", flush=True)
+
+    result = {
+        "runtime": {
+            "ort_version": ort.__version__,
+            "providers": ort.get_available_providers(),
+            "cv2_version": cv2.__version__,
+            "yunet_model": YUNET_MODEL,
+            "mesh_model": MESH_MODEL,
+            "input": OP_INPUT,
+            "score_threshold": OP_SCORE,
+            "crop_scale": CROP_SCALE,
+            "match_iou": MATCH_IOU,
+        },
+        "per_dataset": per_dataset,
+        "notes": notes,
+    }
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_landmarks.py
+++ b/benchmarks/bench_landmarks.py
@@ -14,9 +14,10 @@ standalone paths crop a square of CROP_SCALE x the box side, centered on the
 box, edge-replicated at the frame border (the shipped Rust mesh samples its
 crop square with edge clamping; the copyMakeBorder crop reproduces that
 without rescaling), resize to 256, and run the mesh ([1,256,256,3] RGB in
-[0,1]; output [1,1,1434] = 478 x,y,z in input space). Mapped-back points are
-gated by the same plausibility rule as the runtime (>=half the points within
-the crop plus 25% slop, central 80% span >= 2px on both axes) before scoring.
+[0,1]; output [1,1,1434] = 478 x,y,z in input space). Mapped-back points
+are gated by the same plausibility rule as the runtime (every point
+finite, >=half the points within the crop plus 25% slop, central 80% span
+>= 2px on both axes) before scoring.
 
 GT face box: the tight bounds of the GT landmarks. WFLW's shipped rect is a
 loose region (2.1-5.4x the landmark extent wide on the first test rows), too
@@ -52,6 +53,7 @@ import onnxruntime as ort
 from landmark_score import (
     iou,
     mesh_eye_centers,
+    mesh_plausible,
     nme,
     point_bounds,
 )
@@ -154,32 +156,6 @@ def map_mesh(pts2d, win) -> np.ndarray:
     window."""
     x0, y0, w, h = win
     return pts2d / MESH_INPUT * np.array([w, h]) + np.array([x0, y0])
-
-
-def mesh_plausible(pts: np.ndarray, win) -> bool:
-    """The runtime's mesh_output_plausible, ported: at least half the
-    points inside the sampled window plus a 25% slop margin, and a central
-    80% span of at least 2px on both axes."""
-    x0, y0, w, h = win
-    sx, sy = w * 0.25, h * 0.25
-    inside = int(
-        (
-            (pts[:, 0] >= x0 - sx)
-            & (pts[:, 0] <= x0 + w + sx)
-            & (pts[:, 1] >= y0 - sy)
-            & (pts[:, 1] <= y0 + h + sy)
-        ).sum()
-    )
-    if inside * 2 < len(pts):
-        return False
-
-    def central_span(v):
-        v = np.sort(v)
-        lo = len(v) // 10
-        hi = len(v) - 1 - lo
-        return v[hi] - v[lo] if hi > lo else 0.0
-
-    return central_span(pts[:, 0]) >= 2.0 and central_span(pts[:, 1]) >= 2.0
 
 
 def parse_pts(path: Path) -> np.ndarray:

--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -62,7 +62,135 @@ _WIDER = DatasetSpec(
     ),
 )
 
-_DATASETS: dict[str, DatasetSpec] = {_WIDER.name: _WIDER}
+_THREE00W = DatasetSpec(
+    name="300w",
+    source="hf",
+    repo="quoctai219/300W",
+    files=(
+        DatasetFile(
+            path="300w_dataset.zip",
+            extract=True,
+            size_hint_bytes=2_140_000_000,
+        ),
+    ),
+    license_note=(
+        "300W is distributed for non-commercial research use per its source "
+        "page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://huggingface.co/datasets/quoctai219/300W",
+    notes=(
+        "This zip is the full canonical 300W set. Mirror identity matters "
+        "(see benchmarks/README.md): numbers are valid only for this mirror."
+    ),
+)
+
+_WFLW = DatasetSpec(
+    name="wflw",
+    source="kaggle",
+    repo="mrriandmstique/wflw-wider-facial-landmarks-in-the-wild",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=760_000_000,
+        ),
+    ),
+    license_note=(
+        "WFLW is provided for non-commercial research use per its source "
+        "page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url=(
+        "https://www.kaggle.com/datasets/"
+        "mrriandmstique/wflw-wider-facial-landmarks-in-the-wild"
+    ),
+    notes=(
+        "Test split: 2500 images with 98-point landmark txts. Mirror identity "
+        "matters (see benchmarks/README.md): numbers are valid only for this "
+        "mirror."
+    ),
+)
+
+_AFLW2000 = DatasetSpec(
+    name="aflw2000",
+    source="kaggle",
+    repo="mohamedadlyi/aflw2000-3d",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=87_000_000,
+        ),
+    ),
+    license_note=(
+        "AFLW2000-3D is provided for non-commercial research use per its "
+        "source page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://www.kaggle.com/datasets/mohamedadlyi/aflw2000-3d",
+    notes=(
+        "Ships 2000 jpgs with .mat annotations. Mirror identity matters (see "
+        "benchmarks/README.md): numbers are valid only for this mirror."
+    ),
+)
+
+_CBSR_NIR = DatasetSpec(
+    name="cbsr_nir",
+    source="kaggle",
+    repo="gpreda/cbsr-nir-face-dataset",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=1_200_000_000,
+        ),
+    ),
+    license_note=(
+        "CBSR NIR is research/education only per benchmarks/README.md; the "
+        "exact terms stated on the source page are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://www.kaggle.com/datasets/gpreda/cbsr-nir-face-dataset",
+    notes=(
+        "Bmp images. Mirror identity matters (see benchmarks/README.md): "
+        "numbers are valid only for this mirror. The removed IR adapter was "
+        "trained on this set, so results here are in-training-set numbers."
+    ),
+)
+
+_OULU_CASIA_NIR = DatasetSpec(
+    name="oulu_casia_nir",
+    source="kaggle",
+    repo="aryanbaibaswata/oulu-casia",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=1_200_000_000,
+        ),
+    ),
+    license_note=(
+        "Oulu-CASIA NIR is research only per benchmarks/README.md; the exact "
+        "terms stated on the source page are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://www.kaggle.com/datasets/aryanbaibaswata/oulu-casia",
+    notes=(
+        "Layout: Oulu_CASIA_NIR_VIS/NI/<lighting>/<subject>/. Mirror "
+        "identity matters (see benchmarks/README.md): numbers are valid only "
+        "for this mirror."
+    ),
+)
+
+_DATASETS: dict[str, DatasetSpec] = {
+    _WIDER.name: _WIDER,
+    _THREE00W.name: _THREE00W,
+    _WFLW.name: _WFLW,
+    _AFLW2000.name: _AFLW2000,
+    _CBSR_NIR.name: _CBSR_NIR,
+    _OULU_CASIA_NIR.name: _OULU_CASIA_NIR,
+}
 
 
 def get_dataset(name: str) -> DatasetSpec:

--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -80,8 +80,10 @@ _THREE00W = DatasetSpec(
     ),
     provenance_url="https://huggingface.co/datasets/quoctai219/300W",
     notes=(
-        "This zip is the full canonical 300W set. Mirror identity matters "
-        "(see benchmarks/README.md): numbers are valid only for this mirror."
+        "This mirror ships the 300W common test subset only (600 png+pts "
+        "pairs; no train or AFW images). That subset is the evaluation "
+        "target. Mirror identity matters (see benchmarks/README.md): "
+        "numbers are valid only for this mirror."
     ),
 )
 

--- a/benchmarks/fetch_data.py
+++ b/benchmarks/fetch_data.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import requests
 
-from datasets import get_dataset, list_datasets
+from datasets import DatasetSpec, get_dataset, list_datasets
 from fetchlib import (
     manifest_lines,
     parse_manifest,
@@ -39,6 +39,14 @@ def kaggle_url(repo: str) -> str:
     # Kaggle v1 REST downloads the WHOLE dataset archive per call, so a
     # kaggle-sourced DatasetSpec must define exactly one archive file.
     return f"{KAGGLE_HOST}/api/v1/datasets/download/{repo}"
+
+
+def validate_spec(spec: DatasetSpec) -> None:
+    if spec.source == "kaggle" and len(spec.files) != 1:
+        raise SystemExit(
+            f"{spec.name}: kaggle specs must define exactly one archive "
+            f"file, got {len(spec.files)}"
+        )
 
 
 def load_token(env_var: str, file_path: Path) -> str | None:
@@ -105,6 +113,7 @@ def download_dataset(
     session: requests.Session | None = None,
 ) -> dict:
     spec = get_dataset(spec_name)
+    validate_spec(spec)
     session = session or requests.Session()
     if spec.source == "hf":
         tok = load_token("HF_TOKEN", Path.home() / ".cache/huggingface/token")

--- a/benchmarks/landmark_score.py
+++ b/benchmarks/landmark_score.py
@@ -1,0 +1,151 @@
+"""Pure landmark scoring for the calibration landmark bench.
+
+Dependency-free math only (the letterbox.py precedent): every function
+accepts plain sequences of (x, y[, z]) points so the unit tests run without
+numpy or OpenCV installed.
+
+Conventions:
+- Mesh points are the 478-point face_landmarker topology (468 dense points
+  plus 10 iris points; iris block indices 468-472 left, 473-477 right).
+- ANCHOR_MESH_IDX names the mesh points with an unambiguous counterpart in
+  sparse GT schemes (98-pt WFLW, 68-pt 300W): eye corners, mouth corners,
+  nose tip, chin. Schemes without separate inner-eye corners (68-pt) drop
+  the two inner-corner anchors at the bench layer.
+- NME normalizes by the GT inter-ocular distance (distance between the two
+  GT eye centers), the standard landmark-error denominator.
+"""
+
+import math
+
+
+MESH_N_IRIS = 478
+# Left iris 468-472, right iris 473-477 (face_landmarker iris refinement).
+IRIS_LEFT = range(468, 473)
+IRIS_RIGHT = range(473, 478)
+
+# Mesh anchors with cross-scheme GT counterparts, in correspondence order:
+# 33 left eye outer corner, 133 left eye inner corner, 362 right eye inner
+# corner, 263 right eye outer corner, 61 mouth left corner, 291 mouth right
+# corner, 1 nose tip, 152 chin.
+ANCHOR_MESH_IDX = [33, 133, 362, 263, 61, 291, 1, 152]
+# The two inner-corner anchors, dropped for GT schemes that only pin the
+# eye outline ends (68-pt): keep [33, 263] outer corners instead.
+ANCHOR_MESH_INNER = (133, 362)
+
+
+def _xy(pt) -> tuple[float, float]:
+    return (float(pt[0]), float(pt[1]))
+
+
+def mesh_eye_centers(
+    mesh478,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Predicted eye centers from the 478-point mesh.
+
+    Primary: iris centers, the mean of the left iris block (468-472) and
+    the right iris block (473-477). Fallback when a block is degenerate
+    (any non-finite coordinate, or the five points collapsed onto one
+    spot): the midpoint of the eye corners (33, 133) for the left eye and
+    (362, 263) for the right, the anchors a mesh without iris refinement
+    still gets right.
+
+    Raises ValueError when the input carries fewer than 478 points.
+    """
+    if len(mesh478) < MESH_N_IRIS:
+        raise ValueError(
+            f"expected {MESH_N_IRIS} mesh points, got {len(mesh478)}"
+        )
+    centers = []
+    for block, corner_a, corner_b in (
+        (IRIS_LEFT, 33, 133),
+        (IRIS_RIGHT, 362, 263),
+    ):
+        pts = [mesh478[i] for i in block]
+        xs = [float(p[0]) for p in pts]
+        ys = [float(p[1]) for p in pts]
+        finite = all(math.isfinite(v) for v in xs + ys)
+        span = max(max(xs) - min(xs), max(ys) - min(ys)) if finite else 0.0
+        if finite and span > 1e-9:
+            centers.append((sum(xs) / len(xs), sum(ys) / len(ys)))
+        else:
+            a = _xy(mesh478[corner_a])
+            b = _xy(mesh478[corner_b])
+            centers.append(((a[0] + b[0]) / 2, (a[1] + b[1]) / 2))
+    return centers[0], centers[1]
+
+
+def nme(
+    pred_pts,
+    gt_eye_center_a,
+    gt_eye_center_b,
+    anchors_pred,
+    anchors_gt,
+) -> float:
+    """Normalized mean error: mean L2 over the correspondences divided by
+    the GT inter-ocular distance.
+
+    `pred_pts` is the predicted eye-center pair (as mesh_eye_centers
+    returns) scored against `gt_eye_center_a`/`gt_eye_center_b`, or None
+    to score anchors only. `anchors_pred`/`anchors_gt` are equal-length
+    point lists; the error set is the eye-center pairs followed by the
+    anchor pairs, so the eye NME call passes empty anchor lists and the
+    anchor NME call passes pred_pts=None. Raises ValueError on an
+    anchor-length mismatch or a zero GT inter-ocular distance (a
+    degenerate annotation, never a zero error).
+    """
+    if len(anchors_pred) != len(anchors_gt):
+        raise ValueError(
+            "anchor length mismatch: "
+            f"{len(anchors_pred)} pred vs {len(anchors_gt)} gt"
+        )
+    iod = math.hypot(
+        gt_eye_center_b[0] - gt_eye_center_a[0],
+        gt_eye_center_b[1] - gt_eye_center_a[1],
+    )
+    if iod <= 0.0:
+        raise ValueError("zero inter-ocular distance in GT")
+    errors = []
+    if pred_pts is not None:
+        errors.append(
+            math.hypot(
+                pred_pts[0][0] - gt_eye_center_a[0],
+                pred_pts[0][1] - gt_eye_center_a[1],
+            )
+        )
+        errors.append(
+            math.hypot(
+                pred_pts[1][0] - gt_eye_center_b[0],
+                pred_pts[1][1] - gt_eye_center_b[1],
+            )
+        )
+    for pp, gp in zip(anchors_pred, anchors_gt):
+        errors.append(math.hypot(pp[0] - gp[0], pp[1] - gp[1]))
+    if not errors:
+        raise ValueError("no correspondences to score")
+    return (sum(errors) / len(errors)) / iod
+
+
+def point_bounds(points) -> tuple[float, float, float, float]:
+    """Tight axis-aligned box (x1, y1, x2, y2) around the points."""
+    xs = [float(p[0]) for p in points]
+    ys = [float(p[1]) for p in points]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def iou(a, b) -> float:
+    """Intersection-over-union of two (x1, y1, x2, y2) boxes."""
+    ix1 = max(a[0], b[0])
+    iy1 = max(a[1], b[1])
+    ix2 = min(a[2], b[2])
+    iy2 = min(a[3], b[3])
+    iw = max(0.0, ix2 - ix1)
+    ih = max(0.0, iy2 - iy1)
+    inter = iw * ih
+    if inter <= 0.0:
+        return 0.0
+    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
+    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
+    union = area_a + area_b - inter
+    if union <= 0.0:
+        return 0.0
+    return inter / union

--- a/benchmarks/landmark_score.py
+++ b/benchmarks/landmark_score.py
@@ -149,3 +149,37 @@ def iou(a, b) -> float:
     if union <= 0.0:
         return 0.0
     return inter / union
+
+
+def mesh_plausible(pts, win) -> bool:
+    """The runtime's mesh_output_plausible gate, ported: EVERY point must
+    be finite (a NaN coordinate would otherwise sort past the band check
+    and escape into the anchor errors), at least half the points must sit
+    inside the sampled window plus a 25% slop margin, and the central 80%
+    span must be at least 2px on both axes.
+
+    `win` is the sampled window (x, y, w, h) in original image
+    coordinates, as returned by the bench's crop_square.
+    """
+    x0, y0, w, h = (float(v) for v in win)
+    sx, sy = w * 0.25, h * 0.25
+    inside = 0
+    for p in pts:
+        x, y = float(p[0]), float(p[1])
+        if not (math.isfinite(x) and math.isfinite(y)):
+            return False
+        if x0 - sx <= x <= x0 + w + sx and y0 - sy <= y <= y0 + h + sy:
+            inside += 1
+    if inside * 2 < len(pts):
+        return False
+
+    def central_span(vals):
+        v = sorted(vals)
+        lo = len(v) // 10
+        hi = len(v) - 1 - lo
+        return v[hi] - v[lo] if hi > lo else 0.0
+
+    return (
+        central_span([float(p[0]) for p in pts]) >= 2.0
+        and central_span([float(p[1]) for p in pts]) >= 2.0
+    )

--- a/benchmarks/letterbox.py
+++ b/benchmarks/letterbox.py
@@ -1,0 +1,54 @@
+"""Square letterbox for fixed-input-size face detectors.
+
+Convention: scale the longer side to `target`, center the short side with
+zero padding on a square canvas. `letterbox_params` returns
+(scale_x, scale_y, pad_x, pad_y) and `restore_boxes` undoes both scale and
+padding, clipping to the original frame bounds. `letterbox_image` is the
+only consumer of cv2/numpy; the math helpers stay dependency free so the
+letterbox unit tests run without OpenCV installed.
+"""
+
+
+def letterbox_params(
+    orig_w: int, orig_h: int, target: int
+) -> tuple[float, float, int, int]:
+    scale = target / max(orig_w, orig_h)
+    new_w = int(round(orig_w * scale))
+    new_h = int(round(orig_h * scale))
+    pad_x = (target - new_w) // 2
+    pad_y = (target - new_h) // 2
+    return scale, scale, pad_x, pad_y
+
+
+def letterbox_image(img: "np.ndarray", target: int) -> tuple["np.ndarray", tuple]:
+    import cv2
+    import numpy as np
+
+    h, w = img.shape[:2]
+    sx, sy, pad_x, pad_y = letterbox_params(w, h, target)
+    new_w = int(round(w * sx))
+    new_h = int(round(h * sy))
+    resized = cv2.resize(img, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+    canvas = np.zeros((target, target, 3), dtype=resized.dtype)
+    canvas[pad_y : pad_y + new_h, pad_x : pad_x + new_w] = resized
+    return canvas, (sx, sy, pad_x, pad_y)
+
+
+def restore_boxes(
+    boxes, params: tuple, orig_w: int, orig_h: int
+) -> list[list[float]]:
+    sx, sy, pad_x, pad_y = params
+    max_x = float(orig_w)
+    max_y = float(orig_h)
+    out = []
+    for b in boxes:
+        x1 = (float(b[0]) - pad_x) / sx
+        y1 = (float(b[1]) - pad_y) / sy
+        x2 = (float(b[2]) - pad_x) / sx
+        y2 = (float(b[3]) - pad_y) / sy
+        x1 = min(max(x1, 0.0), max_x)
+        x2 = min(max(x2, 0.0), max_x)
+        y1 = min(max(y1, 0.0), max_y)
+        y2 = min(max(y2, 0.0), max_y)
+        out.append([x1, y1, x2, y2])
+    return out

--- a/benchmarks/requirements-bench.txt
+++ b/benchmarks/requirements-bench.txt
@@ -8,3 +8,4 @@ opencv-python-headless==5.0.0.93
 numpy>=2.0,<3
 requests>=2.32,<3
 pytest>=8
+scipy>=1.11

--- a/benchmarks/results-detection-ir.json
+++ b/benchmarks/results-detection-ir.json
@@ -1,0 +1,45 @@
+{
+  "runtime": {
+    "cv2_version": "5.0.0",
+    "yunet": "face_detection_yunet_2023mar.onnx",
+    "input": 640,
+    "score_threshold": 0.6
+  },
+  "cbsr": {
+    "frames": 3940,
+    "detected": 3940,
+    "rate": 1.0,
+    "score_p50": 0.9320595562458038,
+    "score_p10": 0.9213406860828399
+  },
+  "oulu": {
+    "per_lighting": [
+      {
+        "lighting": "Dark",
+        "frames": 1348,
+        "rate": 1.0
+      },
+      {
+        "lighting": "Strong",
+        "frames": 1298,
+        "rate": 1.0
+      },
+      {
+        "lighting": "Weak",
+        "frames": 1354,
+        "rate": 1.0
+      }
+    ],
+    "overall": {
+      "frames": 4000,
+      "detected": 4000,
+      "rate": 1.0,
+      "score_p50": 0.9333271086215973,
+      "score_p10": 0.9249388337135315
+    }
+  },
+  "notes": [
+    "cbsr run: 3940 of 3940 bmp frames (stride 1, nearest stride-integer approximation of the 4000-frame cap) in one flat sorted walk; the gallery groundtruth file is not consulted.",
+    "oulu run: 4000 of 31995 jpg frames under NI (stride 8, nearest stride-integer approximation of the 4000-frame cap) in one sorted recursive walk, grouped by lighting directory name; the VL/ RGB counterpart is not walked."
+  ]
+}

--- a/benchmarks/results-detection-wider.json
+++ b/benchmarks/results-detection-wider.json
@@ -13,19 +13,21 @@
     "score_threshold": 0.6
   },
   "ap": {
-    "easy": 0.6858673053851181,
-    "medium": 0.6865946197978877,
-    "hard": 0.3963783022634693,
-    "tp": 15826,
-    "fp": 2366,
-    "n_gt": 39123,
+    "easy": 0.85737325681448,
+    "medium": 0.7931565495545686,
+    "hard": 0.47331454598277894,
+    "tp": 15825,
+    "fp": 2345,
+    "n_gt": 32764,
     "images": 3226
   },
   "notes": [
     "ap run: 3226 val images in 42.0s at the operating point (letterbox 640, score 0.6); easy/medium/hard use GT height bands >= 50 / >= 20 / all with predictions unchanged; tp/fp/n_gt are the hard-band totals.",
     "ap run: 3226 val images in 41.1s at the operating point (letterbox 640, score 0.6); easy/medium/hard use GT height bands >= 50 / >= 20 / all with predictions unchanged; tp/fp/n_gt are the hard-band totals.",
     "sweep run: 1613 of 3226 val images (stride 2, nearest stride-integer approximation of the 2000-image target) in 34.5s; decoders run at the lowest sweep threshold 0.3 and rows post-filter scores; recall_at_op_fppi uses this sample's operating-point FPPI 0.7564 (640/0.6 row); ap_hard and recall use all valid val GT faces (hard band).",
-    "cascade run: YuNet at the operating point, BlazeFace short-range rescue only on YuNet-empty images (rescue score 0.5, shipped anchor decode); recall is valid-GT faces matched at IoU 0.5; train sample is 3220 of 12880 train images at stride 4."
+    "cascade run: YuNet at the operating point, BlazeFace short-range rescue only on YuNet-empty images (rescue score 0.5, shipped anchor decode); recall is valid-GT faces matched at IoU 0.5; train sample is 3220 of 12880 train images at stride 4.",
+    "ap run: 3226 val images in 43.5s at the operating point (letterbox 640, score 0.6); official-approximation tier cuts (h>50/h>30/h>=10), off-tier predictions discarded (best-overlap valid GT outside the tier drops the prediction; zero-overlap predictions stay fp candidates); invalid-flag GT boxes excluded everywhere; tp/fp/n_gt are the hard-tier totals.",
+    "height-band approximation run superseded by tier semantics: the earlier h>=50/h>=20/all-valid bands scored easy 0.6859 / medium 0.6866 / hard 0.3964 (tp 15826, fp 2366, n_gt 39123)."
   ],
   "sweep": [
     {

--- a/benchmarks/results-detection-wider.json
+++ b/benchmarks/results-detection-wider.json
@@ -1,0 +1,129 @@
+{
+  "runtime": {
+    "ort_version": "1.27.0",
+    "providers": [
+      "TensorrtExecutionProvider",
+      "CUDAExecutionProvider",
+      "CPUExecutionProvider"
+    ],
+    "cv2_version": "5.0.0"
+  },
+  "operating_point": {
+    "input": 640,
+    "score_threshold": 0.6
+  },
+  "ap": {
+    "easy": 0.6858673053851181,
+    "medium": 0.6865946197978877,
+    "hard": 0.3963783022634693,
+    "tp": 15826,
+    "fp": 2366,
+    "n_gt": 39123,
+    "images": 3226
+  },
+  "notes": [
+    "ap run: 3226 val images in 42.0s at the operating point (letterbox 640, score 0.6); easy/medium/hard use GT height bands >= 50 / >= 20 / all with predictions unchanged; tp/fp/n_gt are the hard-band totals.",
+    "ap run: 3226 val images in 41.1s at the operating point (letterbox 640, score 0.6); easy/medium/hard use GT height bands >= 50 / >= 20 / all with predictions unchanged; tp/fp/n_gt are the hard-band totals.",
+    "sweep run: 1613 of 3226 val images (stride 2, nearest stride-integer approximation of the 2000-image target) in 34.5s; decoders run at the lowest sweep threshold 0.3 and rows post-filter scores; recall_at_op_fppi uses this sample's operating-point FPPI 0.7564 (640/0.6 row); ap_hard and recall use all valid val GT faces (hard band).",
+    "cascade run: YuNet at the operating point, BlazeFace short-range rescue only on YuNet-empty images (rescue score 0.5, shipped anchor decode); recall is valid-GT faces matched at IoU 0.5; train sample is 3220 of 12880 train images at stride 4."
+  ],
+  "sweep": [
+    {
+      "input": 320,
+      "score_threshold": 0.3,
+      "ap_hard": 0.24381529631492171,
+      "recall_at_op_fppi": 0.22755369303300158
+    },
+    {
+      "input": 320,
+      "score_threshold": 0.45,
+      "ap_hard": 0.22826061503427242,
+      "recall_at_op_fppi": 0.22755369303300158
+    },
+    {
+      "input": 320,
+      "score_threshold": 0.6,
+      "ap_hard": 0.20491703959318375,
+      "recall_at_op_fppi": 0.2101100052383447
+    },
+    {
+      "input": 320,
+      "score_threshold": 0.7,
+      "ap_hard": 0.17792717428536076,
+      "recall_at_op_fppi": 0.18019905709795705
+    },
+    {
+      "input": 448,
+      "score_threshold": 0.3,
+      "ap_hard": 0.35205073565751405,
+      "recall_at_op_fppi": 0.3187008905185961
+    },
+    {
+      "input": 448,
+      "score_threshold": 0.45,
+      "ap_hard": 0.33245090116226134,
+      "recall_at_op_fppi": 0.3187008905185961
+    },
+    {
+      "input": 448,
+      "score_threshold": 0.6,
+      "ap_hard": 0.2991855198181052,
+      "recall_at_op_fppi": 0.30607647983237296
+    },
+    {
+      "input": 448,
+      "score_threshold": 0.7,
+      "ap_hard": 0.2620410076475537,
+      "recall_at_op_fppi": 0.2648507071765322
+    },
+    {
+      "input": 640,
+      "score_threshold": 0.3,
+      "ap_hard": 0.4729180720954009,
+      "recall_at_op_fppi": 0.4214248297537978
+    },
+    {
+      "input": 640,
+      "score_threshold": 0.45,
+      "ap_hard": 0.45041893620870965,
+      "recall_at_op_fppi": 0.4214248297537978
+    },
+    {
+      "input": 640,
+      "score_threshold": 0.6,
+      "ap_hard": 0.412442232944838,
+      "recall_at_op_fppi": 0.4212676794133054
+    },
+    {
+      "input": 640,
+      "score_threshold": 0.7,
+      "ap_hard": 0.3668725725643984,
+      "recall_at_op_fppi": 0.3708224201152436
+    }
+  ],
+  "cascade": {
+    "val": {
+      "yunet_recall": 0.40451908084758326,
+      "cascade_recall": 0.4047746849679217,
+      "rescues": 10,
+      "n_gt": 39123,
+      "images": 3226,
+      "yunet_empty_images": 182,
+      "rescue_fired": 182,
+      "rescue_boxes": 27,
+      "elapsed_s": 41.7
+    },
+    "train_sample": {
+      "yunet_recall": 0.40928301511535403,
+      "cascade_recall": 0.4094073190135243,
+      "rescues": 5,
+      "n_gt": 40224,
+      "images": 3220,
+      "yunet_empty_images": 182,
+      "rescue_fired": 182,
+      "rescue_boxes": 22,
+      "elapsed_s": 41.8,
+      "stride": 4
+    }
+  }
+}

--- a/benchmarks/results-landmarks.json
+++ b/benchmarks/results-landmarks.json
@@ -36,13 +36,25 @@
       "align_iou_gain_mean": 0.10019160213714208,
       "n_fail_yunet": 5,
       "n_fail_mesh": 0
+    },
+    "aflw2000": {
+      "images": 2000,
+      "mesh_ok": 1974,
+      "eye_nme_mean": 0.19896590445745124,
+      "eye_nme_p90": 0.437031216528208,
+      "eye_nme_standalone_mean": 0.27949611693397297,
+      "anchor_nme_mean": 0.21120826789504607,
+      "align_iou_gain_mean": 0.10073690034410658,
+      "n_fail_yunet": 26,
+      "n_fail_mesh": 0
     }
   },
   "notes": [
     "pipeline: YuNet at the operating point (640 square letterbox, score 0.6); best detection matched to the GT face box at IoU >= 0.3; matched and standalone paths crop a 1.25x-side square centered on the box, edge-replicated at the frame border, resized to 256; mesh output gated by the runtime plausibility rule before scoring.",
     "gt face box = tight bounds of the GT landmarks: WFLW's shipped rect is a loose region (2.1-5.4x the landmark extent wide on the first test rows), unusable for IoU-0.3 matching or face-scale crops; 300W ships no box. Eye indices pinned by geometry over the first 20 annotations per dataset (evidence in the task report): wflw98 left 60-67/right 68-75 with corners 60/64/68/72, mouth 76/82, nose tip 57, chin 16; pts68 left 36-41/right 42-47 with corners 36/39/42/45, mouth 48/54, nose tip 30, chin 8; eye centers are corner means; the 68-pt scheme scores 6 anchors (its topology has no separate inner-corner points for mesh 133/362), wflw98 scores 8.",
-    "aflw2000 deferred: its MATLAB mat files need scipy, which the pinned bench venv lacks; installing requires controller approval (dataset present on archhost: 2,000 jpg+mat pairs).",
     "wflw_test audit: {\"elapsed_s\": 63.6, \"eye_nme_n\": 2441, \"n_standalone_mesh_fail\": 0, \"n_unreadable\": 0, \"n_zero_iod\": 0, \"rows\": 2500, \"standalone_n\": 2500, \"unique_images\": 2118}",
-    "300w_test audit: {\"elapsed_s\": 49.9, \"eye_nme_n\": 595, \"n_standalone_mesh_fail\": 0, \"n_unreadable\": 0, \"n_zero_iod\": 0, \"rows\": 600, \"standalone_n\": 600, \"unique_images\": 600}"
+    "300w_test audit: {\"elapsed_s\": 49.9, \"eye_nme_n\": 595, \"n_standalone_mesh_fail\": 0, \"n_unreadable\": 0, \"n_zero_iod\": 0, \"rows\": 600, \"standalone_n\": 600, \"unique_images\": 600}",
+    "aflw2000 gt: 68-pt from mat pt3d_68 x/y in image pixel space (flat glob of 2,000 mats; the mirror's Code/ tree holds unrelated mats, excluded); roi ignored as a loose detection region, tight landmark bounds per the shared convention; parsed with scipy 1.18.1; pts68 eye/anchor constants reused, geometry re-verified over the first 20 mats (two tight clusters above the mouth).",
+    "aflw2000 audit: {\"elapsed_s\": 51.7, \"eye_nme_n\": 1974, \"n_standalone_mesh_fail\": 0, \"n_unreadable\": 0, \"n_zero_iod\": 0, \"rows\": 2000, \"standalone_n\": 2000, \"unique_images\": 2000}"
   ]
 }

--- a/benchmarks/results-landmarks.json
+++ b/benchmarks/results-landmarks.json
@@ -1,0 +1,48 @@
+{
+  "runtime": {
+    "ort_version": "1.27.0",
+    "providers": [
+      "TensorrtExecutionProvider",
+      "CUDAExecutionProvider",
+      "CPUExecutionProvider"
+    ],
+    "cv2_version": "5.0.0",
+    "yunet_model": "face_detection_yunet_2023mar.onnx",
+    "mesh_model": "face_landmark.onnx",
+    "input": 640,
+    "score_threshold": 0.6,
+    "crop_scale": 1.25,
+    "match_iou": 0.3
+  },
+  "per_dataset": {
+    "wflw_test": {
+      "images": 2500,
+      "mesh_ok": 2441,
+      "eye_nme_mean": 0.09499063033298641,
+      "eye_nme_p90": 0.170142303990803,
+      "eye_nme_standalone_mean": 0.12324530316516216,
+      "anchor_nme_mean": 0.11480280901387324,
+      "align_iou_gain_mean": 0.08674666391245962,
+      "n_fail_yunet": 59,
+      "n_fail_mesh": 0
+    },
+    "300w_test": {
+      "images": 600,
+      "mesh_ok": 595,
+      "eye_nme_mean": 0.0813231819785711,
+      "eye_nme_p90": 0.12082165358095844,
+      "eye_nme_standalone_mean": 0.08411110436093504,
+      "anchor_nme_mean": 0.08571396667999348,
+      "align_iou_gain_mean": 0.10019160213714208,
+      "n_fail_yunet": 5,
+      "n_fail_mesh": 0
+    }
+  },
+  "notes": [
+    "pipeline: YuNet at the operating point (640 square letterbox, score 0.6); best detection matched to the GT face box at IoU >= 0.3; matched and standalone paths crop a 1.25x-side square centered on the box, edge-replicated at the frame border, resized to 256; mesh output gated by the runtime plausibility rule before scoring.",
+    "gt face box = tight bounds of the GT landmarks: WFLW's shipped rect is a loose region (2.1-5.4x the landmark extent wide on the first test rows), unusable for IoU-0.3 matching or face-scale crops; 300W ships no box. Eye indices pinned by geometry over the first 20 annotations per dataset (evidence in the task report): wflw98 left 60-67/right 68-75 with corners 60/64/68/72, mouth 76/82, nose tip 57, chin 16; pts68 left 36-41/right 42-47 with corners 36/39/42/45, mouth 48/54, nose tip 30, chin 8; eye centers are corner means; the 68-pt scheme scores 6 anchors (its topology has no separate inner-corner points for mesh 133/362), wflw98 scores 8.",
+    "aflw2000 deferred: its MATLAB mat files need scipy, which the pinned bench venv lacks; installing requires controller approval (dataset present on archhost: 2,000 jpg+mat pairs).",
+    "wflw_test audit: {\"elapsed_s\": 63.6, \"eye_nme_n\": 2441, \"n_standalone_mesh_fail\": 0, \"n_unreadable\": 0, \"n_zero_iod\": 0, \"rows\": 2500, \"standalone_n\": 2500, \"unique_images\": 2118}",
+    "300w_test audit: {\"elapsed_s\": 49.9, \"eye_nme_n\": 595, \"n_standalone_mesh_fail\": 0, \"n_unreadable\": 0, \"n_zero_iod\": 0, \"rows\": 600, \"standalone_n\": 600, \"unique_images\": 600}"
+  ]
+}

--- a/benchmarks/tests/test_datasets.py
+++ b/benchmarks/tests/test_datasets.py
@@ -49,3 +49,32 @@ def test_no_em_dashes_anywhere():
     import inspect
     src = inspect.getsource(m)
     assert "\u2014" not in src
+
+
+def test_kaggle_specs_are_single_archive():
+    for name in list_datasets():
+        spec = get_dataset(name)
+        if spec.source == "kaggle":
+            assert len(spec.files) == 1, f"{name} must be a single kaggle archive"
+            assert spec.files[0].path == "kaggle-archive.zip"
+            assert spec.files[0].extract
+
+
+def test_new_landmark_and_ir_entries():
+    wflw = get_dataset("wflw")
+    assert wflw.source == "kaggle"
+    assert wflw.repo == "mrriandmstique/wflw-wider-facial-landmarks-in-the-wild"
+    three = get_dataset("300w")
+    assert three.source == "hf"
+    assert three.repo == "quoctai219/300W"
+    assert three.files[0].path == "300w_dataset.zip"
+    aflw = get_dataset("aflw2000")
+    assert aflw.repo == "mohamedadlyi/aflw2000-3d"
+    cbsr = get_dataset("cbsr_nir")
+    assert cbsr.repo == "gpreda/cbsr-nir-face-dataset"
+    oulu = get_dataset("oulu_casia_nir")
+    assert oulu.repo == "aryanbaibaswata/oulu-casia"
+    for spec in (wflw, three, aflw, cbsr, oulu):
+        assert spec.provenance_url
+        assert spec.license_note
+        assert spec.notes

--- a/benchmarks/tests/test_fetch_data_guard.py
+++ b/benchmarks/tests/test_fetch_data_guard.py
@@ -1,0 +1,31 @@
+import pytest
+
+from datasets import DatasetFile, DatasetSpec, get_dataset
+from fetch_data import validate_spec
+
+
+def _spec(source, files):
+    return DatasetSpec(
+        name="x", source=source, repo="o/d", files=tuple(files),
+        license_note="l", provenance_url="https://example.com", notes="n",
+    )
+
+
+def test_kaggle_multi_file_rejected():
+    with pytest.raises(SystemExit):
+        validate_spec(_spec("kaggle", [
+            DatasetFile(path="a.zip"), DatasetFile(path="b.zip"),
+        ]))
+
+
+def test_kaggle_single_file_ok():
+    validate_spec(_spec("kaggle", [DatasetFile(path="kaggle-archive.zip")]))
+
+
+def test_real_kaggle_specs_pass():
+    for name in ["wflw", "aflw2000", "cbsr_nir", "oulu_casia_nir"]:
+        validate_spec(get_dataset(name))
+
+
+def test_hf_multi_file_ok():
+    validate_spec(get_dataset("wider_face"))

--- a/benchmarks/tests/test_landmark_score.py
+++ b/benchmarks/tests/test_landmark_score.py
@@ -6,6 +6,7 @@ from landmark_score import (
     ANCHOR_MESH_IDX,
     iou,
     mesh_eye_centers,
+    mesh_plausible,
     nme,
     point_bounds,
 )
@@ -130,3 +131,22 @@ class TestGeomHelpers:
     def test_iou_known_overlap(self):
         got = iou((0.0, 0.0, 10.0, 10.0), (0.0, 0.0, 10.0, 5.0))
         assert math.isclose(got, 0.5)
+
+
+def _spread_points(n=478):
+    return [
+        (float(i % 100) + 1.0, float((i * 7) % 200) + 1.0)
+        for i in range(n)
+    ]
+
+
+class TestMeshPlausible:
+    WIN = (0.0, 0.0, 256.0, 256.0)
+
+    def test_nan_at_non_anchor_index_refused(self):
+        pts = _spread_points()
+        assert mesh_plausible(pts, self.WIN) is True
+        idx = 17
+        assert idx not in ANCHOR_MESH_IDX
+        pts[idx] = (float("nan"), pts[idx][1])
+        assert mesh_plausible(pts, self.WIN) is False

--- a/benchmarks/tests/test_landmark_score.py
+++ b/benchmarks/tests/test_landmark_score.py
@@ -1,0 +1,132 @@
+import math
+
+import pytest
+
+from landmark_score import (
+    ANCHOR_MESH_IDX,
+    iou,
+    mesh_eye_centers,
+    nme,
+    point_bounds,
+)
+
+MESH_N_IRIS = 478
+
+
+def _flat_mesh():
+    """478 well-separated deterministic points (i, -i) so any leaked index
+    shows up as a wrong-but-finite coordinate."""
+    return [(float(i), -float(i), 0.0) for i in range(MESH_N_IRIS)]
+
+
+def _with_iris(mesh, left, right):
+    out = [tuple(p) for p in mesh]
+    for k, pt in enumerate(left):
+        out[468 + k] = (pt[0], pt[1], 0.0)
+    for k, pt in enumerate(right):
+        out[473 + k] = (pt[0], pt[1], 0.0)
+    return out
+
+
+class TestAnchorIndices:
+    def test_eight_distinct_in_range(self):
+        assert len(ANCHOR_MESH_IDX) == 8
+        assert len(set(ANCHOR_MESH_IDX)) == 8
+        for i in ANCHOR_MESH_IDX:
+            assert 0 <= i < MESH_N_IRIS
+
+
+class TestMeshEyeCenters:
+    def test_iris_centers_are_block_means(self):
+        left = [(10.0 + k, 20.0 - k) for k in range(5)]
+        right = [(30.0 + k, 40.0 + k) for k in range(5)]
+        mesh = _with_iris(_flat_mesh(), left, right)
+        (lx, ly), (rx, ry) = mesh_eye_centers(mesh)
+        assert math.isclose(lx, 12.0)
+        assert math.isclose(ly, 18.0)
+        assert math.isclose(rx, 32.0)
+        assert math.isclose(ry, 42.0)
+
+    def test_degenerate_iris_falls_back_to_corner_midpoints(self):
+        mesh = _with_iris(_flat_mesh(), [(0.0, 0.0)] * 5, [(0.0, 0.0)] * 5)
+        (lx, ly), (rx, ry) = mesh_eye_centers(mesh)
+        p33 = mesh[33]
+        p133 = mesh[133]
+        p362 = mesh[362]
+        p263 = mesh[263]
+        assert math.isclose(lx, (p33[0] + p133[0]) / 2)
+        assert math.isclose(ly, (p33[1] + p133[1]) / 2)
+        assert math.isclose(rx, (p362[0] + p263[0]) / 2)
+        assert math.isclose(ry, (p362[1] + p263[1]) / 2)
+
+    def test_non_finite_iris_falls_back(self):
+        nan = float("nan")
+        mesh = _with_iris(_flat_mesh(), [(nan, 1.0)] * 5, [(5.0, 5.0)] * 5)
+        (lx, ly), _ = mesh_eye_centers(mesh)
+        p33 = mesh[33]
+        p133 = mesh[133]
+        assert math.isclose(lx, (p33[0] + p133[0]) / 2)
+        assert math.isclose(ly, (p33[1] + p133[1]) / 2)
+
+    def test_short_mesh_raises(self):
+        with pytest.raises(ValueError):
+            mesh_eye_centers([(0.0, 0.0, 0.0)] * 477)
+
+
+class TestNme:
+    def setup_method(self):
+        self.gt_a = (10.0, 50.0)
+        self.gt_b = (60.0, 50.0)
+        self.iod = 50.0
+
+    def test_identical_points_zero(self):
+        anchors = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+        got = nme(
+            (self.gt_a, self.gt_b),
+            self.gt_a,
+            self.gt_b,
+            anchors,
+            anchors,
+        )
+        assert got == 0.0
+
+    def test_eye_offset_known_ratio(self):
+        shift = 0.1 * self.iod
+        pred_a = (self.gt_a[0], self.gt_a[1] + shift)
+        pred_b = (self.gt_b[0], self.gt_b[1] + shift)
+        got = nme((pred_a, pred_b), self.gt_a, self.gt_b, [], [])
+        assert math.isclose(got, 0.1)
+
+    def test_anchor_offset_known_ratio(self):
+        anchors_gt = [(0.0, 0.0), (10.0, 0.0)]
+        anchors_pred = [(0.0, 0.0), (10.0 + 0.2 * self.iod, 0.0)]
+        got = nme(None, self.gt_a, self.gt_b, anchors_pred, anchors_gt)
+        assert math.isclose(got, 0.1)
+
+    def test_mixed_eye_and_anchor_error_is_mean(self):
+        shift = 0.1 * self.iod
+        pred_a = (self.gt_a[0], self.gt_a[1] + shift)
+        pred_b = (self.gt_b[0], self.gt_b[1] + shift)
+        anchors = [(0.0, 0.0)]
+        got = nme((pred_a, pred_b), self.gt_a, self.gt_b, anchors, anchors)
+        assert math.isclose(got, 0.1 * 2 / 3)
+
+    def test_zero_interocular_raises(self):
+        with pytest.raises(ValueError):
+            nme(None, (5.0, 5.0), (5.0, 5.0), [], [])
+
+
+class TestGeomHelpers:
+    def test_point_bounds(self):
+        pts = [(1.0, 5.0), (3.0, 2.0), (2.0, 9.0)]
+        assert point_bounds(pts) == (1.0, 2.0, 3.0, 9.0)
+
+    def test_iou_identical_one(self):
+        assert iou((0.0, 0.0, 10.0, 10.0), (0.0, 0.0, 10.0, 10.0)) == 1.0
+
+    def test_iou_disjoint_zero(self):
+        assert iou((0.0, 0.0, 1.0, 1.0), (5.0, 5.0, 6.0, 6.0)) == 0.0
+
+    def test_iou_known_overlap(self):
+        got = iou((0.0, 0.0, 10.0, 10.0), (0.0, 0.0, 10.0, 5.0))
+        assert math.isclose(got, 0.5)

--- a/benchmarks/tests/test_letterbox.py
+++ b/benchmarks/tests/test_letterbox.py
@@ -1,0 +1,36 @@
+from letterbox import letterbox_params, restore_boxes
+
+
+def test_letterbox_square_input_scales_long_side():
+    sx, sy, pad_x, pad_y = letterbox_params(1280, 960, 640)
+    assert sx == 0.5 and sy == 0.5
+    assert pad_x == 0 and pad_y > 0
+
+
+def test_restore_boxes_roundtrip():
+    p = letterbox_params(1280, 960, 640)
+    boxes = [[10.0, 10.0, 100.0, 100.0]]
+    out = restore_boxes(boxes, p, orig_w=1280, orig_h=960)
+    assert out[0][0] <= out[0][2] and out[0][1] <= out[0][3]
+
+
+def test_letterbox_centered_padding_on_short_side():
+    sx, sy, pad_x, pad_y = letterbox_params(960, 1280, 640)
+    assert sx == 0.5 and sy == 0.5
+    assert pad_x > 0 and pad_y == 0
+    assert pad_x == (640 - int(round(960 * 0.5))) // 2
+
+
+def test_letterbox_params_non_divisible_size():
+    sx, sy, pad_x, pad_y = letterbox_params(1000, 700, 640)
+    assert sx == 0.64 and sy == 0.64
+    assert pad_x == 0
+    assert pad_y == (640 - int(round(700 * 0.64))) // 2
+
+
+def test_restore_boxes_clips_to_original_bounds():
+    p = letterbox_params(1280, 960, 640)
+    out = restore_boxes([[0.0, 0.0, 640.0, 640.0]], p, orig_w=1280, orig_h=960)
+    b = out[0]
+    assert 0.0 <= b[0] <= b[2] <= 1280.0
+    assert 0.0 <= b[1] <= b[3] <= 960.0

--- a/benchmarks/tests/test_wider_ap.py
+++ b/benchmarks/tests/test_wider_ap.py
@@ -43,6 +43,29 @@ def test_parse_val_gt_structure(tmp_path):
     assert gt["0--Parade/0_Parade_marchingband_1_799.jpg"] == []
 
 
+def test_parse_val_gt_space_separated_lines(tmp_path):
+    p = tmp_path / "wider_face_val_bbx_gt.txt"
+    p.write_text(
+        "0--Parade/0_Parade_marchingband_1_849.jpg\n"
+        "1\n"
+        "449 330 122 149 0 0 0 0 0 0 \n"
+        "\n"
+        "0--Parade/0_Parade_Parade_0_452.jpg\n"
+        "2\n"
+        "361 99 60 71 0 0 0 1 0 0\n"
+        "123 456 50 60 0 0 0 0 0 0\n"
+        "\n",
+        encoding="utf-8",
+    )
+    gt = parse_val_gt(p)
+    first = gt["0--Parade/0_Parade_marchingband_1_849.jpg"]
+    assert first[0]["box"] == (449.0, 330.0, 571.0, 479.0)
+    assert first[0]["invalid"] is False
+    second = gt["0--Parade/0_Parade_Parade_0_452.jpg"]
+    assert second[0]["invalid"] is True
+    assert second[1]["box"] == (123.0, 456.0, 173.0, 516.0)
+
+
 def test_iou_identity_overlap_disjoint():
     box = (0.0, 0.0, 10.0, 10.0)
     assert iou(box, box) == 1.0

--- a/benchmarks/tests/test_wider_ap.py
+++ b/benchmarks/tests/test_wider_ap.py
@@ -1,6 +1,13 @@
 import pytest
 
-from wider_ap import evaluate, evaluate_image, iou, parse_val_gt, voc_ap
+from wider_ap import (
+    evaluate,
+    evaluate_image,
+    evaluate_tier,
+    iou,
+    parse_val_gt,
+    voc_ap,
+)
 
 
 GT_SNIPPET = """0--Parade/0_Parade_marchingband_1_849.jpg
@@ -100,6 +107,59 @@ def test_evaluate_image_invalid_gt_excluded_from_tp_and_n_gt():
         (0.8, [40.0, 40.0, 50.0, 50.0]),
     ]
     assert evaluate_image(preds, gt) == (1, 1, 1)
+
+
+def test_evaluate_tier_discards_off_tier_predictions():
+    gt = {
+        "a.jpg": [
+            {"box": (0.0, 0.0, 10.0, 60.0), "invalid": False},
+            {"box": (100.0, 100.0, 105.0, 104.0), "invalid": False},
+        ]
+    }
+    preds = {
+        "a.jpg": [
+            (0.9, [0.0, 0.0, 10.0, 60.0]),
+            (0.8, [100.0, 100.0, 105.0, 104.0]),
+        ]
+    }
+    out = evaluate_tier(preds, gt, min_h=10.0, strict=False)
+    assert out["tp"] == 1
+    assert out["fp"] == 0
+    assert out["n_gt"] == 1
+    assert out["ap"] == pytest.approx(1.0)
+
+
+def test_evaluate_tier_zero_overlap_pred_stays_fp():
+    gt = {
+        "a.jpg": [{"box": (0.0, 0.0, 10.0, 60.0), "invalid": False}]
+    }
+    preds = {
+        "a.jpg": [
+            (0.9, [0.0, 0.0, 10.0, 60.0]),
+            (0.8, [500.0, 500.0, 510.0, 520.0]),
+        ]
+    }
+    out = evaluate_tier(preds, gt, min_h=10.0, strict=False)
+    assert out["tp"] == 1
+    assert out["fp"] == 1
+    assert out["n_gt"] == 1
+
+
+def test_evaluate_tier_strict_cut_and_invalid_excluded():
+    gt = {
+        "a.jpg": [
+            {"box": (0.0, 0.0, 10.0, 50.0), "invalid": False},
+            {"box": (100.0, 100.0, 110.0, 180.0), "invalid": True},
+        ]
+    }
+    preds = {"a.jpg": [(0.9, [0.0, 0.0, 10.0, 50.0])]}
+    strict = evaluate_tier(preds, gt, min_h=50.0, strict=True)
+    assert strict["n_gt"] == 0
+    assert strict["tp"] == 0
+    assert strict["fp"] == 0
+    loose = evaluate_tier(preds, gt, min_h=50.0, strict=False)
+    assert loose["n_gt"] == 1
+    assert loose["tp"] == 1
 
 
 def test_voc_ap_perfect_ranking_is_one():

--- a/benchmarks/tests/test_wider_ap.py
+++ b/benchmarks/tests/test_wider_ap.py
@@ -1,0 +1,112 @@
+import pytest
+
+from wider_ap import evaluate, evaluate_image, iou, parse_val_gt, voc_ap
+
+
+GT_SNIPPET = """0--Parade/0_Parade_marchingband_1_849.jpg
+1
+449,330,122,149,0,0,0,0,0,0
+
+0--Parade/0_Parade_Parade_0_452.jpg
+2
+361,99,60,71,0,0,0,1,0,0
+123,456,50,60,0,0,0,0,0,0
+
+0--Parade/0_Parade_marchingband_1_799.jpg
+0
+
+"""
+
+
+def _write_gt(tmp_path):
+    p = tmp_path / "wider_face_val_bbx_gt.txt"
+    p.write_text(GT_SNIPPET, encoding="utf-8")
+    return p
+
+
+def test_parse_val_gt_structure(tmp_path):
+    gt = parse_val_gt(_write_gt(tmp_path))
+    assert set(gt) == {
+        "0--Parade/0_Parade_marchingband_1_849.jpg",
+        "0--Parade/0_Parade_Parade_0_452.jpg",
+        "0--Parade/0_Parade_marchingband_1_799.jpg",
+    }
+    first = gt["0--Parade/0_Parade_marchingband_1_849.jpg"]
+    assert len(first) == 1
+    assert first[0]["box"] == (449.0, 330.0, 571.0, 479.0)
+    assert first[0]["invalid"] is False
+    second = gt["0--Parade/0_Parade_Parade_0_452.jpg"]
+    assert len(second) == 2
+    assert second[0]["box"] == (361.0, 99.0, 421.0, 170.0)
+    assert second[0]["invalid"] is True
+    assert second[1]["invalid"] is False
+    assert gt["0--Parade/0_Parade_marchingband_1_799.jpg"] == []
+
+
+def test_iou_identity_overlap_disjoint():
+    box = (0.0, 0.0, 10.0, 10.0)
+    assert iou(box, box) == 1.0
+    half_shift = (5.0, 0.0, 15.0, 10.0)
+    assert iou(box, half_shift) == pytest.approx(1.0 / 3.0)
+    far = (100.0, 100.0, 110.0, 110.0)
+    assert iou(box, far) == 0.0
+
+
+def test_evaluate_image_perfect_match():
+    gt = [
+        {"box": (0.0, 0.0, 10.0, 10.0), "invalid": False},
+        {"box": (20.0, 20.0, 30.0, 30.0), "invalid": False},
+    ]
+    preds = [(0.9, [0.0, 0.0, 10.0, 10.0]), (0.8, [20.0, 20.0, 30.0, 30.0])]
+    assert evaluate_image(preds, gt) == (2, 0, 2)
+
+
+def test_evaluate_image_duplicate_detection_is_fp():
+    gt = [{"box": (0.0, 0.0, 10.0, 10.0), "invalid": False}]
+    preds = [(0.9, [0.0, 0.0, 10.0, 10.0]), (0.8, [0.0, 0.0, 10.0, 10.0])]
+    assert evaluate_image(preds, gt) == (1, 1, 1)
+
+
+def test_evaluate_image_invalid_gt_excluded_from_tp_and_n_gt():
+    gt = [
+        {"box": (0.0, 0.0, 10.0, 10.0), "invalid": True},
+        {"box": (40.0, 40.0, 50.0, 50.0), "invalid": False},
+    ]
+    preds = [
+        (0.9, [0.0, 0.0, 10.0, 10.0]),
+        (0.8, [40.0, 40.0, 50.0, 50.0]),
+    ]
+    assert evaluate_image(preds, gt) == (1, 1, 1)
+
+
+def test_voc_ap_perfect_ranking_is_one():
+    assert voc_ap([0.9, 0.8], [1, 1], 2) == pytest.approx(1.0)
+
+
+def test_voc_ap_reversed_ranking_below_half():
+    assert voc_ap([0.9, 0.8, 0.7], [0, 0, 1], 1) < 0.5
+
+
+def test_voc_ap_all_fp_is_zero():
+    assert voc_ap([0.9, 0.8], [0, 0], 2) == 0.0
+
+
+def test_evaluate_aggregates_across_images():
+    gt = {
+        "a.jpg": [{"box": (0.0, 0.0, 10.0, 10.0), "invalid": False}],
+        "b.jpg": [
+            {"box": (0.0, 0.0, 10.0, 10.0), "invalid": False},
+            {"box": (50.0, 50.0, 60.0, 60.0), "invalid": False},
+        ],
+    }
+    preds = {
+        "a.jpg": [(0.95, [0.0, 0.0, 10.0, 10.0])],
+        "b.jpg": [(0.8, [0.0, 0.0, 10.0, 10.0])],
+        "c.jpg": [(0.1, [0.0, 0.0, 10.0, 10.0]), (0.9, [100.0, 100.0, 110.0, 110.0])],
+    }
+    gt["c.jpg"] = [{"box": (0.0, 0.0, 10.0, 10.0), "invalid": False}]
+    out = evaluate(preds, gt)
+    assert out["tp"] == 3
+    assert out["fp"] == 1
+    assert out["n_gt"] == 4
+    assert out["ap"] == pytest.approx(0.625)

--- a/benchmarks/wider_ap.py
+++ b/benchmarks/wider_ap.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Official-protocol WIDER FACE AP evaluator for the calibration campaign.
+
+Parses wider_face_val_bbx_gt.txt (relative image path line, face count line,
+count x "x1,y1,w,h,blur,expression,illumination,invalid,occlusion,pose" box
+lines, blank separator), treats invalid=1 boxes as IGNORE regions (never
+matched as true positives, never counted in n_gt), and scores predictions
+with PASCAL 2010 all-point interpolated AP.
+"""
+
+from pathlib import Path
+from typing import Sequence
+
+
+def parse_val_gt(path: Path) -> dict[str, list[dict]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    gt: dict[str, list[dict]] = {}
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i].strip()
+        if not line.endswith(".jpg"):
+            i += 1
+            continue
+        key = line
+        i += 1
+        count = int(lines[i].strip())
+        i += 1
+        boxes: list[dict] = []
+        for _ in range(count):
+            cols = [c.strip() for c in lines[i].split(",")]
+            x1 = float(cols[0])
+            y1 = float(cols[1])
+            w = float(cols[2])
+            h = float(cols[3])
+            boxes.append(
+                {"box": (x1, y1, x1 + w, y1 + h), "invalid": cols[7] == "1"}
+            )
+            i += 1
+        gt[key] = boxes
+    return gt
+
+
+def iou(a: Sequence[float], b: Sequence[float]) -> float:
+    ix1 = max(a[0], b[0])
+    iy1 = max(a[1], b[1])
+    ix2 = min(a[2], b[2])
+    iy2 = min(a[3], b[3])
+    iw = max(0.0, ix2 - ix1)
+    ih = max(0.0, iy2 - iy1)
+    inter = iw * ih
+    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
+    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
+    union = area_a + area_b - inter
+    if union <= 0.0:
+        return 0.0
+    return inter / union
+
+
+def _match(
+    preds: list[tuple[float, list[float]]], gt: list[dict], iou_thr: float
+) -> list[bool]:
+    order = sorted(range(len(preds)), key=lambda j: preds[j][0], reverse=True)
+    matched = [False] * len(gt)
+    flags: list[bool] = []
+    for j in order:
+        box = preds[j][1]
+        best_iou = 0.0
+        best_k = -1
+        for k, g in enumerate(gt):
+            if matched[k] or g["invalid"]:
+                continue
+            v = iou(box, g["box"])
+            if v >= iou_thr and v > best_iou:
+                best_iou = v
+                best_k = k
+        if best_k >= 0:
+            matched[best_k] = True
+            flags.append(True)
+        else:
+            flags.append(False)
+    return flags
+
+
+def evaluate_image(
+    preds: list[tuple[float, list[float]]],
+    gt: list[dict],
+    iou_thr: float = 0.5,
+) -> tuple[int, int, int]:
+    flags = _match(preds, gt, iou_thr)
+    tp = sum(1 for f in flags if f)
+    n_gt = sum(1 for g in gt if not g["invalid"])
+    return tp, len(flags) - tp, n_gt
+
+
+def voc_ap(scores: list[float], tps: list[int], total_gt: int) -> float:
+    if total_gt <= 0:
+        return 0.0
+    order = sorted(range(len(scores)), key=lambda j: scores[j], reverse=True)
+    flags = [tps[j] for j in order]
+    tp_cum = 0
+    fp_cum = 0
+    rec: list[float] = []
+    prec: list[float] = []
+    for f in flags:
+        if f:
+            tp_cum += 1
+        else:
+            fp_cum += 1
+        rec.append(tp_cum / total_gt)
+        prec.append(tp_cum / (tp_cum + fp_cum))
+    mrec = [0.0] + rec + [1.0]
+    mpre = [0.0] + prec + [0.0]
+    for j in range(len(mpre) - 1, 0, -1):
+        mpre[j - 1] = max(mpre[j - 1], mpre[j])
+    ap = 0.0
+    for j in range(1, len(mrec)):
+        if mrec[j] != mrec[j - 1]:
+            ap += (mrec[j] - mrec[j - 1]) * mpre[j]
+    return ap
+
+
+def evaluate(preds_by_image, gt_by_image) -> dict:
+    tp = fp = n_gt = 0
+    scored: list[tuple[float, int]] = []
+    for key in sorted(set(preds_by_image) | set(gt_by_image)):
+        preds = preds_by_image.get(key, [])
+        gt = gt_by_image.get(key, [])
+        order = sorted(
+            range(len(preds)), key=lambda j: preds[j][0], reverse=True
+        )
+        flags = _match(preds, gt, 0.5)
+        for j, is_tp in zip(order, flags):
+            scored.append((preds[j][0], 1 if is_tp else 0))
+        tp += sum(1 for f in flags if f)
+        fp += sum(1 for f in flags if not f)
+        n_gt += sum(1 for g in gt if not g["invalid"])
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    scores = [s for s, _ in scored]
+    tps = [t for _, t in scored]
+    return {"ap": voc_ap(scores, tps, n_gt), "tp": tp, "fp": fp, "n_gt": n_gt}

--- a/benchmarks/wider_ap.py
+++ b/benchmarks/wider_ap.py
@@ -141,3 +141,62 @@ def evaluate(preds_by_image, gt_by_image) -> dict:
     scores = [s for s, _ in scored]
     tps = [t for _, t in scored]
     return {"ap": voc_ap(scores, tps, n_gt), "tp": tp, "fp": fp, "n_gt": n_gt}
+
+
+def _in_tier(g: dict, min_h: float, strict: bool) -> bool:
+    h = g["box"][3] - g["box"][1]
+    return h > min_h if strict else h >= min_h
+
+
+def _discard_off_tier(preds, gt, tier_gt) -> list:
+    """Official-approximation discard: each prediction is matched to its
+    best-IoU GT among ALL valid boxes of the image; predictions whose
+    best-overlap GT is not in the tier are dropped from evaluation entirely
+    (neither tp nor fp, matching evaluation.m proposal_list=-1). A
+    prediction with zero overlap against every valid GT has no best-overlap
+    GT and is kept as an fp candidate. Invalid-flag boxes never take part
+    in the best-overlap scan."""
+    tier_ids = {id(g) for g in tier_gt}
+    surviving = []
+    for pred in preds:
+        best_iou = 0.0
+        best = None
+        for g in gt:
+            if g["invalid"]:
+                continue
+            v = iou(pred[1], g["box"])
+            if v > best_iou:
+                best_iou = v
+                best = g
+        if best is not None and id(best) not in tier_ids:
+            continue
+        surviving.append(pred)
+    return surviving
+
+
+def evaluate_tier(preds_by_image, gt_by_image, min_h: float, strict: bool) -> dict:
+    """Evaluate one difficulty tier: only GT boxes inside the height cut
+    (h > min_h when strict else h >= min_h) are matchable and counted in
+    n_gt; off-tier predictions are discarded before matching."""
+    tp = fp = n_gt = 0
+    scored: list[tuple[float, int]] = []
+    for key in sorted(set(preds_by_image) | set(gt_by_image)):
+        preds = preds_by_image.get(key, [])
+        gt = gt_by_image.get(key, [])
+        tier_gt = [
+            g for g in gt if not g["invalid"] and _in_tier(g, min_h, strict)
+        ]
+        surviving = _discard_off_tier(preds, gt, tier_gt)
+        order = sorted(
+            range(len(surviving)), key=lambda j: surviving[j][0], reverse=True
+        )
+        flags = _match(surviving, tier_gt, 0.5)
+        for j, is_tp in zip(order, flags):
+            scored.append((surviving[j][0], 1 if is_tp else 0))
+        tp += sum(1 for f in flags if f)
+        fp += sum(1 for f in flags if not f)
+        n_gt += len(tier_gt)
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    scores = [s for s, _ in scored]
+    tps = [t for _, t in scored]
+    return {"ap": voc_ap(scores, tps, n_gt), "tp": tp, "fp": fp, "n_gt": n_gt}

--- a/benchmarks/wider_ap.py
+++ b/benchmarks/wider_ap.py
@@ -29,6 +29,8 @@ def parse_val_gt(path: Path) -> dict[str, list[dict]]:
         boxes: list[dict] = []
         for _ in range(count):
             cols = [c.strip() for c in lines[i].split(",")]
+            if len(cols) == 1:
+                cols = lines[i].split()
             x1 = float(cols[0])
             y1 = float(cols[1])
             w = float(cols[2])

--- a/docs/research/2026-08-30-detection-landmarks-phase1.md
+++ b/docs/research/2026-08-30-detection-landmarks-phase1.md
@@ -1,0 +1,177 @@
+# Detection and landmarks calibration, Phase 1
+
+- **What:** Phase 1 of the model calibration campaign: measurement of the shipped
+  detection stack (YuNet, plus the BlazeFace rescue stage) and the landmark
+  alignment stack (478-point mesh behind YuNet crops) on WIDER FACE (RGB, wild),
+  CBSR NIR and Oulu-CASIA NIR (IR-grey), and WFLW / 300W / AFLW2000 (landmark
+  annotation sets).
+- **Where:** archhost, NVIDIA RTX 3060, ONNX Runtime 1.27.0 with the CUDA
+  execution provider (providers: Tensorrt, CUDA, CPU), OpenCV 5.0.0. Per
+  `benchmarks/README.md`, CPU runs give the same accuracy; only latency differs.
+- **When:** 2026-08-30 (Phase 1 report; dataset fetch provenance 2026-08-29 UTC
+  per the PROVENANCE.md entries on the measurement host).
+- **Sources (committed):** `benchmarks/results-detection-wider.json`,
+  `benchmarks/results-detection-ir.json`, `benchmarks/results-landmarks.json`.
+  Every number below is copied from those files (or from the committed README
+  headlines referenced inline); values are rounded to 4 decimals.
+
+## 1. Detection track (WIDER FACE val)
+
+Operating point: input 640, score threshold 0.6.
+
+Tiered AP at the operating point (3226 val images):
+
+| tier | AP |
+|---|---|
+| easy | 0.8574 |
+| medium | 0.7932 |
+| hard | 0.4733 |
+
+Hard-tier totals per the JSON: tp 15825, fp 2345, n_gt 32764, images 3226.
+
+Protocol note: tiers use the official-approximation cuts (easy h > 50, medium
+h > 30, hard h >= 10). Predictions whose best-overlap valid GT box lies outside
+the tier are discarded entirely (neither tp nor fp); zero-overlap predictions
+stay fp candidates; invalid-flag GT boxes are excluded everywhere. An earlier
+height-band approximation (h >= 50 / h >= 20 / all valid) is superseded; its
+numbers are preserved in the JSON notes: easy 0.6859 / medium 0.6866 /
+hard 0.3964 (tp 15826, fp 2366, n_gt 39123).
+
+### Input and threshold sweep
+
+1613 of 3226 val images (stride 2, the nearest stride-integer approximation of
+the 2000-image target). Decoders run at the 0.3 floor and rows post-filter
+scores. ap_hard over all valid val GT faces on the sample:
+
+| input | thr 0.3 | thr 0.45 | thr 0.6 | thr 0.7 |
+|---|---|---|---|---|
+| 320 | 0.2438 | 0.2283 | 0.2049 | 0.1779 |
+| 448 | 0.3521 | 0.3325 | 0.2992 | 0.2620 |
+| 640 | 0.4729 | 0.4504 | 0.4124 | 0.3669 |
+
+Findings, exactly as the JSON shows them:
+
+- Input 640 dominates 320 and 448 at every threshold: each 640 row exceeds the
+  same-threshold 448 and 320 rows.
+- Threshold 0.3 lifts sample ap_hard to 0.4729 from 0.4124 at the 0.6 row (same
+  1613-image sample, same tiered scoring): recall is bought at FP cost, with
+  the sweep's operating-point FPPI reference recorded at 0.7564 (the 640/0.6
+  row) for the recall_at_op_fppi column.
+
+### Cascade (YuNet + BlazeFace rescue)
+
+BlazeFace short-range fires only on YuNet-empty images (rescue score 0.5,
+shipped anchor decode). Recall = valid-GT faces matched at IoU 0.5.
+
+| split | images | n_gt | yunet_recall | cascade_recall | rescues |
+|---|---|---|---|---|---|
+| val | 3226 | 39123 | 0.4045 | 0.4048 | 10 |
+| train sample (stride 4) | 3220 | 40224 | 0.4093 | 0.4094 | 5 |
+
+Findings:
+
+- Cascade recall is >= YuNet recall on both splits (0.4048 >= 0.4045 val;
+  0.4094 >= 0.4093 train sample).
+- The rescue fired on all 182 YuNet-empty images per split and produced 27
+  boxes (val) and 22 boxes (train), rescuing 10 and 5 GT faces respectively:
+  on WIDER the rescue gain is tiny and never negative.
+- BlazeFace stays a rescue, never a replacement, consistent with
+  `models/README.md` and the outdoor-walking measurement in
+  `benchmarks/README.md`.
+
+## 2. IR-grey detection (CBSR NIR + Oulu-CASIA NIR)
+
+YuNet at the operating point (640, 0.6). Detection rate = frames with at least
+one face above threshold; no GT exists for either set, so nothing beyond rate
+and score percentiles is claimed.
+
+| set | frames | detected | rate |
+|---|---|---|---|
+| CBSR NIR | 3940 | 3940 | 1.0 |
+| Oulu Dark | 1348 | 1348 | 1.0 |
+| Oulu Strong | 1298 | 1298 | 1.0 |
+| Oulu Weak | 1354 | 1354 | 1.0 |
+| Oulu overall | 4000 | 4000 | 1.0 |
+
+Score percentiles of detected faces: CBSR p50 0.9321 / p10 0.9213; Oulu
+overall p50 0.9333 / p10 0.9249.
+
+Headline: YuNet saturates NIR-grey detection on these sets, rate 1.0 on every
+CBSR frame and every Oulu lighting at the operating point, with the score
+floor (p10 0.9213 / 0.9249) far above the 0.6 threshold. Detection is not the
+bottleneck on CBSR/Oulu-class NIR. The bench discriminates nothing below the
+current operating point at threshold 0.6 (ceiling effect, recorded in the
+task-5 report).
+
+## 3. Landmarks track (WFLW / 300W / AFLW2000)
+
+Pipeline: YuNet at the operating point; best detection matched to the GT face
+box at IoU >= 0.3; matched and standalone paths crop a 1.25x-side square
+centered on the box, edge-replicated at frame borders, resized to 256; mesh
+output is gated by the runtime plausibility rule before scoring. GT face box =
+tight bounds of the GT landmarks (WFLW's shipped rect is a loose region,
+unusable for IoU-0.3 matching; 300W ships no box).
+
+| dataset | images | mesh_ok | eye NME pipeline | eye NME standalone | anchor NME | align IoU gain | fail YuNet | fail mesh |
+|---|---|---|---|---|---|---|---|---|
+| wflw_test | 2500 | 2441 | 0.0950 | 0.1232 | 0.1148 | 0.0867 | 59 | 0 |
+| 300w_test | 600 | 595 | 0.0813 | 0.0841 | 0.0857 | 0.1002 | 5 | 0 |
+| aflw2000 | 2000 | 1974 | 0.1990 | 0.2795 | 0.2112 | 0.1007 | 26 | 0 |
+
+Eye NME p90: 0.1701 (WFLW), 0.1208 (300W), 0.4370 (AFLW2000).
+
+Findings:
+
+- The pipeline beats GT-box (tight landmark bounds) standalone crops
+  everywhere: 0.0950 vs 0.1232 (WFLW), 0.0813 vs 0.0841 (300W), 0.1990 vs
+  0.2795 (AFLW2000).
+- Mesh refinement of YuNet boxes adds a consistent positive alignment gain:
+  align_iou_gain_mean 0.0867 / 0.1002 / 0.1007. Zero meshes were rejected as
+  implausible on all 5,100 rows (n_fail_mesh 0 everywhere).
+- AFLW2000 sits a decade above the other two sets (0.1990 pipeline vs
+  0.0950 / 0.0813): the set spans yaw to +/- 90 degrees, where the
+  frontal-biased mesh degrades (profile tail: eye NME p90 0.4370), and its GT
+  is the 3DMM fit's x/y projection (mat pt3d_68), adding fit-error bias on
+  extreme pose.
+- Comparison anchor: the committed CBSR pipeline eye NME is 0.0273
+  (`benchmarks/README.md`, n=985). WFLW and 300W land in the same 10^-2 decade
+  at 0.0950 / 0.0813. Recorded differences: wild-set pose, occlusion,
+  expression, and small faces vs CBSR's constrained high-res NIR bench, plus a
+  convention offset that does not exist in the same-source CBSR comparison
+  (predicted centers are mesh iris-block means; GT centers here are
+  eyelid-corner means).
+
+## 4. Calibration recommendations
+
+| Decision | Recommendation | Evidence |
+|---|---|---|
+| YuNet score threshold | Keep 0.6 as the grant-path default; revisit only with a downstream consumer | The 0.3 sweep row buys sample ap_hard (0.4729 vs 0.4124 at the 0.6 row) at FP cost; relevant only if irlume ever needs a high-recall sweep mode, which it does not have today |
+| Input resolution | Keep 640 | 640 dominates 320 and 448 at every sweep threshold |
+| Cascade switch behavior | Keep BlazeFace as rescue-only (fires only on YuNet-empty images) | Rescue counts are tiny (10 val / 5 train) and cascade recall never drops below YuNet recall on either split (0.4048 >= 0.4045; 0.4094 >= 0.4093) |
+| IR-grey detection posture | No detection-side action on CBSR/Oulu-class NIR | Rate 1.0 on 3940/3940 CBSR frames and on every Oulu lighting sample at the operating point |
+| Landmark alignment fitness | Keep the current alignment (YuNet box refined by the mesh) | Mesh refinement adds a consistent IoU gain (0.0867 / 0.1002 / 0.1007) and the pipeline beats standalone crops on all three sets. WFLW's standalone deficit (0.1232 vs 0.0950) is flagged for Phase 4: if no irlume path feeds GT-like loose boxes, no action |
+
+## 5. Replacement candidates
+
+None evaluated this phase (per plan). Detector and mesh replacement candidates
+join the Phase 4 synthesis.
+
+## 6. Limitations
+
+- The sweep sample is 1613 of 3226 val images (stride 2), the nearest
+  stride-integer approximation of the 2000-image target; sweep rows are sample
+  numbers, not full-val numbers.
+- The tier scorer is an official-protocol approximation: height cuts with
+  off-tier prediction discarding, not the official XOR against evaluation
+  mats; hard n_gt 32764 sits about 2.5% above the official-mat decode. The
+  superseded height-band numbers remain in the JSON notes.
+- Each dataset was measured from a single mirror; provenance (originator,
+  obtained-from, archive SHA-256) is recorded per dataset in PROVENANCE.md and
+  MANIFEST.sha256 on the measurement host. Mirror variance is real: the 300W
+  mirror ships the 600-image common test subset only, and WFLW annotation
+  lists split by face, not by image.
+- CBSR and Oulu produce detection rates only; no GT exists for either set, so
+  no AP or recall is claimed there.
+- The landmark sets use tight-landmark-bounds GT boxes and corner-mean eye
+  centers; comparison against the CBSR 0.0273 anchor carries the convention
+  offsets noted in section 3.

--- a/docs/superpowers/plans/2026-08-30-model-calibration-phase1.md
+++ b/docs/superpowers/plans/2026-08-30-model-calibration-phase1.md
@@ -1,0 +1,256 @@
+# Model Calibration Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce the detection and landmarks calibration evidence: official WIDER FACE AP at irlume's operating point plus threshold and resolution sweeps and the cascade rescue measurement, IR-grey detection behavior on CBSR and Oulu NIR, and landmark accuracy (eye NME, anchor NME, alignment quality) on WFLW, 300W, and AFLW2000.
+
+**Architecture:** Extends the Phase 0 layout. New registry entries ride the existing fetcher. AP evaluation and landmark scoring live in testable pure modules (`wider_ap.py`, `landmark_score.py`); the bench scripts stay thin measurement drivers. All execution on archhost (venv `~/venvs/bench`, code `~/irlume-bench/`, datasets `~/datasets/`).
+
+**Tech Stack:** Same as Phase 0 (Python 3.12, onnxruntime-gpu 1.27.0 CUDA, OpenCV, requests, pytest).
+
+**Spec:** `docs/superpowers/specs/2026-08-30-model-calibration-campaign-design.md` (Detection and Landmarks rows of the validation matrix).
+
+## Global Constraints
+
+- Zero em dashes (U+2014) in every file and commit message.
+- DCO trailer exactly: `Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>`. Repo enforces GPG; on pinentry timeout report BLOCKED, never `--no-gpg-sign`.
+- Never print token values; auth failures report HTTP status only.
+- The user gates every dataset download start. This phase's sets: WFLW ~0.76 GB (Kaggle), 300W ~2.1 GB (HF), AFLW2000 ~87 MB (Kaggle), CBSR NIR ~1.2 GB (Kaggle), Oulu-CASIA NIR ~1.2 GB (Kaggle). Ask once per dataset with exact size before fetching.
+- irlume's real YuNet operating point is INPUT_SIZE 640 square letterbox, SCORE_THRESHOLD 0.6 (crates/irlume-vision/src/detect.rs:19-20). All "operating point" measurements use these values; sweeps bracket them.
+- Research-only datasets are measurement-only; nothing derived ships.
+- Work on branch `calib/phase1` (stacked on `docs/calibration-campaign` @ 9007b190), worktree `/home/wisbfime/irlume/.worktrees/calib-spec`.
+- Kaggle-sourced specs define exactly ONE archive file (v1 REST downloads the whole dataset per call); the fetcher enforces this (Task 2).
+- archhost venv python: `/home/archledger/venvs/bench/bin/python` (absolute path; uv not on non-interactive PATH).
+
+---
+
+### Task 1: Registry additions (5 datasets)
+
+**Files:**
+- Modify: `benchmarks/datasets.py`
+- Test: `benchmarks/tests/test_datasets.py`
+
+**Interfaces:**
+- Consumes: Phase 0 `datasets.py` (DatasetSpec, DatasetFile, _DATASETS dict)
+- Produces: `get_dataset` names `wflw`, `300w`, `aflw2000`, `cbsr_nir`, `oulu_casia_nir`, each kaggle-sourced one being a single-file spec with `path="kaggle-archive.zip"`, `extract=True`.
+
+- [ ] **Step 1: Write the failing tests** (append to `benchmarks/tests/test_datasets.py`)
+
+```python
+def test_kaggle_specs_are_single_archive():
+    for name in list_datasets():
+        spec = get_dataset(name)
+        if spec.source == "kaggle":
+            assert len(spec.files) == 1, f"{name} must be a single kaggle archive"
+            assert spec.files[0].path == "kaggle-archive.zip"
+            assert spec.files[0].extract
+
+
+def test_new_landmark_and_ir_entries():
+    wflw = get_dataset("wflw")
+    assert wflw.source == "kaggle"
+    assert wflw.repo == "mrriandmstique/wflw-wider-facial-landmarks-in-the-wild"
+    three = get_dataset("300w")
+    assert three.source == "hf"
+    assert three.repo == "quoctai219/300W"
+    assert three.files[0].path == "300w_dataset.zip"
+    aflw = get_dataset("aflw2000")
+    assert aflw.repo == "mohamedadlyi/aflw2000-3d"
+    cbsr = get_dataset("cbsr_nir")
+    assert cbsr.repo == "gpreda/cbsr-nir-face-dataset"
+    oulu = get_dataset("oulu_casia_nir")
+    assert oulu.repo == "aryanbaibaswata/oulu-casia"
+    for spec in (wflw, three, aflw, cbsr, oulu):
+        assert spec.provenance_url
+        assert spec.license_note
+        assert spec.notes
+```
+
+- [ ] **Step 2: Run to verify RED**: `.venv-bench/bin/pytest benchmarks/tests/test_datasets.py -q` expect FAIL (KeyError wflw).
+
+- [ ] **Step 3: Add the five entries** to `_DATASETS` (exact refs above; each kaggle entry one DatasetFile `kaggle-archive.zip` with size_hint: wflw 760_000_000, aflw2000 87_000_000, cbsr_nir 1_200_000_000, oulu_casia_nir 1_200_000_000; 300w one DatasetFile `300w_dataset.zip` size 2_140_000_000). license_note for the NIR sets must state research-only terms per benchmarks/README.md (CBSR and Oulu: research/education only; Tufts request-form precedent noted). provenance_url = the kaggle dataset page or HF page. notes must record: mirror identity matters (benchmarks/README.md), Oulu layout `Oulu_CASIA_NIR_VIS/NI/<lighting>/<subject>/`, CBSR bmp images, WFLW test split 2500 images with 98-pt txts, 300W zip is the full canonical set, AFLW2000 ships 2000 jpgs + .mat annotations.
+
+- [ ] **Step 4: Run to verify GREEN** (7 tests in file) then commit `bench: registry entries for landmark and nir sets`.
+
+---
+
+### Task 2: Fetcher kaggle single-archive enforcement
+
+**Files:**
+- Modify: `benchmarks/fetch_data.py`
+- Test: `benchmarks/tests/test_fetch_data_guard.py`
+
+**Interfaces:**
+- Consumes: datasets.get_dataset
+- Produces: `validate_spec(spec)` raising SystemExit when a kaggle spec has more than one file; called at the top of download_dataset.
+
+- [ ] **Step 1: Failing test**
+
+```python
+import pytest
+
+from datasets import DatasetFile, DatasetSpec, get_dataset
+from fetch_data import validate_spec
+
+
+def _spec(source, files):
+    return DatasetSpec(
+        name="x", source=source, repo="o/d", files=tuple(files),
+        license_note="l", provenance_url="https://example.com", notes="n",
+    )
+
+
+def test_kaggle_multi_file_rejected():
+    with pytest.raises(SystemExit):
+        validate_spec(_spec("kaggle", [
+            DatasetFile(path="a.zip"), DatasetFile(path="b.zip"),
+        ]))
+
+
+def test_kaggle_single_file_ok():
+    validate_spec(_spec("kaggle", [DatasetFile(path="kaggle-archive.zip")]))
+
+
+def test_real_kaggle_specs_pass():
+    for name in ["wflw", "aflw2000", "cbsr_nir", "oulu_casia_nir"]:
+        validate_spec(get_dataset(name))
+
+
+def test_hf_multi_file_ok():
+    validate_spec(get_dataset("wider_face"))
+```
+
+- [ ] **Step 2: RED** (ImportError validate_spec), **Step 3: implement** `validate_spec` (2-line rule + clear message), call it first thing inside `download_dataset`. **Step 4: GREEN** all 4 + suite. **Step 5: commit** `bench: enforce kaggle single-archive spec rule`.
+
+---
+
+### Task 3: Official WIDER AP evaluator (`wider_ap.py`)
+
+**Files:**
+- Create: `benchmarks/wider_ap.py`
+- Test: `benchmarks/tests/test_wider_ap.py`
+
+**Interfaces:**
+- Produces (Task 4 consumes):
+  - `parse_val_gt(path: Path) -> dict[str, list[dict]]` keyed by the GT's relative image path; each box dict: `box` (x1,y1,x2,y2 floats), `invalid` (bool from the GT invalid column)
+  - `iou(a, b) -> float`
+  - `evaluate_image(preds: list[tuple[float, list[float]]], gt: list[dict], iou_thr: float = 0.5) -> tuple[int, int, int]` returns (tp, fp, n_gt_valid): greedily match highest-score preds to non-invalid GT by IoU >= thr, one GT once; unmatched pred = fp; invalid GT never matched and not counted
+  - `voc_ap(scores: list[float], tps: list[int], total_gt: int) -> float` all-point interpolated AP (PASCAL 2010 style), preds given sorted descending by score
+  - `evaluate(preds_by_image, gt_by_image) -> dict` returns {"ap": float, "tp": int, "fp": int, "n_gt": int}; caller aggregates per split
+
+- [ ] **Step 1: Failing tests** covering: parse_val_gt on a 3-line synthetic GT snippet (image line then box lines, blank separator, invalid flag honored); iou identity/overlap/disjoint; evaluate_image perfect match = (n, 0, n); duplicate detection on same GT = second is fp; invalid GT excluded from both tp and n_gt; voc_ap perfect ranking = 1.0, reversed ranking < 0.5, all-fp = 0.0.
+- [ ] **Step 2: RED. Step 3: implement. Step 4: GREEN** (new tests + full suite). **Step 5: commit** `bench: official-protocol WIDER AP evaluator`.
+
+---
+
+### Task 4: Letterbox + full detection bench (`bench_detection_wider.py` extension)
+
+**Files:**
+- Modify: `benchmarks/bench_detection_wider.py` (add modes; keep --smoke behavior identical)
+- Modify: `benchmarks/wider_ap.py` only if a defect surfaces (no behavior drift)
+- Create: `benchmarks/results-detection-wider.json` (committed output)
+
+**Interfaces:**
+- Consumes: wider_ap (Task 3), models dir (yunet + blaze_face_short_range.onnx), `~/datasets/wider_face`
+- Produces: results-detection-wider.json schema:
+  `{"runtime": {...}, "operating_point": {"input": 640, "score_threshold": 0.6}, "ap": {"easy": f, "medium": f, "hard": f, "tp": i, "fp": i, "n_gt": i, "images": 3226}, "sweep": [{"input": i, "score_threshold": s, "ap_hard": f, "recall_at_op_fppi": f}...], "cascade": {"val": {"yunet_recall": f, "cascade_recall": f, "rescues": i}, "train_sample": {...}}, "notes": [...]}`
+
+- [ ] **Step 1: Failing tests for the letterbox math** (append to `benchmarks/tests/test_wider_ap.py` or a new test_letterbox.py):
+
+```python
+from letterbox import letterbox_params, restore_boxes
+
+
+def test_letterbox_square_input_scales_long_side():
+    sx, sy, pad_x, pad_y = letterbox_params(1280, 960, 640)
+    assert sx == 0.5 and sy == 0.5
+    assert pad_x == 0 and pad_y > 0
+
+
+def test_restore_boxes_roundtrip():
+    p = letterbox_params(1280, 960, 640)
+    boxes = [[10.0, 10.0, 100.0, 100.0]]
+    out = restore_boxes(boxes, p, orig_w=1280, orig_h=960)
+    assert out[0][0] <= out[0][2] and out[0][1] <= out[0][3]
+```
+
+(Exact letterbox convention: square 640 canvas, uniform scale by the longer side, centered padding on the short side; letterbox_params returns (scale_x, scale_y, pad_x, pad_y) with restore undoing both.)
+
+- [ ] **Step 2: RED for letterbox tests, implement `benchmarks/letterbox.py`, GREEN.**
+- [ ] **Step 3: Extend the bench script** with modes `--ap`, `--sweep`, `--cascade` (all read/write the schema above; sweep runs a stratified 2000-image val sample: every k-th image of the sorted list; cascade measures recall with and without the BlazeFace rescue on YuNet misses, full val plus a 4000-image train sample). Detection at the operating point uses the 640 letterbox and 0.6 threshold. Per-image results print progress every 200 images.
+- [ ] **Step 4: Deploy to archhost, run AP at operating point** (full 3,226-image val; expect minutes on the 3060), then sweep, then cascade. Fetch results back, sanity-check: easy AP >= hard AP (standard WIDER ordering), cascade recall >= yunet recall, rescue count > 0.
+- [ ] **Step 5: commit** `bench: wider ap at operating point with sweep and cascade`.
+
+---
+
+### Task 5: IR-grey detection bench (`bench_detection_ir.py`)
+
+**Files:**
+- Create: `benchmarks/bench_detection_ir.py`
+- Create: `benchmarks/results-detection-ir.json` (committed output)
+
+**Interfaces:**
+- Consumes: letterbox.py, cbsr_nir + oulu_casia_nir datasets, yunet
+- Produces: schema `{"runtime": {...}, "cbsr": {"frames": i, "detected": i, "rate": f, "score_p50": f, "score_p10": f}, "oulu": {"per_lighting": [{"lighting": str, "frames": i, "rate": f}...], "overall": {...}}, "notes": [...]}`
+
+- [ ] **Step 1: Write the script** (structure mirrors bench_detection_wider: YuNet at operating point over full frames, no GT exists so the output is detection rate + score distribution; Oulu grouped by its lighting directory names; CBSR flat over its subject dirs; cap at 4000 frames per dataset, stride-sampled, recorded in the notes).
+- [ ] **Step 2: Local parse check** (`ast.parse`), deploy, **run on archhost** after the two NIR datasets are downloaded (see Task 7 ordering note).
+- [ ] **Step 3: Sanity-check** (CBSR rate high, active-NIR; Oulu per-lighting rates must show dark-vs-strong spread or flat-high, either is informative; zero-rate datasets mean a path bug, stop and investigate).
+- [ ] **Step 4: commit** `bench: ir-grey detection rates on cbsr and oulu nir`.
+
+---
+
+### Task 6: Landmark bench (`bench_landmarks.py`)
+
+**Files:**
+- Create: `benchmarks/landmark_score.py`
+- Create: `benchmarks/bench_landmarks.py`
+- Test: `benchmarks/tests/test_landmark_score.py`
+- Create: `benchmarks/results-landmarks.json` (committed output)
+
+**Interfaces:**
+- Consumes: yunet + face_landmark.onnx (478-point mesh: output float32 [1,1434] reshaped 478x3 + faceflag), letterbox.py, wflw/300w/aflw2000 datasets
+- Produces:
+  - `landmark_score.py`: `nme(pred_pts, gt_eye_center_a, gt_eye_center_b, anchors_pred, anchors_gt) -> float` (mean anchor L2 error / inter-ocular distance); `mesh_eye_centers(mesh478) -> tuple[tuple[float,float], tuple[float,float]]` (iris centers: left mean of indices 468-472, right 473-477; fall back to eye-corner midpoints (33,133) and (362,263) if iris block degenerate); `ANCHOR_MESH_IDX = [33, 133, 362, 263, 61, 291, 1, 152]` with docstring naming them (left eye outer/inner, right eye inner/outer, mouth corners, nose tip, chin)
+  - bench schema: `{"runtime": {...}, "per_dataset": {"wflw_test": {"images": i, "mesh_ok": i, "eye_nme_mean": f, "eye_nme_p90": f, "eye_nme_standalone_mean": f, "anchor_nme_mean": f, "align_iou_gain_mean": f, "n_fail_yunet": i, "n_fail_mesh": i}, "300w_test": {...}, "aflw2000": {...}}, "notes": [...]}`
+- Protocol: YuNet (operating point) -> crop with 1.25x margin -> mesh; GT eye index sets are VERIFIED IN A TASK STEP before scoring (Step 2), then hard-coded as constants with a comment naming the source annotation file that pinned them. BOTH pipeline crops AND standalone GT-box crops are scored (the spec requires the comparison; standalone = mesh fed the GT box crop directly).
+
+- [ ] **Step 1: Failing tests** for nme (identical points = 0; known synthetic = expected ratio), mesh_eye_centers (synthetic 478x3 array with iris block placed off-center; degenerate iris block falls back to corner midpoints), ANCHOR index bounds.
+- [ ] **Step 2: GT eye-index verification step (executes once, on archhost or locally with a downloaded sample):** for each dataset, take the first 20 annotation files, compute per-index mean positions for candidate eye-index sets, and print the cluster geometry; pin the sets that satisfy: two tight clusters, one clearly left and one clearly right of the face midline, both above the mouth candidates. Record the pinned indices + the evidence line in the report. (68-pt schemes: standard left eye 36-41, right 42-47, eye center = corner mean; WFLW 98: derive per this step.)
+- [ ] **Step 3: Implement + GREEN + run on archhost** (full WFLW test 2500, 300W test set as shipped, AFLW2000 2000), fetch results back, sanity: eye NME through the pipeline should land in the same decade as the committed 0.0273 CBSR number; n_fail_yunet/n_fail_mesh recorded per dataset.
+- [ ] **Step 4: commit** `bench: landmark track with eye and anchor nme`.
+
+Scope note (spec conflict resolution, ruled by the controller): the spec matrix lists per-region NME over eyes, brows, nose, mouth, contour, and iris. Cross-scheme correspondence (478-point mesh vs 98/68-point GT) is unambiguous only for the pinned anchors (eye corners, mouth corners, nose tip, chin) plus iris-informed eye centers. Brows, contour, and iris region rows are therefore DEFERRED to the Phase 4 synthesis, where the correspondence question can be settled against measured need; this plan does not silently drop them, it reports the achievable anchor set now.
+
+---
+
+### Task 7: Downloads (USER GATE, interleaved before Tasks 4-6 runs)
+
+**Files:** none (host state only)
+
+- [ ] **Step 1:** Ask the user per dataset (exact sizes above), then fetch+verify each on archhost with the fetcher (`download <name> --root ~/datasets`), verifying: WFLW test annotation txt count + image count match (2500 expected), 300W zip extracts with its shipped test set, AFLW2000 has 2000 jpgs + .mat files, CBSR bmps present, Oulu has the NI/<lighting> layout. Record every verification in the phase report.
+- [ ] **Step 2:** Register MANIFEST/PROVENANCE existence per dataset (fetcher writes them; spot-check).
+
+---
+
+### Task 8: Phase 1 report + calibration table
+
+**Files:**
+- Create: `docs/research/2026-08-30-detection-landmarks-phase1.md`
+- Modify: `docs/superpowers/plans/2026-08-30-model-calibration-phase0.md` only if a Phase 0 claim needs correction (none expected)
+
+- [ ] **Step 1:** Write the report: per-track results with exact numbers traceable to the committed results files, the calibration recommendation table (YuNet score threshold, input resolution, cascade switch behavior, IR-grey detection posture, landmark alignment fitness), and the replacement-candidate note (none evaluated this phase; candidates join Phase 4 synthesis).
+- [ ] **Step 2:** Zero em dashes check, commit `docs: phase 1 detection and landmarks calibration report`.
+
+---
+
+## Phase 1 exit criteria
+
+- results-detection-wider.json, results-detection-ir.json, results-landmarks.json committed; report written.
+- Every recommendation in the report traces to a committed number.
+- All downloads user-gated and PROVENANCE'd.
+- Suite green (`pytest benchmarks/tests -q`), zero new em dashes, every commit GPG + DCO.
+
+## Out of scope for Phase 1
+
+- Recognition suite (Phase 2), PAD tracks (Phase 3), threshold-change PRs and replacement candidates (Phase 4).


### PR DESCRIPTION
Phase 1 of the model calibration campaign (spec: docs/superpowers/specs/2026-08-30-model-calibration-campaign-design.md, plan: docs/superpowers/plans/2026-08-30-model-calibration-phase1.md). Measurement infrastructure only; no daemon, CLI, or shipped-model changes. Rebased onto 0.11.3 main after #596 merged.

## What lands

- Registry entries + fetcher guard: wflw, 300w, aflw2000, cbsr_nir, oulu_casia_nir; kaggle specs enforce the single-archive rule (validate_spec, wired into download_dataset).
- benchmarks/wider_ap.py: official-protocol WIDER AP evaluator (PASCAL 2010 all-point AP, invalid-box ignore, official-approximation tier cuts h>50/h>30/h>=10 with evaluation.m off-tier discard semantics).
- benchmarks/letterbox.py + bench_detection_wider.py --ap/--sweep/--cascade: detection at irlume's real operating point (640 square letterbox, score 0.6).
- benchmarks/bench_detection_ir.py: IR-grey detection rates on CBSR + Oulu NIR full frames.
- benchmarks/landmark_score.py + bench_landmarks.py: landmarks through the YuNet-crop pipeline AND standalone GT-box crops (eye NME with iris-informed centers, anchor NME, alignment IoU gain); scipy pinned for AFLW2000 mat parsing.
- docs/research/2026-08-30-detection-landmarks-phase1.md: the calibration report.

## Headline results (archhost RTX 3060, ORT 1.27.0 CUDA)

- Detection, WIDER val tiered AP at the operating point: easy 0.8574 / medium 0.7932 / hard 0.4733. 640 input dominates 320/448 across the sweep; threshold 0.3 lifts tiered hard AP to 0.4729 vs 0.4124 at 0.6 (FP-costed). Cascade rescues are rare at 640 (10 val / 5 train) and recall never decreases: BlazeFace stays rescue-only.
- IR-grey: YuNet detection rate 1.0 on CBSR (3,940 frames) and on every Oulu lighting (4,000 stride-sampled): NIR-grey detection is fully covered at the operating point; discrimination is a PAD-model question (Phase 3).
- Landmarks (eye NME, pipeline vs standalone): WFLW 0.0950/0.1232, 300W 0.0813/0.0841, AFLW2000 0.1990/0.2795; pipeline beats GT-box crops on every set; mesh refinement adds +0.087..+0.101 IoU over the raw YuNet box; 0 mesh rejections on 5,100 rows.

## Verification

- 52 unit tests green; every number in the report traced to the committed results JSONs (independent review).
- All five downloads user-gated, sha256-manifested, PROVENANCE'd; 300W mirror reality (common test subset, 600 pairs) corrected in the registry and labeled in the report.
- Final whole-branch review: READY, all deferred minors triaged keep.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>