### PR TITLE
fix: doctor searched for the landmarks model under a misspelled name

### DIFF
--- a/crates/irlume-cli/src/models.rs
+++ b/crates/irlume-cli/src/models.rs
@@ -45,7 +45,7 @@ pub(crate) fn stage_statuses() -> Vec<StageStatus> {
         ),
         (
             "landmarks",
-            "face_landmark_detector.tflite",
+            "face_landmarks_detector.tflite",
             "IRLUME_MESH_MODEL",
             false,
         ),
@@ -89,7 +89,7 @@ pub(crate) fn recognizer_space_for(name: &str) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::recognizer_space_for;
+    use super::{recognizer_space_for, stage_statuses};
 
     #[test]
     fn forget_model_accepts_shipped_and_literal_spaces_only() {
@@ -108,5 +108,49 @@ mod tests {
         // must be refused, not silently interpreted.
         assert!(recognizer_space_for("buffalo").is_err());
         assert!(recognizer_space_for("embed:xyz").is_err());
+    }
+
+    /// doctor's stage table must search for the files the package actually
+    /// ships: the packaged unit pins every model path the daemon loads, so a
+    /// filename drifting from it reports a capability as missing while the
+    /// daemon is using it (#600).
+    #[test]
+    fn stage_filenames_match_the_packaged_unit() {
+        let unit = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../packaging/systemd/irlumed.service"
+        ))
+        .expect("packaging/systemd/irlumed.service readable from the workspace");
+        let env_for = [
+            ("detection", "IRLUME_DET_MODEL"),
+            ("landmarks", "IRLUME_MESH_MODEL"),
+            ("recognition", "IRLUME_MODEL"),
+        ];
+        for stage in stage_statuses() {
+            let file = stage.file.expect("every stage names its model file");
+            let env = env_for
+                .iter()
+                .find(|(name, _)| *name == stage.stage)
+                .expect("stage covered by the test table")
+                .1;
+            let prefix = format!("Environment=\"{env}=");
+            let line = unit
+                .lines()
+                .find(|l| l.starts_with(&prefix))
+                .unwrap_or_else(|| panic!("{env} is pinned in the packaged unit"));
+            let pinned = line
+                .strip_prefix(&prefix)
+                .and_then(|v| v.strip_suffix('"'))
+                .unwrap_or_else(|| panic!("{env} line is a quoted absolute path"));
+            let pinned_name = std::path::Path::new(pinned)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .expect("pinned path has a file name");
+            assert_eq!(
+                pinned_name, file,
+                "doctor's {} stage must search for the file the unit loads",
+                stage.stage
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

`irlume doctor` searched for `face_landmark_detector.tflite`; every packaging lane, the packaged unit's `IRLUME_MESH_MODEL`, and the daemon ship `face_landmarks_detector.tflite`. Doctor therefore reported the landmarks stage missing and claimed head gestures and detection-rescue alignment were disabled on installs where the daemon had the model loaded from its unit env.

Reported in #600 with the exact call site. The misspelled name appeared in exactly one place in the tree: the landmarks row of `stage_statuses()` in `crates/irlume-cli/src/models.rs`.

## Fix

One line: the stage's filename now matches the shipped name.

## Regression test

`stage_filenames_match_the_packaged_unit` cross-checks every stage filename (detection, landmarks, recognition) against the model paths pinned in `packaging/systemd/irlumed.service`, so the CLI table cannot drift from the packaging again. Verified RED against the typo before the fix:

```
doctor's landmarks stage must search for the file the unit loads
  left: "face_landmarks_detector.tflite"
 right: "face_landmark_detector.tflite"
```

## Evidence

- RED: `cargo test -p irlume-cli stage_filenames_match_the_packaged_unit` fails at 943afc98 with the mismatch above
- GREEN: same test passes at 8c44adac
- `cargo test -p irlume-cli`: 560 passed, 0 failed, 11 ignored
- `cargo fmt --check -p irlume-cli`: clean
- `cargo clippy -p irlume-cli --all-targets -- -D warnings`: clean
- Commit GPG-signed (C10B8492BD7F30C6), DCO trailer exact

Fixes #600
