### PR TITLE
perf: reuse RGB framing across guided enrollment checks

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -592,6 +592,21 @@ pub fn apply_known_ir_emitter_subject_region(
     Ok(verdict)
 }
 
+/// Demand and reporting confined to one live framing connection. Implementors
+/// must never block the camera worker on socket input or output.
+pub trait PositionObserver {
+    /// Check for one command without waiting. `None` keeps draining the camera.
+    ///
+    /// # Errors
+    /// Returns disconnect, cancellation or protocol errors.
+    fn next(&self) -> irlume_common::Result<Option<irlume_common::PositionSessionControl>>;
+    /// Publish the one report requested by the connection.
+    ///
+    /// # Errors
+    /// Returns cancellation or delivery errors instead of blocking capture.
+    fn report(&self, report: irlume_common::PositionReport) -> irlume_common::Result<()>;
+}
+
 /// Interaction confined to one authorized enrollment operation.
 pub trait EnrollmentObserver {
     /// # Errors
@@ -7431,13 +7446,6 @@ impl Engine {
         &mut self,
         user: Option<&str>,
     ) -> irlume_common::Result<irlume_common::PositionReport> {
-        use irlume_common::PositionReport;
-        // Face width as a fraction of frame width; center tolerance; dim-face
-        // luma bound. MIN_FRAC, CENTER_TOL, and DIM are module-level (shared
-        // with the attempt situation line, #616 step 2); only the upper
-        // bounds stay local to the guide.
-        const MAX_FRAC: f32 = 0.55;
-        const BRIGHT: f32 = 235.0;
         // This user's calibrated pitch neutral, if any (read-only; absent = global default).
         let pitch_neutral = user
             .and_then(|u| irlume_core::storage::load(u).ok().flatten())
@@ -7450,86 +7458,170 @@ impl Engine {
         )?
         .pop()
         .ok_or_else(|| irlume_common::Error::Hardware("no frames captured".into()))?;
-        let view = align::RgbView {
-            data: &rgb.data,
-            width: rgb.width,
-            height: rgb.height,
-        };
-        let faces = self.det.detect(&view)?;
-        let top = top_detection(&faces);
-        // NB: the framing guide is RGB-only so it stays fast enough to poll (the
-        // IR burst would make each sample multi-second). IR readiness is checked
-        // at the actual capture, not in the guide.
-        let ir_ok = false;
-        let (fw, fh) = (rgb.width as f32, rgb.height as f32);
-        let Some(f) = top else {
-            return Ok(PositionReport {
-                ir_ok,
-                guidance: "No face detected; look straight at the camera and center yourself"
-                    .into(),
-                ..Default::default()
-            });
-        };
-        let [x1, y1, x2, y2] = f.bbox;
-        let face_frac = (x2 - x1).max(0.0) / fw;
-        let centered = ((x1 + x2) / 2.0 - fw / 2.0).abs() <= CENTER_TOL * fw
-            && ((y1 + y2) / 2.0 - fh / 2.0).abs() <= CENTER_TOL * fh;
-        let pose = irlume_vision::head_pose(&f.landmarks);
-        let brightness = luma_in_bbox(&rgb.data, rgb.width, rgb.height, &f.bbox);
+        position_report(&mut self.det, &rgb, pitch_neutral)
+    }
 
-        // Quality starts at 100 and the first failing gate deducts by
-        // severity: 45 for too-far (smallest face, least usable capture), 30
-        // for the mid-tier framing/pose/darkness faults, 20 for over-bright
-        // (the mildest; recognition still works under glare more often than
-        // under the other faults).
-        let mut q = 100i32;
-        let mut guidance = "Hold still, looking good".to_string();
-        let mut well = true;
-        let (plo, phi) = pitch_band(pitch_neutral);
-        let frontal = pose.yaw_asym <= FRAME_YAW_ASYM_MAX && (plo..=phi).contains(&pose.pitch_frac);
-        // Live pose numbers for calibrating the framing bounds to a given camera
-        // (`IRLUME_LOG=debug`); `neutral` is this user's calibrated centre (or -).
-        irlume_common::dlog!("framing: yaw_asym={:.2} yaw_signed={:.2} pitch={:.2} band=[{:.2},{:.2}] neutral={} face_frac={:.2} bright={:.0}",
+    /// Serve one bounded framing connection with a single calibration lookup
+    /// and RGB streaming session. The actual enrollment still captures and
+    /// validates its own fresh evidence after this operation has released.
+    ///
+    /// # Errors
+    /// Returns calibration-independent camera/transport/inference errors,
+    /// cancellation, deadline or sample-limit refusals. Calibration lookup
+    /// failures use the same default band as `position_sample`.
+    pub fn position_session(
+        &mut self,
+        user: Option<&str>,
+        observer: &dyn PositionObserver,
+    ) -> irlume_common::Result<()> {
+        use irlume_common::{
+            PositionSessionControl, POSITION_SESSION_MAX_SAMPLES, POSITION_SESSION_SECONDS,
+        };
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(POSITION_SESSION_SECONDS);
+        if self.should_stop() {
+            return Err(irlume_common::Error::Preempted("framing cancelled".into()));
+        }
+        let pitch_neutral = user
+            .and_then(|u| irlume_core::storage::load(u).ok().flatten())
+            .and_then(|e| e.pitch_neutral());
+        if self.should_stop() || std::time::Instant::now() >= deadline {
+            return Err(irlume_common::Error::Preempted(
+                "framing cancelled before camera open".into(),
+            ));
+        }
+        let device = self.rgb_dev.clone();
+        let operation = irlume_camera::lease::acquire_camera_operation(
+            &[device.as_str()],
+            irlume_camera::lease::CameraOperationKind::Enrollment,
+            std::time::Duration::from_secs(2),
+        )
+        .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+        if self.should_stop() || std::time::Instant::now() >= deadline {
+            return Err(irlume_common::Error::Preempted(
+                "framing cancelled while waiting for camera ownership".into(),
+            ));
+        }
+        let camera = operation.open_rgb(&device)?;
+        let mut session = camera.session_with_progress(&self.capture_progress())?;
+        let mut samples = 0;
+        loop {
+            if self.should_stop() {
+                return Err(irlume_common::Error::Preempted("framing cancelled".into()));
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(irlume_common::Error::Protocol(
+                    "framing session expired; restart the guide".into(),
+                ));
+            }
+            match observer.next()? {
+                Some(PositionSessionControl::Finish) => return Ok(()),
+                Some(PositionSessionControl::Sample) => {
+                    if samples >= POSITION_SESSION_MAX_SAMPLES {
+                        return Err(irlume_common::Error::Protocol(
+                            "framing sample limit reached".into(),
+                        ));
+                    }
+                    samples += 1;
+                    // Only YuNet crosses into the scoped processor. The rest
+                    // of the Engine, including TFLite, stays on its owner thread.
+                    let det = &mut self.det;
+                    let report = session
+                        .process_frame(move |rgb| position_report(det, &rgb, pitch_neutral))?;
+                    observer.report(report)?;
+                }
+                None => session.discard_frame()?,
+            }
+        }
+    }
+}
+
+fn position_report(
+    det: &mut Detector,
+    rgb: &irlume_camera::Frame,
+    pitch_neutral: Option<f32>,
+) -> irlume_common::Result<irlume_common::PositionReport> {
+    use irlume_common::PositionReport;
+    const MAX_FRAC: f32 = 0.55;
+    const BRIGHT: f32 = 235.0;
+    let view = align::RgbView {
+        data: &rgb.data,
+        width: rgb.width,
+        height: rgb.height,
+    };
+    let faces = det.detect(&view)?;
+    let top = top_detection(&faces);
+    // NB: the framing guide is RGB-only so it stays fast enough to poll (the
+    // IR burst would make each sample multi-second). IR readiness is checked
+    // at the actual capture, not in the guide.
+    let ir_ok = false;
+    let (fw, fh) = (rgb.width as f32, rgb.height as f32);
+    let Some(f) = top else {
+        return Ok(PositionReport {
+            ir_ok,
+            guidance: "No face detected; look straight at the camera and center yourself".into(),
+            ..Default::default()
+        });
+    };
+    let [x1, y1, x2, y2] = f.bbox;
+    let face_frac = (x2 - x1).max(0.0) / fw;
+    let centered = ((x1 + x2) / 2.0 - fw / 2.0).abs() <= CENTER_TOL * fw
+        && ((y1 + y2) / 2.0 - fh / 2.0).abs() <= CENTER_TOL * fh;
+    let pose = irlume_vision::head_pose(&f.landmarks);
+    let brightness = luma_in_bbox(&rgb.data, rgb.width, rgb.height, &f.bbox);
+
+    // Quality starts at 100 and the first failing gate deducts by
+    // severity: 45 for too-far (smallest face, least usable capture), 30
+    // for the mid-tier framing/pose/darkness faults, 20 for over-bright
+    // (the mildest; recognition still works under glare more often than
+    // under the other faults).
+    let mut q = 100i32;
+    let mut guidance = "Hold still, looking good".to_string();
+    let mut well = true;
+    let (plo, phi) = pitch_band(pitch_neutral);
+    let frontal = pose.yaw_asym <= FRAME_YAW_ASYM_MAX && (plo..=phi).contains(&pose.pitch_frac);
+    // Live pose numbers for calibrating the framing bounds to a given camera
+    // (`IRLUME_LOG=debug`); `neutral` is this user's calibrated centre (or -).
+    irlume_common::dlog!("framing: yaw_asym={:.2} yaw_signed={:.2} pitch={:.2} band=[{:.2},{:.2}] neutral={} face_frac={:.2} bright={:.0}",
             pose.yaw_asym, pose.yaw_signed, pose.pitch_frac, plo, phi,
             pitch_neutral.map(|n| format!("{n:.2}")).unwrap_or_else(|| "-".into()), face_frac, brightness);
-        if face_frac < MIN_FRAC {
-            guidance = "Move closer".into();
-            well = false;
-            q -= 45;
-        } else if face_frac > MAX_FRAC {
-            guidance = "Move back a little".into();
-            well = false;
-            q -= 30;
-        } else if !centered {
-            guidance = "Center your face in the frame".into();
-            well = false;
-            q -= 30;
-        } else if !frontal {
-            guidance = frontality_hint(&pose, pitch_neutral);
-            well = false;
-            q -= 30;
-        } else if brightness < DIM {
-            guidance = "Too dark: add light or face a window".into();
-            well = false;
-            q -= 30;
-        } else if brightness > BRIGHT {
-            guidance = "Too bright: reduce glare/backlight".into();
-            well = false;
-            q -= 20;
-        }
-        Ok(PositionReport {
-            face: true,
-            face_frac,
-            centered,
-            yaw_asym: pose.yaw_asym,
-            pitch_frac: pose.pitch_frac,
-            brightness,
-            ir_ok,
-            quality: q.clamp(0, 100) as u8,
-            well_framed: well,
-            guidance,
-        })
+    if face_frac < MIN_FRAC {
+        guidance = "Move closer".into();
+        well = false;
+        q -= 45;
+    } else if face_frac > MAX_FRAC {
+        guidance = "Move back a little".into();
+        well = false;
+        q -= 30;
+    } else if !centered {
+        guidance = "Center your face in the frame".into();
+        well = false;
+        q -= 30;
+    } else if !frontal {
+        guidance = frontality_hint(&pose, pitch_neutral);
+        well = false;
+        q -= 30;
+    } else if brightness < DIM {
+        guidance = "Too dark: add light or face a window".into();
+        well = false;
+        q -= 30;
+    } else if brightness > BRIGHT {
+        guidance = "Too bright: reduce glare/backlight".into();
+        well = false;
+        q -= 20;
     }
+    Ok(PositionReport {
+        face: true,
+        face_frac,
+        centered,
+        yaw_asym: pose.yaw_asym,
+        pitch_frac: pose.pitch_frac,
+        brightness,
+        ir_ok,
+        quality: q.clamp(0, 100) as u8,
+        well_framed: well,
+        guidance,
+    })
 }
 
 /// Framing-guide frontality bounds: deliberately STRICTER than the liveness

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2149,6 +2149,38 @@ fn drain_pair_frame<S: ValidatedStream>(
     Ok(())
 }
 
+/// Process captured pixels while their owning thread continues validating the
+/// camera queue. A failed tail drain invalidates even successful processing.
+fn process_while_draining<T: Send, R: Send>(
+    frame: T,
+    process: impl FnOnce(T) -> irlume_common::Result<R> + Send,
+    mut drain: impl FnMut() -> irlume_common::Result<()>,
+) -> irlume_common::Result<R> {
+    std::thread::scope(|scope| {
+        let worker = scope.spawn(move || process(frame));
+        let mut transport = Ok(());
+        let mut drained = 0;
+        while !worker.is_finished() {
+            if drained == 2 * MAX_RATE_FILL_ATTEMPTS {
+                transport = Err(Error::Hardware(
+                    "framing processing exceeded its bounded drain".into(),
+                ));
+                break;
+            }
+            if let Err(error) = drain() {
+                transport = Err(error);
+                break;
+            }
+            drained += 1;
+        }
+        let processed = worker
+            .join()
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        transport?;
+        processed
+    })
+}
+
 fn fill_rate_then_drain_metadata<E>(
     fill_rate: impl FnOnce() -> Result<(), E>,
     drain_metadata: impl FnOnce(),
@@ -4399,6 +4431,37 @@ impl<'a> RgbSession<'a> {
         self.burst(1)?
             .pop()
             .ok_or_else(|| Error::Hardware("no frames captured".into()))
+    }
+
+    /// Consume one validated frame without converting or retaining its pixels.
+    /// Use between framing requests so a live stream never accumulates old work.
+    ///
+    /// # Errors
+    /// Preserves warm-up, lease, rate, continuity and transport refusals.
+    pub fn discard_frame(&mut self) -> irlume_common::Result<()> {
+        self.warm_up()?;
+        self.cam
+            .lease
+            .require_endpoint(&self.cam.device)
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        drain_pair_frame(&mut self.stream, &self.cam.device)
+    }
+
+    /// Process a fresh frame while this thread continues servicing the stream.
+    /// The processing worker is scoped to this call and always joined.
+    ///
+    /// # Errors
+    /// Returns capture/processing errors or invalidates processing when the
+    /// subsequent bounded transport drain fails.
+    ///
+    /// # Panics
+    /// Resumes a processing callback panic after its worker has been joined.
+    pub fn process_frame<R: Send>(
+        &mut self,
+        process: impl FnOnce(Frame) -> irlume_common::Result<R> + Send,
+    ) -> irlume_common::Result<R> {
+        let frame = self.frame()?;
+        process_while_draining(frame, process, || self.discard_frame())
     }
 
     /// The recognition path's denoised frame: a per-pixel temporal median over
@@ -16857,6 +16920,87 @@ mod tests {
             error.to_string().contains("continuity"),
             "a cached success cannot hide a later gap"
         );
+    }
+
+    #[test]
+    fn framing_processing_keeps_consuming_while_the_processor_waits() {
+        let (release, waiting) = std::sync::mpsc::sync_channel(0);
+        let mut release = Some(release);
+        let mut drained = 0;
+        let result = process_while_draining(
+            7,
+            move |frame| {
+                waiting
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .unwrap();
+                Ok(frame * 2)
+            },
+            || {
+                drained += 1;
+                if let Some(release) = release.take() {
+                    release.send(()).unwrap();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(result, 14);
+        assert!(drained > 0, "processing must not pause the camera queue");
+    }
+
+    #[test]
+    fn framing_processing_discards_success_if_the_tail_drain_fails() {
+        struct Processed(std::sync::Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for Processed {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let discarded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = discarded.clone();
+        let (release, waiting) = std::sync::mpsc::sync_channel(0);
+        let result = process_while_draining(
+            (),
+            move |_| {
+                waiting
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .unwrap();
+                Ok(Processed(observed))
+            },
+            || {
+                release.send(()).unwrap();
+                Err(Error::Hardware("fixture continuity failure".into()))
+            },
+        );
+        assert!(
+            matches!(result, Err(Error::Hardware(ref error)) if error == "fixture continuity failure")
+        );
+        assert!(discarded.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn framing_processing_joins_and_drops_the_frame_before_resuming_a_panic() {
+        struct Pixels(std::sync::Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for Pixels {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let dropped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = dropped.clone();
+        let panic = std::panic::catch_unwind(|| {
+            let _: irlume_common::Result<()> = process_while_draining(
+                Pixels(observed),
+                |_pixels| panic!("fixture processing panic"),
+                || {
+                    std::thread::yield_now();
+                    Ok(())
+                },
+            );
+        });
+        assert!(panic.is_err());
+        assert!(dropped.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -7469,11 +7469,35 @@ fn enroll_worker(
 ) {
     let send = |m| tx.send(m).is_ok();
     let mut misses = 0;
+    let mut session = match irlume_common::client::PositionSession::connect(&user, &stop) {
+        Ok(session) => session,
+        Err(error) => {
+            let _ = send(WMsg::Err(format!("camera guide could not start: {error}")));
+            return;
+        }
+    };
     loop {
-        match guide_until_capture(&user, &stop, &send, &mut crate::daemon_sample, &mut misses) {
+        let mut sample = |request: &Request| match session.as_mut() {
+            Some(session) => Ok(match session.sample(&stop) {
+                Ok(report) => Response::Position(report),
+                // An accepted session cannot safely resume through another
+                // connection after a framing, transport or deadline failure.
+                Err(error) => Response::Error(format!("camera guide stopped: {error}")),
+            }),
+            None => crate::daemon_sample(request),
+        };
+        match guide_until_capture(&user, &stop, &send, &mut sample, &mut misses) {
             GuideOutcome::Ready => break,
             GuideOutcome::Reframe => continue,
             GuideOutcome::Halt => return,
+        }
+    }
+    // Await release, not just socket close: the daemon polls disconnects, so
+    // a second camera request could otherwise overtake release of this one.
+    if let Some(session) = session {
+        if let Err(error) = session.finish(&stop) {
+            let _ = send(WMsg::Err(format!("camera guide could not finish: {error}")));
+            return;
         }
     }
     if !send(WMsg::Authorizing) {
@@ -7729,6 +7753,24 @@ mod tests {
         let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
         std::env::set_var("IRLUME_SOCKET", &path);
         let server = std::thread::spawn(move || {
+            // The compatibility daemon rejects the new request before any
+            // framing session is accepted, then serves the original API.
+            let (mut unsupported, _) = listener.accept().unwrap();
+            let mut initial = String::new();
+            std::io::BufReader::new(&unsupported)
+                .read_line(&mut initial)
+                .unwrap();
+            assert!(matches!(
+                serde_json::from_str::<Request>(&initial).unwrap(),
+                Request::PositionSession { .. }
+            ));
+            writeln!(
+                unsupported,
+                "{}",
+                serde_json::to_string(&Response::Error("bad request".into())).unwrap()
+            )
+            .unwrap();
+            drop(unsupported);
             for _ in 0..6 {
                 let (mut socket, _) = listener.accept().unwrap();
                 let mut line = String::new();
@@ -7805,6 +7847,178 @@ mod tests {
             3
         );
         assert!(messages.iter().any(|m| matches!(m, WMsg::Done { .. })));
+    }
+
+    #[test]
+    fn guided_enrollment_reuses_framing_connection_and_releases_it_before_authorization() {
+        use std::io::{BufRead, Write};
+        let _guard = dead_socket();
+        let path =
+            std::env::temp_dir().join(format!("irlume-guided-framing-{}.sock", std::process::id()));
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let server = std::thread::spawn(move || {
+            let (mut guide, _) = listener.accept().unwrap();
+            guide
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut reader = std::io::BufReader::new(guide.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            if serde_json::from_str::<serde_json::Value>(&line).unwrap()
+                != serde_json::json!({"PositionSession":{"user":"test-user"}})
+            {
+                return false;
+            }
+            writeln!(guide, "\"PositionSessionStarted\"").unwrap();
+            for _ in 0..6 {
+                line.clear();
+                reader.read_line(&mut line).unwrap();
+                assert_eq!(
+                    serde_json::from_str::<serde_json::Value>(&line).unwrap(),
+                    "Sample"
+                );
+                writeln!(
+                    guide,
+                    "{}",
+                    serde_json::to_string(&Response::Position(good_report("Ready"))).unwrap()
+                )
+                .unwrap();
+            }
+            line.clear();
+            assert!(
+                reader.read_line(&mut line).unwrap() > 0,
+                "client must request and await camera release before enrollment"
+            );
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&line).unwrap(),
+                "Finish"
+            );
+            writeln!(guide, "\"PositionSessionEnded\"").unwrap();
+            line.clear();
+            assert_eq!(
+                reader.read_line(&mut line).unwrap(),
+                0,
+                "framing must close before enrollment authorization starts"
+            );
+            drop(reader);
+            drop(guide);
+            let (mut socket, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            std::io::BufReader::new(&socket)
+                .read_line(&mut line)
+                .unwrap();
+            let batch = matches!(serde_json::from_str::<Request>(&line).unwrap(),Request::EnrollmentSession { scans:10, improve:false, ref user, .. } if user=="test-user");
+            if !batch {
+                writeln!(
+                    socket,
+                    "{}",
+                    serde_json::to_string(&Response::Error("expected one batch".into())).unwrap()
+                )
+                .unwrap();
+                return false;
+            }
+            for response in [
+                Response::EnrollmentSession(irlume_common::EnrollmentEvent::Started),
+                Response::EnrollmentSession(irlume_common::EnrollmentEvent::Progress {
+                    captured: 10,
+                    target: 10,
+                }),
+                Response::Enrolled {
+                    profile: "New".into(),
+                    created: true,
+                    added: 10,
+                    total: 10,
+                    room: Some(20),
+                    added_scans: vec![],
+                    ambient_lit: Some(0),
+                },
+            ] {
+                writeln!(socket, "{}", serde_json::to_string(&response).unwrap()).unwrap();
+            }
+            true
+        });
+        let (tx, rx) = mpsc::channel();
+        enroll_worker(
+            "test-user".into(),
+            "New".into(),
+            None,
+            10,
+            Arc::new(AtomicBool::new(false)),
+            tx,
+        );
+        let messages: Vec<_> = rx.try_iter().collect();
+        let batch = server.join().unwrap();
+        std::fs::remove_file(path).unwrap();
+        assert!(
+            batch,
+            "guided enrollment must authorize and capture one bounded batch"
+        );
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|m| matches!(m, WMsg::Count(_)))
+                .count(),
+            3
+        );
+        assert!(messages.iter().any(|m| matches!(m, WMsg::Done { .. })));
+    }
+
+    #[test]
+    fn accepted_framing_failure_never_falls_back_or_starts_enrollment() {
+        use std::io::{BufRead, Write};
+        let _guard = dead_socket();
+        let path =
+            std::env::temp_dir().join(format!("irlume-guide-accepted-{}.sock", std::process::id()));
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            assert!(matches!(
+                serde_json::from_str::<Request>(&line).unwrap(),
+                Request::PositionSession { .. }
+            ));
+            writeln!(stream, "\"PositionSessionStarted\"").unwrap();
+            line.clear();
+            reader.read_line(&mut line).unwrap();
+            assert_eq!(line, "\"Sample\"\n");
+            // The compatibility phrase is only meaningful BEFORE acceptance.
+            writeln!(
+                stream,
+                "{}",
+                serde_json::to_string(&Response::Error("bad request".into())).unwrap()
+            )
+            .unwrap();
+            line.clear();
+            assert_eq!(reader.read_line(&mut line).unwrap(), 0);
+            listener.set_nonblocking(true).unwrap();
+            assert_eq!(
+                listener.accept().unwrap_err().kind(),
+                std::io::ErrorKind::WouldBlock
+            );
+        });
+        let (tx, rx) = mpsc::channel();
+        enroll_worker(
+            "test-user".into(),
+            "New".into(),
+            None,
+            10,
+            Arc::new(AtomicBool::new(false)),
+            tx,
+        );
+        let messages: Vec<_> = rx.try_iter().collect();
+        server.join().unwrap();
+        std::fs::remove_file(path).unwrap();
+        assert!(messages.iter().any(|m| matches!(m, WMsg::Err(_))));
+        assert!(!messages
+            .iter()
+            .any(|m| matches!(m, WMsg::Authorizing | WMsg::Done { .. })));
     }
 
     #[test]

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -19,6 +19,9 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use zeroize::Zeroizing;
 
+mod position_session;
+pub use position_session::PositionSession;
+
 /// Bounded wait for the initial connect (distinct from the read timeout, which
 /// must be long enough for a camera capture).
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);

--- a/crates/irlume-common/src/client/position_session.rs
+++ b/crates/irlume-common/src/client/position_session.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use std::io::{self, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use zeroize::Zeroizing;
+
+use crate::{PositionReport, PositionSessionControl, Request, Response};
+
+/// One explicitly paced framing connection. Call [`Self::finish`] before
+/// enrollment authorization to confirm release of the camera. Drop cancels.
+pub struct PositionSession {
+    stream: UnixStream,
+    deadline: Instant,
+    samples: usize,
+}
+
+impl PositionSession {
+    /// Start a framing session. `None` means an older daemon rejected the new
+    /// request with its exact pre-acceptance `bad request` response.
+    ///
+    /// # Errors
+    /// Returns transport, cancellation, deadline or protocol errors. All other
+    /// daemon refusals are errors and must not trigger compatibility fallback.
+    pub fn connect(user: &str, cancelled: &AtomicBool) -> io::Result<Option<Self>> {
+        let stream = super::connect_stream(Duration::from_millis(100))?;
+        let mut session = Self {
+            stream,
+            deadline: Instant::now() + Duration::from_secs(crate::POSITION_SESSION_SECONDS + 5),
+            samples: 0,
+        };
+        session.check(cancelled)?;
+        (&session.stream).write_all(&super::serialize_request(&Request::PositionSession {
+            user: Some(user.to_owned()),
+        })?)?;
+        match session.reply(cancelled)? {
+            Response::PositionSessionStarted => Ok(Some(session)),
+            Response::Error(error) if error == "bad request" => Ok(None),
+            Response::Error(error) => Err(io::Error::other(error)),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected framing-session reply",
+            )),
+        }
+    }
+
+    /// Ask for a newly computed report from the continuously drained stream.
+    ///
+    /// # Errors
+    /// Returns transport, cancellation, bounded-session or daemon errors. A
+    /// failed accepted session is never retried as a one-shot request.
+    pub fn sample(&mut self, cancelled: &AtomicBool) -> io::Result<PositionReport> {
+        self.check(cancelled)?;
+        if self.samples >= crate::POSITION_SESSION_MAX_SAMPLES {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "framing sample limit reached",
+            ));
+        }
+        self.samples += 1;
+        let mut line = serde_json::to_vec(&PositionSessionControl::Sample)?;
+        line.push(b'\n');
+        (&self.stream).write_all(&line)?;
+        match self.reply(cancelled)? {
+            Response::Position(report) => Ok(report),
+            Response::Error(error) => Err(io::Error::other(error)),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected framing sample reply",
+            )),
+        }
+    }
+
+    /// End the guide and wait until the daemon has released the camera slot.
+    /// Merely dropping a socket would race the next enrollment request against
+    /// the daemon's disconnect polling.
+    ///
+    /// # Errors
+    /// Returns cancellation, deadline, transport or unexpected-reply errors.
+    /// A failure must stop the guide rather than begin enrollment anyway.
+    pub fn finish(mut self, cancelled: &AtomicBool) -> io::Result<()> {
+        self.check(cancelled)?;
+        let mut line = serde_json::to_vec(&PositionSessionControl::Finish)?;
+        line.push(b'\n');
+        (&self.stream).write_all(&line)?;
+        match self.reply(cancelled)? {
+            Response::PositionSessionEnded => Ok(()),
+            Response::Error(error) => Err(io::Error::other(error)),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "camera release was not confirmed",
+            )),
+        }
+    }
+
+    fn check(&self, cancelled: &AtomicBool) -> io::Result<()> {
+        if cancelled.load(Ordering::Relaxed) {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "framing cancelled",
+            ));
+        }
+        if Instant::now() >= self.deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "framing session expired",
+            ));
+        }
+        Ok(())
+    }
+
+    fn reply(&mut self, cancelled: &AtomicBool) -> io::Result<Response> {
+        let mut reader = super::CancellableReply {
+            stream: &self.stream,
+            cancelled,
+            deadline: self.deadline.min(Instant::now() + Duration::from_secs(10)),
+        };
+        let mut bytes = Zeroizing::new(Vec::new());
+        let mut chunk = Zeroizing::new([0u8; 4096]);
+        loop {
+            let read = reader.read(&mut chunk[..])?;
+            if read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "framing connection closed",
+                ));
+            }
+            bytes.extend_from_slice(&chunk[..read]);
+            if bytes.len() as u64 >= super::MAX_RESPONSE_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "oversized framing reply",
+                ));
+            }
+            if let Some(end) = bytes.iter().position(|b| *b == b'\n') {
+                // One credit permits exactly one reply, never a queue of old
+                // reports for future countdown beats.
+                if end + 1 != bytes.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "unsolicited framing replies",
+                    ));
+                }
+                return serde_json::from_slice(bytes.trim_ascii())
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local_session() -> (PositionSession, UnixStream) {
+        let (stream, peer) = UnixStream::pair().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        (
+            PositionSession {
+                stream,
+                deadline: Instant::now() + Duration::from_secs(2),
+                samples: 0,
+            },
+            peer,
+        )
+    }
+
+    #[test]
+    fn cancellation_expiry_and_sample_cap_do_not_send_another_command() {
+        for condition in 0..3 {
+            let (mut session, mut peer) = local_session();
+            let stop = AtomicBool::new(condition == 0);
+            if condition == 1 {
+                session.deadline = Instant::now();
+            }
+            if condition == 2 {
+                session.samples = crate::POSITION_SESSION_MAX_SAMPLES;
+            }
+            assert!(session.sample(&stop).is_err());
+            peer.set_nonblocking(true).unwrap();
+            assert_eq!(
+                peer.read(&mut [0u8; 64]).unwrap_err().kind(),
+                io::ErrorKind::WouldBlock
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_truncated_and_unsolicited_replies_are_refused() {
+        use std::io::BufRead;
+        let reply = serde_json::to_string(&Response::Position(PositionReport::default())).unwrap();
+        let fixtures = [
+            (b"not json\n".to_vec(), io::ErrorKind::InvalidData),
+            (reply.as_bytes().to_vec(), io::ErrorKind::UnexpectedEof),
+            (
+                format!("{reply}\n{reply}\n").into_bytes(),
+                io::ErrorKind::InvalidData,
+            ),
+            (
+                vec![b'x'; super::super::MAX_RESPONSE_BYTES as usize],
+                io::ErrorKind::InvalidData,
+            ),
+        ];
+        for (bytes, expected) in fixtures {
+            let (mut session, mut peer) = local_session();
+            let server = std::thread::spawn(move || {
+                peer.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+                let mut line = String::new();
+                std::io::BufReader::new(&peer).read_line(&mut line).unwrap();
+                assert_eq!(line, "\"Sample\"\n");
+                peer.write_all(&bytes).unwrap();
+            });
+            let result = session.sample(&AtomicBool::new(false));
+            server.join().unwrap();
+            assert_eq!(result.unwrap_err().kind(), expected);
+        }
+    }
+
+    #[test]
+    fn finish_requires_the_release_acknowledgment() {
+        use std::io::BufRead;
+        for acknowledged in [true, false] {
+            let (session, mut peer) = local_session();
+            let server = std::thread::spawn(move || {
+                peer.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+                let mut line = String::new();
+                std::io::BufReader::new(&peer).read_line(&mut line).unwrap();
+                assert_eq!(line, "\"Finish\"\n");
+                peer.write_all(if acknowledged {
+                    b"\"PositionSessionEnded\"\n"
+                } else {
+                    b"{\"Ok\":\"not released\"}\n"
+                })
+                .unwrap();
+                assert_eq!(peer.read(&mut [0u8; 1]).unwrap(), 0);
+            });
+            assert_eq!(
+                session.finish(&AtomicBool::new(false)).is_ok(),
+                acknowledged
+            );
+            server.join().unwrap();
+        }
+    }
+}

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -450,6 +450,19 @@ pub struct EnrollmentDecision {
     pub accept: bool,
 }
 
+/// Control an accepted framing connection. Reports are never generated ahead
+/// of demand. Finish waits for camera release; disconnect cancels instead.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum PositionSessionControl {
+    Sample,
+    Finish,
+}
+
+/// Hard protocol bounds for one interactive framing operation.
+pub const POSITION_SESSION_SECONDS: u64 = 60;
+/// Bounds an untrusted peer independently of the elapsed-time limit.
+pub const POSITION_SESSION_MAX_SAMPLES: usize = 256;
+
 /// Request from an untrusted client to the privileged daemon.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Request {
@@ -625,6 +638,12 @@ pub enum Request {
     /// enrolled: it tunes the pitch band to that user's calibrated neutral (a
     /// read-only lookup) so the guide matches the capture gate. `None` = default band.
     PositionSample { user: Option<String> },
+    /// A bounded RGB framing session, with the same account-hint rules as
+    /// `PositionSample`. After `PositionSessionStarted`, each
+    /// `PositionSessionControl::Sample` receives one fresh `Position` report.
+    /// Finish receives `PositionSessionEnded` after camera release. Closing
+    /// the connection cancels. No enrollment or auth.
+    PositionSession { user: Option<String> },
 
     // --- keyring unlock (TPM-sealed password) -------------------------------
     /// Seal `user`'s login password in the TPM so a later face login can release
@@ -1015,6 +1034,11 @@ pub enum Response {
     },
     /// A framing-guide sample (`PositionSample`).
     Position(PositionReport),
+    /// Framing connection accepted. Errors after acceptance must not cause
+    /// a client to silently restart through the one-shot compatibility path.
+    PositionSessionStarted,
+    /// Framing finished and the camera worker released its operation slot.
+    PositionSessionEnded,
     /// Delivered-rate diagnostic report (`CameraDiagnostics`).
     CameraDiagnostics(Box<CameraDiagnosticsReport>),
     /// Retired `CaptureEarMedian` response tombstone. No current request

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -100,6 +100,7 @@ pub fn classify(req: &Request) -> Class {
         // worker if a caller reaches this seam independently.
         | TraceSubscribe { .. } => Class::Status,
         PositionSample { .. }
+        | PositionSession { .. }
         | Identify
         | Enroll { .. }
         | EnrollmentSession { .. }
@@ -564,6 +565,10 @@ mod tests {
         );
         assert_eq!(
             classify(&Request::PositionSample { user: None }),
+            Class::Camera
+        );
+        assert_eq!(
+            classify(&Request::PositionSession { user: None }),
             Class::Camera
         );
         // Read-only status answers on the connection thread (#212): a TPM-

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -61,6 +61,7 @@ mod arbiter;
 mod diagnostics;
 mod enrollment_authorization;
 mod enrollment_session;
+mod position_session;
 mod users;
 
 /// Release checksums of the bundled models (models/SHA256SUMS, committed next
@@ -861,6 +862,7 @@ fn main() {
                             let Queued {
                                 authorization,
                                 session,
+                                position,
                                 req,
                                 peer,
                                 reply,
@@ -889,7 +891,7 @@ fn main() {
                             // unwind out of the worker and take down all face auth for
                             // every user.
                             let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                dispatch_scoped_session(req, &peer, &mut engine, &scope, authorization, session.as_ref())
+                                dispatch_scoped_session(req, &peer, &mut engine, &scope, authorization, session.as_ref(), position.as_ref())
                             }));
                             // Release the slot before anything else can fail, so a
                             // panicking request cannot lock its uid out of the camera
@@ -1439,6 +1441,7 @@ const MAX_REQUEST_BYTES: u64 = 64 * 1024;
 struct Queued {
     authorization: Option<enrollment_authorization::Grant>,
     session: Option<enrollment_session::Worker>,
+    position: Option<position_session::Worker>,
     req: Request,
     peer: Peer,
     reply: std::sync::mpsc::Sender<Response>,
@@ -2686,12 +2689,20 @@ fn serve_peer(
                 } else {
                     (None, None)
                 };
+            let (position, mut position_connection) =
+                if matches!(req, Request::PositionSession { .. }) {
+                    let (worker, connection) = position_session::channel(arbiter.cancel_token());
+                    (Some(worker), Some(connection))
+                } else {
+                    (None, None)
+                };
             let scope = diagnostic_state.begin(diagnostic_operation_class(&req));
             let (reply, answer) = std::sync::mpsc::channel();
             let link = std::sync::Arc::new(ClientLink::default());
             let queued = Queued {
                 authorization,
                 session,
+                position,
                 req,
                 peer: peer.clone(),
                 reply,
@@ -2722,16 +2733,29 @@ fn serve_peer(
                         return Err(error);
                     }
                 }
+                if let Some(connection) = &mut position_connection {
+                    if let Err(error) = connection.pump(&stream) {
+                        if link.abandon() {
+                            arbiter.cancel_token().request_stop();
+                        }
+                        return Err(error);
+                    }
+                }
                 match answer.recv_timeout(CLIENT_ALIVE_POLL) {
                     Ok(resp) => {
                         if let Some(connection) = &mut session_connection {
+                            connection.pump(&stream)?;
+                        }
+                        if let Some(connection) = &mut position_connection {
                             connection.pump(&stream)?;
                         }
                         break resp;
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                         if std::time::Instant::now() >= deadline {
-                            if session_connection.is_some() && link.abandon() {
+                            if (session_connection.is_some() || position_connection.is_some())
+                                && link.abandon()
+                            {
                                 arbiter.cancel_token().request_stop();
                             }
                             break Response::Error("request did not complete".into());
@@ -3109,7 +3133,7 @@ fn posture(req: &Request) -> RequestPosture<'_> {
         },
         // Framing guide: the optional user only tunes the pitch band, but it is
         // still interpolated into a state path, so it is screened like the rest.
-        PositionSample { user } => RequestPosture {
+        PositionSample { user } | PositionSession { user } => RequestPosture {
             privilege: AnyPeer,
             user: user.as_deref(),
             enrollment: Reads,
@@ -4069,9 +4093,11 @@ fn diagnostic_operation_class(req: &Request) -> irlume_common::diagnostics::Oper
         Authenticate { .. } | UnsealPassword { .. } | UnsealKeyring { .. } => {
             OperationClass::Authentication
         }
-        Enroll { .. } | EnrollmentSession { .. } | AddScan { .. } | PositionSample { .. } => {
-            OperationClass::Enrollment
-        }
+        Enroll { .. }
+        | EnrollmentSession { .. }
+        | AddScan { .. }
+        | PositionSample { .. }
+        | PositionSession { .. } => OperationClass::Enrollment,
         Identify => OperationClass::Identification,
         TuneCaptureMode { .. } => OperationClass::CaptureQualification,
         SupportProbe { .. } => OperationClass::SupportProbe,
@@ -4147,7 +4173,7 @@ fn dispatch_scoped(
     scope: &diagnostics::OperationScope,
     authorization: Option<enrollment_authorization::Grant>,
 ) -> Response {
-    dispatch_scoped_session(req, peer, engine, scope, authorization, None)
+    dispatch_scoped_session(req, peer, engine, scope, authorization, None, None)
 }
 
 fn dispatch_scoped_session(
@@ -4157,6 +4183,7 @@ fn dispatch_scoped_session(
     scope: &diagnostics::OperationScope,
     authorization: Option<enrollment_authorization::Grant>,
     session: Option<&enrollment_session::Worker>,
+    position: Option<&position_session::Worker>,
 ) -> Response {
     // Status requests are normally answered on the connection thread and
     // never reach here; delegating keeps this dispatch total (and identical
@@ -4325,6 +4352,21 @@ fn dispatch_scoped_session(
                     irlume_common::OperationErrorCode::OperationFailed,
                     e.to_string(),
                 ),
+            }
+        }
+        Request::PositionSession { user } => {
+            let Some(observer) = position else {
+                return Response::Error("framing requires its live connection".into());
+            };
+            if let Err(error) = observer.started() {
+                return Response::Error(error.to_string());
+            }
+            match engine.position_session(
+                user.as_deref().filter(|u| authorized_for(peer, u)),
+                observer,
+            ) {
+                Ok(()) => Response::PositionSessionEnded,
+                Err(error) => Response::Error(error.to_string()),
             }
         }
         Request::PositionSample { user } => {
@@ -6454,10 +6496,11 @@ mod tests {
         //
         // `include_str!` and not a runtime read: a renamed or deleted module
         // is then a compile error rather than a silently smaller scan.
-        let sources: [(&str, &str); 6] = [
+        let sources: [(&str, &str); 7] = [
             ("main.rs", include_str!("main.rs")),
             ("users.rs", include_str!("users.rs")),
             ("arbiter.rs", include_str!("arbiter.rs")),
+            ("position_session.rs", include_str!("position_session.rs")),
             (
                 "enrollment_session.rs",
                 include_str!("enrollment_session.rs"),
@@ -6870,6 +6913,7 @@ mod tests {
         TraceSubscribe => Request::TraceSubscribe { duration_ms: 60_000 },
         // The user-bearing form, so the traversal walk covers it.
         PositionSample => Request::PositionSample { user: Some(u()) },
+        PositionSession => Request::PositionSession { user: Some(u()) },
         SealPassword => Request::SealPassword {
             user: u(),
             password: secret(),
@@ -7559,6 +7603,7 @@ mod tests {
                 Queued {
                     authorization: None,
                     session: None,
+                    position: None,
                     req: Request::Ping,
                     peer: Peer {
                         uid: 0,
@@ -7870,6 +7915,7 @@ mod tests {
                     let Queued {
                         authorization,
                         session: _,
+                        position: _,
                         req,
                         peer,
                         reply,
@@ -8348,6 +8394,7 @@ mod tests {
                 Queued {
                     authorization: None,
                     session: None,
+                    position: None,
                     req: Request::Ping,
                     peer: Peer {
                         uid: 0,

--- a/crates/irlume-daemon/src/position_session.rs
+++ b/crates/irlume-daemon/src/position_session.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! One bounded, explicitly paced framing connection. Socket writes belong to
+//! the connection thread; the camera worker only uses nonblocking channels.
+use std::cell::Cell;
+use std::io::{self, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
+use std::time::{Duration, Instant};
+
+use irlume_auth::PositionObserver;
+use irlume_common::{PositionReport, PositionSessionControl, Response};
+
+pub(super) struct Worker {
+    commands: Receiver<PositionSessionControl>,
+    events: SyncSender<Response>,
+    stop: super::arbiter::CancelToken,
+    deadline: Instant,
+    pending: Cell<bool>,
+    processing: Cell<bool>,
+    next_sample: Cell<Instant>,
+}
+
+pub(super) struct Connection {
+    commands: SyncSender<PositionSessionControl>,
+    events: Receiver<Response>,
+    input: Vec<u8>,
+    waiting: bool,
+    finishing: bool,
+}
+
+pub(super) fn channel(stop: super::arbiter::CancelToken) -> (Worker, Connection) {
+    let (commands, requests) = mpsc::sync_channel(1);
+    let (events, replies) = mpsc::sync_channel(1);
+    let now = Instant::now();
+    (
+        Worker {
+            commands: requests,
+            events,
+            stop,
+            deadline: now + Duration::from_secs(irlume_common::POSITION_SESSION_SECONDS),
+            pending: Cell::new(false),
+            processing: Cell::new(false),
+            next_sample: Cell::new(now),
+        },
+        Connection {
+            commands,
+            events: replies,
+            input: Vec::new(),
+            waiting: false,
+            finishing: false,
+        },
+    )
+}
+
+fn stopped() -> irlume_common::Error {
+    irlume_common::Error::Preempted("framing stopped; restart the guide".into())
+}
+
+impl Worker {
+    fn check(&self) -> irlume_common::Result<()> {
+        if self.stop.stop_requested() || Instant::now() >= self.deadline {
+            Err(stopped())
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) fn started(&self) -> irlume_common::Result<()> {
+        self.check()?;
+        self.events
+            .try_send(Response::PositionSessionStarted)
+            .map_err(|_| stopped())
+    }
+}
+
+impl PositionObserver for Worker {
+    fn next(&self) -> irlume_common::Result<Option<PositionSessionControl>> {
+        self.check()?;
+        match self.commands.try_recv() {
+            Ok(PositionSessionControl::Finish) => return Ok(Some(PositionSessionControl::Finish)),
+            Ok(PositionSessionControl::Sample) => {
+                if self.pending.replace(true) || self.processing.get() {
+                    return Err(stopped());
+                }
+            }
+            Err(TryRecvError::Disconnected) => return Err(stopped()),
+            Err(TryRecvError::Empty) => {}
+        }
+        if self.pending.get() && Instant::now() >= self.next_sample.get() {
+            self.pending.set(false);
+            self.processing.set(true);
+            Ok(Some(PositionSessionControl::Sample))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn report(&self, report: PositionReport) -> irlume_common::Result<()> {
+        self.check()?;
+        if !self.processing.replace(false) {
+            return Err(stopped());
+        }
+        self.events
+            .try_send(Response::Position(report))
+            .map_err(|_| stopped())?;
+        self.next_sample
+            .set(Instant::now() + Duration::from_millis(250));
+        Ok(())
+    }
+}
+
+impl Connection {
+    pub(super) fn pump(&mut self, stream: &UnixStream) -> io::Result<()> {
+        while let Ok(event) = self.events.try_recv() {
+            if matches!(event, Response::Position(_)) {
+                if !self.waiting || self.finishing {
+                    return Err(io::Error::other("unsolicited framing report"));
+                }
+                self.waiting = false;
+            }
+            let mut line = serde_json::to_vec(&event)?;
+            line.push(b'\n');
+            (&*stream).write_all(&line)?;
+        }
+        let mut bytes = [0u8; 64];
+        // SAFETY: stream owns a live descriptor and bytes is writable for its
+        // full length. MSG_DONTWAIT affects this call only.
+        let read = unsafe {
+            libc::recv(
+                stream.as_raw_fd(),
+                bytes.as_mut_ptr().cast(),
+                bytes.len(),
+                libc::MSG_DONTWAIT,
+            )
+        };
+        if read < 0 {
+            let error = io::Error::last_os_error();
+            return if matches!(
+                error.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+            ) {
+                Ok(())
+            } else {
+                Err(error)
+            };
+        }
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "framing client left",
+            ));
+        }
+        self.input.extend_from_slice(&bytes[..read as usize]);
+        if self.input.len() > 64 {
+            return Err(io::Error::other("oversized framing command"));
+        }
+        if let Some(end) = self.input.iter().position(|b| *b == b'\n') {
+            if self.waiting || self.finishing || end + 1 != self.input.len() {
+                return Err(io::Error::other("extra framing command"));
+            }
+            let command: PositionSessionControl = serde_json::from_slice(&self.input[..end])?;
+            self.finishing = matches!(command, PositionSessionControl::Finish);
+            self.waiting = true;
+            self.commands
+                .try_send(command)
+                .map_err(|_| io::Error::other("framing is no longer waiting"))?;
+            self.input.clear();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_report_needs_a_credit_and_finish_does_not_wait_for_sample_pacing() {
+        let (worker, mut connection) = channel(super::super::arbiter::CancelToken::new());
+        let (server, mut client) = UnixStream::pair().unwrap();
+        assert!(worker.report(PositionReport::default()).is_err());
+        client.write_all(b"\"Sample\"\n").unwrap();
+        connection.pump(&server).unwrap();
+        assert!(matches!(
+            worker.next().unwrap(),
+            Some(PositionSessionControl::Sample)
+        ));
+        worker.report(PositionReport::default()).unwrap();
+        connection.pump(&server).unwrap();
+        assert!(worker.next().unwrap().is_none());
+        client.write_all(b"\"Finish\"\n").unwrap();
+        connection.pump(&server).unwrap();
+        assert!(matches!(
+            worker.next().unwrap(),
+            Some(PositionSessionControl::Finish)
+        ));
+    }
+
+    #[test]
+    fn expired_preempted_and_disconnected_framing_cannot_request_another_frame() {
+        for condition in 0..3 {
+            let stop = super::super::arbiter::CancelToken::new();
+            let (mut worker, connection) = channel(stop.clone());
+            match condition {
+                0 => worker.deadline = Instant::now(),
+                1 => stop.request_stop(),
+                _ => drop(connection),
+            }
+            assert!(worker.next().is_err());
+        }
+    }
+
+    #[test]
+    fn framing_rejects_pipelined_or_unknown_commands() {
+        for input in [
+            b"\"Sample\"\n\"Sample\"\n".as_slice(),
+            b"{\"Sample\":{\"user\":\"other\"}}\n",
+            b"\"Unknown\"\n",
+        ] {
+            let (_worker, mut connection) = channel(super::super::arbiter::CancelToken::new());
+            let (server, mut client) = UnixStream::pair().unwrap();
+            client.write_all(input).unwrap();
+            assert!(connection.pump(&server).is_err());
+        }
+    }
+}

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -48,7 +48,14 @@ The current limit is 30 scans per profile for each recognizer.
    profile, provided a person slot is available. At three profiles, an existing
    person can still take the improvement route; a fourth person is refused.
 
-The guided operation uses one connection and has a bounded duration. A merge
+The framing guide keeps the RGB camera open through its initial checks and
+countdown. It loads the account's calibration once and requests a new report
+for each check. Framing ends after one minute if you have not completed the
+guide; start again when ready. Cancelling releases the camera, and login
+requests can interrupt the guide. After interruption, start a new operation.
+
+The camera is released before the system authorization prompt. The authorized
+capture operation then uses one connection and has a bounded duration. A merge
 prompt expires after 60 seconds. Cancellation or interruption before the final
 save discards the pending batch. A connection lost after the save can hide the
 success reply; refresh the profile list before starting again.
@@ -58,6 +65,11 @@ then warns and uses its older per-scan flow. That flow repeats approval/countdow
 and saves the first matching scan before confirmation; Cancel attempts to remove
 it, and abrupt termination can leave it saved. Update and restart the daemon to
 use the bounded guided flow.
+
+If only the framing-session request is unsupported, the TUI uses individual
+framing checks, with the same cues and countdown. Update and restart the daemon
+to use the continuous framing session. A failure after a session starts stops
+the operation; it does not silently switch to the older flow.
 
 Use F2 for custom scan counts or **Replace face enrollment**. Replacement
 replaces all profiles for the account after successful capture, so it is a


### PR DESCRIPTION
## What & why

Guided enrollment reopened the RGB camera and reloaded account calibration for every framing/countdown check. Keep one bounded framing session, continuously drain validated frames while waiting or detecting, and require explicit demand for each fresh report. Confirm camera and arbiter release before enrollment authorization starts.

Retain the same framing thresholds, three good samples, three countdown checks, enrollment authorization, PAD requirements and profile limits. Old daemons can use the one-shot framing path only after an exact initial unsupported-request refusal. Accepted-session failures stop the guide. The server session lasts at most 60 seconds under cooperative cancellation; scoped inference is joined and has no hard timeout if a foreign callback hangs.

Stacked on #658 (`perf/enrollment-session`).

## Testing

- [ ] `cargo test --workspace` passes: relevant ordinary suites ran, 1,721 passed with 45 existing ignored; full workspace execution remains for CI.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs updated in `docs/TUI.md`
- [x] Hardware-validated on archhost with Logitech Brio

Also passed Rust 1.88 all-target compilation, optimized CLI/daemon builds and 170 TUI tests under AddressSanitizer (8 threads). Regression coverage checks one framing connection, release before authorization, protocol limits, cancellation, preemption signals, compatibility behavior, and transport failure/panic cleanup. All model-dependent execution used archhost.

Two successful TUI trials per build, same account and 15 starting scans, administrator context: candidate framing 12.560/9.186 seconds; baseline 29.253/58.502 seconds. Matching prompts appeared at 45.034/41.520 seconds versus 63.268/91.116 seconds. All four prompts were declined before publication and all original scans preserved. These are stage timings, not full enrollment or password/polkit latency measurements.

An additional baseline trial failed after framing during a USB disconnect/reconnect. Both framing APIs and direct V4L2 streaming subsequently failed; a physical reconnect restored 3/3 direct frames before the successful baseline retry. The failure is retained in the evidence, its cause remains unresolved, and the baseline variation limits a general speedup claim. This was not an uninterrupted four-run experiment.

On the candidate after recovery, abrupt disconnect released the camera in 0.373 seconds. An idle session expired at 60.164 seconds and released the camera within another 0.093 seconds. Both left the daemon responsive, its service unchanged, and all 15 scans/publication intact. Authentication preemption has automated coverage but was not exercised as a live login in this trial.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>