### PR TITLE
feat: make the privileged `yes` confirmation optional per machine

### DIFF
--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -953,10 +953,76 @@ pub fn forbid_external_cameras_visible() -> Option<bool> {
     }
 }
 
+/// Whether privileged services must collect the literal `yes` before a face
+/// attempt (`privileged_face_consent`), or `None` when settings.conf exists and
+/// this process may not read it.
+///
+/// The odd one out among these keys: it defaults **on**, so an absent file or an
+/// absent key means the confirmation is required, and the key exists to turn a
+/// protection off rather than on. That asymmetry is deliberate. No surface
+/// irlume wires runs hands-free by default, and this key does not make one: it
+/// puts privileged prompts on a standing-consent footing as the machine owner's
+/// own choice, distinct from every default surface, without moving that line
+/// for anyone who does not ask (ADR-0018).
+///
+/// Read by both sides. The PAM module skips the prompt, and the daemon consults
+/// it again before honouring [`crate::IntentAttestation::PolicyWaived`], so a client
+/// cannot waive a confirmation the machine's own policy still requires.
+pub fn privileged_face_consent_visible() -> Option<bool> {
+    if let Ok(v) = std::env::var("IRLUME_PRIVILEGED_FACE_CONSENT") {
+        return Some(truthy(&v));
+    }
+    match observe_kv("settings.conf", "privileged_face_consent") {
+        KvObservation::Value(v) => Some(truthy(&v)),
+        // Absent is unambiguous here too, but the default is ON.
+        KvObservation::Absent => Some(true),
+        KvObservation::Unknown(_) => None,
+    }
+}
+
+/// [`privileged_face_consent_visible`] resolved for a decision: unreadable
+/// settings keep the confirmation, because a policy this process cannot read is
+/// not a policy that waived anything.
+#[must_use]
+pub fn privileged_face_consent_required() -> bool {
+    privileged_face_consent_visible().unwrap_or(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testenv;
+
+    /// The privileged-consent key reads env-over-settings like its neighbours,
+    /// but Absent means ON: it exists to switch a protection off, so anything
+    /// that fails to say otherwise has to leave it standing.
+    #[test]
+    fn privileged_face_consent_defaults_on_and_env_wins_over_settings() {
+        let _g = testenv::lock();
+        let dir = std::env::temp_dir().join(format!("irlume-cfg-consent-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+        std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
+
+        // Absent key: required, and unambiguously so.
+        assert_eq!(privileged_face_consent_visible(), Some(true));
+        assert!(privileged_face_consent_required());
+
+        // Settings file turns it off.
+        write_kv("settings.conf", "privileged_face_consent", "0").unwrap();
+        assert_eq!(privileged_face_consent_visible(), Some(false));
+        assert!(!privileged_face_consent_required());
+
+        // The env override wins over the file, in both directions.
+        std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", "1");
+        assert_eq!(privileged_face_consent_visible(), Some(true));
+        std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", "no");
+        assert_eq!(privileged_face_consent_visible(), Some(false));
+
+        std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// The external-camera prohibition reads env-over-settings with Absent
     /// meaning off, exactly like the biopolicy gate it mirrors.

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -428,6 +428,11 @@ pub fn write_atomic_reporting(
 pub enum IntentAttestation {
     /// A root PAM client reports collecting the conventional confirmation.
     PamConversation,
+    /// A root PAM client reports that this machine's policy waives the
+    /// confirmation (`privileged_face_consent=0`). Never trusted on its own:
+    /// the daemon re-reads the same policy before honouring it, so a client
+    /// cannot waive a confirmation the machine still requires.
+    PolicyWaived,
 }
 
 /// Request from an (untrusted) client to the (privileged) daemon.

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2888,11 +2888,18 @@ fn intent_confirmation_gate(req: &Request, peer: &Peer) -> Option<Response> {
         .as_deref()
         .and_then(irlume_common::pam_service::classify)
         .is_some_and(ServiceKind::requires_face_intent_confirmation);
+    // A waiver is honoured only when the daemon's own read of the policy agrees
+    // with the client's. The client is root, but "root said so" is not the
+    // guarantee here: the guarantee is that the machine's configuration waived
+    // the confirmation, and the daemon is the one that decides it did.
     let has_trusted_confirmation = peer.uid == 0
-        && matches!(
-            intent_confirmation,
-            Some(IntentAttestation::PamConversation)
-        );
+        && match intent_confirmation {
+            Some(IntentAttestation::PamConversation) => true,
+            Some(IntentAttestation::PolicyWaived) => {
+                !irlume_common::config::privileged_face_consent_required()
+            }
+            None => false,
+        };
     let valid = if requires_confirmation {
         has_trusted_confirmation
     } else {
@@ -8251,6 +8258,57 @@ mod tests {
     /// A uid outside any account database (same sentinel the identify-scope
     /// test uses): authorized_for() is false for every user.
     const NOBODY: u32 = 0xfffe_fffe;
+
+    /// A waiver is a claim about the machine's policy, not about the caller, so
+    /// the daemon has to agree with it independently. A root PAM client saying
+    /// "policy waived this" on a machine whose policy did not waive anything is
+    /// refused exactly like a missing confirmation, which is what stops the
+    /// waiver from becoming a way for a root client to skip the gate.
+    #[test]
+    fn policy_waiver_is_honoured_only_when_the_daemon_reads_the_same_policy() {
+        let _g = env_lock();
+        let sudo_with = |attestation| Request::Authenticate {
+            user: "root".into(),
+            service: Some("sudo".into()),
+            intent_confirmation: attestation,
+        };
+
+        std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", "1");
+        assert!(
+            intent_confirmation_gate(&sudo_with(Some(IntentAttestation::PolicyWaived)), &peer(0))
+                .is_some(),
+            "a waiver must be refused while the policy still requires confirmation"
+        );
+        assert!(
+            intent_confirmation_gate(
+                &sudo_with(Some(IntentAttestation::PamConversation)),
+                &peer(0)
+            )
+            .is_none(),
+            "a real confirmation still passes"
+        );
+
+        std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", "0");
+        assert!(
+            intent_confirmation_gate(&sudo_with(Some(IntentAttestation::PolicyWaived)), &peer(0))
+                .is_none(),
+            "a waiver passes once the policy waives the confirmation"
+        );
+        assert!(
+            intent_confirmation_gate(
+                &sudo_with(Some(IntentAttestation::PolicyWaived)),
+                &peer(NOBODY)
+            )
+            .is_some(),
+            "a waiver from a non-root peer is refused whatever the policy says"
+        );
+        assert!(
+            intent_confirmation_gate(&sudo_with(None), &peer(0)).is_some(),
+            "a waived policy is not an invitation to send no attestation at all"
+        );
+
+        std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
+    }
 
     fn peer(uid: u32) -> Peer {
         Peer {

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -362,10 +362,20 @@ impl PamServiceModule for IrlumePam {
                     if wait || unseal {
                         return PamError::IGNORE;
                     }
-                    match confirm_face_intent(&pamh, kind) {
-                        IntentConfirmation::Confirmed => Some(IntentAttestation::PamConversation),
-                        IntentConfirmation::Fallback => return PamError::IGNORE,
-                        IntentConfirmation::Abort => return PamError::ABORT,
+                    // The machine's owner can put privileged services on the
+                    // same footing as screen unlock, where the PAM wiring is
+                    // itself the consent. Off by default; the daemon checks the
+                    // same key before it honours the waiver.
+                    if !irlume_common::config::privileged_face_consent_required() {
+                        Some(IntentAttestation::PolicyWaived)
+                    } else {
+                        match confirm_face_intent(&pamh, kind) {
+                            IntentConfirmation::Confirmed => {
+                                Some(IntentAttestation::PamConversation)
+                            }
+                            IntentConfirmation::Fallback => return PamError::IGNORE,
+                            IntentConfirmation::Abort => return PamError::ABORT,
+                        }
                     }
                 }
                 _ => None,

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -169,6 +169,13 @@ password/fingerprint without opening the camera; `yes` authorizes one face
 attempt. Login, logout, lock-screen, and credential-release flows do not gain
 this extra irlume prompt.
 
+That prompt is on by default and can be turned off per machine with
+`privileged_face_consent=0` in `/etc/irlume/settings.conf`, the machine owner's
+waiver: a privileged face attempt then starts when the PAM prompt appears, with
+no per-attempt word. The trade is that
+every `sudo` then opens the camera, including one typed by someone else at the
+machine; passive PAD and the password fallback are unaffected.
+
 An experimental **head gesture** can be explicitly added as a second gate and
 defaults off everywhere. Repeated nodding approves and a head shake declines;
 on Plasma 6 the KDE polkit agent may re-prompt before closing its window

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -311,8 +311,16 @@ Test it in a fresh terminal with `sudo -k` (clear the cached credential) then
 `sudo true`. PAM shows `Type yes to use face authentication` above the normal
 hidden field. Type `yes` for one face attempt, or type the ordinary password
 once for the password/fingerprint path. Empty Enter never starts the camera and
-falls through to the password provider. This confirmation is mandatory and has
-no disable setting.
+falls through to the password provider.
+
+This confirmation is on by default and stays that way unless the machine's
+owner turns it off. `privileged_face_consent=0` in `/etc/irlume/settings.conf`
+(or `IRLUME_PRIVILEGED_FACE_CONSENT=0`) is the owner's waiver of that keyword:
+the scan starts when the privileged PAM prompt appears, with no per-attempt
+word. Do it only if you accept what follows: every
+`sudo` opens the camera, including one typed by someone else at your machine
+and one run from a script. Passive PAD still applies, and the password still
+works.
 
 ## App prompts via polkit (optional)
 
@@ -325,7 +333,8 @@ sudo irlume login enable --with-polkit --apply
 
 The daemon treats polkit as verify-only (it never releases the TPM-sealed
 credential to it). PAM shows `Type yes to use face authentication` above the
-normal hidden field. Type `yes` for one face attempt, or type the ordinary
+normal hidden field, unless `privileged_face_consent=0` waives it as described
+above. Type `yes` for one face attempt, or type the ordinary
 password once for the password/fingerprint path. Empty Enter and cancellation
 never open the camera. An experimental head gesture can be explicitly added as
 a second gate, but defaults off and never replaces keyboard confirmation.
@@ -453,7 +462,7 @@ live in them; sealed envelopes are stored separately (see
 
 | File | Holds | Written by |
 |---|---|---|
-| `/etc/irlume/settings.conf` | `credential_release_challenge=1` opts IN to a head gesture before the login-keyring credential is released (default off); every `service_gesture.<service>` also defaults off, with `=1` adding an experimental gesture after mandatory privileged keyboard confirmation; the legacy `polkit_gesture=1` switch remains an explicit polkit opt-in. `enforce_biopolicy=1` opts into operation-class gating; `forbid_external_cameras=1` restricts face authentication to cameras the kernel reports as `removable: fixed` (internal only; `removable: unknown` fails closed to the password, mirroring Windows ShouldForbidExternalCameras post-CVE-2021-34466); the legacy `third_party_pad` / `third_party_recognizer` keys are ignored with a startup notice (the third-party lane was removed, ADR-0015). During the migration window, `consent_gesture=closure` or malformed values block only a gesture-gated request until removed or changed to `nod` | TUI Settings; `sudo irlume credential-release-challenge [<service>] on\|off` |
+| `/etc/irlume/settings.conf` | `credential_release_challenge=1` opts IN to a head gesture before the login-keyring credential is released (default off); every `service_gesture.<service>` also defaults off, with `=1` adding an experimental gesture after mandatory privileged keyboard confirmation; the legacy `polkit_gesture=1` switch remains an explicit polkit opt-in. `privileged_face_consent=0` is the machine owner's waiver of the literal `yes` on privileged services, so the scan starts when the privileged PAM prompt appears, with no per-attempt word (default on: the confirmation is required, and an unreadable settings file keeps it). `enforce_biopolicy=1` opts into operation-class gating; `forbid_external_cameras=1` restricts face authentication to cameras the kernel reports as `removable: fixed` (internal only; `removable: unknown` fails closed to the password, mirroring Windows ShouldForbidExternalCameras post-CVE-2021-34466); the legacy `third_party_pad` / `third_party_recognizer` keys are ignored with a startup notice (the third-party lane was removed, ADR-0015). During the migration window, `consent_gesture=closure` or malformed values block only a gesture-gated request until removed or changed to `nod` | TUI Settings; `sudo irlume credential-release-challenge [<service>] on\|off` |
 | `/etc/irlume/cameras.conf` | `rgb=` / `ir=` device nodes of the active camera pair | TUI camera picker, or `sudo irlume set-cameras <rgb> <ir>` |
 | `/etc/irlume/method` | one line: the active auth method (`auto`, `face`, `fingerprint`, or `both` = face OR fingerprint) | `irlume fingerprint enable/disable` |
 | `/var/lib/irlume/ir_emitter.conf` | the UVC extension-unit control that lights the emitter | `irlume ir-setup` |
@@ -475,6 +484,7 @@ Set these on the service, not in a shell (`sudo systemctl edit irlumed`, then
 | Variable | Effect | Default |
 |---|---|---|
 | `IRLUME_MODELS_STRICT` | refuse to start when a model file is missing or fails the checksum manifest, instead of warning | warn and continue |
+| `IRLUME_PRIVILEGED_FACE_CONSENT` | same switch as `privileged_face_consent` in `settings.conf`; the env var wins. `0` waives the literal `yes` on privileged services | on |
 | `IRLUME_ENFORCE_BIOPOLICY` | same switch as `enforce_biopolicy` in `settings.conf`; the env var wins | off |
 | `IRLUME_FORBID_EXTERNAL_CAMERAS` | same switch as `forbid_external_cameras` in `settings.conf`; the env var wins | off |
 | `IRLUME_CREDENTIAL_RELEASE_CHALLENGE` | same switch as `credential_release_challenge` in `settings.conf`. Precedence: `service_gesture.credential_release` has highest priority; when that key is absent, this variable overrides the `settings.conf` key. Set `1` to add a gesture before the keyring password is released | off |


### PR DESCRIPTION
Closes #602.

Adds `privileged_face_consent` to `settings.conf`, defaulting **on**, so nothing changes for anyone who does not set it. With `privileged_face_consent=0` a face attempt on `sudo` and polkit starts the way one at the lock screen does, with no keyword.

## Correction to the case I originally made

> **The argument this PR was opened on was wrong, and I am leaving the correction visible rather than quietly rewriting it.**

I argued that irlume already accepts standing consent on the lock screen and was therefore inconsistent in refusing it for privileged services. That hands-free behaviour is basecamp/omarchy#7935's doing, not irlume's: that shell arms a `PamContext` on its own PAM service continuously, so the scan starts with no gesture because the shell starts it. Every surface irlume wires itself takes an explicit act — empty Enter at the greeters and the KDE lock, the typed `yes` on the stock Omarchy lane. As @archledger put it in #602, the line is between a shell that took responsibility for arming and everything else.

So the asymmetry case does not hold. What remains is a plainer argument: `login enable --with-sudo` is already a deliberate, separate decision, exactly because granting root by face is its own choice, and this makes the per-invocation prompt optional for an owner who has made it. That is a weaker case than the one I opened with, and the maintainer's reason for holding the line — with `pam_irlume` first and `sufficient`, every `sudo` then opens the camera, scripted ones included — is a real cost.

I am leaving the branch up because the implementation may be useful whatever is decided about the policy, particularly the daemon-side half below. Per #602 the maintainer's leaning is toward unifying the privileged trigger with the on-demand empty-Enter convention instead; I am happy to rework this into that shape, or to have it closed in favour of their own implementation.

## The daemon stays the authority

`intent_confirmation_gate` refuses a privileged request without a trusted confirmation, so a client-side skip on its own would be rejected — which is the right design and worth preserving rather than working around.

So the waiver is a distinct `IntentAttestation::PolicyWaived` rather than the PAM module claiming a `PamConversation` it never collected, and **the daemon re-reads the same policy before honouring it**. A root client asserting "policy waived this" on a machine whose policy did not waive anything is refused exactly like a missing confirmation. Without that, the option would turn into a way for any root client to skip the gate — worse than the annoyance it removes.

Absent, unset, or unreadable settings all mean the confirmation is required. A policy this process cannot read is not a policy that waived anything.

## What is in the diff

- `privileged_face_consent_visible()` / `privileged_face_consent_required()` in `config.rs`, same env-over-settings shape as `enforce_biopolicy` and `forbid_external_cameras`, with the default inverted because this key turns a protection off rather than on
- `IntentAttestation::PolicyWaived`
- the PAM module skips the prompt when policy waives it
- the daemon honours the waiver only when its own read agrees, and only from a root peer
- `SETUP.md` and `FAQ.md`, including the line that read "This confirmation is mandatory and has no disable setting", plus both the settings and environment tables

## Tests

- `privileged_face_consent_defaults_on_and_env_wins_over_settings`: absent means on, the file turns it off, the env var wins in both directions
- `policy_waiver_is_honoured_only_when_the_daemon_reads_the_same_policy`: refused on policy mismatch, refused from a non-root peer, a real `PamConversation` still passes, and a waived policy still does not accept a missing attestation

`cargo test` clean for `irlume-common`, `irlume-pam` and `irlume-daemon` (117 / 138 / 141). `cargo fmt --all --check` clean. `cargo clippy` adds no new warnings — the two that fire are pre-existing, in `uvc_descriptor.rs:405` and `main.rs:3037`.

## How it was exercised

Running on Arch with irlume 0.11.3 as the face backend for Omarchy's dedicated lock lane, with sudo and polkit wired. With the key set, `sudo -k && sudo true` authenticates by face with no keyword and no password prompt; with the camera covered, the same command falls through to the password prompt as it should. The lock screen is unchanged.

Happy to adjust the naming, the default's shape, or the attestation variant if you would rather express this differently — the part I would argue for keeping is the daemon checking the policy itself rather than trusting the client's word for it.

Context, since it came up in #602 and basecamp/omarchy#7935: I have been testing irlume as the backend for that PR's dedicated face lane, and this was the one part of daily use that consistently grated.

