### PR TITLE
feat: one action-oriented prompt line for usability situations (#616)

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -105,6 +105,12 @@ pub struct Engine {
     /// attempt (#616 step 2); every attempt refreshes it before any Outcome
     /// exists, so it can never be read stale.
     last_attempt_facts: AttemptFacts,
+    /// The classified situation of the most recent FAILED attempt (#616
+    /// step 3): stored under the same `!out.granted` guard that journals
+    /// the situation line, cleared by a granted final attempt, and exposed
+    /// read-only as the label the daemon wires onto `AuthResult` for
+    /// pam_irlume's prompt wording. Reporting only: it gates nothing.
+    last_attempt_situation: Option<AttemptSituation>,
     /// Asked between whole captures: "should this long operation stop now?".
     ///
     /// The daemon points this at its arbiter so an enrolment yields the camera
@@ -2919,6 +2925,7 @@ impl Engine {
             head_consent_before_match: HeadConsentVerdict::NoGesture,
             stop_requested: None,
             last_attempt_facts: AttemptFacts::default(),
+            last_attempt_situation: None,
         })
     }
 
@@ -5330,6 +5337,15 @@ impl Engine {
         .0
     }
 
+    /// The stable situation label of the final FAILED authentication
+    /// attempt (#616 step 3), for the daemon to carry on `AuthResult`:
+    /// `None` when the final attempt granted or nothing ran, so a stale
+    /// label can never reach a prompt. Read-only reporting; gates nothing,
+    /// scores nothing, moves no bar.
+    pub fn last_attempt_situation_label(&self) -> Option<&'static str> {
+        self.last_attempt_situation.map(attempt_situation_label)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn authentication_attempt_loop(
         &mut self,
@@ -5390,6 +5406,15 @@ impl Engine {
                     "{}",
                     attempt_situation_line(out.kind, out.score, &self.last_attempt_facts)
                 );
+                // #616 step 3: the wire reads what the journal just said.
+                // Same guard, same facts: the prompt situation can never
+                // disagree with the journaled one.
+                self.last_attempt_situation =
+                    Some(auth_attempt_situation(out.kind, &self.last_attempt_facts));
+            } else {
+                // A granted final attempt clears the label, so a later
+                // reader can never prompt off a stale failure.
+                self.last_attempt_situation = None;
             }
             let expired = std::time::Instant::now() >= deadline;
             let retry_wont_fit = !expired

--- a/crates/irlume-auth/tests/attempt_situation_wiring.rs
+++ b/crates/irlume-auth/tests/attempt_situation_wiring.rs
@@ -65,3 +65,62 @@ fn every_failed_attempt_emits_exactly_one_situation_line() {
          definition and the single emission site"
     );
 }
+
+/// #616 step 3: the FINAL failed attempt's situation must be readable from
+/// the engine, because the daemon puts it on the wire and pam_irlume turns
+/// it into action wording at the prompt. The store happens under the SAME
+/// `!out.granted` guard that journals the line, so the wire can never
+/// disagree with the journal about what the situation was, and a granted
+/// final attempt clears it so a stale label can never reach a prompt.
+#[test]
+fn the_final_failed_attempts_situation_is_exposed_for_the_prompt() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
+    let text = std::fs::read_to_string(&src).expect("read irlume-auth/src/lib.rs");
+
+    // The engine keeps the classified situation beside the facts snapshot.
+    assert!(
+        text.contains("    last_attempt_situation: Option<AttemptSituation>,"),
+        "the engine must store the classified situation for the wire"
+    );
+
+    // The store and the clear both live in the retry loop: set under the
+    // failed-attempt guard that emits the journal line, cleared on a grant.
+    // Whitespace-flattened so rustfmt's line wrapping cannot break the
+    // needles.
+    let loop_start = text
+        .find("    fn authentication_attempt_loop(")
+        .expect("the grace-retry loop exists");
+    let loop_end = text[loop_start..]
+        .find("\n    fn authenticate_once(")
+        .map(|offset| loop_start + offset)
+        .expect("authenticate_once follows the loop");
+    let retry_loop = &text[loop_start..loop_end];
+    let flat = retry_loop.split_whitespace().collect::<Vec<_>>().join(" ");
+    let guard = flat
+        .find("if !out.granted {")
+        .expect("the loop guards the emission on a failed outcome");
+    let store = flat[guard..]
+        .find("self.last_attempt_situation = Some(auth_attempt_situation(")
+        .expect("the guard stores the classified situation for the wire");
+    // And it stores before the guard closes: the next statement after the
+    // store must still be inside the guard (the else-clear follows the
+    // guard's close, never the store).
+    let guard_close = flat[guard..]
+        .find("} else {")
+        .expect("the guard closes with an else for the grant clear");
+    assert!(store < guard_close, "the store sits inside the guard");
+    assert!(
+        flat.contains("self.last_attempt_situation = None;"),
+        "a granted final attempt must clear the stored situation"
+    );
+
+    // Exactly one public getter in production: the label the daemon wires.
+    let production = &text[..text.find("\nmod tests").expect("tests module exists")];
+    assert_eq!(
+        production
+            .matches("pub fn last_attempt_situation_label")
+            .count(),
+        1,
+        "exactly one public situation getter may exist"
+    );
+}

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -833,6 +833,15 @@ pub enum Response {
         /// daemon that never sets it decodes as `false` (no abort).
         #[serde(default)]
         declined_by_gesture: bool,
+        /// The final FAILED attempt's situation, in the #616 step 2 stable
+        /// vocabulary ("no face", "too far", ...), carried so pam_irlume can
+        /// word its prompt (#616 step 3). Empty on a grant, on every
+        /// pre-camera policy refusal, and from an older daemon
+        /// (`#[serde(default)]`); attack-shaped labels are carried too, but
+        /// the PAM layer stays silent on them: no threshold value ever
+        /// reaches a prompt surface.
+        #[serde(default)]
+        situation: String,
     },
     Profiles(Vec<String>),
     /// Answer to [`Request::ListCameras`]: every physical camera exposing an
@@ -1227,6 +1236,28 @@ pub(crate) mod testenv {
 #[cfg(test)]
 mod tests {
 
+    /// `AuthResult.situation` (#616 step 3) is `#[serde(default)]` so an
+    /// OLDER daemon's reply, which predates the field, still decodes: the
+    /// empty string means "no situation to prompt on" and pam stays silent.
+    /// Round-trips when set, so the daemon's label reaches pam verbatim.
+    #[test]
+    fn auth_result_situation_defaults_empty_for_old_daemons() {
+        let old = r#"{"AuthResult":{"granted":false,"score":0.25,"live":false,"reason":"no match","refused_by_policy":false,"declined_by_gesture":false}}"#;
+        match serde_json::from_str::<Response>(old).expect("old reply decodes") {
+            Response::AuthResult { situation, .. } => {
+                assert_eq!(situation, "", "an old daemon decodes with no situation");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+        let new = r#"{"AuthResult":{"granted":false,"score":0.25,"live":false,"reason":"no match","refused_by_policy":false,"declined_by_gesture":false,"situation":"too far"}}"#;
+        match serde_json::from_str::<Response>(new).expect("new reply decodes") {
+            Response::AuthResult { situation, .. } => {
+                assert_eq!(situation, "too far", "the label round-trips verbatim");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
     /// The delivered-rate DTO is a plain serializable carrier: snake_case JSON
     /// round-trips every field, and the typed error keeps a stable,
     /// machine-parseable message with the evidence recoverable from the payload
@@ -1394,6 +1425,7 @@ mod tests {
             reason: "no match".into(),
             declined_by_gesture: true,
             refused_by_policy: false,
+            situation: "too far".into(),
         };
         let mut v = serde_json::to_value(&full).expect("serialize");
         let obj = v

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1645,6 +1645,50 @@ mod worker_engine {
             );
         }
 
+        /// #616 step 3: the ONE wire site that carries an engine outcome onto
+        /// an `AuthResult` also carries the final failed attempt's situation
+        /// label, so pam_irlume can word its prompt. Every OTHER construction
+        /// site (the root gate and the policy early-returns above the camera)
+        /// sends an EMPTY situation: there is nothing usability-shaped to say
+        /// about a refusal that never looked at a face. Field presence at
+        /// every site is the compiler's job once the field exists; this pins
+        /// the VALUES. Needles are assembled from pieces so this test's own
+        /// source cannot satisfy them.
+        #[test]
+        fn the_engine_outcome_wire_carries_the_attempt_situation() {
+            let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+            let text = std::fs::read_to_string(&src).expect("read the daemon source");
+            // Whitespace-flattened so rustfmt's line wrapping cannot break
+            // the needle.
+            let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+            let head = [
+                "situation: if o.granted { String::new() } else { ",
+                "engine",
+            ]
+            .concat();
+            let sites: Vec<usize> = flat.match_indices(&head).map(|(i, _)| i).collect();
+            let getter = ["last_attempt_situation", "_label"].concat();
+            assert_eq!(
+                sites.len(),
+                1,
+                "exactly one site carries the engine's situation label"
+            );
+            let tail = &flat[sites[0]..sites[0] + 300];
+            assert!(
+                tail.contains(&getter) && tail.contains(".unwrap_or_default()"),
+                "the wire reads the engine's getter and defaults to empty when \
+                 nothing ran"
+            );
+            let empty = ["situation: String::new", "(),"].concat();
+            assert_eq!(
+                flat.matches(&empty).count(),
+                5,
+                "the five pre-camera refusal sites (root gate + four policy \
+                 early-returns) each send an empty situation; a new site must \
+                 consciously pick wire-or-empty and update this pin"
+            );
+        }
+
         #[test]
         fn cannot_stream_verdict_names_capture_failure_facts() {
             let mut report = healthy_concurrent(6, 6);
@@ -2946,6 +2990,7 @@ fn intent_confirmation_gate(req: &Request, peer: &Peer) -> Option<Response> {
         reason: "privileged face authentication requires PAM conversation confirmation".into(),
         declined_by_gesture: false,
         refused_by_policy: true,
+        situation: String::new(),
     })
 }
 
@@ -3758,6 +3803,7 @@ fn dispatch_scoped(
                     reason: "face auth disabled: the configured method is fingerprint".into(),
                     declined_by_gesture: false,
                     refused_by_policy: true,
+                    situation: String::new(),
                 };
             }
             // Smart-Auto tier gate: on a CONVENIENCE (RGB-only) device, a face
@@ -3797,6 +3843,7 @@ fn dispatch_scoped(
                         ),
                         declined_by_gesture: false,
                         refused_by_policy: true,
+                        situation: String::new(),
                     };
                 }
             }
@@ -3823,6 +3870,7 @@ fn dispatch_scoped(
                         reason: format!("biopolicy: face may not satisfy '{svc}'"),
                         declined_by_gesture: false,
                         refused_by_policy: true,
+                        situation: String::new(),
                     };
                 }
             }
@@ -3835,6 +3883,7 @@ fn dispatch_scoped(
                     reason: "too many recent face attempts; use your password".into(),
                     declined_by_gesture: false,
                     refused_by_policy: true,
+                    situation: String::new(),
                 };
             }
             let convenience = engine.tier() == irlume_core::biopolicy::Tier::Convenience;
@@ -3875,6 +3924,18 @@ fn dispatch_scoped(
                         // at (or looked for). The policy refusals return above,
                         // before the camera.
                         refused_by_policy: false,
+                        // #616 step 3: the final failed attempt's situation,
+                        // in the stable journal vocabulary, for pam's action
+                        // wording; empty on a grant and on every pre-camera
+                        // refusal (they send `situation: String::new()`).
+                        situation: if o.granted {
+                            String::new()
+                        } else {
+                            engine
+                                .last_attempt_situation_label()
+                                .unwrap_or_default()
+                                .to_string()
+                        },
                         reason: o.reason,
                     }
                 }
@@ -6443,6 +6504,7 @@ mod tests {
                     reason,
                     declined_by_gesture,
                     refused_by_policy,
+                    situation: _,
                 }) => {
                     assert!(!granted && !live && !declined_by_gesture);
                     assert_eq!(score, 0.0);
@@ -6940,6 +7002,7 @@ mod tests {
                     reason,
                     declined_by_gesture: false,
                     refused_by_policy: true,
+                    situation: _,
                 } => {
                     assert_eq!(score, 0.0);
                     assert_eq!(
@@ -8706,6 +8769,7 @@ mod tests {
                 reason,
                 declined_by_gesture,
                 refused_by_policy,
+                situation: _,
             } => {
                 assert!(!granted && !live);
                 assert_eq!(score, 0.0);

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -834,12 +834,35 @@ fn read_stdout_bounded(
     }
 }
 
+/// #616 step 3: action wording for a failed attempt's situation, mapped
+/// from the daemon-reported stable vocabulary. Usability situations tell
+/// the person what to DO; attack-shaped situations (`spoof`, `glint
+/// below`, `below score`), `declined`, `other`, and unknown or empty
+/// labels return `None` and stay SILENT at the prompt: wording that names
+/// the cue that fired is a free oracle for a presentation attacker tuning
+/// a spoof, and no threshold value ever reaches a prompt surface (the
+/// numbers live in the journal and the diagnostic trace, root-visible).
+fn situation_prompt(situation: &str) -> Option<&'static str> {
+    match situation {
+        "no face" => Some("look at the camera"),
+        "too far" => Some("come closer"),
+        "off-center" => Some("center your face in the frame"),
+        "looking away" => Some("look directly at the camera"),
+        "too dark" => Some("it is too dark to see your face; add light"),
+        _ => None,
+    }
+}
+
 /// One verify attempt (sudo / polkit / in-session unlock): no password released.
 /// Returns `SUCCESS` on a live match; `ABORT` on a DELIBERATE head-shake decline
 /// at a polkit consent dialog, so the whole stack aborts and the agent closes its
 /// window; and `IGNORE` on anything else so the password fallback survives. Passes
 /// the PAM service so the daemon can apply tier×operation-class gating (an RGB-only
 /// convenience device honours only a screen-unlock service).
+///
+/// #616 step 3: a denial whose situation is usability-shaped also puts ONE
+/// action-oriented line at the prompt via [`situation_prompt`] before the
+/// password fallback.
 fn try_verify(pamh: &Pam, user: &str, intent_confirmation: Option<IntentAttestation>) -> PamError {
     let service = pamh
         .get_service()
@@ -877,6 +900,23 @@ fn try_verify(pamh: &Pam, user: &str, intent_confirmation: Option<IntentAttestat
             declined_by_gesture: true,
             ..
         }) if is_polkit_consent => PamError::ABORT,
+        // #616 step 3: a usability situation gets ONE best-effort action
+        // line at the prompt (some agents never display module info text;
+        // the XFCE lesson), numbers-free by construction. Attack-shaped
+        // situations map to nothing and stay silent: wording that names the
+        // cue that fired is a free oracle for a presentation attacker
+        // tuning a spoof, and no threshold value ever reaches a prompt
+        // surface (the numbers live in the journal and trace, root-visible).
+        Ok(Response::AuthResult {
+            granted: false,
+            situation,
+            ..
+        }) => {
+            if let Some(action) = situation_prompt(&situation) {
+                let _ = pamh.info(&format!("irlume: {action}"));
+            }
+            PamError::IGNORE
+        }
         _ => PamError::IGNORE,
     }
 }
@@ -1331,5 +1371,103 @@ mod tests {
         assert!(got.is_none(), "output past the cap must read as failure");
         assert!(started.elapsed() < Duration::from_secs(5));
         assert!(matches!(child.try_wait(), Ok(Some(_))));
+    }
+
+    /// #616 step 3: usability situations get one action-oriented line at the
+    /// prompt; attack-shaped situations stay SILENT (wording that names the
+    /// cue that fired is a free oracle for a presentation attacker tuning a
+    /// spoof). Hand-written expectations: the table IS the contract.
+    #[test]
+    fn usability_situations_get_action_wording_attack_signals_stay_silent() {
+        use super::situation_prompt;
+        assert_eq!(situation_prompt("no face"), Some("look at the camera"));
+        assert_eq!(situation_prompt("too far"), Some("come closer"));
+        assert_eq!(
+            situation_prompt("off-center"),
+            Some("center your face in the frame")
+        );
+        assert_eq!(
+            situation_prompt("looking away"),
+            Some("look directly at the camera")
+        );
+        assert_eq!(
+            situation_prompt("too dark"),
+            Some("it is too dark to see your face; add light")
+        );
+        for silent in [
+            "spoof",
+            "glint below",
+            "below score",
+            "declined",
+            "other",
+            "",
+            "too farfetched",
+        ] {
+            assert_eq!(
+                situation_prompt(silent),
+                None,
+                "{silent:?} must stay silent at the prompt"
+            );
+        }
+    }
+
+    /// The #616 step 3 split: rich numbers live in the journal and the
+    /// diagnostic trace, NEVER at a prompt surface. No mapped wording may
+    /// carry a digit, so no threshold value can leak through a label.
+    #[test]
+    fn no_prompt_wording_ever_carries_a_number() {
+        use super::situation_prompt;
+        for label in [
+            "no face",
+            "too far",
+            "off-center",
+            "looking away",
+            "too dark",
+        ] {
+            if let Some(text) = situation_prompt(label) {
+                assert!(
+                    !text.bytes().any(|b| b.is_ascii_digit()),
+                    "prompt wording must carry no numbers: {text}"
+                );
+            }
+        }
+    }
+
+    /// #616 step 3 wiring: `try_verify` turns the daemon's situation label
+    /// into ONE best-effort info line before cascading to the password.
+    /// Pinned against the source the way the auth crate pins its seams: no
+    /// camera-less test can drive a full reply through the PAM stack.
+    #[test]
+    fn try_verify_prompts_one_action_line_from_the_reply_situation() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
+        let text = std::fs::read_to_string(&src).expect("read irlume-pam/src/lib.rs");
+        let fn_start = text.find("fn try_verify(").expect("try_verify exists");
+        let fn_end = text[fn_start..]
+            .find("\n/// One unseal attempt")
+            .map(|offset| fn_start + offset)
+            .expect("the unseal helper follows try_verify");
+        let body = &text[fn_start..fn_end];
+        // Assembled from pieces so this test's own source cannot satisfy the
+        // needle it searches for (the auth crate's tripwire idiom).
+        let info_call = ["pamh.info(&format!(\"irlume: {", "action}\"))"].concat();
+        let arm = body
+            .find("situation,")
+            .expect("try_verify binds the reply's situation");
+        let consult = body[arm..]
+            .find("situation_prompt(&situation)")
+            .expect("the situation is mapped through the prompt table");
+        let emit = body[arm..]
+            .find(&info_call)
+            .expect("the action line is emitted once, best-effort");
+        assert!(
+            consult < emit,
+            "the mapping is consulted before the emission"
+        );
+        // And the mapping is best-effort: an info failure never changes the
+        // return code (the emission's result is discarded).
+        assert!(
+            body[arm..].contains("let _ = "),
+            "the info emission must be best-effort"
+        );
     }
 }

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -352,6 +352,7 @@ fn grant() -> Response {
         reason: "match".into(),
         declined_by_gesture: false,
         refused_by_policy: false,
+        situation: String::new(),
     }
 }
 
@@ -639,6 +640,7 @@ fn pamwrap_face_denial_clears_yes_before_password_fallback() {
         reason: "no match".into(),
         declined_by_gesture: false,
         refused_by_policy: false,
+        situation: String::new(),
     });
     let checker = h.token_checker("face-denial", FIXED_TEST_TOKEN);
     h.write_service(
@@ -987,6 +989,7 @@ fn pamwrap_polkit_confirmation_precedes_the_optional_gesture() {
         reason: "face not granted".into(),
         declined_by_gesture: false,
         refused_by_policy: false,
+        situation: String::new(),
     });
 
     // A plain verify (no `unseal`) on the polkit service.
@@ -1065,6 +1068,7 @@ fn pamwrap_polkit_migration_remedy_tracks_the_environment_override() {
         reason: "face not granted".into(),
         declined_by_gesture: false,
         refused_by_policy: false,
+        situation: String::new(),
     });
     h.write_service("polkit-1", &[h.auth_line("required", "")]);
     h.write_settings(Some("service_gesture.polkit-1=1\nconsent_gesture=nod\n"));
@@ -1128,6 +1132,7 @@ fn pamwrap_polkit_shake_aborts_only_the_polkit_stack() {
         reason: "denied".into(),
         declined_by_gesture: d.load(Ordering::SeqCst),
         refused_by_policy: false,
+        situation: String::new(),
     });
     h.write_settings(Some("service_gesture.polkit-1=1\nservice_gesture.sudo=1\n"));
 
@@ -1355,6 +1360,7 @@ fn pamwrap_wait_mode_retries_until_a_match() {
                     reason: "below threshold".into(),
                     declined_by_gesture: false,
                     refused_by_policy: false,
+                    situation: String::new(),
                 }
             } else {
                 grant()
@@ -1737,5 +1743,79 @@ fn pamwrap_secret_stash_replaces_and_completes_without_printing() {
             "the replaced stash must read back the exact live secret"
         ),
         other => panic!("expected ResealPassword, daemon saw {other:?}"),
+    }
+}
+
+/// #616 step 3: a denied verify whose situation is usability-shaped puts
+/// ONE action-oriented line at the prompt, and the stack still cascades to
+/// the password (IGNORE, no abort).
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_usability_situation_prompts_one_action_line() {
+    let Some(h) = Harness::try_new("situation-prompt") else {
+        return;
+    };
+    h.write_service("irlume-lock", &[h.auth_line("required", "")]);
+    serve(&h.socket, |req| match req {
+        Request::Authenticate { .. } => Response::AuthResult {
+            granted: false,
+            score: 0.10,
+            live: false,
+            reason: "no match".into(),
+            declined_by_gesture: false,
+            refused_by_policy: false,
+            situation: "too far".into(),
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (ok, out) = h.run("irlume-lock", &["authenticate"], "\n", None);
+    assert!(!ok, "a denial must not authenticate: {out}");
+    assert!(
+        out.contains("irlume: come closer"),
+        "the action wording reached the prompt: {out}"
+    );
+}
+
+/// The attacker-oracle split of #616 step 3: an attack-shaped situation
+/// names NOTHING at the prompt. No cue name, no action wording, nothing a
+/// presentation attacker could tune against; the numbers live in the
+/// journal and diagnostic trace, root-visible.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_attack_situation_stays_silent_at_the_prompt() {
+    let Some(h) = Harness::try_new("situation-silent") else {
+        return;
+    };
+    h.write_service("irlume-lock", &[h.auth_line("required", "")]);
+    serve(&h.socket, |req| match req {
+        Request::Authenticate { .. } => Response::AuthResult {
+            granted: false,
+            score: 0.10,
+            live: false,
+            reason: "no match".into(),
+            declined_by_gesture: false,
+            refused_by_policy: false,
+            situation: "spoof".into(),
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+
+    let (ok, out) = h.run("irlume-lock", &["authenticate"], "\n", None);
+    assert!(!ok, "a denial must not authenticate: {out}");
+    for absent in [
+        "spoof",
+        "glint",
+        "look at the camera",
+        "look directly at the camera",
+        "come closer",
+        "center your face",
+        "add light",
+    ] {
+        assert!(
+            !out.contains(absent),
+            "an attack-shaped situation must name nothing at the prompt \
+         ({absent} leaked): {out}"
+        );
     }
 }


### PR DESCRIPTION
## What

Step 3 of #616, the last: a denied face attempt whose situation is usability-shaped now puts ONE action-oriented line at the prompt, and attack-shaped situations stay silent.

- `irlume-auth`: the grace-retry loop stores the classified situation of the final FAILED attempt under the SAME `!out.granted` guard that journals the situation line (a granted final attempt clears it), exposed read-only as `Engine::last_attempt_situation_label()`. The wire can never disagree with the journal.
- `irlume-common`: `AuthResult` carries `situation` (the stable step-2 vocabulary label), `#[serde(default)]` so an older daemon's reply decodes as empty and the prompt stays silent against it.
- `irlume-daemon`: the ONE engine-outcome wire site carries the label (empty on a grant); the five pre-camera refusal sites (root gate + four policy early-returns) each send an empty situation: there is nothing usability-shaped to say about a refusal that never looked at a face.
- `irlume-pam`: `situation_prompt` maps only `no face` / `too far` / `off-center` / `looking away` / `too dark` to action wording ("look at the camera", "come closer", "center your face in the frame", "look directly at the camera", "it is too dark to see your face; add light"), emitted once, best-effort, before the password fallback. `spoof`, `glint below`, `below score`, `declined`, `other`, and unknown or empty labels return `None` and stay SILENT: wording that names the cue that fired is a free oracle for a presentation attacker tuning a spoof, and no threshold value ever reaches a prompt surface (the numbers live in the journal and the diagnostic trace, root-visible). Some agents never display module info text (the XFCE lesson); the emission is best-effort and never changes the return code.

## Evidence

- Hand-written mapper table (every usability label, plus the silent set including prefix collisions like `too farfetched`).
- Digit-free wording property: no mapped text may carry an ASCII digit, so no threshold can leak through a label.
- Source pins (the repo's camera-less seam idiom): the engine stores under the journal guard and clears on grant; the daemon wire values (one getter site, five empty sites); `try_verify` consults the mapper and emits once.
- `#[serde(default)]` old-daemon decode test, mirroring `refused_by_policy` / `declined_by_gesture`.
- Two pamwrap end-to-end tests through a real PAM stack (pam_wrapper + pamtester, the repo's existing harness): the action line reaches the conversation and the denial still cascades to the password; an attack situation names NOTHING at the prompt.
- Mutation-verified, all caught: attack label given wording, digit introduced in wording, emission removed, grant-clear removed, store removed, wire site hardcoded empty, serde default dropped.
- Gates: workspace 1830/0, pamwrap --include-ignored 28/28, clippy `-D warnings` clean, fmt, zero em dashes.

Closes #616 (step 3 of 3; steps 1 and 2 landed in #617 and #623)
