### PR TITLE
perf: collect complete sequential PAD evidence in bounded groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Changed
 
+- Collect complete sequential login PAD evidence in bounded RGB/IR groups and
+  defer identity inference to the final eligible sample.
+
 - Bound paired camera streaming to each assessment, coordinate paired startup,
   and service companion queues through burst completion.
 

--- a/crates/irlume-auth/src/engine_tests/grouped_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/grouped_tests.rs
@@ -1,0 +1,740 @@
+use super::*;
+use crate::grouped_auth::PreparedGroup;
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+fn sample(
+    e: &mut Engine,
+    index: usize,
+    score: f32,
+) -> DeferredAssessment<(usize, [f32; EMBED_DIM])> {
+    let deny = e.vit_pad_votes_deny(score);
+    let (_, mut assessment) = pad_matching_fixture(score, deny);
+    assessment.signals.rgb_face = Some(irlume_liveness::FaceBox {
+        cx: 0.5,
+        cy: 0.5,
+        score: 0.9,
+    });
+    assessment.ir_pad = PadEvidence::Score(0.1);
+    let identity = (index, assessment.embedding.take().unwrap());
+    DeferredAssessment {
+        assessment,
+        identity,
+    }
+}
+
+#[test]
+fn grouped_five_votes_materialize_only_final_sample_and_admit_once_qualified() {
+    let _guard = env_guard();
+    let mut s = shared();
+    let e = &mut s.engine;
+    let calls = Cell::new(0);
+    let result = e
+        .evaluate_grouped_samples_with(
+            (0..5).collect(),
+            Instant::now() + Duration::from_secs(15),
+            |e, i| Ok(sample(e, i, 0.2)),
+            |_, mut evidence| {
+                calls.set(calls.get() + 1);
+                assert_eq!(evidence.identity.0, 4);
+                evidence.assessment.embedding = Some(evidence.identity.1);
+                evidence.assessment.ir_embedding = Some(evidence.identity.1.to_vec());
+                Ok(evidence.assessment)
+            },
+            Instant::now,
+        )
+        .unwrap();
+    assert_eq!(calls.get(), 1);
+    let PreparedGroup::Ready(a) = result else {
+        panic!("complete live group refused")
+    };
+    let (mut enr, _) = pad_matching_fixture(0.2, false);
+    enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+    let prior_ir = e.ir_available;
+    e.ir_available = true;
+    let out = e
+        .authenticate_qualified_assessment(
+            &enr,
+            AuthenticationPurpose::Verify,
+            Some("login"),
+            *a,
+            &(),
+        )
+        .unwrap();
+    e.vit_scores.clear();
+    e.ir_available = prior_ir;
+    assert!(out.granted, "{}", out.reason);
+}
+
+#[test]
+fn grouped_incomplete_or_spoof_evidence_never_materializes_identity() {
+    let _guard = env_guard();
+    let mut s = shared();
+    for (count, score) in [(4, 0.2), (0, 0.2), (6, 0.2), (5, 0.99)] {
+        s.engine.vit_scores.extend([0.2; 4]);
+        let calls = Cell::new(0);
+        let result = s.engine.evaluate_grouped_samples_with(
+            (0..count).collect(),
+            Instant::now() + Duration::from_secs(15),
+            |e, i| Ok(sample(e, i, score)),
+            |_, evidence| {
+                calls.set(calls.get() + 1);
+                Ok(evidence.assessment)
+            },
+            Instant::now,
+        );
+        assert_eq!(calls.get(), 0, "count={count}, score={score}");
+        assert!(!matches!(result, Ok(PreparedGroup::Ready(_))));
+        assert!(s.engine.vit_scores.is_empty());
+    }
+}
+
+#[test]
+fn grouped_interrupted_evidence_does_not_reuse_prior_votes() {
+    let _guard = env_guard();
+    let mut s = shared();
+    s.engine.vit_scores.extend([0.2; 4]);
+    let result = s
+        .engine
+        .evaluate_grouped_samples_with(
+            (0..5).collect(),
+            Instant::now() + Duration::from_secs(15),
+            |e, i| {
+                let mut v = sample(e, i, 0.2);
+                if i == 2 {
+                    v.assessment.verdict = Verdict::Uncertain;
+                    v.assessment.reason = "unusable evidence".into();
+                }
+                Ok(v)
+            },
+            |_, _| panic!("interrupted votes reached identity"),
+            Instant::now,
+        )
+        .unwrap();
+    assert!(matches!(result, PreparedGroup::Refused(_)));
+    assert!(s.engine.vit_scores.is_empty());
+}
+
+#[test]
+fn grouped_required_pad_failure_is_terminal_before_identity() {
+    let _guard = env_guard();
+    let mut s = shared();
+    for rgb_failure in [false, true] {
+        let calls = Cell::new(0);
+        let result = s
+            .engine
+            .evaluate_grouped_samples_with(
+                (0..5).collect(),
+                Instant::now() + Duration::from_secs(15),
+                |e, i| {
+                    calls.set(calls.get() + 1);
+                    let mut v = sample(e, i, 0.2);
+                    if rgb_failure {
+                        v.assessment.rgb_pad = PadEvidence::Score(f32::NAN);
+                    } else {
+                        v.assessment.ir_pad = PadEvidence::InferenceFailed;
+                    }
+                    Ok(v)
+                },
+                |_, _| panic!("failed PAD reached identity"),
+                Instant::now,
+            )
+            .unwrap();
+        let PreparedGroup::Refused(out) = result else {
+            panic!("failed PAD admitted")
+        };
+        assert_eq!(out.kind, OutcomeKind::OtherDeny);
+        assert_eq!(calls.get(), 1);
+        assert!(s.engine.vit_scores.is_empty());
+    }
+}
+
+#[test]
+fn grouped_deadline_checks_before_and_after_inference() {
+    let _guard = env_guard();
+    let mut s = shared();
+    for expire_at in [0, 1, 5, 6] {
+        let start = Instant::now();
+        let deadline = start + Duration::from_secs(15);
+        let clock = Cell::new(start);
+        if expire_at == 0 {
+            clock.set(deadline);
+        }
+        let identities = Cell::new(0);
+        let assessed = Cell::new(0);
+        let result = s
+            .engine
+            .evaluate_grouped_samples_with(
+                (0..5).collect(),
+                deadline,
+                |e, i| {
+                    assessed.set(assessed.get() + 1);
+                    let v = sample(e, i, 0.2);
+                    if expire_at == i + 1 {
+                        clock.set(deadline);
+                    }
+                    Ok(v)
+                },
+                |_, v| {
+                    identities.set(identities.get() + 1);
+                    clock.set(deadline);
+                    Ok(v.assessment)
+                },
+                || clock.get(),
+            )
+            .unwrap();
+        assert!(matches!(result, PreparedGroup::Refused(_)));
+        assert_eq!(identities.get(), usize::from(expire_at == 6));
+        if expire_at == 0 {
+            assert_eq!(assessed.get(), 0);
+        }
+        assert!(s.engine.vit_scores.is_empty());
+    }
+}
+
+#[test]
+fn grouped_inference_errors_clear_all_evidence() {
+    let _guard = env_guard();
+    let mut s = shared();
+    for fail_materialize in [false, true] {
+        let result = s.engine.evaluate_grouped_samples_with(
+            (0..5).collect(),
+            Instant::now() + Duration::from_secs(15),
+            |e, i| {
+                let v = sample(e, i, 0.2);
+                if i == 2 && !fail_materialize {
+                    Err(irlume_common::Error::Hardware("scripted failure".into()))
+                } else {
+                    Ok(v)
+                }
+            },
+            |_, _| {
+                Err(irlume_common::Error::Hardware(
+                    "scripted identity failure".into(),
+                ))
+            },
+            Instant::now,
+        );
+        assert!(result.is_err());
+        assert!(s.engine.vit_scores.is_empty());
+    }
+}
+
+#[test]
+fn grouped_sequential_pair_requires_final_ir_identity() {
+    let _guard = env_guard();
+    let mut s = shared();
+    let e = &mut s.engine;
+    let prior_ir = e.ir_available;
+    e.ir_available = true;
+    for (gap_ms, ir_matches) in [
+        (1000, false),
+        (3000, false),
+        (3001, false),
+        (1000, true),
+        (3000, true),
+        (3001, true),
+    ] {
+        let identities = Cell::new(0);
+        let result = e
+            .evaluate_grouped_samples_with(
+                (0..5).collect(),
+                Instant::now() + Duration::from_secs(15),
+                |e, i| {
+                    let mut v = sample(e, i, 0.2);
+                    // Emulate the shared legacy assessment's result; grouped
+                    // preparation must enforce its separated capture policy.
+                    v.assessment.sequential_pair =
+                        pair_admitted_sequentially(Duration::from_millis(gap_ms), true);
+                    Ok(v)
+                },
+                |_, mut v| {
+                    identities.set(identities.get() + 1);
+                    v.assessment.embedding = Some(v.identity.1);
+                    let mut ir = v.identity.1.to_vec();
+                    if !ir_matches {
+                        ir[0] = 0.0;
+                        ir[1] = 1.0;
+                    }
+                    v.assessment.ir_embedding = Some(ir);
+                    Ok(v.assessment)
+                },
+                Instant::now,
+            )
+            .unwrap();
+        let PreparedGroup::Ready(a) = result else {
+            panic!("live paired group refused before match")
+        };
+        let (mut enr, _) = pad_matching_fixture(0.2, false);
+        enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+        let out = e
+            .authenticate_qualified_assessment(
+                &enr,
+                AuthenticationPurpose::Verify,
+                Some("login"),
+                *a,
+                &(),
+            )
+            .unwrap();
+        assert_eq!(identities.get(), 1);
+        assert_eq!(out.granted, ir_matches, "{}", out.reason);
+        if !ir_matches {
+            assert_eq!(out.kind, OutcomeKind::BelowThreshold);
+            assert!(!presence_retryable(&out));
+        }
+    }
+    e.ir_available = prior_ir;
+    e.vit_scores.clear();
+}
+
+#[test]
+fn grouped_dark_final_sample_uses_real_ir_presence_and_existing_gates() {
+    let _guard = env_guard();
+    let mut s = shared();
+    let e = &mut s.engine;
+    let prior_ir = e.ir_available;
+    e.ir_available = true;
+    for (lit, ir_failure, ir_matches) in [
+        (false, false, true),
+        (true, false, true),
+        (false, true, true),
+        (false, false, false),
+    ] {
+        let identities = Cell::new(0);
+        let result = e
+            .evaluate_grouped_samples_with(
+                (0..5).collect(),
+                Instant::now() + Duration::from_secs(15),
+                |e, i| {
+                    let mut v = sample(e, i, 0.2);
+                    v.assessment.signals = Signals {
+                        rgb_face: None,
+                        ir_face: Some(irlume_liveness::FaceBox {
+                            cx: 0.5,
+                            cy: 0.5,
+                            score: 0.9,
+                        }),
+                        ir_face_brightness: 90.0,
+                        ir_center_edge_ratio: 1.2,
+                        ir_eye_glint: Some(220.0),
+                        ir_ceiling_known: true,
+                        ir_saturated_frac: Some(0.0),
+                        ..Signals::default()
+                    };
+                    v.assessment.verdict = Verdict::Uncertain;
+                    v.assessment.reason = "no RGB face".into();
+                    v.assessment.rgb_pad = PadEvidence::NotApplicable;
+                    v.assessment.rgb_frame_mean = if lit { 120.0 } else { 10.0 };
+                    if ir_failure {
+                        v.assessment.ir_pad = PadEvidence::InferenceFailed;
+                    }
+                    Ok(v)
+                },
+                |_, mut v| {
+                    identities.set(identities.get() + 1);
+                    let mut ir = v.identity.1.to_vec();
+                    if !ir_matches {
+                        ir[0] = 0.0;
+                        ir[1] = 1.0;
+                    }
+                    v.assessment.ir_embedding = Some(ir);
+                    Ok(v.assessment)
+                },
+                Instant::now,
+            )
+            .unwrap();
+        let out = match result {
+            PreparedGroup::Refused(o) => o,
+            PreparedGroup::Ready(a) => {
+                assert!(a.embedding.is_none());
+                let (mut enr, _) = pad_matching_fixture(0.2, false);
+                enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+                e.authenticate_qualified_assessment(
+                    &enr,
+                    AuthenticationPurpose::Verify,
+                    Some("login"),
+                    *a,
+                    &(),
+                )
+                .unwrap()
+            }
+        };
+        assert_eq!(
+            out.granted,
+            !lit && !ir_failure && ir_matches,
+            "{}",
+            out.reason
+        );
+        assert_eq!(identities.get(), usize::from(!lit && !ir_failure));
+    }
+    e.ir_available = prior_ir;
+    e.vit_scores.clear();
+}
+
+#[test]
+fn grouped_pending_retry_keeps_existing_budget_and_never_adds_identity_attempts() {
+    let _guard = env_guard();
+    let mut s = shared();
+    let start = Instant::now();
+    let clock = Cell::new(start);
+    let groups = Cell::new(0);
+    let mut worst = Duration::ZERO;
+    let (result, fallback) = s.engine.authentication_attempt_loop_with(
+        start + Duration::from_secs(15),
+        15_000,
+        &mut worst,
+        |e| {
+            groups.set(groups.get() + 1);
+            assert_eq!(groups.get(), 1, "extra expensive group");
+            let prepared = e
+                .evaluate_grouped_samples_with(
+                    (0..5).collect(),
+                    start + Duration::from_secs(15),
+                    |e, i| {
+                        clock.set(clock.get() + Duration::from_millis(2000));
+                        let mut v = sample(e, i, 0.2);
+                        if i == 1 {
+                            v.assessment.verdict = Verdict::Uncertain;
+                            v.assessment.reason = "unusable".into();
+                        }
+                        Ok(v)
+                    },
+                    |_, _| panic!("incomplete group reached identity"),
+                    || clock.get(),
+                )
+                .unwrap();
+            let PreparedGroup::Refused(o) = prepared else {
+                panic!("pending group admitted")
+            };
+            (Ok(o), false)
+        },
+        || clock.get(),
+    );
+    assert!(!fallback);
+    assert!(!result.unwrap().granted);
+    assert_eq!(groups.get(), 1);
+    assert_eq!(worst, Duration::from_secs(10));
+}
+
+#[test]
+fn grouped_required_pad_failures_precede_retryable_outcomes_and_stop_before_dark_final() {
+    let _guard = env_guard();
+    let mut s = shared();
+    for failure in [
+        PadEvidence::Unavailable,
+        PadEvidence::InferenceFailed,
+        PadEvidence::Score(f32::NAN),
+        PadEvidence::Score(f32::INFINITY),
+    ] {
+        for route in 0..4 {
+            let assessed = Cell::new(0);
+            let identities = Cell::new(0);
+            let result = s
+                .engine
+                .evaluate_grouped_samples_with(
+                    (0..5).collect(),
+                    Instant::now() + Duration::from_secs(15),
+                    |e, i| {
+                        assessed.set(assessed.get() + 1);
+                        let mut v = sample(e, i, 0.2);
+                        v.assessment.signals.ir_face = Some(irlume_liveness::FaceBox {
+                            cx: 0.5,
+                            cy: 0.5,
+                            score: 0.9,
+                        });
+                        if i == 0 {
+                            v.assessment.verdict = Verdict::Uncertain;
+                            v.assessment.rgb_pad = PadEvidence::NotApplicable;
+                            v.assessment.ir_pad = failure;
+                            if route > 0 {
+                                v.assessment.signals.rgb_face = None;
+                            }
+                            v.assessment.rgb_frame_mean = if route == 1 { 120.0 } else { 10.0 };
+                            if route == 3 {
+                                v.assessment.signals.rgb_face = Some(irlume_liveness::FaceBox {
+                                    cx: 0.5,
+                                    cy: 0.5,
+                                    score: 0.9,
+                                });
+                                v.assessment.rgb_pad = failure;
+                                v.assessment.ir_pad = PadEvidence::Score(0.1);
+                            }
+                        } else {
+                            // If the failure is swallowed, later evidence can reach
+                            // the independent dark identity route without RGB votes.
+                            v.assessment.signals = Signals {
+                                ir_face: v.assessment.signals.ir_face,
+                                ir_face_brightness: 90.0,
+                                ir_center_edge_ratio: 1.2,
+                                ir_eye_glint: Some(220.0),
+                                ir_ceiling_known: true,
+                                ir_saturated_frac: Some(0.0),
+                                ..Signals::default()
+                            };
+                            v.assessment.verdict = Verdict::Uncertain;
+                            v.assessment.rgb_pad = PadEvidence::NotApplicable;
+                            v.assessment.rgb_frame_mean = 10.0;
+                        }
+                        Ok(v)
+                    },
+                    |_, v| {
+                        identities.set(identities.get() + 1);
+                        Ok(v.assessment)
+                    },
+                    Instant::now,
+                )
+                .unwrap();
+            assert_eq!(identities.get(), 0, "route={route}, failure={failure:?}");
+            assert_eq!(
+                assessed.get(),
+                1,
+                "required failure must terminate the batch"
+            );
+            let PreparedGroup::Refused(out) = result else {
+                panic!("failure reached final identity")
+            };
+            assert_eq!(out.kind, OutcomeKind::OtherDeny);
+            assert!(!presence_retryable(&out));
+            assert!(s.engine.vit_scores.is_empty());
+        }
+    }
+}
+
+#[test]
+fn grouped_deadline_facts_are_current_or_empty_before_any_assessment() {
+    let _guard = env_guard();
+    let mut s = shared();
+    for expire_after in [0, 1, 2] {
+        s.engine.last_attempt_facts = AttemptFacts {
+            rgb_face: Some((0.9, 0.9)),
+            face_frac: 0.2,
+            ..AttemptFacts::default()
+        };
+        let start = Instant::now();
+        let deadline = start + Duration::from_secs(15);
+        let clock = Cell::new(if expire_after == 0 { deadline } else { start });
+        let result = s
+            .engine
+            .evaluate_grouped_samples_with(
+                (0..5).collect(),
+                deadline,
+                |e, i| {
+                    let mut v = sample(e, i, 0.2);
+                    v.assessment.signals.face_frac = 0.2;
+                    v.assessment.signals.rgb_face_brightness = 150.0;
+                    v.assessment.signals.head_yaw_asym =
+                        if i + 1 == expire_after { 1.0 } else { 0.0 };
+                    if i + 1 == expire_after {
+                        clock.set(deadline);
+                    }
+                    Ok(v)
+                },
+                |_, _| panic!("expired group reached identity"),
+                || clock.get(),
+            )
+            .unwrap();
+        let PreparedGroup::Refused(out) = result else {
+            panic!("expired group admitted")
+        };
+        assert_eq!(
+            auth_attempt_situation(out.kind, &s.engine.last_attempt_facts),
+            if expire_after == 0 {
+                AttemptSituation::NoFace
+            } else {
+                AttemptSituation::LookingAway
+            }
+        );
+    }
+}
+
+fn measured_sequential_configuration() -> CaptureModeSelection {
+    CaptureModeSelection {
+        sequential: true,
+        source: STORED_CAPTURE_MODE_SOURCE,
+        runtime_key: Some("fixture".into()),
+        runtime_contract: None,
+        qualification_state: irlume_common::diagnostics::QualificationState::MeasuredSequential,
+        qualification_reason: None,
+        authoritative_rate_shortfalls: None,
+        latest_attempt_rate_shortfalls: None,
+        operation_demoted: Cell::new(false),
+    }
+}
+
+#[test]
+fn grouped_eligibility_keeps_service_and_purpose_scope_despite_long_override() {
+    let _guard = env_guard();
+    let saved = std::env::var_os("IRLUME_GRACE_MS");
+    std::env::set_var("IRLUME_GRACE_MS", "30000");
+    let mode = measured_sequential_configuration();
+    let mut results = Vec::new();
+    for (service, expected) in [
+        (Some("login"), true),
+        (Some("swaylock"), true),
+        (None, true),
+        (Some("unknown-local-service"), true),
+        (Some(" sudo "), false),
+        (Some("su"), false),
+        (Some("doas"), false),
+        (Some("polkit-1"), false),
+        (Some("sshd"), false),
+    ] {
+        for purpose in [
+            AuthenticationPurpose::Verify,
+            AuthenticationPurpose::AppConsent,
+            AuthenticationPurpose::CredentialRelease {
+                temporal_challenge: false,
+            },
+            AuthenticationPurpose::CredentialRelease {
+                temporal_challenge: true,
+            },
+        ] {
+            let actual = crate::grouped_auth::eligible_configuration(
+                &mode,
+                true,
+                true,
+                true,
+                grace_window_ms(service),
+                purpose,
+                service,
+            );
+            results.push((
+                service,
+                purpose,
+                actual,
+                expected && purpose == AuthenticationPurpose::Verify,
+            ));
+        }
+    }
+    match saved {
+        Some(v) => std::env::set_var("IRLUME_GRACE_MS", v),
+        None => std::env::remove_var("IRLUME_GRACE_MS"),
+    }
+    for (service, purpose, actual, expected) in results {
+        assert_eq!(actual, expected, "service={service:?}, purpose={purpose:?}");
+    }
+}
+
+#[test]
+fn grouped_eligibility_requires_qualification_models_budget_and_exact_contract() {
+    use irlume_common::diagnostics::QualificationState;
+    let check = |mode: &CaptureModeSelection, ir, rgb_pad, ir_pad, window| {
+        crate::grouped_auth::eligible_configuration(
+            mode,
+            ir,
+            rgb_pad,
+            ir_pad,
+            window,
+            AuthenticationPurpose::Verify,
+            Some("login"),
+        )
+    };
+    let mut mode = measured_sequential_configuration();
+    assert!(check(&mode, true, true, true, 15000));
+    assert!(check(&mode, true, true, true, 30000));
+    for (ir, rgb_pad, ir_pad, window) in [
+        (false, true, true, 15000),
+        (true, false, true, 15000),
+        (true, true, false, 15000),
+        (true, true, true, 14999),
+    ] {
+        assert!(!check(&mode, ir, rgb_pad, ir_pad, window));
+    }
+    assert!(
+        !crate::grouped_auth::eligible(
+            &mode,
+            true,
+            true,
+            true,
+            15000,
+            AuthenticationPurpose::Verify,
+            Some("login")
+        ),
+        "configuration cannot manufacture a runtime contract"
+    );
+    mode.sequential = false;
+    assert!(!check(&mode, true, true, true, 15000));
+    mode.sequential = true;
+    mode.source = ENV_CAPTURE_MODE_SOURCE;
+    assert!(!check(&mode, true, true, true, 15000));
+    mode.source = STORED_CAPTURE_MODE_SOURCE;
+    mode.qualification_state = QualificationState::QualifiedConcurrent;
+    assert!(!check(&mode, true, true, true, 15000));
+    mode.qualification_state = QualificationState::MeasuredSequential;
+    mode.operation_demoted.set(true);
+    assert!(!check(&mode, true, true, true, 15000));
+}
+
+#[test]
+fn grouped_missing_face_not_applicable_is_retryable_before_valid_dark_identity() {
+    let _guard = env_guard();
+    let mut s = shared();
+    for rgb_present in [false, true] {
+        let assessed = Cell::new(0);
+        let identities = Cell::new(0);
+        let result = s
+            .engine
+            .evaluate_grouped_samples_with(
+                (0..5).collect(),
+                Instant::now() + Duration::from_secs(15),
+                |e, i| {
+                    assessed.set(assessed.get() + 1);
+                    let mut v = sample(e, i, 0.2);
+                    v.assessment.verdict = Verdict::Uncertain;
+                    v.assessment.rgb_pad = PadEvidence::NotApplicable;
+                    v.assessment.ir_pad = PadEvidence::NotApplicable;
+                    if !rgb_present {
+                        v.assessment.signals.rgb_face = None;
+                    }
+                    if i == 4 {
+                        v.assessment.signals = Signals {
+                            ir_face: Some(irlume_liveness::FaceBox {
+                                cx: 0.5,
+                                cy: 0.5,
+                                score: 0.9,
+                            }),
+                            ir_face_brightness: 90.0,
+                            ir_center_edge_ratio: 1.2,
+                            ir_eye_glint: Some(220.0),
+                            ir_ceiling_known: true,
+                            ir_saturated_frac: Some(0.0),
+                            ..Signals::default()
+                        };
+                        v.assessment.ir_pad = PadEvidence::Score(0.1);
+                        v.assessment.rgb_frame_mean = 10.0;
+                    }
+                    Ok(v)
+                },
+                |_, mut v| {
+                    identities.set(identities.get() + 1);
+                    assert_eq!(v.identity.0, 4);
+                    v.assessment.ir_embedding = Some(v.identity.1.to_vec());
+                    Ok(v.assessment)
+                },
+                Instant::now,
+            )
+            .unwrap();
+        assert_eq!(assessed.get(), 5);
+        assert_eq!(identities.get(), 1);
+        let PreparedGroup::Ready(a) = result else {
+            panic!("missing face permanently denied later dark evidence")
+        };
+        let (mut enr, _) = pad_matching_fixture(0.2, false);
+        enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+        let prior_ir = s.engine.ir_available;
+        s.engine.ir_available = true;
+        let out = s
+            .engine
+            .authenticate_qualified_assessment(
+                &enr,
+                AuthenticationPurpose::Verify,
+                Some("login"),
+                *a,
+                &(),
+            )
+            .unwrap();
+        s.engine.ir_available = prior_ir;
+        s.engine.vit_scores.clear();
+        assert!(out.granted, "{}", out.reason);
+    }
+}

--- a/crates/irlume-auth/src/grouped_auth.rs
+++ b/crates/irlume-auth/src/grouped_auth.rs
@@ -1,0 +1,292 @@
+//! Bounded sequential evidence evaluation. Unfinished identity inputs remain
+//! private and only the final admissible sample can reach identity inference.
+
+use super::*;
+use std::time::Instant;
+
+pub(super) enum PreparedGroup {
+    Ready(Box<Assessment>),
+    Refused(Outcome),
+}
+
+pub(super) fn eligible(
+    mode: &CaptureModeSelection,
+    has_ir: bool,
+    has_rgb_pad: bool,
+    has_ir_pad: bool,
+    window: u64,
+    purpose: AuthenticationPurpose,
+    service: Option<&str>,
+) -> bool {
+    mode.runtime_contract.is_some()
+        && eligible_configuration(
+            mode,
+            has_ir,
+            has_rgb_pad,
+            has_ir_pad,
+            window,
+            purpose,
+            service,
+        )
+}
+
+// Keep exact runtime authority in the outer gate; this policy decision is
+// testable without manufacturing camera contracts or widening their API.
+pub(super) fn eligible_configuration(
+    mode: &CaptureModeSelection,
+    has_ir: bool,
+    has_rgb_pad: bool,
+    has_ir_pad: bool,
+    window: u64,
+    purpose: AuthenticationPurpose,
+    service: Option<&str>,
+) -> bool {
+    // Unknown/absent services deliberately share the login eligibility default.
+    // A budget override cannot opt elevation, app consent or release into it.
+    purpose == AuthenticationPurpose::Verify
+        && matches!(
+            service.and_then(irlume_common::pam_service::classify),
+            None | Some(
+                irlume_common::pam_service::ServiceKind::Greeter
+                    | irlume_common::pam_service::ServiceKind::ScreenUnlock
+            )
+        )
+        && mode.is_sequential()
+        && mode.source == STORED_CAPTURE_MODE_SOURCE
+        && !mode.operation_demoted.get()
+        && mode.qualification_state
+            == irlume_common::diagnostics::QualificationState::MeasuredSequential
+        && has_ir
+        && has_rgb_pad
+        && has_ir_pad
+        && window >= GRACE_WINDOW_MS
+}
+
+fn expired() -> Outcome {
+    Outcome::deny(
+        OutcomeKind::OtherDeny,
+        "authentication window expired while collecting complete face evidence; use your password",
+    )
+}
+
+impl Engine {
+    fn begin_grouped_attempt(&mut self) {
+        self.vit_scores.clear();
+        self.last_attempt_facts = AttemptFacts::default();
+    }
+
+    /// Pre-identity gates use detected face presence, never missing embeddings
+    /// from an unfinished assessment. Final admission repeats its existing gates.
+    fn grouped_evidence_refusal(&self, a: &Assessment) -> Option<Outcome> {
+        let rgb = a.signals.rgb_face.is_some();
+        let ir = a.signals.ir_face.is_some();
+        // Actual required execution failures are terminal even when scene or
+        // liveness evidence would otherwise invite another sample. Missing
+        // faces can legitimately produce NotApplicable; optional dark RGB
+        // evidence must not become a new requirement.
+        for (modality, required, evidence) in [
+            (PadModality::Rgb, rgb, a.rgb_pad),
+            (PadModality::Ir, rgb || ir, a.ir_pad),
+        ] {
+            if !required {
+                continue;
+            }
+            let failure = match evidence {
+                PadEvidence::Unavailable | PadEvidence::InferenceFailed => Some(evidence),
+                PadEvidence::Score(p) if !p.is_finite() => Some(PadEvidence::InferenceFailed),
+                _ => None,
+            };
+            if let Some(failure) = failure {
+                return pad_evidence_refusal(modality, failure);
+            }
+        }
+        if uncertain_short_circuits(a.verdict, rgb, ir) || (rgb && a.verdict != Verdict::Live) {
+            return Some(Outcome::deny(
+                liveness_deny_kind(a.verdict, &a.reason),
+                format!("liveness {:?}: {}", a.verdict, a.reason),
+            ));
+        }
+        if rgb {
+            return pad_policy_refusal(PadRequirements::RgbAndIr, a.rgb_pad, a.ir_pad);
+        }
+        if !ir {
+            return Some(Outcome::deny(OutcomeKind::NoFace, "no face detected"));
+        }
+        // Preserve the independent dark route, including scene and IR PAD
+        // gates, without spending an identity comparison on intermediate frames.
+        if scene_conclusively_lit(a.rgb_frame_mean) {
+            return Some(Outcome::deny(
+                OutcomeKind::Uncertain,
+                "the room is lit but no face is visible to the RGB camera; dark (IR-only) authentication requires a dark room — add light so the RGB camera can see you, or use your password",
+            ));
+        }
+        let (verdict, _, reason) = self.gate.evaluate_ir_only(&a.signals);
+        if verdict != Verdict::Live {
+            return Some(Outcome::deny(
+                liveness_deny_kind(verdict, &reason),
+                format!("dark liveness {verdict:?}: {reason}"),
+            ));
+        }
+        if let Some(refusal) = pad_policy_refusal(PadRequirements::IrOnly, a.rgb_pad, a.ir_pad) {
+            return Some(refusal);
+        }
+        if pad_downgrades(verdict, a.shipped_ir_fake, IR_PAD_THRESHOLD) {
+            return Some(Outcome::deny(
+                OutcomeKind::Spoof,
+                "dark liveness: IR PAD cue flags a spoof; use your password",
+            ));
+        }
+        None
+    }
+
+    /// Clock and inference boundaries are replaceable for behavioral tests;
+    /// PAD qualification and readiness decisions remain production code.
+    pub(super) fn evaluate_grouped_samples_with<T, I>(
+        &mut self,
+        samples: Vec<T>,
+        deadline: Instant,
+        mut assess: impl FnMut(&mut Self, T) -> irlume_common::Result<DeferredAssessment<I>>,
+        mut materialize: impl FnMut(
+            &mut Self,
+            DeferredAssessment<I>,
+        ) -> irlume_common::Result<Assessment>,
+        now: impl Fn() -> Instant,
+    ) -> irlume_common::Result<PreparedGroup> {
+        self.begin_grouped_attempt();
+        // The closure makes all errors and refusals share the evidence reset.
+        let result = (|| {
+            if samples.len() != VIT_PAD_VOTE_N {
+                return Err(irlume_common::Error::Hardware(
+                    "incomplete grouped evidence".into(),
+                ));
+            }
+            for (index, sample) in samples.into_iter().enumerate() {
+                self.note_capture_boundary();
+                if now() >= deadline {
+                    return Ok(PreparedGroup::Refused(expired()));
+                }
+                let mut evidence = assess(self, sample)?;
+                self.last_attempt_facts = AttemptFacts::from_assessment(&evidence.assessment);
+                if now() >= deadline {
+                    return Ok(PreparedGroup::Refused(expired()));
+                }
+                // Grouped capture always separates the RGB and IR phases,
+                // including gaps inside the legacy concurrent skew ceiling.
+                // Preserve this identity requirement before deferred inputs can
+                // materialize; the legacy single-pair classifier is unchanged.
+                evidence.assessment.sequential_pair |=
+                    evidence.assessment.signals.rgb_face.is_some();
+                self.qualify_rgb_pad_evidence(&mut evidence.assessment);
+                let final_sample = index + 1 == VIT_PAD_VOTE_N;
+                if let Some(outcome) = self.grouped_evidence_refusal(&evidence.assessment) {
+                    if final_sample || !presence_retryable(&outcome) {
+                        return Ok(PreparedGroup::Refused(outcome));
+                    }
+                    continue;
+                }
+                if final_sample {
+                    if now() >= deadline {
+                        return Ok(PreparedGroup::Refused(expired()));
+                    }
+                    let assessment = materialize(self, evidence)?;
+                    if now() >= deadline {
+                        return Ok(PreparedGroup::Refused(expired()));
+                    }
+                    return Ok(PreparedGroup::Ready(Box::new(assessment)));
+                }
+                // Dropping unfinished inputs here performs no identity work.
+            }
+            Err(irlume_common::Error::Hardware(
+                "group ended without final evidence".into(),
+            ))
+        })();
+        if !matches!(result, Ok(PreparedGroup::Ready(_))) {
+            self.vit_scores.clear();
+        }
+        result
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "mirrors the existing scoped authentication attempt"
+    )]
+    pub(super) fn authenticate_grouped_once(
+        &mut self,
+        enr: &irlume_core::storage::Enrollment,
+        purpose: AuthenticationPurpose,
+        service: Option<&str>,
+        cameras: &(irlume_camera::RgbCamera, irlume_camera::IrCamera),
+        mode: &CaptureModeSelection,
+        deadline: Instant,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        self.begin_grouped_attempt();
+        if Instant::now() >= deadline {
+            return Ok(expired());
+        }
+        let contract = mode.runtime_contract.as_ref().ok_or_else(|| {
+            irlume_common::Error::Hardware(
+                "grouped capture requires an exact runtime contract".into(),
+            )
+        })?;
+        let progress = self.capture_progress();
+        let started = Instant::now();
+        let samples = irlume_camera::capture_sequential_batch_with_progress(
+            &cameras.0,
+            &cameras.1,
+            contract,
+            irlume_camera::SequentialBatchRequest {
+                pairs: VIT_PAD_VOTE_N,
+                pair_gap_limit: SEQUENTIAL_MAX_CROSS_SPECTRUM_SKEW,
+                deadline,
+            },
+            &progress,
+        )?;
+        irlume_common::dlog!(
+            "[assessment-stage] grouped-capture: pairs={} elapsed={}ms",
+            samples.len(),
+            started.elapsed().as_millis()
+        );
+        let prepared = self.evaluate_grouped_samples_with(
+            samples,
+            deadline,
+            |engine, (rgb, ir, stats)| {
+                let detected = engine.detect_rgb_assessment(&rgb, None, diagnostics)?;
+                engine
+                    .assess_captured_pair(
+                        rgb,
+                        ir,
+                        stats,
+                        detected,
+                        PairAssessmentContext {
+                            sequential: true,
+                            pair_sequential_retried: false,
+                            rgb_hard_retried: false,
+                            held_sessions: false,
+                            ir_ms: None,
+                            diagnostics,
+                        },
+                    )
+                    .map_err(CapturePathError::into_inner)
+            },
+            |engine, evidence| engine.materialize_pair_identity(evidence),
+            Instant::now,
+        )?;
+        match prepared {
+            PreparedGroup::Refused(outcome) => Ok(outcome),
+            PreparedGroup::Ready(a) => {
+                if Instant::now() >= deadline {
+                    self.vit_scores.clear();
+                    return Ok(expired());
+                }
+                let outcome =
+                    self.authenticate_qualified_assessment(enr, purpose, service, *a, diagnostics);
+                self.vit_scores.clear();
+                if Instant::now() >= deadline {
+                    return Ok(expired());
+                }
+                outcome
+            }
+        }
+    }
+}

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -188,6 +188,33 @@ pub struct Assessment {
     pub sequential_pair: bool,
 }
 
+// An unfinished assessment cannot enter the public identity-admission boundary.
+// Its identity inputs carry actual detected faces, not placeholder embeddings.
+mod grouped_auth;
+
+struct DeferredAssessment<I> {
+    assessment: Assessment,
+    identity: I,
+}
+
+struct IdentityImage {
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
+    face: Detection,
+}
+
+type PairIdentity = (Option<IdentityImage>, Option<IdentityImage>);
+
+struct PairAssessmentContext<'a> {
+    sequential: bool,
+    pair_sequential_retried: bool,
+    rgb_hard_retried: bool,
+    held_sessions: bool,
+    ir_ms: Option<u128>,
+    diagnostics: &'a dyn irlume_common::diagnostics::DiagnosticSink,
+}
+
 /// The authentication decision for a user.
 // Debug is diagnostic-only (tests, dlog); derives add no behavior.
 #[derive(Debug)]
@@ -4317,7 +4344,7 @@ impl Engine {
         // switch, missing node) fails again with the same error. Logged so a
         // silent retry can't make the timing lines below lie about a slow login.
         let mut rgb_hard_retried = pair_sequential_retried;
-        let mut rgb = match rgb_res {
+        let rgb = match rgb_res {
             Ok(f) => f,
             // Standalone reopen is only safe when THIS call opened one-shot:
             // with held sessions the device queue belongs to the caller's
@@ -4337,8 +4364,46 @@ impl Engine {
             }
             Err(e) => return Err(e.into()),
         };
+        let (rgb_faces, rgb_top) = self.detect_rgb_assessment(&rgb, Some(rgb_ms), diagnostics)?;
+
+        // `None` = sequential mode skipped IR after an RGB fault; the RGB `?`
+        // above already returned, so reaching here with `None` is unreachable,
+        // but capture alone rather than unwrap to stay panic-free.
+        let (ir, ir_stats) = match ir_res {
+            Ok(Some(f)) => f,
+            Ok(None) => irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?,
+            Err(e) if !held_sessions && !pair_sequential_retried => {
+                irlume_common::dlog!("assess: ir capture retry (concurrent failed: {e})");
+                irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let evidence = self.assess_captured_pair(
+            rgb,
+            ir,
+            ir_stats,
+            (rgb_faces, rgb_top),
+            PairAssessmentContext {
+                sequential,
+                pair_sequential_retried,
+                rgb_hard_retried,
+                held_sessions,
+                ir_ms: Some(ir_ms),
+                diagnostics,
+            },
+        )?;
+        self.materialize_pair_identity(evidence)
+            .map_err(CapturePathError::from)
+    }
+
+    fn detect_rgb_assessment(
+        &mut self,
+        rgb: &irlume_camera::Frame,
+        rgb_ms: Option<u128>,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<(Vec<Detection>, Option<Detection>)> {
         let rgb_detection_started = std::time::Instant::now();
-        let mut rgb_faces = self.det.detect(&align::RgbView {
+        let rgb_faces = self.det.detect(&align::RgbView {
             data: &rgb.data,
             width: rgb.width,
             height: rgb.height,
@@ -4349,8 +4414,10 @@ impl Engine {
                 .unwrap_or(u64::MAX),
         });
         let mut rgb_top = top_detection(&rgb_faces).cloned();
+        let capture_timing =
+            rgb_ms.map_or_else(|| "from grouped capture".into(), |ms| format!("in {ms}ms"));
         irlume_common::dlog!(
-            "assess: rgb {}x{} in {rgb_ms}ms, faces={} top-det={:.2}",
+            "assess: rgb {}x{} {capture_timing}, faces={} top-det={:.2}",
             rgb.width,
             rgb.height,
             rgb_faces.len(),
@@ -4367,18 +4434,26 @@ impl Engine {
             );
         }
 
-        // `None` = sequential mode skipped IR after an RGB fault; the RGB `?`
-        // above already returned, so reaching here with `None` is unreachable,
-        // but capture alone rather than unwrap to stay panic-free.
-        let (ir, ir_stats) = match ir_res {
-            Ok(Some(f)) => f,
-            Ok(None) => irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?,
-            Err(e) if !held_sessions && !pair_sequential_retried => {
-                irlume_common::dlog!("assess: ir capture retry (concurrent failed: {e})");
-                irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?
-            }
-            Err(e) => return Err(e.into()),
-        };
+        Ok((rgb_faces, rgb_top))
+    }
+
+    fn assess_captured_pair(
+        &mut self,
+        mut rgb: irlume_camera::Frame,
+        ir: irlume_camera::Frame,
+        ir_stats: irlume_camera::IrCaptureStats,
+        (mut rgb_faces, mut rgb_top): (Vec<Detection>, Option<Detection>),
+        context: PairAssessmentContext<'_>,
+    ) -> Result<DeferredAssessment<PairIdentity>, CapturePathError> {
+        let PairAssessmentContext {
+            sequential,
+            pair_sequential_retried,
+            rgb_hard_retried,
+            held_sessions,
+            ir_ms,
+            diagnostics,
+        } = context;
+        let progress = self.capture_progress();
         let ir_grey_rgb = irlume_camera::grey_to_rgb(&ir.data);
         let ir_view = align::RgbView {
             data: &ir_grey_rgb,
@@ -4393,8 +4468,10 @@ impl Engine {
                 .unwrap_or(u64::MAX),
         });
         let mut ir_top = top_detection(&ir_faces).cloned();
+        let capture_timing =
+            ir_ms.map_or_else(|| "from grouped capture".into(), |ms| format!("in {ms}ms"));
         irlume_common::dlog!(
-            "assess: ir {}x{} in {ir_ms}ms, faces={} top-det={:.2}",
+            "assess: ir {}x{} {capture_timing}, faces={} top-det={:.2}",
             ir.width,
             ir.height,
             ir_faces.len(),
@@ -4530,7 +4607,7 @@ impl Engine {
                     verdict: irlume_common::diagnostics::TraceVerdict::Uncertain,
                     measurements,
                 });
-                return Ok(Assessment {
+                return Ok(DeferredAssessment { assessment: Assessment {
                     verdict: Verdict::Uncertain,
                     rgb_frame_mean: irlume_camera::frame_mean(&rgb.data),
                     reason: format!(
@@ -4548,7 +4625,7 @@ impl Engine {
                     rgb_pad: PadEvidence::NotApplicable,
                     ir_pad: PadEvidence::NotApplicable,
                     sequential_pair: false, // rejected pair: no pair survives
-                });
+                }, identity: (None, None) });
             }
         };
         if stale_pair_reason.is_some() {
@@ -4742,39 +4819,12 @@ impl Engine {
             verdict, &signals,
         ));
 
-        // Rebuild the view against the final RGB frame (it may have been
-        // recaptured by the cross-spectrum self-heal above).
-        let rgb_view = align::RgbView {
-            data: &rgb.data,
-            width: rgb.width,
-            height: rgb.height,
-        };
-        let embedding = match &rgb_top {
-            Some(f) => {
-                let chip = align::align_to_arcface(&rgb_view, &f.landmarks)?;
-                Some(self.emb.embed_tta(&chip)?) // TTA flip-average (RGB only; cuts FRR)
-            }
-            None => None,
-        };
-        // IR-face embedding (for dark operation): align + embed the IR image,
-        // then apply the domain-adaptation adapter if loaded.
-        let ir_embedding = match &ir_top {
-            Some(f) => {
-                let chip = align::align_to_arcface(&ir_view, &f.landmarks)?;
-                let raw = self.emb.embed(&chip)?;
-                Some(match &mut self.ir_adapter {
-                    Some(a) => a.apply(&raw)?,
-                    None => raw.to_vec(),
-                })
-            }
-            None => None,
-        };
-        Ok(Assessment {
+        let assessment = Assessment {
             verdict,
             reason,
-            embedding,
+            embedding: None,
             rgb_frame_mean: irlume_camera::frame_mean(&rgb.data),
-            ir_embedding,
+            ir_embedding: None,
             signals,
             ir_center_edge_ratio,
             ir_brightness,
@@ -4792,7 +4842,70 @@ impl Engine {
             // ceiling: the bursts ran as separated one-shots (ADR-0014). Such
             // pairs defer the RGB-primary grant (rgb_primary_grant_admissible).
             sequential_pair: pair_admitted_sequentially(skew, rgb_top.is_some()),
+        };
+        Ok(DeferredAssessment {
+            assessment,
+            identity: (
+                rgb_top.map(|face| IdentityImage {
+                    data: rgb.data,
+                    width: rgb.width,
+                    height: rgb.height,
+                    face,
+                }),
+                ir_top.map(|face| IdentityImage {
+                    data: ir_grey_rgb,
+                    width: ir.width,
+                    height: ir.height,
+                    face,
+                }),
+            ),
         })
+    }
+
+    fn materialize_pair_identity(
+        &mut self,
+        evidence: DeferredAssessment<PairIdentity>,
+    ) -> irlume_common::Result<Assessment> {
+        let DeferredAssessment {
+            mut assessment,
+            identity: (rgb, ir),
+        } = evidence;
+        let started = std::time::Instant::now();
+        assessment.embedding = match rgb {
+            Some(image) => {
+                let view = align::RgbView {
+                    data: &image.data,
+                    width: image.width,
+                    height: image.height,
+                };
+                let chip = align::align_to_arcface(&view, &image.face.landmarks)?;
+                Some(self.emb.embed_tta(&chip)?)
+            }
+            None => None,
+        };
+        let rgb_embedding_ms = started.elapsed().as_millis();
+        let started = std::time::Instant::now();
+        assessment.ir_embedding = match ir {
+            Some(image) => {
+                let view = align::RgbView {
+                    data: &image.data,
+                    width: image.width,
+                    height: image.height,
+                };
+                let chip = align::align_to_arcface(&view, &image.face.landmarks)?;
+                let raw = self.emb.embed(&chip)?;
+                Some(match &mut self.ir_adapter {
+                    Some(a) => a.apply(&raw)?,
+                    None => raw.to_vec(),
+                })
+            }
+            None => None,
+        };
+        irlume_common::dlog!(
+            "[assessment-stage] embeddings: rgb={rgb_embedding_ms}ms ir={}ms",
+            started.elapsed().as_millis()
+        );
+        Ok(assessment)
     }
 
     /// Capture a temporal IR sequence and record per-frame HEAD POSE (pitch and
@@ -5373,6 +5486,20 @@ impl Engine {
             );
         }
         let sequential = capture_mode.is_sequential();
+        let grouped = grouped_auth::eligible(
+            &capture_mode,
+            self.ir_available,
+            self.has_vit_pad(),
+            self.has_pad_ir(),
+            window,
+            purpose,
+            service,
+        );
+        let (grouped_cams, resolved_cams) = if grouped {
+            (resolved_cams, None)
+        } else {
+            (None, resolved_cams)
+        };
         let held_cams = cameras_for_held_pair(sequential, resolved_cams);
         // Resolve enrollment before streaming. A loader wait can exceed a
         // camera queue's capacity; no stream may be armed across this wait.
@@ -5417,6 +5544,33 @@ impl Engine {
             if let Some(outcome) = self.enrollment_policy_refusal(user, &enr) {
                 return Ok(outcome);
             }
+        }
+        if let Some(cameras) = grouped_cams {
+            let mut costliest_attempt = std::time::Duration::ZERO;
+            return self
+                .authentication_attempt_loop_with(
+                    deadline,
+                    window,
+                    &mut costliest_attempt,
+                    |engine| {
+                        (
+                            Self::run_camera_operation(&camera_operation, || {
+                                engine.authenticate_grouped_once(
+                                    &enr,
+                                    purpose,
+                                    service,
+                                    &cameras,
+                                    &capture_mode,
+                                    deadline,
+                                    diagnostics,
+                                )
+                            }),
+                            false,
+                        )
+                    },
+                    std::time::Instant::now,
+                )
+                .0;
         }
         if held_cams.is_none() || !self.ir_available {
             drop(held_cams);
@@ -5676,6 +5830,17 @@ impl Engine {
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> irlume_common::Result<Outcome> {
         self.qualify_rgb_pad_evidence(&mut a);
+        self.authenticate_qualified_assessment(enr, purpose, service, a, diagnostics)
+    }
+
+    fn authenticate_qualified_assessment(
+        &mut self,
+        enr: &irlume_core::storage::Enrollment,
+        purpose: AuthenticationPurpose,
+        service: Option<&str>,
+        a: Assessment,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
         // An unreadable frame is reported as unreadable before anything derived
         // from it is consulted. Uncertain is the only verdict this promotes; a
         // Spoof still reaches its own branch below with its own reason.
@@ -10388,6 +10553,7 @@ mod pad_cue_tests {
 /// build (the 512-D recognizer session), so one instance is shared.
 #[cfg(test)]
 mod engine_tests {
+    mod grouped_tests;
     use super::tests::env_guard;
     use super::*;
     use irlume_core::storage::{CameraBinding, Enrollment, FaceProfile, FaceScan};

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -50,6 +50,8 @@ pub mod lease;
 mod lifecycle;
 mod media_graph;
 mod rate_gate;
+mod sequential_batch;
+pub use sequential_batch::{capture_sequential_batch_with_progress, SequentialBatchRequest};
 // Public for exactly one item, `pending_summary`, doctor's read-only view of
 // the store (#429); every record type stays crate-private so no other code
 // path grows a reader of these files.
@@ -9336,6 +9338,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    mod sequential_batch_tests {
+        include!("sequential_batch_tests.rs");
+    }
     /// #586: the round-continuity verdict is four nameable conditions; the
     /// classifier must pick the right one, in check order, for every shape.
     #[test]

--- a/crates/irlume-camera/src/sequential_batch.rs
+++ b/crates/irlume-camera/src/sequential_batch.rs
@@ -1,0 +1,145 @@
+use super::{Frame, IrCamera, IrCaptureStats, Progress, RgbCamera, RuntimePairContract};
+use irlume_common::{Error, Result};
+use std::time::{Duration, Instant};
+
+/// Bounds for one all-or-nothing sequential capture batch.
+#[derive(Clone, Copy, Debug)]
+pub struct SequentialBatchRequest {
+    /// Number of fresh pairs, from one through five.
+    pub pairs: usize,
+    /// Maximum allowed separation between corresponding RGB and IR windows.
+    pub pair_gap_limit: Duration,
+    /// Original operation deadline; capture never extends it.
+    pub deadline: Instant,
+}
+
+/// Collect bounded fresh sequential evidence using already negotiated cameras.
+///
+/// The caller owns the camera operation and qualification/security policy.
+/// RGB is fully released before IR starts. No recovery or partial batch reuse is
+/// performed. An in-flight bounded driver call cannot be interrupted, but an
+/// expired batch is never returned.
+///
+/// # Errors
+/// Returns an error on invalid count, capture/lease failure, invalid runtime
+/// contract, overlapping/out-of-order windows, excessive pair gap or deadline.
+pub fn capture_sequential_batch_with_progress(
+    rgb: &RgbCamera,
+    ir: &IrCamera,
+    contract: &RuntimePairContract,
+    request: SequentialBatchRequest,
+    progress: &Progress,
+) -> Result<Vec<(Frame, Frame, IrCaptureStats)>> {
+    capture_batch_with(
+        request,
+        contract,
+        (
+            || rgb.session_with_progress(progress),
+            |session| session.denoised(),
+        ),
+        (
+            || ir.session_with_startup(progress, super::IrSessionStartup::Adaptive),
+            |session| session.capture_with_stats(),
+        ),
+        Instant::now,
+        || {
+            rgb.lease
+                .require_endpoint(&rgb.device)
+                .and_then(|()| ir.lease.require_endpoint(&ir.device))
+                .map_err(|error| Error::Hardware(error.to_string()))
+        },
+    )
+}
+
+pub(super) fn capture_batch_with<R, I>(
+    request: SequentialBatchRequest,
+    contract: &RuntimePairContract,
+    rgb: (
+        impl FnOnce() -> Result<R>,
+        impl FnMut(&mut R) -> Result<Frame>,
+    ),
+    ir: (
+        impl FnOnce() -> Result<I>,
+        impl FnMut(&mut I) -> Result<(Frame, IrCaptureStats)>,
+    ),
+    now: impl Fn() -> Instant,
+    live: impl FnOnce() -> Result<()>,
+) -> Result<Vec<(Frame, Frame, IrCaptureStats)>> {
+    if !(1..=5).contains(&request.pairs) {
+        return Err(Error::Hardware(
+            "sequential batch requires one through five pairs".into(),
+        ));
+    }
+    let checkpoint = || {
+        if now() >= request.deadline {
+            Err(Error::Hardware("sequential batch deadline expired".into()))
+        } else {
+            Ok(())
+        }
+    };
+    // Each phase owns its stream, including all error/unwind paths. The first
+    // owner is dropped before the second opener can run; neither survives into
+    // validation or downstream inference.
+    let rgb = collect_phase(request.pairs, rgb, &checkpoint)?;
+    let ir = collect_phase(request.pairs, ir, &checkpoint)?;
+    checkpoint()?;
+    if rgb
+        .last()
+        .zip(ir.first())
+        .is_some_and(|(r, (i, _))| r.captured.end >= i.captured.start)
+    {
+        return Err(Error::Hardware(
+            "sequential batch capture phases overlap".into(),
+        ));
+    }
+    let mut pairs = Vec::with_capacity(request.pairs);
+    let mut previous: Option<(super::CaptureWindow, super::CaptureWindow)> = None;
+    for (r, (i, stats)) in rgb.into_iter().zip(ir) {
+        checkpoint()?;
+        contract.validate_pair(&r, &i).map_err(|error| {
+            Error::Hardware(format!("invalid sequential batch pair: {error:?}"))
+        })?;
+        let rw = r.captured;
+        let iw = i.captured;
+        if rw.start > rw.end
+            || iw.start > iw.end
+            || previous.is_some_and(|(pr, pi)| pr.end >= rw.start || pi.end >= iw.start)
+        {
+            return Err(Error::Hardware(
+                "sequential batch samples are not ordered and disjoint".into(),
+            ));
+        }
+        if rw.gap_to(iw) > request.pair_gap_limit {
+            return Err(Error::Hardware(
+                "sequential batch pair gap exceeds limit".into(),
+            ));
+        }
+        previous = Some((rw, iw));
+        checkpoint()?;
+        pairs.push((r, i, stats));
+    }
+    checkpoint()?;
+    live()?;
+    checkpoint()?;
+    Ok(pairs)
+}
+
+fn collect_phase<S, T>(
+    count: usize,
+    (open, mut capture): (impl FnOnce() -> Result<S>, impl FnMut(&mut S) -> Result<T>),
+    checkpoint: &impl Fn() -> Result<()>,
+) -> Result<Vec<T>> {
+    checkpoint()?;
+    let mut session = open()?;
+    checkpoint()?;
+    let mut samples = Vec::with_capacity(count);
+    for _ in 0..count {
+        checkpoint()?;
+        samples.push(capture(&mut session)?);
+        checkpoint()?;
+    }
+    checkpoint()?;
+    drop(session);
+    checkpoint()?;
+    Ok(samples)
+}

--- a/crates/irlume-camera/src/sequential_batch_tests.rs
+++ b/crates/irlume-camera/src/sequential_batch_tests.rs
@@ -1,0 +1,382 @@
+use super::*;
+use crate::sequential_batch::capture_batch_with;
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+struct Owner<'a> {
+    role: &'static str,
+    events: &'a RefCell<Vec<String>>,
+    now: &'a Cell<Instant>,
+    expire_on_drop: bool,
+    deadline: Instant,
+}
+
+impl Drop for Owner<'_> {
+    fn drop(&mut self) {
+        self.events
+            .borrow_mut()
+            .push(format!("{} close", self.role));
+        if self.expire_on_drop {
+            self.now.set(self.deadline);
+        }
+    }
+}
+
+struct BatchFixture {
+    request: SequentialBatchRequest,
+    now: Cell<Instant>,
+    events: RefCell<Vec<String>>,
+    rgb: VecDeque<Frame>,
+    ir: VecDeque<(Frame, IrCaptureStats)>,
+}
+
+impl BatchFixture {
+    fn new(count: usize) -> Self {
+        let base = Instant::now();
+        let mut rgb = VecDeque::new();
+        let mut ir = VecDeque::new();
+        for n in 0..count {
+            let mut r = runtime_gate_frame(
+                contracts::StreamRole::Rgb,
+                Spectrum::Rgb,
+                contracts::IlluminationProvenance::Unknown,
+                'a',
+                1,
+                *b"RGB3",
+                true,
+                false,
+            );
+            let mut i = runtime_gate_frame(
+                contracts::StreamRole::Ir,
+                Spectrum::Ir,
+                contracts::IlluminationProvenance::ActiveIr,
+                'a',
+                1,
+                *b"GREY",
+                true,
+                false,
+            );
+            // Script the public monotonic windows independently of wall time.
+            r.captured = CaptureWindow::at(base + Duration::from_millis(n as u64 * 100));
+            i.captured = CaptureWindow::at(base + Duration::from_millis(1000 + n as u64 * 100));
+            r.data[0] = n as u8;
+            i.data[0] = (10 + n) as u8;
+            rgb.push_back(r);
+            ir.push_back((i, stats((20 + n) as f32)));
+        }
+        Self {
+            request: SequentialBatchRequest {
+                pairs: count,
+                pair_gap_limit: Duration::from_secs(8),
+                deadline: base + Duration::from_secs(15),
+            },
+            now: Cell::new(base),
+            events: RefCell::new(Vec::new()),
+            rgb,
+            ir,
+        }
+    }
+
+    fn run(&mut self, fault: &str) -> irlume_common::Result<Vec<(Frame, Frame, IrCaptureStats)>> {
+        let events = &self.events;
+        let now = &self.now;
+        let deadline = self.request.deadline;
+        let open = |role| {
+            events.borrow_mut().push(format!("{role} open"));
+            if fault == format!("{role} open error") {
+                return Err(Error::Hardware("scripted open failure".into()));
+            }
+            if fault == format!("{role} open deadline") {
+                now.set(deadline);
+            }
+            Ok(Owner {
+                role,
+                events,
+                now,
+                deadline,
+                expire_on_drop: fault == format!("{role} close deadline"),
+            })
+        };
+        let validation_checkpoints = Cell::new(0);
+        capture_batch_with(
+            self.request,
+            &runtime_gate_contract(),
+            (
+                || open("rgb"),
+                |_: &mut Owner<'_>| {
+                    events.borrow_mut().push("rgb capture".into());
+                    if fault == "rgb capture error" && self.rgb.len() == 3 {
+                        return Err(Error::Hardware("scripted capture failure".into()));
+                    }
+                    assert_ne!(fault, "rgb panic", "scripted panic");
+                    if fault == "rgb capture deadline" {
+                        now.set(deadline);
+                    }
+                    Ok(self.rgb.pop_front().expect("bounded RGB capture"))
+                },
+            ),
+            (
+                || open("ir"),
+                |_: &mut Owner<'_>| {
+                    events.borrow_mut().push("ir capture".into());
+                    if fault == "ir capture error" && self.ir.len() == 3 {
+                        return Err(Error::Hardware("scripted capture failure".into()));
+                    }
+                    assert_ne!(fault, "ir panic", "scripted panic");
+                    if fault == "ir capture deadline" {
+                        now.set(deadline);
+                    }
+                    Ok(self.ir.pop_front().expect("bounded IR capture"))
+                },
+            ),
+            || {
+                // After IR closes, checkpoints cover phase completion, the
+                // whole batch, then before and after each pair validation.
+                if events.borrow().last().is_some_and(|e| e == "ir close") {
+                    validation_checkpoints.set(validation_checkpoints.get() + 1);
+                    if (fault == "validation deadline" && validation_checkpoints.get() == 3)
+                        || (fault == "validation after deadline"
+                            && validation_checkpoints.get() == 4)
+                    {
+                        now.set(deadline);
+                    }
+                }
+                now.get()
+            },
+            || {
+                events.borrow_mut().push("lease check".into());
+                if fault == "lease deadline" {
+                    now.set(deadline);
+                }
+                if fault == "lease stale" {
+                    Err(Error::Hardware("stale lease".into()))
+                } else {
+                    Ok(())
+                }
+            },
+        )
+    }
+}
+
+#[test]
+fn batch_preserves_order_stats_and_releases_both_sessions_before_return() {
+    for count in [1, 5] {
+        let mut fixture = BatchFixture::new(count);
+        let result = fixture.run("").expect("valid batch");
+        assert_eq!(result.len(), count);
+        for (n, (r, i, s)) in result.into_iter().enumerate() {
+            assert_eq!(
+                (r.data[0], i.data[0], s.lit_mean),
+                (n as u8, (10 + n) as u8, (20 + n) as f32)
+            );
+            assert_eq!(s.burst_frames, 8);
+        }
+        let events = fixture.events.borrow();
+        let rgb_close = events.iter().position(|e| e == "rgb close").unwrap();
+        let ir_open = events.iter().position(|e| e == "ir open").unwrap();
+        assert!(rgb_close < ir_open);
+        assert_eq!(&events[events.len() - 2..], ["ir close", "lease check"]);
+    }
+}
+
+#[test]
+fn batch_rejects_unbounded_count_before_open() {
+    for count in [0, 6, usize::MAX] {
+        let mut fixture = BatchFixture::new(0);
+        fixture.request.pairs = count;
+        assert!(fixture.run("").is_err());
+        assert!(fixture.events.borrow().is_empty());
+    }
+}
+
+#[test]
+fn batch_deadline_equality_prevents_open() {
+    let mut fixture = BatchFixture::new(5);
+    fixture.now.set(fixture.request.deadline);
+    assert!(fixture.run("").is_err());
+    assert!(fixture.events.borrow().is_empty());
+}
+
+#[test]
+fn batch_drops_owners_on_capture_errors_and_never_returns_partial_samples() {
+    for role in ["rgb", "ir"] {
+        let mut fixture = BatchFixture::new(5);
+        assert!(fixture.run(&format!("{role} capture error")).is_err());
+        assert_eq!(
+            fixture.events.borrow().last().unwrap(),
+            &format!("{role} close")
+        );
+        assert_eq!(
+            fixture
+                .events
+                .borrow()
+                .iter()
+                .filter(|e| **e == format!("{role} capture"))
+                .count(),
+            3
+        );
+        assert!(!fixture.events.borrow().iter().any(|e| e == "lease check"));
+    }
+}
+
+#[test]
+fn batch_drops_owners_on_panic() {
+    for role in ["rgb", "ir"] {
+        let mut fixture = BatchFixture::new(5);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            fixture.run(&format!("{role} panic"))
+        }));
+        assert!(result.is_err());
+        assert_eq!(
+            fixture.events.borrow().last().unwrap(),
+            &format!("{role} close")
+        );
+    }
+}
+
+#[test]
+fn batch_checks_deadline_after_open_capture_close_validation_and_lease() {
+    for fault in [
+        "rgb open deadline",
+        "ir open deadline",
+        "rgb capture deadline",
+        "ir capture deadline",
+        "rgb close deadline",
+        "ir close deadline",
+        "validation deadline",
+        "validation after deadline",
+        "lease deadline",
+    ] {
+        let mut fixture = BatchFixture::new(5);
+        assert!(fixture.run(fault).is_err(), "{fault}");
+        let events = fixture.events.borrow();
+        for role in ["rgb", "ir"] {
+            if events.contains(&format!("{role} open")) {
+                assert!(events.contains(&format!("{role} close")), "{fault}");
+            }
+        }
+        if fault == "rgb open deadline" {
+            assert!(!events.contains(&"rgb capture".into()));
+        }
+        if fault == "ir open deadline" {
+            assert!(!events.contains(&"ir capture".into()));
+        }
+        if fault.starts_with("rgb") {
+            assert!(!events.contains(&"ir open".into()));
+        }
+    }
+}
+
+#[test]
+fn batch_open_failure_stops_without_recovery() {
+    for role in ["rgb", "ir"] {
+        let mut fixture = BatchFixture::new(5);
+        assert!(fixture.run(&format!("{role} open error")).is_err());
+        assert_eq!(
+            fixture.events.borrow().last().unwrap(),
+            &format!("{role} open")
+        );
+    }
+}
+
+#[test]
+fn batch_rejects_lease_invalidation_after_successful_captures() {
+    let mut fixture = BatchFixture::new(5);
+    assert!(fixture.run("lease stale").is_err());
+    assert_eq!(fixture.events.borrow().last().unwrap(), "lease check");
+}
+
+#[test]
+fn batch_gap_limit_is_inclusive() {
+    let mut fixture = BatchFixture::new(5);
+    fixture.request.pair_gap_limit = Duration::from_secs(1);
+    assert!(fixture.run("").is_ok());
+    let mut fixture = BatchFixture::new(5);
+    fixture.request.pair_gap_limit = Duration::from_secs(1) - Duration::from_nanos(1);
+    assert!(fixture.run("").is_err());
+}
+
+#[test]
+fn batch_refuses_repeated_reversed_and_overlapping_windows() {
+    for role in ["rgb", "ir"] {
+        for offset in [0, 2] {
+            let mut fixture = BatchFixture::new(5);
+            if role == "rgb" {
+                fixture.rgb[3].captured = fixture.rgb[offset].captured;
+            } else {
+                fixture.ir[3].0.captured = fixture.ir[offset].0.captured;
+            }
+            assert!(fixture.run("").is_err());
+        }
+    }
+}
+
+#[test]
+fn batch_refuses_overlapping_phases_and_malformed_windows() {
+    let mut fixture = BatchFixture::new(5);
+    fixture.ir[0].0.captured = fixture.rgb[4].captured;
+    assert!(fixture.run("").is_err());
+    for role in ["rgb", "ir"] {
+        let mut fixture = BatchFixture::new(5);
+        let window = if role == "rgb" {
+            &mut fixture.rgb[2].captured
+        } else {
+            &mut fixture.ir[2].0.captured
+        };
+        window.start += Duration::from_nanos(1);
+        assert!(fixture.run("").is_err());
+
+        let mut fixture = BatchFixture::new(5);
+        if role == "rgb" {
+            fixture.rgb[2].captured.end = fixture.rgb[3].captured.start;
+        } else {
+            fixture.ir[2].0.captured.end = fixture.ir[3].0.captured.start;
+        }
+        assert!(fixture.run("").is_err());
+    }
+}
+
+#[test]
+fn batch_rejects_each_real_runtime_contract_failure() {
+    for role in [Spectrum::Rgb, Spectrum::Ir] {
+        for case in ["generation", "format", "rate", "continuity", "illumination"] {
+            if role == Spectrum::Rgb && case == "illumination" {
+                continue; // Active illumination is required only for IR.
+            }
+            let mut fixture = BatchFixture::new(5);
+            let mut invalid = runtime_gate_frame(
+                if role == Spectrum::Rgb {
+                    contracts::StreamRole::Rgb
+                } else {
+                    contracts::StreamRole::Ir
+                },
+                role,
+                if role == Spectrum::Rgb || case == "illumination" {
+                    contracts::IlluminationProvenance::Unknown
+                } else {
+                    contracts::IlluminationProvenance::ActiveIr
+                },
+                'a',
+                if case == "generation" { 2 } else { 1 },
+                if case == "format" {
+                    *b"Y16 "
+                } else if role == Spectrum::Rgb {
+                    *b"RGB3"
+                } else {
+                    *b"GREY"
+                },
+                case != "rate",
+                case == "continuity",
+            );
+            if role == Spectrum::Rgb {
+                invalid.captured = fixture.rgb[3].captured;
+                fixture.rgb[3] = invalid;
+            } else {
+                invalid.captured = fixture.ir[3].0.captured;
+                fixture.ir[3].0 = invalid;
+            }
+            assert!(fixture.run("").is_err(), "{role:?}: {case}");
+        }
+    }
+}

--- a/docs/research/2026-09-05-grouped-sequential-validation.md
+++ b/docs/research/2026-09-05-grouped-sequential-validation.md
@@ -1,0 +1,34 @@
+# Grouped sequential authentication validation
+
+Qualified sequential login/unlock captures five RGB samples, releases RGB, then
+captures five IR samples and releases IR. Every pair retains its exact runtime
+contract, delivered-rate/continuity evidence, active IR provenance and existing
+eight-second gap limit. Evidence is assessed in order; only the final eligible
+sample materializes identity and reaches the existing matcher. The five-score
+PAD rule, separated IR identity and 15-second login deadline remain enforced.
+Elevation, app consent, credential release and known remote services are excluded.
+
+The final combined source passed 1,978 workspace tests, zero failed and 101
+existing ignored, plus all-target Clippy and workspace rustdoc with warnings
+denied, formatting and diff checks. Fourteen grouped-auth tests and twelve camera
+collector tests cover the new path. Independent review found no new grouped/PAD
+correctness issue after the earlier four review findings were corrected.
+
+ASUS built-in RGB/IR isolated trials used temporary encrypted enrollment and the
+measured sequential qualification. Genuine grants took 12.044 seconds and then
+11.999, 11.982 and 12.015 seconds. In the adjacent recovery sequence, confirmed
+absence denied in 10.172 seconds with both cameras absent in all five samples,
+zero PAD samples and no identity-embedding timing event. Confirmed return granted
+in 11.844 seconds with five fresh PAD samples and one final embedding timing event.
+The same candidate and enrollment served both logins. An initial enrollment was
+retried after the user moved away before completion; both attempts were retained
+in local aggregate evidence. No installed enrollment/configuration/binary changed,
+and candidate/enrollment cleanup, camera release and installed service state were
+independently verified.
+
+These observations apply to the complete dependency chain. They are single-user,
+condition-specific observations, not a broad reliability result or end-to-end
+speedup benchmark. Dim-light validation was explicitly skipped and remains
+untested. No per-species APCER/BPCER study, installed-desktop unlock qualification,
+elevation qualification or spoof-resistance certification is claimed. Remote CI
+and MSRV lanes must run on the eventual PR commits.


### PR DESCRIPTION
## What & why

Qualified sequential login/unlock can spend its existing authentication window reopening streams before collecting a complete PAD vote. Collect five RGB samples, release RGB, then collect five IR samples and release IR. Assess the five pairs in order and materialize identity only for the final eligible sample.

Every pair retains its exact runtime contract, full-rate and continuity evidence, active IR provenance and the existing eight-second gap limit. The complete five-score PAD rule, required IR identity, independent dark-route gates and 15-second login deadline remain enforced. Grouping does not opt elevation, app consent, credential release or known remote services into this schedule.

This delta adds only the six grouped auth/camera source/test files relative to its declared parent. The camera lifecycle changes belong to the first PR. It also retains numeric capture/embedding duration diagnostics without recording frames, embeddings or identity scores.

## Testing

- [x] Final combined source: 1,978 workspace tests passed, zero failed, 101 existing ignored.
- [x] Workspace all-target Clippy and workspace rustdoc pass with warnings denied.
- [x] cargo fmt --all --check and diff checks pass.
- [x] Fourteen grouped-auth tests and twelve collector tests cover admission, identity, expiry, scope, reset, release and contract boundaries.
- [x] Independent final code review found no new grouped/PAD correctness issue.
- [x] Source-only patch series replays to the exact live-tested source.
- [x] ASUS isolated sequential trial: encrypted enrollment, genuine grants, no-face denial and return recovery completed with cleanup verified.
- [ ] Required remote CI/MSRV/hardware lanes on the eventual PR commits have not run.
- [ ] PAD per-species APCER/BPCER study not run; no spoof-resistance certification.

Observed final-candidate genuine logins: 12.044 seconds, then three repeats at 11.999/11.982/12.015 seconds. The adjacent recovery sequence denied with both cameras absent in 10.172 seconds, then granted after return in 11.844 seconds with five fresh PAD samples on the same candidate/enrollment. These are descriptive measurements; the camera-only baseline comparison is not an end-to-end authentication speedup claim.

Dim-light validation was explicitly skipped and remains untested. Installed desktop unlock, elevation and broad reliability remain outside these live results. No installed configuration, enrollment or binary was changed by the isolated trials.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>