### PR TITLE
bench: PAD calibration phase 3 (RGB ViT, IR FLIR, wired lines kept)

### DIFF
--- a/benchmarks/bench_pad_ir.py
+++ b/benchmarks/bench_pad_ir.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""IR PAD lane for the calibration campaign: CBSR NIR and Oulu-CASIA NIR
+through the shipped FLIR chain.
+
+Chain replicates PadIr::p_fake exactly (irlume-vision/src/lib.rs 1516+,
+crates/irlume-auth/src/lib.rs:358-364 IR_PAD_THRESHOLD = 0.9): face box ->
+expand by 16/112 per side (integer math) clamped to the frame -> square the
+crop about its center (clamped; xo/yo re-center the clamped region) -> sample
+the 112 center of a virtual 128 square (scale = dst/128, cv2 INTER_LINEAR
+convention) -> 127 gray fill outside the crop -> (px-127.5)/128, NCHW
+1x3x112x112 -> two logits -> P(fake) = softmax index 0. IR frames are
+luma-replicated (Grey8View convention; cv2.IMREAD_COLOR on grayscale sources
+yields equal channels, so channel 0 carries the luma).
+
+Score semantics are pad_score.py: s = P(spoof); a genuine frame is FLAGGED
+when s >= 0.9 (the BPCER side of the wired deny line).
+
+CONTROLLER SCOPE RULING: no IR attack data exists on disk, so this lane
+measures the GENUINE-side flag rate at the wired flir line:
+flagged_rate_at_wired = fraction of scored genuine frames with
+P(fake) >= 0.9, NOT attack TPR (the brief's tpr_at_wired key is replaced
+accordingly). Attack-side IR evidence remains the fleet/banner measurements
+(docs/pad-results/2026-07-17-third-party-pad-candidates.md; models/README.md
+flir row), a spec-honest limitation recorded in notes.
+
+Detection: shipped YuNet at the operating point (640 square letterbox,
+score 0.6), best detection = highest score (column 14), same decode as
+bench_detection_wider.py --ap (the bench_detection_ir.py convention on
+IR-grey frames).
+
+Dataset walks (both BONA FIDE only; ALL subjects, no stride cap):
+  CBSR NIR: flat sorted walk of every .bmp under the root (the mirror nests
+  the frames one level under NIR_face_dataset; subjects are encoded in the
+  filename prefix; the gallery groundtruth file is not consulted). This
+  supersedes the 197-identity revalidation sample in models/README.md.
+  Oulu-CASIA NIR: sorted recursive walk of every .jpeg under NI/ only,
+  grouped by the lighting directory name (Dark/Strong/Weak); the VL/ RGB
+  counterpart is not walked. The Dark rows are the money numbers: the
+  dim-strobe genuine failure regime the fleet work documented.
+
+Usage (archhost; sequential runs merge into one results JSON):
+  bench_pad_ir.py --models-dir M --cbsr-root D --set cbsr --out R
+  bench_pad_ir.py --models-dir M --oulu-root D --set oulu --out R
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+from letterbox import letterbox_image, restore_boxes
+
+OP_INPUT = 640
+OP_SCORE = 0.6
+YUNET_MODEL = "face_detection_yunet_2023mar.onnx"
+FLIR_MODEL = "flir.onnx"
+IR_THRESHOLD = 0.9
+SWEEP = (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99)
+PAD = 16
+OUT_SIZE = 112
+MODEL_SQUARE = 128
+CROP_MARGIN = 8
+
+
+def collect_files(root: Path, exts: tuple[str, ...]) -> list[Path]:
+    return sorted(
+        p for p in root.rglob("*")
+        if p.is_file() and p.suffix.lower() in exts
+    )
+
+
+def best_face(det, img: "np.ndarray") -> list[float] | None:
+    """YuNet at the 640 letterbox operating point; returns the best
+    detection's [x1, y1, x2, y2] in original pixels, or None."""
+    canvas, params = letterbox_image(img, OP_INPUT)
+    _, faces = det.detect(canvas)
+    if faces is None or len(faces) == 0:
+        return None
+    h, w = img.shape[:2]
+    best_idx = int(np.argmax(faces[:, 14]))
+    f = faces[best_idx]
+    return restore_boxes(
+        [[float(f[0]), float(f[1]), float(f[0] + f[2]), float(f[1] + f[3])]],
+        params, w, h,
+    )[0]
+
+
+def pad_ir_input(gray: "np.ndarray", bbox: list[float]) -> "np.ndarray":
+    """PadIr::p_fake preprocessing on a luma plane; returns the
+    1x3x112x112 float32 tensor. bbox is [x1, y1, x2, y2] in frame pixels
+    (truncated to integers exactly as the Rust f32 -> i64 casts)."""
+    h, w = gray.shape
+    b = [int(v) for v in bbox]
+    px = (b[2] - b[0] + 1) * PAD // OUT_SIZE
+    py = (b[3] - b[1] + 1) * PAD // OUT_SIZE
+    b = [
+        max(0, b[0] - px),
+        max(0, b[1] - py),
+        min(w - 1, b[2] + px),
+        min(h - 1, b[3] + py),
+    ]
+    pw = b[2] - b[0] + 1
+    ph = b[3] - b[1] + 1
+    if pw > ph:
+        off = (pw - ph) // 2
+        b[1] = max(0, b[1] - off)
+        b[3] = min(h - 1, b[1] + pw - 1)
+        dst = pw
+    else:
+        off = (ph - pw) // 2
+        b[0] = max(0, b[0] - off)
+        b[2] = min(w - 1, b[0] + ph - 1)
+        dst = ph
+    # Crop offsets center the (possibly clamped) region in the square.
+    xo = (dst - (b[2] - b[0] + 1)) // 2
+    yo = (dst - (b[3] - b[1] + 1)) // 2
+    scale = dst / MODEL_SQUARE
+    oy, ox = np.mgrid[0:OUT_SIZE, 0:OUT_SIZE]
+    fx = (ox + CROP_MARGIN + 0.5) * scale - 0.5 - xo + b[0]
+    fy = (oy + CROP_MARGIN + 0.5) * scale - 0.5 - yo + b[1]
+    outside = (
+        (fx < b[0] - 0.5) | (fy < b[1] - 0.5)
+        | (fx > b[2] + 0.5) | (fy > b[3] + 0.5)
+    )
+    x0 = np.floor(fx).astype(np.int64)
+    y0 = np.floor(fy).astype(np.int64)
+    dx = fx - x0
+    dy = fy - y0
+    x0c = np.clip(x0, 0, w - 1)
+    x1c = np.clip(x0 + 1, 0, w - 1)
+    y0c = np.clip(y0, 0, h - 1)
+    y1c = np.clip(y0 + 1, 0, h - 1)
+    g = gray.astype(np.float32)
+    top = g[y0c, x0c] * (1.0 - dx) + g[y0c, x1c] * dx
+    bot = g[y1c, x0c] * (1.0 - dx) + g[y1c, x1c] * dx
+    sampled = top * (1.0 - dy) + bot * dy
+    vals = np.where(outside, 127.0, sampled)
+    plane = ((vals - 127.5) * 0.0078125).astype(np.float32)
+    return np.stack([plane, plane, plane])[np.newaxis]
+
+
+class FlirScorer:
+    """The shipped FLIR PAD cue: 112x112x3, (px-127.5)/128, NCHW,
+    P(fake) = softmax index 0."""
+
+    def __init__(self, models_dir: Path):
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        available = ort.get_available_providers()
+        providers = [p for p in providers if p in available] or ["CPUExecutionProvider"]
+        self.sess = ort.InferenceSession(str(models_dir / FLIR_MODEL), providers=providers)
+        self.input_name = self.sess.get_inputs()[0].name
+
+    def score(self, tensor: "np.ndarray") -> float:
+        logits = self.sess.run(None, {self.input_name: tensor})[0][0]
+        e = np.exp(logits - logits.max())
+        return float((e / e.sum())[0])  # softmax index 0 = P(fake)
+
+
+def flagged_rate(scores: list[float], thr: float) -> float:
+    if not scores:
+        return 0.0
+    return sum(1 for s in scores if s >= thr) / len(scores)
+
+
+def sweep_rows(scores: list[float]) -> list[dict]:
+    return [
+        {"threshold": thr, "flagged_rate": flagged_rate(scores, thr)}
+        for thr in SWEEP
+    ]
+
+
+def score_stats(scores: list[float]) -> tuple[float, float]:
+    if not scores:
+        return 0.0, 0.0
+    arr = np.asarray(scores, dtype=np.float64)
+    return float(np.percentile(arr, 50)), float(np.percentile(arr, 10))
+
+
+def merge_section(args, key: str, section: dict, notes: list[str]) -> None:
+    result = {}
+    if args.out.exists():
+        try:
+            result = json.loads(args.out.read_text())
+        except json.JSONDecodeError:
+            result = {}
+    result["runtime"] = {
+        "ort_version": ort.__version__,
+        "providers": ort.get_available_providers(),
+        "cv2_version": cv2.__version__,
+    }
+    result["wired"] = {
+        "flir_threshold": IR_THRESHOLD,
+        "rationale": (
+            "irlume-auth/src/lib.rs:358-364: IR_PAD_THRESHOLD 0.9 is the "
+            "measured deny-only operating point (highest genuine 0.702, "
+            "banner attack floor 0.941); models/README.md flir row: "
+            "deny-only at 0.9, revalidated 0/3,940 above the line on CBSR "
+            "850nm at 197 identities"
+        ),
+    }
+    result[key] = section
+    result["notes"] = list(result.get("notes", [])) + notes
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps({k: v for k, v in section.items() if k != "per_lighting"}, default=str))
+    print(f"merged {key} into {args.out}", flush=True)
+
+
+def run_group(
+    det, flir: FlirScorer, files: list[Path], tag: str
+) -> list[float]:
+    scores: list[float] = []
+    t0 = time.time()
+    for i, path in enumerate(files, 1):
+        img = cv2.imread(str(path), cv2.IMREAD_COLOR)
+        if img is None:
+            continue
+        box = best_face(det, img)
+        if box is None:
+            continue
+        scores.append(flir.score(pad_ir_input(img[:, :, 0], box)))
+        if i % 500 == 0:
+            print(f"[{tag}] {i}/{len(files)} frames", flush=True)
+    print(
+        f"[{tag}] {len(scores)} scored in {time.time() - t0:.1f}s",
+        flush=True,
+    )
+    return scores
+
+
+def run_cbsr(args, det, flir) -> None:
+    t0 = time.time()
+    files = collect_files(args.cbsr_root, (".bmp",))
+    if not files:
+        raise SystemExit(f"error: no .bmp frames under {args.cbsr_root}")
+    scores = run_group(det, flir, files, "cbsr")
+    p50, p10 = score_stats(scores)
+    section = {
+        "frames": len(files),
+        "scored": len(scores),
+        "flagged_rate_at_wired": flagged_rate(scores, IR_THRESHOLD),
+        "score_p50": p50,
+        "score_p10": p10,
+        "threshold_sweep": sweep_rows(scores),
+        "wall_s": round(time.time() - t0, 1),
+    }
+    notes = [
+        (
+            "CONTROLLER SCOPE RULING: no IR attack data exists on disk, so "
+            "this lane measures the GENUINE-side flag rate at the wired "
+            "flir deny line: flagged_rate_at_wired = fraction of scored "
+            "genuine frames with P(fake) >= 0.9 (the BPCER side of the "
+            "deny line), NOT attack TPR; the brief's tpr_at_wired schema "
+            "key is replaced accordingly. Attack-side IR evidence remains "
+            "the fleet/banner measurements (models/README.md flir row: "
+            "122/123 banner frames flagged; "
+            "docs/pad-results/2026-07-17-third-party-pad-candidates.md), "
+            "a spec-honest limitation of this lane."
+        ),
+        (
+            "cbsr: flat sorted walk of ALL .bmp frames under the root (the "
+            "mirror nests the frames one level under NIR_face_dataset); "
+            "subjects are encoded in the filename prefix and ALL subjects "
+            "are included (supersedes the 197-identity revalidation sample "
+            "in models/README.md); the gallery groundtruth file is not "
+            "consulted; flagged_rate_at_wired denominators are scored "
+            "frames (YuNet detection at the operating point required)."
+        ),
+        (
+            "cbsr finding: 1/3,940 scored frames flagged at the wired 0.9 "
+            "line (sweep 2/3,940 at 0.5, 0 at 0.99; score_p50 2.2e-06), "
+            "consistent with the committed 197-identity revalidation "
+            "(models/README.md: 0/3,940 above the line at lit frames)."
+        ),
+    ]
+    merge_section(args, "cbsr", section, notes)
+
+
+def run_oulu(args, det, flir) -> None:
+    t0 = time.time()
+    ni = args.oulu_root / "NI"
+    if not ni.is_dir():
+        raise SystemExit(f"error: missing NI/ under {args.oulu_root}")
+    files = collect_files(ni, (".jpg", ".jpeg"))
+    if not files:
+        raise SystemExit(f"error: no jpg frames under {ni}")
+    by_lighting: dict[str, list[Path]] = {}
+    for p in files:
+        by_lighting.setdefault(p.relative_to(ni).parts[0], []).append(p)
+    per_lighting = []
+    all_scores: list[float] = []
+    tot_frames = 0
+    for lighting in sorted(by_lighting):
+        scores = run_group(det, flir, by_lighting[lighting], f"oulu-{lighting}")
+        p50, p10 = score_stats(scores)
+        per_lighting.append(
+            {
+                "lighting": lighting,
+                "frames": len(by_lighting[lighting]),
+                "scored": len(scores),
+                "flagged_rate_at_wired": flagged_rate(scores, IR_THRESHOLD),
+                "score_p50": p50,
+                "score_p10": p10,
+            }
+        )
+        tot_frames += len(by_lighting[lighting])
+        all_scores.extend(scores)
+    p50, p10 = score_stats(all_scores)
+    section = {
+        "per_lighting": per_lighting,
+        "overall": {
+            "frames": tot_frames,
+            "scored": len(all_scores),
+            "flagged_rate_at_wired": flagged_rate(all_scores, IR_THRESHOLD),
+            "score_p50": p50,
+            "score_p10": p10,
+            "threshold_sweep": sweep_rows(all_scores),
+        },
+        "wall_s": round(time.time() - t0, 1),
+    }
+    notes = [
+        (
+            "oulu: sorted recursive walk of ALL .jpeg frames under NI only "
+            "(70 Thumbs.db files excluded), grouped by the lighting "
+            "directory name (Dark/Strong/Weak); the VL/ RGB counterpart is "
+            "not walked; flagged_rate_at_wired denominators are scored "
+            "frames (YuNet detection at the operating point required)."
+        ),
+        (
+            "oulu finding: the dim-lighting hypothesis is NOT confirmed at "
+            "the wired line. Dark never crosses 0.9 (0/10,782; widest "
+            "sub-threshold tail of the three lightings: 59 frames >= 0.1, "
+            "max 0.8204); the only wired-line flags are 4/10,379 Strong "
+            "frames concentrated in two subjects (P049 Disgust 010-012, "
+            "P012 Happiness 017; max 0.9606); Weak 0/10,834. The fleet "
+            "dim-strobe genuine failure regime (models/README.md) does not "
+            "reproduce at frame level on this mirror through this chain "
+            "and remains fleet-measurement evidence."
+        ),
+    ]
+    merge_section(args, "oulu", section, notes)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models-dir", type=Path, required=True)
+    ap.add_argument("--cbsr-root", type=Path)
+    ap.add_argument("--oulu-root", type=Path)
+    ap.add_argument("--set", choices=("cbsr", "oulu"), required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args(argv)
+    if args.set == "cbsr" and not args.cbsr_root:
+        raise SystemExit("error: --set cbsr needs --cbsr-root")
+    if args.set == "oulu" and not args.oulu_root:
+        raise SystemExit("error: --set oulu needs --oulu-root")
+    det = cv2.FaceDetectorYN_create(
+        str(args.models_dir / YUNET_MODEL),
+        "",
+        (OP_INPUT, OP_INPUT),
+        score_threshold=OP_SCORE,
+    )
+    flir = FlirScorer(args.models_dir)
+    if args.set == "cbsr":
+        run_cbsr(args, det, flir)
+    else:
+        run_oulu(args, det, flir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_pad_ir.py
+++ b/benchmarks/bench_pad_ir.py
@@ -60,7 +60,7 @@ OP_SCORE = 0.6
 YUNET_MODEL = "face_detection_yunet_2023mar.onnx"
 FLIR_MODEL = "flir.onnx"
 IR_THRESHOLD = 0.9
-SWEEP = (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99)
+SWEEP = (0.1, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99)
 PAD = 16
 OUT_SIZE = 112
 MODEL_SQUARE = 128
@@ -119,28 +119,34 @@ def pad_ir_input(gray: "np.ndarray", bbox: list[float]) -> "np.ndarray":
     # Crop offsets center the (possibly clamped) region in the square.
     xo = (dst - (b[2] - b[0] + 1)) // 2
     yo = (dst - (b[3] - b[1] + 1)) // 2
-    scale = dst / MODEL_SQUARE
+    scale = np.float32(dst) / np.float32(MODEL_SQUARE)
     oy, ox = np.mgrid[0:OUT_SIZE, 0:OUT_SIZE]
-    fx = (ox + CROP_MARGIN + 0.5) * scale - 0.5 - xo + b[0]
-    fy = (oy + CROP_MARGIN + 0.5) * scale - 0.5 - yo + b[1]
+    sqx = (ox + CROP_MARGIN).astype(np.float32) + np.float32(0.5)
+    sqy = (oy + CROP_MARGIN).astype(np.float32) + np.float32(0.5)
+    sqx = sqx * scale - np.float32(0.5)
+    sqy = sqy * scale - np.float32(0.5)
+    fx = sqx - np.float32(xo) + np.float32(b[0])
+    fy = sqy - np.float32(yo) + np.float32(b[1])
     outside = (
-        (fx < b[0] - 0.5) | (fy < b[1] - 0.5)
-        | (fx > b[2] + 0.5) | (fy > b[3] + 0.5)
+        (fx < np.float32(b[0]) - np.float32(0.5))
+        | (fy < np.float32(b[1]) - np.float32(0.5))
+        | (fx > np.float32(b[2]) + np.float32(0.5))
+        | (fy > np.float32(b[3]) + np.float32(0.5))
     )
-    x0 = np.floor(fx).astype(np.int64)
-    y0 = np.floor(fy).astype(np.int64)
-    dx = fx - x0
-    dy = fy - y0
+    x0 = np.floor(fx).astype(np.int32)
+    y0 = np.floor(fy).astype(np.int32)
+    dx = fx - x0.astype(np.float32)
+    dy = fy - y0.astype(np.float32)
     x0c = np.clip(x0, 0, w - 1)
     x1c = np.clip(x0 + 1, 0, w - 1)
     y0c = np.clip(y0, 0, h - 1)
     y1c = np.clip(y0 + 1, 0, h - 1)
     g = gray.astype(np.float32)
-    top = g[y0c, x0c] * (1.0 - dx) + g[y0c, x1c] * dx
-    bot = g[y1c, x0c] * (1.0 - dx) + g[y1c, x1c] * dx
-    sampled = top * (1.0 - dy) + bot * dy
-    vals = np.where(outside, 127.0, sampled)
-    plane = ((vals - 127.5) * 0.0078125).astype(np.float32)
+    top = g[y0c, x0c] * (np.float32(1.0) - dx) + g[y0c, x1c] * dx
+    bot = g[y1c, x0c] * (np.float32(1.0) - dx) + g[y1c, x1c] * dx
+    sampled = top * (np.float32(1.0) - dy) + bot * dy
+    vals = np.where(outside, np.float32(127.0), sampled)
+    plane = ((vals - np.float32(127.5)) * np.float32(0.0078125)).astype(np.float32)
     return np.stack([plane, plane, plane])[np.newaxis]
 
 
@@ -187,6 +193,7 @@ def merge_section(args, key: str, section: dict, notes: list[str]) -> None:
         try:
             result = json.loads(args.out.read_text())
         except json.JSONDecodeError:
+            print(f"warning: {args.out} is not valid JSON, resetting", flush=True)
             result = {}
     result["runtime"] = {
         "ort_version": ort.__version__,
@@ -211,25 +218,36 @@ def merge_section(args, key: str, section: dict, notes: list[str]) -> None:
 
 
 def run_group(
-    det, flir: FlirScorer, files: list[Path], tag: str
-) -> list[float]:
+    det, flir: FlirScorer, files: list[Path], tag: str, rel_root: Path
+) -> tuple[list[float], list[dict], int, int]:
     scores: list[float] = []
+    flagged: list[dict] = []
+    read_failures = 0
+    detect_failures = 0
     t0 = time.time()
     for i, path in enumerate(files, 1):
         img = cv2.imread(str(path), cv2.IMREAD_COLOR)
         if img is None:
+            read_failures += 1
             continue
         box = best_face(det, img)
         if box is None:
+            detect_failures += 1
             continue
-        scores.append(flir.score(pad_ir_input(img[:, :, 0], box)))
+        s = flir.score(pad_ir_input(img[:, :, 0], box))
+        scores.append(s)
+        if s >= IR_THRESHOLD:
+            flagged.append(
+                {"path": str(path.relative_to(rel_root)), "score": s}
+            )
         if i % 500 == 0:
             print(f"[{tag}] {i}/{len(files)} frames", flush=True)
     print(
-        f"[{tag}] {len(scores)} scored in {time.time() - t0:.1f}s",
+        f"[{tag}] {len(scores)} scored ({read_failures} read failures, "
+        f"{detect_failures} detect failures) in {time.time() - t0:.1f}s",
         flush=True,
     )
-    return scores
+    return scores, flagged, read_failures, detect_failures
 
 
 def run_cbsr(args, det, flir) -> None:
@@ -237,14 +255,20 @@ def run_cbsr(args, det, flir) -> None:
     files = collect_files(args.cbsr_root, (".bmp",))
     if not files:
         raise SystemExit(f"error: no .bmp frames under {args.cbsr_root}")
-    scores = run_group(det, flir, files, "cbsr")
+    scores, flagged, read_fail, detect_fail = run_group(
+        det, flir, files, "cbsr", args.cbsr_root
+    )
     p50, p10 = score_stats(scores)
     section = {
         "frames": len(files),
         "scored": len(scores),
+        "read_failures": read_fail,
+        "detect_failures": detect_fail,
         "flagged_rate_at_wired": flagged_rate(scores, IR_THRESHOLD),
         "score_p50": p50,
         "score_p10": p10,
+        "score_max": max(scores) if scores else 0.0,
+        "flagged_frames": flagged,
         "threshold_sweep": sweep_rows(scores),
         "wall_s": round(time.time() - t0, 1),
     }
@@ -293,31 +317,47 @@ def run_oulu(args, det, flir) -> None:
         by_lighting.setdefault(p.relative_to(ni).parts[0], []).append(p)
     per_lighting = []
     all_scores: list[float] = []
+    all_flagged: list[dict] = []
+    tot_read_fail = 0
+    tot_detect_fail = 0
     tot_frames = 0
     for lighting in sorted(by_lighting):
-        scores = run_group(det, flir, by_lighting[lighting], f"oulu-{lighting}")
+        scores, flagged, read_fail, detect_fail = run_group(
+            det, flir, by_lighting[lighting], f"oulu-{lighting}", ni
+        )
         p50, p10 = score_stats(scores)
         per_lighting.append(
             {
                 "lighting": lighting,
                 "frames": len(by_lighting[lighting]),
                 "scored": len(scores),
+                "read_failures": read_fail,
+                "detect_failures": detect_fail,
                 "flagged_rate_at_wired": flagged_rate(scores, IR_THRESHOLD),
                 "score_p50": p50,
                 "score_p10": p10,
+                "score_max": max(scores) if scores else 0.0,
+                "threshold_sweep": sweep_rows(scores),
             }
         )
         tot_frames += len(by_lighting[lighting])
+        tot_read_fail += read_fail
+        tot_detect_fail += detect_fail
         all_scores.extend(scores)
+        all_flagged.extend(flagged)
     p50, p10 = score_stats(all_scores)
     section = {
         "per_lighting": per_lighting,
         "overall": {
             "frames": tot_frames,
             "scored": len(all_scores),
+            "read_failures": tot_read_fail,
+            "detect_failures": tot_detect_fail,
             "flagged_rate_at_wired": flagged_rate(all_scores, IR_THRESHOLD),
             "score_p50": p50,
             "score_p10": p10,
+            "score_max": max(all_scores) if all_scores else 0.0,
+            "flagged_frames": all_flagged,
             "threshold_sweep": sweep_rows(all_scores),
         },
         "wall_s": round(time.time() - t0, 1),
@@ -336,7 +376,10 @@ def run_oulu(args, det, flir) -> None:
             "sub-threshold tail of the three lightings: 59 frames >= 0.1, "
             "max 0.8204); the only wired-line flags are 4/10,379 Strong "
             "frames concentrated in two subjects (P049 Disgust 010-012, "
-            "P012 Happiness 017; max 0.9606); Weak 0/10,834. The fleet "
+            "P012 Happiness 017; max 0.9606); Weak 0/10,834. Every figure "
+            "in this note is a committed field: per_lighting "
+            "threshold_sweep at 0.1, per_lighting score_max, and the "
+            "flagged_frames list. The fleet "
             "dim-strobe genuine failure regime (models/README.md) does not "
             "reproduce at frame level on this mirror through this chain "
             "and remains fleet-measurement evidence."

--- a/benchmarks/bench_pad_rgb.py
+++ b/benchmarks/bench_pad_rgb.py
@@ -2,7 +2,8 @@
 """RGB PAD lane for the calibration campaign: CASIA-FASD, OULU-NPU,
 CelebA-Spoof through the shipped ViT chain.
 
-Chain mirrors the shipped Rust path exactly (irlume-vision/src/lib.rs
+Chain mirrors the shipped chain's preprocessing conventions
+(irlume-vision/src/lib.rs
 1316-1401 PadVit / pad_vit_input; crates/irlume-auth/src/lib.rs:350
 VIT_PAD_THRESHOLD = 0.55, :356 VIT_PAD_VOTE_N = 5): face box -> expand by
 96/112 of w/h per side CLAMPED to the frame (no fill) -> bilinear resize
@@ -29,7 +30,7 @@ Dataset label pins (verified 2026-08-29 on archhost):
   No split column: the split comes from the shard FILENAME prefix
   (train-* / valid-* / test-*). Headline metrics use the test shards.
   CASIA-FASD: frame-extracted mirror, 123,533 frames under train/test x
-  live/spooof directories; label from the directory. Frame-level scoring
+  live/spoof directories; label from the directory. Frame-level scoring
   only (the video structure is not in the mirror, so no voting is
   possible). Headline metrics use the test split.
   OULU-NPU: mirror-limited test subset, 1,701 flat frames under true/

--- a/benchmarks/bench_pad_rgb.py
+++ b/benchmarks/bench_pad_rgb.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""RGB PAD lane for the calibration campaign: CASIA-FASD, OULU-NPU,
+CelebA-Spoof through the shipped ViT chain.
+
+Chain mirrors the shipped Rust path exactly (irlume-vision/src/lib.rs
+1316-1401 PadVit / pad_vit_input; crates/irlume-auth/src/lib.rs:350
+VIT_PAD_THRESHOLD = 0.55, :356 VIT_PAD_VOTE_N = 5): face box -> expand by
+96/112 of w/h per side CLAMPED to the frame (no fill) -> bilinear resize
+224 -> RGB, (px/255 - 0.5)/0.5, CHW -> two logits -> P(spoof) = softmax
+index 1 (id2label: 0 = real, 1 = spoof). Score semantics are pad_score.py:
+s = P(spoof); APCER = attack frames with s < threshold; BPCER = genuine
+frames with s >= threshold.
+
+Detection:
+  CASIA-FASD, OULU-NPU: shipped YuNet at the operating point (640 square
+  letterbox, score 0.6), best detection = highest score (score column 14),
+  same decode as bench_detection_wider.py --ap.
+  CelebA-Spoof: the mirror's Bbox column supplies the face box directly.
+  Pinned convention, verified 2026-08-29 on shard test-00000 against YuNet
+  at score 0.5: Bbox = [x1, y1, x2, y2] (mean IoU 0.877; the [x, y, w, h]
+  reading is rejected: mean IoU 0.263 and x+w exceeds the frame width in
+  every probed row).
+
+Dataset label pins (verified 2026-08-29 on archhost):
+  CelebA-Spoof (Ar4ikov/celebA_spoof parquet whale): 167 shards, 525,864
+  rows. Class column carries exactly {"live": 177262, "spoof": 348602}
+  (full-column scan); the 10 attack species of the original dataset are NOT
+  labeled in this mirror, so per_species covers the labeled species only.
+  No split column: the split comes from the shard FILENAME prefix
+  (train-* / valid-* / test-*). Headline metrics use the test shards.
+  CASIA-FASD: frame-extracted mirror, 123,533 frames under train/test x
+  live/spooof directories; label from the directory. Frame-level scoring
+  only (the video structure is not in the mirror, so no voting is
+  possible). Headline metrics use the test split.
+  OULU-NPU: mirror-limited test subset, 1,701 flat frames under true/
+  (genuine) and false/ (attack). Filename pattern
+  <subject>_<env>_<clip>_<frame>_<const>: grouping by the first three
+  underscore fields yields 703 label-scoped clips (numeric clip ids are
+  shared across the two classes, so clips are grouped WITHIN each label):
+  343 genuine clips with EXACTLY ONE frame each, 360 attack clips with
+  2-4 frames (CONTROLLER RULING: scored honestly as mirror-limited;
+  subjects 1-6 of 55 only). Per-clip vote = median of the clip's
+  available frame scores; genuine voting is impossible on this mirror
+  (median-of-1). Frames scored at stride 1.
+
+Resumability (CelebA-Spoof): per-shard result files under --progress-dir
+(.pad_progress/): shard-<idx>-done.json when complete, shard-<idx>-
+partial.json overwritten every 1000 rows, progress.jsonl appended per
+1000-row boundary. A re-run skips completed shards and resumes partials
+from the recorded row offset.
+
+Usage (archhost, sequential runs merge into one results JSON):
+  bench_pad_rgb.py --models-dir M --casia-root D --set casia --out R
+  bench_pad_rgb.py --models-dir M --oulu-root D --set oulu --out R
+  bench_pad_rgb.py --models-dir M --celeba-root D --set celeba_score --out R
+  bench_pad_rgb.py --models-dir M --celeba-root D --set celeba_agg --out R
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+from letterbox import letterbox_image, restore_boxes
+from pad_score import apcer_bpcer, roc_auc, species_breakdown
+
+OP_INPUT = 640
+OP_SCORE = 0.6
+YUNET_MODEL = "face_detection_yunet_2023mar.onnx"
+VIT_MODEL = "liveness_vit.onnx"
+MARGIN = 96.0 / 112.0
+VIT_SIZE = 224
+THRESHOLD = 0.55
+VOTE_WINDOW = 5
+SWEEP = (0.35, 0.45, 0.5, 0.55, 0.6, 0.7)
+PROGRESS_EVERY = 1000
+BATCH = 256
+CLASSES = ("live", "spoof")
+SPLITS = ("train", "valid", "test")
+
+
+def threshold_sweep(scores_attack, scores_genuine) -> list[dict]:
+    rows = []
+    for thr in SWEEP:
+        r = apcer_bpcer(scores_attack, scores_genuine, thr)
+        rows.append({"threshold": thr, **r})
+    return rows
+
+
+class VitScorer:
+    """The shipped ViT PAD chain: m96 crop, resize 224, RGB, /255 mean 0.5
+    std 0.5, CHW, P(spoof) = softmax index 1."""
+
+    def __init__(self, models_dir: Path):
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        available = ort.get_available_providers()
+        providers = [p for p in providers if p in available] or ["CPUExecutionProvider"]
+        self.sess = ort.InferenceSession(str(models_dir / VIT_MODEL), providers=providers)
+        self.input_name = self.sess.get_inputs()[0].name
+
+    def m96_crop(self, img: "np.ndarray", bbox) -> "np.ndarray":
+        """Expand the box by MARGIN per side, clamp to the frame (no fill),
+        crop. bbox is [x1, y1, x2, y2] in frame pixels."""
+        h, w = img.shape[:2]
+        bw = float(bbox[2]) - float(bbox[0])
+        bh = float(bbox[3]) - float(bbox[1])
+        x1 = max(0.0, float(bbox[0]) - bw * MARGIN)
+        y1 = max(0.0, float(bbox[1]) - bh * MARGIN)
+        x2 = min(float(w - 1), float(bbox[2]) + bw * MARGIN)
+        y2 = min(float(h - 1), float(bbox[3]) + bh * MARGIN)
+        xi1, yi1 = int(x1), int(y1)
+        xi2, yi2 = min(w, int(x2) + 1), min(h, int(y2) + 1)
+        return img[max(0, yi1):max(0, yi2), max(0, xi1):max(0, xi2)]
+
+    def score(self, chip_bgr: "np.ndarray") -> float | None:
+        if chip_bgr is None or chip_bgr.size == 0:
+            return None
+        rgb = cv2.cvtColor(chip_bgr, cv2.COLOR_BGR2RGB)
+        rgb = cv2.resize(rgb, (VIT_SIZE, VIT_SIZE), interpolation=cv2.INTER_LINEAR)
+        x = rgb.astype(np.float32) / 255.0
+        x = (x - 0.5) / 0.5
+        t = x.transpose(2, 0, 1)[np.newaxis]
+        logits = self.sess.run(None, {self.input_name: t})[0][0]
+        e = np.exp(logits - logits.max())
+        return float((e / e.sum())[1])  # id2label: 0 = real, 1 = spoof
+
+
+def best_face(det, img: "np.ndarray") -> list[float] | None:
+    """YuNet at the 640 letterbox operating point; returns the best
+    detection's [x1, y1, x2, y2] in original pixels, or None."""
+    canvas, params = letterbox_image(img, OP_INPUT)
+    _, faces = det.detect(canvas)
+    if faces is None or len(faces) == 0:
+        return None
+    h, w = img.shape[:2]
+    best_idx = int(np.argmax(faces[:, 14]))
+    f = faces[best_idx]
+    return restore_boxes(
+        [[float(f[0]), float(f[1]), float(f[0] + f[2]), float(f[1] + f[3])]],
+        params, w, h,
+    )[0]
+
+
+def eval_pairs(scores_attack: list[float], scores_genuine: list[float]) -> dict:
+    out: dict = {"apcer": None, "bpcer": None, "auc": None}
+    if scores_attack and scores_genuine:
+        out.update(apcer_bpcer(scores_attack, scores_genuine, THRESHOLD))
+        out["auc"] = roc_auc(scores_attack, scores_genuine)
+        out["threshold_sweep"] = threshold_sweep(scores_attack, scores_genuine)
+    return out
+
+
+def merge_section(args, key: str, section: dict, notes: list[str]) -> None:
+    result = {}
+    if args.out.exists():
+        try:
+            result = json.loads(args.out.read_text())
+        except json.JSONDecodeError:
+            result = {}
+    result["runtime"] = {
+        "ort_version": ort.__version__,
+        "providers": ort.get_available_providers(),
+        "cv2_version": cv2.__version__,
+    }
+    result["wired"] = {
+        "vit_threshold": THRESHOLD,
+        "vote_window": VOTE_WINDOW,
+        "rationale": (
+            "irlume-auth/src/lib.rs:339-356: 0.55 with 5-frame-median "
+            "voting is the measured operating point; 0.50 and 0.60 are "
+            "the documented rejected alternatives"
+        ),
+    }
+    result[key] = section
+    result["notes"] = list(result.get("notes", [])) + notes
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps({k: v for k, v in section.items() if k != "per_video"}, default=str))
+    print(f"merged {key} into {args.out}", flush=True)
+
+
+def scan_image_dirs(root: Path) -> list[tuple[Path, str, str]]:
+    """Sorted (path, split, cls) for <split>/<cls>/* image dirs."""
+    exts = {".jpg", ".jpeg", ".png", ".bmp"}
+    out = []
+    for split in sorted(p for p in root.iterdir() if p.is_dir()):
+        for cls in sorted(p for p in split.iterdir() if p.is_dir()):
+            for f in sorted(cls.iterdir()):
+                if f.suffix.lower() in exts:
+                    out.append((f, split.name, cls.name))
+    return out
+
+
+def run_casia(args, det, vit) -> None:
+    t0 = time.time()
+    items = scan_image_dirs(args.casia_root)
+    by_cond: dict[tuple[str, str], list[float]] = {}
+    counts: dict[tuple[str, str], list[int]] = {}
+    for i, (fp, split, cls) in enumerate(items, 1):
+        img = cv2.imread(str(fp), cv2.IMREAD_COLOR)
+        scored = detected = 0
+        if img is not None:
+            scored = 1
+            box = best_face(det, img)
+            if box is not None:
+                s = vit.score(vit.m96_crop(img, box))
+                if s is not None:
+                    detected = 1
+                    by_cond.setdefault((split, cls), []).append(s)
+        c = counts.setdefault((split, cls), [0, 0, 0])
+        c[0] += 1
+        c[1] += scored
+        c[2] += detected
+        if i % 500 == 0:
+            print(f"[casia] {i}/{len(items)} frames", flush=True)
+    att = by_cond.get(("test", "spoof"), [])
+    gen = by_cond.get(("test", "live"), [])
+    section = {
+        "images": sum(c[0] for c in counts.values()),
+        "scored": sum(c[1] for c in counts.values()),
+        "detected": sum(c[2] for c in counts.values()),
+        **eval_pairs(att, gen),
+        "per_split": {
+            split: {
+                "images": sum(counts.get((split, cl), [0])[0] for cl in CLASSES),
+                "detected": sum(counts.get((split, cl), [0, 0, 0])[2] for cl in CLASSES),
+                **eval_pairs(by_cond.get((split, "spoof"), []), by_cond.get((split, "live"), [])),
+            }
+            for split in ("train", "test")
+        },
+        "per_condition": {
+            f"{split}_{cls}": {
+                "images": counts[split, cls][0],
+                "detected": counts[split, cls][2],
+                "n_scores": len(by_cond.get((split, cls), [])),
+            }
+            for split in ("train", "test") for cls in CLASSES
+            if (split, cls) in counts
+        },
+        "wall_s": round(time.time() - t0, 1),
+    }
+    notes = [
+        (
+            "casia_fasd: frame-extracted mirror (123,533 frame images under "
+            "train/test x live/spoof directories; the original 550-video "
+            "structure is not in this mirror), so scoring is FRAME-LEVEL "
+            "with no vote; label from the directory (live = genuine, spoof "
+            "= attack); headline apcer/bpcer/auc use the test split, "
+            "per_split carries both; frames without a YuNet detection at "
+            "the operating point are excluded from the metrics and counted "
+            "in detected/images."
+        ),
+        (
+            f"casia wall time {section['wall_s']}s at the operating point "
+            f"(YuNet letterbox {OP_INPUT} score {OP_SCORE}, ViT 224 m96)."
+        ),
+    ]
+    merge_section(args, "casia_fasd", section, notes)
+
+
+def run_oulu(args, det, vit) -> None:
+    t0 = time.time()
+    clips: dict[str, dict[str, float]] = {}
+    frames: dict[str, list[float]] = {"attack": [], "genuine": []}
+    per_video = []
+    n_images = n_scored = n_detected = 0
+    for cls_dir, label in (("true", "genuine"), ("false", "attack")):
+        files = sorted((args.oulu_root / cls_dir).glob("*.jpg"))
+        by_clip: dict[str, list[float]] = {}
+        for fp in files:
+            n_images += 1
+            img = cv2.imread(str(fp), cv2.IMREAD_COLOR)
+            if img is None:
+                continue
+            n_scored += 1
+            box = best_face(det, img)
+            if box is None:
+                continue
+            s = vit.score(vit.m96_crop(img, box))
+            if s is None:
+                continue
+            n_detected += 1
+            clip = "_".join(fp.stem.split("_")[:3])
+            by_clip.setdefault(clip, []).append(s)
+            frames[label].append(s)
+        for clip, ss in sorted(by_clip.items()):
+            vote = float(np.median(ss))
+            clips.setdefault(label, {})[clip] = vote
+            per_video.append(
+                {"clip": clip, "cls": label, "n_frames": len(ss), "vote": round(vote, 6)}
+            )
+    vote_att = list(clips.get("attack", {}).values())
+    vote_gen = list(clips.get("genuine", {}).values())
+    section = {
+        "clips": sum(len(v) for v in clips.values()),
+        "images": n_images,
+        "scored": n_scored,
+        "detected": n_detected,
+        "voted": eval_pairs(vote_att, vote_gen),
+        "frame_level": eval_pairs(frames["attack"], frames["genuine"]),
+        "per_video": per_video,
+        "wall_s": round(time.time() - t0, 1),
+    }
+    notes = [
+        (
+            "oulu_npu: MIRROR-LIMITED test subset (CONTROLLER RULING: "
+            "scored honestly as such): 1,701 flat frames; the genuine "
+            "side (true/) is 343 clips with EXACTLY ONE frame each, so "
+            "genuine voting is impossible there (median-of-1); the "
+            "attack side (false/) is 360 clips with 2-4 frames (298 x 4, "
+            "42 x 3, 20 x 2); subjects 1-6 of the protocol 55; the "
+            "primary source is test-subset-only and the deeper fallback "
+            "mirror was dead (404), so session breadth is NOT covered."
+        ),
+        (
+            "oulu filename pattern <subject>_<env>_<clip>_<frame>_<const>: "
+            "video grouping derives from the first three underscore fields"
+            "; numeric clip ids are shared across the two classes (343 of "
+            "360 attack ids also occur as a genuine id), so clips are "
+            "grouped WITHIN each label: 703 label-scoped clips over 360 "
+            "unique ids. Per-clip vote = median of the clip available "
+            "frame scores; every clip has at most 5 frames, so "
+            "median-of-available equals the shipped median-of-last-5 (the "
+            "runtime itself abstains on fewer than 5 scores, which on "
+            "this mirror means a genuine presentation would abstain "
+            "rather than vote). Frames scored at stride 1."
+        ),
+        (
+            f"oulu wall time {section['wall_s']}s at the operating point "
+            f"(YuNet letterbox {OP_INPUT} score {OP_SCORE}, ViT 224 m96)."
+        ),
+    ]
+    merge_section(args, "oulu_npu", section, notes)
+
+
+def shard_split(name: str) -> str:
+    for s in SPLITS:
+        if name.startswith(s + "-"):
+            return s
+    return "unknown"
+
+
+def run_celeba_score(args, vit) -> None:
+    import pyarrow.parquet as pq
+
+    shards = sorted((args.celeba_root / "data").glob("*.parquet"))
+    prog = args.progress_dir
+    prog.mkdir(parents=True, exist_ok=True)
+    t0 = time.time()
+    for idx, shard in enumerate(shards):
+        done = prog / f"shard-{idx}-done.json"
+        if done.exists():
+            continue
+        pf = pq.ParquetFile(shard)
+        partial_path = prog / f"shard-{idx}-partial.json"
+        offset = 0
+        scores: list[list] = []
+        n_no_bbox = 0
+        if partial_path.exists():
+            st = json.loads(partial_path.read_text())
+            offset = st["rows_done"]
+            scores = st["scores"]
+            n_no_bbox = st["n_no_bbox"]
+        rows_done = offset
+        last_mark = offset // PROGRESS_EVERY
+        t_shard = time.time()
+        batches = pf.iter_batches(batch_size=BATCH, columns=["Filepath", "Bbox", "Class"])
+        for batch in batches:
+            fps = batch.column(0)
+            bbs = batch.column(1)
+            cls = batch.column(2).to_pylist()
+            for j in range(batch.num_rows):
+                rows_done += 1
+                if rows_done <= offset:
+                    continue
+                bbox = bbs[j].as_py()
+                label = 1 if cls[j] == "spoof" else 0
+                s = None
+                if (
+                    bbox is not None
+                    and len(bbox) == 4
+                    and all(v is not None for v in bbox)
+                    and bbox[2] > bbox[0]
+                    and bbox[3] > bbox[1]
+                ):
+                    raw = fps[j]["bytes"].as_py()
+                    img = cv2.imdecode(np.frombuffer(raw, np.uint8), cv2.IMREAD_COLOR)
+                    if img is not None:
+                        h, w = img.shape[:2]
+                        in_frame = bbox[0] < w - 1 and bbox[1] < h - 1 and bbox[2] > 0 and bbox[3] > 0
+                        if in_frame:
+                            s = vit.score(vit.m96_crop(img, bbox))
+                if s is None:
+                    n_no_bbox += 1
+                else:
+                    scores.append([shard_split(shard.name), label, round(s, 6)])
+            if rows_done // PROGRESS_EVERY > last_mark:
+                last_mark = rows_done // PROGRESS_EVERY
+                partial_path.write_text(
+                    json.dumps(
+                        {
+                            "shard": shard.name,
+                            "rows_done": rows_done,
+                            "n_no_bbox": n_no_bbox,
+                            "scores": scores,
+                        }
+                    )
+                )
+                with (prog / "progress.jsonl").open("a") as fh:
+                    fh.write(
+                        json.dumps(
+                            {
+                                "shard_idx": idx,
+                                "rows_done": rows_done,
+                                "elapsed_s": round(time.time() - t0, 1),
+                            }
+                        )
+                        + "\n"
+                    )
+                print(
+                    f"[celeba {idx}/{len(shards)}] {rows_done}/{pf.metadata.num_rows} rows",
+                    flush=True,
+                )
+        done.write_text(
+            json.dumps(
+                {
+                    "shard": shard.name,
+                    "rows": pf.metadata.num_rows,
+                    "n_no_bbox": n_no_bbox,
+                    "scores": scores,
+                }
+            )
+        )
+        partial_path.unlink(missing_ok=True)
+        print(
+            f"[celeba] shard {idx} done: {len(scores)} scored, {n_no_bbox} "
+            f"skipped, {time.time() - t_shard:.1f}s",
+            flush=True,
+        )
+    print(f"[celeba] all shards scored in {time.time() - t0:.1f}s", flush=True)
+
+
+def run_celeba_agg(args) -> None:
+    prog = args.progress_dir
+    per_split_scores: dict[str, dict[int, list[float]]] = {}
+    per_split_skips: dict[str, dict[str, int]] = {}
+    total_rows = total_no_bbox = 0
+    for done in sorted(prog.glob("shard-*-done.json")):
+        st = json.loads(done.read_text())
+        split = shard_split(st["shard"])
+        per_split_skips.setdefault(split, {"no_bbox": 0})
+        per_split_skips[split]["no_bbox"] += st["n_no_bbox"]
+        total_rows += st["rows"]
+        total_no_bbox += st["n_no_bbox"]
+        for split_code, label, s in st["scores"]:
+            d = per_split_scores.setdefault(split, {0: [], 1: []})
+            d[label].append(s)
+    att = per_split_scores.get("test", {}).get(1, [])
+    gen = per_split_scores.get("test", {}).get(0, [])
+    section = {
+        "images": total_rows,
+        "scored": sum(len(v) for d in per_split_scores.values() for v in d.values()),
+        "detected": sum(len(v) for d in per_split_scores.values() for v in d.values()),
+        **eval_pairs(att, gen),
+        "per_species": species_breakdown([("spoof", s) for s in att], THRESHOLD),
+        "per_split": {
+            split: {
+                "scored": sum(len(v) for v in d.values()),
+                **eval_pairs(d.get(1, []), d.get(0, [])),
+            }
+            for split, d in sorted(per_split_scores.items())
+        },
+        "skipped_no_usable_bbox": total_no_bbox,
+    }
+    notes = [
+        (
+            "celeba_spoof: parquet whale mirror (167 shards, 525,864 rows "
+            "scanned; NO split column, the split comes from the shard "
+            "FILENAME prefix train-*/valid-*/test-*); Class column carries "
+            "exactly live/spoof (full-column scan: 177,262 live, 348,602 "
+            "spoof), so the original dataset's 10 attack species are NOT "
+            "labeled in this mirror: per_species covers the labeled attack "
+            "species only (one spoof row). The phone-at-distance attack "
+            "gap is NOT separately labeled in CelebA-Spoof."
+        ),
+        (
+            "celeba_spoof: Bbox convention pinned empirically on shard "
+            "test-00000 (YuNet cross-check at score 0.5): Bbox = [x1, y1, "
+            "x2, y2], mean IoU 0.877; the [x, y, w, h] reading is rejected "
+            "(mean IoU 0.263, boxes out of frame). The provided bbox feeds "
+            "the m96 crop directly; NO YuNet detection on this set, so "
+            "detected counts rows scored through the provided box. Rows "
+            "without a usable bbox are skipped and counted in "
+            "skipped_no_usable_bbox. Headline metrics use the test shards; "
+            "per_split carries train/valid too."
+        ),
+    ]
+    merge_section(args, "celeba_spoof", section, notes)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models-dir", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--casia-root", type=Path)
+    ap.add_argument("--oulu-root", type=Path)
+    ap.add_argument("--celeba-root", type=Path)
+    ap.add_argument(
+        "--progress-dir", type=Path, default=Path.home() / "irlume-bench/benchmarks/.pad_progress"
+    )
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--set", choices=["casia", "oulu", "celeba_score", "celeba_agg"])
+    args = ap.parse_args(argv)
+
+    det = None
+    if args.set in ("casia", "oulu"):
+        det = cv2.FaceDetectorYN_create(
+            str(args.models_dir / YUNET_MODEL), "", (OP_INPUT, OP_INPUT), score_threshold=OP_SCORE
+        )
+    vit = VitScorer(args.models_dir)
+    if args.set == "casia":
+        run_casia(args, det, vit)
+    elif args.set == "oulu":
+        run_oulu(args, det, vit)
+    elif args.set == "celeba_score":
+        run_celeba_score(args, vit)
+    else:
+        run_celeba_agg(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_pad_rgb.py
+++ b/benchmarks/bench_pad_rgb.py
@@ -68,7 +68,7 @@ import numpy as np
 import onnxruntime as ort
 
 from letterbox import letterbox_image, restore_boxes
-from pad_score import apcer_bpcer, roc_auc, species_breakdown
+from pad_score import apcer_bpcer, median_vote, roc_auc, species_breakdown
 
 OP_INPUT = 640
 OP_SCORE = 0.6
@@ -162,6 +162,7 @@ def merge_section(args, key: str, section: dict, notes: list[str]) -> None:
         try:
             result = json.loads(args.out.read_text())
         except json.JSONDecodeError:
+            print(f"warning: {args.out} is not valid JSON, resetting", flush=True)
             result = {}
     result["runtime"] = {
         "ort_version": ort.__version__,
@@ -289,7 +290,7 @@ def run_oulu(args, det, vit) -> None:
             by_clip.setdefault(clip, []).append(s)
             frames[label].append(s)
         for clip, ss in sorted(by_clip.items()):
-            vote = float(np.median(ss))
+            vote = float(median_vote(ss))
             clips.setdefault(label, {})[clip] = vote
             per_video.append(
                 {"clip": clip, "cls": label, "n_frames": len(ss), "vote": round(vote, 6)}

--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -262,6 +262,76 @@ _ALIGNED_FR_BUNDLE = DatasetSpec(
     ),
 )
 
+_CASIA_FASD = DatasetSpec(
+    name="casia_fasd",
+    source="kaggle",
+    repo="immada/casia-fasd",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=2_200_000_000,
+        ),
+    ),
+    license_note=(
+        "CASIA-FASD is provided for non-commercial research use per its "
+        "source page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://www.kaggle.com/datasets/immada/casia-fasd",
+    notes=(
+        "Single kaggle archive (~2.2 GB). Mirror identity matters (see "
+        "benchmarks/README.md): numbers are valid only for this mirror."
+    ),
+)
+
+_OULU_NPU = DatasetSpec(
+    name="oulu_npu",
+    source="kaggle",
+    repo="mizaku/oulu-npu-test",
+    files=(
+        DatasetFile(
+            path="kaggle-archive.zip",
+            extract=True,
+            size_hint_bytes=500_000_000,
+        ),
+    ),
+    license_note=(
+        "Oulu-NPU is provided for non-commercial research use per its source "
+        "page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://www.kaggle.com/datasets/mizaku/oulu-npu-test",
+    notes=(
+        "Start with mizaku/oulu-npu-test (~500 MB). Decision rule: if "
+        "extraction shows test-split-only content and the bench needs "
+        "sessions breadth, fetch minhtranv/oulu-npu-w-depth "
+        "(2_760_000_000 bytes hint) as the fallback instead and record in "
+        "the result JSON which mirror was used. Mirror identity matters "
+        "(see benchmarks/README.md): numbers are valid only for this mirror."
+    ),
+)
+
+_CELEBA_SPOOF_HF = DatasetSpec(
+    name="celeba_spoof_hf",
+    source="hf",
+    repo="Ar4ikov/celebA_spoof",
+    files=(),
+    license_note=(
+        "CelebA-Spoof is provided for non-commercial research use per its "
+        "source page; the exact terms stated there are quoted verbatim into "
+        "PROVENANCE.md at download time."
+    ),
+    provenance_url="https://huggingface.co/datasets/Ar4ikov/celebA_spoof",
+    notes=(
+        "Parquet shard snapshot lane: fetch with fetch_data.py --snapshot, "
+        "which runs huggingface_hub snapshot_download with allow_patterns "
+        "data/* into the dataset dir; no per-file resolve entries. Mirror "
+        "identity matters (see benchmarks/README.md): numbers are valid "
+        "only for this mirror."
+    ),
+)
+
 _DATASETS: dict[str, DatasetSpec] = {
     _WIDER.name: _WIDER,
     _THREE00W.name: _THREE00W,
@@ -272,6 +342,9 @@ _DATASETS: dict[str, DatasetSpec] = {
     _LFW.name: _LFW,
     _CFPW.name: _CFPW,
     _ALIGNED_FR_BUNDLE.name: _ALIGNED_FR_BUNDLE,
+    _CASIA_FASD.name: _CASIA_FASD,
+    _OULU_NPU.name: _OULU_NPU,
+    _CELEBA_SPOOF_HF.name: _CELEBA_SPOOF_HF,
 }
 
 

--- a/benchmarks/fetch_data.py
+++ b/benchmarks/fetch_data.py
@@ -49,6 +49,18 @@ def validate_spec(spec: DatasetSpec) -> None:
         )
 
 
+def validate_snapshot(spec: DatasetSpec) -> None:
+    if spec.source != "hf":
+        raise SystemExit(
+            f"{spec.name}: --snapshot requires source hf, got {spec.source}"
+        )
+    if spec.files:
+        raise SystemExit(
+            f"{spec.name}: --snapshot requires an empty files tuple, got "
+            f"{len(spec.files)} files"
+        )
+
+
 def load_token(env_var: str, file_path: Path) -> str | None:
     tok = os.environ.get(env_var, "").strip()
     if tok:
@@ -114,6 +126,8 @@ def download_dataset(
 ) -> dict:
     spec = get_dataset(spec_name)
     validate_spec(spec)
+    if not spec.files:
+        raise SystemExit(f"{spec.name}: spec declares no files; use --snapshot")
     session = session or requests.Session()
     if spec.source == "hf":
         tok = load_token("HF_TOKEN", Path.home() / ".cache/huggingface/token")
@@ -178,6 +192,36 @@ def download_dataset(
     return {"dataset": spec.name, "files": sorted(hashes), "extracted": extracted}
 
 
+def download_dataset_snapshot(spec_name: str, root: Path) -> dict:
+    spec = get_dataset(spec_name)
+    validate_snapshot(spec)
+    from huggingface_hub import snapshot_download
+
+    tok = load_token("HF_TOKEN", Path.home() / ".cache/huggingface/token")
+    ddir = root / spec.name
+    ddir.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id=spec.repo,
+        repo_type="dataset",
+        local_dir=ddir,
+        allow_patterns=["data/*"],
+        token=tok,
+    )
+
+    data_dir = ddir / "data"
+    shard_files = sorted(p for p in data_dir.rglob("*") if p.is_file())
+    hashes = {p.relative_to(ddir).as_posix(): sha256_file(p) for p in shard_files}
+
+    manifest_path = ddir / "MANIFEST.sha256"
+    prior = parse_manifest(manifest_path.read_text()) if manifest_path.is_file() else {}
+    prior.update(hashes)
+    manifest_path.write_text(manifest_lines(prior))
+
+    terms = _terms_from_readme(spec, requests.Session())
+    (ddir / "PROVENANCE.md").write_text(render_provenance(spec, prior, terms))
+    return {"dataset": spec.name, "files": sorted(hashes), "extracted": {}}
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     sub = ap.add_subparsers(dest="cmd", required=True)
@@ -186,6 +230,14 @@ def main(argv: list[str] | None = None) -> int:
     d.add_argument("--root", type=Path, required=True, help="datasets root, e.g. ~/datasets")
     d.add_argument("--only", action="append", default=[], help="substring filter on file paths")
     d.add_argument("--keep-archives", action="store_true")
+    d.add_argument(
+        "--snapshot",
+        action="store_true",
+        help=(
+            "hf snapshot lane: snapshot_download with allow_patterns "
+            "data/*; requires an empty-files hf spec"
+        ),
+    )
     d.add_argument("--dry-run", action="store_true", help="print the plan, touch nothing")
     sub.add_parser("list")
     args = ap.parse_args(argv)
@@ -198,10 +250,19 @@ def main(argv: list[str] | None = None) -> int:
 
     spec = get_dataset(args.name)
     if args.dry_run:
+        if not spec.files:
+            print(
+                f"would snapshot-download {spec.repo} (allow_patterns "
+                f"data/*) into {args.root / spec.name}"
+            )
+            return 0
         for f in spec.files:
             print(f"would fetch {f.path} (~{f.size_hint_bytes} bytes)")
         return 0
-    summary = download_dataset(args.name, args.root, args.only or None, args.keep_archives)
+    if args.snapshot:
+        summary = download_dataset_snapshot(args.name, args.root)
+    else:
+        summary = download_dataset(args.name, args.root, args.only or None, args.keep_archives)
     print(json.dumps(summary, indent=2))
     return 0
 

--- a/benchmarks/pad_score.py
+++ b/benchmarks/pad_score.py
@@ -1,0 +1,76 @@
+"""PAD scoring for the calibration campaign.
+
+Score semantics are pinned: s = P(spoof). APCER is the fraction of ATTACK
+samples with s < threshold; BPCER is the fraction of GENUINE samples with
+s >= threshold. AUC is rank-based (Mann-Whitney) with average ranks for
+tied scores. The vote functions emulate the ADR-0013 5-frame median vote:
+a video's vote at each time step is the median of the last 5 frames'
+scores.
+"""
+
+import statistics
+
+
+def apcer_bpcer(
+    scores_attack: list[float],
+    scores_genuine: list[float],
+    threshold: float,
+) -> dict:
+    if not scores_attack or not scores_genuine:
+        raise ValueError("apcer_bpcer needs at least one attack and one genuine score")
+    apcer = sum(1 for s in scores_attack if s < threshold) / len(scores_attack)
+    bpcer = sum(1 for s in scores_genuine if s >= threshold) / len(scores_genuine)
+    return {"apcer": apcer, "bpcer": bpcer}
+
+
+def roc_auc(scores_attack: list[float], scores_genuine: list[float]) -> float:
+    n_attack = len(scores_attack)
+    n_genuine = len(scores_genuine)
+    if n_attack == 0 or n_genuine == 0:
+        raise ValueError("roc_auc needs at least one attack and one genuine score")
+    combined = sorted(scores_attack + scores_genuine)
+    avg_ranks: dict[float, float] = {}
+    i = 0
+    while i < len(combined):
+        j = i
+        while j + 1 < len(combined) and combined[j + 1] == combined[i]:
+            j += 1
+        avg_ranks[combined[i]] = (i + j) / 2 + 1
+        i = j + 1
+    rank_sum_attack = sum(avg_ranks[s] for s in scores_attack)
+    u = rank_sum_attack - n_attack * (n_attack + 1) / 2
+    return u / (n_attack * n_genuine)
+
+
+def species_breakdown(
+    per_sample: list[tuple[str, float]],
+    threshold: float,
+) -> list[dict]:
+    by_species: dict[str, list[float]] = {}
+    for species, s in per_sample:
+        by_species.setdefault(species, []).append(s)
+    rows = []
+    for species in sorted(by_species):
+        scores = by_species[species]
+        caught = sum(1 for s in scores if s >= threshold)
+        rows.append(
+            {
+                "species": species,
+                "n": len(scores),
+                "caught": caught,
+                "tpr": caught / len(scores),
+            }
+        )
+    return rows
+
+
+def median_vote(scores: list[float]) -> float:
+    return statistics.median(scores)
+
+
+def vote_video(frames: list[list[float]]) -> list[float]:
+    votes = []
+    for t in range(len(frames)):
+        window = [s for fr in frames[max(0, t - 4) : t + 1] for s in fr]
+        votes.append(statistics.median(window))
+    return votes

--- a/benchmarks/requirements-bench.txt
+++ b/benchmarks/requirements-bench.txt
@@ -9,3 +9,5 @@ numpy>=2.0,<3
 requests>=2.32,<3
 pytest>=8
 scipy>=1.11
+pyarrow>=14
+huggingface_hub>=0.30

--- a/benchmarks/results-pad-ir.json
+++ b/benchmarks/results-pad-ir.json
@@ -1,0 +1,126 @@
+{
+  "runtime": {
+    "ort_version": "1.27.0",
+    "providers": [
+      "TensorrtExecutionProvider",
+      "CUDAExecutionProvider",
+      "CPUExecutionProvider"
+    ],
+    "cv2_version": "5.0.0"
+  },
+  "wired": {
+    "flir_threshold": 0.9,
+    "rationale": "irlume-auth/src/lib.rs:358-364: IR_PAD_THRESHOLD 0.9 is the measured deny-only operating point (highest genuine 0.702, banner attack floor 0.941); models/README.md flir row: deny-only at 0.9, revalidated 0/3,940 above the line on CBSR 850nm at 197 identities"
+  },
+  "cbsr": {
+    "frames": 3940,
+    "scored": 3940,
+    "flagged_rate_at_wired": 0.0002538071065989848,
+    "score_p50": 2.2464078028860968e-06,
+    "score_p10": 5.950176458213719e-08,
+    "threshold_sweep": [
+      {
+        "threshold": 0.5,
+        "flagged_rate": 0.0005076142131979696
+      },
+      {
+        "threshold": 0.6,
+        "flagged_rate": 0.0005076142131979696
+      },
+      {
+        "threshold": 0.7,
+        "flagged_rate": 0.0005076142131979696
+      },
+      {
+        "threshold": 0.8,
+        "flagged_rate": 0.0005076142131979696
+      },
+      {
+        "threshold": 0.9,
+        "flagged_rate": 0.0002538071065989848
+      },
+      {
+        "threshold": 0.95,
+        "flagged_rate": 0.0002538071065989848
+      },
+      {
+        "threshold": 0.99,
+        "flagged_rate": 0.0
+      }
+    ],
+    "wall_s": 46.2
+  },
+  "notes": [
+    "CONTROLLER SCOPE RULING: no IR attack data exists on disk, so this lane measures the GENUINE-side flag rate at the wired flir deny line: flagged_rate_at_wired = fraction of scored genuine frames with P(fake) >= 0.9 (the BPCER side of the deny line), NOT attack TPR; the brief's tpr_at_wired schema key is replaced accordingly. Attack-side IR evidence remains the fleet/banner measurements (models/README.md flir row: 122/123 banner frames flagged; docs/pad-results/2026-07-17-third-party-pad-candidates.md), a spec-honest limitation of this lane.",
+    "cbsr: flat sorted walk of ALL .bmp frames under the root (the mirror nests the frames one level under NIR_face_dataset); subjects are encoded in the filename prefix and ALL subjects are included (supersedes the 197-identity revalidation sample in models/README.md); the gallery groundtruth file is not consulted; flagged_rate_at_wired denominators are scored frames (YuNet detection at the operating point required).",
+    "cbsr finding: 1/3,940 scored frames flagged at the wired 0.9 line (sweep 2/3,940 at 0.5, 0 at 0.99; score_p50 2.2e-06), consistent with the committed 197-identity revalidation (models/README.md: 0/3,940 above the line at lit frames).",
+    "oulu: sorted recursive walk of ALL .jpeg frames under NI only (70 Thumbs.db files excluded), grouped by the lighting directory name (Dark/Strong/Weak); the VL/ RGB counterpart is not walked; flagged_rate_at_wired denominators are scored frames (YuNet detection at the operating point required).",
+    "oulu finding: the dim-lighting hypothesis is NOT confirmed at the wired line. Dark never crosses 0.9 (0/10,782; widest sub-threshold tail of the three lightings: 59 frames >= 0.1, max 0.8204); the only wired-line flags are 4/10,379 Strong frames concentrated in two subjects (P049 Disgust 010-012, P012 Happiness 017; max 0.9606); Weak 0/10,834. The fleet dim-strobe genuine failure regime (models/README.md) does not reproduce at frame level on this mirror through this chain and remains fleet-measurement evidence."
+  ],
+  "oulu": {
+    "per_lighting": [
+      {
+        "lighting": "Dark",
+        "frames": 10782,
+        "scored": 10782,
+        "flagged_rate_at_wired": 0.0,
+        "score_p50": 3.385749323570053e-06,
+        "score_p10": 3.3710983160517595e-08
+      },
+      {
+        "lighting": "Strong",
+        "frames": 10379,
+        "scored": 10379,
+        "flagged_rate_at_wired": 0.00038539358319683977,
+        "score_p50": 5.922064246988157e-06,
+        "score_p10": 4.871862131494708e-08
+      },
+      {
+        "lighting": "Weak",
+        "frames": 10834,
+        "scored": 10834,
+        "flagged_rate_at_wired": 0.0,
+        "score_p50": 4.184301133136614e-06,
+        "score_p10": 3.68059023259093e-08
+      }
+    ],
+    "overall": {
+      "frames": 31995,
+      "scored": 31995,
+      "flagged_rate_at_wired": 0.00012501953430223473,
+      "score_p50": 4.4191097003931645e-06,
+      "score_p10": 3.9056352818533924e-08,
+      "threshold_sweep": [
+        {
+          "threshold": 0.5,
+          "flagged_rate": 0.0005313330207844975
+        },
+        {
+          "threshold": 0.6,
+          "flagged_rate": 0.00046882325363338024
+        },
+        {
+          "threshold": 0.7,
+          "flagged_rate": 0.00037505860290670416
+        },
+        {
+          "threshold": 0.8,
+          "flagged_rate": 0.00025003906860446946
+        },
+        {
+          "threshold": 0.9,
+          "flagged_rate": 0.00012501953430223473
+        },
+        {
+          "threshold": 0.95,
+          "flagged_rate": 3.125488357555868e-05
+        },
+        {
+          "threshold": 0.99,
+          "flagged_rate": 0.0
+        }
+      ]
+    },
+    "wall_s": 368.5
+  }
+}

--- a/benchmarks/results-pad-ir.json
+++ b/benchmarks/results-pad-ir.json
@@ -15,10 +15,23 @@
   "cbsr": {
     "frames": 3940,
     "scored": 3940,
+    "read_failures": 0,
+    "detect_failures": 0,
     "flagged_rate_at_wired": 0.0002538071065989848,
     "score_p50": 2.2464078028860968e-06,
     "score_p10": 5.950176458213719e-08,
+    "score_max": 0.9750435948371887,
+    "flagged_frames": [
+      {
+        "path": "NIR_face_dataset/NIR_face_dataset/0085-00-a.bmp",
+        "score": 0.9750435948371887
+      }
+    ],
     "threshold_sweep": [
+      {
+        "threshold": 0.1,
+        "flagged_rate": 0.0007614213197969543
+      },
       {
         "threshold": 0.5,
         "flagged_rate": 0.0005076142131979696
@@ -48,14 +61,14 @@
         "flagged_rate": 0.0
       }
     ],
-    "wall_s": 46.2
+    "wall_s": 47.5
   },
   "notes": [
     "CONTROLLER SCOPE RULING: no IR attack data exists on disk, so this lane measures the GENUINE-side flag rate at the wired flir deny line: flagged_rate_at_wired = fraction of scored genuine frames with P(fake) >= 0.9 (the BPCER side of the deny line), NOT attack TPR; the brief's tpr_at_wired schema key is replaced accordingly. Attack-side IR evidence remains the fleet/banner measurements (models/README.md flir row: 122/123 banner frames flagged; docs/pad-results/2026-07-17-third-party-pad-candidates.md), a spec-honest limitation of this lane.",
     "cbsr: flat sorted walk of ALL .bmp frames under the root (the mirror nests the frames one level under NIR_face_dataset); subjects are encoded in the filename prefix and ALL subjects are included (supersedes the 197-identity revalidation sample in models/README.md); the gallery groundtruth file is not consulted; flagged_rate_at_wired denominators are scored frames (YuNet detection at the operating point required).",
     "cbsr finding: 1/3,940 scored frames flagged at the wired 0.9 line (sweep 2/3,940 at 0.5, 0 at 0.99; score_p50 2.2e-06), consistent with the committed 197-identity revalidation (models/README.md: 0/3,940 above the line at lit frames).",
     "oulu: sorted recursive walk of ALL .jpeg frames under NI only (70 Thumbs.db files excluded), grouped by the lighting directory name (Dark/Strong/Weak); the VL/ RGB counterpart is not walked; flagged_rate_at_wired denominators are scored frames (YuNet detection at the operating point required).",
-    "oulu finding: the dim-lighting hypothesis is NOT confirmed at the wired line. Dark never crosses 0.9 (0/10,782; widest sub-threshold tail of the three lightings: 59 frames >= 0.1, max 0.8204); the only wired-line flags are 4/10,379 Strong frames concentrated in two subjects (P049 Disgust 010-012, P012 Happiness 017; max 0.9606); Weak 0/10,834. The fleet dim-strobe genuine failure regime (models/README.md) does not reproduce at frame level on this mirror through this chain and remains fleet-measurement evidence."
+    "oulu finding: the dim-lighting hypothesis is NOT confirmed at the wired line. Dark never crosses 0.9 (0/10,782; widest sub-threshold tail of the three lightings: 59 frames >= 0.1, max 0.8204); the only wired-line flags are 4/10,379 Strong frames concentrated in two subjects (P049 Disgust 010-012, P012 Happiness 017; max 0.9606); Weak 0/10,834. Every figure in this note is a committed field: per_lighting threshold_sweep at 0.1, per_lighting score_max, and the flagged_frames list. The fleet dim-strobe genuine failure regime (models/README.md) does not reproduce at frame level on this mirror through this chain and remains fleet-measurement evidence."
   ],
   "oulu": {
     "per_lighting": [
@@ -63,34 +76,170 @@
         "lighting": "Dark",
         "frames": 10782,
         "scored": 10782,
+        "read_failures": 0,
+        "detect_failures": 0,
         "flagged_rate_at_wired": 0.0,
         "score_p50": 3.385749323570053e-06,
-        "score_p10": 3.3710983160517595e-08
+        "score_p10": 3.3710983160517595e-08,
+        "score_max": 0.8204322457313538,
+        "threshold_sweep": [
+          {
+            "threshold": 0.1,
+            "flagged_rate": 0.0054720831014654055
+          },
+          {
+            "threshold": 0.5,
+            "flagged_rate": 0.0002782415136338342
+          },
+          {
+            "threshold": 0.6,
+            "flagged_rate": 0.0002782415136338342
+          },
+          {
+            "threshold": 0.7,
+            "flagged_rate": 0.0001854943424225561
+          },
+          {
+            "threshold": 0.8,
+            "flagged_rate": 9.274717121127805e-05
+          },
+          {
+            "threshold": 0.9,
+            "flagged_rate": 0.0
+          },
+          {
+            "threshold": 0.95,
+            "flagged_rate": 0.0
+          },
+          {
+            "threshold": 0.99,
+            "flagged_rate": 0.0
+          }
+        ]
       },
       {
         "lighting": "Strong",
         "frames": 10379,
         "scored": 10379,
+        "read_failures": 0,
+        "detect_failures": 0,
         "flagged_rate_at_wired": 0.00038539358319683977,
         "score_p50": 5.922064246988157e-06,
-        "score_p10": 4.871862131494708e-08
+        "score_p10": 4.871862131494708e-08,
+        "score_max": 0.960635244846344,
+        "threshold_sweep": [
+          {
+            "threshold": 0.1,
+            "flagged_rate": 0.005973600539551017
+          },
+          {
+            "threshold": 0.5,
+            "flagged_rate": 0.0012525291453897292
+          },
+          {
+            "threshold": 0.6,
+            "flagged_rate": 0.0011561807495905194
+          },
+          {
+            "threshold": 0.7,
+            "flagged_rate": 0.0009634839579920994
+          },
+          {
+            "threshold": 0.8,
+            "flagged_rate": 0.0006744387705944696
+          },
+          {
+            "threshold": 0.9,
+            "flagged_rate": 0.00038539358319683977
+          },
+          {
+            "threshold": 0.95,
+            "flagged_rate": 9.634839579920994e-05
+          },
+          {
+            "threshold": 0.99,
+            "flagged_rate": 0.0
+          }
+        ]
       },
       {
         "lighting": "Weak",
         "frames": 10834,
         "scored": 10834,
+        "read_failures": 0,
+        "detect_failures": 0,
         "flagged_rate_at_wired": 0.0,
         "score_p50": 4.184301133136614e-06,
-        "score_p10": 3.68059023259093e-08
+        "score_p10": 3.68059023259093e-08,
+        "score_max": 0.5791825652122498,
+        "threshold_sweep": [
+          {
+            "threshold": 0.1,
+            "flagged_rate": 0.0027690603655159685
+          },
+          {
+            "threshold": 0.5,
+            "flagged_rate": 9.230201218386561e-05
+          },
+          {
+            "threshold": 0.6,
+            "flagged_rate": 0.0
+          },
+          {
+            "threshold": 0.7,
+            "flagged_rate": 0.0
+          },
+          {
+            "threshold": 0.8,
+            "flagged_rate": 0.0
+          },
+          {
+            "threshold": 0.9,
+            "flagged_rate": 0.0
+          },
+          {
+            "threshold": 0.95,
+            "flagged_rate": 0.0
+          },
+          {
+            "threshold": 0.99,
+            "flagged_rate": 0.0
+          }
+        ]
       }
     ],
     "overall": {
       "frames": 31995,
       "scored": 31995,
+      "read_failures": 0,
+      "detect_failures": 0,
       "flagged_rate_at_wired": 0.00012501953430223473,
       "score_p50": 4.4191097003931645e-06,
       "score_p10": 3.9056352818533924e-08,
+      "score_max": 0.960635244846344,
+      "flagged_frames": [
+        {
+          "path": "Strong/P012/Happiness/017.jpeg",
+          "score": 0.9009260535240173
+        },
+        {
+          "path": "Strong/P049/Disgust/010.jpeg",
+          "score": 0.960635244846344
+        },
+        {
+          "path": "Strong/P049/Disgust/011.jpeg",
+          "score": 0.9437823295593262
+        },
+        {
+          "path": "Strong/P049/Disgust/012.jpeg",
+          "score": 0.9036170840263367
+        }
+      ],
       "threshold_sweep": [
+        {
+          "threshold": 0.1,
+          "flagged_rate": 0.004719487419909361
+        },
         {
           "threshold": 0.5,
           "flagged_rate": 0.0005313330207844975
@@ -121,6 +270,6 @@
         }
       ]
     },
-    "wall_s": 368.5
+    "wall_s": 361.8
   }
 }

--- a/benchmarks/results-pad-ir.log
+++ b/benchmarks/results-pad-ir.log
@@ -1,0 +1,79 @@
+[ WARN:0@0.044] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
+[cbsr] 500/3940 frames
+[cbsr] 1000/3940 frames
+[cbsr] 1500/3940 frames
+[cbsr] 2000/3940 frames
+[cbsr] 2500/3940 frames
+[cbsr] 3000/3940 frames
+[cbsr] 3500/3940 frames
+[cbsr] 3940 scored in 46.2s
+{"frames": 3940, "scored": 3940, "flagged_rate_at_wired": 0.0002538071065989848, "score_p50": 2.2464078028860968e-06, "score_p10": 5.950176458213719e-08, "threshold_sweep": [{"threshold": 0.5, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.6, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.7, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.8, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.9, "flagged_rate": 0.0002538071065989848}, {"threshold": 0.95, "flagged_rate": 0.0002538071065989848}, {"threshold": 0.99, "flagged_rate": 0.0}], "wall_s": 46.2}
+merged cbsr into results-pad-ir.json
+[ WARN:0@0.043] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
+[oulu-Dark] 500/10782 frames
+[oulu-Dark] 1000/10782 frames
+[oulu-Dark] 1500/10782 frames
+[oulu-Dark] 2000/10782 frames
+[oulu-Dark] 2500/10782 frames
+[oulu-Dark] 3000/10782 frames
+[oulu-Dark] 3500/10782 frames
+[oulu-Dark] 4000/10782 frames
+[oulu-Dark] 4500/10782 frames
+[oulu-Dark] 5000/10782 frames
+[oulu-Dark] 5500/10782 frames
+[oulu-Dark] 6000/10782 frames
+[oulu-Dark] 6500/10782 frames
+[oulu-Dark] 7000/10782 frames
+[oulu-Dark] 7500/10782 frames
+[oulu-Dark] 8000/10782 frames
+[oulu-Dark] 8500/10782 frames
+[oulu-Dark] 9000/10782 frames
+[oulu-Dark] 9500/10782 frames
+[oulu-Dark] 10000/10782 frames
+[oulu-Dark] 10500/10782 frames
+[oulu-Dark] 10782 scored in 128.3s
+[oulu-Strong] 500/10379 frames
+[oulu-Strong] 1000/10379 frames
+[oulu-Strong] 1500/10379 frames
+[oulu-Strong] 2000/10379 frames
+[oulu-Strong] 2500/10379 frames
+[oulu-Strong] 3000/10379 frames
+[oulu-Strong] 3500/10379 frames
+[oulu-Strong] 4000/10379 frames
+[oulu-Strong] 4500/10379 frames
+[oulu-Strong] 5000/10379 frames
+[oulu-Strong] 5500/10379 frames
+[oulu-Strong] 6000/10379 frames
+[oulu-Strong] 6500/10379 frames
+[oulu-Strong] 7000/10379 frames
+[oulu-Strong] 7500/10379 frames
+[oulu-Strong] 8000/10379 frames
+[oulu-Strong] 8500/10379 frames
+[oulu-Strong] 9000/10379 frames
+[oulu-Strong] 9500/10379 frames
+[oulu-Strong] 10000/10379 frames
+[oulu-Strong] 10379 scored in 117.3s
+[oulu-Weak] 500/10834 frames
+[oulu-Weak] 1000/10834 frames
+[oulu-Weak] 1500/10834 frames
+[oulu-Weak] 2000/10834 frames
+[oulu-Weak] 2500/10834 frames
+[oulu-Weak] 3000/10834 frames
+[oulu-Weak] 3500/10834 frames
+[oulu-Weak] 4000/10834 frames
+[oulu-Weak] 4500/10834 frames
+[oulu-Weak] 5000/10834 frames
+[oulu-Weak] 5500/10834 frames
+[oulu-Weak] 6000/10834 frames
+[oulu-Weak] 6500/10834 frames
+[oulu-Weak] 7000/10834 frames
+[oulu-Weak] 7500/10834 frames
+[oulu-Weak] 8000/10834 frames
+[oulu-Weak] 8500/10834 frames
+[oulu-Weak] 9000/10834 frames
+[oulu-Weak] 9500/10834 frames
+[oulu-Weak] 10000/10834 frames
+[oulu-Weak] 10500/10834 frames
+[oulu-Weak] 10834 scored in 121.7s
+{"overall": {"frames": 31995, "scored": 31995, "flagged_rate_at_wired": 0.00012501953430223473, "score_p50": 4.4191097003931645e-06, "score_p10": 3.9056352818533924e-08, "threshold_sweep": [{"threshold": 0.5, "flagged_rate": 0.0005313330207844975}, {"threshold": 0.6, "flagged_rate": 0.00046882325363338024}, {"threshold": 0.7, "flagged_rate": 0.00037505860290670416}, {"threshold": 0.8, "flagged_rate": 0.00025003906860446946}, {"threshold": 0.9, "flagged_rate": 0.00012501953430223473}, {"threshold": 0.95, "flagged_rate": 3.125488357555868e-05}, {"threshold": 0.99, "flagged_rate": 0.0}]}, "wall_s": 368.5}
+merged oulu into results-pad-ir.json

--- a/benchmarks/results-pad-ir.log
+++ b/benchmarks/results-pad-ir.log
@@ -1,4 +1,4 @@
-[ WARN:0@0.044] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
+[ WARN:0@0.041] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
 [cbsr] 500/3940 frames
 [cbsr] 1000/3940 frames
 [cbsr] 1500/3940 frames
@@ -6,10 +6,10 @@
 [cbsr] 2500/3940 frames
 [cbsr] 3000/3940 frames
 [cbsr] 3500/3940 frames
-[cbsr] 3940 scored in 46.2s
-{"frames": 3940, "scored": 3940, "flagged_rate_at_wired": 0.0002538071065989848, "score_p50": 2.2464078028860968e-06, "score_p10": 5.950176458213719e-08, "threshold_sweep": [{"threshold": 0.5, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.6, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.7, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.8, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.9, "flagged_rate": 0.0002538071065989848}, {"threshold": 0.95, "flagged_rate": 0.0002538071065989848}, {"threshold": 0.99, "flagged_rate": 0.0}], "wall_s": 46.2}
+[cbsr] 3940 scored (0 read failures, 0 detect failures) in 47.4s
+{"frames": 3940, "scored": 3940, "read_failures": 0, "detect_failures": 0, "flagged_rate_at_wired": 0.0002538071065989848, "score_p50": 2.2464078028860968e-06, "score_p10": 5.950176458213719e-08, "score_max": 0.9750435948371887, "flagged_frames": [{"path": "NIR_face_dataset/NIR_face_dataset/0085-00-a.bmp", "score": 0.9750435948371887}], "threshold_sweep": [{"threshold": 0.1, "flagged_rate": 0.0007614213197969543}, {"threshold": 0.5, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.6, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.7, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.8, "flagged_rate": 0.0005076142131979696}, {"threshold": 0.9, "flagged_rate": 0.0002538071065989848}, {"threshold": 0.95, "flagged_rate": 0.0002538071065989848}, {"threshold": 0.99, "flagged_rate": 0.0}], "wall_s": 47.5}
 merged cbsr into results-pad-ir.json
-[ WARN:0@0.043] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
+[ WARN:0@0.046] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
 [oulu-Dark] 500/10782 frames
 [oulu-Dark] 1000/10782 frames
 [oulu-Dark] 1500/10782 frames
@@ -31,7 +31,7 @@ merged cbsr into results-pad-ir.json
 [oulu-Dark] 9500/10782 frames
 [oulu-Dark] 10000/10782 frames
 [oulu-Dark] 10500/10782 frames
-[oulu-Dark] 10782 scored in 128.3s
+[oulu-Dark] 10782 scored (0 read failures, 0 detect failures) in 120.5s
 [oulu-Strong] 500/10379 frames
 [oulu-Strong] 1000/10379 frames
 [oulu-Strong] 1500/10379 frames
@@ -52,7 +52,7 @@ merged cbsr into results-pad-ir.json
 [oulu-Strong] 9000/10379 frames
 [oulu-Strong] 9500/10379 frames
 [oulu-Strong] 10000/10379 frames
-[oulu-Strong] 10379 scored in 117.3s
+[oulu-Strong] 10379 scored (0 read failures, 0 detect failures) in 117.1s
 [oulu-Weak] 500/10834 frames
 [oulu-Weak] 1000/10834 frames
 [oulu-Weak] 1500/10834 frames
@@ -74,6 +74,6 @@ merged cbsr into results-pad-ir.json
 [oulu-Weak] 9500/10834 frames
 [oulu-Weak] 10000/10834 frames
 [oulu-Weak] 10500/10834 frames
-[oulu-Weak] 10834 scored in 121.7s
-{"overall": {"frames": 31995, "scored": 31995, "flagged_rate_at_wired": 0.00012501953430223473, "score_p50": 4.4191097003931645e-06, "score_p10": 3.9056352818533924e-08, "threshold_sweep": [{"threshold": 0.5, "flagged_rate": 0.0005313330207844975}, {"threshold": 0.6, "flagged_rate": 0.00046882325363338024}, {"threshold": 0.7, "flagged_rate": 0.00037505860290670416}, {"threshold": 0.8, "flagged_rate": 0.00025003906860446946}, {"threshold": 0.9, "flagged_rate": 0.00012501953430223473}, {"threshold": 0.95, "flagged_rate": 3.125488357555868e-05}, {"threshold": 0.99, "flagged_rate": 0.0}]}, "wall_s": 368.5}
+[oulu-Weak] 10834 scored (0 read failures, 0 detect failures) in 123.1s
+{"overall": {"frames": 31995, "scored": 31995, "read_failures": 0, "detect_failures": 0, "flagged_rate_at_wired": 0.00012501953430223473, "score_p50": 4.4191097003931645e-06, "score_p10": 3.9056352818533924e-08, "score_max": 0.960635244846344, "flagged_frames": [{"path": "Strong/P012/Happiness/017.jpeg", "score": 0.9009260535240173}, {"path": "Strong/P049/Disgust/010.jpeg", "score": 0.960635244846344}, {"path": "Strong/P049/Disgust/011.jpeg", "score": 0.9437823295593262}, {"path": "Strong/P049/Disgust/012.jpeg", "score": 0.9036170840263367}], "threshold_sweep": [{"threshold": 0.1, "flagged_rate": 0.004719487419909361}, {"threshold": 0.5, "flagged_rate": 0.0005313330207844975}, {"threshold": 0.6, "flagged_rate": 0.00046882325363338024}, {"threshold": 0.7, "flagged_rate": 0.00037505860290670416}, {"threshold": 0.8, "flagged_rate": 0.00025003906860446946}, {"threshold": 0.9, "flagged_rate": 0.00012501953430223473}, {"threshold": 0.95, "flagged_rate": 3.125488357555868e-05}, {"threshold": 0.99, "flagged_rate": 0.0}]}, "wall_s": 361.8}
 merged oulu into results-pad-ir.json

--- a/benchmarks/results-pad-rgb.json
+++ b/benchmarks/results-pad-rgb.json
@@ -1,0 +1,4638 @@
+{
+  "runtime": {
+    "ort_version": "1.27.0",
+    "providers": [
+      "TensorrtExecutionProvider",
+      "CUDAExecutionProvider",
+      "CPUExecutionProvider"
+    ],
+    "cv2_version": "5.0.0"
+  },
+  "wired": {
+    "vit_threshold": 0.55,
+    "vote_window": 5,
+    "rationale": "irlume-auth/src/lib.rs:339-356: 0.55 with 5-frame-median voting is the measured operating point; 0.50 and 0.60 are the documented rejected alternatives"
+  },
+  "casia_fasd": {
+    "images": 123533,
+    "scored": 123533,
+    "detected": 123214,
+    "apcer": 0.4701160802663547,
+    "bpcer": 0.1412914691943128,
+    "auc": 0.6099671527404322,
+    "threshold_sweep": [
+      {
+        "threshold": 0.35,
+        "apcer": 0.18000539908215604,
+        "bpcer": 0.9999012638230648
+      },
+      {
+        "threshold": 0.45,
+        "apcer": 0.33467110591199495,
+        "bpcer": 0.7966034755134281
+      },
+      {
+        "threshold": 0.5,
+        "apcer": 0.3916854134797084,
+        "bpcer": 0.3570300157977883
+      },
+      {
+        "threshold": 0.55,
+        "apcer": 0.4701160802663547,
+        "bpcer": 0.1412914691943128
+      },
+      {
+        "threshold": 0.6,
+        "apcer": 0.6367497525420679,
+        "bpcer": 0.011749605055292258
+      },
+      {
+        "threshold": 0.7,
+        "apcer": 0.9739224331863583,
+        "bpcer": 0.0
+      }
+    ],
+    "per_split": {
+      "train": {
+        "images": 57747,
+        "detected": 57521,
+        "apcer": 0.5328728707935189,
+        "bpcer": 0.11331474564679889,
+        "auc": 0.5640491351395157,
+        "threshold_sweep": [
+          {
+            "threshold": 0.35,
+            "apcer": 0.19300477773161612,
+            "bpcer": 1.0
+          },
+          {
+            "threshold": 0.45,
+            "apcer": 0.3763502285002077,
+            "bpcer": 0.7461728654847704
+          },
+          {
+            "threshold": 0.5,
+            "apcer": 0.4437058579144163,
+            "bpcer": 0.3983902362039034
+          },
+          {
+            "threshold": 0.55,
+            "apcer": 0.5328728707935189,
+            "bpcer": 0.11331474564679889
+          },
+          {
+            "threshold": 0.6,
+            "apcer": 0.6946925633568758,
+            "bpcer": 0.010679151980640749
+          },
+          {
+            "threshold": 0.7,
+            "apcer": 0.9929891981719984,
+            "bpcer": 0.0
+          }
+        ]
+      },
+      "test": {
+        "images": 65786,
+        "detected": 65693,
+        "apcer": 0.4701160802663547,
+        "bpcer": 0.1412914691943128,
+        "auc": 0.6099671527404322,
+        "threshold_sweep": [
+          {
+            "threshold": 0.35,
+            "apcer": 0.18000539908215604,
+            "bpcer": 0.9999012638230648
+          },
+          {
+            "threshold": 0.45,
+            "apcer": 0.33467110591199495,
+            "bpcer": 0.7966034755134281
+          },
+          {
+            "threshold": 0.5,
+            "apcer": 0.3916854134797084,
+            "bpcer": 0.3570300157977883
+          },
+          {
+            "threshold": 0.55,
+            "apcer": 0.4701160802663547,
+            "bpcer": 0.1412914691943128
+          },
+          {
+            "threshold": 0.6,
+            "apcer": 0.6367497525420679,
+            "bpcer": 0.011749605055292258
+          },
+          {
+            "threshold": 0.7,
+            "apcer": 0.9739224331863583,
+            "bpcer": 0.0
+          }
+        ]
+      }
+    },
+    "per_condition": {
+      "train_live": {
+        "images": 19011,
+        "detected": 19009,
+        "n_scores": 19009
+      },
+      "train_spoof": {
+        "images": 38736,
+        "detected": 38512,
+        "n_scores": 38512
+      },
+      "test_live": {
+        "images": 10128,
+        "detected": 10128,
+        "n_scores": 10128
+      },
+      "test_spoof": {
+        "images": 55658,
+        "detected": 55565,
+        "n_scores": 55565
+      }
+    },
+    "wall_s": 2126.1
+  },
+  "notes": [
+    "casia_fasd: frame-extracted mirror (123,533 frame images under train/test x live/spoof directories; the original 550-video structure is not in this mirror), so scoring is FRAME-LEVEL with no vote; label from the directory (live = genuine, spoof = attack); headline apcer/bpcer/auc use the test split, per_split carries both; frames without a YuNet detection at the operating point are excluded from the metrics and counted in detected/images.",
+    "casia wall time 2126.1s at the operating point (YuNet letterbox 640 score 0.6, ViT 224 m96).",
+    "oulu_npu: MIRROR-LIMITED test subset (CONTROLLER RULING: scored honestly as such): 1,701 flat frames; the genuine side (true/) is 343 clips with EXACTLY ONE frame each, so genuine voting is impossible there (median-of-1); the attack side (false/) is 360 clips with 2-4 frames (298 x 4, 42 x 3, 20 x 2); subjects 1-6 of the protocol 55; the primary source is test-subset-only and the deeper fallback mirror was dead (404), so session breadth is NOT covered.",
+    "oulu filename pattern <subject>_<env>_<clip>_<frame>_<const>: video grouping derives from the first three underscore fields; numeric clip ids are shared across the two classes (343 of 360 attack ids also occur as a genuine id), so clips are grouped WITHIN each label: 703 label-scoped clips over 360 unique ids. Per-clip vote = median of the clip available frame scores; every clip has at most 5 frames, so median-of-available equals the shipped median-of-last-5 (the runtime itself abstains on fewer than 5 scores, which on this mirror means a genuine presentation would abstain rather than vote). Frames scored at stride 1.",
+    "oulu wall time 40.4s at the operating point (YuNet letterbox 640 score 0.6, ViT 224 m96).",
+    "celeba_spoof: parquet whale mirror (167 shards, 525,864 rows scanned; NO split column, the split comes from the shard FILENAME prefix train-*/valid-*/test-*); Class column carries exactly live/spoof (full-column scan: 177,262 live, 348,602 spoof), so the original dataset's 10 attack species are NOT labeled in this mirror: per_species covers the labeled attack species only (one spoof row). The phone-at-distance attack gap is NOT separately labeled in CelebA-Spoof.",
+    "celeba_spoof: Bbox convention pinned empirically on shard test-00000 (YuNet cross-check at score 0.5): Bbox = [x1, y1, x2, y2], mean IoU 0.877; the [x, y, w, h] reading is rejected (mean IoU 0.263, boxes out of frame). The provided bbox feeds the m96 crop directly; NO YuNet detection on this set, so detected counts rows scored through the provided box. Rows without a usable bbox are skipped and counted in skipped_no_usable_bbox. Headline metrics use the test shards; per_split carries train/valid too.",
+    "celeba_spoof: wall time for the scoring pass 4606.7s on archhost (ViT-base 224 CUDA, 167 shards; casia 2126.1s and oulu 40.4s are in their sections).",
+    "celeba_spoof VERIFIED (determinism check): 20 rows of shard test-00000 re-run through the crop+score path after the completed run; every recomputed score equals the recorded score at 6dp (20/20) and rows 0, 7, 19 re-scored BITWISE identical in a second pass (archhost, CUDA provider).",
+    "celeba_spoof VERIFIED (split source): the mirror test shards are 100% PNG (59,191 rows) while train and valid shards are 100% JPG (full path crosstab over all 167 shards); the test-vs-train gap is entirely ATTACK-side (attack score median 0.4936 test vs 0.5689 train / 0.5692 valid; genuine medians stable 0.4071 / 0.4085 / 0.4171), so the low test AUC 0.676 reflects a test-protocol attack population the shipped model ranks as more live-like, NOT genuine-side drift. HYPOTHESIS (not verified): the PNG test source carries a different acquisition/post-processing chain or a harder attack-type mix than the JPG train/valid source.",
+    "celeba_spoof VERIFIED (bbox source, 20-row sample of shard test-00000): mirror boxes vs YuNet at score 0.5 give mean box aspect 0.740 vs 0.728 and mean IoU 0.898, so the m96 crop geometry from the provided boxes matches YuNet boxes on that sample; the box source is NOT the lead explanation for the low test AUC. The lead explanations are the binary Class label (no 10-way species, limiting the per_species table) and the PNG-sourced test split's harder attack population (see split source note)."
+  ],
+  "oulu_npu": {
+    "clips": 703,
+    "images": 1701,
+    "scored": 1701,
+    "detected": 1701,
+    "voted": {
+      "apcer": 0.8416666666666667,
+      "bpcer": 0.0,
+      "auc": 0.9311386459345643,
+      "threshold_sweep": [
+        {
+          "threshold": 0.35,
+          "apcer": 0.011111111111111112,
+          "bpcer": 0.673469387755102
+        },
+        {
+          "threshold": 0.45,
+          "apcer": 0.2972222222222222,
+          "bpcer": 0.026239067055393587
+        },
+        {
+          "threshold": 0.5,
+          "apcer": 0.5944444444444444,
+          "bpcer": 0.0058309037900874635
+        },
+        {
+          "threshold": 0.55,
+          "apcer": 0.8416666666666667,
+          "bpcer": 0.0
+        },
+        {
+          "threshold": 0.6,
+          "apcer": 0.9527777777777777,
+          "bpcer": 0.0
+        },
+        {
+          "threshold": 0.7,
+          "apcer": 1.0,
+          "bpcer": 0.0
+        }
+      ]
+    },
+    "frame_level": {
+      "apcer": 0.7569955817378498,
+      "bpcer": 0.0,
+      "auc": 0.8950888160860809,
+      "threshold_sweep": [
+        {
+          "threshold": 0.35,
+          "apcer": 0.04050073637702504,
+          "bpcer": 0.673469387755102
+        },
+        {
+          "threshold": 0.45,
+          "apcer": 0.3431516936671576,
+          "bpcer": 0.026239067055393587
+        },
+        {
+          "threshold": 0.5,
+          "apcer": 0.5743740795287187,
+          "bpcer": 0.0058309037900874635
+        },
+        {
+          "threshold": 0.55,
+          "apcer": 0.7569955817378498,
+          "bpcer": 0.0
+        },
+        {
+          "threshold": 0.6,
+          "apcer": 0.9013254786450663,
+          "bpcer": 0.0
+        },
+        {
+          "threshold": 0.7,
+          "apcer": 0.9977908689248896,
+          "bpcer": 0.0
+        }
+      ]
+    },
+    "per_video": [
+      {
+        "clip": "1_1_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.419738
+      },
+      {
+        "clip": "1_1_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.368907
+      },
+      {
+        "clip": "1_1_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.353893
+      },
+      {
+        "clip": "1_1_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.455588
+      },
+      {
+        "clip": "1_1_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.343891
+      },
+      {
+        "clip": "1_1_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.375976
+      },
+      {
+        "clip": "1_1_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.405966
+      },
+      {
+        "clip": "1_1_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.336596
+      },
+      {
+        "clip": "1_1_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.302971
+      },
+      {
+        "clip": "1_1_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.389884
+      },
+      {
+        "clip": "1_1_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.432792
+      },
+      {
+        "clip": "1_1_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.295858
+      },
+      {
+        "clip": "1_1_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.416019
+      },
+      {
+        "clip": "1_1_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.378412
+      },
+      {
+        "clip": "1_1_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.441163
+      },
+      {
+        "clip": "1_1_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.448468
+      },
+      {
+        "clip": "1_1_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.471629
+      },
+      {
+        "clip": "1_1_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.40671
+      },
+      {
+        "clip": "1_2_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.467902
+      },
+      {
+        "clip": "1_2_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.344943
+      },
+      {
+        "clip": "1_2_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.387853
+      },
+      {
+        "clip": "1_2_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.474319
+      },
+      {
+        "clip": "1_2_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.37687
+      },
+      {
+        "clip": "1_2_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.421453
+      },
+      {
+        "clip": "1_2_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.395181
+      },
+      {
+        "clip": "1_2_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.336345
+      },
+      {
+        "clip": "1_2_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.418782
+      },
+      {
+        "clip": "1_2_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.37127
+      },
+      {
+        "clip": "1_2_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.30734
+      },
+      {
+        "clip": "1_2_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.42106
+      },
+      {
+        "clip": "1_2_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.349271
+      },
+      {
+        "clip": "1_2_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.35966
+      },
+      {
+        "clip": "1_2_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.433727
+      },
+      {
+        "clip": "1_2_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.405082
+      },
+      {
+        "clip": "1_2_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.418076
+      },
+      {
+        "clip": "1_2_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.389966
+      },
+      {
+        "clip": "1_3_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.425679
+      },
+      {
+        "clip": "1_3_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.365396
+      },
+      {
+        "clip": "1_3_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.417522
+      },
+      {
+        "clip": "1_3_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.413902
+      },
+      {
+        "clip": "1_3_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.372601
+      },
+      {
+        "clip": "1_3_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.44844
+      },
+      {
+        "clip": "1_3_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.397834
+      },
+      {
+        "clip": "1_3_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.391214
+      },
+      {
+        "clip": "1_3_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.32928
+      },
+      {
+        "clip": "1_3_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.342532
+      },
+      {
+        "clip": "1_3_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.364989
+      },
+      {
+        "clip": "1_3_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.294412
+      },
+      {
+        "clip": "1_3_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.38997
+      },
+      {
+        "clip": "1_3_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.376348
+      },
+      {
+        "clip": "1_3_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.433603
+      },
+      {
+        "clip": "1_3_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.432292
+      },
+      {
+        "clip": "1_3_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.337634
+      },
+      {
+        "clip": "1_3_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.417609
+      },
+      {
+        "clip": "1_3_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.310554
+      },
+      {
+        "clip": "1_3_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.341443
+      },
+      {
+        "clip": "2_1_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.406369
+      },
+      {
+        "clip": "2_1_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.355549
+      },
+      {
+        "clip": "2_1_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.314958
+      },
+      {
+        "clip": "2_1_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.422975
+      },
+      {
+        "clip": "2_1_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.319786
+      },
+      {
+        "clip": "2_1_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.388792
+      },
+      {
+        "clip": "2_1_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.429346
+      },
+      {
+        "clip": "2_1_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.344607
+      },
+      {
+        "clip": "2_1_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.295434
+      },
+      {
+        "clip": "2_1_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.411061
+      },
+      {
+        "clip": "2_1_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.368688
+      },
+      {
+        "clip": "2_1_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.297027
+      },
+      {
+        "clip": "2_1_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.377335
+      },
+      {
+        "clip": "2_1_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.35479
+      },
+      {
+        "clip": "2_1_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.371972
+      },
+      {
+        "clip": "2_1_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.387587
+      },
+      {
+        "clip": "2_1_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.384379
+      },
+      {
+        "clip": "2_1_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.320072
+      },
+      {
+        "clip": "2_1_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.368371
+      },
+      {
+        "clip": "2_2_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.399767
+      },
+      {
+        "clip": "2_2_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.350035
+      },
+      {
+        "clip": "2_2_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.404438
+      },
+      {
+        "clip": "2_2_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.327305
+      },
+      {
+        "clip": "2_2_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.40811
+      },
+      {
+        "clip": "2_2_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.39017
+      },
+      {
+        "clip": "2_2_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.370053
+      },
+      {
+        "clip": "2_2_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.337884
+      },
+      {
+        "clip": "2_2_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.402053
+      },
+      {
+        "clip": "2_2_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.388662
+      },
+      {
+        "clip": "2_2_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.310364
+      },
+      {
+        "clip": "2_2_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.381866
+      },
+      {
+        "clip": "2_2_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.417295
+      },
+      {
+        "clip": "2_2_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.349567
+      },
+      {
+        "clip": "2_2_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.375573
+      },
+      {
+        "clip": "2_2_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.3897
+      },
+      {
+        "clip": "2_2_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.331214
+      },
+      {
+        "clip": "2_2_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.400373
+      },
+      {
+        "clip": "2_3_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.419018
+      },
+      {
+        "clip": "2_3_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.315803
+      },
+      {
+        "clip": "2_3_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.419641
+      },
+      {
+        "clip": "2_3_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.386201
+      },
+      {
+        "clip": "2_3_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.351002
+      },
+      {
+        "clip": "2_3_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.420271
+      },
+      {
+        "clip": "2_3_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.418235
+      },
+      {
+        "clip": "2_3_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.380863
+      },
+      {
+        "clip": "2_3_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.327078
+      },
+      {
+        "clip": "2_3_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.421886
+      },
+      {
+        "clip": "2_3_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.366796
+      },
+      {
+        "clip": "2_3_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.320216
+      },
+      {
+        "clip": "2_3_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.421473
+      },
+      {
+        "clip": "2_3_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.376311
+      },
+      {
+        "clip": "2_3_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.441963
+      },
+      {
+        "clip": "2_3_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.428668
+      },
+      {
+        "clip": "2_3_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.394078
+      },
+      {
+        "clip": "2_3_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.467736
+      },
+      {
+        "clip": "2_3_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.251083
+      },
+      {
+        "clip": "2_3_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.360208
+      },
+      {
+        "clip": "3_1_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.331543
+      },
+      {
+        "clip": "3_1_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.299986
+      },
+      {
+        "clip": "3_1_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.297319
+      },
+      {
+        "clip": "3_1_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.371772
+      },
+      {
+        "clip": "3_1_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.315889
+      },
+      {
+        "clip": "3_1_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.399202
+      },
+      {
+        "clip": "3_1_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.415389
+      },
+      {
+        "clip": "3_1_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.25376
+      },
+      {
+        "clip": "3_1_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.25167
+      },
+      {
+        "clip": "3_1_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.35384
+      },
+      {
+        "clip": "3_1_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.330091
+      },
+      {
+        "clip": "3_1_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.334664
+      },
+      {
+        "clip": "3_1_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.37044
+      },
+      {
+        "clip": "3_1_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.420247
+      },
+      {
+        "clip": "3_1_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.37156
+      },
+      {
+        "clip": "3_1_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.371096
+      },
+      {
+        "clip": "3_1_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.396138
+      },
+      {
+        "clip": "3_1_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.294085
+      },
+      {
+        "clip": "3_1_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.344007
+      },
+      {
+        "clip": "3_2_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.446764
+      },
+      {
+        "clip": "3_2_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.363543
+      },
+      {
+        "clip": "3_2_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.425069
+      },
+      {
+        "clip": "3_2_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.368443
+      },
+      {
+        "clip": "3_2_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.358958
+      },
+      {
+        "clip": "3_2_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.31025
+      },
+      {
+        "clip": "3_2_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.324732
+      },
+      {
+        "clip": "3_2_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.324928
+      },
+      {
+        "clip": "3_2_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.312649
+      },
+      {
+        "clip": "3_2_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.333577
+      },
+      {
+        "clip": "3_2_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.339959
+      },
+      {
+        "clip": "3_2_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.319909
+      },
+      {
+        "clip": "3_2_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.341731
+      },
+      {
+        "clip": "3_2_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.317621
+      },
+      {
+        "clip": "3_2_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.368072
+      },
+      {
+        "clip": "3_2_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.313975
+      },
+      {
+        "clip": "3_2_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.370156
+      },
+      {
+        "clip": "3_3_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.357237
+      },
+      {
+        "clip": "3_3_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.273307
+      },
+      {
+        "clip": "3_3_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.389068
+      },
+      {
+        "clip": "3_3_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.332736
+      },
+      {
+        "clip": "3_3_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.374227
+      },
+      {
+        "clip": "3_3_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.383498
+      },
+      {
+        "clip": "3_3_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.323048
+      },
+      {
+        "clip": "3_3_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.314335
+      },
+      {
+        "clip": "3_3_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.296747
+      },
+      {
+        "clip": "3_3_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.331438
+      },
+      {
+        "clip": "3_3_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.397009
+      },
+      {
+        "clip": "3_3_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.319481
+      },
+      {
+        "clip": "3_3_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.370742
+      },
+      {
+        "clip": "3_3_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.389415
+      },
+      {
+        "clip": "3_3_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.414094
+      },
+      {
+        "clip": "3_3_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.400823
+      },
+      {
+        "clip": "3_3_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.428358
+      },
+      {
+        "clip": "3_3_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.364242
+      },
+      {
+        "clip": "3_3_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.382962
+      },
+      {
+        "clip": "4_1_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.388466
+      },
+      {
+        "clip": "4_1_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.367227
+      },
+      {
+        "clip": "4_1_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.329357
+      },
+      {
+        "clip": "4_1_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.374035
+      },
+      {
+        "clip": "4_1_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.342445
+      },
+      {
+        "clip": "4_1_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.403906
+      },
+      {
+        "clip": "4_1_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.311238
+      },
+      {
+        "clip": "4_1_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.39147
+      },
+      {
+        "clip": "4_1_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.371486
+      },
+      {
+        "clip": "4_1_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.287655
+      },
+      {
+        "clip": "4_1_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.377713
+      },
+      {
+        "clip": "4_1_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.3826
+      },
+      {
+        "clip": "4_1_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.432034
+      },
+      {
+        "clip": "4_1_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.385675
+      },
+      {
+        "clip": "4_1_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.396369
+      },
+      {
+        "clip": "4_1_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.405312
+      },
+      {
+        "clip": "4_1_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.396453
+      },
+      {
+        "clip": "4_1_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.344709
+      },
+      {
+        "clip": "4_2_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.415341
+      },
+      {
+        "clip": "4_2_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.40339
+      },
+      {
+        "clip": "4_2_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.393303
+      },
+      {
+        "clip": "4_2_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.410505
+      },
+      {
+        "clip": "4_2_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.343786
+      },
+      {
+        "clip": "4_2_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.369315
+      },
+      {
+        "clip": "4_2_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.363938
+      },
+      {
+        "clip": "4_2_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.339586
+      },
+      {
+        "clip": "4_2_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.311658
+      },
+      {
+        "clip": "4_2_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.319683
+      },
+      {
+        "clip": "4_2_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.367397
+      },
+      {
+        "clip": "4_2_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.345789
+      },
+      {
+        "clip": "4_2_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.412739
+      },
+      {
+        "clip": "4_2_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.3236
+      },
+      {
+        "clip": "4_2_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.338457
+      },
+      {
+        "clip": "4_2_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.358422
+      },
+      {
+        "clip": "4_2_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.344925
+      },
+      {
+        "clip": "4_2_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.304722
+      },
+      {
+        "clip": "4_2_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.407938
+      },
+      {
+        "clip": "4_3_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.412322
+      },
+      {
+        "clip": "4_3_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.361423
+      },
+      {
+        "clip": "4_3_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.392351
+      },
+      {
+        "clip": "4_3_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.432998
+      },
+      {
+        "clip": "4_3_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.368665
+      },
+      {
+        "clip": "4_3_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.406718
+      },
+      {
+        "clip": "4_3_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.385713
+      },
+      {
+        "clip": "4_3_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.350619
+      },
+      {
+        "clip": "4_3_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.300211
+      },
+      {
+        "clip": "4_3_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.382793
+      },
+      {
+        "clip": "4_3_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.363545
+      },
+      {
+        "clip": "4_3_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.345038
+      },
+      {
+        "clip": "4_3_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.357346
+      },
+      {
+        "clip": "4_3_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.363271
+      },
+      {
+        "clip": "4_3_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.418131
+      },
+      {
+        "clip": "4_3_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.364401
+      },
+      {
+        "clip": "4_3_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.359329
+      },
+      {
+        "clip": "4_3_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.398002
+      },
+      {
+        "clip": "4_3_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.303929
+      },
+      {
+        "clip": "4_3_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.289553
+      },
+      {
+        "clip": "5_1_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.412886
+      },
+      {
+        "clip": "5_1_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.318747
+      },
+      {
+        "clip": "5_1_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.298162
+      },
+      {
+        "clip": "5_1_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.391464
+      },
+      {
+        "clip": "5_1_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.331827
+      },
+      {
+        "clip": "5_1_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.329519
+      },
+      {
+        "clip": "5_1_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.377682
+      },
+      {
+        "clip": "5_1_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.26489
+      },
+      {
+        "clip": "5_1_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.296403
+      },
+      {
+        "clip": "5_1_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.375785
+      },
+      {
+        "clip": "5_1_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.362291
+      },
+      {
+        "clip": "5_1_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.31646
+      },
+      {
+        "clip": "5_1_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.416019
+      },
+      {
+        "clip": "5_1_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.342395
+      },
+      {
+        "clip": "5_1_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.504818
+      },
+      {
+        "clip": "5_1_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.382617
+      },
+      {
+        "clip": "5_1_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.402502
+      },
+      {
+        "clip": "5_1_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.356352
+      },
+      {
+        "clip": "5_1_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.344304
+      },
+      {
+        "clip": "5_1_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.384478
+      },
+      {
+        "clip": "5_2_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.359798
+      },
+      {
+        "clip": "5_2_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.386121
+      },
+      {
+        "clip": "5_2_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.323719
+      },
+      {
+        "clip": "5_2_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.328974
+      },
+      {
+        "clip": "5_2_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.333014
+      },
+      {
+        "clip": "5_2_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.374904
+      },
+      {
+        "clip": "5_2_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.258738
+      },
+      {
+        "clip": "5_2_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.336263
+      },
+      {
+        "clip": "5_2_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.341989
+      },
+      {
+        "clip": "5_2_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.323982
+      },
+      {
+        "clip": "5_2_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.382655
+      },
+      {
+        "clip": "5_2_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.357327
+      },
+      {
+        "clip": "5_2_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.356307
+      },
+      {
+        "clip": "5_2_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.394855
+      },
+      {
+        "clip": "5_2_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.386401
+      },
+      {
+        "clip": "5_2_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.323236
+      },
+      {
+        "clip": "5_2_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.279911
+      },
+      {
+        "clip": "5_2_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.384286
+      },
+      {
+        "clip": "5_3_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.421271
+      },
+      {
+        "clip": "5_3_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.370083
+      },
+      {
+        "clip": "5_3_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.384996
+      },
+      {
+        "clip": "5_3_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.376642
+      },
+      {
+        "clip": "5_3_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.338257
+      },
+      {
+        "clip": "5_3_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.384391
+      },
+      {
+        "clip": "5_3_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.390564
+      },
+      {
+        "clip": "5_3_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.335207
+      },
+      {
+        "clip": "5_3_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.279472
+      },
+      {
+        "clip": "5_3_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.351534
+      },
+      {
+        "clip": "5_3_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.395473
+      },
+      {
+        "clip": "5_3_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.323568
+      },
+      {
+        "clip": "5_3_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.376197
+      },
+      {
+        "clip": "5_3_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.365063
+      },
+      {
+        "clip": "5_3_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.41596
+      },
+      {
+        "clip": "5_3_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.404835
+      },
+      {
+        "clip": "5_3_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.335043
+      },
+      {
+        "clip": "5_3_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.419558
+      },
+      {
+        "clip": "5_3_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.270762
+      },
+      {
+        "clip": "5_3_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.378386
+      },
+      {
+        "clip": "6_1_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.403397
+      },
+      {
+        "clip": "6_1_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.363086
+      },
+      {
+        "clip": "6_1_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.339042
+      },
+      {
+        "clip": "6_1_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.390025
+      },
+      {
+        "clip": "6_1_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.353008
+      },
+      {
+        "clip": "6_1_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.363175
+      },
+      {
+        "clip": "6_1_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.45657
+      },
+      {
+        "clip": "6_1_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.338075
+      },
+      {
+        "clip": "6_1_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.319594
+      },
+      {
+        "clip": "6_1_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.373959
+      },
+      {
+        "clip": "6_1_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.347751
+      },
+      {
+        "clip": "6_1_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.291079
+      },
+      {
+        "clip": "6_1_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.338878
+      },
+      {
+        "clip": "6_1_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.352922
+      },
+      {
+        "clip": "6_1_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.447772
+      },
+      {
+        "clip": "6_1_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.375452
+      },
+      {
+        "clip": "6_1_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.399186
+      },
+      {
+        "clip": "6_1_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.352264
+      },
+      {
+        "clip": "6_1_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.390325
+      },
+      {
+        "clip": "6_1_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.327191
+      },
+      {
+        "clip": "6_2_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.464517
+      },
+      {
+        "clip": "6_2_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.42532
+      },
+      {
+        "clip": "6_2_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.361775
+      },
+      {
+        "clip": "6_2_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.418865
+      },
+      {
+        "clip": "6_2_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.381417
+      },
+      {
+        "clip": "6_2_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.39629
+      },
+      {
+        "clip": "6_2_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.405804
+      },
+      {
+        "clip": "6_2_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.323731
+      },
+      {
+        "clip": "6_2_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.30855
+      },
+      {
+        "clip": "6_2_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.39349
+      },
+      {
+        "clip": "6_2_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.37839
+      },
+      {
+        "clip": "6_2_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.324131
+      },
+      {
+        "clip": "6_2_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.416
+      },
+      {
+        "clip": "6_2_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.405034
+      },
+      {
+        "clip": "6_2_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.425821
+      },
+      {
+        "clip": "6_2_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.421376
+      },
+      {
+        "clip": "6_2_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.426383
+      },
+      {
+        "clip": "6_2_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.348492
+      },
+      {
+        "clip": "6_2_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.401912
+      },
+      {
+        "clip": "6_2_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.412439
+      },
+      {
+        "clip": "6_3_36",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.438509
+      },
+      {
+        "clip": "6_3_37",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.391741
+      },
+      {
+        "clip": "6_3_38",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.441378
+      },
+      {
+        "clip": "6_3_39",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.378196
+      },
+      {
+        "clip": "6_3_40",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.375119
+      },
+      {
+        "clip": "6_3_41",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.425799
+      },
+      {
+        "clip": "6_3_42",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.401917
+      },
+      {
+        "clip": "6_3_43",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.326911
+      },
+      {
+        "clip": "6_3_44",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.377648
+      },
+      {
+        "clip": "6_3_45",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.423577
+      },
+      {
+        "clip": "6_3_46",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.394103
+      },
+      {
+        "clip": "6_3_47",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.325625
+      },
+      {
+        "clip": "6_3_48",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.375353
+      },
+      {
+        "clip": "6_3_49",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.439057
+      },
+      {
+        "clip": "6_3_50",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.433084
+      },
+      {
+        "clip": "6_3_51",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.399056
+      },
+      {
+        "clip": "6_3_52",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.378179
+      },
+      {
+        "clip": "6_3_53",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.507034
+      },
+      {
+        "clip": "6_3_54",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.23746
+      },
+      {
+        "clip": "6_3_55",
+        "cls": "genuine",
+        "n_frames": 1,
+        "vote": 0.376764
+      },
+      {
+        "clip": "1_1_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.544042
+      },
+      {
+        "clip": "1_1_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.469335
+      },
+      {
+        "clip": "1_1_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.396467
+      },
+      {
+        "clip": "1_1_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.534055
+      },
+      {
+        "clip": "1_1_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.453583
+      },
+      {
+        "clip": "1_1_41",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.466102
+      },
+      {
+        "clip": "1_1_42",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.594414
+      },
+      {
+        "clip": "1_1_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.454054
+      },
+      {
+        "clip": "1_1_44",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.417231
+      },
+      {
+        "clip": "1_1_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.477981
+      },
+      {
+        "clip": "1_1_46",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.510103
+      },
+      {
+        "clip": "1_1_47",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.461099
+      },
+      {
+        "clip": "1_1_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.482124
+      },
+      {
+        "clip": "1_1_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.567767
+      },
+      {
+        "clip": "1_1_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.616033
+      },
+      {
+        "clip": "1_1_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.487772
+      },
+      {
+        "clip": "1_1_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.544928
+      },
+      {
+        "clip": "1_1_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.5428
+      },
+      {
+        "clip": "1_1_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.594512
+      },
+      {
+        "clip": "1_1_55",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.593487
+      },
+      {
+        "clip": "1_2_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.656775
+      },
+      {
+        "clip": "1_2_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.617513
+      },
+      {
+        "clip": "1_2_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.565832
+      },
+      {
+        "clip": "1_2_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.579494
+      },
+      {
+        "clip": "1_2_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.512775
+      },
+      {
+        "clip": "1_2_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.545249
+      },
+      {
+        "clip": "1_2_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.57857
+      },
+      {
+        "clip": "1_2_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.410206
+      },
+      {
+        "clip": "1_2_44",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.4996
+      },
+      {
+        "clip": "1_2_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.520024
+      },
+      {
+        "clip": "1_2_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.463275
+      },
+      {
+        "clip": "1_2_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.509011
+      },
+      {
+        "clip": "1_2_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.557548
+      },
+      {
+        "clip": "1_2_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.512311
+      },
+      {
+        "clip": "1_2_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.563633
+      },
+      {
+        "clip": "1_2_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.587709
+      },
+      {
+        "clip": "1_2_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.598013
+      },
+      {
+        "clip": "1_2_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.512242
+      },
+      {
+        "clip": "1_2_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.555435
+      },
+      {
+        "clip": "1_2_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.567116
+      },
+      {
+        "clip": "1_3_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.587215
+      },
+      {
+        "clip": "1_3_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.651811
+      },
+      {
+        "clip": "1_3_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.499573
+      },
+      {
+        "clip": "1_3_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.525143
+      },
+      {
+        "clip": "1_3_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.458187
+      },
+      {
+        "clip": "1_3_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.511869
+      },
+      {
+        "clip": "1_3_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.528374
+      },
+      {
+        "clip": "1_3_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.479562
+      },
+      {
+        "clip": "1_3_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.535576
+      },
+      {
+        "clip": "1_3_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.49105
+      },
+      {
+        "clip": "1_3_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.561881
+      },
+      {
+        "clip": "1_3_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.59273
+      },
+      {
+        "clip": "1_3_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.521977
+      },
+      {
+        "clip": "1_3_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.617944
+      },
+      {
+        "clip": "1_3_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.565143
+      },
+      {
+        "clip": "1_3_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.605389
+      },
+      {
+        "clip": "1_3_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.547636
+      },
+      {
+        "clip": "1_3_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.549516
+      },
+      {
+        "clip": "1_3_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.42158
+      },
+      {
+        "clip": "1_3_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.539058
+      },
+      {
+        "clip": "2_1_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.456594
+      },
+      {
+        "clip": "2_1_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.399196
+      },
+      {
+        "clip": "2_1_38",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.37901
+      },
+      {
+        "clip": "2_1_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.495231
+      },
+      {
+        "clip": "2_1_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.381919
+      },
+      {
+        "clip": "2_1_41",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.480408
+      },
+      {
+        "clip": "2_1_42",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.54579
+      },
+      {
+        "clip": "2_1_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.457025
+      },
+      {
+        "clip": "2_1_44",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.380593
+      },
+      {
+        "clip": "2_1_45",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.461046
+      },
+      {
+        "clip": "2_1_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.437172
+      },
+      {
+        "clip": "2_1_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.321878
+      },
+      {
+        "clip": "2_1_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.42095
+      },
+      {
+        "clip": "2_1_49",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.529426
+      },
+      {
+        "clip": "2_1_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.532998
+      },
+      {
+        "clip": "2_1_51",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.453339
+      },
+      {
+        "clip": "2_1_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.442432
+      },
+      {
+        "clip": "2_1_53",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.521985
+      },
+      {
+        "clip": "2_1_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.450652
+      },
+      {
+        "clip": "2_1_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.461767
+      },
+      {
+        "clip": "2_2_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.55475
+      },
+      {
+        "clip": "2_2_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.514444
+      },
+      {
+        "clip": "2_2_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.52666
+      },
+      {
+        "clip": "2_2_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.533397
+      },
+      {
+        "clip": "2_2_40",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.439138
+      },
+      {
+        "clip": "2_2_41",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.487198
+      },
+      {
+        "clip": "2_2_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.494828
+      },
+      {
+        "clip": "2_2_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.426135
+      },
+      {
+        "clip": "2_2_44",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.451811
+      },
+      {
+        "clip": "2_2_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.464519
+      },
+      {
+        "clip": "2_2_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.484114
+      },
+      {
+        "clip": "2_2_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.367056
+      },
+      {
+        "clip": "2_2_48",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.489237
+      },
+      {
+        "clip": "2_2_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.49917
+      },
+      {
+        "clip": "2_2_50",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.620306
+      },
+      {
+        "clip": "2_2_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.510299
+      },
+      {
+        "clip": "2_2_52",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.504477
+      },
+      {
+        "clip": "2_2_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.490005
+      },
+      {
+        "clip": "2_2_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.57848
+      },
+      {
+        "clip": "2_2_55",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.443935
+      },
+      {
+        "clip": "2_3_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.553576
+      },
+      {
+        "clip": "2_3_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.634269
+      },
+      {
+        "clip": "2_3_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.474011
+      },
+      {
+        "clip": "2_3_39",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.495366
+      },
+      {
+        "clip": "2_3_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.408671
+      },
+      {
+        "clip": "2_3_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.474126
+      },
+      {
+        "clip": "2_3_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.439213
+      },
+      {
+        "clip": "2_3_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.422402
+      },
+      {
+        "clip": "2_3_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.488788
+      },
+      {
+        "clip": "2_3_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.469653
+      },
+      {
+        "clip": "2_3_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.485237
+      },
+      {
+        "clip": "2_3_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.488866
+      },
+      {
+        "clip": "2_3_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.49061
+      },
+      {
+        "clip": "2_3_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.531691
+      },
+      {
+        "clip": "2_3_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.518081
+      },
+      {
+        "clip": "2_3_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.544178
+      },
+      {
+        "clip": "2_3_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.46481
+      },
+      {
+        "clip": "2_3_53",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.548003
+      },
+      {
+        "clip": "2_3_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.391298
+      },
+      {
+        "clip": "2_3_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.473585
+      },
+      {
+        "clip": "3_1_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.531983
+      },
+      {
+        "clip": "3_1_37",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.448796
+      },
+      {
+        "clip": "3_1_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.419156
+      },
+      {
+        "clip": "3_1_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.499672
+      },
+      {
+        "clip": "3_1_40",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.423091
+      },
+      {
+        "clip": "3_1_41",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.493301
+      },
+      {
+        "clip": "3_1_42",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.46179
+      },
+      {
+        "clip": "3_1_43",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.435843
+      },
+      {
+        "clip": "3_1_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.404684
+      },
+      {
+        "clip": "3_1_45",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.46725
+      },
+      {
+        "clip": "3_1_46",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.473642
+      },
+      {
+        "clip": "3_1_47",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.42592
+      },
+      {
+        "clip": "3_1_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.459368
+      },
+      {
+        "clip": "3_1_49",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.54077
+      },
+      {
+        "clip": "3_1_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.562659
+      },
+      {
+        "clip": "3_1_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.474239
+      },
+      {
+        "clip": "3_1_52",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.474678
+      },
+      {
+        "clip": "3_1_53",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.525852
+      },
+      {
+        "clip": "3_1_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.554577
+      },
+      {
+        "clip": "3_1_55",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.462317
+      },
+      {
+        "clip": "3_2_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.597187
+      },
+      {
+        "clip": "3_2_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.602063
+      },
+      {
+        "clip": "3_2_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.582019
+      },
+      {
+        "clip": "3_2_39",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.495644
+      },
+      {
+        "clip": "3_2_40",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.509804
+      },
+      {
+        "clip": "3_2_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.556492
+      },
+      {
+        "clip": "3_2_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.516504
+      },
+      {
+        "clip": "3_2_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.446206
+      },
+      {
+        "clip": "3_2_44",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.44405
+      },
+      {
+        "clip": "3_2_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.467879
+      },
+      {
+        "clip": "3_2_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.482191
+      },
+      {
+        "clip": "3_2_47",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.471976
+      },
+      {
+        "clip": "3_2_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.529407
+      },
+      {
+        "clip": "3_2_49",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.551796
+      },
+      {
+        "clip": "3_2_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.601875
+      },
+      {
+        "clip": "3_2_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.603496
+      },
+      {
+        "clip": "3_2_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.547786
+      },
+      {
+        "clip": "3_2_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.519404
+      },
+      {
+        "clip": "3_2_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.534922
+      },
+      {
+        "clip": "3_2_55",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.473257
+      },
+      {
+        "clip": "3_3_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.559665
+      },
+      {
+        "clip": "3_3_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.648344
+      },
+      {
+        "clip": "3_3_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.50508
+      },
+      {
+        "clip": "3_3_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.482307
+      },
+      {
+        "clip": "3_3_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.467575
+      },
+      {
+        "clip": "3_3_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.476261
+      },
+      {
+        "clip": "3_3_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.423143
+      },
+      {
+        "clip": "3_3_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.472654
+      },
+      {
+        "clip": "3_3_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.448994
+      },
+      {
+        "clip": "3_3_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.43609
+      },
+      {
+        "clip": "3_3_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.515943
+      },
+      {
+        "clip": "3_3_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.499789
+      },
+      {
+        "clip": "3_3_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.518898
+      },
+      {
+        "clip": "3_3_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.570926
+      },
+      {
+        "clip": "3_3_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.549652
+      },
+      {
+        "clip": "3_3_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.528472
+      },
+      {
+        "clip": "3_3_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.534846
+      },
+      {
+        "clip": "3_3_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.547665
+      },
+      {
+        "clip": "3_3_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.410831
+      },
+      {
+        "clip": "3_3_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.528226
+      },
+      {
+        "clip": "4_1_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.479198
+      },
+      {
+        "clip": "4_1_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.409371
+      },
+      {
+        "clip": "4_1_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.401699
+      },
+      {
+        "clip": "4_1_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.505498
+      },
+      {
+        "clip": "4_1_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.39847
+      },
+      {
+        "clip": "4_1_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.479052
+      },
+      {
+        "clip": "4_1_42",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.460447
+      },
+      {
+        "clip": "4_1_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.435762
+      },
+      {
+        "clip": "4_1_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.38576
+      },
+      {
+        "clip": "4_1_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.431772
+      },
+      {
+        "clip": "4_1_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.437717
+      },
+      {
+        "clip": "4_1_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.380854
+      },
+      {
+        "clip": "4_1_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.415052
+      },
+      {
+        "clip": "4_1_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.46753
+      },
+      {
+        "clip": "4_1_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.528563
+      },
+      {
+        "clip": "4_1_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.41195
+      },
+      {
+        "clip": "4_1_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.45156
+      },
+      {
+        "clip": "4_1_53",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.419688
+      },
+      {
+        "clip": "4_1_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.467653
+      },
+      {
+        "clip": "4_1_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.432382
+      },
+      {
+        "clip": "4_2_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.578923
+      },
+      {
+        "clip": "4_2_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.556452
+      },
+      {
+        "clip": "4_2_38",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.486243
+      },
+      {
+        "clip": "4_2_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.49101
+      },
+      {
+        "clip": "4_2_40",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.391948
+      },
+      {
+        "clip": "4_2_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.51574
+      },
+      {
+        "clip": "4_2_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.497307
+      },
+      {
+        "clip": "4_2_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.407194
+      },
+      {
+        "clip": "4_2_44",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.40819
+      },
+      {
+        "clip": "4_2_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.470446
+      },
+      {
+        "clip": "4_2_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.420584
+      },
+      {
+        "clip": "4_2_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.410935
+      },
+      {
+        "clip": "4_2_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.502321
+      },
+      {
+        "clip": "4_2_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.43588
+      },
+      {
+        "clip": "4_2_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.510572
+      },
+      {
+        "clip": "4_2_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.527613
+      },
+      {
+        "clip": "4_2_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.557443
+      },
+      {
+        "clip": "4_2_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.514093
+      },
+      {
+        "clip": "4_2_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.599633
+      },
+      {
+        "clip": "4_2_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.478779
+      },
+      {
+        "clip": "4_3_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.510113
+      },
+      {
+        "clip": "4_3_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.468651
+      },
+      {
+        "clip": "4_3_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.413166
+      },
+      {
+        "clip": "4_3_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.480834
+      },
+      {
+        "clip": "4_3_40",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.395345
+      },
+      {
+        "clip": "4_3_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.455884
+      },
+      {
+        "clip": "4_3_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.353354
+      },
+      {
+        "clip": "4_3_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.386693
+      },
+      {
+        "clip": "4_3_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.355632
+      },
+      {
+        "clip": "4_3_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.425198
+      },
+      {
+        "clip": "4_3_46",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.445896
+      },
+      {
+        "clip": "4_3_47",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.477854
+      },
+      {
+        "clip": "4_3_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.467485
+      },
+      {
+        "clip": "4_3_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.539127
+      },
+      {
+        "clip": "4_3_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.507145
+      },
+      {
+        "clip": "4_3_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.501432
+      },
+      {
+        "clip": "4_3_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.47573
+      },
+      {
+        "clip": "4_3_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.495601
+      },
+      {
+        "clip": "4_3_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.325087
+      },
+      {
+        "clip": "4_3_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.432835
+      },
+      {
+        "clip": "5_1_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.377434
+      },
+      {
+        "clip": "5_1_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.404508
+      },
+      {
+        "clip": "5_1_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.366615
+      },
+      {
+        "clip": "5_1_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.453038
+      },
+      {
+        "clip": "5_1_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.352482
+      },
+      {
+        "clip": "5_1_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.398484
+      },
+      {
+        "clip": "5_1_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.444985
+      },
+      {
+        "clip": "5_1_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.400686
+      },
+      {
+        "clip": "5_1_44",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.309869
+      },
+      {
+        "clip": "5_1_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.392152
+      },
+      {
+        "clip": "5_1_46",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.395713
+      },
+      {
+        "clip": "5_1_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.358558
+      },
+      {
+        "clip": "5_1_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.408186
+      },
+      {
+        "clip": "5_1_49",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.487398
+      },
+      {
+        "clip": "5_1_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.516757
+      },
+      {
+        "clip": "5_1_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.419992
+      },
+      {
+        "clip": "5_1_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.444949
+      },
+      {
+        "clip": "5_1_53",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.429252
+      },
+      {
+        "clip": "5_1_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.440202
+      },
+      {
+        "clip": "5_1_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.414078
+      },
+      {
+        "clip": "5_2_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.513763
+      },
+      {
+        "clip": "5_2_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.52011
+      },
+      {
+        "clip": "5_2_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.492667
+      },
+      {
+        "clip": "5_2_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.495258
+      },
+      {
+        "clip": "5_2_40",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.429777
+      },
+      {
+        "clip": "5_2_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.410358
+      },
+      {
+        "clip": "5_2_42",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.489363
+      },
+      {
+        "clip": "5_2_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.333212
+      },
+      {
+        "clip": "5_2_44",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.410059
+      },
+      {
+        "clip": "5_2_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.383339
+      },
+      {
+        "clip": "5_2_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.394631
+      },
+      {
+        "clip": "5_2_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.361177
+      },
+      {
+        "clip": "5_2_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.437706
+      },
+      {
+        "clip": "5_2_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.430259
+      },
+      {
+        "clip": "5_2_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.447364
+      },
+      {
+        "clip": "5_2_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.488374
+      },
+      {
+        "clip": "5_2_52",
+        "cls": "attack",
+        "n_frames": 2,
+        "vote": 0.501812
+      },
+      {
+        "clip": "5_2_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.446253
+      },
+      {
+        "clip": "5_2_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.451133
+      },
+      {
+        "clip": "5_2_55",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.438632
+      },
+      {
+        "clip": "5_3_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.523952
+      },
+      {
+        "clip": "5_3_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.533382
+      },
+      {
+        "clip": "5_3_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.471296
+      },
+      {
+        "clip": "5_3_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.44158
+      },
+      {
+        "clip": "5_3_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.442506
+      },
+      {
+        "clip": "5_3_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.47205
+      },
+      {
+        "clip": "5_3_42",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.414086
+      },
+      {
+        "clip": "5_3_43",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.387353
+      },
+      {
+        "clip": "5_3_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.420355
+      },
+      {
+        "clip": "5_3_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.427419
+      },
+      {
+        "clip": "5_3_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.465213
+      },
+      {
+        "clip": "5_3_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.467017
+      },
+      {
+        "clip": "5_3_48",
+        "cls": "attack",
+        "n_frames": 3,
+        "vote": 0.488227
+      },
+      {
+        "clip": "5_3_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.506524
+      },
+      {
+        "clip": "5_3_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.483094
+      },
+      {
+        "clip": "5_3_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.484135
+      },
+      {
+        "clip": "5_3_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.43006
+      },
+      {
+        "clip": "5_3_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.503838
+      },
+      {
+        "clip": "5_3_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.387259
+      },
+      {
+        "clip": "5_3_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.469227
+      },
+      {
+        "clip": "6_1_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.548494
+      },
+      {
+        "clip": "6_1_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.447165
+      },
+      {
+        "clip": "6_1_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.383657
+      },
+      {
+        "clip": "6_1_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.483361
+      },
+      {
+        "clip": "6_1_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.433642
+      },
+      {
+        "clip": "6_1_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.436078
+      },
+      {
+        "clip": "6_1_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.496562
+      },
+      {
+        "clip": "6_1_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.415476
+      },
+      {
+        "clip": "6_1_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.401806
+      },
+      {
+        "clip": "6_1_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.460418
+      },
+      {
+        "clip": "6_1_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.440793
+      },
+      {
+        "clip": "6_1_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.389989
+      },
+      {
+        "clip": "6_1_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.442004
+      },
+      {
+        "clip": "6_1_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.476659
+      },
+      {
+        "clip": "6_1_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.553384
+      },
+      {
+        "clip": "6_1_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.504758
+      },
+      {
+        "clip": "6_1_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.464661
+      },
+      {
+        "clip": "6_1_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.518255
+      },
+      {
+        "clip": "6_1_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.502899
+      },
+      {
+        "clip": "6_1_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.474829
+      },
+      {
+        "clip": "6_2_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.620982
+      },
+      {
+        "clip": "6_2_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.612186
+      },
+      {
+        "clip": "6_2_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.562969
+      },
+      {
+        "clip": "6_2_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.534121
+      },
+      {
+        "clip": "6_2_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.46396
+      },
+      {
+        "clip": "6_2_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.552411
+      },
+      {
+        "clip": "6_2_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.614954
+      },
+      {
+        "clip": "6_2_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.430253
+      },
+      {
+        "clip": "6_2_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.535239
+      },
+      {
+        "clip": "6_2_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.489979
+      },
+      {
+        "clip": "6_2_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.501182
+      },
+      {
+        "clip": "6_2_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.428696
+      },
+      {
+        "clip": "6_2_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.542165
+      },
+      {
+        "clip": "6_2_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.503201
+      },
+      {
+        "clip": "6_2_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.583214
+      },
+      {
+        "clip": "6_2_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.53518
+      },
+      {
+        "clip": "6_2_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.579854
+      },
+      {
+        "clip": "6_2_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.483985
+      },
+      {
+        "clip": "6_2_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.623044
+      },
+      {
+        "clip": "6_2_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.538597
+      },
+      {
+        "clip": "6_3_36",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.545722
+      },
+      {
+        "clip": "6_3_37",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.619888
+      },
+      {
+        "clip": "6_3_38",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.532877
+      },
+      {
+        "clip": "6_3_39",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.551233
+      },
+      {
+        "clip": "6_3_40",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.464692
+      },
+      {
+        "clip": "6_3_41",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.502575
+      },
+      {
+        "clip": "6_3_42",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.479253
+      },
+      {
+        "clip": "6_3_43",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.486987
+      },
+      {
+        "clip": "6_3_44",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.499383
+      },
+      {
+        "clip": "6_3_45",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.505636
+      },
+      {
+        "clip": "6_3_46",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.5136
+      },
+      {
+        "clip": "6_3_47",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.54945
+      },
+      {
+        "clip": "6_3_48",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.519187
+      },
+      {
+        "clip": "6_3_49",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.560373
+      },
+      {
+        "clip": "6_3_50",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.533389
+      },
+      {
+        "clip": "6_3_51",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.535058
+      },
+      {
+        "clip": "6_3_52",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.571718
+      },
+      {
+        "clip": "6_3_53",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.548629
+      },
+      {
+        "clip": "6_3_54",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.489463
+      },
+      {
+        "clip": "6_3_55",
+        "cls": "attack",
+        "n_frames": 4,
+        "vote": 0.493451
+      }
+    ],
+    "wall_s": 40.4
+  },
+  "celeba_spoof": {
+    "images": 525864,
+    "scored": 525864,
+    "detected": 525864,
+    "apcer": 0.6436865021770682,
+    "bpcer": 0.05281369513749772,
+    "auc": 0.6764737558070265,
+    "threshold_sweep": [
+      {
+        "threshold": 0.35,
+        "apcer": 0.1615244159370757,
+        "bpcer": 0.797911734353184
+      },
+      {
+        "threshold": 0.45,
+        "apcer": 0.3854113020272485,
+        "bpcer": 0.33903964062405145
+      },
+      {
+        "threshold": 0.5,
+        "apcer": 0.5175570017322908,
+        "bpcer": 0.14915315971589874
+      },
+      {
+        "threshold": 0.55,
+        "apcer": 0.6436865021770682,
+        "bpcer": 0.05281369513749772
+      },
+      {
+        "threshold": 0.6,
+        "apcer": 0.7478580457886606,
+        "bpcer": 0.014751411400473502
+      },
+      {
+        "threshold": 0.7,
+        "apcer": 0.9032960344585421,
+        "bpcer": 0.00048564317367813997
+      }
+    ],
+    "per_species": [
+      {
+        "species": "spoof",
+        "n": 42718,
+        "caught": 15221,
+        "tpr": 0.3563134978229318
+      }
+    ],
+    "per_split": {
+      "test": {
+        "scored": 59191,
+        "apcer": 0.6436865021770682,
+        "bpcer": 0.05281369513749772,
+        "auc": 0.6764737558070265,
+        "threshold_sweep": [
+          {
+            "threshold": 0.35,
+            "apcer": 0.1615244159370757,
+            "bpcer": 0.797911734353184
+          },
+          {
+            "threshold": 0.45,
+            "apcer": 0.3854113020272485,
+            "bpcer": 0.33903964062405145
+          },
+          {
+            "threshold": 0.5,
+            "apcer": 0.5175570017322908,
+            "bpcer": 0.14915315971589874
+          },
+          {
+            "threshold": 0.55,
+            "apcer": 0.6436865021770682,
+            "bpcer": 0.05281369513749772
+          },
+          {
+            "threshold": 0.6,
+            "apcer": 0.7478580457886606,
+            "bpcer": 0.014751411400473502
+          },
+          {
+            "threshold": 0.7,
+            "apcer": 0.9032960344585421,
+            "bpcer": 0.00048564317367813997
+          }
+        ]
+      },
+      "train": {
+        "scored": 419935,
+        "apcer": 0.46183938106134903,
+        "bpcer": 0.045697493517718235,
+        "auc": 0.7647177359429539,
+        "threshold_sweep": [
+          {
+            "threshold": 0.35,
+            "apcer": 0.14398677854055428,
+            "bpcer": 0.7608850475367329
+          },
+          {
+            "threshold": 0.45,
+            "apcer": 0.28888888888888886,
+            "bpcer": 0.2948522039757995
+          },
+          {
+            "threshold": 0.5,
+            "apcer": 0.3700809996004504,
+            "bpcer": 0.1265894554883319
+          },
+          {
+            "threshold": 0.55,
+            "apcer": 0.46183938106134903,
+            "bpcer": 0.045697493517718235
+          },
+          {
+            "threshold": 0.6,
+            "apcer": 0.5671679197994988,
+            "bpcer": 0.01698876404494382
+          },
+          {
+            "threshold": 0.7,
+            "apcer": 0.8205768043296647,
+            "bpcer": 0.002184961106309421
+          }
+        ]
+      },
+      "valid": {
+        "scored": 46738,
+        "apcer": 0.4605220121672009,
+        "bpcer": 0.04726552833457065,
+        "auc": 0.763956052234078,
+        "threshold_sweep": [
+          {
+            "threshold": 0.35,
+            "apcer": 0.14185255445803624,
+            "bpcer": 0.7629918337045286
+          },
+          {
+            "threshold": 0.45,
+            "apcer": 0.2901484921829005,
+            "bpcer": 0.30332838406335066
+          },
+          {
+            "threshold": 0.5,
+            "apcer": 0.3684830247923072,
+            "bpcer": 0.13146498391487255
+          },
+          {
+            "threshold": 0.55,
+            "apcer": 0.4605220121672009,
+            "bpcer": 0.04726552833457065
+          },
+          {
+            "threshold": 0.6,
+            "apcer": 0.5661019166612155,
+            "bpcer": 0.018188567186340016
+          },
+          {
+            "threshold": 0.7,
+            "apcer": 0.8195198534702689,
+            "bpcer": 0.0022890373669883692
+          }
+        ]
+      }
+    },
+    "skipped_no_usable_bbox": 0
+  }
+}

--- a/benchmarks/results-pad-rgb.log
+++ b/benchmarks/results-pad-rgb.log
@@ -1,0 +1,841 @@
+[ WARN:0@0.044] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
+[casia] 500/123533 frames
+[casia] 1000/123533 frames
+[casia] 1500/123533 frames
+[casia] 2000/123533 frames
+[casia] 2500/123533 frames
+[casia] 3000/123533 frames
+[casia] 3500/123533 frames
+[casia] 4000/123533 frames
+[casia] 4500/123533 frames
+[casia] 5000/123533 frames
+[casia] 5500/123533 frames
+[casia] 6000/123533 frames
+[casia] 6500/123533 frames
+[casia] 7000/123533 frames
+[casia] 7500/123533 frames
+[casia] 8000/123533 frames
+[casia] 8500/123533 frames
+[casia] 9000/123533 frames
+[casia] 9500/123533 frames
+[casia] 10000/123533 frames
+[casia] 10500/123533 frames
+[casia] 11000/123533 frames
+[casia] 11500/123533 frames
+[casia] 12000/123533 frames
+[casia] 12500/123533 frames
+[casia] 13000/123533 frames
+[casia] 13500/123533 frames
+[casia] 14000/123533 frames
+[casia] 14500/123533 frames
+[casia] 15000/123533 frames
+[casia] 15500/123533 frames
+[casia] 16000/123533 frames
+[casia] 16500/123533 frames
+[casia] 17000/123533 frames
+[casia] 17500/123533 frames
+[casia] 18000/123533 frames
+[casia] 18500/123533 frames
+[casia] 19000/123533 frames
+[casia] 19500/123533 frames
+[casia] 20000/123533 frames
+[casia] 20500/123533 frames
+[casia] 21000/123533 frames
+[casia] 21500/123533 frames
+[casia] 22000/123533 frames
+[casia] 22500/123533 frames
+[casia] 23000/123533 frames
+[casia] 23500/123533 frames
+[casia] 24000/123533 frames
+[casia] 24500/123533 frames
+[casia] 25000/123533 frames
+[casia] 25500/123533 frames
+[casia] 26000/123533 frames
+[casia] 26500/123533 frames
+[casia] 27000/123533 frames
+[casia] 27500/123533 frames
+[casia] 28000/123533 frames
+[casia] 28500/123533 frames
+[casia] 29000/123533 frames
+[casia] 29500/123533 frames
+[casia] 30000/123533 frames
+[casia] 30500/123533 frames
+[casia] 31000/123533 frames
+[casia] 31500/123533 frames
+[casia] 32000/123533 frames
+[casia] 32500/123533 frames
+[casia] 33000/123533 frames
+[casia] 33500/123533 frames
+[casia] 34000/123533 frames
+[casia] 34500/123533 frames
+[casia] 35000/123533 frames
+[casia] 35500/123533 frames
+[casia] 36000/123533 frames
+[casia] 36500/123533 frames
+[casia] 37000/123533 frames
+[casia] 37500/123533 frames
+[casia] 38000/123533 frames
+[casia] 38500/123533 frames
+[casia] 39000/123533 frames
+[casia] 39500/123533 frames
+[casia] 40000/123533 frames
+[casia] 40500/123533 frames
+[casia] 41000/123533 frames
+[casia] 41500/123533 frames
+[casia] 42000/123533 frames
+[casia] 42500/123533 frames
+[casia] 43000/123533 frames
+[casia] 43500/123533 frames
+[casia] 44000/123533 frames
+[casia] 44500/123533 frames
+[casia] 45000/123533 frames
+[casia] 45500/123533 frames
+[casia] 46000/123533 frames
+[casia] 46500/123533 frames
+[casia] 47000/123533 frames
+[casia] 47500/123533 frames
+[casia] 48000/123533 frames
+[casia] 48500/123533 frames
+[casia] 49000/123533 frames
+[casia] 49500/123533 frames
+[casia] 50000/123533 frames
+[casia] 50500/123533 frames
+[casia] 51000/123533 frames
+[casia] 51500/123533 frames
+[casia] 52000/123533 frames
+[casia] 52500/123533 frames
+[casia] 53000/123533 frames
+[casia] 53500/123533 frames
+[casia] 54000/123533 frames
+[casia] 54500/123533 frames
+[casia] 55000/123533 frames
+[casia] 55500/123533 frames
+[casia] 56000/123533 frames
+[casia] 56500/123533 frames
+[casia] 57000/123533 frames
+[casia] 57500/123533 frames
+[casia] 58000/123533 frames
+[casia] 58500/123533 frames
+[casia] 59000/123533 frames
+[casia] 59500/123533 frames
+[casia] 60000/123533 frames
+[casia] 60500/123533 frames
+[casia] 61000/123533 frames
+[casia] 61500/123533 frames
+[casia] 62000/123533 frames
+[casia] 62500/123533 frames
+[casia] 63000/123533 frames
+[casia] 63500/123533 frames
+[casia] 64000/123533 frames
+[casia] 64500/123533 frames
+[casia] 65000/123533 frames
+[casia] 65500/123533 frames
+[casia] 66000/123533 frames
+[casia] 66500/123533 frames
+[casia] 67000/123533 frames
+[casia] 67500/123533 frames
+[casia] 68000/123533 frames
+[casia] 68500/123533 frames
+[casia] 69000/123533 frames
+[casia] 69500/123533 frames
+[casia] 70000/123533 frames
+[casia] 70500/123533 frames
+[casia] 71000/123533 frames
+[casia] 71500/123533 frames
+[casia] 72000/123533 frames
+[casia] 72500/123533 frames
+[casia] 73000/123533 frames
+[casia] 73500/123533 frames
+[casia] 74000/123533 frames
+[casia] 74500/123533 frames
+[casia] 75000/123533 frames
+[casia] 75500/123533 frames
+[casia] 76000/123533 frames
+[casia] 76500/123533 frames
+[casia] 77000/123533 frames
+[casia] 77500/123533 frames
+[casia] 78000/123533 frames
+[casia] 78500/123533 frames
+[casia] 79000/123533 frames
+[casia] 79500/123533 frames
+[casia] 80000/123533 frames
+[casia] 80500/123533 frames
+[casia] 81000/123533 frames
+[casia] 81500/123533 frames
+[casia] 82000/123533 frames
+[casia] 82500/123533 frames
+[casia] 83000/123533 frames
+[casia] 83500/123533 frames
+[casia] 84000/123533 frames
+[casia] 84500/123533 frames
+[casia] 85000/123533 frames
+[casia] 85500/123533 frames
+[casia] 86000/123533 frames
+[casia] 86500/123533 frames
+[casia] 87000/123533 frames
+[casia] 87500/123533 frames
+[casia] 88000/123533 frames
+[casia] 88500/123533 frames
+[casia] 89000/123533 frames
+[casia] 89500/123533 frames
+[casia] 90000/123533 frames
+[casia] 90500/123533 frames
+[casia] 91000/123533 frames
+[casia] 91500/123533 frames
+[casia] 92000/123533 frames
+[casia] 92500/123533 frames
+[casia] 93000/123533 frames
+[casia] 93500/123533 frames
+[casia] 94000/123533 frames
+[casia] 94500/123533 frames
+[casia] 95000/123533 frames
+[casia] 95500/123533 frames
+[casia] 96000/123533 frames
+[casia] 96500/123533 frames
+[casia] 97000/123533 frames
+[casia] 97500/123533 frames
+[casia] 98000/123533 frames
+[casia] 98500/123533 frames
+[casia] 99000/123533 frames
+[casia] 99500/123533 frames
+[casia] 100000/123533 frames
+[casia] 100500/123533 frames
+[casia] 101000/123533 frames
+[casia] 101500/123533 frames
+[casia] 102000/123533 frames
+[casia] 102500/123533 frames
+[casia] 103000/123533 frames
+[casia] 103500/123533 frames
+[casia] 104000/123533 frames
+[casia] 104500/123533 frames
+[casia] 105000/123533 frames
+[casia] 105500/123533 frames
+[casia] 106000/123533 frames
+[casia] 106500/123533 frames
+[casia] 107000/123533 frames
+[casia] 107500/123533 frames
+[casia] 108000/123533 frames
+[casia] 108500/123533 frames
+[casia] 109000/123533 frames
+[casia] 109500/123533 frames
+[casia] 110000/123533 frames
+[casia] 110500/123533 frames
+[casia] 111000/123533 frames
+[casia] 111500/123533 frames
+[casia] 112000/123533 frames
+[casia] 112500/123533 frames
+[casia] 113000/123533 frames
+[casia] 113500/123533 frames
+[casia] 114000/123533 frames
+[casia] 114500/123533 frames
+[casia] 115000/123533 frames
+[casia] 115500/123533 frames
+[casia] 116000/123533 frames
+[casia] 116500/123533 frames
+[casia] 117000/123533 frames
+[casia] 117500/123533 frames
+[casia] 118000/123533 frames
+[casia] 118500/123533 frames
+[casia] 119000/123533 frames
+[casia] 119500/123533 frames
+[casia] 120000/123533 frames
+[casia] 120500/123533 frames
+[casia] 121000/123533 frames
+[casia] 121500/123533 frames
+[casia] 122000/123533 frames
+[casia] 122500/123533 frames
+[casia] 123000/123533 frames
+[casia] 123500/123533 frames
+{"images": 123533, "scored": 123533, "detected": 123214, "apcer": 0.4701160802663547, "bpcer": 0.1412914691943128, "auc": 0.6099671527404322, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.18000539908215604, "bpcer": 0.9999012638230648}, {"threshold": 0.45, "apcer": 0.33467110591199495, "bpcer": 0.7966034755134281}, {"threshold": 0.5, "apcer": 0.3916854134797084, "bpcer": 0.3570300157977883}, {"threshold": 0.55, "apcer": 0.4701160802663547, "bpcer": 0.1412914691943128}, {"threshold": 0.6, "apcer": 0.6367497525420679, "bpcer": 0.011749605055292258}, {"threshold": 0.7, "apcer": 0.9739224331863583, "bpcer": 0.0}], "per_split": {"train": {"images": 57747, "detected": 57521, "apcer": 0.5328728707935189, "bpcer": 0.11331474564679889, "auc": 0.5640491351395157, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.19300477773161612, "bpcer": 1.0}, {"threshold": 0.45, "apcer": 0.3763502285002077, "bpcer": 0.7461728654847704}, {"threshold": 0.5, "apcer": 0.4437058579144163, "bpcer": 0.3983902362039034}, {"threshold": 0.55, "apcer": 0.5328728707935189, "bpcer": 0.11331474564679889}, {"threshold": 0.6, "apcer": 0.6946925633568758, "bpcer": 0.010679151980640749}, {"threshold": 0.7, "apcer": 0.9929891981719984, "bpcer": 0.0}]}, "test": {"images": 65786, "detected": 65693, "apcer": 0.4701160802663547, "bpcer": 0.1412914691943128, "auc": 0.6099671527404322, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.18000539908215604, "bpcer": 0.9999012638230648}, {"threshold": 0.45, "apcer": 0.33467110591199495, "bpcer": 0.7966034755134281}, {"threshold": 0.5, "apcer": 0.3916854134797084, "bpcer": 0.3570300157977883}, {"threshold": 0.55, "apcer": 0.4701160802663547, "bpcer": 0.1412914691943128}, {"threshold": 0.6, "apcer": 0.6367497525420679, "bpcer": 0.011749605055292258}, {"threshold": 0.7, "apcer": 0.9739224331863583, "bpcer": 0.0}]}}, "per_condition": {"train_live": {"images": 19011, "detected": 19009, "n_scores": 19009}, "train_spoof": {"images": 38736, "detected": 38512, "n_scores": 38512}, "test_live": {"images": 10128, "detected": 10128, "n_scores": 10128}, "test_spoof": {"images": 55658, "detected": 55565, "n_scores": 55565}}, "wall_s": 2126.1}
+merged casia_fasd into /home/archledger/irlume-bench/benchmarks/results-pad-rgb.json
+[ WARN:0@0.054] global net_impl_backend.cpp:345 setPreferableTarget Targets are not supported by the new graph engine for now
+{"clips": 703, "images": 1701, "scored": 1701, "detected": 1701, "voted": {"apcer": 0.8416666666666667, "bpcer": 0.0, "auc": 0.9311386459345643, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.011111111111111112, "bpcer": 0.673469387755102}, {"threshold": 0.45, "apcer": 0.2972222222222222, "bpcer": 0.026239067055393587}, {"threshold": 0.5, "apcer": 0.5944444444444444, "bpcer": 0.0058309037900874635}, {"threshold": 0.55, "apcer": 0.8416666666666667, "bpcer": 0.0}, {"threshold": 0.6, "apcer": 0.9527777777777777, "bpcer": 0.0}, {"threshold": 0.7, "apcer": 1.0, "bpcer": 0.0}]}, "frame_level": {"apcer": 0.7569955817378498, "bpcer": 0.0, "auc": 0.8950888160860809, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.04050073637702504, "bpcer": 0.673469387755102}, {"threshold": 0.45, "apcer": 0.3431516936671576, "bpcer": 0.026239067055393587}, {"threshold": 0.5, "apcer": 0.5743740795287187, "bpcer": 0.0058309037900874635}, {"threshold": 0.55, "apcer": 0.7569955817378498, "bpcer": 0.0}, {"threshold": 0.6, "apcer": 0.9013254786450663, "bpcer": 0.0}, {"threshold": 0.7, "apcer": 0.9977908689248896, "bpcer": 0.0}]}, "wall_s": 40.4}
+merged oulu_npu into /home/archledger/irlume-bench/benchmarks/results-pad-rgb.json
+[celeba] shard 0 done: 911 scored, 0 skipped, 12.3s
+[celeba] shard 1 done: 911 scored, 0 skipped, 11.2s
+[celeba] shard 2 done: 911 scored, 0 skipped, 10.6s
+[celeba] shard 3 done: 911 scored, 0 skipped, 12.5s
+[celeba] shard 4 done: 911 scored, 0 skipped, 10.6s
+[celeba] shard 5 done: 911 scored, 0 skipped, 10.8s
+[celeba] shard 6 done: 911 scored, 0 skipped, 10.9s
+[celeba] shard 7 done: 911 scored, 0 skipped, 12.1s
+[celeba] shard 8 done: 911 scored, 0 skipped, 11.4s
+[celeba] shard 9 done: 911 scored, 0 skipped, 12.4s
+[celeba] shard 10 done: 911 scored, 0 skipped, 10.9s
+[celeba] shard 11 done: 911 scored, 0 skipped, 11.0s
+[celeba] shard 12 done: 911 scored, 0 skipped, 10.2s
+[celeba] shard 13 done: 911 scored, 0 skipped, 11.9s
+[celeba] shard 14 done: 911 scored, 0 skipped, 12.4s
+[celeba] shard 15 done: 911 scored, 0 skipped, 10.9s
+[celeba] shard 16 done: 911 scored, 0 skipped, 10.5s
+[celeba] shard 17 done: 911 scored, 0 skipped, 11.0s
+[celeba] shard 18 done: 911 scored, 0 skipped, 12.0s
+[celeba] shard 19 done: 911 scored, 0 skipped, 12.1s
+[celeba] shard 20 done: 911 scored, 0 skipped, 9.8s
+[celeba] shard 21 done: 911 scored, 0 skipped, 11.1s
+[celeba] shard 22 done: 911 scored, 0 skipped, 11.1s
+[celeba] shard 23 done: 911 scored, 0 skipped, 10.2s
+[celeba] shard 24 done: 911 scored, 0 skipped, 10.4s
+[celeba] shard 25 done: 911 scored, 0 skipped, 10.7s
+[celeba] shard 26 done: 911 scored, 0 skipped, 10.9s
+[celeba] shard 27 done: 911 scored, 0 skipped, 11.1s
+[celeba] shard 28 done: 911 scored, 0 skipped, 11.8s
+[celeba] shard 29 done: 911 scored, 0 skipped, 10.3s
+[celeba] shard 30 done: 911 scored, 0 skipped, 10.7s
+[celeba] shard 31 done: 911 scored, 0 skipped, 10.3s
+[celeba] shard 32 done: 911 scored, 0 skipped, 11.6s
+[celeba] shard 33 done: 911 scored, 0 skipped, 10.8s
+[celeba] shard 34 done: 911 scored, 0 skipped, 11.0s
+[celeba] shard 35 done: 911 scored, 0 skipped, 10.7s
+[celeba] shard 36 done: 911 scored, 0 skipped, 10.8s
+[celeba] shard 37 done: 911 scored, 0 skipped, 10.6s
+[celeba] shard 38 done: 911 scored, 0 skipped, 11.6s
+[celeba] shard 39 done: 911 scored, 0 skipped, 10.8s
+[celeba] shard 40 done: 911 scored, 0 skipped, 11.8s
+[celeba] shard 41 done: 910 scored, 0 skipped, 10.1s
+[celeba] shard 42 done: 910 scored, 0 skipped, 11.2s
+[celeba] shard 43 done: 910 scored, 0 skipped, 11.3s
+[celeba] shard 44 done: 910 scored, 0 skipped, 10.6s
+[celeba] shard 45 done: 910 scored, 0 skipped, 12.0s
+[celeba] shard 46 done: 910 scored, 0 skipped, 10.6s
+[celeba] shard 47 done: 910 scored, 0 skipped, 10.5s
+[celeba] shard 48 done: 910 scored, 0 skipped, 11.4s
+[celeba] shard 49 done: 910 scored, 0 skipped, 10.2s
+[celeba] shard 50 done: 910 scored, 0 skipped, 11.9s
+[celeba] shard 51 done: 910 scored, 0 skipped, 10.6s
+[celeba] shard 52 done: 910 scored, 0 skipped, 10.9s
+[celeba] shard 53 done: 910 scored, 0 skipped, 10.5s
+[celeba] shard 54 done: 910 scored, 0 skipped, 11.5s
+[celeba] shard 55 done: 910 scored, 0 skipped, 11.9s
+[celeba] shard 56 done: 910 scored, 0 skipped, 10.4s
+[celeba] shard 57 done: 910 scored, 0 skipped, 11.2s
+[celeba] shard 58 done: 910 scored, 0 skipped, 10.5s
+[celeba] shard 59 done: 910 scored, 0 skipped, 11.1s
+[celeba] shard 60 done: 910 scored, 0 skipped, 10.8s
+[celeba] shard 61 done: 910 scored, 0 skipped, 11.3s
+[celeba] shard 62 done: 910 scored, 0 skipped, 10.6s
+[celeba] shard 63 done: 910 scored, 0 skipped, 11.2s
+[celeba] shard 64 done: 910 scored, 0 skipped, 11.4s
+[celeba 65/167] 1024/4516 rows
+[celeba 65/167] 2048/4516 rows
+[celeba 65/167] 3072/4516 rows
+[celeba 65/167] 4096/4516 rows
+[celeba] shard 65 done: 4516 scored, 0 skipped, 37.5s
+[celeba 66/167] 1024/4516 rows
+[celeba 66/167] 2048/4516 rows
+[celeba 66/167] 3072/4516 rows
+[celeba 66/167] 4096/4516 rows
+[celeba] shard 66 done: 4516 scored, 0 skipped, 37.6s
+[celeba 67/167] 1024/4516 rows
+[celeba 67/167] 2048/4516 rows
+[celeba 67/167] 3072/4516 rows
+[celeba 67/167] 4096/4516 rows
+[celeba] shard 67 done: 4516 scored, 0 skipped, 37.4s
+[celeba 68/167] 1024/4516 rows
+[celeba 68/167] 2048/4516 rows
+[celeba 68/167] 3072/4516 rows
+[celeba 68/167] 4096/4516 rows
+[celeba] shard 68 done: 4516 scored, 0 skipped, 38.4s
+[celeba 69/167] 1024/4516 rows
+[celeba 69/167] 2048/4516 rows
+[celeba 69/167] 3072/4516 rows
+[celeba 69/167] 4096/4516 rows
+[celeba] shard 69 done: 4516 scored, 0 skipped, 37.4s
+[celeba 70/167] 1024/4516 rows
+[celeba 70/167] 2048/4516 rows
+[celeba 70/167] 3072/4516 rows
+[celeba 70/167] 4096/4516 rows
+[celeba] shard 70 done: 4516 scored, 0 skipped, 37.6s
+[celeba 71/167] 1024/4516 rows
+[celeba 71/167] 2048/4516 rows
+[celeba 71/167] 3072/4516 rows
+[celeba 71/167] 4096/4516 rows
+[celeba] shard 71 done: 4516 scored, 0 skipped, 38.3s
+[celeba 72/167] 1024/4516 rows
+[celeba 72/167] 2048/4516 rows
+[celeba 72/167] 3072/4516 rows
+[celeba 72/167] 4096/4516 rows
+[celeba] shard 72 done: 4516 scored, 0 skipped, 37.8s
+[celeba 73/167] 1024/4516 rows
+[celeba 73/167] 2048/4516 rows
+[celeba 73/167] 3072/4516 rows
+[celeba 73/167] 4096/4516 rows
+[celeba] shard 73 done: 4516 scored, 0 skipped, 37.7s
+[celeba 74/167] 1024/4516 rows
+[celeba 74/167] 2048/4516 rows
+[celeba 74/167] 3072/4516 rows
+[celeba 74/167] 4096/4516 rows
+[celeba] shard 74 done: 4516 scored, 0 skipped, 37.6s
+[celeba 75/167] 1024/4516 rows
+[celeba 75/167] 2048/4516 rows
+[celeba 75/167] 3072/4516 rows
+[celeba 75/167] 4096/4516 rows
+[celeba] shard 75 done: 4516 scored, 0 skipped, 38.6s
+[celeba 76/167] 1024/4516 rows
+[celeba 76/167] 2048/4516 rows
+[celeba 76/167] 3072/4516 rows
+[celeba 76/167] 4096/4516 rows
+[celeba] shard 76 done: 4516 scored, 0 skipped, 38.0s
+[celeba 77/167] 1024/4516 rows
+[celeba 77/167] 2048/4516 rows
+[celeba 77/167] 3072/4516 rows
+[celeba 77/167] 4096/4516 rows
+[celeba] shard 77 done: 4516 scored, 0 skipped, 37.3s
+[celeba 78/167] 1024/4516 rows
+[celeba 78/167] 2048/4516 rows
+[celeba 78/167] 3072/4516 rows
+[celeba 78/167] 4096/4516 rows
+[celeba] shard 78 done: 4516 scored, 0 skipped, 37.7s
+[celeba 79/167] 1024/4516 rows
+[celeba 79/167] 2048/4516 rows
+[celeba 79/167] 3072/4516 rows
+[celeba 79/167] 4096/4516 rows
+[celeba] shard 79 done: 4516 scored, 0 skipped, 37.4s
+[celeba 80/167] 1024/4516 rows
+[celeba 80/167] 2048/4516 rows
+[celeba 80/167] 3072/4516 rows
+[celeba 80/167] 4096/4516 rows
+[celeba] shard 80 done: 4516 scored, 0 skipped, 37.7s
+[celeba 81/167] 1024/4516 rows
+[celeba 81/167] 2048/4516 rows
+[celeba 81/167] 3072/4516 rows
+[celeba 81/167] 4096/4516 rows
+[celeba] shard 81 done: 4516 scored, 0 skipped, 37.7s
+[celeba 82/167] 1024/4516 rows
+[celeba 82/167] 2048/4516 rows
+[celeba 82/167] 3072/4516 rows
+[celeba 82/167] 4096/4516 rows
+[celeba] shard 82 done: 4516 scored, 0 skipped, 37.2s
+[celeba 83/167] 1024/4516 rows
+[celeba 83/167] 2048/4516 rows
+[celeba 83/167] 3072/4516 rows
+[celeba 83/167] 4096/4516 rows
+[celeba] shard 83 done: 4516 scored, 0 skipped, 37.7s
+[celeba 84/167] 1024/4516 rows
+[celeba 84/167] 2048/4516 rows
+[celeba 84/167] 3072/4516 rows
+[celeba 84/167] 4096/4516 rows
+[celeba] shard 84 done: 4516 scored, 0 skipped, 37.9s
+[celeba 85/167] 1024/4516 rows
+[celeba 85/167] 2048/4516 rows
+[celeba 85/167] 3072/4516 rows
+[celeba 85/167] 4096/4516 rows
+[celeba] shard 85 done: 4516 scored, 0 skipped, 37.5s
+[celeba 86/167] 1024/4516 rows
+[celeba 86/167] 2048/4516 rows
+[celeba 86/167] 3072/4516 rows
+[celeba 86/167] 4096/4516 rows
+[celeba] shard 86 done: 4516 scored, 0 skipped, 36.9s
+[celeba 87/167] 1024/4516 rows
+[celeba 87/167] 2048/4516 rows
+[celeba 87/167] 3072/4516 rows
+[celeba 87/167] 4096/4516 rows
+[celeba] shard 87 done: 4516 scored, 0 skipped, 37.7s
+[celeba 88/167] 1024/4516 rows
+[celeba 88/167] 2048/4516 rows
+[celeba 88/167] 3072/4516 rows
+[celeba 88/167] 4096/4516 rows
+[celeba] shard 88 done: 4516 scored, 0 skipped, 37.6s
+[celeba 89/167] 1024/4516 rows
+[celeba 89/167] 2048/4516 rows
+[celeba 89/167] 3072/4516 rows
+[celeba 89/167] 4096/4516 rows
+[celeba] shard 89 done: 4516 scored, 0 skipped, 37.5s
+[celeba 90/167] 1024/4516 rows
+[celeba 90/167] 2048/4516 rows
+[celeba 90/167] 3072/4516 rows
+[celeba 90/167] 4096/4516 rows
+[celeba] shard 90 done: 4516 scored, 0 skipped, 37.4s
+[celeba 91/167] 1024/4516 rows
+[celeba 91/167] 2048/4516 rows
+[celeba 91/167] 3072/4516 rows
+[celeba 91/167] 4096/4516 rows
+[celeba] shard 91 done: 4516 scored, 0 skipped, 36.8s
+[celeba 92/167] 1024/4516 rows
+[celeba 92/167] 2048/4516 rows
+[celeba 92/167] 3072/4516 rows
+[celeba 92/167] 4096/4516 rows
+[celeba] shard 92 done: 4516 scored, 0 skipped, 37.6s
+[celeba 93/167] 1024/4516 rows
+[celeba 93/167] 2048/4516 rows
+[celeba 93/167] 3072/4516 rows
+[celeba 93/167] 4096/4516 rows
+[celeba] shard 93 done: 4516 scored, 0 skipped, 38.3s
+[celeba 94/167] 1024/4516 rows
+[celeba 94/167] 2048/4516 rows
+[celeba 94/167] 3072/4516 rows
+[celeba 94/167] 4096/4516 rows
+[celeba] shard 94 done: 4516 scored, 0 skipped, 37.8s
+[celeba 95/167] 1024/4516 rows
+[celeba 95/167] 2048/4516 rows
+[celeba 95/167] 3072/4516 rows
+[celeba 95/167] 4096/4516 rows
+[celeba] shard 95 done: 4516 scored, 0 skipped, 37.7s
+[celeba 96/167] 1024/4516 rows
+[celeba 96/167] 2048/4516 rows
+[celeba 96/167] 3072/4516 rows
+[celeba 96/167] 4096/4516 rows
+[celeba] shard 96 done: 4516 scored, 0 skipped, 36.9s
+[celeba 97/167] 1024/4516 rows
+[celeba 97/167] 2048/4516 rows
+[celeba 97/167] 3072/4516 rows
+[celeba 97/167] 4096/4516 rows
+[celeba] shard 97 done: 4516 scored, 0 skipped, 37.9s
+[celeba 98/167] 1024/4516 rows
+[celeba 98/167] 2048/4516 rows
+[celeba 98/167] 3072/4516 rows
+[celeba 98/167] 4096/4516 rows
+[celeba] shard 98 done: 4516 scored, 0 skipped, 37.7s
+[celeba 99/167] 1024/4516 rows
+[celeba 99/167] 2048/4516 rows
+[celeba 99/167] 3072/4516 rows
+[celeba 99/167] 4096/4516 rows
+[celeba] shard 99 done: 4516 scored, 0 skipped, 37.4s
+[celeba 100/167] 1024/4516 rows
+[celeba 100/167] 2048/4516 rows
+[celeba 100/167] 3072/4516 rows
+[celeba 100/167] 4096/4516 rows
+[celeba] shard 100 done: 4516 scored, 0 skipped, 37.5s
+[celeba 101/167] 1024/4516 rows
+[celeba 101/167] 2048/4516 rows
+[celeba 101/167] 3072/4516 rows
+[celeba 101/167] 4096/4516 rows
+[celeba] shard 101 done: 4516 scored, 0 skipped, 38.4s
+[celeba 102/167] 1024/4516 rows
+[celeba 102/167] 2048/4516 rows
+[celeba 102/167] 3072/4516 rows
+[celeba 102/167] 4096/4516 rows
+[celeba] shard 102 done: 4516 scored, 0 skipped, 37.4s
+[celeba 103/167] 1024/4516 rows
+[celeba 103/167] 2048/4516 rows
+[celeba 103/167] 3072/4516 rows
+[celeba 103/167] 4096/4516 rows
+[celeba] shard 103 done: 4516 scored, 0 skipped, 38.2s
+[celeba 104/167] 1024/4516 rows
+[celeba 104/167] 2048/4516 rows
+[celeba 104/167] 3072/4516 rows
+[celeba 104/167] 4096/4516 rows
+[celeba] shard 104 done: 4516 scored, 0 skipped, 37.1s
+[celeba 105/167] 1024/4515 rows
+[celeba 105/167] 2048/4515 rows
+[celeba 105/167] 3072/4515 rows
+[celeba 105/167] 4096/4515 rows
+[celeba] shard 105 done: 4515 scored, 0 skipped, 37.3s
+[celeba 106/167] 1024/4515 rows
+[celeba 106/167] 2048/4515 rows
+[celeba 106/167] 3072/4515 rows
+[celeba 106/167] 4096/4515 rows
+[celeba] shard 106 done: 4515 scored, 0 skipped, 38.2s
+[celeba 107/167] 1024/4515 rows
+[celeba 107/167] 2048/4515 rows
+[celeba 107/167] 3072/4515 rows
+[celeba 107/167] 4096/4515 rows
+[celeba] shard 107 done: 4515 scored, 0 skipped, 37.8s
+[celeba 108/167] 1024/4515 rows
+[celeba 108/167] 2048/4515 rows
+[celeba 108/167] 3072/4515 rows
+[celeba 108/167] 4096/4515 rows
+[celeba] shard 108 done: 4515 scored, 0 skipped, 37.2s
+[celeba 109/167] 1024/4515 rows
+[celeba 109/167] 2048/4515 rows
+[celeba 109/167] 3072/4515 rows
+[celeba 109/167] 4096/4515 rows
+[celeba] shard 109 done: 4515 scored, 0 skipped, 37.9s
+[celeba 110/167] 1024/4515 rows
+[celeba 110/167] 2048/4515 rows
+[celeba 110/167] 3072/4515 rows
+[celeba 110/167] 4096/4515 rows
+[celeba] shard 110 done: 4515 scored, 0 skipped, 37.2s
+[celeba 111/167] 1024/4515 rows
+[celeba 111/167] 2048/4515 rows
+[celeba 111/167] 3072/4515 rows
+[celeba 111/167] 4096/4515 rows
+[celeba] shard 111 done: 4515 scored, 0 skipped, 37.4s
+[celeba 112/167] 1024/4515 rows
+[celeba 112/167] 2048/4515 rows
+[celeba 112/167] 3072/4515 rows
+[celeba 112/167] 4096/4515 rows
+[celeba] shard 112 done: 4515 scored, 0 skipped, 37.8s
+[celeba 113/167] 1024/4515 rows
+[celeba 113/167] 2048/4515 rows
+[celeba 113/167] 3072/4515 rows
+[celeba 113/167] 4096/4515 rows
+[celeba] shard 113 done: 4515 scored, 0 skipped, 37.3s
+[celeba 114/167] 1024/4515 rows
+[celeba 114/167] 2048/4515 rows
+[celeba 114/167] 3072/4515 rows
+[celeba 114/167] 4096/4515 rows
+[celeba] shard 114 done: 4515 scored, 0 skipped, 37.7s
+[celeba 115/167] 1024/4515 rows
+[celeba 115/167] 2048/4515 rows
+[celeba 115/167] 3072/4515 rows
+[celeba 115/167] 4096/4515 rows
+[celeba] shard 115 done: 4515 scored, 0 skipped, 37.7s
+[celeba 116/167] 1024/4515 rows
+[celeba 116/167] 2048/4515 rows
+[celeba 116/167] 3072/4515 rows
+[celeba 116/167] 4096/4515 rows
+[celeba] shard 116 done: 4515 scored, 0 skipped, 37.5s
+[celeba 117/167] 1024/4515 rows
+[celeba 117/167] 2048/4515 rows
+[celeba 117/167] 3072/4515 rows
+[celeba 117/167] 4096/4515 rows
+[celeba] shard 117 done: 4515 scored, 0 skipped, 37.4s
+[celeba 118/167] 1024/4515 rows
+[celeba 118/167] 2048/4515 rows
+[celeba 118/167] 3072/4515 rows
+[celeba 118/167] 4096/4515 rows
+[celeba] shard 118 done: 4515 scored, 0 skipped, 37.1s
+[celeba 119/167] 1024/4515 rows
+[celeba 119/167] 2048/4515 rows
+[celeba 119/167] 3072/4515 rows
+[celeba 119/167] 4096/4515 rows
+[celeba] shard 119 done: 4515 scored, 0 skipped, 38.2s
+[celeba 120/167] 1024/4515 rows
+[celeba 120/167] 2048/4515 rows
+[celeba 120/167] 3072/4515 rows
+[celeba 120/167] 4096/4515 rows
+[celeba] shard 120 done: 4515 scored, 0 skipped, 37.1s
+[celeba 121/167] 1024/4515 rows
+[celeba 121/167] 2048/4515 rows
+[celeba 121/167] 3072/4515 rows
+[celeba 121/167] 4096/4515 rows
+[celeba] shard 121 done: 4515 scored, 0 skipped, 37.1s
+[celeba 122/167] 1024/4515 rows
+[celeba 122/167] 2048/4515 rows
+[celeba 122/167] 3072/4515 rows
+[celeba 122/167] 4096/4515 rows
+[celeba] shard 122 done: 4515 scored, 0 skipped, 38.4s
+[celeba 123/167] 1024/4515 rows
+[celeba 123/167] 2048/4515 rows
+[celeba 123/167] 3072/4515 rows
+[celeba 123/167] 4096/4515 rows
+[celeba] shard 123 done: 4515 scored, 0 skipped, 37.3s
+[celeba 124/167] 1024/4515 rows
+[celeba 124/167] 2048/4515 rows
+[celeba 124/167] 3072/4515 rows
+[celeba 124/167] 4096/4515 rows
+[celeba] shard 124 done: 4515 scored, 0 skipped, 37.8s
+[celeba 125/167] 1024/4515 rows
+[celeba 125/167] 2048/4515 rows
+[celeba 125/167] 3072/4515 rows
+[celeba 125/167] 4096/4515 rows
+[celeba] shard 125 done: 4515 scored, 0 skipped, 37.8s
+[celeba 126/167] 1024/4515 rows
+[celeba 126/167] 2048/4515 rows
+[celeba 126/167] 3072/4515 rows
+[celeba 126/167] 4096/4515 rows
+[celeba] shard 126 done: 4515 scored, 0 skipped, 37.1s
+[celeba 127/167] 1024/4515 rows
+[celeba 127/167] 2048/4515 rows
+[celeba 127/167] 3072/4515 rows
+[celeba 127/167] 4096/4515 rows
+[celeba] shard 127 done: 4515 scored, 0 skipped, 38.1s
+[celeba 128/167] 1024/4515 rows
+[celeba 128/167] 2048/4515 rows
+[celeba 128/167] 3072/4515 rows
+[celeba 128/167] 4096/4515 rows
+[celeba] shard 128 done: 4515 scored, 0 skipped, 38.2s
+[celeba 129/167] 1024/4515 rows
+[celeba 129/167] 2048/4515 rows
+[celeba 129/167] 3072/4515 rows
+[celeba 129/167] 4096/4515 rows
+[celeba] shard 129 done: 4515 scored, 0 skipped, 37.4s
+[celeba 130/167] 1024/4515 rows
+[celeba 130/167] 2048/4515 rows
+[celeba 130/167] 3072/4515 rows
+[celeba 130/167] 4096/4515 rows
+[celeba] shard 130 done: 4515 scored, 0 skipped, 37.5s
+[celeba 131/167] 1024/4515 rows
+[celeba 131/167] 2048/4515 rows
+[celeba 131/167] 3072/4515 rows
+[celeba 131/167] 4096/4515 rows
+[celeba] shard 131 done: 4515 scored, 0 skipped, 37.7s
+[celeba 132/167] 1024/4515 rows
+[celeba 132/167] 2048/4515 rows
+[celeba 132/167] 3072/4515 rows
+[celeba 132/167] 4096/4515 rows
+[celeba] shard 132 done: 4515 scored, 0 skipped, 37.9s
+[celeba 133/167] 1024/4515 rows
+[celeba 133/167] 2048/4515 rows
+[celeba 133/167] 3072/4515 rows
+[celeba 133/167] 4096/4515 rows
+[celeba] shard 133 done: 4515 scored, 0 skipped, 37.3s
+[celeba 134/167] 1024/4515 rows
+[celeba 134/167] 2048/4515 rows
+[celeba 134/167] 3072/4515 rows
+[celeba 134/167] 4096/4515 rows
+[celeba] shard 134 done: 4515 scored, 0 skipped, 37.9s
+[celeba 135/167] 1024/4515 rows
+[celeba 135/167] 2048/4515 rows
+[celeba 135/167] 3072/4515 rows
+[celeba 135/167] 4096/4515 rows
+[celeba] shard 135 done: 4515 scored, 0 skipped, 37.6s
+[celeba 136/167] 1024/4515 rows
+[celeba 136/167] 2048/4515 rows
+[celeba 136/167] 3072/4515 rows
+[celeba 136/167] 4096/4515 rows
+[celeba] shard 136 done: 4515 scored, 0 skipped, 37.6s
+[celeba 137/167] 1024/4515 rows
+[celeba 137/167] 2048/4515 rows
+[celeba 137/167] 3072/4515 rows
+[celeba 137/167] 4096/4515 rows
+[celeba] shard 137 done: 4515 scored, 0 skipped, 37.6s
+[celeba 138/167] 1024/4515 rows
+[celeba 138/167] 2048/4515 rows
+[celeba 138/167] 3072/4515 rows
+[celeba 138/167] 4096/4515 rows
+[celeba] shard 138 done: 4515 scored, 0 skipped, 37.3s
+[celeba 139/167] 1024/4515 rows
+[celeba 139/167] 2048/4515 rows
+[celeba 139/167] 3072/4515 rows
+[celeba 139/167] 4096/4515 rows
+[celeba] shard 139 done: 4515 scored, 0 skipped, 38.3s
+[celeba 140/167] 1024/4515 rows
+[celeba 140/167] 2048/4515 rows
+[celeba 140/167] 3072/4515 rows
+[celeba 140/167] 4096/4515 rows
+[celeba] shard 140 done: 4515 scored, 0 skipped, 36.9s
+[celeba 141/167] 1024/4515 rows
+[celeba 141/167] 2048/4515 rows
+[celeba 141/167] 3072/4515 rows
+[celeba 141/167] 4096/4515 rows
+[celeba] shard 141 done: 4515 scored, 0 skipped, 37.7s
+[celeba 142/167] 1024/4515 rows
+[celeba 142/167] 2048/4515 rows
+[celeba 142/167] 3072/4515 rows
+[celeba 142/167] 4096/4515 rows
+[celeba] shard 142 done: 4515 scored, 0 skipped, 37.4s
+[celeba 143/167] 1024/4515 rows
+[celeba 143/167] 2048/4515 rows
+[celeba 143/167] 3072/4515 rows
+[celeba 143/167] 4096/4515 rows
+[celeba] shard 143 done: 4515 scored, 0 skipped, 38.0s
+[celeba 144/167] 1024/4515 rows
+[celeba 144/167] 2048/4515 rows
+[celeba 144/167] 3072/4515 rows
+[celeba 144/167] 4096/4515 rows
+[celeba] shard 144 done: 4515 scored, 0 skipped, 37.4s
+[celeba 145/167] 1024/4515 rows
+[celeba 145/167] 2048/4515 rows
+[celeba 145/167] 3072/4515 rows
+[celeba 145/167] 4096/4515 rows
+[celeba] shard 145 done: 4515 scored, 0 skipped, 37.6s
+[celeba 146/167] 1024/4515 rows
+[celeba 146/167] 2048/4515 rows
+[celeba 146/167] 3072/4515 rows
+[celeba 146/167] 4096/4515 rows
+[celeba] shard 146 done: 4515 scored, 0 skipped, 37.6s
+[celeba 147/167] 1024/4515 rows
+[celeba 147/167] 2048/4515 rows
+[celeba 147/167] 3072/4515 rows
+[celeba 147/167] 4096/4515 rows
+[celeba] shard 147 done: 4515 scored, 0 skipped, 37.4s
+[celeba 148/167] 1024/4515 rows
+[celeba 148/167] 2048/4515 rows
+[celeba 148/167] 3072/4515 rows
+[celeba 148/167] 4096/4515 rows
+[celeba] shard 148 done: 4515 scored, 0 skipped, 37.8s
+[celeba 149/167] 1024/4515 rows
+[celeba 149/167] 2048/4515 rows
+[celeba 149/167] 3072/4515 rows
+[celeba 149/167] 4096/4515 rows
+[celeba] shard 149 done: 4515 scored, 0 skipped, 37.4s
+[celeba 150/167] 1024/4515 rows
+[celeba 150/167] 2048/4515 rows
+[celeba 150/167] 3072/4515 rows
+[celeba 150/167] 4096/4515 rows
+[celeba] shard 150 done: 4515 scored, 0 skipped, 37.2s
+[celeba 151/167] 1024/4515 rows
+[celeba 151/167] 2048/4515 rows
+[celeba 151/167] 3072/4515 rows
+[celeba 151/167] 4096/4515 rows
+[celeba] shard 151 done: 4515 scored, 0 skipped, 37.2s
+[celeba 152/167] 1024/4515 rows
+[celeba 152/167] 2048/4515 rows
+[celeba 152/167] 3072/4515 rows
+[celeba 152/167] 4096/4515 rows
+[celeba] shard 152 done: 4515 scored, 0 skipped, 37.1s
+[celeba 153/167] 1024/4515 rows
+[celeba 153/167] 2048/4515 rows
+[celeba 153/167] 3072/4515 rows
+[celeba 153/167] 4096/4515 rows
+[celeba] shard 153 done: 4515 scored, 0 skipped, 37.5s
+[celeba 154/167] 1024/4515 rows
+[celeba 154/167] 2048/4515 rows
+[celeba 154/167] 3072/4515 rows
+[celeba 154/167] 4096/4515 rows
+[celeba] shard 154 done: 4515 scored, 0 skipped, 37.0s
+[celeba 155/167] 1024/4515 rows
+[celeba 155/167] 2048/4515 rows
+[celeba 155/167] 3072/4515 rows
+[celeba 155/167] 4096/4515 rows
+[celeba] shard 155 done: 4515 scored, 0 skipped, 37.7s
+[celeba 156/167] 1024/4515 rows
+[celeba 156/167] 2048/4515 rows
+[celeba 156/167] 3072/4515 rows
+[celeba 156/167] 4096/4515 rows
+[celeba] shard 156 done: 4515 scored, 0 skipped, 37.8s
+[celeba 157/167] 1024/4515 rows
+[celeba 157/167] 2048/4515 rows
+[celeba 157/167] 3072/4515 rows
+[celeba 157/167] 4096/4515 rows
+[celeba] shard 157 done: 4515 scored, 0 skipped, 37.1s
+[celeba 158/167] 1024/5194 rows
+[celeba 158/167] 2048/5194 rows
+[celeba 158/167] 3072/5194 rows
+[celeba 158/167] 4096/5194 rows
+[celeba 158/167] 5120/5194 rows
+[celeba] shard 158 done: 5194 scored, 0 skipped, 43.9s
+[celeba 159/167] 1024/5193 rows
+[celeba 159/167] 2048/5193 rows
+[celeba 159/167] 3072/5193 rows
+[celeba 159/167] 4096/5193 rows
+[celeba 159/167] 5120/5193 rows
+[celeba] shard 159 done: 5193 scored, 0 skipped, 42.9s
+[celeba 160/167] 1024/5193 rows
+[celeba 160/167] 2048/5193 rows
+[celeba 160/167] 3072/5193 rows
+[celeba 160/167] 4096/5193 rows
+[celeba 160/167] 5120/5193 rows
+[celeba] shard 160 done: 5193 scored, 0 skipped, 42.9s
+[celeba 161/167] 1024/5193 rows
+[celeba 161/167] 2048/5193 rows
+[celeba 161/167] 3072/5193 rows
+[celeba 161/167] 4096/5193 rows
+[celeba 161/167] 5120/5193 rows
+[celeba] shard 161 done: 5193 scored, 0 skipped, 43.8s
+[celeba 162/167] 1024/5193 rows
+[celeba 162/167] 2048/5193 rows
+[celeba 162/167] 3072/5193 rows
+[celeba 162/167] 4096/5193 rows
+[celeba 162/167] 5120/5193 rows
+[celeba] shard 162 done: 5193 scored, 0 skipped, 43.3s
+[celeba 163/167] 1024/5193 rows
+[celeba 163/167] 2048/5193 rows
+[celeba 163/167] 3072/5193 rows
+[celeba 163/167] 4096/5193 rows
+[celeba 163/167] 5120/5193 rows
+[celeba] shard 163 done: 5193 scored, 0 skipped, 43.0s
+[celeba 164/167] 1024/5193 rows
+[celeba 164/167] 2048/5193 rows
+[celeba 164/167] 3072/5193 rows
+[celeba 164/167] 4096/5193 rows
+[celeba 164/167] 5120/5193 rows
+[celeba] shard 164 done: 5193 scored, 0 skipped, 43.6s
+[celeba 165/167] 1024/5193 rows
+[celeba 165/167] 2048/5193 rows
+[celeba 165/167] 3072/5193 rows
+[celeba 165/167] 4096/5193 rows
+[celeba 165/167] 5120/5193 rows
+[celeba] shard 165 done: 5193 scored, 0 skipped, 43.9s
+[celeba 166/167] 1024/5193 rows
+[celeba 166/167] 2048/5193 rows
+[celeba 166/167] 3072/5193 rows
+[celeba 166/167] 4096/5193 rows
+[celeba 166/167] 5120/5193 rows
+[celeba] shard 166 done: 5193 scored, 0 skipped, 43.5s
+[celeba] all shards scored in 4606.7s
+{"images": 525864, "scored": 525864, "detected": 525864, "apcer": 0.6436865021770682, "bpcer": 0.05281369513749772, "auc": 0.6764737558070265, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.1615244159370757, "bpcer": 0.797911734353184}, {"threshold": 0.45, "apcer": 0.3854113020272485, "bpcer": 0.33903964062405145}, {"threshold": 0.5, "apcer": 0.5175570017322908, "bpcer": 0.14915315971589874}, {"threshold": 0.55, "apcer": 0.6436865021770682, "bpcer": 0.05281369513749772}, {"threshold": 0.6, "apcer": 0.7478580457886606, "bpcer": 0.014751411400473502}, {"threshold": 0.7, "apcer": 0.9032960344585421, "bpcer": 0.00048564317367813997}], "per_species": [{"species": "spoof", "n": 42718, "caught": 15221, "tpr": 0.3563134978229318}], "per_split": {"test": {"scored": 59191, "apcer": 0.6436865021770682, "bpcer": 0.05281369513749772, "auc": 0.6764737558070265, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.1615244159370757, "bpcer": 0.797911734353184}, {"threshold": 0.45, "apcer": 0.3854113020272485, "bpcer": 0.33903964062405145}, {"threshold": 0.5, "apcer": 0.5175570017322908, "bpcer": 0.14915315971589874}, {"threshold": 0.55, "apcer": 0.6436865021770682, "bpcer": 0.05281369513749772}, {"threshold": 0.6, "apcer": 0.7478580457886606, "bpcer": 0.014751411400473502}, {"threshold": 0.7, "apcer": 0.9032960344585421, "bpcer": 0.00048564317367813997}]}, "train": {"scored": 419935, "apcer": 0.46183938106134903, "bpcer": 0.045697493517718235, "auc": 0.7647177359429539, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.14398677854055428, "bpcer": 0.7608850475367329}, {"threshold": 0.45, "apcer": 0.28888888888888886, "bpcer": 0.2948522039757995}, {"threshold": 0.5, "apcer": 0.3700809996004504, "bpcer": 0.1265894554883319}, {"threshold": 0.55, "apcer": 0.46183938106134903, "bpcer": 0.045697493517718235}, {"threshold": 0.6, "apcer": 0.5671679197994988, "bpcer": 0.01698876404494382}, {"threshold": 0.7, "apcer": 0.8205768043296647, "bpcer": 0.002184961106309421}]}, "valid": {"scored": 46738, "apcer": 0.4605220121672009, "bpcer": 0.04726552833457065, "auc": 0.763956052234078, "threshold_sweep": [{"threshold": 0.35, "apcer": 0.14185255445803624, "bpcer": 0.7629918337045286}, {"threshold": 0.45, "apcer": 0.2901484921829005, "bpcer": 0.30332838406335066}, {"threshold": 0.5, "apcer": 0.3684830247923072, "bpcer": 0.13146498391487255}, {"threshold": 0.55, "apcer": 0.4605220121672009, "bpcer": 0.04726552833457065}, {"threshold": 0.6, "apcer": 0.5661019166612155, "bpcer": 0.018188567186340016}, {"threshold": 0.7, "apcer": 0.8195198534702689, "bpcer": 0.0022890373669883692}]}}, "skipped_no_usable_bbox": 0}
+merged celeba_spoof into /home/archledger/irlume-bench/benchmarks/results-pad-rgb.json
+ALL-DONE

--- a/benchmarks/tests/test_datasets.py
+++ b/benchmarks/tests/test_datasets.py
@@ -23,7 +23,10 @@ def test_every_entry_has_required_fields():
         assert spec.name == name
         assert spec.source in ("hf", "kaggle")
         assert spec.repo
-        assert spec.files
+        if not spec.files:
+            assert spec.source == "hf", (
+                f"{name}: only hf specs may use the empty-files snapshot lane"
+            )
         assert spec.license_note
         assert spec.provenance_url
         assert spec.notes
@@ -116,3 +119,43 @@ def test_new_recognition_entries():
     assert "112" in bundle.notes
     assert "pair" in bundle.notes.lower()
     assert "published-comparable" in bundle.notes
+
+
+def test_pad_entries_pinned_mirrors():
+    casia = get_dataset("casia_fasd")
+    assert casia.source == "kaggle"
+    assert casia.repo == "immada/casia-fasd"
+    assert casia.files[0].path == "kaggle-archive.zip"
+    assert casia.files[0].extract
+    assert casia.files[0].size_hint_bytes == 2_200_000_000
+    npu = get_dataset("oulu_npu")
+    assert npu.source == "kaggle"
+    assert npu.repo == "mizaku/oulu-npu-test"
+    assert npu.files[0].path == "kaggle-archive.zip"
+    assert npu.files[0].extract
+    assert npu.files[0].size_hint_bytes == 500_000_000
+    assert "minhtranv/oulu-npu-w-depth" in npu.notes
+    assert "2_760_000_000" in npu.notes
+    assert "record" in npu.notes.lower()
+    celeba = get_dataset("celeba_spoof_hf")
+    assert celeba.source == "hf"
+    assert celeba.repo == "Ar4ikov/celebA_spoof"
+    assert celeba.files == ()
+    assert "snapshot_download" in celeba.notes
+    assert "data/*" in celeba.notes
+    for spec in (casia, npu, celeba):
+        assert spec.provenance_url
+        assert spec.license_note
+        assert spec.notes
+
+
+def test_snapshot_guard_signature():
+    from fetch_data import validate_snapshot
+
+    validate_snapshot(get_dataset("celeba_spoof_hf"))
+    with pytest.raises(SystemExit):
+        validate_snapshot(get_dataset("casia_fasd"))
+    with pytest.raises(SystemExit):
+        validate_snapshot(get_dataset("oulu_npu"))
+    with pytest.raises(SystemExit):
+        validate_snapshot(get_dataset("wider_face"))

--- a/benchmarks/tests/test_pad_score.py
+++ b/benchmarks/tests/test_pad_score.py
@@ -1,0 +1,81 @@
+import pytest
+
+from pad_score import (
+    apcer_bpcer,
+    median_vote,
+    roc_auc,
+    species_breakdown,
+    vote_video,
+)
+
+
+def test_apcer_bpcer_perfect_separation():
+    r = apcer_bpcer([0.9, 0.8], [0.1, 0.2], 0.5)
+    assert r == {"apcer": 0.0, "bpcer": 0.0}
+
+
+def test_apcer_bpcer_known_fractions():
+    r = apcer_bpcer([0.4, 0.9, 0.6], [0.2, 0.7], 0.5)
+    assert r["apcer"] == pytest.approx(1 / 3)
+    assert r["bpcer"] == pytest.approx(1 / 2)
+
+
+def test_apcer_bpcer_boundary_semantics():
+    r = apcer_bpcer([0.5], [0.5], 0.5)
+    assert r == {"apcer": 0.0, "bpcer": 1.0}
+
+
+def test_apcer_bpcer_rejects_empty_inputs():
+    with pytest.raises(ValueError):
+        apcer_bpcer([], [0.1], 0.5)
+    with pytest.raises(ValueError):
+        apcer_bpcer([0.9], [], 0.5)
+
+
+def test_roc_auc_perfect_separation():
+    assert roc_auc([0.8, 0.9], [0.1, 0.2]) == pytest.approx(1.0)
+    assert roc_auc([0.1, 0.2], [0.8, 0.9]) == pytest.approx(0.0)
+
+
+def test_roc_auc_tie_handling():
+    assert roc_auc([0.5, 0.8], [0.5, 0.2]) == pytest.approx(0.875)
+
+
+def test_roc_auc_rejects_empty_inputs():
+    with pytest.raises(ValueError):
+        roc_auc([], [0.1])
+    with pytest.raises(ValueError):
+        roc_auc([0.9], [])
+
+
+def test_species_breakdown_rows_sorted_and_exact():
+    rows = species_breakdown(
+        [("cat", 0.9), ("cat", 0.2), ("dog", 0.6), ("bird", 0.4)], 0.5
+    )
+    assert rows == [
+        {"species": "bird", "n": 1, "caught": 0, "tpr": 0.0},
+        {"species": "cat", "n": 2, "caught": 1, "tpr": 0.5},
+        {"species": "dog", "n": 1, "caught": 1, "tpr": 1.0},
+    ]
+
+
+def test_species_breakdown_threshold_is_inclusive():
+    rows = species_breakdown([("x", 0.5)], 0.5)
+    assert rows == [{"species": "x", "n": 1, "caught": 1, "tpr": 1.0}]
+    assert species_breakdown([], 0.5) == []
+
+
+def test_median_vote_known_values():
+    assert median_vote([0.1, 0.9, 0.5]) == pytest.approx(0.5)
+    assert median_vote([0.1, 0.2, 0.3, 0.9]) == pytest.approx(0.25)
+    assert median_vote([0.7]) == pytest.approx(0.7)
+
+
+def test_vote_video_rolling_median_7_frames():
+    frames = [[0.1], [0.9], [0.5], [0.3], [0.7], [0.2], [0.8]]
+    assert vote_video(frames) == pytest.approx([0.1, 0.5, 0.5, 0.4, 0.5, 0.5, 0.5])
+
+
+def test_vote_video_short_windows_use_what_exists():
+    assert vote_video([[0.2], [0.8]]) == pytest.approx([0.2, 0.5])
+    assert vote_video([]) == []

--- a/docs/research/2026-08-30-pad-phase3.md
+++ b/docs/research/2026-08-30-pad-phase3.md
@@ -20,8 +20,11 @@
   `a1cf06319be7bdfa591d1c8a53de0c119c6fa6674b8ff3095eb9c1fe4b1d0a80`),
   `benchmarks/results-pad-ir.json` (sha256
   `a062b12f6030836351632255a47fbe9e2d79180a8ff8a0d4425fc5dbd5a9c412`),
-  produced by `benchmarks/bench_pad_rgb.py` and `benchmarks/bench_pad_ir.py`
-  over `benchmarks/pad_score.py`. Every number below is copied from those
+  produced by `benchmarks/bench_pad_rgb.py` and `benchmarks/bench_pad_ir.py`;
+  the RGB metrics (APCER/BPCER, rank AUC, sweeps, species breakdown) come
+  from `benchmarks/pad_score.py`, and the IR lane's flag rate follows the
+  same pinned BPCER-side definition in its own `flagged_rate` (the lane
+  does not import the module). Every number below is copied from those
   files. Suite status at this tree: 76 passed.
 
 ## 1. RGB PAD (ViT, wired line 0.55, 5-frame-median vote)
@@ -36,6 +39,10 @@ APCER/BPCER at the wired 0.55 line, rank AUC over all scores:
 | casia test | 65,786 | 0.4701 | 0.1413 | 0.6100 |
 | oulu voted | 1,701 frames / 703 clips | 0.8417 | 0.0 | 0.9311 |
 
+Full threshold sweeps for every set and split (0.35 to 0.7 for RGB, 0.1
+to 0.99 for IR, wired lines included) are committed as `threshold_sweep`
+arrays in the two results files.
+
 **The headline calibration finding: the shipped ViT PAD does not transfer
 to the CelebA-Spoof test protocol.** The test split inverts the train and
 valid picture (AUC 0.6765 vs 0.7647/0.7640; APCER@0.55 0.6437 vs
@@ -47,10 +54,10 @@ investigation:
   0.0528/0.0457/0.0473), so the wired 0.55 line lands mid-distribution on
   test attacks.
 - Split-source composition: test shards are 100% PNG (59,191 rows), train
-  and valid 100% JPG, and test payloads are far larger per image. The
-  leading hypothesis (labeled as such in the results notes) is that the
-  PNG-sourced test protocol preserves attack artifacts differently than
-  the JPG source the model's training distribution resembles.
+  and valid 100% JPG. The leading hypothesis (labeled as such in the
+  results notes) is that the PNG-sourced test protocol preserves attack
+  artifacts differently than the JPG source the model's training
+  distribution resembles.
 - Detection source exonerated: mirror-box vs YuNet geometry crosscheck on
   the same rows gives mean IoU 0.898, so the bbox source does not explain
   the gap.
@@ -158,6 +165,15 @@ protocols.
   fleet/banner (see section 2 scope ruling).
 - Tufts is absent (request-form acquisition; user decision pending), so
   no unseen-faces NIR control exists in this phase either.
+- Schema and interface deltas from the plan, recorded: the OULU RGB
+  section delivers `per_video` (per-clip median) where the plan named
+  `per_session`; `roc_auc` is omitted from the IR results because both
+  IR sets are single-class genuine (no rank pairs exist); the plan's
+  `genuine_regimes` key is covered by the results notes per the Task 4
+  scope ruling; and `pad_score.vote_video` (the shipped sliding-window
+  vote emulation) is unused because the flat-frame mirror carries no
+  per-frame time axis to slide over, so the lane votes per clip with
+  `median_vote` and discloses the median-of-1 composition above.
 - Single measurement host (archhost, RTX 3060); the RGB lanes ran once
   per set and the IR lane ran twice with identical results across the
   float32-grid fix round (all rates, percentiles, sweeps, and flagged

--- a/docs/research/2026-08-30-pad-phase3.md
+++ b/docs/research/2026-08-30-pad-phase3.md
@@ -1,0 +1,164 @@
+# Presentation-attack detection calibration, Phase 3
+
+- **What:** Phase 3 of the model calibration campaign: the two shipped PAD
+  cues measured on public data. RGB: the ViT PAD model
+  (`liveness_vit.onnx`) on CelebA-Spoof (HF parquet mirror), CASIA-FASD
+  (frame-extracted mirror), and OULU-NPU (mirror-limited test subset),
+  scored with ISO-semantics APCER/BPCER against the wired 0.55 line with
+  the 5-frame-median vote emulated. IR: the FLIR cue (`flir.onnx`) on
+  CBSR and Oulu NI genuine frames, scored as the genuine-side flag rate
+  against the wired 0.9 deny line. Measurement evidence only; no runtime
+  code changed.
+- **Where:** archhost, NVIDIA RTX 3060, ONNX Runtime 1.27.0 with the CUDA
+  execution provider, OpenCV 5.0.0. The RGB lane replicates the shipped
+  ViT PAD input chain and the IR lane transcribes `PadIr::p_fake`
+  (crates/irlume-vision/src/lib.rs:1516+) with a float32 sampling grid;
+  the IR transcription was proven bit-exact against a scalar line-by-line
+  port of the Rust before the runs (12 trials, both square branches).
+- **When:** measurement runs 2026-08-29/30 UTC; report 2026-08-30.
+- **Sources (committed):** `benchmarks/results-pad-rgb.json` (sha256
+  `a1cf06319be7bdfa591d1c8a53de0c119c6fa6674b8ff3095eb9c1fe4b1d0a80`),
+  `benchmarks/results-pad-ir.json` (sha256
+  `a062b12f6030836351632255a47fbe9e2d79180a8ff8a0d4425fc5dbd5a9c412`),
+  produced by `benchmarks/bench_pad_rgb.py` and `benchmarks/bench_pad_ir.py`
+  over `benchmarks/pad_score.py`. Every number below is copied from those
+  files. Suite status at this tree: 76 passed.
+
+## 1. RGB PAD (ViT, wired line 0.55, 5-frame-median vote)
+
+APCER/BPCER at the wired 0.55 line, rank AUC over all scores:
+
+| set | scored | APCER@0.55 | BPCER@0.55 | AUC |
+|---|---|---|---|---|
+| celeba test | 59,191 | 0.6437 | 0.0528 | 0.6765 |
+| celeba train | 419,935 | 0.4618 | 0.0457 | 0.7647 |
+| celeba valid | 46,738 | 0.4605 | 0.0473 | 0.7640 |
+| casia test | 65,786 | 0.4701 | 0.1413 | 0.6100 |
+| oulu voted | 1,701 frames / 703 clips | 0.8417 | 0.0 | 0.9311 |
+
+**The headline calibration finding: the shipped ViT PAD does not transfer
+to the CelebA-Spoof test protocol.** The test split inverts the train and
+valid picture (AUC 0.6765 vs 0.7647/0.7640; APCER@0.55 0.6437 vs
+0.4618/0.4605). Decomposition, all from committed data and the task-3
+investigation:
+
+- Attack-score median 0.494 on test vs 0.569/0.569 on train/valid: the
+  test attacks score lower, not the genuines higher (BPCER is flat at
+  0.0528/0.0457/0.0473), so the wired 0.55 line lands mid-distribution on
+  test attacks.
+- Split-source composition: test shards are 100% PNG (59,191 rows), train
+  and valid 100% JPG, and test payloads are far larger per image. The
+  leading hypothesis (labeled as such in the results notes) is that the
+  PNG-sourced test protocol preserves attack artifacts differently than
+  the JPG source the model's training distribution resembles.
+- Detection source exonerated: mirror-box vs YuNet geometry crosscheck on
+  the same rows gives mean IoU 0.898, so the bbox source does not explain
+  the gap.
+- Per-species analysis is impossible on this mirror: the label column is
+  binary live/spoof, so `per_species` is a single spoof row (test attacks
+  n=42,718, caught 15,221, TPR@0.55 0.3563; 1 - 0.3563 = 0.6437 APCER).
+
+CASIA-FASD mirror: 123,533 frame images (train_live 19,011 / train_spoof
+38,736 / test_live 10,128 / test_spoof 55,658; 319 undetected, counted).
+Test APCER@0.55 0.4701, BPCER 0.1413, AUC 0.6100; the AUC is low on both
+sides of the sweep, consistent with a frame-extracted re-encoding whose
+relation to the original 550-video protocol is not established.
+
+OULU-NPU mirror: the fallback source is dead (404) and the usable mirror
+carries only a 300-video test subset (703 clips after grouping, 1,701
+flat frames, true/false dirs), scored honestly as mirror-limited. Voted
+(median-of-5 emulation; on this subset most windows hold a single frame,
+median-of-1): APCER@0.55 0.8417, BPCER 0.0, AUC 0.9311. Frame level for
+comparison: APCER 0.7570, BPCER 0.0, AUC 0.8951. The vote direction on
+this subset pushes attack-side scores down (more attacks pass at the same
+line); with mostly single-frame windows this is a disclosure, not a
+vote-quality claim. Fleet banner numbers remain the operating truth for
+this model; none of these public protocols are portable to it as tuned
+evidence.
+
+## 2. IR PAD (FLIR cue, wired deny line 0.9)
+
+Scope ruling: no IR attack data exists on disk, so this lane measures the
+GENUINE-side flag rate at the wired line (the BPCER side of the deny
+line); attack-side IR evidence remains the fleet/banner measurements
+(models/README.md flir row: 122/123 banner frames flagged). Both sets are
+all-subjects, 100% detection coverage, zero read failures.
+
+| set | scored | flagged at 0.9 | score_p50 | score_max | frames >= 0.1 |
+|---|---|---|---|---|---|
+| cbsr (all subjects) | 3,940 | 1 (0.000254) | 2.2e-06 | 0.9750 | 3 |
+| oulu Dark | 10,782 | 0 | 3.4e-06 | 0.8204 | 59 |
+| oulu Strong | 10,379 | 4 (0.000385) | 5.9e-06 | 0.9606 | 62 |
+| oulu Weak | 10,834 | 0 | 4.2e-06 | 0.5792 | 30 |
+
+The single CBSR flag is `NIR_face_dataset/NIR_face_dataset/0085-00-a.bmp`
+at 0.9750; the four Oulu flags are all Strong frames in two subjects
+(P049 Disgust 010/011/012 at 0.9606/0.9438/0.9036, P012 Happiness 017 at
+0.9009), committed as `flagged_frames` with paths and scores. Every
+figure in this section is a committed field (per-set sweeps including the
+0.1 row, score_max, flagged_frames).
+
+**The dim-lighting hypothesis is NOT confirmed at the wire.** The
+expectation from the fleet's dim-strobe genuine failure regime was a
+higher Dark flag rate. Measured: Dark 0/10,782 at 0.9. Dark does carry
+the widest sub-threshold tail (59 frames at or above 0.1, max 0.8204),
+but the only wired-line flags are Strong frames concentrated in two
+subjects, a subject/frame-content pattern rather than a lighting regime.
+The fleet dim-strobe genuine failure regime does not reproduce at frame
+level on this mirror through this chain and remains fleet-measurement
+evidence.
+
+## 3. Coverage statement
+
+Phone-at-distance and screen-at-distance presentations are not labeled as
+such in any public set used here: the CelebA-Spoof mirror is binary, the
+CASIA mirror is frame-extracted without species dirs, and the Oulu mirror
+carries true/false only. Species-resolved attack evidence (which attack
+types miss the line) is therefore not derivable from this phase, and the
+IR attack side has no public data at all. Operating claims about attack
+coverage continue to rest on the fleet banner measurements and the
+third-party PAD candidate study (docs/pad-results/), not on these public
+protocols.
+
+## 4. Calibration recommendations (evidence only; changes are Phase 4 PRs)
+
+- **Keep the wired RGB 0.55 line unchanged.** No public-set evidence
+  supports moving it: the only large test protocol here (CelebA-Spoof
+  test) fails transfer for this model, so tuning against it would tune
+  to a distribution the model does not carry; CASIA and Oulu mirrors are
+  re-encodings with unestablished protocol relation and a dead fallback
+  source. The line's existing justification (measured operating point,
+  0.50 and 0.60 documented as rejected alternatives) stands.
+- **Keep the wired IR 0.9 deny line unchanged.** The genuine-side flag
+  rate at 0.9 is 1/3,940 on CBSR and 4/31,995 on Oulu NI including dark
+  lighting, with the sub-threshold tail (max genuine 0.8204 in Dark)
+  comfortably below the line; the banner attack floor (0.941) sits above
+  it. The margin statement in models/README.md is reproduced, not
+  revised.
+- **Phase 4 inputs from this phase:** the RGB PAD model's transfer
+  failure is the strongest replacement-candidate motivation in the
+  campaign (a cue whose test-protocol AUC is 0.68 on the largest public
+  spoof set is weak evidence to carry into threshold synthesis); the IR
+  cue's genuine-side margin is reproduced and wide. Threshold synthesis
+  should weight fleet measurements first and use public sets for
+  candidate comparison only.
+
+## 5. Limitations
+
+- Mirror provenance per set (PROVENANCE.md + MANIFEST.sha256 on the
+  measurement host): CelebA-Spoof via 167 HF parquet shards (binary
+  Class labels; split parsed from shard filename); CASIA-FASD from a
+  Kaggle frame-extracted mirror, not the 550-video original; OULU-NPU
+  mirror-limited to its test subset with the fallback source dead
+  (404); CBSR from the Kaggle NIR mirror; Oulu NI walked with .jpg and
+  .jpeg (70 Thumbs.db excluded).
+- The Oulu voted-vs-frame comparison is a median-of-1 disclosure on a
+  1,701-frame subset; no vote-quality claim is made.
+- The IR lane is genuine-side only; attack-side IR evidence is
+  fleet/banner (see section 2 scope ruling).
+- Tufts is absent (request-form acquisition; user decision pending), so
+  no unseen-faces NIR control exists in this phase either.
+- Single measurement host (archhost, RTX 3060); the RGB lanes ran once
+  per set and the IR lane ran twice with identical results across the
+  float32-grid fix round (all rates, percentiles, sweeps, and flagged
+  frames reproduced exactly).

--- a/docs/superpowers/plans/2026-08-30-model-calibration-phase3.md
+++ b/docs/superpowers/plans/2026-08-30-model-calibration-phase3.md
@@ -1,0 +1,118 @@
+# Model Calibration Phase 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce the PAD calibration evidence: RGB PAD (liveness_vit.onnx) APCER/BPCER at the wired deny line with full ROC and per-species breakdown on full CelebA-Spoof plus CASIA-FASD and OULU-NPU, and IR PAD (flir.onnx) at the 0.9 wired line on CBSR + Oulu NIR over all subjects with genuine-failure regimes.
+
+**Architecture:** New pure scoring module (`pad_score.py`) under TDD; two bench scripts (`bench_pad_rgb.py`, `bench_pad_ir.py`); the CelebA-Spoof whale arrives as HF parquet shards read directly by the bench (no zip extraction, per-file streaming fits the disk).
+
+**Tech Stack:** Same as Phases 0-2 plus pyarrow (Apache-2.0) and huggingface_hub (Apache-2.0), controller-approved for the measurement venv only.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-model-calibration-campaign-design.md` (RGB PAD and IR PAD rows).
+
+## Global Constraints
+
+- Zero em dashes (U+2014); DCO trailer exactly `Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>`; GPG-signed commits (BLOCKED on pinentry timeout); never `--no-gpg-sign`.
+- Never print token values.
+- User gates every download. This phase: CASIA-FASD ~2.2 GB (Kaggle immada/casia-fasd), OULU-NPU ~0.5-2.8 GB (Kaggle, decision rule in Task 1), CelebA-Spoof HF parquet ~60-75 GB (the whale).
+- READ THE RUST CONSTANTS FIRST (the Phase 1 lesson): the wired RGB PAD line is `VIT_PAD_THRESHOLD = 0.55` with a 5-frame-median vote (crates/irlume-vision/src/lib.rs:350-354); the ViT feed is the m96 convention (bbox expanded by 96/112 of w/h per side, CLAMPED no fill, bilinear 224, RGB, (px/255-0.5)/0.5, CHW; P(spoof) = softmax index 1, lib.rs:1316-1370). Find and read the PadIr preprocessing (lib.rs:1516+) before writing the IR lane. Grep for any threshold changes in irlume-auth before trusting 0.55/0.9 as the wired lines.
+- Metrics semantics (ISO-style, pinned): with s = P(spoof): APCER = fraction of ATTACK (spoof) samples with s < threshold (missed attacks); BPCER = fraction of GENUINE samples with s >= threshold (false rejections). At a wired line T, attacks caught = s >= T.
+- Work on branch `calib/phase3` stacked on `calib/phase2`; after #599 merges, rebase the whole stacked series onto main (the established pattern).
+- archhost venv python: `/home/archledger/venvs/bench/bin/python`. Disk check before the whale: `df -h /` must show >= 80G free; if not, prune per the Task 5 ruling.
+
+---
+
+### Task 1: Registry entries + snapshot fetch mode
+
+**Files:**
+- Modify: `benchmarks/datasets.py`
+- Modify: `benchmarks/fetch_data.py`
+- Modify: `benchmarks/requirements-bench.txt` (append pyarrow>=14, huggingface_hub>=0.30)
+- Test: `benchmarks/tests/test_datasets.py`
+
+**Interfaces:**
+- Produces: registry names `casia_fasd` (kaggle immada/casia-fasd, single archive, 2_200_000_000 hint), `oulu_npu` (kaggle mizaku/oulu-npu-test, 500_000_000 hint; notes carry the decision rule: if extraction shows test-split-only content and the bench needs sessions breadth, fetch minhtranv/oulu-npu-w-depth 2_760_000_000 as the fallback and record which was used), and `celeba_spoof_hf` (hf repo Ar4ikov/celebA_spoof, `source="hf"`, files = empty tuple, notes: parquet shard snapshot lane, read via snapshot_download allow_patterns data/*).
+- `fetch_data.py` gains `download <name> --snapshot`: when the spec has zero files and source hf, use huggingface_hub snapshot_download(repo_id, repo_type="dataset", local_dir=root/name, allow_patterns="data/*", token=load_token(...)) then write PROVENANCE.md + MANIFEST.sha256 over the downloaded shard files.
+
+- [ ] **Step 1: Failing tests** (registry assertions for the three names; a fetch_data guard test that --snapshot rejects specs with files, and non-hf specs).
+- [ ] **Step 2: RED. Step 3: implement. Step 4: GREEN** (suite + new). **Step 5: commit** `bench: pad registry entries and hf snapshot fetch mode`.
+
+---
+
+### Task 2: PAD scoring module (`pad_score.py`)
+
+**Files:**
+- Create: `benchmarks/pad_score.py`
+- Test: `benchmarks/tests/test_pad_score.py`
+
+**Interfaces:**
+- Produces (Tasks 3-4 consume):
+  - `apcer_bpcer(scores_attack: list[float], scores_genuine: list[float], threshold: float) -> dict` {"apcer": f, "bpcer": f} per the pinned ISO semantics in Global Constraints
+  - `roc_auc(scores_attack, scores_genuine) -> float` (rank-based, tie-handled)
+  - `species_breakdown(per_sample: list[tuple[str, float]], threshold: float) -> list[dict]` rows {"species": s, "n": i, "caught": i, "tpr": f} (TPR = fraction with s >= threshold)
+  - `median_vote(scores: list[float]) -> float` (the 5-frame-median emulation: statistics.median)
+  - `vote_video(frames: list[list[float]]) -> list[float]` (per-time-step rolling median of the last N=5 scores, matching the ADR-0013 vote semantics; window shorter than 5 uses what exists)
+- [ ] **Step 1: Failing tests** with hand-computed cases (perfect separation -> APCER 0/BPCER 0 at sane thresholds; known small mixes -> exact fractions; tie handling in AUC; rolling median on a synthetic 7-frame sequence).
+- [ ] **Step 2: RED. Step 3: implement. Step 4: GREEN** + suite. **Step 5: commit** `bench: pad scoring module`.
+
+---
+
+### Task 3: RGB PAD lane (`bench_pad_rgb.py`)
+
+**Files:**
+- Create: `benchmarks/bench_pad_rgb.py`
+- Create: `benchmarks/results-pad-rgb.json` (committed output)
+
+**Interfaces:**
+- Consumes: pad_score.py, letterbox.py, yunet + liveness_vit.onnx, the three datasets
+- Produces schema: `{"runtime": {...}, "wired": {"vit_threshold": 0.55, "vote_window": 5}, "celeba_spoof": {"images": i, "scored": i, "detected": i, "apcer": f, "bpcer": f, "auc": f, "per_species": [...], "threshold_sweep": [...]}, "casia_fasd": {...}, "oulu_npu": {"clips": i, "voted": {...}, "per_session": [...]}, "notes": [...]}`
+- Protocol: YuNet at the 640 letterbox operating point -> best detection -> m96 crop convention -> P(spoof); CelebA-Spoof labels give live vs 10 attack species (discover the parquet schema first with a one-off print step, pin the column names in a code comment); CASIA-FASD real/attack from its directory protocol; OULU-NPU per-video 5-frame-median voting (sample frames at a fixed stride recorded in notes).
+
+- [ ] **Step 1: Write the lane** (parquet read via pyarrow streaming batches; decode bytes to BGR; resumable progress file every 5000 rows so a killed run resumes). 
+- [ ] **Step 2: Local parse check, deploy, run** on archhost: CASIA-FASD first (smallest, validates the chain), OULU-NPU next, CelebA-Spoof LAST via nohup with polling (ViT-base at 224 on a 3060 over ~600k images is a multi-hour run; the resumable progress file makes interruption safe). Record wall time.
+- [ ] **Step 3: Sanity**: CelebA-Spoof AUC should sit well above 0.5; the known-uncovered phone-at-distance class is NOT separately labeled in CelebA-Spoof (record that the per-species table covers the labeled species only); CASIA/OULU numbers plausible vs the deny-only design (documented banner measurements caught 100% at 0.55 on the fleet; academic-set numbers will differ and that is the finding).
+- [ ] **Step 4: commit** `bench: rgb pad lane on celeba spoof casia and oulu`.
+
+---
+
+### Task 4: IR PAD lane (`bench_pad_ir.py`)
+
+**Files:**
+- Create: `benchmarks/bench_pad_ir.py`
+- Create: `benchmarks/results-pad-ir.json` (committed output)
+
+**Interfaces:**
+- Consumes: pad_score.py, letterbox.py, yunet + flir.onnx (READ PadIr preprocessing in lib.rs first), cbsr_nir + oulu_casia_nir datasets (already on archhost)
+- Produces schema: `{"runtime": {...}, "wired": {"flir_threshold": 0.9}, "cbsr": {"frames": i, "scored": i, "tpr_at_wired": f, "roc_auc": f, "threshold_sweep": [...]}, "oulu": {"per_lighting": [{"lighting": str, "tpr_at_wired": f, "score_p50": f}...], "overall": {...}}, "genuine_regimes": "cross-reference: no genuine-attack pairs exist in these sets; genuine-side behavior rides on the Phase 1 detection ceiling and the fleet measurements", "notes": [...]}`
+
+- [ ] **Step 1: Write the lane** (both sets are BONA FIDE only: no IR attack data exists on disk, so this lane measures the false-rejection side (BPCER-analog: genuine frames flagged as spoof at 0.9) and score distributions, NOT attack TPR. The schema above is corrected accordingly: replace tpr_at_wired with "flagged_rate_at_wired" = fraction of genuine frames at/above the deny line; keep the sweep + per-lighting rows. State in notes that attack-side IR evidence remains the fleet/banner measurements, a spec-honest limitation).
+- [ ] **Step 2: Run on archhost** (all subjects, superseding the 197-identity sample; Oulu grouped by lighting incl. Dark, where the dim-strobe genuine failure regime lives).
+- [ ] **Step 3: Sanity**: flagged_rate near 0 on lit CBSR frames (the committed measurement was 1/3,940 above the line); Oulu Dark flagged_rate expected higher (the dim genuine failure regime) and that number is the finding.
+- [ ] **Step 4: commit** `bench: ir pad lane on cbsr and oulu all subjects`.
+
+---
+
+### Task 5: Downloads (USER GATE, ordering: small -> whale)
+
+**Files:** none (host state)
+
+- [ ] **Step 1:** Ask per dataset: CASIA-FASD ~2.2 GB, OULU-NPU ~0.5-2.8 GB, CelebA-Spoof parquet ~60-75 GB. Whale gate includes the disk check (>= 80G free; prune ruling if needed: the Phase 1/2 raw sets wider_face, 300w, aligned_fr_bundle, cfpw, lfw may be deleted on archhost to free ~5.7G since their results are committed; CBSR + Oulu NIR MUST STAY, they feed Task 4).
+- [ ] **Step 2:** Fetch + verify: CASIA-FASD real/attack dirs present; OULU-NPU decision rule applied (test-split-only vs fallback); CelebA-Spoof shards land via the snapshot lane, shard count + total bytes + parquet schema printout recorded; MANIFEST/PROVENANCE per set.
+
+---
+
+### Task 6: Phase 3 report + calibration table
+
+**Files:**
+- Create: `docs/research/2026-08-30-pad-phase3.md`
+
+- [ ] **Step 1:** Report: RGB PAD table (per set: APCER/BPCER at the wired 0.55 line, AUC, per-species TPR table incl. which labeled species miss the line, sweep summary), the vote effect (OULU voted vs single-frame), IR PAD table (flagged rates at 0.9 per set per lighting, the Dark regime finding), the coverage statement (phone-at-distance not labeled in any public set; IR attack-side evidence remains fleet-only), and the calibration recommendations (keep/adjust the wired lines, all evidence-backed, changes only via Phase 4 PRs).
+- [ ] **Step 2:** Zero em dashes, commit `docs: phase 3 pad calibration report`.
+
+## Phase 3 exit criteria
+
+- results-pad-rgb.json + results-pad-ir.json committed; report written; suite green; whale run resumable and completed or explicitly partial with committed partials labeled; downloads gated + PROVENANCE'd.
+
+## Out of scope for Phase 3
+
+- Threshold-change PRs, replacement candidates, cross-track synthesis (Phase 4).


### PR DESCRIPTION
## What

Phase 3 of the model calibration campaign (Phase 1 in #599, Phase 2 in #619): the two shipped PAD cues measured on public data. RGB: the ViT PAD model (`liveness_vit.onnx`) on CelebA-Spoof (HF parquet mirror), CASIA-FASD (frame-extracted mirror), and OULU-NPU (mirror-limited test subset) with ISO-semantics APCER/BPCER at the wired 0.55 line and the 5-frame-median vote emulated. IR: the FLIR cue (`flir.onnx`) on CBSR and Oulu NI genuine frames as the genuine-side flag rate at the wired 0.9 deny line. Measurement evidence only; no runtime code changed. Bench suite 76/76 on this tree.

## Findings

**The shipped ViT PAD does not transfer to the CelebA-Spoof test protocol.** Test APCER/BPCER@0.55 0.6437/0.0528, AUC 0.6765, against train 0.4618/0.0457/0.7647 and valid 0.4605/0.0473/0.7640. The attack-score median drops to 0.494 on test (0.569 train/valid), test shards are 100% PNG vs 100% JPG train/valid, and the bbox source is exonerated by an IoU 0.898 crosscheck: the fleet banner numbers are not portable to this protocol, and tuning against it would tune to a distribution the model does not carry. CASIA test 0.4701/0.1413/0.6100; Oulu voted 0.8417/0.0/0.9311 (median-of-1 disclosure on the mirror-limited subset).

**The IR deny line's genuine-side margin is reproduced and wide, including dark lighting.** CBSR 1/3,940 flagged at 0.9; Oulu NI overall 4/31,995 (Dark 0/10,782, Strong 4/10,379, Weak 0/10,834; max genuine 0.8204 in Dark, banner attack floor 0.941 above the line). The dim-lighting hypothesis is NOT confirmed at the wire: the four wired-line flags are Strong frames in two subjects, committed as `flagged_frames` with paths and scores.

**Calibration recommendations (evidence only): keep both wired lines unchanged** (RGB 0.55, IR 0.9); the RGB model's transfer failure is the strongest replacement-candidate motivation entering Phase 4. Every figure in the report is checkable from the committed JSONs alone (sweeps including a 0.1 row, score_max, flagged_frames).

## Sources and limitations

Committed evidence: `benchmarks/results-pad-rgb.json` (sha256 `a1cf06319be7bdfa591d1c8a53de0c119c6fa6674b8ff3095eb9c1fe4b1d0a80`), `benchmarks/results-pad-ir.json` (sha256 `a062b12f6030836351632255a47fbe9e2d79180a8ff8a0d4425fc5dbd5a9c412`), report `docs/research/2026-08-30-pad-phase3.md` (limitations section 5: mirror provenance per set, binary CelebA labels killing per-species analysis, dead Oulu fallback source, genuine-side-only IR scope, Tufts absent, schema deltas recorded). Determinism: the IR lane ran twice with identical results across the float32-grid fix round; the OULU RGB median_vote swap re-run reproduced the committed section exactly.
