### PR TITLE
feat: defer the startup IR-emitter verification to the first authentication

### DIFF
--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -382,10 +382,14 @@ fn main() {
                     "irlumed: no camera found (face auth unavailable; password/fingerprint only)"
                 );
             }
-            // Re-apply the KNOWN emitter control at startup. The emitter is camera
-            // hardware state that resets on a USB/power cycle or a daemon restart, so
-            // without this the first auth after a restart gets a dark IR frame (the
-            // "worked at enroll, failed at the lock screen" case).
+            // The emitter verification is deliberately NOT run at startup
+            // (#603). Applying the KNOWN control is part of every capture's
+            // open path (see `capture_ir`), so the first authentication
+            // re-applies and verifies it there; running it at daemon start
+            // meant opening the IR camera, lighting the emitter, and grabbing
+            // a frame on every boot with no user action anywhere, which the
+            // consent wording never declared. The first auth is the declared
+            // moment.
             //
             // This used to fall through to a blind search when IR came back dark, which
             // is what destroyed a reporter's camera in #159. A daemon start is not
@@ -393,15 +397,11 @@ fn main() {
             // even imply the emitter is the problem: an unlit room or an empty chair
             // produces exactly the same measurement. Discovery now happens only when
             // someone runs `irlume ir-setup` and accepts the warning.
-            if std::path::Path::new(&ir_dev).exists() {
-                match irlume_auth::apply_known_ir_emitter(&ir_dev) {
-                    Ok(true) => eprintln!("irlumed: IR emitter ready"),
-                    Ok(false) => eprintln!(
-                        "irlumed: IR is dark (dark-mode unlock may be unavailable). If this camera needs an \
-                         emitter control irlume does not know, run `sudo irlume ir-setup`."
-                    ),
-                    Err(e) => eprintln!("irlumed: IR emitter check skipped: {e}"),
-                }
+            if !ir_dev.is_empty() {
+                eprintln!(
+                    "irlumed: IR emitter verification deferred to the first authentication \
+                     (no camera opens at boot; every capture re-applies the known control)"
+                );
             }
             // Background auto-requalification (#586 gap): when the stored
             // qualification's context no longer matches the live cameras
@@ -1620,6 +1620,31 @@ mod worker_engine {
         /// #606: the cannot-stream branch names the per-round failure facts
         /// with counts, so the verdict says how the arm died, not just that
         /// it did.
+        /// #603: the daemon must not open any camera at startup. The emitter
+        /// verification is deferred to the first authentication, which
+        /// re-applies the known control as part of every capture's open path;
+        /// running it at boot lit the IR emitter on every start with no user
+        /// action. Source-scanned like the auth crate's probe tripwire,
+        /// because the invariant lives in startup glue.
+        #[test]
+        fn the_daemon_does_not_open_the_camera_at_startup() {
+            let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+            let text = std::fs::read_to_string(&src).expect("read the daemon source");
+            assert!(
+                text.contains("deferred to the first authentication"),
+                "the startup deferral notice must stay: journal readers and this \
+                 test both pin the behavior by it"
+            );
+            // Assembled from pieces so this test's own source cannot satisfy
+            // the needle it searches for.
+            let startup_call = ["match irlume_auth::apply_known_ir_", "emitter(&ir_dev)"].concat();
+            assert!(
+                !text.contains(&startup_call),
+                "the startup path must not apply the emitter control (#603); the \
+                 legitimate callers are the enrollment preflight and diagnostics"
+            );
+        }
+
         #[test]
         fn cannot_stream_verdict_names_capture_failure_facts() {
             let mut report = healthy_concurrent(6, 6);

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -3,6 +3,21 @@
 What irlume does not do, and the measurements behind each statement. The
 summary lives on the [README](../README.md); this is the detail.
 
+- **The daemon does not open any camera at startup.** The startup
+  IR-emitter verification used to open the IR camera, light the emitter,
+  and grab one frame on every daemon start, with no user action anywhere;
+  since #603 it is deferred to the first authentication, which re-applies
+  the known emitter control as part of every capture's open path and
+  surfaces a dark emitter through the auth-path diagnostics. One capture
+  without a user action remains, and it is conditional: when the stored
+  capture qualification no longer matches the live cameras (a kernel
+  upgrade, USB replug, or driver update), a background requalification
+  probe re-measures the pair for up to a minute, IR emitter firing,
+  starting 60 seconds after the daemon does; it yields to any
+  authentication via the camera lease and the same measurement is
+  available on demand with `irlume camera-tune`. Camera discovery and
+  classification are query-only: no streaming, no frames, no emitter
+  writes.
 - **Face unlock does not work on the XFCE lock screen (xfce4-screensaver),
   by design.** The screensaver pre-starts its PAM conversation the moment
   the lock engages and auto-answers module prompts without user action, so


### PR DESCRIPTION
## What

At every daemon start, with no user action anywhere, irlume opened the IR camera, lit the emitter, and captured one frame to verify the known emitter control (#603): roughly 2s of lit emitter per boot (2-7s across the fleet), undeclared by the consent wording, visible enough that the reporter's user noticed it at boot and asked why. The check was also redundant with correctness: every capture applies the known control on open (`capture_ir`), so the first authentication re-applies and verifies it as part of its normal path - confirmed during the #606 investigation and again for this PR on hardware.

## Changes

- The startup thread opens no camera and prints one notice: the emitter verification is deferred to the first authentication. The #159 guard is untouched (a daemon start is not consent to write guessed values; discovery stays behind `irlume ir-setup`).
- `the_daemon_does_not_open_the_camera_at_startup`: a source-scanned tripwire (the auth crate's probe-tripwire pattern) pinning that the startup path never re-gains the emitter-apply call; mutation-verified by reintroducing the call and watching the test fail.
- LIMITATIONS.md now declares the camera behavior honestly: no camera opens at boot; the one remaining no-user-action capture is the conditional background requalification probe (context-changed only: kernel upgrade, replug, driver update; yields to auth via the camera lease; the same measurement runs on demand via `camera-tune`); discovery and classification are query-only.

## Evidence

- Hardware-verified on the local ASUS pair against a binary strings-confirmed to contain the change: the startup window opens no camera (zero capture/metadata/emitter lines in the journal, deferral notice printed) and the first authentication exercises the IR capture path with the control applied on open, exactly as before.
- `cargo test --workspace`: 1811 passed, 0 failed; clippy `-D warnings` clean; fmt; zero em dashes.
- Fleet note: cold-boot verification (the emitter staying dark through a real boot, not a service restart) is listed for in-person verification before the next release; restart-path verification is done above.

Fixes #603
