### PR TITLE
fix: require recorded IR template provenance

### DIFF
--- a/crates/irlume-auth/src/engine_tests/grouped_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/grouped_tests.rs
@@ -50,6 +50,8 @@ fn grouped_five_votes_materialize_only_final_sample_and_admit_once_qualified() {
     };
     let (mut enr, _) = pad_matching_fixture(0.2, false);
     enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+    // This fixture models a new raw-IR capture, whose producer records a tag.
+    enr.profiles[0].scans[0].ir_space = Some("raw".into());
     let prior_ir = e.ir_available;
     e.ir_available = true;
     let out = e
@@ -235,13 +237,16 @@ fn grouped_sequential_pair_requires_final_ir_identity() {
     let e = &mut s.engine;
     let prior_ir = e.ir_available;
     e.ir_available = true;
-    for (gap_ms, ir_matches) in [
-        (1000, false),
-        (3000, false),
-        (3001, false),
-        (1000, true),
-        (3000, true),
-        (3001, true),
+    for (gap_ms, ir_matches, tagged) in [
+        (1000, false, true),
+        (3000, false, true),
+        (3001, false, true),
+        (1000, true, true),
+        (3000, true, true),
+        (3001, true, true),
+        (1000, true, false),
+        (3000, true, false),
+        (3001, true, false),
     ] {
         let identities = Cell::new(0);
         let result = e
@@ -275,6 +280,8 @@ fn grouped_sequential_pair_requires_final_ir_identity() {
         };
         let (mut enr, _) = pad_matching_fixture(0.2, false);
         enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+        // This fixture models a new raw-IR capture, whose producer records a tag.
+        enr.profiles[0].scans[0].ir_space = tagged.then(|| "raw".into());
         let out = e
             .authenticate_qualified_assessment(
                 &enr,
@@ -285,8 +292,8 @@ fn grouped_sequential_pair_requires_final_ir_identity() {
             )
             .unwrap();
         assert_eq!(identities.get(), 1);
-        assert_eq!(out.granted, ir_matches, "{}", out.reason);
-        if !ir_matches {
+        assert_eq!(out.granted, ir_matches && tagged, "{}", out.reason);
+        if !ir_matches || !tagged {
             assert_eq!(out.kind, OutcomeKind::BelowThreshold);
             assert!(!presence_retryable(&out));
         }
@@ -302,11 +309,12 @@ fn grouped_dark_final_sample_uses_real_ir_presence_and_existing_gates() {
     let e = &mut s.engine;
     let prior_ir = e.ir_available;
     e.ir_available = true;
-    for (lit, ir_failure, ir_matches) in [
-        (false, false, true),
-        (true, false, true),
-        (false, true, true),
-        (false, false, false),
+    for (lit, ir_failure, ir_matches, tagged) in [
+        (false, false, true, true),
+        (true, false, true, true),
+        (false, true, true, true),
+        (false, false, false, true),
+        (false, false, true, false),
     ] {
         let identities = Cell::new(0);
         let result = e
@@ -357,6 +365,8 @@ fn grouped_dark_final_sample_uses_real_ir_presence_and_existing_gates() {
                 assert!(a.embedding.is_none());
                 let (mut enr, _) = pad_matching_fixture(0.2, false);
                 enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+                // This fixture models a new raw-IR capture, whose producer records a tag.
+                enr.profiles[0].scans[0].ir_space = tagged.then(|| "raw".into());
                 e.authenticate_qualified_assessment(
                     &enr,
                     AuthenticationPurpose::Verify,
@@ -369,11 +379,15 @@ fn grouped_dark_final_sample_uses_real_ir_presence_and_existing_gates() {
         };
         assert_eq!(
             out.granted,
-            !lit && !ir_failure && ir_matches,
+            !lit && !ir_failure && ir_matches && tagged,
             "{}",
             out.reason
         );
         assert_eq!(identities.get(), usize::from(!lit && !ir_failure));
+        if !tagged {
+            assert_eq!(out.kind, OutcomeKind::OtherDeny);
+            assert!(out.reason.contains("no enrolled IR scans are compatible"));
+        }
     }
     e.ir_available = prior_ir;
     e.vit_scores.clear();
@@ -791,6 +805,8 @@ fn grouped_missing_face_not_applicable_is_retryable_before_valid_dark_identity()
         };
         let (mut enr, _) = pad_matching_fixture(0.2, false);
         enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+        // This fixture models a new raw-IR capture, whose producer records a tag.
+        enr.profiles[0].scans[0].ir_space = Some("raw".into());
         let prior_ir = s.engine.ir_available;
         s.engine.ir_available = true;
         let out = s

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -1302,10 +1302,9 @@ fn ir_match_in(
                 if ir.len() != probe.len() {
                     return None;
                 }
-                match &s.ir_space {
-                    Some(sp) if sp != space => None,
-                    _ => Some(ir.as_slice()),
-                }
+                // Before tagging, both raw and adapted IR shipped. An absent
+                // tag cannot establish either space, even at the same width.
+                (s.ir_space.as_deref() == Some(space)).then_some(ir.as_slice())
             })
             .collect();
         if tmpls.is_empty() {
@@ -3266,7 +3265,7 @@ impl Engine {
             if ir.len() != dim || s.rgb.len() != dim {
                 continue;
             }
-            if matches!(&s.ir_space, Some(sp) if sp != &self.ir_space) {
+            if s.ir_space.as_deref() != Some(self.ir_space.as_str()) {
                 continue;
             }
             ir_rows.push(ir.clone());
@@ -6068,8 +6067,9 @@ impl Engine {
                 let reason = if enr.ir_scans().is_empty() {
                     "dark, but no IR scans enrolled; re-enroll to enable dark unlock"
                 } else {
-                    "dark, but the enrolled IR scans are from a different IR \
-                     pipeline (adapter changed); re-enroll to refresh dark unlock"
+                    "dark, but no enrolled IR scans are compatible with the current \
+                     pipeline (unknown or changed IR space, recognizer or dimension); \
+                     add fresh scans to your profile to restore dark unlock"
                 };
                 return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
             }
@@ -9094,7 +9094,8 @@ mod tests {
         // keyed one puts another model's transform on these templates.
         let (mut prof, probe) = calibrated_profile(16);
         // Control: the calibration is in the legacy slot and the scans are
-        // untagged, so the shipped recognizer finds it and scores a centroid.
+        // recognizer-untagged but IR-tagged raw, so the shipped recognizer
+        // finds it and scores a centroid.
         let mut enr = Enrollment::new("u");
         enr.profiles.push(prof.clone());
         let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
@@ -10091,17 +10092,50 @@ mod tests {
     }
 
     #[test]
-    fn ir_match_grandfathers_untagged_templates_into_any_space() {
+    fn unknown_ir_never_reaches_matching_or_centroid_in_any_space() {
         let (mut prof, probe) = calibrated_profile(16);
         for s in &mut prof.scans {
-            s.ir_space = None; // pre-tagging enrollment
+            s.ir_space = None;
         }
         let mut enr = Enrollment::new("u");
         enr.profiles.push(prof);
-        for space in ["raw", "adapter:deadbeef0123"] {
-            let m = ir_match_in(space, LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
-            assert_eq!(m.n_templates, 5, "untagged templates must match in {space}");
+        for (space, adapter) in [("raw", false), ("adapter:deadbeef0123", true)] {
+            let m = ir_match_in(space, LEGACY_RECOGNIZER_SPACE, adapter, &enr, &probe);
+            assert_eq!(m.n_templates, 0, "unknown templates in {space}");
+            assert_eq!(m.best, f32::NEG_INFINITY);
+            assert!(m.best_who.is_empty());
+            assert!(m.centroid.is_none());
         }
+    }
+
+    #[test]
+    fn unknown_ir_cannot_influence_tagged_matches_through_cached_calibration() {
+        let (mut prof, probe) = calibrated_profile(16);
+        prof.scans[0].ir_space = None;
+        let mut enr = Enrollment::new("u");
+        enr.profiles.push(prof);
+        let before = serde_json::to_value(&enr).unwrap();
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
+        assert_eq!(m.n_templates, 4);
+        assert!(
+            m.centroid.is_none(),
+            "unattributable calibration must not create a centroid"
+        );
+        let expected = enr.profiles[0].scans[1..]
+            .iter()
+            .map(|s| align::cosine(&probe, s.ir.as_ref().unwrap()))
+            .fold(f32::NEG_INFINITY, f32::max);
+        assert_eq!(
+            m.best, expected,
+            "tagged templates still score in raw space"
+        );
+        assert_eq!(serde_json::to_value(&enr).unwrap(), before);
+        // A different profile's fully tagged calibration remains available.
+        let (clean, _) = calibrated_profile(16);
+        enr.profiles.push(clean);
+        let m = ir_match_in("raw", LEGACY_RECOGNIZER_SPACE, false, &enr, &probe);
+        assert_eq!(m.n_templates, 9);
+        assert!(m.centroid.is_some());
     }
 
     #[test]
@@ -11141,6 +11175,58 @@ mod engine_tests {
     }
 
     #[test]
+    fn unknown_ir_preserves_rgb_grants_and_denies_ir_dependent_paths() {
+        let _guard = env_guard();
+        let mut s = shared();
+        for case in ["rgb", "below-rgb", "sequential", "dark"] {
+            let (mut enr, mut a) = pad_matching_fixture(0.0, false);
+            let identity = a.embedding.unwrap();
+            enr.profiles[0].scans[0].ir = Some(identity.to_vec());
+            a.ir_embedding = Some(identity.to_vec());
+            match case {
+                "below-rgb" => {
+                    let mut other = [0.0; EMBED_DIM];
+                    other[1] = 1.0;
+                    a.embedding = Some(other);
+                }
+                "sequential" => a.sequential_pair = true,
+                "dark" => {
+                    a.embedding = None;
+                    a.rgb_frame_mean = 0.0;
+                }
+                _ => {}
+            }
+            let out = s
+                .engine
+                .authenticate_qualified_assessment(
+                    &enr,
+                    AuthenticationPurpose::Verify,
+                    Some("login"),
+                    a,
+                    &(),
+                )
+                .unwrap();
+            match case {
+                "rgb" => assert!(out.granted, "RGB identity remains valid: {}", out.reason),
+                "dark" => {
+                    assert!(!out.granted);
+                    assert_eq!(out.kind, OutcomeKind::OtherDeny);
+                    assert!(out.reason.contains("no enrolled IR scans are compatible"));
+                }
+                _ => {
+                    assert!(!out.granted);
+                    assert_eq!(
+                        out.kind,
+                        OutcomeKind::BelowThreshold,
+                        "{case}: {}",
+                        out.reason
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn authentication_situation_is_request_local() {
         let _guard = env_guard();
         let mut s = shared();
@@ -11644,6 +11730,25 @@ mod engine_tests {
         };
         s.engine.refit_profile_calib(&mut foreign_rec);
         assert!(foreign_rec.ir_calib.is_none());
+        // Unknown IR cannot be used to fit or refresh either cached slot.
+        let mut unknown = prof.clone();
+        for scan in &mut unknown.scans {
+            scan.ir_space = None;
+        }
+        s.engine.refit_profile_calib(&mut unknown);
+        assert!(unknown.ir_calib.is_none());
+        assert!(!unknown
+            .ir_calibs
+            .contains_key(irlume_core::storage::LEGACY_RECOGNIZER_SPACE));
+        // Mixed input fits only known pairs; storage still withholds that cache
+        // until the profile no longer contains unknown IR for this recognizer.
+        let mut mixed = prof.clone();
+        mixed.scans.push(scan512(5, true, None));
+        s.engine.refit_profile_calib(&mut mixed);
+        assert_eq!(mixed.ir_calib.as_ref().unwrap().fitted_pairs, 5);
+        assert!(mixed
+            .calib_for(irlume_core::storage::LEGACY_RECOGNIZER_SPACE)
+            .is_none());
         // With a global adapter loaded, refit is a no-op: an existing
         // calibration is left untouched and none is fitted.
         let adapter = Adapter::load_from_file(&model_path("blaze_face_short_range.onnx")).unwrap();

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -55,7 +55,8 @@ pub struct FaceScan {
     /// `"adapter:<sha256 prefix>"` of the adapter that produced it. Templates
     /// only match probes from the same space, so swapping or removing the
     /// adapter can never silently score against stale-space templates.
-    /// `None` = scan predates space tagging; grandfathered as compatible.
+    /// `None` = unknown IR pipeline; retained for loading old enrollments,
+    /// but excluded from IR matching and calibration.
     #[serde(default)]
     pub ir_space: Option<String>,
     /// The RECOGNIZER that produced `rgb` (and, before any adapter, `ir`),
@@ -74,9 +75,8 @@ pub struct FaceScan {
     /// `None` = scan predates this tagging, which means exactly one recognizer
     /// can have produced it: the historically shipped one. Compatibility is
     /// decided by [`recognizer_space_matches`], which accepts `None` only when
-    /// the running recognizer IS [`LEGACY_RECOGNIZER_SPACE`] — not the blanket
-    /// grandfathering `ir_space` applies, because a template handed to an
-    /// arbitrary future model is the hole this field closes.
+    /// the running recognizer IS [`LEGACY_RECOGNIZER_SPACE`]. IR adapter
+    /// provenance is independent: an absent `ir_space` remains unknown.
     #[serde(default)]
     pub embed_space: Option<String>,
     /// Per-scan IR liveness calibration: the center/edge brightness ratio of the
@@ -140,8 +140,20 @@ impl FaceProfile {
     /// This profile's calibration for `space`, or `None`.
     ///
     /// Falls back to the legacy single slot for the shipped recognizer, so a
-    /// profile written before per-model keying keeps its calibration.
+    /// profile written before per-model keying keeps its calibration. Withhold
+    /// both slots while this recognizer has untagged IR: older fits admitted
+    /// those scans and the cache does not record which pairs produced it.
+    /// Tagged templates can still match without calibration. This read never
+    /// changes stored scans or calibration; adding tagged scans alone does not
+    /// establish the provenance of a cache in a mixed legacy profile.
     pub fn calib_for(&self, space: &str) -> Option<&crate::calib::IrCalibration> {
+        if self.scans.iter().any(|s| {
+            s.ir.is_some()
+                && s.ir_space.is_none()
+                && recognizer_space_matches(s.embed_space.as_deref(), space)
+        }) {
+            return None;
+        }
         self.ir_calibs.get(space).or_else(|| {
             (space == LEGACY_RECOGNIZER_SPACE)
                 .then_some(self.ir_calib.as_ref())
@@ -222,8 +234,8 @@ pub fn recognizer_space_matches(have: Option<&str>, want: &str) -> bool {
     }
 }
 
-/// The IR embedding space of the shipped pipeline with no adapter loaded. The
-/// only space an untagged legacy scan can have come from.
+/// The IR embedding space of the shipped pipeline with no adapter loaded.
+/// Untagged legacy scans may instead predate the adapter removal (ADR-0004).
 pub const IR_RAW_SPACE: &str = "raw";
 
 impl Enrollment {
@@ -293,10 +305,10 @@ impl Enrollment {
             .collect()
     }
 
-    /// IR templates compatible with the live pipeline: same embedding space
-    /// (untagged legacy scans are grandfathered) and same dimensionality as
-    /// the probe. A v1 256-D or foreign-adapter template never reaches the
-    /// cosine matcher, where it would score garbage instead of failing loud.
+    /// IR templates with an explicit matching pipeline tag and the same
+    /// dimensionality as the probe. Recognizer filtering is the caller's job.
+    /// Wrong-dimension or foreign-adapter templates never reach this selector's
+    /// consumers for comparison.
     pub fn ir_scans_for(&self, space: &str, dim: usize) -> Vec<(&str, &str, &[f32])> {
         self.profiles
             .iter()
@@ -306,83 +318,48 @@ impl Enrollment {
                     if ir.len() != dim {
                         return None;
                     }
-                    match &s.ir_space {
-                        Some(sp) if sp != space => None,
-                        _ => Some((p.name.as_str(), s.name.as_str(), ir.as_slice())),
-                    }
+                    (s.ir_space.as_deref() == Some(space)).then_some((
+                        p.name.as_str(),
+                        s.name.as_str(),
+                        ir.as_slice(),
+                    ))
                 })
             })
             .collect()
     }
 
-    /// IR scans that were enrolled in a DIFFERENT embedding space than the live
-    /// pipeline (e.g. under an IR adapter that is no longer loaded). These are
-    /// skipped by [`Enrollment::ir_scans_for`], so dark/dim login cannot match
-    /// them: the user must re-enroll. Untagged legacy scans are grandfathered
-    /// (they are retagged to the live space by [`Enrollment::retag_untagged_ir`]),
-    /// so this counts only genuinely foreign-tagged scans. Call AFTER retagging.
+    /// IR scans with an unknown or different pipeline tag. These cannot be
+    /// selected by [`Enrollment::ir_scans_for`]; fresh captures are needed to
+    /// use this pipeline. Stored RGB data remains available.
     pub fn stale_ir_scans(&self, live_space: &str) -> usize {
         self.profiles
             .iter()
             .flat_map(|p| &p.scans)
             .filter(|s| s.ir.is_some())
-            .filter(|s| matches!(&s.ir_space, Some(sp) if sp != live_space))
+            .filter(|s| s.ir_space.as_deref() != Some(live_space))
             .count()
     }
 
-    /// IR scans matching that dark/dim login CAN score: tagged with the live
-    /// space, or untagged (grandfathered, see [`Enrollment::retag_untagged_ir`]).
-    /// The complement of [`Enrollment::stale_ir_scans`]. Used to decide whether
-    /// stale scans are an outage (none usable: dark login is broken, tell the
-    /// user to re-enroll) or leftovers (fresh scans exist alongside them, dark
-    /// login works, stay quiet).
+    /// IR scans explicitly tagged with the live pipeline. This is the
+    /// complement of [`Enrollment::stale_ir_scans`], for compatibility notices;
+    /// it does not check recognizer or dimension and is not an auth decision.
     pub fn usable_ir_scans(&self, live_space: &str) -> usize {
         self.profiles
             .iter()
             .flat_map(|p| &p.scans)
             .filter(|s| s.ir.is_some())
-            .filter(|s| s.ir_space.as_deref().is_none_or(|sp| sp == live_space))
+            .filter(|s| s.ir_space.as_deref() == Some(live_space))
             .count()
     }
 
-    /// Stamp untagged IR scans with the space of the pipeline they were
-    /// captured under (only scans matching the live pipeline's embedding
-    /// dimension). Called by the daemon at startup while the pipeline is
-    /// unchanged, so that a FUTURE adapter swap/removal finds every scan
-    /// explicitly tagged and can fail loud ("re-enroll") instead of scoring
-    /// across spaces. Idempotent; returns how many scans were stamped.
-    pub fn retag_untagged_ir(&mut self, space: &str, dim: usize) -> usize {
-        // Only ever stamp the RAW space, and never an adapter's.
-        //
-        // An untagged scan predates tagging, and no IR adapter has ever shipped
-        // (ADR-0004), so an untagged IR template is raw by construction. The
-        // caller passes the LIVE pipeline's space, which is taken after
-        // `with_ir_adapter` has run, so on a machine whose first tagging-aware
-        // start already has `IRLUME_IR_ADAPTER` set, every legacy raw template
-        // would be permanently relabelled adapter-space. `ir_match_in` would
-        // then compare an ADAPTED probe against RAW templates at the adapted
-        // threshold of 0.40, the lowest number in the codebase, on a
-        // grant-capable path: a genuine cross-space cosine, which is the one
-        // thing the space tag exists to prevent.
-        //
-        // Refusing here loses nothing. The scans stay untagged, which
-        // `recognizer_space_matches` already treats as legacy, and the next
-        // start without an adapter stamps them correctly.
-        if space != IR_RAW_SPACE {
-            return 0;
-        }
-        let mut n = 0;
-        for p in &mut self.profiles {
-            for s in &mut p.scans {
-                if let Some(ir) = &s.ir {
-                    if s.ir_space.is_none() && ir.len() == dim {
-                        s.ir_space = Some(space.into());
-                        n += 1;
-                    }
-                }
-            }
-        }
-        n
+    /// Retired migration, retained as a no-op for source compatibility.
+    ///
+    /// Old releases shipped raw and adapted IR before tags existed (ADR-0004).
+    /// Neither the live pipeline nor the vector dimension proves which one
+    /// produced an untagged scan. Never invent that provenance: preserve all
+    /// data and return zero. Fresh enrollment captures carry an explicit tag.
+    pub fn retag_untagged_ir(&mut self, _space: &str, _dim: usize) -> usize {
+        0
     }
 
     /// Per-user floor on the IR center/edge brightness ratio for the
@@ -773,9 +750,11 @@ pub fn delete(user: &str) -> irlume_common::Result<bool> {
     Ok(existed)
 }
 
-/// Has the one-time IR retag already run for this embedding space?
+/// Has the startup IR compatibility sweep already run for this space?
+/// The historical name and marker format are retained for compatibility;
+/// the daemon no longer retags enrollment data.
 ///
-/// The retag itself is cheap; ASKING is not. The answer lives inside the
+/// Reading scan metadata is not free. The answer lives inside the
 /// encrypted enrollment, so the daemon used to unseal every user's TPM-sealed
 /// template key at startup just to find nothing to do. On a discrete TPM that
 /// is seconds per user, it happens on every boot, and the TPM serializes, so it
@@ -828,48 +807,64 @@ pub fn list_users() -> Vec<String> {
 #[cfg(test)]
 mod tests {
 
-    /// An untagged IR scan predates tagging, and no adapter has ever shipped,
-    /// so it is raw by construction. The daemon passes the LIVE pipeline's
-    /// space, taken after any adapter loads, so a machine whose first
-    /// tagging-aware start already had IRLUME_IR_ADAPTER set would have had
-    /// every legacy raw template relabelled adapter-space. `ir_match_in` would
-    /// then score an ADAPTED probe against RAW templates at the adapted
-    /// threshold of 0.40, the lowest in the codebase, on a grant-capable path.
     #[test]
-    fn retag_refuses_to_stamp_legacy_ir_with_an_adapter_space() {
+    fn unknown_ir_retag_preserves_all_scan_data_in_every_live_space() {
         let mut enr = Enrollment::new("u");
         enr.profiles.push(FaceProfile {
+            name: "p".into(),
             ir_calib: None,
             ir_calibs: Default::default(),
-            name: "P".into(),
-            scans: vec![FaceScan {
-                name: "s1".into(),
-                rgb: vec![0.1; 4],
-                ir: Some(vec![0.2; 4]),
-                // Untagged: what a scan written before tagging existed looks like.
-                ir_space: None,
-                embed_space: None,
-                ir_center_edge_ratio: 0.0,
-                ir_brightness: 0.0,
-                pitch: 0.0,
-            }],
+            scans: vec![
+                scan_in_space("legacy", 4, None),
+                scan_in_space("tagged", 4, Some("raw")),
+                scan_in_space("adapter", 4, Some("adapter:old")),
+                scan_in_space("old-dimension", 2, None),
+            ],
         });
+        let before = serde_json::to_value(&enr).unwrap();
+        for space in ["adapter:new", IR_RAW_SPACE] {
+            for dim in [2, 4, 512] {
+                assert_eq!(enr.retag_untagged_ir(space, dim), 0);
+                assert_eq!(serde_json::to_value(&enr).unwrap(), before);
+            }
+        }
+    }
 
+    #[test]
+    fn unknown_ir_withholds_both_calibration_slots_only_for_its_recognizer() {
+        let c = crate::calib::IrCalibration {
+            m: vec![vec![1.0]],
+            n_rows: vec![vec![1.0]],
+            lambda: 0.1,
+            fitted_pairs: 5,
+        };
+        let mut p = FaceProfile {
+            name: "p".into(),
+            scans: vec![scan_in_space("legacy", 4, None)],
+            ir_calib: Some(c.clone()),
+            ir_calibs: Default::default(),
+        };
+        // Old calibration may have fitted this unknown IR, even though newly
+        // tagged templates are the only templates that matching will admit.
+        assert!(p.calib_for(LEGACY_RECOGNIZER_SPACE).is_none());
+        p.set_calib_for(LEGACY_RECOGNIZER_SPACE, Some(c.clone()));
+        assert!(p.calib_for(LEGACY_RECOGNIZER_SPACE).is_none());
+        p.set_calib_for("embed:other", Some(c));
+        assert!(p.calib_for("embed:other").is_some());
+        let before = serde_json::to_value(&p).unwrap();
+        assert!(p.calib_for(LEGACY_RECOGNIZER_SPACE).is_none());
         assert_eq!(
-            enr.retag_untagged_ir("adapter:deadbeef", 4),
-            0,
-            "an adapter space must never be stamped onto an untagged scan"
+            serde_json::to_value(&p).unwrap(),
+            before,
+            "read preserves stored data"
         );
+        p.scans[0].embed_space = Some("embed:other".into());
+        assert!(p.calib_for(LEGACY_RECOGNIZER_SPACE).is_some());
+        assert!(p.calib_for("embed:other").is_none());
+        p.scans[0].ir = None;
         assert!(
-            enr.profiles[0].scans[0].ir_space.is_none(),
-            "the scan must stay untagged, which already reads as legacy"
-        );
-
-        // The raw space is still stamped, which is the whole point of the sweep.
-        assert_eq!(enr.retag_untagged_ir(IR_RAW_SPACE, 4), 1);
-        assert_eq!(
-            enr.profiles[0].scans[0].ir_space.as_deref(),
-            Some(IR_RAW_SPACE)
+            p.calib_for("embed:other").is_some(),
+            "RGB-only is not unknown IR"
         );
     }
 
@@ -1313,7 +1308,7 @@ mod tests {
     }
 
     #[test]
-    fn ir_scans_for_filters_space_and_dimension() {
+    fn unknown_ir_selection_requires_a_tag_and_matching_dimension() {
         let mut e = Enrollment::new("u");
         e.profiles.push(FaceProfile {
             ir_calib: None,
@@ -1323,50 +1318,31 @@ mod tests {
                 scan_in_space("legacy-untagged", 4, None),
                 scan_in_space("raw", 4, Some("raw")),
                 scan_in_space("v3", 4, Some("adapter:abc123")),
-                scan_in_space("v1-256", 2, None), // stale dim: never matches a 4-D probe
+                scan_in_space("v1-256", 2, None), // unknown regardless of width
+                scan_in_space("tagged-short", 2, Some("raw")),
             ],
         });
-        // Raw pipeline: legacy grandfathered + raw-tagged; v3-tagged excluded.
+        // Only the explicitly matching tag is admitted in either pipeline.
         let raw: Vec<_> = e.ir_scans_for("raw", 4).iter().map(|s| s.1).collect();
-        assert_eq!(raw, vec!["legacy-untagged", "raw"]);
-        // Adapter pipeline: legacy grandfathered + matching adapter; raw excluded.
+        assert_eq!(raw, vec!["raw"]);
+        // A matching adapter tag remains usable.
         let v3: Vec<_> = e
             .ir_scans_for("adapter:abc123", 4)
             .iter()
             .map(|s| s.1)
             .collect();
-        assert_eq!(v3, vec!["legacy-untagged", "v3"]);
-        // A different adapter build sees only the grandfathered scan.
-        assert_eq!(e.ir_scans_for("adapter:zzz999", 4).len(), 1);
+        assert_eq!(v3, vec!["v3"]);
+        // Unknown provenance cannot substitute for a different adapter build.
+        assert!(e.ir_scans_for("adapter:zzz999", 4).is_empty());
         // The unfiltered accessor still reports every IR-bearing scan.
-        assert_eq!(e.ir_scans().len(), 4);
-    }
-
-    #[test]
-    fn retag_untagged_ir_stamps_only_matching_legacy_scans() {
-        let mut e = Enrollment::new("u");
-        e.profiles.push(FaceProfile {
-            ir_calib: None,
-            ir_calibs: Default::default(),
-            name: "p".into(),
-            scans: vec![
-                scan_in_space("legacy", 4, None),          // stamped
-                scan_in_space("tagged", 4, Some("other")), // left alone
-                scan_in_space("stale-dim", 2, None),       // wrong dim: left alone
-            ],
-        });
-        // The space is the RAW one now: stamping an adapter space onto a scan
-        // that predates tagging would invent a provenance it never had, and the
-        // sibling test covers that refusal.
-        assert_eq!(e.retag_untagged_ir(IR_RAW_SPACE, 4), 1);
+        assert_eq!(e.ir_scans().len(), 5);
         assert_eq!(
-            e.profiles[0].scans[0].ir_space.as_deref(),
-            Some(IR_RAW_SPACE)
+            e.ir_scans_for("raw", 2)
+                .iter()
+                .map(|s| s.1)
+                .collect::<Vec<_>>(),
+            vec!["tagged-short"]
         );
-        assert_eq!(e.profiles[0].scans[1].ir_space.as_deref(), Some("other"));
-        assert!(e.profiles[0].scans[2].ir_space.is_none());
-        // Idempotent: nothing left to stamp.
-        assert_eq!(e.retag_untagged_ir(IR_RAW_SPACE, 4), 0);
     }
 
     #[test]
@@ -1644,7 +1620,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_and_usable_ir_counts_partition_the_scans() {
+    fn unknown_ir_counts_as_stale_and_counts_partition_the_scans() {
         let ir_scan = |name: &str, space: Option<&str>| FaceScan {
             name: name.into(),
             rgb: vec![0.0; 4],
@@ -1667,9 +1643,9 @@ mod tests {
             ],
         });
         // The upgrade-outage notice keys off this split: stale>0 AND usable==0.
-        assert_eq!(e.stale_ir_scans("raw"), 1);
-        assert_eq!(e.usable_ir_scans("raw"), 2); // tagged-current + grandfathered
-                                                 // Post-0.2.0, pre-re-enroll: everything stale, nothing usable -> notice.
+        assert_eq!(e.stale_ir_scans("raw"), 2);
+        assert_eq!(e.usable_ir_scans("raw"), 1);
+        // Everything stale, nothing usable -> notice.
         e.profiles[0].scans.retain(|s| s.name == "adapter-era");
         assert_eq!(e.stale_ir_scans("raw"), 1);
         assert_eq!(e.usable_ir_scans("raw"), 0);

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -699,86 +699,45 @@ fn main() {
             let (engine, rgb_pad_status, ir_pad_status) = engine;
             publish_engine_bits(&engine, rgb_pad_status, ir_pad_status);
 
-            // One-time inoculation: stamp legacy (untagged) IR scans with the current
-            // embedding space while it is still the space they were captured under.
-            // A later adapter swap/removal then degrades to a clear "re-enroll" for
-            // dark unlock instead of silently scoring across embedding spaces.
-            // Skip the whole sweep once it has completed for this embedding
-            // space. Asking a user whether they need a retag costs a TPM unseal,
-            // because the answer is inside the encrypted enrollment, and the TPM
-            // serializes: that startup work collided with the very login it was
-            // delaying, taking a keyring unseal from 2.70s to 18.97s on a
-            // discrete TPM (#249). The marker only skips work; a missing or
-            // stale one just runs the sweep as before.
-            let retag_space = engine.ir_space().to_string();
-            let sweep_needed = !irlume_core::storage::retag_done_for(&retag_space);
-            if !sweep_needed {
-                irlume_common::dlog!(
-                    "startup: IR retag already done for '{retag_space}'; skipping the sweep"
-                );
-            }
-            // A user whose load or save failed has NOT been swept, and marking
-            // the space done would retire the migration for them permanently:
-            // the marker is only written when every user was actually handled.
-            let mut all_swept = true;
-            for user in irlume_core::storage::list_users() {
-                if !sweep_needed {
-                    break;
-                }
-                let loaded = irlume_core::storage::load(&user);
-                if let Err(ref e) = loaded {
-                    eprintln!(
-                        "irlumed: could not read '{user}' during the IR retag sweep ({e}); \
-                         leaving the sweep owed"
-                    );
-                    all_swept = false;
-                }
-                if let Ok(Some(mut enr)) = loaded {
-                    let n = enr.retag_untagged_ir(engine.ir_space(), engine.ir_dim());
-                    if n > 0 {
-                        match irlume_core::storage::save(&enr) {
-                            Ok(()) => eprintln!(
-                                "irlumed: tagged {n} legacy IR scan(s) for '{user}' as '{}'",
-                                engine.ir_space()
-                            ),
-                            Err(e) => {
+            // Read-only compatibility notices. Historical untagged IR may be
+            // raw or adapted; the live pipeline cannot safely retag it. Keep
+            // the existing sweep marker to avoid repeated TPM unseals (#249).
+            // The marker only skips notices; matching always checks tags.
+            let ir_space = engine.ir_space();
+            let sweep_needed = !irlume_core::storage::retag_done_for(ir_space);
+            if sweep_needed {
+                let mut all_swept = true;
+                for user in irlume_core::storage::list_users() {
+                    match irlume_core::storage::load(&user) {
+                        Ok(Some(enr)) => {
+                            let stale = enr.stale_ir_scans(ir_space);
+                            if stale > 0 && enr.usable_ir_scans(ir_space) == 0 {
                                 eprintln!(
-                                    "irlumed: could not retag IR scans for '{user}': {e}"
+                                    "irlumed: NOTE for '{user}': {stale} IR template(s) have an \
+                                     unknown or different IR pipeline and cannot match. \
+                                     RGB templates are preserved; run `irlume enroll` to capture \
+                                     fresh scans into your existing profile for dark/dim login."
                                 );
-                                all_swept = false;
                             }
                         }
-                    }
-                    // Upgrade notice: IR scans enrolled under a now-absent adapter (e.g.
-                    // 0.1.x -> 0.2.0, where the research-only IR adapter was removed) are
-                    // in a foreign embedding space and cannot match. Bright-light RGB
-                    // login still works; dark/dim login needs a re-enroll. Surfaced here
-                    // (journal, and `irlume logs`) because the daemon restarts on upgrade.
-                    // Only an OUTAGE gets the notice: once the user re-enrolls, the fresh
-                    // usable scans coexist with the stale ones (whose RGB templates still
-                    // help), and nagging them to re-run the remedy they already ran is
-                    // noise on every restart.
-                    let stale = enr.stale_ir_scans(engine.ir_space());
-                    if stale > 0 && enr.usable_ir_scans(engine.ir_space()) == 0 {
-                        eprintln!(
-                            "irlumed: NOTE for '{user}': {stale} IR template(s) were enrolled under a \
-                             removed IR adapter and no longer match. Bright-light face login still works; \
-                             run `irlume enroll` to capture fresh scans into your existing profile and \
-                             restore dark/dim login."
-                        );
+                        Ok(None) => {}
+                        Err(e) => {
+                            eprintln!(
+                                "irlumed: could not read '{user}' during the IR compatibility \
+                                 sweep ({e}); leaving the sweep owed"
+                            );
+                            all_swept = false;
+                        }
                     }
                 }
-            }
-            // Recorded only after a sweep that actually reached every user, so a
-            // TPM error or an unwritable enrollment leaves the migration owed
-            // instead of silently retiring it for that user.
-            if sweep_needed && all_swept {
-                irlume_core::storage::mark_retag_done(&retag_space);
-            } else if sweep_needed {
-                eprintln!(
-                    "irlumed: the IR retag sweep did not complete for every user; \
-                     it will run again next start"
-                );
+                if all_swept {
+                    irlume_core::storage::mark_retag_done(ir_space);
+                } else {
+                    eprintln!(
+                        "irlumed: the IR compatibility sweep did not complete for every user; \
+                         it will run again next start"
+                    );
+                }
             }
 
             // SO_PEERCRED is the authorization boundary, and the socket mode must not

--- a/docs/adr/0004-per-enrollment-ir-adapter.md
+++ b/docs/adr/0004-per-enrollment-ir-adapter.md
@@ -91,3 +91,27 @@ Two more measurements close the case for removal:
 - The 2026-07-15 self-captured dataset (1,137 pairs and growing) becomes the
   validation bed for the calibration feature and for any future revisit of a
   global adapter, should a large consented cohort ever exist.
+
+## Compatibility correction (2026-09-06)
+
+Before tagging was introduced in `e6c23f5`, both raw and adapted IR scans
+existed. An absent `ir_space` therefore means unknown provenance, not raw.
+The original startup migration assumed the pipeline had not changed; later
+raw-only retagging still could not establish what produced those scans.
+
+Matching and new calibration fits now require an explicit matching IR tag.
+Startup no longer writes guessed tags. Untagged scans retain their RGB data
+and stored IR data, but cannot supply IR identity evidence. Capture fresh
+scans into the existing profile to restore compatible IR templates.
+
+A cached calibration does not record its source pairs. While a profile has
+untagged IR for the requested recognizer, its cached calibration is withheld;
+known IR templates still use raw matching. Adding known scans alone does not
+remove that conservative restriction while unknown scans remain. Other
+recognizers and other profiles retain their calibrations.
+
+This correction cannot identify scans already tagged by an older automatic
+migration, or attribute cached fits after their original scans were removed.
+It preserves the stored format and existing explicit tags; it does not claim
+to reconstruct missing historical provenance. The legacy retag API remains
+a no-op, and the old startup marker only caches compatibility notices.


### PR DESCRIPTION
## What & why

Legacy IR scans without a pipeline tag were admitted under both raw and adapted pipelines, while startup could label them raw without knowing what produced them. ADR0004 and the original tagging commit document that adapters shipped before tagging existed.

Require an explicit matching IR tag for matching and new calibration fits. Withhold cached calibration while the same profile/recognizer contains unknown IR, since old fits did not record their source pairs. Tagged templates still score raw. Stop startup enrollment retagging; retain its public API as a no-op and its marker as a compatibility-notice cache. Preserve RGB data, explicit tags, stored/wire formats, public signatures, thresholds, liveness/PAD gates and retry accounting. Stacked on #673 (`fix/runtime-refusals`).

Already auto-tagged historical scans cannot be identified retrospectively. Mixed legacy profiles retain raw tagged matching but do not use cached calibration while unknown IR remains; adding known scans alone does not remove that restriction. ADR0004 records the migration behavior and limits. No claim of measured false-accept or performance improvement.

## Testing

Six focused regressions reproduced unsafe admission, counts, retagging and cache use. Final minihost suites passed **502 tests**:178 auth,193 daemon,131 core;33 existing ignored. Coverage includes valid/foreign/dimension/recognizer controls, cached and new calibration, RGB grants, and dark/sequential/grouped refusal of unknown IR. Four existing grouped success fixtures now record the raw tag that a real new capture produces; all positive assertions remain and unknown-tag negative cases were added.

Exact sources/binaries and seven model hashes verified. Cameras, TPM devices and live runtime sockets hidden; temporary stages independently removed and installed service/binaries/models unchanged. No local model inference, live camera, install or merge.

- [x] Whole-workspace CI (all eleven checks passed at the draft head)
- [x] Full camera-free core/auth/daemon suites on minihost
- [x] Workspace all-target Clippy with warnings denied
- [x] Rust1.88 workspace all-target check
- [x] Workspace rustfmt check
- [x] Workspace rustdoc with warnings denied
- [x] ADR migration guidance and compatibility limits updated

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>