### PR TITLE
fix: take the `profiles` subcommand from the arguments, not position 1

### DIFF
--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -168,7 +168,7 @@ fn main() -> std::process::ExitCode {
         {
             machine::profiles_list(&args)
         }
-        (Some("profiles"), sub) => profiles(sub, &args),
+        (Some("profiles"), _) => profiles(profiles_sub(&args), &args),
         (Some("verify"), _) => verify(&args),
         (Some("enrolldev"), _) => enrolldev(&args),
         (Some("keyring"), sub) => keyring(sub, &args),
@@ -373,6 +373,32 @@ fn enroll(args: &[String]) -> std::process::ExitCode {
 /// inside single quotes.
 fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+/// The `profiles` subcommand, wherever it sits among the flags.
+///
+/// The usage line documents `irlume profiles [--user U] <subcommand>`, and the
+/// machine path above already matches on presence rather than position for the
+/// same reason. Reading `args[1]` made a leading flag the subcommand, so the
+/// documented order answered usage on a well-formed command: `profiles --user
+/// tester list` looked for a subcommand named `--user`.
+///
+/// A flag spelled `--flag value` carries its value in the next argument, so the
+/// scan steps over it; `--flag=value` carries its own and does not.
+fn profiles_sub(args: &[String]) -> Option<&str> {
+    const VALUED: [&str; 5] = ["--user", "--profile", "--scans", "--name", "--scan"];
+    let mut i = 1;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if !a.starts_with('-') {
+            return Some(a);
+        }
+        if VALUED.contains(&a) {
+            i += 1;
+        }
+        i += 1;
+    }
+    None
 }
 
 /// `irlume profiles [list|add-scan|rename|delete|eyes-open] ...`: manage the up-

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -1154,3 +1154,43 @@ fn logs_reports_when_journalctl_cannot_be_run() {
     assert_eq!(code, 1);
     assert!(err.contains("could not run journalctl"), "{err}");
 }
+
+// `profiles` takes its subcommand from the arguments, not from position 1. The
+// usage line documents `irlume profiles [--user U] <subcommand>`, and the
+// machine path already matches on presence for exactly this reason, but the
+// human path read args[1]: `profiles --user tester list` made "--user" the
+// subcommand and answered usage on a well-formed command.
+#[test]
+fn profiles_accepts_a_flag_before_the_subcommand() {
+    let sb = Sandbox::new("profiles-flag-first");
+    serve(&sb.sock(), |req| match req {
+        Request::Ping => Response::Pong,
+        Request::ListProfiles { .. } => Response::Enrollment {
+            profiles: one_profile(),
+            require_eyes_open: false,
+            closure_calibrated: false,
+            ir_ratio_calibrated: false,
+        },
+        _ => Response::Error("unexpected".into()),
+    });
+
+    let (code, out, err) = run(
+        &mut sb.cmd(&["profiles", "--user", "tester", "list"]),
+        "profiles --user tester list",
+    );
+    assert_eq!(code, 0, "stdout={out} stderr={err}");
+    assert!(out.contains("Face Profile 1"), "stdout={out} stderr={err}");
+    assert!(
+        !err.contains("usage: irlume profiles"),
+        "the documented order must not print usage; stderr={err}"
+    );
+
+    // The `--flag=value` spelling carries its own value, so the subcommand is
+    // the very next argument rather than one further along.
+    let (code, out, err) = run(
+        &mut sb.cmd(&["profiles", "--user=tester", "list"]),
+        "profiles --user=tester list",
+    );
+    assert_eq!(code, 0, "stdout={out} stderr={err}");
+    assert!(out.contains("Face Profile 1"), "stdout={out} stderr={err}");
+}


### PR DESCRIPTION
The usage line documents `irlume profiles [--user U] <subcommand>`, but the human dispatch read `args[1]`, so writing the flag first made it the subcommand:

```
$ irlume profiles --user pawel add-scan --profile pawel --scans 3
usage: irlume profiles [--user U] <subcommand>
```

Nothing is wrong with that command. It is the order the usage line itself prints, and it is what someone types after running `irlume profiles` with no arguments and reading the answer.

The rule this restores is already in the file. Two arms above, the machine path matches on presence rather than position, with a comment giving the same reason:

> Matched on PRESENCE of the subcommand, not on its position. Binding it to args[1] meant a flag before it displaced it: `profiles --contract 9 list --json` fell through to the human handler and answered a machine caller with prose on stderr and exit 2, while `doctor`/`status`/`version` accepted the same flag anywhere. The contract documents no ordering rule, so all five now behave the same way.

This finishes applying it to the human path.

## The scan

`profiles_sub` walks the arguments and returns the first one that is not a flag, stepping over the value of a `--flag value` pair so a username cannot be mistaken for a subcommand, and leaving `--flag=value` alone because it carries its own value. With the subcommand written first, nothing changes.

Written test-first: `profiles_accepts_a_flag_before_the_subcommand` in `tests/cli_dispatch.rs` covers both spellings and fails on `main` with exit 2 before the change.

- `cargo test -p irlume-cli --test cli_dispatch`: 24 passed
- `cargo fmt --check`: clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --locked -p irlume-cli`: clean

## One unrelated failure, flagged so it is not read as mine

`pamwire::tests::surface_facts_cover_every_wirable_service_in_report_order` fails on this machine, on `main` as well as on this branch, and my change does not touch `pamwire`. It is host-dependent rather than broken:

```
 left: [... ("omarchy-lock-password", "lock-screen"), ("sudo", "sudo"), ("polkit-1", "polkit")]
right: [... ("kde",                    "lock-screen"), ("sudo", "sudo"), ("polkit-1", "polkit")]
```

The expected row is `kde`, but the lock surface is chosen from the running desktop, and on an Omarchy host it resolves to `omarchy-lock-password`. A bare CI runner resolves to `kde`, which is why it is green there. Happy to open it as its own issue if you want it tracked; I left it alone here to keep this diff to one thing.
