### PR TITLE
ci: bump the pinned codeql-action trio to 4.37.8 in one commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -82,6 +82,6 @@ jobs:
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -54,6 +54,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Supersedes #629, #630, #631.

## Why one commit

The repo pins init, analyze, and upload-sarif to the SAME codeql-action commit by design (the comment above the pin: one codeql-action version across the repo). Dependabot opened one PR per reference, and any single one of them leaves the workflow with mixed action versions, which the CodeQL runtime refuses outright: "Loaded a configuration file for version '4.37.7', but running version '4.37.8'". That is exactly why the Analyze jobs fail on two of the three PRs, and why no merge order can turn them green one at a time.

This moves all three pins to the 4.37.8 commit (db488dd) in one commit, from the same hash dependabot resolved, so the invariant holds at every point in history.