### PR TITLE
fix: accept the relative time forms people type in logs --since (#561)

### DIFF
--- a/crates/irlume-cli/src/logs.rs
+++ b/crates/irlume-cli/src/logs.rs
@@ -42,6 +42,57 @@ pub fn run(sub: Option<&str>, args: &[String]) -> ExitCode {
 /// error message for a bad option. Extracted verbatim from `view` so the argv
 /// assembly (the whole point of the option parse) is unit-testable without
 /// execing journalctl; `view` just runs what this returns. Zero behavior change.
+/// Normalize a `--since` value into a form journalctl accepts (#561).
+///
+/// `2 min`, `5m`, `90s`, `2min`, `1h` (the shapes people type because the
+/// CLI's own usage hint suggests `10 min ago`) become `<n> <unit> ago`, with
+/// the one-letter abbreviations expanded to units systemd documents. Anything
+/// else passes through byte-for-byte: values that already parse (`... ago`,
+/// negative offsets, absolute timestamps, `yesterday`) must not be rewritten,
+/// and multi-term or malformed input stays journalctl's to judge, with the
+/// failure hint behind it. Pure, so the table is unit-testable.
+fn normalize_since(value: &str) -> String {
+    let trimmed = value.trim();
+    // Exactly one number, optional space, one alpha unit: the bare relative
+    // shape. A leading minus is already a systemd offset; leave it alone.
+    if trimmed.starts_with('-') || trimmed.is_empty() {
+        return value.to_string();
+    }
+    let (number, unit) = match trimmed.find(char::is_alphabetic) {
+        Some(at) => {
+            let n = trimmed[..at].trim();
+            if !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()) {
+                (n, &trimmed[at..])
+            } else {
+                return value.to_string();
+            }
+        }
+        None => return value.to_string(),
+    };
+    let unit = match unit.trim() {
+        "s" | "sec" => "sec".to_string(),
+        "m" => "min".to_string(),
+        "h" => "hr".to_string(),
+        other => other.to_string(),
+    };
+    if unit.chars().all(|c| c.is_ascii_alphabetic()) && !unit.is_empty() {
+        format!("{number} {unit} ago")
+    } else {
+        value.to_string()
+    }
+}
+
+/// What `view` prints when journalctl itself rejects the `--since` value
+/// anyway: the accepted syntax and the exact retry command, so the user never
+/// sees journalctl's bare parse error alone. Pure, so the wording is pinned.
+fn since_hint(rejected: &str) -> String {
+    format!(
+        "[logs] journalctl rejected --since '{rejected}'. Accepted: an absolute timestamp \
+         (2026-08-27 12:00:00), \"<N> sec|min|hr|day|week[s] ago\", or a negative offset \
+         like \"-90s\". Retry: irlume logs --since \"10 min ago\""
+    )
+}
+
 fn build_view_argv(opts: &[String]) -> Result<Vec<String>, String> {
     let mut argv = vec![
         "journalctl".to_string(),
@@ -59,7 +110,9 @@ fn build_view_argv(opts: &[String]) -> Result<Vec<String>, String> {
                 Some(v) => {
                     since = true;
                     argv.push("--since".to_string());
-                    argv.push(v.to_string());
+                    // #561: bare relative forms are normalized here, once, on
+                    // the only path into journalctl.
+                    argv.push(normalize_since(v));
                 }
                 None => {
                     return Err(
@@ -100,12 +153,28 @@ fn view(opts: &[String]) -> ExitCode {
     }
     match cmd.status() {
         Ok(s) if s.success() => ExitCode::SUCCESS,
-        Ok(_) => ExitCode::FAILURE,
+        Ok(_) => {
+            // #561: journalctl's own error ("Failed to parse timestamp: ...")
+            // names neither the accepted forms nor the retry; add both. Only
+            // meaningful when a --since value was in play.
+            if let Some(hint) = failure_hint(&argv) {
+                eprintln!("{hint}");
+            }
+            ExitCode::FAILURE
+        }
         Err(e) => {
             eprintln!("[logs] could not run journalctl: {e}");
             ExitCode::FAILURE
         }
     }
+}
+
+/// The hint `view` prints when journalctl rejected the `--since` value, or
+/// `None` when no window was given (the failure is then journalctl's own
+/// story to tell). Pure, so the gating is unit-testable.
+fn failure_hint(argv: &[String]) -> Option<String> {
+    let pos = argv.iter().position(|a| a == "--since")?;
+    Some(since_hint(&argv[pos + 1]))
 }
 
 fn debug(action: Option<&str>) -> ExitCode {
@@ -229,10 +298,99 @@ mod tests {
 
     #[test]
     fn follow_and_since_compose() {
-        // Both given: --since value present AND -f appended, still no -b.
-        let argv = build_view_argv(&opts(&["--since", "1h", "-f"])).unwrap();
-        assert!(argv.windows(2).any(|w| w == ["--since", "1h"]));
+        // Both given: an already-valid --since value passes through untouched
+        // AND -f is appended, still no -b.
+        let argv = build_view_argv(&opts(&["--since", "10 min ago", "-f"])).unwrap();
+        assert!(argv.windows(2).any(|w| w == ["--since", "10 min ago"]));
         assert_eq!(argv.last().unwrap(), "-f");
         assert!(!argv.contains(&"-b".to_string()));
+    }
+
+    // ---- #561: normalize the common relative --since forms ----
+
+    /// Bare relative forms a user actually types become the systemd-accepted
+    /// "<n> <unit> ago" shape; abbreviations expand to units journalctl
+    /// documents.
+    #[test]
+    fn since_normalizes_bare_relative_forms() {
+        assert_eq!(normalize_since("2 min"), "2 min ago");
+        assert_eq!(normalize_since("5m"), "5 min ago");
+        assert_eq!(normalize_since("90s"), "90 sec ago");
+        assert_eq!(normalize_since("2min"), "2 min ago");
+        assert_eq!(normalize_since("1h"), "1 hr ago");
+        assert_eq!(normalize_since("3 hours"), "3 hours ago");
+        assert_eq!(normalize_since("2 days"), "2 days ago");
+        assert_eq!(normalize_since("  10  min  "), "10 min ago");
+    }
+
+    /// Anything journalctl already accepts passes through byte-for-byte:
+    /// "... ago" forms, negative offsets, absolute timestamps, and words like
+    /// yesterday; also multi-term values and garbage, which stay journalctl's
+    /// to judge (with our failure hint behind them).
+    #[test]
+    fn since_passes_through_already_valid_forms() {
+        for untouched in [
+            "10 min ago",
+            "-90s",
+            "-2min",
+            "2026-08-27 12:00",
+            "yesterday",
+            "now",
+            "2 min 30 sec",
+            "in 5 minutes",
+            "",
+        ] {
+            assert_eq!(
+                normalize_since(untouched),
+                untouched,
+                "value: {untouched:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_view_argv_feeds_the_normalized_value_to_journalctl() {
+        let argv = build_view_argv(&opts(&["--since", "5m"])).unwrap();
+        assert!(argv.windows(2).any(|w| w == ["--since", "5 min ago"]));
+    }
+
+    /// The failure hint exists exactly when a --since window was given, and
+    /// it names the value journalctl actually saw (the normalized one).
+    #[test]
+    fn the_failure_hint_gates_on_a_since_window_and_names_its_value() {
+        let with_since = ["journalctl", "--no-pager", "--since", "5 min ago"]
+            .map(String::from)
+            .to_vec();
+        let hint = failure_hint(&with_since).expect("a window was given");
+        assert!(hint.contains("'5 min ago'"), "names the value: {hint}");
+        let without_since = [
+            "journalctl".to_string(),
+            "--no-pager".to_string(),
+            "-b".to_string(),
+        ];
+        assert!(
+            failure_hint(&without_since).is_none(),
+            "no window, no hint: the failure is journalctl's own story"
+        );
+    }
+
+    /// When journalctl still rejects the value, the hint names the accepted
+    /// syntax and carries the exact retry command (#561 acceptance).
+    #[test]
+    fn the_failure_hint_names_accepted_syntax_and_the_retry_command() {
+        let hint = since_hint("nonsense value");
+        assert!(
+            hint.contains("Accepted"),
+            "must say what is accepted: {hint}"
+        );
+        assert!(
+            hint.contains("irlume logs --since"),
+            "must carry the exact retry command: {hint}"
+        );
+        let with_value = since_hint("2 fortnights");
+        assert!(
+            with_value.contains("'2 fortnights'"),
+            "must name the rejected value: {with_value}"
+        );
     }
 }


### PR DESCRIPTION
Closes #561.

## What

`irlume logs --since` handed its value straight to journalctl, so the forms people actually type after reading the CLI's own usage hint (`2 min`, `5m`, `90s`, `2min`, `1h`) died with journalctl's bare parse error. The value is now normalized on the single path into journalctl: a bare `<number><unit>` becomes `<n> <unit> ago`, with the one-letter abbreviations expanded to units systemd documents (`m` -> `min`, `s` -> `sec`, `h` -> `hr`).

Anything journalctl already accepts passes through byte-for-byte: `... ago` forms, negative offsets (`-90s`), absolute timestamps, `yesterday`. Multi-term values and malformed input stay journalctl's to judge, but when journalctl still rejects the value, `logs` now prints the accepted syntax and the exact retry command instead of leaving the user with a one-line parse failure (`failure_hint`, gated on a `--since` window actually being present).

## Tests

The normalizer table (normalizes / passes-through), the argv integration (journalctl receives the normalized value), the hint wording (accepted syntax + retry command + rejected value named), and the hint's gating. 4/4 mutation probes caught: normalizer no-op, abbreviation left unexpanded, argv skipping normalization, hint never firing. Workspace 1852/0, clippy -D warnings clean, fmt clean, cargo doc -D warnings clean, 0 em dashes.

Good-first-issue acceptance from #561: `"2 min"` and `5m` work, absolute timestamps unchanged, unit tests cover the normalizer including pass-through.