### PR TITLE
fix: persist recorded face retry state

### DIFF
--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -62,6 +62,7 @@ mod diagnostics;
 mod enrollment_authorization;
 mod enrollment_session;
 mod position_session;
+mod retry_throttle;
 mod users;
 
 /// Release checksums of the bundled models (models/SHA256SUMS, committed next
@@ -1109,96 +1110,33 @@ fn main() {
     // The accept loop above only ends if the listener dies; nothing to join.
 }
 
-// ---------------------------------------------------------------------------
-// Consecutive-failure throttle (NIST SP 800-63B-4 s3.2.3 intent).
-//
-// After a run of failed face attempts, stop firing the camera on the gesture
-// for a short cooldown and let PAM fall straight to the password. Deliberately
-// a THROTTLE, not a hard biometric-disable: irlume's password is always the
-// fallback and there is no account lockout, so the standard's disable-and-
-// offer-another-factor tier would only add friction (the "other factor" that
-// re-enables face IS the password the throttled user is already typing). Every
-// platform (Face ID, Android, Windows Hello) also uses ~5 fails then falls to a
-// non-biometric factor. State is per-user and in-memory only; a daemon restart
-// clears it (there is nothing to protect on disk since the password is the
-// floor). Tunable/testable via env; 0 strikes disables the throttle.
-// ---------------------------------------------------------------------------
-#[derive(Default)]
-struct FailState {
-    strikes: u32,
-    cooldown_until: Option<std::time::Instant>,
+/// A retry-state error is an ordinary refusal, never a gesture abort. The same
+/// completion boundary guards both verification and sealed-password release.
+fn recorded_face_response(
+    record: impl FnOnce() -> Result<(), &'static str>,
+    refuse: fn(&str) -> Response,
+    complete: impl FnOnce() -> Response,
+) -> Response {
+    match record() {
+        Ok(()) => complete(),
+        Err(reason) => refuse(reason),
+    }
 }
 
-fn rate_state() -> &'static std::sync::Mutex<std::collections::HashMap<String, FailState>> {
-    static S: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, FailState>>> =
-        std::sync::OnceLock::new();
-    S.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+fn retry_verify_refusal(reason: &str) -> Response {
+    Response::AuthResult {
+        granted: false,
+        score: 0.0,
+        live: false,
+        reason: reason.into(),
+        declined_by_gesture: false,
+        refused_by_policy: true,
+        situation: String::new(),
+    }
 }
 
-fn rate_max_strikes() -> u32 {
-    env_or("IRLUME_RATE_LIMIT", "5").parse().unwrap_or(5)
-}
-
-fn rate_cooldown() -> std::time::Duration {
-    std::time::Duration::from_secs(
-        env_or("IRLUME_RATE_COOLDOWN_SECS", "30")
-            .parse()
-            .unwrap_or(30),
-    )
-}
-
-/// True when `user` is in a cooldown window: skip the camera and fall to the
-/// password. Clears an expired window as a side effect.
-fn rate_limited(user: &str) -> bool {
-    if rate_max_strikes() == 0 {
-        return false;
-    }
-    let mut map = rate_state().lock().unwrap_or_else(|e| e.into_inner());
-    if let Some(s) = map.get_mut(user) {
-        if let Some(until) = s.cooldown_until {
-            if std::time::Instant::now() < until {
-                return true;
-            }
-            s.cooldown_until = None;
-            s.strikes = 0;
-        }
-    }
-    false
-}
-
-/// Record a face attempt's outcome. A grant resets the user; a rejected real
-/// presentation is a strike, and `rate_max_strikes()` of them starts a cooldown.
-/// `faced` is the *strike-worthy* signal: it must be true for a genuine failed
-/// presentation, which includes a hard spoof rejection (those return
-/// `live=false, score=0`, so an earlier `live || score>0` test never struck on
-/// the actual attack it is meant to throttle). Callers pass
-/// `!presence_retryable(&outcome)`: false only for the retryable no-face /
-/// uncertain-liveness outcomes (nobody in frame, walk-away, transient
-/// uncertainty), which must never count against the user.
-fn rate_record(user: &str, granted: bool, faced: bool) {
-    if rate_max_strikes() == 0 {
-        return;
-    }
-    let mut map = rate_state().lock().unwrap_or_else(|e| e.into_inner());
-    let s = map.entry(user.to_string()).or_default();
-    if granted {
-        s.strikes = 0;
-        s.cooldown_until = None;
-        return;
-    }
-    if !faced {
-        return;
-    }
-    s.strikes += 1;
-    if s.strikes >= rate_max_strikes() {
-        s.cooldown_until = Some(std::time::Instant::now() + rate_cooldown());
-        s.strikes = 0;
-        eprintln!(
-            "irlumed: '{user}' hit {} consecutive face failures; face throttled for {}s (password still works)",
-            rate_max_strikes(),
-            rate_cooldown().as_secs()
-        );
-    }
+fn retry_unseal_refusal(reason: &str) -> Response {
+    Response::Error(reason.into())
 }
 
 /// Minimum interval in seconds between unprivileged camera probes. Two seconds
@@ -4465,70 +4403,65 @@ fn dispatch_scoped_session(
                 }
             }
             // Too many recent failures: don't fire the camera, fall to password.
-            if rate_limited(&user) {
-                return Response::AuthResult {
-                    granted: false,
-                    score: 0.0,
-                    live: false,
-                    reason: "too many recent face attempts; use your password".into(),
-                    declined_by_gesture: false,
-                    refused_by_policy: true,
-                    situation: String::new(),
-                };
+            if let Err(reason) = retry_throttle::check(&user) {
+                return retry_verify_refusal(reason);
             }
             let convenience = engine.tier() == irlume_core::biopolicy::Tier::Convenience;
             let t = std::time::Instant::now();
             match engine.authenticate_with_diagnostics(&user, service.as_deref(), scope) {
-                Ok(o) => {
-                    rate_record(&user, o.granted, !irlume_auth::presence_retryable(&o));
-                    if convenience || irlume_common::dbglog::on() {
-                        // Denied score + reason measurements quantized/redacted
-                        // unless tracing (anti-oracle); grants log exact.
-                        let (score, reason) = if o.granted {
-                            (format!("{:.3}", o.score), o.reason.clone())
-                        } else {
-                            (deny_score(o.score), deny_reason(&o.reason))
-                        };
-                        eprintln!("irlumed: face auth '{user}': granted={} live={} score={score} ({reason})",
+                Ok(o) => recorded_face_response(
+                    || retry_throttle::record(&user, &o),
+                    retry_verify_refusal,
+                    || {
+                        if convenience || irlume_common::dbglog::on() {
+                            // Denied score + reason measurements quantized/redacted
+                            // unless tracing (anti-oracle); grants log exact.
+                            let (score, reason) = if o.granted {
+                                (format!("{:.3}", o.score), o.reason.clone())
+                            } else {
+                                (deny_score(o.score), deny_reason(&o.reason))
+                            };
+                            eprintln!("irlumed: face auth '{user}': granted={} live={} score={score} ({reason})",
                             o.granted, o.live);
-                    }
-                    irlume_common::dlog!("verify '{user}' total {}ms", t.elapsed().as_millis());
-                    Response::AuthResult {
-                        granted: o.granted,
-                        score: o.score,
-                        live: o.live,
-                        // The ONE site that carries the engine outcome onto the wire:
-                        // a deliberate head-shake becomes the flag pam_irlume aborts a
-                        // polkit dialog on, and only it. Every other outcome kind, and
-                        // every policy early-return above, is false. `is_gesture_decline`
-                        // and the shared `gesture_declined` constructor are unit-tested
-                        // (a revert of the shake kind to OtherDeny fails there), but this
-                        // call site itself, and the live detection path shake ->
-                        // gesture_declined, are covered ONLY by the hardware gesture test:
-                        // nothing camera-less forces a GestureDeclined outcome through
-                        // dispatch, so a `false` slip here would pass the suite (see the
-                        // handoff's coverage gap). Evaluated before the `reason` move: it
-                        // borrows `o`, the move does not.
-                        declined_by_gesture: irlume_auth::is_gesture_decline(&o),
-                        // This arm carries an ENGINE verdict: a face was looked
-                        // at (or looked for). The policy refusals return above,
-                        // before the camera.
-                        refused_by_policy: false,
-                        // #616 step 3: the final failed attempt's situation,
-                        // in the stable journal vocabulary, for pam's action
-                        // wording; empty on a grant and on every pre-camera
-                        // refusal (they send `situation: String::new()`).
-                        situation: if o.granted {
-                            String::new()
-                        } else {
-                            engine
-                                .last_attempt_situation_label()
-                                .unwrap_or_default()
-                                .to_string()
-                        },
-                        reason: o.reason,
-                    }
-                }
+                        }
+                        irlume_common::dlog!("verify '{user}' total {}ms", t.elapsed().as_millis());
+                        Response::AuthResult {
+                            granted: o.granted,
+                            score: o.score,
+                            live: o.live,
+                            // The ONE site that carries the engine outcome onto the wire:
+                            // a deliberate head-shake becomes the flag pam_irlume aborts a
+                            // polkit dialog on, and only it. Every other outcome kind, and
+                            // every policy early-return above, is false. `is_gesture_decline`
+                            // and the shared `gesture_declined` constructor are unit-tested
+                            // (a revert of the shake kind to OtherDeny fails there), but this
+                            // call site itself, and the live detection path shake ->
+                            // gesture_declined, are covered ONLY by the hardware gesture test:
+                            // nothing camera-less forces a GestureDeclined outcome through
+                            // dispatch, so a `false` slip here would pass the suite (see the
+                            // handoff's coverage gap). Evaluated before the `reason` move: it
+                            // borrows `o`, the move does not.
+                            declined_by_gesture: irlume_auth::is_gesture_decline(&o),
+                            // This arm carries an ENGINE verdict: a face was looked
+                            // at (or looked for). The policy refusals return above,
+                            // before the camera.
+                            refused_by_policy: false,
+                            // #616 step 3: the final failed attempt's situation,
+                            // in the stable journal vocabulary, for pam's action
+                            // wording; empty on a grant and on every pre-camera
+                            // refusal (they send `situation: String::new()`).
+                            situation: if o.granted {
+                                String::new()
+                            } else {
+                                engine
+                                    .last_attempt_situation_label()
+                                    .unwrap_or_default()
+                                    .to_string()
+                            },
+                            reason: o.reason.clone(),
+                        }
+                    },
+                ),
                 Err(e) => Response::Error(e.to_string()),
             }
         }
@@ -5495,8 +5428,8 @@ fn do_unseal_password_scoped(
     }
     // Same failure throttle as the login/sudo path: after a run of failures,
     // skip the camera and let PAM fall to the password.
-    if rate_limited(user) {
-        return Response::Error("too many recent face attempts; use your password".into());
+    if let Err(reason) = retry_throttle::check(user) {
+        return retry_unseal_refusal(reason);
     }
     let outcome = match engine.authenticate_for_with_diagnostics(
         user,
@@ -5520,11 +5453,18 @@ fn do_unseal_password_scoped(
             return Response::Error(e.to_string());
         }
     };
-    rate_record(
-        user,
-        outcome.granted,
-        !irlume_auth::presence_retryable(&outcome),
-    );
+    recorded_face_response(
+        || retry_throttle::record(user, &outcome),
+        retry_unseal_refusal,
+        || finish_unseal_password(user, &outcome, t),
+    )
+}
+
+fn finish_unseal_password(
+    user: &str,
+    outcome: &irlume_auth::Outcome,
+    t: std::time::Instant,
+) -> Response {
     if !outcome.granted {
         // Denied-attempt scores are QUANTIZED to one decimal unless tracing is
         // on: a 4-decimal score after every try is a gradient a journal-reading
@@ -6496,9 +6436,17 @@ mod tests {
         //
         // `include_str!` and not a runtime read: a renamed or deleted module
         // is then a compile error rather than a silently smaller scan.
-        let sources: [(&str, &str); 7] = [
+        let sources: [(&str, &str); 8] = [
             ("main.rs", include_str!("main.rs")),
             ("users.rs", include_str!("users.rs")),
+            (
+                "retry_throttle.rs",
+                concat!(
+                    include_str!("retry_throttle.rs"),
+                    "\n",
+                    include_str!("retry_throttle/tests.rs")
+                ),
+            ),
             ("arbiter.rs", include_str!("arbiter.rs")),
             ("position_session.rs", include_str!("position_session.rs")),
             (
@@ -6519,6 +6467,9 @@ mod tests {
             "pregate(",
             "authorized_for(",
             "uid_of(",
+            "retry_throttle::check(",
+            "retry_throttle::record(",
+            "account(",
             "uid_for_name(",
             "name_for_uid(",
             "identify_scope(",
@@ -8835,54 +8786,6 @@ mod tests {
     }
 
     #[test]
-    fn rate_throttle_trips_after_the_limit_and_resets_on_grant() {
-        let _g = env_lock();
-        std::env::set_var("IRLUME_RATE_LIMIT", "3");
-        std::env::set_var("IRLUME_RATE_COOLDOWN_SECS", "30");
-        // Unique user so the process-global map does not bleed across tests.
-        let u = format!("throttle-{}", std::process::id());
-
-        // Below the limit: strikes accumulate, not yet throttled.
-        assert!(!rate_limited(&u));
-        rate_record(&u, false, true); // strike 1
-        rate_record(&u, false, true); // strike 2
-        assert!(!rate_limited(&u), "under the limit must not throttle");
-        rate_record(&u, false, true); // strike 3 -> cooldown
-        assert!(rate_limited(&u), "at the limit the user is throttled");
-
-        // No-face outcomes (nobody in frame) never count: fresh user stays open
-        // even after many of them.
-        let u2 = format!("noface-{}", std::process::id());
-        for _ in 0..10 {
-            rate_record(&u2, false, false);
-        }
-        assert!(!rate_limited(&u2), "absence must not throttle");
-
-        // A grant clears the throttle immediately.
-        let u3 = format!("grant-{}", std::process::id());
-        rate_record(&u3, false, true);
-        rate_record(&u3, false, true);
-        rate_record(&u3, false, true);
-        assert!(rate_limited(&u3));
-        rate_record(&u3, true, true);
-        assert!(!rate_limited(&u3), "a grant resets the throttle");
-
-        // Limit of 0 disables the throttle entirely.
-        std::env::set_var("IRLUME_RATE_LIMIT", "0");
-        let u4 = format!("disabled-{}", std::process::id());
-        for _ in 0..20 {
-            rate_record(&u4, false, true);
-        }
-        assert!(
-            !rate_limited(&u4),
-            "IRLUME_RATE_LIMIT=0 disables the throttle"
-        );
-
-        std::env::remove_var("IRLUME_RATE_LIMIT");
-        std::env::remove_var("IRLUME_RATE_COOLDOWN_SECS");
-    }
-
-    #[test]
     fn env_or_prefers_the_env_var_over_the_default() {
         let _g = env_lock();
         std::env::remove_var("IRLUME_TEST_ENV_OR");
@@ -9660,6 +9563,7 @@ mod tests {
     #[test]
     fn authenticate_refuses_an_unenrolled_user_before_the_camera() {
         let _g = env_lock();
+        let user = users::name_for_uid(0).expect("root NSS account");
         let mut e = engine();
         let sb = sandbox("auth-ghost");
         let _ = &sb;
@@ -9668,7 +9572,7 @@ mod tests {
         // capture (the devices don't exist, so reaching the camera would error).
         match dispatch(
             Request::Authenticate {
-                user: "irlume-test-ghost".into(),
+                user: user.clone(),
                 service: Some("kde".into()),
                 intent_confirmation: None,
             },
@@ -9682,7 +9586,7 @@ mod tests {
                 ..
             } => {
                 assert!(!granted && !live);
-                assert_eq!(reason, "'irlume-test-ghost' is not enrolled");
+                assert_eq!(reason, format!("'{user}' is not enrolled"));
                 // The reason must survive journal redaction unchanged (no
                 // numeric payload for a spoofer to tune against).
                 assert_eq!(deny_reason(&reason), reason);
@@ -9694,12 +9598,13 @@ mod tests {
     #[test]
     fn authenticate_surfaces_a_capture_error_for_an_enrolled_user() {
         let _g = env_lock();
+        let user = users::name_for_uid(0).expect("root NSS account");
         let mut e = engine();
         let sb = sandbox("auth-cam");
-        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
+        write_enrollment(&sb.dir, &enrollment_with(&user, &["Face Scan 1"]));
         match dispatch(
             Request::Authenticate {
-                user: "carol".into(),
+                user: user.clone(),
                 service: Some("kde".into()),
                 intent_confirmation: None,
             },
@@ -10838,31 +10743,32 @@ mod tests {
     #[test]
     fn do_unseal_password_requires_an_armed_seal_then_a_granted_face() {
         let _g = env_lock();
+        let user = users::name_for_uid(0).expect("root NSS account");
         let mut e = engine();
         let sb = sandbox("do-unseal");
         // Nothing armed: refused before any capture or TPM traffic.
-        match do_unseal_password("carol", None, &mut e) {
+        match do_unseal_password(&user, None, &mut e) {
             Response::Error(msg) => {
                 assert_eq!(
                     msg,
-                    "no sealed password for 'carol': run `irlume keyring arm`"
+                    format!("no sealed password for '{user}': run `irlume keyring arm`")
                 )
             }
             other => panic!("unarmed unseal must be refused, got {other:?}"),
         }
         // Armed (existence check only) but the user is not enrolled: the face
         // check denies before the camera and the envelope is never opened.
-        plant_fake_envelope("carol");
-        match do_unseal_password("carol", None, &mut e) {
+        plant_fake_envelope(&user);
+        match do_unseal_password(&user, None, &mut e) {
             Response::Error(msg) => {
-                assert_eq!(msg, "face not granted: 'carol' is not enrolled")
+                assert_eq!(msg, format!("face not granted: '{user}' is not enrolled"))
             }
             other => panic!("unenrolled unseal must be refused, got {other:?}"),
         }
         // Enrolled: the capture itself fails on this hardware and maps to a
         // clean Error (the non-drift branch: no remedy hint appended).
-        write_enrollment(&sb.dir, &enrollment_with("carol", &["Face Scan 1"]));
-        match do_unseal_password("carol", None, &mut e) {
+        write_enrollment(&sb.dir, &enrollment_with(&user, &["Face Scan 1"]));
+        match do_unseal_password(&user, None, &mut e) {
             Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
             other => panic!("missing camera must be an Error, got {other:?}"),
         }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -11202,17 +11202,18 @@ mod tests {
     #[ignore = "needs v4l2loopback feeder nodes; set IRLUME_TEST_RGB_DEVICE/IRLUME_TEST_IR_DEVICE (CI does this)"]
     fn loopback_authenticate_dispatches_to_a_no_face_denial() {
         let _g = env_lock();
+        let user = users::name_for_uid(0).expect("root NSS account");
         let mut e = loopback_engine();
         let sb = sandbox("lb-auth");
         // One-shot capture instead of a grace window: a no-face run finishes
         // in one camera round.
         std::env::set_var("IRLUME_GRACE_MS", "0");
-        write_enrollment(&sb.dir, &enrollment_with("lbuser", &["Face Scan 1"]));
+        write_enrollment(&sb.dir, &enrollment_with(&user, &["Face Scan 1"]));
         // "kde" is a ScreenUnlock in every tier, so the dispatch gates pass
         // whether or not the runner's loopback nodes register as an IR pair.
         let resp = dispatch(
             Request::Authenticate {
-                user: "lbuser".into(),
+                user: user.clone(),
                 service: Some("kde".into()),
                 intent_confirmation: None,
             },
@@ -11225,10 +11226,15 @@ mod tests {
                 granted,
                 live,
                 reason,
+                refused_by_policy,
                 ..
             } => {
                 assert!(!granted, "no face on the feed must never grant");
                 assert!(!live);
+                assert!(
+                    !refused_by_policy,
+                    "the loopback fixture must reach the engine"
+                );
                 assert!(
                     reason.to_lowercase().contains("face"),
                     "denial should name the missing face, got: {reason}"

--- a/crates/irlume-daemon/src/retry_throttle.rs
+++ b/crates/irlume-daemon/src/retry_throttle.rs
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Recorded account failures survive daemon restarts. Terminal recording is not
+//! a write-ahead reservation of every matcher opportunity or an overall ceiling.
+//! Disk is authoritative: no cached counter can disagree with a visible rename.
+
+use irlume_common::{write_atomic_reporting, AtomicWrite};
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+
+const MAX_RECORD: u64 = 4096;
+const NANOS: u64 = 1_000_000_000;
+pub(crate) const UNAVAILABLE: &str =
+    "face retry state unavailable; use your password and ask an administrator to check /var/lib/irlume/retry";
+pub(crate) const LIMITED: &str = "too many recent face attempts; use your password";
+
+fn invalid() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "invalid face retry state")
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Account {
+    uid: u32,
+    name: String,
+}
+
+#[derive(Clone, Copy)]
+struct Policy {
+    limit: u32,
+    seconds: u64,
+}
+
+impl Policy {
+    fn configured() -> Self {
+        Self {
+            limit: crate::env_or("IRLUME_RATE_LIMIT", "5").parse().unwrap_or(5),
+            seconds: crate::env_or("IRLUME_RATE_COOLDOWN_SECS", "30")
+                .parse()
+                .unwrap_or(30),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Tick {
+    boot: String,
+    nanos: u64,
+}
+
+fn valid_boot(boot: &str) -> bool {
+    boot.len() == 36
+        && boot.bytes().enumerate().all(|(i, b)| {
+            if [8, 13, 18, 23].contains(&i) {
+                b == b'-'
+            } else {
+                b.is_ascii_hexdigit()
+            }
+        })
+}
+
+fn linux_clock() -> io::Result<Tick> {
+    let boot = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")?;
+    let boot = boot.trim().to_owned();
+    if !valid_boot(&boot) {
+        return Err(invalid());
+    }
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: ts is a writable timespec and CLOCK_MONOTONIC is a Linux clock ID.
+    if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let seconds = u64::try_from(ts.tv_sec).map_err(|_| invalid())?;
+    let fractional = u64::try_from(ts.tv_nsec).map_err(|_| invalid())?;
+    if fractional >= NANOS {
+        return Err(invalid());
+    }
+    let nanos = seconds
+        .checked_mul(NANOS)
+        .and_then(|n| n.checked_add(fractional))
+        .ok_or_else(invalid)?;
+    Ok(Tick { boot, nanos })
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Cooldown {
+    boot_id: String,
+    deadline_nanos: u64,
+    duration_nanos: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Record {
+    version: u32,
+    uid: u32,
+    account: String,
+    strikes: u32,
+    #[serde(deserialize_with = "Option::deserialize")]
+    cooldown: Option<Cooldown>,
+}
+
+impl Record {
+    fn empty(account: &Account) -> Self {
+        Self {
+            version: 1,
+            uid: account.uid,
+            account: account.name.clone(),
+            strikes: 0,
+            cooldown: None,
+        }
+    }
+
+    fn validate(&self, account: &Account) -> io::Result<()> {
+        if self.version != 1
+            || self.uid != account.uid
+            || self.account != account.name
+            || self.account.is_empty()
+            || self.account.len() > 256
+            || self.account.chars().any(char::is_control)
+            || self.cooldown.as_ref().is_some_and(|c| {
+                !valid_boot(&c.boot_id) || c.deadline_nanos < c.duration_nanos || self.strikes != 0
+            })
+        {
+            return Err(invalid());
+        }
+        Ok(())
+    }
+
+    fn arm(&mut self, now: &Tick, duration: u64) -> io::Result<()> {
+        self.cooldown = Some(Cooldown {
+            boot_id: now.boot.clone(),
+            deadline_nanos: now.nanos.checked_add(duration).ok_or_else(invalid)?,
+            duration_nanos: duration,
+        });
+        self.strikes = 0;
+        Ok(())
+    }
+}
+
+/// The parent is daemon-selected, never request-selected. Production additionally
+/// verifies its fixed ancestors. Tests supply a private parent and its owner.
+struct Store {
+    parent: PathBuf,
+    owner: u32,
+}
+
+fn open_dir(path: &Path, owner: u32, private: bool) -> io::Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)?;
+    let meta = file.metadata()?;
+    let mode = meta.mode() & 0o7777;
+    if meta.uid() != owner
+        || !meta.is_dir()
+        || if private {
+            mode != 0o700
+        } else {
+            mode & 0o022 != 0
+        }
+    {
+        return Err(invalid());
+    }
+    Ok(file)
+}
+
+impl Store {
+    /// Open and exclusively lock the directory inode. All subsequent accesses are
+    /// pinned through its fd, including the existing atomic writer, so a renamed
+    /// parent cannot redirect publication. Closing the fd releases flock even on error.
+    fn lock(&self) -> io::Result<File> {
+        let parent = open_dir(&self.parent, self.owner, false)?;
+        let path = PathBuf::from(format!("/proc/self/fd/{}/retry", parent.as_raw_fd()));
+        match std::fs::DirBuilder::new().mode(0o700).create(&path) {
+            Ok(()) => (),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => (),
+            Err(e) => return Err(e),
+        }
+        let dir = open_dir(&path, self.owner, true)?;
+        // Also retries directory-creation durability following an earlier error.
+        parent.sync_all()?;
+        // SAFETY: dir owns a valid fd throughout the lock lifetime.
+        if unsafe { libc::flock(dir.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(dir)
+    }
+
+    fn path(dir: &File, account: &Account) -> PathBuf {
+        PathBuf::from(format!(
+            "/proc/self/fd/{}/{}.json",
+            dir.as_raw_fd(),
+            account.uid
+        ))
+    }
+
+    fn read(&self, dir: &File, account: &Account) -> io::Result<Record> {
+        let path = Self::path(dir, account);
+        let file = match OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(path)
+        {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Record::empty(account)),
+            Err(e) => return Err(e),
+        };
+        let meta = file.metadata()?;
+        if !meta.is_file()
+            || meta.uid() != self.owner
+            || meta.mode() & 0o7777 != 0o600
+            || meta.nlink() != 1
+            || meta.len() > MAX_RECORD
+        {
+            return Err(invalid());
+        }
+        let mut bytes = Vec::new();
+        (&file).take(MAX_RECORD + 1).read_to_end(&mut bytes)?;
+        if bytes.len() > MAX_RECORD as usize {
+            return Err(invalid());
+        }
+        let record: Record = serde_json::from_slice(&bytes).map_err(|_| invalid())?;
+        record.validate(account)?;
+        // A previous rename may have been visible but not durable. Re-read and
+        // establish durability before permitting face again, including after a
+        // process restart. There is no stale in-memory copy to restore on error.
+        file.sync_all()?;
+        dir.sync_all()?;
+        Ok(record)
+    }
+
+    fn commit(&self, dir: &File, record: &Record, writer: Writer) -> io::Result<()> {
+        record.validate(&Account {
+            uid: record.uid,
+            name: record.account.clone(),
+        })?;
+        let bytes = serde_json::to_vec(record).map_err(|_| invalid())?;
+        if bytes.len() > MAX_RECORD as usize {
+            return Err(invalid());
+        }
+        let account = Account {
+            uid: record.uid,
+            name: record.account.clone(),
+        };
+        match writer(&Self::path(dir, &account), &bytes, 0o600)? {
+            AtomicWrite::Durable => Ok(()),
+            AtomicWrite::VisibleNotDurable(error) => Err(error),
+        }
+    }
+
+    fn check(
+        &self,
+        account: &Account,
+        policy: Policy,
+        clock: Clock,
+        writer: Writer,
+    ) -> io::Result<bool> {
+        if policy.limit == 0 {
+            return Ok(false);
+        }
+        let now = clock()?;
+        if !valid_boot(&now.boot) {
+            return Err(invalid());
+        }
+        let dir = self.lock()?;
+        let mut record = self.read(&dir, account)?;
+        let before = record.clone();
+        if let Some(c) = &record.cooldown {
+            if c.boot_id != now.boot {
+                record.arm(&now, c.duration_nanos)?;
+            } else if c.deadline_nanos.saturating_sub(now.nanos) > c.duration_nanos {
+                return Err(invalid()); // Clock moved backwards or impossible deadline.
+            } else if now.nanos >= c.deadline_nanos {
+                record.cooldown = None;
+                record.strikes = 0;
+            }
+        } else if record.strikes >= policy.limit {
+            // A lowered threshold cannot replenish the already recorded budget.
+            record.arm(&now, policy.seconds.checked_mul(NANOS).ok_or_else(invalid)?)?;
+        }
+        if record != before {
+            self.commit(&dir, &record, writer)?;
+        }
+        Ok(record
+            .cooldown
+            .as_ref()
+            .is_some_and(|c| now.nanos < c.deadline_nanos))
+    }
+
+    fn record(
+        &self,
+        account: &Account,
+        policy: Policy,
+        outcome: &irlume_auth::Outcome,
+        clock: Clock,
+        writer: Writer,
+    ) -> io::Result<()> {
+        if policy.limit == 0 {
+            return Ok(());
+        }
+        // No fresh record or write solely for absence, uncertainty or cancellation.
+        // Preflight already validated the store. An explicit cancellation remains final.
+        if !outcome.granted
+            && (irlume_auth::presence_retryable(outcome)
+                || irlume_auth::is_gesture_decline(outcome))
+        {
+            return Ok(());
+        }
+        let now = clock()?;
+        if !valid_boot(&now.boot) {
+            return Err(invalid());
+        }
+        let dir = self.lock()?;
+        let mut record = self.read(&dir, account)?;
+        if outcome.granted {
+            record.strikes = 0;
+            record.cooldown = None;
+        } else if record.cooldown.is_none() {
+            record.strikes = record.strikes.checked_add(1).ok_or_else(invalid)?;
+            if record.strikes >= policy.limit {
+                record.arm(&now, policy.seconds.checked_mul(NANOS).ok_or_else(invalid)?)?;
+            }
+        }
+        self.commit(&dir, &record, writer)
+    }
+}
+
+type Clock = fn() -> io::Result<Tick>;
+type Writer = fn(&Path, &[u8], u32) -> io::Result<AtomicWrite>;
+
+fn account(user: &str) -> io::Result<Account> {
+    let uid = crate::users::uid_for_name(user).ok_or_else(invalid)?;
+    let name = crate::users::name_for_uid(uid).ok_or_else(invalid)?;
+    Ok(Account { uid, name })
+}
+
+#[cfg(not(test))]
+fn production_store() -> io::Result<Store> {
+    // Fixed trusted ancestors. Do not accept an unprivileged socket path or
+    // reuse the enrollment store's environment override for retry enforcement.
+    for path in ["/", "/var", "/var/lib"] {
+        open_dir(Path::new(path), 0, false)?;
+    }
+    match std::fs::DirBuilder::new()
+        .mode(0o700)
+        .create("/var/lib/irlume")
+    {
+        Ok(()) => (),
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => (),
+        Err(e) => return Err(e),
+    }
+    File::open("/var/lib")?.sync_all()?;
+    Ok(Store {
+        parent: "/var/lib/irlume".into(),
+        owner: 0,
+    })
+}
+
+// Unit/engine fixtures must never access installed retry records, even when
+// cargo test is run as root. Only the store location/owner is injected; parsing,
+// transitions, locking, clock, writer and NSS resolution are unchanged.
+#[cfg(test)]
+fn production_store() -> io::Result<Store> {
+    let parent = std::env::var_os("IRLUME_STATE_DIR").ok_or_else(invalid)?;
+    Ok(Store {
+        parent: parent.into(),
+        // SAFETY: geteuid has no preconditions.
+        owner: unsafe { libc::geteuid() },
+    })
+}
+
+pub(crate) fn check(user: &str) -> Result<(), &'static str> {
+    let policy = Policy::configured();
+    if policy.limit == 0 {
+        return Ok(());
+    }
+    let result = account(user)
+        .and_then(|a| production_store()?.check(&a, policy, linux_clock, write_atomic_reporting));
+    match result {
+        Ok(false) => Ok(()),
+        Ok(true) => Err(LIMITED),
+        Err(e) => {
+            eprintln!("irlumed: face retry preflight failed: {e}");
+            Err(UNAVAILABLE)
+        }
+    }
+}
+
+pub(crate) fn record(user: &str, outcome: &irlume_auth::Outcome) -> Result<(), &'static str> {
+    let policy = Policy::configured();
+    if policy.limit == 0 {
+        return Ok(());
+    }
+    let result = account(user).and_then(|a| {
+        production_store()?.record(&a, policy, outcome, linux_clock, write_atomic_reporting)
+    });
+    result.map_err(|e| {
+        eprintln!("irlumed: face retry recording failed: {e}");
+        UNAVAILABLE
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/irlume-daemon/src/retry_throttle/tests.rs
+++ b/crates/irlume-daemon/src/retry_throttle/tests.rs
@@ -1,0 +1,763 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use super::*;
+use irlume_auth::OutcomeKind as Kind;
+use std::os::unix::fs::{symlink, PermissionsExt};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const BOOT: &str = "00000000-0000-4000-8000-000000000001";
+const NEXT_BOOT: &str = "00000000-0000-4000-8000-000000000002";
+const POLICY: Policy = Policy {
+    limit: 3,
+    seconds: 30,
+};
+
+fn now() -> io::Result<Tick> {
+    Ok(Tick {
+        boot: BOOT.into(),
+        nanos: 100 * NANOS,
+    })
+}
+fn later() -> io::Result<Tick> {
+    Ok(Tick {
+        boot: BOOT.into(),
+        nanos: 131 * NANOS,
+    })
+}
+fn reboot() -> io::Result<Tick> {
+    Ok(Tick {
+        boot: NEXT_BOOT.into(),
+        nanos: NANOS,
+    })
+}
+fn bad_clock() -> io::Result<Tick> {
+    Err(io::Error::other("synthetic clock failure"))
+}
+fn bad_boot() -> io::Result<Tick> {
+    Ok(Tick {
+        boot: "invalid".into(),
+        nanos: 0,
+    })
+}
+fn overflow() -> io::Result<Tick> {
+    Ok(Tick {
+        boot: BOOT.into(),
+        nanos: u64::MAX,
+    })
+}
+fn before_rename(_: &Path, _: &[u8], _: u32) -> io::Result<AtomicWrite> {
+    Err(io::Error::other("synthetic pre-publication failure"))
+}
+fn after_rename(path: &Path, bytes: &[u8], mode: u32) -> io::Result<AtomicWrite> {
+    // Real atomic publication, then inject the writer's uncertain-durability
+    // result at its boundary. This tests caller semantics, not kernel fsync faults.
+    write_atomic_reporting(path, bytes, mode)?;
+    Ok(AtomicWrite::VisibleNotDurable(io::Error::other(
+        "synthetic fsync failure",
+    )))
+}
+
+fn outcome(kind: Kind) -> irlume_auth::Outcome {
+    let live = matches!(kind, Kind::Granted | Kind::BelowThreshold);
+    irlume_auth::Outcome {
+        granted: kind == Kind::Granted,
+        live,
+        score: if live { 0.5 } else { 0.0 },
+        reason: "synthetic outcome; classify by type".into(),
+        kind,
+    }
+}
+fn account_one() -> Account {
+    Account {
+        uid: 1001,
+        name: "synthetic-one".into(),
+    }
+}
+
+struct Fixture {
+    store: Store,
+}
+impl Fixture {
+    fn new() -> Self {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let parent = std::env::temp_dir().join(format!(
+            "irlume-retry-test-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&parent)
+            .unwrap();
+        Self {
+            store: Store {
+                parent,
+                // SAFETY: geteuid has no preconditions.
+                owner: unsafe { libc::geteuid() },
+            },
+        }
+    }
+    fn path(&self) -> PathBuf {
+        self.store.parent.join("retry/1001.json")
+    }
+    fn check(&self) -> bool {
+        self.store
+            .check(&account_one(), POLICY, now, write_atomic_reporting)
+            .unwrap()
+    }
+    fn record(&self, kind: Kind) {
+        self.store
+            .record(
+                &account_one(),
+                POLICY,
+                &outcome(kind),
+                now,
+                write_atomic_reporting,
+            )
+            .unwrap();
+    }
+    fn bytes(&self) -> Vec<u8> {
+        std::fs::read(self.path()).unwrap()
+    }
+    fn saved(&self) -> Record {
+        serde_json::from_slice(&self.bytes()).unwrap()
+    }
+    fn plant(&self, bytes: &[u8]) {
+        let dir = self.store.lock().unwrap();
+        write_atomic_reporting(&Store::path(&dir, &account_one()), bytes, 0o600).unwrap();
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.store.parent).unwrap();
+    }
+}
+
+// Migrated original consent-throttle regressions: the real persistent store now
+// replaces direct inspection/deletion of a process-local map.
+#[test]
+fn rate_throttle_outcome_classes_preserve_rejection_policy() {
+    for (kind, limited) in [
+        (Kind::Granted, false),
+        (Kind::NoFace, false),
+        (Kind::Uncertain, false),
+        (Kind::SpoofNoIrFace, false),
+        (Kind::GestureDeclined, false),
+        (Kind::Spoof, true),
+        (Kind::BelowThreshold, true),
+        (Kind::OtherDeny, true),
+    ] {
+        let f = Fixture::new();
+        let policy = Policy { limit: 1, ..POLICY };
+        f.store
+            .record(
+                &account_one(),
+                policy,
+                &outcome(kind),
+                now,
+                write_atomic_reporting,
+            )
+            .unwrap();
+        assert_eq!(
+            f.store
+                .check(&account_one(), policy, now, write_atomic_reporting)
+                .unwrap(),
+            limited,
+            "{kind:?}"
+        );
+        if matches!(
+            kind,
+            Kind::NoFace | Kind::Uncertain | Kind::SpoofNoIrFace | Kind::GestureDeclined
+        ) {
+            assert!(
+                !f.path().exists(),
+                "ignored outcomes must not create records"
+            );
+        }
+    }
+}
+
+#[test]
+fn rate_throttle_cancellation_preserves_an_active_cooldown() {
+    let f = Fixture::new();
+    for _ in 0..3 {
+        f.record(Kind::Spoof);
+    }
+    let before = f.bytes();
+    assert!(f.saved().cooldown.is_some());
+    f.record(Kind::GestureDeclined);
+    assert!(f.check());
+    assert_eq!(
+        f.bytes(),
+        before,
+        "cancellation must neither extend nor clear cooldown"
+    );
+}
+
+#[test]
+fn rate_throttle_cancellation_does_not_add_or_clear_failures() {
+    for live in [false, true] {
+        let f = Fixture::new();
+        f.record(Kind::BelowThreshold);
+        f.record(Kind::BelowThreshold);
+        let before = f.bytes();
+        let decline = irlume_auth::Outcome {
+            live,
+            score: if live { 0.9 } else { 0.0 },
+            ..outcome(Kind::GestureDeclined)
+        };
+        for _ in 0..6 {
+            f.store
+                .record(
+                    &account_one(),
+                    POLICY,
+                    &decline,
+                    now,
+                    write_atomic_reporting,
+                )
+                .unwrap();
+            assert!(!f.check());
+            assert_eq!(f.bytes(), before);
+        }
+        f.record(Kind::BelowThreshold);
+        assert!(f.check(), "cancellation must not clear prior strikes");
+    }
+}
+
+#[test]
+fn rate_throttle_trips_after_the_limit_and_resets_on_grant() {
+    let f = Fixture::new();
+    assert!(!f.check());
+    f.record(Kind::Spoof);
+    f.record(Kind::Spoof);
+    assert!(!f.check());
+    f.record(Kind::Spoof);
+    assert!(f.check());
+    f.record(Kind::Granted);
+    assert!(!f.check());
+    let absent = Fixture::new();
+    for _ in 0..10 {
+        absent.record(Kind::NoFace);
+    }
+    assert!(!absent.check());
+    assert!(!absent.path().exists());
+    f.record(Kind::Spoof);
+    let before = f.bytes();
+    let disabled = Policy { limit: 0, ..POLICY };
+    for _ in 0..20 {
+        f.store
+            .record(
+                &account_one(),
+                disabled,
+                &outcome(Kind::Spoof),
+                bad_clock,
+                before_rename,
+            )
+            .unwrap();
+    }
+    f.store
+        .record(
+            &account_one(),
+            disabled,
+            &outcome(Kind::Granted),
+            bad_clock,
+            before_rename,
+        )
+        .unwrap();
+    assert!(!f
+        .store
+        .check(&account_one(), disabled, bad_clock, before_rename)
+        .unwrap());
+    assert_eq!(f.bytes(), before, "disable must retain history");
+}
+
+#[test]
+fn rate_throttle_restart_preserves_recorded_cooldown() {
+    let f = Fixture::new();
+    f.record(Kind::Spoof);
+    f.record(Kind::Spoof);
+    let reopened = Store {
+        parent: f.store.parent.clone(),
+        owner: f.store.owner,
+    };
+    assert!(!reopened
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .unwrap());
+    reopened
+        .record(
+            &account_one(),
+            POLICY,
+            &outcome(Kind::Spoof),
+            now,
+            write_atomic_reporting,
+        )
+        .unwrap();
+    let before = f.bytes();
+    drop(reopened);
+    let restarted = Store {
+        parent: f.store.parent.clone(),
+        owner: f.store.owner,
+    };
+    assert!(restarted
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .unwrap());
+    assert_eq!(
+        f.bytes(),
+        before,
+        "same-boot reopen must not extend cooldown"
+    );
+}
+
+#[test]
+fn expiry_and_boot_change_are_durable_and_conservative() {
+    let f = Fixture::new();
+    f.record(Kind::Spoof);
+    assert!(!f
+        .store
+        .check(&account_one(), POLICY, reboot, write_atomic_reporting)
+        .unwrap());
+    assert_eq!(f.saved().strikes, 1, "partial failures survive reboot");
+    f.record(Kind::Spoof);
+    f.record(Kind::Spoof);
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, reboot, write_atomic_reporting)
+        .unwrap());
+    let c = f.saved().cooldown.unwrap();
+    assert_eq!(c.boot_id, NEXT_BOOT);
+    assert_eq!(c.deadline_nanos, 31 * NANOS);
+    assert_eq!(c.duration_nanos, 30 * NANOS);
+    // Reboot re-arm must retain the original duration after a config change.
+    assert!(f
+        .store
+        .check(
+            &account_one(),
+            Policy {
+                seconds: 0,
+                ..POLICY
+            },
+            reboot,
+            write_atomic_reporting
+        )
+        .unwrap());
+    assert_eq!(f.saved().cooldown.unwrap(), c);
+    let f = Fixture::new();
+    for _ in 0..3 {
+        f.record(Kind::Spoof);
+    }
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, later, before_rename)
+        .is_err());
+    assert!(
+        f.saved().cooldown.is_some(),
+        "failed expiry must not publish a reset"
+    );
+    assert!(!f
+        .store
+        .check(&account_one(), POLICY, later, write_atomic_reporting)
+        .unwrap());
+    assert!(f.saved().cooldown.is_none());
+    assert_eq!(f.saved().strikes, 0);
+}
+
+#[test]
+fn lowered_threshold_does_not_replenish_and_accounts_are_independent() {
+    let f = Fixture::new();
+    f.record(Kind::Spoof);
+    f.record(Kind::Spoof);
+    let other = Account {
+        uid: 1002,
+        name: "synthetic-two".into(),
+    };
+    assert!(!f
+        .store
+        .check(&other, POLICY, now, write_atomic_reporting)
+        .unwrap());
+    assert!(f
+        .store
+        .check(
+            &account_one(),
+            Policy { limit: 1, ..POLICY },
+            now,
+            write_atomic_reporting
+        )
+        .unwrap());
+    assert!(!f
+        .store
+        .check(&other, POLICY, now, write_atomic_reporting)
+        .unwrap());
+    // Service/profile are deliberately not inputs: all paths key by account UID.
+    let renamed = Account {
+        name: "new-owner-of-uid".into(),
+        ..account_one()
+    };
+    assert!(f
+        .store
+        .check(&renamed, POLICY, now, write_atomic_reporting)
+        .is_err());
+    assert!(f
+        .store
+        .record(
+            &renamed,
+            POLICY,
+            &outcome(Kind::Granted),
+            now,
+            write_atomic_reporting
+        )
+        .is_err());
+}
+
+#[test]
+fn invalid_records_never_become_empty_history() {
+    let f = Fixture::new();
+    f.record(Kind::Spoof);
+    let valid = String::from_utf8(f.bytes()).unwrap();
+    for bad in [
+        "{".into(),
+        "[]".into(),
+        " ".repeat(4097),
+        valid.replace("\"version\":1", "\"version\":2"),
+        valid.replace("\"version\":1", "\"version\":1,\"version\":1"),
+        valid.replace("\"strikes\":1", "\"strikes\":1,\"unknown\":0"),
+        valid.replace("\"uid\":1001", "\"uid\":1002"),
+        valid.replace("synthetic-one", "different-user"),
+        valid.replace("\"strikes\":1", "\"strikes\":-1"),
+        valid.replace("\"strikes\":1", "\"strikes\":4294967296"),
+    ] {
+        f.plant(bad.as_bytes());
+        assert!(
+            f.store
+                .check(&account_one(), POLICY, now, write_atomic_reporting)
+                .is_err(),
+            "{bad:.80}"
+        );
+        assert!(f
+            .store
+            .record(
+                &account_one(),
+                POLICY,
+                &outcome(Kind::Granted),
+                now,
+                write_atomic_reporting
+            )
+            .is_err());
+        assert_eq!(f.bytes(), bad.as_bytes());
+    }
+    f.plant(valid.as_bytes());
+    assert!(!f.check(), "repaired state must be re-read");
+}
+
+#[test]
+fn file_and_directory_trust_checks_reject_unsafe_state() {
+    let f = Fixture::new();
+    f.record(Kind::Spoof);
+    std::fs::set_permissions(f.path(), std::fs::Permissions::from_mode(0o644)).unwrap();
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+    std::fs::set_permissions(f.path(), std::fs::Permissions::from_mode(0o600)).unwrap();
+    let wrong_owner = Store {
+        parent: f.store.parent.clone(),
+        owner: f.store.owner.wrapping_add(1),
+    };
+    assert!(wrong_owner
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+    let target = f.store.parent.join("target");
+    std::fs::rename(f.path(), &target).unwrap();
+    symlink(&target, f.path()).unwrap();
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+    assert!(f
+        .store
+        .record(
+            &account_one(),
+            POLICY,
+            &outcome(Kind::Granted),
+            now,
+            write_atomic_reporting
+        )
+        .is_err());
+    std::fs::remove_file(f.path()).unwrap();
+    std::fs::hard_link(&target, f.path()).unwrap();
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+    std::fs::remove_file(f.path()).unwrap();
+    std::fs::create_dir(f.path()).unwrap();
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+    std::fs::remove_dir(f.path()).unwrap();
+    std::fs::set_permissions(
+        f.store.parent.join("retry"),
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+    std::fs::remove_dir(f.store.parent.join("retry")).unwrap();
+    symlink(&f.store.parent, f.store.parent.join("retry")).unwrap();
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+}
+
+#[test]
+fn clocks_and_duration_overflow_fail_without_writing() {
+    let f = Fixture::new();
+    for clock in [bad_clock as Clock, bad_boot] {
+        assert!(f
+            .store
+            .check(&account_one(), POLICY, clock, write_atomic_reporting)
+            .is_err());
+        assert!(f
+            .store
+            .record(
+                &account_one(),
+                POLICY,
+                &outcome(Kind::Granted),
+                clock,
+                write_atomic_reporting
+            )
+            .is_err());
+        assert!(!f.path().exists());
+    }
+    let threshold = Policy { limit: 1, ..POLICY };
+    assert!(f
+        .store
+        .record(
+            &account_one(),
+            threshold,
+            &outcome(Kind::Spoof),
+            overflow,
+            write_atomic_reporting
+        )
+        .is_err());
+    assert!(f
+        .store
+        .record(
+            &account_one(),
+            Policy {
+                limit: 1,
+                seconds: u64::MAX
+            },
+            &outcome(Kind::Spoof),
+            now,
+            write_atomic_reporting
+        )
+        .is_err());
+    assert!(!f.path().exists());
+    for _ in 0..3 {
+        f.record(Kind::Spoof);
+    }
+    let mut record = f.saved();
+    record.cooldown.as_mut().unwrap().deadline_nanos = 200 * NANOS;
+    f.plant(&serde_json::to_vec(&record).unwrap());
+    assert!(f
+        .store
+        .check(&account_one(), POLICY, now, write_atomic_reporting)
+        .is_err());
+}
+
+#[test]
+fn publication_failure_preserves_the_actual_visible_state() {
+    for writer in [before_rename as Writer, after_rename] {
+        let f = Fixture::new();
+        f.record(Kind::Spoof);
+        assert!(f
+            .store
+            .record(&account_one(), POLICY, &outcome(Kind::Spoof), now, writer)
+            .is_err());
+        let expected = if std::ptr::fn_addr_eq(writer, before_rename as Writer) {
+            1
+        } else {
+            2
+        };
+        assert_eq!(f.saved().strikes, expected);
+        // The next operation re-reads and fsyncs the visible file, never a cache.
+        assert!(!f.check());
+        assert_eq!(f.saved().strikes, expected);
+    }
+}
+
+#[test]
+fn both_completion_paths_refuse_before_grant_or_secret_release_on_failed_commit() {
+    for refuse in [
+        crate::retry_verify_refusal as fn(&str) -> irlume_common::Response,
+        crate::retry_unseal_refusal,
+    ] {
+        for writer in [before_rename as Writer, after_rename] {
+            let f = Fixture::new();
+            f.record(Kind::Spoof);
+            let released = std::cell::Cell::new(false);
+            let response = crate::recorded_face_response(
+                || {
+                    f.store
+                        .record(&account_one(), POLICY, &outcome(Kind::Granted), now, writer)
+                        .map_err(|_| UNAVAILABLE)
+                },
+                refuse,
+                || {
+                    released.set(true);
+                    irlume_common::Response::Ok("synthetic completion".into())
+                },
+            );
+            assert!(
+                !released.get(),
+                "no grant or password release after failed commit"
+            );
+            match response {
+                irlume_common::Response::AuthResult {
+                    granted,
+                    declined_by_gesture,
+                    refused_by_policy,
+                    reason,
+                    ..
+                } => {
+                    assert!(!granted);
+                    assert!(!declined_by_gesture);
+                    assert!(refused_by_policy);
+                    assert_eq!(reason, UNAVAILABLE);
+                }
+                irlume_common::Response::Error(reason) => assert_eq!(reason, UNAVAILABLE),
+                other => panic!("unexpected response {other:?}"),
+            }
+            // A successful commit permits the continuation and resets history.
+            let response = crate::recorded_face_response(
+                || {
+                    f.store
+                        .record(
+                            &account_one(),
+                            POLICY,
+                            &outcome(Kind::Granted),
+                            now,
+                            write_atomic_reporting,
+                        )
+                        .map_err(|_| UNAVAILABLE)
+                },
+                refuse,
+                || {
+                    released.set(true);
+                    irlume_common::Response::Ok("synthetic completion".into())
+                },
+            );
+            assert!(matches!(response, irlume_common::Response::Ok(_)));
+            assert!(released.get());
+            assert_eq!(f.saved().strikes, 0);
+        }
+    }
+}
+
+#[test]
+fn independent_process_reads_the_same_deadline() {
+    const CHILD: &str = "IRLUME_RETRY_TEST_CHILD";
+    let _guard = crate::test_support::env_read();
+    if let Some(parent) = std::env::var_os(CHILD) {
+        let store = Store {
+            parent: parent.into(),
+            // SAFETY: geteuid has no preconditions.
+            owner: unsafe { libc::geteuid() },
+        };
+        assert!(store
+            .check(&account_one(), POLICY, now, write_atomic_reporting)
+            .unwrap());
+        return;
+    }
+    let f = Fixture::new();
+    for _ in 0..3 {
+        f.record(Kind::Spoof);
+    }
+    let bytes = f.bytes();
+    let result = std::process::Command::new(std::env::current_exe().unwrap())
+        .arg("retry_throttle::tests::independent_process_reads_the_same_deadline")
+        .arg("--exact")
+        .env(CHILD, &f.store.parent)
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stdout)
+    );
+    assert_eq!(f.bytes(), bytes);
+}
+
+#[test]
+fn explicit_linux_clock_has_valid_boot_and_monotonic_order() {
+    let a = linux_clock().unwrap();
+    let b = linux_clock().unwrap();
+    assert!(valid_boot(&a.boot));
+    assert_eq!(a.boot, b.boot);
+    assert!(b.nanos >= a.nanos);
+}
+
+#[test]
+fn concurrent_writers_do_not_lose_recorded_failures() {
+    let f = Fixture::new();
+    std::thread::scope(|scope| {
+        for _ in 0..12 {
+            let store = &f.store;
+            scope.spawn(move || {
+                store
+                    .record(
+                        &account_one(),
+                        Policy {
+                            limit: 100,
+                            ..POLICY
+                        },
+                        &outcome(Kind::Spoof),
+                        now,
+                        write_atomic_reporting,
+                    )
+                    .unwrap()
+            });
+        }
+    });
+    assert_eq!(f.saved().strikes, 12);
+}
+
+#[test]
+fn record_owner_and_nested_cooldown_schema_are_checked() {
+    let f = Fixture::new();
+    for _ in 0..3 {
+        f.record(Kind::Spoof);
+    }
+    let dir = f.store.lock().unwrap();
+    let wrong = Store {
+        parent: f.store.parent.clone(),
+        owner: f.store.owner.wrapping_add(1),
+    };
+    assert!(wrong.read(&dir, &account_one()).is_err());
+    drop(dir);
+    let valid = String::from_utf8(f.bytes()).unwrap();
+    for bad in [
+        valid.replace(
+            "\"duration_nanos\":30000000000",
+            "\"duration_nanos\":30000000000,\"extra\":1",
+        ),
+        valid.replace(
+            "\"duration_nanos\":30000000000",
+            "\"duration_nanos\":1,\"duration_nanos\":2",
+        ),
+        valid.replace(BOOT, "bad-boot"),
+        valid.replace("\"strikes\":0", "\"strikes\":1"),
+    ] {
+        assert_ne!(bad, valid);
+        f.plant(bad.as_bytes());
+        assert!(f
+            .store
+            .check(&account_one(), POLICY, now, write_atomic_reporting)
+            .is_err());
+    }
+}

--- a/docs/DISABLE.md
+++ b/docs/DISABLE.md
@@ -110,6 +110,55 @@ repeated failures the camera itself rests while the password keeps working
 (5 strikes by default, then a 30-second camera cooldown; `IRLUME_RATE_LIMIT`
 and `IRLUME_RATE_COOLDOWN_SECS` adjust both).
 
+A deliberate head-shake cancellation ends the request without adding a failure
+or clearing previous failures. No-face and uncertain-evidence outcomes also do
+not consume strikes; hard spoof and below-threshold rejections do. Login face
+verification and face-gated password release share this per-user counter.
+A face grant or cooldown expiry resets it. Recorded failures and an active
+cooldown survive daemon restarts. Profiles and PAM services for the same Linux
+account share the budget. The counter does not receive password-success events
+and is not an overall cumulative attempt ceiling.
+
+### Persistent retry records
+
+The daemon stores version-1 records in `/var/lib/irlume/retry/<uid>.json`.
+The directory is root-owned mode 0700; files are root-owned mode 0600. A record
+contains the account UID/name, consecutive count, and an optional monotonic
+clock deadline, boot identifier and original cooldown duration. It contains no
+biometric data or credentials. The retry location is fixed; enrollment path
+overrides do not redirect it. No same-user command can reset these records.
+
+A daemon restart in the same boot keeps the original deadline. Civil-clock
+changes do not affect it. After reboot, partial failures remain and a recorded
+cooldown starts again for its original duration; this can extend the wait.
+`IRLUME_RATE_LIMIT=0` disables enforcement without deleting history. Re-enabling
+it restores that history; lowering the limit cannot replenish recorded strikes.
+
+Missing records start empty on adoption. Existing malformed, oversized,
+unreadable, wrongly owned or unsafe records refuse the face path with a password
+fallback message. UID/name mismatches also refuse: a reused UID or renamed
+account must be reconciled by an administrator. A successful face match cannot
+return a grant or release a sealed password until its reset is durably committed.
+If publication succeeds but its durability check fails, that request still
+refuses; the next operation re-reads and synchronizes the visible state before
+allowing face again.
+
+For repair, use password authentication and inspect `journalctl -u irlumed`.
+Stop `irlumed.socket` and `irlumed.service` while correcting the affected
+record's ownership, permissions,
+account binding or malformed content; preserve the count and deadline whenever
+they can be established. Inspect the exact UID with `id -u <account>` and do not
+follow symlinks or change other users' records. Removing the affected record is
+an explicit root reset of its history; do so only if the administrator intends
+that reset, then start the socket and daemon. Corrected state is re-read automatically.
+An older daemon ignores these records: downgrading loses persistence enforcement
+until the new daemon returns, even if the files remain. Do not delete them as
+part of a binary rollback.
+
+This protects recorded state across restarts, not root deletion, disk rollback,
+or a crash before a terminal outcome is committed. A crash-proof cumulative
+ceiling and independently verified recovery remain separate policy work.
+
 ## Remove everything
 
 ```sh

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -167,6 +167,13 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   /etc/irlume/*.lock rwk,
   /home/*/.local/share/irlume/ rw,
   /home/*/.local/share/irlume/** rw,
+  # Retry accounting verifies its fixed ancestors, reads the boot identity,
+  # and flocks the private directory inode before publishing account records.
+  / r,
+  /var/ r,
+  /var/lib/ r,
+  /proc/sys/kernel/random/boot_id r,
+  /var/lib/irlume/retry/ rwk,
   /var/lib/irlume/ rw,
   /var/lib/irlume/** rw,
 

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -129,6 +129,13 @@ profile irlumed /usr/local/bin/irlumed {
   /etc/irlume/*.lock rwk,
   /home/*/.local/share/irlume/ rw,
   /home/*/.local/share/irlume/** rw,
+  # Retry accounting verifies its fixed ancestors, reads the boot identity,
+  # and flocks the private directory inode before publishing account records.
+  / r,
+  /var/ r,
+  /var/lib/ r,
+  /proc/sys/kernel/random/boot_id r,
+  /var/lib/irlume/retry/ rwk,
   /var/lib/irlume/ rw,
   /var/lib/irlume/** rw,
 


### PR DESCRIPTION
## What & why

Recorded face failures and cooldowns now survive daemon restarts. Verify and face-gated password release share one UID-bound record, so switching a PAM service or face profile does not replenish the account budget. Defaults stay five counted refusals followed by 30 seconds; absence, uncertain evidence and deliberate cancellation preserve history. This includes the consent-throttle correction prepared on the same base.

A private daemon module reads strict root-owned records under `/var/lib/irlume/retry`, serializes transitions with a directory lock, and uses the existing atomic writer. There is no cached counter to diverge after a visible-but-not-durable rename. A reset must be committed before a face grant or password release; invalid state or failed durability returns ordinary password fallback. Same-boot deadlines use Linux monotonic time. Reboot preserves partial failures and re-arms a stored cooldown for its original duration. Narrow AppArmor rules permit the directory lock and boot-identity read.

Design boundary: this preserves recorded terminal outcomes. It does not add a cumulative ceiling, crash reservations, or password-proven recovery; a crash before terminal recording remains outside this change. Root deletion/disk rollback and older daemons ignoring records remain administrative boundaries. DISABLE.md documents repair, UID/name mismatch, override and downgrade behavior.

Stacked on #659 (`perf/framing-session`, base `917e6f78378f0d1cce6fe290ad9a010b684893ec`).

## Testing

- Regression reproduced the old restart reset before implementation. Sixteen persistent-store tests cover the migrated consent cases, process reopen, clocks/reboot/expiry, accounts, concurrent writers, invalid schema/files, and pre-publication/visible-publication failure injection at the writer boundary. Both response continuations refuse on a failed grant reset. Injection tests validate caller behavior, not real kernel fsync failure.
- Minihost, exact implementation source/test executables (before the test-only loopback follow-up): 181 daemon tests passed, four existing hardware/TPM ignores; the selected model-backed consent fixture passed. All seven installed model checksums matched. Both AppArmor profiles parsed on minihost and passed the current and oldest-supported-parser CI steps; enforcing AppArmor runtime remains platform follow-up.
- Installed minihost service: exact optimized candidate passed 29 categorical assertions with camera devices hidden and a bind-mounted synthetic state directory. Real Verify and UnsealPassword requests shared strikes; partial counts and original cooldown bytes survived service restarts; corrupt records, repair, expiry and UID/name mismatch behaved as specified. Used an explicit 5/120-second setting for the restart test. Original service and installed binaries restored; temporary override, rollback timer and staging independently absent/inactive. No user enrollment, live face, credential or host reboot was used.
- Final daemon all-target Clippy, Rust 1.88 all-target check, warnings-denied daemon rustdoc, workspace formatting and optimized build passed. Exact patch reconstruction and preserved earlier worktree verified.

- [x] `cargo test --workspace` passes (final-head CI and stable lanes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (final-head virtual-workspace CI)
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean (final-head CI)
- [x] Docs/CHANGELOG updated if user-facing
- [ ] Hardware-validated (installed-service restart validation passed with synthetic state and hidden cameras; attended live-camera validation remains pending)

The final test-only follow-up uses a real NSS account for the loopback auth fixture and requires an engine refusal, preventing a preflight error from falsely satisfying its no-face assertion. All local gates passed again and the optimized binary is byte-for-byte unchanged. A repeat minihost run was cancelled at a fresh SSH identity check before remote execution; Final-head GitHub CI passed the strengthened loopback fixture and the complete virtual-camera step.

All nine GitHub validation checks passed on final head `492cf365ec68cf725b766a799160b96f56ec4398`; the two external Fedora RPM builds were still pending at readback. Kept as a draft for review and attended live-camera follow-up. No merge or permanent deployment.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>