### PR TITLE
feat: attribute the IR session arm's interior in the debug trace

### DIFF
--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -5057,6 +5057,7 @@ impl IrCamera {
         // restore while the stream was still live, the very mid-stream write
         // this change removes. Assigned further down, once the stream exists.
         let mode;
+        let arm_alloc_started = std::time::Instant::now();
         let mut stream = TrackedStream::new(
             SafeStream::open(
                 V4l2CameraState::with_ir_interval(
@@ -5074,12 +5075,15 @@ impl IrCamera {
                 self.accepted_interval,
             ),
         );
+        let alloc_ms = arm_alloc_started.elapsed().as_millis();
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
         // 25s when video went first). `SafeStream::open` only allocates
         // buffers; STREAMON happens on the first dequeue, which is inside
         // `warm_up_stream` below. This is the window, and it is the only one.
+        let meta_started = std::time::Instant::now();
         let mut meta = ir_metadata::IlluminationLog::open(&self.device);
+        let metadata_ms = meta_started.elapsed().as_millis();
         // BEFORE the warm-up, because the warm-up's first dequeue is STREAMON.
         // Microsoft's sequence sets the property and THEN starts streaming, and
         // this ran the other way round: every authentication set the mode under
@@ -5104,6 +5108,7 @@ impl IrCamera {
         self.lease
             .require_endpoint(&self.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
+        let emitter_started = std::time::Instant::now();
         mode = enable_ir_emitter_privacy_bounded(
             &self.device,
             &self.dev,
@@ -5111,21 +5116,31 @@ impl IrCamera {
             self.lease.clone(),
             "before Face Authentication D1",
         )?;
+        let emitter_ms = emitter_started.elapsed().as_millis();
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
+        let warmup_started = std::time::Instant::now();
         warm_up_stream(&self.device, &mut stream, progress)?;
+        let warmup_ms = warmup_started.elapsed().as_millis();
         // Rate establishment internally discards more frames than the metadata
         // ring can hold. Drain those records now, after the fill, so buffers are
         // requeued before the first frame a caller can observe.
-        fill_rate_then_drain_metadata(
+        let fill_started = std::time::Instant::now();
+        let fill_result = fill_rate_then_drain_metadata(
             || stream.fill_rate_evidence(),
             || {
                 if let Some(log) = meta.as_mut() {
                     log.drain();
                 }
             },
-        )
-        .map_err(|error| map_io(&self.device, error))?;
+        );
+        let fill_ms = fill_started.elapsed().as_millis();
+        irlume_common::dlog!(
+            "[capture-stage] ir-arm {}: alloc={alloc_ms}ms metadata={metadata_ms}ms \
+             emitter={emitter_ms}ms warmup(streamon+flush)={warmup_ms}ms rate-fill={fill_ms}ms",
+            self.device
+        );
+        fill_result.map_err(|error| map_io(&self.device, error))?;
         Ok(IrSession {
             cam: self,
             stream,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -7639,6 +7639,17 @@ fn held_concurrent_arm<'d>(
                 .map_err(|error| Error::Hardware(error.to_string()))?;
             accumulate(into, &mut continuity, &rgb, &ir, t0.elapsed(), context);
         }
+        // #606: the verdict names these facts only when the whole probe is
+        // conclusive, so a dark-scene inconclusive run used to leave the
+        // concurrent arm's failure mode unreadable. Say them when they
+        // happened, whatever the scene.
+        if !into.continuity_facts.is_empty() || !into.capture_failure_facts.is_empty() {
+            irlume_common::dlog!(
+                "[capture-stage] concurrent-arm facts: continuity={:?} capture={:?}",
+                into.continuity_facts,
+                into.capture_failure_facts
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## What

The IR one-shot arm measured 2.9s on the local ASUS pair while its visible parts looked cheap, so the capture-stage trace now splits it: buffer allocation, metadata node open, the emitter control write, warmup (STREAMON plus the role flush), and the rate-window fill.

## Measured with it (7-run medians, sequential identify, no face)

```
[capture-stage] ir-arm /dev/video2: alloc=0ms metadata=0ms emitter=19ms warmup(streamon+flush)=141ms rate-fill=2732ms
```

The arm was never emitter or kernel stream-start cost; it is the per-open rate evidence (2732ms of the 2892ms). That attribution is the input the window-policy and skew-budget decisions need: it kills the "slow emitter write" and "kernel arm latency" hypotheses with data and locates the whole cost in the 30-delta fill the 2026-08-22 fleet measurement already analyzed.

## Changes

Debug-only spans in `IrCamera::session_with_progress`; no behavior change; numbers only, per the diagnostic-trace policy. Companion to #609.

## Evidence

- `cargo test -p irlume-camera --lib`: 567 passed, 0 failed
- `cargo clippy -p irlume-camera --all-targets -- -D warnings`: clean; fmt; zero em dashes
- Hardware run on the dev-box pair; system daemon restored and verified after
- Commit `f29f891d` GPG-signed, DCO trailer exact

Refs #606
