### PR TITLE
fix: authorize recovery credential management

### DIFF
--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -1296,11 +1296,14 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
 pub(crate) fn daemon_request(
     req: &irlume_common::Request,
 ) -> Result<irlume_common::Response, String> {
-    // Enrollment allows OS approval, queue admission and the worker budget.
+    // Trust changes allow OS approval, queue admission and the worker budget.
     // Other operations keep their existing timeout, including authentication.
     let seconds = if matches!(
         req,
-        irlume_common::Request::Enroll { .. } | irlume_common::Request::AddScan { .. }
+        irlume_common::Request::Enroll { .. }
+            | irlume_common::Request::AddScan { .. }
+            | irlume_common::Request::RecoverySetup { .. }
+            | irlume_common::Request::RecoveryForget { .. }
     ) {
         380
     } else {

--- a/crates/irlume-cli/src/recovery.rs
+++ b/crates/irlume-cli/src/recovery.rs
@@ -86,6 +86,7 @@ fn setup(user: &str) -> ExitCode {
          firmware/dbx update, or disk move, WITHOUT re-enrolling. It is separate\n\
          from your login password; store it somewhere safe (like a BitLocker/LUKS key)."
     );
+    println!("[recovery] Setting or replacing recovery requires OS approval for a non-root user.");
     let Some(pass) = read_passphrase_confirmed() else {
         return ExitCode::from(2);
     };
@@ -131,7 +132,7 @@ fn restore(user: &str) -> ExitCode {
         Ok(Response::Ok(msg)) => {
             println!("[recovery] ✓ {msg}");
             println!(
-                "[recovery] Encrypted face templates are readable again; face unlock is restored."
+                "[recovery] Template-key restoration does not reset face retry limits or bypass other authentication checks."
             );
             ExitCode::SUCCESS
         }
@@ -151,6 +152,7 @@ fn restore(user: &str) -> ExitCode {
 }
 
 fn forget(user: &str) -> ExitCode {
+    println!("[recovery] Removing recovery requires OS approval for a non-root user.");
     match daemon_request(&Request::RecoveryForget { user: user.into() }) {
         Ok(Response::Ok(msg)) => {
             println!("[recovery] {msg}");

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -3778,7 +3778,7 @@ impl App {
             // Recovery: masked in-TUI entry.
             (SC_RECOVERY, KeyCode::Char('s')) => {
                 self.input = Some((
-                    "New recovery passphrase (••):".into(),
+                    "New recovery passphrase (OS approval follows):".into(),
                     String::new(),
                     Pending::RecoveryPw(None),
                 ));
@@ -3792,7 +3792,7 @@ impl App {
             }
             (SC_RECOVERY, KeyCode::Char('f')) => {
                 self.confirm = Some((
-                    "Erase the recovery passphrase? (templates stay encrypted)".into(),
+                    "Erase the recovery passphrase? OS approval follows; templates stay encrypted.".into(),
                     "Erase",
                     ConfirmAct::Daemon(Request::RecoveryForget {
                         user: self.user.clone(),

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -287,6 +287,9 @@ fn remove_source_files() -> Result<String, String> {
     targets.push(PathBuf::from(
         "/usr/share/polkit-1/actions/org.irlume.enroll.policy",
     ));
+    targets.push(PathBuf::from(
+        "/usr/share/polkit-1/actions/org.irlume.recovery-manage.policy",
+    ));
     // The systemd unit and any drop-ins.
     targets.push(PathBuf::from("/etc/systemd/system/irlumed.service"));
     let _ = std::fs::remove_dir_all("/etc/systemd/system/irlumed.service.d");

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1532,7 +1532,8 @@ fn recovery_success_paths_with_a_live_daemon() {
         "correct horse\n",
     );
     assert_eq!(code, 0);
-    assert!(out.contains("face unlock is restored"), "{out}");
+    assert!(out.contains("template key restored"), "{out}");
+    assert!(!out.contains("face unlock is restored"), "{out}");
 
     let (code, out, _) = run(&mut sb.cmd(&["recovery", "forget", "--user", "tester"]));
     assert_eq!(code, 0);

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -1262,6 +1262,31 @@ fn recovery_accepts_a_flag_before_the_subcommand() {
 }
 
 #[test]
+fn recovery_restore_does_not_claim_a_successful_face_authentication() {
+    let sb = Sandbox::new("recovery-restore-scope");
+    serve(&sb.sock(), |req| match req {
+        Request::Ping => Response::Pong,
+        Request::RecoveryRestore { user, passphrase }
+            if user == "tester" && passphrase.expose() == b"synthetic passphrase" =>
+        {
+            Response::Ok("template key restored and re-sealed for 'tester'".into())
+        }
+        _ => Response::Error("unexpected recovery request".into()),
+    });
+    let (code, out, err) = run_stdin(
+        &mut sb.cmd(&["recovery", "restore", "--user", "tester"]),
+        "synthetic passphrase\n",
+        "recovery restore scope",
+    );
+    assert_eq!(code, 0, "{err}");
+    assert!(out.contains("template key restored"), "{out}");
+    assert!(
+        !out.contains("face unlock is restored"),
+        "key restoration does not override authentication policy: {out}"
+    );
+}
+
+#[test]
 fn fingerprint_accepts_a_flag_before_the_subcommand() {
     // status answers without fprintd installed (it reports the absence), so
     // the discriminating assertion is the usage line: the position-1 binding

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -59,8 +59,8 @@ pub(crate) mod test_support {
 
 mod arbiter;
 mod diagnostics;
-mod enrollment_authorization;
 mod enrollment_session;
+mod operation_authorization;
 mod position_session;
 mod retry_throttle;
 mod users;
@@ -1377,7 +1377,7 @@ const MAX_REQUEST_BYTES: u64 = 64 * 1024;
 /// the worker, so a client that stops reading stalls its own connection thread
 /// instead of the one thread every login needs.
 struct Queued {
-    authorization: Option<enrollment_authorization::Grant>,
+    authorization: Option<operation_authorization::Grant>,
     session: Option<enrollment_session::Worker>,
     position: Option<position_session::Worker>,
     req: Request,
@@ -2597,7 +2597,7 @@ fn serve_peer(
                 scope.finish(categorical_outcome(&resp));
                 return respond(stream, &resp);
             }
-            let authorization = match enrollment_authorization::authorize(&req, &peer, &stream) {
+            let authorization = match operation_authorization::authorize(&req, &peer, &stream) {
                 Ok(grant) => grant,
                 Err(error) => return respond(stream, &Response::Error(error)),
             };
@@ -4109,7 +4109,7 @@ fn dispatch_scoped(
     peer: &Peer,
     engine: &mut irlume_auth::Engine,
     scope: &diagnostics::OperationScope,
-    authorization: Option<enrollment_authorization::Grant>,
+    authorization: Option<operation_authorization::Grant>,
 ) -> Response {
     dispatch_scoped_session(req, peer, engine, scope, authorization, None, None)
 }
@@ -4119,7 +4119,7 @@ fn dispatch_scoped_session(
     peer: &Peer,
     engine: &mut irlume_auth::Engine,
     scope: &diagnostics::OperationScope,
-    authorization: Option<enrollment_authorization::Grant>,
+    authorization: Option<operation_authorization::Grant>,
     session: Option<&enrollment_session::Worker>,
     position: Option<&position_session::Worker>,
 ) -> Response {
@@ -4135,9 +4135,9 @@ fn dispatch_scoped_session(
     if let Some(resp) = pregate(&req, peer) {
         return resp;
     }
-    if enrollment_authorization::required(&req, peer) {
+    if operation_authorization::required(&req, peer) {
         let result = authorization
-            .ok_or_else(|| "enrollment requires OS authorization".to_owned())
+            .ok_or_else(|| operation_authorization::REFUSED.to_owned())
             .and_then(|grant| grant.consume(&req, peer));
         if let Err(error) = result {
             return Response::Error(error);
@@ -6455,8 +6455,8 @@ mod tests {
             ),
             ("diagnostics.rs", include_str!("diagnostics.rs")),
             (
-                "enrollment_authorization.rs",
-                include_str!("enrollment_authorization.rs"),
+                "operation_authorization.rs",
+                include_str!("operation_authorization.rs"),
             ),
         ];
         // The calls that end in glibc's getpwnam_r/getpwuid_r. `serve(` is
@@ -7414,7 +7414,7 @@ mod tests {
     }
 
     #[test]
-    fn enrollment_authorization_rejects_exited_owner_before_queue() {
+    fn operation_authorization_rejects_exited_owner_before_queue() {
         // Removing the pre-queue authorization gate makes these requests
         // reach the stand-in worker and return Ok. No engine or camera runs.
         let _passwd = passwd_lock();
@@ -7451,6 +7451,11 @@ mod tests {
                 scans: None,
                 report_enrollment: false,
             },
+            Request::RecoverySetup {
+                user: user.into(),
+                passphrase: irlume_common::SecretBytes::new(b"synthetic phrase".to_vec()),
+            },
+            Request::RecoveryForget { user: user.into() },
         ] {
             let (mut client, server) = UnixStream::pair().unwrap();
             client
@@ -8147,7 +8152,7 @@ mod tests {
     /// charge that account's next listing a storage load and its TPM work
     /// (#349). The authorized mutation must still invalidate before it runs.
     #[test]
-    fn enrollment_authorization_worker_refuses_missing_grant_without_cache_mutation() {
+    fn operation_authorization_worker_refuses_missing_grant_without_cache_mutation() {
         let _g = enrollment_summary_test_lock();
         let mut engine = engine();
         let _sandbox = sandbox("enrollment-authorization");
@@ -8179,6 +8184,11 @@ mod tests {
                 scans: 5,
                 improve: true,
             },
+            Request::RecoverySetup {
+                user: user.into(),
+                passphrase: irlume_common::SecretBytes::new(b"synthetic phrase".to_vec()),
+            },
+            Request::RecoveryForget { user: user.into() },
         ] {
             publish_enrollment_summary(
                 user,
@@ -8189,7 +8199,7 @@ mod tests {
             );
             let response = dispatch(request, &owner, &mut engine);
             assert!(
-                matches!(response, Response::Error(ref message) if message == "enrollment requires OS authorization")
+                matches!(response, Response::Error(ref message) if message == operation_authorization::REFUSED)
             );
             assert!(cached_enrollment_summary(user).is_some());
         }
@@ -10978,6 +10988,75 @@ mod tests {
             }
             other => panic!("empty reseal must be refused, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn recovery_authorization_preserves_envelope_on_refusal_and_allows_approved_removal() {
+        let _g = env_lock();
+        let mut e = engine();
+        let sb = sandbox("recovery-authorization");
+        // Real process identity is required by the grant, including start time.
+        // SAFETY: these credential getters have no preconditions.
+        let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
+        let owner = Peer {
+            uid,
+            gid,
+            pid: std::process::id() as i32,
+        };
+        let user = users::name_for_uid(uid).unwrap();
+        let envelope = irlume_core::recovery::wrap(b"synthetic old passphrase", &[7; 32]).unwrap();
+        let bytes = serde_json::to_vec(&envelope).unwrap();
+        let path = sb.dir.join("recovery").join(format!("{user}.json"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+        let setup = Request::RecoverySetup {
+            user: user.clone(),
+            passphrase: irlume_common::SecretBytes::new(b"synthetic new passphrase".to_vec()),
+        };
+        let forget = Request::RecoveryForget { user: user.clone() };
+        let other = peer(if uid == NOBODY { 1 } else { NOBODY });
+        for req in [setup.clone(), forget.clone()] {
+            assert!(matches!(dispatch(req, &other, &mut e), Response::Error(_)));
+            assert_eq!(std::fs::read(&path).unwrap(), bytes);
+        }
+        // Missing approval must also preserve a same-user envelope. Root is
+        // explicitly exempt; that branch is exercised below as administration.
+        if uid != 0 {
+            for req in [setup.clone(), forget.clone()] {
+                assert!(
+                    matches!(dispatch(req, &owner, &mut e), Response::Error(ref error) if error.contains("requires OS authorization"))
+                );
+                assert_eq!(std::fs::read(&path).unwrap(), bytes);
+            }
+        }
+        let (client, server) = UnixStream::pair().unwrap();
+        let grant = operation_authorization::authorize_for_test(&setup, &owner, &server).unwrap();
+        let state = diagnostics::DiagnosticState::default();
+        let scope = state.begin(diagnostic_operation_class(&setup));
+        // Approval reaches the real setup operation; without a TPM-sealed key
+        // it must return the storage error and preserve the existing envelope.
+        assert!(
+            matches!(dispatch_scoped(setup, &owner, &mut e, &scope, grant), Response::Error(ref error) if error.contains("no template key sealed"))
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+        let restore = Request::RecoveryRestore {
+            user: user.clone(),
+            passphrase: irlume_common::SecretBytes::new(b"wrong synthetic passphrase".to_vec()),
+        };
+        assert!(
+            matches!(dispatch(restore, &owner, &mut e), Response::Error(ref error) if error.contains("wrong recovery passphrase"))
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+        let grant = operation_authorization::authorize_for_test(&forget, &owner, &server).unwrap();
+        assert!(matches!(
+            dispatch_scoped(forget, &owner, &mut e, &scope, grant),
+            Response::Ok(_)
+        ));
+        assert!(
+            !path.exists(),
+            "approved removal must reach the real filesystem mutation"
+        );
+        drop(client);
     }
 
     #[test]

--- a/crates/irlume-daemon/src/operation_authorization.rs
+++ b/crates/irlume-daemon/src/operation_authorization.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright the irlume contributors.
 
-//! Per-request OS authorization before trusted templates can be added.
+//! Per-request OS authorization for enrollment and recovery management.
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -14,9 +14,9 @@ use std::time::{Duration, Instant};
 use dbus::arg::{PropMap, Variant};
 use dbus::channel::Channel;
 use dbus::Message;
-use irlume_common::Request;
+use irlume_common::{Request, SecretBytes};
 
-use super::{peer_gone, posture, uid_of, EnrollmentEffect, Peer};
+use super::{peer_gone, posture, uid_of, Peer};
 
 const ACTION: &str = "org.irlume.enroll";
 const AUTHORITY: &str = "org.freedesktop.PolicyKit1";
@@ -25,10 +25,40 @@ const INTERFACE: &str = "org.freedesktop.PolicyKit1.Authority";
 const APPROVAL_BUDGET: Duration = Duration::from_secs(60);
 const QUEUE_FRESHNESS: Duration = Duration::from_secs(15);
 const POLL: Duration = Duration::from_millis(100);
-const REFUSED: &str = "enrollment requires OS authorization; approve the system dialog or register a terminal agent with pkttyagent";
+pub(super) const REFUSED: &str = "operation requires OS authorization; approve the system dialog or register a terminal agent with pkttyagent; if the action is unavailable, repair the Irlume policy installation";
 
 pub(super) fn required(req: &Request, peer: &Peer) -> bool {
-    peer.uid != 0 && posture(req).enrollment == EnrollmentEffect::AddsTrust
+    peer.uid != 0 && approval_operation(req).is_some()
+}
+
+// Approval policy is independent of enrollment cache invalidation semantics.
+fn approval_operation(req: &Request) -> Option<(&'static str, &'static str)> {
+    Some(match req {
+        Request::Enroll { reset: true, .. } => (ACTION, "replace enrolled faces"),
+        Request::Enroll { .. } | Request::EnrollmentSession { improve: false, .. } => {
+            (ACTION, "enroll a face")
+        }
+        Request::AddScan { .. } | Request::EnrollmentSession { improve: true, .. } => {
+            (ACTION, "add face scans")
+        }
+        Request::RecoverySetup { .. } => (
+            "org.irlume.recovery-manage",
+            "set or replace the recovery passphrase",
+        ),
+        Request::RecoveryForget { .. } => (
+            "org.irlume.recovery-manage",
+            "erase the recovery passphrase",
+        ),
+        _ => return None,
+    })
+}
+
+// RecoverySetup contains a passphrase. Protect both the retained binding and
+// the comparison buffer; Debug redaction on Request does not affect serde.
+fn request_binding(req: &Request) -> Result<SecretBytes, String> {
+    let mut bytes = zeroize::Zeroizing::new(Vec::new());
+    serde_json::to_writer(&mut *bytes, req).map_err(|_| REFUSED)?;
+    Ok(SecretBytes::new(std::mem::take(&mut *bytes)))
 }
 
 /// An open proc directory keeps lookups on the original process even if its
@@ -121,14 +151,14 @@ fn uids_match(status: &str, uid: u32) -> bool {
 /// dispatch consumes it before it can invalidate or mutate enrollment state.
 pub(super) struct Grant {
     subject: Subject,
-    request: String,
+    request: SecretBytes,
     approved: Instant,
 }
 
 impl Grant {
     pub(super) fn consume(self, req: &Request, peer: &Peer) -> Result<(), String> {
         if self.approved.elapsed() >= QUEUE_FRESHNESS
-            || serde_json::to_string(req).map_err(|_| REFUSED)? != self.request
+            || request_binding(req)?.expose() != self.request.expose()
             || posture(req).user.and_then(uid_of) != Some(peer.uid)
         {
             return Err(REFUSED.into());
@@ -147,9 +177,7 @@ impl Pending {
     fn acquire(&self, uid: u32) -> Result<Slot<'_>, String> {
         let mut pending = self.0.lock().map_err(|_| REFUSED)?;
         if pending.len() >= 8 || !pending.insert(uid) {
-            return Err(
-                "another enrollment approval is pending; try again after it finishes".into(),
-            );
+            return Err("another Irlume approval is pending; try again after it finishes".into());
         }
         Ok(Slot { pending: self, uid })
     }
@@ -200,7 +228,7 @@ fn authorize_using(
     static PENDING: OnceLock<Pending> = OnceLock::new();
     let _slot = PENDING.get_or_init(Pending::default).acquire(peer.uid)?;
     let subject = Subject::capture(peer)?;
-    let request = serde_json::to_string(req).map_err(|_| REFUSED)?;
+    let request = request_binding(req)?;
     let deadline = Instant::now() + APPROVAL_BUDGET;
     verify(&subject, req, deadline)?;
     if peer_gone(stream) || Instant::now() >= deadline {
@@ -214,6 +242,17 @@ fn authorize_using(
     }))
 }
 
+// Tests replace only the external approval decision. Subject/request binding,
+// pending limits and freshness remain the production implementation.
+#[cfg(test)]
+pub(super) fn authorize_for_test(
+    req: &Request,
+    peer: &Peer,
+    stream: &UnixStream,
+) -> Result<Option<Grant>, String> {
+    authorize_using(req, peer, stream, |_, _, _| Ok(()))
+}
+
 fn method(owner: &str, name: &str) -> Result<Message, String> {
     Message::new_method_call(owner, OBJECT, INTERFACE, name).map_err(|_| REFUSED.into())
 }
@@ -225,16 +264,7 @@ fn approval_message(owner: &str, subject: &Subject, req: &Request) -> Result<Mes
     properties.insert("start-time".into(), Variant(Box::new(subject.start)));
     let mut details = HashMap::<String, String>::new();
     details.insert("user".into(), posture(req).user.ok_or(REFUSED)?.into());
-    let operation = match req {
-        Request::Enroll { reset: true, .. } => "replace enrolled faces",
-        Request::Enroll { .. } | Request::EnrollmentSession { improve: false, .. } => {
-            "enroll a face"
-        }
-        Request::AddScan { .. } | Request::EnrollmentSession { improve: true, .. } => {
-            "add face scans"
-        }
-        _ => return Err(REFUSED.into()),
-    };
+    let (action, operation) = approval_operation(req).ok_or(REFUSED)?;
     details.insert("operation".into(), operation.into());
     details.insert(
         "polkit.message".into(),
@@ -243,7 +273,7 @@ fn approval_message(owner: &str, subject: &Subject, req: &Request) -> Result<Mes
     // One private bus connection per request makes this cancellation ID unique
     // for its caller without exposing a token to the socket client.
     Ok(method(owner, "CheckAuthorization")?
-        .append3(("unix-process", properties), ACTION, details)
+        .append3(("unix-process", properties), action, details)
         .append2(1u32, "enrollment"))
 }
 
@@ -345,6 +375,7 @@ fn check(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::EnrollmentEffect;
     use std::io::{BufRead, BufReader};
     use std::process::{Child, Command, Stdio};
 
@@ -365,6 +396,119 @@ mod tests {
             scans: None,
             reset: false,
         }
+    }
+
+    #[test]
+    fn recovery_management_requires_approval_but_restore_and_status_do_not() {
+        let owner = Peer {
+            uid: 1000,
+            gid: 1000,
+            pid: 1,
+        };
+        let root = Peer {
+            uid: 0,
+            gid: 0,
+            pid: 1,
+        };
+        for req in [
+            Request::RecoverySetup {
+                user: "alice".into(),
+                passphrase: irlume_common::SecretBytes::new(b"synthetic phrase".to_vec()),
+            },
+            Request::RecoveryForget {
+                user: "alice".into(),
+            },
+        ] {
+            assert!(
+                required(&req, &owner),
+                "same-user recovery management needs approval"
+            );
+            assert!(!required(&req, &root), "root retains administration");
+            assert_eq!(posture(&req).enrollment, EnrollmentEffect::Mutates);
+        }
+        for req in [
+            Request::RecoveryRestore {
+                user: "alice".into(),
+                passphrase: irlume_common::SecretBytes::new(b"synthetic phrase".to_vec()),
+            },
+            Request::RecoveryStatus {
+                user: "alice".into(),
+            },
+        ] {
+            assert!(!required(&req, &owner));
+        }
+    }
+
+    #[test]
+    fn recovery_approval_has_its_own_action_and_never_sends_the_secret_to_polkit() {
+        let peer = peer();
+        let subject = Subject::capture(&peer).unwrap();
+        for (req, operation) in [
+            (
+                Request::RecoverySetup {
+                    user: "alice".into(),
+                    passphrase: irlume_common::SecretBytes::new(b"synthetic phrase".to_vec()),
+                },
+                "set or replace the recovery passphrase",
+            ),
+            (
+                Request::RecoveryForget {
+                    user: "alice".into(),
+                },
+                "erase the recovery passphrase",
+            ),
+        ] {
+            let message = approval_message(":1.42", &subject, &req).unwrap();
+            type Args = (
+                (String, PropMap),
+                String,
+                HashMap<String, String>,
+                u32,
+                String,
+            );
+            let (_, action, details, flags, _): Args = message.read_all().unwrap();
+            assert_eq!(action, "org.irlume.recovery-manage");
+            assert_eq!(flags, 1);
+            assert_eq!(details["user"], "alice");
+            assert_eq!(details["operation"], operation);
+            assert_eq!(
+                details.len(),
+                3,
+                "only user, operation and prompt may cross this boundary"
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_grant_redacts_binding_and_rejects_changed_secret_or_operation() {
+        let _passwd = crate::tests::passwd_lock();
+        let peer = peer();
+        let user = crate::users::name_for_uid(peer.uid).unwrap();
+        let req = Request::RecoverySetup {
+            user: user.clone(),
+            passphrase: irlume_common::SecretBytes::new(b"synthetic phrase".to_vec()),
+        };
+        let grant = || Grant {
+            subject: Subject::capture(&peer).unwrap(),
+            request: request_binding(&req).unwrap(),
+            approved: Instant::now(),
+        };
+        assert!(
+            !format!("{:?}", grant().request).contains("RecoverySetup"),
+            "secret-bearing binding must have redacted Debug"
+        );
+        grant().consume(&req, &peer).unwrap();
+        let changed = Request::RecoverySetup {
+            user: user.clone(),
+            passphrase: irlume_common::SecretBytes::new(b"different phrase".to_vec()),
+        };
+        assert!(grant().consume(&changed, &peer).is_err());
+        assert!(grant()
+            .consume(&Request::RecoveryForget { user }, &peer)
+            .is_err());
+        let mut expired = grant();
+        expired.approved -= Duration::from_secs(16);
+        assert!(expired.consume(&req, &peer).is_err());
     }
 
     #[test]
@@ -408,7 +552,7 @@ mod tests {
         let req = request(&peer);
         let grant = || Grant {
             subject: Subject::capture(&peer).unwrap(),
-            request: serde_json::to_string(&req).unwrap(),
+            request: request_binding(&req).unwrap(),
             approved: Instant::now(),
         };
         grant().consume(&req, &peer).unwrap();
@@ -462,7 +606,7 @@ mod tests {
             );
             let grant = || Grant {
                 subject: Subject::capture(&peer).unwrap(),
-                request: serde_json::to_string(&req).unwrap(),
+                request: request_binding(&req).unwrap(),
                 approved: Instant::now(),
             };
             grant().consume(&req, &peer).unwrap();
@@ -536,13 +680,33 @@ mod tests {
     #[test]
     fn real_dbus_exchange_checks_subject_action_denial_and_cancellation() {
         let _passwd = crate::tests::passwd_lock();
-        for mode in ["allow", "deny", "malformed", "cancel", "forged"] {
+        for (mode, recovery) in ["allow", "deny", "malformed", "cancel", "forged"]
+            .into_iter()
+            .flat_map(|mode| [(mode, false), (mode, true)])
+        {
             let (_bus, address) = bus();
             let server = dbus::blocking::Connection::new_address(&address).unwrap();
             server.request_name(AUTHORITY, false, true, false).unwrap();
             let client = dbus::blocking::Connection::new_address(&address).unwrap();
             let peer = peer();
-            let req = request(&peer);
+            let req = if recovery {
+                Request::RecoverySetup {
+                    user: crate::users::name_for_uid(peer.uid).unwrap(),
+                    passphrase: SecretBytes::new(b"synthetic phrase".to_vec()),
+                }
+            } else {
+                request(&peer)
+            };
+            let expected_action = if recovery {
+                "org.irlume.recovery-manage"
+            } else {
+                "org.irlume.enroll"
+            };
+            let expected_operation = if recovery {
+                "set or replace the recovery passphrase"
+            } else {
+                "enroll a face"
+            };
             let subject = Subject::capture(&peer).unwrap();
             let expected = (subject.pid, subject.uid, subject.start);
             let expected_user = posture(&req).user.unwrap().to_owned();
@@ -568,14 +732,15 @@ mod tests {
                         );
                         let (subject, action, details, flags, cancellation): Args =
                             message.read_all().unwrap();
-                        assert_eq!(action, "org.irlume.enroll");
+                        assert_eq!(action, expected_action);
                         assert_eq!(flags, 1);
                         assert_eq!(subject.0, "unix-process");
                         assert_eq!(subject.1["pid"].0.as_u64(), Some(u64::from(expected.0)));
                         assert_eq!(subject.1["uid"].0.as_i64(), Some(i64::from(expected.1)));
                         assert_eq!(subject.1["start-time"].0.as_u64(), Some(expected.2));
                         assert_eq!(details["user"], expected_user);
-                        assert_eq!(details["operation"], "enroll a face");
+                        assert_eq!(details["operation"], expected_operation);
+                        assert_eq!(details.len(), 3);
                         assert_eq!(cancellation, "enrollment");
                         checked = true;
                         if mode == "forged" {

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -116,6 +116,23 @@ IRLUME_DEV=1 irlume gesturecap replay nod.jsonl
 
 Adding or replacing trusted faces requires OS authorization for a non-root account owner. This covers `enroll`, `enroll --reset`, and `profiles add-scan`, including the guided TUI and direct socket clients. Each request needs its own authorization; root retains administrative access. A successful replacement preserves the existing template key and recovery setup, and failed capture preserves the old enrollment.
 
+Setting, replacing or erasing a recovery passphrase (`recovery setup` and
+`recovery forget`) also requires OS authorization for non-root users, including
+TUI and direct socket requests. The dialog identifies the account and operation;
+no recovery passphrase is sent to polkit. Root retains administrative access.
+The separate `org.irlume.recovery-manage` action ships with the package. If the
+action is missing, repair the Irlume policy installation; terminal users can
+register a `pkttyagent` when no desktop agent is available. Administrator polkit
+rules can override the shipped authentication requirement.
+
+`recovery restore` still verifies the existing recovery passphrase and reseals
+the template key without a new OS approval requirement. It does not reset retry
+history or override other face-authentication checks. OS authorization for
+recovery management does not attest which authentication factor was used.
+Older clients can use the new daemon with an available authorization agent;
+older daemons, including after a binary rollback, do not enforce this new gate.
+Rollback leaves recovery envelopes and retry records intact.
+
 Install polkit and run a desktop authentication agent. For terminal sessions, register `pkttyagent` for the requesting process/session before enrollment. Missing authority or agent, denial, cancellation and expired approval refuse enrollment. The dialog uses configured OS authentication, which may include an existing face or fingerprint. The shipped policy does not retain approvals; administrator policy overrides remain authoritative.
 
 The daemon enforces this rule. Restart into the updated daemon after upgrading; a new client with an older running daemon does not provide this protection. Older clients can meet the new dialog but retain their shorter reply timeout.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -566,6 +566,23 @@ PAM, canceling a running scan, full uninstall), read [DISABLE.md](DISABLE.md).
 
 Adding or replacing trusted faces requires OS authorization for a non-root account owner. This covers `enroll`, `enroll --reset`, and `profiles add-scan`, including the guided TUI and direct socket clients. Each request needs its own authorization; root retains administrative access. A successful replacement preserves the existing template key and recovery setup, and failed capture preserves the old enrollment.
 
+Setting, replacing or erasing a recovery passphrase (`recovery setup` and
+`recovery forget`) also requires OS authorization for non-root users, including
+TUI and direct socket requests. The dialog identifies the account and operation;
+no recovery passphrase is sent to polkit. Root retains administrative access.
+The separate `org.irlume.recovery-manage` action ships with the package. If the
+action is missing, repair the Irlume policy installation; terminal users can
+register a `pkttyagent` when no desktop agent is available. Administrator polkit
+rules can override the shipped authentication requirement.
+
+`recovery restore` still verifies the existing recovery passphrase and reseals
+the template key without a new OS approval requirement. It does not reset retry
+history or override other face-authentication checks. OS authorization for
+recovery management does not attest which authentication factor was used.
+Older clients can use the new daemon with an available authorization agent;
+older daemons, including after a binary rollback, do not enforce this new gate.
+Rollback leaves recovery envelopes and retry records intact.
+
 Install polkit and run a desktop authentication agent. For terminal sessions, register `pkttyagent` for the requesting process/session before enrollment. Missing authority or agent, denial, cancellation and expired approval refuse enrollment. The dialog uses configured OS authentication, which may include an existing face or fingerprint. The shipped policy does not retain approvals; administrator policy overrides remain authoritative.
 
 The daemon enforces this rule. Restart into the updated daemon after upgrading; a new client with an older running daemon does not provide this protection. Older clients can meet the new dialog but retain their shorter reply timeout.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -174,6 +174,8 @@ rustPlatform.buildRustPackage {
 
     install -Dm0644 packaging/polkit/org.irlume.enroll.policy \
       "$out/share/polkit-1/actions/org.irlume.enroll.policy"
+    install -Dm0644 packaging/polkit/org.irlume.recovery-manage.policy \
+      "$out/share/polkit-1/actions/org.irlume.recovery-manage.policy"
 
     # tmpfiles.d rule for the setgid root:video emitter-lock directory (#542);
     # the NixOS module applies it via systemd.tmpfiles.rules.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -100,6 +100,7 @@ package() {
     install -Dm0644 "$srcdir/$pkgname/packaging/licenses/THIRD-PARTY-NOTICES.tflite" \
         "$pkgdir/usr/share/irlume/tflite/THIRD-PARTY-NOTICES"
     install -Dm0644 packaging/polkit/org.irlume.enroll.policy "$pkgdir/usr/share/polkit-1/actions/org.irlume.enroll.policy"
+    install -Dm0644 packaging/polkit/org.irlume.recovery-manage.policy "$pkgdir/usr/share/polkit-1/actions/org.irlume.recovery-manage.policy"
     install -Dm0644 packaging/systemd/irlumed.service "$pkgdir/usr/lib/systemd/system/irlumed.service"
     install -Dm0644 packaging/systemd/irlumed.socket "$pkgdir/usr/lib/systemd/system/irlumed.socket"
     # Self-heal: re-applies irlume's greeter PAM lines if a distro update strips

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -44,6 +44,8 @@ recommends:
 contents:
   - src: ../polkit/org.irlume.enroll.policy
     dst: /usr/share/polkit-1/actions/org.irlume.enroll.policy
+  - src: ../polkit/org.irlume.recovery-manage.policy
+    dst: /usr/share/polkit-1/actions/org.irlume.recovery-manage.policy
   - src: ../../target/release/irlumed
     dst: /usr/bin/irlumed
   - src: ../../target/release/irlume

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -114,6 +114,7 @@ make -f %{_datadir}/selinux/devel/Makefile -C packaging/selinux irlume.pp
 
 %install
 install -Dm0644 packaging/polkit/org.irlume.enroll.policy %{buildroot}%{_datadir}/polkit-1/actions/org.irlume.enroll.policy
+install -Dm0644 packaging/polkit/org.irlume.recovery-manage.policy %{buildroot}%{_datadir}/polkit-1/actions/org.irlume.recovery-manage.policy
 install -Dm0755 target/release/irlumed %{buildroot}%{_bindir}/irlumed
 install -Dm0755 target/release/irlume  %{buildroot}%{_bindir}/irlume
 install -Dm0644 target/release/libpam_irlume.so %{buildroot}%{_libdir}/security/pam_irlume.so
@@ -244,6 +245,7 @@ restorecon /run/irlume.sock 2>/dev/null || :
 
 %files
 %{_datadir}/polkit-1/actions/org.irlume.enroll.policy
+%{_datadir}/polkit-1/actions/org.irlume.recovery-manage.policy
 %license LICENSE
 %doc README.md docs/SECURITY_AT_REST.md docs/MACHINE-API.md docs/INTEGRATION.md
 %{_bindir}/irlumed

--- a/packaging/polkit/org.irlume.recovery-manage.policy
+++ b/packaging/polkit/org.irlume.recovery-manage.policy
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>Irlume</vendor>
+  <vendor_url>https://github.com/archledger/irlume</vendor_url>
+  <action id="org.irlume.recovery-manage">
+    <description>Manage the recovery passphrase</description>
+    <message>Authenticate to set, replace or erase the recovery passphrase in Irlume</message>
+    <defaults>
+      <allow_any>auth_self</allow_any>
+      <allow_inactive>auth_self</allow_inactive>
+      <allow_active>auth_self</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -33,6 +33,8 @@ override_dh_clean:
 override_dh_auto_install:
 	install -D -m0644 packaging/polkit/org.irlume.enroll.policy \
 		debian/irlume/usr/share/polkit-1/actions/org.irlume.enroll.policy
+	install -D -m0644 packaging/polkit/org.irlume.recovery-manage.policy \
+		debian/irlume/usr/share/polkit-1/actions/org.irlume.recovery-manage.policy
 	install -D -m0755 target/release/irlumed debian/irlume/usr/bin/irlumed
 	install -D -m0755 target/release/irlume debian/irlume/usr/bin/irlume
 	install -D -m0644 target/release/libpam_irlume.so \

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -55,7 +55,9 @@ STATE_HOME="$(getent passwd "${SUDO_USER:-root}" | cut -d: -f6)"
 
 install -Dm0644 "$REPO/packaging/polkit/org.irlume.enroll.policy" \
   /usr/share/polkit-1/actions/org.irlume.enroll.policy
-printf "%s\n" "Enrollment requires polkit and a desktop or registered terminal authentication agent."
+install -Dm0644 "$REPO/packaging/polkit/org.irlume.recovery-manage.policy" \
+  /usr/share/polkit-1/actions/org.irlume.recovery-manage.policy
+printf "%s\n" "Enrollment and recovery management require polkit and a desktop or registered terminal authentication agent."
 install -m 0755 "$REPO/target/release/irlumed" "$REPO/target/release/irlume" /usr/local/bin/
 
 cat > /etc/systemd/system/irlumed.service <<EOF


### PR DESCRIPTION
## What & why

An ordinary process running as the account owner could replace or erase its recovery passphrase without the OS approval required for enrollment. Obtain approval for `RecoverySetup` and `RecoveryForget` before queue admission and validate its one-use grant before worker mutation, using a distinct `org.irlume.recovery-manage` action. Root retains administrative access, and `RecoveryRestore` continues to verify the existing passphrase.

Share the existing authorization adapter across enrollment and recovery. Keep exact request/process binding and expiry, but protect both serialized request buffers with zeroizing, redacted secret ownership and best-effort memory locking. Passphrases do not enter polkit details. Include the action in all six installation routes and source uninstall.

CLI and TUI explain approval and allow the existing enrollment-sized timeout for recovery management. Correct the CLI message that equated template-key restoration with restored face authentication. Retry counters/defaults, profile limits, PAM configuration and the wire API are unchanged. OS approval does not establish which factor authenticated the user.

Stacked on #660 (`feat/persistent-throttle`).

## Testing

Regression tests first reproduced missing recovery approval/action selection, unredacted request binding and the misleading CLI success claim. Focused tests exercise real local D-Bus exchanges for enrollment/recovery allow, deny, malformed reply, cancellation and forged sender; changed-secret/operation/expired grants; and refusal before socket requests reach the worker. The model-backed daemon suite includes a synthetic recovery-envelope preservation/removal test, with only the external approval decision substituted.

Local verification: CLI/TUI, core and common suites; focused daemon authorization/socket/NSS tests; warnings-denied Clippy and rustdoc for daemon/CLI; Rust 1.88 all-target checks; formatter; policy XML and installer shell syntax. All nine GitHub validation checks passed at commit `9b3e865b8ffe353c5137e3adcdc9d1f925ef7044`, including model-backed tests, ASan/LeakSanitizer, Nix, fuzzing, virtual-camera, software/real TPM and PAM-wrapper checks. The sanitizer log explicitly confirms the new envelope-preservation/removal and missing-grant worker tests passed. Local totals: 885 passed, 37 existing ignored. Both external Fedora 43/44 package builds also passed, bringing the total to 11 passing checks.

- [x] `cargo test --workspace` passes (CI)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (CI)
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean (CI)
- [x] Docs updated for the user-facing change
- [x] Automated installed-host recovery/TPM and CLI compatibility validation (minihost)
- [ ] Attended installed authentication-agent dialog/cancellation validation

Minihost installed validation passed 30 assertions (26 distinct checks) using the exact optimized daemon/CLI and synthetic state bound over the real state root. Both staged daemon versions had inaccessible camera devices and access only to the TPM resource-manager device. The shipped recovery action loaded with three auth_self defaults and required an authorization challenge. Process-scoped real-polkit denial/approval rules exercised refused setup/removal with envelope preservation, foreign-UID refusal, successful real-TPM replacement and restoration, wrong-phrase refusal, approved removal, and root administration. New and installed CLIs read the new daemon and respected its refusals; the new CLI restored the key with precise wording and read the installed older daemon. Synthetic retry files stayed unchanged. All seven installed model checksums matched the repository manifest.

The two initial runs stopped on test-harness stdout-capture assumptions; both were reproduced/corrected and the complete third run passed. Product code was unchanged. An independent restoration check confirmed original daemon/CLI/unit hashes, a healthy service without overrides, removal of the temporary policy/rule/staging and an inactive rollback timer. No live camera, PAM configuration or real recovery/enrollment mutation occurred. Automated approval used a rule scoped to one live test process, action and target; it does not validate a human password dialog or establish an independent authentication factor. Attended dialog/cancellation remains unverified, so this PR remains draft. A binary rollback restores the older authorization behavior while leaving envelopes and retry files intact.

A separate lifecycle boundary remains: `DeleteProfile` and other enrollment mutations that remove the final profile call `storage::delete`, which retires the template key and recovery envelope. This patch gates the explicit recovery-management requests; it does not add approval to whole-enrollment deletion. Review that lifecycle before treating recovery as an independently protected lockout-reset factor. This is source evidence, not a live deletion trial.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>