### PR TITLE
fix: reset authentication hints at request entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- Clear previous authentication hints when a new request is refused during setup,
+  so missing enrollment cannot prompt the user to look at the camera.
+
 - Require the complete RGB PAD vote before authentication and enrollment admission.
 
 ## [0.11.3] - 2026-08-29

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -5278,6 +5278,9 @@ impl Engine {
         purpose: AuthenticationPurpose,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> irlume_common::Result<Outcome> {
+        // The daemon reuses this engine across requests. Setup refusals and
+        // errors can return before the attempt loop publishes a new situation.
+        self.last_attempt_situation = None;
         self.head_consent_before_match = HeadConsentVerdict::NoGesture;
         // Fresh ViT PAD vote ring per authentication: votes must not mix
         // presentations across requests (ADR-0013 protocol).
@@ -11061,6 +11064,73 @@ mod engine_tests {
         assert!(!fallback);
         assert_eq!(e.head_consent_before_match, HeadConsentVerdict::NoGesture);
         (result.unwrap(), calls.get(), costliest)
+    }
+
+    #[test]
+    fn authentication_situation_is_request_local() {
+        let _guard = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("situation-reset");
+        let mut stale = Vec::new();
+        for purpose in [
+            AuthenticationPurpose::Verify,
+            AuthenticationPurpose::AppConsent,
+            AuthenticationPurpose::CredentialRelease {
+                temporal_challenge: false,
+            },
+        ] {
+            for case in ["missing", "fingerprint", "foreign-model", "camera-error"] {
+                // Establish a real failed-attempt label through the production
+                // retry loop; the next call reuses this same daemon engine.
+                let (out, calls, _) =
+                    scripted_pad_retry(&mut s.engine, 15_000, 100, &[7_800], 0.20, 0);
+                assert!(!out.granted);
+                assert_eq!(calls, 1);
+                assert!(s.engine.last_attempt_situation_label().is_some());
+                std::env::set_var("IRLUME_METHOD_CONF", dir.join("no-method-conf"));
+                let user = "situation-next-request";
+                let path = dir.join(format!("{user}.json"));
+                if path.exists() {
+                    std::fs::remove_file(path).unwrap();
+                }
+                match case {
+                    "fingerprint" => {
+                        std::fs::write(dir.join("method"), "fingerprint").unwrap();
+                        std::env::set_var("IRLUME_METHOD_CONF", dir.join("method"));
+                    }
+                    "foreign-model" | "camera-error" => {
+                        let (mut enrollment, _) = pad_matching_fixture(0.2, false);
+                        enrollment.user = user.into();
+                        if case == "foreign-model" {
+                            enrollment.profiles[0].scans[0].embed_space =
+                                Some("embed:retired-fixture".into());
+                        }
+                        write_enrollment(&dir, &enrollment);
+                    }
+                    _ => (),
+                }
+                let result = s.engine.authenticate_for(user, Some("login"), purpose);
+                if case == "camera-error" {
+                    assert!(result.unwrap_err().to_string().contains(NO_RGB));
+                } else {
+                    let out = result.unwrap();
+                    assert!(!out.granted && !out.live);
+                    assert_eq!(
+                        out.kind,
+                        if case == "fingerprint" {
+                            OutcomeKind::OtherDeny
+                        } else {
+                            OutcomeKind::SetupUnavailable
+                        }
+                    );
+                }
+                if let Some(label) = s.engine.last_attempt_situation_label() {
+                    stale.push(format!("{purpose:?}/{case}: {label}"));
+                }
+            }
+        }
+        teardown_sandbox(&dir);
+        assert!(stale.is_empty(), "previous request hints leaked: {stale:?}");
     }
 
     #[test]

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -4442,14 +4442,15 @@ fn dispatch_scoped_session(
                             // handoff's coverage gap). Evaluated before the `reason` move: it
                             // borrows `o`, the move does not.
                             declined_by_gesture: irlume_auth::is_gesture_decline(&o),
-                            // This arm carries an ENGINE verdict: a face was looked
-                            // at (or looked for). The policy refusals return above,
-                            // before the camera.
+                            // This arm carries an engine verdict, including setup
+                            // refusals before capture. Daemon policy refusals return
+                            // above with refused_by_policy set.
                             refused_by_policy: false,
                             // #616 step 3: the final failed attempt's situation,
                             // in the stable journal vocabulary, for pam's action
-                            // wording; empty on a grant and on every pre-camera
-                            // refusal (they send `situation: String::new()`).
+                            // wording. The engine resets it at request entry, so
+                            // early setup refusals cannot reuse an older hint;
+                            // grants and daemon policy refusals also send empty.
                             situation: if o.granted {
                                 String::new()
                             } else {


### PR DESCRIPTION
## What & why

A failed authentication left its situation label in the shared engine. A later request refused during setup could carry that old label into PAM, producing advice such as “look at the camera” for missing enrollment.

Clear the optional situation at authentication entry, before early returns. Current-attempt reporting and grant clearing remain intact. Update the daemon comments and changelog. Authentication decisions, retry accounting, thresholds and wire/storage formats are unchanged. Stacked on #670 (`fix/recognizer-preflight`).

## Testing

The new regression first failed on minihost in all twelve transitions: three authentication purposes across missing enrollment, fingerprint mode, foreign-model scans and a missing-device error. It now passes; the complete auth suite passed 174 tests with three existing ignored. Tests establish the engine behavior; daemon/PAM propagation was source-reviewed, without an attended PAM-dialog trial.

Exact source/test binaries and all seven model hashes were verified. Tests ran with camera devices and live runtime sockets hidden; installed service/binaries/models stayed unchanged and both temporary snapshots were independently verified removed. No local inference or live capture ran.

- [x] `cargo test --workspace` passes (CI; full auth suite also passed on minihost)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Rust 1.88 workspace all-target checks pass
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Changelog updated
- [x] Camera-free minihost validation; installed service unchanged

All eleven reported CI checks passed at the unchanged draft head, including both Fedora builds.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>