### PR TITLE
perf: block idle ONNX workers between inferences

### DIFF
--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -246,11 +246,9 @@ mod onnx {
     use ort::session::{builder::GraphOptimizationLevel, Session};
     use ort::value::Tensor;
 
-    /// Intra-op threads per ONNX session. 2 matches the measured TFLite
-    /// XNNPACK knee for these small single-image models, and the ONNX
-    /// determinism notes (by the PINNED_EMBEDDING gate) found counts 1-8
-    /// bit-identical, so a small fixed cap only removes idle-pool contention
-    /// with capture threads.
+    /// Intra-op threads per ONNX session. Keep two threads for model latency;
+    /// disable idle spinning separately in `build` so resident sessions do
+    /// not spend CPU time waiting for their next inference.
     const ORT_INTRA_THREADS: usize = 2;
 
     fn err<E: std::fmt::Display>(e: E) -> irlume_common::Error {
@@ -543,15 +541,11 @@ mod onnx {
                 .with_execution_providers([ort::ep::CoreML::default().build()])
                 .map_err(err)?;
         }
-        // Cap the intra-op pool explicitly. The runtime default sizes one pool
-        // per session to the physical-core count; this daemon holds up to four
-        // ONNX sessions plus a TFLite session, and idle pools contend with the
-        // capture and consent-watch threads inside the seconds-scale auth
-        // budget. The repo's own measurement (see the determinism notes by the
-        // PINNED_EMBEDDING gate) found intra-op thread counts 1, 2, 4 and 8
-        // bit-identical for the embedder, so capping costs nothing and removes
-        // the contention.
+        // Each resident model has its own pool. Let idle workers block while
+        // another model runs, retaining two threads for each active inference.
         b.with_intra_threads(ORT_INTRA_THREADS)
+            .map_err(err)?
+            .with_intra_op_spinning(false)
             .map_err(err)?
             .with_optimization_level(GraphOptimizationLevel::Level3)
             .map_err(err)?

--- a/docs/research/2026-09-05-onnx-idle-pools.md
+++ b/docs/research/2026-09-05-onnx-idle-pools.md
@@ -1,0 +1,68 @@
+# Block idle ONNX workers between inferences
+
+The shared ONNX session builder retains two intra-op threads and disables
+intra-op spinning. Multiple model sessions stay resident, so idle workers should
+block while another model runs. No graph optimization, model, threshold, PAD
+sample count, identity operation or deadline changes.
+
+The preceding three-model experiment found a 13.46% reduction in grouped model
+time with spinning disabled, no benefit for isolated ViT, and a 65.77% increase
+when reducing each session to one thread. Retain two threads; changing the pool
+size is a different optimization and was rejected for this workload.
+
+## Candidate measurements
+
+Measured on archhost, AMD Ryzen 7 5700G, CPUs 0 and 1, nice 0, with the existing
+performance governor unchanged. Baseline is the vision library from source base
+`3531ae7ecc54062de2c56a49eca66c013b33e197`. Candidate adds only the spinning option
+and explanatory comments. Both use the same optimized Rust harness and pinned
+model files. `ort` is 2.0.0-rc.13 with dynamic runtime loading.
+
+| ONNX Runtime | FaceMesh backend | Baseline, ms | Candidate, ms | Reduction |
+|---|---|---:|---:|---:|
+| 1.28.0 | Production TFLite | 1422.301 | 1206.373 | 15.18% |
+| 1.28.0 | Legacy ONNX | 1435.794 | 1209.003 | 15.80% |
+| 1.24.1 | Production TFLite | 1313.542 | 1158.715 | 11.79% |
+| 1.24.1 | Legacy ONNX | 1304.953 | 1150.308 | 11.85% |
+
+Each row uses baseline/candidate/candidate/baseline process order. Each process
+runs two warmup and eight measured rounds. A round invokes YuNet, BlazeFace and
+FaceMesh, five IR/RGB PAD pairs, RGB embedding with TTA and one IR embedding.
+All six models remain loaded. Both repeats show improvement, larger than the
+observed differences between repeats. Timing excludes loading and output
+comparison. Rescue models run every round in this harness; the real daemon
+invokes them conditionally. These are model-call totals, not login latency.
+
+## Numerical and software validation
+
+All 2,208 candidate comparisons were bit-identical to baseline within the same
+runtime/backend combination, with matching status and zero maximum absolute
+difference. This includes 1,200 synthetic calls and 1,008 calls on 36 images
+reused across four runtime/backend combinations. The image sample contains
+12 LFW RGB images, 12 Oulu-CASIA NIR images and 12 CelebA-Spoof snapshot images
+with nine spoof and three live labels. This is numerical parity on a small
+varied sample, not a statistically representative accuracy evaluation.
+
+Images were resized to 320x240. Detection supplied alignment when available;
+fixed-box crops exercised wrappers when detection returned no face. RGB-source
+grayscale conversions used for IR wrapper checks are not paired IR captures.
+No authentication decisions or spoof-detection rates were evaluated. Pixels,
+identities, output tensors and per-image hashes were not saved. Only aggregate
+parity, success/refusal counts and synthetic timings were retained.
+
+All 72 existing vision tests passed on each runtime, including the explicitly
+run pinned TFLite mesh test. Workspace release check, all-target/all-feature
+vision Clippy, warnings-denied rustdoc, and formatting passed. Six aggregate
+validation checks reject missing processes, output/status differences and
+missing PAD timings. Builds used Rust/Cargo 1.96.0; this task did not run fresh
+MSRV, packaging, remote CI or accelerated-provider tests.
+
+The runtime [configuration definitions for 1.28.0](https://raw.githubusercontent.com/microsoft/onnxruntime/v1.28.0/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h)
+document the spinning option and its build-dependent default. The 1.24.1
+runtime was extracted from a SHA-verified official PyPI wheel into temporary
+storage. That runtime and all remote scratch were removed after validation.
+Installed services, models and power settings remained unchanged.
+
+This supports the CPU candidate on the tested configurations. It does not
+establish end-to-end login improvement, energy savings, every supported runtime
+or platform, or biometric accuracy. Existing security checks remain required.


### PR DESCRIPTION
## What & why

Resident ONNX session workers compete for CPU while other models run. Disable intra-op spinning in the shared session builder while retaining two threads per active inference. This changes one runtime option and corrects the surrounding comments; model processing, PAD sample counts, identity operations, thresholds and deadlines remain unchanged.

Full-resident model-call time on archhost fell from 1422.301 to 1206.373 ms with installed ORT 1.28.0 and production TFLite FaceMesh (15.18%). Reductions across ORT 1.28.0/1.24.1 and TFLite/legacy ONNX FaceMesh ranged from 11.79% to 15.80%, using ABBA order. The research note records the method and limits. These are model timings, not end-to-end login or accuracy results.

Stacked on #656 (`fix/frame-interval-lifecycle`); this PR contains only the two-file idle-pool change and its evidence note. Rebase and retarget after the parent stack is merged.

## Testing

- All 72 existing vision tests passed on each tested runtime on archhost, including the explicitly invoked pinned TFLite mesh test. The test binaries compiled the actual candidate module and existing tests.
- All 24 comparison processes succeeded. All 2,208 candidate output comparisons were bit-identical with matching status, including 1,008 calls on a 36-image RGB/NIR/spoof sample reused across four runtime/backend combinations. No raw biometric data was saved or included here.
- Six aggregate-evidence checks passed. The reviewed patch and production source hashes match the validated candidate.
- [ ] `cargo test --workspace` rerun for this candidate: pending CI; focused real-model tests are recorded above.
- [x] `cargo clippy --workspace --all-targets --release --locked --offline -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --release --locked --offline`
- [x] Research note added; no user-facing option or interface change.
- [ ] End-to-end camera/PAM login validation: not performed for this candidate. Model validation ran on archhost, Ryzen 7 5700G, CPUs 0/1, unchanged governor and installed service.

The temporary runtime and remote scratch were removed. This remains a draft for review; no deployment, energy-saving claim, biometric-accuracy claim, or accelerated-provider validation is included.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>