### PR TITLE
feat: name the failure mode of errored capture-qualification rounds

### DIFF
--- a/crates/irlume-camera/src/capture_qualification.rs
+++ b/crates/irlume-camera/src/capture_qualification.rs
@@ -818,6 +818,13 @@ pub struct ArmEvidence {
     /// Failed rounds carrying typed below-floor delivery evidence.
     #[serde(default)]
     rate_shortfall_failures: u32,
+    /// Per-fact counts of capture-level round failures (#606), naming HOW an
+    /// arm's rounds errored (stream delivery, rate-window establishment).
+    /// Additive and defaulted, like `rate_shortfall_failures` before it, so
+    /// schema-version-2 records written without this field still parse and
+    /// revalidate.
+    #[serde(default)]
+    capture_failure_facts: std::collections::BTreeMap<String, u32>,
     rgb_mean: f32,
     ir_mean: f32,
     elapsed_ms: u64,
@@ -846,6 +853,7 @@ impl ArmEvidence {
         arm_failures: u32,
         capture_failures: u32,
         rate_shortfall_failures: u32,
+        capture_failure_facts: std::collections::BTreeMap<String, u32>,
         rgb_mean: f32,
         ir_mean: f32,
         elapsed_ms: u64,
@@ -866,6 +874,7 @@ impl ArmEvidence {
             arm_failures,
             capture_failures,
             rate_shortfall_failures,
+            capture_failure_facts,
             rgb_mean,
             ir_mean,
             elapsed_ms,
@@ -1633,8 +1642,25 @@ mod tests {
 
     fn arm(rounds: u32) -> ArmEvidence {
         ArmEvidence::new(
-            rounds, rounds, 0, rounds, rounds, rounds, rounds, 0, 0, 0, 0, 0, 0, 0, 0, 140.0,
-            120.0, 850,
+            rounds,
+            rounds,
+            0,
+            rounds,
+            rounds,
+            rounds,
+            rounds,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Default::default(),
+            140.0,
+            120.0,
+            850,
         )
         .unwrap()
     }
@@ -1742,6 +1768,40 @@ mod tests {
         assert_eq!(decoded, expected);
     }
 
+    /// #606: `capture_failure_facts` is additive. A schema-version-2 record
+    /// written before the field existed must still parse, revalidate, and
+    /// authorize the exact same context, so stored authority survives the
+    /// upgrade and a downgrade can still read new records (serde ignores the
+    /// unknown key on the old binary).
+    #[test]
+    fn records_written_before_failure_facts_still_authorize() {
+        fn strip_facts(value: &mut serde_json::Value) {
+            if let serde_json::Value::Object(map) = value {
+                map.remove("capture_failure_facts");
+                for (_, nested) in map.iter_mut() {
+                    strip_facts(nested);
+                }
+            }
+        }
+        let attempt = concurrent_attempt("/devices/pci0000:00/usb3/3-2");
+        let record =
+            CaptureQualificationRecord::new(1, attempt.clone(), Some(attempt.clone())).unwrap();
+        let json = record.to_json().unwrap();
+        let mut legacy: serde_json::Value = serde_json::from_str(&json).unwrap();
+        strip_facts(&mut legacy);
+        assert!(
+            !legacy.to_string().contains("capture_failure_facts"),
+            "fixture genuinely models a pre-field record"
+        );
+        let parsed = CaptureQualificationRecord::from_json(legacy.to_string().as_bytes())
+            .expect("a pre-field schema-version-2 record parses and revalidates");
+        assert_eq!(
+            parsed.resolve(attempt.context()),
+            QualificationResolution::ConcurrentQualified,
+            "stored authority is untouched by the additive field"
+        );
+    }
+
     #[test]
     fn one_stream_tuple_change_invalidates_concurrent_authority() {
         let attempt = concurrent_attempt("/devices/pci0000:00/usb3/3-2");
@@ -1769,7 +1829,25 @@ mod tests {
             ctx,
             arm(6),
             ArmEvidence::new(
-                6, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 3, 0, 80.0, 90.0, 2_000,
+                6,
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                3,
+                0,
+                Default::default(),
+                80.0,
+                90.0,
+                2_000,
             )
             .unwrap(),
             false,
@@ -1811,11 +1889,52 @@ mod tests {
         )
         .is_err());
         assert!(
-            ArmEvidence::new(1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1.0, 1.0, 1).is_err(),
+            ArmEvidence::new(
+                1,
+                1,
+                0,
+                1,
+                1,
+                1,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                Default::default(),
+                1.0,
+                1.0,
+                1
+            )
+            .is_err(),
             "one completed round cannot both match and fail the same contract"
         );
-        let partial_rate_failure =
-            ArmEvidence::new(6, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1.0, 1.0, 1).unwrap();
+        let partial_rate_failure = ArmEvidence::new(
+            6,
+            1,
+            0,
+            1,
+            0,
+            1,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Default::default(),
+            1.0,
+            1.0,
+            1,
+        )
+        .unwrap();
         assert!(
             QualificationAttempt::new(
                 1,
@@ -1829,8 +1948,28 @@ mod tests {
             .is_err(),
             "one rate-failed frame cannot authorize a six-round sequential verdict"
         );
-        let typed_rate_shortfall =
-            ArmEvidence::new(6, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0.0, 0.0, 1).unwrap();
+        let typed_rate_shortfall = ArmEvidence::new(
+            6,
+            0,
+            6,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            Default::default(),
+            0.0,
+            0.0,
+            1,
+        )
+        .unwrap();
         assert!(
             QualificationAttempt::new(
                 1,
@@ -2010,7 +2149,25 @@ mod tests {
             conclusive.context().clone(),
             arm(6),
             ArmEvidence::new(
-                6, 4, 2, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 2, 0, 80.0, 90.0, 2_000,
+                6,
+                4,
+                2,
+                4,
+                4,
+                4,
+                4,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2,
+                0,
+                Default::default(),
+                80.0,
+                90.0,
+                2_000,
             )
             .unwrap(),
             false,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -6462,6 +6462,12 @@ pub struct PairSample {
     /// diagnostic detail; deliberately NOT carried into the persisted
     /// ArmEvidence, whose schema stays untouched.
     pub continuity_facts: std::collections::BTreeMap<&'static str, usize>,
+    /// Per-fact counts of capture-level round failures (#606): an aggregate
+    /// count cannot say HOW a concurrent arm refused to stream. Rounds whose
+    /// leg errored at delivery are named here, and the map is mirrored into
+    /// the persisted ArmEvidence (additive, serde-defaulted) so a stored
+    /// verdict names its facts months later.
+    pub capture_failure_facts: std::collections::BTreeMap<&'static str, usize>,
 }
 
 impl PairSample {
@@ -7435,6 +7441,15 @@ fn qualification_arm(
     let requested_rounds = count(requested_rounds, "round")?;
     let completed_rounds = count(sample.rounds, "completed")?;
     let failed_rounds = count(sample.failed, "failure")?;
+    let capture_failure_facts = sample
+        .capture_failure_facts
+        .iter()
+        .map(|(fact, value)| {
+            u32::try_from(*value)
+                .map(|value| ((*fact).to_string(), value))
+                .map_err(|_| Error::Hardware("capture qualification fact count overflow".into()))
+        })
+        .collect::<std::result::Result<std::collections::BTreeMap<String, u32>, _>>()?;
     if !sample.total_ms.is_finite() || sample.total_ms < 0.0 || sample.total_ms > u64::MAX as f32 {
         return Err(Error::Hardware(
             "capture qualification elapsed time is invalid".into(),
@@ -7456,6 +7471,7 @@ fn qualification_arm(
         count(sample.arm_failures, "arm-failure")?,
         count(sample.capture_failures, "capture-failure")?,
         count(sample.rate_shortfall_failures, "rate-shortfall-failure")?,
+        capture_failure_facts,
         sample.rgb_mean,
         sample.ir_mean,
         sample.total_ms.round() as u64,
@@ -7578,6 +7594,10 @@ fn record_concurrent_establishment_failure(
     );
     into.failed += rounds;
     into.capture_failures += rounds;
+    *into
+        .capture_failure_facts
+        .entry("rate-window-establishment")
+        .or_insert(0) += rounds;
 }
 
 /// [`measure_contention_with_progress`] over injected captures and an
@@ -7998,6 +8018,15 @@ fn accumulate(
             into.rate_shortfall_failures += 1;
         } else {
             into.capture_failures += 1;
+            // #606: open and arm failures are counted separately above, so a
+            // leg erroring here failed at delivery by construction. Name it:
+            // the count alone cannot distinguish this camera from one whose
+            // rounds die mid-stream for other reasons, and the stored verdict
+            // is all a future support reader has.
+            *into
+                .capture_failure_facts
+                .entry("stream-delivery-failure")
+                .or_insert(0) += 1;
         }
         return;
     };
@@ -11902,6 +11931,7 @@ mod tests {
                 capture_failures: failed,
                 rate_shortfall_failures: 0,
                 continuity_facts: Default::default(),
+                capture_failure_facts: Default::default(),
             };
             ContentionReport {
                 sequential: sample(seq),
@@ -12248,6 +12278,91 @@ mod tests {
                 capture_qualification::SequentialReason::DeliveredRateShortfall
             )
         );
+    }
+
+    /// #606: an errored round names its failure fact. The typed rate bucket
+    /// stays separate, so the map's total always equals capture_failures.
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
+    fn capture_failure_facts_name_errored_rounds() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let rgb_calls = AtomicUsize::new(0);
+        let rgb = || {
+            let call = rgb_calls.fetch_add(1, Ordering::SeqCst);
+            if (2..4).contains(&call) {
+                Err(Error::Hardware(
+                    "/dev/video4: the camera never delivered".into(),
+                ))
+            } else {
+                Ok(frame(&[120; 4]))
+            }
+        };
+        let ir = || Ok((frame(&[20; 4]), stats(60.0)));
+        let report =
+            measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &no_progress(), None)
+                .expect("errored concurrent rounds are a measurement, not a probe abort");
+        assert_eq!(report.concurrent.failed, 2);
+        assert_eq!(report.concurrent.capture_failures, 2);
+        assert_eq!(
+            report
+                .concurrent
+                .capture_failure_facts
+                .get("stream-delivery-failure"),
+            Some(&2),
+            "each errored round records the nameable delivery fact"
+        );
+        assert_eq!(
+            report
+                .concurrent
+                .capture_failure_facts
+                .values()
+                .sum::<usize>(),
+            report.concurrent.capture_failures,
+            "the facts account for every capture failure, nothing else"
+        );
+        assert_eq!(report.concurrent.rate_shortfall_failures, 0);
+    }
+
+    /// #606: a pair that cannot even establish its rate windows names that
+    /// fact, distinct from a round that died mid-arm.
+    #[test]
+    fn establishment_failure_names_its_fact() {
+        let mut sample = PairSample::default();
+        record_concurrent_establishment_failure(&mut sample, 6, &"synthetic refusal");
+        assert_eq!(sample.failed, 6);
+        assert_eq!(sample.capture_failures, 6);
+        assert_eq!(
+            sample
+                .capture_failure_facts
+                .get("rate-window-establishment"),
+            Some(&6)
+        );
+    }
+
+    /// #606: the fact map survives the conversion into the persisted
+    /// ArmEvidence and round-trips, so a stored verdict names its facts.
+    #[test]
+    fn qualification_arm_carries_capture_failure_facts() {
+        let mut sample = PairSample {
+            rounds: 6,
+            contract_rounds: 6,
+            rate_floor_rounds: 6,
+            continuous_rounds: 6,
+            active_ir_rounds: 6,
+            total_ms: 1_000.0,
+            ..Default::default()
+        };
+        sample
+            .capture_failure_facts
+            .insert("stream-delivery-failure", 6);
+        let arm = qualification_arm(&sample, 6).expect("valid arm");
+        let json = serde_json::to_string(&arm).unwrap();
+        assert!(
+            json.contains("\"stream-delivery-failure\":6"),
+            "the persisted form carries the fact: {json}"
+        );
+        let parsed: capture_qualification::ArmEvidence = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, arm);
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1590,6 +1590,7 @@ mod worker_engine {
                     capture_failures: 0,
                     rate_shortfall_failures: 0,
                     continuity_facts: Default::default(),
+                    capture_failure_facts: Default::default(),
                 },
                 concurrent: PairSample {
                     rgb_mean: 140.0,
@@ -1610,9 +1611,37 @@ mod worker_engine {
                     capture_failures: 0,
                     rate_shortfall_failures: 0,
                     continuity_facts: Default::default(),
+                    capture_failure_facts: Default::default(),
                 },
                 trailing_sequential_control: true,
             }
+        }
+
+        /// #606: the cannot-stream branch names the per-round failure facts
+        /// with counts, so the verdict says how the arm died, not just that
+        /// it did.
+        #[test]
+        fn cannot_stream_verdict_names_capture_failure_facts() {
+            let mut report = healthy_concurrent(6, 6);
+            report.concurrent = PairSample {
+                failed: 6,
+                capture_failure_facts: [("stream-delivery-failure", 6usize)].into_iter().collect(),
+                ..Default::default()
+            };
+            report.trailing_sequential_control = true;
+            let msg = camera_tune_verdict_message(
+                &report,
+                AttemptOutcome::SequentialRequired(SequentialReason::ConcurrentUnavailable),
+                6,
+            );
+            assert!(
+                msg.starts_with("capture mode sequential for this camera"),
+                "the persisted verdict leads: {msg}"
+            );
+            assert!(
+                msg.contains("all 6 concurrent attempts errored (6x stream-delivery-failure)"),
+                "the failure mode is named with its count: {msg}"
+            );
         }
 
         /// #586 exactly: full brightness retention (100% RGB, 102% IR) with
@@ -3216,10 +3245,25 @@ fn camera_tune_verdict_message(
     if report.concurrent_impossible() {
         // Observed counts, not the requested round count: a sequential arm
         // can complete fewer rounds than were asked for, and "measured fine"
-        // must not overstate its evidence.
+        // must not overstate its evidence. Name the per-round failure facts
+        // (#606): "all N errored" alone cannot say the rounds died at stream
+        // delivery, which is the fact a stored verdict and a support reader
+        // need months later.
+        let mut facts: Vec<(&&str, &usize)> =
+            report.concurrent.capture_failure_facts.iter().collect();
+        facts.sort_by(|a, b| b.1.cmp(a.1));
+        let detail = if facts.is_empty() {
+            String::new()
+        } else {
+            let named: Vec<String> = facts
+                .iter()
+                .map(|(fact, count)| format!("{count}x {fact}"))
+                .collect();
+            format!(" ({})", named.join("; "))
+        };
         return format!(
             "capture mode sequential for this camera: it cannot stream RGB and IR \
-             at once (all {} concurrent attempts errored; {} sequential \
+             at once (all {} concurrent attempts errored{detail}; {} sequential \
              round(s) completed, {} errored; a trailing one-at-a-time \
              control confirmed the camera still answers)",
             report.concurrent.failed, report.sequential.rounds, report.sequential.failed,


### PR DESCRIPTION
## What

A concurrent arm whose every round errors stored only counts: during the #606 investigation we had to strace the daemon to learn the rounds died at stream delivery (`VIDIOC_STREAMON` never returning while the other interface streams), because neither the stored qualification record nor the camera-tune verdict could say how the arm failed. The #586 continuity work solved exactly this shape for provenance facts; this PR extends the pattern to capture-level failures.

## Changes

- `PairSample.capture_failure_facts` (stable-name map, `BTreeMap<&'static str, usize>`):
  - a round whose leg errors at delivery records `stream-delivery-failure` (open and arm failures are already counted separately, so a leg error here failed at delivery by construction)
  - a pair that cannot establish its rate windows records `rate-window-establishment`
  - the typed delivered-rate bucket stays separate and factless
- The map is mirrored into the persisted `ArmEvidence` as an additive, `#[serde(default)]` field, following the `rate_shortfall_failures` precedent: schema version stays 2, records written before the field still parse, revalidate, and authorize (covered by a test that strips the key from a serialized record and asserts resolution), and an older binary ignores the unknown key.
- The camera-tune verdict's cannot-stream branch now names the facts with counts: `all 6 concurrent attempts errored (6x stream-delivery-failure); ...`

## Tests (all mutation-verified: removing each recording site fails its test)

- `capture_failure_facts_name_errored_rounds` - facts recorded per errored round; facts total equals `capture_failures`; rate bucket separate
- `establishment_failure_names_its_fact`
- `qualification_arm_carries_capture_failure_facts` - persistence round-trip carries the fact
- `records_written_before_failure_facts_still_authorize` - pre-field schema-2 record still resolves `ConcurrentQualified`
- `cannot_stream_verdict_names_capture_failure_facts` - verdict naming

## Evidence

- `cargo test --workspace`: 1808 passed, 0 failed
- `cargo clippy -p irlume-camera -p irlume-daemon --all-targets -- -D warnings`: clean
- `cargo fmt --all`: applied
- Commit `e0d6d2b3` GPG-signed (`C10B8492BD7F30C6`), DCO trailer exact

Refs #606 (recording half; the underlying concurrent refusal is a host xHCI/camera interaction, root-caused with strace in the issue)
