### PR TITLE
fix: skip redundant KDE key release when password is available

### DIFF
--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -686,8 +686,8 @@ pub enum Request {
         #[serde(default)]
         service: Option<String>,
         /// Whether the PAM stack already holds a typed password. For a
-        /// `LoginPassword` envelope that makes the unseal pointless (the keyring
-        /// self-unlocks from the typed password) and the daemon answers
+        /// `LoginPassword` or `KdeWalletKey` envelope that makes the unseal
+        /// pointless (the keyring/wallet opens from the typed password) and the daemon answers
         /// [`Response::KeyringUnlockNotNeeded`] without touching the TPM. For a
         /// `GnomeKeyringToken` envelope the typed password does NOT open the
         /// keyring, so the unseal proceeds regardless. The decision lives in
@@ -1098,8 +1098,8 @@ pub enum Response {
         #[serde(default)]
         minted: bool,
     },
-    /// `UnsealKeyring` with `have_password: true` against a `LoginPassword`
-    /// envelope: the typed password already opens the keyring, so nothing was
+    /// `UnsealKeyring` with `have_password: true` against a `LoginPassword` or
+    /// `KdeWalletKey` envelope: the password already opens it, so nothing was
     /// unsealed and nothing needs releasing.
     KeyringUnlockNotNeeded,
     /// Face matched and the TPM released the secret (`UnsealPassword` /

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2428,7 +2428,7 @@ fn unseal_keyring(user: &str, service: Option<&str>, have_password: bool, peer: 
             return Response::Error(format!("keyring unseal not allowed for {class:?}"));
         }
     }
-    // A typed password already opens a password-keyed keyring, so touching the
+    // A typed password already opens a password-keyed keyring or KDE wallet, so touching the
     // TPM would spend an unseal (up to seconds on a discrete TPM) to release a
     // secret the caller then discards. For a token envelope the typed password
     // opens nothing, so the release must proceed. The kind read here is a
@@ -2436,8 +2436,13 @@ fn unseal_keyring(user: &str, service: Option<&str>, have_password: bool, peer: 
     // atomically, so a concurrent re-arm at worst turns this into the old
     // always-unseal behaviour.
     if have_password
-        && irlume_core::keyring::sealed_kind(&user)
-            == Some(irlume_core::envelope::SecretKind::LoginPassword)
+        && matches!(
+            irlume_core::keyring::sealed_kind(&user),
+            Some(
+                irlume_core::envelope::SecretKind::LoginPassword
+                    | irlume_core::envelope::SecretKind::KdeWalletKey
+            )
+        )
     {
         return Response::KeyringUnlockNotNeeded;
     }
@@ -10921,6 +10926,49 @@ mod tests {
         match do_unseal_password(&user, None, &mut e) {
             Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
             other => panic!("missing camera must be an Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn password_present_skips_kde_key_release_before_tpm_access() {
+        let _g = env_lock();
+        let _sb = sandbox("password-present-kde");
+        let path = irlume_core::keyring::envelope_path("carol");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // An invalid TCTI prevents every release arm from opening a real TPM.
+        // Metadata-only skip paths must still work when the TPM is unavailable.
+        let previous = std::env::var_os("IRLUME_TCTI");
+        std::env::set_var("IRLUME_TCTI", "invalid-irlume-test-tcti");
+        let mut outcomes = Vec::new();
+        for kind in ["LoginPassword", "KdeWalletKey", "GnomeKeyringToken"] {
+            let envelope = serde_json::json!({
+                "version": 1, "secret": kind, "pcrs": [], "public": "", "private": ""
+            });
+            std::fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+            outcomes.push((
+                kind,
+                unseal_keyring("carol", Some("plasmalogin"), true, &peer(0)),
+                unseal_keyring("carol", Some("plasmalogin"), false, &peer(0)),
+                unseal_keyring("carol", Some("sudo"), true, &peer(0)),
+                unseal_keyring("carol", Some("plasmalogin"), true, &peer(NOBODY)),
+            ));
+        }
+        match previous {
+            Some(value) => std::env::set_var("IRLUME_TCTI", value),
+            None => std::env::remove_var("IRLUME_TCTI"),
+        }
+        for (kind, password_present, no_password, elevation, unprivileged) in outcomes {
+            if kind == "GnomeKeyringToken" {
+                assert!(matches!(password_present, Response::Error(_)));
+            } else {
+                assert!(
+                    matches!(password_present, Response::KeyringUnlockNotNeeded),
+                    "{kind}"
+                );
+            }
+            assert!(matches!(no_password, Response::Error(_)));
+            assert!(matches!(elevation, Response::Error(_)));
+            assert!(matches!(unprivileged, Response::Error(_)));
         }
     }
 

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -539,7 +539,7 @@ fn deliver_gnome_token(pamh: &Pam, user: &str) {
                 .flatten()
                 .and_then(|c| c.to_str().ok().map(str::to_string));
             // `true` is accurate here, not a convenient lie. The flag drives
-            // exactly one decision: whether a PASSWORD-keyed keyring is
+            // exactly one decision: whether a password-derived keyring secret is
             // already served. By the session phase it always is, either
             // because the user typed a password or because the auth phase
             // released the sealed one into `PAM_AUTHTOK`; and if neither
@@ -547,6 +547,8 @@ fn deliver_gnome_token(pamh: &Pam, user: &str) {
             // instead would make the daemon unseal a login password on every
             // session open, which this hook then discards, spending a TPM
             // round trip (seconds on a discrete TPM) per login for nothing.
+            // KDE wallet keys are password-derived too. This GNOME-only hook
+            // cannot deliver one, so the daemon must skip them here as well.
             match request(&Request::UnsealKeyring {
                 user: user.to_string(),
                 service,


### PR DESCRIPTION
A session hook can request a keyring secret with `have_password: true` and then discard a returned KDE wallet key because the hook only delivers GNOME tokens. The daemon previously skipped TPM release only for login-password envelopes. It now also skips password-derived KDE wallet keys, while GNOME token requests and password-absent releases retain their behavior. Root and service authorization checks still run first.

Validation: the new daemon regression first failed for KdeWalletKey and then passed. It covers all three envelope kinds, password-present/absent requests, elevation and non-root refusal using synthetic envelopes and an invalid TCTI that prevents real TPM access. All 116 common tests and 44 PAM tests passed (including all 26 real PAM-wrapper tests, no skips); workspace Clippy, Rust 1.88 checks, rustdoc and formatting passed.

This fixes an unnecessary release. It does not change cold/warm session classification or wallet-provider selection.

Signed-off-by: Wisbendji Fimerlus <archledger236@gmail.com>