### PR TITLE
feat: persist per-role qualification rate shortfalls

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1339,6 +1339,8 @@ struct CaptureModeSelection {
     runtime_contract: Option<irlume_camera::RuntimePairContract>,
     qualification_state: irlume_common::diagnostics::QualificationState,
     qualification_reason: Option<irlume_common::diagnostics::QualificationReason>,
+    authoritative_rate_shortfalls: Option<irlume_common::diagnostics::RateShortfallsByArm>,
+    latest_attempt_rate_shortfalls: Option<irlume_common::diagnostics::RateShortfallsByArm>,
     operation_demoted: std::cell::Cell<bool>,
 }
 
@@ -1492,6 +1494,8 @@ fn unavailable_capture_mode_selection() -> CaptureModeSelection {
         qualification_reason: Some(
             irlume_common::diagnostics::QualificationReason::StoreUnreadable,
         ),
+        authoritative_rate_shortfalls: None,
+        latest_attempt_rate_shortfalls: None,
         operation_demoted: std::cell::Cell::new(false),
     }
 }
@@ -1510,6 +1514,8 @@ fn rgb_only_enrollment_capture_mode_selection() -> CaptureModeSelection {
         // operation genuinely runs RGB-only, which is what NoIrPair names.
         qualification_state: irlume_common::diagnostics::QualificationState::NoIrPair,
         qualification_reason: None,
+        authoritative_rate_shortfalls: None,
+        latest_attempt_rate_shortfalls: None,
         operation_demoted: std::cell::Cell::new(false),
     }
 }
@@ -1536,14 +1542,20 @@ fn capture_mode_selection_with_diagnostics(
                 return unavailable_capture_mode_selection();
             }
         };
-    let (stored, runtime_key, qualification_state, qualification_reason) =
-        match irlume_camera::stored_capture_qualification_state_from_cameras(rgb_camera, ir_camera)
-        {
-            Ok(state) => {
-                diagnostics.emit_share_safe(diagnostic_qualification_event(&state));
-                let (qualification_state, qualification_reason) =
-                    diagnostic_qualification_state(&state);
-                let stored = match state.resolution {
+    let (
+        stored,
+        runtime_key,
+        qualification_state,
+        qualification_reason,
+        authoritative_rate_shortfalls,
+        latest_attempt_rate_shortfalls,
+    ) = match irlume_camera::stored_capture_qualification_state_from_cameras(rgb_camera, ir_camera)
+    {
+        Ok(state) => {
+            diagnostics.emit_share_safe(diagnostic_qualification_event(&state));
+            let (qualification_state, qualification_reason) =
+                diagnostic_qualification_state(&state);
+            let stored = match state.resolution {
                     irlume_camera::capture_qualification::QualificationResolution::ConcurrentQualified => {
                         Some(irlume_camera::CaptureMode::Concurrent)
                     }
@@ -1554,33 +1566,35 @@ fn capture_mode_selection_with_diagnostics(
                         _,
                     ) => None,
                 };
-                (
-                    stored,
-                    Some(state.runtime_key),
-                    qualification_state,
-                    qualification_reason,
-                )
-            }
-            Err(error) => {
-                diagnostics.emit_share_safe(
-                    irlume_common::diagnostics::ShareSafeEventKind::QualificationChanged {
-                        state: irlume_common::diagnostics::QualificationState::Unreadable,
-                        reason: Some(
-                            irlume_common::diagnostics::QualificationReason::StoreUnreadable,
-                        ),
-                    },
-                );
-                irlume_common::dlog!(
-                    "capture qualification unreadable ({error}); selecting one-at-a-time capture"
-                );
-                (
-                    None,
-                    None,
-                    irlume_common::diagnostics::QualificationState::Unreadable,
-                    Some(irlume_common::diagnostics::QualificationReason::StoreUnreadable),
-                )
-            }
-        };
+            (
+                stored,
+                Some(state.runtime_key),
+                qualification_state,
+                qualification_reason,
+                state.authoritative_rate_shortfalls,
+                state.latest_attempt_rate_shortfalls,
+            )
+        }
+        Err(error) => {
+            diagnostics.emit_share_safe(
+                irlume_common::diagnostics::ShareSafeEventKind::QualificationChanged {
+                    state: irlume_common::diagnostics::QualificationState::Unreadable,
+                    reason: Some(irlume_common::diagnostics::QualificationReason::StoreUnreadable),
+                },
+            );
+            irlume_common::dlog!(
+                "capture qualification unreadable ({error}); selecting one-at-a-time capture"
+            );
+            (
+                None,
+                None,
+                irlume_common::diagnostics::QualificationState::Unreadable,
+                Some(irlume_common::diagnostics::QualificationReason::StoreUnreadable),
+                None,
+                None,
+            )
+        }
+    };
     let env = std::env::var("IRLUME_SEQUENTIAL_CAPTURE").ok();
     let selected = capture_mode_decision(env.as_deref(), stored);
     let selected = with_runtime_capture_health(|health| {
@@ -1593,6 +1607,8 @@ fn capture_mode_selection_with_diagnostics(
         runtime_contract: Some(runtime_contract),
         qualification_state,
         qualification_reason,
+        authoritative_rate_shortfalls,
+        latest_attempt_rate_shortfalls,
         operation_demoted: std::cell::Cell::new(false),
     }
 }
@@ -1998,6 +2014,27 @@ fn diagnostic_capture_schedule(
     (schedule, source)
 }
 
+fn diagnostic_capture_status(
+    selection: &CaptureModeSelection,
+    ir_available: bool,
+    runtime_context: Option<irlume_common::diagnostics::DigestToken>,
+    qualification_context: Option<irlume_common::diagnostics::DigestToken>,
+    runtime_degradation: Option<irlume_common::diagnostics::RuntimeViolationLabel>,
+) -> irlume_common::diagnostics::CaptureStatus {
+    let (schedule, source) = diagnostic_capture_schedule(selection, ir_available);
+    irlume_common::diagnostics::CaptureStatus {
+        schedule,
+        source,
+        runtime_context,
+        qualification_state: selection.qualification_state,
+        qualification_reason: selection.qualification_reason,
+        qualification_context,
+        runtime_degradation,
+        authoritative_rate_shortfalls: selection.authoritative_rate_shortfalls.clone(),
+        latest_attempt_rate_shortfalls: selection.latest_attempt_rate_shortfalls.clone(),
+    }
+}
+
 fn diagnostic_qualification_event(
     state: &irlume_camera::StoredCaptureQualificationState,
 ) -> irlume_common::diagnostics::ShareSafeEventKind {
@@ -2057,7 +2094,7 @@ fn emit_capture_context(
     diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
 ) {
     use irlume_common::diagnostics::{
-        CameraRoleLabel, CaptureStatus, DigestToken, QualificationState, ShareSafeEventKind,
+        CameraRoleLabel, DigestToken, QualificationState, ShareSafeEventKind,
     };
     emit_capture_schedule(selection, ir_available, diagnostics);
     if let Some(contract) = selection.runtime_contract.as_ref() {
@@ -2070,17 +2107,14 @@ fn emit_capture_context(
                 with_runtime_capture_health(|health| health.degradation(key))
                     .map(diagnostic_runtime_violation)
             });
-            let (schedule, source) = diagnostic_capture_schedule(selection, ir_available);
             diagnostics.publish_support_context(
-                CaptureStatus {
-                    schedule,
-                    source,
-                    runtime_context: Some(runtime_context),
-                    qualification_state: selection.qualification_state,
-                    qualification_reason: selection.qualification_reason,
+                diagnostic_capture_status(
+                    selection,
+                    ir_available,
+                    Some(runtime_context),
                     qualification_context,
                     runtime_degradation,
-                },
+                ),
                 cameras.into(),
             );
         }
@@ -2117,6 +2151,8 @@ fn publish_rgb_only_support_context(
             qualification_reason: None,
             qualification_context: None,
             runtime_degradation: None,
+            authoritative_rate_shortfalls: None,
+            latest_attempt_rate_shortfalls: None,
         },
         vec![camera],
     );
@@ -2514,6 +2550,8 @@ mod capture_mode_switch_tests {
             runtime_contract: None,
             qualification_state: QualificationState::QualifiedConcurrent,
             qualification_reason: None,
+            authoritative_rate_shortfalls: None,
+            latest_attempt_rate_shortfalls: None,
             operation_demoted: std::cell::Cell::new(false),
         };
 
@@ -2526,6 +2564,62 @@ mod capture_mode_switch_tests {
                 source: CaptureScheduleSource::StoredQualification,
             }]
         );
+    }
+
+    #[test]
+    fn rate_shortfall_support_context_preserves_authoritative_and_latest_attempt() {
+        use irlume_common::diagnostics::{
+            CameraRoleLabel, DigestToken, RateShortfallEvidence, RateShortfallsByArm,
+            RateShortfallsByRole,
+        };
+
+        let evidence = |role, failure_count| RateShortfallEvidence {
+            role,
+            failure_count,
+            delivered_num: 10,
+            delivered_den: 1,
+            floor_num: 15,
+            floor_den: 1,
+            tolerance_percent: 98,
+            window_count: 30,
+            window_span_us: 3_000_000,
+        };
+        let authoritative = RateShortfallsByArm {
+            sequential: Some(RateShortfallsByRole::default()),
+            concurrent: Some(RateShortfallsByRole {
+                rgb: Some(evidence(CameraRoleLabel::Rgb, 4)),
+                ir: None,
+            }),
+        };
+        let latest = RateShortfallsByArm {
+            sequential: Some(RateShortfallsByRole::default()),
+            concurrent: Some(RateShortfallsByRole {
+                rgb: None,
+                ir: Some(evidence(CameraRoleLabel::Ir, 1)),
+            }),
+        };
+        let selection = CaptureModeSelection {
+            sequential: true,
+            source: STORED_CAPTURE_MODE_SOURCE,
+            runtime_key: Some("dock-a".into()),
+            runtime_contract: None,
+            qualification_state: QualificationState::MeasuredSequential,
+            qualification_reason: Some(QualificationReason::DeliveredRateShortfall),
+            authoritative_rate_shortfalls: Some(authoritative.clone()),
+            latest_attempt_rate_shortfalls: Some(latest.clone()),
+            operation_demoted: std::cell::Cell::new(false),
+        };
+
+        let status = diagnostic_capture_status(
+            &selection,
+            true,
+            Some(DigestToken::from_sha256_hex(&"a".repeat(64)).unwrap()),
+            Some(DigestToken::from_sha256_hex(&"b".repeat(64)).unwrap()),
+            None,
+        );
+
+        assert_eq!(status.authoritative_rate_shortfalls, Some(authoritative));
+        assert_eq!(status.latest_attempt_rate_shortfalls, Some(latest));
     }
 
     #[test]
@@ -2550,6 +2644,8 @@ mod capture_mode_switch_tests {
             ),
             runtime_key: "context".into(),
             last_attempt_outcome: None,
+            authoritative_rate_shortfalls: None,
+            latest_attempt_rate_shortfalls: None,
         };
 
         assert_eq!(
@@ -2665,6 +2761,8 @@ mod capture_mode_switch_tests {
             runtime_contract: None,
             qualification_state: QualificationState::QualifiedConcurrent,
             qualification_reason: None,
+            authoritative_rate_shortfalls: None,
+            latest_attempt_rate_shortfalls: None,
             operation_demoted: std::cell::Cell::new(false),
         };
         assert!(pair_rate_failure_is_degradation(&qualified));

--- a/crates/irlume-camera/src/capture_qualification.rs
+++ b/crates/irlume-camera/src/capture_qualification.rs
@@ -818,6 +818,10 @@ pub struct ArmEvidence {
     /// Failed rounds carrying typed below-floor delivery evidence.
     #[serde(default)]
     rate_shortfall_failures: u32,
+    /// Per-role typed below-floor details. `None` means a legacy producer did
+    /// not record them; `Some(default)` means a fresh arm measured none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    rate_shortfalls: Option<irlume_common::diagnostics::RateShortfallsByRole>,
     /// Per-fact counts of capture-level round failures (#606), naming HOW an
     /// arm's rounds errored (stream delivery, rate-window establishment).
     /// Additive and defaulted, like `rate_shortfall_failures` before it, so
@@ -858,6 +862,7 @@ impl ArmEvidence {
         arm_failures: u32,
         capture_failures: u32,
         rate_shortfall_failures: u32,
+        rate_shortfalls: irlume_common::diagnostics::RateShortfallsByRole,
         capture_failure_facts: std::collections::BTreeMap<String, u32>,
         ir_camera_classified_frames: u32,
         rgb_mean: f32,
@@ -880,6 +885,7 @@ impl ArmEvidence {
             arm_failures,
             capture_failures,
             rate_shortfall_failures,
+            rate_shortfalls: Some(rate_shortfalls),
             capture_failure_facts,
             ir_camera_classified_frames: Some(ir_camera_classified_frames),
             rgb_mean,
@@ -898,7 +904,30 @@ impl ArmEvidence {
         self.ir_camera_classified_frames
     }
 
+    /// Per-role delivered-rate shortfalls, or `None` for a legacy arm.
+    #[must_use]
+    pub const fn rate_shortfalls(
+        &self,
+    ) -> Option<&irlume_common::diagnostics::RateShortfallsByRole> {
+        self.rate_shortfalls.as_ref()
+    }
+
     fn validate(&self) -> Result<(), QualificationError> {
+        let valid_shortfall =
+            |evidence: &irlume_common::diagnostics::RateShortfallEvidence,
+             role: irlume_common::diagnostics::CameraRoleLabel| {
+                evidence.role == role
+                    && evidence.failure_count != 0
+                    && evidence.delivered_den != 0
+                    && evidence.floor_den != 0
+            };
+        let rate_shortfalls_valid = self.rate_shortfalls.as_ref().is_none_or(|shortfalls| {
+            shortfalls.rgb.as_ref().is_none_or(|evidence| {
+                valid_shortfall(evidence, irlume_common::diagnostics::CameraRoleLabel::Rgb)
+            }) && shortfalls.ir.as_ref().is_none_or(|evidence| {
+                valid_shortfall(evidence, irlume_common::diagnostics::CameraRoleLabel::Ir)
+            })
+        });
         let exceeds_completed = |healthy: u32, failed: u32| {
             healthy
                 .checked_add(failed)
@@ -928,6 +957,7 @@ impl ArmEvidence {
             || !self.ir_mean.is_finite()
             || self.rgb_mean < 0.0
             || self.ir_mean < 0.0
+            || !rate_shortfalls_valid
         {
             return Err(QualificationError::InvalidEvidence);
         }
@@ -1061,6 +1091,15 @@ impl QualificationAttempt {
     #[must_use]
     pub const fn ir_illumination_metadata(&self) -> Option<IlluminationMetadataPresence> {
         self.ir_illumination_metadata
+    }
+
+    /// Per-role delivered-rate shortfalls projected by capture schedule.
+    #[must_use]
+    pub fn rate_shortfalls(&self) -> irlume_common::diagnostics::RateShortfallsByArm {
+        irlume_common::diagnostics::RateShortfallsByArm {
+            sequential: self.sequential.rate_shortfalls.clone(),
+            concurrent: self.concurrent.rate_shortfalls.clone(),
+        }
     }
 
     fn validate(&self) -> Result<(), QualificationError> {
@@ -1660,6 +1699,18 @@ mod tests {
     }
 
     fn arm_with_ir_classified(rounds: u32, ir_camera_classified: u32) -> ArmEvidence {
+        arm_with_rate_shortfalls(
+            rounds,
+            ir_camera_classified,
+            irlume_common::diagnostics::RateShortfallsByRole::default(),
+        )
+    }
+
+    fn arm_with_rate_shortfalls(
+        rounds: u32,
+        ir_camera_classified: u32,
+        rate_shortfalls: irlume_common::diagnostics::RateShortfallsByRole,
+    ) -> ArmEvidence {
         ArmEvidence::new(
             rounds,
             rounds,
@@ -1676,6 +1727,7 @@ mod tests {
             0,
             0,
             0,
+            rate_shortfalls,
             Default::default(),
             ir_camera_classified,
             140.0,
@@ -1683,6 +1735,22 @@ mod tests {
             850,
         )
         .unwrap()
+    }
+
+    fn rate_shortfall(
+        role: irlume_common::diagnostics::CameraRoleLabel,
+    ) -> irlume_common::diagnostics::RateShortfallEvidence {
+        irlume_common::diagnostics::RateShortfallEvidence {
+            role,
+            failure_count: 2,
+            delivered_num: 29,
+            delivered_den: 2,
+            floor_num: 15,
+            floor_den: 1,
+            tolerance_percent: 98,
+            window_count: 30,
+            window_span_us: 2_000_000,
+        }
     }
 
     /// #606: absence means an older producer did not measure the count, while
@@ -1710,6 +1778,92 @@ mod tests {
         );
         let back: ArmEvidence = serde_json::from_value(json).expect("the new record round-trips");
         assert_eq!(back.ir_camera_classified_frames(), Some(47));
+    }
+
+    #[test]
+    fn rate_shortfall_persistence_preserves_unknown_measured_empty_and_roles() {
+        use irlume_common::diagnostics::{CameraRoleLabel, RateShortfallsByRole};
+
+        let fresh = arm(6);
+        assert_eq!(
+            fresh.rate_shortfalls(),
+            Some(&RateShortfallsByRole::default())
+        );
+        assert_eq!(SCHEMA_VERSION, 2);
+
+        let mut legacy = serde_json::to_value(&fresh).unwrap();
+        legacy.as_object_mut().unwrap().remove("rate_shortfalls");
+        let legacy: ArmEvidence = serde_json::from_value(legacy).expect("legacy record parses");
+        assert_eq!(legacy.rate_shortfalls(), None);
+
+        let shortfalls = RateShortfallsByRole {
+            rgb: Some(rate_shortfall(CameraRoleLabel::Rgb)),
+            ir: Some(rate_shortfall(CameraRoleLabel::Ir)),
+        };
+        let populated = arm_with_rate_shortfalls(6, 0, shortfalls.clone());
+        let json = serde_json::to_vec(&populated).unwrap();
+        let decoded: ArmEvidence = serde_json::from_slice(&json).unwrap();
+        assert_eq!(decoded.rate_shortfalls(), Some(&shortfalls));
+    }
+
+    #[test]
+    fn rate_shortfall_populated_slots_validate_role_counts_and_denominators() {
+        use irlume_common::diagnostics::{CameraRoleLabel, RateShortfallsByRole};
+
+        let valid = rate_shortfall(CameraRoleLabel::Rgb);
+        let mut invalid_values = Vec::new();
+
+        let mut wrong_role = valid.clone();
+        wrong_role.role = CameraRoleLabel::Ir;
+        invalid_values.push(wrong_role);
+        let mut zero_count = valid.clone();
+        zero_count.failure_count = 0;
+        invalid_values.push(zero_count);
+        let mut zero_delivered_den = valid.clone();
+        zero_delivered_den.delivered_den = 0;
+        invalid_values.push(zero_delivered_den);
+        let mut zero_floor_den = valid;
+        zero_floor_den.floor_den = 0;
+        invalid_values.push(zero_floor_den);
+
+        for invalid in invalid_values {
+            let mut arm = arm(6);
+            arm.rate_shortfalls = Some(RateShortfallsByRole {
+                rgb: Some(invalid),
+                ir: None,
+            });
+            assert_eq!(arm.validate(), Err(QualificationError::InvalidEvidence));
+        }
+    }
+
+    #[test]
+    fn rate_shortfall_qualification_attempt_projects_both_arms() {
+        use irlume_common::diagnostics::{
+            CameraRoleLabel, RateShortfallsByArm, RateShortfallsByRole,
+        };
+
+        let concurrent = RateShortfallsByRole {
+            rgb: Some(rate_shortfall(CameraRoleLabel::Rgb)),
+            ir: None,
+        };
+        let attempt = QualificationAttempt::new(
+            1_786_944_000,
+            context("/devices/pci0000:00/usb3/3-2"),
+            arm(6),
+            arm_with_rate_shortfalls(6, 0, concurrent.clone()),
+            false,
+            AttemptOutcome::ConcurrentQualified,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            attempt.rate_shortfalls(),
+            RateShortfallsByArm {
+                sequential: Some(RateShortfallsByRole::default()),
+                concurrent: Some(concurrent),
+            }
+        );
     }
 
     fn concurrent_attempt(port: &str) -> QualificationAttempt {
@@ -1892,6 +2046,7 @@ mod tests {
                 3,
                 0,
                 Default::default(),
+                Default::default(),
                 0,
                 80.0,
                 90.0,
@@ -1954,6 +2109,7 @@ mod tests {
                 0,
                 0,
                 Default::default(),
+                Default::default(),
                 0,
                 1.0,
                 1.0,
@@ -1978,6 +2134,7 @@ mod tests {
             0,
             0,
             0,
+            Default::default(),
             Default::default(),
             0,
             1.0,
@@ -2014,6 +2171,7 @@ mod tests {
             0,
             0,
             6,
+            Default::default(),
             Default::default(),
             0,
             0.0,
@@ -2237,6 +2395,7 @@ mod tests {
                 0,
                 2,
                 0,
+                Default::default(),
                 Default::default(),
                 0,
                 80.0,

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -6525,6 +6525,8 @@ pub struct PairSample {
     pub capture_failures: usize,
     /// Failed rounds carrying typed delivered-rate-below-floor evidence.
     pub rate_shortfall_failures: usize,
+    /// Per-role details retained from typed delivered-rate-below-floor errors.
+    pub rate_shortfalls: irlume_common::diagnostics::RateShortfallsByRole,
     /// Per-fact counts of the cross-round continuity failures (#586): which
     /// of the four nameable conditions fired, and how often. Arm-local
     /// diagnostic detail; deliberately NOT carried into the persisted
@@ -7546,6 +7548,7 @@ fn qualification_arm(
         count(sample.arm_failures, "arm-failure")?,
         count(sample.capture_failures, "capture-failure")?,
         count(sample.rate_shortfall_failures, "rate-shortfall-failure")?,
+        sample.rate_shortfalls.clone(),
         capture_failure_facts,
         count(sample.ir_camera_classified_frames, "ir-camera-classified")?,
         sample.rgb_mean,
@@ -8076,6 +8079,88 @@ struct PairContinuityState {
 
 impl PairContinuityState {}
 
+fn fraction_is_lower(
+    mut left_num: u128,
+    mut left_den: u128,
+    mut right_num: u128,
+    mut right_den: u128,
+) -> bool {
+    let mut reversed = false;
+    loop {
+        let left_quotient = left_num / left_den;
+        let right_quotient = right_num / right_den;
+        if left_quotient != right_quotient {
+            return if reversed {
+                left_quotient > right_quotient
+            } else {
+                left_quotient < right_quotient
+            };
+        }
+
+        let left_remainder = left_num % left_den;
+        let right_remainder = right_num % right_den;
+        if left_remainder == 0 && right_remainder == 0 {
+            return false;
+        }
+        if left_remainder == 0 || right_remainder == 0 {
+            let lower = left_remainder == 0 && right_remainder != 0;
+            return if reversed { !lower } else { lower };
+        }
+
+        (left_num, left_den) = (left_den, left_remainder);
+        (right_num, right_den) = (right_den, right_remainder);
+        reversed = !reversed;
+    }
+}
+
+fn observe_rate_shortfall(into: &mut PairSample, error: &irlume_common::Error) {
+    let irlume_common::Error::DeliveredRate(rate) = error else {
+        return;
+    };
+    if rate.delivered_den == 0 || rate.floor_num == 0 || rate.floor_den == 0 {
+        return;
+    }
+
+    let (role, slot) = match rate.role.as_str() {
+        "rgb" => (
+            irlume_common::diagnostics::CameraRoleLabel::Rgb,
+            &mut into.rate_shortfalls.rgb,
+        ),
+        "ir" => (
+            irlume_common::diagnostics::CameraRoleLabel::Ir,
+            &mut into.rate_shortfalls.ir,
+        ),
+        _ => return,
+    };
+    let failure_count = slot
+        .as_ref()
+        .map_or(1, |retained| retained.failure_count.saturating_add(1));
+    let candidate = irlume_common::diagnostics::RateShortfallEvidence {
+        role,
+        failure_count,
+        delivered_num: rate.delivered_num,
+        delivered_den: rate.delivered_den,
+        floor_num: rate.floor_num,
+        floor_den: rate.floor_den,
+        tolerance_percent: rate.tolerance_percent,
+        window_count: rate.window_count,
+        window_span_us: rate.window_span_us,
+    };
+    let replace = slot.as_ref().is_none_or(|retained| {
+        fraction_is_lower(
+            u128::from(candidate.delivered_num) * u128::from(candidate.floor_den),
+            u128::from(candidate.delivered_den) * u128::from(candidate.floor_num),
+            u128::from(retained.delivered_num) * u128::from(retained.floor_den),
+            u128::from(retained.delivered_den) * u128::from(retained.floor_num),
+        )
+    });
+    if replace {
+        *slot = Some(candidate);
+    } else if let Some(retained) = slot {
+        retained.failure_count = failure_count;
+    }
+}
+
 /// Fold one probe round into a running mean.
 ///
 /// The IR figure is the burst's `lit_mean`, NOT the returned frame's own mean.
@@ -8099,6 +8184,12 @@ fn accumulate(
 ) {
     let (Ok(rgb), Ok((ir, ir_stats))) = (rgb, ir) else {
         into.failed += 1;
+        if let Err(error) = rgb {
+            observe_rate_shortfall(into, error);
+        }
+        if let Err(error) = ir {
+            observe_rate_shortfall(into, error);
+        }
         if matches!(rgb, Err(irlume_common::Error::DeliveredRate(_)))
             || matches!(ir, Err(irlume_common::Error::DeliveredRate(_)))
         {
@@ -11999,6 +12090,7 @@ mod tests {
                 arm_failures: 0,
                 capture_failures: failed,
                 rate_shortfall_failures: 0,
+                rate_shortfalls: Default::default(),
                 continuity_facts: Default::default(),
                 capture_failure_facts: Default::default(),
                 ir_camera_classified_frames: 0,
@@ -12290,20 +12382,26 @@ mod tests {
         }
     }
 
-    fn below_floor_error(role: &str) -> Error {
+    fn below_floor_error(
+        role: &str,
+        delivered_num: u64,
+        delivered_den: u64,
+        floor_num: u32,
+        floor_den: u32,
+    ) -> Error {
         Error::DeliveredRate(Box::new(irlume_common::CameraStreamRateEvidence {
             role: role.into(),
             requested_num: 1,
             requested_den: 30,
             accepted_num: 1,
             accepted_den: 30,
-            floor_num: 15,
-            floor_den: 1,
+            floor_num,
+            floor_den,
             tolerance_percent: 98,
             window_count: 30,
             window_span_us: 3_000_000,
-            delivered_num: 10,
-            delivered_den: 1,
+            delivered_num,
+            delivered_den,
             meets_floor: false,
             sequence_gap: 0,
             cumulative_drops: 0,
@@ -12322,7 +12420,7 @@ mod tests {
         let rgb = || {
             let call = rgb_calls.fetch_add(1, Ordering::SeqCst);
             if (2..4).contains(&call) {
-                Err(below_floor_error("rgb"))
+                Err(below_floor_error("rgb", 10, 1, 15, 1))
             } else {
                 Ok(frame(&[120; 4]))
             }
@@ -12347,6 +12445,66 @@ mod tests {
             capture_qualification::AttemptOutcome::SequentialRequired(
                 capture_qualification::SequentialReason::DeliveredRateShortfall
             )
+        );
+    }
+
+    #[test]
+    fn rate_shortfall_retains_the_lower_exact_delivered_to_floor_ratio() {
+        let mut sample = PairSample::default();
+        let mut continuity = PairContinuityState::default();
+        let ir = Ok((frame(&[20; 4]), stats(60.0)));
+
+        for rgb in [
+            Err(below_floor_error("rgb", 667, 1_000, 1, 1)),
+            Err(below_floor_error("rgb", 2, 3, 1, 1)),
+        ] {
+            accumulate(
+                &mut sample,
+                &mut continuity,
+                &rgb,
+                &ir,
+                std::time::Duration::ZERO,
+                None,
+            );
+        }
+
+        let rgb = sample.rate_shortfalls.rgb.expect("RGB shortfall");
+        assert_eq!(rgb.failure_count, 2);
+        assert_eq!((rgb.delivered_num, rgb.delivered_den), (2, 3));
+        assert_eq!((rgb.floor_num, rgb.floor_den), (1, 1));
+    }
+
+    #[test]
+    fn rate_shortfall_counts_both_roles_once_in_one_failed_round() {
+        let mut sample = PairSample::default();
+        accumulate(
+            &mut sample,
+            &mut PairContinuityState::default(),
+            &Err(below_floor_error("rgb", 7, 1, 15, 1)),
+            &Err(below_floor_error("ir", 14, 1, 15, 1)),
+            std::time::Duration::ZERO,
+            None,
+        );
+
+        assert_eq!(sample.failed, 1);
+        assert_eq!(sample.rate_shortfall_failures, 1);
+        assert_eq!(
+            sample
+                .rate_shortfalls
+                .rgb
+                .as_ref()
+                .expect("RGB shortfall")
+                .failure_count,
+            1
+        );
+        assert_eq!(
+            sample
+                .rate_shortfalls
+                .ir
+                .as_ref()
+                .expect("IR shortfall")
+                .failure_count,
+            1
         );
     }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -7511,17 +7511,23 @@ fn resolve_capture_qualification_record(
     let latest_attempt_rate_shortfalls = record
         .as_ref()
         .map(|record| record.last_attempt().rate_shortfalls());
-    let authoritative_rate_shortfalls = record.as_ref().and_then(|record| {
-        record
-            .authoritative()
-            .map(capture_qualification::QualificationAttempt::rate_shortfalls)
-    });
-    let resolution = record.map_or(
+    let resolution = record.as_ref().map_or(
         capture_qualification::QualificationResolution::Unqualified(
             capture_qualification::QualificationMismatch::NoAuthority,
         ),
         |record| record.resolve(context),
     );
+    let authoritative_rate_shortfalls = match resolution {
+        capture_qualification::QualificationResolution::ConcurrentQualified
+        | capture_qualification::QualificationResolution::SequentialRequired(_) => {
+            record.as_ref().and_then(|record| {
+                record
+                    .authoritative()
+                    .map(capture_qualification::QualificationAttempt::rate_shortfalls)
+            })
+        }
+        capture_qualification::QualificationResolution::Unqualified(_) => None,
+    };
     StoredCaptureQualificationState {
         resolution,
         runtime_key,
@@ -11845,6 +11851,58 @@ mod tests {
             Some(RateShortfallsByArm {
                 sequential: Some(RateShortfallsByRole::default()),
                 concurrent: Some(latest_shortfalls),
+            })
+        );
+    }
+
+    #[test]
+    fn context_mismatch_hides_authoritative_rate_shortfalls() {
+        use capture_qualification::{
+            AttemptOutcome, CaptureQualificationRecord, QualificationAttempt,
+            QualificationMismatch, QualificationResolution, SequentialReason,
+        };
+        use irlume_common::diagnostics::{
+            CameraRoleLabel, RateShortfallsByArm, RateShortfallsByRole,
+        };
+
+        let authoritative_context = runtime_gate_contract().context().clone();
+        let current_context = runtime_gate_contract_with_interval((1, 15))
+            .context()
+            .clone();
+        let healthy = qualification_arm_with_shortfalls(6, 0, RateShortfallsByRole::default());
+        let shortfalls = RateShortfallsByRole {
+            rgb: Some(qualification_shortfall(CameraRoleLabel::Rgb, 4)),
+            ir: None,
+        };
+        let authoritative = QualificationAttempt::new(
+            1_786_944_000,
+            authoritative_context,
+            healthy.clone(),
+            qualification_arm_with_shortfalls(0, 6, shortfalls.clone()),
+            true,
+            AttemptOutcome::SequentialRequired(SequentialReason::DeliveredRateShortfall),
+            None,
+        )
+        .unwrap();
+        let record =
+            CaptureQualificationRecord::new(1, authoritative.clone(), Some(authoritative)).unwrap();
+
+        let state = resolve_capture_qualification_record(
+            &current_context,
+            "runtime-key".into(),
+            Some(record),
+        );
+
+        assert_eq!(
+            state.resolution,
+            QualificationResolution::Unqualified(QualificationMismatch::ContextChanged)
+        );
+        assert_eq!(state.authoritative_rate_shortfalls, None);
+        assert_eq!(
+            state.latest_attempt_rate_shortfalls,
+            Some(RateShortfallsByArm {
+                sequential: Some(RateShortfallsByRole::default()),
+                concurrent: Some(shortfalls),
             })
         );
     }

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -7153,6 +7153,8 @@ pub struct StoredCaptureQualificationState {
     pub resolution: capture_qualification::QualificationResolution,
     pub runtime_key: String,
     pub last_attempt_outcome: Option<capture_qualification::AttemptOutcome>,
+    pub authoritative_rate_shortfalls: Option<irlume_common::diagnostics::RateShortfallsByArm>,
+    pub latest_attempt_rate_shortfalls: Option<irlume_common::diagnostics::RateShortfallsByArm>,
 }
 
 /// Exact live contract a concurrent production pair must satisfy before use.
@@ -7491,20 +7493,42 @@ fn resolve_capture_qualification_state(
     let record = capture_qualification::QualificationStore::system()
         .load(&context)
         .map_err(|error| Error::Hardware(error.to_string()))?;
+    Ok(resolve_capture_qualification_record(
+        &context,
+        runtime_key,
+        record,
+    ))
+}
+
+fn resolve_capture_qualification_record(
+    context: &capture_qualification::QualificationContext,
+    runtime_key: String,
+    record: Option<capture_qualification::CaptureQualificationRecord>,
+) -> StoredCaptureQualificationState {
     let last_attempt_outcome = record
         .as_ref()
         .map(|record| record.last_attempt().outcome().clone());
+    let latest_attempt_rate_shortfalls = record
+        .as_ref()
+        .map(|record| record.last_attempt().rate_shortfalls());
+    let authoritative_rate_shortfalls = record.as_ref().and_then(|record| {
+        record
+            .authoritative()
+            .map(capture_qualification::QualificationAttempt::rate_shortfalls)
+    });
     let resolution = record.map_or(
         capture_qualification::QualificationResolution::Unqualified(
             capture_qualification::QualificationMismatch::NoAuthority,
         ),
-        |record| record.resolve(&context),
+        |record| record.resolve(context),
     );
-    Ok(StoredCaptureQualificationState {
+    StoredCaptureQualificationState {
         resolution,
         runtime_key,
         last_attempt_outcome,
-    })
+        authoritative_rate_shortfalls,
+        latest_attempt_rate_shortfalls,
+    }
 }
 
 fn qualification_arm(
@@ -11710,6 +11734,119 @@ mod tests {
 
     fn runtime_gate_contract() -> RuntimePairContract {
         runtime_gate_contract_with_interval((2, 15))
+    }
+
+    fn qualification_arm_with_shortfalls(
+        completed_rounds: u32,
+        failed_rounds: u32,
+        rate_shortfalls: irlume_common::diagnostics::RateShortfallsByRole,
+    ) -> capture_qualification::ArmEvidence {
+        capture_qualification::ArmEvidence::new(
+            6,
+            completed_rounds,
+            failed_rounds,
+            completed_rounds,
+            completed_rounds,
+            completed_rounds,
+            completed_rounds,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            failed_rounds,
+            rate_shortfalls,
+            Default::default(),
+            0,
+            100.0,
+            100.0,
+            1_000,
+        )
+        .unwrap()
+    }
+
+    fn qualification_shortfall(
+        role: irlume_common::diagnostics::CameraRoleLabel,
+        failure_count: u32,
+    ) -> irlume_common::diagnostics::RateShortfallEvidence {
+        irlume_common::diagnostics::RateShortfallEvidence {
+            role,
+            failure_count,
+            delivered_num: 10,
+            delivered_den: 1,
+            floor_num: 15,
+            floor_den: 1,
+            tolerance_percent: 98,
+            window_count: 30,
+            window_span_us: 3_000_000,
+        }
+    }
+
+    #[test]
+    fn inconclusive_attempt_preserves_authoritative_rate_shortfalls() {
+        use capture_qualification::{
+            AttemptOutcome, CaptureQualificationRecord, InconclusiveReason, QualificationAttempt,
+            QualificationResolution, SequentialReason,
+        };
+        use irlume_common::diagnostics::{
+            CameraRoleLabel, RateShortfallsByArm, RateShortfallsByRole,
+        };
+
+        let context = runtime_gate_contract().context().clone();
+        let healthy = qualification_arm_with_shortfalls(6, 0, RateShortfallsByRole::default());
+        let authoritative_shortfalls = RateShortfallsByRole {
+            rgb: Some(qualification_shortfall(CameraRoleLabel::Rgb, 4)),
+            ir: None,
+        };
+        let authoritative = QualificationAttempt::new(
+            1_786_944_000,
+            context.clone(),
+            healthy.clone(),
+            qualification_arm_with_shortfalls(0, 6, authoritative_shortfalls.clone()),
+            true,
+            AttemptOutcome::SequentialRequired(SequentialReason::DeliveredRateShortfall),
+            None,
+        )
+        .unwrap();
+        let latest_shortfalls = RateShortfallsByRole {
+            rgb: None,
+            ir: Some(qualification_shortfall(CameraRoleLabel::Ir, 1)),
+        };
+        let latest = QualificationAttempt::new(
+            1_786_944_001,
+            context.clone(),
+            healthy,
+            qualification_arm_with_shortfalls(4, 2, latest_shortfalls.clone()),
+            false,
+            AttemptOutcome::Inconclusive(InconclusiveReason::IncompleteRounds),
+            None,
+        )
+        .unwrap();
+        let record = CaptureQualificationRecord::new(2, latest, Some(authoritative)).unwrap();
+
+        let state =
+            resolve_capture_qualification_record(&context, "runtime-key".into(), Some(record));
+
+        assert_eq!(
+            state.resolution,
+            QualificationResolution::SequentialRequired(SequentialReason::DeliveredRateShortfall)
+        );
+        assert_eq!(
+            state.authoritative_rate_shortfalls,
+            Some(RateShortfallsByArm {
+                sequential: Some(RateShortfallsByRole::default()),
+                concurrent: Some(authoritative_shortfalls),
+            })
+        );
+        assert_eq!(
+            state.latest_attempt_rate_shortfalls,
+            Some(RateShortfallsByArm {
+                sequential: Some(RateShortfallsByRole::default()),
+                concurrent: Some(latest_shortfalls),
+            })
+        );
     }
 
     #[test]

--- a/crates/irlume-cli/src/support_report.rs
+++ b/crates/irlume-cli/src/support_report.rs
@@ -6,8 +6,9 @@
 use irlume_common::artifact::SecureArtifact;
 use irlume_common::diagnostics::{
     CaptureSchedule, CaptureScheduleSource, DigestToken, ExactStreamContract, ProbeOutcome,
-    ProbeRoleOutcome, QualificationReason, QualificationState, RuntimeViolationLabel,
-    ShareSafeEventKind, SupportProbeResult, SupportSnapshot, SupportUnavailable, UnavailableReason,
+    ProbeRoleOutcome, QualificationReason, QualificationState, RateShortfallEvidence,
+    RateShortfallsByArm, RateShortfallsByRole, RuntimeViolationLabel, ShareSafeEventKind,
+    SupportProbeResult, SupportSnapshot, SupportUnavailable, UnavailableReason,
 };
 use irlume_common::{Request, Response};
 use serde::Serialize;
@@ -379,6 +380,16 @@ pub(crate) fn render_text(report: &SupportReport) -> Result<Vec<u8>, &'static st
                 .unwrap_or("none"),
         )
         .unwrap();
+        write_rate_shortfall_section(
+            &mut body,
+            "authoritative",
+            capture.authoritative_rate_shortfalls.as_ref(),
+        );
+        write_rate_shortfall_section(
+            &mut body,
+            "latest-attempt",
+            capture.latest_attempt_rate_shortfalls.as_ref(),
+        );
     }
 
     writeln!(body).unwrap();
@@ -726,6 +737,59 @@ fn optional_digest_token_text(value: Option<DigestToken>) -> String {
     value.map_or_else(|| "none".into(), digest_token_text)
 }
 
+fn write_rate_shortfall_role(
+    body: &mut String,
+    arm: &str,
+    role: &str,
+    evidence: &RateShortfallEvidence,
+) {
+    let plural = if evidence.failure_count == 1 { "" } else { "s" };
+    writeln!(
+        body,
+        "    {arm} {role}: {} shortfall{plural}, worst delivered {}/{} fps, required {}/{} fps, tolerance {}%, window {} deltas over {}us",
+        evidence.failure_count,
+        evidence.delivered_num,
+        evidence.delivered_den,
+        evidence.floor_num,
+        evidence.floor_den,
+        evidence.tolerance_percent,
+        evidence.window_count,
+        evidence.window_span_us,
+    )
+    .unwrap();
+}
+
+fn write_rate_shortfall_arm(body: &mut String, arm: &str, evidence: Option<&RateShortfallsByRole>) {
+    let Some(evidence) = evidence else {
+        writeln!(body, "    {arm}: legacy unknown").unwrap();
+        return;
+    };
+    if evidence.rgb.is_none() && evidence.ir.is_none() {
+        writeln!(body, "    {arm}: measured, no delivered-rate shortfalls").unwrap();
+        return;
+    }
+    if let Some(rgb) = &evidence.rgb {
+        write_rate_shortfall_role(body, arm, "RGB", rgb);
+    }
+    if let Some(ir) = &evidence.ir {
+        write_rate_shortfall_role(body, arm, "IR", ir);
+    }
+}
+
+fn write_rate_shortfall_section(
+    body: &mut String,
+    authority: &str,
+    evidence: Option<&RateShortfallsByArm>,
+) {
+    let Some(evidence) = evidence else {
+        writeln!(body, "  {authority} rate shortfalls: unavailable").unwrap();
+        return;
+    };
+    writeln!(body, "  {authority} rate shortfalls").unwrap();
+    write_rate_shortfall_arm(body, "sequential", evidence.sequential.as_ref());
+    write_rate_shortfall_arm(body, "concurrent", evidence.concurrent.as_ref());
+}
+
 fn stream_contract_text(value: &ExactStreamContract) -> String {
     let fourcc = std::str::from_utf8(value.fourcc.as_bytes()).unwrap_or("????");
     format!(
@@ -810,8 +874,8 @@ mod tests {
     use super::*;
     use irlume_common::diagnostics::{
         CameraRoleLabel, CaptureStatus, DigestToken, ExactFraction, ExactStreamContract, FourCc,
-        QualificationReason, QualificationState, RuntimeViolationLabel, SafeLabel,
-        SanitizedCameraContext,
+        QualificationReason, QualificationState, RateShortfallEvidence, RateShortfallsByArm,
+        RateShortfallsByRole, RuntimeViolationLabel, SafeLabel, SanitizedCameraContext,
     };
 
     fn fixture_report() -> SupportReport {
@@ -836,7 +900,10 @@ mod tests {
         }
     }
 
-    fn fixture_camera_report() -> SupportReport {
+    fn fixture_camera_report_with_rate_shortfalls(
+        authoritative_rate_shortfalls: Option<RateShortfallsByArm>,
+        latest_attempt_rate_shortfalls: Option<RateShortfallsByArm>,
+    ) -> SupportReport {
         let stream = ExactStreamContract {
             width: 640,
             height: 480,
@@ -869,6 +936,8 @@ mod tests {
             qualification_reason: Some(QualificationReason::DeliveredRateShortfall),
             qualification_context: Some(DigestToken::from_bytes([0x34; 8])),
             runtime_degradation: Some(RuntimeViolationLabel::DeliveredRateShortfall),
+            authoritative_rate_shortfalls,
+            latest_attempt_rate_shortfalls,
         };
         let mut report = fixture_report();
         report.daemon = Some(SupportSnapshot::bounded(
@@ -880,6 +949,45 @@ mod tests {
             Vec::new(),
         ));
         report
+    }
+
+    fn fixture_camera_report() -> SupportReport {
+        fixture_camera_report_with_rate_shortfalls(
+            Some(RateShortfallsByArm {
+                sequential: None,
+                concurrent: Some(RateShortfallsByRole {
+                    rgb: Some(RateShortfallEvidence {
+                        role: CameraRoleLabel::Rgb,
+                        failure_count: 4,
+                        delivered_num: 10,
+                        delivered_den: 1,
+                        floor_num: 15,
+                        floor_den: 1,
+                        tolerance_percent: 98,
+                        window_count: 30,
+                        window_span_us: 3_000_000,
+                    }),
+                    ir: None,
+                }),
+            }),
+            Some(RateShortfallsByArm {
+                sequential: Some(RateShortfallsByRole::default()),
+                concurrent: Some(RateShortfallsByRole {
+                    rgb: None,
+                    ir: Some(RateShortfallEvidence {
+                        role: CameraRoleLabel::Ir,
+                        failure_count: 1,
+                        delivered_num: 14,
+                        delivered_den: 1,
+                        floor_num: 15,
+                        floor_den: 1,
+                        tolerance_percent: 98,
+                        window_count: 30,
+                        window_span_us: 3_000_000,
+                    }),
+                }),
+            }),
+        )
     }
 
     #[test]
@@ -909,8 +1017,38 @@ mod tests {
         assert!(text.contains(
             "contexts: runtime=5656565656565656 qualification=3434343434343434 degradation=delivered_rate_shortfall"
         ));
+        assert!(text.contains("authoritative rate shortfalls"));
+        assert!(text
+            .contains("concurrent RGB: 4 shortfalls, worst delivered 10/1 fps, required 15/1 fps"));
+        assert!(text.contains("latest-attempt rate shortfalls"));
+        assert!(text.contains("sequential: measured, no delivered-rate shortfalls"));
+        assert!(text
+            .contains("concurrent IR: 1 shortfall, worst delivered 14/1 fps, required 15/1 fps"));
         assert!(!text.contains("/dev/video"));
         assert!(!text.contains("raw-serial"));
+    }
+
+    #[test]
+    fn human_report_distinguishes_legacy_unknown_rate_shortfall_arms() {
+        let report = fixture_camera_report_with_rate_shortfalls(
+            Some(RateShortfallsByArm::default()),
+            Some(RateShortfallsByArm::default()),
+        );
+        let text = String::from_utf8(render_text(&report).unwrap()).unwrap();
+
+        assert!(text.contains("authoritative rate shortfalls"));
+        assert!(text.contains("sequential: legacy unknown"));
+        assert!(text.contains("concurrent: legacy unknown"));
+        assert!(text.contains("latest-attempt rate shortfalls"));
+    }
+
+    #[test]
+    fn human_report_marks_absent_rate_shortfall_sections_unavailable() {
+        let report = fixture_camera_report_with_rate_shortfalls(None, None);
+        let text = String::from_utf8(render_text(&report).unwrap()).unwrap();
+
+        assert!(text.contains("authoritative rate shortfalls: unavailable"));
+        assert!(text.contains("latest-attempt rate shortfalls: unavailable"));
     }
 
     #[test]

--- a/crates/irlume-cli/src/support_report.rs
+++ b/crates/irlume-cli/src/support_report.rs
@@ -1017,13 +1017,15 @@ mod tests {
         assert!(text.contains(
             "contexts: runtime=5656565656565656 qualification=3434343434343434 degradation=delivered_rate_shortfall"
         ));
-        assert!(text.contains("authoritative rate shortfalls"));
-        assert!(text
-            .contains("concurrent RGB: 4 shortfalls, worst delivered 10/1 fps, required 15/1 fps"));
-        assert!(text.contains("latest-attempt rate shortfalls"));
-        assert!(text.contains("sequential: measured, no delivered-rate shortfalls"));
-        assert!(text
-            .contains("concurrent IR: 1 shortfall, worst delivered 14/1 fps, required 15/1 fps"));
+        let rate_sections = concat!(
+            "  authoritative rate shortfalls\n",
+            "    sequential: legacy unknown\n",
+            "    concurrent RGB: 4 shortfalls, worst delivered 10/1 fps, required 15/1 fps, tolerance 98%, window 30 deltas over 3000000us\n",
+            "  latest-attempt rate shortfalls\n",
+            "    sequential: measured, no delivered-rate shortfalls\n",
+            "    concurrent IR: 1 shortfall, worst delivered 14/1 fps, required 15/1 fps, tolerance 98%, window 30 deltas over 3000000us",
+        );
+        assert!(text.contains(rate_sections));
         assert!(!text.contains("/dev/video"));
         assert!(!text.contains("raw-serial"));
     }

--- a/crates/irlume-common/src/diagnostics.rs
+++ b/crates/irlume-common/src/diagnostics.rs
@@ -275,6 +275,35 @@ pub enum CameraRoleLabel {
     Ir,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RateShortfallEvidence {
+    pub role: CameraRoleLabel,
+    pub failure_count: u32,
+    pub delivered_num: u64,
+    pub delivered_den: u64,
+    pub floor_num: u32,
+    pub floor_den: u32,
+    pub tolerance_percent: u32,
+    pub window_count: u32,
+    pub window_span_us: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RateShortfallsByRole {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rgb: Option<RateShortfallEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ir: Option<RateShortfallEvidence>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RateShortfallsByArm {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sequential: Option<RateShortfallsByRole>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrent: Option<RateShortfallsByRole>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct SanitizedCameraContext {
     pub vid: u16,
@@ -462,6 +491,10 @@ pub struct CaptureStatus {
     pub qualification_context: Option<DigestToken>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_degradation: Option<RuntimeViolationLabel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authoritative_rate_shortfalls: Option<RateShortfallsByArm>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_attempt_rate_shortfalls: Option<RateShortfallsByArm>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1081,7 +1114,90 @@ mod tests {
             qualification_reason: Some(QualificationReason::DeliveredRateShortfall),
             qualification_context: Some(DigestToken::from_bytes([0x78; 8])),
             runtime_degradation: Some(RuntimeViolationLabel::DeliveredRateShortfall),
+            authoritative_rate_shortfalls: None,
+            latest_attempt_rate_shortfalls: None,
         }
+    }
+
+    #[test]
+    fn rate_shortfall_contract_serializes_exact_fixed_slots() {
+        let shortfalls = RateShortfallsByArm {
+            sequential: Some(RateShortfallsByRole::default()),
+            concurrent: Some(RateShortfallsByRole {
+                rgb: Some(RateShortfallEvidence {
+                    role: CameraRoleLabel::Rgb,
+                    failure_count: 4,
+                    delivered_num: 10,
+                    delivered_den: 1,
+                    floor_num: 15,
+                    floor_den: 1,
+                    tolerance_percent: 98,
+                    window_count: 30,
+                    window_span_us: 3_000_000,
+                }),
+                ir: Some(RateShortfallEvidence {
+                    role: CameraRoleLabel::Ir,
+                    failure_count: 1,
+                    delivered_num: 29_761,
+                    delivered_den: 1_000,
+                    floor_num: 30,
+                    floor_den: 1,
+                    tolerance_percent: 98,
+                    window_count: 30,
+                    window_span_us: 1_008_030,
+                }),
+            }),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&shortfalls).unwrap(),
+            serde_json::json!({
+                "sequential": {},
+                "concurrent": {
+                    "rgb": {
+                        "role": "rgb",
+                        "failure_count": 4,
+                        "delivered_num": 10,
+                        "delivered_den": 1,
+                        "floor_num": 15,
+                        "floor_den": 1,
+                        "tolerance_percent": 98,
+                        "window_count": 30,
+                        "window_span_us": 3_000_000
+                    },
+                    "ir": {
+                        "role": "ir",
+                        "failure_count": 1,
+                        "delivered_num": 29_761,
+                        "delivered_den": 1_000,
+                        "floor_num": 30,
+                        "floor_den": 1,
+                        "tolerance_percent": 98,
+                        "window_count": 30,
+                        "window_span_us": 1_008_030
+                    }
+                }
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<RateShortfallsByArm>(
+                serde_json::to_value(&shortfalls).unwrap()
+            )
+            .unwrap(),
+            shortfalls
+        );
+        assert_eq!(
+            serde_json::to_value(RateShortfallsByArm::default()).unwrap(),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn old_capture_status_defaults_rate_shortfall_sections_to_absent() {
+        let old = r#"{"schedule":"sequential","source":"stored_qualification","qualification_state":"measured_sequential"}"#;
+        let status: CaptureStatus = serde_json::from_str(old).unwrap();
+        assert_eq!(status.authoritative_rate_shortfalls, None);
+        assert_eq!(status.latest_attempt_rate_shortfalls, None);
     }
 
     fn event(sequence: u64) -> ShareSafeEvent {

--- a/crates/irlume-daemon/src/diagnostics.rs
+++ b/crates/irlume-daemon/src/diagnostics.rs
@@ -659,6 +659,8 @@ mod tests {
             qualification_reason: None,
             qualification_context: Some(DigestToken::from_bytes([2; 8])),
             runtime_degradation: None,
+            authoritative_rate_shortfalls: None,
+            latest_attempt_rate_shortfalls: None,
         };
 
         operation.publish_support_context(capture.clone(), vec![camera()]);

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1566,8 +1566,30 @@ mod worker_engine {
 
     #[cfg(test)]
     mod tune_message_tests {
-        use super::super::camera_tune_verdict_message;
+        use super::super::{camera_tune_verdict_message, incomplete_probe_why};
         use irlume_auth::{AttemptOutcome, ContentionReport, PairSample, SequentialReason};
+        use irlume_common::diagnostics::{
+            CameraRoleLabel, RateShortfallEvidence, RateShortfallsByRole,
+        };
+
+        fn rate_shortfall(
+            role: CameraRoleLabel,
+            failure_count: u32,
+            delivered_num: u64,
+            floor_num: u32,
+        ) -> RateShortfallEvidence {
+            RateShortfallEvidence {
+                role,
+                failure_count,
+                delivered_num,
+                delivered_den: 1,
+                floor_num,
+                floor_den: 1,
+                tolerance_percent: 98,
+                window_count: 30,
+                window_span_us: 3_000_000,
+            }
+        }
 
         fn healthy_concurrent(rounds: usize, continuous: usize) -> ContentionReport {
             ContentionReport {
@@ -1589,6 +1611,7 @@ mod worker_engine {
                     arm_failures: 0,
                     capture_failures: 0,
                     rate_shortfall_failures: 0,
+                    rate_shortfalls: Default::default(),
                     continuity_facts: Default::default(),
                     capture_failure_facts: Default::default(),
                     ir_camera_classified_frames: 0,
@@ -1611,6 +1634,7 @@ mod worker_engine {
                     arm_failures: 0,
                     capture_failures: 0,
                     rate_shortfall_failures: 0,
+                    rate_shortfalls: Default::default(),
                     continuity_facts: Default::default(),
                     capture_failure_facts: Default::default(),
                     ir_camera_classified_frames: 0,
@@ -1840,6 +1864,114 @@ mod worker_engine {
             );
             assert!(msg.starts_with("capture mode sequential for this camera"));
             assert!(msg.contains("delivered-rate"), "{msg}");
+        }
+
+        #[test]
+        fn rate_shortfall_verdict_names_one_role_with_exact_facts() {
+            let mut report = healthy_concurrent(5, 5);
+            report.concurrent.rate_floor_rounds = 1;
+            report.concurrent.rate_shortfall_failures = 4;
+            report.concurrent.rate_shortfalls.rgb =
+                Some(rate_shortfall(CameraRoleLabel::Rgb, 4, 10, 15));
+
+            let message = camera_tune_verdict_message(
+                &report,
+                AttemptOutcome::SequentialRequired(SequentialReason::DeliveredRateShortfall),
+                5,
+            );
+
+            assert!(message.contains("RGB: 4 shortfalls"), "{message}");
+            assert!(
+                message.contains("worst delivered 10/1 fps; required 15/1 fps"),
+                "{message}"
+            );
+            assert!(
+                message.contains("tolerance 98%; window 30 deltas over 3000000us"),
+                "{message}"
+            );
+            assert!(!message.contains("IR:"), "{message}");
+        }
+
+        #[test]
+        fn rate_shortfall_verdict_names_simultaneous_roles_rgb_first() {
+            let mut report = healthy_concurrent(5, 5);
+            report.concurrent.rate_floor_rounds = 0;
+            report.concurrent.rate_shortfall_failures = 5;
+            report.concurrent.rate_shortfalls = RateShortfallsByRole {
+                rgb: Some(rate_shortfall(CameraRoleLabel::Rgb, 4, 10, 15)),
+                ir: Some(rate_shortfall(CameraRoleLabel::Ir, 2, 20, 30)),
+            };
+
+            let message = camera_tune_verdict_message(
+                &report,
+                AttemptOutcome::SequentialRequired(SequentialReason::DeliveredRateShortfall),
+                5,
+            );
+
+            let rgb = message.find("RGB: 4 shortfalls").expect("RGB facts");
+            let ir = message.find("IR: 2 shortfalls").expect("IR facts");
+            assert!(rgb < ir, "RGB facts must precede IR facts: {message}");
+            assert!(
+                message.contains("worst delivered 20/1 fps; required 30/1 fps"),
+                "{message}"
+            );
+        }
+
+        #[test]
+        fn rate_shortfall_all_error_verdict_keeps_typed_role_facts() {
+            let mut report = healthy_concurrent(5, 5);
+            report.concurrent = PairSample {
+                failed: 5,
+                rate_shortfall_failures: 5,
+                rate_shortfalls: RateShortfallsByRole {
+                    rgb: Some(rate_shortfall(CameraRoleLabel::Rgb, 5, 10, 15)),
+                    ir: Some(rate_shortfall(CameraRoleLabel::Ir, 3, 20, 30)),
+                },
+                ..Default::default()
+            };
+
+            let message = camera_tune_verdict_message(
+                &report,
+                AttemptOutcome::SequentialRequired(SequentialReason::ConcurrentUnavailable),
+                5,
+            );
+
+            assert!(
+                message.contains("all 5 concurrent attempts errored"),
+                "{message}"
+            );
+            assert!(message.contains("RGB: 5 shortfalls"), "{message}");
+            assert!(message.contains("IR: 3 shortfalls"), "{message}");
+            assert!(
+                message.contains("tolerance 98%; window 30 deltas over 3000000us"),
+                "{message}"
+            );
+        }
+
+        #[test]
+        fn rate_shortfall_inconclusive_message_reports_one_of_five_partial_facts() {
+            let mut report = healthy_concurrent(5, 5);
+            report.concurrent.rounds = 1;
+            report.concurrent.failed = 4;
+            report.concurrent.rate_shortfall_failures = 4;
+            report.concurrent.rate_shortfalls.rgb =
+                Some(rate_shortfall(CameraRoleLabel::Rgb, 4, 10, 15));
+
+            let message = incomplete_probe_why(&report, 5);
+
+            assert!(
+                message.contains("1 of 5 concurrent rounds completed"),
+                "{message}"
+            );
+            assert!(message.contains("RGB: 4 shortfalls"), "{message}");
+            assert!(
+                message.contains("worst delivered 10/1 fps; required 15/1 fps"),
+                "{message}"
+            );
+            assert!(
+                message.contains("tolerance 98%; window 30 deltas over 3000000us"),
+                "{message}"
+            );
         }
 
         /// #612: an inconclusive probe that leaves a previous authority in
@@ -3376,7 +3508,7 @@ fn run_capture_mode_probe(
                 report.sequential.rgb_mean
             )
         } else {
-            format!("the probe did not complete {rounds} clean rounds in both capture modes")
+            incomplete_probe_why(report, rounds)
         };
         return Ok(inconclusive_probe_message(
             &why,
@@ -3391,6 +3523,47 @@ fn run_capture_mode_probe(
         persisted_outcome,
         rounds,
     ))
+}
+
+/// Exact typed delivered-rate facts in stable role order. The role labels come
+/// from the fixed DTO slots, not from inference or aggregate failure counts.
+fn format_rate_shortfall_facts(
+    shortfalls: &irlume_common::diagnostics::RateShortfallsByRole,
+) -> String {
+    let mut facts = Vec::with_capacity(2);
+    for (label, evidence) in [
+        ("RGB", shortfalls.rgb.as_ref()),
+        ("IR", shortfalls.ir.as_ref()),
+    ] {
+        if let Some(evidence) = evidence {
+            facts.push(format!(
+                "{label}: {} shortfalls; worst delivered {}/{} fps; required {}/{} fps; \
+                 tolerance {}%; window {} deltas over {}us",
+                evidence.failure_count,
+                evidence.delivered_num,
+                evidence.delivered_den,
+                evidence.floor_num,
+                evidence.floor_den,
+                evidence.tolerance_percent,
+                evidence.window_count,
+                evidence.window_span_us,
+            ));
+        }
+    }
+    if facts.is_empty() {
+        String::new()
+    } else {
+        format!("; rate shortfalls: {}", facts.join("; "))
+    }
+}
+
+fn incomplete_probe_why(report: &irlume_auth::ContentionReport, rounds: usize) -> String {
+    let rate_facts = format_rate_shortfall_facts(&report.concurrent.rate_shortfalls);
+    format!(
+        "the probe did not complete {rounds} clean rounds in both capture modes \
+         ({} of {rounds} concurrent rounds completed, {} errored{rate_facts})",
+        report.concurrent.rounds, report.concurrent.failed,
+    )
 }
 
 /// The message for a probe whose attempt was inconclusive, so no NEW verdict
@@ -3473,9 +3646,10 @@ fn camera_tune_verdict_message(
                 .collect();
             format!(" ({})", named.join("; "))
         };
+        let rate_facts = format_rate_shortfall_facts(&report.concurrent.rate_shortfalls);
         return format!(
             "capture mode sequential for this camera: it cannot stream RGB and IR \
-             at once (all {} concurrent attempts errored{detail}; {} sequential \
+             at once (all {} concurrent attempts errored{detail}{rate_facts}; {} sequential \
              round(s) completed, {} errored; a trailing one-at-a-time \
              control confirmed the camera still answers)",
             report.concurrent.failed, report.sequential.rounds, report.sequential.failed,
@@ -3525,11 +3699,16 @@ fn camera_tune_verdict_message(
                         rounds - report.concurrent.continuous_rounds.min(rounds),
                     )
                 }
-                irlume_auth::SequentialReason::DeliveredRateShortfall => format!(
-                    "concurrent rounds failed their delivered-rate floors ({} below floor), \
-                     so the safe one-at-a-time mode is what was measured and persisted",
-                    rounds - report.concurrent.rate_floor_rounds.min(rounds),
-                ),
+                irlume_auth::SequentialReason::DeliveredRateShortfall => {
+                    let rate_facts =
+                        format_rate_shortfall_facts(&report.concurrent.rate_shortfalls);
+                    format!(
+                        "concurrent rounds failed their delivered-rate floors ({} below floor\
+                         {rate_facts}), so the safe one-at-a-time mode is what was measured \
+                         and persisted",
+                        rounds - report.concurrent.rate_floor_rounds.min(rounds),
+                    )
+                }
                 irlume_auth::SequentialReason::SignalLoss => {
                     // #606 (the T14s report): a concurrent arm that classified
                     // ZERO illumination-metadata frames while the sequential

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -1974,6 +1974,45 @@ mod worker_engine {
             );
         }
 
+        #[test]
+        fn rate_shortfall_inconclusive_message_labels_partial_sequential_and_concurrent_arms() {
+            let mut report = healthy_concurrent(5, 5);
+            report.sequential.rounds = 1;
+            report.sequential.failed = 4;
+            report.sequential.rate_shortfall_failures = 4;
+            report.sequential.rate_shortfalls.ir =
+                Some(rate_shortfall(CameraRoleLabel::Ir, 4, 8, 15));
+            report.concurrent.rounds = 1;
+            report.concurrent.failed = 4;
+            report.concurrent.rate_shortfall_failures = 4;
+            report.concurrent.rate_shortfalls.rgb =
+                Some(rate_shortfall(CameraRoleLabel::Rgb, 4, 10, 15));
+
+            let message = incomplete_probe_why(&report, 5);
+
+            assert!(
+                message.contains("1 of 5 concurrent rounds completed, 4 errored"),
+                "{message}"
+            );
+            assert!(
+                message.contains(
+                    "sequential rate shortfalls: IR: 4 shortfalls; worst delivered 8/1 fps; \
+                     required 15/1 fps; tolerance 98%; window 30 deltas over 3000000us"
+                ),
+                "{message}"
+            );
+            assert!(
+                message.contains(
+                    "concurrent rate shortfalls: RGB: 4 shortfalls; worst delivered 10/1 fps; \
+                     required 15/1 fps; tolerance 98%; window 30 deltas over 3000000us"
+                ),
+                "{message}"
+            );
+            let sequential = message.find("sequential rate shortfalls").unwrap();
+            let concurrent = message.find("concurrent rate shortfalls").unwrap();
+            assert!(sequential < concurrent, "{message}");
+        }
+
         /// #612: an inconclusive probe that leaves a previous authority in
         /// force must not tell the operator nothing is stored. The message
         /// names the stored verdict instead of the bare "left unmeasured".
@@ -3557,11 +3596,26 @@ fn format_rate_shortfall_facts(
     }
 }
 
+fn format_arm_rate_shortfall_facts(
+    arm: &str,
+    shortfalls: &irlume_common::diagnostics::RateShortfallsByRole,
+) -> String {
+    format_rate_shortfall_facts(shortfalls)
+        .strip_prefix("; rate shortfalls: ")
+        .map_or_else(String::new, |facts| {
+            format!("; {arm} rate shortfalls: {facts}")
+        })
+}
+
 fn incomplete_probe_why(report: &irlume_auth::ContentionReport, rounds: usize) -> String {
-    let rate_facts = format_rate_shortfall_facts(&report.concurrent.rate_shortfalls);
+    let sequential_rate_facts =
+        format_arm_rate_shortfall_facts("sequential", &report.sequential.rate_shortfalls);
+    let concurrent_rate_facts =
+        format_arm_rate_shortfall_facts("concurrent", &report.concurrent.rate_shortfalls);
     format!(
         "the probe did not complete {rounds} clean rounds in both capture modes \
-         ({} of {rounds} concurrent rounds completed, {} errored{rate_facts})",
+         ({} of {rounds} concurrent rounds completed, {} errored{sequential_rate_facts}\
+          {concurrent_rate_facts})",
         report.concurrent.rounds, report.concurrent.failed,
     )
 }

--- a/docs/superpowers/plans/2026-08-31-rate-shortfall-evidence.md
+++ b/docs/superpowers/plans/2026-08-31-rate-shortfall-evidence.md
@@ -1,0 +1,342 @@
+# Per-Role Delivered-Rate Shortfall Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist and present exact per-role delivered-rate shortfall evidence without changing capture qualification or authentication policy.
+
+**Architecture:** Add fixed-size share-safe DTOs in `irlume-common`, fold typed `Error::DeliveredRate` payloads into each camera probe arm, and persist the measured summary as an additive optional field in schema-2 `ArmEvidence`. Project authoritative and latest-attempt evidence separately through the existing camera-to-auth diagnostic path, then render exact facts in `camera-tune` and support reports.
+
+**Tech Stack:** Rust, Serde, Cargo unit tests, existing `irlume-common`, `irlume-camera`, `irlume-auth`, `irlume-daemon`, and `irlume-cli` crates.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-rate-shortfall-evidence-design.md`
+
+## Global Constraints
+
+- Keep capture qualification schema version exactly `2`.
+- Do not change delivered-rate floors, the `98` percent tolerance, retry counts, requested rounds, outcomes, authority replacement, capture schedules, or authentication behavior.
+- Use fixed RGB and IR slots, never an unbounded map or vector.
+- Compare delivered-to-floor ratios with exact integer arithmetic, never floating point.
+- Preserve missing persisted evidence as legacy unknown and fresh empty evidence as measured empty.
+- Label authoritative and latest-attempt evidence separately.
+- Keep all output share-safe and free of device paths, serial values, frames, embeddings, and identity.
+- Use plain punctuation and introduce no U+2014 em dash.
+
+---
+
+### Task 1: Fixed-Size Common Evidence Contract
+
+**Files:**
+- Modify: `crates/irlume-common/src/diagnostics.rs:271-465`
+- Test: `crates/irlume-common/src/diagnostics.rs:1040-1200`
+
+**Interfaces:**
+- Consumes: existing `CameraRoleLabel` and Serde support.
+- Produces: `RateShortfallEvidence`, `RateShortfallsByRole`, and `RateShortfallsByArm`; additive `CaptureStatus.authoritative_rate_shortfalls` and `CaptureStatus.latest_attempt_rate_shortfalls` fields.
+
+- [ ] **Step 1: Write failing DTO and old-wire tests**
+
+Add tests that construct fixed RGB and IR slots, serialize exact numerator and denominator fields, reject no data implicitly by preserving `Option`, and deserialize the pre-#644 `CaptureStatus` JSON with both new fields equal to `None`:
+
+```rust
+#[test]
+fn old_capture_status_defaults_rate_shortfall_sections_to_absent() {
+    let old = r#"{"schedule":"sequential","source":"stored_qualification","qualification_state":"measured_sequential"}"#;
+    let status: CaptureStatus = serde_json::from_str(old).unwrap();
+    assert_eq!(status.authoritative_rate_shortfalls, None);
+    assert_eq!(status.latest_attempt_rate_shortfalls, None);
+}
+```
+
+- [ ] **Step 2: Run the common test and verify RED**
+
+Run: `cargo test -p irlume-common --lib old_capture_status_defaults_rate_shortfall_sections_to_absent`
+
+Expected: compilation fails because the new fields and DTOs do not exist.
+
+- [ ] **Step 3: Implement the bounded DTOs and additive fields**
+
+Define the DTO shape with public serializable fields so downstream presentation stays mechanical:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RateShortfallEvidence {
+    pub role: CameraRoleLabel,
+    pub failure_count: u32,
+    pub delivered_num: u64,
+    pub delivered_den: u64,
+    pub floor_num: u32,
+    pub floor_den: u32,
+    pub tolerance_percent: u32,
+    pub window_count: u32,
+    pub window_span_us: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RateShortfallsByRole {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rgb: Option<RateShortfallEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ir: Option<RateShortfallEvidence>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RateShortfallsByArm {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sequential: Option<RateShortfallsByRole>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrent: Option<RateShortfallsByRole>,
+}
+```
+
+Add both `CaptureStatus` fields with `#[serde(default, skip_serializing_if = "Option::is_none")]` and update existing fixtures with `None`.
+
+- [ ] **Step 4: Run common tests and verify GREEN**
+
+Run: `cargo test -p irlume-common --lib diagnostics::tests`
+
+Expected: all diagnostics tests pass, including old-wire compatibility and share-safe key checks.
+
+- [ ] **Step 5: Commit the contract slice**
+
+```bash
+git add crates/irlume-common/src/diagnostics.rs
+git commit -s -m "feat: define rate shortfall diagnostics"
+```
+
+### Task 2: Exact Accumulation And Schema-2 Persistence
+
+**Files:**
+- Modify: `crates/irlume-camera/src/lib.rs:6490-6577,7483-7555,8079-8119,12293-12479`
+- Modify: `crates/irlume-camera/src/capture_qualification.rs:801-966,1015-1064,1170-1282,1658-1739`
+- Test: `crates/irlume-camera/src/lib.rs`
+- Test: `crates/irlume-camera/src/capture_qualification.rs`
+
+**Interfaces:**
+- Consumes: common DTOs from Task 1 and existing `CameraStreamRateEvidence` payloads.
+- Produces: `PairSample.rate_shortfalls: RateShortfallsByRole`, `ArmEvidence::rate_shortfalls() -> Option<&RateShortfallsByRole>`, and `QualificationAttempt::rate_shortfalls() -> RateShortfallsByArm`.
+
+- [ ] **Step 1: Write failing exact-accumulation tests**
+
+Extend the existing `below_floor_error` helper to accept exact delivered and floor fractions. Add tests proving that two RGB errors retain the lower exact delivered-to-floor ratio even when decimal rounding would tie, and that one round with RGB and IR typed errors increments the round failure once while creating one count in each role slot.
+
+```rust
+assert_eq!(sample.failed, 1);
+assert_eq!(sample.rate_shortfall_failures, 1);
+assert_eq!(sample.rate_shortfalls.rgb.as_ref().unwrap().failure_count, 1);
+assert_eq!(sample.rate_shortfalls.ir.as_ref().unwrap().failure_count, 1);
+```
+
+- [ ] **Step 2: Run focused accumulation tests and verify RED**
+
+Run: `cargo test -p irlume-camera --lib rate_shortfall -- --nocapture`
+
+Expected: compilation fails because `PairSample.rate_shortfalls` does not exist.
+
+- [ ] **Step 3: Implement exact fixed-slot observation**
+
+Add a private observer that parses only `rgb` and `ir`, increments that slot's failure count, and replaces the retained sample only when its exact ratio is lower. Form each ratio as `(delivered_num * floor_den) / (delivered_den * floor_num)` in `u128`, then compare two `u128` fractions with quotient and remainder steps rather than overflow-prone cross multiplication. Keep the existing per-round `rate_shortfall_failures` count and observe both error legs before returning.
+
+- [ ] **Step 4: Run focused accumulation tests and verify GREEN**
+
+Run: `cargo test -p irlume-camera --lib rate_shortfall -- --nocapture`
+
+Expected: worst-sample and simultaneous-role tests pass; existing typed shortfall tests remain green.
+
+- [ ] **Step 5: Write failing persistence semantics tests**
+
+Add tests that remove `rate_shortfalls` from serialized `ArmEvidence` and observe `None`, construct a current healthy arm and observe `Some(RateShortfallsByRole::default())`, round-trip RGB and IR evidence, and assert `SCHEMA_VERSION == 2`.
+
+```rust
+assert_eq!(legacy.rate_shortfalls(), None);
+assert_eq!(fresh.rate_shortfalls(), Some(&RateShortfallsByRole::default()));
+assert_eq!(SCHEMA_VERSION, 2);
+```
+
+- [ ] **Step 6: Run persistence tests and verify RED**
+
+Run: `cargo test -p irlume-camera --lib capture_qualification::tests::rate_shortfall`
+
+Expected: compilation fails because `ArmEvidence` has no optional persisted summary or getter.
+
+- [ ] **Step 7: Implement additive persistence and attempt projection**
+
+Add `#[serde(default, skip_serializing_if = "Option::is_none")] rate_shortfalls: Option<RateShortfallsByRole>` to `ArmEvidence`. Add a concrete `RateShortfallsByRole` argument to `ArmEvidence::new`, store it as `Some`, pass `PairSample.rate_shortfalls.clone()` from `qualification_arm`, and update all constructor call sites with measured-empty values. Validate that populated RGB and IR slots carry their matching role and nonzero failure counts and denominators. Add getters and build `RateShortfallsByArm` from the sequential and concurrent arm options without changing outcome logic.
+
+- [ ] **Step 8: Run camera tests and verify GREEN**
+
+Run: `cargo test -p irlume-camera --lib`
+
+Expected: all runnable camera tests pass; hardware-only tests remain ignored.
+
+- [ ] **Step 9: Commit the accumulation and persistence slice**
+
+```bash
+git add crates/irlume-camera/src/lib.rs crates/irlume-camera/src/capture_qualification.rs
+git commit -s -m "feat: persist per-role rate shortfalls"
+```
+
+### Task 3: Preserve Authoritative And Latest Attempt Evidence
+
+**Files:**
+- Modify: `crates/irlume-camera/src/lib.rs:7148-7154,7483-7506`
+- Modify: `crates/irlume-auth/src/lib.rs:1334-1448,1476-1600,2000-2123`
+- Test: `crates/irlume-camera/src/capture_qualification.rs`
+- Test: `crates/irlume-auth/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `QualificationAttempt::rate_shortfalls()` from Task 2.
+- Produces: `StoredCaptureQualificationState.authoritative_rate_shortfalls`, `StoredCaptureQualificationState.latest_attempt_rate_shortfalls`, and matching `CaptureStatus` projection.
+
+- [ ] **Step 1: Write failing authority-preservation tests**
+
+Create a conclusive authoritative attempt with a concurrent RGB shortfall, then save an inconclusive latest attempt with a different IR shortfall. Assert that resolution still uses the original authority and that the two projected summaries remain distinct.
+
+```rust
+assert_eq!(state.resolution, QualificationResolution::SequentialRequired(SequentialReason::DeliveredRateShortfall));
+assert_eq!(state.authoritative_rate_shortfalls.unwrap().concurrent.unwrap().rgb.unwrap().failure_count, 4);
+assert_eq!(state.latest_attempt_rate_shortfalls.unwrap().concurrent.unwrap().ir.unwrap().failure_count, 1);
+```
+
+- [ ] **Step 2: Run authority tests and verify RED**
+
+Run: `cargo test -p irlume-camera --lib inconclusive_attempt_preserves_authoritative_rate_shortfalls`
+
+Expected: compilation fails because stored state exposes no evidence fields.
+
+- [ ] **Step 3: Project both record views through camera state**
+
+In `resolve_capture_qualification_state`, derive latest evidence from `record.last_attempt()` and authoritative evidence from `record.authoritative()` before resolving the record. Preserve `None` when no record or no authority exists.
+
+- [ ] **Step 4: Write failing auth support-context tests**
+
+Extend capture-selection fixtures so `emit_capture_context` publishes a `CaptureStatus` with separately labeled authoritative and latest-attempt values. Assert an inconclusive latest attempt does not overwrite the authoritative field.
+
+- [ ] **Step 5: Run auth tests and verify RED**
+
+Run: `cargo test -p irlume-auth --lib rate_shortfall`
+
+Expected: compilation fails because `CaptureModeSelection` and `CaptureStatus` do not carry the new fields.
+
+- [ ] **Step 6: Thread evidence through auth diagnostics only**
+
+Add the two optional summaries to `CaptureModeSelection`, populate them from `StoredCaptureQualificationState`, default them to `None` for unavailable and RGB-only selections, and copy them into `CaptureStatus` in `emit_capture_context`. Do not consult either field in schedule selection, runtime degradation, liveness, or authentication.
+
+- [ ] **Step 7: Run camera and auth tests and verify GREEN**
+
+Run: `cargo test -p irlume-camera -p irlume-auth --lib`
+
+Expected: all runnable tests pass and the authority-preservation regression is green.
+
+- [ ] **Step 8: Commit the diagnostic projection slice**
+
+```bash
+git add crates/irlume-camera/src/lib.rs crates/irlume-auth/src/lib.rs
+git commit -s -m "feat: expose qualification rate evidence"
+```
+
+### Task 4: Camera-Tune Exact Facts
+
+**Files:**
+- Modify: `crates/irlume-daemon/src/main.rs:1569-1845,3273-3574`
+- Test: `crates/irlume-daemon/src/main.rs`
+
+**Interfaces:**
+- Consumes: `ContentionReport` and `PairSample.rate_shortfalls` from Task 2.
+- Produces: stable human-readable per-role exact-rate wording for conclusive and inconclusive `camera-tune` results.
+
+- [ ] **Step 1: Write failing conclusive and partial wording tests**
+
+Add one report with four RGB typed shortfalls and one completed concurrent round, and one conclusive all-shortfall report with both roles represented. Assert the text includes role, count, exact delivered and required rates, tolerance, and window facts. The partial assertion must include the observed `1 of 5` shape rather than claiming five clean rounds.
+
+```rust
+assert!(message.contains("RGB: 4 shortfalls"));
+assert!(message.contains("worst delivered 10/1 fps; required 15/1 fps"));
+assert!(message.contains("tolerance 98%; window 30 deltas over 3000000us"));
+```
+
+- [ ] **Step 2: Run daemon wording tests and verify RED**
+
+Run: `cargo test -p irlume-daemon --bin irlumed rate_shortfall -- --nocapture`
+
+Expected: assertions fail because current wording prints only aggregate below-floor counts.
+
+- [ ] **Step 3: Implement one bounded formatter and use it in both paths**
+
+Add a pure formatter that emits RGB then IR from fixed slots. Append it to delivered-rate sequential verdicts, the all-error early return when typed rate evidence exists, and the incomplete-round `why` passed to `inconclusive_probe_message`. Keep existing verdict and authority wording intact.
+
+- [ ] **Step 4: Run daemon tests and verify GREEN**
+
+Run: `cargo test -p irlume-daemon --bin irlumed rate_shortfall -- --nocapture`
+
+Expected: conclusive, simultaneous-role, and partial-attempt wording tests pass.
+
+- [ ] **Step 5: Commit the camera-tune slice**
+
+```bash
+git add crates/irlume-daemon/src/main.rs
+git commit -s -m "feat: report exact camera rate shortfalls"
+```
+
+### Task 5: Support Report And Final Verification
+
+**Files:**
+- Modify: `crates/irlume-cli/src/support_report.rs:331-382,808-924`
+- Modify fixtures: `crates/irlume-daemon/src/diagnostics.rs:620-669`
+- Modify fixtures: `crates/irlume-common/src/diagnostics.rs:1075-1085`
+
+**Interfaces:**
+- Consumes: the two additive `CaptureStatus` evidence fields from Task 1 and populated values from Task 3.
+- Produces: separately labeled authoritative and latest-attempt support-report sections with explicit unknown, measured-empty, and measured-shortfall states.
+
+- [ ] **Step 1: Write failing support rendering tests**
+
+Extend the support fixture so authoritative concurrent RGB has four shortfalls, latest sequential is measured-empty, and latest concurrent IR has one shortfall. Add a legacy fixture with absent arm evidence. Assert exact labels and values:
+
+```rust
+assert!(text.contains("authoritative rate shortfalls"));
+assert!(text.contains("concurrent RGB: 4 shortfalls, worst delivered 10/1 fps, required 15/1 fps"));
+assert!(text.contains("latest-attempt rate shortfalls"));
+assert!(text.contains("sequential: measured, no delivered-rate shortfalls"));
+assert!(legacy_text.contains("concurrent: legacy unknown"));
+```
+
+- [ ] **Step 2: Run support tests and verify RED**
+
+Run: `cargo test -p irlume-cli --bin irlume support_report::tests::human_report_includes_sanitized_topology_contracts_and_capture_authority -- --exact`
+
+Expected: assertions fail because no rate-evidence sections are rendered.
+
+- [ ] **Step 3: Implement bounded support rendering**
+
+Add pure helpers for one role, one arm, and one authority label. Render absent outer evidence as unavailable, absent arm evidence as legacy unknown, empty fixed slots as measured with no shortfalls, and populated slots with exact facts. Keep the report schema unchanged because the source `CaptureStatus` fields are additive and defaulted.
+
+- [ ] **Step 4: Run support and daemon diagnostic tests and verify GREEN**
+
+Run: `cargo test -p irlume-cli --bin irlume support_report::tests`
+
+Run: `cargo test -p irlume-daemon --bin irlumed diagnostics::tests`
+
+Expected: all targeted tests pass and existing privacy assertions still reject paths and identity fields.
+
+- [ ] **Step 5: Run formatting, static checks, and the full workspace gate**
+
+Run: `cargo fmt --all -- --check`
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+
+Run: `cargo test --workspace --all-targets --all-features`
+
+Run: `git diff --check`
+
+Run: `! git diff --unified=0 f8698b49 -- crates/irlume-common/src/diagnostics.rs crates/irlume-camera/src/lib.rs crates/irlume-camera/src/capture_qualification.rs crates/irlume-auth/src/lib.rs crates/irlume-daemon/src/main.rs crates/irlume-daemon/src/diagnostics.rs | rg '^\+.*\u2014'`
+
+Run: `! rg -n $'\u2014' crates/irlume-cli/src/support_report.rs docs/superpowers/specs/2026-08-31-rate-shortfall-evidence-design.md docs/superpowers/plans/2026-08-31-rate-shortfall-evidence.md`
+
+Expected: formatting, Clippy, tests, diff hygiene, and plain-punctuation checks all pass. Hardware-dependent tests may remain explicitly ignored.
+
+- [ ] **Step 6: Commit the support and verification slice**
+
+```bash
+git add crates/irlume-cli/src/support_report.rs crates/irlume-daemon/src/diagnostics.rs crates/irlume-common/src/diagnostics.rs docs/superpowers/specs/2026-08-31-rate-shortfall-evidence-design.md docs/superpowers/plans/2026-08-31-rate-shortfall-evidence.md
+git commit -s -m "feat: render qualification rate evidence"
+```

--- a/docs/superpowers/specs/2026-08-31-rate-shortfall-evidence-design.md
+++ b/docs/superpowers/specs/2026-08-31-rate-shortfall-evidence-design.md
@@ -1,0 +1,48 @@
+# Per-Role Delivered-Rate Shortfall Evidence Design
+
+## Problem
+
+Capture qualification already receives typed `Error::DeliveredRate` payloads with the exact role, delivered rate, required floor, tolerance, and rolling-window facts. The qualification accumulator currently discards that payload and retains only a round count. A stored sequential verdict and a partial `camera-tune` attempt therefore cannot explain which stream missed its floor or by how much.
+
+## Scope
+
+Add diagnostics-only evidence for issue #644. Preserve every qualification threshold, tolerance, retry count, attempt outcome, authority replacement rule, capture schedule, and authentication decision.
+
+## Data Contract
+
+`irlume-common` owns the share-safe DTOs:
+
+- `RateShortfallEvidence` records a typed RGB or IR role, failure count, worst exact delivered rate, exact required floor, tolerance percent, window count, and window span.
+- `RateShortfallsByRole` has fixed optional RGB and IR slots. No map or unbounded collection is permitted.
+- `RateShortfallsByArm` has optional sequential and concurrent `RateShortfallsByRole` values.
+
+The worst sample for one role is the minimum exact delivered-to-floor ratio. Selection uses integer arithmetic and must not convert the ratio to floating point. A round in which both streams report `Error::DeliveredRate` increments the arm's failed-round count once and each role's shortfall count once.
+
+## Persistence Semantics
+
+`ArmEvidence` gains an additive `Option<RateShortfallsByRole>` field:
+
+- Missing field or `None`: a legacy producer did not record per-role shortfall evidence.
+- `Some` with empty RGB and IR slots: a current producer measured the arm and observed no typed shortfall.
+- `Some` with one or both slots: a current producer measured typed shortfalls.
+
+Fresh `ArmEvidence::new` values always store `Some`, including measured-empty values. Capture qualification schema version remains `2`; old schema-2 records continue to deserialize and validate.
+
+## Authority Semantics
+
+`CaptureStatus` exposes two separately labeled optional `RateShortfallsByArm` fields:
+
+- `authoritative_rate_shortfalls`: evidence attached to the conclusive attempt that currently governs capture.
+- `latest_attempt_rate_shortfalls`: evidence attached to the most recent attempt, including an inconclusive retune.
+
+An inconclusive retune may update latest-attempt evidence but cannot replace or visually masquerade as authoritative evidence.
+
+## Presentation
+
+`camera-tune` names each failing role and prints its failure count, worst exact delivered rate, exact required floor, tolerance, and window. This applies to conclusive delivered-rate verdicts and partial attempts such as one completed round plus four typed shortfalls.
+
+The human support report renders authoritative and latest-attempt evidence in separate labeled sections. For each arm it distinguishes legacy unknown, measured with no shortfalls, and measured shortfalls. The output remains share-safe and contains no paths, serial values, frames, embeddings, or user identity.
+
+## Compatibility And Tests
+
+Tests cover exact worst-sample selection, simultaneous RGB and IR failures, legacy unknown versus measured-empty persistence, schema-2 round trips, inconclusive attempts preserving authority, old `CaptureStatus` payloads, daemon wording for conclusive and partial attempts, and support-report rendering.


### PR DESCRIPTION
## Summary

- retain a bounded deterministic RGB/IR summary from typed delivered-rate failures for sequential and concurrent qualification arms
- persist exact delivered and required rational rates, window, tolerance, and continuity evidence while preserving legacy absence as unknown
- expose separately labeled authoritative and latest-attempt evidence in capture status, support reports, and partial `camera-tune` diagnostics
- preserve qualification thresholds, retries, authority replacement, capture schedules, liveness, and authentication policy

Fixes #644.

## Verification

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- focused RED/GREEN regressions for worst-sample selection, dual-role failures, legacy unknown, measured-empty evidence, persistence round trips, inconclusive authority preservation, context-mismatched authority, partial sequential and concurrent wording, old wire payloads, and support heading association
- independent final review: both prior Important findings addressed, no residual Critical or Important findings
- all eight commits have good signatures and exact DCO trailers
