### PR TITLE
fix: distinguish unavailable authentication runtime evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- Report required PAD/runtime failures as unavailable with password guidance,
+  without changing authentication admission or retry accounting.
+
 - Report grouped authentication deadlines as a timeout with password guidance,
   while preserving retry accounting and captured diagnostic measurements.
 

--- a/crates/irlume-auth/src/engine_tests/grouped_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/grouped_tests.rs
@@ -143,7 +143,7 @@ fn grouped_required_pad_failure_is_terminal_before_identity() {
         let PreparedGroup::Refused(out) = result else {
             panic!("failed PAD admitted")
         };
-        assert_eq!(out.kind, OutcomeKind::OtherDeny);
+        assert_eq!(out.kind, OutcomeKind::RuntimeUnavailable);
         assert_eq!(calls.get(), 1);
         assert!(s.engine.vit_scores.is_empty());
     }
@@ -501,7 +501,7 @@ fn grouped_required_pad_failures_precede_retryable_outcomes_and_stop_before_dark
             let PreparedGroup::Refused(out) = result else {
                 panic!("failure reached final identity")
             };
-            assert_eq!(out.kind, OutcomeKind::OtherDeny);
+            assert_eq!(out.kind, OutcomeKind::RuntimeUnavailable);
             assert!(!presence_retryable(&out));
             assert!(s.engine.vit_scores.is_empty());
         }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -255,6 +255,9 @@ pub enum OutcomeKind {
     /// The authentication deadline expired before complete evidence could be
     /// accepted. Terminal and non-retryable, with password fallback guidance.
     DeadlineExpired,
+    /// Required PAD evidence could not be evaluated, or the IR format cannot
+    /// support exposure measurement. Terminal; keeps existing retry accounting.
+    RuntimeUnavailable,
     /// Every other refusal: pre-camera policy/state denials, camera-binding
     /// mismatches, challenge-gate failures.
     OtherDeny,
@@ -363,6 +366,7 @@ fn enrollment_ir_enabled(ir_available: bool, force_rgb_only: bool) -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AttemptSituation {
     TimedOut,
+    Unavailable,
     NoFace,
     TooFar,
     OffCenter,
@@ -381,6 +385,7 @@ enum AttemptSituation {
 const fn attempt_situation_label(situation: AttemptSituation) -> &'static str {
     match situation {
         AttemptSituation::TimedOut => "timed out",
+        AttemptSituation::Unavailable => "unavailable",
         AttemptSituation::NoFace => "no face",
         AttemptSituation::TooFar => "too far",
         AttemptSituation::OffCenter => "off-center",
@@ -423,8 +428,8 @@ impl AttemptFacts {
     }
 }
 
-/// Classify one failed attempt. A terminal deadline takes precedence over
-/// framing facts, which remain available in the debug line. Otherwise,
+/// Classify one failed attempt. Deadlines and unavailable evidence take
+/// precedence over framing facts, which remain in the debug line. Otherwise,
 /// precedence mirrors the framing guide's
 /// severity order, usability situations first, so a genuine user's #617
 /// shape (a Spoof verdict on a turned head) reads `looking away` rather
@@ -433,6 +438,9 @@ impl AttemptFacts {
 fn auth_attempt_situation(kind: OutcomeKind, f: &AttemptFacts) -> AttemptSituation {
     if kind == OutcomeKind::DeadlineExpired {
         return AttemptSituation::TimedOut;
+    }
+    if kind == OutcomeKind::RuntimeUnavailable {
+        return AttemptSituation::Unavailable;
     }
     if kind == OutcomeKind::GestureDeclined {
         return AttemptSituation::Declined;
@@ -1198,10 +1206,10 @@ fn liveness_deny_kind(verdict: Verdict, reason: &str) -> OutcomeKind {
         // retries. An unmeasurable IR format is neither: it is a property of
         // the camera that will hold for every frame, so retrying spends the
         // whole window to reach the same answer while telling the user to
-        // adjust something that cannot help (#358). OtherDeny is the
-        // non-retryable class for a state refusal like this.
+        // adjust something that cannot help (#358). Report unavailable,
+        // preserving terminal fallback and the existing account strike.
         Verdict::Uncertain if reason.starts_with(EXPOSURE_UNMEASURABLE_PREFIX) => {
-            OutcomeKind::OtherDeny
+            OutcomeKind::RuntimeUnavailable
         }
         Verdict::Uncertain => OutcomeKind::Uncertain,
         Verdict::Spoof if reason.starts_with("no face in IR") => OutcomeKind::SpoofNoIrFace,
@@ -1397,7 +1405,7 @@ fn pad_evidence_refusal(modality: PadModality, evidence: PadEvidence) -> Option<
         }
         PadEvidence::Score(_) => return None,
     };
-    Some(Outcome::deny(OutcomeKind::OtherDeny, reason))
+    Some(Outcome::deny(OutcomeKind::RuntimeUnavailable, reason))
 }
 
 fn pad_policy_refusal(
@@ -8670,7 +8678,7 @@ mod tests {
         let kind = liveness_deny_kind(verdict, &reason);
         assert_eq!(
             kind,
-            OutcomeKind::OtherDeny,
+            OutcomeKind::RuntimeUnavailable,
             "must leave the retryable class"
         );
         assert!(
@@ -8701,7 +8709,7 @@ mod tests {
             "the dark evaluator stopped producing the pinned prefix: {dr}"
         );
         let dk = liveness_deny_kind(dv, &dr);
-        assert_eq!(dk, OutcomeKind::OtherDeny, "{dr}");
+        assert_eq!(dk, OutcomeKind::RuntimeUnavailable, "{dr}");
         assert!(!presence_retryable(&denied(dk, &dr, false)), "{dr}");
 
         // And the dark path's ordinary refusals stay exactly as they were, so
@@ -10539,11 +10547,67 @@ mod pad_cue_tests {
     use irlume_liveness::Verdict;
 
     #[test]
+    fn runtime_failure_situations_override_framing() {
+        use super::{attempt_situation_label, auth_attempt_situation, AttemptFacts};
+        let facts = [
+            AttemptFacts::default(),
+            AttemptFacts {
+                rgb_face: Some((0.9, 0.9)),
+                face_frac: 0.2,
+                rgb_face_brightness: 150.0,
+                ..Default::default()
+            },
+            AttemptFacts {
+                rgb_face: Some((0.5, 0.5)),
+                face_frac: 0.2,
+                rgb_face_brightness: 150.0,
+                glint: Some(0.0),
+                ..Default::default()
+            },
+        ];
+        let mut kinds = Vec::new();
+        for modality in [PadModality::Rgb, PadModality::Ir] {
+            for evidence in [
+                PadEvidence::Unavailable,
+                PadEvidence::InferenceFailed,
+                PadEvidence::NotApplicable,
+            ] {
+                let out = pad_evidence_refusal(modality, evidence).unwrap();
+                assert!(!out.granted && !out.live);
+                assert_eq!(out.score, 0.0);
+                assert!(!super::presence_retryable(&out));
+                assert!(!super::is_gesture_decline(&out));
+                kinds.push(out.kind);
+            }
+        }
+        kinds.push(super::liveness_deny_kind(
+            Verdict::Uncertain,
+            super::EXPOSURE_UNMEASURABLE_PREFIX,
+        ));
+        for kind in kinds {
+            for f in &facts {
+                assert_eq!(
+                    attempt_situation_label(auth_attempt_situation(kind, f)),
+                    "unavailable",
+                    "{kind:?}: {f:?}"
+                );
+            }
+        }
+        // Only the explicit operational refusal overrides these measurements.
+        for (f, expected) in facts.iter().zip(["no face", "off-center", "glint below"]) {
+            assert_eq!(
+                attempt_situation_label(auth_attempt_situation(super::OutcomeKind::OtherDeny, f)),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn applicable_pad_unavailable_is_terminal_password_fallback_not_abstention() {
         let refusal = pad_evidence_refusal(PadModality::Rgb, PadEvidence::Unavailable)
             .expect("required unavailable PAD must refuse face authentication");
 
-        assert_eq!(refusal.kind, super::OutcomeKind::OtherDeny);
+        assert_eq!(refusal.kind, super::OutcomeKind::RuntimeUnavailable);
         assert!(!super::presence_retryable(&refusal));
         assert!(refusal.reason.contains("RGB PAD is unavailable"));
         assert!(refusal.reason.contains("use your password"));
@@ -10605,7 +10669,7 @@ mod pad_cue_tests {
         )
         .expect("required failed PAD inference must refuse face authentication");
 
-        assert_eq!(refusal.kind, super::OutcomeKind::OtherDeny);
+        assert_eq!(refusal.kind, super::OutcomeKind::RuntimeUnavailable);
         assert!(!super::presence_retryable(&refusal));
         assert!(refusal.reason.contains("IR PAD inference failed"));
         assert!(refusal.reason.contains("use your password"));
@@ -11381,7 +11445,9 @@ mod engine_tests {
             let out = e
                 .authenticate_assessment(&enr, AuthenticationPurpose::Verify, None, a, &())
                 .unwrap();
-            assert!(!out.granted);
+            assert!(!out.granted && !out.live);
+            assert_eq!(out.kind, OutcomeKind::RuntimeUnavailable);
+            assert_eq!(out.score, 0.0);
             assert!(!presence_retryable(&out));
             assert!(e.vit_scores.is_empty());
             let deny = e.vit_pad_votes_deny(0.20);

--- a/crates/irlume-daemon/src/retry_throttle.rs
+++ b/crates/irlume-daemon/src/retry_throttle.rs
@@ -321,9 +321,10 @@ impl Store {
                 OutcomeKind::Granted
                 | OutcomeKind::Spoof
                 | OutcomeKind::BelowThreshold
-                // Grouped expiry previously used OtherDeny and consumed a
-                // strike; the diagnostic label does not change that policy.
+                // These terminal refusals previously used OtherDeny and
+                // consumed strikes; diagnostic labels do not change that policy.
                 | OutcomeKind::DeadlineExpired
+                | OutcomeKind::RuntimeUnavailable
                 | OutcomeKind::OtherDeny => (),
             }
         }

--- a/crates/irlume-daemon/src/retry_throttle/tests.rs
+++ b/crates/irlume-daemon/src/retry_throttle/tests.rs
@@ -148,6 +148,7 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
         (Kind::Spoof, true),
         (Kind::BelowThreshold, true),
         (Kind::DeadlineExpired, true),
+        (Kind::RuntimeUnavailable, true),
         (Kind::OtherDeny, true),
     ] {
         let f = Fixture::new();
@@ -185,18 +186,24 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
 }
 
 #[test]
-fn deadline_expiry_preserves_existing_other_deny_accounting() {
-    for strikes in [0, 2, 3] {
-        let old = Fixture::new();
-        let deadline = Fixture::new();
-        for _ in 0..strikes {
+fn terminal_diagnostic_classes_preserve_existing_other_deny_accounting() {
+    for kind in [Kind::DeadlineExpired, Kind::RuntimeUnavailable] {
+        for strikes in [0, 2, 3] {
+            let old = Fixture::new();
+            let classified = Fixture::new();
+            for _ in 0..strikes {
+                old.record(Kind::OtherDeny);
+                classified.record(Kind::OtherDeny);
+            }
             old.record(Kind::OtherDeny);
-            deadline.record(Kind::OtherDeny);
+            classified.record(kind);
+            assert_eq!(
+                old.bytes(),
+                classified.bytes(),
+                "{kind:?}, strikes: {strikes}"
+            );
+            assert_eq!(old.check(), classified.check());
         }
-        old.record(Kind::OtherDeny);
-        deadline.record(Kind::DeadlineExpired);
-        assert_eq!(old.bytes(), deadline.bytes(), "prior strikes: {strikes}");
-        assert_eq!(old.check(), deadline.check());
     }
 }
 

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -845,6 +845,7 @@ fn read_stdout_bounded(
 fn situation_prompt(situation: &str) -> Option<&'static str> {
     match situation {
         "timed out" => Some("authentication timed out; use your password"),
+        "unavailable" => Some("face authentication unavailable; use your password"),
         "no face" => Some("look at the camera"),
         "too far" => Some("come closer"),
         "off-center" => Some("center your face in the frame"),
@@ -1433,10 +1434,19 @@ mod tests {
     /// diagnostic trace, NEVER at a prompt surface. No mapped wording may
     /// carry a digit, so no threshold value can leak through a label.
     #[test]
+    fn runtime_unavailable_prompts_password_fallback() {
+        assert_eq!(
+            super::situation_prompt("unavailable"),
+            Some("face authentication unavailable; use your password")
+        );
+    }
+
+    #[test]
     fn no_situation_prompt_wording_ever_carries_a_number() {
         use super::situation_prompt;
         for label in [
             "timed out",
+            "unavailable",
             "no face",
             "too far",
             "off-center",

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -630,7 +630,7 @@ fn pamwrap_empty_input_clears_before_password_fallback() {
 #[test]
 #[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
 fn pamwrap_face_denial_clears_yes_before_password_fallback() {
-    for situation in ["", "timed out"] {
+    for situation in ["", "timed out", "unavailable"] {
         let Some(h) = Harness::try_new("intent-face-denial") else {
             return;
         };
@@ -671,6 +671,12 @@ fn pamwrap_face_denial_clears_yes_before_password_fallback() {
             out.matches("authentication timed out; use your password")
                 .count(),
             usize::from(situation == "timed out"),
+            "{out}"
+        );
+        assert_eq!(
+            out.matches("face authentication unavailable; use your password")
+                .count(),
+            usize::from(situation == "unavailable"),
             "{out}"
         );
         let requests = log.lock().unwrap();

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -117,6 +117,14 @@ their existing situation labels and retry rules. Grouped expiry still counts
 as one completed refusal for the account throttle. An ordinary grace-window
 expiry retains its last outcome and existing accounting.
 
+Required PAD evidence that is unavailable, fails inference or was not evaluated,
+and IR formats that cannot measure exposure, report `unavailable` when they are
+the deciding refusal. PAM says "face authentication unavailable; use your
+password" instead of deriving framing advice from incomplete evidence. These
+remain terminal, counted refusals. Existing spoof, consent and camera-binding
+precedence, optional modalities and ordinary retryable quality failures keep
+their behavior; the label does not classify every camera or engine error.
+
 **Security note: treat tracing as a diagnostic session, not a resident
 setting.** While tracing is on, *denied* attempts log their exact match score
 next to the threshold. To anyone who can read the system journal (root or the


### PR DESCRIPTION
## What & why

Required PAD/runtime failures could be labeled “no face” or another framing problem because their generic refusal shared framing-based situation selection. Add `RuntimeUnavailable` at the existing required PAD-evidence refusal and unmeasurable IR-exposure boundaries. PAM now says “face authentication unavailable; use your password”; detailed reasons and measured facts remain available in diagnostics.

Keep refusal precedence, admission gates, optional modalities, grace retryability and account strikes unchanged. The persistent throttle explicitly counts this class as its previous `OtherDeny` classification did. Do not reclassify general camera errors, consent, camera binding, spoof or template mismatch. Stacked on #672 (`fix/timeout-integration`).

No wire/storage shape, dependency or configuration change. Older PAM ignores unknown situation labels and retains fallback. The public Rust outcome enum gains a variant; workspace consumers are checked, external Rust consumers are untested.

## Testing

Fresh RED tests reproduced the incorrect no-face classification and missing PAM wording. Final auth/daemon and PAM suite results are recorded below. Coverage includes21 runtime/facts combinations, ordinary-framing controls, real liveness producers for unsupported exposure, failed-evidence admission/vote reset, grouped failures before identity, persisted-history equivalence, and one unavailable prompt followed by fresh password fallback through a private real PAM stack.

The exact source/test binaries and seven installed model hashes are verified for minihost tests. Cameras and live runtime sockets are hidden; original service/binaries/models stay unchanged and temporary staging removal is independently verified. No local model inference, live camera, installed-system PAM change, merge or deployment.

176 auth and193 daemon tests passed on minihost;46 PAM tests passed locally (18unit+28wrapper):415 distinct passes,7 existing ignored and no missing-tool skips.

- [x] `cargo test --workspace` passes (all eleven CI checks passed at the draft head)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Rust1.88 workspace all-target check passes
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Debugging guide and changelog updated
- [x] Camera-free minihost and real userspace PAM-wrapper validation

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>