### PR TITLE
feat: record illumination-metadata classified frames per qualification arm (#606)

### DIFF
--- a/crates/irlume-camera/src/capture_qualification.rs
+++ b/crates/irlume-camera/src/capture_qualification.rs
@@ -825,6 +825,12 @@ pub struct ArmEvidence {
     /// revalidate.
     #[serde(default)]
     capture_failure_facts: std::collections::BTreeMap<String, u32>,
+    /// Burst frames the camera's illumination metadata classified as lit or
+    /// dark, summed over the arm's completed rounds (#606). Additive and
+    /// defaulted like `capture_failure_facts`, so schema-2 records written
+    /// before the field still parse and revalidate.
+    #[serde(default)]
+    ir_camera_classified_frames: u32,
     rgb_mean: f32,
     ir_mean: f32,
     elapsed_ms: u64,
@@ -854,6 +860,7 @@ impl ArmEvidence {
         capture_failures: u32,
         rate_shortfall_failures: u32,
         capture_failure_facts: std::collections::BTreeMap<String, u32>,
+        ir_camera_classified_frames: u32,
         rgb_mean: f32,
         ir_mean: f32,
         elapsed_ms: u64,
@@ -875,12 +882,20 @@ impl ArmEvidence {
             capture_failures,
             rate_shortfall_failures,
             capture_failure_facts,
+            ir_camera_classified_frames,
             rgb_mean,
             ir_mean,
             elapsed_ms,
         };
         value.validate()?;
         Ok(value)
+    }
+
+    /// Burst frames the camera's illumination metadata classified as lit or
+    /// dark across the arm's completed rounds (#606).
+    #[must_use]
+    pub const fn ir_camera_classified_frames(&self) -> u32 {
+        self.ir_camera_classified_frames
     }
 
     fn validate(&self) -> Result<(), QualificationError> {
@@ -1641,6 +1656,10 @@ mod tests {
     }
 
     fn arm(rounds: u32) -> ArmEvidence {
+        arm_with_ir_classified(rounds, 0)
+    }
+
+    fn arm_with_ir_classified(rounds: u32, ir_camera_classified: u32) -> ArmEvidence {
         ArmEvidence::new(
             rounds,
             rounds,
@@ -1658,11 +1677,32 @@ mod tests {
             0,
             0,
             Default::default(),
+            ir_camera_classified,
             140.0,
             120.0,
             850,
         )
         .unwrap()
+    }
+
+    /// #606: the illumination-metadata classified-frame count is additive and
+    /// defaulted: schema-2 records written before the field still parse and
+    /// revalidate, and new records round-trip it.
+    #[test]
+    fn ir_camera_classified_frames_is_additive_and_round_trips() {
+        assert_eq!(arm(6).ir_camera_classified_frames(), 0);
+        // A record serialized before the field existed decodes with zero.
+        let json = serde_json::to_value(arm_with_ir_classified(6, 47)).unwrap();
+        let mut legacy = json.clone();
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("ir_camera_classified_frames");
+        let decoded: ArmEvidence = serde_json::from_value(legacy).expect("legacy record parses");
+        assert_eq!(decoded.ir_camera_classified_frames(), 0);
+        // And a new record round-trips the value.
+        let back: ArmEvidence = serde_json::from_value(json).expect("the new record round-trips");
+        assert_eq!(back.ir_camera_classified_frames(), 47);
     }
 
     fn concurrent_attempt(port: &str) -> QualificationAttempt {
@@ -1845,6 +1885,7 @@ mod tests {
                 3,
                 0,
                 Default::default(),
+                0,
                 80.0,
                 90.0,
                 2_000,
@@ -1906,6 +1947,7 @@ mod tests {
                 0,
                 0,
                 Default::default(),
+                0,
                 1.0,
                 1.0,
                 1
@@ -1930,6 +1972,7 @@ mod tests {
             0,
             0,
             Default::default(),
+            0,
             1.0,
             1.0,
             1,
@@ -1965,6 +2008,7 @@ mod tests {
             0,
             6,
             Default::default(),
+            0,
             0.0,
             0.0,
             1,
@@ -2165,6 +2209,7 @@ mod tests {
                 2,
                 0,
                 Default::default(),
+                0,
                 80.0,
                 90.0,
                 2_000,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -6536,6 +6536,13 @@ pub struct PairSample {
     /// the persisted ArmEvidence (additive, serde-defaulted) so a stored
     /// verdict names its facts months later.
     pub capture_failure_facts: std::collections::BTreeMap<&'static str, usize>,
+    /// Burst frames the camera's own illumination metadata classified as lit
+    /// or dark, summed over the arm's completed rounds (#606). The T14s
+    /// report: a concurrent arm can deliver every buffer yet classify ZERO
+    /// frames while the sequential arm classifies fine, so a signal-loss
+    /// verdict needs this count to say whether the brightness collapsed with
+    /// a silent metadata path or on a camera that reports nothing either way.
+    pub ir_camera_classified_frames: usize,
 }
 
 impl PairSample {
@@ -7540,6 +7547,7 @@ fn qualification_arm(
         count(sample.capture_failures, "capture-failure")?,
         count(sample.rate_shortfall_failures, "rate-shortfall-failure")?,
         capture_failure_facts,
+        count(sample.ir_camera_classified_frames, "ir-camera-classified")?,
         sample.rgb_mean,
         sample.ir_mean,
         sample.total_ms.round() as u64,
@@ -8113,6 +8121,10 @@ fn accumulate(
     let mix = |old: f32, new: f32| (old * n + new) / (n + 1.0);
     into.rgb_mean = mix(into.rgb_mean, frame_mean(&rgb.data));
     into.ir_mean = mix(into.ir_mean, ir_stats.lit_mean);
+    // #606: fold the camera's own illumination-metadata classification count
+    // beside the brightness it gated on, so the arm can name a metadata path
+    // that went silent under concurrency.
+    into.ir_camera_classified_frames += ir_stats.camera_classified_frames;
     into.total_ms = mix(into.total_ms, elapsed.as_millis() as f32);
     into.rounds += 1;
 
@@ -11989,6 +12001,7 @@ mod tests {
                 rate_shortfall_failures: 0,
                 continuity_facts: Default::default(),
                 capture_failure_facts: Default::default(),
+                ir_camera_classified_frames: 0,
             };
             ContentionReport {
                 sequential: sample(seq),
@@ -12378,6 +12391,49 @@ mod tests {
             "the facts account for every capture failure, nothing else"
         );
         assert_eq!(report.concurrent.rate_shortfall_failures, 0);
+    }
+
+    /// #606: how many burst frames the camera's own illumination metadata
+    /// classified folds into each arm, so a verdict can name a metadata path
+    /// that went silent exactly under concurrency (the T14s signature:
+    /// sequential rounds classify, concurrent rounds deliver buffers but
+    /// classify nothing).
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
+    fn ir_camera_classified_counts_fold_into_the_arm() {
+        let rgb = || Ok(frame(&[120; 4]));
+        let ir = || {
+            let mut s = stats(60.0);
+            s.camera_classified_frames = 7;
+            s.camera_lit_frames = 7;
+            Ok((frame(&[20; 4]), s))
+        };
+        let report =
+            measure_contention_impl(&rgb, &ir, scripted_arm(&rgb, &ir), 2, &no_progress(), None)
+                .expect("the probe completes");
+        assert_eq!(
+            report.sequential.ir_camera_classified_frames, 14,
+            "two sequential rounds of 7 classified frames"
+        );
+        assert_eq!(
+            report.concurrent.ir_camera_classified_frames, 14,
+            "the concurrent arm folds the same per-round count"
+        );
+    }
+
+    /// #606: the folded count survives into the persisted ArmEvidence.
+    #[test]
+    fn qualification_arm_carries_the_ir_camera_classified_count() {
+        let sample = PairSample {
+            rounds: 2,
+            ir_camera_classified_frames: 23,
+            rgb_mean: 100.0,
+            ir_mean: 60.0,
+            total_ms: 10.0,
+            ..PairSample::default()
+        };
+        let evidence = qualification_arm(&sample, 2).expect("bounded counts");
+        assert_eq!(evidence.ir_camera_classified_frames(), 23);
     }
 
     /// #606: a pair that cannot even establish its rate windows names that

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1591,6 +1591,7 @@ mod worker_engine {
                     rate_shortfall_failures: 0,
                     continuity_facts: Default::default(),
                     capture_failure_facts: Default::default(),
+                    ir_camera_classified_frames: 0,
                 },
                 concurrent: PairSample {
                     rgb_mean: 140.0,
@@ -1612,9 +1613,66 @@ mod worker_engine {
                     rate_shortfall_failures: 0,
                     continuity_facts: Default::default(),
                     capture_failure_facts: Default::default(),
+                    ir_camera_classified_frames: 0,
                 },
                 trailing_sequential_control: true,
             }
+        }
+
+        /// #606: a signal-loss verdict whose concurrent arm classified ZERO
+        /// illumination-metadata frames while the sequential arm classified
+        /// some names that divergence: brightness collapsed AND the camera's
+        /// own metadata path went silent exactly under concurrency, which is
+        /// a different finding from plain dimming and the fact a support
+        /// reader needs months later (the T14s report).
+        #[test]
+        fn signal_loss_names_a_metadata_path_that_went_silent() {
+            let mut report = healthy_concurrent(6, 6);
+            report.sequential.ir_camera_classified_frames = 60;
+            report.concurrent.ir_camera_classified_frames = 0;
+            report.concurrent.ir_mean = 30.0;
+            let message = camera_tune_verdict_message(
+                &report,
+                AttemptOutcome::SequentialRequired(SequentialReason::SignalLoss),
+                6,
+            );
+            assert!(
+                message.contains(
+                    "illumination metadata classified 60 frame(s) \
+                 sequentially and 0 concurrently"
+                ),
+                "the divergence is named with counts: {message}"
+            );
+            // Plain dimming with a healthy metadata path stays plain.
+            let mut healthy = healthy_concurrent(6, 6);
+            healthy.sequential.ir_camera_classified_frames = 60;
+            healthy.concurrent.ir_camera_classified_frames = 58;
+            healthy.concurrent.ir_mean = 30.0;
+            let plain = camera_tune_verdict_message(
+                &healthy,
+                AttemptOutcome::SequentialRequired(SequentialReason::SignalLoss),
+                6,
+            );
+            assert!(
+                !plain.contains("illumination metadata"),
+                "no divergence, no metadata clause: {plain}"
+            );
+            // A camera that reports nothing in EITHER arm (metadata-less
+            // hardware) also keeps the plain wording: silence alone, with no
+            // sequential baseline, is not a divergence.
+            let mut silent = healthy_concurrent(6, 6);
+            silent.sequential.ir_camera_classified_frames = 0;
+            silent.concurrent.ir_camera_classified_frames = 0;
+            silent.concurrent.ir_mean = 30.0;
+            let plain = camera_tune_verdict_message(
+                &silent,
+                AttemptOutcome::SequentialRequired(SequentialReason::SignalLoss),
+                6,
+            );
+            assert!(
+                !plain.contains("illumination metadata"),
+                "no sequential baseline, no metadata clause: {plain}"
+            );
         }
 
         /// #606: the cannot-stream branch names the per-round failure facts
@@ -3472,7 +3530,34 @@ fn camera_tune_verdict_message(
                      so the safe one-at-a-time mode is what was measured and persisted",
                     rounds - report.concurrent.rate_floor_rounds.min(rounds),
                 ),
-                _ => format!(
+                irlume_auth::SequentialReason::SignalLoss => {
+                    // #606 (the T14s report): a concurrent arm that classified
+                    // ZERO illumination-metadata frames while the sequential
+                    // arm classified some lost brightness AND the camera's own
+                    // metadata path went silent exactly under concurrency.
+                    // That combination is a different finding from plain
+                    // dimming and the fact a support reader needs months
+                    // later, so it is named with counts; a healthy metadata
+                    // path keeps the plain retention wording.
+                    let metadata_silent = report.concurrent.ir_camera_classified_frames == 0
+                        && report.sequential.ir_camera_classified_frames > 0;
+                    let detail = if metadata_silent {
+                        format!(
+                            "; the camera's illumination metadata classified {} frame(s) \
+                             sequentially and 0 concurrently",
+                            report.sequential.ir_camera_classified_frames
+                        )
+                    } else {
+                        String::new()
+                    };
+                    format!(
+                        "{retention}{detail}, but the safe one-at-a-time mode is what was \
+                         measured and persisted"
+                    )
+                }
+                // Unreachable behind the concurrent_impossible() early return
+                // above; rendered defensively so the match stays exhaustive.
+                irlume_auth::SequentialReason::ConcurrentUnavailable => format!(
                     "{retention}, but the safe one-at-a-time mode is what was \
                      measured and persisted"
                 ),


### PR DESCRIPTION
Follow-up to the #606 thread: your T14s data shows a THIRD concurrent-refusal mechanism (streams deliver, illumination metadata classifies nothing), and today's stored verdict cannot name it. This records the fact.

## What

- Each qualification arm (sequential and concurrent) now folds `ir_camera_classified_frames`: the burst frames the camera's own UVC illumination metadata classified as lit or dark, summed over completed rounds.
- The count is mirrored into the persisted `ArmEvidence` as an additive, serde-defaulted field, so schema-2 records written before this still parse and revalidate (same pattern as the #608 capture-failure facts).
- The `camera-tune` signal-loss verdict names the divergence when it is real: concurrent arm classified ZERO metadata frames while the sequential arm classified some, the exact T14s signature (buffers deliver, classification goes silent under concurrency). Plain dimming with a healthy metadata path, and metadata-less cameras (zero in both arms), keep the existing wording.

## Tests

TDD: RED first (E0061/E0599/E0609), then GREEN. Accumulate folds per-round counts into both arms; the folded count survives into ArmEvidence; legacy-record decode defaults zero and new records round-trip; the verdict message names the divergence with counts and stays silent without a sequential baseline. 4/4 mutation probes caught (fold removed, arm zeroed, serde default dropped, verdict fires without a baseline).

Workspace 1836/0, clippy -D warnings clean, fmt clean, cargo doc -D warnings clean, 0 em dashes.

## Effect on the reporter's machine

After this ships, a `camera-tune` run on the T14s will end with the stored record saying e.g. `ir_camera_classified_frames: 60` on the sequential arm and `0` on the concurrent arm, and the verdict line naming that split: the next report answers the open question (whether the 60-byte illumination status payload vanishing under concurrency is the dimming's cause or its sibling) without a strace.
