### PR TITLE
feat: require reviewed camera qualification evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,3 +28,28 @@ _Avoid_: Log dump, support bundle
 A privileged, time-bounded stream of structured events from live Irlume
 operations.
 _Avoid_: Debug mode, permanent verbose logging
+
+**Campaign policy**:
+The versioned maintainer rules that fix cohort, attack, statistical, retention,
+review, and invalidation requirements for release qualification.
+_Avoid_: Test settings, campaign options
+
+**Campaign protocol**:
+A signed declaration that applies one campaign policy to one exact hardware
+class and baseline/candidate profile pair before authorizing capture.
+_Avoid_: Test plan, run configuration
+
+**Private campaign bundle**:
+The frozen, encrypted, content-addressed biometric inputs and audit records for
+one release qualification campaign.
+_Avoid_: Dataset, corpus archive
+
+**Reviewed aggregate**:
+The canonical identity-free envelope binding a campaign result to its passing
+independent review attestation.
+_Avoid_: Benchmark report, raw result
+
+**Publication boundary**:
+The point at which a reviewed aggregate becomes an immutable released fact;
+later withdrawal removes retained assets and future use, not the published fact.
+_Avoid_: Consent cutoff, release freeze

--- a/crates/irlume-camera/src/capture_qualification.rs
+++ b/crates/irlume-camera/src/capture_qualification.rs
@@ -205,6 +205,18 @@ impl ConnectionContext {
         validate_text(&self.driver)?;
         validate_text(&self.backend)
     }
+
+    pub(crate) const fn speed_millimbps(&self) -> u64 {
+        self.speed_millimbps
+    }
+
+    pub(crate) fn driver(&self) -> &str {
+        &self.driver
+    }
+
+    pub(crate) fn backend(&self) -> &str {
+        &self.backend
+    }
 }
 
 /// Persistent identity of one endpoint, collected from its opened fd.
@@ -380,6 +392,22 @@ impl CameraEndpoint {
     #[must_use]
     pub const fn role(&self) -> QualifiedStreamRole {
         self.role
+    }
+
+    pub(crate) fn descriptor_sha256(&self) -> &str {
+        &self.descriptor_sha256
+    }
+
+    pub(crate) const fn vid(&self) -> u16 {
+        self.vid
+    }
+
+    pub(crate) const fn pid(&self) -> u16 {
+        self.pid
+    }
+
+    pub(crate) const fn interface_number(&self) -> u8 {
+        self.interface_number
     }
 }
 

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -57,6 +57,7 @@ pub mod profile;
 pub mod profile_qualification;
 mod rate_gate;
 mod release_qualification;
+mod release_qualification_signature;
 // Public for exactly one item, `pending_summary`, doctor's read-only view of
 // the store (#429); every record type stays crate-private so no other code
 // path grows a reader of these files.

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -54,6 +54,7 @@ pub mod lease;
 mod lifecycle;
 mod media_graph;
 pub mod profile;
+mod profile_commissioning;
 pub mod profile_qualification;
 mod rate_gate;
 mod release_qualification;

--- a/crates/irlume-camera/src/profile_commissioning.rs
+++ b/crates/irlume-camera/src/profile_commissioning.rs
@@ -1,0 +1,961 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Non-biometric local commissioning evidence for camera profiles.
+
+#![allow(
+    dead_code,
+    reason = "selection consumes validated commissioning evidence in the next plan task"
+)]
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    capture_qualification::QualificationContext,
+    profile::{CaptureSchedule, PairTransportProfile},
+    release_qualification::ReleaseHardwareScope,
+};
+
+const LOCAL_COMMISSIONING_SCHEMA_VERSION: u32 = 1;
+const LOCAL_COMMISSIONING_POLICY_VERSION: u32 = 1;
+const LOCAL_COMMISSIONING_PRODUCER_VERSION: u32 = 1;
+const MAX_LOCAL_COMMISSIONING_BYTES: usize = 256 * 1024;
+const MAX_IDENTIFIER_BYTES: usize = 256;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ProfileCommissioningError {
+    UnsupportedSchema(u32),
+    UnsupportedPolicy(u32),
+    UnsupportedProducer(u32),
+    InvalidIdentifier,
+    InvalidDigest,
+    InvalidTime,
+    InvalidContext,
+    InvalidLatency,
+    LocalGateFailed,
+    NotYetValid,
+    Stale,
+    ContextMismatch,
+    HardwareScopeMismatch,
+    ProfileMismatch,
+    ConditioningMismatch,
+    DocumentTooLarge,
+    Json,
+}
+
+impl fmt::Display for ProfileCommissioningError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedSchema(version) => {
+                write!(
+                    formatter,
+                    "unsupported local commissioning schema {version}"
+                )
+            }
+            Self::UnsupportedPolicy(version) => {
+                write!(
+                    formatter,
+                    "unsupported local commissioning policy {version}"
+                )
+            }
+            Self::UnsupportedProducer(version) => {
+                write!(
+                    formatter,
+                    "unsupported local commissioning producer {version}"
+                )
+            }
+            Self::InvalidIdentifier => formatter.write_str("invalid commissioning identifier"),
+            Self::InvalidDigest => formatter.write_str("invalid commissioning digest"),
+            Self::InvalidTime => formatter.write_str("invalid commissioning time interval"),
+            Self::InvalidContext => formatter.write_str("invalid commissioning context"),
+            Self::InvalidLatency => formatter.write_str("invalid commissioning latency"),
+            Self::LocalGateFailed => formatter.write_str("local commissioning gate failed"),
+            Self::NotYetValid => formatter.write_str("local commissioning is not yet valid"),
+            Self::Stale => formatter.write_str("local commissioning is stale"),
+            Self::ContextMismatch => formatter.write_str("local commissioning context changed"),
+            Self::HardwareScopeMismatch => {
+                formatter.write_str("local commissioning hardware scope changed")
+            }
+            Self::ProfileMismatch => formatter.write_str("local commissioning profile changed"),
+            Self::ConditioningMismatch => {
+                formatter.write_str("local commissioning conditioning changed")
+            }
+            Self::DocumentTooLarge => {
+                formatter.write_str("local commissioning document exceeds its size limit")
+            }
+            Self::Json => formatter.write_str("invalid local commissioning JSON"),
+        }
+    }
+}
+
+impl std::error::Error for ProfileCommissioningError {}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LocalCommissioningGates {
+    negotiation_passed: bool,
+    transport_passed: bool,
+    continuity_passed: bool,
+    signal_sanity_passed: bool,
+    conditioning_applied: bool,
+    restoration_exact: bool,
+    runtime_degradation_compatible: bool,
+    p50_latency_ms: u64,
+    p95_latency_ms: u64,
+    latency_budget_ms: u64,
+}
+
+impl LocalCommissioningGates {
+    fn validate(&self) -> Result<(), ProfileCommissioningError> {
+        if [
+            self.negotiation_passed,
+            self.transport_passed,
+            self.continuity_passed,
+            self.signal_sanity_passed,
+            self.conditioning_applied,
+            self.restoration_exact,
+            self.runtime_degradation_compatible,
+        ]
+        .into_iter()
+        .all(|gate| gate)
+        {
+            if self.p50_latency_ms > 0
+                && self.p50_latency_ms <= self.p95_latency_ms
+                && self.p95_latency_ms <= self.latency_budget_ms
+            {
+                Ok(())
+            } else {
+                Err(ProfileCommissioningError::InvalidLatency)
+            }
+        } else {
+            Err(ProfileCommissioningError::LocalGateFailed)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LocalCommissioningRecord {
+    schema_version: u32,
+    policy_version: u32,
+    producer_version: u32,
+    measured_at_unix: u64,
+    expires_at_unix: u64,
+    profile_id: String,
+    context: QualificationContext,
+    schedule: CaptureSchedule,
+    conditioning_catalog_sha256: String,
+    selected_policy_sha256: String,
+    interface_layout_sha256: String,
+    gates: LocalCommissioningGates,
+}
+
+impl LocalCommissioningRecord {
+    pub(crate) fn from_canonical_json(bytes: &[u8]) -> Result<Self, ProfileCommissioningError> {
+        if bytes.len() > MAX_LOCAL_COMMISSIONING_BYTES {
+            return Err(ProfileCommissioningError::DocumentTooLarge);
+        }
+        let record: Self =
+            serde_json::from_slice(bytes).map_err(|_| ProfileCommissioningError::Json)?;
+        record.validate_structure()?;
+        if serde_json::to_vec(&record).map_err(|_| ProfileCommissioningError::Json)? != bytes {
+            return Err(ProfileCommissioningError::Json);
+        }
+        Ok(record)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn validate_for(
+        &self,
+        release_scope: &ReleaseHardwareScope,
+        candidate: &PairTransportProfile,
+        current_context: &QualificationContext,
+        expected_conditioning_catalog_sha256: &str,
+        expected_selected_policy_sha256: &str,
+        now_unix: u64,
+    ) -> Result<ValidatedLocalCommissioning, ProfileCommissioningError> {
+        self.validate_structure()?;
+        if now_unix < self.measured_at_unix {
+            return Err(ProfileCommissioningError::NotYetValid);
+        }
+        if now_unix >= self.expires_at_unix {
+            return Err(ProfileCommissioningError::Stale);
+        }
+        current_context
+            .validate()
+            .map_err(|_| ProfileCommissioningError::InvalidContext)?;
+        if self.context != *current_context {
+            return Err(ProfileCommissioningError::ContextMismatch);
+        }
+
+        let profile = self.to_profile()?;
+        if profile != *candidate {
+            return Err(ProfileCommissioningError::ProfileMismatch);
+        }
+        if !release_scope.matches_context(&self.context, &self.interface_layout_sha256) {
+            return Err(ProfileCommissioningError::HardwareScopeMismatch);
+        }
+        if self.conditioning_catalog_sha256 != expected_conditioning_catalog_sha256
+            || self.selected_policy_sha256 != expected_selected_policy_sha256
+        {
+            return Err(ProfileCommissioningError::ConditioningMismatch);
+        }
+
+        let canonical = serde_json::to_vec(self).map_err(|_| ProfileCommissioningError::Json)?;
+        Ok(ValidatedLocalCommissioning {
+            profile,
+            context: self.context.clone(),
+            conditioning_catalog_sha256: self.conditioning_catalog_sha256.clone(),
+            selected_policy_sha256: self.selected_policy_sha256.clone(),
+            measured_at_unix: self.measured_at_unix,
+            p50_latency_ms: self.gates.p50_latency_ms,
+            p95_latency_ms: self.gates.p95_latency_ms,
+            record_sha256: irlume_common::sha256_hex(&canonical),
+        })
+    }
+
+    fn validate_structure(&self) -> Result<(), ProfileCommissioningError> {
+        if self.schema_version != LOCAL_COMMISSIONING_SCHEMA_VERSION {
+            return Err(ProfileCommissioningError::UnsupportedSchema(
+                self.schema_version,
+            ));
+        }
+        if self.policy_version != LOCAL_COMMISSIONING_POLICY_VERSION {
+            return Err(ProfileCommissioningError::UnsupportedPolicy(
+                self.policy_version,
+            ));
+        }
+        if self.producer_version != LOCAL_COMMISSIONING_PRODUCER_VERSION {
+            return Err(ProfileCommissioningError::UnsupportedProducer(
+                self.producer_version,
+            ));
+        }
+        validate_identifier(&self.profile_id)?;
+        validate_digest(&self.interface_layout_sha256)?;
+        validate_digest(&self.conditioning_catalog_sha256)?;
+        validate_digest(&self.selected_policy_sha256)?;
+        if self.measured_at_unix == 0
+            || self.expires_at_unix == 0
+            || self.measured_at_unix >= self.expires_at_unix
+        {
+            return Err(ProfileCommissioningError::InvalidTime);
+        }
+        self.context
+            .validate()
+            .map_err(|_| ProfileCommissioningError::InvalidContext)?;
+        self.gates.validate()
+    }
+
+    fn to_profile(&self) -> Result<PairTransportProfile, ProfileCommissioningError> {
+        PairTransportProfile::from_negotiated(
+            self.profile_id.clone(),
+            self.context
+                .rgb_stream()
+                .requested_tuple()
+                .ok_or(ProfileCommissioningError::InvalidContext)?,
+            self.context
+                .rgb_stream()
+                .accepted_tuple()
+                .ok_or(ProfileCommissioningError::InvalidContext)?,
+            self.context
+                .ir_stream()
+                .requested_tuple()
+                .ok_or(ProfileCommissioningError::InvalidContext)?,
+            self.context
+                .ir_stream()
+                .accepted_tuple()
+                .ok_or(ProfileCommissioningError::InvalidContext)?,
+            self.schedule,
+        )
+        .map_err(|_| ProfileCommissioningError::InvalidContext)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ValidatedLocalCommissioning {
+    profile: PairTransportProfile,
+    context: QualificationContext,
+    conditioning_catalog_sha256: String,
+    selected_policy_sha256: String,
+    measured_at_unix: u64,
+    p50_latency_ms: u64,
+    p95_latency_ms: u64,
+    record_sha256: String,
+}
+
+impl ValidatedLocalCommissioning {
+    pub(crate) fn profile_id(&self) -> &str {
+        self.profile.id()
+    }
+
+    pub(crate) const fn context(&self) -> &QualificationContext {
+        &self.context
+    }
+
+    pub(crate) const fn p95_latency_ms(&self) -> u64 {
+        self.p95_latency_ms
+    }
+}
+
+fn validate_identifier(value: &str) -> Result<(), ProfileCommissioningError> {
+    if value.is_empty() || value.len() > MAX_IDENTIFIER_BYTES || value.chars().any(char::is_control)
+    {
+        return Err(ProfileCommissioningError::InvalidIdentifier);
+    }
+    Ok(())
+}
+
+fn validate_digest(value: &str) -> Result<(), ProfileCommissioningError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(ProfileCommissioningError::InvalidDigest);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+use crate::{
+    capture_qualification::{
+        AcceptedStream, CameraEndpoint, ConnectionContext, ExactInterval, ExactRate,
+        QualifiedStreamRole, RequestedStream, StreamContract,
+    },
+    contracts::StreamRole,
+    frame_interval::FrameInterval,
+    profile::{DecodedPixelFormat, StreamTuple},
+};
+
+#[cfg(test)]
+const FIXTURE_CONDITIONING_CATALOG_SHA256: &str =
+    "4444444444444444444444444444444444444444444444444444444444444444";
+#[cfg(test)]
+const FIXTURE_SELECTED_POLICY_SHA256: &str =
+    "5555555555555555555555555555555555555555555555555555555555555555";
+
+#[cfg(test)]
+#[derive(Clone)]
+struct ContextOverrides {
+    rgb_descriptor_sha256: String,
+    rgb_vid: u16,
+    rgb_pid: u16,
+    rgb_serial: Option<String>,
+    rgb_interface: u8,
+    rgb_devpath: String,
+    ir_descriptor_sha256: String,
+    ir_vid: u16,
+    ir_pid: u16,
+    ir_interface: u8,
+    driver: String,
+    backend: String,
+    speed_millimbps: u64,
+}
+
+#[cfg(test)]
+impl Default for ContextOverrides {
+    fn default() -> Self {
+        Self {
+            rgb_descriptor_sha256: "ab".repeat(32),
+            rgb_vid: 0x0bda,
+            rgb_pid: 0x5678,
+            rgb_serial: Some("synthetic-camera".to_owned()),
+            rgb_interface: 0,
+            rgb_devpath: "/devices/pci0000:00/usb1/1-1/1-1:1.0".to_owned(),
+            ir_descriptor_sha256: "ab".repeat(32),
+            ir_vid: 0x0bda,
+            ir_pid: 0x5678,
+            ir_interface: 2,
+            driver: "uvcvideo".to_owned(),
+            backend: "v4l2-uvc".to_owned(),
+            speed_millimbps: 5_000_000,
+        }
+    }
+}
+
+#[cfg(test)]
+fn fixture_context_with(
+    rgb_fps: u32,
+    ir_fps: u32,
+    overrides: &ContextOverrides,
+) -> QualificationContext {
+    let connection = |controller: &str| {
+        ConnectionContext::new(
+            controller.to_owned(),
+            overrides.speed_millimbps,
+            overrides.driver.clone(),
+            overrides.backend.clone(),
+        )
+        .unwrap()
+    };
+    let rgb_endpoint = CameraEndpoint::new(
+        overrides.rgb_descriptor_sha256.clone(),
+        overrides.rgb_vid,
+        overrides.rgb_pid,
+        overrides.rgb_serial.clone(),
+        overrides.rgb_interface,
+        overrides.rgb_devpath.clone(),
+        QualifiedStreamRole::Rgb,
+        connection("/devices/pci0000:00/usb1/1-1"),
+    )
+    .unwrap();
+    let ir_endpoint = CameraEndpoint::new(
+        overrides.ir_descriptor_sha256.clone(),
+        overrides.ir_vid,
+        overrides.ir_pid,
+        Some("synthetic-camera".to_owned()),
+        overrides.ir_interface,
+        "/devices/pci0000:00/usb1/1-1/1-1:1.2".to_owned(),
+        QualifiedStreamRole::Ir,
+        connection("/devices/pci0000:00/usb1/1-1"),
+    )
+    .unwrap();
+    let stream = |role, width, height, fourcc: &str, fps, stride| {
+        StreamContract::new(
+            role,
+            RequestedStream::new(
+                width,
+                height,
+                fourcc.to_owned(),
+                ExactInterval::new(1, fps).unwrap(),
+            )
+            .unwrap(),
+            AcceptedStream::new(
+                width,
+                height,
+                fourcc.to_owned(),
+                stride,
+                stride * height,
+                1,
+                8,
+                1,
+                1,
+                0,
+                ExactInterval::new(1, fps).unwrap(),
+            )
+            .unwrap(),
+            ExactRate::new(fps, 1).unwrap(),
+        )
+        .unwrap()
+    };
+    QualificationContext::new(
+        rgb_endpoint,
+        ir_endpoint,
+        stream(QualifiedStreamRole::Rgb, 640, 480, "YUYV", rgb_fps, 1280),
+        stream(QualifiedStreamRole::Ir, 640, 400, "GREY", ir_fps, 640),
+    )
+    .unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn fixture_current_context(rgb_fps: u32, ir_fps: u32) -> QualificationContext {
+    fixture_context_with(rgb_fps, ir_fps, &ContextOverrides::default())
+}
+
+#[cfg(test)]
+pub(crate) fn fixture_candidate_profile(
+    id: &str,
+    rgb_fps: u32,
+    ir_fps: u32,
+    schedule: CaptureSchedule,
+) -> PairTransportProfile {
+    let tuple = |role, format, width, height, fps| {
+        StreamTuple::new(
+            role,
+            format,
+            width,
+            height,
+            FrameInterval::new(1, fps).unwrap(),
+        )
+        .unwrap()
+    };
+    PairTransportProfile::new(
+        id,
+        tuple(StreamRole::Rgb, DecodedPixelFormat::Yuyv, 640, 480, rgb_fps),
+        tuple(StreamRole::Ir, DecodedPixelFormat::Grey8, 640, 400, ir_fps),
+        schedule,
+    )
+    .unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn fixture_commissioning_value(
+    id: &str,
+    rgb_fps: u32,
+    ir_fps: u32,
+    schedule: CaptureSchedule,
+) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": 1,
+        "policy_version": 1,
+        "producer_version": 1,
+        "measured_at_unix": 1_788_192_000_u64,
+        "expires_at_unix": 1_788_278_400_u64,
+        "profile_id": id,
+        "context": fixture_current_context(rgb_fps, ir_fps),
+        "schedule": schedule,
+        "conditioning_catalog_sha256": FIXTURE_CONDITIONING_CATALOG_SHA256,
+        "selected_policy_sha256": FIXTURE_SELECTED_POLICY_SHA256,
+        "interface_layout_sha256": "33".repeat(32),
+        "gates": {
+            "negotiation_passed": true,
+            "transport_passed": true,
+            "continuity_passed": true,
+            "signal_sanity_passed": true,
+            "conditioning_applied": true,
+            "restoration_exact": true,
+            "runtime_degradation_compatible": true,
+            "p50_latency_ms": 4_000,
+            "p95_latency_ms": 6_000,
+            "latency_budget_ms": 8_000,
+        },
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn validated_commissioning_fixture(
+    candidate_id: &str,
+    candidate_rgb_fps: u32,
+    candidate_ir_fps: u32,
+    candidate_schedule: CaptureSchedule,
+    now_unix: u64,
+) -> ValidatedLocalCommissioning {
+    let mut value = fixture_commissioning_value(
+        candidate_id,
+        candidate_rgb_fps,
+        candidate_ir_fps,
+        candidate_schedule,
+    );
+    value["measured_at_unix"] = serde_json::json!(now_unix.checked_sub(50).unwrap());
+    value["expires_at_unix"] = serde_json::json!(now_unix.checked_add(86_400).unwrap());
+    let wire: LocalCommissioningRecord = serde_json::from_value(value).unwrap();
+    let canonical = serde_json::to_vec(&wire).unwrap();
+    LocalCommissioningRecord::from_canonical_json(&canonical)
+        .unwrap()
+        .validate_for(
+            &crate::release_qualification::fixture_release_scope(),
+            &fixture_candidate_profile(
+                candidate_id,
+                candidate_rgb_fps,
+                candidate_ir_fps,
+                candidate_schedule,
+            ),
+            &fixture_current_context(candidate_rgb_fps, candidate_ir_fps),
+            FIXTURE_CONDITIONING_CATALOG_SHA256,
+            FIXTURE_SELECTED_POLICY_SHA256,
+            now_unix,
+        )
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::release_qualification::fixture_release_scope;
+
+    const FIXED_NOW: u64 = 1_788_192_050;
+
+    fn record_from_value(value: serde_json::Value) -> LocalCommissioningRecord {
+        let record: LocalCommissioningRecord = serde_json::from_value(value).unwrap();
+        LocalCommissioningRecord::from_canonical_json(&serde_json::to_vec(&record).unwrap())
+            .unwrap()
+    }
+
+    fn fixture_commissioning() -> LocalCommissioningRecord {
+        record_from_value(fixture_commissioning_value(
+            "candidate-15-15",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+        ))
+    }
+
+    fn validate_record(
+        record: &LocalCommissioningRecord,
+        candidate: &PairTransportProfile,
+        context: &QualificationContext,
+    ) -> Result<ValidatedLocalCommissioning, ProfileCommissioningError> {
+        record.validate_for(
+            &fixture_release_scope(),
+            candidate,
+            context,
+            FIXTURE_CONDITIONING_CATALOG_SHA256,
+            FIXTURE_SELECTED_POLICY_SHA256,
+            FIXED_NOW,
+        )
+    }
+
+    fn validate_mutation(
+        field: &str,
+        value: serde_json::Value,
+    ) -> Result<ValidatedLocalCommissioning, ProfileCommissioningError> {
+        let mut fixture =
+            fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+        fixture[field] = value;
+        validate_record(
+            &record_from_value(fixture),
+            &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent),
+            &fixture_current_context(15, 15),
+        )
+    }
+
+    fn validate_changed_connection(
+    ) -> Result<ValidatedLocalCommissioning, ProfileCommissioningError> {
+        let overrides = ContextOverrides {
+            backend: "alternate-backend".to_owned(),
+            ..ContextOverrides::default()
+        };
+        let context = fixture_context_with(15, 15, &overrides);
+        let mut value =
+            fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+        value["context"] = serde_json::to_value(&context).unwrap();
+        validate_record(
+            &record_from_value(value),
+            &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent),
+            &context,
+        )
+    }
+
+    fn validate_changed_tuple() -> Result<ValidatedLocalCommissioning, ProfileCommissioningError> {
+        let record = record_from_value(fixture_commissioning_value(
+            "candidate-15-15",
+            10,
+            15,
+            CaptureSchedule::Concurrent,
+        ));
+        validate_record(
+            &record,
+            &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent),
+            &fixture_current_context(10, 15),
+        )
+    }
+
+    fn validate_failed_restoration(
+    ) -> Result<ValidatedLocalCommissioning, ProfileCommissioningError> {
+        let mut value =
+            fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+        value["gates"]["restoration_exact"] = serde_json::json!(false);
+        let wire: LocalCommissioningRecord = serde_json::from_value(value).unwrap();
+        let record =
+            LocalCommissioningRecord::from_canonical_json(&serde_json::to_vec(&wire).unwrap())?;
+        validate_record(
+            &record,
+            &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent),
+            &fixture_current_context(15, 15),
+        )
+    }
+
+    #[test]
+    fn complete_fresh_local_record_matches_one_exact_device_and_release_scope() {
+        let validated = fixture_commissioning()
+            .validate_for(
+                &fixture_release_scope(),
+                &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent),
+                &fixture_current_context(15, 15),
+                FIXTURE_CONDITIONING_CATALOG_SHA256,
+                FIXTURE_SELECTED_POLICY_SHA256,
+                FIXED_NOW,
+            )
+            .unwrap();
+        assert_eq!(validated.profile_id(), "candidate-15-15");
+        assert_eq!(validated.p95_latency_ms(), 6_000);
+        assert_eq!(validated.context(), &fixture_current_context(15, 15));
+        assert_eq!(validated.record_sha256.len(), 64);
+    }
+
+    #[test]
+    fn model_or_biometric_fields_are_not_local_commissioning_vocabulary() {
+        for field in ["recognition", "liveness", "rgb_pad", "ir_pad", "scene"] {
+            let mut value =
+                fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+            value[field] = serde_json::json!("passed");
+            assert_eq!(
+                LocalCommissioningRecord::from_canonical_json(value.to_string().as_bytes()),
+                Err(ProfileCommissioningError::Json),
+                "{field}"
+            );
+        }
+    }
+
+    #[test]
+    fn stale_scope_tuple_or_restoration_failure_authorizes_nothing() {
+        assert_eq!(
+            validate_mutation("expires_at_unix", serde_json::json!(FIXED_NOW)),
+            Err(ProfileCommissioningError::Stale),
+        );
+        assert_eq!(
+            fixture_commissioning().validate_for(
+                &fixture_release_scope(),
+                &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent,),
+                &fixture_current_context(15, 15),
+                FIXTURE_CONDITIONING_CATALOG_SHA256,
+                FIXTURE_SELECTED_POLICY_SHA256,
+                1_788_191_999,
+            ),
+            Err(ProfileCommissioningError::NotYetValid),
+        );
+        assert_eq!(
+            validate_changed_connection(),
+            Err(ProfileCommissioningError::HardwareScopeMismatch),
+        );
+        assert_eq!(
+            validate_changed_tuple(),
+            Err(ProfileCommissioningError::ProfileMismatch),
+        );
+        assert_eq!(
+            validate_failed_restoration(),
+            Err(ProfileCommissioningError::LocalGateFailed),
+        );
+    }
+
+    #[test]
+    fn versions_identifiers_digests_and_times_are_closed_and_bounded() {
+        for (field, value, expected) in [
+            (
+                "schema_version",
+                serde_json::json!(2),
+                ProfileCommissioningError::UnsupportedSchema(2),
+            ),
+            (
+                "policy_version",
+                serde_json::json!(2),
+                ProfileCommissioningError::UnsupportedPolicy(2),
+            ),
+            (
+                "producer_version",
+                serde_json::json!(2),
+                ProfileCommissioningError::UnsupportedProducer(2),
+            ),
+            (
+                "profile_id",
+                serde_json::json!(""),
+                ProfileCommissioningError::InvalidIdentifier,
+            ),
+            (
+                "profile_id",
+                serde_json::json!("x".repeat(257)),
+                ProfileCommissioningError::InvalidIdentifier,
+            ),
+            (
+                "measured_at_unix",
+                serde_json::json!(0),
+                ProfileCommissioningError::InvalidTime,
+            ),
+            (
+                "expires_at_unix",
+                serde_json::json!(1_788_192_000_u64),
+                ProfileCommissioningError::InvalidTime,
+            ),
+        ] {
+            let mut fixture =
+                fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+            fixture[field] = value;
+            let wire: LocalCommissioningRecord = serde_json::from_value(fixture).unwrap();
+            assert_eq!(
+                LocalCommissioningRecord::from_canonical_json(&serde_json::to_vec(&wire).unwrap()),
+                Err(expected),
+                "{field}"
+            );
+        }
+        for field in [
+            "conditioning_catalog_sha256",
+            "selected_policy_sha256",
+            "interface_layout_sha256",
+        ] {
+            let mut fixture =
+                fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+            fixture[field] = serde_json::json!("not-a-digest");
+            let wire: LocalCommissioningRecord = serde_json::from_value(fixture).unwrap();
+            assert_eq!(
+                LocalCommissioningRecord::from_canonical_json(&serde_json::to_vec(&wire).unwrap()),
+                Err(ProfileCommissioningError::InvalidDigest),
+                "{field}"
+            );
+        }
+        assert_eq!(
+            LocalCommissioningRecord::from_canonical_json(&vec![b' '; 256 * 1024 + 1]),
+            Err(ProfileCommissioningError::DocumentTooLarge),
+        );
+    }
+
+    #[test]
+    fn exact_context_rejects_serial_devpath_role_and_release_hardware_drift() {
+        let record = fixture_commissioning();
+        let candidate =
+            fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+        for overrides in [
+            ContextOverrides {
+                rgb_serial: Some("changed-serial".to_owned()),
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                rgb_devpath: "/devices/pci0000:00/usb1/1-9/1-9:1.0".to_owned(),
+                ..ContextOverrides::default()
+            },
+        ] {
+            assert_eq!(
+                validate_record(
+                    &record,
+                    &candidate,
+                    &fixture_context_with(15, 15, &overrides)
+                ),
+                Err(ProfileCommissioningError::ContextMismatch),
+            );
+        }
+
+        for overrides in [
+            ContextOverrides {
+                rgb_descriptor_sha256: "ac".repeat(32),
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                ir_descriptor_sha256: "ac".repeat(32),
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                rgb_vid: 0x1234,
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                rgb_pid: 0x1234,
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                rgb_interface: 1,
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                driver: "other-driver".to_owned(),
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                backend: "other-backend".to_owned(),
+                ..ContextOverrides::default()
+            },
+            ContextOverrides {
+                speed_millimbps: 480_000,
+                ..ContextOverrides::default()
+            },
+        ] {
+            let context = fixture_context_with(15, 15, &overrides);
+            let mut value =
+                fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+            value["context"] = serde_json::to_value(&context).unwrap();
+            assert_eq!(
+                validate_record(&record_from_value(value), &candidate, &context),
+                Err(ProfileCommissioningError::HardwareScopeMismatch),
+            );
+        }
+
+        let mut wrong_role =
+            fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+        wrong_role["context"]["rgb_endpoint"]["role"] = serde_json::json!("ir");
+        let wire: LocalCommissioningRecord = serde_json::from_value(wrong_role).unwrap();
+        assert_eq!(
+            LocalCommissioningRecord::from_canonical_json(&serde_json::to_vec(&wire).unwrap()),
+            Err(ProfileCommissioningError::InvalidContext),
+        );
+    }
+
+    #[test]
+    fn schedule_conditioning_layout_gates_and_latency_all_fail_closed() {
+        assert_eq!(
+            validate_mutation("schedule", serde_json::json!("sequential")),
+            Err(ProfileCommissioningError::ProfileMismatch),
+        );
+        assert_eq!(
+            validate_mutation(
+                "interface_layout_sha256",
+                serde_json::json!("34".repeat(32))
+            ),
+            Err(ProfileCommissioningError::HardwareScopeMismatch),
+        );
+
+        let record = fixture_commissioning();
+        assert_eq!(
+            record.validate_for(
+                &fixture_release_scope(),
+                &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent,),
+                &fixture_current_context(15, 15),
+                &"45".repeat(32),
+                FIXTURE_SELECTED_POLICY_SHA256,
+                FIXED_NOW,
+            ),
+            Err(ProfileCommissioningError::ConditioningMismatch),
+        );
+        assert_eq!(
+            record.validate_for(
+                &fixture_release_scope(),
+                &fixture_candidate_profile("candidate-15-15", 15, 15, CaptureSchedule::Concurrent,),
+                &fixture_current_context(15, 15),
+                FIXTURE_CONDITIONING_CATALOG_SHA256,
+                &"56".repeat(32),
+                FIXED_NOW,
+            ),
+            Err(ProfileCommissioningError::ConditioningMismatch),
+        );
+
+        for gate in [
+            "negotiation_passed",
+            "transport_passed",
+            "continuity_passed",
+            "signal_sanity_passed",
+            "conditioning_applied",
+            "restoration_exact",
+            "runtime_degradation_compatible",
+        ] {
+            let mut value =
+                fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+            value["gates"][gate] = serde_json::json!(false);
+            let wire: LocalCommissioningRecord = serde_json::from_value(value).unwrap();
+            assert_eq!(
+                LocalCommissioningRecord::from_canonical_json(&serde_json::to_vec(&wire).unwrap()),
+                Err(ProfileCommissioningError::LocalGateFailed),
+                "{gate}"
+            );
+        }
+
+        for (p50, p95, budget) in [
+            (0, 6_000, 8_000),
+            (7_000, 6_000, 8_000),
+            (4_000, 9_000, 8_000),
+        ] {
+            let mut value =
+                fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+            value["gates"]["p50_latency_ms"] = serde_json::json!(p50);
+            value["gates"]["p95_latency_ms"] = serde_json::json!(p95);
+            value["gates"]["latency_budget_ms"] = serde_json::json!(budget);
+            let wire: LocalCommissioningRecord = serde_json::from_value(value).unwrap();
+            assert_eq!(
+                LocalCommissioningRecord::from_canonical_json(&serde_json::to_vec(&wire).unwrap()),
+                Err(ProfileCommissioningError::InvalidLatency),
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_or_noncanonical_json_authorizes_nothing() {
+        let mut unknown =
+            fixture_commissioning_value("candidate-15-15", 15, 15, CaptureSchedule::Concurrent);
+        unknown["unknown"] = serde_json::json!(true);
+        assert_eq!(
+            LocalCommissioningRecord::from_canonical_json(unknown.to_string().as_bytes()),
+            Err(ProfileCommissioningError::Json),
+        );
+        assert_eq!(
+            LocalCommissioningRecord::from_canonical_json(
+                serde_json::to_string_pretty(&fixture_commissioning_value(
+                    "candidate-15-15",
+                    15,
+                    15,
+                    CaptureSchedule::Concurrent,
+                ))
+                .unwrap()
+                .as_bytes(),
+            ),
+            Err(ProfileCommissioningError::Json),
+        );
+    }
+}

--- a/crates/irlume-camera/src/profile_commissioning.rs
+++ b/crates/irlume-camera/src/profile_commissioning.rs
@@ -209,6 +209,7 @@ impl LocalCommissioningRecord {
             context: self.context.clone(),
             conditioning_catalog_sha256: self.conditioning_catalog_sha256.clone(),
             selected_policy_sha256: self.selected_policy_sha256.clone(),
+            interface_layout_sha256: self.interface_layout_sha256.clone(),
             measured_at_unix: self.measured_at_unix,
             p50_latency_ms: self.gates.p50_latency_ms,
             p95_latency_ms: self.gates.p95_latency_ms,
@@ -279,6 +280,7 @@ pub(crate) struct ValidatedLocalCommissioning {
     context: QualificationContext,
     conditioning_catalog_sha256: String,
     selected_policy_sha256: String,
+    interface_layout_sha256: String,
     measured_at_unix: u64,
     p50_latency_ms: u64,
     p95_latency_ms: u64,
@@ -286,6 +288,10 @@ pub(crate) struct ValidatedLocalCommissioning {
 }
 
 impl ValidatedLocalCommissioning {
+    pub(crate) const fn profile(&self) -> &PairTransportProfile {
+        &self.profile
+    }
+
     pub(crate) fn profile_id(&self) -> &str {
         self.profile.id()
     }
@@ -296,6 +302,30 @@ impl ValidatedLocalCommissioning {
 
     pub(crate) const fn p95_latency_ms(&self) -> u64 {
         self.p95_latency_ms
+    }
+
+    pub(crate) const fn p50_latency_ms(&self) -> u64 {
+        self.p50_latency_ms
+    }
+
+    pub(crate) fn conditioning_catalog_sha256(&self) -> &str {
+        &self.conditioning_catalog_sha256
+    }
+
+    pub(crate) fn selected_policy_sha256(&self) -> &str {
+        &self.selected_policy_sha256
+    }
+
+    pub(crate) const fn measured_at_unix(&self) -> u64 {
+        self.measured_at_unix
+    }
+
+    pub(crate) fn record_sha256(&self) -> &str {
+        &self.record_sha256
+    }
+
+    pub(crate) fn interface_layout_sha256(&self) -> &str {
+        &self.interface_layout_sha256
     }
 }
 
@@ -522,6 +552,83 @@ pub(crate) fn validated_commissioning_fixture(
     candidate_schedule: CaptureSchedule,
     now_unix: u64,
 ) -> ValidatedLocalCommissioning {
+    validated_commissioning_fixture_with(
+        candidate_id,
+        candidate_rgb_fps,
+        candidate_ir_fps,
+        candidate_schedule,
+        now_unix,
+        fixture_current_context(candidate_rgb_fps, candidate_ir_fps),
+        FIXTURE_CONDITIONING_CATALOG_SHA256.to_owned(),
+        FIXTURE_SELECTED_POLICY_SHA256.to_owned(),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn validated_commissioning_fixture_with_bindings(
+    candidate_id: &str,
+    candidate_rgb_fps: u32,
+    candidate_ir_fps: u32,
+    candidate_schedule: CaptureSchedule,
+    now_unix: u64,
+    conditioning_catalog_byte: u8,
+    selected_policy_byte: u8,
+) -> ValidatedLocalCommissioning {
+    validated_commissioning_fixture_with(
+        candidate_id,
+        candidate_rgb_fps,
+        candidate_ir_fps,
+        candidate_schedule,
+        now_unix,
+        fixture_current_context(candidate_rgb_fps, candidate_ir_fps),
+        format!("{conditioning_catalog_byte:02x}").repeat(32),
+        format!("{selected_policy_byte:02x}").repeat(32),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn validated_commissioning_fixture_with_serial(
+    candidate_id: &str,
+    candidate_rgb_fps: u32,
+    candidate_ir_fps: u32,
+    candidate_schedule: CaptureSchedule,
+    now_unix: u64,
+    serial: &str,
+) -> ValidatedLocalCommissioning {
+    let context = fixture_context_with(
+        candidate_rgb_fps,
+        candidate_ir_fps,
+        &ContextOverrides {
+            rgb_serial: Some(serial.to_owned()),
+            ..ContextOverrides::default()
+        },
+    );
+    validated_commissioning_fixture_with(
+        candidate_id,
+        candidate_rgb_fps,
+        candidate_ir_fps,
+        candidate_schedule,
+        now_unix,
+        context,
+        FIXTURE_CONDITIONING_CATALOG_SHA256.to_owned(),
+        FIXTURE_SELECTED_POLICY_SHA256.to_owned(),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn validated_commissioning_fixture_with(
+    candidate_id: &str,
+    candidate_rgb_fps: u32,
+    candidate_ir_fps: u32,
+    candidate_schedule: CaptureSchedule,
+    now_unix: u64,
+    context: QualificationContext,
+    conditioning_catalog_sha256: String,
+    selected_policy_sha256: String,
+) -> ValidatedLocalCommissioning {
     let mut value = fixture_commissioning_value(
         candidate_id,
         candidate_rgb_fps,
@@ -530,6 +637,9 @@ pub(crate) fn validated_commissioning_fixture(
     );
     value["measured_at_unix"] = serde_json::json!(now_unix.checked_sub(50).unwrap());
     value["expires_at_unix"] = serde_json::json!(now_unix.checked_add(86_400).unwrap());
+    value["context"] = serde_json::to_value(&context).unwrap();
+    value["conditioning_catalog_sha256"] = serde_json::json!(conditioning_catalog_sha256.clone());
+    value["selected_policy_sha256"] = serde_json::json!(selected_policy_sha256.clone());
     let wire: LocalCommissioningRecord = serde_json::from_value(value).unwrap();
     let canonical = serde_json::to_vec(&wire).unwrap();
     LocalCommissioningRecord::from_canonical_json(&canonical)
@@ -542,9 +652,9 @@ pub(crate) fn validated_commissioning_fixture(
                 candidate_ir_fps,
                 candidate_schedule,
             ),
-            &fixture_current_context(candidate_rgb_fps, candidate_ir_fps),
-            FIXTURE_CONDITIONING_CATALOG_SHA256,
-            FIXTURE_SELECTED_POLICY_SHA256,
+            &context,
+            &conditioning_catalog_sha256,
+            &selected_policy_sha256,
             now_unix,
         )
         .unwrap()

--- a/crates/irlume-camera/src/profile_qualification.rs
+++ b/crates/irlume-camera/src/profile_qualification.rs
@@ -11,6 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashSet,
     io::Read as _,
     path::{Path, PathBuf},
 };
@@ -20,14 +21,20 @@ use crate::{
         CameraEndpoint, QualificationContext, QualificationError, QualifiedStreamRole,
     },
     profile::{
-        rank_balanced, CandidateVerdict, CaptureSchedule, PairTransportProfile, ProfileGate,
-        QualificationScene, QualifiedProfileMetrics, RankingBudget,
+        rank_balanced, CandidateVerdict, CaptureSchedule, PairTransportProfile,
+        QualifiedProfileMetrics, RankingBudget,
     },
+    profile_commissioning::ValidatedLocalCommissioning,
+    release_qualification::{
+        HARDWARE_SCOPE_MATCH_POLICY_VERSION, RELEASE_QUALIFICATION_POLICY_VERSION,
+        RELEASE_QUALIFICATION_PRODUCER_VERSION,
+    },
+    release_qualification_signature::VerifiedReleaseQualification,
 };
 
 /// Profile-selection record shape understood by this build.
 pub const PROFILE_SELECTION_SCHEMA_VERSION: u32 = 1;
-/// Full-quality gate policy understood by this build.
+/// Profile-selection policy understood by this build.
 pub const PROFILE_SELECTION_POLICY_VERSION: u32 = 1;
 /// Version of the profile qualification producer.
 pub const PROFILE_QUALIFICATION_PRODUCER_VERSION: u32 = 1;
@@ -38,260 +45,9 @@ pub const MAX_PROFILE_SELECTION_RECORD_BYTES: usize = 256 * 1024;
 
 const MAX_PROFILE_ID_BYTES: usize = 256;
 
-/// Aggregate result for one gate. Scores and biometric outputs are deliberately absent.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum GateStatus {
-    Passed,
-    Failed,
-    NotApplicable,
-}
-
-/// Aggregate model-gate output. It cannot carry identities, scores, or authority writes.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct ProfileAuthGateEvidence {
-    detection: GateStatus,
-    recognition: GateStatus,
-    liveness: GateStatus,
-    rgb_pad: GateStatus,
-    ir_pad: GateStatus,
-}
-
-impl ProfileAuthGateEvidence {
-    /// Constructs one aggregate model assessment without biometric values.
-    #[must_use]
-    #[expect(
-        dead_code,
-        reason = "reserved for a future authorizing qualification runner"
-    )]
-    pub(crate) const fn new(
-        detection: GateStatus,
-        recognition: GateStatus,
-        liveness: GateStatus,
-        rgb_pad: GateStatus,
-        ir_pad: GateStatus,
-    ) -> Self {
-        Self {
-            detection,
-            recognition,
-            liveness,
-            rgb_pad,
-            ir_pad,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-struct SceneGateEvidence {
-    required: bool,
-    status: Option<GateStatus>,
-}
-
-/// Bounded aggregate evidence for every full-quality hard gate.
-///
-/// Aggregate model evidence is not constructible outside camera qualification.
-///
-/// ```compile_fail
-/// use irlume_camera::profile_qualification::ProfileAuthGateEvidence;
-/// let _ = ProfileAuthGateEvidence::new(
-///     irlume_camera::profile_qualification::GateStatus::Passed,
-///     irlume_camera::profile_qualification::GateStatus::Passed,
-///     irlume_camera::profile_qualification::GateStatus::Passed,
-///     irlume_camera::profile_qualification::GateStatus::Passed,
-///     irlume_camera::profile_qualification::GateStatus::Passed,
-/// );
-/// ```
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ProfileGateEvidence {
-    negotiation: Option<GateStatus>,
-    transport: Option<GateStatus>,
-    lit: SceneGateEvidence,
-    backlit: SceneGateEvidence,
-    low_light: SceneGateEvidence,
-    dark_ir: SceneGateEvidence,
-    detection: Option<GateStatus>,
-    recognition: Option<GateStatus>,
-    liveness: Option<GateStatus>,
-    rgb_pad: Option<GateStatus>,
-    ir_pad: Option<GateStatus>,
-    p50_latency_ms: Option<u64>,
-    p95_latency_ms: Option<u64>,
-    latency_budget_ms: Option<u64>,
-}
-
-impl ProfileGateEvidence {
-    /// Starts an incomplete diagnostic attempt. It grants no authority until complete.
-    #[must_use]
-    pub const fn empty() -> Self {
-        Self {
-            negotiation: None,
-            transport: None,
-            lit: SceneGateEvidence {
-                required: false,
-                status: None,
-            },
-            backlit: SceneGateEvidence {
-                required: false,
-                status: None,
-            },
-            low_light: SceneGateEvidence {
-                required: false,
-                status: None,
-            },
-            dark_ir: SceneGateEvidence {
-                required: false,
-                status: None,
-            },
-            detection: None,
-            recognition: None,
-            liveness: None,
-            rgb_pad: None,
-            ir_pad: None,
-            p50_latency_ms: None,
-            p95_latency_ms: None,
-            latency_budget_ms: None,
-        }
-    }
-
-    /// Records one non-scene gate without exposing model scores.
-    #[must_use]
-    pub fn with_gate(mut self, gate: ProfileGate, status: GateStatus) -> Self {
-        match gate {
-            ProfileGate::Negotiation => self.negotiation = Some(status),
-            ProfileGate::Transport => self.transport = Some(status),
-            ProfileGate::Detection => self.detection = Some(status),
-            ProfileGate::Recognition => self.recognition = Some(status),
-            ProfileGate::Liveness => self.liveness = Some(status),
-            ProfileGate::Signal | ProfileGate::Pad | ProfileGate::Latency => {}
-        }
-        self
-    }
-
-    /// Records whether one fixed scene is applicable and its aggregate result.
-    #[must_use]
-    pub fn with_scene(
-        mut self,
-        scene: QualificationScene,
-        required: bool,
-        status: GateStatus,
-    ) -> Self {
-        *self.scene_mut(scene) = SceneGateEvidence {
-            required,
-            status: Some(status),
-        };
-        self
-    }
-
-    /// Records aggregate RGB and IR PAD dispositions independently.
-    #[must_use]
-    pub const fn with_pad(mut self, rgb: GateStatus, ir: GateStatus) -> Self {
-        self.rgb_pad = Some(rgb);
-        self.ir_pad = Some(ir);
-        self
-    }
-
-    /// Records bounded wall-time percentiles and the fixed policy ceiling.
-    #[must_use]
-    pub const fn with_latency(mut self, p50_ms: u64, p95_ms: u64, budget_ms: u64) -> Self {
-        self.p50_latency_ms = Some(p50_ms);
-        self.p95_latency_ms = Some(p95_ms);
-        self.latency_budget_ms = Some(budget_ms);
-        self
-    }
-
-    #[cfg(test)]
-    fn without_gate(mut self, gate: ProfileGate) -> Self {
-        match gate {
-            ProfileGate::Negotiation => self.negotiation = None,
-            ProfileGate::Transport => self.transport = None,
-            ProfileGate::Detection => self.detection = None,
-            ProfileGate::Recognition => self.recognition = None,
-            ProfileGate::Liveness => self.liveness = None,
-            ProfileGate::Pad => {
-                self.rgb_pad = None;
-                self.ir_pad = None;
-            }
-            ProfileGate::Latency => {
-                self.p50_latency_ms = None;
-                self.p95_latency_ms = None;
-                self.latency_budget_ms = None;
-            }
-            ProfileGate::Signal => {
-                self.lit.status = None;
-            }
-        }
-        self
-    }
-
-    fn scene_mut(&mut self, scene: QualificationScene) -> &mut SceneGateEvidence {
-        match scene {
-            QualificationScene::Lit => &mut self.lit,
-            QualificationScene::Backlit => &mut self.backlit,
-            QualificationScene::LowLight => &mut self.low_light,
-            QualificationScene::DarkIr => &mut self.dark_ir,
-        }
-    }
-
-    fn validate(&self) -> Result<(), ProfileQualificationError> {
-        require_gate(ProfileGate::Negotiation, self.negotiation)?;
-        require_gate(ProfileGate::Transport, self.transport)?;
-        for scene in [self.lit, self.backlit, self.low_light, self.dark_ir] {
-            match (scene.required, scene.status) {
-                (true, None) | (false, None) => {
-                    return Err(ProfileQualificationError::MissingGate(ProfileGate::Signal));
-                }
-                (true, Some(GateStatus::Passed)) | (false, Some(GateStatus::NotApplicable)) => {}
-                (true, Some(GateStatus::Failed)) => {
-                    return Err(ProfileQualificationError::RejectedGate(ProfileGate::Signal));
-                }
-                _ => return Err(ProfileQualificationError::InvalidEvidence),
-            }
-        }
-        require_gate(ProfileGate::Detection, self.detection)?;
-        require_gate(ProfileGate::Recognition, self.recognition)?;
-        require_gate(ProfileGate::Liveness, self.liveness)?;
-        let (Some(rgb_pad), Some(ir_pad)) = (self.rgb_pad, self.ir_pad) else {
-            return Err(ProfileQualificationError::MissingGate(ProfileGate::Pad));
-        };
-        if matches!(rgb_pad, GateStatus::Failed) || matches!(ir_pad, GateStatus::Failed) {
-            return Err(ProfileQualificationError::RejectedGate(ProfileGate::Pad));
-        }
-        if !matches!(rgb_pad, GateStatus::Passed) && !matches!(ir_pad, GateStatus::Passed) {
-            return Err(ProfileQualificationError::InvalidEvidence);
-        }
-        let (Some(p50), Some(p95), Some(budget)) = (
-            self.p50_latency_ms,
-            self.p95_latency_ms,
-            self.latency_budget_ms,
-        ) else {
-            return Err(ProfileQualificationError::MissingGate(ProfileGate::Latency));
-        };
-        if p50 == 0 || p95 == 0 || budget == 0 || p50 > p95 {
-            return Err(ProfileQualificationError::InvalidEvidence);
-        }
-        if p95 > budget {
-            return Err(ProfileQualificationError::RejectedGate(
-                ProfileGate::Latency,
-            ));
-        }
-        Ok(())
-    }
-}
-
-fn require_gate(
-    gate: ProfileGate,
-    status: Option<GateStatus>,
-) -> Result<(), ProfileQualificationError> {
-    match status {
-        None => Err(ProfileQualificationError::MissingGate(gate)),
-        Some(GateStatus::Passed) => Ok(()),
-        Some(GateStatus::Failed) => Err(ProfileQualificationError::RejectedGate(gate)),
-        Some(GateStatus::NotApplicable) => Err(ProfileQualificationError::InvalidEvidence),
-    }
-}
-
 /// Camera-pair identity and connection facts collected before format selection.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProfileScope {
     rgb_endpoint: CameraEndpoint,
     ir_endpoint: CameraEndpoint,
@@ -342,184 +98,134 @@ impl ProfileScope {
     }
 }
 
-/// Current model and conditioning authority against which attempts are checked.
+/// Current installed contracts against which opaque evidence is checked.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct QualificationAuthorityContext {
-    model_contract_digest: String,
-    conditioning_catalog_digest: String,
+pub(crate) struct QualificationAuthorityContext {
+    model_contract_sha256: String,
+    preprocessing_contract_sha256: String,
+    conditioning_catalog_sha256: String,
+    selected_policy_sha256: String,
 }
 
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "reserved for reviewed profile-selection integration"
+    )
+)]
 impl QualificationAuthorityContext {
-    #[must_use]
-    pub const fn new(model_contract_digest: String, conditioning_catalog_digest: String) -> Self {
-        Self {
-            model_contract_digest,
-            conditioning_catalog_digest,
-        }
-    }
-
-    fn validate(&self) -> Result<(), ProfileQualificationError> {
-        validate_digest(&self.model_contract_digest)?;
-        validate_digest(&self.conditioning_catalog_digest)
-    }
-}
-
-/// One candidate attempt. Incomplete evidence remains diagnostic-only.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ProfileQualificationAttempt {
-    producer_version: u32,
-    measured_at_unix: u64,
-    profile_id: String,
-    context: QualificationContext,
-    schedule: CaptureSchedule,
-    gates: ProfileGateEvidence,
-    model_contract_digest: String,
-    conditioning_catalog_digest: String,
-    evaluation_manifest_digest: String,
-    pre_scope: ProfileScope,
-    post_scope: ProfileScope,
-}
-
-impl ProfileQualificationAttempt {
-    /// Constructs a bounded attempt without treating incomplete gates as authority.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for invalid profile, context, version, or digest facts.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        measured_at_unix: u64,
-        profile_id: String,
-        context: QualificationContext,
-        schedule: CaptureSchedule,
-        gates: ProfileGateEvidence,
-        model_contract_digest: String,
-        conditioning_catalog_digest: String,
-        evaluation_manifest_digest: String,
-        post_scope: ProfileScope,
+    pub(crate) fn new(
+        model_contract_sha256: String,
+        preprocessing_contract_sha256: String,
+        conditioning_catalog_sha256: String,
+        selected_policy_sha256: String,
     ) -> Result<Self, ProfileQualificationError> {
-        let pre_scope = ProfileScope::from_context(&context)?;
         let value = Self {
-            producer_version: PROFILE_QUALIFICATION_PRODUCER_VERSION,
-            measured_at_unix,
-            profile_id,
-            context,
-            schedule,
-            gates,
-            model_contract_digest,
-            conditioning_catalog_digest,
-            evaluation_manifest_digest,
-            pre_scope,
-            post_scope,
+            model_contract_sha256,
+            preprocessing_contract_sha256,
+            conditioning_catalog_sha256,
+            selected_policy_sha256,
         };
-        value.validate_structure()?;
+        value.validate()?;
         Ok(value)
     }
 
-    fn validate_structure(&self) -> Result<(), ProfileQualificationError> {
-        if self.producer_version != PROFILE_QUALIFICATION_PRODUCER_VERSION
-            || self.measured_at_unix == 0
-        {
-            return Err(ProfileQualificationError::InvalidEvidence);
+    fn validate(&self) -> Result<(), ProfileQualificationError> {
+        validate_digest(&self.model_contract_sha256)?;
+        validate_digest(&self.preprocessing_contract_sha256)?;
+        validate_digest(&self.conditioning_catalog_sha256)?;
+        validate_digest(&self.selected_policy_sha256)
+    }
+}
+
+/// One candidate backed by separate verified release and local evidence.
+#[derive(Debug)]
+pub(crate) struct QualifiedCandidateEvidence {
+    release: VerifiedReleaseQualification,
+    local: ValidatedLocalCommissioning,
+}
+
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "reserved for reviewed profile-selection integration"
+    )
+)]
+impl QualifiedCandidateEvidence {
+    pub(crate) fn new(
+        release: VerifiedReleaseQualification,
+        local: ValidatedLocalCommissioning,
+        authority: &QualificationAuthorityContext,
+    ) -> Result<Self, ProfileQualificationError> {
+        let value = Self { release, local };
+        value.validate_for(authority)?;
+        Ok(value)
+    }
+
+    fn validate_for(
+        &self,
+        authority: &QualificationAuthorityContext,
+    ) -> Result<(), ProfileQualificationError> {
+        authority.validate()?;
+        let artifact = self.release.artifact();
+        let release_profile = artifact
+            .candidate_profile()
+            .to_profile()
+            .map_err(|_| ProfileQualificationError::InvalidEvidence)?;
+        if release_profile != *self.local.profile() {
+            return Err(ProfileQualificationError::ProfileMismatch);
         }
-        validate_profile_id(&self.profile_id)?;
-        self.pre_scope.validate()?;
-        self.post_scope.validate()?;
-        validate_digest(&self.model_contract_digest)?;
-        validate_digest(&self.conditioning_catalog_digest)?;
-        validate_digest(&self.evaluation_manifest_digest)?;
-        self.profile()?;
+        if !artifact
+            .hardware_scope()
+            .matches_context(self.local.context(), self.local.interface_layout_sha256())
+        {
+            return Err(ProfileQualificationError::HardwareScopeMismatch);
+        }
+        if artifact.model_contract_sha256() != authority.model_contract_sha256 {
+            return Err(ProfileQualificationError::ModelContractChanged);
+        }
+        if artifact.preprocessing_contract_sha256() != authority.preprocessing_contract_sha256 {
+            return Err(ProfileQualificationError::PreprocessingContractChanged);
+        }
+        if artifact.conditioning_catalog_sha256() != authority.conditioning_catalog_sha256
+            || self.local.conditioning_catalog_sha256() != authority.conditioning_catalog_sha256
+        {
+            return Err(ProfileQualificationError::ConditioningCatalogChanged);
+        }
+        if artifact.selected_policy_sha256() != authority.selected_policy_sha256
+            || self.local.selected_policy_sha256() != authority.selected_policy_sha256
+        {
+            return Err(ProfileQualificationError::SelectedPolicyChanged);
+        }
         Ok(())
     }
 
-    /// Resolves this attempt against the authority it recorded.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first missing, failed, stale, or inconsistent qualification gate.
-    pub fn qualified(&self) -> Result<QualifiedProfileRecord, ProfileQualificationError> {
-        self.qualified_for(&QualificationAuthorityContext::new(
-            self.model_contract_digest.clone(),
-            self.conditioning_catalog_digest.clone(),
-        ))
-    }
-
-    /// Resolves this attempt only if current model and catalog authority still match.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first missing, failed, stale, or inconsistent qualification gate.
-    pub fn qualified_for(
-        &self,
-        authority: &QualificationAuthorityContext,
-    ) -> Result<QualifiedProfileRecord, ProfileQualificationError> {
-        self.validate_structure()?;
-        authority.validate()?;
-        if self.model_contract_digest != authority.model_contract_digest {
-            return Err(ProfileQualificationError::ModelContractChanged);
+    fn to_record(&self) -> QualifiedProfileRecord {
+        QualifiedProfileRecord {
+            profile_id: self.local.profile_id().to_owned(),
+            context: self.local.context().clone(),
+            schedule: self.local.profile().schedule(),
+            p50_latency_ms: self.local.p50_latency_ms(),
+            p95_latency_ms: self.local.p95_latency_ms(),
+            release_qualification_sha256: self.release.artifact_sha256().to_owned(),
+            local_commissioning_sha256: self.local.record_sha256().to_owned(),
         }
-        if self.conditioning_catalog_digest != authority.conditioning_catalog_digest {
-            return Err(ProfileQualificationError::ConditioningCatalogChanged);
-        }
-        if self.pre_scope != self.post_scope {
-            return Err(ProfileQualificationError::ContextChanged);
-        }
-        self.gates.validate()?;
-        let p50_latency_ms = self
-            .gates
-            .p50_latency_ms
-            .ok_or(ProfileQualificationError::MissingGate(ProfileGate::Latency))?;
-        let p95_latency_ms = self
-            .gates
-            .p95_latency_ms
-            .ok_or(ProfileQualificationError::MissingGate(ProfileGate::Latency))?;
-        Ok(QualifiedProfileRecord {
-            profile_id: self.profile_id.clone(),
-            context: self.context.clone(),
-            schedule: self.schedule,
-            p50_latency_ms,
-            p95_latency_ms,
-            evaluation_manifest_digest: self.evaluation_manifest_digest.clone(),
-        })
-    }
-
-    fn profile(&self) -> Result<PairTransportProfile, ProfileQualificationError> {
-        self.context
-            .validate()
-            .map_err(ProfileQualificationError::Context)?;
-        PairTransportProfile::from_negotiated(
-            self.profile_id.clone(),
-            self.context
-                .rgb_stream()
-                .requested_tuple()
-                .ok_or(ProfileQualificationError::InvalidEvidence)?,
-            self.context
-                .rgb_stream()
-                .accepted_tuple()
-                .ok_or(ProfileQualificationError::InvalidEvidence)?,
-            self.context
-                .ir_stream()
-                .requested_tuple()
-                .ok_or(ProfileQualificationError::InvalidEvidence)?,
-            self.context
-                .ir_stream()
-                .accepted_tuple()
-                .ok_or(ProfileQualificationError::InvalidEvidence)?,
-            self.schedule,
-        )
-        .map_err(|_| ProfileQualificationError::InvalidEvidence)
     }
 }
 
 /// One exact profile whose full-quality gates passed.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct QualifiedProfileRecord {
     profile_id: String,
     context: QualificationContext,
     schedule: CaptureSchedule,
     p50_latency_ms: u64,
     p95_latency_ms: u64,
-    evaluation_manifest_digest: String,
+    release_qualification_sha256: String,
+    local_commissioning_sha256: String,
 }
 
 impl QualifiedProfileRecord {
@@ -533,9 +239,26 @@ impl QualifiedProfileRecord {
         self.schedule
     }
 
+    #[must_use]
+    pub fn release_qualification_sha256(&self) -> &str {
+        &self.release_qualification_sha256
+    }
+
+    #[must_use]
+    pub fn local_commissioning_sha256(&self) -> &str {
+        &self.local_commissioning_sha256
+    }
+
     fn profile(&self) -> Result<PairTransportProfile, ProfileQualificationError> {
         validate_profile_id(&self.profile_id)?;
-        validate_digest(&self.evaluation_manifest_digest)?;
+        validate_digest(&self.release_qualification_sha256)?;
+        validate_digest(&self.local_commissioning_sha256)?;
+        if self.p50_latency_ms == 0
+            || self.p95_latency_ms == 0
+            || self.p50_latency_ms > self.p95_latency_ms
+        {
+            return Err(ProfileQualificationError::InvalidEvidence);
+        }
         self.context
             .validate()
             .map_err(ProfileQualificationError::Context)?;
@@ -574,15 +297,24 @@ impl QualifiedProfileRecord {
 
 /// Separate, versioned profile-selection authority for one physical pair scope.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProfileSelectionRecord {
     schema_version: u32,
     policy_version: u32,
     producer_version: u32,
     measured_at_unix: u64,
     scope: ProfileScope,
-    model_contract_digest: String,
-    conditioning_catalog_digest: String,
-    evaluation_manifest_digest: String,
+    release_policy_version: u32,
+    release_producer_version: u32,
+    hardware_match_policy_version: u32,
+    campaign_id: String,
+    campaign_protocol_sha256: String,
+    campaign_result_sha256: String,
+    baseline_profile_sha256: String,
+    model_contract_sha256: String,
+    preprocessing_contract_sha256: String,
+    conditioning_catalog_sha256: String,
+    selected_policy_sha256: String,
     selected: QualifiedProfileRecord,
     sequential_fallback: Option<QualifiedProfileRecord>,
 }
@@ -595,8 +327,7 @@ impl ProfileSelectionRecord {
     /// Returns an error when authority is invalid or JSON serialization fails.
     pub fn to_json(&self) -> Result<String, ProfileQualificationError> {
         self.validate()?;
-        serde_json::to_string_pretty(self)
-            .map_err(|error| ProfileQualificationError::Json(error.to_string()))
+        serde_json::to_string_pretty(self).map_err(|_| ProfileQualificationError::Json)
     }
 
     /// Parse bounded untrusted bytes and revalidate all nested authority.
@@ -608,8 +339,8 @@ impl ProfileSelectionRecord {
         if bytes.len() > MAX_PROFILE_SELECTION_RECORD_BYTES {
             return Err(ProfileQualificationError::RecordTooLarge);
         }
-        let value: Self = serde_json::from_slice(bytes)
-            .map_err(|error| ProfileQualificationError::Json(error.to_string()))?;
+        let value: Self =
+            serde_json::from_slice(bytes).map_err(|_| ProfileQualificationError::Json)?;
         value.validate()?;
         Ok(value)
     }
@@ -630,8 +361,8 @@ impl ProfileSelectionRecord {
     }
 
     #[must_use]
-    pub fn model_contract_digest(&self) -> &str {
-        &self.model_contract_digest
+    pub fn model_contract_sha256(&self) -> &str {
+        &self.model_contract_sha256
     }
 
     fn validate(&self) -> Result<(), ProfileQualificationError> {
@@ -647,24 +378,32 @@ impl ProfileSelectionRecord {
         }
         if self.producer_version != PROFILE_QUALIFICATION_PRODUCER_VERSION
             || self.measured_at_unix == 0
+            || self.release_policy_version != RELEASE_QUALIFICATION_POLICY_VERSION
+            || self.release_producer_version != RELEASE_QUALIFICATION_PRODUCER_VERSION
+            || self.hardware_match_policy_version != HARDWARE_SCOPE_MATCH_POLICY_VERSION
         {
             return Err(ProfileQualificationError::InvalidEvidence);
         }
         self.scope.validate()?;
-        validate_digest(&self.model_contract_digest)?;
-        validate_digest(&self.conditioning_catalog_digest)?;
-        validate_digest(&self.evaluation_manifest_digest)?;
+        validate_profile_id(&self.campaign_id)?;
+        for digest in [
+            &self.campaign_protocol_sha256,
+            &self.campaign_result_sha256,
+            &self.baseline_profile_sha256,
+            &self.model_contract_sha256,
+            &self.preprocessing_contract_sha256,
+            &self.conditioning_catalog_sha256,
+            &self.selected_policy_sha256,
+        ] {
+            validate_digest(digest)?;
+        }
         self.selected.profile()?;
         if ProfileScope::from_context(&self.selected.context)? != self.scope {
             return Err(ProfileQualificationError::ContextChanged);
         }
-        if self.selected.evaluation_manifest_digest != self.evaluation_manifest_digest {
-            return Err(ProfileQualificationError::InvalidEvidence);
-        }
         if let Some(fallback) = &self.sequential_fallback {
             fallback.profile()?;
             if fallback.schedule != CaptureSchedule::Sequential
-                || fallback.evaluation_manifest_digest != self.evaluation_manifest_digest
                 || ProfileScope::from_context(&fallback.context)? != self.scope
             {
                 return Err(ProfileQualificationError::InvalidEvidence);
@@ -741,7 +480,7 @@ impl ProfileSelectionStore {
         Self::at(irlume_common::state_dir().join("profile-selections"))
     }
 
-    fn at(dir: PathBuf) -> Self {
+    pub(crate) fn at(dir: PathBuf) -> Self {
         Self { dir }
     }
 
@@ -763,7 +502,8 @@ impl ProfileSelectionStore {
     /// # Errors
     ///
     /// Returns an error for invalid authority, stale revision, or publication failure.
-    pub fn save(
+    #[cfg(test)]
+    pub(crate) fn save(
         &self,
         record: ProfileSelectionRecord,
         expected_revision: Option<u64>,
@@ -786,8 +526,8 @@ impl ProfileSelectionStore {
             .ok_or(ProfileSelectionStoreError::RevisionExhausted)?;
         let stored = StoredProfileSelection { revision, record };
         stored.validate()?;
-        let mut body = serde_json::to_vec_pretty(&stored)
-            .map_err(|error| ProfileQualificationError::Json(error.to_string()))?;
+        let mut body =
+            serde_json::to_vec_pretty(&stored).map_err(|_| ProfileQualificationError::Json)?;
         body.push(b'\n');
         if body.len() > MAX_PROFILE_SELECTION_RECORD_BYTES {
             return Err(ProfileQualificationError::RecordTooLarge.into());
@@ -805,6 +545,7 @@ impl ProfileSelectionStore {
         }
     }
 
+    #[cfg(test)]
     fn ensure_dir(&self) -> Result<(), ProfileSelectionStoreError> {
         let existed = self.dir.exists();
         std::fs::create_dir_all(&self.dir)
@@ -865,16 +606,18 @@ fn read_stored_selection(
     if body.len() > MAX_PROFILE_SELECTION_RECORD_BYTES {
         return Err(ProfileQualificationError::RecordTooLarge.into());
     }
-    let stored: StoredProfileSelection = serde_json::from_slice(&body)
-        .map_err(|error| ProfileQualificationError::Json(error.to_string()))?;
+    let stored: StoredProfileSelection =
+        serde_json::from_slice(&body).map_err(|_| ProfileQualificationError::Json)?;
     stored.validate()?;
     Ok(Some(stored))
 }
 
+#[cfg(test)]
 struct ProfileStoreLock {
     _file: std::fs::File,
 }
 
+#[cfg(test)]
 impl ProfileStoreLock {
     fn acquire(path: &Path) -> Result<Self, ProfileSelectionStoreError> {
         #[cfg(unix)]
@@ -923,36 +666,72 @@ fn profile_store_io(
 ///
 /// # Errors
 ///
-/// Returns an error when no complete candidate passes or shared authority is inconsistent.
-pub fn select_profiles(
-    attempts: Vec<ProfileQualificationAttempt>,
+/// Returns an error when candidate evidence or shared authority is inconsistent.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "reserved for reviewed profile-selection integration"
+    )
+)]
+pub(crate) fn select_profiles(
+    candidates: Vec<QualifiedCandidateEvidence>,
     authority: QualificationAuthorityContext,
     budget: RankingBudget,
 ) -> Result<ProfileSelectionRecord, ProfileQualificationError> {
-    if attempts.is_empty() || attempts.len() > MAX_PROFILE_CANDIDATES {
+    if candidates.is_empty() || candidates.len() > MAX_PROFILE_CANDIDATES {
         return Err(ProfileQualificationError::CandidateCount);
     }
     authority.validate()?;
-    let measured_at_unix = attempts
+    let first = &candidates[0];
+    first.validate_for(&authority)?;
+    let first_artifact = first.release.artifact();
+    let scope = ProfileScope::from_context(first.local.context())?;
+    let release_policy_version = first_artifact.policy_version();
+    let release_producer_version = first_artifact.producer_version();
+    let hardware_match_policy_version = first_artifact.hardware_scope().match_policy_version();
+    let campaign_id = first_artifact.campaign_id().to_owned();
+    let campaign_protocol_sha256 = first_artifact.campaign_protocol_sha256().to_owned();
+    let campaign_result_sha256 = first_artifact.campaign_result_sha256().to_owned();
+    let baseline_profile_sha256 = first_artifact
+        .baseline_profile_sha256()
+        .map_err(|_| ProfileQualificationError::InvalidEvidence)?;
+    let measured_at_unix = candidates
         .iter()
-        .map(|attempt| attempt.measured_at_unix)
+        .map(|candidate| candidate.local.measured_at_unix())
         .max()
         .ok_or(ProfileQualificationError::CandidateCount)?;
-    let scope = attempts[0].pre_scope.clone();
-    let manifest = attempts[0].evaluation_manifest_digest.clone();
-    let mut qualified = Vec::with_capacity(attempts.len());
-    for attempt in attempts {
-        if attempt.pre_scope != scope || attempt.evaluation_manifest_digest != manifest {
+    let mut unique_candidates = HashSet::with_capacity(candidates.len());
+    let mut qualified = Vec::with_capacity(candidates.len());
+    for candidate in &candidates {
+        candidate.validate_for(&authority)?;
+        let artifact = candidate.release.artifact();
+        if !unique_candidates.insert((
+            candidate.local.profile_id().to_owned(),
+            candidate.local.profile().schedule(),
+        )) {
+            return Err(ProfileQualificationError::DuplicateCandidate);
+        }
+        if ProfileScope::from_context(candidate.local.context())? != scope {
             return Err(ProfileQualificationError::ContextChanged);
         }
-        match attempt.qualified_for(&authority) {
-            Ok(candidate) => qualified.push(candidate),
-            Err(
-                ProfileQualificationError::MissingGate(_)
-                | ProfileQualificationError::RejectedGate(_),
-            ) => {}
-            Err(error) => return Err(error),
+        if artifact
+            .baseline_profile_sha256()
+            .map_err(|_| ProfileQualificationError::InvalidEvidence)?
+            != baseline_profile_sha256
+        {
+            return Err(ProfileQualificationError::BaselineProfileMismatch);
         }
+        if artifact.policy_version() != release_policy_version
+            || artifact.producer_version() != release_producer_version
+            || artifact.hardware_scope().match_policy_version() != hardware_match_policy_version
+            || artifact.campaign_id() != campaign_id
+            || artifact.campaign_protocol_sha256() != campaign_protocol_sha256
+            || artifact.campaign_result_sha256() != campaign_result_sha256
+        {
+            return Err(ProfileQualificationError::ContextChanged);
+        }
+        qualified.push(candidate.to_record());
     }
     let concurrent: Vec<_> = qualified
         .iter()
@@ -969,7 +748,7 @@ pub fn select_profiles(
     } else {
         rank_balanced(&concurrent, budget)
     }
-    .ok_or(ProfileQualificationError::NoPassingProfile)?;
+    .ok_or(ProfileQualificationError::InvalidEvidence)?;
     let selected = qualified
         .iter()
         .find(|candidate| {
@@ -993,9 +772,17 @@ pub fn select_profiles(
         producer_version: PROFILE_QUALIFICATION_PRODUCER_VERSION,
         measured_at_unix,
         scope,
-        model_contract_digest: authority.model_contract_digest,
-        conditioning_catalog_digest: authority.conditioning_catalog_digest,
-        evaluation_manifest_digest: manifest,
+        release_policy_version,
+        release_producer_version,
+        hardware_match_policy_version,
+        campaign_id,
+        campaign_protocol_sha256,
+        campaign_result_sha256,
+        baseline_profile_sha256,
+        model_contract_sha256: authority.model_contract_sha256,
+        preprocessing_contract_sha256: authority.preprocessing_contract_sha256,
+        conditioning_catalog_sha256: authority.conditioning_catalog_sha256,
+        selected_policy_sha256: authority.selected_policy_sha256,
         selected,
         sequential_fallback,
     };
@@ -1022,30 +809,53 @@ fn validate_digest(value: &str) -> Result<(), ProfileQualificationError> {
     Ok(())
 }
 
-/// Why incomplete or stale full-quality evidence cannot grant selection authority.
+/// Why dual profile evidence cannot grant selection authority.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ProfileQualificationError {
-    MissingGate(ProfileGate),
-    RejectedGate(ProfileGate),
+    ProfileMismatch,
+    HardwareScopeMismatch,
+    BaselineProfileMismatch,
     ModelContractChanged,
+    PreprocessingContractChanged,
     ConditioningCatalogChanged,
+    SelectedPolicyChanged,
     ContextChanged,
+    DuplicateCandidate,
     InvalidEvidence,
     InvalidProfileId,
     InvalidDigest,
     CandidateCount,
-    NoPassingProfile,
     UnsupportedSchema(u32),
     UnsupportedPolicy(u32),
     RecordTooLarge,
-    Json(String),
+    Json,
     Context(QualificationError),
 }
 
 impl std::fmt::Display for ProfileQualificationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "profile qualification failed: {self:?}")
+        let category = match self {
+            Self::ProfileMismatch => "profile_mismatch",
+            Self::HardwareScopeMismatch => "hardware_scope_mismatch",
+            Self::BaselineProfileMismatch => "baseline_profile_mismatch",
+            Self::ModelContractChanged => "model_contract_changed",
+            Self::PreprocessingContractChanged => "preprocessing_contract_changed",
+            Self::ConditioningCatalogChanged => "conditioning_catalog_changed",
+            Self::SelectedPolicyChanged => "selected_policy_changed",
+            Self::ContextChanged => "camera_context_changed",
+            Self::DuplicateCandidate => "duplicate_candidate",
+            Self::InvalidEvidence => "profile_evidence_invalid",
+            Self::InvalidProfileId => "profile_identifier_invalid",
+            Self::InvalidDigest => "profile_digest_invalid",
+            Self::CandidateCount => "profile_candidate_count_invalid",
+            Self::UnsupportedSchema(_) => "profile_selection_schema_unsupported",
+            Self::UnsupportedPolicy(_) => "profile_selection_policy_unsupported",
+            Self::RecordTooLarge => "profile_selection_too_large",
+            Self::Json => "profile_selection_json_invalid",
+            Self::Context(_) => "profile_context_invalid",
+        };
+        formatter.write_str(category)
     }
 }
 
@@ -1055,259 +865,422 @@ impl std::error::Error for ProfileQualificationError {}
 mod tests {
     use super::*;
     use crate::{
-        capture_qualification::{
-            AcceptedStream, CameraEndpoint, ConnectionContext, ExactInterval, ExactRate,
-            QualificationContext, QualifiedStreamRole, RequestedStream, StreamContract,
+        profile::{CaptureSchedule, RankingBudget},
+        profile_commissioning::{
+            validated_commissioning_fixture, validated_commissioning_fixture_with_bindings,
+            validated_commissioning_fixture_with_serial,
         },
-        profile::{CaptureSchedule, ProfileGate, RankingBudget},
+        release_qualification_signature::{
+            verified_release_fixture, verified_release_fixture_with_descriptor,
+        },
     };
 
-    fn endpoint(role: QualifiedStreamRole) -> CameraEndpoint {
-        CameraEndpoint::new(
-            "ab".repeat(32),
-            0x0bda,
-            0x5678,
-            Some("fixture-serial".into()),
-            match role {
-                QualifiedStreamRole::Rgb => 0,
-                QualifiedStreamRole::Ir => 2,
-            },
-            "/devices/pci0000:00/0000:00:14.0/usb4/4-2".into(),
-            role,
-            ConnectionContext::new(
-                "/devices/pci0000:00/0000:00:14.0".into(),
-                5_000_000,
-                "uvcvideo".into(),
-                "v4l2-uvc".into(),
-            )
-            .unwrap(),
+    const FIXED_NOW: u64 = 1_788_192_050;
+
+    fn authority_fixture() -> QualificationAuthorityContext {
+        QualificationAuthorityContext::new(
+            "77".repeat(32),
+            "66".repeat(32),
+            "44".repeat(32),
+            "55".repeat(32),
         )
         .unwrap()
     }
 
-    fn stream(role: QualifiedStreamRole, height: u32, fps: u32) -> StreamContract {
-        let fourcc = match role {
-            QualifiedStreamRole::Rgb => "YUYV",
-            QualifiedStreamRole::Ir => "GREY",
-        };
-        StreamContract::new(
-            role,
-            RequestedStream::new(
-                640,
-                height,
-                fourcc.into(),
-                ExactInterval::new(1, fps).unwrap(),
-            )
-            .unwrap(),
-            AcceptedStream::new(
-                640,
-                height,
-                fourcc.into(),
-                1_280,
-                640 * height * 2,
-                0,
-                8,
-                1,
-                1,
-                0,
-                ExactInterval::new(1, fps).unwrap(),
-            )
-            .unwrap(),
-            ExactRate::new(15, 2).unwrap(),
-        )
-        .unwrap()
-    }
-
-    fn context(fps: u32) -> QualificationContext {
-        QualificationContext::new(
-            endpoint(QualifiedStreamRole::Rgb),
-            endpoint(QualifiedStreamRole::Ir),
-            stream(QualifiedStreamRole::Rgb, 480, fps),
-            stream(QualifiedStreamRole::Ir, 400, fps),
-        )
-        .unwrap()
-    }
-
-    fn complete_gates() -> ProfileGateEvidence {
-        ProfileGateEvidence::empty()
-            .with_gate(ProfileGate::Negotiation, GateStatus::Passed)
-            .with_gate(ProfileGate::Transport, GateStatus::Passed)
-            .with_scene(QualificationScene::Lit, true, GateStatus::Passed)
-            .with_scene(QualificationScene::Backlit, true, GateStatus::Passed)
-            .with_scene(QualificationScene::LowLight, true, GateStatus::Passed)
-            .with_scene(QualificationScene::DarkIr, true, GateStatus::Passed)
-            .with_gate(ProfileGate::Detection, GateStatus::Passed)
-            .with_gate(ProfileGate::Recognition, GateStatus::Passed)
-            .with_gate(ProfileGate::Liveness, GateStatus::Passed)
-            .with_pad(GateStatus::Passed, GateStatus::Passed)
-            .with_latency(4_000, 6_000, 8_000)
-    }
-
-    fn attempt(
+    fn candidate_fixture(
         id: &str,
-        fps: u32,
+        rgb_fps: u32,
+        ir_fps: u32,
         schedule: CaptureSchedule,
-        gates: ProfileGateEvidence,
-    ) -> ProfileQualificationAttempt {
-        let context = context(fps);
-        let post_scope = ProfileScope::from_context(&context).unwrap();
-        ProfileQualificationAttempt::new(
-            1_788_192_000,
-            id.into(),
-            context,
+    ) -> QualifiedCandidateEvidence {
+        candidate_fixture_with_release("baseline-30-15", id, rgb_fps, ir_fps, schedule, 0x44)
+    }
+
+    fn candidate_fixture_with_release(
+        baseline_id: &str,
+        id: &str,
+        rgb_fps: u32,
+        ir_fps: u32,
+        schedule: CaptureSchedule,
+        campaign_byte: u8,
+    ) -> QualifiedCandidateEvidence {
+        let release = verified_release_fixture(
+            baseline_id,
+            id,
+            rgb_fps,
+            ir_fps,
             schedule,
-            gates,
-            "11".repeat(32),
-            "22".repeat(32),
-            "33".repeat(32),
-            post_scope,
+            campaign_byte,
+            FIXED_NOW,
+        );
+        let local = validated_commissioning_fixture(id, rgb_fps, ir_fps, schedule, FIXED_NOW);
+        QualifiedCandidateEvidence::new(release, local, &authority_fixture()).unwrap()
+    }
+
+    fn candidate_with_profile_mismatch(
+    ) -> Result<QualifiedCandidateEvidence, ProfileQualificationError> {
+        let release = verified_release_fixture(
+            "baseline-30-15",
+            "release-candidate",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+            0x44,
+            FIXED_NOW,
+        );
+        let local = validated_commissioning_fixture(
+            "local-candidate",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+            FIXED_NOW,
+        );
+        QualifiedCandidateEvidence::new(release, local, &authority_fixture())
+    }
+
+    fn candidate_with_scope_mismatch(
+    ) -> Result<QualifiedCandidateEvidence, ProfileQualificationError> {
+        let release = verified_release_fixture_with_descriptor(
+            "baseline-30-15",
+            "candidate-15-15",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+            0x44,
+            FIXED_NOW,
+            &"cd".repeat(32),
+        );
+        let local = validated_commissioning_fixture(
+            "candidate-15-15",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+            FIXED_NOW,
+        );
+        QualifiedCandidateEvidence::new(release, local, &authority_fixture())
+    }
+
+    fn candidate_with_model_drift() -> Result<QualifiedCandidateEvidence, ProfileQualificationError>
+    {
+        let release = verified_release_fixture(
+            "baseline-30-15",
+            "candidate-15-15",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+            0x44,
+            FIXED_NOW,
+        );
+        let local = validated_commissioning_fixture(
+            "candidate-15-15",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+            FIXED_NOW,
+        );
+        let authority = QualificationAuthorityContext::new(
+            "78".repeat(32),
+            "66".repeat(32),
+            "44".repeat(32),
+            "55".repeat(32),
         )
-        .unwrap()
+        .unwrap();
+        QualifiedCandidateEvidence::new(release, local, &authority)
     }
 
     #[test]
-    fn transport_only_attempt_cannot_select_a_profile() {
-        let gates = ProfileGateEvidence::empty()
-            .with_gate(ProfileGate::Negotiation, GateStatus::Passed)
-            .with_gate(ProfileGate::Transport, GateStatus::Passed)
-            .with_scene(QualificationScene::Lit, true, GateStatus::Passed)
-            .with_scene(
-                QualificationScene::Backlit,
-                false,
-                GateStatus::NotApplicable,
-            )
-            .with_scene(
-                QualificationScene::LowLight,
-                false,
-                GateStatus::NotApplicable,
-            )
-            .with_scene(QualificationScene::DarkIr, false, GateStatus::NotApplicable);
-        let attempt = attempt("transport-only", 15, CaptureSchedule::Concurrent, gates);
+    fn release_and_local_pass_select_balanced_candidate_and_sequential_fallback() {
+        let candidates = vec![
+            candidate_fixture("concurrent-30-15", 30, 15, CaptureSchedule::Concurrent),
+            candidate_fixture("concurrent-15-15", 15, 15, CaptureSchedule::Concurrent),
+            candidate_fixture("sequential-15-15", 15, 15, CaptureSchedule::Sequential),
+        ];
+        let record = select_profiles(
+            candidates,
+            authority_fixture(),
+            RankingBudget::new(1, 20_000_000, 10_000).unwrap(),
+        )
+        .unwrap();
 
+        assert_eq!(record.selected().profile_id(), "concurrent-15-15");
         assert_eq!(
-            attempt.qualified().unwrap_err(),
-            ProfileQualificationError::MissingGate(ProfileGate::Detection)
+            record.sequential_fallback().unwrap().profile_id(),
+            "sequential-15-15"
+        );
+        assert_ne!(
+            record.selected().release_qualification_sha256(),
+            record.selected().local_commissioning_sha256(),
+        );
+        assert_eq!(record.model_contract_sha256(), "77".repeat(32));
+    }
+
+    #[test]
+    fn mismatched_evidence_never_enters_ranking() {
+        assert_eq!(
+            candidate_with_profile_mismatch().unwrap_err(),
+            ProfileQualificationError::ProfileMismatch,
+        );
+        assert_eq!(
+            candidate_with_scope_mismatch().unwrap_err(),
+            ProfileQualificationError::HardwareScopeMismatch,
+        );
+        assert_eq!(
+            candidate_with_model_drift().unwrap_err(),
+            ProfileQualificationError::ModelContractChanged,
         );
     }
 
     #[test]
-    fn every_model_quality_and_latency_gate_is_mandatory() {
-        let cases = [
+    fn every_current_contract_binding_is_mandatory() {
+        let authority_cases = [
             (
-                ProfileGate::Detection,
-                complete_gates().without_gate(ProfileGate::Detection),
+                QualificationAuthorityContext::new(
+                    "77".repeat(32),
+                    "67".repeat(32),
+                    "44".repeat(32),
+                    "55".repeat(32),
+                )
+                .unwrap(),
+                ProfileQualificationError::PreprocessingContractChanged,
             ),
             (
-                ProfileGate::Recognition,
-                complete_gates().without_gate(ProfileGate::Recognition),
+                QualificationAuthorityContext::new(
+                    "77".repeat(32),
+                    "66".repeat(32),
+                    "45".repeat(32),
+                    "55".repeat(32),
+                )
+                .unwrap(),
+                ProfileQualificationError::ConditioningCatalogChanged,
             ),
             (
-                ProfileGate::Liveness,
-                complete_gates().without_gate(ProfileGate::Liveness),
-            ),
-            (
-                ProfileGate::Pad,
-                complete_gates().without_gate(ProfileGate::Pad),
-            ),
-            (
-                ProfileGate::Latency,
-                complete_gates().without_gate(ProfileGate::Latency),
+                QualificationAuthorityContext::new(
+                    "77".repeat(32),
+                    "66".repeat(32),
+                    "44".repeat(32),
+                    "56".repeat(32),
+                )
+                .unwrap(),
+                ProfileQualificationError::SelectedPolicyChanged,
             ),
         ];
-        for (missing, gates) in cases {
-            let attempt = attempt("missing-gate", 15, CaptureSchedule::Concurrent, gates);
+        for (authority, expected) in authority_cases {
+            let release = verified_release_fixture(
+                "baseline-30-15",
+                "candidate-15-15",
+                15,
+                15,
+                CaptureSchedule::Concurrent,
+                0x44,
+                FIXED_NOW,
+            );
+            let local = validated_commissioning_fixture(
+                "candidate-15-15",
+                15,
+                15,
+                CaptureSchedule::Concurrent,
+                FIXED_NOW,
+            );
             assert_eq!(
-                attempt.qualified().unwrap_err(),
-                ProfileQualificationError::MissingGate(missing)
+                QualifiedCandidateEvidence::new(release, local, &authority).unwrap_err(),
+                expected,
+            );
+        }
+
+        for (catalog_byte, policy_byte, expected) in [
+            (
+                0x45,
+                0x55,
+                ProfileQualificationError::ConditioningCatalogChanged,
+            ),
+            (0x44, 0x56, ProfileQualificationError::SelectedPolicyChanged),
+        ] {
+            let release = verified_release_fixture(
+                "baseline-30-15",
+                "candidate-15-15",
+                15,
+                15,
+                CaptureSchedule::Concurrent,
+                0x44,
+                FIXED_NOW,
+            );
+            let local = validated_commissioning_fixture_with_bindings(
+                "candidate-15-15",
+                15,
+                15,
+                CaptureSchedule::Concurrent,
+                FIXED_NOW,
+                catalog_byte,
+                policy_byte,
+            );
+            assert_eq!(
+                QualifiedCandidateEvidence::new(release, local, &authority_fixture()).unwrap_err(),
+                expected,
             );
         }
     }
 
     #[test]
-    fn digest_or_endpoint_context_drift_authorizes_nothing() {
-        let mut digest_drift = attempt(
-            "digest-drift",
-            15,
-            CaptureSchedule::Concurrent,
-            complete_gates(),
-        );
-        digest_drift.model_contract_digest = "44".repeat(32);
+    fn mixed_baselines_campaigns_scopes_and_duplicate_pairs_fail_closed() {
+        let budget = RankingBudget::new(1, 20_000_000, 10_000).unwrap();
         assert_eq!(
-            digest_drift
-                .qualified_for(&QualificationAuthorityContext::new(
-                    "11".repeat(32),
-                    "22".repeat(32),
-                ))
-                .unwrap_err(),
-            ProfileQualificationError::ModelContractChanged
+            select_profiles(
+                vec![
+                    candidate_fixture_with_release(
+                        "baseline-30-15",
+                        "candidate-a",
+                        15,
+                        15,
+                        CaptureSchedule::Concurrent,
+                        0x44,
+                    ),
+                    candidate_fixture_with_release(
+                        "other-baseline",
+                        "candidate-b",
+                        15,
+                        15,
+                        CaptureSchedule::Concurrent,
+                        0x44,
+                    ),
+                ],
+                authority_fixture(),
+                budget,
+            )
+            .unwrap_err(),
+            ProfileQualificationError::BaselineProfileMismatch,
+        );
+        assert_eq!(
+            select_profiles(
+                vec![
+                    candidate_fixture_with_release(
+                        "baseline-30-15",
+                        "candidate-a",
+                        15,
+                        15,
+                        CaptureSchedule::Concurrent,
+                        0x44,
+                    ),
+                    candidate_fixture_with_release(
+                        "baseline-30-15",
+                        "candidate-b",
+                        15,
+                        15,
+                        CaptureSchedule::Concurrent,
+                        0x45,
+                    ),
+                ],
+                authority_fixture(),
+                budget,
+            )
+            .unwrap_err(),
+            ProfileQualificationError::ContextChanged,
         );
 
-        let mut context_drift = attempt(
-            "context-drift",
+        let changed_context_release = verified_release_fixture(
+            "baseline-30-15",
+            "candidate-b",
+            15,
             15,
             CaptureSchedule::Concurrent,
-            complete_gates(),
+            0x44,
+            FIXED_NOW,
         );
-        context_drift.post_scope = ProfileScope::from_context(&context(30)).unwrap();
-        context_drift.post_scope.rgb_endpoint = CameraEndpoint::new(
-            "cd".repeat(32),
-            0x0bda,
-            0x5678,
-            Some("replacement".into()),
-            0,
-            "/devices/pci0000:00/0000:00:14.0/usb4/4-3".into(),
-            QualifiedStreamRole::Rgb,
-            ConnectionContext::new(
-                "/devices/pci0000:00/0000:00:14.0".into(),
-                5_000_000,
-                "uvcvideo".into(),
-                "v4l2-uvc".into(),
-            )
-            .unwrap(),
+        let changed_context_local = validated_commissioning_fixture_with_serial(
+            "candidate-b",
+            15,
+            15,
+            CaptureSchedule::Concurrent,
+            FIXED_NOW,
+            "other-device",
+        );
+        let changed_context = QualifiedCandidateEvidence::new(
+            changed_context_release,
+            changed_context_local,
+            &authority_fixture(),
         )
         .unwrap();
         assert_eq!(
-            context_drift.qualified().unwrap_err(),
-            ProfileQualificationError::ContextChanged
+            select_profiles(
+                vec![
+                    candidate_fixture("candidate-a", 15, 15, CaptureSchedule::Concurrent),
+                    changed_context,
+                ],
+                authority_fixture(),
+                budget,
+            )
+            .unwrap_err(),
+            ProfileQualificationError::ContextChanged,
+        );
+
+        assert_eq!(
+            select_profiles(
+                vec![
+                    candidate_fixture("duplicate", 15, 15, CaptureSchedule::Concurrent),
+                    candidate_fixture("duplicate", 15, 15, CaptureSchedule::Concurrent),
+                ],
+                authority_fixture(),
+                budget,
+            )
+            .unwrap_err(),
+            ProfileQualificationError::DuplicateCandidate,
         );
     }
 
     #[test]
-    fn complete_record_selects_balanced_winner_and_sequential_fallback() {
-        let attempts = vec![
-            attempt(
-                "concurrent-30",
-                30,
-                CaptureSchedule::Concurrent,
-                complete_gates(),
-            ),
-            attempt(
-                "concurrent-15",
-                15,
-                CaptureSchedule::Concurrent,
-                complete_gates(),
-            ),
-            attempt(
-                "sequential-15",
-                15,
-                CaptureSchedule::Sequential,
-                complete_gates(),
-            ),
-        ];
-        let authority = QualificationAuthorityContext::new("11".repeat(32), "22".repeat(32));
+    fn sequential_only_candidates_rank_without_fabricating_a_concurrent_profile() {
         let record = select_profiles(
-            attempts,
-            authority,
+            vec![
+                candidate_fixture("sequential-30-15", 30, 15, CaptureSchedule::Sequential),
+                candidate_fixture("sequential-15-15", 15, 15, CaptureSchedule::Sequential),
+            ],
+            authority_fixture(),
             RankingBudget::new(1, 20_000_000, 10_000).unwrap(),
         )
         .unwrap();
-
-        assert_eq!(record.selected().profile_id(), "concurrent-15");
+        assert_eq!(record.selected().profile_id(), "sequential-15-15");
+        assert_eq!(record.selected().schedule(), CaptureSchedule::Sequential);
         assert_eq!(
             record.sequential_fallback().unwrap().profile_id(),
-            "sequential-15"
+            "sequential-15-15",
         );
-        assert_eq!(record.model_contract_digest(), "11".repeat(32));
+
+        let same_id = select_profiles(
+            vec![
+                candidate_fixture("same-id", 15, 15, CaptureSchedule::Concurrent),
+                candidate_fixture("same-id", 15, 15, CaptureSchedule::Sequential),
+            ],
+            authority_fixture(),
+            RankingBudget::new(1, 20_000_000, 10_000).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(same_id.selected().schedule(), CaptureSchedule::Concurrent);
+        assert_eq!(
+            same_id.sequential_fallback().unwrap().schedule(),
+            CaptureSchedule::Sequential,
+        );
+    }
+
+    #[test]
+    fn candidate_count_is_bounded_before_ranking() {
+        let budget = RankingBudget::new(1, 20_000_000, 10_000).unwrap();
+        assert_eq!(
+            select_profiles(Vec::new(), authority_fixture(), budget).unwrap_err(),
+            ProfileQualificationError::CandidateCount,
+        );
+        let candidates = (0..33)
+            .map(|index| {
+                candidate_fixture(
+                    &format!("candidate-{index:02}"),
+                    15,
+                    15,
+                    CaptureSchedule::Concurrent,
+                )
+            })
+            .collect();
+        assert_eq!(
+            select_profiles(candidates, authority_fixture(), budget).unwrap_err(),
+            ProfileQualificationError::CandidateCount,
+        );
     }
 
     struct TempStore {
@@ -1340,20 +1313,10 @@ mod tests {
     fn selection_record() -> ProfileSelectionRecord {
         select_profiles(
             vec![
-                attempt(
-                    "concurrent-15",
-                    15,
-                    CaptureSchedule::Concurrent,
-                    complete_gates(),
-                ),
-                attempt(
-                    "sequential-15",
-                    15,
-                    CaptureSchedule::Sequential,
-                    complete_gates(),
-                ),
+                candidate_fixture("concurrent-15-15", 15, 15, CaptureSchedule::Concurrent),
+                candidate_fixture("sequential-15-15", 15, 15, CaptureSchedule::Sequential),
             ],
-            QualificationAuthorityContext::new("11".repeat(32), "22".repeat(32)),
+            authority_fixture(),
             RankingBudget::new(1, 20_000_000, 10_000).unwrap(),
         )
         .unwrap()
@@ -1368,11 +1331,43 @@ mod tests {
             record
         );
 
+        let mut value: serde_json::Value = serde_json::from_str(&body).unwrap();
+        value["unknown"] = serde_json::json!(true);
+        assert_eq!(
+            ProfileSelectionRecord::from_json(value.to_string().as_bytes()).unwrap_err(),
+            ProfileQualificationError::Json,
+        );
+
+        let mut value: serde_json::Value = serde_json::from_str(&body).unwrap();
+        value["selected"]["unknown"] = serde_json::json!(true);
+        assert_eq!(
+            ProfileSelectionRecord::from_json(value.to_string().as_bytes()).unwrap_err(),
+            ProfileQualificationError::Json,
+        );
+
         let mut unsupported: serde_json::Value = serde_json::from_str(&body).unwrap();
         unsupported["schema_version"] = serde_json::json!(99);
         assert_eq!(
             ProfileSelectionRecord::from_json(unsupported.to_string().as_bytes()).unwrap_err(),
             ProfileQualificationError::UnsupportedSchema(99)
+        );
+
+        for field in ["release_qualification_sha256", "local_commissioning_sha256"] {
+            let mut malformed: serde_json::Value = serde_json::from_str(&body).unwrap();
+            malformed["selected"][field] = serde_json::json!("not-a-digest");
+            assert_eq!(
+                ProfileSelectionRecord::from_json(malformed.to_string().as_bytes()).unwrap_err(),
+                ProfileQualificationError::InvalidDigest,
+                "{field}",
+            );
+        }
+
+        let mut changed_scope: serde_json::Value = serde_json::from_str(&body).unwrap();
+        changed_scope["selected"]["context"]["rgb_endpoint"]["serial"] =
+            serde_json::json!("different-device");
+        assert_eq!(
+            ProfileSelectionRecord::from_json(changed_scope.to_string().as_bytes()).unwrap_err(),
+            ProfileQualificationError::ContextChanged,
         );
         assert_eq!(
             ProfileSelectionRecord::from_json(&vec![b' '; MAX_PROFILE_SELECTION_RECORD_BYTES + 1])

--- a/crates/irlume-camera/src/profile_qualification.rs
+++ b/crates/irlume-camera/src/profile_qualification.rs
@@ -8,6 +8,29 @@
 //! ```compile_fail
 //! use irlume_camera::profile_evaluation::ProfileEvaluationProtocolManifest;
 //! ```
+//!
+//! Release evidence cannot be fabricated outside camera verification.
+//!
+//! ```compile_fail
+//! use irlume_camera::release_qualification_signature::VerifiedReleaseQualification;
+//! let _ = VerifiedReleaseQualification::new_for_test();
+//! ```
+//!
+//! Local commissioning evidence cannot be fabricated from release data.
+//!
+//! ```compile_fail
+//! use irlume_camera::profile_commissioning::ValidatedLocalCommissioning;
+//! let _ = ValidatedLocalCommissioning::new_for_test();
+//! ```
+//!
+//! Profile-selection publication is not an external API.
+//!
+//! ```compile_fail
+//! let store = irlume_camera::profile_qualification::ProfileSelectionStore::system();
+//! let record = irlume_camera::profile_qualification::ProfileSelectionRecord::from_json(b"{}")
+//!     .unwrap();
+//! store.save(record, None).unwrap();
+//! ```
 
 use serde::{Deserialize, Serialize};
 use std::{
@@ -24,12 +47,12 @@ use crate::{
         rank_balanced, CandidateVerdict, CaptureSchedule, PairTransportProfile,
         QualifiedProfileMetrics, RankingBudget,
     },
-    profile_commissioning::ValidatedLocalCommissioning,
+    profile_commissioning::{ProfileCommissioningError, ValidatedLocalCommissioning},
     release_qualification::{
-        HARDWARE_SCOPE_MATCH_POLICY_VERSION, RELEASE_QUALIFICATION_POLICY_VERSION,
-        RELEASE_QUALIFICATION_PRODUCER_VERSION,
+        ReleaseQualificationError, HARDWARE_SCOPE_MATCH_POLICY_VERSION,
+        RELEASE_QUALIFICATION_POLICY_VERSION, RELEASE_QUALIFICATION_PRODUCER_VERSION,
     },
-    release_qualification_signature::VerifiedReleaseQualification,
+    release_qualification_signature::{ReleaseSignatureError, VerifiedReleaseQualification},
 };
 
 /// Profile-selection record shape understood by this build.
@@ -861,6 +884,191 @@ impl std::fmt::Display for ProfileQualificationError {
 
 impl std::error::Error for ProfileQualificationError {}
 
+/// Share-safe reason that profile qualification authority is unavailable.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfileQualificationDiagnostic {
+    /// No signed release artifact is available.
+    ArtifactMissing,
+    /// The signed release artifact exceeds its bound.
+    ArtifactTooLarge,
+    /// The release artifact schema or policy is unsupported or malformed.
+    ArtifactSchemaUnsupported,
+    /// The detached release signature is absent.
+    SignatureMissing,
+    /// The detached release signature cannot be verified.
+    SignatureInvalid,
+    /// The release signer is not trusted.
+    SignerUntrusted,
+    /// The release artifact is outside its validity interval.
+    ArtifactExpired,
+    /// Release hardware scope does not match the local camera pair.
+    HardwareScopeMismatch,
+    /// Candidates do not share one exact release baseline.
+    BaselineProfileMismatch,
+    /// Release and local profile tuples or schedules differ.
+    ProfileTupleMismatch,
+    /// Local camera identity or connection context differs.
+    CameraContextMismatch,
+    /// The installed model contract differs from release evidence.
+    ModelDigestChanged,
+    /// The installed preprocessing contract differs from release evidence.
+    PreprocessingDigestChanged,
+    /// Conditioning catalog or selected policy evidence differs.
+    ConditioningDigestChanged,
+    /// No valid local commissioning authority is available.
+    CommissioningMissing,
+    /// Local commissioning evidence is outside its validity interval.
+    CommissioningStale,
+    /// At least one release qualification gate failed.
+    ReleaseGateFailed,
+    /// At least one local commissioning gate failed.
+    LocalGateFailed,
+}
+
+impl std::fmt::Display for ProfileQualificationDiagnostic {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::ArtifactMissing => "artifact_missing",
+            Self::ArtifactTooLarge => "artifact_too_large",
+            Self::ArtifactSchemaUnsupported => "artifact_schema_unsupported",
+            Self::SignatureMissing => "signature_missing",
+            Self::SignatureInvalid => "signature_invalid",
+            Self::SignerUntrusted => "signer_untrusted",
+            Self::ArtifactExpired => "artifact_expired",
+            Self::HardwareScopeMismatch => "hardware_scope_mismatch",
+            Self::BaselineProfileMismatch => "baseline_profile_mismatch",
+            Self::ProfileTupleMismatch => "profile_tuple_mismatch",
+            Self::CameraContextMismatch => "camera_context_mismatch",
+            Self::ModelDigestChanged => "model_digest_changed",
+            Self::PreprocessingDigestChanged => "preprocessing_digest_changed",
+            Self::ConditioningDigestChanged => "conditioning_digest_changed",
+            Self::CommissioningMissing => "commissioning_missing",
+            Self::CommissioningStale => "commissioning_stale",
+            Self::ReleaseGateFailed => "release_gate_failed",
+            Self::LocalGateFailed => "local_gate_failed",
+        })
+    }
+}
+
+impl std::error::Error for ProfileQualificationDiagnostic {}
+
+impl From<ReleaseQualificationError> for ProfileQualificationDiagnostic {
+    fn from(error: ReleaseQualificationError) -> Self {
+        match error {
+            ReleaseQualificationError::DocumentTooLarge => Self::ArtifactTooLarge,
+            ReleaseQualificationError::UnsupportedHardwareMatchPolicy(_) => {
+                Self::HardwareScopeMismatch
+            }
+            ReleaseQualificationError::InvalidSignerFingerprint => Self::SignerUntrusted,
+            ReleaseQualificationError::InvalidProfile
+            | ReleaseQualificationError::IdenticalProfiles => Self::ProfileTupleMismatch,
+            ReleaseQualificationError::InvalidTime
+            | ReleaseQualificationError::ArtifactNotYetValid
+            | ReleaseQualificationError::ArtifactExpired => Self::ArtifactExpired,
+            ReleaseQualificationError::ReleaseGateFailed => Self::ReleaseGateFailed,
+            ReleaseQualificationError::Json
+            | ReleaseQualificationError::UnsupportedSchema(_)
+            | ReleaseQualificationError::UnsupportedPolicy(_)
+            | ReleaseQualificationError::UnsupportedProducer(_)
+            | ReleaseQualificationError::InvalidIdentifier
+            | ReleaseQualificationError::InvalidDigest => Self::ArtifactSchemaUnsupported,
+        }
+    }
+}
+
+impl From<ReleaseSignatureError> for ProfileQualificationDiagnostic {
+    fn from(error: ReleaseSignatureError) -> Self {
+        match error {
+            ReleaseSignatureError::Artifact(error) => error.into(),
+            ReleaseSignatureError::ArtifactMissing | ReleaseSignatureError::FileMissing => {
+                Self::ArtifactMissing
+            }
+            ReleaseSignatureError::ArtifactTooLarge | ReleaseSignatureError::FileTooLarge => {
+                Self::ArtifactTooLarge
+            }
+            ReleaseSignatureError::SignatureMissing => Self::SignatureMissing,
+            ReleaseSignatureError::SignerUntrusted
+            | ReleaseSignatureError::MetadataSignerMismatch => Self::SignerUntrusted,
+            ReleaseSignatureError::SignatureTooLarge
+            | ReleaseSignatureError::InvalidSignature
+            | ReleaseSignatureError::InvalidConfiguration
+            | ReleaseSignatureError::TrustedKeyMissing
+            | ReleaseSignatureError::TrustedKeyTooLarge
+            | ReleaseSignatureError::Io
+            | ReleaseSignatureError::ProcessFailed
+            | ReleaseSignatureError::Timeout
+            | ReleaseSignatureError::StatusTooLarge
+            | ReleaseSignatureError::InvalidStatus
+            | ReleaseSignatureError::InvalidArtifactName
+            | ReleaseSignatureError::UnsafeFile => Self::SignatureInvalid,
+        }
+    }
+}
+
+impl From<ProfileCommissioningError> for ProfileQualificationDiagnostic {
+    fn from(error: ProfileCommissioningError) -> Self {
+        match error {
+            ProfileCommissioningError::InvalidTime
+            | ProfileCommissioningError::NotYetValid
+            | ProfileCommissioningError::Stale => Self::CommissioningStale,
+            ProfileCommissioningError::InvalidContext
+            | ProfileCommissioningError::ContextMismatch => Self::CameraContextMismatch,
+            ProfileCommissioningError::InvalidLatency
+            | ProfileCommissioningError::LocalGateFailed => Self::LocalGateFailed,
+            ProfileCommissioningError::HardwareScopeMismatch => Self::HardwareScopeMismatch,
+            ProfileCommissioningError::ProfileMismatch => Self::ProfileTupleMismatch,
+            ProfileCommissioningError::ConditioningMismatch => Self::ConditioningDigestChanged,
+            ProfileCommissioningError::UnsupportedSchema(_)
+            | ProfileCommissioningError::UnsupportedPolicy(_)
+            | ProfileCommissioningError::UnsupportedProducer(_)
+            | ProfileCommissioningError::InvalidIdentifier
+            | ProfileCommissioningError::InvalidDigest
+            | ProfileCommissioningError::DocumentTooLarge
+            | ProfileCommissioningError::Json => Self::CommissioningMissing,
+        }
+    }
+}
+
+impl From<ProfileQualificationError> for ProfileQualificationDiagnostic {
+    fn from(error: ProfileQualificationError) -> Self {
+        match error {
+            ProfileQualificationError::ProfileMismatch
+            | ProfileQualificationError::InvalidProfileId => Self::ProfileTupleMismatch,
+            ProfileQualificationError::HardwareScopeMismatch => Self::HardwareScopeMismatch,
+            ProfileQualificationError::BaselineProfileMismatch => Self::BaselineProfileMismatch,
+            ProfileQualificationError::ModelContractChanged => Self::ModelDigestChanged,
+            ProfileQualificationError::PreprocessingContractChanged => {
+                Self::PreprocessingDigestChanged
+            }
+            ProfileQualificationError::ConditioningCatalogChanged
+            | ProfileQualificationError::SelectedPolicyChanged => Self::ConditioningDigestChanged,
+            ProfileQualificationError::ContextChanged | ProfileQualificationError::Context(_) => {
+                Self::CameraContextMismatch
+            }
+            ProfileQualificationError::DuplicateCandidate
+            | ProfileQualificationError::InvalidEvidence
+            | ProfileQualificationError::InvalidDigest
+            | ProfileQualificationError::CandidateCount
+            | ProfileQualificationError::UnsupportedSchema(_)
+            | ProfileQualificationError::UnsupportedPolicy(_)
+            | ProfileQualificationError::RecordTooLarge
+            | ProfileQualificationError::Json => Self::CommissioningMissing,
+        }
+    }
+}
+
+impl From<ProfileSelectionStoreError> for ProfileQualificationDiagnostic {
+    fn from(error: ProfileSelectionStoreError) -> Self {
+        match error {
+            ProfileSelectionStoreError::InvalidRecord(error) => error.into(),
+            ProfileSelectionStoreError::Io(_)
+            | ProfileSelectionStoreError::StaleRevision { .. }
+            | ProfileSelectionStoreError::RevisionExhausted
+            | ProfileSelectionStoreError::VisibleNotDurable(_) => Self::CommissioningMissing,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -868,10 +1076,12 @@ mod tests {
         profile::{CaptureSchedule, RankingBudget},
         profile_commissioning::{
             validated_commissioning_fixture, validated_commissioning_fixture_with_bindings,
-            validated_commissioning_fixture_with_serial,
+            validated_commissioning_fixture_with_serial, ProfileCommissioningError,
         },
+        release_qualification::ReleaseQualificationError,
         release_qualification_signature::{
             verified_release_fixture, verified_release_fixture_with_descriptor,
+            ReleaseSignatureError,
         },
     };
 
@@ -1281,6 +1491,198 @@ mod tests {
             select_profiles(candidates, authority_fixture(), budget).unwrap_err(),
             ProfileQualificationError::CandidateCount,
         );
+    }
+
+    #[test]
+    fn internal_failures_project_to_the_fixed_diagnostic_vocabulary() {
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseSignatureError::ArtifactMissing),
+            ProfileQualificationDiagnostic::ArtifactMissing,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseQualificationError::DocumentTooLarge),
+            ProfileQualificationDiagnostic::ArtifactTooLarge,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseQualificationError::UnsupportedSchema(2)),
+            ProfileQualificationDiagnostic::ArtifactSchemaUnsupported,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseSignatureError::SignatureMissing),
+            ProfileQualificationDiagnostic::SignatureMissing,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseSignatureError::InvalidSignature),
+            ProfileQualificationDiagnostic::SignatureInvalid,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseSignatureError::SignerUntrusted),
+            ProfileQualificationDiagnostic::SignerUntrusted,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseQualificationError::ArtifactExpired),
+            ProfileQualificationDiagnostic::ArtifactExpired,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ProfileQualificationError::HardwareScopeMismatch,),
+            ProfileQualificationDiagnostic::HardwareScopeMismatch,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(
+                ProfileQualificationError::BaselineProfileMismatch,
+            ),
+            ProfileQualificationDiagnostic::BaselineProfileMismatch,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ProfileQualificationError::ProfileMismatch),
+            ProfileQualificationDiagnostic::ProfileTupleMismatch,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ProfileQualificationError::ContextChanged),
+            ProfileQualificationDiagnostic::CameraContextMismatch,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ProfileQualificationError::ModelContractChanged,),
+            ProfileQualificationDiagnostic::ModelDigestChanged,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(
+                ProfileQualificationError::PreprocessingContractChanged,
+            ),
+            ProfileQualificationDiagnostic::PreprocessingDigestChanged,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(
+                ProfileQualificationError::ConditioningCatalogChanged,
+            ),
+            ProfileQualificationDiagnostic::ConditioningDigestChanged,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ProfileCommissioningError::Json),
+            ProfileQualificationDiagnostic::CommissioningMissing,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ProfileCommissioningError::Stale),
+            ProfileQualificationDiagnostic::CommissioningStale,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ReleaseQualificationError::ReleaseGateFailed,),
+            ProfileQualificationDiagnostic::ReleaseGateFailed,
+        );
+        assert_eq!(
+            ProfileQualificationDiagnostic::from(ProfileCommissioningError::LocalGateFailed),
+            ProfileQualificationDiagnostic::LocalGateFailed,
+        );
+    }
+
+    #[test]
+    fn diagnostic_display_is_exact_and_never_leaks_internal_text() {
+        let cases = [
+            (
+                ProfileQualificationDiagnostic::ArtifactMissing,
+                "artifact_missing",
+            ),
+            (
+                ProfileQualificationDiagnostic::ArtifactTooLarge,
+                "artifact_too_large",
+            ),
+            (
+                ProfileQualificationDiagnostic::ArtifactSchemaUnsupported,
+                "artifact_schema_unsupported",
+            ),
+            (
+                ProfileQualificationDiagnostic::SignatureMissing,
+                "signature_missing",
+            ),
+            (
+                ProfileQualificationDiagnostic::SignatureInvalid,
+                "signature_invalid",
+            ),
+            (
+                ProfileQualificationDiagnostic::SignerUntrusted,
+                "signer_untrusted",
+            ),
+            (
+                ProfileQualificationDiagnostic::ArtifactExpired,
+                "artifact_expired",
+            ),
+            (
+                ProfileQualificationDiagnostic::HardwareScopeMismatch,
+                "hardware_scope_mismatch",
+            ),
+            (
+                ProfileQualificationDiagnostic::BaselineProfileMismatch,
+                "baseline_profile_mismatch",
+            ),
+            (
+                ProfileQualificationDiagnostic::ProfileTupleMismatch,
+                "profile_tuple_mismatch",
+            ),
+            (
+                ProfileQualificationDiagnostic::CameraContextMismatch,
+                "camera_context_mismatch",
+            ),
+            (
+                ProfileQualificationDiagnostic::ModelDigestChanged,
+                "model_digest_changed",
+            ),
+            (
+                ProfileQualificationDiagnostic::PreprocessingDigestChanged,
+                "preprocessing_digest_changed",
+            ),
+            (
+                ProfileQualificationDiagnostic::ConditioningDigestChanged,
+                "conditioning_digest_changed",
+            ),
+            (
+                ProfileQualificationDiagnostic::CommissioningMissing,
+                "commissioning_missing",
+            ),
+            (
+                ProfileQualificationDiagnostic::CommissioningStale,
+                "commissioning_stale",
+            ),
+            (
+                ProfileQualificationDiagnostic::ReleaseGateFailed,
+                "release_gate_failed",
+            ),
+            (
+                ProfileQualificationDiagnostic::LocalGateFailed,
+                "local_gate_failed",
+            ),
+        ];
+        for (diagnostic, expected) in cases {
+            assert_eq!(diagnostic.to_string(), expected);
+        }
+
+        let unsafe_text = "gpg: /tmp/private/campaign serial score fixture-id";
+        for diagnostic in [
+            ProfileQualificationDiagnostic::from(ProfileQualificationError::Context(
+                QualificationError::System(unsafe_text.to_owned()),
+            )),
+            ProfileQualificationDiagnostic::from(ProfileSelectionStoreError::Io(
+                unsafe_text.to_owned(),
+            )),
+            ProfileQualificationDiagnostic::from(ProfileSelectionStoreError::VisibleNotDurable(
+                unsafe_text.to_owned(),
+            )),
+        ] {
+            let rendered = diagnostic.to_string();
+            for forbidden in [
+                "/",
+                "\\",
+                "gpg:",
+                "campaign",
+                "serial",
+                "score",
+                "fixture-id",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "{rendered} leaked {forbidden}"
+                );
+            }
+        }
     }
 
     struct TempStore {

--- a/crates/irlume-camera/src/release_qualification.rs
+++ b/crates/irlume-camera/src/release_qualification.rs
@@ -207,6 +207,10 @@ impl ReleaseHardwareScope {
             && self.rgb.matches_endpoint(context.rgb_endpoint())
             && self.ir.matches_endpoint(context.ir_endpoint())
     }
+
+    pub(crate) const fn match_policy_version(&self) -> u32 {
+        self.match_policy_version
+    }
 }
 
 impl ReleaseEndpointScope {
@@ -375,6 +379,42 @@ impl ReleaseQualificationArtifact {
 
     pub(crate) const fn signature(&self) -> &ReleaseSignatureMetadata {
         &self.signature
+    }
+
+    pub(crate) const fn policy_version(&self) -> u32 {
+        self.policy_version
+    }
+
+    pub(crate) const fn producer_version(&self) -> u32 {
+        self.producer_version
+    }
+
+    pub(crate) fn campaign_id(&self) -> &str {
+        &self.campaign_id
+    }
+
+    pub(crate) fn campaign_protocol_sha256(&self) -> &str {
+        &self.campaign_protocol_sha256
+    }
+
+    pub(crate) fn campaign_result_sha256(&self) -> &str {
+        &self.campaign_result_sha256
+    }
+
+    pub(crate) fn conditioning_catalog_sha256(&self) -> &str {
+        &self.conditioning_catalog_sha256
+    }
+
+    pub(crate) fn selected_policy_sha256(&self) -> &str {
+        &self.selected_policy_sha256
+    }
+
+    pub(crate) fn preprocessing_contract_sha256(&self) -> &str {
+        &self.preprocessing_contract_sha256
+    }
+
+    pub(crate) fn model_contract_sha256(&self) -> &str {
+        &self.model_contract_sha256
     }
 }
 

--- a/crates/irlume-camera/src/release_qualification.rs
+++ b/crates/irlume-camera/src/release_qualification.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    capture_qualification::{CameraEndpoint, QualificationContext},
     contracts::StreamRole,
     frame_interval::FrameInterval,
     profile::{CaptureSchedule, DecodedPixelFormat, PairTransportProfile, StreamTuple},
@@ -194,6 +195,29 @@ impl ReleaseHardwareScope {
         self.rgb.validate()?;
         self.ir.validate()?;
         Ok(())
+    }
+
+    pub(crate) fn matches_context(
+        &self,
+        context: &QualificationContext,
+        interface_layout_sha256: &str,
+    ) -> bool {
+        self.match_policy_version == HARDWARE_SCOPE_MATCH_POLICY_VERSION
+            && self.interface_layout_sha256 == interface_layout_sha256
+            && self.rgb.matches_endpoint(context.rgb_endpoint())
+            && self.ir.matches_endpoint(context.ir_endpoint())
+    }
+}
+
+impl ReleaseEndpointScope {
+    fn matches_endpoint(&self, endpoint: &CameraEndpoint) -> bool {
+        self.descriptor_sha256 == endpoint.descriptor_sha256()
+            && self.vid == endpoint.vid()
+            && self.pid == endpoint.pid()
+            && self.interface_number == endpoint.interface_number()
+            && self.driver == endpoint.connection().driver()
+            && self.backend == endpoint.connection().backend()
+            && self.speed_millimbps == endpoint.connection().speed_millimbps()
     }
 }
 

--- a/crates/irlume-camera/src/release_qualification_signature.rs
+++ b/crates/irlume-camera/src/release_qualification_signature.rs
@@ -254,6 +254,54 @@ pub(crate) fn verified_release_fixture(
     campaign_byte: u8,
     now_unix: u64,
 ) -> VerifiedReleaseQualification {
+    verified_release_fixture_with_optional_descriptor(
+        baseline_id,
+        candidate_id,
+        candidate_rgb_fps,
+        candidate_ir_fps,
+        candidate_schedule,
+        campaign_byte,
+        now_unix,
+        None,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn verified_release_fixture_with_descriptor(
+    baseline_id: &str,
+    candidate_id: &str,
+    candidate_rgb_fps: u32,
+    candidate_ir_fps: u32,
+    candidate_schedule: crate::profile::CaptureSchedule,
+    campaign_byte: u8,
+    now_unix: u64,
+    rgb_descriptor_sha256: &str,
+) -> VerifiedReleaseQualification {
+    verified_release_fixture_with_optional_descriptor(
+        baseline_id,
+        candidate_id,
+        candidate_rgb_fps,
+        candidate_ir_fps,
+        candidate_schedule,
+        campaign_byte,
+        now_unix,
+        Some(rgb_descriptor_sha256),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn verified_release_fixture_with_optional_descriptor(
+    baseline_id: &str,
+    candidate_id: &str,
+    candidate_rgb_fps: u32,
+    candidate_ir_fps: u32,
+    candidate_schedule: crate::profile::CaptureSchedule,
+    campaign_byte: u8,
+    now_unix: u64,
+    rgb_descriptor_sha256: Option<&str>,
+) -> VerifiedReleaseQualification {
     assert!(now_unix > 1 && now_unix < u64::MAX - 604_800);
     let mut value = crate::release_qualification::fixture_artifact_value(baseline_id, candidate_id);
     for stream in ["requested_rgb", "accepted_rgb"] {
@@ -264,6 +312,9 @@ pub(crate) fn verified_release_fixture(
     }
     value["candidate"]["schedule"] = serde_json::to_value(candidate_schedule).unwrap();
     value["campaign_result_sha256"] = serde_json::json!(format!("{campaign_byte:02x}").repeat(32));
+    if let Some(descriptor) = rgb_descriptor_sha256 {
+        value["hardware_scope"]["rgb"]["descriptor_sha256"] = serde_json::json!(descriptor);
+    }
     value["qualified_at_unix"] = serde_json::json!(now_unix - 1);
     value["expires_at_unix"] = serde_json::json!(now_unix + 604_800);
     let artifact: ReleaseQualificationArtifact = serde_json::from_value(value).unwrap();

--- a/crates/irlume-camera/src/release_qualification_signature.rs
+++ b/crates/irlume-camera/src/release_qualification_signature.rs
@@ -1,0 +1,1485 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Detached signature verification for release-qualification artifacts.
+
+#![allow(
+    dead_code,
+    reason = "production loading and selection consumers are implemented in later plan tasks"
+)]
+
+use std::{
+    fmt,
+    io::{Read as _, Write as _},
+    os::{
+        fd::AsRawFd as _,
+        unix::fs::{
+            DirBuilderExt as _, MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _,
+        },
+    },
+    path::{Path, PathBuf},
+    process::{Child, Command, ExitStatus, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+use crate::release_qualification::{
+    ReleaseQualificationArtifact, ReleaseQualificationError, MAX_RELEASE_QUALIFICATION_BYTES,
+};
+
+pub(crate) const ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT: &str =
+    "F35053398E3C80FE20891B82C10B8492BD7F30C6";
+
+const MAX_DETACHED_SIGNATURE_BYTES: usize = 64 * 1024;
+const MAX_TRUSTED_PUBLIC_KEY_BYTES: usize = 64 * 1024;
+const MAX_GPG_STATUS_BYTES: usize = 64 * 1024;
+const DEFAULT_GPG_TIMEOUT: Duration = Duration::from_secs(5);
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(5);
+const MAX_ARTIFACT_NAME_BYTES: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReleaseQualificationPaths {
+    artifact: PathBuf,
+    signature: PathBuf,
+    trusted_key: PathBuf,
+}
+
+impl ReleaseQualificationPaths {
+    pub(crate) fn system(artifact_name: &str) -> Result<Self, ReleaseSignatureError> {
+        Self::under(Path::new("/usr"), artifact_name)
+    }
+
+    pub(crate) fn under(
+        package_root: &Path,
+        artifact_name: &str,
+    ) -> Result<Self, ReleaseSignatureError> {
+        if artifact_name.is_empty()
+            || artifact_name.len() > MAX_ARTIFACT_NAME_BYTES
+            || !artifact_name.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' || byte == b'_'
+            })
+        {
+            return Err(ReleaseSignatureError::InvalidArtifactName);
+        }
+        let share_root = package_root.join("share/irlume");
+        let artifact = share_root
+            .join("profile-qualifications")
+            .join(format!("{artifact_name}.json"));
+        Ok(Self {
+            signature: artifact.with_extension("json.asc"),
+            artifact,
+            trusted_key: share_root.join("release-qualification-key.asc"),
+        })
+    }
+
+    pub(crate) fn artifact(&self) -> &Path {
+        &self.artifact
+    }
+
+    pub(crate) fn signature(&self) -> &Path {
+        &self.signature
+    }
+
+    pub(crate) fn trusted_key(&self) -> &Path {
+        &self.trusted_key
+    }
+}
+
+pub(crate) trait DetachedSignatureVerifier {
+    fn verify(
+        &self,
+        canonical_payload: &[u8],
+        detached_signature: &[u8],
+    ) -> Result<VerifiedSigner, ReleaseSignatureError>;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct VerifiedSigner {
+    fingerprint: String,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct VerifiedReleaseQualification {
+    artifact: ReleaseQualificationArtifact,
+    artifact_sha256: String,
+    signer_fingerprint: String,
+}
+
+impl VerifiedReleaseQualification {
+    pub(crate) const fn artifact(&self) -> &ReleaseQualificationArtifact {
+        &self.artifact
+    }
+
+    pub(crate) fn artifact_sha256(&self) -> &str {
+        &self.artifact_sha256
+    }
+
+    pub(crate) fn signer_fingerprint(&self) -> &str {
+        &self.signer_fingerprint
+    }
+}
+
+pub(crate) fn verify_release_qualification_bytes(
+    canonical_payload: &[u8],
+    detached_signature: &[u8],
+    now_unix: u64,
+    verifier: &impl DetachedSignatureVerifier,
+) -> Result<VerifiedReleaseQualification, ReleaseSignatureError> {
+    if canonical_payload.len() > MAX_RELEASE_QUALIFICATION_BYTES {
+        return Err(ReleaseSignatureError::ArtifactTooLarge);
+    }
+    if detached_signature.is_empty() {
+        return Err(ReleaseSignatureError::SignatureMissing);
+    }
+    if detached_signature.len() > MAX_DETACHED_SIGNATURE_BYTES {
+        return Err(ReleaseSignatureError::SignatureTooLarge);
+    }
+
+    let signer = verifier.verify(canonical_payload, detached_signature)?;
+    if signer.fingerprint != ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT {
+        return Err(ReleaseSignatureError::SignerUntrusted);
+    }
+    let artifact = ReleaseQualificationArtifact::from_canonical_json(canonical_payload)?;
+    artifact.validate_at(now_unix)?;
+    if artifact.signature().signer_fingerprint() != signer.fingerprint {
+        return Err(ReleaseSignatureError::MetadataSignerMismatch);
+    }
+    Ok(VerifiedReleaseQualification {
+        artifact,
+        artifact_sha256: irlume_common::sha256_hex(canonical_payload),
+        signer_fingerprint: signer.fingerprint,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ReleaseSignatureError {
+    Artifact(ReleaseQualificationError),
+    ArtifactMissing,
+    ArtifactTooLarge,
+    SignatureMissing,
+    SignatureTooLarge,
+    SignerUntrusted,
+    MetadataSignerMismatch,
+    InvalidSignature,
+    InvalidConfiguration,
+    TrustedKeyMissing,
+    TrustedKeyTooLarge,
+    Io,
+    ProcessFailed,
+    Timeout,
+    StatusTooLarge,
+    InvalidStatus,
+    InvalidArtifactName,
+    FileMissing,
+    FileTooLarge,
+    UnsafeFile,
+}
+
+impl From<ReleaseQualificationError> for ReleaseSignatureError {
+    fn from(error: ReleaseQualificationError) -> Self {
+        Self::Artifact(error)
+    }
+}
+
+impl fmt::Display for ReleaseSignatureError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::Artifact(error) => return error.fmt(formatter),
+            Self::ArtifactMissing => "release_qualification_missing",
+            Self::ArtifactTooLarge => "release_qualification_too_large",
+            Self::SignatureMissing => "release_qualification_signature_missing",
+            Self::SignatureTooLarge => "release_qualification_signature_too_large",
+            Self::SignerUntrusted => "release_qualification_signer_untrusted",
+            Self::MetadataSignerMismatch => "release_qualification_signer_mismatch",
+            Self::InvalidSignature => "release_qualification_signature_invalid",
+            Self::InvalidConfiguration => "release_qualification_verifier_invalid",
+            Self::TrustedKeyMissing => "release_qualification_key_missing",
+            Self::TrustedKeyTooLarge => "release_qualification_key_too_large",
+            Self::Io => "release_qualification_io_failed",
+            Self::ProcessFailed => "release_qualification_verifier_failed",
+            Self::Timeout => "release_qualification_verifier_timeout",
+            Self::StatusTooLarge => "release_qualification_status_too_large",
+            Self::InvalidStatus => "release_qualification_status_invalid",
+            Self::InvalidArtifactName => "release_qualification_artifact_name_invalid",
+            Self::FileMissing => "release_qualification_file_missing",
+            Self::FileTooLarge => "release_qualification_file_too_large",
+            Self::UnsafeFile => "release_qualification_file_unsafe",
+        };
+        formatter.write_str(category)
+    }
+}
+
+impl std::error::Error for ReleaseSignatureError {}
+
+#[cfg(test)]
+pub(crate) struct FakeVerifier {
+    result: Result<VerifiedSigner, ReleaseSignatureError>,
+}
+
+#[cfg(test)]
+impl FakeVerifier {
+    pub(crate) fn valid(fingerprint: &str) -> Self {
+        Self {
+            result: Ok(VerifiedSigner {
+                fingerprint: fingerprint.to_owned(),
+            }),
+        }
+    }
+
+    pub(crate) fn invalid_signature() -> Self {
+        Self {
+            result: Err(ReleaseSignatureError::InvalidSignature),
+        }
+    }
+}
+
+#[cfg(test)]
+impl DetachedSignatureVerifier for FakeVerifier {
+    fn verify(
+        &self,
+        _canonical_payload: &[u8],
+        _detached_signature: &[u8],
+    ) -> Result<VerifiedSigner, ReleaseSignatureError> {
+        self.result.clone()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn verified_release_fixture(
+    baseline_id: &str,
+    candidate_id: &str,
+    candidate_rgb_fps: u32,
+    candidate_ir_fps: u32,
+    candidate_schedule: crate::profile::CaptureSchedule,
+    campaign_byte: u8,
+    now_unix: u64,
+) -> VerifiedReleaseQualification {
+    assert!(now_unix > 1 && now_unix < u64::MAX - 604_800);
+    let mut value = crate::release_qualification::fixture_artifact_value(baseline_id, candidate_id);
+    for stream in ["requested_rgb", "accepted_rgb"] {
+        value["candidate"][stream]["interval_denominator"] = serde_json::json!(candidate_rgb_fps);
+    }
+    for stream in ["requested_ir", "accepted_ir"] {
+        value["candidate"][stream]["interval_denominator"] = serde_json::json!(candidate_ir_fps);
+    }
+    value["candidate"]["schedule"] = serde_json::to_value(candidate_schedule).unwrap();
+    value["campaign_result_sha256"] = serde_json::json!(format!("{campaign_byte:02x}").repeat(32));
+    value["qualified_at_unix"] = serde_json::json!(now_unix - 1);
+    value["expires_at_unix"] = serde_json::json!(now_unix + 604_800);
+    let artifact: ReleaseQualificationArtifact = serde_json::from_value(value).unwrap();
+    let canonical_payload = artifact.to_canonical_json().unwrap();
+    verify_release_qualification_bytes(
+        canonical_payload.as_bytes(),
+        b"synthetic-signature",
+        now_unix,
+        &FakeVerifier::valid(ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT),
+    )
+    .unwrap()
+}
+
+pub(crate) struct GpgDetachedSignatureVerifier {
+    executable_path: PathBuf,
+    trusted_public_key: Vec<u8>,
+    timeout: Duration,
+    temp_root: PathBuf,
+}
+
+impl GpgDetachedSignatureVerifier {
+    pub(crate) fn new(
+        executable_path: PathBuf,
+        trusted_public_key: Vec<u8>,
+    ) -> Result<Self, ReleaseSignatureError> {
+        Self::with_configuration(
+            executable_path,
+            trusted_public_key,
+            DEFAULT_GPG_TIMEOUT,
+            std::env::temp_dir(),
+        )
+    }
+
+    fn with_configuration(
+        executable_path: PathBuf,
+        trusted_public_key: Vec<u8>,
+        timeout: Duration,
+        temp_root: PathBuf,
+    ) -> Result<Self, ReleaseSignatureError> {
+        if !executable_path.is_absolute() || timeout.is_zero() {
+            return Err(ReleaseSignatureError::InvalidConfiguration);
+        }
+        if trusted_public_key.is_empty() {
+            return Err(ReleaseSignatureError::TrustedKeyMissing);
+        }
+        if trusted_public_key.len() > MAX_TRUSTED_PUBLIC_KEY_BYTES {
+            return Err(ReleaseSignatureError::TrustedKeyTooLarge);
+        }
+        Ok(Self {
+            executable_path,
+            trusted_public_key,
+            timeout,
+            temp_root,
+        })
+    }
+
+    #[cfg(test)]
+    fn with_timeout_and_temp_root_for_test(
+        executable_path: PathBuf,
+        trusted_public_key: Vec<u8>,
+        timeout: Duration,
+        temp_root: PathBuf,
+    ) -> Result<Self, ReleaseSignatureError> {
+        Self::with_configuration(executable_path, trusted_public_key, timeout, temp_root)
+    }
+
+    fn base_command(&self, home: &Path, status_path: &Path) -> Command {
+        let mut command = Command::new(&self.executable_path);
+        command
+            .env_clear()
+            .env("LC_ALL", "C")
+            .args([
+                "--batch",
+                "--no-options",
+                "--no-tty",
+                "--no-autostart",
+                "--disable-dirmngr",
+            ])
+            .arg("--homedir")
+            .arg(home)
+            .arg("--status-file")
+            .arg(status_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        command
+    }
+}
+
+impl DetachedSignatureVerifier for GpgDetachedSignatureVerifier {
+    fn verify(
+        &self,
+        canonical_payload: &[u8],
+        detached_signature: &[u8],
+    ) -> Result<VerifiedSigner, ReleaseSignatureError> {
+        if canonical_payload.len() > MAX_RELEASE_QUALIFICATION_BYTES {
+            return Err(ReleaseSignatureError::ArtifactTooLarge);
+        }
+        if detached_signature.is_empty() {
+            return Err(ReleaseSignatureError::SignatureMissing);
+        }
+        if detached_signature.len() > MAX_DETACHED_SIGNATURE_BYTES {
+            return Err(ReleaseSignatureError::SignatureTooLarge);
+        }
+
+        let home = TemporaryGpgHome::create(&self.temp_root)?;
+        let key_path = home.path().join("trusted-key.asc");
+        let signature_path = home.path().join("detached-signature.asc");
+        let status_path = home.path().join("status");
+        write_private_file(&key_path, &self.trusted_public_key)?;
+        write_private_file(&signature_path, detached_signature)?;
+        write_private_file(&status_path, b"")?;
+
+        let mut import = self.base_command(home.path(), &status_path);
+        import.arg("--import").arg(&key_path).stdin(Stdio::null());
+        run_child_without_input(&mut import, self.timeout)?;
+        truncate_private_file(&status_path)?;
+
+        let mut verify = self.base_command(home.path(), &status_path);
+        verify
+            .arg("--verify")
+            .arg(&signature_path)
+            .arg("-")
+            .stdin(Stdio::piped());
+        run_child_with_input(&mut verify, canonical_payload, self.timeout)?;
+        let status = read_status_file(&status_path)?;
+        parse_valid_signer(&status)
+    }
+}
+
+pub(crate) fn verify_release_qualification_files(
+    artifact_path: &Path,
+    signature_path: &Path,
+    trusted_key_path: &Path,
+    executable_path: &Path,
+    now_unix: u64,
+) -> Result<VerifiedReleaseQualification, ReleaseSignatureError> {
+    verify_release_qualification_files_with_owner(
+        artifact_path,
+        signature_path,
+        trusted_key_path,
+        executable_path,
+        now_unix,
+        0,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn verify_release_qualification_files_for_owner(
+    artifact_path: &Path,
+    signature_path: &Path,
+    trusted_key_path: &Path,
+    executable_path: &Path,
+    now_unix: u64,
+    expected_owner_uid: u32,
+) -> Result<VerifiedReleaseQualification, ReleaseSignatureError> {
+    verify_release_qualification_files_with_owner(
+        artifact_path,
+        signature_path,
+        trusted_key_path,
+        executable_path,
+        now_unix,
+        expected_owner_uid,
+    )
+}
+
+fn verify_release_qualification_files_with_owner(
+    artifact_path: &Path,
+    signature_path: &Path,
+    trusted_key_path: &Path,
+    executable_path: &Path,
+    now_unix: u64,
+    expected_owner_uid: u32,
+) -> Result<VerifiedReleaseQualification, ReleaseSignatureError> {
+    let artifact = read_required_trusted_file(
+        artifact_path,
+        MAX_RELEASE_QUALIFICATION_BYTES,
+        expected_owner_uid,
+        ReleaseSignatureError::ArtifactMissing,
+        ReleaseSignatureError::ArtifactTooLarge,
+    )?;
+    let signature = read_required_trusted_file(
+        signature_path,
+        MAX_DETACHED_SIGNATURE_BYTES,
+        expected_owner_uid,
+        ReleaseSignatureError::SignatureMissing,
+        ReleaseSignatureError::SignatureTooLarge,
+    )?;
+    let trusted_key = read_required_trusted_file(
+        trusted_key_path,
+        MAX_TRUSTED_PUBLIC_KEY_BYTES,
+        expected_owner_uid,
+        ReleaseSignatureError::TrustedKeyMissing,
+        ReleaseSignatureError::TrustedKeyTooLarge,
+    )?;
+    let verifier = GpgDetachedSignatureVerifier::new(executable_path.to_path_buf(), trusted_key)?;
+    verify_release_qualification_bytes(&artifact, &signature, now_unix, &verifier)
+}
+
+fn read_required_trusted_file(
+    path: &Path,
+    max_bytes: usize,
+    expected_owner_uid: u32,
+    missing_error: ReleaseSignatureError,
+    too_large_error: ReleaseSignatureError,
+) -> Result<Vec<u8>, ReleaseSignatureError> {
+    match read_trusted_file(path, max_bytes, expected_owner_uid) {
+        Ok(bytes) if bytes.is_empty() => Err(missing_error),
+        Ok(bytes) => Ok(bytes),
+        Err(ReleaseSignatureError::FileMissing) => Err(missing_error),
+        Err(ReleaseSignatureError::FileTooLarge) => Err(too_large_error),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_trusted_file(
+    path: &Path,
+    max_bytes: usize,
+    expected_owner_uid: u32,
+) -> Result<Vec<u8>, ReleaseSignatureError> {
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|error| match error.raw_os_error() {
+            Some(libc::ENOENT) => ReleaseSignatureError::FileMissing,
+            Some(libc::ELOOP) => ReleaseSignatureError::UnsafeFile,
+            _ => ReleaseSignatureError::Io,
+        })?;
+    let metadata = file.metadata().map_err(|_| ReleaseSignatureError::Io)?;
+    validate_trusted_file_metadata(
+        metadata.file_type().is_file(),
+        metadata.uid(),
+        metadata.mode(),
+        expected_owner_uid,
+    )?;
+    if metadata.len() > max_bytes as u64 {
+        return Err(ReleaseSignatureError::FileTooLarge);
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    std::io::Read::by_ref(&mut file)
+        .take(max_bytes as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| ReleaseSignatureError::Io)?;
+    if bytes.len() > max_bytes {
+        return Err(ReleaseSignatureError::FileTooLarge);
+    }
+    Ok(bytes)
+}
+
+fn validate_trusted_file_metadata(
+    is_regular_file: bool,
+    owner_uid: u32,
+    mode: u32,
+    expected_owner_uid: u32,
+) -> Result<(), ReleaseSignatureError> {
+    if !is_regular_file || owner_uid != expected_owner_uid || mode & 0o022 != 0 {
+        return Err(ReleaseSignatureError::UnsafeFile);
+    }
+    Ok(())
+}
+
+struct TemporaryGpgHome {
+    path: PathBuf,
+}
+
+impl TemporaryGpgHome {
+    fn create(root: &Path) -> Result<Self, ReleaseSignatureError> {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        loop {
+            let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
+            let path = root.join(format!("gpg-home-{}-{sequence}", std::process::id()));
+            match std::fs::DirBuilder::new().mode(0o700).create(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(_) => return Err(ReleaseSignatureError::Io),
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TemporaryGpgHome {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), ReleaseSignatureError> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|_| ReleaseSignatureError::Io)?;
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))
+        .map_err(|_| ReleaseSignatureError::Io)?;
+    file.write_all(bytes).map_err(|_| ReleaseSignatureError::Io)
+}
+
+fn truncate_private_file(path: &Path) -> Result<(), ReleaseSignatureError> {
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|_| ReleaseSignatureError::Io)?;
+    let metadata = file.metadata().map_err(|_| ReleaseSignatureError::Io)?;
+    if !metadata.file_type().is_file() {
+        return Err(ReleaseSignatureError::Io);
+    }
+    Ok(())
+}
+
+fn run_child_without_input(
+    command: &mut Command,
+    timeout: Duration,
+) -> Result<(), ReleaseSignatureError> {
+    let mut child = command
+        .spawn()
+        .map_err(|_| ReleaseSignatureError::ProcessFailed)?;
+    let status = wait_for_child(&mut child, Instant::now() + timeout)?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(ReleaseSignatureError::ProcessFailed)
+    }
+}
+
+fn run_child_with_input(
+    command: &mut Command,
+    payload: &[u8],
+    timeout: Duration,
+) -> Result<(), ReleaseSignatureError> {
+    let mut child = command
+        .spawn()
+        .map_err(|_| ReleaseSignatureError::ProcessFailed)?;
+    let Some(stdin) = child.stdin.take() else {
+        terminate_and_reap(&mut child);
+        return Err(ReleaseSignatureError::ProcessFailed);
+    };
+    if let Err(error) = set_nonblocking(stdin.as_raw_fd()) {
+        terminate_and_reap(&mut child);
+        return Err(error);
+    }
+    let deadline = Instant::now() + timeout;
+    let (status, write_result) = std::thread::scope(|scope| {
+        let writer = scope.spawn(move || write_payload_until(stdin, payload, deadline));
+        let status = wait_for_child(&mut child, deadline);
+        if status.is_err() {
+            terminate_and_reap(&mut child);
+        }
+        let write_result = writer
+            .join()
+            .unwrap_or(Err(ReleaseSignatureError::ProcessFailed));
+        (status, write_result)
+    });
+    let status = status?;
+    write_result?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(ReleaseSignatureError::ProcessFailed)
+    }
+}
+
+fn set_nonblocking(fd: std::os::fd::RawFd) -> Result<(), ReleaseSignatureError> {
+    // SAFETY: `fd` is a live descriptor owned by the child-stdin handle. F_GETFL
+    // and F_SETFL do not take ownership or dereference user pointers.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(ReleaseSignatureError::Io);
+    }
+    // SAFETY: same live descriptor and integer flags established above.
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(ReleaseSignatureError::Io);
+    }
+    Ok(())
+}
+
+fn write_payload_until(
+    mut stdin: std::process::ChildStdin,
+    payload: &[u8],
+    deadline: Instant,
+) -> Result<(), ReleaseSignatureError> {
+    let mut offset = 0;
+    while offset < payload.len() {
+        match stdin.write(&payload[offset..]) {
+            Ok(0) => return Err(ReleaseSignatureError::ProcessFailed),
+            Ok(written) => offset += written,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(ReleaseSignatureError::Timeout);
+                }
+                std::thread::sleep(PROCESS_POLL_INTERVAL);
+            }
+            Err(_) => return Err(ReleaseSignatureError::ProcessFailed),
+        }
+    }
+    Ok(())
+}
+
+fn wait_for_child(
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<ExitStatus, ReleaseSignatureError> {
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(PROCESS_POLL_INTERVAL);
+            }
+            Ok(None) => {
+                terminate_and_reap(child);
+                return Err(ReleaseSignatureError::Timeout);
+            }
+            Err(_) => {
+                terminate_and_reap(child);
+                return Err(ReleaseSignatureError::ProcessFailed);
+            }
+        }
+    }
+}
+
+fn terminate_and_reap(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn read_status_file(path: &Path) -> Result<Vec<u8>, ReleaseSignatureError> {
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK | libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|_| ReleaseSignatureError::Io)?;
+    let metadata = file.metadata().map_err(|_| ReleaseSignatureError::Io)?;
+    if !metadata.file_type().is_file() {
+        return Err(ReleaseSignatureError::Io);
+    }
+    let mut status = Vec::with_capacity(MAX_GPG_STATUS_BYTES);
+    std::io::Read::by_ref(&mut file)
+        .take((MAX_GPG_STATUS_BYTES + 1) as u64)
+        .read_to_end(&mut status)
+        .map_err(|_| ReleaseSignatureError::Io)?;
+    if status.len() > MAX_GPG_STATUS_BYTES {
+        return Err(ReleaseSignatureError::StatusTooLarge);
+    }
+    Ok(status)
+}
+
+fn parse_valid_signer(status: &[u8]) -> Result<VerifiedSigner, ReleaseSignatureError> {
+    let text = std::str::from_utf8(status).map_err(|_| ReleaseSignatureError::InvalidStatus)?;
+    let mut valid_fingerprint = None;
+    let mut signature_failure = false;
+    for line in text.lines().filter(|line| !line.is_empty()) {
+        let fields: Vec<_> = line.split_ascii_whitespace().collect();
+        if fields.len() < 2 || fields[0] != "[GNUPG:]" {
+            return Err(ReleaseSignatureError::InvalidStatus);
+        }
+        match fields[1] {
+            "VALIDSIG" => {
+                let fingerprint = fields.get(2).ok_or(ReleaseSignatureError::InvalidStatus)?;
+                if valid_fingerprint.replace(*fingerprint).is_some() {
+                    return Err(ReleaseSignatureError::InvalidStatus);
+                }
+            }
+            "BADSIG" | "ERRSIG" | "EXPSIG" | "EXPKEYSIG" | "REVKEYSIG" | "NO_PUBKEY" => {
+                signature_failure = true;
+            }
+            _ => {}
+        }
+    }
+    if signature_failure {
+        return Err(ReleaseSignatureError::InvalidSignature);
+    }
+    let fingerprint = valid_fingerprint.ok_or(ReleaseSignatureError::InvalidSignature)?;
+    if fingerprint != ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT {
+        return Err(ReleaseSignatureError::SignerUntrusted);
+    }
+    Ok(VerifiedSigner {
+        fingerprint: fingerprint.to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::release_qualification::{
+        fixture_artifact_value, fixture_canonical_artifact, ReleaseQualificationArtifact,
+        ReleaseQualificationError,
+    };
+    use std::{
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+        time::Duration,
+    };
+
+    const FIXED_NOW: u64 = 1_788_192_050;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(tag: &str) -> Self {
+            static NEXT: AtomicU64 = AtomicU64::new(0);
+            let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "irlume-release-signature-{tag}-{}-{sequence}",
+                std::process::id()
+            ));
+            std::fs::create_dir(&path).unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    struct FakeGpgSpec<'a> {
+        verify_status: &'a str,
+        import_exit: i32,
+        verify_exit: i32,
+        read_stdin: bool,
+        sleep_verify: bool,
+    }
+
+    fn shell_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\"'\"'"))
+    }
+
+    fn write_fake_gpg(root: &TestDir, name: &str, spec: FakeGpgSpec<'_>) -> (PathBuf, PathBuf) {
+        let executable = root.path().join(name);
+        let record = root.path().join("fake-gpg-record");
+        let script = format!(
+            "#!/bin/sh\n\
+             record={}\n\
+             status=\n\
+             homedir=\n\
+             mode=\n\
+             want=\n\
+             for arg in \"$@\"; do\n\
+               /usr/bin/printf 'ARG=%s\\n' \"$arg\" >> \"$record\"\n\
+               if [ \"$want\" = status ]; then status=$arg; want=; continue; fi\n\
+               if [ \"$want\" = homedir ]; then homedir=$arg; want=; continue; fi\n\
+               case \"$arg\" in\n\
+                 --status-file) want=status ;;\n\
+                 --homedir) want=homedir ;;\n\
+                 --import) mode=import ;;\n\
+                 --verify) mode=verify ;;\n\
+               esac\n\
+             done\n\
+             if [ \"$mode\" = import ]; then\n\
+               /usr/bin/printf '%s' '[GNUPG:] IMPORT_OK 1 synthetic\\n' > \"$status\"\n\
+               exit {}\n\
+             fi\n\
+             for entry in \"$homedir\"/*; do\n\
+               if [ -f \"$entry\" ]; then /usr/bin/printf 'FILE=%s\\n' \"${{entry##*/}}\" >> \"$record\"; fi\n\
+             done\n\
+             {}\n\
+             {}\n\
+             /usr/bin/printf '%s' {} > \"$status\"\n\
+             exit {}\n",
+            shell_quote(record.to_str().unwrap()),
+            spec.import_exit,
+            if spec.sleep_verify {
+                "while :; do :; done"
+            } else {
+                ":"
+            },
+            if spec.read_stdin { "/bin/cat >/dev/null" } else { ":" },
+            shell_quote(spec.verify_status),
+            spec.verify_exit,
+        );
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o700)
+            .open(&executable)
+            .unwrap();
+        file.write_all(script.as_bytes()).unwrap();
+        file.set_permissions(std::fs::Permissions::from_mode(0o700))
+            .unwrap();
+        (executable, record)
+    }
+
+    fn write_fixture_file(path: &Path, bytes: &[u8], mode: u32) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(path)
+            .unwrap();
+        file.write_all(bytes).unwrap();
+        file.set_permissions(std::fs::Permissions::from_mode(mode))
+            .unwrap();
+    }
+
+    fn write_package_fixture(root: &TestDir, name: &str) -> ReleaseQualificationPaths {
+        let paths = ReleaseQualificationPaths::under(root.path(), name).unwrap();
+        write_fixture_file(paths.artifact(), &fixture_canonical_artifact(), 0o644);
+        write_fixture_file(paths.signature(), b"synthetic-signature", 0o644);
+        write_fixture_file(paths.trusted_key(), b"synthetic-public-key", 0o644);
+        paths
+    }
+
+    fn assert_no_gpg_homes(root: &TestDir) {
+        assert!(!std::fs::read_dir(root.path()).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with("gpg-home-")
+        }));
+    }
+
+    fn canonical_payload_from_value(value: serde_json::Value) -> Vec<u8> {
+        let artifact: ReleaseQualificationArtifact = serde_json::from_value(value).unwrap();
+        artifact.to_canonical_json().unwrap().into_bytes()
+    }
+
+    #[test]
+    fn valid_signature_mints_opaque_release_evidence() {
+        let payload = fixture_canonical_artifact();
+        let verified = verify_release_qualification_bytes(
+            &payload,
+            b"synthetic-signature",
+            FIXED_NOW,
+            &FakeVerifier::valid(ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT),
+        )
+        .unwrap();
+        assert_eq!(
+            verified.artifact_sha256(),
+            irlume_common::sha256_hex(&payload)
+        );
+        assert_eq!(
+            verified.signer_fingerprint(),
+            ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+        );
+        assert_eq!(
+            verified.artifact().candidate_profile().id(),
+            "candidate-15-15"
+        );
+    }
+
+    #[test]
+    fn wrong_short_or_modified_signature_authorizes_nothing() {
+        for verifier in [
+            FakeVerifier::valid("BD7F30C6"),
+            FakeVerifier::valid("035053398E3C80FE20891B82C10B8492BD7F30C6"),
+            FakeVerifier::invalid_signature(),
+        ] {
+            assert!(verify_release_qualification_bytes(
+                &fixture_canonical_artifact(),
+                b"synthetic-signature",
+                FIXED_NOW,
+                &verifier,
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn missing_or_oversized_inputs_authorize_nothing() {
+        let valid = FakeVerifier::valid(ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT);
+        assert_eq!(
+            verify_release_qualification_bytes(
+                &fixture_canonical_artifact(),
+                b"",
+                FIXED_NOW,
+                &valid,
+            ),
+            Err(ReleaseSignatureError::SignatureMissing),
+        );
+        assert_eq!(
+            verify_release_qualification_bytes(
+                &vec![b' '; 256 * 1024 + 1],
+                b"synthetic-signature",
+                FIXED_NOW,
+                &valid,
+            ),
+            Err(ReleaseSignatureError::ArtifactTooLarge),
+        );
+        assert_eq!(
+            verify_release_qualification_bytes(
+                &fixture_canonical_artifact(),
+                &vec![b'x'; 64 * 1024 + 1],
+                FIXED_NOW,
+                &valid,
+            ),
+            Err(ReleaseSignatureError::SignatureTooLarge),
+        );
+        assert_eq!(
+            GpgDetachedSignatureVerifier::new(PathBuf::from("/synthetic/gpg"), Vec::new()).err(),
+            Some(ReleaseSignatureError::TrustedKeyMissing),
+        );
+        assert_eq!(
+            GpgDetachedSignatureVerifier::new(
+                PathBuf::from("/synthetic/gpg"),
+                vec![b'x'; MAX_TRUSTED_PUBLIC_KEY_BYTES + 1],
+            )
+            .err(),
+            Some(ReleaseSignatureError::TrustedKeyTooLarge),
+        );
+    }
+
+    #[test]
+    fn noncanonical_or_metadata_mismatched_payload_authorizes_nothing() {
+        let valid = FakeVerifier::valid(ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT);
+        let pretty =
+            serde_json::to_vec_pretty(&fixture_artifact_value("baseline-30-15", "candidate-15-15"))
+                .unwrap();
+        assert_eq!(
+            verify_release_qualification_bytes(&pretty, b"synthetic-signature", FIXED_NOW, &valid,),
+            Err(ReleaseSignatureError::Artifact(
+                ReleaseQualificationError::Json
+            )),
+        );
+
+        let mut mismatched = fixture_artifact_value("baseline-30-15", "candidate-15-15");
+        mismatched["signature"]["signer_fingerprint"] =
+            serde_json::json!("A35053398E3C80FE20891B82C10B8492BD7F30C6");
+        assert_eq!(
+            verify_release_qualification_bytes(
+                &canonical_payload_from_value(mismatched),
+                b"synthetic-signature",
+                FIXED_NOW,
+                &valid,
+            ),
+            Err(ReleaseSignatureError::MetadataSignerMismatch),
+        );
+
+        let reordered =
+            serde_json::to_vec(&fixture_artifact_value("baseline-30-15", "candidate-15-15"))
+                .unwrap();
+        assert_ne!(reordered, fixture_canonical_artifact());
+        assert_eq!(
+            verify_release_qualification_bytes(
+                &reordered,
+                b"synthetic-signature",
+                FIXED_NOW,
+                &valid,
+            ),
+            Err(ReleaseSignatureError::Artifact(
+                ReleaseQualificationError::Json
+            )),
+        );
+    }
+
+    #[test]
+    fn sibling_fixture_mints_only_through_byte_verification() {
+        let verified = verified_release_fixture(
+            "baseline-fixture",
+            "candidate-fixture",
+            24,
+            12,
+            crate::profile::CaptureSchedule::Sequential,
+            0xa5,
+            FIXED_NOW,
+        );
+        let candidate = verified.artifact().candidate_profile();
+        assert_eq!(candidate.id(), "candidate-fixture");
+        assert_eq!(
+            verified.signer_fingerprint(),
+            ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+        );
+    }
+
+    #[test]
+    fn not_yet_valid_or_expired_payload_authorizes_nothing() {
+        let valid = FakeVerifier::valid(ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT);
+        assert_eq!(
+            verify_release_qualification_bytes(
+                &fixture_canonical_artifact(),
+                b"synthetic-signature",
+                1_788_191_999,
+                &valid,
+            ),
+            Err(ReleaseSignatureError::Artifact(
+                ReleaseQualificationError::ArtifactNotYetValid
+            )),
+        );
+        assert_eq!(
+            verify_release_qualification_bytes(
+                &fixture_canonical_artifact(),
+                b"synthetic-signature",
+                1_788_278_400,
+                &valid,
+            ),
+            Err(ReleaseSignatureError::Artifact(
+                ReleaseQualificationError::ArtifactExpired
+            )),
+        );
+    }
+
+    #[test]
+    fn isolated_gpg_uses_direct_arguments_stdin_and_cleans_its_home() {
+        let root = TestDir::new("success");
+        let status = format!(
+            "[GNUPG:] VALIDSIG {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT} 2026-09-01 0 4 0 22 8 00 {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT}\n"
+        );
+        let (executable, record) = write_fake_gpg(
+            &root,
+            "fake gpg with spaces",
+            FakeGpgSpec {
+                verify_status: &status,
+                import_exit: 0,
+                verify_exit: 0,
+                read_stdin: true,
+                sleep_verify: false,
+            },
+        );
+        let verifier = GpgDetachedSignatureVerifier::with_timeout_and_temp_root_for_test(
+            executable,
+            b"synthetic-public-key".to_vec(),
+            Duration::from_secs(1),
+            root.path().to_owned(),
+        )
+        .unwrap();
+        let signer = verifier
+            .verify(&fixture_canonical_artifact(), b"synthetic-signature")
+            .unwrap();
+        assert_eq!(signer.fingerprint, ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT);
+
+        let recorded = std::fs::read_to_string(record).unwrap();
+        for required in [
+            "ARG=--batch",
+            "ARG=--no-options",
+            "ARG=--no-tty",
+            "ARG=--no-autostart",
+            "ARG=--disable-dirmngr",
+            "ARG=--homedir",
+            "ARG=--status-file",
+            "ARG=--import",
+            "ARG=--verify",
+            "ARG=-",
+            "FILE=trusted-key.asc",
+            "FILE=detached-signature.asc",
+            "FILE=status",
+        ] {
+            assert!(recorded.lines().any(|line| line == required), "{required}");
+        }
+        let mut temporary_files: Vec<_> = recorded
+            .lines()
+            .filter_map(|line| line.strip_prefix("FILE="))
+            .collect();
+        temporary_files.sort_unstable();
+        assert_eq!(
+            temporary_files,
+            ["detached-signature.asc", "status", "trusted-key.asc"]
+        );
+        assert!(!recorded.contains(&String::from_utf8(fixture_canonical_artifact()).unwrap()));
+        assert_no_gpg_homes(&root);
+    }
+
+    #[test]
+    fn gpg_status_requires_one_exact_validsig_and_successful_exit() {
+        let cases = [
+            (
+                "goodsig-only",
+                "[GNUPG:] GOODSIG BD7F30C6 synthetic\n".to_owned(),
+                0,
+                ReleaseSignatureError::InvalidSignature,
+            ),
+            (
+                "short",
+                "[GNUPG:] VALIDSIG BD7F30C6 rest\n".to_owned(),
+                0,
+                ReleaseSignatureError::SignerUntrusted,
+            ),
+            (
+                "wrong",
+                "[GNUPG:] VALIDSIG A35053398E3C80FE20891B82C10B8492BD7F30C6 rest\n".to_owned(),
+                0,
+                ReleaseSignatureError::SignerUntrusted,
+            ),
+            (
+                "duplicate",
+                format!(
+                    "[GNUPG:] VALIDSIG {0} rest\n[GNUPG:] VALIDSIG {0} rest\n",
+                    ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+                ),
+                0,
+                ReleaseSignatureError::InvalidStatus,
+            ),
+            (
+                "conflicting",
+                format!(
+                    "[GNUPG:] VALIDSIG {} rest\n[GNUPG:] BADSIG BD7F30C6 bad\n",
+                    ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+                ),
+                0,
+                ReleaseSignatureError::InvalidSignature,
+            ),
+            (
+                "nonzero",
+                format!(
+                    "[GNUPG:] VALIDSIG {} rest\n",
+                    ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+                ),
+                2,
+                ReleaseSignatureError::ProcessFailed,
+            ),
+        ];
+        for (tag, status, verify_exit, expected) in cases {
+            let root = TestDir::new(tag);
+            let (executable, _) = write_fake_gpg(
+                &root,
+                "fake-gpg",
+                FakeGpgSpec {
+                    verify_status: &status,
+                    import_exit: 0,
+                    verify_exit,
+                    read_stdin: true,
+                    sleep_verify: false,
+                },
+            );
+            let verifier = GpgDetachedSignatureVerifier::with_timeout_and_temp_root_for_test(
+                executable,
+                b"synthetic-public-key".to_vec(),
+                Duration::from_secs(1),
+                root.path().to_owned(),
+            )
+            .unwrap();
+            assert_eq!(
+                verifier.verify(&fixture_canonical_artifact(), b"synthetic-signature"),
+                Err(expected),
+                "{tag}"
+            );
+            assert_no_gpg_homes(&root);
+        }
+    }
+
+    #[test]
+    fn gpg_rejects_import_failure_oversized_status_and_timeout() {
+        let valid_status = format!(
+            "[GNUPG:] VALIDSIG {} rest\n",
+            ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+        );
+        let oversized_status = "x".repeat(64 * 1024 + 1);
+        for (tag, spec, expected) in [
+            (
+                "import-failure",
+                FakeGpgSpec {
+                    verify_status: &valid_status,
+                    import_exit: 2,
+                    verify_exit: 0,
+                    read_stdin: true,
+                    sleep_verify: false,
+                },
+                ReleaseSignatureError::ProcessFailed,
+            ),
+            (
+                "oversized-status",
+                FakeGpgSpec {
+                    verify_status: &oversized_status,
+                    import_exit: 0,
+                    verify_exit: 0,
+                    read_stdin: true,
+                    sleep_verify: false,
+                },
+                ReleaseSignatureError::StatusTooLarge,
+            ),
+            (
+                "timeout",
+                FakeGpgSpec {
+                    verify_status: &valid_status,
+                    import_exit: 0,
+                    verify_exit: 0,
+                    read_stdin: false,
+                    sleep_verify: true,
+                },
+                ReleaseSignatureError::Timeout,
+            ),
+        ] {
+            let root = TestDir::new(tag);
+            let (executable, _) = write_fake_gpg(&root, "fake-gpg", spec);
+            let verifier = GpgDetachedSignatureVerifier::with_timeout_and_temp_root_for_test(
+                executable,
+                b"synthetic-public-key".to_vec(),
+                Duration::from_millis(75),
+                root.path().to_owned(),
+            )
+            .unwrap();
+            let payload = if tag == "timeout" {
+                vec![b'x'; MAX_RELEASE_QUALIFICATION_BYTES]
+            } else {
+                fixture_canonical_artifact()
+            };
+            assert_eq!(
+                verifier.verify(&payload, b"synthetic-signature"),
+                Err(expected),
+                "{tag}"
+            );
+            assert_no_gpg_homes(&root);
+        }
+    }
+
+    #[test]
+    fn release_paths_are_deterministic_and_labels_are_closed() {
+        let root = Path::new("/opt/irlume-package");
+        let paths = ReleaseQualificationPaths::under(root, "candidate_15-15").unwrap();
+        assert_eq!(
+            paths.artifact(),
+            Path::new(
+                "/opt/irlume-package/share/irlume/profile-qualifications/candidate_15-15.json"
+            )
+        );
+        assert_eq!(
+            paths.signature(),
+            Path::new(
+                "/opt/irlume-package/share/irlume/profile-qualifications/candidate_15-15.json.asc"
+            )
+        );
+        assert_eq!(
+            paths.trusted_key(),
+            Path::new("/opt/irlume-package/share/irlume/release-qualification-key.asc")
+        );
+        assert_eq!(
+            ReleaseQualificationPaths::system("candidate_15-15")
+                .unwrap()
+                .artifact(),
+            Path::new("/usr/share/irlume/profile-qualifications/candidate_15-15.json")
+        );
+        for invalid in [
+            "",
+            ".",
+            "Candidate",
+            "candidate.json",
+            "../candidate",
+            "candidate/name",
+            &"x".repeat(129),
+        ] {
+            assert_eq!(
+                ReleaseQualificationPaths::under(root, invalid),
+                Err(ReleaseSignatureError::InvalidArtifactName),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn synthetic_package_root_verifies_through_current_owner_seam() {
+        let root = TestDir::new("package-success");
+        let paths = write_package_fixture(&root, "candidate_15-15");
+        let status = format!(
+            "[GNUPG:] VALIDSIG {} rest\n",
+            ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+        );
+        let (executable, _) = write_fake_gpg(
+            &root,
+            "fake-gpg",
+            FakeGpgSpec {
+                verify_status: &status,
+                import_exit: 0,
+                verify_exit: 0,
+                read_stdin: true,
+                sleep_verify: false,
+            },
+        );
+        // SAFETY: geteuid has no preconditions or side effects.
+        let owner_uid = unsafe { libc::geteuid() };
+        let verified = verify_release_qualification_files_for_owner(
+            paths.artifact(),
+            paths.signature(),
+            paths.trusted_key(),
+            &executable,
+            FIXED_NOW,
+            owner_uid,
+        )
+        .unwrap();
+        assert_eq!(
+            verified.artifact_sha256(),
+            irlume_common::sha256_hex(&fixture_canonical_artifact())
+        );
+    }
+
+    #[test]
+    fn trusted_file_loading_rejects_symlinks_unsafe_modes_and_bounds() {
+        // SAFETY: geteuid has no preconditions or side effects.
+        let owner_uid = unsafe { libc::geteuid() };
+
+        let symlink_root = TestDir::new("package-symlink");
+        let symlink_paths = write_package_fixture(&symlink_root, "candidate");
+        std::fs::remove_file(symlink_paths.signature()).unwrap();
+        std::os::unix::fs::symlink(symlink_paths.artifact(), symlink_paths.signature()).unwrap();
+        assert_eq!(
+            read_trusted_file(
+                symlink_paths.signature(),
+                MAX_DETACHED_SIGNATURE_BYTES,
+                owner_uid,
+            ),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+
+        for (tag, selected, source, max_bytes) in [
+            (
+                "artifact-symlink",
+                "artifact",
+                "signature",
+                MAX_RELEASE_QUALIFICATION_BYTES,
+            ),
+            (
+                "key-symlink",
+                "key",
+                "artifact",
+                MAX_TRUSTED_PUBLIC_KEY_BYTES,
+            ),
+        ] {
+            let root = TestDir::new(tag);
+            let paths = write_package_fixture(&root, "candidate");
+            let selected_path = match selected {
+                "artifact" => paths.artifact(),
+                "key" => paths.trusted_key(),
+                _ => unreachable!(),
+            };
+            let source_path = match source {
+                "artifact" => paths.artifact(),
+                "signature" => paths.signature(),
+                _ => unreachable!(),
+            };
+            std::fs::remove_file(selected_path).unwrap();
+            std::os::unix::fs::symlink(source_path, selected_path).unwrap();
+            assert_eq!(
+                read_trusted_file(selected_path, max_bytes, owner_uid),
+                Err(ReleaseSignatureError::UnsafeFile),
+                "{tag}"
+            );
+        }
+
+        let nonregular_root = TestDir::new("package-nonregular");
+        let nonregular_paths = write_package_fixture(&nonregular_root, "candidate");
+        std::fs::remove_file(nonregular_paths.artifact()).unwrap();
+        std::fs::create_dir(nonregular_paths.artifact()).unwrap();
+        assert_eq!(
+            read_trusted_file(
+                nonregular_paths.artifact(),
+                MAX_RELEASE_QUALIFICATION_BYTES,
+                owner_uid,
+            ),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+
+        let mode_root = TestDir::new("package-mode");
+        let mode_paths = write_package_fixture(&mode_root, "candidate");
+        std::fs::set_permissions(
+            mode_paths.artifact(),
+            std::fs::Permissions::from_mode(0o666),
+        )
+        .unwrap();
+        assert_eq!(
+            read_trusted_file(
+                mode_paths.artifact(),
+                MAX_RELEASE_QUALIFICATION_BYTES,
+                owner_uid,
+            ),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+
+        let bound_root = TestDir::new("package-bound");
+        let bound_paths = ReleaseQualificationPaths::under(bound_root.path(), "candidate").unwrap();
+        write_fixture_file(
+            bound_paths.artifact(),
+            &vec![b'x'; MAX_RELEASE_QUALIFICATION_BYTES + 1],
+            0o644,
+        );
+        assert_eq!(
+            read_trusted_file(
+                bound_paths.artifact(),
+                MAX_RELEASE_QUALIFICATION_BYTES,
+                owner_uid,
+            ),
+            Err(ReleaseSignatureError::FileTooLarge),
+        );
+
+        assert_eq!(
+            read_trusted_file(
+                mode_paths.signature(),
+                MAX_DETACHED_SIGNATURE_BYTES,
+                owner_uid.wrapping_add(1),
+            ),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+    }
+
+    #[test]
+    fn production_metadata_policy_requires_root_and_no_group_or_world_write() {
+        assert_eq!(validate_trusted_file_metadata(true, 0, 0o644, 0), Ok(()));
+        assert_eq!(
+            validate_trusted_file_metadata(true, 1000, 0o644, 0),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+        assert_eq!(
+            validate_trusted_file_metadata(true, 0, 0o664, 0),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+        assert_eq!(
+            validate_trusted_file_metadata(true, 0, 0o646, 0),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+        assert_eq!(
+            validate_trusted_file_metadata(false, 0, 0o644, 0),
+            Err(ReleaseSignatureError::UnsafeFile),
+        );
+    }
+}

--- a/crates/irlume-camera/src/release_qualification_signature.rs
+++ b/crates/irlume-camera/src/release_qualification_signature.rs
@@ -1207,8 +1207,7 @@ mod tests {
             (
                 "duplicate",
                 format!(
-                    "[GNUPG:] VALIDSIG {0} rest\n[GNUPG:] VALIDSIG {0} rest\n",
-                    ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+                    "[GNUPG:] VALIDSIG {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT} rest\n[GNUPG:] VALIDSIG {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT} rest\n"
                 ),
                 0,
                 ReleaseSignatureError::InvalidStatus,
@@ -1216,18 +1215,14 @@ mod tests {
             (
                 "conflicting",
                 format!(
-                    "[GNUPG:] VALIDSIG {} rest\n[GNUPG:] BADSIG BD7F30C6 bad\n",
-                    ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
+                    "[GNUPG:] VALIDSIG {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT} rest\n[GNUPG:] BADSIG BD7F30C6 bad\n"
                 ),
                 0,
                 ReleaseSignatureError::InvalidSignature,
             ),
             (
                 "nonzero",
-                format!(
-                    "[GNUPG:] VALIDSIG {} rest\n",
-                    ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
-                ),
+                format!("[GNUPG:] VALIDSIG {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT} rest\n"),
                 2,
                 ReleaseSignatureError::ProcessFailed,
             ),
@@ -1263,10 +1258,8 @@ mod tests {
 
     #[test]
     fn gpg_rejects_import_failure_oversized_status_and_timeout() {
-        let valid_status = format!(
-            "[GNUPG:] VALIDSIG {} rest\n",
-            ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
-        );
+        let valid_status =
+            format!("[GNUPG:] VALIDSIG {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT} rest\n");
         let oversized_status = "x".repeat(64 * 1024 + 1);
         for (tag, spec, expected) in [
             (
@@ -1373,10 +1366,7 @@ mod tests {
     fn synthetic_package_root_verifies_through_current_owner_seam() {
         let root = TestDir::new("package-success");
         let paths = write_package_fixture(&root, "candidate_15-15");
-        let status = format!(
-            "[GNUPG:] VALIDSIG {} rest\n",
-            ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT
-        );
+        let status = format!("[GNUPG:] VALIDSIG {ALLOWLISTED_RELEASE_SIGNER_FINGERPRINT} rest\n");
         let (executable, _) = write_fake_gpg(
             &root,
             "fake-gpg",

--- a/docs/adr/0021-release-qualified-camera-profile-evidence.md
+++ b/docs/adr/0021-release-qualified-camera-profile-evidence.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-09-01
 **Amends:** [ADR-0020](0020-layered-camera-profile-and-evidence-engine.md)
+**Amended by:** [ADR-0022](0022-sealed-maintainer-qualification-campaign.md)
 **Design:** [Camera Profile Release Qualification](../superpowers/specs/2026-09-01-camera-profile-release-qualification-design.md)
 
 ## Context

--- a/docs/adr/0022-sealed-maintainer-qualification-campaign.md
+++ b/docs/adr/0022-sealed-maintainer-qualification-campaign.md
@@ -1,0 +1,74 @@
+# ADR-0022: Seal maintainer qualification campaigns before release signing
+
+**Status:** Accepted
+**Date:** 2026-09-02
+**Amends:** [ADR-0021](0021-release-qualified-camera-profile-evidence.md)
+**Design:** [Maintainer Qualification Campaign](../superpowers/specs/2026-09-02-camera-profile-maintainer-qualification-campaign-design.md)
+
+## Context
+
+ADR-0021 requires a signed aggregate release qualification artifact, but an
+artifact signature alone cannot prove that labels were frozen before capture,
+the cohort and attack matrix were complete, statistical rules were not changed
+after seeing results, or a second person reviewed the evidence. A single
+end-to-end tool would combine biometric access, evaluation, review, and release
+authority. Procedural scripts would leave the same facts unverifiable.
+
+## Decision
+
+Use a sealed, one-way campaign workflow. A versioned campaign policy constrains
+a signed campaign protocol. The protocol constrains a frozen private campaign
+bundle. A deterministic evaluator produces a private transcript and an
+aggregate-only public result. A distinct reviewer signs an attestation binding
+every predecessor digest and the exact public result. A canonical reviewed
+aggregate envelope binds that public result to the attestation. Its digest is
+the campaign-result digest compiled into the existing release artifact. A
+compiler with no vault access may then emit canonical unsigned artifact bytes.
+Release signing and publication remain separate explicit gates.
+
+Each campaign qualifies one exact hardware class and one baseline/candidate
+profile pair. The framework is reusable across campaigns, but a campaign never
+generalizes its evidence to nearby hardware or profiles. Profile acceptance is
+a paired non-inferiority claim against the exact baseline, not a new population
+certification of Irlume's biometric models.
+
+Participant withdrawal before publication invalidates a referencing campaign.
+After publication, withdrawal deletes retained biometric assets and prevents
+future use, while the identity-free reviewed aggregate remains valid only until
+its fixed artifact expiry. Private assets are retained no longer than that
+validity period and never longer than one year from collection.
+
+## Alternatives Considered
+
+### One End-To-End Tool
+
+Rejected because one process could collect biometric data, choose analysis,
+declare a pass, and prepare authority output without an independently
+verifiable boundary.
+
+### Manual Governance Plus Measurement Scripts
+
+Rejected because procedures alone cannot prove immutable labels, complete
+denominators, reviewer independence, or that compiled artifact bytes came from
+the reviewed result.
+
+### Absolute Population Recertification Per Profile
+
+Rejected because profile qualification asks whether an exact candidate
+preserves an already approved operating point. Repeating a population-scale
+model certification for every transport profile is a different and much larger
+program.
+
+## Consequences
+
+- Campaign collection, evaluation, review, compilation, signing, local
+  commissioning, and production selection remain separate authorities.
+- A failed campaign cannot be repaired by editing labels, margins, denominators,
+  or results under the same campaign identifier.
+- The release artifact and repository contain only identity-free aggregates and
+  digests. Raw assets and biometric intermediates remain in the encrypted
+  maintainer vault.
+- A second reviewer is mandatory before release-artifact compilation.
+- Real recruitment, biometric capture, hardware execution, release signing,
+  publication, commissioning, and production integration each require a later
+  explicit gate.

--- a/docs/superpowers/specs/2026-09-01-camera-profile-release-qualification-design.md
+++ b/docs/superpowers/specs/2026-09-01-camera-profile-release-qualification-design.md
@@ -1,6 +1,7 @@
 # Camera Profile Release Qualification: Design
 
-Status: approved design, pending implementation plan
+Status: software-only authority design implemented and independently approved;
+campaign and production integration remain separate
 Date: 2026-09-01
 Agent: opencode
 Scope: Task 7 release qualification authority, local non-biometric commissioning,
@@ -21,6 +22,10 @@ Amends:
 Decision record:
 
 - `docs/adr/0021-release-qualified-camera-profile-evidence.md`
+
+Campaign design:
+
+- `docs/superpowers/specs/2026-09-02-camera-profile-maintainer-qualification-campaign-design.md`
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-09-02-camera-profile-maintainer-qualification-campaign-design.md
+++ b/docs/superpowers/specs/2026-09-02-camera-profile-maintainer-qualification-campaign-design.md
@@ -1,0 +1,843 @@
+# Camera Profile Maintainer Qualification Campaign: Design
+
+Status: approved design, pending implementation plan
+Date: 2026-09-02
+Agent: opencode
+Scope: generic maintainer campaign contracts, governance, paired statistical
+policy, review authority, and aggregate artifact production. This document does
+not authorize recruitment, biometric access, vault creation, hardware capture,
+release signing, artifact publication, packaging, local commissioning, profile
+selection writes, or production changes.
+
+Amends:
+
+- `docs/superpowers/specs/2026-09-01-camera-profile-release-qualification-design.md`
+- `docs/adr/0021-release-qualified-camera-profile-evidence.md`
+
+Decision record:
+
+- `docs/adr/0022-sealed-maintainer-qualification-campaign.md`
+
+## Goal
+
+Define a reusable maintainer-controlled campaign framework that can determine
+whether one exact candidate camera profile is non-inferior to one exact baseline
+profile without shipping or exposing campaign biometrics.
+
+One campaign evaluates one hardware class and one baseline/candidate pair. It
+freezes labels, cohort composition, attacks, ordering, operating points,
+statistical margins, software, models, and exclusions before authorizing
+capture. A deterministic evaluator produces an identity-free aggregate. A
+distinct reviewer verifies the sealed evidence before an isolated compiler may
+prepare the existing schema-1 release qualification artifact.
+
+The framework supports many independent campaigns. Evidence from one campaign
+never generalizes to a nearby camera, profile, tuple, schedule, conditioning
+policy, preprocessing contract, model contract, or software revision.
+
+## Evidence Basis And Claim Boundary
+
+This design uses established biometric testing concepts without claiming
+certification:
+
+- FIDO Biometrics Requirements 4.0 fixes biometric operating points during
+  testing, reports IAPAR per PAI species, separates bona fide and attack
+  performance, defines test-crew composition, and requires privacy-protecting
+  reports.
+- ISO/IEC 19795 and ISO/IEC 30107 terminology, as summarized by FIDO, separates
+  mated, non-mated, bona fide, and presentation-attack trials.
+- NIST IR 8280 demonstrates that face-recognition error behavior must be
+  examined across demographic groups rather than only as one pooled rate.
+- Microsoft's Windows Hello requirements illustrate why absolute low-FAR
+  population claims require millions of comparisons and thousands of unique
+  samples.
+- Matched-pair non-inferiority literature treats a predeclared confidence bound
+  on the paired response-rate difference as the relevant decision, rather than
+  comparing two unrelated point estimates.
+
+The campaign claim is narrower than certification. It states that changing one
+exact camera profile did not produce a disallowed paired regression under the
+approved protocol. It does not establish a new absolute FAR, TAR, PAD
+certification, demographic fairness certification, or protection against attack
+classes outside the protocol.
+
+Primary references:
+
+- https://fidoalliance.org/specs/biometric/requirements/Biometrics-Requirements-v4.0-fd-20240522.html
+- https://doi.org/10.6028/NIST.IR.8280
+- https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/windows-hello-biometric-requirements
+- https://doi.org/10.1002/sim.1012
+- https://doi.org/10.1080/10543406.2024.2390888
+
+## Binding Constraints
+
+- End users never create, manage, or contribute a release qualification corpus.
+- Production enrollment is never read, copied, modified, or used as a campaign
+  reference source.
+- Campaign tooling cannot authenticate, release a credential, enroll a user,
+  write profile selection, or mint verified release evidence.
+- Security and model-quality outcomes are hard gates. Payload and latency may
+  rank only profiles that pass every gate.
+- Labels, expected outcomes, cohort strata, attack species, operating points,
+  margins, sample size, stopping rules, exclusions, and software are frozen
+  before authorizing capture.
+- Baseline and candidate inputs are paired within the same participant or PAI,
+  scene, expected outcome, and bounded collection block.
+- Candidate results never define ground truth or alter the protocol.
+- No stage may construct the authority output of a later stage.
+- A passing evaluator result without independent review creates no artifact.
+- A reviewed aggregate without explicit release signing and publication creates
+  no installed authority.
+- Raw private assets and biometric intermediates never enter source control,
+  packages, support output, or the release qualification artifact.
+- Missing, malformed, stale, incomplete, mismatched, or withdrawn evidence fails
+  closed.
+- Software-only success does not authorize recruitment, biometrics, hardware,
+  signing, publication, commissioning, or production integration.
+
+## Vocabulary
+
+**Campaign policy**:
+The versioned maintainer rules that fix cohort, attack, statistical, retention,
+review, and invalidation requirements. An operator cannot weaken policy through
+a campaign protocol.
+
+**Campaign protocol**:
+A signed campaign-specific declaration applying one campaign policy to one
+exact hardware class and baseline/candidate profile pair before capture.
+
+**Private campaign bundle**:
+The frozen, encrypted, content-addressed biometric assets, manifests, consent
+eligibility snapshot, and audit records for one campaign.
+
+**Private case transcript**:
+The deterministic vault-local record of per-case validation and model outcomes.
+It may contain campaign-scoped participant tokens and bounded internal values
+needed for independent review.
+
+**Public aggregate result**:
+The identity-free canonical projection containing only denominators, aggregate
+counts, confidence bounds, latency summaries, dispositions, and predecessor
+digests.
+
+**Review attestation**:
+A distinct reviewer's signed decision binding the frozen inputs, evaluator,
+private transcript, public aggregate, policy checks, and approval outcome.
+
+**Reviewed aggregate**:
+A canonical envelope binding one passing public aggregate result to its valid
+matching independent review attestation. Its digest is the release artifact's
+campaign result digest.
+
+**Publication boundary**:
+The point at which a reviewed aggregate becomes an immutable released fact.
+Later participant withdrawal removes retained assets and future use, not the
+already published identity-free fact.
+
+## Architecture And Authority
+
+The workflow is one-way:
+
+```text
+campaign policy
+  -> signed campaign protocol
+  -> collection eligibility snapshot
+  -> frozen private campaign bundle
+  -> evaluation eligibility snapshot
+  -> deterministic private transcript and public aggregate
+  -> publication eligibility snapshot
+  -> independent review attestation
+  -> reviewed aggregate envelope
+  -> canonical unsigned release artifact
+  -> detached release signature and publication
+```
+
+### Authority Matrix
+
+| Stage | May read | May emit | Must not do |
+|---|---|---|---|
+| Policy authoring | Approved standards and repository contracts | Campaign policy | Read biometrics or declare a campaign pass |
+| Protocol authoring | Policy and exact target contracts | Signed campaign protocol | Capture, evaluate, or change policy |
+| Collection | Protocol, eligibility snapshot, hardware | Staging assets and capture manifests | Evaluate, review, compile, sign, enroll, or authenticate |
+| Freeze | Staging bundle | Frozen private bundle | Repair missing evidence or alter labels |
+| Evaluation | Frozen bundle and exact software | Private transcript and public aggregate | Change inputs, review itself, or create artifact authority |
+| Review | Frozen bundle, both results, policy, software | Signed pass/fail attestation | Edit inputs, results, labels, margins, or denominators |
+| Aggregate assembly | Passing public aggregate and attestation | Reviewed aggregate envelope | Change either reviewed input or declare release authority |
+| Artifact compilation | Reviewed aggregate envelope and exact target contracts | Canonical unsigned artifact bytes | Access vault, biometrics, release key, or selection store |
+| Release signing | Exact compiler bytes and publication approval | Detached signature | Recompute or repair campaign results |
+| Product verification | Packaged artifact, signature, allowlisted public key | Opaque verified release evidence | Access campaign data or infer missing authority |
+
+The campaign operator and reviewer must have distinct full signing
+fingerprints. The release key is a role-specific allowlisted key that never
+enters the biometric vault. A reviewer may reject a campaign but cannot waive a
+gate or edit a result.
+
+## Versioned Documents
+
+Every document uses a closed schema, compact canonical JSON, bounded fields,
+unknown-field rejection, and a deterministic SHA-256 digest. Each metadata
+document is limited to 256 KiB. Larger case sets use ordered signed indexes and
+bounded shards rather than raised parser limits.
+
+All signatures are detached OpenPGP signatures verified against exact full
+fingerprints assigned to protocol-author, operator, reviewer, or release roles.
+Trust-database status and short key IDs are not authority.
+
+### Campaign Policy
+
+The policy contains:
+
+- schema and policy versions;
+- policy identifier and canonical digest;
+- target-population and permitted hardware-class rules;
+- required demographic and operational stratification axes;
+- required bona fide, no-face, non-mated, and 2D PAI classes;
+- fixed expected-outcome vocabulary;
+- paired collection and order-balancing rules;
+- security hard-gate definitions;
+- matched-pair non-inferiority method and margins;
+- confidence, power, sample-size, and stopping rules;
+- latency method and budget relationship;
+- missingness and bounded-repeat rules;
+- protocol, bundle, result, review, and artifact expiry rules;
+- one-year absolute private-asset retention ceiling;
+- publication-boundary withdrawal semantics;
+- role separation and signer policy;
+- safe public projection version;
+- minimum public stratum cell size;
+- invalidation rules.
+
+Policy values are not caller options. A changed method, margin, attack minimum,
+stratum rule, or lifecycle rule requires a new policy version.
+
+### Campaign Protocol
+
+The signed protocol contains:
+
+- schema version, campaign ID, policy ID, and policy digest;
+- planned creation, collection, evaluation, review, and expiry bounds;
+- exact source revision and evaluator build identity;
+- exact hardware scope and match-policy version;
+- exact baseline and candidate profile contracts, including requested and
+  accepted RGB and IR tuples and schedules;
+- exact conditioning catalog and selected-policy digests;
+- exact preprocessing, model, producer, and threshold-contract digests;
+- fixed biometric operating points;
+- target-population definition;
+- predeclared demographic and operational strata with required counts;
+- mated, non-mated, no-face, scene, and PAI case matrices;
+- PAI production methods and instrument identifiers that reveal no identity;
+- campaign-scoped reference and probe relationships;
+- deterministic balanced ordering seed;
+- pilot-estimated discordance inputs and locked authorizing sample sizes;
+- exact confidence, power, margins, stopping rule, and attempt caps inherited
+  from policy;
+- allowed pre-outcome equipment invalidations;
+- expected outcomes frozen independently of candidate output;
+- full protocol-author signer fingerprint.
+
+One protocol binds one hardware class and one baseline/candidate pair. Another
+pair requires another campaign ID and protocol even when policy is unchanged.
+
+### Consent Eligibility Snapshots
+
+Private eligibility snapshots are produced from a separate encrypted consent
+registry before collection, evaluation, and publication review. They share one
+closed schema with a fixed `collection`, `evaluation`, or `publication` phase.
+Each contains only campaign-scoped participant tokens and eligibility facts
+needed by the campaign:
+
+- exact protocol digest and purpose;
+- allowed bona fide and presentation classes;
+- collection and retention windows;
+- aggregate-publication acknowledgement;
+- publication-boundary withdrawal acknowledgement;
+- active, expired, or withdrawn status;
+- registry revision and predecessor digest;
+- operator signature.
+
+Real identities and consent documents remain in the separate registry and are
+not copied into protocols, manifests, transcripts, aggregates, or artifacts.
+The collection snapshot is part of the frozen bundle. The evaluation snapshot
+binds the exact token set and collection-snapshot digest into the private
+transcript. The publication snapshot binds the same token set and both prior
+snapshot digests into the review attestation. A missing token, disconnected
+registry revision, expiry, or withdrawal at any phase fails closed.
+
+### Capture Manifests And Bundle Index
+
+The bundle contains an ordered signed index and bounded capture shards. One
+capture shard contains no more than 128 paired cases, no more than 32 assets per
+role per case, and no asset larger than the policy maximum or the framework
+ceiling of 64 MiB.
+
+Each case binds:
+
+- protocol, participant or PAI token, case, stratum, scene, and expected outcome;
+- exact baseline or candidate profile and balanced order position;
+- camera and connection context;
+- requested and accepted tuples and capture schedule;
+- conditioning application and restoration proof;
+- preprocessing, model, producer, policy, and software digests;
+- bounded relative asset paths, media shapes, sequence positions, and SHA-256;
+- capture start and end facts;
+- pre-outcome invalidation and bounded-repeat history.
+
+Baseline and candidate cases must have exact logical parity and independent
+capture provenance. Missing, duplicate, extra, relabeled, or mismatched cases
+prevent freeze.
+
+### Private Case Transcript
+
+The transcript records enough vault-local information for deterministic review:
+
+- every input and predecessor digest;
+- every case validation outcome;
+- expected and actual categorical stage outcomes;
+- bounded model values needed to recompute category decisions;
+- latency observations;
+- missingness and attempt history;
+- stratum and PAI membership by campaign token;
+- exact reducer inputs and output digest.
+
+The transcript cannot contain real identity, consent-document content,
+production enrollment handles, authentication grants, or release-key material.
+
+### Public Aggregate Result
+
+The public result contains only:
+
+- schema, campaign, policy, protocol, bundle, evaluator, and transcript digests;
+- exact hardware, profile, conditioning, preprocessing, model, and producer
+  contract digests;
+- aggregate and predeclared stratum denominators;
+- mated, non-mated, no-face, and per-PAI categorical counts;
+- paired 2 by 2 tables for each binary non-inferiority gate;
+- confidence bounds, margins, and pass/fail dispositions;
+- latency p50 and p95 summaries and paired upper bound;
+- provenance, completeness, security, availability, and latency dispositions;
+- collection and evaluation time bounds;
+- explicit 3D-mask and active-IR exclusions;
+- evaluator signer fingerprint.
+
+It contains no participant or PAI token, identity, consent content, path, serial
+number, frame, crop, tensor, template, embedding, per-case value, or model score.
+
+### Review Attestation
+
+The review attestation binds:
+
+- policy, protocol, collection, evaluation, and publication eligibility
+  snapshot, bundle, evaluator, transcript, and public-result digests;
+- exact source revision and independently reproduced result digest;
+- consent, cohort, case, attack, ordering, provenance, completeness,
+  statistical, projection, and expiry checks;
+- passing or rejected decision with fixed safe categories;
+- operator and reviewer full fingerprints;
+- review timestamp and reviewer signature.
+
+The attestation is valid only when the reviewer fingerprint differs from the
+operator fingerprint and every check passes. A rejection cannot be converted to
+a pass without a new campaign ID.
+
+### Reviewed Aggregate Envelope
+
+After a passing review, a pure assembler creates a closed canonical envelope
+containing:
+
+- schema version and campaign ID;
+- policy and protocol digests;
+- public aggregate result digest;
+- passing review attestation digest;
+- public aggregate and reviewer signer fingerprints;
+- review timestamp copied exactly from the signed attestation.
+
+The assembler verifies both canonical inputs and the review signature before
+emitting the envelope. It has no vault, biometric, release-key, package, or
+selection-store access. The SHA-256 of the canonical envelope is the exact
+`campaign_result_sha256` written into the schema-1 release qualification
+artifact. This binds independent review without changing the implemented
+artifact wire schema.
+
+### Deletion Record
+
+A signed deletion record contains only affected campaign and asset digests,
+reason category, completion timestamp, reviewer fingerprint, and completion
+status. It never lists identities or recoverable paths. Deletion failure remains
+an unresolved governance incident and blocks future use of the affected vault.
+
+## Corpus And Consent Governance
+
+### Cohort Structure
+
+Recruitment is multi-participant and maintainer-controlled. Policy requires
+predeclared demographic axes for age, gender, and skin tone plus operational
+axes that materially affect camera evidence, including eyewear, facial hair or
+occlusion where applicable, and required lighting or pose conditions.
+
+The target population, category instrument, category values, intersections to
+be tested, and minimum count per stratum are fixed in policy and protocol before
+recruitment closes. Categories are self-described or collected through the
+approved instrument. They are not inferred by Irlume models. A short stratum
+makes the campaign incomplete and is never pooled away after results are known.
+
+Demographic fields exist only in the private registry, eligibility snapshot,
+and private transcript. The public result identifies bounded stratum IDs and
+denominators defined by policy, not participant attributes or tokens. Policy
+fixes a minimum public cell size before recruitment. A short cell makes the
+campaign incomplete; it is not suppressed, merged, or relabeled after results
+are known.
+
+### Presentation Attacks
+
+Policy version 1 covers the product's currently claimed 2D scope:
+
+- no-face presentations;
+- non-mated live cross-identity presentations;
+- printed-face PAI species;
+- display and replay PAI species at the supported login distance;
+- protocol-defined cutout or partial-face variants where applicable to the
+  existing threat claim.
+
+PAI production method, source diversity, display or print properties, distance,
+lighting, and attempts are frozen before capture. Attack operators have separate
+consent for each presentation class. The operating point remains fixed.
+
+Three-dimensional masks and active-IR attacks are outside policy version 1.
+Every public result and artifact review records these exclusions. Their absence
+cannot be described as a pass or certification.
+
+### Consent And Withdrawal
+
+Consent states:
+
+- exact `camera_profile_release_qualification` purpose;
+- allowed bona fide and presentation classes;
+- collection and retention windows;
+- private replay and independent review;
+- identity-free aggregate publication;
+- publication-boundary withdrawal behavior;
+- deletion and future-use consequences.
+
+Withdrawal before artifact publication invalidates every referencing snapshot,
+bundle, transcript, aggregate, and attestation. Signing is blocked.
+
+Withdrawal after publication triggers reviewed deletion of retained assets and
+prevents future campaign use. It does not retract the already published
+identity-free aggregate or artifact, which remains eligible only until its fixed
+expiry. Consent must explain this boundary before collection.
+
+### Retention And Storage
+
+The private snapshot is retained only through the artifact validity and audit
+window and never beyond one year from collection. An earlier participant
+withdrawal after publication shortens asset retention for that participant.
+
+The vault is:
+
+- encrypted and maintainer-controlled;
+- outside the repository, production daemon state, enrollment state, benchmark
+  roots, unencrypted backups, and support output;
+- owner-restricted while writable staging exists;
+- frozen and mounted read-only for evaluation and review;
+- offline during private evaluation;
+- configured to avoid core dumps and persistent model intermediates;
+- accessed only through bounded relative paths with no symlink traversal.
+
+Minimal consent and deletion audit records may remain where required, but they
+must not reconstruct biometric content.
+
+### Public Regression Lane
+
+Public research datasets remain a separate profile-independent lane. Their
+license, source, mirror identity, and content digests are recorded. Existing
+model-calibration results may be bound by protocol and result digest.
+
+Public regression evidence may strengthen confidence in the fixed model
+operating point. It cannot replace exact profile-bound private captures, repair
+a failed campaign gate, or authorize a hardware class by itself.
+
+## Collection Protocol
+
+Baseline and candidate cases are collected in deterministic balanced crossover
+order. Long baseline and candidate blocks are prohibited. The protocol limits
+time between paired cases and records scene, context, conditioning,
+negotiation, capture, and restoration evidence for each side.
+
+The collector:
+
+1. verifies policy, protocol, signer, collection eligibility snapshot, and
+   target scope;
+2. verifies exact camera endpoints and connection context;
+3. applies the protocol's next balanced profile and conditioning policy;
+4. verifies requested and accepted tuples before capture;
+5. captures one complete bounded evidence window;
+6. verifies exact conditioning restoration;
+7. records content digests and provenance into staging;
+8. advances only when the paired-case rules permit it.
+
+A failure to acquire, model-relevant capture failure, timeout, missing PAD
+evidence, or restoration uncertainty is an incorrect outcome, not an exclusion.
+Only a predeclared equipment or provenance invalidation detected before model
+evaluation may be repeated. The protocol fixes a repeat cap. Every invalidation
+and attempt remains in the private audit record. Exceeding the cap makes the
+campaign incomplete.
+
+Collection has no network, enrollment, authentication, selection-store,
+artifact-compilation, review, or release-signing capability.
+
+## Deterministic Evaluation
+
+Evaluation is ordered and fail closed:
+
+1. mount the frozen bundle read-only;
+2. verify exact signatures, roles, schemas, bounds, and predecessor digests;
+3. obtain and verify the evaluation-phase eligibility snapshot;
+4. verify every relative path, descriptor, type, size, and asset digest before
+   decoding;
+5. require exact baseline/candidate case, stratum, scene, and ordering parity;
+6. require exact hardware, profile, conditioning, preprocessing, model,
+   producer, policy, threshold, and software provenance;
+7. construct campaign-only recognition references in memory;
+8. run the same canonical evidence and typed model-input contracts as Irlume;
+9. reduce each case to frozen expected-versus-actual categorical outcomes;
+10. destroy temporary templates and model intermediates;
+11. compute the private transcript and public aggregate deterministically;
+12. sign both result digests with the evaluator role key.
+
+There is no fallback to production enrollment, legacy assets, unsigned labels,
+another profile, nearby hardware, stale consent, partial cases, or changed
+thresholds.
+
+## Statistical Acceptance Policy
+
+### Unit Of Analysis
+
+The unit is a paired case under baseline and candidate profiles for the same
+participant or PAI, scene, expected outcome, logical reference relationship,
+and bounded collection block.
+
+Before the authorizing protocol is signed, a non-authorizing pilot with
+different participants and instruments estimates discordant-pair rates. The
+authorizing sample size is then locked. Pilot observations never enter the
+authorizing denominator.
+
+### Security Direction
+
+Zero candidate accepts are tolerated for:
+
+- non-mated identity trials;
+- no-face trials;
+- required print PAI species;
+- required display or replay PAI species;
+- every other policy-required security-direction case.
+
+Any candidate accept fails the campaign. Any case accepted by both baseline and
+candidate also blocks publication and triggers security review. A known
+baseline failure cannot normalize candidate authority.
+
+IAPAR is reported per PAI species and pooled at the fixed production operating
+point. The result includes exact one-sided 95 percent Clopper-Pearson upper
+bounds and full denominators. These values describe the campaign and do not
+claim FIDO or ISO certification.
+
+### Bona Fide Non-Inferiority
+
+Detection, recognition, liveness, RGB PAD, and IR PAD are co-primary paired
+binary gates. Policy version 1 uses the MOVER-Wilson matched-pair risk-difference
+method, identified as `paired_mover_wilson_v1`.
+
+For every gate:
+
+- the one-sided 95 percent lower confidence bound for
+  `candidate_success_rate - baseline_success_rate` must exceed `-0.02` overall;
+- the corresponding bound must exceed `-0.05` in every predeclared demographic
+  and operational stratum;
+- the exact paired 2 by 2 table and denominator are retained in the public
+  aggregate;
+- all overall and stratum tests must pass.
+
+The implementation must pin the formula, numerical precision, boundary
+behavior, and reference vectors under the method version. Changing any of them
+requires a new policy method version.
+
+### Power And Sample Size
+
+Each authorizing overall and stratum test requires at least 80 percent planned
+power at one-sided alpha `0.05`, using the non-authorizing pilot's predeclared
+discordant-pair estimates and the applicable 2 or 5 percentage-point margin.
+
+The sample-size calculator and inputs are part of the signed protocol. Capture
+cannot stop early for apparent success. A stratum that cannot meet its locked
+sample size makes the campaign incomplete.
+
+Every component is required to pass, so the final decision is an
+intersection-union decision. A strong result in one gate or stratum cannot
+compensate for another failure.
+
+### Latency
+
+Candidate end-to-end p95 latency must remain within the existing fixed budget.
+Using 10,000 deterministic participant-cluster bootstrap resamples seeded from
+the signed protocol, the one-sided 95 percent upper bound for the paired
+candidate-minus-baseline latency increase must not exceed 5 percent of that
+budget.
+
+The bootstrap unit is the participant or PAI cluster, not an individual frame.
+The resampling algorithm, seed derivation, quantile convention, precision, and
+reference vectors are fixed by policy method version.
+
+### Missingness And Exclusions
+
+Model rejection, failure to acquire, timeout, missing required PAD evidence,
+and incomplete model-relevant capture count as incorrect. They cannot disappear
+from a denominator.
+
+Only a protocol-listed equipment or provenance invalidation detected before
+model evaluation may use the bounded repeat rule. The private transcript keeps
+the original invalidation and repeat. No outcome-known exclusion, relabeling,
+threshold change, optional stopping, or denominator reduction is allowed.
+
+## Independent Review
+
+The reviewer obtains read-only access to the frozen bundle and exact evaluator
+build. Review requires:
+
+- distinct operator and reviewer full fingerprints;
+- valid policy and protocol signatures;
+- complete eligible cohort and every locked stratum;
+- exact case, attack, order, and denominator completeness;
+- a current publication-phase eligibility snapshot connected to the collection
+  and evaluation snapshots;
+- exact provenance and asset digest verification;
+- deterministic reproduction of private and public result digests;
+- independent recomputation of statistical tables and bounds;
+- confirmation that every hard gate and intersection component passed;
+- confirmation that the public projection contains no prohibited content;
+- confirmation that expiry and retention remain valid;
+- a signed pass or rejection attestation.
+
+The reviewer cannot edit evidence or waive a gate. A failed review requires a
+new campaign ID after the cause is corrected.
+
+## Artifact Compilation And Publication
+
+The artifact compiler runs outside the vault and accepts only:
+
+- a canonical reviewed aggregate envelope;
+- its canonical passing public aggregate and valid matching independent review
+  attestation for digest and signature verification;
+- exact schema-1 release artifact target values;
+- the intended allowlisted release signer fingerprint.
+
+The compiler verifies every predecessor digest and projects:
+
+- campaign ID, protocol digest, and reviewed aggregate envelope digest;
+- exact hardware scope;
+- exact baseline and candidate profile contracts;
+- conditioning catalog and selected-policy digests;
+- preprocessing and model-contract digests;
+- policy and producer versions;
+- passing aggregate gate dispositions;
+- qualification time copied exactly from the signed review timestamp;
+- expiry no later than both protocol expiry and one year after collection;
+- release signature metadata.
+
+It emits canonical unsigned bytes only. It cannot access the private bundle,
+consent registry, biometric data, release private key, package root, local
+commissioning store, or profile-selection store.
+
+Release signing and publication require another explicit gate. Signing covers
+the exact compiler bytes with the allowlisted release key. Packaging,
+commissioning, artifact installation, and production profile selection remain
+separate later plans.
+
+## Failure Handling And Safe Diagnostics
+
+Fixed public campaign categories are:
+
+- `policy_unsupported`;
+- `protocol_invalid`;
+- `consent_ineligible`;
+- `cohort_incomplete`;
+- `bundle_unsafe`;
+- `capture_incomplete`;
+- `provenance_mismatch`;
+- `evaluator_drift`;
+- `security_gate_failed`;
+- `noninferiority_failed`;
+- `latency_failed`;
+- `review_missing`;
+- `review_rejected`;
+- `artifact_compile_failed`.
+
+Public output may identify a gate, denominator, aggregate count, margin, and
+confidence bound. It never includes tokens, identities, paths, serials,
+third-party error text, per-case values, model scores, or asset details.
+
+Unknown schema, field, enum, signer, role, policy, method, or analysis version
+fails. A crash leaves staging data only. Restart verifies all immutable
+predecessors rather than trusting partial progress.
+
+A failed result cannot be repaired by changing labels, margins, exclusions,
+denominators, or outputs under the same campaign ID. A method change requires a
+new policy version; a campaign-specific correction requires a new protocol and
+campaign ID.
+
+## Verification
+
+All software-only tests use synthetic, non-biometric fixtures.
+
+### Contract Tests
+
+- canonical-byte round trips and deterministic digests;
+- closed schemas, enums, bounds, identifiers, lists, shards, and total sizes;
+- unknown-field and unsupported-version rejection;
+- invalid, missing, duplicate, wrong-role, short-ID, and wrong-fingerprint
+  signatures;
+- predecessor digest mismatch and reordered-index rejection;
+- disconnected collection, evaluation, or publication eligibility snapshots;
+- reviewed aggregate envelope, public-result, and review-attestation mismatch;
+- invalid campaign, hardware, profile, model, preprocessing, conditioning,
+  policy, operating-point, and expiry bindings.
+
+### Statistical Tests
+
+- hand-computed and published matched-pair non-inferiority fixtures;
+- exhaustive small-sample paired 2 by 2 tables;
+- exact Clopper-Pearson boundary fixtures;
+- power and sample-size boundary fixtures;
+- deterministic cluster-bootstrap reference vectors;
+- exact 2 percent overall, 5 percent stratum, and 5 percent latency-margin
+  boundaries;
+- minimum public stratum cell-size boundaries;
+- security zero-tolerance and shared baseline/candidate failure cases;
+- intersection decisions where each component fails independently;
+- monotonicity: removing, corrupting, or failing evidence cannot improve a
+  verdict.
+
+### Consent And Lifecycle Tests
+
+- purpose and presentation-scope enforcement;
+- active, expired, missing, and pre-publication withdrawn consent;
+- post-publication withdrawal and asset deletion;
+- artifact-life and one-year retention ceilings;
+- signed deletion success, interruption, and unresolved failure;
+- no real identity or consent content enters non-registry fixtures.
+
+### Filesystem And Determinism Tests
+
+- traversal, absolute path, symlink, non-regular file, root escape, duplicate,
+  size, and digest rejection;
+- interrupted staging never appears frozen;
+- frozen bundles reject mutation;
+- read-only replay produces byte-identical private and public results;
+- changed software, models, policy, thresholds, or contracts produce drift,
+  never silent recomputation.
+
+### Projection And Authority Tests
+
+- no token, identity, path, image, crop, tensor, template, embedding, per-case
+  value, score, or unsafe text reaches public results or artifacts;
+- collection cannot evaluate, review, compile, or sign;
+- evaluation cannot review itself or compile authority;
+- review cannot alter evidence or waive gates;
+- compilation cannot access the vault or release key;
+- campaign tooling cannot access enrollment, authentication grants, local
+  commissioning writers, or `ProfileSelectionStore::save`;
+- synthetic end-to-end pass and every fixed failure category;
+- operator/reviewer fingerprint collision and artifact tampering rejection;
+- detached release-signature verification through the existing production
+  boundary.
+
+Real biometric and hardware tests remain declared and ignored until separately
+authorized. Synthetic success creates no release, local, or production
+authority.
+
+## Delivery Phases And Gates
+
+1. Commit this design, glossary additions, and ADR-0022.
+2. Implement closed policy, protocol, eligibility-snapshot, bundle-index,
+   result, review-attestation, reviewed-envelope, and deletion-record contracts
+   with synthetic fixtures.
+3. Implement and independently verify the paired reducer, power calculator,
+   public projection, and unsigned schema-1 artifact compiler.
+4. Implement synthetic vault, filesystem, and deterministic evaluator
+   boundaries without real assets, enrollment, hardware, or network.
+5. Complete an independent software-only authority review and keep every writer
+   disconnected.
+6. Design and approve one exact real campaign protocol under the generic
+   framework.
+7. Obtain separate approval before recruitment, consent execution, or private
+   vault creation.
+8. Obtain separate approval before each biometric collection and hardware
+   campaign.
+9. Independently review the frozen campaign and aggregate result.
+10. Obtain separate approval before release signing or publication.
+11. Design local commissioning and production integration only after a
+   published artifact passes its own review.
+
+No phase inherits authorization for the next phase.
+
+## Alternatives Rejected
+
+### One End-To-End Campaign Tool
+
+Rejected because one process could collect biometrics, choose analysis, declare
+a pass, and prepare authority output without an independently verifiable
+boundary.
+
+### Manual Governance Plus Measurement Scripts
+
+Rejected because procedures alone cannot prove immutable labels, complete
+denominators, reviewer independence, or that artifact bytes came from the
+reviewed result.
+
+### Absolute Population Recertification Per Profile
+
+Rejected because the profile question is whether an exact candidate preserves
+an approved operating point. Repeating population-scale model certification for
+every transport profile is a separate program.
+
+### Aggregate-Only Cohort Evaluation
+
+Rejected because a pooled pass can hide a demographic or operational stratum
+regression caused by changed camera evidence.
+
+### Optional Independent Review
+
+Rejected because reproducibility by the same operator does not establish that
+cohort, consent, analysis, and public projection were independently checked.
+
+### Immediate Revocation After Post-Publication Withdrawal
+
+Rejected for schema 1 because no signed revocation channel exists. The approved
+publication boundary deletes retained data and blocks future use while fixed
+artifact expiry bounds already released authority.
+
+### Delete All Assets At Publication
+
+Rejected because exact replay and post-release audit would become impossible.
+Retention remains bounded by withdrawal, artifact life, and an absolute
+one-year ceiling.
+
+## Success Criteria
+
+- Every campaign document is bounded, canonical, versioned,
+  content-addressed, and closed to unknown input.
+- One campaign binds one exact hardware class and one baseline/candidate pair.
+- Labels, strata, attacks, margins, sample size, order, exclusions, software,
+  models, and operating points are frozen before authorizing capture.
+- Security failures cannot be averaged away.
+- Every overall and predeclared stratum non-inferiority gate passes.
+- Consent withdrawal and retention obey the publication boundary and one-year
+  maximum.
+- Collection, evaluation, review, compilation, signing, commissioning, and
+  production selection remain separate authorities.
+- The public result and release artifact are aggregate-only and privacy-safe.
+- The compiler cannot access biometrics, and campaign tooling cannot access
+  enrollment, authentication grants, or production selection writers.
+- Synthetic tests cover every contract, statistical boundary, fixed failure
+  category, lifecycle transition, and authority separation.
+- Real-data, hardware, signing, packaging, commissioning, and production actions
+  remain separately gated.


### PR DESCRIPTION
## What & why

Replays the five independently reviewed camera qualification commits onto the merged PR #647 base without semantic changes.

- verify bounded canonical release artifacts through an exact allowlisted OpenPGP signer
- validate separate non-biometric local commissioning evidence for one exact camera context
- require matching opaque release and local evidence before deterministic profile ranking
- keep profile-selection publication test-only and production integration unavailable
- record ADR-0022 and the approved sealed maintainer qualification campaign design

`git range-diff` reports all five replayed patches as exact matches to their signed source commits. Focused interaction review found no security findings; report: `/tmp/opencode/irlume-camera-qualification-followup-review.md` (local review artifact, no biometric data).

This PR does not authorize recruitment, biometric access, hardware capture, release signing, artifact publication, local commissioning, profile-selection writes, production integration, or production NPU enablement.

## Testing

- [x] `./scripts/run-tests-guarded.sh --min 2058 -- cargo test --workspace --all-targets --all-features --locked` (2,086 passed, 0 failed)
- [x] `cargo check --workspace --all-targets --all-features --locked`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- [x] all seven model checksums
- [x] `git diff --check`
- [x] five exact `git range-diff` matches, good EdDSA signatures, and exact DCO trailers
- [x] Docs/CHANGELOG updated if user-facing
- [ ] Hardware-validated (not required: new authority paths have zero production callers; real campaign and production gates remain separately blocked)