### PR TITLE
fix: report grouped authentication timeouts accurately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- Report grouped authentication deadlines as a timeout with password guidance,
+  while preserving retry accounting and captured diagnostic measurements.
+
 - Clear previous authentication hints when a new request is refused during setup,
   so missing enrollment cannot prompt the user to look at the camera.
 

--- a/crates/irlume-auth/src/engine_tests/grouped_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/grouped_tests.rs
@@ -183,7 +183,15 @@ fn grouped_deadline_checks_before_and_after_inference() {
                 || clock.get(),
             )
             .unwrap();
-        assert!(matches!(result, PreparedGroup::Refused(_)));
+        let PreparedGroup::Refused(out) = result else {
+            panic!("expired group admitted")
+        };
+        assert_eq!(out.kind, OutcomeKind::DeadlineExpired);
+        assert!(!out.granted);
+        assert!(!out.live);
+        assert_eq!(out.score, 0.0);
+        assert!(!presence_retryable(&out));
+        assert!(!is_gesture_decline(&out));
         assert_eq!(identities.get(), usize::from(expire_at == 6));
         if expire_at == 0 {
             assert_eq!(assessed.get(), 0);
@@ -536,15 +544,77 @@ fn grouped_deadline_facts_are_current_or_empty_before_any_assessment() {
         let PreparedGroup::Refused(out) = result else {
             panic!("expired group admitted")
         };
+        let facts = &s.engine.last_attempt_facts;
+        if expire_after == 0 {
+            assert!(facts.rgb_face.is_none());
+            assert_eq!(facts.face_frac, 0.0);
+            assert_eq!(facts.yaw_asym, 0.0);
+        } else {
+            assert_eq!(facts.face_frac, 0.2);
+            assert_eq!(facts.rgb_face_brightness, 150.0);
+            assert_eq!(facts.yaw_asym, 1.0);
+            assert_ne!(facts.rgb_face, Some((0.9, 0.9)));
+        }
         assert_eq!(
-            auth_attempt_situation(out.kind, &s.engine.last_attempt_facts),
-            if expire_after == 0 {
-                AttemptSituation::NoFace
-            } else {
-                AttemptSituation::LookingAway
-            }
+            attempt_situation_label(auth_attempt_situation(out.kind, facts)),
+            "timed out"
         );
     }
+}
+
+#[test]
+fn grouped_deadline_keeps_timeout_label_through_retry_loop() {
+    let _guard = env_guard();
+    let mut s = shared();
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs(15);
+    let clock = Cell::new(start);
+    let mut calls = 0;
+    let mut costliest = Duration::ZERO;
+    let (result, fallback) = s.engine.authentication_attempt_loop_with(
+        deadline,
+        15_000,
+        &mut costliest,
+        |engine| {
+            calls += 1;
+            assert_eq!(calls, 1, "expired evidence must not be retried");
+            let prepared = engine.evaluate_grouped_samples_with(
+                (0..5).collect(),
+                deadline,
+                |e, i| {
+                    let mut v = sample(e, i, 0.2);
+                    v.assessment.signals.face_frac = 0.2;
+                    v.assessment.signals.rgb_face_brightness = 150.0;
+                    v.assessment.signals.ir_eye_glint = Some(0.0);
+                    clock.set(deadline);
+                    Ok(v)
+                },
+                |_, _| panic!("expired group reached identity"),
+                || clock.get(),
+            );
+            let PreparedGroup::Refused(out) = prepared.unwrap() else {
+                panic!("expired group admitted")
+            };
+            (Ok(out), false)
+        },
+        || clock.get(),
+    );
+    let out = result.unwrap();
+    assert_eq!(calls, 1);
+    assert_eq!(costliest, Duration::from_secs(15));
+    assert!(!fallback);
+    assert_eq!(out.kind, OutcomeKind::DeadlineExpired);
+    assert!(!out.granted);
+    assert!(!presence_retryable(&out));
+    assert_eq!(s.engine.last_attempt_situation_label(), Some("timed out"));
+    let facts = &s.engine.last_attempt_facts;
+    assert_eq!(facts.glint, Some(0.0));
+    assert!(attempt_situation_line(out.kind, out.score, facts).starts_with("attempt: timed out;"));
+    assert_eq!(
+        auth_attempt_situation(OutcomeKind::OtherDeny, facts),
+        AttemptSituation::GlintBelow,
+        "ordinary refusals must retain their framing classification"
+    );
 }
 
 fn measured_sequential_configuration() -> CaptureModeSelection {

--- a/crates/irlume-auth/src/grouped_auth.rs
+++ b/crates/irlume-auth/src/grouped_auth.rs
@@ -64,7 +64,7 @@ pub(super) fn eligible_configuration(
 
 fn expired() -> Outcome {
     Outcome::deny(
-        OutcomeKind::OtherDeny,
+        OutcomeKind::DeadlineExpired,
         "authentication window expired while collecting complete face evidence; use your password",
     )
 }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -252,6 +252,9 @@ pub enum OutcomeKind {
     /// Missing, empty or recognizer-incompatible enrollment, or retired/invalid settings.
     /// Terminal (not presence-retryable), but preserves account retry history.
     SetupUnavailable,
+    /// The authentication deadline expired before complete evidence could be
+    /// accepted. Terminal and non-retryable, with password fallback guidance.
+    DeadlineExpired,
     /// Every other refusal: pre-camera policy/state denials, camera-binding
     /// mismatches, challenge-gate failures.
     OtherDeny,
@@ -355,10 +358,11 @@ fn enrollment_ir_enabled(ir_available: bool, force_rgb_only: bool) -> bool {
 
 /// One failed authentication attempt's situation, in the stable vocabulary a
 /// person reads in `irlume logs` (#616 step 2). Reporting only: derived from
-/// facts the attempt already measured, it gates nothing, scores nothing, and
-/// moves no bar.
+/// the outcome and facts the attempt already measured, it gates nothing,
+/// scores nothing, and moves no bar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AttemptSituation {
+    TimedOut,
     NoFace,
     TooFar,
     OffCenter,
@@ -376,6 +380,7 @@ enum AttemptSituation {
 /// string each, so `irlume logs` greps by situation.
 const fn attempt_situation_label(situation: AttemptSituation) -> &'static str {
     match situation {
+        AttemptSituation::TimedOut => "timed out",
         AttemptSituation::NoFace => "no face",
         AttemptSituation::TooFar => "too far",
         AttemptSituation::OffCenter => "off-center",
@@ -418,12 +423,17 @@ impl AttemptFacts {
     }
 }
 
-/// Classify one failed attempt. Precedence mirrors the framing guide's
+/// Classify one failed attempt. A terminal deadline takes precedence over
+/// framing facts, which remain available in the debug line. Otherwise,
+/// precedence mirrors the framing guide's
 /// severity order, usability situations first, so a genuine user's #617
 /// shape (a Spoof verdict on a turned head) reads `looking away` rather
 /// than the attack label. Dark-path attempts enter with no RGB face by
 /// design and fall through to the IR facts and the outcome kind.
 fn auth_attempt_situation(kind: OutcomeKind, f: &AttemptFacts) -> AttemptSituation {
+    if kind == OutcomeKind::DeadlineExpired {
+        return AttemptSituation::TimedOut;
+    }
     if kind == OutcomeKind::GestureDeclined {
         return AttemptSituation::Declined;
     }

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -888,8 +888,8 @@ pub enum Response {
         #[serde(default)]
         declined_by_gesture: bool,
         /// The final FAILED attempt's situation, in the #616 step 2 stable
-        /// vocabulary ("no face", "too far", ...), carried so pam_irlume can
-        /// word its prompt (#616 step 3). Empty on a grant, on every
+        /// vocabulary ("timed out", "no face", "too far", ...), carried so
+        /// pam_irlume can word its prompt (#616 step 3). Empty on a grant, on every
         /// pre-camera policy refusal, and from an older daemon
         /// (`#[serde(default)]`); attack-shaped labels are carried too, but
         /// the PAM layer stays silent on them: no threshold value ever

--- a/crates/irlume-daemon/src/retry_throttle.rs
+++ b/crates/irlume-daemon/src/retry_throttle.rs
@@ -321,6 +321,9 @@ impl Store {
                 OutcomeKind::Granted
                 | OutcomeKind::Spoof
                 | OutcomeKind::BelowThreshold
+                // Grouped expiry previously used OtherDeny and consumed a
+                // strike; the diagnostic label does not change that policy.
+                | OutcomeKind::DeadlineExpired
                 | OutcomeKind::OtherDeny => (),
             }
         }

--- a/crates/irlume-daemon/src/retry_throttle/tests.rs
+++ b/crates/irlume-daemon/src/retry_throttle/tests.rs
@@ -147,6 +147,7 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
         (Kind::SetupUnavailable, false),
         (Kind::Spoof, true),
         (Kind::BelowThreshold, true),
+        (Kind::DeadlineExpired, true),
         (Kind::OtherDeny, true),
     ] {
         let f = Fixture::new();
@@ -180,6 +181,22 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
                 "ignored outcomes must not create records"
             );
         }
+    }
+}
+
+#[test]
+fn deadline_expiry_preserves_existing_other_deny_accounting() {
+    for strikes in [0, 2, 3] {
+        let old = Fixture::new();
+        let deadline = Fixture::new();
+        for _ in 0..strikes {
+            old.record(Kind::OtherDeny);
+            deadline.record(Kind::OtherDeny);
+        }
+        old.record(Kind::OtherDeny);
+        deadline.record(Kind::DeadlineExpired);
+        assert_eq!(old.bytes(), deadline.bytes(), "prior strikes: {strikes}");
+        assert_eq!(old.check(), deadline.check());
     }
 }
 

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -844,6 +844,7 @@ fn read_stdout_bounded(
 /// numbers live in the journal and the diagnostic trace, root-visible).
 fn situation_prompt(situation: &str) -> Option<&'static str> {
     match situation {
+        "timed out" => Some("authentication timed out; use your password"),
         "no face" => Some("look at the camera"),
         "too far" => Some("come closer"),
         "off-center" => Some("center your face in the frame"),
@@ -1384,6 +1385,10 @@ mod tests {
     fn usability_situations_get_action_wording_attack_signals_stay_silent() {
         use super::situation_prompt;
         assert_eq!(situation_prompt("no face"), Some("look at the camera"));
+        assert_eq!(
+            situation_prompt("timed out"),
+            Some("authentication timed out; use your password")
+        );
         assert_eq!(situation_prompt("too far"), Some("come closer"));
         assert_eq!(
             situation_prompt("off-center"),
@@ -1431,6 +1436,7 @@ mod tests {
     fn no_situation_prompt_wording_ever_carries_a_number() {
         use super::situation_prompt;
         for label in [
+            "timed out",
             "no face",
             "too far",
             "off-center",

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -630,51 +630,59 @@ fn pamwrap_empty_input_clears_before_password_fallback() {
 #[test]
 #[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
 fn pamwrap_face_denial_clears_yes_before_password_fallback() {
-    let Some(h) = Harness::try_new("intent-face-denial") else {
-        return;
-    };
-    let log = serve(&h.socket, |_| Response::AuthResult {
-        granted: false,
-        score: 0.0,
-        live: false,
-        reason: "no match".into(),
-        declined_by_gesture: false,
-        refused_by_policy: false,
-        situation: String::new(),
-    });
-    let checker = h.token_checker("face-denial", FIXED_TEST_TOKEN);
-    h.write_service(
-        "sudo",
-        &[
-            h.auth_line("sufficient", ""),
-            format!(
-                "auth required pam_exec.so expose_authtok {}",
-                checker.display()
-            ),
-        ],
-    );
+    for situation in ["", "timed out"] {
+        let Some(h) = Harness::try_new("intent-face-denial") else {
+            return;
+        };
+        let log = serve(&h.socket, move |_| Response::AuthResult {
+            granted: false,
+            score: 0.0,
+            live: false,
+            reason: "no match".into(),
+            declined_by_gesture: false,
+            refused_by_policy: false,
+            situation: situation.into(),
+        });
+        let checker = h.token_checker("face-denial", FIXED_TEST_TOKEN);
+        h.write_service(
+            "sudo",
+            &[
+                h.auth_line("sufficient", ""),
+                format!(
+                    "auth required pam_exec.so expose_authtok {}",
+                    checker.display()
+                ),
+            ],
+        );
 
-    let (ok, out) = h.run(
-        "sudo",
-        &["authenticate"],
-        &format!("yes\n{FIXED_TEST_TOKEN}\n"),
-        None,
-    );
-    assert!(
-        ok,
-        "face denial must preserve fresh password fallback: {out}"
-    );
-    assert_eq!(out.matches(FACE_INTENT_INFO).count(), 1, "{out}");
-    assert!(!out.contains(FIXED_TEST_TOKEN), "secret displayed: {out}");
-    let requests = log.lock().unwrap();
-    assert_eq!(requests.len(), 1, "exactly one face request: {requests:?}");
-    assert!(matches!(
-        &requests[0],
-        Request::Authenticate {
-            intent_confirmation: Some(IntentAttestation::PamConversation),
-            ..
-        }
-    ));
+        let (ok, out) = h.run(
+            "sudo",
+            &["authenticate"],
+            &format!("yes\n{FIXED_TEST_TOKEN}\n"),
+            None,
+        );
+        assert!(
+            ok,
+            "face denial must preserve fresh password fallback: {out}"
+        );
+        assert_eq!(out.matches(FACE_INTENT_INFO).count(), 1, "{out}");
+        assert!(!out.contains(FIXED_TEST_TOKEN), "secret displayed: {out}");
+        assert_eq!(
+            out.matches("authentication timed out; use your password")
+                .count(),
+            usize::from(situation == "timed out"),
+            "{out}"
+        );
+        let requests = log.lock().unwrap();
+        assert_eq!(requests.len(), 1, "exactly one face request: {requests:?}");
+        assert!(matches!(
+            &requests[0],
+            Request::Authenticate {
+                intent_confirmation: Some(IntentAttestation::PamConversation),
+                ..
+            }
+        ));
+    }
 }
 
 /// A password supplied by an earlier PAM module is not fresh face intent. It

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -107,6 +107,16 @@ settling); a below-threshold match or a real spoof verdict settles immediately.
 `IRLUME_GRACE_MS` on the daemon overrides both windows; `0` restores the old
 one-shot behavior.
 
+When grouped authentication expires before complete evidence is accepted, its
+final situation is `timed out`. PAM says "authentication timed out; use your
+password". The detailed refusal reason remains in the daemon reply and journal;
+the debug `attempt:` line retains the available framing measurements alongside
+the timeout label. Those measurements describe the captured evidence, but do
+not replace the deadline as the reason for this refusal. Other denials retain
+their existing situation labels and retry rules. Grouped expiry still counts
+as one completed refusal for the account throttle. An ordinary grace-window
+expiry retains its last outcome and existing accounting.
+
 **Security note: treat tracing as a diagnostic session, not a resident
 setting.** While tracing is on, *denied* attempts log their exact match score
 next to the threshold. To anyone who can read the system journal (root or the


### PR DESCRIPTION
## What & why

Grouped authentication could reach its deadline and then report “no face”, “looking away” or another framing hint from incomplete evidence. Restore the preserved timeout-diagnostics patch on the current stack: return `DeadlineExpired`, report `timed out`, and have PAM say “authentication timed out; use your password”. Keep measured facts in debug output.

Integrate with the newer setup classification and request-local hint reset. Explicitly keep grouped expiry counted in the persistent throttle, with a regression comparing stored history against the previous `OtherDeny` behavior. Ordinary grace expiry, setup exemptions, admission gates, thresholds and password fallback remain unchanged. Stacked on #671 (`fix/auth-situation-reset`).

The wire shape stays unchanged; `situation` is still a string and older PAM ignores unknown labels. The public Rust `OutcomeKind` enum gains a variant; workspace exhaustive matches are covered, external Rust consumers are untested. The original uncommitted timeout worktree remains untouched.

## Testing

Fresh integrated validation: 175 auth and 193 daemon tests passed on minihost, plus 45 local PAM tests including all 28 userspace PAM-wrapper cases: 413 passed, seven existing ignored, no missing-tool skips. Coverage checks deadline boundaries before/after inference, timeout-label priority, retained measurements, terminal refusal, request-local hints, persisted strike equivalence and one timeout prompt followed by fresh password fallback. Original RED receipts reproduced the incorrect label and absent PAM wording before the preserved patch.

Remote tests verified exact source/binaries and all seven model hashes, hid camera devices and live runtime sockets, preserved the installed service/binaries/models, and independently verified staging removal. Local PAM tests used private fixtures, without changing system PAM. No local inference or live capture; no installation or merge.

- [x] `cargo test --workspace` passes (CI; full auth/daemon/PAM suites also passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Rust 1.88 workspace all-target checks pass
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Debugging guide and changelog updated
- [x] Camera-free minihost validation and userspace PAM-wrapper fallback tests

All eleven reported CI checks passed at the unchanged draft head, including both Fedora builds.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>