### PR TITLE
fix: bound paired camera sessions to each assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to irlume are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Bound paired camera streaming to each assessment, coordinate paired startup,
+  and service companion queues through burst completion.
+
 ## [0.11.3] - 2026-08-29
 
 ### Added

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1737,8 +1737,8 @@ fn capture_mode_decision(
 /// and RGB has not already been re-fetched.
 ///
 /// `held_sessions` is the clause this function exists for. The recapture is a
-/// STANDALONE reopen of the RGB node, and enrolment holds both streams open for
-/// the whole capture loop, so under held sessions it opens a device this very
+/// STANDALONE reopen of the RGB node. Paired assessments hold both streams
+/// through inference, so under held sessions it opens a device this very
 /// process is already streaming. Most UVC modules permit that second open and
 /// nothing is visible; a module that answers EBUSY fails the enrolment outright,
 /// which is #187: a Chicony 04f2:b874 that never completed one capture cycle and
@@ -1748,8 +1748,7 @@ fn capture_mode_decision(
 ///
 /// Skipping the recovery when sessions are held costs little: the caller is a
 /// loop that captures repeatedly, so the next scan gets a fresh pair of frames
-/// anyway. Authentication is unaffected — it captures one-shot, holds nothing,
-/// and still self-heals exactly as before.
+/// anyway. Per-capture assessments can still use the standalone recovery.
 fn self_heal_may_recapture(
     rgb_lost_the_face: bool,
     ir_kept_the_face: bool,
@@ -2469,8 +2468,8 @@ mod capture_mode_decision_tests {
         // written for: RGB lost the face, IR kept it, captured concurrently,
         // nothing re-fetched yet.
         assert!(self_heal_may_recapture(true, true, false, false, false));
-        // The same signature during ENROLMENT, which holds both streams open
-        // for the whole capture loop. Recapturing here opens a device this
+        // The same signature during a paired assessment, which holds both
+        // streams through inference. Recapturing here opens a device this
         // process is already streaming, and a module that answers EBUSY to the
         // second open fails the enrolment outright (#187). The hard retry
         // above refuses for exactly this reason; so must this.
@@ -2996,20 +2995,10 @@ mod capture_mode_switch_tests {
     }
 }
 
-/// Hand the camera back before anything opens it again.
-///
-/// Dropping the sessions is the release: an `IrSession` owns the device's
-/// buffer queue, and uvcvideo grants stream privileges to one file handle at
-/// a time, so a consent watch that opens its own stream while one is alive
-/// gets EBUSY from this same process. Named rather than inlined so all seven
-/// release sites are one greppable thing, and so the next reader sees that
-/// the release is a DROP and not a flag.
-fn release_held(
-    rgb: &mut Option<irlume_camera::RgbSession<'_>>,
-    ir: &mut Option<irlume_camera::IrSession<'_>>,
-) {
-    *rgb = None;
-    *ir = None;
+/// Own streaming queues only for one assessment. The result cannot borrow
+/// either session, so both drop before matching, consent or another attempt.
+fn with_owned_pair<R, I, T>(mut pair: (R, I), assess: impl FnOnce(&mut R, &mut I) -> T) -> T {
+    assess(&mut pair.0, &mut pair.1)
 }
 
 /// Keep camera objects only when this operation will arm a held pair.
@@ -3601,7 +3590,7 @@ impl Engine {
             let progress = self.capture_progress();
             match arm_pair_transactionally(
                 || rgb.session_with_progress(&progress),
-                || ir.session_with_progress(&progress),
+                || ir.session_for_pair_with_progress(&progress),
             ) {
                 Ok((mut rgb_session, mut ir_session)) => {
                     match irlume_camera::establish_pair_rate(&mut rgb_session, &mut ir_session) {
@@ -3835,21 +3824,60 @@ impl Engine {
         })
     }
 
-    /// Streams held open across a run of captures, so a loop pays the open,
-    /// format negotiation, buffer mapping, STREAMON and auto-exposure warm-up
-    /// once instead of per capture. Measured on the ASUS built-in: ~700ms of
-    /// every RGB capture is that setup.
-    ///
-    /// Only handed to loops that capture repeatedly under one request, never
-    /// held across requests: an idle stream reserves the camera against other
-    /// applications, keeps the capture LED lit, and would go stale across a
-    /// suspend.
+    /// Assess one pair using the selected per-capture strategy.
     fn assess_full(
         &mut self,
         operation: &irlume_camera::lease::CameraOperationSession,
     ) -> irlume_common::Result<Assessment> {
         self.assess_full_with(None, None, operation, &())
             .map_err(CapturePathError::into_inner)
+    }
+
+    /// Fresh streams for every assessment: caller work between attempts must
+    /// never leave a reusable mmap queue overflowing while nobody drains it.
+    fn assess_with_fresh_pair(
+        &mut self,
+        rgb: &irlume_camera::RgbCamera,
+        ir: &irlume_camera::IrCamera,
+        mode: Option<&CaptureModeSelection>,
+        operation: &irlume_camera::lease::CameraOperationSession,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> Result<Assessment, CapturePathError> {
+        let setup_error = |reason, error| {
+            irlume_common::dlog!("concurrent assessment setup failed ({reason:?}): {error}");
+            emit_capture_fallback(reason, diagnostics);
+            if let Some(selection) = mode {
+                if pair_rate_failure_is_degradation(selection) {
+                    if let Some(key) = selection.runtime_key.as_deref() {
+                        trip_runtime_capture_health(key, reason);
+                    }
+                }
+            }
+            CapturePathError::ConcurrentPair(error)
+        };
+        let progress = self.capture_progress();
+        let started = std::time::Instant::now();
+        let pair = arm_pair_transactionally(
+            || rgb.session_with_progress(&progress),
+            || ir.session_for_pair_with_progress(&progress),
+        );
+        diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
+            stage: irlume_common::diagnostics::TraceStage::StreamArm,
+            elapsed_us: u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
+        });
+        let pair = pair.map_err(|error| setup_error(RuntimeDegradation::PairArmFailure, error))?;
+        with_owned_pair(pair, |rgb, ir| {
+            let started = std::time::Instant::now();
+            let rate = irlume_camera::establish_pair_rate(rgb, ir);
+            diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
+                stage: irlume_common::diagnostics::TraceStage::RateEstablishment,
+                elapsed_us: u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
+            });
+            rate.map_err(|error| {
+                setup_error(RuntimeDegradation::PairRateEstablishmentFailure, error)
+            })?;
+            self.assess_full_with(Some((rgb, ir)), mode, operation, diagnostics)
+        })
     }
 
     fn assess_full_with_operation(
@@ -3998,38 +4026,44 @@ impl Engine {
                         )
                     }
                 } else {
-                    std::thread::scope(|s| {
-                        let ir_thread = s.spawn(move || {
+                    let (mut rgb_ms, mut ir_ms) = (0, 0);
+                    let (mut rgb_recovered, mut ir_recovered) = (false, false);
+                    let (rgb, ir) = irlume_camera::capture_pair_with(
+                        rgb_s,
+                        ir_s,
+                        |session| {
                             let t = std::time::Instant::now();
-                            let captured = Self::run_camera_operation(operation, || {
-                                let (capture, recovered) = held_ir_capture(ir_s);
-                                capture.map(|frame| (frame, recovered))
-                            });
-                            (captured, t.elapsed().as_millis())
-                        });
-                        let t = std::time::Instant::now();
-                        let (rgb, rgb_recovered) = held_rgb_capture(rgb_s);
-                        let rgb_ms = t.elapsed().as_millis();
-                        let (ir, ir_ms) = ir_thread.join().unwrap_or_else(|_| {
-                            (
-                                Err(irlume_common::Error::Hardware(
-                                    "IR capture thread panicked".into(),
-                                )),
-                                0,
-                            )
-                        });
-                        let (ir, ir_recovered) = match ir {
-                            Ok((frame, recovered)) => (Ok(frame), recovered),
-                            Err(error) => (Err(error), false),
-                        };
-                        (
-                            rgb,
-                            rgb_ms,
-                            ir.map(Some),
-                            ir_ms,
-                            rgb_recovered || ir_recovered,
-                        )
-                    })
+                            let (capture, recovered) = held_rgb_capture(session);
+                            rgb_ms = t.elapsed().as_millis();
+                            rgb_recovered = recovered;
+                            capture
+                        },
+                        |session| {
+                            let t = std::time::Instant::now();
+                            let capture =
+                                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    Self::run_camera_operation(operation, || {
+                                        let (capture, recovered) = held_ir_capture(session);
+                                        ir_recovered = recovered;
+                                        capture
+                                    })
+                                }))
+                                .unwrap_or_else(|_| {
+                                    Err(irlume_common::Error::Hardware(
+                                        "IR capture thread panicked".into(),
+                                    ))
+                                });
+                            ir_ms = t.elapsed().as_millis();
+                            capture
+                        },
+                    );
+                    (
+                        rgb,
+                        rgb_ms,
+                        ir.map(Some),
+                        ir_ms,
+                        rgb_recovered || ir_recovered,
+                    )
                 }
             } else if sequential {
                 let t = std::time::Instant::now();
@@ -5162,30 +5196,15 @@ impl Engine {
                 "face disabled (fingerprint mode)",
             ));
         }
-        // Load the enrollment once per authentication, not once per retry.
-        // Every retry in the loop below was re-reading the profile file and
-        // re-calling template_key::load_key → tpm::unseal. On a discrete TPM
-        // that unseal costs 2.7s quiet and 18.97s contended, and TPM and
-        // camera are independent devices, so it can leave the critical path
-        // entirely. The key is dropped inside load; only the decrypted
-        // Enrollment is held, which is already plaintext in memory during
-        // each authenticate_once today.
-        //
-        // It leaves the critical path HERE, for the case that has a critical
-        // path to leave: an ENCRYPTED store, whose unseal costs 2.7s quiet /
-        // 18.97s contended on a discrete TPM. A plaintext store loads with no
-        // TPM at all, so it stays synchronous and keeps the historical
-        // deny-before-camera precedence for every policy check below (tests
-        // and plaintext hosts see identical behavior to before). For an
-        // encrypted store the full load runs on a helper thread CONCURRENTLY
-        // with the camera lease, stream arming, delivered-rate establishment
-        // and the consent watch below (>=5s of camera-bound work in
-        // concurrent mode), joined before the first enrollment-dependent
-        // decision. The one precedence change: on an encrypted store whose
-        // camera path ALSO fails hard, the hardware error now precedes the
-        // empty-scans/binding deny lines — both end at the password, so the
-        // user-visible outcome is unchanged. A panic inside the loader maps
-        // to an error (password fallback), never a daemon crash.
+        // Load enrollment once per authentication, not once per retry. The key
+        // is dropped inside load; only the decrypted Enrollment stays in memory
+        // for this request. Encrypted stores load on a helper while the caller
+        // acquires the lease, handles pre-match consent and opens camera handles.
+        // Join before arming streams: an unseal wait must not idle their queues.
+        // Plaintext stores remain synchronous, preserving deny-before-camera
+        // precedence. For an encrypted store whose camera preflight also fails,
+        // that hardware error can precede enrollment-dependent denials. Both
+        // paths retain password fallback; a loader panic maps to an error.
         let load_started = std::time::Instant::now();
         let mut loader = match irlume_core::storage::store_is_encrypted(user)? {
             // No file at all: the instant deny, before anything else wakes.
@@ -5290,27 +5309,9 @@ impl Engine {
                 return Ok(Outcome::gesture_declined(false, 0.0));
             }
         }
-        // Hold the camera sessions across the grace window's retries. Every retry
-        // otherwise re-opens, re-negotiates, re-maps and re-warms both streams
-        // (~700ms of setup per attempt, 58% of a one-shot capture). The enrolment
-        // path already holds sessions for its whole capture loop; the auth path
-        // extends that to the retry loop. The shape matches capture_scans: open
-        // the devices, create sessions from them, fall back to per-capture when
-        // the session path cannot hold them (sequential mode, or a camera that
-        // cannot be opened).
-        //
-        // Declared in reverse drop order: the sessions borrow from `held_cams`, so
-        // Rust drops the sessions first and the cameras after.
-        //
-        // The sessions are passed to `authenticate_once` AS THE OWNING OPTIONS,
-        // not as borrows of them. That is the whole point: the match path
-        // releases the camera before the consent watch opens its own IR stream,
-        // and it can only do that by dropping the session itself. Handing down
-        // `&mut Option<(&mut RgbSession, &mut IrSession)>` made every release
-        // site drop a pair of REFERENCES while these two kept the buffer queue,
-        // so the watch's S_FMT and REQBUFS hit EBUSY against this very process:
-        // the self-collision #187 diagnosed, reintroduced by #346 and caught by
-        // the release audit before it shipped.
+        // Keep negotiated camera handles for this request. Each assessment
+        // creates and drops its own streams, so loader/inference/retry delays
+        // cannot overflow queues retained from an earlier capture.
         let camera_open_started = std::time::Instant::now();
         let resolved_cams = match (
             camera_operation.open_rgb(&rgb_dev),
@@ -5339,75 +5340,9 @@ impl Engine {
         }
         let sequential = capture_mode.is_sequential();
         let held_cams = cameras_for_held_pair(sequential, resolved_cams);
-        let mut held_rgb: Option<irlume_camera::RgbSession<'_>> = None;
-        let mut held_ir: Option<irlume_camera::IrSession<'_>> = None;
-        if let (Some((cam_r, cam_i)), true) = (&held_cams, !sequential && self.ir_available) {
-            let progress = self.capture_progress();
-            // The camera pair is declared before the sessions so it outlives them.
-            let arm_started = std::time::Instant::now();
-            let armed = arm_pair_transactionally(
-                || cam_r.session_with_progress(&progress),
-                || cam_i.session_with_progress(&progress),
-            );
-            diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
-                stage: irlume_common::diagnostics::TraceStage::StreamArm,
-                elapsed_us: u64::try_from(arm_started.elapsed().as_micros()).unwrap_or(u64::MAX),
-            });
-            match armed {
-                Ok((mut rs, mut is)) => {
-                    // Establish the delivered-rate windows for the HELD PAIR up
-                    // front, draining both streams concurrently. A failure drops
-                    // both streams and selects the one-at-a-time path below.
-                    let rate_started = std::time::Instant::now();
-                    let rate = irlume_camera::establish_pair_rate(&mut rs, &mut is);
-                    diagnostics.emit_trace(
-                        irlume_common::diagnostics::TraceEventKind::StageTiming {
-                            stage: irlume_common::diagnostics::TraceStage::RateEstablishment,
-                            elapsed_us: u64::try_from(rate_started.elapsed().as_micros())
-                                .unwrap_or(u64::MAX),
-                        },
-                    );
-                    match rate {
-                        Ok(()) => {
-                            held_rgb = Some(rs);
-                            held_ir = Some(is);
-                        }
-                        Err(error) => {
-                            irlume_common::dlog!(
-                                "auth: held pair could not establish delivered-rate evidence \
-                                 ({error}); dropping both streams and retrying one-at-a-time"
-                            );
-                            emit_capture_fallback(
-                                RuntimeDegradation::PairRateEstablishmentFailure,
-                                diagnostics,
-                            );
-                            demote_after_pair_rate_failure(&mut capture_mode);
-                        }
-                    }
-                }
-                Err(error) => {
-                    irlume_common::dlog!(
-                        "auth: held pair could not arm transactionally ({error}); \
-                         retrying one-at-a-time"
-                    );
-                    emit_capture_fallback(RuntimeDegradation::PairArmFailure, diagnostics);
-                    demote_after_pair_arm_failure(&mut capture_mode);
-                }
-            }
-        }
-        // Join the enrollment loader. Everything between the spawn and HERE —
-        // camera lease, consent watch, stream arming, delivered-rate
-        // establishment — is the overlap window the TPM unseal ran inside;
-        // on every measured host that window exceeds the unseal (2.7s quiet),
-        // so the load costs the auth path nothing. First enrollment-dependent
-        // decision happens after this join, before any capture is spent.
-        // The wait is bounded by the authentication deadline: a wedged unseal
-        // (stuck tpmrm, or a user-state flock held by a wedged sibling) must
-        // not pin the camera lease forever — on timeout the auth fails closed
-        // to the password and the detached loader releases its locks whenever
-        // it finishes. A ready result is returned even at zero remaining
-        // time, so a healthy load that already finished is never mistaken
-        // for a timeout. The arms live in [`resolve_loader`].
+        // Resolve enrollment before streaming. A loader wait can exceed a
+        // camera queue's capacity; no stream may be armed across this wait.
+        // The wait remains bounded by the authentication deadline.
         let enr = match loader.take() {
             Some(rx) => {
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -5439,7 +5374,7 @@ impl Engine {
             "auth: enrollment load took {:?} ({})",
             load_started.elapsed(),
             if loader_was_async {
-                "overlapped with camera setup"
+                "overlapped with camera preflight"
             } else {
                 "plaintext, synchronous"
             }
@@ -5449,12 +5384,8 @@ impl Engine {
                 return Ok(outcome);
             }
         }
-        if held_rgb.is_none() || held_ir.is_none() {
-            drop(held_rgb);
-            drop(held_ir);
+        if held_cams.is_none() || !self.ir_available {
             drop(held_cams);
-            let mut no_rgb = None;
-            let mut no_ir = None;
             let mut costliest_attempt = std::time::Duration::ZERO;
             return self
                 .authentication_attempt_loop(
@@ -5463,8 +5394,7 @@ impl Engine {
                     service,
                     deadline,
                     window,
-                    &mut no_rgb,
-                    &mut no_ir,
+                    None,
                     &capture_mode,
                     &camera_operation,
                     diagnostics,
@@ -5479,8 +5409,7 @@ impl Engine {
             service,
             deadline,
             window,
-            &mut held_rgb,
-            &mut held_ir,
+            held_cams.as_ref(),
             &capture_mode,
             &camera_operation,
             diagnostics,
@@ -5490,15 +5419,14 @@ impl Engine {
             return first_result;
         }
         let error = first_result.expect_err("held-pair failure must return an error");
-        // The sequential fallback re-opens both cameras: ~3.1 s of machinery
-        // per stream, ~7 s for the pair (the loop comment below derives it).
+        // The sequential fallback re-opens both cameras. Retain its existing
+        // conservative setup-cost floor when deciding whether it fits.
         // Bound its FIRST attempt the same way the loop bounds retries: when
         // the cost of that attempt cannot finish before the deadline, do not
         // start it — the camera is released and the password fallback answers
         // inside the window instead of the lease overrunning mid-capture
         // (ADR-0014). The estimator is the observed costliest attempt raised
-        // to that floor: the concurrent loop's own attempts (~1 s) would
-        // never bound a ~7 s sequential reopen.
+        // to that floor: a concurrent attempt need not bound a sequential reopen.
         let fallback_cost = costliest_attempt.max(SEQUENTIAL_PAIR_ATTEMPT_COST);
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining < fallback_cost {
@@ -5509,15 +5437,11 @@ impl Engine {
             );
             return Err(error);
         }
-        drop(held_rgb);
-        drop(held_ir);
         drop(held_cams);
         demote_after_concurrent_capture_failure(&mut capture_mode);
         irlume_common::dlog!(
             "auth: {error}; dropped both held streams and camera handles; retrying RGB then IR"
         );
-        let mut no_rgb = None;
-        let mut no_ir = None;
         // Seed with the first loop's costliest attempt so the fallback's own
         // retry decisions account for what this deadline has already spent.
         self.authentication_attempt_loop(
@@ -5526,8 +5450,7 @@ impl Engine {
             service,
             deadline,
             window,
-            &mut no_rgb,
-            &mut no_ir,
+            None,
             &capture_mode,
             &camera_operation,
             diagnostics,
@@ -5553,8 +5476,7 @@ impl Engine {
         service: Option<&str>,
         deadline: std::time::Instant,
         window: u64,
-        held_rgb: &mut Option<irlume_camera::RgbSession<'_>>,
-        held_ir: &mut Option<irlume_camera::IrSession<'_>>,
+        cameras: Option<&(irlume_camera::RgbCamera, irlume_camera::IrCamera)>,
         capture_mode: &CaptureModeSelection,
         camera_operation: &irlume_camera::lease::CameraOperationSession,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
@@ -5566,9 +5488,8 @@ impl Engine {
         // cannot FINISH before the deadline would overrun mid-capture —
         // holding the camera past the window for a result that can never be
         // used. The costliest (not latest) attempt is the estimator because a
-        // retry can be far slower than the attempt before it: the
-        // held-concurrent pair costs ~1s, and its sequential fallback re-opens
-        // both cameras at ~7s.
+        // retry can be slower than the attempt before it. Each concurrent
+        // attempt now includes fresh stream arming and rate establishment.
         loop {
             attempt += 1;
             let mut held_pair_failed = false;
@@ -5578,8 +5499,7 @@ impl Engine {
                     enr,
                     purpose,
                     service,
-                    held_rgb,
-                    held_ir,
+                    cameras,
                     AuthenticationCaptureContext {
                         mode: Some(capture_mode),
                         operation: Some(camera_operation),
@@ -5588,6 +5508,7 @@ impl Engine {
                     },
                 )
             });
+            *costliest_attempt = (*costliest_attempt).max(attempt_started.elapsed());
             let out = match attempt_result {
                 Ok(out) => out,
                 Err(error) => {
@@ -5595,7 +5516,6 @@ impl Engine {
                     return (Err(error), held_pair_failed);
                 }
             };
-            *costliest_attempt = (*costliest_attempt).max(attempt_started.elapsed());
             // One situation line per FAILED attempt (#616 step 2), including
             // attempts the grace window retries: the "why did it fail" a
             // person reads in `irlume logs`, from the facts this attempt
@@ -5652,11 +5572,7 @@ impl Engine {
         enr: &irlume_core::storage::Enrollment,
         purpose: AuthenticationPurpose,
         service: Option<&str>,
-        // The OWNING options, so a release site can actually drop the sessions
-        // and hand the camera back; see the declaration comment in
-        // `authenticate_for`.
-        held_rgb: &mut Option<irlume_camera::RgbSession<'_>>,
-        held_ir: &mut Option<irlume_camera::IrSession<'_>>,
+        cameras: Option<&(irlume_camera::RgbCamera, irlume_camera::IrCamera)>,
         capture: AuthenticationCaptureContext<'_>,
     ) -> irlume_common::Result<Outcome> {
         let AuthenticationCaptureContext {
@@ -5668,10 +5584,8 @@ impl Engine {
         let assessment = if !self.ir_available {
             self.assess_rgb_only_with_diagnostics(diagnostics)
                 .map_err(CapturePathError::from)
-        } else if let (Some(rs), Some(is), Some(operation)) =
-            (held_rgb.as_mut(), held_ir.as_mut(), operation)
-        {
-            self.assess_full_with(Some((rs, is)), mode, operation, diagnostics)
+        } else if let (Some((rgb, ir)), Some(operation)) = (cameras, operation) {
+            self.assess_with_fresh_pair(rgb, ir, mode, operation, diagnostics)
         } else if let Some(operation) = operation {
             self.assess_full_with(None, mode, operation, diagnostics)
         } else {
@@ -5786,7 +5700,6 @@ impl Engine {
                 score >= thr,
             );
             if rgb_primary_grant_admissible(score, thr, a.sequential_pair) {
-                release_held(held_rgb, held_ir);
                 return self.challenge_if_required(
                     purpose,
                     service,
@@ -5838,7 +5751,6 @@ impl Engine {
                     );
                     if f.grant && !a.sequential_pair {
                         let who = if ir_score >= score { ir_who } else { who };
-                        release_held(held_rgb, held_ir);
                         return self.challenge_if_required(
                     purpose,
                     service,
@@ -5874,7 +5786,6 @@ impl Engine {
                         ir_score >= ir_thr,
                     );
                     if ir_score >= ir_thr {
-                        release_held(held_rgb, held_ir);
                         return self.challenge_if_required(
                     purpose,
                     service,
@@ -5896,7 +5807,6 @@ impl Engine {
                             *cs >= cthr,
                         );
                         if *cs >= cthr {
-                            release_held(held_rgb, held_ir);
                             return self.challenge_if_required(
                     purpose,
                     service,
@@ -6066,7 +5976,6 @@ impl Engine {
             // calibrated centroid at the base threshold (no best-of-N FAR
             // inflation; the prototype-validated mean-template protocol).
             if score >= ir_thr {
-                release_held(held_rgb, held_ir);
                 return self.challenge_if_required(
                     purpose,
                     service,
@@ -6084,7 +5993,6 @@ impl Engine {
                     *cs >= cthr,
                 );
                 if *cs >= cthr {
-                    release_held(held_rgb, held_ir);
                     return self.challenge_if_required(
                         purpose,
                         service,
@@ -6095,7 +6003,6 @@ impl Engine {
                     );
                 }
             }
-            release_held(held_rgb, held_ir);
             return self.challenge_if_required(
                 purpose,
                 service,
@@ -6276,20 +6183,9 @@ impl Engine {
         // presentation (the enrollment), and a banner presented to enroll is
         // exactly the sustained presentation the vote exists to deny.
         self.vit_scores.clear();
-        // Hold the cameras open for the whole loop. This is the heaviest repeated
-        // capture in the codebase (the budget below is ten assessments per wanted
-        // scan), and every one of them otherwise re-opened, re-negotiated,
-        // re-mapped and re-warmed both streams, plus blinked the capture LED.
-        // Measured on the ASUS built-in with examples/session_bench.rs: an
-        // RGB+IR pair costs 1912ms per-call against 797ms on a held session,
-        // so 1115ms of every attempt was setup (58%). Safe to hold
-        // for a burst this long because the emitter does not go dark: measured at
-        // a flat lit level for 30s of continuous streaming on both modules we
-        // have (examples/ir_refire_probe.rs).
-        //
-        // A camera that cannot be opened is NOT fatal here: fall back to the
-        // per-capture path, which is exactly today's behaviour, so enrolment
-        // still works on hardware the session path cannot hold.
+        // Reuse negotiated camera handles when concurrency is selected, but
+        // arm fresh streams per assessment so inference cannot leave stale
+        // queues for the next scan. If opens fail, use per-capture fallback.
         // Asked to yield before the first frame: do not even open the device.
         // A queued enrolment that already knows an authentication is waiting has
         // no business claiming the camera for the moment it takes to notice.
@@ -6319,18 +6215,8 @@ impl Engine {
         } else {
             None
         };
-        // Fast path: hold both streams for the whole loop.
-        //
-        // NOT under sequential capture mode. A held session arms its stream
-        // at creation, so holding both means both stream at once and
-        // "sequential" only orders the reads. Measured on a Logitech Brio on
-        // a USB2 link (#187 hardware session, strace + dmesg): with the IR
-        // stream armed, the RGB stream gets no isochronous bandwidth at all;
-        // STREAMON succeeds, no frame ever arrives, and the queue dies with
-        // QBUF EINVAL ("Failed to resubmit video URB" in dmesg). Sequential
-        // mode exists for exactly the cameras that cannot sustain both
-        // streams, so on them this loop takes the per-frame path, which
-        // opens one stream at a time and releases it before the other.
+        // Retain camera handles only for concurrent operation. Streaming
+        // sessions are scoped to one assessment, including each enrollment scan.
         let mut capture_mode = if use_ir {
             cams.as_ref()
                 .map_or_else(unavailable_capture_mode_selection, |(rgb, ir)| {
@@ -6356,65 +6242,25 @@ impl Engine {
                 "enroll: sequential capture mode (from {mode_source}); not holding \
                  both streams, capturing per-frame"
             );
-        } else if let Some((r, i)) = &cams {
-            let progress = self.capture_progress();
-            match arm_pair_transactionally(
-                || r.session_with_progress(&progress),
-                || i.session_with_progress(&progress),
+        } else if let Some((rgb, ir)) = &cams {
+            match self.capture_scan_loop(
+                want,
+                pitch_neutral,
+                Some((rgb, ir)),
+                EnrollmentCapturePolicy {
+                    mode: &capture_mode,
+                    use_ir,
+                    diagnostics,
+                },
+                &operation,
+                observed,
             ) {
-                Ok((mut rs, mut is)) => {
-                    // Establish the delivered-rate windows for the HELD PAIR up
-                    // front, draining both streams concurrently so neither starves
-                    // the other's buffer queue. A failure drops both streams and
-                    // selects the one-at-a-time path below.
-                    match irlume_camera::establish_pair_rate(&mut rs, &mut is) {
-                        Ok(()) => {
-                            let held_result = self.capture_scan_loop(
-                                want,
-                                pitch_neutral,
-                                Some((&mut rs, &mut is)),
-                                EnrollmentCapturePolicy {
-                                    mode: &capture_mode,
-                                    use_ir,
-                                    diagnostics,
-                                },
-                                &operation,
-                                observed,
-                            );
-                            match held_result {
-                                Ok(scans) => return Ok(scans),
-                                Err(CapturePathError::ConcurrentPair(error)) => {
-                                    drop(rs);
-                                    drop(is);
-                                    demote_after_concurrent_capture_failure(&mut capture_mode);
-                                    irlume_common::dlog!(
-                                    "enroll: {error}; dropped both held streams and restarting RGB then IR"
-                                );
-                                }
-                                Err(error) => return Err(error.into_inner()),
-                            }
-                        }
-                        Err(error) => {
-                            irlume_common::dlog!(
-                                "enroll: held pair could not establish delivered-rate evidence \
-                             ({error}); dropping both streams and retrying one-at-a-time"
-                            );
-                            emit_capture_fallback(
-                                RuntimeDegradation::PairRateEstablishmentFailure,
-                                diagnostics,
-                            );
-                            demote_after_pair_rate_failure(&mut capture_mode);
-                        }
-                    }
+                Ok(scans) => return Ok(scans),
+                Err(CapturePathError::ConcurrentPair(error)) => {
+                    demote_after_concurrent_capture_failure(&mut capture_mode);
+                    irlume_common::dlog!("enroll: {error}; restarting RGB then IR");
                 }
-                Err(error) => {
-                    irlume_common::dlog!(
-                        "enroll: held pair could not arm transactionally ({error}); \
-                         retrying one-at-a-time"
-                    );
-                    emit_capture_fallback(RuntimeDegradation::PairArmFailure, diagnostics);
-                    demote_after_pair_arm_failure(&mut capture_mode);
-                }
+                Err(error) => return Err(error.into_inner()),
             }
         }
         // No held session. RELEASE THE DEVICES FIRST. The per-frame path below
@@ -6447,8 +6293,8 @@ impl Engine {
         .map_err(CapturePathError::into_inner)
     }
 
-    /// The enrolment capture loop, over held streams when `sessions` is given
-    /// and re-opening per frame when it is not.
+    /// The enrolment loop arms fresh paired streams per assessment when
+    /// `cameras` is given, otherwise it uses the per-capture strategy.
     ///
     /// Split out from [`Self::capture_scans`] so the per-frame path runs with
     /// the held cameras already dropped: the two capture strategies must never
@@ -6457,19 +6303,16 @@ impl Engine {
         &mut self,
         want: usize,
         pitch_neutral: Option<f32>,
-        mut sessions: Option<(
-            &mut irlume_camera::RgbSession<'_>,
-            &mut irlume_camera::IrSession<'_>,
-        )>,
+        cameras: Option<(&irlume_camera::RgbCamera, &irlume_camera::IrCamera)>,
         policy: EnrollmentCapturePolicy<'_>,
         operation: &irlume_camera::lease::CameraOperationSession,
         observed: &mut CaptureShape,
     ) -> Result<Vec<CapturedScan>, CapturePathError> {
         let mut out = Vec::new();
-        // Read once, before the loop: `sessions` is borrowed per iteration but
+        // Read once, before the loop: `cameras` is borrowed per iteration but
         // never taken, so this is the whole loop's answer (#389).
         let mut shape = CaptureShape {
-            held_sessions: sessions.is_some(),
+            held_sessions: cameras.is_some(),
             ..CaptureShape::default()
         };
         // Budget (was ×4) absorbs the added frontality gate (a frame grabbed the
@@ -6488,9 +6331,10 @@ impl Engine {
                 )));
             }
             let a = operation
-                .run(|| match &mut sessions {
-                    Some((rs, is)) => self.assess_full_with(
-                        Some((rs, is)),
+                .run(|| match cameras {
+                    Some((rgb, ir)) => self.assess_with_fresh_pair(
+                        rgb,
+                        ir,
                         Some(policy.mode),
                         operation,
                         policy.diagnostics,
@@ -6620,10 +6464,11 @@ impl Engine {
             _ => return false,
         };
         let progress = self.capture_progress();
-        let sessions = cams
-            .0
-            .session_with_progress(&progress)
-            .and_then(|rs| cams.1.session_with_progress(&progress).map(|is| (rs, is)));
+        let sessions = cams.0.session_with_progress(&progress).and_then(|rs| {
+            cams.1
+                .session_for_pair_with_progress(&progress)
+                .map(|is| (rs, is))
+        });
         let (mut rs, mut is) = match sessions {
             Ok(pair) => pair,
             Err(_) => return false,
@@ -6637,24 +6482,27 @@ impl Engine {
                  ({error}); the per-frame fill will retry"
             );
         }
-        let (rgb, ir) = std::thread::scope(|scope| {
-            let ir_thread = scope.spawn(|| {
+        let (rgb, ir) = irlume_camera::capture_pair_with(
+            &mut rs,
+            &mut is,
+            |session| {
                 operation
-                    .run(|| is.capture_with_stats())
+                    .run(|| session.denoised())
                     .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?
-            });
-            let rgb = operation
-                .run(|| rs.denoised())
-                .map_err(|error| irlume_common::Error::Hardware(error.to_string()))
-                .and_then(|capture| capture);
-            let ir = match ir_thread.join() {
-                Ok(result) => result,
-                Err(_) => Err(irlume_common::Error::Hardware(
-                    "IR capture thread panicked".into(),
-                )),
-            };
-            (rgb, ir)
-        });
+            },
+            |session| {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    operation
+                        .run(|| session.capture_with_stats())
+                        .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?
+                }))
+                .unwrap_or_else(|_| {
+                    Err(irlume_common::Error::Hardware(
+                        "IR capture thread panicked".into(),
+                    ))
+                })
+            },
+        );
         let (Ok(rgb), Ok(_)) = (&rgb, &ir) else {
             return false;
         };
@@ -7493,7 +7341,7 @@ struct StarvationProbeResult {
 // is constructed literally rather than accumulated.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 struct CaptureShape {
-    /// The loop ran over held streams, which is the clause that suppresses the
+    /// Each assessment held paired streams, which suppresses the
     /// cross-spectrum self-heal in [`self_heal_may_recapture`]. It matters to
     /// the message because on the OTHER path the self-heal recaptures RGB
     /// standalone and reassigns `rgb_top`, so an IR-only attempt there means
@@ -12150,23 +11998,70 @@ mod engine_tests {
         (var("IRLUME_TEST_RGB_DEVICE"), var("IRLUME_TEST_IR_DEVICE"))
     }
 
-    /// `release_held` must HAND THE CAMERA BACK, which is the whole reason the
-    /// grant paths call it before `challenge_if_required` opens its own IR
-    /// stream for the consent watch.
-    ///
-    /// The bug this pins: `held` used to be `&mut Option<(&mut RgbSession,
-    /// &mut IrSession)>`, so every release site dropped a pair of REFERENCES
-    /// while the sessions themselves stayed alive in `authenticate_for`. The
-    /// watch's `S_FMT` and `REQBUFS` then hit EBUSY against this same process,
-    /// the self-collision #187 diagnosed, and a successful match was thrown
-    /// away for a password prompt. Introduced by #346, so it never shipped.
-    ///
-    /// The CONTROL is the point: a second stream must FAIL while the session
-    /// is alive, or this test cannot tell a working release from a camera that
-    /// was never held in the first place.
+    struct AttemptStream<'a>(&'a std::cell::Cell<usize>);
+
+    impl<'a> AttemptStream<'a> {
+        fn open(active: &'a std::cell::Cell<usize>) -> Self {
+            active.set(active.get() + 1);
+            Self(active)
+        }
+    }
+
+    impl Drop for AttemptStream<'_> {
+        fn drop(&mut self) {
+            self.0.set(self.0.get() - 1);
+        }
+    }
+
+    #[test]
+    fn attempt_scope_releases_both_streams_before_an_idle_retry() {
+        let active = std::cell::Cell::new(0);
+        for attempt in 0..3 {
+            let output = with_owned_pair(
+                (AttemptStream::open(&active), AttemptStream::open(&active)),
+                |_, _| {
+                    assert_eq!(active.get(), 2);
+                    attempt
+                },
+            );
+            assert_eq!(output, attempt);
+            assert_eq!(
+                active.get(),
+                0,
+                "matching and the next attempt must not retain streaming queues"
+            );
+        }
+    }
+
+    #[test]
+    fn attempt_scope_releases_both_streams_on_assessment_error() {
+        let active = std::cell::Cell::new(0);
+        let result = with_owned_pair(
+            (AttemptStream::open(&active), AttemptStream::open(&active)),
+            |_, _| Err::<(), _>("assessment refused"),
+        );
+        assert_eq!(result, Err("assessment refused"));
+        assert_eq!(active.get(), 0);
+    }
+
+    #[test]
+    fn attempt_scope_releases_both_streams_on_panic() {
+        let active = std::cell::Cell::new(0);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_owned_pair(
+                (AttemptStream::open(&active), AttemptStream::open(&active)),
+                |_, _| panic!("assessment panicked"),
+            );
+        }));
+        assert!(result.is_err());
+        assert_eq!(active.get(), 0);
+    }
+
+    /// The attempt scope must release both actual stream owners before a
+    /// consent watch can open them. The busy control proves a real queue was held.
     #[test]
     #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
-    fn loopback_release_held_hands_the_camera_back() {
+    fn loopback_attempt_scope_hands_the_camera_back() {
         let (rgb, ir) = loopback_pair();
         let _g = env_guard();
         let operation = irlume_camera::lease::acquire_camera_operation(
@@ -12177,29 +12072,21 @@ mod engine_tests {
         .expect("acquire one RGB+IR operation");
         let cam = operation.open_ir(&ir).expect("open the IR node");
         let rgb_cam = operation.open_rgb(&rgb).expect("open the RGB node");
-        let mut held_ir = Some(cam.session().expect("hold an IR session"));
-        // BOTH halves must release: the review round noted the test proved
-        // only the IR side, and release_held drops two owners.
-        let mut held_rgb = Some(rgb_cam.session().expect("hold an RGB session"));
-
-        // Control: with the session alive, a second stream on the same node
-        // must be refused. If this passes, the rest proves nothing.
-        let busy_ir = cam.session();
-        let busy_rgb = rgb_cam.session();
-        assert!(
-            busy_ir.is_err() && busy_rgb.is_err(),
-            "control failed: live IR and RGB sessions must each block a second stream, or this \
-             test cannot distinguish a real release from a camera nobody held"
-        );
-
-        release_held(&mut held_rgb, &mut held_ir);
-        assert!(
-            held_ir.is_none() && held_rgb.is_none(),
-            "the release must clear BOTH session slots"
+        with_owned_pair(
+            (
+                rgb_cam.session().expect("hold RGB"),
+                cam.session().expect("hold IR"),
+            ),
+            |_, _| {
+                assert!(
+                    cam.session().is_err() && rgb_cam.session().is_err(),
+                    "control: both live sessions must block a second stream"
+                );
+            },
         );
 
         // The observation: the original cameras accept fresh sessions after
-        // release_held drops both owners and their per-camera slots reset.
+        // the attempt scope drops both owners and their per-camera slots reset.
         let mut after = cam.session().expect("open IR session after release");
         let after_capture = after.capture_with_stats();
         assert!(

--- a/crates/irlume-auth/tests/held_pair_fallback_contract.rs
+++ b/crates/irlume-auth/tests/held_pair_fallback_contract.rs
@@ -9,6 +9,27 @@ fn function<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
     &source[start..end]
 }
 
+fn assert_scoped_pair_assessment(source: &str) {
+    let assessment = function(
+        source,
+        "    fn assess_with_fresh_pair(",
+        "\n    fn assess_full_with_operation(",
+    );
+    let owner = assessment
+        .find("with_owned_pair(pair,")
+        .expect("own both sessions");
+    let capture = assessment
+        .find("self.assess_full_with(Some((rgb, ir))")
+        .expect("paired assessment");
+    assert!(
+        owner < capture,
+        "capture must finish inside the session owner scope"
+    );
+    assert!(assessment.contains("Result<Assessment, CapturePathError>"));
+    assert!(assessment.contains("arm_pair_transactionally("));
+    assert!(assessment.contains("establish_pair_rate(rgb, ir)"));
+}
+
 #[test]
 fn held_concurrent_failure_is_returned_to_the_pair_owner() {
     let source = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
@@ -35,10 +56,31 @@ fn authentication_fallback_drops_the_entire_held_pair_before_retry() {
         "\n    fn authenticate_once(",
     );
 
-    for release in ["drop(held_rgb)", "drop(held_ir)", "drop(held_cams)"] {
-        assert!(authenticate.contains(release), "missing {release}");
-    }
-    assert!(authenticate.contains("demote_after_concurrent_capture_failure"));
+    // Streams belong to the assessment scope now, not the retry loop. The
+    // runtime owner tests cover Drop on success/error/panic; pin both callers
+    // to that scope so moving streams back outside the loop cannot pass.
+    assert_scoped_pair_assessment(&source);
+    let attempt = function(
+        &source,
+        "    fn authenticate_once(",
+        "\n    pub fn identify(",
+    );
+    assert!(attempt.contains("self.assess_with_fresh_pair(rgb, ir, mode, operation, diagnostics)"));
+    assert!(!authenticate.contains("RgbSession"));
+    assert!(!authenticate.contains("IrSession"));
+    let fallback = authenticate
+        .split("let error = first_result.expect_err")
+        .nth(1)
+        .expect("concurrent failure fallback");
+    let release = fallback.find("drop(held_cams)").expect("release handles");
+    let retry = fallback
+        .find("self.authentication_attempt_loop(")
+        .expect("sequential retry");
+    assert!(
+        release < retry,
+        "fallback must release handles before reopening"
+    );
+    assert!(fallback[..retry].contains("demote_after_concurrent_capture_failure"));
 }
 
 #[test]
@@ -53,8 +95,19 @@ fn enrollment_fallback_restarts_without_held_sessions() {
 
     assert!(capture.contains("CapturePathError::ConcurrentPair"));
     assert!(capture.contains("demote_after_concurrent_capture_failure"));
-    assert!(capture.contains("drop(rs)"));
-    assert!(capture.contains("drop(is)"));
+    assert_scoped_pair_assessment(&source);
+    assert!(!capture.contains("RgbSession"));
+    assert!(!capture.contains("IrSession"));
+    let release = capture.find("drop(cams)").expect("release handles");
+    let retry = capture
+        .rfind("self.capture_scan_loop(")
+        .expect("sequential retry");
+    assert!(
+        release < retry,
+        "fallback must release handles before reopening"
+    );
+    let scan_loop = function(&source, "    fn capture_scan_loop(", "\n    ///");
+    assert!(scan_loop.contains("self.assess_with_fresh_pair("));
 }
 
 #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2050,6 +2050,103 @@ impl<S: ValidatedStream> TrackedStream<S> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum IrSessionStartup {
+    Fixed,
+    Adaptive,
+    Paired,
+}
+
+impl IrSessionStartup {
+    fn warm_up<S: ValidatedStream>(
+        self,
+        device: &str,
+        stream: &mut TrackedStream<S>,
+        progress: &Progress,
+    ) -> irlume_common::Result<()> {
+        match self {
+            // The mode and metadata are armed, but paired image STREAMON must
+            // wait until RGB has started. NexiGo otherwise sends JPEG-prefixed data
+            // through its negotiated YUYV endpoint.
+            Self::Paired => Ok(()),
+            Self::Fixed | Self::Adaptive => warm_up_stream(device, stream, progress),
+        }
+    }
+
+    fn fill<S: ValidatedStream>(self, stream: &mut TrackedStream<S>) -> std::io::Result<()> {
+        match self {
+            // The joint fill resets both windows and measures simultaneous
+            // delivery. A solo IR window would only be thrown away there.
+            Self::Paired => Ok(()),
+            Self::Fixed => stream.fill_rate_evidence(),
+            Self::Adaptive => stream.fill_rate_evidence_with_startup(true),
+        }
+    }
+}
+
+// Prime a fresh pair without claiming delivered-rate readiness. Observation
+// counters survive recovery, so a pending epoch also means streaming must start.
+fn start_rgb_before_ir<A: ValidatedStream, B: ValidatedStream>(
+    device: &str,
+    rgb: &mut TrackedStream<A>,
+    ir: &TrackedStream<B>,
+    progress: &Progress,
+) -> irlume_common::Result<()> {
+    if (rgb.observations == 0 || rgb.recovery_epoch_pending)
+        && (ir.observations == 0 || ir.recovery_epoch_pending)
+    {
+        warm_up_stream(device, rgb, progress)?;
+    }
+    Ok(())
+}
+
+// A finished burst must keep servicing its queue while its companion captures.
+fn capture_and_drain<S, R>(
+    session: &mut S,
+    completed: &std::sync::atomic::AtomicUsize,
+    capture: impl FnOnce(&mut S) -> irlume_common::Result<R>,
+    mut drain: impl FnMut(&mut S) -> irlume_common::Result<()>,
+) -> irlume_common::Result<R> {
+    use std::sync::atomic::Ordering;
+    struct Completed<'a>(&'a std::sync::atomic::AtomicUsize);
+    impl Drop for Completed<'_> {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::Release);
+        }
+    }
+    let frame = {
+        let _completed = Completed(completed);
+        capture(session)
+    }?;
+    let mut drained = 0;
+    while completed.load(Ordering::Acquire) < 2 {
+        if drained == 2 * MAX_RATE_FILL_ATTEMPTS {
+            return Err(Error::Hardware(
+                "paired capture exceeded its bounded companion drain".into(),
+            ));
+        }
+        drain(session)?;
+        drained += 1;
+    }
+    Ok(frame)
+}
+
+// Discard pixels, but preserve every transport refusal, including a gap that
+// would otherwise occur after the cached capture's provenance was assembled.
+fn drain_pair_frame<S: ValidatedStream>(
+    stream: &mut TrackedStream<S>,
+    device: &str,
+) -> irlume_common::Result<()> {
+    let (_, _, sequence, timestamp, _) =
+        stream.next().map_err(|error| map_delivery(device, error))?;
+    if sequence.gap() != 0 || sequence.discontinuity() || timestamp.discontinuity() {
+        return Err(Error::Hardware(format!(
+            "{device}: continuity failed while draining paired capture"
+        )));
+    }
+    Ok(())
+}
+
 fn fill_rate_then_drain_metadata<E>(
     fill_rate: impl FnOnce() -> Result<(), E>,
     drain_metadata: impl FnOnce(),
@@ -4976,7 +5073,7 @@ pub fn capture_ir_with_stats_and_progress(
     device: &str,
     progress: &Progress,
 ) -> irlume_common::Result<(Frame, IrCaptureStats)> {
-    capture_ir_with_startup(device, progress, false)
+    capture_ir_with_startup(device, progress, IrSessionStartup::Fixed)
 }
 
 /// Capture IR alone, allowing a healthy full rate window to end startup early.
@@ -4992,19 +5089,19 @@ pub fn capture_ir_sequential_with_stats_and_progress(
     device: &str,
     progress: &Progress,
 ) -> irlume_common::Result<(Frame, IrCaptureStats)> {
-    capture_ir_with_startup(device, progress, true)
+    capture_ir_with_startup(device, progress, IrSessionStartup::Adaptive)
 }
 
 fn capture_ir_with_startup(
     device: &str,
     progress: &Progress,
-    adaptive_ir: bool,
+    startup: IrSessionStartup,
 ) -> irlume_common::Result<(Frame, IrCaptureStats)> {
     let opened = std::time::Instant::now();
     let cam = IrCamera::open(device)?;
     let open_ms = opened.elapsed().as_millis();
     let armed = std::time::Instant::now();
-    let mut session = cam.session_with_startup(progress, adaptive_ir)?;
+    let mut session = cam.session_with_startup(progress, startup)?;
     let arm_ms = armed.elapsed().as_millis();
     let captured = std::time::Instant::now();
     let shot = session.capture_with_stats();
@@ -5165,13 +5262,30 @@ impl IrCamera {
         &self,
         progress: &Progress,
     ) -> irlume_common::Result<IrSession<'_>> {
-        self.session_with_startup(progress, false)
+        self.session_with_startup(progress, IrSessionStartup::Fixed)
+    }
+
+    /// Arm IR for a held pair, deferring its rate window to [`establish_pair_rate`].
+    ///
+    /// Emitter setup and metadata ordering are preserved. Image STREAMON waits
+    /// for the joint fill, which starts RGB first before both streams are drained
+    /// together. Capturing directly still enforces the ordinary per-frame gate.
+    ///
+    /// # Errors
+    ///
+    /// Returns camera, lease, emitter or privacy errors encountered while arming.
+    /// Rate-establishment errors are deferred to the joint fill or first capture.
+    pub fn session_for_pair_with_progress(
+        &self,
+        progress: &Progress,
+    ) -> irlume_common::Result<IrSession<'_>> {
+        self.session_with_startup(progress, IrSessionStartup::Paired)
     }
 
     fn session_with_startup(
         &self,
         progress: &Progress,
-        adaptive_ir: bool,
+        startup: IrSessionStartup,
     ) -> irlume_common::Result<IrSession<'_>> {
         self.lease
             .require_endpoint(&self.device)
@@ -5205,12 +5319,12 @@ impl IrCamera {
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
         // 25s when video went first). `SafeStream::open` only allocates
-        // buffers; STREAMON happens on the first dequeue, which is inside
-        // `warm_up_stream` below. This is the window, and it is the only one.
+        // buffers; STREAMON happens on the first dequeue, inside ordinary
+        // warm-up below or the paired joint fill. Metadata must start here.
         let meta_started = std::time::Instant::now();
         let mut meta = ir_metadata::IlluminationLog::open(&self.device);
         let metadata_ms = meta_started.elapsed().as_millis();
-        // BEFORE the warm-up, because the warm-up's first dequeue is STREAMON.
+        // BEFORE any image dequeue, because the first dequeue is STREAMON.
         // Microsoft's sequence sets the property and THEN starts streaming, and
         // this ran the other way round: every authentication set the mode under
         // an already-running stream, the mid-stream write the rest of #168
@@ -5246,14 +5360,14 @@ impl IrCamera {
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
         let warmup_started = std::time::Instant::now();
-        warm_up_stream(&self.device, &mut stream, progress)?;
+        startup.warm_up(&self.device, &mut stream, progress)?;
         let warmup_ms = warmup_started.elapsed().as_millis();
         // Rate establishment internally discards more frames than the metadata
         // ring can hold. Drain those records now, after the fill, so buffers are
         // requeued before the first frame a caller can observe.
         let fill_started = std::time::Instant::now();
         let fill_result = fill_rate_then_drain_metadata(
-            || stream.fill_rate_evidence_with_startup(adaptive_ir),
+            || startup.fill(&mut stream),
             || {
                 if let Some(log) = meta.as_mut() {
                     log.drain();
@@ -5821,6 +5935,7 @@ pub fn establish_pair_rate(
     ir: &mut IrSession<'_>,
 ) -> irlume_common::Result<()> {
     let device = rgb.cam.device.clone();
+    start_rgb_before_ir(&device, &mut rgb.stream, &ir.stream, &rgb.progress)?;
     let result = establish_concurrent_rate(&mut rgb.stream, &mut ir.stream);
     let privacy_refused = ir.stream.privacy_refused();
     let result = finish_hidden_rate_fill(result, privacy_refused, || {
@@ -5841,6 +5956,64 @@ pub fn establish_pair_rate(
         return Err(ir.stop_after_privacy_refusal(refusal));
     }
     result.map_err(|error| map_io(&device, error))
+}
+
+/// Capture a held pair while draining the finished side until both captures end.
+///
+/// The callbacks retain their caller's capture/recovery policy. Successful
+/// pixels are returned only if the subsequent drain also stayed healthy. This
+/// prevents asymmetric bursts from overflowing the faster side's mmap queue.
+/// It does not keep streams serviced between calls, for example during inference.
+///
+/// # Errors
+///
+/// Each result preserves its callback error or a rate, continuity, privacy,
+/// lease or bounded-drain failure. Callers must discard both frames if either
+/// result fails. IR privacy refusal stops its queues and restores the emitter.
+///
+/// # Panics
+///
+/// Propagates a panic from either callback after joining the companion worker.
+pub fn capture_pair_with<R: Send, I: Send>(
+    rgb: &mut RgbSession<'_>,
+    ir: &mut IrSession<'_>,
+    capture_rgb: impl FnOnce(&mut RgbSession<'_>) -> irlume_common::Result<R>,
+    capture_ir: impl FnOnce(&mut IrSession<'_>) -> irlume_common::Result<I> + Send,
+) -> (irlume_common::Result<R>, irlume_common::Result<I>) {
+    let completed = std::sync::atomic::AtomicUsize::new(0);
+    std::thread::scope(|scope| {
+        let ir_thread = scope.spawn(|| {
+            let lease = ir.cam.lease.clone();
+            lease.run_active(|| {
+                capture_and_drain(ir, &completed, capture_ir, |ir| {
+                    let result = drain_pair_frame(&mut ir.stream, &ir.cam.device);
+                    let privacy_refused = ir.stream.privacy_refused();
+                    let result = finish_hidden_rate_fill(result, privacy_refused, || {
+                        if let Some(log) = ir.meta.as_mut() {
+                            log.drain();
+                        }
+                    });
+                    if ir.stream.take_privacy_refusal() {
+                        let refusal = result.err().unwrap_or_else(|| {
+                            Error::Hardware("IR privacy refused paired drain".into())
+                        });
+                        return Err(ir.stop_after_privacy_refusal(refusal));
+                    }
+                    result
+                })
+            })
+        });
+        let lease = rgb.cam.lease.clone();
+        let rgb = lease.run_active(|| {
+            capture_and_drain(rgb, &completed, capture_rgb, |rgb| {
+                drain_pair_frame(&mut rgb.stream, &rgb.cam.device)
+            })
+        });
+        let ir = ir_thread
+            .join()
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload));
+        (rgb, ir)
+    })
 }
 
 /// Ambient-subtraction helpers (Windows-Hello-style illuminated minus ambient).
@@ -7764,9 +7937,11 @@ fn held_concurrent_arm<'d>(
                 ));
             }
         }
-        let sessions = rgb_cam
-            .session_with_progress(progress)
-            .and_then(|rs| ir_cam.session_with_progress(progress).map(|is| (rs, is)));
+        let sessions = rgb_cam.session_with_progress(progress).and_then(|rs| {
+            ir_cam
+                .session_for_pair_with_progress(progress)
+                .map(|is| (rs, is))
+        });
         let (mut rs, mut is) = match sessions {
             Ok(pair) => pair,
             Err(e) => {
@@ -7792,21 +7967,16 @@ fn held_concurrent_arm<'d>(
             let t0 = std::time::Instant::now();
             let (rgb, ir) = operation
                 .run(|| {
-                    std::thread::scope(|scope| {
-                        let ir_thread = scope.spawn(|| {
+                    capture_pair_with(
+                        &mut rs,
+                        &mut is,
+                        |session| session.burst(RGB_BURST).and_then(median_frame),
+                        |session| {
                             operation
-                                .run(|| is.capture_with_stats())
+                                .run(|| session.capture_with_stats())
                                 .map_err(|error| Error::Hardware(error.to_string()))?
-                        });
-                        let rgb = rs.burst(RGB_BURST).and_then(median_frame);
-                        let ir = match ir_thread.join() {
-                            Ok(result) => result,
-                            // Re-raise into the composer's catch_unwind: a panic is a
-                            // software defect, never a stored hardware verdict (#263).
-                            Err(payload) => std::panic::resume_unwind(payload),
-                        };
-                        (rgb, ir)
-                    })
+                        },
+                    )
                 })
                 .map_err(|error| Error::Hardware(error.to_string()))?;
             accumulate(into, &mut continuity, &rgb, &ir, t0.elapsed(), context);
@@ -10713,6 +10883,142 @@ mod tests {
         assert_eq!(evidence.window_count(), 30);
         assert_eq!(evidence.window_span_us(), 30 * 100_000);
         assert!(evidence.meets_floor());
+    }
+
+    #[test]
+    fn paired_startup_leaves_ir_unstarted_until_rgb_has_a_buffer() {
+        let mut rgb = rate_fill_fixture(contracts::StreamRole::Rgb, 100, 66_667);
+        let mut ir = rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667);
+        IrSessionStartup::Paired
+            .warm_up("ir", &mut ir, &no_progress())
+            .unwrap();
+        assert_eq!(
+            ir.observations, 0,
+            "arming paired IR must not issue STREAMON"
+        );
+        start_rgb_before_ir("rgb", &mut rgb, &ir, &no_progress()).unwrap();
+        assert_eq!(rgb.observations, 1, "RGB must dequeue before IR starts");
+        assert_eq!(ir.observations, 0);
+        assert!(!rgb.rate_window.ready());
+        assert!(!ir.rate_window.ready());
+    }
+
+    #[test]
+    fn paired_startup_rejects_bad_rgb_before_starting_ir() {
+        let mut rgb = rate_fill_fixture(contracts::StreamRole::Rgb, 100, 66_667);
+        rgb.stream_mut().unwrap().metadata[0].bytesused = 0;
+        let ir = rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667);
+        assert!(start_rgb_before_ir("rgb", &mut rgb, &ir, &no_progress()).is_err());
+        assert_eq!(ir.observations, 0);
+        assert!(!rgb.rate_window.ready());
+    }
+
+    #[test]
+    fn paired_startup_primes_rgb_again_when_both_streams_were_recovered() {
+        let mut rgb = rate_fill_fixture(contracts::StreamRole::Rgb, 100, 66_667);
+        let mut ir = rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667);
+        rgb.next_discarded().unwrap();
+        ir.next_discarded().unwrap();
+        rgb.take();
+        ir.take();
+        rgb.install_recovered(
+            rate_fill_fixture(contracts::StreamRole::Rgb, 100, 66_667)
+                .take()
+                .unwrap(),
+        )
+        .unwrap();
+        ir.install_recovered(
+            rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667)
+                .take()
+                .unwrap(),
+        )
+        .unwrap();
+        let before = (rgb.observations, ir.observations);
+        start_rgb_before_ir("rgb", &mut rgb, &ir, &no_progress()).unwrap();
+        assert_eq!(rgb.observations, before.0 + 1);
+        assert_eq!(ir.observations, before.1, "recovered IR must still wait");
+        assert!(!rgb.recovery_epoch_pending);
+        assert!(ir.recovery_epoch_pending);
+    }
+
+    #[test]
+    fn paired_startup_does_not_reprime_an_observed_pair() {
+        for observed_rgb in [true, false] {
+            let mut rgb = rate_fill_fixture(contracts::StreamRole::Rgb, 100, 66_667);
+            let mut ir = rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667);
+            if observed_rgb {
+                rgb.next_discarded().unwrap();
+            } else {
+                ir.next_discarded().unwrap();
+            }
+            let before = (rgb.observations, ir.observations);
+            start_rgb_before_ir("rgb", &mut rgb, &ir, &no_progress()).unwrap();
+            assert_eq!((rgb.observations, ir.observations), before);
+        }
+    }
+
+    #[test]
+    fn individual_ir_startup_keeps_its_existing_rate_work() {
+        for (startup, expected_observations) in [
+            (IrSessionStartup::Fixed, 42),
+            (IrSessionStartup::Adaptive, 32),
+        ] {
+            let mut stream = rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667);
+            startup.warm_up("ir", &mut stream, &no_progress()).unwrap();
+            startup.fill(&mut stream).unwrap();
+            assert_eq!(stream.observations, expected_observations);
+            assert!(stream.rate_window.ready());
+        }
+    }
+
+    #[test]
+    fn paired_ir_startup_defers_rate_dequeues_without_claiming_readiness() {
+        let mut stream = rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667);
+        IrSessionStartup::Paired
+            .warm_up("ir", &mut stream, &no_progress())
+            .unwrap();
+        IrSessionStartup::Paired.fill(&mut stream).unwrap();
+        assert_eq!(
+            stream.observations, 0,
+            "paired arming leaves image streaming to joint startup"
+        );
+        assert!(
+            !stream.rate_window.ready(),
+            "joint fill still owes a full window"
+        );
+    }
+
+    #[test]
+    fn paired_ir_startup_cannot_bypass_the_delivery_gate_without_joint_fill() {
+        for interval_us in [66_667, 200_000] {
+            let mut stream = rate_fill_fixture(contracts::StreamRole::Ir, 100, interval_us);
+            IrSessionStartup::Paired
+                .warm_up("ir", &mut stream, &no_progress())
+                .unwrap();
+            IrSessionStartup::Paired.fill(&mut stream).unwrap();
+            let result = stream.next();
+            if interval_us == 66_667 {
+                let (_, facts, _, _, evidence) = result.unwrap();
+                assert_eq!(facts.sequence_raw(), 42);
+                assert_eq!(evidence.window_count(), 30);
+                assert!(evidence.meets_floor());
+            } else {
+                assert!(matches!(result, Err(DeliveryError::BelowFloor(_))));
+            }
+        }
+    }
+
+    #[test]
+    fn paired_ir_startup_does_not_hide_missing_rate_evidence() {
+        let mut stream = rate_fill_fixture(contracts::StreamRole::Ir, 1, 66_667);
+        IrSessionStartup::Paired
+            .warm_up("ir", &mut stream, &no_progress())
+            .unwrap();
+        IrSessionStartup::Paired.fill(&mut stream).unwrap();
+        assert!(
+            stream.next().is_err(),
+            "warm-up alone cannot deliver a frame"
+        );
     }
 
     #[test]
@@ -15718,6 +16024,49 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "needs a camera pair; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE"]
+    fn paired_capture_drain_privacy_refusal_stops_ir_before_returning() {
+        let (rgb_path, ir_path) = loopback_pair();
+        let operation = lease::acquire_camera_operation(
+            &[rgb_path.as_str(), ir_path.as_str()],
+            lease::CameraOperationKind::Diagnostics,
+            std::time::Duration::from_secs(2),
+        )
+        .expect("acquire pair operation");
+        let rgb_camera = operation.open_rgb(&rgb_path).expect("open RGB");
+        let ir_camera = operation.open_ir(&ir_path).expect("open IR");
+        let mut rgb = rgb_camera.session().expect("arm RGB");
+        let mut ir = ir_camera.session().expect("arm IR");
+        let boundary = std::sync::Arc::new(std::sync::Barrier::new(2));
+        ir.stream.synchronize_next_boundary(boundary.clone());
+        ir.stream.refuse_privacy_after(1);
+        let (rgb_result, ir_result) = capture_pair_with(
+            &mut rgb,
+            &mut ir,
+            |_| {
+                boundary.wait();
+                Ok(())
+            },
+            |_| Ok(()), // a cached success must be invalidated by the tail drain
+        );
+        assert!(rgb_result.is_ok());
+        let error = ir_result.expect_err("the drain must propagate privacy refusal");
+        assert!(
+            error
+                .to_string()
+                .contains("injected privacy boundary failure"),
+            "{error}"
+        );
+        assert!(ir.stream.stream.is_none(), "IR image queue must stop");
+        assert!(ir.meta.is_none(), "IR metadata queue must stop");
+        assert!(
+            !ir.lit && !ir._mode.owns_restore(),
+            "emitter guard must be restored and inert"
+        );
+        assert!(rgb.stream.stream.is_some(), "the companion stays reusable");
+    }
+
+    #[test]
     #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
     fn loopback_pair_rate_privacy_refusal_stops_only_ir_and_cancels_rgb() {
         let (rgb_path, ir_path) = loopback_pair();
@@ -16488,6 +16837,124 @@ mod tests {
     }
 
     #[test]
+    fn paired_capture_drain_preserves_typed_rate_refusal_and_continuity() {
+        let mut slow = rate_fill_fixture(contracts::StreamRole::Ir, 100, 200_000);
+        assert!(matches!(
+            drain_pair_frame(&mut slow, "fixture"),
+            Err(Error::DeliveredRate(_))
+        ));
+        let mut gap = rate_fill_fixture(contracts::StreamRole::Rgb, 100, 66_667);
+        gap.next().unwrap(); // first capture has healthy provenance
+        let next = gap.stream_mut().unwrap().metadata.front_mut().unwrap();
+        next.sequence += 1;
+        let error = drain_pair_frame(&mut gap, "fixture").unwrap_err();
+        assert!(
+            error.to_string().contains("continuity"),
+            "a cached success cannot hide a later gap"
+        );
+    }
+
+    #[test]
+    fn paired_capture_drains_a_finished_stream_until_its_companion_finishes() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let completed = AtomicUsize::new(0);
+        let mut drained = 0;
+        let frame = capture_and_drain(
+            &mut drained,
+            &completed,
+            |_| Ok(42),
+            |drained| {
+                *drained += 1;
+                if *drained == 3 {
+                    completed.fetch_add(1, Ordering::Release);
+                }
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(frame, 42);
+        assert_eq!(drained, 3, "a finished burst must service its queue");
+    }
+
+    #[test]
+    fn paired_capture_does_not_drain_after_both_captures_finish() {
+        let completed = std::sync::atomic::AtomicUsize::new(1);
+        assert_eq!(
+            capture_and_drain(
+                &mut (),
+                &completed,
+                |_| Ok(42),
+                |_| panic!("unneeded dequeue")
+            )
+            .unwrap(),
+            42
+        );
+    }
+
+    #[test]
+    fn paired_capture_preserves_capture_and_drain_errors() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let completed = AtomicUsize::new(0);
+        let error = capture_and_drain(
+            &mut (),
+            &completed,
+            |_| Err::<(), _>(Error::Hardware("capture failed".into())),
+            |_| panic!("failed capture must not drain"),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("capture failed"));
+        assert_eq!(completed.load(Ordering::Acquire), 1);
+        let completed = AtomicUsize::new(0);
+        let error = capture_and_drain(
+            &mut (),
+            &completed,
+            |_| Ok(42),
+            |_| Err(Error::Hardware("privacy refusal".into())),
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("privacy refusal"),
+            "do not return cached pixels after a drain refusal"
+        );
+    }
+
+    #[test]
+    fn paired_capture_notifies_its_companion_even_when_capture_panics() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let completed = AtomicUsize::new(0);
+        let panic = std::panic::catch_unwind(|| {
+            capture_and_drain(
+                &mut (),
+                &completed,
+                |_| -> irlume_common::Result<()> { panic!("capture bug") },
+                |_| Ok(()),
+            )
+        });
+        assert!(panic.is_err());
+        assert_eq!(completed.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn paired_capture_bounds_drain_work_when_its_companion_stalls() {
+        let completed = std::sync::atomic::AtomicUsize::new(0);
+        let mut drained = 0;
+        let result = capture_and_drain(
+            &mut drained,
+            &completed,
+            |_| Ok(42),
+            |n| {
+                *n += 1;
+                Ok(())
+            },
+        );
+        assert!(
+            result.is_err(),
+            "a stalled companion cannot license unbounded work"
+        );
+        assert_eq!(drained, 2 * MAX_RATE_FILL_ATTEMPTS);
+    }
+
+    #[test]
     fn concurrent_rate_fill_drains_both_streams_in_parallel() {
         // The fill must drive both streams on two threads SIMULTANEOUSLY. A
         // serial (round-robin) fill throttles the faster stream to the slower
@@ -16561,6 +17028,7 @@ mod tests {
 
         let (done, ready) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
+            IrSessionStartup::Paired.fill(&mut ir).unwrap();
             let result = establish_concurrent_rate(&mut rgb, &mut ir);
             let _ = done.send(result.map(|()| (rgb.rate_window.ready(), ir.rate_window.ready())));
         });

--- a/docs/research/2026-09-05-paired-session-review.md
+++ b/docs/research/2026-09-05-paired-session-review.md
@@ -1,0 +1,17 @@
+# Paired camera assessment lifecycle
+
+The candidate drains a completed camera burst until its companion completes,
+starts paired RGB before IR, and scopes streams to one authentication or enrollment
+assessment. Negotiated handles can survive retries, but streaming queues are
+re-created so later assessments do not reuse queues left idle through inference.
+
+This changes concurrent retry and enrollment setup cost. Payload, privacy, rate,
+continuity and qualification checks remain enforced; concurrent mode is not
+enabled by the change. Stream owners drop before matching and consent.
+
+Fresh scoped authentication/camera verification: 776 passed, zero failed,
+30 existing ignored. Historical capture experiments were mixed: NexiGo passed
+six RGB-first pairs, ASUS retained intermittent short payload refusals, and BRIO
+refused capture. These results do not qualify full concurrent authentication,
+consent, retry latency or every camera model. Keep this work under review before
+rollout and preserve the existing stored sequential selection.


### PR DESCRIPTION
## What & why

Paired streams can stop servicing one camera while its companion finishes a burst, or sit idle across inference and retries. This change drains the completed side until its companion finishes, starts paired RGB before IR, and scopes both streaming sessions to one authentication/enrollment assessment. Each retry or scan establishes fresh rate evidence and releases its streams before matching or consent.

Driver payload, privacy, rate, continuity and qualification gates remain enforced. Captures that fail those gates still fall back; the patch does not enable concurrent mode. Per-assessment setup can increase retry/enrollment cost and removes overlap between enrollment unsealing and stream setup.

## Testing

- Fresh scoped authentication/camera suites: 776 passed, zero failed, 30 existing ignored.
- The final combined source passes 1,978 workspace tests and warnings-denied Clippy/docs, plus formatting. Those final-tree results are additional integration evidence, not an independent full-suite run on this prerequisite.
- Historical capture probes showed mixed hardware behavior: NexiGo RGB-first paired capture 6/6; ASUS intermittent short RGB payloads; BRIO refused capture. These are capture-only observations, not an end-to-end concurrent authentication qualification.
- Existing real loopback/privacy tests remain declared ignored unless their hardware requirements are provided.
- Documentation note supplied in this review package. The nine original research reports remain preserved separately.

Draft only: retain the current stored sequential selection. Concurrent full authentication, consent and retry behavior has not been qualified by the later sequential live trials.

