### PR TITLE
feat: attribute one-shot capture wall time in the debug trace

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -4114,6 +4114,7 @@ impl<'a> RgbSession<'a> {
         }
         let device = self.cam.device.clone();
         let progress = self.progress.clone();
+        let warmup_started = std::time::Instant::now();
         warm_up_stream(&device, &mut self.stream, &progress)?;
         for _ in 0..AE_WARMUP {
             self.cam
@@ -4125,6 +4126,11 @@ impl<'a> RgbSession<'a> {
                 .map_err(|e| map_io(&device, e))?; // discard while AE settles
         }
         self.warmed = true;
+        irlume_common::dlog!(
+            "[capture-stage] warmup {device}: {}ms (stream recovery discards plus \
+             AE settle; the delivered-rate window fills during these)",
+            warmup_started.elapsed().as_millis()
+        );
         Ok(())
     }
 
@@ -4147,6 +4153,7 @@ impl<'a> RgbSession<'a> {
         let format =
             frame_provenance::ValidatedFormatIdentity::from_stable_format(&self.cam.negotiated);
         let mut frames = Vec::with_capacity(n.max(1));
+        let burst_started = std::time::Instant::now();
         for _ in 0..n.max(1) {
             self.cam
                 .lease
@@ -4156,6 +4163,13 @@ impl<'a> RgbSession<'a> {
                 .stream
                 .next()
                 .map_err(|error| map_delivery(&device, error))?;
+            if frames.is_empty() {
+                irlume_common::dlog!(
+                    "[capture-stage] first-frame {device}: {}ms after warmup \
+                     (the gated delivery window fills here)",
+                    burst_started.elapsed().as_millis()
+                );
+            }
             let taken = std::time::Instant::now();
             let data = match &chosen {
                 b"NV12" => nv12_to_rgb(buf, w, h),
@@ -4221,12 +4235,41 @@ pub fn capture_rgb_burst_with_progress(
     n: usize,
     progress: &Progress,
 ) -> irlume_common::Result<Vec<Frame>> {
+    let opened = std::time::Instant::now();
     let cam = RgbCamera::open(device)?;
+    let open_ms = opened.elapsed().as_millis();
+    let armed = std::time::Instant::now();
     let mut session = cam.session_with_progress(progress)?;
+    let arm_ms = armed.elapsed().as_millis();
+    let captured = std::time::Instant::now();
     let frames = session.burst(n);
+    let capture_ms = captured.elapsed().as_millis();
     // Drop the stream before `cam`: the session borrows the device.
     drop(session);
+    irlume_common::dlog!(
+        "{}",
+        capture_stage_summary("rgb", device, open_ms, arm_ms, capture_ms)
+    );
     frames
+}
+
+/// One debug-trace line naming where a one-shot capture's wall time went.
+/// The sequential path measured ~89% ramp on some hosts (#606 follow-up), and
+/// the next tuning decision needs that ramp attributed: device open and
+/// negotiation, session arm (buffer claim plus stream start), and the capture
+/// itself (warmup discards, rate-window fill, burst). Numbers only, per the
+/// diagnostic-trace policy: never frames, embeddings, or identities.
+fn capture_stage_summary(
+    role: &str,
+    device: &str,
+    open_ms: u128,
+    arm_ms: u128,
+    capture_ms: u128,
+) -> String {
+    format!(
+        "[capture-stage] {role} {device}: open={open_ms}ms arm={arm_ms}ms \
+         capture(warmup+fill+burst)={capture_ms}ms"
+    )
 }
 
 /// The uncompressed RGB fourccs the capture path can decode, best first.
@@ -4839,11 +4882,21 @@ pub fn capture_ir_with_stats_and_progress(
     device: &str,
     progress: &Progress,
 ) -> irlume_common::Result<(Frame, IrCaptureStats)> {
+    let opened = std::time::Instant::now();
     let cam = IrCamera::open(device)?;
+    let open_ms = opened.elapsed().as_millis();
+    let armed = std::time::Instant::now();
     let mut session = cam.session_with_progress(progress)?;
+    let arm_ms = armed.elapsed().as_millis();
+    let captured = std::time::Instant::now();
     let shot = session.capture_with_stats();
+    let capture_ms = captured.elapsed().as_millis();
     // Drop the stream before `cam`: the session borrows the device.
     drop(session);
+    irlume_common::dlog!(
+        "{}",
+        capture_stage_summary("ir", device, open_ms, arm_ms, capture_ms)
+    );
     shot
 }
 
@@ -12363,6 +12416,22 @@ mod tests {
         );
         let parsed: capture_qualification::ArmEvidence = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, arm);
+    }
+
+    /// The capture-stage trace line names every span with numbers only, so
+    /// the diagnostic-trace policy (never frames or embeddings) holds and the
+    /// format stays stable for journal tooling.
+    #[test]
+    fn capture_stage_summary_names_every_span_with_numbers_only() {
+        let line = capture_stage_summary("ir", "/dev/video6", 12, 34, 5678);
+        assert_eq!(
+            line,
+            "[capture-stage] ir /dev/video6: open=12ms arm=34ms capture(warmup+fill+burst)=5678ms"
+        );
+        assert!(
+            !line.contains('\u{2014}'),
+            "no em dashes in trace vocabulary"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The sequential auth path measured ~89% ramp on concurrent-refusing hosts (#606 follow-up), but the trace could not say where the ramp went: the assess lines carry per-phase totals only. Deciding between the candidate fixes (fill policy, warmup constants, anything touching the arm) needs the ramp attributed per substage first. This PR adds that attribution; it changes no behavior.

## Changes (debug-only)

Three stage lines bracket the one-shot capture path (`capture_rgb_burst_with_progress`, `capture_ir_with_stats_and_progress`): `open` (device open and negotiation), `arm` (buffer claim plus stream start, including the IR metadata node), `capture` (warmup discards, rate-window fill, burst). The RGB `warm_up` and the gated first delivery are timed separately inside the burst. Numbers only, per the diagnostic-trace policy; the summary format is pinned by a unit test (`capture_stage_summary_names_every_span_with_numbers_only`).

## Measured with this instrumentation

Sequential `irlume identify`, no face present, full capture path exercised:

| host / camera | rgb phase | ir phase | decomposition |
|---|---|---|---|
| dev box, ASUS FHD pair | 3349ms | 3598ms | rgb = open 110 + arm 1 + warmup 648 + **first-frame gate 2144** + burst ~180; ir = open 1 + **arm 2889 (device stream start)** + capture 690 |
| archhost, NexiGo N930W @480M | 2194ms (span 136) | 6069ms (span 600) | per-phase totals from the assess lines; same instrumentation applies |

The two big levers, now precisely sized:

1. **RGB gated first-delivery: 2144ms**, measured AFTER warmup discards already filled a delivered-rate window. Why the gate re-fills (window reset between discards and the first kept frame? a second complete window required?) is the design question for the next change; if the warmup-filled window is valid evidence, reusing it is an implementation fix, not an evidence-policy change.
2. **IR stream-start arm: 2889ms** on this camera (kernel/device side; consistent with the startup emitter check's arm=2892ms on the same host). Not userspace-addressable beyond deeper attribution.

## Evidence

- `cargo test -p irlume-camera --lib`: 567 passed, 0 failed
- `cargo clippy -p irlume-camera --all-targets -- -D warnings`: clean; fmt applied; zero em dashes
- Hardware run: branch daemon on the dev box (ASUS pair, sequential), system units stopped and restored, state verified after
- Commit `97f15823` GPG-signed, DCO trailer exact

Refs #606
