### PR TITLE
feat: recognise gtklock and waylock as screen-unlock PAM services (#563)

### DIFF
--- a/crates/irlume-common/src/pam_service.rs
+++ b/crates/irlume-common/src/pam_service.rs
@@ -62,6 +62,13 @@ pub const SERVICES: &[(&str, ServiceKind)] = &[
     ("swaylock", ServiceKind::ScreenUnlock),
     ("i3lock", ServiceKind::ScreenUnlock),
     ("hyprlock", ServiceKind::ScreenUnlock),
+    // gtklock: upstream calls pam_start("gtklock", ...) (src/auth.c) and the
+    // Arch extra package ships /etc/pam.d/gtklock.
+    ("gtklock", ServiceKind::ScreenUnlock),
+    // waylock: upstream calls pam_start("waylock", ...) (src/auth.zig); it
+    // does NOT reuse swaylock's name, and the Arch extra package ships
+    // /etc/pam.d/waylock.
+    ("waylock", ServiceKind::ScreenUnlock),
     ("omarchy-lock-face", ServiceKind::ScreenUnlock),
     // The stock Omarchy lock's password lane: with the distro's autologin
     // default, this is where a cold boot actually prompts, and pam_irlume
@@ -206,6 +213,22 @@ mod tests {
             classify("cinnamon-screensaver"),
             Some(ServiceKind::ScreenUnlock)
         );
+    }
+
+    /// gtklock starts its OWN PAM service (upstream pam_start("gtklock", ...)
+    /// in src/auth.c; Arch extra ships /etc/pam.d/gtklock): a live-session
+    /// screen unlock (#563).
+    #[test]
+    fn gtklock_is_screen_unlock() {
+        assert_eq!(classify("gtklock"), Some(ServiceKind::ScreenUnlock));
+    }
+
+    /// waylock starts its OWN PAM service (upstream pam_start("waylock", ...)
+    /// in src/auth.zig, NOT swaylock's name; Arch extra ships
+    /// /etc/pam.d/waylock): a live-session screen unlock (#563).
+    #[test]
+    fn waylock_is_screen_unlock() {
+        assert_eq!(classify("waylock"), Some(ServiceKind::ScreenUnlock));
     }
 
     /// The divergence that prompted this: doas was Elevation for the policy and


### PR DESCRIPTION
Closes #563.

## Added, with evidence

- `gtklock` -> ScreenUnlock. Upstream calls `pam_start("gtklock", ...)` (jovanlanik/gtklock, src/auth.c) and the Arch extra package ships `/etc/pam.d/gtklock` (visible in the package file list).
- `waylock` -> ScreenUnlock. Upstream calls `pam_start("waylock", ...)` (ifreund/waylock, src/auth.zig); notably it does NOT reuse swaylock's service name, so the swaylock row alone would never match it. The Arch extra package ships `/etc/pam.d/waylock`.

## Investigated and deliberately NOT added

- `xsecurelock` has no service name of its own: upstream makes `--with-pam-service-name` a mandatory build flag with no default (configure.ac), and every distro checked points it at an existing stack instead of shipping `/etc/pam.d/xsecurelock`: Arch AUR and Fedora pass `system-auth`, Debian passes `common-auth`. Adding an `xsecurelock` row would be exactly the guessed-name drift the table's doc comment forbids.

## Tests

One regression test per added name (the issue's acceptance), plus the table's existing invariants (no duplicates, normalized rows) keep passing. Both rows' removal was mutation-probed and caught by their tests. `cargo test -p irlume-common` 120/0; workspace 1849/0, clippy -D warnings clean, fmt clean, cargo doc -D warnings clean, 0 em dashes.