### PR TITLE
bench: recognition calibration phase 2 (RGB, CFP pose, NIR, threshold-to-FAR)

### DIFF
--- a/benchmarks/bench_recog_suite.py
+++ b/benchmarks/bench_recog_suite.py
@@ -18,6 +18,13 @@ calibrations:
     Pair_list_F.txt / Pair_list_P.txt. Wild (unaligned) images scored
     with the same detect + warp path as LFW; the ff vs fp rows quantify
     the pose gap.
+  - NIR (Task 5): CBSR (OTCBVS 07) verification on the shipped
+    gallery/probe ground truth with the bench_nir_ext.py preprocessing
+    (YuNet 5-point warp, ground-truth two-eye fallback), and a seeded
+    10,000-pair Oulu-CASIA NIR protocol over subject-disjoint fold
+    halves. Pools both sets into a NIR grant-threshold calibration whose
+    candidate sweep spans 0.2-0.6, covering both the band NIR evidence
+    operates in and its impostor tail.
 
 The embedding path reuses bench_faceid.py exactly (YuNet detect + 5-point
 similarity warp to 112x112 for unaligned sets; (x - 127.5) / 128
@@ -26,19 +33,20 @@ the numbers stay comparable with the committed results. Metrics come from
 verification_metrics (eer, far_threshold_table, fold_accuracy, ten_fold).
 
 The aligned-set protocols ship no folds, so those sets report fold_accuracy
-at the fixed 0.45 line (key acc_at_045) plus eer and tar_table; LFW and
-CFPW report acc10fold over their shipped folds.
+at the fixed 0.45 line (key acc_at_045) plus eer and tar_table; LFW, CFPW
+and Oulu report acc10fold over their folds.
 
 Usage:
   python3 bench_recog_suite.py --models-dir ~/irlume-bench/models \
       --lfw ~/datasets/lfw --bundle ~/datasets/aligned_fr_bundle \
-      --cfp ~/datasets/cfpw --out results-recognition.json
+      --cfp ~/datasets/cfpw --cbsr ~/datasets/cbsr_nir \
+      --oulu ~/datasets/oulu_casia_nir --out results-recognition.json
 
 The out file is merged, not replaced: lanes not run in this invocation
 keep their existing rows, and threshold_calibration.rgb stays frozen to
 the task 3 pool (lfw, agedb30, calfw, cplfw) it was derived from.
 """
-import argparse, hashlib, json, sys, time
+import argparse, hashlib, json, random, sys, time
 from pathlib import Path
 
 import cv2
@@ -47,11 +55,18 @@ import onnxruntime as ort
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import verification_metrics as vm
-from bench_faceid import Detector, Embedder, align_or_center, lfw_tenfold_accuracy
+from bench_faceid import (Embedder, align_or_center, estimate_norm,
+                          lfw_tenfold_accuracy)
+from bench_nir_ext import DetectorFull, load_cbsr_gt, two_point_norm
 
 FARS = [0.1, 0.03, 0.01, 0.003, 0.001]
 GRANT_THRESHOLDS = [0.3, 0.35, 0.4, 0.45, 0.5]
 GRANT_FAR_CAP = 1e-3
+NIR_SEED = 42
+NIR_CBSR_PAIRS = 3000
+OULU_PER_FOLD = 2500
+NIR_GRANT_THRESHOLDS = [0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6]
+NIR_OPERATING_BAND = (0.2, 0.4)
 ALIGNED_SETS = {
     "agedb30": "agedb_30_ann.txt",
     "calfw": "calfw_ann.txt",
@@ -346,9 +361,161 @@ def run_cfp(cfp_dir, det, emb):
     return {"ff": rows["ff"], "fp": rows["fp"]}, skipped
 
 
-def grant_calibration(pooled_gen, pooled_imp):
+def run_cbsr(cbsr_dir, det, emb, n_pairs=NIR_CBSR_PAIRS, seed=NIR_SEED):
+    """Score CBSR NIR verification on the shipped gallery/probe split.
+
+    Preprocessing is the bench_nir_ext.py NIR path: YuNet largest-face
+    5-point warp, falling back to the ground-truth two-eye similarity
+    warp so coverage stays at 100%. Genuine pairs are seeded same-subject
+    (gallery, probe) combinations; impostor pairs are seeded
+    different-subject (gallery, probe) pairs over the same subjects.
+    """
+    gt = load_cbsr_gt(cbsr_dir)
+    img_dir = cbsr_dir / "NIR_face_dataset" / "NIR_face_dataset"
+    chips, fallbacks, missing = {}, 0, 0
+    t0 = time.perf_counter()
+    for i, n in enumerate(sorted(gt), 1):
+        img = cv2.imread(str(img_dir / n), cv2.IMREAD_COLOR)
+        if img is None:
+            missing += 1
+            continue
+        f = det.largest_face(img)
+        if f is not None:
+            m = estimate_norm(f[4:14].reshape(5, 2))
+        else:
+            fallbacks += 1
+            m = two_point_norm(gt[n]["le"], gt[n]["re"])
+        chips[n] = cv2.warpAffine(img, m, (112, 112), flags=cv2.INTER_LINEAR)
+        if i % 500 == 0:
+            print(f"[cbsr] {i}/{len(gt)} chips "
+                  f"({time.perf_counter() - t0:.0f}s)", flush=True)
+
+    gal, probe = {}, {}
+    for n in sorted(chips):
+        by = n.split("-")[0]
+        (gal if gt[n]["split"] == "gallery" else probe).setdefault(
+            by, []).append(n)
+    elig = sorted(set(gal) & set(probe))
+    rng = random.Random(seed)
+    pairs = []
+    while len(pairs) < n_pairs:
+        i = rng.choice(elig)
+        pairs.append((rng.choice(gal[i]), rng.choice(probe[i]), 1))
+    while len(pairs) < 2 * n_pairs:
+        i, j = rng.sample(elig, 2)
+        pairs.append((rng.choice(gal[i]), rng.choice(probe[j]), 0))
+
+    embs = {}
+    for i, (n, c) in enumerate(chips.items(), 1):
+        embs[n] = emb.embed(c, flip_tta=True)
+        if i % 500 == 0:
+            print(f"[cbsr] {i}/{len(chips)} embedded "
+                  f"({time.perf_counter() - t0:.0f}s)", flush=True)
+    scores = [float(embs[a] @ embs[b]) for a, b, _ in pairs]
+    labels = [l for _, _, l in pairs]
+    genuine = [s for s, l in zip(scores, labels) if l == 1]
+    impostor = [s for s, l in zip(scores, labels) if l == 0]
+    r = {
+        "eer": vm.eer(genuine, impostor),
+        "tar_table": vm.far_threshold_table(genuine, impostor, FARS),
+        "acc_at_045": vm.fold_accuracy(list(zip(scores, labels)), 0.45),
+        "pairs": len(scores),
+        "images": len(chips),
+        "gt_align_fallbacks": fallbacks,
+        "missing_images": missing,
+        "seed": seed,
+    }
+    print(f"[cbsr] eer={r['eer']:.4f} acc@0.45={r['acc_at_045']:.4f} "
+          f"images={len(chips)} fallbacks={fallbacks} missing={missing}",
+          flush=True)
+    return r, genuine, impostor
+
+
+def run_oulu(oulu_dir, det, emb, per_fold=OULU_PER_FOLD, seed=NIR_SEED):
+    """Score the seeded Oulu-CASIA NIR verification protocol.
+
+    Identity is the P### subject across the Dark/Strong/Weak lighting
+    trees. The sorted usable subject list is split into two disjoint
+    halves; each half contributes per_fold genuine (same subject,
+    different image) and per_fold impostor (different subjects) pairs,
+    so the two fold halves are subject-disjoint. Deterministic under
+    random.Random(seed); pairs with no detected face are skipped and
+    counted.
+    """
+    by_id = {}
+    for lighting in sorted(p for p in (oulu_dir / "NI").iterdir()
+                           if p.is_dir()):
+        for subj in sorted(p for p in lighting.iterdir() if p.is_dir()):
+            for emo in sorted(p for p in subj.iterdir() if p.is_dir()):
+                for p in sorted(emo.iterdir()):
+                    if p.suffix.lower() in (".jpg", ".jpeg"):
+                        by_id.setdefault(subj.name, []).append(p)
+    usable = sorted(i for i in by_id if len(by_id[i]) >= 2)
+    if len(usable) < 4 or len(usable) % 2:
+        raise ValueError(
+            f"oulu: cannot split {len(usable)} subjects into halves")
+    halves = (usable[:len(usable) // 2], usable[len(usable) // 2:])
+    rng = random.Random(seed)
+    pairs = []
+    for fold, half in enumerate(halves):
+        n = 0
+        while n < per_fold:
+            i = rng.choice(half)
+            a, b = rng.sample(by_id[i], 2)
+            pairs.append((a, b, 1, fold))
+            n += 1
+        n = 0
+        while n < per_fold:
+            i, j = rng.sample(half, 2)
+            pairs.append((rng.choice(by_id[i]), rng.choice(by_id[j]), 0, fold))
+            n += 1
+
+    cache = embed_images([p for pr in pairs for p in pr[:2]],
+                         det, emb, "oulu", detect=True)
+    scores, labels, folds, skipped = [], [], [], 0
+    for p1, p2, label, fold in pairs:
+        a, b = cache.get(p1), cache.get(p2)
+        if a is None or b is None:
+            skipped += 1
+            continue
+        scores.append(float(a @ b))
+        labels.append(label)
+        folds.append(fold)
+    genuine = [s for s, l in zip(scores, labels) if l == 1]
+    impostor = [s for s, l in zip(scores, labels) if l == 0]
+    tf = vm.ten_fold(scores, labels, folds)
+    r = {
+        "acc10fold": tf["acc10fold"],
+        "acc_sd": tf["sd"],
+        "eer": vm.eer(genuine, impostor),
+        "tar_table": vm.far_threshold_table(genuine, impostor, FARS),
+        "acc_at_045": vm.fold_accuracy(list(zip(scores, labels)), 0.45),
+        "pairs": len(scores),
+        "subjects": len(usable),
+        "seed": seed,
+        "skipped": skipped,
+    }
+    print(f"[oulu] acc10fold={tf['acc10fold']:.4f}±{tf['sd']:.4f} "
+          f"eer={r['eer']:.4f} acc@0.45={r['acc_at_045']:.4f} "
+          f"skip={skipped}", flush=True)
+    return r, genuine, impostor
+
+
+def nir_operating_band(pooled_gen, pooled_imp):
+    """FAR/TAR rows across the NIR operating band of the grant paths."""
+    rows = []
+    for t in NIR_GRANT_THRESHOLDS:
+        if not (NIR_OPERATING_BAND[0] <= t <= NIR_OPERATING_BAND[1]):
+            continue
+        far = sum(1 for s in pooled_imp if s > t) / len(pooled_imp)
+        tar = sum(1 for s in pooled_gen if s > t) / len(pooled_gen)
+        rows.append({"threshold": t, "far": far, "tar": tar})
+    return rows
+
+
+def grant_calibration(pooled_gen, pooled_imp, thresholds=GRANT_THRESHOLDS):
     table = []
-    for t in GRANT_THRESHOLDS:
+    for t in thresholds:
         far = sum(1 for s in pooled_imp if s > t) / len(pooled_imp)
         tar = sum(1 for s in pooled_gen if s > t) / len(pooled_gen)
         table.append({"threshold": t, "far": far, "tar": tar})
@@ -368,6 +535,8 @@ def main():
     ap.add_argument("--lfw", type=Path)
     ap.add_argument("--bundle", type=Path)
     ap.add_argument("--cfp", type=Path)
+    ap.add_argument("--cbsr", type=Path)
+    ap.add_argument("--oulu", type=Path)
     ap.add_argument("--out", type=Path, default=Path("results-recognition.json"))
     a = ap.parse_args()
 
@@ -378,8 +547,8 @@ def main():
     print(f"onnxruntime {ort.__version__} cuda={have_cuda}", flush=True)
 
     model_path = a.models_dir / "glintr100.onnx"
-    need_detect = bool(a.lfw or a.cfp)
-    det = (Detector(a.models_dir / "face_detection_yunet_2023mar.onnx")
+    need_detect = bool(a.lfw or a.cfp or a.cbsr or a.oulu)
+    det = (DetectorFull(a.models_dir / "face_detection_yunet_2023mar.onnx")
            if need_detect else None)
     emb = Embedder(model_path, 128.0, prov)
 
@@ -471,7 +640,64 @@ def main():
             "table stays frozen to its task 3 pool (lfw, agedb30, calfw, "
             "cplfw) and cfpw is reported alongside as the pose-gap evidence.")
 
+    nir = dict(results.get("nir", {}))
+    nir_gen, nir_imp = [], []
     calibration = dict(results.get("threshold_calibration", {}))
+    if a.cbsr:
+        t0 = time.perf_counter()
+        r, gen, imp = run_cbsr(a.cbsr, det, emb)
+        per_set_seconds["cbsr_nir"] = round(time.perf_counter() - t0, 1)
+        nir["cbsr"] = r
+        nir_gen += gen
+        nir_imp += imp
+        add_note(
+            "cbsr protocol consumed: gallery-groundtruth.txt (1,576 lines) "
+            "and probe-groundtruth.txt (2,364 lines), 'name,lx,ly,rx,ry' per "
+            "image; the split field of each ground-truth entry defines the "
+            "gallery/probe membership and the name prefix before '-' the "
+            "subject; verification pairs are seeded (seed 42): 3,000 genuine "
+            "same-subject (gallery, probe) pairs and 3,000 impostor "
+            "different-subject (gallery, probe) pairs over subjects present "
+            "in both splits; preprocessing is the bench_nir_ext.py NIR path "
+            "(YuNet largest-face 5-point warp, ground-truth two-eye "
+            "similarity warp fallback keeps coverage at 100%); embeddings "
+            "use the suite flip-TTA path, while the committed bench_nir_ext "
+            "numbers used no TTA, so eers are not directly comparable.")
+    if a.oulu:
+        t0 = time.perf_counter()
+        r, gen, imp = run_oulu(a.oulu, det, emb)
+        per_set_seconds["oulu_nir"] = round(time.perf_counter() - t0, 1)
+        nir["oulu"] = r
+        nir_gen += gen
+        nir_imp += imp
+        add_note(
+            "oulu protocol is constructed, not canonical (no shipped pair "
+            "list): identity is the P### subject across the Dark/Strong/Weak "
+            "lighting trees; the sorted usable subject list splits into two "
+            "disjoint halves, each contributing 2,500 genuine (same subject, "
+            "different image, any lighting and emotion) and 2,500 impostor "
+            "pairs under random.Random(seed 42), so acc10fold averages the "
+            "two subject-disjoint fold halves; pairs with no detected face "
+            "are skipped and counted.")
+    if nir_gen and a.cbsr and a.oulu:
+        calibration["nir"] = grant_calibration(
+            nir_gen, nir_imp, NIR_GRANT_THRESHOLDS)
+        calibration["nir"]["operating_band"] = nir_operating_band(
+            nir_gen, nir_imp)
+        t50 = next(r for r in calibration["nir"]["table"]
+                   if r["threshold"] == 0.5)
+        add_note(
+            "nir grant calibration pools the impostor and genuine cosine "
+            "scores of the cbsr and oulu pairs of this run; derivation "
+            "matches rgb (smallest candidate threshold with realized FAR <= "
+            "1e-3, best TAR, lowest threshold on ties, strict inequality); "
+            "the candidate sweep spans 0.2-0.6 because same-modality NIR "
+            "evidence concentrates lower than RGB while the pooled impostor "
+            f"tail reaches past 0.5 (FAR {t50['far']:.2e} at 0.5 on this "
+            "run); operating_band lists FAR/TAR at 0.2-0.4, the realistic "
+            "operating band of the recognition grant paths on NIR evidence; "
+            "calibration-only evidence, no runtime change.")
+
     if pool_gen:
         calibration["rgb"] = grant_calibration(pool_gen, pool_imp)
         add_note(
@@ -494,9 +720,11 @@ def main():
             "per_set_seconds": per_set_seconds,
         },
         "rgb": rgb,
-        "threshold_calibration": calibration,
-        "notes": notes,
     }
+    if nir:
+        out["nir"] = nir
+    out["threshold_calibration"] = calibration
+    out["notes"] = notes
     a.out.write_text(json.dumps(out, indent=2))
     print(f"wrote {a.out}", flush=True)
 

--- a/benchmarks/bench_recog_suite.py
+++ b/benchmarks/bench_recog_suite.py
@@ -1,31 +1,42 @@
 #!/usr/bin/env python3
-"""RGB recognition lane for calibration phase 2 (Task 3).
+"""Recognition suite for calibration phase 2 (Tasks 3-5).
 
-Scores AuraFace glintr100 (the recognizer irlume ships) over four standard
-RGB verification protocols and derives the RGB grant-threshold calibration:
+Scores AuraFace glintr100 (the recognizer irlume ships) over standard
+verification protocols and derives per-modality grant-threshold
+calibrations:
 
-  - LFW deepfunneled, shipped pairs.csv 10-fold protocol (6,000 pairs,
-    10 folds x [300 match + 300 mismatch] in canonical row order).
-    Continuity cross-check against the committed results-lfw.json
+  - LFW deepfunneled (Task 3), shipped pairs.csv 10-fold protocol
+    (6,000 pairs, 10 folds x [300 match + 300 mismatch] in canonical row
+    order). Continuity cross-check against the committed results-lfw.json
     auraface flip-TTA number (acc10fold 0.9903).
-  - AgeDB-30 / CALFW / CPLFW from the aligned_fr_bundle mirror:
+  - AgeDB-30 / CALFW / CPLFW (Task 3) from the aligned_fr_bundle mirror:
     pre-aligned 112x112 crops scored over each set's shipped 6,000-pair
     annotation file.
+  - CFPW (Task 4): official 10-fold frontal-frontal (FF) and
+    frontal-profile (FP) verification, 350 same + 350 diff pairs per
+    fold per protocol (7,000 pairs each), resolved through
+    Pair_list_F.txt / Pair_list_P.txt. Wild (unaligned) images scored
+    with the same detect + warp path as LFW; the ff vs fp rows quantify
+    the pose gap.
 
 The embedding path reuses bench_faceid.py exactly (YuNet detect + 5-point
-similarity warp to 112x112 for LFW; (x - 127.5) / 128 normalization, flip
-TTA, 512-D L2-normalized embedding, cosine scoring) so the numbers stay
-comparable with the committed results. Metrics come from
+similarity warp to 112x112 for unaligned sets; (x - 127.5) / 128
+normalization, flip TTA, 512-D L2-normalized embedding, cosine scoring) so
+the numbers stay comparable with the committed results. Metrics come from
 verification_metrics (eer, far_threshold_table, fold_accuracy, ten_fold).
 
 The aligned-set protocols ship no folds, so those sets report fold_accuracy
-at the fixed 0.45 line (key acc_at_045) plus eer and tar_table; only LFW
-reports acc10fold.
+at the fixed 0.45 line (key acc_at_045) plus eer and tar_table; LFW and
+CFPW report acc10fold over their shipped folds.
 
 Usage:
   python3 bench_recog_suite.py --models-dir ~/irlume-bench/models \
       --lfw ~/datasets/lfw --bundle ~/datasets/aligned_fr_bundle \
-      --out results-recognition.json
+      --cfp ~/datasets/cfpw --out results-recognition.json
+
+The out file is merged, not replaced: lanes not run in this invocation
+keep their existing rows, and threshold_calibration.rgb stays frozen to
+the task 3 pool (lfw, agedb30, calfw, cplfw) it was derived from.
 """
 import argparse, hashlib, json, sys, time
 from pathlib import Path
@@ -234,6 +245,107 @@ def bundle_lfw_crosscheck(bundle_root, emb):
     return eer, float(accs[best_i])
 
 
+def load_cfp_pairs(cfp_dir):
+    """Resolve the CFPW 10-fold FF/FP pair files to image paths.
+
+    Protocol/Split/{FF,FP}/{01..10}/{same,diff}.txt hold 'a,b' 1-based
+    image indices per fold (350 same + 350 diff rows each). Indices point
+    into Protocol/Pair_list_F.txt (5,000 frontal images) and
+    Protocol/Pair_list_P.txt (2,000 profile images); FF lines index the
+    frontal list twice, FP lines are (frontal, profile). Fold directories
+    are identity-separable per the shipped Readme.
+    """
+    def read_index(path):
+        out = {}
+        for ln in path.read_text().splitlines():
+            ln = ln.strip()
+            if not ln:
+                continue
+            idx, rel = ln.split(None, 1)
+            out[int(idx)] = (path.parent / rel.strip()).resolve()
+        return out
+
+    proto_dir = cfp_dir / "Protocol"
+    flist = read_index(proto_dir / "Pair_list_F.txt")
+    plist = read_index(proto_dir / "Pair_list_P.txt")
+    subjects = ({p.parent.parent.name for p in flist.values()}
+                | {p.parent.parent.name for p in plist.values()})
+    if len(subjects) != 500:
+        raise ValueError(
+            f"cfpw: expected 500 identities, got {len(subjects)}")
+    protos = {}
+    for proto in ("ff", "fp"):
+        pairs = []
+        split_dir = proto_dir / "Split" / proto.upper()
+        fold_dirs = sorted(d for d in split_dir.iterdir() if d.is_dir())
+        if len(fold_dirs) != 10:
+            raise ValueError(
+                f"cfpw {proto}: expected 10 fold dirs, got {len(fold_dirs)}")
+        for fold, d in enumerate(fold_dirs):
+            for label, name in ((1, "same.txt"), (0, "diff.txt")):
+                rows = [ln.strip() for ln
+                        in (d / name).read_text().splitlines() if ln.strip()]
+                if len(rows) != 350:
+                    raise ValueError(
+                        f"{d / name}: expected 350 rows, got {len(rows)}")
+                for ln in rows:
+                    ia, ib = (int(x) for x in ln.split(","))
+                    if proto == "ff":
+                        p1, p2 = flist[ia], flist[ib]
+                        ok = (p1.parent.name == "frontal"
+                              and p2.parent.name == "frontal")
+                    else:
+                        p1, p2 = flist[ia], plist[ib]
+                        ok = (p1.parent.name == "frontal"
+                              and p2.parent.name == "profile")
+                    if not ok:
+                        raise ValueError(
+                            f"cfpw {proto}: pose mismatch at "
+                            f"{d.name}/{name}: {ln}")
+                    pairs.append((p1, p2, label, fold))
+        protos[proto] = pairs
+    return protos
+
+
+def run_cfp(cfp_dir, det, emb):
+    """Score the CFPW FF and FP protocols; returns rows + skipped counts.
+
+    The pose gap is the ff row vs the fp row: frontal-frontal accuracy
+    against frontal-profile accuracy under the identical embedding path.
+    """
+    protos = load_cfp_pairs(cfp_dir)
+    cache = embed_images(
+        [p for pr in (protos["ff"] + protos["fp"]) for p in pr[:2]],
+        det, emb, "cfpw", detect=True)
+    rows, skipped = {}, {}
+    for proto in ("ff", "fp"):
+        scores, labels, folds, skip = [], [], [], 0
+        for p1, p2, label, fold in protos[proto]:
+            a, b = cache.get(p1), cache.get(p2)
+            if a is None or b is None:
+                skip += 1
+                continue
+            scores.append(float(a @ b))
+            labels.append(label)
+            folds.append(fold)
+        genuine = [s for s, l in zip(scores, labels) if l == 1]
+        impostor = [s for s, l in zip(scores, labels) if l == 0]
+        tf = vm.ten_fold(scores, labels, folds)
+        rows[proto] = {
+            "acc10fold": tf["acc10fold"],
+            "acc_sd": tf["sd"],
+            "eer": vm.eer(genuine, impostor),
+            "tar_table": vm.far_threshold_table(genuine, impostor, FARS),
+            "acc_at_045": vm.fold_accuracy(list(zip(scores, labels)), 0.45),
+            "pairs": len(scores),
+        }
+        skipped[proto] = skip
+        print(f"[cfp_{proto}] acc10fold={tf['acc10fold']:.4f}±{tf['sd']:.4f} "
+              f"eer={rows[proto]['eer']:.4f} acc@0.45="
+              f"{rows[proto]['acc_at_045']:.4f} skip={skip}", flush=True)
+    return {"ff": rows["ff"], "fp": rows["fp"]}, skipped
+
+
 def grant_calibration(pooled_gen, pooled_imp):
     table = []
     for t in GRANT_THRESHOLDS:
@@ -255,6 +367,7 @@ def main():
     ap.add_argument("--models-dir", type=Path, required=True)
     ap.add_argument("--lfw", type=Path)
     ap.add_argument("--bundle", type=Path)
+    ap.add_argument("--cfp", type=Path)
     ap.add_argument("--out", type=Path, default=Path("results-recognition.json"))
     a = ap.parse_args()
 
@@ -265,12 +378,23 @@ def main():
     print(f"onnxruntime {ort.__version__} cuda={have_cuda}", flush=True)
 
     model_path = a.models_dir / "glintr100.onnx"
-    det = Detector(a.models_dir / "face_detection_yunet_2023mar.onnx") if a.lfw else None
+    need_detect = bool(a.lfw or a.cfp)
+    det = (Detector(a.models_dir / "face_detection_yunet_2023mar.onnx")
+           if need_detect else None)
     emb = Embedder(model_path, 128.0, prov)
 
-    notes = []
-    rgb, pool_gen, pool_imp = {}, [], []
-    per_set_seconds = {}
+    results = {}
+    if a.out.exists():
+        results = json.loads(a.out.read_text())
+    notes = list(results.get("notes", []))
+    per_set_seconds = dict(
+        results.get("runtime", {}).get("per_set_seconds", {}))
+
+    def add_note(text):
+        if text not in notes:
+            notes.append(text)
+
+    rgb, pool_gen, pool_imp = dict(results.get("rgb", {})), [], []
     if a.lfw:
         t0 = time.perf_counter()
         lfw_r, lfw_extra = run_lfw(a.lfw, det, emb)
@@ -278,7 +402,7 @@ def main():
         rgb["lfw"] = lfw_r
         pool_gen += lfw_extra["gen"]
         pool_imp += lfw_extra["imp"]
-        notes.append(
+        add_note(
             "lfw acc10fold uses verification_metrics.ten_fold (per-fold optimal "
             f"threshold on the fold itself, ties to lowest threshold). The "
             f"bench_faceid.py held-out-train-fold-threshold protocol gives "
@@ -286,18 +410,19 @@ def main():
             "run; the committed results-lfw.json continuity number 0.9903 used "
             "that protocol with the same auraface flip-TTA embedding path.")
         if lfw_extra["skipped"]:
-            notes.append(f"lfw: {lfw_extra['skipped']} pairs skipped (no face "
-                         "detected in at least one image).")
+            add_note(f"lfw: {lfw_extra['skipped']} pairs skipped (no face "
+                     "detected in at least one image).")
     if a.bundle:
         t0 = time.perf_counter()
         x_eer, x_acc = bundle_lfw_crosscheck(a.bundle, emb)
         per_set_seconds["bundle_lfw_crosscheck"] = round(
             time.perf_counter() - t0, 1)
         if a.lfw:
-            notes.append(
-                f"bundle coherence cross-check: the bundle's own aligned-LFW "
-                f"annotation (lfw_ann.txt, 6,000 pairs) through the identical "
-                f"embedding path gives eer={x_eer:.4f} and best-threshold "
+            add_note(
+                "bundle coherence cross-check: the bundle's own aligned-LFW "
+                "annotation (lfw_ann.txt, 6,000 pairs) through the identical "
+                "embedding path gives eer="
+                f"{x_eer:.4f} and best-threshold "
                 f"accuracy {x_acc:.4f} on its 112x112 crops, vs eer="
                 f"{rgb['lfw']['eer']:.4f} for the deepfunneled detect+warp lane; "
                 "the bundle data and the pipeline are consistent.")
@@ -308,28 +433,56 @@ def main():
             rgb[key] = r
             pool_gen += extra["gen"]
             pool_imp += extra["imp"]
-        notes.append(
+        add_note(
             "aligned sets (agedb30, calfw, cplfw): pre-aligned 112x112 crops "
             "embedded directly without detection; the shipped protocols define "
             "no folds, so each set reports acc_at_045 = "
             "verification_metrics.fold_accuracy at the fixed 0.45 line plus "
             "eer and tar_table; acc10fold is reported for lfw only.")
-        notes.append(
+        add_note(
             "aligned bundle annotations consumed: agedb_30_ann.txt, "
             "calfw_ann.txt, cplfw_ann.txt at the bundle root, label-first "
             "'<1|0> <img1> <img2>' format, 6,000 pairs (3,000 genuine / 3,000 "
             "impostor) per set, paths relative to the bundle root.")
+    if a.cfp:
+        t0 = time.perf_counter()
+        cfp_r, cfp_skip = run_cfp(a.cfp, det, emb)
+        per_set_seconds["cfpw"] = round(time.perf_counter() - t0, 1)
+        rgb["cfpw"] = cfp_r
+        add_note(
+            "cfpw protocol consumed: Protocol/Split/{FF,FP}/{01..10}/"
+            "{same,diff}.txt with 350 same + 350 diff rows per fold per "
+            "protocol; 'a,b' lines are 1-based image indices resolved through "
+            "Pair_list_F.txt (5,000 frontal) and Pair_list_P.txt (2,000 "
+            "profile); FF lines index the frontal list twice, FP lines are "
+            "(frontal, profile); 500 identities asserted across both lists; "
+            "folds are identity-separable per the shipped Readme, so "
+            "acc10fold uses verification_metrics.ten_fold (per-fold optimal "
+            "threshold on the fold itself, ties to lowest) and acc_sd is the "
+            "population sd across the 10 folds.")
+        add_note(
+            "cfpw pose gap: compare rgb.cfpw.ff (frontal-frontal) with "
+            "rgb.cfpw.fp (frontal-profile) accuracy and eer; images are wild "
+            "(unaligned) photos embedded with the same detect + warp path as "
+            "lfw; pairs with no detected face are skipped and counted "
+            f"(ff skipped={cfp_skip['ff']}, fp skipped={cfp_skip['fp']}).")
+        add_note(
+            "cfpw scores are not pooled into threshold_calibration.rgb; that "
+            "table stays frozen to its task 3 pool (lfw, agedb30, calfw, "
+            "cplfw) and cfpw is reported alongside as the pose-gap evidence.")
 
-    calibration = {"rgb": grant_calibration(pool_gen, pool_imp)}
-    notes.append(
-        "rgb grant calibration pools the impostor and genuine cosine scores of "
-        "all scored pairs across the four sets above; grant rule is score > "
-        "threshold; far/tar fractions use strict inequality; "
-        "grant_recommendation is the candidate threshold with realized FAR <= "
-        "1e-3 and the best TAR (lowest threshold on ties).")
+    calibration = dict(results.get("threshold_calibration", {}))
+    if pool_gen:
+        calibration["rgb"] = grant_calibration(pool_gen, pool_imp)
+        add_note(
+            "rgb grant calibration pools the impostor and genuine cosine scores of "
+            "all scored pairs across the four sets above; grant rule is score > "
+            "threshold; far/tar fractions use strict inequality; "
+            "grant_recommendation is the candidate threshold with realized FAR <= "
+            "1e-3 and the best TAR (lowest threshold on ties).")
 
     wall = time.perf_counter() - t_start
-    results = {
+    out = {
         "runtime": {
             "host_model": str(model_path),
             "model_sha256": sha256_file(model_path),
@@ -344,7 +497,7 @@ def main():
         "threshold_calibration": calibration,
         "notes": notes,
     }
-    a.out.write_text(json.dumps(results, indent=2))
+    a.out.write_text(json.dumps(out, indent=2))
     print(f"wrote {a.out}", flush=True)
 
 

--- a/benchmarks/bench_recog_suite.py
+++ b/benchmarks/bench_recog_suite.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""RGB recognition lane for calibration phase 2 (Task 3).
+
+Scores AuraFace glintr100 (the recognizer irlume ships) over four standard
+RGB verification protocols and derives the RGB grant-threshold calibration:
+
+  - LFW deepfunneled, shipped pairs.csv 10-fold protocol (6,000 pairs,
+    10 folds x [300 match + 300 mismatch] in canonical row order).
+    Continuity cross-check against the committed results-lfw.json
+    auraface flip-TTA number (acc10fold 0.9903).
+  - AgeDB-30 / CALFW / CPLFW from the aligned_fr_bundle mirror:
+    pre-aligned 112x112 crops scored over each set's shipped 6,000-pair
+    annotation file.
+
+The embedding path reuses bench_faceid.py exactly (YuNet detect + 5-point
+similarity warp to 112x112 for LFW; (x - 127.5) / 128 normalization, flip
+TTA, 512-D L2-normalized embedding, cosine scoring) so the numbers stay
+comparable with the committed results. Metrics come from
+verification_metrics (eer, far_threshold_table, fold_accuracy, ten_fold).
+
+The aligned-set protocols ship no folds, so those sets report fold_accuracy
+at the fixed 0.45 line (key acc_at_045) plus eer and tar_table; only LFW
+reports acc10fold.
+
+Usage:
+  python3 bench_recog_suite.py --models-dir ~/irlume-bench/models \
+      --lfw ~/datasets/lfw --bundle ~/datasets/aligned_fr_bundle \
+      --out results-recognition.json
+"""
+import argparse, hashlib, json, sys, time
+from pathlib import Path
+
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import verification_metrics as vm
+from bench_faceid import Detector, Embedder, align_or_center, lfw_tenfold_accuracy
+
+FARS = [0.1, 0.03, 0.01, 0.003, 0.001]
+GRANT_THRESHOLDS = [0.3, 0.35, 0.4, 0.45, 0.5]
+GRANT_FAR_CAP = 1e-3
+ALIGNED_SETS = {
+    "agedb30": "agedb_30_ann.txt",
+    "calfw": "calfw_ann.txt",
+    "cplfw": "cplfw_ann.txt",
+}
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_lfw_pairs(pairs_csv, img_root):
+    """Parse the shipped pairs.csv into (path1, path2, label, fold) tuples.
+
+    Row formats (header row first): match rows have 3 cells
+    (name, imagenum1, imagenum2), mismatch rows 4 cells
+    (name1, num1, name2, num2). Fold k is rows [600k, 600k+600) per the
+    canonical LFW 10-fold layout; the 300/300 match/mismatch split per
+    block is asserted, not assumed for scoring.
+    """
+    lines = [ln.strip() for ln in pairs_csv.read_text().splitlines() if ln.strip()]
+    pairs = []
+    for i, ln in enumerate(lines[1:]):
+        cells = [c.strip() for c in ln.split(",")]
+        while cells and cells[-1] == "":
+            cells.pop()
+        if len(cells) == 3:
+            name, num1, num2 = cells
+            pairs.append((name, int(num1), name, int(num2), 1))
+        elif len(cells) == 4:
+            name1, num1, name2, num2 = cells
+            pairs.append((name1, int(num1), name2, int(num2), 0))
+        else:
+            raise ValueError(f"pairs.csv row {i + 2}: unexpected shape {cells}")
+    if len(pairs) != 6000:
+        raise ValueError(f"pairs.csv: expected 6000 rows, got {len(pairs)}")
+    out = []
+    for i, (n1, u1, n2, u2, label) in enumerate(pairs):
+        block = i // 600
+        if i % 600 == 0 and label != 1:
+            raise ValueError(f"pairs.csv: fold block {block} does not start with matches")
+        if i % 600 == 300 and label != 0:
+            raise ValueError(f"pairs.csv: fold block {block} mismatch half out of place")
+        p1 = img_root / n1 / f"{n1}_{u1:04d}.jpg"
+        p2 = img_root / n2 / f"{n2}_{u2:04d}.jpg"
+        out.append((p1, p2, label, block))
+    return out
+
+
+def load_ann_pairs(ann_path, bundle_root):
+    """Parse a label-first annotation line '1 p1 p2' into (path1, path2, label)."""
+    pairs = []
+    for ln in ann_path.read_text().splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        label, p1, p2 = ln.split()
+        pairs.append((bundle_root / p1, bundle_root / p2, int(label)))
+    labels = [lab for _, _, lab in pairs]
+    if len(pairs) != 6000 or sum(labels) != 3000:
+        raise ValueError(
+            f"{ann_path.name}: expected 6000 pairs with 3000 genuine, "
+            f"got {len(pairs)} pairs / {sum(labels)} genuine")
+    return pairs
+
+
+def embed_images(paths, det, emb, tag, detect):
+    """Embed unique images; returns {path: vec or None}. Progress every 500."""
+    cache = {}
+    t0 = time.perf_counter()
+    for i, p in enumerate(sorted(set(paths))):
+        if p in cache:
+            continue
+        img = cv2.imread(str(p), cv2.IMREAD_COLOR)
+        if img is None:
+            cache[p] = None
+            continue
+        if detect:
+            chip = align_or_center(img, det)
+        else:
+            chip = img if img.shape[:2] == (112, 112) else cv2.resize(img, (112, 112))
+        cache[p] = None if chip is None else emb.embed(chip, flip_tta=True)
+        if (len(cache)) % 500 == 0:
+            print(f"[{tag}] {len(cache)} embedded "
+                  f"({time.perf_counter() - t0:.0f}s)", flush=True)
+    n_none = sum(1 for v in cache.values() if v is None)
+    print(f"[{tag}] {len(cache) - n_none}/{len(cache)} embedded, {n_none} failed",
+          flush=True)
+    return cache
+
+
+def run_lfw(lfw_dir, det, emb):
+    inner = lfw_dir / "lfw-deepfunneled" / "lfw-deepfunneled"
+    if not inner.is_dir():
+        inner = lfw_dir / "lfw-deepfunneled"
+    pairs = load_lfw_pairs(lfw_dir / "pairs.csv", inner)
+    cache = embed_images([p for pr in pairs for p in pr[:2]], det, emb, "lfw",
+                         detect=True)
+    scores, labels, folds, skipped = [], [], [], 0
+    for p1, p2, label, fold in pairs:
+        a, b = cache.get(p1), cache.get(p2)
+        if a is None or b is None:
+            skipped += 1
+            continue
+        scores.append(float(a @ b))
+        labels.append(label)
+        folds.append(fold)
+    genuine = [s for s, l in zip(scores, labels) if l == 1]
+    impostor = [s for s, l in zip(scores, labels) if l == 0]
+    tf = vm.ten_fold(scores, labels, folds)
+    heldout_acc, heldout_std = lfw_tenfold_accuracy(scores, labels, folds)
+    r = {
+        "acc10fold": tf["acc10fold"],
+        "eer": vm.eer(genuine, impostor),
+        "tar_table": vm.far_threshold_table(genuine, impostor, FARS),
+        "pairs": len(scores),
+    }
+    print(f"[lfw] acc10fold={r['acc10fold']:.4f} eer={r['eer']:.4f} "
+          f"skip={skipped} heldout={heldout_acc:.4f}±{heldout_std:.4f}", flush=True)
+    extra = {
+        "heldout_acc": heldout_acc,
+        "heldout_std": heldout_std,
+        "skipped": skipped,
+        "gen": genuine,
+        "imp": impostor,
+    }
+    return r, extra
+
+
+def run_aligned_set(bundle_root, ann_name, key, emb):
+    pairs = load_ann_pairs(bundle_root / ann_name, bundle_root)
+    cache = embed_images([p for pr in pairs for p in pr[:2]], None, emb, key,
+                         detect=False)
+    scores, labels, failed = [], [], 0
+    for p1, p2, label in pairs:
+        a, b = cache.get(p1), cache.get(p2)
+        if a is None or b is None:
+            failed += 1
+            continue
+        scores.append(float(a @ b))
+        labels.append(label)
+    genuine = [s for s, l in zip(scores, labels) if l == 1]
+    impostor = [s for s, l in zip(scores, labels) if l == 0]
+    r = {
+        "eer": vm.eer(genuine, impostor),
+        "tar_table": vm.far_threshold_table(genuine, impostor, FARS),
+        "acc_at_045": vm.fold_accuracy(list(zip(scores, labels)), 0.45),
+        "pairs": len(scores),
+    }
+    print(f"[{key}] eer={r['eer']:.4f} acc@0.45={r['acc_at_045']:.4f} "
+          f"failed={failed}", flush=True)
+    if failed:
+        raise RuntimeError(f"{key}: {failed} pairs lost to unreadable images")
+    return r, {"gen": genuine, "imp": impostor}
+
+
+def bundle_lfw_crosscheck(bundle_root, emb):
+    """Score the bundle's own aligned-LFW annotation with the same path.
+
+    Coherence evidence for the bundle and the embedding pipeline: if this
+    lands near the deepfunneled continuity numbers, the bmp reading, the
+    score path, and the pair lists are all consistent.
+    """
+    pairs = load_ann_pairs(bundle_root / "lfw_ann.txt", bundle_root)
+    cache = embed_images([p for pr in pairs for p in pr[:2]], None, emb,
+                         "bundle_lfw", detect=False)
+    scores, labels, failed = [], [], 0
+    for p1, p2, label in pairs:
+        a, b = cache.get(p1), cache.get(p2)
+        if a is None or b is None:
+            failed += 1
+            continue
+        scores.append(float(a @ b))
+        labels.append(label)
+    genuine = [s for s, l in zip(scores, labels) if l == 1]
+    impostor = [s for s, l in zip(scores, labels) if l == 0]
+    eer = vm.eer(genuine, impostor)
+    thresholds = np.linspace(0.0, 1.0, 1001)
+    accs = [vm.fold_accuracy(list(zip(scores, labels)), float(t))
+            for t in thresholds]
+    best_i = int(np.argmax(accs))
+    print(f"[bundle_lfw] eer={eer:.4f} "
+          f"best_acc={accs[best_i]:.4f}@t={thresholds[best_i]:.3f} "
+          f"failed={failed}", flush=True)
+    if failed:
+        raise RuntimeError(f"bundle_lfw: {failed} pairs lost to unreadable images")
+    return eer, float(accs[best_i])
+
+
+def grant_calibration(pooled_gen, pooled_imp):
+    table = []
+    for t in GRANT_THRESHOLDS:
+        far = sum(1 for s in pooled_imp if s > t) / len(pooled_imp)
+        tar = sum(1 for s in pooled_gen if s > t) / len(pooled_gen)
+        table.append({"threshold": t, "far": far, "tar": tar})
+    ok = [row for row in table if row["far"] <= GRANT_FAR_CAP]
+    if ok:
+        best = max(ok, key=lambda row: (row["tar"], -row["threshold"]))
+        rec = {"grant_recommendation": best["threshold"],
+               "far_at_grant": best["far"], "table": table}
+    else:
+        rec = {"grant_recommendation": None, "far_at_grant": None, "table": table}
+    return rec
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--models-dir", type=Path, required=True)
+    ap.add_argument("--lfw", type=Path)
+    ap.add_argument("--bundle", type=Path)
+    ap.add_argument("--out", type=Path, default=Path("results-recognition.json"))
+    a = ap.parse_args()
+
+    t_start = time.perf_counter()
+    have_cuda = "CUDAExecutionProvider" in ort.get_available_providers()
+    prov = (["CUDAExecutionProvider", "CPUExecutionProvider"]
+            if have_cuda else ["CPUExecutionProvider"])
+    print(f"onnxruntime {ort.__version__} cuda={have_cuda}", flush=True)
+
+    model_path = a.models_dir / "glintr100.onnx"
+    det = Detector(a.models_dir / "face_detection_yunet_2023mar.onnx") if a.lfw else None
+    emb = Embedder(model_path, 128.0, prov)
+
+    notes = []
+    rgb, pool_gen, pool_imp = {}, [], []
+    per_set_seconds = {}
+    if a.lfw:
+        t0 = time.perf_counter()
+        lfw_r, lfw_extra = run_lfw(a.lfw, det, emb)
+        per_set_seconds["lfw"] = round(time.perf_counter() - t0, 1)
+        rgb["lfw"] = lfw_r
+        pool_gen += lfw_extra["gen"]
+        pool_imp += lfw_extra["imp"]
+        notes.append(
+            "lfw acc10fold uses verification_metrics.ten_fold (per-fold optimal "
+            f"threshold on the fold itself, ties to lowest threshold). The "
+            f"bench_faceid.py held-out-train-fold-threshold protocol gives "
+            f"{lfw_extra['heldout_acc']:.4f}±{lfw_extra['heldout_std']:.4f} on this "
+            "run; the committed results-lfw.json continuity number 0.9903 used "
+            "that protocol with the same auraface flip-TTA embedding path.")
+        if lfw_extra["skipped"]:
+            notes.append(f"lfw: {lfw_extra['skipped']} pairs skipped (no face "
+                         "detected in at least one image).")
+    if a.bundle:
+        t0 = time.perf_counter()
+        x_eer, x_acc = bundle_lfw_crosscheck(a.bundle, emb)
+        per_set_seconds["bundle_lfw_crosscheck"] = round(
+            time.perf_counter() - t0, 1)
+        if a.lfw:
+            notes.append(
+                f"bundle coherence cross-check: the bundle's own aligned-LFW "
+                f"annotation (lfw_ann.txt, 6,000 pairs) through the identical "
+                f"embedding path gives eer={x_eer:.4f} and best-threshold "
+                f"accuracy {x_acc:.4f} on its 112x112 crops, vs eer="
+                f"{rgb['lfw']['eer']:.4f} for the deepfunneled detect+warp lane; "
+                "the bundle data and the pipeline are consistent.")
+        for key, ann_name in ALIGNED_SETS.items():
+            t0 = time.perf_counter()
+            r, extra = run_aligned_set(a.bundle, ann_name, key, emb)
+            per_set_seconds[key] = round(time.perf_counter() - t0, 1)
+            rgb[key] = r
+            pool_gen += extra["gen"]
+            pool_imp += extra["imp"]
+        notes.append(
+            "aligned sets (agedb30, calfw, cplfw): pre-aligned 112x112 crops "
+            "embedded directly without detection; the shipped protocols define "
+            "no folds, so each set reports acc_at_045 = "
+            "verification_metrics.fold_accuracy at the fixed 0.45 line plus "
+            "eer and tar_table; acc10fold is reported for lfw only.")
+        notes.append(
+            "aligned bundle annotations consumed: agedb_30_ann.txt, "
+            "calfw_ann.txt, cplfw_ann.txt at the bundle root, label-first "
+            "'<1|0> <img1> <img2>' format, 6,000 pairs (3,000 genuine / 3,000 "
+            "impostor) per set, paths relative to the bundle root.")
+
+    calibration = {"rgb": grant_calibration(pool_gen, pool_imp)}
+    notes.append(
+        "rgb grant calibration pools the impostor and genuine cosine scores of "
+        "all scored pairs across the four sets above; grant rule is score > "
+        "threshold; far/tar fractions use strict inequality; "
+        "grant_recommendation is the candidate threshold with realized FAR <= "
+        "1e-3 and the best TAR (lowest threshold on ties).")
+
+    wall = time.perf_counter() - t_start
+    results = {
+        "runtime": {
+            "host_model": str(model_path),
+            "model_sha256": sha256_file(model_path),
+            "ort": ort.__version__,
+            "cuda": have_cuda,
+            "flip_tta": True,
+            "started_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "wall_seconds": round(wall, 1),
+            "per_set_seconds": per_set_seconds,
+        },
+        "rgb": rgb,
+        "threshold_calibration": calibration,
+        "notes": notes,
+    }
+    a.out.write_text(json.dumps(results, indent=2))
+    print(f"wrote {a.out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -185,6 +185,83 @@ _OULU_CASIA_NIR = DatasetSpec(
     ),
 )
 
+_LFW = DatasetSpec(
+    name="lfw",
+    source="kaggle",
+    repo="jessicali9530/lfw-dataset",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=112_000_000,
+        ),
+    ),
+    license_note=(
+        "LFW is provided for non-commercial research use per its source "
+        "page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://www.kaggle.com/datasets/jessicali9530/lfw-dataset",
+    notes=(
+        "Must contain the lfw-deepfunneled images; verify at download before "
+        "benchmarking. The committed 99.03 percent accuracy is on "
+        "deepfunneled. Mirror identity matters (see benchmarks/README.md): "
+        "numbers are valid only for this mirror."
+    ),
+)
+
+_CFPW = DatasetSpec(
+    name="cfpw",
+    source="kaggle",
+    repo="chinafax/cfpw-dataset",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=86_000_000,
+        ),
+    ),
+    license_note=(
+        "CFPW is provided for non-commercial research use per its source "
+        "page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://www.kaggle.com/datasets/chinafax/cfpw-dataset",
+    notes=(
+        "Official protocol: 500 identities, 10 folds, 7000 pairs; verify at "
+        "download. If the mirror is short, score what exists and label it "
+        "honestly. Mirror identity matters (see benchmarks/README.md): "
+        "numbers are valid only for this mirror."
+    ),
+)
+
+_ALIGNED_FR_BUNDLE = DatasetSpec(
+    name="aligned_fr_bundle",
+    source="kaggle",
+    repo="yakhyokhuja/agedb-30-calfw-cplfw-lfw-aligned-112x112",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=1_400_000_000,
+        ),
+    ),
+    license_note=(
+        "AgeDB-30, CALFW, CPLFW and LFW are each provided for non-commercial "
+        "research use per their source pages; the exact terms stated there "
+        "are quoted verbatim into PROVENANCE.md at download time."
+    ),
+    provenance_url=(
+        "https://www.kaggle.com/datasets/"
+        "yakhyokhuja/agedb-30-calfw-cplfw-lfw-aligned-112x112"
+    ),
+    notes=(
+        "AgeDB-30, CALFW, CPLFW and LFW aligned at 112x112 with shipped pair "
+        "lists; the published-comparable lane. Mirror identity matters (see "
+        "benchmarks/README.md): numbers are valid only for this mirror."
+    ),
+)
+
 _DATASETS: dict[str, DatasetSpec] = {
     _WIDER.name: _WIDER,
     _THREE00W.name: _THREE00W,
@@ -192,6 +269,9 @@ _DATASETS: dict[str, DatasetSpec] = {
     _AFLW2000.name: _AFLW2000,
     _CBSR_NIR.name: _CBSR_NIR,
     _OULU_CASIA_NIR.name: _OULU_CASIA_NIR,
+    _LFW.name: _LFW,
+    _CFPW.name: _CFPW,
+    _ALIGNED_FR_BUNDLE.name: _ALIGNED_FR_BUNDLE,
 }
 
 

--- a/benchmarks/results-recognition.json
+++ b/benchmarks/results-recognition.json
@@ -5,15 +5,17 @@
     "ort": "1.27.0",
     "cuda": true,
     "flip_tta": true,
-    "started_utc": "2026-08-29T14:26:15Z",
-    "wall_seconds": 132.9,
+    "started_utc": "2026-08-29T14:55:02Z",
+    "wall_seconds": 377.6,
     "per_set_seconds": {
       "lfw": 142.5,
       "bundle_lfw_crosscheck": 194.4,
       "agedb30": 194.0,
       "calfw": 194.0,
       "cplfw": 194.0,
-      "cfpw": 132.4
+      "cfpw": 132.4,
+      "cbsr_nir": 93.2,
+      "oulu_nir": 283.8
     }
   },
   "rgb": {
@@ -216,6 +218,81 @@
       }
     }
   },
+  "nir": {
+    "cbsr": {
+      "eer": 0.008333333333333333,
+      "tar_table": [
+        {
+          "far": 0.1,
+          "threshold": 0.38981467485427856,
+          "tar": 0.999
+        },
+        {
+          "far": 0.03,
+          "threshold": 0.4545297622680664,
+          "tar": 0.9956666666666667
+        },
+        {
+          "far": 0.01,
+          "threshold": 0.5074434280395508,
+          "tar": 0.992
+        },
+        {
+          "far": 0.003,
+          "threshold": 0.534734845161438,
+          "tar": 0.9903333333333333
+        },
+        {
+          "far": 0.001,
+          "threshold": 0.5735234022140503,
+          "tar": 0.982
+        }
+      ],
+      "acc_at_045": 0.9818333333333333,
+      "pairs": 6000,
+      "images": 3940,
+      "gt_align_fallbacks": 0,
+      "missing_images": 0,
+      "seed": 42
+    },
+    "oulu": {
+      "acc10fold": 0.9883,
+      "acc_sd": 0.005300000000000027,
+      "eer": 0.0122,
+      "tar_table": [
+        {
+          "far": 0.1,
+          "threshold": 0.3000190258026123,
+          "tar": 0.9994
+        },
+        {
+          "far": 0.03,
+          "threshold": 0.3757762312889099,
+          "tar": 0.995
+        },
+        {
+          "far": 0.01,
+          "threshold": 0.4334918260574341,
+          "tar": 0.9854
+        },
+        {
+          "far": 0.003,
+          "threshold": 0.4800117313861847,
+          "tar": 0.9696
+        },
+        {
+          "far": 0.001,
+          "threshold": 0.5080506801605225,
+          "tar": 0.9522
+        }
+      ],
+      "acc_at_045": 0.9862,
+      "pairs": 10000,
+      "subjects": 80,
+      "seed": 42,
+      "skipped": 0
+    }
+  },
   "threshold_calibration": {
     "rgb": {
       "grant_recommendation": 0.35,
@@ -247,6 +324,84 @@
           "tar": 0.4685
         }
       ]
+    },
+    "nir": {
+      "grant_recommendation": 0.6,
+      "far_at_grant": 0.0,
+      "table": [
+        {
+          "threshold": 0.2,
+          "far": 0.4955,
+          "tar": 1.0
+        },
+        {
+          "threshold": 0.25,
+          "far": 0.32725,
+          "tar": 0.99975
+        },
+        {
+          "threshold": 0.3,
+          "far": 0.196625,
+          "tar": 0.999625
+        },
+        {
+          "threshold": 0.35,
+          "far": 0.099125,
+          "tar": 0.9985
+        },
+        {
+          "threshold": 0.4,
+          "far": 0.041625,
+          "tar": 0.99425
+        },
+        {
+          "threshold": 0.45,
+          "far": 0.017,
+          "tar": 0.986125
+        },
+        {
+          "threshold": 0.5,
+          "far": 0.005625,
+          "tar": 0.971125
+        },
+        {
+          "threshold": 0.55,
+          "far": 0.001125,
+          "tar": 0.945125
+        },
+        {
+          "threshold": 0.6,
+          "far": 0.0,
+          "tar": 0.9045
+        }
+      ],
+      "operating_band": [
+        {
+          "threshold": 0.2,
+          "far": 0.4955,
+          "tar": 1.0
+        },
+        {
+          "threshold": 0.25,
+          "far": 0.32725,
+          "tar": 0.99975
+        },
+        {
+          "threshold": 0.3,
+          "far": 0.196625,
+          "tar": 0.999625
+        },
+        {
+          "threshold": 0.35,
+          "far": 0.099125,
+          "tar": 0.9985
+        },
+        {
+          "threshold": 0.4,
+          "far": 0.041625,
+          "tar": 0.99425
+        }
+      ]
     }
   },
   "notes": [
@@ -257,6 +412,9 @@
     "rgb grant calibration pools the impostor and genuine cosine scores of all scored pairs across the four sets above; grant rule is score > threshold; far/tar fractions use strict inequality; grant_recommendation is the candidate threshold with realized FAR <= 1e-3 and the best TAR (lowest threshold on ties).",
     "cfpw protocol consumed: Protocol/Split/{FF,FP}/{01..10}/{same,diff}.txt with 350 same + 350 diff rows per fold per protocol; 'a,b' lines are 1-based image indices resolved through Pair_list_F.txt (5,000 frontal) and Pair_list_P.txt (2,000 profile); FF lines index the frontal list twice, FP lines are (frontal, profile); 500 identities asserted across both lists; folds are identity-separable per the shipped Readme, so acc10fold uses verification_metrics.ten_fold (per-fold optimal threshold on the fold itself, ties to lowest) and acc_sd is the population sd across the 10 folds.",
     "cfpw pose gap: compare rgb.cfpw.ff (frontal-frontal) with rgb.cfpw.fp (frontal-profile) accuracy and eer; images are wild (unaligned) photos embedded with the same detect + warp path as lfw; pairs with no detected face are skipped and counted (ff skipped=10, fp skipped=101).",
-    "cfpw scores are not pooled into threshold_calibration.rgb; that table stays frozen to its task 3 pool (lfw, agedb30, calfw, cplfw) and cfpw is reported alongside as the pose-gap evidence."
+    "cfpw scores are not pooled into threshold_calibration.rgb; that table stays frozen to its task 3 pool (lfw, agedb30, calfw, cplfw) and cfpw is reported alongside as the pose-gap evidence.",
+    "cbsr protocol consumed: gallery-groundtruth.txt (1,576 lines) and probe-groundtruth.txt (2,364 lines), 'name,lx,ly,rx,ry' per image; the split field of each ground-truth entry defines the gallery/probe membership and the name prefix before '-' the subject; verification pairs are seeded (seed 42): 3,000 genuine same-subject (gallery, probe) pairs and 3,000 impostor different-subject (gallery, probe) pairs over subjects present in both splits; preprocessing is the bench_nir_ext.py NIR path (YuNet largest-face 5-point warp, ground-truth two-eye similarity warp fallback keeps coverage at 100%); embeddings use the suite flip-TTA path, while the committed bench_nir_ext numbers used no TTA, so eers are not directly comparable.",
+    "oulu protocol is constructed, not canonical (no shipped pair list): identity is the P### subject across the Dark/Strong/Weak lighting trees; the sorted usable subject list splits into two disjoint halves, each contributing 2,500 genuine (same subject, different image, any lighting and emotion) and 2,500 impostor pairs under random.Random(seed 42), so acc10fold averages the two subject-disjoint fold halves; pairs with no detected face are skipped and counted.",
+    "nir grant calibration pools the impostor and genuine cosine scores of the cbsr and oulu pairs of this run; derivation matches rgb (smallest candidate threshold with realized FAR <= 1e-3, best TAR, lowest threshold on ties, strict inequality); the candidate sweep spans 0.2-0.6 because same-modality NIR evidence concentrates lower than RGB while the pooled impostor tail reaches past 0.5 (FAR 5.62e-03 at 0.5 on this run); operating_band lists FAR/TAR at 0.2-0.4, the realistic operating band of the recognition grant paths on NIR evidence; calibration-only evidence, no runtime change."
   ]
 }

--- a/benchmarks/results-recognition.json
+++ b/benchmarks/results-recognition.json
@@ -1,0 +1,188 @@
+{
+  "runtime": {
+    "host_model": "/home/archledger/irlume-bench/models/glintr100.onnx",
+    "model_sha256": "a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60",
+    "ort": "1.27.0",
+    "cuda": true,
+    "flip_tta": true,
+    "started_utc": "2026-08-29T13:57:23Z",
+    "wall_seconds": 919.4,
+    "per_set_seconds": {
+      "lfw": 142.5,
+      "bundle_lfw_crosscheck": 194.4,
+      "agedb30": 194.0,
+      "calfw": 194.0,
+      "cplfw": 194.0
+    }
+  },
+  "rgb": {
+    "lfw": {
+      "acc10fold": 0.9918333333333333,
+      "eer": 0.012666666666666666,
+      "tar_table": [
+        {
+          "far": 0.1,
+          "threshold": 0.13998645544052124,
+          "tar": 0.9933333333333333
+        },
+        {
+          "far": 0.03,
+          "threshold": 0.18320134282112122,
+          "tar": 0.9896666666666667
+        },
+        {
+          "far": 0.01,
+          "threshold": 0.2266618311405182,
+          "tar": 0.987
+        },
+        {
+          "far": 0.003,
+          "threshold": 0.25557735562324524,
+          "tar": 0.9846666666666667
+        },
+        {
+          "far": 0.001,
+          "threshold": 0.30397218465805054,
+          "tar": 0.976
+        }
+      ],
+      "pairs": 6000
+    },
+    "agedb30": {
+      "eer": 0.044,
+      "tar_table": [
+        {
+          "far": 0.1,
+          "threshold": 0.16937951743602753,
+          "tar": 0.9726666666666667
+        },
+        {
+          "far": 0.03,
+          "threshold": 0.21740920841693878,
+          "tar": 0.946
+        },
+        {
+          "far": 0.01,
+          "threshold": 0.2646714746952057,
+          "tar": 0.8916666666666667
+        },
+        {
+          "far": 0.003,
+          "threshold": 0.2996916174888611,
+          "tar": 0.8386666666666667
+        },
+        {
+          "far": 0.001,
+          "threshold": 0.3358559012413025,
+          "tar": 0.7546666666666667
+        }
+      ],
+      "acc_at_045": 0.6995,
+      "pairs": 6000
+    },
+    "calfw": {
+      "eer": 0.06633333333333333,
+      "tar_table": [
+        {
+          "far": 0.1,
+          "threshold": 0.17696551978588104,
+          "tar": 0.9426666666666667
+        },
+        {
+          "far": 0.03,
+          "threshold": 0.2342020869255066,
+          "tar": 0.9133333333333333
+        },
+        {
+          "far": 0.01,
+          "threshold": 0.2844330966472626,
+          "tar": 0.8773333333333333
+        },
+        {
+          "far": 0.003,
+          "threshold": 0.32392334938049316,
+          "tar": 0.8456666666666667
+        },
+        {
+          "far": 0.001,
+          "threshold": 0.343755304813385,
+          "tar": 0.8246666666666667
+        }
+      ],
+      "acc_at_045": 0.815,
+      "pairs": 6000
+    },
+    "cplfw": {
+      "eer": 0.11966666666666667,
+      "tar_table": [
+        {
+          "far": 0.1,
+          "threshold": 0.18139153718948364,
+          "tar": 0.8743333333333333
+        },
+        {
+          "far": 0.03,
+          "threshold": 0.23878023028373718,
+          "tar": 0.8166666666666667
+        },
+        {
+          "far": 0.01,
+          "threshold": 0.27155399322509766,
+          "tar": 0.7763333333333333
+        },
+        {
+          "far": 0.003,
+          "threshold": 0.3168729245662689,
+          "tar": 0.6956666666666667
+        },
+        {
+          "far": 0.001,
+          "threshold": 0.35672250390052795,
+          "tar": 0.6246666666666667
+        }
+      ],
+      "acc_at_045": 0.7053333333333334,
+      "pairs": 6000
+    }
+  },
+  "threshold_calibration": {
+    "rgb": {
+      "grant_recommendation": 0.35,
+      "far_at_grant": 0.0006666666666666666,
+      "table": [
+        {
+          "threshold": 0.3,
+          "far": 0.003833333333333333,
+          "tar": 0.8525833333333334
+        },
+        {
+          "threshold": 0.35,
+          "far": 0.0006666666666666666,
+          "tar": 0.7825
+        },
+        {
+          "threshold": 0.4,
+          "far": 8.333333333333333e-05,
+          "tar": 0.6929166666666666
+        },
+        {
+          "threshold": 0.45,
+          "far": 8.333333333333333e-05,
+          "tar": 0.5835
+        },
+        {
+          "threshold": 0.5,
+          "far": 8.333333333333333e-05,
+          "tar": 0.4685
+        }
+      ]
+    }
+  },
+  "notes": [
+    "lfw acc10fold uses verification_metrics.ten_fold (per-fold optimal threshold on the fold itself, ties to lowest threshold). The bench_faceid.py held-out-train-fold-threshold protocol gives 0.9902\u00b10.0038 on this run; the committed results-lfw.json continuity number 0.9903 used that protocol with the same auraface flip-TTA embedding path.",
+    "bundle coherence cross-check: the bundle's own aligned-LFW annotation (lfw_ann.txt, 6,000 pairs) through the identical embedding path gives eer=0.0067 and best-threshold accuracy 0.9948 on its 112x112 crops, vs eer=0.0127 for the deepfunneled detect+warp lane; the bundle data and the pipeline are consistent.",
+    "aligned sets (agedb30, calfw, cplfw): pre-aligned 112x112 crops embedded directly without detection; the shipped protocols define no folds, so each set reports acc_at_045 = verification_metrics.fold_accuracy at the fixed 0.45 line plus eer and tar_table; acc10fold is reported for lfw only.",
+    "aligned bundle annotations consumed: agedb_30_ann.txt, calfw_ann.txt, cplfw_ann.txt at the bundle root, label-first '<1|0> <img1> <img2>' format, 6,000 pairs (3,000 genuine / 3,000 impostor) per set, paths relative to the bundle root.",
+    "rgb grant calibration pools the impostor and genuine cosine scores of all scored pairs across the four sets above; grant rule is score > threshold; far/tar fractions use strict inequality; grant_recommendation is the candidate threshold with realized FAR <= 1e-3 and the best TAR (lowest threshold on ties)."
+  ]
+}

--- a/benchmarks/results-recognition.json
+++ b/benchmarks/results-recognition.json
@@ -5,14 +5,15 @@
     "ort": "1.27.0",
     "cuda": true,
     "flip_tta": true,
-    "started_utc": "2026-08-29T13:57:23Z",
-    "wall_seconds": 919.4,
+    "started_utc": "2026-08-29T14:26:15Z",
+    "wall_seconds": 132.9,
     "per_set_seconds": {
       "lfw": 142.5,
       "bundle_lfw_crosscheck": 194.4,
       "agedb30": 194.0,
       "calfw": 194.0,
-      "cplfw": 194.0
+      "cplfw": 194.0,
+      "cfpw": 132.4
     }
   },
   "rgb": {
@@ -143,6 +144,76 @@
       ],
       "acc_at_045": 0.7053333333333334,
       "pairs": 6000
+    },
+    "cfpw": {
+      "ff": {
+        "acc10fold": 0.9954240475345072,
+        "acc_sd": 0.003427871269124747,
+        "eer": 0.007153078164990466,
+        "tar_table": [
+          {
+            "far": 0.1,
+            "threshold": 0.14836134016513824,
+            "tar": 0.9974234182651016
+          },
+          {
+            "far": 0.03,
+            "threshold": 0.19883783161640167,
+            "tar": 0.9965645576868022
+          },
+          {
+            "far": 0.01,
+            "threshold": 0.23265235126018524,
+            "tar": 0.9945605496707701
+          },
+          {
+            "far": 0.003,
+            "threshold": 0.28206557035446167,
+            "tar": 0.988834812482107
+          },
+          {
+            "far": 0.001,
+            "threshold": 0.29740291833877563,
+            "tar": 0.9862582307472088
+          }
+        ],
+        "acc_at_045": 0.957653791130186,
+        "pairs": 6990
+      },
+      "fp": {
+        "acc10fold": 0.9601043907608677,
+        "acc_sd": 0.01068565456609313,
+        "eer": 0.04667343191263168,
+        "tar_table": [
+          {
+            "far": 0.1,
+            "threshold": 0.15008127689361572,
+            "tar": 0.9692664540446506
+          },
+          {
+            "far": 0.03,
+            "threshold": 0.1935785710811615,
+            "tar": 0.9394027254276602
+          },
+          {
+            "far": 0.01,
+            "threshold": 0.23861075937747955,
+            "tar": 0.895042041171354
+          },
+          {
+            "far": 0.003,
+            "threshold": 0.27218765020370483,
+            "tar": 0.8498115395766889
+          },
+          {
+            "far": 0.001,
+            "threshold": 0.3119370937347412,
+            "tar": 0.7755871267033922
+          }
+        ],
+        "acc_at_045": 0.6890853746919844,
+        "pairs": 6899
+      }
     }
   },
   "threshold_calibration": {
@@ -183,6 +254,9 @@
     "bundle coherence cross-check: the bundle's own aligned-LFW annotation (lfw_ann.txt, 6,000 pairs) through the identical embedding path gives eer=0.0067 and best-threshold accuracy 0.9948 on its 112x112 crops, vs eer=0.0127 for the deepfunneled detect+warp lane; the bundle data and the pipeline are consistent.",
     "aligned sets (agedb30, calfw, cplfw): pre-aligned 112x112 crops embedded directly without detection; the shipped protocols define no folds, so each set reports acc_at_045 = verification_metrics.fold_accuracy at the fixed 0.45 line plus eer and tar_table; acc10fold is reported for lfw only.",
     "aligned bundle annotations consumed: agedb_30_ann.txt, calfw_ann.txt, cplfw_ann.txt at the bundle root, label-first '<1|0> <img1> <img2>' format, 6,000 pairs (3,000 genuine / 3,000 impostor) per set, paths relative to the bundle root.",
-    "rgb grant calibration pools the impostor and genuine cosine scores of all scored pairs across the four sets above; grant rule is score > threshold; far/tar fractions use strict inequality; grant_recommendation is the candidate threshold with realized FAR <= 1e-3 and the best TAR (lowest threshold on ties)."
+    "rgb grant calibration pools the impostor and genuine cosine scores of all scored pairs across the four sets above; grant rule is score > threshold; far/tar fractions use strict inequality; grant_recommendation is the candidate threshold with realized FAR <= 1e-3 and the best TAR (lowest threshold on ties).",
+    "cfpw protocol consumed: Protocol/Split/{FF,FP}/{01..10}/{same,diff}.txt with 350 same + 350 diff rows per fold per protocol; 'a,b' lines are 1-based image indices resolved through Pair_list_F.txt (5,000 frontal) and Pair_list_P.txt (2,000 profile); FF lines index the frontal list twice, FP lines are (frontal, profile); 500 identities asserted across both lists; folds are identity-separable per the shipped Readme, so acc10fold uses verification_metrics.ten_fold (per-fold optimal threshold on the fold itself, ties to lowest) and acc_sd is the population sd across the 10 folds.",
+    "cfpw pose gap: compare rgb.cfpw.ff (frontal-frontal) with rgb.cfpw.fp (frontal-profile) accuracy and eer; images are wild (unaligned) photos embedded with the same detect + warp path as lfw; pairs with no detected face are skipped and counted (ff skipped=10, fp skipped=101).",
+    "cfpw scores are not pooled into threshold_calibration.rgb; that table stays frozen to its task 3 pool (lfw, agedb30, calfw, cplfw) and cfpw is reported alongside as the pose-gap evidence."
   ]
 }

--- a/benchmarks/tests/test_datasets.py
+++ b/benchmarks/tests/test_datasets.py
@@ -78,3 +78,41 @@ def test_new_landmark_and_ir_entries():
         assert spec.provenance_url
         assert spec.license_note
         assert spec.notes
+
+
+def test_new_recognition_entries():
+    lfw = get_dataset("lfw")
+    assert lfw.source == "kaggle"
+    assert lfw.repo == "jessicali9530/lfw-dataset"
+    assert lfw.files[0].path == "kaggle-archive.zip"
+    assert lfw.files[0].extract
+    assert lfw.files[0].size_hint_bytes == 112_000_000
+    cfpw = get_dataset("cfpw")
+    assert cfpw.source == "kaggle"
+    assert cfpw.repo == "chinafax/cfpw-dataset"
+    assert cfpw.files[0].path == "kaggle-archive.zip"
+    assert cfpw.files[0].extract
+    assert cfpw.files[0].size_hint_bytes == 86_000_000
+    bundle = get_dataset("aligned_fr_bundle")
+    assert bundle.source == "kaggle"
+    assert bundle.repo == (
+        "yakhyokhuja/agedb-30-calfw-cplfw-lfw-aligned-112x112"
+    )
+    assert bundle.files[0].path == "kaggle-archive.zip"
+    assert bundle.files[0].extract
+    assert bundle.files[0].size_hint_bytes == 1_400_000_000
+    for spec in (lfw, cfpw, bundle):
+        assert spec.provenance_url == (
+            "https://www.kaggle.com/datasets/" + spec.repo
+        )
+        assert "research" in spec.license_note.lower()
+        assert spec.notes
+    assert "deepfunneled" in lfw.notes
+    assert "verify" in lfw.notes.lower()
+    assert "verify" in cfpw.notes.lower()
+    assert "500" in cfpw.notes
+    assert "7000" in cfpw.notes
+    assert "honestly" in cfpw.notes.lower()
+    assert "112" in bundle.notes
+    assert "pair" in bundle.notes.lower()
+    assert "published-comparable" in bundle.notes

--- a/benchmarks/tests/test_verification_metrics.py
+++ b/benchmarks/tests/test_verification_metrics.py
@@ -1,0 +1,78 @@
+import pytest
+
+from verification_metrics import (
+    eer,
+    far_threshold_table,
+    fold_accuracy,
+    tar_at_far,
+    ten_fold,
+)
+
+
+def test_eer_separable_distributions_is_zero():
+    assert eer([0.8, 0.9, 0.95], [0.1, 0.2, 0.3]) == 0.0
+
+
+def test_eer_identical_distributions_is_half():
+    scores = [0.1 * i for i in range(1, 11)]
+    assert eer(scores, list(scores)) == pytest.approx(0.5)
+
+
+def test_eer_rejects_empty_inputs():
+    with pytest.raises(ValueError):
+        eer([], [0.1])
+    with pytest.raises(ValueError):
+        eer([0.1], [])
+
+
+def test_tar_at_far_exact_quantile():
+    genuine = [0.2, 0.35, 0.5, 0.9]
+    impostor = [0.1, 0.2, 0.3, 0.4]
+    assert tar_at_far(genuine, impostor, 0.25) == pytest.approx(0.75)
+    assert tar_at_far(genuine, impostor, 0.0) == pytest.approx(0.5)
+    assert tar_at_far(genuine, impostor, 0.5) == pytest.approx(0.75)
+    assert tar_at_far(genuine, impostor, 1.0) == pytest.approx(1.0)
+
+
+def test_tar_at_far_rejects_out_of_range_far():
+    with pytest.raises(ValueError):
+        tar_at_far([0.5], [0.1], -0.1)
+    with pytest.raises(ValueError):
+        tar_at_far([0.5], [0.1], 1.5)
+
+
+def test_far_threshold_table_rows():
+    genuine = [0.2, 0.35, 0.5, 0.9]
+    impostor = [0.1, 0.2, 0.3, 0.4]
+    rows = far_threshold_table(genuine, impostor, [0.0, 0.25, 1.0])
+    assert [r["far"] for r in rows] == [0.0, 0.25, 1.0]
+    assert rows[0]["threshold"] == pytest.approx(0.4)
+    assert rows[0]["tar"] == pytest.approx(0.5)
+    assert rows[1]["threshold"] == pytest.approx(0.3)
+    assert rows[1]["tar"] == pytest.approx(0.75)
+    assert rows[2]["threshold"] < min(impostor)
+    assert rows[2]["tar"] == pytest.approx(1.0)
+
+
+def test_fold_accuracy_exact_fractions():
+    pairs = [(0.9, 1), (0.8, 1), (0.2, 0), (0.3, 1)]
+    assert fold_accuracy(pairs, 0.5) == pytest.approx(0.75)
+    assert fold_accuracy([(0.5, 1)], 0.5) == pytest.approx(0.0)
+    assert fold_accuracy([(0.5, 0)], 0.5) == pytest.approx(1.0)
+
+
+def test_ten_fold_constructed_two_fold_case():
+    scores = [0.9, 0.1, 0.6, 0.2, 0.7]
+    labels = [1, 0, 1, 0, 0]
+    folds = [0, 0, 1, 1, 1]
+    out = ten_fold(scores, labels, folds)
+    assert out["per_fold"] == pytest.approx([1.0, 2.0 / 3.0])
+    assert out["acc10fold"] == pytest.approx(5.0 / 6.0)
+    assert out["sd"] == pytest.approx(1.0 / 6.0)
+
+
+def test_ten_fold_rejects_mismatched_lengths():
+    with pytest.raises(ValueError):
+        ten_fold([0.1, 0.2], [1], [0, 0])
+    with pytest.raises(ValueError):
+        ten_fold([], [], [])

--- a/benchmarks/verification_metrics.py
+++ b/benchmarks/verification_metrics.py
@@ -1,0 +1,115 @@
+"""Verification metrics for face recognition benchmarks.
+
+Conventions (Tasks 3-5 consume these exactly):
+- Scores are cosine similarities in [-1, 1]; genuine and impostor are
+  separate score lists over the pooled evaluation pairs.
+- FAR operating points use the impostor quantile: the threshold is the
+  k-th largest impostor score with k = floor(far * n) + 1, so the
+  realized impostor fraction strictly above the threshold is <= far.
+- TAR counts genuine scores strictly above the threshold.
+- Fold accuracy scores a pair positive when score > threshold (label 1
+  means genuine); a score equal to the threshold counts as negative.
+- ten_fold reports each fold's accuracy at that fold's optimal
+  threshold (the threshold maximizing the fold's accuracy; ties go to
+  the lowest threshold) plus the mean and population sd (ddof 0).
+"""
+
+import math
+
+
+def _far_threshold(scores_impostor: list[float], far: float) -> float:
+    if not scores_impostor:
+        raise ValueError("impostor scores must be non-empty")
+    if not 0.0 <= far <= 1.0:
+        raise ValueError(f"far must be in [0, 1], got {far}")
+    desc = sorted(scores_impostor, reverse=True)
+    k = math.floor(far * len(desc)) + 1
+    if k > len(desc):
+        return desc[-1] - 1.0
+    return desc[k - 1]
+
+
+def eer(scores_genuine: list[float], scores_impostor: list[float]) -> float:
+    """Equal error rate over the pooled similarity distributions."""
+    if not scores_genuine or not scores_impostor:
+        raise ValueError("eer requires non-empty genuine and impostor scores")
+    union = sorted(set(scores_genuine) | set(scores_impostor))
+    candidates = [union[0] - 1.0]
+    candidates.extend((a + b) / 2.0 for a, b in zip(union, union[1:]))
+    candidates.append(union[-1] + 1.0)
+    n_gen = len(scores_genuine)
+    n_imp = len(scores_impostor)
+    best_gap: float | None = None
+    best_eer = 0.0
+    for t in candidates:
+        far = sum(1 for s in scores_impostor if s >= t) / n_imp
+        frr = sum(1 for s in scores_genuine if s < t) / n_gen
+        gap = abs(far - frr)
+        if best_gap is None or gap < best_gap:
+            best_gap = gap
+            best_eer = (far + frr) / 2.0
+    return best_eer
+
+
+def tar_at_far(
+    scores_genuine: list[float], scores_impostor: list[float], far: float
+) -> float:
+    """Genuine fraction strictly above the impostor quantile at far."""
+    if not scores_genuine:
+        raise ValueError("genuine scores must be non-empty")
+    threshold = _far_threshold(scores_impostor, far)
+    above = sum(1 for s in scores_genuine if s > threshold)
+    return above / len(scores_genuine)
+
+
+def far_threshold_table(
+    scores_genuine: list[float],
+    scores_impostor: list[float],
+    fars: list[float],
+) -> list[dict]:
+    """Rows {"far": f, "threshold": t, "tar": v} for each requested far."""
+    if not scores_genuine:
+        raise ValueError("genuine scores must be non-empty")
+    rows = []
+    for f in fars:
+        t = _far_threshold(scores_impostor, f)
+        tar = sum(1 for s in scores_genuine if s > t) / len(scores_genuine)
+        rows.append({"far": f, "threshold": t, "tar": tar})
+    return rows
+
+
+def fold_accuracy(pairs: list[tuple[float, int]], threshold: float) -> float:
+    """Accuracy of score > threshold against labels (1 = genuine)."""
+    if not pairs:
+        raise ValueError("pairs must be non-empty")
+    correct = sum(
+        1 for score, label in pairs if (score > threshold) == (label == 1)
+    )
+    return correct / len(pairs)
+
+
+def ten_fold(
+    scores: list[float], labels: list[int], folds: list[int]
+) -> dict:
+    """Per-fold accuracy at the per-fold optimal threshold, mean and sd."""
+    if not (len(scores) == len(labels) == len(folds)):
+        raise ValueError("scores, labels and folds must have equal length")
+    if not scores:
+        raise ValueError("scores must be non-empty")
+    by_fold: dict[int, list[tuple[float, int]]] = {}
+    for score, label, fold in zip(scores, labels, folds):
+        by_fold.setdefault(fold, []).append((score, label))
+    per_fold = []
+    for fold in sorted(by_fold):
+        pairs = by_fold[fold]
+        candidates = sorted({score for score, _ in pairs})
+        best_acc = fold_accuracy(pairs, candidates[0] - 1.0)
+        for t in candidates:
+            acc = fold_accuracy(pairs, t)
+            if acc > best_acc:
+                best_acc = acc
+        per_fold.append(best_acc)
+    n = len(per_fold)
+    mean = sum(per_fold) / n
+    var = sum((v - mean) ** 2 for v in per_fold) / n
+    return {"acc10fold": mean, "sd": math.sqrt(var), "per_fold": per_fold}

--- a/docs/research/2026-08-30-recognition-phase2.md
+++ b/docs/research/2026-08-30-recognition-phase2.md
@@ -1,0 +1,210 @@
+# Recognition calibration, Phase 2
+
+- **What:** Phase 2 of the model calibration campaign: verification quality of the
+  shipped recognition model on RGB, CFP pose split, and NIR evidence, plus
+  threshold-to-FAR calibration per modality with grant recommendations. Model:
+  `glintr100.onnx` (fal AuraFace-v1, Apache-2.0, 512-d embeddings, cosine
+  scoring), sha256
+  `a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60`, flip TTA on.
+- **Where:** archhost, NVIDIA RTX 3060, ONNX Runtime 1.27.0 with the CUDA
+  execution provider, OpenCV 5.0.0. Embedding paths: the wild RGB sets reuse
+  `bench_faceid.py` exactly (YuNet detect, 5-point similarity warp to 112x112,
+  `(x - 127.5) / 128` normalization, flip TTA, L2 norm); the pre-aligned sets
+  embed their 112x112 crops directly with no detection; NIR reuses
+  `bench_nir_ext.py` preprocessing (YuNet largest-face 5-point warp, GT
+  two-eye similarity-warp fallback; 0 fallbacks needed on CBSR).
+- **When:** measurement runs 2026-08-29 UTC (runtime block `started_utc`
+  2026-08-29T14:55:02Z); report 2026-08-30.
+- **Sources (committed):** `benchmarks/results-recognition.json` (sha256
+  `c41c5e980b88df28ef489dc58ed1b7ec924dca82f233e8e511d652c975c723fa`),
+  produced by `benchmarks/bench_recog_suite.py` over
+  `benchmarks/verification_metrics.py`. Every number below is copied from that
+  file or from the committed README headlines referenced inline; values are
+  rounded to 4 decimals. Suite status at this tree: 62 passed.
+
+## 1. RGB track
+
+6,000 pairs per set. `acc10fold` (LFW only) uses the shipped 10-fold protocol
+with per-fold optimal threshold on the fold itself (ties to lowest); the
+aligned sets ship no folds, so their accuracy column is `acc@0.45`, the
+`fold_accuracy` at the fixed 0.45 line.
+
+| set | pairs | acc | eer | TAR@1e-1 | TAR@1e-2 | TAR@1e-3 |
+|---|---|---|---|---|---|---|
+| lfw (deepfunneled, detect+warp) | 6,000 | 0.9918 (acc10fold) | 0.0127 | 0.9933 | 0.9870 | 0.9760 |
+| agedb30 (aligned 112x112) | 6,000 | 0.6995 (acc@0.45) | 0.0440 | 0.9727 | 0.8917 | 0.7547 |
+| calfw (aligned 112x112) | 6,000 | 0.8150 (acc@0.45) | 0.0663 | 0.9427 | 0.8773 | 0.8247 |
+| cplfw (aligned 112x112) | 6,000 | 0.7053 (acc@0.45) | 0.1197 | 0.8743 | 0.7763 | 0.6247 |
+
+LFW continuity: the committed headline (`benchmarks/README.md`) is AuraFace
+99.03% 10-fold accuracy (`results-lfw-cascade.json`, held-out-train-fold
+threshold protocol), EER 1.37%. This run reuses the identical embedding path
+and reproduces it: held-out protocol 0.9902 +/- 0.0038 vs committed 0.9903,
+one pair of 6,000 differing (GPU run noise). The `ten_fold` semantics carried
+in the acc column (0.9918) sits slightly above the held-out protocol as
+expected. EER 0.0127 vs committed 0.0137 is consistent magnitude across runs.
+
+Alignment-lane crosscheck: the bundle's own aligned-112 LFW annotation
+(`lfw_ann.txt`, 6,000 pairs) pushed through the identical embedding path gives
+EER 0.0067 and best accuracy 0.9948, vs EER 0.0127 for the deepfunneled
+detect+warp lane. The bundle data and the irlume pipeline are consistent; the
+deepfunneled lane's deficit is the alignment variant, not a pipeline defect.
+
+Published-delta note: optimal-threshold accuracies on the aligned sets
+(0.9582 / 0.9422 / 0.8975 at thresholds 0.214 / 0.235 / 0.212, task-3
+investigation) run ~1.5-2.6pt under published ResNet100 ArcFace-class figures
+(AgeDB-30 ~98.1-98.4, CALFW ~95.5-96.1, CPLFW ~91.5-92.3). The shortfall is
+uniform and in the same direction on all three sets, genuine score
+distributions are sane, and the difficulty ordering (agedb30 < calfw < cplfw)
+matches the published pattern. Attributed to AuraFace retrain behavior:
+`glintr100` is a third-party retrain, not the published MS1MV3 weights, and
+the license-over-peak-accuracy tradeoff vs InsightFace buffalo (99.4% LFW,
+non-commercial) is already the committed position (`benchmarks/README.md`,
+`models/README.md`). Data+pipeline coherence is evidenced by the bundle-LFW
+crosscheck above; the w600k_r50 reference anchor was not runnable (absent from
+the measurement host; a new download was out of scope). The fixed 0.45 grant
+line sits far above this recognizer's optimal band (0.21-0.24) on these sets,
+which the calibration table in section 4 quantifies.
+
+## 2. CFP pose track (CFP-W, wild images, detect+warp)
+
+Shipped official protocol: `Protocol/Split/{FF,FP}/{01..10}` with 350 same +
+350 diff rows per fold per protocol; `a,b` indices resolved through
+`Pair_list_F.txt` (5,000 frontal) and `Pair_list_P.txt` (2,000 profile);
+500 identities asserted. Folds are identity-separable, so `ten_fold` applies
+directly.
+
+| protocol | pairs | acc10fold | sd | eer | acc@0.45 | TAR@1e-1 | TAR@1e-2 | TAR@1e-3 |
+|---|---|---|---|---|---|---|---|---|
+| ff (frontal-frontal) | 6,990 | 0.9954 | 0.0034 | 0.0072 | 0.9577 | 0.9974 | 0.9946 | 0.9883 |
+| fp (frontal-profile) | 6,899 | 0.9601 | 0.0107 | 0.0467 | 0.6891 | 0.9693 | 0.8950 | 0.7756 |
+
+Pose gap, stated plainly: profile costs ~3.5pt of acc10fold (0.9601 vs
+0.9954), raises EER from 0.72% to 4.67%, and drops TAR@1e-3 from 0.9883 to
+0.7756 under the identical embedding path. FP is the weakest RGB condition
+measured in this campaign, consistent with an RGB grant line tuned on
+cooperative frontal evidence.
+
+Detection-skip accounting: pairs with no detected face are skipped and
+counted, never silently dropped: 10 FF pairs and 101 FP pairs skipped (34
+wild images without a detectable face).
+
+## 3. NIR track
+
+CBSR: gallery/probe membership from the shipped ground truth
+(`gallery-groundtruth.txt`, 1,576 entries; `probe-groundtruth.txt`, 2,364);
+seeded (42) 3,000 genuine same-subject (gallery, probe) + 3,000 impostor
+different-subject pairs over the 197 subjects present in both splits; 3,940
+images, 0 GT-align fallbacks, 0 missing.
+
+Oulu: constructed protocol, not canonical (no shipped pair list): identity is
+the P### subject across the Dark/Strong/Weak lighting trees; 80 subjects; two
+subject-disjoint halves each contributing 2,500 genuine + 2,500 impostor
+pairs under `random.Random(42)`; 10,000 pairs, 0 skipped. `acc10fold` averages
+the two halves.
+
+| set | pairs | acc | eer | TAR@1e-1 | TAR@1e-2 | TAR@1e-3 |
+|---|---|---|---|---|---|---|
+| cbsr (gallery/probe, seed 42) | 6,000 | 0.9818 (acc@0.45) | 0.0083 | 0.9990 | 0.9920 | 0.9820 |
+| oulu (seeded 10k, seed 42) | 10,000 | 0.9883 +/- 0.0053 (acc10fold); 0.9862 (acc@0.45) | 0.0122 | 0.9994 | 0.9854 | 0.9522 |
+
+Comparability caveat vs the committed CBSR number: `benchmarks/README.md`
+records AuraFace CBSR EER 0.77% (`results-nir_results.json`). That figure used
+a different seeded pair-construction protocol and no flip TTA; this run's
+0.83% uses the gallery/probe protocol and the suite flip-TTA path. Consistent
+magnitude, different protocol: indicative context, not a continuity gate.
+
+Tufts-absent note: Tufts (request-form dataset; the Kaggle
+`kpvisionlab/tufts-face-database` entry is not the dataset per
+`benchmarks/README.md`) was not acquired this phase, so there is no
+unseen-faces NIR control here; NIR coverage rides on CBSR + Oulu. See
+limitations.
+
+## 4. Threshold calibration (calibration evidence only)
+
+Pooling rule: impostor and genuine cosine scores of the scored pairs, pooled
+across sets; grant rule is score > threshold with strict inequality;
+`grant_recommendation` is the smallest candidate threshold with realized
+FAR <= 1e-3 and the best TAR (lowest threshold on ties). CFPW scores are
+deliberately NOT pooled into the RGB table (frozen to the task-3 pool: lfw,
+agedb30, calfw, cplfw); CFPW stands alongside as pose-gap evidence. All of
+this section is calibration evidence; no runtime code changed.
+
+RGB (pooled 24,000 pairs from the four sets in section 1):
+
+| threshold | FAR | TAR |
+|---|---|---|
+| 0.30 | 3.833e-3 | 0.8526 |
+| 0.35 | 6.667e-4 | 0.7825 |
+| 0.40 | 8.333e-5 | 0.6929 |
+| 0.45 | 8.333e-5 | 0.5835 |
+| 0.50 | 8.333e-5 | 0.4685 |
+
+RGB grant recommendation: 0.35, realized FAR 6.67e-4, TAR 0.7825.
+
+NIR (pooled 8,000 genuine + 8,000 impostor from cbsr + oulu; candidate sweep
+extended to 0.2-0.6 because same-modality NIR evidence concentrates lower
+while the pooled impostor tail reaches past 0.5):
+
+| threshold | FAR | TAR |
+|---|---|---|
+| 0.20 | 4.955e-1 | 1.0000 |
+| 0.25 | 3.273e-1 | 0.9998 |
+| 0.30 | 1.966e-1 | 0.9996 |
+| 0.35 | 9.913e-2 | 0.9985 |
+| 0.40 | 4.163e-2 | 0.9942 |
+| 0.45 | 1.700e-2 | 0.9861 |
+| 0.50 | 5.625e-3 | 0.9711 |
+| 0.55 | 1.125e-3 | 0.9451 |
+| 0.60 | 0.0 | 0.9045 |
+
+NIR grant recommendation: 0.6, realized FAR 0.0, TAR 0.9045 (0.55 misses the
+1e-3 cap at 1.125e-3). The 0.2-0.4 rows above are also recorded as
+`operating_band`, the realistic operating band of the current grant paths on
+NIR evidence.
+
+Per-modality finding, stated as evidence: RGB-band thresholds (0.2-0.4)
+applied to the pooled NIR table give FAR 4.955e-1 down to 4.163e-2, i.e. a 4
+to 50 percent impostor grant rate, and no threshold in the RGB band meets the
+1e-3 FAR cap on NIR evidence. Conversely, the NIR grant line (0.6) sits above
+the entire RGB table (pooled RGB TAR is already 0.4685 at 0.5 and falls
+monotonically). A single cross-modality threshold is not viable on this
+evidence; per-modality thresholds or modality-aware gating is the Phase 4
+synthesis question.
+
+## 5. Limitations
+
+- Mirror provenance, per set (PROVENANCE.md + MANIFEST.sha256 recorded on the
+  measurement host): lfw from Kaggle `jessicali9530/lfw-dataset`
+  (deepfunneled-only mirror; 5,749 identities / 13,233 images verified); cfpw
+  from Kaggle `chinafax/cfpw-dataset` (full official protocol, 500 IDs, 7,000
+  FF + 7,000 FP pair lines); the aligned bundle from Kaggle
+  `yakhyokhuja/agedb-30-calfw-cplfw-lfw-aligned-112x112` (48,000 referenced
+  paths verified present); cbsr from Kaggle `gpreda/cbsr-nir-face-dataset`
+  and oulu from Kaggle `aryanbaibaswata/oulu-casia` (per
+  `benchmarks/README.md`). Mirror variance is real; figures are
+  mirror-as-measured.
+- The Oulu protocol is seeded and constructed (seed 42, two subject-disjoint
+  halves), not a canonical Oulu benchmark protocol; its numbers are not
+  comparable to published Oulu figures and exist to give irlume-sized NIR
+  operating evidence.
+- The CBSR protocol is likewise seeded (gallery/probe over the shipped GT)
+  and differs from the committed `bench_nir_ext.py` construction (see the
+  comparability caveat in section 3).
+- CFPW detection skips: 34 wild images had no detectable face (10 FF + 101 FP
+  pairs skipped, counted); the reported CFPW figures condition on detected
+  faces.
+- Tufts is absent (request-form acquisition; user decision pending). Tufts was
+  the clean unseen-faces NIR control in prior benches; this phase has no such
+  control, and CBSR/Oulu are also the sets the removed IR adapter trained on,
+  which is context the Tufts control would have disentangled.
+- The published-delta investigation ran without a reference-model anchor
+  (w600k_r50 absent from the measurement host); the conclusion rests on the
+  bundle-LFW crosscheck plus distribution and ordering checks.
+- Determinism: the pipeline is deterministic (task-3 rerun reproduced every
+  number; NIR lane run twice with identical metrics; CFP lane single run).
+
+## 6. Replacement candidates
+
+None evaluated this phase (per plan). Recognizer replacement candidates join
+the Phase 4 synthesis.

--- a/docs/research/2026-08-30-recognition-phase2.md
+++ b/docs/research/2026-08-30-recognition-phase2.md
@@ -76,18 +76,19 @@ directly.
 
 | protocol | pairs | acc10fold | sd | eer | acc@0.45 | TAR@1e-1 | TAR@1e-2 | TAR@1e-3 |
 |---|---|---|---|---|---|---|---|---|
-| ff (frontal-frontal) | 6,990 | 0.9954 | 0.0034 | 0.0072 | 0.9577 | 0.9974 | 0.9946 | 0.9883 |
+| ff (frontal-frontal) | 6,990 | 0.9954 | 0.0034 | 0.0072 | 0.9577 | 0.9974 | 0.9946 | 0.9863 |
 | fp (frontal-profile) | 6,899 | 0.9601 | 0.0107 | 0.0467 | 0.6891 | 0.9693 | 0.8950 | 0.7756 |
 
 Pose gap, stated plainly: profile costs ~3.5pt of acc10fold (0.9601 vs
-0.9954), raises EER from 0.72% to 4.67%, and drops TAR@1e-3 from 0.9883 to
+0.9954), raises EER from 0.72% to 4.67%, and drops TAR@1e-3 from 0.9863 to
 0.7756 under the identical embedding path. FP is the weakest RGB condition
 measured in this campaign, consistent with an RGB grant line tuned on
 cooperative frontal evidence.
 
 Detection-skip accounting: pairs with no detected face are skipped and
-counted, never silently dropped: 10 FF pairs and 101 FP pairs skipped (34
-wild images without a detectable face).
+counted, never silently dropped: 10 FF pairs and 101 FP pairs skipped (the
+verification run counted 34 undetected wild images; task-4 verification
+count, not a committed JSON field).
 
 ## 3. NIR track
 
@@ -191,9 +192,10 @@ synthesis question.
 - The CBSR protocol is likewise seeded (gallery/probe over the shipped GT)
   and differs from the committed `bench_nir_ext.py` construction (see the
   comparability caveat in section 3).
-- CFPW detection skips: 34 wild images had no detectable face (10 FF + 101 FP
-  pairs skipped, counted); the reported CFPW figures condition on detected
-  faces.
+- CFPW detection skips: the verification run counted 34 undetected wild
+  images (task-4 verification count, not a committed JSON field); 10 FF +
+  101 FP pairs skipped, counted. The reported CFPW figures condition on
+  detected faces.
 - Tufts is absent (request-form acquisition; user decision pending). Tufts was
   the clean unseen-faces NIR control in prior benches; this phase has no such
   control, and CBSR/Oulu are also the sets the removed IR adapter trained on,

--- a/docs/superpowers/plans/2026-08-30-model-calibration-phase2.md
+++ b/docs/superpowers/plans/2026-08-30-model-calibration-phase2.md
@@ -1,0 +1,126 @@
+# Model Calibration Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce the recognition calibration evidence: AuraFace (glintr100.onnx) verification accuracy, EER, TAR@FAR, and threshold-to-FAR calibration tables per modality on LFW, CFP(FW), AgeDB-30, CALFW, CPLFW (RGB) and CBSR + Oulu-CASIA NIR, through irlume's own embedding path.
+
+**Architecture:** New pure metrics module (`verification_metrics.py`) under TDD; one bench script (`bench_recog_suite.py`) with lanes per modality; registry + fetcher reuse from Phases 0-1. Execution on archhost in the established layout.
+
+**Tech Stack:** Same as Phases 0-1.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-model-calibration-campaign-design.md` (Recognition row).
+
+## Global Constraints
+
+- Zero em dashes (U+2014) everywhere; DCO trailer exactly `Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>`; GPG-signed commits (BLOCKED on pinentry timeout); no `--no-gpg-sign`.
+- Never print token values.
+- User gates every download. New sets: aligned-112 bundle (AgeDB-30 + CALFW + CPLFW + LFW aligned) ~1.4 GB Kaggle, CFPW ~86 MB Kaggle, LFW ~112 MB Kaggle. CBSR + Oulu NIR reuse the Phase 1 downloads.
+- The alignment/embedding path MUST reproduce what the committed benchmark numbers used: read `benchmarks/bench_faceid.py` and `benchmarks/bench_nir_ext.py` FIRST and reuse their pipeline (they produced results-lfw.json 99.03% and results-nir_results.json). If the old scripts' approach conflicts with irlume's current Rust pipeline, note the divergence in the report and follow the old scripts (continuity of the committed numbers).
+- Work on branch `calib/phase2` stacked on `calib/phase1`; after #599 merges, rebase `--onto origin/main <phase1-head>` (the Phase 1 pattern, clean skip expected).
+- archhost venv python: `/home/archledger/venvs/bench/bin/python`.
+
+## Dataset decisions (controller rulings, execute as written)
+
+- Aligned bundle: kaggle `yakhyokhuja/agedb-30-calfw-cplfw-lfw-aligned-112x112`, single ~1.4 GB archive containing AgeDB-30, CALFW, CPLFW, LFW in aligned 112x112 form WITH their standard pair lists. This lane gives published-comparable numbers (the standard protocol for these sets).
+- CFPW: kaggle `chinafax/cfpw-dataset` (~86 MB). VERIFY at extraction: 500 identities, frontal/profile structure, protocol folds. If the mirror is short of the official CFP protocol (7000 pairs, 10 folds), record the shortfall and score what exists, labeled honestly (reviewer precedent: mirror reality is recorded, never papered over).
+- LFW: kaggle `jessicali9530/lfw-dataset` (the benchmarks README's documented source). VERIFY it contains the deepfunneled alignment (the committed 99.03% is lfw-deepfunneled; the README warns alignment variants are not comparable). The archhost `~/datasets-recog/lfw` copy is an HF-style restructure (train/ + metadata.csv), NOT deepfunneled: do not reuse it. If the Kaggle mirror lacks deepfunneled, fetch the deepfunneled tarball from its canonical public source and record provenance accordingly.
+- Tufts NIR: the archhost copy is GONE (verified 2026-08-30) and Tufts is request-form gated. NIR cross-domain coverage rides on CBSR + Oulu this phase; Tufts returns only if the user re-requests it. Record this in the report.
+- NIR pairs: CBSR ships gallery/probe ground truth (verified in the Phase 1 download); Oulu has no canonical pair list, so build a seeded deterministic protocol (10,000 pairs: 5,000 genuine, 5,000 impostor, subject-disjoint folds) pinned in the report and reproducible from the seed.
+
+---
+
+### Task 1: Registry entries (3 datasets)
+
+**Files:**
+- Modify: `benchmarks/datasets.py`
+- Test: `benchmarks/tests/test_datasets.py`
+
+**Interfaces:**
+- Produces: `get_dataset` names `lfw`, `cfpw`, `aligned_fr_bundle`, all kaggle single-archive specs (`kaggle-archive.zip`).
+
+- [ ] **Step 1: Failing tests** (append): `test_new_recognition_entries` asserting the three refs above + required fields; `test_kaggle_specs_are_single_archive` already covers the invariant.
+- [ ] **Step 2: RED. Step 3: implement** (size hints: lfw 112_000_000, cfpw 86_000_000, aligned_fr_bundle 1_400_000_000; notes record: LFW must contain deepfunneled (verify at download), CFPW official protocol counts to verify, aligned bundle = published-comparable lane). **Step 4: GREEN** (suite + new). **Step 5: commit** `bench: recognition registry entries`.
+
+---
+
+### Task 2: Verification metrics (`verification_metrics.py`)
+
+**Files:**
+- Create: `benchmarks/verification_metrics.py`
+- Test: `benchmarks/tests/test_verification_metrics.py`
+
+**Interfaces:**
+- Produces (Task 3-5 consume):
+  - `eer(scores_genuine: list[float], scores_impostor: list[float]) -> float` (equal error rate over the pooled similarity distributions, cosine scores in [-1,1])
+  - `tar_at_far(scores_genuine, scores_impostor, far: float) -> float` (threshold = impostor quantile at FAR, TAR = genuine fraction above it)
+  - `far_threshold_table(scores_genuine, scores_impostor, fars: list[float]) -> list[dict]` rows {"far": f, "threshold": t, "tar": v}
+  - `fold_accuracy(pairs: list[tuple[float, int]], threshold: float) -> float` (accuracy of cosine > threshold vs label)
+  - `ten_fold(scores: list[float], labels: list[int], folds: list[int]) -> dict` (per-fold accuracy at the per-fold optimal threshold, mean and sd; the LFW-style protocol)
+- [ ] **Step 1: Failing tests** with hand-computed synthetic cases (separable distributions -> EER 0; identical distributions -> EER ~0.5; known quantile -> exact TAR; fold accuracy exact fractions).
+- [ ] **Step 2: RED. Step 3: implement. Step 4: GREEN** + full suite. **Step 5: commit** `bench: verification metrics module`.
+
+---
+
+### Task 3: RGB lane (`bench_recog_suite.py`)
+
+**Files:**
+- Create: `benchmarks/bench_recog_suite.py`
+- Create: `benchmarks/results-recognition.json` (committed output)
+
+**Interfaces:**
+- Consumes: verification_metrics.py, models dir (glintr100.onnx), the embedding/alignment approach from bench_faceid.py (READ IT FIRST, reuse its functions or copy its exact preprocessing)
+- Produces: schema `{"runtime": {...}, "rgb": {"lfw": {"acc10fold": f, "eer": f, "tar_table": [...], "pairs": 6000}, "agedb30": {...}, "calfw": {...}, "cplfw": {...}}, "threshold_calibration": {"rgb": {"grant_recommendation": f, "far_at_grant": f, "table": [...]}, "nir": {...}}, "notes": [...]}`
+
+- [ ] **Step 1: Write the lane**: load pairs from each set's shipped pair list (LFW pairs.txt 10-fold 6000; AgeDB-30/CALFW/CPLFW pair lists inside the aligned bundle), embed via the bench_faceid.py path, score cosine, run ten_fold + eer + far_threshold_table.
+- [ ] **Step 2: Local parse check, deploy, run on archhost** (the aligned bundle serves AgeDB-30/CALFW/CPLFW + the aligned-LFW cross-check; lfw deepfunneled serves the continuity number vs the committed 99.03%; expect the continuity number to land within run-to-run noise of 99.03 or EXPLAIN the delta in notes).
+- [ ] **Step 3: Sanity + commit** `bench: rgb recognition lane`.
+
+---
+
+### Task 4: CFP lane (frontal-profile)
+
+**Files:**
+- Modify: `benchmarks/bench_recog_suite.py` (add `--cfp` lane)
+
+**Interfaces:**
+- Produces: `rgb.cfpw` row (frontal-profile verification, 10 folds per the shipped protocol; accuracy + EER + TAR table; pose-gap analysis = error rate on frontal-profile vs frontal-frontal pairs)
+
+- [ ] **Step 1: Implement the CFPW protocol reader** (verify 500 IDs / folds at extraction; if short, score what exists with honest labeling). **Step 2: Run + merge into results JSON. Step 3: commit** `bench: cfp frontal-profile lane`.
+
+---
+
+### Task 5: NIR lane (CBSR + Oulu)
+
+**Files:**
+- Modify: `benchmarks/bench_recog_suite.py` (add `--nir` lane)
+- Modify: `benchmarks/results-recognition.json` (merge)
+
+**Interfaces:**
+- Produces: `nir.cbsr` row (gallery/probe per the shipped ground truth), `nir.oulu` row (seeded 10k-pair protocol), `threshold_calibration.nir` (grant/deny cosine thresholds per modality)
+
+- [ ] **Step 1: Implement**: CBSR gallery/probe per its ground-truth files; Oulu seeded protocol (document the seed + construction in JSON notes); NIR embedding path from bench_nir_ext.py. **Step 2: Run + merge. Step 3: commit** `bench: nir recognition lane with calibration tables`.
+
+---
+
+### Task 6: Downloads (USER GATE, before Task 3 runs)
+
+- [ ] **Step 1:** Ask per dataset: aligned bundle ~1.4 GB, CFPW ~86 MB, LFW ~112 MB (~1.6 GB total).
+- [ ] **Step 2:** Fetch + verify each on archhost (LFW deepfunneled present; CFPW protocol counts; aligned bundle pair lists present); MANIFEST + PROVENANCE per set.
+
+---
+
+### Task 7: Phase 2 report + calibration table
+
+**Files:**
+- Create: `docs/research/2026-08-30-recognition-phase2.md`
+
+- [ ] **Step 1:** Report: per-set table (acc/EER/TAR@1e-3/1e-2/1e-1), the threshold-to-FAR calibration tables per modality with grant/deny recommendations, continuity vs committed numbers (LFW 99.03, CBSR EER 0.77, Tufts-absent note), alignment-lane comparison note (deepfunneled vs aligned-112 vs irlume-pipeline), limitations (mirror provenance per set, seeded Oulu protocol).
+- [ ] **Step 2:** Zero em dashes, commit `docs: phase 2 recognition calibration report`.
+
+## Phase 2 exit criteria
+
+- results-recognition.json committed with rgb + cfpw + nir + threshold_calibration sections; report written; suite green; downloads gated + PROVENANCE'd; every recommendation traceable.
+
+## Out of scope for Phase 2
+
+- PAD tracks (Phase 3), threshold-change PRs and replacement candidates (Phase 4), Tufts re-acquisition (user decision).


### PR DESCRIPTION
## What

Phase 2 of the model calibration campaign (plan: `docs/superpowers/plans/2026-08-30-model-calibration-phase2.md`; Phase 1 landed in #599): verification quality of the shipped recognition model (`glintr100.onnx`, fal AuraFace-v1, Apache-2.0, sha256 `a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60`) on RGB, CFP pose, and NIR evidence, plus threshold-to-FAR calibration per modality with grant recommendations. Measurement evidence only; no runtime code changed. Bench suite 62/62 on this tree.

## Findings

**RGB** (LFW, AgeDB-30, CALFW, CPLFW): LFW 10-fold 0.9918, EER 0.0127, reproducing the committed AuraFace headline (held-out protocol 0.9902 with sd 0.0038 vs committed 0.9903, one pair of 6,000 differing). Optimal-threshold accuracies on the aligned sets run 1.5 to 2.6 points under published ResNet100 ArcFace-class figures, uniform in direction with matching difficulty ordering; attributed to the AuraFace retrain license-over-accuracy tradeoff. The bundle-LFW crosscheck (EER 0.0067 through the identical embedding path) exonerates the pipeline.

**CFP pose**: frontal to profile raises EER from 0.72% to 4.67% and drops TAR at 1e-3 from 0.9863; the pose gap is real on wild detect+warp evidence.

**NIR**: cbsr EER 0.0083, TAR at 1e-3 0.9820; oulu (seeded) EER 0.0122, TAR at 1e-3 0.9522.

**Threshold calibration** (grant rule: smallest threshold with realized FAR at or under 1e-3, best TAR on ties):

| track | grant line | realized FAR | TAR |
|---|---|---|---|
| RGB (pooled 24,000 pairs) | 0.35 | 6.67e-4 | 0.7825 |
| NIR (pooled 16,000 pairs) | 0.6 | 0.0 | 0.9045 |

The wired 0.45 line sits far above this recognizer's optimal band on the aligned sets (0.21 to 0.24), and 0.55 on NIR misses the cap (FAR 1.125e-3). Cross-modality: RGB-band thresholds (0.2 to 0.4) applied to pooled NIR evidence give FAR 4.955e-1 down to 4.163e-2, a 4 to 50 percent impostor grant rate; no RGB-band threshold meets 1e-3 on NIR, and the NIR 0.6 line sits above the entire RGB table. A single cross-modality threshold is not viable on this evidence; per-modality thresholds or modality-aware gating is the Phase 4 synthesis question.

## Sources and limitations

Committed evidence: `benchmarks/results-recognition.json` (sha256 `c41c5e980b88df28ef489dc58ed1b7ec924dca82f233e8e511d652c975c723fa`), report `docs/research/2026-08-30-recognition-phase2.md` (limitations in section 5: mirror provenance per set, seeded CBSR/Oulu protocols not comparable to published figures, 101 FP plus 10 FF CFPW pairs skipped on undetected faces, Tufts control absent pending acquisition decision, no reference-model anchor for the published-delta investigation). Determinism: task-3 rerun reproduced every number; the NIR lane ran twice with identical metrics.
