### PR TITLE
fix: explain persistent IR saturation denials

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -331,6 +331,7 @@ enum AttemptSituation {
     TooFar,
     OffCenter,
     LookingAway,
+    IrSource,
     TooDark,
     GlintBelow,
     BelowScore,
@@ -347,6 +348,7 @@ const fn attempt_situation_label(situation: AttemptSituation) -> &'static str {
         AttemptSituation::TooFar => "too far",
         AttemptSituation::OffCenter => "off-center",
         AttemptSituation::LookingAway => "looking away",
+        AttemptSituation::IrSource => "IR source",
         AttemptSituation::TooDark => "too dark",
         AttemptSituation::GlintBelow => "glint below",
         AttemptSituation::BelowScore => "below score",
@@ -367,6 +369,7 @@ struct AttemptFacts {
     rgb_face_brightness: f32,
     glint: Option<f32>,
     ir_bright: f32,
+    persistent_ir_source_overwhelms: bool,
 }
 
 impl AttemptFacts {
@@ -378,6 +381,7 @@ impl AttemptFacts {
             rgb_face_brightness: a.signals.rgb_face_brightness,
             glint: a.signals.ir_eye_glint,
             ir_bright: a.ir_brightness,
+            persistent_ir_source_overwhelms: a.signals.persistent_ir_source_overwhelms(),
         }
     }
 }
@@ -407,6 +411,9 @@ fn auth_attempt_situation(kind: OutcomeKind, f: &AttemptFacts) -> AttemptSituati
     }
     if f.yaw_asym > FRAME_YAW_ASYM_MAX {
         return AttemptSituation::LookingAway;
+    }
+    if f.persistent_ir_source_overwhelms {
+        return AttemptSituation::IrSource;
     }
     if f.rgb_face.is_some() && f.rgb_face_brightness < DIM {
         return AttemptSituation::TooDark;
@@ -3573,6 +3580,7 @@ impl Engine {
             face_frac: face_frac_of(rgb_top.as_ref().map(|f| &f.bbox), rgb.width),
             // RGB-only path: no IR frame exists to clip.
             ir_saturated_frac: None,
+            ir_persistent_saturated_frac: None,
             ir_ceiling_known: false,
             rgb_face_brightness: rgb_brightness,
             rgb_specular_frac: rgb_specular,
@@ -4367,6 +4375,7 @@ impl Engine {
                 ir_top.as_ref().map(|f| &f.bbox),
                 ir_stats.white_level,
             ),
+            ir_persistent_saturated_frac: ir_stats.persistent_saturated_frac,
             // Whether the FORMAT could be measured, which is not the same
             // question as whether this capture produced a number: the call
             // above also yields None when no face was found (#358).
@@ -11192,6 +11201,7 @@ mod engine_tests {
             rgb_face_brightness: 120.0,
             glint: Some(250.0),
             ir_bright: 140.0,
+            persistent_ir_source_overwhelms: false,
         };
         let line = |kind, score, facts: &AttemptFacts| {
             let text = attempt_situation_line(kind, score, facts);
@@ -11279,6 +11289,7 @@ mod engine_tests {
             rgb_face_brightness: 0.0,
             glint: None,
             ir_bright: 140.0,
+            persistent_ir_source_overwhelms: false,
         };
         assert_eq!(
             attempt_situation_line(OutcomeKind::NoFace, 0.0, &facts),
@@ -11298,6 +11309,7 @@ mod engine_tests {
             rgb_face_brightness: 120.0,
             glint: Some(72.0),
             ir_bright: 140.0,
+            persistent_ir_source_overwhelms: false,
         };
         assert_eq!(
             auth_attempt_situation(OutcomeKind::Spoof, &turned),
@@ -11383,6 +11395,7 @@ mod engine_tests {
                 ir_ambient: 30.0,
                 face_frac: 0.22,
                 ir_saturated_frac: None,
+                ir_persistent_saturated_frac: None,
                 ir_ceiling_known: false,
                 rgb_face_brightness: 90.0,
                 rgb_moire_score: 0.0,
@@ -11402,6 +11415,155 @@ mod engine_tests {
         assert_eq!(facts.rgb_face_brightness, 90.0);
         assert_eq!(facts.glint, None);
         assert_eq!(facts.ir_bright, 150.0);
+        assert!(!facts.persistent_ir_source_overwhelms);
+    }
+
+    #[test]
+    fn ir_source_situation_requires_persistent_clipping_and_a_failed_cue() {
+        use super::{
+            auth_attempt_situation, liveness_deny_kind, Assessment, AttemptFacts, AttemptSituation,
+            OutcomeKind,
+        };
+        use irlume_liveness::{FaceBox, LivenessGate, Signals, Verdict};
+
+        let base = Signals {
+            rgb_face: Some(FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: 0.9,
+            }),
+            ir_face: Some(FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: 0.9,
+            }),
+            ir_face_brightness: 90.0,
+            ir_center_edge_ratio: 1.2,
+            ir_eye_glint: Some(220.0),
+            face_frac: 0.30,
+            ir_saturated_frac: Some(0.0),
+            ir_ceiling_known: true,
+            rgb_face_brightness: 120.0,
+            ..Default::default()
+        };
+        let situation = |signals: Signals, kind: OutcomeKind| {
+            let ir_brightness = signals.ir_face_brightness;
+            let assessment = Assessment {
+                verdict: Verdict::Spoof,
+                reason: "failed liveness assessment".into(),
+                embedding: None,
+                ir_embedding: None,
+                signals,
+                ir_center_edge_ratio: 0.0,
+                ir_brightness,
+                ir_ambient_share: None,
+                rgb_frame_mean: 0.0,
+                shipped_ir_fake: None,
+                sequential_pair: false,
+            };
+            auth_attempt_situation(kind, &AttemptFacts::from_assessment(&assessment))
+        };
+
+        for cue in ["dark", "flat"] {
+            let mut thinkpad = base.clone();
+            thinkpad.ir_persistent_saturated_frac = Some(0.1702);
+            match cue {
+                "dark" => {
+                    thinkpad.ir_face_brightness = 20.0;
+                    thinkpad.rgb_face_brightness = 30.0;
+                }
+                "flat" => thinkpad.ir_center_edge_ratio = 1.0,
+                _ => unreachable!(),
+            }
+            let (verdict, _, reason) = LivenessGate::new().evaluate(&thinkpad);
+            assert_eq!(verdict, Verdict::Spoof, "{cue}: {reason}");
+            let kind = liveness_deny_kind(verdict, &reason);
+            assert_eq!(kind, OutcomeKind::Spoof, "{cue}: {reason}");
+            assert_eq!(
+                situation(thinkpad.clone(), kind),
+                AttemptSituation::IrSource,
+                "{cue}: {reason}"
+            );
+
+            let mut turned = thinkpad;
+            turned.head_yaw_asym = 0.52;
+            assert_eq!(
+                situation(turned, kind),
+                AttemptSituation::LookingAway,
+                "framing and orientation must keep precedence"
+            );
+        }
+
+        for fraction in [Some(0.0031), None] {
+            let mut dark = base.clone();
+            dark.ir_face_brightness = 20.0;
+            dark.ir_persistent_saturated_frac = fraction;
+            let (verdict, _, reason) = LivenessGate::new().evaluate(&dark);
+            assert_eq!(verdict, Verdict::Spoof, "fraction {fraction:?}: {reason}");
+            let kind = liveness_deny_kind(verdict, &reason);
+            assert_eq!(
+                situation(dark, kind),
+                AttemptSituation::Spoof,
+                "fraction {fraction:?}: {reason}"
+            );
+        }
+
+        let mut healthy = base;
+        healthy.ir_persistent_saturated_frac = Some(0.1702);
+        let (verdict, _, reason) = LivenessGate::new().evaluate(&healthy);
+        assert_eq!(verdict, Verdict::Live, "{reason}");
+        assert_eq!(
+            situation(healthy, OutcomeKind::BelowThreshold),
+            AttemptSituation::BelowScore,
+            "persistent clipping without a dark or flat cue is not IR source"
+        );
+        assert_eq!(
+            super::attempt_situation_label(AttemptSituation::IrSource),
+            "IR source"
+        );
+    }
+
+    #[test]
+    fn ir_source_rewording_does_not_change_the_liveness_deny_kind() {
+        use irlume_liveness::{FaceBox, LivenessGate, Signals, Verdict};
+
+        let old = Signals {
+            rgb_face: Some(FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: 0.9,
+            }),
+            ir_face: Some(FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: 0.9,
+            }),
+            ir_face_brightness: 90.0,
+            ir_center_edge_ratio: 1.0,
+            ir_eye_glint: Some(220.0),
+            ir_saturated_frac: Some(0.0),
+            ir_persistent_saturated_frac: Some(0.0031),
+            ir_ceiling_known: true,
+            ..Default::default()
+        };
+        let mut reworded = old.clone();
+        reworded.ir_persistent_saturated_frac = Some(0.1702);
+
+        let gate = LivenessGate::new();
+        let (old_verdict, _, old_reason) = gate.evaluate(&old);
+        let (new_verdict, _, new_reason) = gate.evaluate(&reworded);
+        assert_eq!(old_verdict, Verdict::Spoof, "{old_reason}");
+        assert_eq!(new_verdict, Verdict::Spoof, "{new_reason}");
+        assert!(!old_reason.contains("IR-bright source"), "{old_reason}");
+        assert!(new_reason.contains("IR-bright source"), "{new_reason}");
+        assert_eq!(
+            super::liveness_deny_kind(old_verdict, &old_reason),
+            super::liveness_deny_kind(new_verdict, &new_reason)
+        );
+        assert_eq!(
+            super::liveness_deny_kind(new_verdict, &new_reason),
+            super::OutcomeKind::Spoof
+        );
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -376,6 +376,19 @@ pub struct IrCaptureStats {
     /// add a ceiling here without first adding something that guarantees the
     /// selected node is an emitter-lit IR source (#385).
     pub white_level: Option<u8>,
+    /// Whole-frame clipping in the selected metadata-lit frame. This is
+    /// diagnostic evidence only, not a grant gate. `None` means the capture
+    /// lacked either a sensor ceiling or explicit lit metadata.
+    pub lit_saturated_frac: Option<f32>,
+    /// Whole-frame clipping in the selected frame's adjacent metadata-dark
+    /// partner. This is diagnostic evidence only, not a grant gate. `None`
+    /// means no explicit adjacent ambient partner was available.
+    pub ambient_saturated_frac: Option<f32>,
+    /// Whole-frame clipping at the same pixel positions in both the selected
+    /// metadata-lit frame and its metadata-dark partner. This is diagnostic
+    /// evidence only, not a grant gate. `None` means the paired measurement
+    /// was unavailable or the decoded frame dimensions disagreed.
+    pub persistent_saturated_frac: Option<f32>,
     /// The gate frame's RAW pixels, present only when the returned frame is no
     /// longer them: ambient subtraction replaces the payload, and a caller
     /// measuring clipping must not measure the replacement.
@@ -390,6 +403,60 @@ pub struct IrCaptureStats {
     ///
     /// `None` means the returned frame IS the raw gate frame, so measure that.
     pub saturation_frame: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct PairedSaturationEvidence {
+    lit_saturated_frac: Option<f32>,
+    ambient_saturated_frac: Option<f32>,
+    persistent_saturated_frac: Option<f32>,
+}
+
+fn paired_saturation_evidence(
+    frames: &[Vec<u8>],
+    means: &[f64],
+    flags: &[Option<ir_metadata::Illumination>],
+    lit_i: usize,
+    white_level: Option<u8>,
+) -> PairedSaturationEvidence {
+    let Some(white) = white_level else {
+        return PairedSaturationEvidence::default();
+    };
+    if !matches!(flags.get(lit_i), Some(Some(ir_metadata::Illumination::Lit))) {
+        return PairedSaturationEvidence::default();
+    }
+    let Some(lit) = frames.get(lit_i).filter(|frame| !frame.is_empty()) else {
+        return PairedSaturationEvidence::default();
+    };
+
+    let mut evidence = PairedSaturationEvidence {
+        lit_saturated_frac: Some(ir_probe::saturated_fraction(lit, white) as f32),
+        ..PairedSaturationEvidence::default()
+    };
+    let Some(ambient_i) = ir_metadata::ambient_partner(lit_i, means, flags) else {
+        return evidence;
+    };
+    if !matches!(
+        flags.get(ambient_i),
+        Some(Some(ir_metadata::Illumination::Dark))
+    ) {
+        return evidence;
+    }
+    let Some(ambient) = frames.get(ambient_i).filter(|frame| !frame.is_empty()) else {
+        return evidence;
+    };
+
+    evidence.ambient_saturated_frac = Some(ir_probe::saturated_fraction(ambient, white) as f32);
+    if lit.len() == ambient.len() {
+        evidence.persistent_saturated_frac = Some(
+            lit.iter()
+                .zip(ambient)
+                .filter(|(lit, ambient)| **lit >= white && **ambient >= white)
+                .count() as f32
+                / lit.len() as f32,
+        );
+    }
+    evidence
 }
 
 /// Default `--rgb`/`--ir` flag values for the dev diagnostic tools, and the
@@ -5367,6 +5434,8 @@ impl IrSession<'_> {
         });
         let best_i =
             ir_metadata::best_gate_frame(&means, &flags, clipped_fracs.as_deref()).unwrap_or(0);
+        let paired_saturation =
+            paired_saturation_evidence(&frames, &means, &flags, best_i, white_level);
         let mut best = Some(frames[best_i].clone());
 
         // Windows-Hello-style ambient subtraction. EXPERIMENTAL, opt-in. On a
@@ -5594,6 +5663,9 @@ impl IrSession<'_> {
                 camera_classified_frames: from_camera,
                 camera_lit_frames: ir_metadata::count_lit(&flags),
                 white_level,
+                lit_saturated_frac: paired_saturation.lit_saturated_frac,
+                ambient_saturated_frac: paired_saturation.ambient_saturated_frac,
+                persistent_saturated_frac: paired_saturation.persistent_saturated_frac,
             },
         ))
     }
@@ -9145,6 +9217,9 @@ mod tests {
             camera_classified_frames: 12,
             camera_lit_frames: 5,
             white_level: None,
+            lit_saturated_frac: None,
+            ambient_saturated_frac: None,
+            persistent_saturated_frac: None,
             saturation_frame: None,
         };
         let state = illumination_state(Present, Some(&stats));
@@ -12253,6 +12328,9 @@ mod tests {
             camera_classified_frames: 0,
             camera_lit_frames: 0,
             white_level: None,
+            lit_saturated_frac: None,
+            ambient_saturated_frac: None,
+            persistent_saturated_frac: None,
             saturation_frame: None,
         }
     }
@@ -13004,6 +13082,125 @@ mod tests {
         );
         assert_eq!(ir_probe::saturated_fraction(&[0, 1, 254], u8::MAX), 0.0);
         assert_eq!(ir_probe::saturated_fraction(&[], u8::MAX), 0.0);
+    }
+
+    #[test]
+    fn persistent_saturation_matches_thinkpad_field_measurement() {
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        let mut ambient = vec![0; 10_000];
+        ambient[..1_702].fill(u8::MAX);
+        let mut lit = ambient.clone();
+        lit[1_702..1_725].fill(u8::MAX);
+        let evidence = paired_saturation_evidence(
+            &[ambient, lit],
+            &[0.0, 0.0],
+            &[Some(Dark), Some(Lit)],
+            1,
+            Some(u8::MAX),
+        );
+
+        assert_eq!(evidence.lit_saturated_frac, Some(0.1725));
+        assert_eq!(evidence.ambient_saturated_frac, Some(0.1702));
+        assert_eq!(evidence.persistent_saturated_frac, Some(0.1702));
+    }
+
+    #[test]
+    fn persistent_saturation_distinguishes_brio_emitter_clipping() {
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        let mut ambient = vec![0; 10_000];
+        ambient[..31].fill(u8::MAX);
+        let mut lit = ambient.clone();
+        lit[31..1_403].fill(u8::MAX);
+        let evidence = paired_saturation_evidence(
+            &[ambient, lit],
+            &[0.0, 0.0],
+            &[Some(Dark), Some(Lit)],
+            1,
+            Some(u8::MAX),
+        );
+
+        assert_eq!(evidence.lit_saturated_frac, Some(0.1403));
+        assert_eq!(evidence.ambient_saturated_frac, Some(0.0031));
+        assert_eq!(evidence.persistent_saturated_frac, Some(0.0031));
+    }
+
+    #[test]
+    fn persistent_saturation_is_unavailable_without_required_evidence() {
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        let frames = [vec![u8::MAX; 4], vec![u8::MAX; 4]];
+        let means = [255.0, 255.0];
+
+        let no_ceiling =
+            paired_saturation_evidence(&frames, &means, &[Some(Dark), Some(Lit)], 1, None);
+        assert_eq!(no_ceiling.lit_saturated_frac, None);
+        assert_eq!(no_ceiling.ambient_saturated_frac, None);
+        assert_eq!(no_ceiling.persistent_saturated_frac, None);
+
+        let selected_dark =
+            paired_saturation_evidence(&frames, &means, &[Some(Lit), Some(Dark)], 1, Some(u8::MAX));
+        assert_eq!(selected_dark.lit_saturated_frac, None);
+        assert_eq!(selected_dark.ambient_saturated_frac, None);
+        assert_eq!(selected_dark.persistent_saturated_frac, None);
+
+        let no_dark_partner =
+            paired_saturation_evidence(&frames, &means, &[None, Some(Lit)], 1, Some(u8::MAX));
+        assert_eq!(no_dark_partner.lit_saturated_frac, Some(1.0));
+        assert_eq!(no_dark_partner.ambient_saturated_frac, None);
+        assert_eq!(no_dark_partner.persistent_saturated_frac, None);
+    }
+
+    #[test]
+    fn persistent_saturation_requires_equal_nonempty_frames_for_overlap() {
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        let evidence = paired_saturation_evidence(
+            &[vec![u8::MAX; 3], vec![u8::MAX; 4]],
+            &[0.0, 0.0],
+            &[Some(Dark), Some(Lit)],
+            1,
+            Some(u8::MAX),
+        );
+
+        assert_eq!(evidence.lit_saturated_frac, Some(1.0));
+        assert_eq!(evidence.ambient_saturated_frac, Some(1.0));
+        assert_eq!(evidence.persistent_saturated_frac, None);
+    }
+
+    #[test]
+    fn persistent_saturation_is_unavailable_for_an_empty_lit_frame() {
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        let evidence = paired_saturation_evidence(
+            &[vec![u8::MAX; 4], Vec::new()],
+            &[255.0, 0.0],
+            &[Some(Dark), Some(Lit)],
+            1,
+            Some(u8::MAX),
+        );
+
+        assert_eq!(evidence.lit_saturated_frac, None);
+        assert_eq!(evidence.ambient_saturated_frac, None);
+        assert_eq!(evidence.persistent_saturated_frac, None);
+    }
+
+    #[test]
+    fn persistent_saturation_is_unavailable_for_an_empty_dark_frame() {
+        use ir_metadata::Illumination::{Dark, Lit};
+
+        let evidence = paired_saturation_evidence(
+            &[Vec::new(), vec![u8::MAX; 4]],
+            &[0.0, 255.0],
+            &[Some(Dark), Some(Lit)],
+            1,
+            Some(u8::MAX),
+        );
+
+        assert_eq!(evidence.lit_saturated_frac, Some(1.0));
+        assert_eq!(evidence.ambient_saturated_frac, None);
+        assert_eq!(evidence.persistent_saturated_frac, None);
     }
 
     /// The whole of #394: a limited-range stream rails at 235, and counting

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -2409,6 +2409,7 @@ fn liveness_probe(args: &[String]) -> std::process::ExitCode {
                 ir_top_face.map(|f| &f.bbox),
                 ir_stats.white_level,
             ),
+            ir_persistent_saturated_frac: ir_stats.persistent_saturated_frac,
             ir_ceiling_known: ir_stats.white_level.is_some(),
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,

--- a/crates/irlume-cli/src/pad.rs
+++ b/crates/irlume-cli/src/pad.rs
@@ -157,6 +157,7 @@ fn capture_once(
             ir_top.as_ref().map(|f| &f.bbox),
             ir_stats.white_level,
         ),
+        ir_persistent_saturated_frac: ir_stats.persistent_saturated_frac,
         // Set from the SAME white level the fraction above is computed from.
         // `Signals::default()` says false, the fail-safe answer for a struct
         // nobody filled in, and `..Default::default()` below would silently

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -148,6 +148,11 @@ pub struct Signals {
     /// [`face_frac`]: Self::face_frac
     /// [`ir_center_edge_ratio`]: Self::ir_center_edge_ratio
     pub ir_saturated_frac: Option<f32>,
+    /// Fraction (0-1) of the whole IR frame saturated in both the selected lit
+    /// frame and its adjacent explicit dark frame. `None` means the diagnostic
+    /// evidence was unavailable. This can reword an existing denial but cannot
+    /// grant or deny by itself.
+    pub ir_persistent_saturated_frac: Option<f32>,
 }
 
 impl Default for Signals {
@@ -162,6 +167,7 @@ impl Default for Signals {
             head_pitch_frac: 0.5, // frontal
             face_frac: 0.0,
             ir_saturated_frac: None,
+            ir_persistent_saturated_frac: None,
             rgb_face_brightness: 0.0,
             rgb_specular_frac: 0.0,
             rgb_moire_score: 0.0,
@@ -446,6 +452,22 @@ pub const MIN_CENTER_EDGE_RATIO: f32 = 1.03;
 /// constant should know the population it is fitted to is GREY8 only.
 pub const IR_SATURATED_FRAC_MAX: f32 = 0.10;
 
+/// Persistent whole-frame saturation above this fraction can explain an
+/// already-dark or already-flat IR reading. This is a reason selector, not a
+/// grant or denial threshold.
+pub const IR_PERSISTENT_SATURATED_FRAC_MIN: f32 = 0.10;
+
+impl Signals {
+    /// Whether persistent external IR saturation explains an existing dark or
+    /// flat denial.
+    pub fn persistent_ir_source_overwhelms(&self) -> bool {
+        self.ir_persistent_saturated_frac
+            .is_some_and(|fraction| fraction > IR_PERSISTENT_SATURATED_FRAC_MIN)
+            && (self.ir_face_brightness < IR_FACE_MIN_BRIGHTNESS
+                || self.ir_center_edge_ratio < MIN_CENTER_EDGE_RATIO)
+    }
+}
+
 /// Ambient IR (see [`Signals::ir_ambient`]) above which the brightness and
 /// center/edge cues are physically starved rather than measuring a spoof: the scene's
 /// own infrared swamps the emitter, so the strobe adds almost nothing to read
@@ -459,6 +481,13 @@ pub const IR_SATURATED_FRAC_MAX: f32 = 0.10;
 /// sky, sun, and strong lamps look identical in IR), so the message names
 /// examples, not a diagnosis.
 pub const IR_AMBIENT_FLOOD: f32 = 170.0;
+
+/// The actionable rejection for a dark or flat reading explained by a
+/// persistent external IR source.
+fn persistent_ir_source_reason() -> String {
+    "a persistent IR-bright source overwhelms the camera; reposition away from it or use your password"
+        .into()
+}
 
 /// The actionable rejection for ambient-flooded IR scenes.
 fn flood_reason(ambient: f32) -> String {
@@ -579,7 +608,9 @@ impl LivenessGate {
         // IR skin reflectance: the face region must be brightly lit.
         cues.ir_reflectance_ok = s.ir_face_brightness >= IR_FACE_MIN_BRIGHTNESS;
         if !cues.ir_reflectance_ok {
-            let reason = if s.ir_ambient >= IR_AMBIENT_FLOOD {
+            let reason = if s.persistent_ir_source_overwhelms() {
+                persistent_ir_source_reason()
+            } else if s.ir_ambient >= IR_AMBIENT_FLOOD {
                 flood_reason(s.ir_ambient)
             } else {
                 format!(
@@ -593,7 +624,9 @@ impl LivenessGate {
         // Anti-flat: a real 3D face shows center-vs-edge IR falloff.
         cues.center_edge_ratio_ok = s.ir_center_edge_ratio >= MIN_CENTER_EDGE_RATIO;
         if !cues.center_edge_ratio_ok {
-            let reason = if s.ir_ambient >= IR_AMBIENT_FLOOD {
+            let reason = if s.persistent_ir_source_overwhelms() {
+                persistent_ir_source_reason()
+            } else if s.ir_ambient >= IR_AMBIENT_FLOOD {
                 flood_reason(s.ir_ambient)
             } else if eyes_off_lens(s.ir_eye_glint) {
                 off_axis_reason(s.ir_center_edge_ratio, s.ir_eye_glint)
@@ -692,7 +725,9 @@ impl LivenessGate {
         }
         cues.ir_reflectance_ok = s.ir_face_brightness >= IR_FACE_MIN_BRIGHTNESS;
         if !cues.ir_reflectance_ok {
-            let reason = if s.ir_ambient >= IR_AMBIENT_FLOOD {
+            let reason = if s.persistent_ir_source_overwhelms() {
+                persistent_ir_source_reason()
+            } else if s.ir_ambient >= IR_AMBIENT_FLOOD {
                 flood_reason(s.ir_ambient)
             } else {
                 format!("IR face too dark ({:.0})", s.ir_face_brightness)
@@ -701,7 +736,9 @@ impl LivenessGate {
         }
         cues.center_edge_ratio_ok = s.ir_center_edge_ratio >= MIN_CENTER_EDGE_RATIO;
         if !cues.center_edge_ratio_ok {
-            let reason = if s.ir_ambient >= IR_AMBIENT_FLOOD {
+            let reason = if s.persistent_ir_source_overwhelms() {
+                persistent_ir_source_reason()
+            } else if s.ir_ambient >= IR_AMBIENT_FLOOD {
                 flood_reason(s.ir_ambient)
             } else if eyes_off_lens(s.ir_eye_glint) {
                 off_axis_reason(s.ir_center_edge_ratio, s.ir_eye_glint)
@@ -1690,7 +1727,104 @@ mod tests {
             // cannot reach, because a measurable format with a face present
             // always yields a number (#358).
             ir_saturated_frac: Some(0.0),
+            ir_persistent_saturated_frac: None,
             ..Default::default() // frontal pose
+        }
+    }
+
+    #[test]
+    fn persistent_ir_source_rewords_existing_denials_on_both_paths() {
+        let gate = LivenessGate::new();
+        for cue in ["dark", "flat"] {
+            let mut s = live_signals();
+            s.ir_persistent_saturated_frac = Some(0.1702); // ThinkPad field evidence
+            match cue {
+                "dark" => s.ir_face_brightness = 20.0,
+                "flat" => s.ir_center_edge_ratio = 1.0,
+                _ => unreachable!(),
+            }
+
+            for (path, (verdict, _, reason)) in [
+                ("cross-spectrum", gate.evaluate(&s)),
+                ("ir-only", gate.evaluate_ir_only(&s)),
+            ] {
+                assert_eq!(verdict, Verdict::Spoof, "{path}/{cue}: {reason}");
+                assert!(
+                    reason.contains("IR-bright source"),
+                    "{path}/{cue}: {reason}"
+                );
+                assert!(reason.contains("reposition"), "{path}/{cue}: {reason}");
+                assert!(reason.contains("password"), "{path}/{cue}: {reason}");
+                assert!(!reason.contains("ir-setup"), "{path}/{cue}: {reason}");
+            }
+        }
+    }
+
+    #[test]
+    fn persistent_ir_source_boundary_rewords_only_above_ten_percent() {
+        let gate = LivenessGate::new();
+        for (fraction, reworded) in [
+            (None, false),
+            (Some(0.0031), false), // BRIO field evidence
+            (Some(0.10), false),
+            (Some(0.1001), true),
+        ] {
+            for cue in ["dark", "flat"] {
+                let mut s = live_signals();
+                s.ir_persistent_saturated_frac = fraction;
+                match cue {
+                    "dark" => s.ir_face_brightness = 20.0,
+                    "flat" => s.ir_center_edge_ratio = 1.0,
+                    _ => unreachable!(),
+                }
+
+                for (path, (verdict, _, reason), old_reason) in [
+                    (
+                        "cross-spectrum",
+                        gate.evaluate(&s),
+                        match cue {
+                            "dark" => "IR face too dark (20); not reflecting IR like skin",
+                            "flat" => "IR too flat (center/edge 1.00); looks 2D, not a 3D face",
+                            _ => unreachable!(),
+                        },
+                    ),
+                    (
+                        "ir-only",
+                        gate.evaluate_ir_only(&s),
+                        match cue {
+                            "dark" => "IR face too dark (20)",
+                            "flat" => "IR too flat (center/edge 1.00)",
+                            _ => unreachable!(),
+                        },
+                    ),
+                ] {
+                    assert_eq!(verdict, Verdict::Spoof, "{path}/{cue}: {reason}");
+                    if reworded {
+                        assert_ne!(reason, old_reason, "{path}/{cue} at {fraction:?}");
+                        assert!(
+                            reason.contains("IR-bright source"),
+                            "{path}/{cue} at {fraction:?}: {reason}"
+                        );
+                    } else {
+                        assert_eq!(reason, old_reason, "{path}/{cue} at {fraction:?}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn persistent_ir_source_evidence_alone_changes_no_verdict() {
+        let gate = LivenessGate::new();
+        let mut s = live_signals();
+        s.ir_persistent_saturated_frac = Some(0.1702);
+
+        assert!(!s.persistent_ir_source_overwhelms());
+        for (path, (verdict, _, reason)) in [
+            ("cross-spectrum", gate.evaluate(&s)),
+            ("ir-only", gate.evaluate_ir_only(&s)),
+        ] {
+            assert_eq!(verdict, Verdict::Live, "{path}: {reason}");
         }
     }
 

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -849,6 +849,9 @@ fn situation_prompt(situation: &str) -> Option<&'static str> {
         "off-center" => Some("center your face in the frame"),
         "looking away" => Some("look directly at the camera"),
         "too dark" => Some("it is too dark to see your face; add light"),
+        "IR source" => {
+            Some("an IR-bright source is overwhelming the camera; reposition or use your password")
+        }
         _ => None,
     }
 }
@@ -1411,11 +1414,21 @@ mod tests {
         }
     }
 
+    #[test]
+    #[allow(non_snake_case)]
+    fn IR_source_situation_gets_action_wording() {
+        use super::situation_prompt;
+        assert_eq!(
+            situation_prompt("IR source"),
+            Some("an IR-bright source is overwhelming the camera; reposition or use your password")
+        );
+    }
+
     /// The #616 step 3 split: rich numbers live in the journal and the
     /// diagnostic trace, NEVER at a prompt surface. No mapped wording may
     /// carry a digit, so no threshold value can leak through a label.
     #[test]
-    fn no_prompt_wording_ever_carries_a_number() {
+    fn no_situation_prompt_wording_ever_carries_a_number() {
         use super::situation_prompt;
         for label in [
             "no face",
@@ -1423,6 +1436,7 @@ mod tests {
             "off-center",
             "looking away",
             "too dark",
+            "IR source",
         ] {
             if let Some(text) = situation_prompt(label) {
                 assert!(

--- a/docs/superpowers/plans/2026-08-30-ir-persistent-saturation-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-30-ir-persistent-saturation-diagnostics.md
@@ -1,0 +1,271 @@
+# Persistent IR Saturation Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Diagnose fail-closed authentication denials caused by a localized IR-bright source that remains saturated while the camera emitter is off.
+
+**Architecture:** The camera records whole-frame clipping for the selected metadata-lit frame, its adjacent metadata-dark partner, and the exact pixel overlap clipped in both. Auth passes the overlap into liveness, where it selects a more accurate reason only when the existing dark or flat cue already denies; auth and PAM expose one stable, action-oriented situation without changing any verdict, score, grant threshold, retry class, or enrollment behavior.
+
+**Tech Stack:** Rust 1.88 workspace, V4L2/UVC illumination metadata, existing `irlume-camera`, `irlume-liveness`, `irlume-auth`, and `irlume-pam` unit tests.
+
+**Spec:** `/home/wisbfime/archledger-gp/project-irlume.md` (approved issue #636 bounded design)
+
+## Global Constraints
+
+- Preserve every grant threshold, liveness verdict, score, and fail-closed path.
+- Use paired evidence only when the selected frame is metadata-lit, an adjacent partner is metadata-dark, and the negotiated format supplies a clipping ceiling.
+- Keep missing metadata, missing ceiling, malformed frame geometry, and missing ambient partners as `None`, never zero.
+- Keep single-frame enrollment preflight unchanged.
+- The new evidence is a reason and situation selector only.
+- Do not recommend `ir-setup` for persistent ambient saturation.
+- Do not commit unless the user explicitly requests a commit.
+
+---
+
+### Task 1: Capture Paired Whole-Frame Saturation
+
+**Files:**
+- Modify: `crates/irlume-camera/src/lib.rs:307-393,5362-5597`
+- Test: `crates/irlume-camera/src/lib.rs` test module
+
+**Interfaces:**
+- Consumes: decoded burst frames, `ir_metadata::Illumination`, selected gate index, and `white_level: Option<u8>`.
+- Produces: `IrCaptureStats::{lit_saturated_frac, ambient_saturated_frac, persistent_saturated_frac}: Option<f32>`.
+
+- [ ] **Step 1: Write failing camera evidence tests**
+
+Add tests that construct metadata-lit/dark synthetic frames matching the field measurements:
+
+```rust
+// ThinkPad: 17.25% lit, 17.02% ambient, with the ambient-clipped pixels
+// overlapping the lit-clipped window.
+assert_eq!(evidence.lit_saturated_frac, Some(0.1725));
+assert_eq!(evidence.ambient_saturated_frac, Some(0.1702));
+assert_eq!(evidence.persistent_saturated_frac, Some(0.1702));
+
+// BRIO: emitter-created clipping disappears in the dark partner.
+assert_eq!(evidence.lit_saturated_frac, Some(0.1403));
+assert_eq!(evidence.ambient_saturated_frac, Some(0.0031));
+assert_eq!(evidence.persistent_saturated_frac, Some(0.0031));
+```
+
+Also assert all evidence is `None` without a ceiling or selected lit metadata, and ambient/persistent evidence is `None` without an adjacent metadata-dark partner.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test -p irlume-camera persistent_saturation -- --nocapture`
+
+Expected: compilation failure because the paired-evidence function and `IrCaptureStats` fields do not exist.
+
+- [ ] **Step 3: Implement exact paired evidence**
+
+Add one private capture helper returning a small private evidence value. It must:
+
+```rust
+let lit_saturated_frac = ir_probe::saturated_fraction(lit, white) as f32;
+let ambient_saturated_frac = ir_probe::saturated_fraction(ambient, white) as f32;
+let persistent_saturated_frac = lit
+    .iter()
+    .zip(ambient)
+    .filter(|(lit, ambient)| **lit >= white && **ambient >= white)
+    .count() as f32
+    / lit.len() as f32;
+```
+
+Require equal, non-empty frame lengths before computing overlap. Select the ambient index with `ir_metadata::ambient_partner`, but accept it only when the selected frame is explicitly `Lit` and the partner is explicitly `Dark`. Populate the three public stats fields and document that they are whole-frame diagnostics, not grant gates.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `cargo test -p irlume-camera persistent_saturation -- --nocapture`
+
+Expected: PASS for ThinkPad, BRIO, and unavailable-evidence cases.
+
+- [ ] **Step 5: Review checkpoint**
+
+Inspect `git diff -- crates/irlume-camera/src/lib.rs` and confirm capture selection, subtraction, returned pixels, and enrollment preflight are unchanged. Do not commit.
+
+### Task 2: Select Accurate Liveness Reasons
+
+**Files:**
+- Modify: `crates/irlume-liveness/src/lib.rs:30-170,449-469,575-711`
+- Test: `crates/irlume-liveness/src/lib.rs` test module
+
+**Interfaces:**
+- Consumes: `Signals::ir_persistent_saturated_frac: Option<f32>`.
+- Produces: `Signals::persistent_ir_source_overwhelms() -> bool` and reason text for already-denied dark/flat captures.
+
+- [ ] **Step 1: Write failing liveness tests**
+
+Extend `live_signals()` with `ir_persistent_saturated_frac: None`. Add table-driven tests using `0.1702` for ThinkPad and `0.0031` for BRIO. For both `evaluate` and `evaluate_ir_only`, assert:
+
+```rust
+assert_eq!(verdict, Verdict::Spoof);
+assert!(reason.contains("IR-bright source"));
+assert!(reason.contains("reposition"));
+assert!(reason.contains("password"));
+assert!(!reason.contains("ir-setup"));
+```
+
+Exercise both existing denial cues independently: `ir_face_brightness < IR_FACE_MIN_BRIGHTNESS` and `ir_center_edge_ratio < MIN_CENTER_EDGE_RATIO`. Assert BRIO, `None`, and exactly the diagnostic boundary retain their old reasons and verdicts; a value immediately above the boundary rewords only the reason.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test -p irlume-liveness persistent_ir_source -- --nocapture`
+
+Expected: compilation failure because the new signal and selector do not exist.
+
+- [ ] **Step 3: Implement the reason selector**
+
+Add `IR_PERSISTENT_SATURATED_FRAC_MIN: f32 = 0.10` as a diagnostic threshold, not a grant threshold. Implement:
+
+```rust
+pub fn persistent_ir_source_overwhelms(&self) -> bool {
+    self.ir_persistent_saturated_frac
+        .is_some_and(|fraction| fraction > IR_PERSISTENT_SATURATED_FRAC_MIN)
+        && (self.ir_face_brightness < IR_FACE_MIN_BRIGHTNESS
+            || self.ir_center_edge_ratio < MIN_CENTER_EDGE_RATIO)
+}
+```
+
+In each existing dark and flat branch, prefer the persistent-source reason before the broader ambient-mean and glint selectors. Keep the current `Verdict::Spoof` return values and leave `exposure_refusal` unchanged.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `cargo test -p irlume-liveness persistent_ir_source -- --nocapture`
+
+Expected: PASS on both credential-releasing evaluators and both cue branches, with unchanged verdicts.
+
+- [ ] **Step 5: Review checkpoint**
+
+Inspect `git diff -- crates/irlume-liveness/src/lib.rs` and confirm only reason selection changed. Do not commit.
+
+### Task 3: Thread Evidence and Classify the Authentication Situation
+
+**Files:**
+- Modify: `crates/irlume-auth/src/lib.rs:324-445,3559-3580,4338-4377`
+- Modify: `crates/irlume-cli/src/pad.rs:141-168`
+- Modify: `crates/irlume-cli/src/main.rs:2379-2416`
+- Test: `crates/irlume-auth/src/lib.rs` test modules
+
+**Interfaces:**
+- Consumes: `IrCaptureStats::persistent_saturated_frac` and `Signals::persistent_ir_source_overwhelms()`.
+- Produces: stable `AttemptSituation::IrSource` label `"IR source"` and unchanged `OutcomeKind` values.
+
+- [ ] **Step 1: Write failing auth tests**
+
+Add tests proving a failed assessment with ThinkPad persistent clipping and an existing dark/flat denial maps to `AttemptSituation::IrSource`, while BRIO clipping, unavailable evidence, and an otherwise healthy face do not. Pin `attempt_situation_label(AttemptSituation::IrSource) == "IR source"`, preserve all existing precedence tests, and assert `liveness_deny_kind` returns the same kind before and after rewording.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test -p irlume-auth ir_source -- --nocapture`
+
+Expected: compilation failure because the signal plumbing and situation variant do not exist.
+
+- [ ] **Step 3: Thread and classify evidence**
+
+Populate `Signals::ir_persistent_saturated_frac` from `ir_stats.persistent_saturated_frac` in auth, `padcapture`, and the developer gate probe. Set it to `None` on RGB-only paths. Add one `AttemptFacts` boolean populated by `a.signals.persistent_ir_source_overwhelms()` and classify it after framing/orientation conditions but before generic darkness, score, and spoof labels. Do not inspect reason strings and do not change outcome classification or retryability.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `cargo test -p irlume-auth ir_source -- --nocapture`
+
+Expected: PASS with the stable journal situation and unchanged deny kinds.
+
+- [ ] **Step 5: Review checkpoint**
+
+Inspect diffs for auth and CLI callers. Confirm every IR `Signals` producer carries the evidence, every RGB-only producer uses `None`, and no enrollment preflight changed. Do not commit.
+
+### Task 4: Add Actionable PAM Wording
+
+**Files:**
+- Modify: `crates/irlume-pam/src/lib.rs:837-853,1376-1433`
+- Test: `crates/irlume-pam/src/lib.rs` test module
+
+**Interfaces:**
+- Consumes: daemon situation label `"IR source"`.
+- Produces: one number-free prompt line recommending repositioning or password fallback.
+
+- [ ] **Step 1: Write the failing PAM test**
+
+Assert:
+
+```rust
+assert_eq!(
+    situation_prompt("IR source"),
+    Some("an IR-bright source is overwhelming the camera; reposition or use your password")
+);
+```
+
+Include the label in the no-digits prompt test and keep attack-shaped situations silent.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test -p irlume-pam IR_source -- --nocapture`
+
+Expected: FAIL because `situation_prompt("IR source")` returns `None`.
+
+- [ ] **Step 3: Add the prompt mapping**
+
+Add only the `"IR source"` match arm. Do not include percentages, thresholds, source guesses, or `ir-setup`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `cargo test -p irlume-pam situation -- --nocapture`
+
+Expected: PASS for usability mapping, silence policy, and number-free wording.
+
+- [ ] **Step 5: Review checkpoint**
+
+Inspect `git diff -- crates/irlume-pam/src/lib.rs` and confirm fallback behavior is unchanged. Do not commit.
+
+### Task 5: Regression, Mutation, and Workspace Verification
+
+**Files:**
+- Verify all modified files.
+- Update: `/home/wisbfime/archledger-gp/project-irlume.md`
+- Update: `/home/wisbfime/archledger-gp/index.md`
+
+**Interfaces:**
+- Consumes: all preceding task outputs.
+- Produces: verified issue #636 implementation and exact resumption state.
+
+- [ ] **Step 1: Validate the production algorithm against issue #636 raw frames**
+
+Download the six full-resolution PNGs linked by `https://github.com/archledger/irlume/issues/636` into `/tmp/opencode/irlume-636-frames`, verify they are 8-bit grayscale at the reported 640x360 ThinkPad and 340x340 BRIO dimensions, and record SHA-256 hashes. Convert temporary raw GREY8 payloads with ImageMagick and add a temporary camera unit test that feeds each adjacent pair through `paired_saturation_evidence` at the production GREY8 ceiling `255`.
+
+Assert the observed values within `0.00001`: window-in lit `0.16778`, dark `0.16521`, exact overlap `0.16487`; window-out lit `0.00718`, dark `0.00072`, exact overlap `0.00067`; BRIO lit, dark, and overlap `0.0` at the actual ceiling. The issue's BRIO `14.03%`/`0.31%` figures used `>=250`, so zero at `255` is expected and is stronger separation, not a contradiction. Run the temporary test, then remove the temporary source test and generated raw payloads; retain only the downloaded public PNG evidence outside the worktree.
+
+- [ ] **Step 2: Run focused regression suites**
+
+Run: `cargo test -p irlume-camera -p irlume-liveness -p irlume-auth -p irlume-pam`
+
+Expected: all non-hardware tests pass; only explicitly environment-gated hardware/PAM-wrapper tests may remain ignored.
+
+- [ ] **Step 3: Run mutation probes**
+
+Temporarily invert each of these independently, run the named focused test, and restore the line immediately: require `>=` instead of `>` at the diagnostic boundary; drop the metadata-dark requirement; replace exact overlap with lit-only clipping; remove auth situation precedence; remove the PAM mapping. Each probe must make its focused test fail.
+
+- [ ] **Step 4: Run workspace quality gates**
+
+Run:
+
+```text
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+```
+
+Expected: all commands exit zero, except documented environment-gated tests remain ignored rather than failed.
+
+- [ ] **Step 5: Run the sandboxed fleet control**
+
+Build the branch daemon and CLI, snapshot the installed daemon/socket state plus hashes of production enrollment and emitter configuration, and run the branch daemon under `/tmp/opencode/irlume-636-hw/{state,config,irlumed.sock}` with copied capture qualification and encrypted enrollment inputs. Exercise one ordinary live identify attempt on the available ASUS fleet pair, confirm the new IR-source situation does not appear without persistent paired clipping, and retain the branch daemon's numeric diagnostic lines. Restore the installed daemon and socket, verify the original selected pair and byte-identical production hashes, and record exact rollback evidence. Never print or persist frame data, embeddings, credentials, decrypted enrollment material, or emitter payloads.
+
+- [ ] **Step 6: Inspect final scope**
+
+Run `git status --short` and `git diff --check`, then inspect the complete diff. Confirm no model symlink, captured frame, biometric data, threshold change, enrollment behavior, or unrelated file is tracked.
+
+- [ ] **Step 7: Refresh project handoff**
+
+Update the mutable current state, append an `agent: opencode` checkpoint using `/home/wisbfime/archledger-gp/session-summary-template.md`, and refresh the irlume row in `/home/wisbfime/archledger-gp/index.md`. Record exact commands and outcomes without secrets or biometric data. Do not commit unless explicitly requested.


### PR DESCRIPTION
## What & why

Fixes #636.

A localized IR-bright source can remain clipped in both emitter-lit and metadata-dark frames, pin camera exposure, and leave the face dark or flat. The existing attempt diagnosis then recommends emitter setup even though the emitter is working.

This change records whole-frame clipping for the selected metadata-lit frame, its adjacent metadata-dark partner, and the exact same-pixel overlap. Persistent clipping only selects a more accurate denial reason and stable `IR source` situation. It does not change liveness verdicts, grants, scores, retryability, existing cue thresholds, or single-frame enrollment preflight behavior.

PAM now recommends repositioning or password fallback rather than `ir-setup` for this situation.

## Testing

- [x] `cargo test --workspace` passes, 1,881 passed, 0 failed, 100 environment-gated ignored
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [ ] Docs/CHANGELOG updated if user-facing
- [x] Hardware-validated (if it touches PAM, the daemon, or capture)

Additional evidence:

- Focused camera, liveness, auth, and PAM suites: 807 passed, 0 failed.
- Five mutation probes detected changes to the strict boundary, dark metadata requirement, exact overlap, auth precedence, and PAM mapping.
- The production helper matched all six public issue frames. ThinkPad window-in overlap was 0.16487 at the GREY8 ceiling; window-out was 0.00067; BRIO overlap was 0.0.
- A sandboxed ASUS RGB+IR capture exercised the ordinary no-face path without false `IR source` wording, then production state was restored and revalidated.
- Final metadata-complete ASUS hardware validation measured lit saturation 0.47828, dark saturation 0.46420, and exact persistent same-pixel overlap 0.45612. The centered face remained detected, the existing cue returned `Spoof`, and the exact `AuthResult` wire carried `IR source` with `granted=false` and `live=false`.

Two independent implementation reviews found no Critical, Important, or Minor findings. A final pre-merge differential review covered all seven changed files, found no Critical or Important issues, recorded two non-blocking test-hardening suggestions, and recommended approval.
