### PR TITLE
fix: preserve face retry history on setup failures

### DIFF
--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -249,6 +249,9 @@ pub enum OutcomeKind {
     Spoof,
     /// A real match verdict landed below the threshold.
     BelowThreshold,
+    /// Missing/empty enrollment or retired/invalid enrollment/consent settings.
+    /// Terminal (not presence-retryable), but preserves account retry history.
+    SetupUnavailable,
     /// Every other refusal: pre-camera policy/state denials, camera-binding
     /// mismatches, challenge-gate failures.
     OtherDeny,
@@ -5128,7 +5131,7 @@ impl Engine {
                 live: outcome.live,
                 score: outcome.score,
                 reason: policy.instruction("approve"),
-                kind: OutcomeKind::OtherDeny,
+                kind: OutcomeKind::SetupUnavailable,
             });
         }
         if purpose.demands_gesture(service) {
@@ -5303,7 +5306,7 @@ impl Engine {
             // No file at all: the instant deny, before anything else wakes.
             None => {
                 return Ok(Outcome::deny(
-                    OutcomeKind::OtherDeny,
+                    OutcomeKind::SetupUnavailable,
                     format!("'{user}' is not enrolled"),
                 ));
             }
@@ -5337,7 +5340,7 @@ impl Engine {
                 },
                 None => {
                     return Ok(Outcome::deny(
-                        OutcomeKind::OtherDeny,
+                        OutcomeKind::SetupUnavailable,
                         format!("'{user}' is not enrolled"),
                     ));
                 }
@@ -5348,7 +5351,7 @@ impl Engine {
         if let Some(policy) = blocking_head_consent_policy(purpose, service) {
             finish_loader(&mut loader);
             return Ok(Outcome::deny(
-                OutcomeKind::OtherDeny,
+                OutcomeKind::SetupUnavailable,
                 policy.instruction("approve"),
             ));
         }
@@ -5457,7 +5460,7 @@ impl Engine {
                     Ok(enr) => enr,
                     Err(LoaderExit::NotEnrolled) => {
                         return Ok(Outcome::deny(
-                            OutcomeKind::OtherDeny,
+                            OutcomeKind::SetupUnavailable,
                             format!("'{user}' is not enrolled"),
                         ));
                     }
@@ -5471,7 +5474,7 @@ impl Engine {
                 // a future edit cannot crash the daemon here.
                 None => {
                     return Ok(Outcome::deny(
-                        OutcomeKind::OtherDeny,
+                        OutcomeKind::SetupUnavailable,
                         format!("'{user}' is not enrolled"),
                     ));
                 }
@@ -7225,11 +7228,11 @@ impl Engine {
         enr: &irlume_core::storage::Enrollment,
     ) -> Option<Outcome> {
         if let Err(reason) = legacy_eye_policy(enr) {
-            return Some(Outcome::deny(OutcomeKind::OtherDeny, reason));
+            return Some(Outcome::deny(OutcomeKind::SetupUnavailable, reason));
         }
         if enr.profiles.iter().all(|p| p.scans.is_empty()) {
             return Some(Outcome::deny(
-                OutcomeKind::OtherDeny,
+                OutcomeKind::SetupUnavailable,
                 format!("'{user}' has no face scans enrolled"),
             ));
         }
@@ -8749,6 +8752,7 @@ mod tests {
             OutcomeKind::Spoof,
             OutcomeKind::BelowThreshold,
             OutcomeKind::OtherDeny,
+            OutcomeKind::SetupUnavailable,
         ] {
             assert!(
                 !is_gesture_decline(&Outcome::deny(kind, "x")),
@@ -11133,7 +11137,11 @@ mod engine_tests {
         let e = &mut s.engine;
         let now = std::time::Instant::now();
         let deadline = now + std::time::Duration::from_secs(15);
-        for fails in [false, true] {
+        for (fails, kind) in [
+            (false, OutcomeKind::BelowThreshold),
+            (false, OutcomeKind::SetupUnavailable),
+            (true, OutcomeKind::OtherDeny),
+        ] {
             let mut calls = 0;
             let mut costliest = std::time::Duration::ZERO;
             e.head_consent_before_match = HeadConsentVerdict::Approve;
@@ -11152,13 +11160,7 @@ mod engine_tests {
                             true,
                         )
                     } else {
-                        (
-                            Ok(Outcome::deny(
-                                OutcomeKind::BelowThreshold,
-                                "scripted match denial",
-                            )),
-                            false,
-                        )
+                        (Ok(Outcome::deny(kind, "scripted terminal denial")), false)
                     }
                 },
                 || now,
@@ -11643,6 +11645,7 @@ mod engine_tests {
         let o = s.engine.authenticate("irlume-test-ghost", None).unwrap();
         assert!(!o.granted);
         assert_eq!(o.reason, "'irlume-test-ghost' is not enrolled");
+        assert_eq!(o.kind, OutcomeKind::SetupUnavailable);
 
         // Enrolled but with zero scans.
         let mut e = Enrollment::new("irlume-test-empty");
@@ -11656,6 +11659,7 @@ mod engine_tests {
         let o = s.engine.authenticate("irlume-test-empty", None).unwrap();
         assert!(!o.granted);
         assert_eq!(o.reason, "'irlume-test-empty' has no face scans enrolled");
+        assert_eq!(o.kind, OutcomeKind::SetupUnavailable);
 
         // Camera binding mismatch: anti-swap refusal before any capture.
         let mut e = Enrollment::new("irlume-test-bound");
@@ -11671,6 +11675,7 @@ mod engine_tests {
         });
         write_enrollment(&dir, &e);
         let o = s.engine.authenticate("irlume-test-bound", None).unwrap();
+        assert_eq!(o.kind, OutcomeKind::OtherDeny);
         assert!(!o.granted && !o.live);
         assert!(
             o.reason.contains("camera changed since enrollment"),
@@ -11703,7 +11708,7 @@ mod engine_tests {
             .authenticate("irlume-test-legacy-eyes-open", None)
             .expect("legacy eye policy must deny before the missing camera is opened");
         assert!(!o.granted && !o.live);
-        assert_eq!(o.kind, OutcomeKind::OtherDeny);
+        assert_eq!(o.kind, OutcomeKind::SetupUnavailable);
         assert!(o.reason.contains("profiles eyes-open off"), "{}", o.reason);
         assert!(o.reason.contains("password or fingerprint"), "{}", o.reason);
 
@@ -11758,8 +11763,18 @@ mod engine_tests {
                 .authenticate("irlume-test-legacy-gesture", Some("sudo"))
                 .expect("retired policy must deny before the missing camera is opened");
             assert!(!out.granted, "{configured} granted: {}", out.reason);
-            assert_eq!(out.kind, OutcomeKind::OtherDeny, "{configured}");
+            assert_eq!(out.kind, OutcomeKind::SetupUnavailable, "{configured}");
             assert_eq!(out.reason, expected, "{configured}");
+            let post_match = s.engine.challenge_if_required(
+                AuthenticationPurpose::Verify,
+                Some("sudo"),
+                Outcome::grant(0.9, "synthetic prior match"),
+            ).unwrap();
+            assert!(!post_match.granted && post_match.live);
+            assert_eq!(post_match.score, 0.9);
+            assert_eq!(post_match.kind, OutcomeKind::SetupUnavailable);
+            assert!(!presence_retryable(&post_match));
+            assert!(!is_gesture_decline(&post_match));
         }
 
         std::fs::write(
@@ -11783,8 +11798,18 @@ mod engine_tests {
                 .authenticate("irlume-test-legacy-gesture", Some("sudo"))
                 .expect("environment policy must deny before the missing camera is opened");
             assert!(!out.granted, "{configured} granted: {}", out.reason);
-            assert_eq!(out.kind, OutcomeKind::OtherDeny, "{configured}");
+            assert_eq!(out.kind, OutcomeKind::SetupUnavailable, "{configured}");
             assert_eq!(out.reason, expected, "{configured}");
+            let post_match = s.engine.challenge_if_required(
+                AuthenticationPurpose::Verify,
+                Some("sudo"),
+                Outcome::grant(0.9, "synthetic prior match"),
+            ).unwrap();
+            assert!(!post_match.granted && post_match.live);
+            assert_eq!(post_match.score, 0.9);
+            assert_eq!(post_match.kind, OutcomeKind::SetupUnavailable);
+            assert!(!presence_retryable(&post_match));
+            assert!(!is_gesture_decline(&post_match));
         }
 
         std::env::remove_var("IRLUME_CONSENT_GESTURE");
@@ -11941,6 +11966,8 @@ mod engine_tests {
             "the gesture gate must be the one that ran: {}",
             out.reason
         );
+
+        assert_eq!(out.kind, OutcomeKind::OtherDeny);
 
         // temporal_challenge OFF (the default): a grant, no gesture.
         let out = s

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -9622,6 +9622,108 @@ mod tests {
     }
 
     #[test]
+    fn setup_refusals_preserve_verify_retry_history() {
+        let _g = env_lock();
+        setup_refusals_preserve_retry_history(false);
+    }
+
+    #[test]
+    fn setup_refusals_preserve_unseal_retry_history() {
+        let _g = env_lock();
+        setup_refusals_preserve_retry_history(true);
+    }
+
+    // Runs under the callers' environment lock, using the real engine and
+    // persistent store. Only camera devices and enrolled data are fixtures.
+    fn setup_refusals_preserve_retry_history(unseal: bool) {
+        let user = users::name_for_uid(0).expect("root NSS account");
+        let mut e = engine();
+        for prior_rejection in [false, true] {
+            let sb = sandbox("setup-retry");
+            plant_fake_envelope(&user);
+            let record = sb.dir.join("retry/0.json");
+            if prior_rejection {
+                retry_throttle::record(
+                    &user,
+                    &irlume_auth::Outcome {
+                        granted: false,
+                        live: true,
+                        score: 0.1,
+                        reason: "synthetic rejected match".into(),
+                        kind: irlume_auth::OutcomeKind::BelowThreshold,
+                    },
+                )
+                .unwrap();
+            }
+            let read_history = || match std::fs::read(&record) {
+                Ok(bytes) => Some(bytes),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => panic!("retry history read failed: {error}"),
+            };
+            let before = read_history();
+            for _ in 0..6 {
+                let response = if unseal {
+                    do_unseal_password(&user, None, &mut e)
+                } else {
+                    dispatch(
+                        Request::Authenticate {
+                            user: user.clone(),
+                            service: Some("kde".into()),
+                            intent_confirmation: None,
+                        },
+                        &peer(0),
+                        &mut e,
+                    )
+                };
+                match response {
+                    Response::AuthResult {
+                        granted,
+                        live,
+                        declined_by_gesture,
+                        reason,
+                        ..
+                    } if !unseal => {
+                        assert!(!granted && !live && !declined_by_gesture);
+                        assert_eq!(reason, format!("'{user}' is not enrolled"));
+                    }
+                    Response::Error(reason) if unseal => {
+                        assert_eq!(
+                            reason,
+                            format!("face not granted: '{user}' is not enrolled")
+                        );
+                    }
+                    other => panic!("setup must remain a terminal refusal: {other:?}"),
+                }
+                assert_eq!(
+                    read_history(),
+                    before,
+                    "setup refusal must neither create nor change retry history"
+                );
+            }
+            // Repairing enrollment reaches the missing-camera boundary. It
+            // must not replenish the account's prior face retry budget.
+            write_enrollment(&sb.dir, &enrollment_with(&user, &["Face Scan 1"]));
+            let response = if unseal {
+                do_unseal_password(&user, None, &mut e)
+            } else {
+                dispatch(
+                    Request::Authenticate {
+                        user: user.clone(),
+                        service: Some("kde".into()),
+                        intent_confirmation: None,
+                    },
+                    &peer(0),
+                    &mut e,
+                )
+            };
+            assert!(
+                matches!(response, Response::Error(ref reason) if reason.contains("no camera found"))
+            );
+            assert_eq!(read_history(), before);
+        }
+    }
+
+    #[test]
     fn authenticate_surfaces_a_capture_error_for_an_enrolled_user() {
         let _g = env_lock();
         let user = users::name_for_uid(0).expect("root NSS account");

--- a/crates/irlume-daemon/src/retry_throttle.rs
+++ b/crates/irlume-daemon/src/retry_throttle.rs
@@ -307,13 +307,22 @@ impl Store {
         if policy.limit == 0 {
             return Ok(());
         }
-        // No fresh record or write solely for absence, uncertainty or cancellation.
-        // Preflight already validated the store. An explicit cancellation remains final.
-        if !outcome.granted
-            && (irlume_auth::presence_retryable(outcome)
-                || irlume_auth::is_gesture_decline(outcome))
-        {
-            return Ok(());
+        // Capture retryability and account strikes are separate decisions:
+        // setup failures are terminal but must not spend or replenish history.
+        // Keep this exhaustive so every new outcome needs an accounting choice.
+        if !outcome.granted {
+            use irlume_auth::OutcomeKind;
+            match outcome.kind {
+                OutcomeKind::NoFace
+                | OutcomeKind::Uncertain
+                | OutcomeKind::SpoofNoIrFace
+                | OutcomeKind::GestureDeclined
+                | OutcomeKind::SetupUnavailable => return Ok(()),
+                OutcomeKind::Granted
+                | OutcomeKind::Spoof
+                | OutcomeKind::BelowThreshold
+                | OutcomeKind::OtherDeny => (),
+            }
         }
         let now = clock()?;
         if !valid_boot(&now.boot) {

--- a/crates/irlume-daemon/src/retry_throttle/tests.rs
+++ b/crates/irlume-daemon/src/retry_throttle/tests.rs
@@ -144,6 +144,7 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
         (Kind::Uncertain, false),
         (Kind::SpoofNoIrFace, false),
         (Kind::GestureDeclined, false),
+        (Kind::SetupUnavailable, false),
         (Kind::Spoof, true),
         (Kind::BelowThreshold, true),
         (Kind::OtherDeny, true),
@@ -168,12 +169,52 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
         );
         if matches!(
             kind,
-            Kind::NoFace | Kind::Uncertain | Kind::SpoofNoIrFace | Kind::GestureDeclined
+            Kind::NoFace
+                | Kind::Uncertain
+                | Kind::SpoofNoIrFace
+                | Kind::GestureDeclined
+                | Kind::SetupUnavailable
         ) {
             assert!(
                 !f.path().exists(),
                 "ignored outcomes must not create records"
             );
+        }
+    }
+}
+
+#[test]
+fn setup_unavailable_preserves_missing_partial_and_cooldown_history() {
+    for live in [false, true] {
+        for strikes in [0, 2, 3] {
+            let f = Fixture::new();
+            for _ in 0..strikes {
+                f.record(Kind::BelowThreshold);
+            }
+            let before = (strikes > 0).then(|| f.bytes());
+            let refusal = irlume_auth::Outcome {
+                // A configuration change can also be caught by the defensive
+                // post-match consent check. It must not reset earlier strikes.
+                live,
+                score: if live { 0.9 } else { 0.0 },
+                ..outcome(Kind::SetupUnavailable)
+            };
+            assert!(!irlume_auth::presence_retryable(&refusal));
+            assert!(!irlume_auth::is_gesture_decline(&refusal));
+            for _ in 0..6 {
+                f.store
+                    .record(&account_one(), POLICY, &refusal, bad_clock, before_rename)
+                    .expect("setup refusal must not reach the clock or writer");
+                match &before {
+                    Some(bytes) => assert_eq!(&f.bytes(), bytes),
+                    None => assert!(!f.path().exists()),
+                }
+            }
+            // Real rejections still consume the original remaining budget.
+            for _ in strikes..3 {
+                f.record(Kind::Spoof);
+            }
+            assert!(f.check());
         }
     }
 }

--- a/docs/DISABLE.md
+++ b/docs/DISABLE.md
@@ -114,6 +114,12 @@ A deliberate head-shake cancellation ends the request without adding a failure
 or clearing previous failures. No-face and uncertain-evidence outcomes also do
 not consume strikes; hard spoof and below-threshold rejections do. Login face
 verification and face-gated password release share this per-user counter.
+Missing or empty enrollment, a retired eyes-open setting, and invalid or retired
+consent settings end the request without adding or clearing strikes. Fixing those
+settings does not erase earlier face rejections or cancel an active cooldown.
+Camera-binding refusals, missing consent gestures, PAD failures and grouped
+capture timeouts retain their existing strike behavior.
+
 A face grant or cooldown expiry resets it. Recorded failures and an active
 cooldown survive daemon restarts. Profiles and PAM services for the same Linux
 account share the budget. The counter does not receive password-success events


### PR DESCRIPTION
## What & why

Missing or empty enrollment and retired/invalid eye or consent settings previously consumed the same persistent retry budget as a rejected face. Repeated setup errors could trigger a camera cooldown without a biometric rejection.

Classify those cases as `SetupUnavailable` and make the existing throttle's outcome decision exhaustive. Setup refusals remain terminal and preserve existing retry records; repairing configuration does not clear earlier strikes. Camera-binding refusals, ordinary consent failures, PAD errors and deadline behavior retain their existing treatment. No wire/storage format or numerical retry policy changes.

Stacked on #668 (`fix/enrollment-removal-authorization`). The public Rust outcome enum gains one variant; all workspace consumers were compiled, while external exhaustive consumers are unverified. Older installed daemons retain the previous behavior until updated.

## Testing

Both real daemon regressions first failed because an unenrolled request created a retry record. They now pass through verification and armed face-gated password release, with missing and prior history and after enrollment repair. Additional coverage checks byte-for-byte preservation of active cooldowns, terminal retry-loop behavior, pre/post-match configuration refusal, and unchanged camera-binding/consent classifications.

Minihost passed 190 daemon and 172 authentication tests (362 total; seven existing ignored). Cameras and live runtime sockets were hidden, all seven installed model checksums verified, and the exact source/binary snapshot checked. Original binaries/models/service remained unchanged; staging removal was independently verified. No local model inference or live capture ran.

Whole-workspace all-target Clippy with warnings denied, Rust 1.88 checks, rustdoc with warnings denied, formatter and patch checks passed. All eleven reported CI checks passed, including full workspace tests, sanitizers, fuzzing, Nix, hardware checks and Fedora 43/44 builds.

- [x] `cargo test --workspace` passes (CI)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs updated for the user-facing change
- [x] Model-backed validation on minihost; no attended live-camera validation

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>