### PR TITLE
fix: prevent duplicate login scans and improve camera-busy feedback

### DIFF
--- a/crates/irlume-auth/src/engine_tests/grouped_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/grouped_tests.rs
@@ -28,44 +28,43 @@ fn grouped_five_votes_materialize_only_final_sample_and_admit_once_qualified() {
     let _guard = env_guard();
     let mut s = shared();
     let e = &mut s.engine;
-    let calls = Cell::new(0);
-    let result = e
-        .evaluate_grouped_samples_with(
-            (0..5).collect(),
-            Instant::now() + Duration::from_secs(15),
-            |e, i| Ok(sample(e, i, 0.2)),
-            |_, mut evidence| {
-                calls.set(calls.get() + 1);
-                assert_eq!(evidence.identity.0, 4);
-                evidence.assessment.embedding = Some(evidence.identity.1);
-                evidence.assessment.ir_embedding = Some(evidence.identity.1.to_vec());
-                Ok(evidence.assessment)
-            },
-            Instant::now,
-        )
-        .unwrap();
-    assert_eq!(calls.get(), 1);
-    let PreparedGroup::Ready(a) = result else {
-        panic!("complete live group refused")
-    };
-    let (mut enr, _) = pad_matching_fixture(0.2, false);
-    enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
-    // This fixture models a new raw-IR capture, whose producer records a tag.
-    enr.profiles[0].scans[0].ir_space = Some("raw".into());
-    let prior_ir = e.ir_available;
-    e.ir_available = true;
-    let out = e
-        .authenticate_qualified_assessment(
-            &enr,
-            AuthenticationPurpose::Verify,
-            Some("login"),
-            *a,
-            &(),
-        )
-        .unwrap();
-    e.vit_scores.clear();
-    e.ir_available = prior_ir;
-    assert!(out.granted, "{}", out.reason);
+    for purpose in [
+        AuthenticationPurpose::Verify,
+        AuthenticationPurpose::CredentialRelease,
+    ] {
+        let calls = Cell::new(0);
+        let result = e
+            .evaluate_grouped_samples_with(
+                (0..5).collect(),
+                Instant::now() + Duration::from_secs(15),
+                |e, i| Ok(sample(e, i, 0.2)),
+                |_, mut evidence| {
+                    calls.set(calls.get() + 1);
+                    assert_eq!(evidence.identity.0, 4);
+                    evidence.assessment.embedding = Some(evidence.identity.1);
+                    evidence.assessment.ir_embedding = Some(evidence.identity.1.to_vec());
+                    Ok(evidence.assessment)
+                },
+                Instant::now,
+            )
+            .unwrap();
+        assert_eq!(calls.get(), 1);
+        let PreparedGroup::Ready(a) = result else {
+            panic!("complete live group refused")
+        };
+        let (mut enr, _) = pad_matching_fixture(0.2, false);
+        enr.profiles[0].scans[0].ir = Some(enr.profiles[0].scans[0].rgb.clone());
+        // This fixture models a new raw-IR capture, whose producer records a tag.
+        enr.profiles[0].scans[0].ir_space = Some("raw".into());
+        let prior_ir = e.ir_available;
+        e.ir_available = true;
+        let out = e
+            .authenticate_qualified_assessment(&enr, purpose, Some("login"), *a, &())
+            .unwrap();
+        e.vit_scores.clear();
+        e.ir_available = prior_ir;
+        assert!(out.granted, "{}", out.reason);
+    }
 }
 
 #[test]
@@ -651,16 +650,16 @@ fn grouped_eligibility_keeps_service_and_purpose_scope_despite_long_override() {
     std::env::set_var("IRLUME_GRACE_MS", "30000");
     let mode = measured_sequential_configuration();
     let mut results = Vec::new();
-    for (service, expected) in [
-        (Some("login"), true),
-        (Some("swaylock"), true),
-        (None, true),
-        (Some("unknown-local-service"), true),
-        (Some(" sudo "), false),
-        (Some("su"), false),
-        (Some("doas"), false),
-        (Some("polkit-1"), false),
-        (Some("sshd"), false),
+    for (service, verify, release) in [
+        (Some("login"), true, true),
+        (Some("swaylock"), true, true),
+        (None, true, false),
+        (Some("unknown-local-service"), true, false),
+        (Some(" sudo "), false, false),
+        (Some("su"), false, false),
+        (Some("doas"), false, false),
+        (Some("polkit-1"), false, false),
+        (Some("sshd"), false, false),
     ] {
         for purpose in [
             AuthenticationPurpose::Verify,
@@ -680,7 +679,11 @@ fn grouped_eligibility_keeps_service_and_purpose_scope_despite_long_override() {
                 service,
                 purpose,
                 actual,
-                expected && purpose == AuthenticationPurpose::Verify,
+                match purpose {
+                    AuthenticationPurpose::Verify => verify,
+                    AuthenticationPurpose::CredentialRelease => release,
+                    AuthenticationPurpose::AppConsent => false,
+                },
             ));
         }
     }
@@ -694,53 +697,81 @@ fn grouped_eligibility_keeps_service_and_purpose_scope_despite_long_override() {
 }
 
 #[test]
+fn grouped_cold_login_release_uses_complete_collection_only_for_known_local_services() {
+    let mode = measured_sequential_configuration();
+    for (service, expected) in [
+        (Some("plasmalogin"), true),
+        (Some("gdm-password"), true),
+        (Some("cosmic-greeter"), true),
+        (Some("login"), true),
+        (Some("kde"), true),
+        (Some("sudo"), false),
+        (Some("polkit-1"), false),
+        (Some("sshd"), false),
+        (Some("unknown-local-service"), false),
+        (None, false),
+    ] {
+        assert_eq!(
+            crate::grouped_auth::eligible_configuration(
+                &mode,
+                true,
+                true,
+                true,
+                15_000,
+                AuthenticationPurpose::CredentialRelease,
+                service,
+            ),
+            expected,
+            "service={service:?}"
+        );
+    }
+}
+
+#[test]
 fn grouped_eligibility_requires_qualification_models_budget_and_exact_contract() {
     use irlume_common::diagnostics::QualificationState;
-    let check = |mode: &CaptureModeSelection, ir, rgb_pad, ir_pad, window| {
-        crate::grouped_auth::eligible_configuration(
-            mode,
-            ir,
-            rgb_pad,
-            ir_pad,
-            window,
-            AuthenticationPurpose::Verify,
-            Some("login"),
-        )
-    };
-    let mut mode = measured_sequential_configuration();
-    assert!(check(&mode, true, true, true, 15000));
-    assert!(check(&mode, true, true, true, 30000));
-    for (ir, rgb_pad, ir_pad, window) in [
-        (false, true, true, 15000),
-        (true, false, true, 15000),
-        (true, true, false, 15000),
-        (true, true, true, 14999),
+    for purpose in [
+        AuthenticationPurpose::Verify,
+        AuthenticationPurpose::CredentialRelease,
     ] {
-        assert!(!check(&mode, ir, rgb_pad, ir_pad, window));
+        let check = |mode: &CaptureModeSelection, ir, rgb_pad, ir_pad, window| {
+            crate::grouped_auth::eligible_configuration(
+                mode,
+                ir,
+                rgb_pad,
+                ir_pad,
+                window,
+                purpose,
+                Some("login"),
+            )
+        };
+        let mut mode = measured_sequential_configuration();
+        assert!(check(&mode, true, true, true, 15000));
+        assert!(check(&mode, true, true, true, 30000));
+        for (ir, rgb_pad, ir_pad, window) in [
+            (false, true, true, 15000),
+            (true, false, true, 15000),
+            (true, true, false, 15000),
+            (true, true, true, 14999),
+        ] {
+            assert!(!check(&mode, ir, rgb_pad, ir_pad, window));
+        }
+        assert!(
+            !crate::grouped_auth::eligible(&mode, true, true, true, 15000, purpose, Some("login")),
+            "configuration cannot manufacture a runtime contract"
+        );
+        mode.sequential = false;
+        assert!(!check(&mode, true, true, true, 15000));
+        mode.sequential = true;
+        mode.source = ENV_CAPTURE_MODE_SOURCE;
+        assert!(!check(&mode, true, true, true, 15000));
+        mode.source = STORED_CAPTURE_MODE_SOURCE;
+        mode.qualification_state = QualificationState::QualifiedConcurrent;
+        assert!(!check(&mode, true, true, true, 15000));
+        mode.qualification_state = QualificationState::MeasuredSequential;
+        mode.operation_demoted.set(true);
+        assert!(!check(&mode, true, true, true, 15000));
     }
-    assert!(
-        !crate::grouped_auth::eligible(
-            &mode,
-            true,
-            true,
-            true,
-            15000,
-            AuthenticationPurpose::Verify,
-            Some("login")
-        ),
-        "configuration cannot manufacture a runtime contract"
-    );
-    mode.sequential = false;
-    assert!(!check(&mode, true, true, true, 15000));
-    mode.sequential = true;
-    mode.source = ENV_CAPTURE_MODE_SOURCE;
-    assert!(!check(&mode, true, true, true, 15000));
-    mode.source = STORED_CAPTURE_MODE_SOURCE;
-    mode.qualification_state = QualificationState::QualifiedConcurrent;
-    assert!(!check(&mode, true, true, true, 15000));
-    mode.qualification_state = QualificationState::MeasuredSequential;
-    mode.operation_demoted.set(true);
-    assert!(!check(&mode, true, true, true, 15000));
 }
 
 #[test]

--- a/crates/irlume-auth/src/grouped_auth.rs
+++ b/crates/irlume-auth/src/grouped_auth.rs
@@ -41,16 +41,26 @@ pub(super) fn eligible_configuration(
     purpose: AuthenticationPurpose,
     service: Option<&str>,
 ) -> bool {
-    // Unknown/absent services deliberately share the login eligibility default.
-    // A budget override cannot opt elevation, app consent or release into it.
-    purpose == AuthenticationPurpose::Verify
-        && matches!(
-            service.and_then(irlume_common::pam_service::classify),
-            None | Some(
-                irlume_common::pam_service::ServiceKind::Greeter
-                    | irlume_common::pam_service::ServiceKind::ScreenUnlock
-            )
+    let local_session = matches!(
+        service.and_then(irlume_common::pam_service::classify),
+        Some(
+            irlume_common::pam_service::ServiceKind::Greeter
+                | irlume_common::pam_service::ServiceKind::ScreenUnlock
         )
+    );
+    // Preserve Verify's unknown-service default. Credential release must name
+    // a recognized local login/lock service; budgets cannot widen this scope.
+    let in_scope = match purpose {
+        AuthenticationPurpose::Verify => {
+            local_session
+                || service
+                    .and_then(irlume_common::pam_service::classify)
+                    .is_none()
+        }
+        AuthenticationPurpose::CredentialRelease => local_session,
+        AuthenticationPurpose::AppConsent => false,
+    };
+    in_scope
         && mode.is_sequential()
         && mode.source == STORED_CAPTURE_MODE_SOURCE
         && !mode.operation_demoted.get()

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -4742,8 +4742,8 @@ impl Engine {
 
     /// [`Self::authenticate`] with the purpose stated explicitly, for callers that
     /// know something the service name does not say: the daemon's `UnsealPassword`
-    /// arm passes [`AuthenticationPurpose::CredentialRelease`] so releasing the
-    /// sealed keyring password cannot enter a verify-only capture optimization.
+    /// arm passes [`AuthenticationPurpose::CredentialRelease`] so grouped
+    /// capture requires a recognized local login or lock-screen service.
     ///
     /// The purpose stays explicit through capture selection; credential release
     /// must never be mistaken for plain session verification.

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2400,39 +2400,45 @@ const GREY_FOURCCS: [&[u8; 4]; 3] = [b"GREY", b"Y8  ", b"Y800"];
 /// classification treats these as IR too, and capture decodes them to 8-bit.
 const GREY16_FOURCCS: [&[u8; 4]; 3] = [b"Y16 ", b"Y10 ", b"Y12 "];
 
+// Only a driver EBUSY reaches this mapping. Preserve the observed-holder
+// distinction: an identified self-only conflict is an Irlume bug, not advice
+// to close another app. An incomplete scan does not identify an owner.
+fn camera_busy_error(device: &str, holders: Holders) -> Error {
+    let self_only = matches!(holders, Holders::SelfOnly);
+    let message = match holders {
+        Holders::Other(who) => format!(
+            "{device}: camera busy, in use by {who}. \
+                     Close that app (e.g. a camera/video/conferencing app) and retry."
+        ),
+        Holders::SelfOnly => format!(
+            "{device}: camera busy, and the only process holding it is irlume itself \
+                     (pid {}). That is an irlume bug, not an app you can close; please report \
+                     it with the output of `irlume doctor`.",
+            std::process::id()
+        ),
+        Holders::UnknownBlind => format!(
+            "{device}: camera busy. irlume could not identify the holder, because it \
+                     cannot read every process (see issue #207); `sudo fuser -v {device}` will \
+                     name it. Close that app and retry."
+        ),
+        Holders::None => format!(
+            "{device}: camera busy, another app is using it. \
+                     Close that app (e.g. a camera/video/conferencing app) and retry."
+        ),
+    };
+    if self_only {
+        Error::Hardware(message)
+    } else {
+        Error::CameraBusy(message)
+    }
+}
+
 /// Map common io errors to actionable messages (linhello lesson: EBUSY/privacy
 /// are routine and need a clear cause, not a raw errno).
 fn map_io(device: &str, e: std::io::Error) -> Error {
     use std::io::ErrorKind;
     match e.raw_os_error() {
-        Some(16) => {
-            // 16 == EBUSY. The advice has to match what the scan actually
-            // established: telling someone to close an app is useless when the
-            // holder is irlume itself, and worse when the scan could not see
-            // the holder at all (#187 restarted the daemon for days on the
-            // strength of a sentence naming irlumed).
-            Error::Hardware(match camera_holders(device) {
-                Holders::Other(who) => format!(
-                    "{device}: camera busy, in use by {who}. \
-                     Close that app (e.g. a camera/video/conferencing app) and retry."
-                ),
-                Holders::SelfOnly => format!(
-                    "{device}: camera busy, and the only process holding it is irlume itself \
-                     (pid {}). That is an irlume bug, not an app you can close; please report \
-                     it with the output of `irlume doctor`.",
-                    std::process::id()
-                ),
-                Holders::UnknownBlind => format!(
-                    "{device}: camera busy. irlume could not identify the holder, because it \
-                     cannot read every process (see issue #207); `sudo fuser -v {device}` will \
-                     name it. Close that app and retry."
-                ),
-                Holders::None => format!(
-                    "{device}: camera busy, another app is using it. \
-                     Close that app (e.g. a camera/video/conferencing app) and retry."
-                ),
-            })
-        }
+        Some(libc::EBUSY) => camera_busy_error(device, camera_holders(device)),
         _ if e.kind() == ErrorKind::PermissionDenied => Error::Hardware(format!(
             "{device}: permission denied; add your user to the 'video' group (camera) and re-login"
         )),
@@ -14571,6 +14577,43 @@ mod tests {
         assert_eq!(ir_frame_disposition(10.0), IrFrameDisposition::Deliver);
         assert_eq!(ir_frame_disposition(244.9), IrFrameDisposition::Deliver);
         assert_eq!(ir_frame_disposition(245.0), IrFrameDisposition::SkipBlown);
+    }
+
+    #[test]
+    fn camera_busy_type_preserves_self_contention_and_real_errno() {
+        for holder in [
+            Holders::Other("fixture app".into()),
+            Holders::UnknownBlind,
+            Holders::None,
+        ] {
+            assert!(matches!(
+                camera_busy_error("/dev/fixture", holder),
+                Error::CameraBusy(_)
+            ));
+        }
+        assert!(matches!(
+            camera_busy_error("/dev/fixture", Holders::SelfOnly),
+            Error::Hardware(_)
+        ));
+        assert!(matches!(
+            map_io(
+                "/dev/irlume-test-missing",
+                std::io::Error::from_raw_os_error(libc::EBUSY)
+            ),
+            Error::CameraBusy(_)
+        ));
+        // Similar prose cannot turn an unrelated failure into a retryable busy error.
+        assert!(matches!(
+            map_io("/dev/fixture", std::io::Error::other("camera busy")),
+            Error::Hardware(_)
+        ));
+        assert!(matches!(
+            map_io(
+                "/dev/fixture",
+                std::io::Error::from_raw_os_error(libc::EACCES)
+            ),
+            Error::Hardware(_)
+        ));
     }
 
     #[test]

--- a/crates/irlume-cli/src/machine.rs
+++ b/crates/irlume-cli/src/machine.rs
@@ -117,6 +117,8 @@ struct Document {
 struct MachineError {
     code: &'static str,
     retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<&'static str>,
 }
 
 fn success(command: &'static str, data: Value, contract: u32) -> Document {
@@ -139,7 +141,11 @@ fn failure(command: &'static str, code: &'static str, retryable: bool, contract:
         command,
         ok: false,
         data: None,
-        error: Some(MachineError { code, retryable }),
+        error: Some(MachineError {
+            code,
+            retryable,
+            message: (code == "camera-busy").then_some(CAMERA_BUSY_MESSAGE),
+        }),
     }
 }
 
@@ -148,6 +154,7 @@ fn failure(command: &'static str, code: &'static str, retryable: bool, contract:
 /// than inventing a meaning for it.
 fn error_code(code: OperationErrorCode) -> &'static str {
     match code {
+        OperationErrorCode::CameraBusy => "camera-busy",
         OperationErrorCode::NotAuthorized => "not-authorized",
         OperationErrorCode::OperationFailed | OperationErrorCode::Unknown => "operation-failed",
     }
@@ -255,7 +262,16 @@ impl EventStream {
 
     /// The single terminal line, as a failure.
     fn fail(mut self, code: &'static str, retryable: bool) -> ExitCode {
-        self.line("error", true, None, Some(MachineError { code, retryable }));
+        self.line(
+            "error",
+            true,
+            None,
+            Some(MachineError {
+                code,
+                retryable,
+                message: (code == "camera-busy").then_some(CAMERA_BUSY_MESSAGE),
+            }),
+        );
         ExitCode::FAILURE
     }
 }
@@ -1897,6 +1913,19 @@ impl SessionGuard {
     }
 }
 
+pub(crate) const CAMERA_BUSY_MESSAGE: &str =
+    "Camera busy. Close any app using the camera, then retry.";
+
+/// Verification only: no PAM surface or credential release.
+fn auth_test_request(user: String) -> Result<Response, String> {
+    crate::daemon_request(&Request::Authenticate {
+        user,
+        service: None,
+        intent_confirmation: None,
+        structured_errors: true,
+    })
+}
+
 /// `irlume auth test --events=jsonl`: does the claimed user's live face match
 /// their own enrolment?
 ///
@@ -1967,13 +1996,7 @@ pub fn auth_test(args: &[String]) -> ExitCode {
     stream.progress("started", json!({ "operation": "auth-test" }));
     stream.progress("capturing", json!({}));
 
-    match crate::daemon_request(&Request::Authenticate {
-        user,
-        // No PAM service: this is a diagnostic, not an authentication for a
-        // surface, so it must not inherit any surface's tier allowances.
-        service: None,
-        intent_confirmation: None,
-    }) {
+    match auth_test_request(user) {
         Ok(Response::AuthResult {
             granted,
             live,

--- a/crates/irlume-cli/src/secrets.rs
+++ b/crates/irlume-cli/src/secrets.rs
@@ -2,11 +2,10 @@
 //!
 //! Bitwarden's biometric unlock, and any app that stores secrets, needs a
 //! Secret Service provider (GNOME Keyring or KWallet) running on the session
-//! bus with the login collection unlocked. When face login releases the
-//! TPM-sealed password through PAM, `pam_gnome_keyring` / `pam_kwallet5` unlock
-//! that collection automatically; if the collection is still locked after a
-//! face login, the keyring password did not match the login password (a stale
-//! `irlume keyring arm`) and secrets fall back to a manual unlock prompt.
+//! bus with a default collection unlocked. The provider can be running without
+//! a default collection, or applications can reach a different provider from
+//! the wallet Irlume unlocks. Report those states separately from a locked
+//! wallet; none alone proves that the sealed credential is stale.
 //!
 //! This probe shells out to `busctl --user` rather than linking a D-Bus client,
 //! matching how irlume-fingerprint talks to fprintd. It only inspects the
@@ -16,15 +15,17 @@ use crate::dout;
 use std::path::PathBuf;
 use std::process::Command;
 
-/// The default (login) collection alias every Secret Service provider exposes.
-const DEFAULT_COLLECTION: &str = "/org/freedesktop/secrets/aliases/default";
+/// The service can exist without a default collection (ReadAlias returns `/`).
+const SECRETS_PATH: &str = "/org/freedesktop/secrets";
 const SECRETS_BUS: &str = "org.freedesktop.secrets";
 
 /// Locale-pinned `busctl --user`, or `None` when busctl is not installed.
 fn busctl_user() -> Option<Command> {
     let path = which_busctl()?;
     let mut c = Command::new(path);
-    c.env("LC_ALL", "C").env("LANG", "C").arg("--user");
+    c.env("LC_ALL", "C")
+        .env("LANG", "C")
+        .args(["--user", "--timeout=3", "--auto-start=no"]);
     Some(c)
 }
 
@@ -53,6 +54,33 @@ enum Collection {
     Present { locked: bool },
     /// No provider owns `org.freedesktop.secrets` on this bus.
     NoProvider,
+    /// A provider answered ReadAlias, but has no default collection.
+    MissingDefault,
+    /// The bus, provider, or reply could not be checked reliably.
+    Unavailable,
+}
+
+/// Actionable state shared by doctor and the TUI Repair page.
+#[derive(Clone, Copy)]
+pub(crate) enum LoginKeyringProblem {
+    Locked,
+    MissingDefault,
+}
+
+impl LoginKeyringProblem {
+    pub(crate) fn description(self) -> &'static str {
+        match self {
+            Self::Locked => "the default wallet is locked; apps cannot read its secrets yet",
+            Self::MissingDefault => "the running Secret Service provider has no default collection; apps may ask to create a keyring",
+        }
+    }
+
+    pub(crate) fn advice(self) -> &'static str {
+        match self {
+            Self::Locked => "Unlock the existing wallet and check `irlume keyring status` before re-arming.",
+            Self::MissingDefault => "Check your desktop's preferred Secret Service provider and select an existing default wallet before arming Irlume.",
+        }
+    }
 }
 
 /// The process backing `org.freedesktop.secrets`, as a friendly name. KDE
@@ -84,29 +112,72 @@ fn unlock_module_for(provider: &str) -> Option<&'static str> {
     }
 }
 
-/// Query the default collection's `Locked` property. A successful reply means a
-/// provider is running (the query D-Bus-activates it if it is merely
-/// registered); a failure means no provider is installed or reachable.
+/// Read provider ownership and the default collection without activating a
+/// provider or prompting. A missing alias is not a missing provider. Errors
+/// remain unknown, including a provider that disappears between these reads.
 fn query_collection() -> Collection {
-    let Some(mut cmd) = busctl_user() else {
-        return Collection::NoProvider;
-    };
-    let out = cmd
-        .args([
-            "get-property",
-            SECRETS_BUS,
-            DEFAULT_COLLECTION,
-            "org.freedesktop.Secret.Collection",
-            "Locked",
-        ])
-        .output();
-    match out {
-        Ok(o) if o.status.success() => match parse_locked(&String::from_utf8_lossy(&o.stdout)) {
-            Some(locked) => Collection::Present { locked },
-            None => Collection::NoProvider,
-        },
-        _ => Collection::NoProvider,
+    match busctl_output(&[
+        "call",
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus",
+        "NameHasOwner",
+        "s",
+        SECRETS_BUS,
+    ])
+    .as_deref()
+    .and_then(parse_locked)
+    {
+        Some(false) => return Collection::NoProvider,
+        Some(true) => {}
+        None => return Collection::Unavailable,
     }
+    let alias = busctl_output(&[
+        "call",
+        SECRETS_BUS,
+        SECRETS_PATH,
+        "org.freedesktop.Secret.Service",
+        "ReadAlias",
+        "s",
+        "default",
+    ]);
+    let Some(path) = alias.as_deref().and_then(parse_collection_path) else {
+        return Collection::Unavailable;
+    };
+    if path == "/" {
+        return Collection::MissingDefault;
+    }
+    match busctl_output(&[
+        "get-property",
+        SECRETS_BUS,
+        &path,
+        "org.freedesktop.Secret.Collection",
+        "Locked",
+    ])
+    .as_deref()
+    .and_then(parse_locked)
+    {
+        Some(locked) => Collection::Present { locked },
+        None => Collection::Unavailable,
+    }
+}
+
+fn busctl_output(args: &[&str]) -> Option<String> {
+    let out = busctl_user()?.args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+fn parse_collection_path(reply: &str) -> Option<String> {
+    let path: String = serde_json::from_str(reply.trim().strip_prefix("o ")?).ok()?;
+    let valid = path == "/"
+        || path.strip_prefix('/').is_some_and(|rest| {
+            rest.split('/').all(|part| {
+                !part.is_empty() && part.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+            })
+        });
+    valid.then_some(path)
 }
 
 /// Parse a `busctl get-property … Locked` reply. The wire form is `b true` or
@@ -123,20 +194,16 @@ fn parse_locked(reply: &str) -> Option<bool> {
     }
 }
 
-/// Print one doctor line about the login keyring, or nothing when there is no
-/// session bus to inspect (e.g. under sudo). Only call for the current user.
-/// For the TUI Repair check: `Some(true)` when a Secret Service provider is up
-/// but the login collection is LOCKED (apps like Bitwarden can't read secrets),
-/// `Some(false)` when unlocked, `None` when there's no session bus or provider
-/// to judge (so Repair stays quiet rather than warning on a headless/no-wallet
-/// box). Only meaningful run as the user (a session bus), like the report.
-pub(crate) fn login_keyring_locked() -> Option<bool> {
+/// Read actionable default-keyring state for the TUI without treating a
+/// missing collection as an absent provider. No session bus means no verdict.
+pub(crate) fn login_keyring_problem() -> Option<LoginKeyringProblem> {
     if !have_session_bus() {
         return None;
     }
     match query_collection() {
-        Collection::Present { locked } => Some(locked),
-        Collection::NoProvider => None,
+        Collection::Present { locked: true } => Some(LoginKeyringProblem::Locked),
+        Collection::MissingDefault => Some(LoginKeyringProblem::MissingDefault),
+        _ => None,
     }
 }
 
@@ -150,51 +217,194 @@ pub fn report_keyring_status(report: &mut crate::doctor_report::Report) {
         report.check("keyring-secrets", State::Unknown);
         return;
     }
-    // Name the provider (ksecretd on Plasma 6, kwalletd, gnome-keyring) so the
-    // hint points at the exact PAM module carrying the face-released password.
+    let collection = query_collection();
     let provider = provider_name();
     let via = provider
         .as_deref()
         .and_then(unlock_module_for)
         .map(|m| format!("via {m}"))
-        .unwrap_or_else(|| "via pam_gnome_keyring/pam_kwallet5".to_string());
+        .unwrap_or_else(|| "via your desktop's PAM keyring module".to_string());
     let who = provider
         .as_deref()
         .map(|p| format!(" [{p}]"))
         .unwrap_or_default();
-    report.check(
-        "keyring-secrets",
-        match query_collection() {
-            Collection::Present { locked: false } => State::Pass,
-            Collection::Present { locked: true } => State::Warn,
-            Collection::NoProvider => State::Info,
-        },
-    );
-    match query_collection() {
-        Collection::Present { locked: false } => dout!(
-            report,
-            "[doctor] login keyring{who}: unlocked ✓ (Secret Service apps like Bitwarden \
-             can read secrets after a face login)"
-        ),
-        Collection::Present { locked: true } => dout!(
-            report,
-            "[doctor] login keyring{who}: LOCKED. A face login should unlock it {via}.\n     \
-             If it stays locked, the sealed keyring password is stale; re-run: \
-             sudo irlume keyring arm"
-        ),
-        Collection::NoProvider => dout!(
-            report,
-            "[doctor] login keyring: no Secret Service provider running \
-             (GNOME Keyring / KWallet).\n     \
-             Bitwarden and other secret-storing apps need one; your desktop \
-             normally starts it at login."
-        ),
-    }
+    let (state, message) = match collection {
+        Collection::Present { locked: false } => (State::Pass,
+            format!("login keyring{who}: unlocked ✓ (Secret Service apps can read secrets)")),
+        Collection::Present { locked: true } => (State::Warn,
+            format!("login keyring{who}: {}. Login normally unlocks it {via}.\n     {}",
+                LoginKeyringProblem::Locked.description(), LoginKeyringProblem::Locked.advice())),
+        Collection::MissingDefault => (State::Warn,
+            format!("login keyring{who}: {}.\n     {}",
+                LoginKeyringProblem::MissingDefault.description(), LoginKeyringProblem::MissingDefault.advice())),
+        Collection::NoProvider => (State::Info,
+            "login keyring: no Secret Service provider running (GNOME Keyring / KWallet). Your desktop normally starts it at login.".to_string()),
+        Collection::Unavailable => (State::Unknown,
+            "login keyring: could not determine the default collection's state; check the session bus and Secret Service provider.".to_string()),
+    };
+    // One observation supplies both outputs, including the actionable reason.
+    report.check_detail("keyring-secrets", state, &message);
+    dout!(report, "[doctor] {message}");
 }
 
 #[cfg(test)]
 mod tests {
     use super::{parse_locked, unlock_module_for};
+
+    // Run the real probe/report in a child process so fixture PATH and bus
+    // environment cannot race unrelated unit tests or touch the user's bus.
+    #[test]
+    fn doctor_reports_secret_service_states() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir =
+            std::env::temp_dir().join(format!("irlume-secrets-test-{}", rand::random::<u64>()));
+        std::fs::create_dir(&dir).unwrap();
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _cleanup = Cleanup(dir.clone());
+        let busctl = dir.join("busctl");
+        std::fs::write(
+            &busctl,
+            r#"#!/bin/sh
+no_activation=0
+for arg do
+  if [ "$arg" = "--auto-start=no" ]; then no_activation=1; fi
+done
+[ "$no_activation" = 1 ] || exit 65
+case "$*" in
+  *"status org.freedesktop.secrets") printf 'Comm=gnome-keyring-d\n' ;;
+  *"NameHasOwner s org.freedesktop.secrets")
+    case "$IRLUME_TEST_SECRET_STATE" in
+      no-provider) printf 'b false\n' ;;
+      unavailable) exit 1 ;;
+      *) printf 'b true\n' ;;
+    esac ;;
+  *"ReadAlias s default")
+    case "$IRLUME_TEST_SECRET_STATE" in
+      missing) printf 'o "/"\n' ;;
+      unavailable) exit 1 ;;
+      malformed-alias) printf 's "wrong type"\n' ;;
+      *) printf 'o "/org/freedesktop/secrets/collection/login"\n' ;;
+    esac ;;
+  *"org.freedesktop.Secret.Collection Locked")
+    case "$IRLUME_TEST_SECRET_STATE" in
+      locked) printf 'b true\n' ;;
+      unlocked) printf 'b false\n' ;;
+      malformed-lock) printf 's "false"\n' ;;
+      *) exit 1 ;;
+    esac ;;
+  *) exit 64 ;;
+esac
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&busctl, std::fs::Permissions::from_mode(0o700)).unwrap();
+        for (scenario, want) in [
+            ("missing", "warn"),
+            ("locked", "warn"),
+            ("unlocked", "pass"),
+            ("no-provider", "info"),
+            ("unavailable", "unknown"),
+            ("malformed-alias", "unknown"),
+            ("malformed-lock", "unknown"),
+        ] {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "secrets::tests::secret_service_fixture_child",
+                    "--nocapture",
+                ])
+                .env("PATH", &dir)
+                .env(
+                    "DBUS_SESSION_BUS_ADDRESS",
+                    "unix:path=/nonexistent-irlume-test-bus",
+                )
+                .env("IRLUME_TEST_SECRET_STATE", scenario)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{scenario}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            let json = stdout
+                .lines()
+                .find_map(|line| line.split_once("IRLUME_FIXTURE_RESULT=").map(|(_, v)| v))
+                .expect(&stdout);
+            let checks: serde_json::Value = serde_json::from_str(json).unwrap();
+            assert_eq!(checks["checks"][0]["id"], "keyring-secrets");
+            assert_eq!(checks["checks"][0]["state"], want, "{scenario}");
+            assert!(
+                !checks["checks"][0]["detail"]
+                    .as_str()
+                    .unwrap()
+                    .contains("[doctor]"),
+                "human report prefix leaked into machine detail: {scenario}"
+            );
+            let problem = &checks["problem"];
+            if matches!(scenario, "missing" | "locked") {
+                let description = problem["description"].as_str().unwrap();
+                let detail = checks["checks"][0]["detail"].as_str().unwrap();
+                assert!(detail.contains(description), "doctor and TUI must agree");
+                if scenario == "missing" {
+                    assert!(description.contains("no default collection"));
+                    assert!(!problem["advice"].as_str().unwrap().contains("keyring arm"));
+                } else {
+                    assert!(description.contains("locked"));
+                }
+            } else {
+                assert!(
+                    problem.is_null(),
+                    "{scenario} is not a confirmed wallet problem"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn secret_service_fixture_child() {
+        if std::env::var_os("IRLUME_TEST_SECRET_STATE").is_none() {
+            return;
+        }
+        let mut report = crate::doctor_report::Report::new(crate::doctor_report::Mode::Collect);
+        super::report_keyring_status(&mut report);
+        let problem = super::login_keyring_problem().map(|problem| {
+            serde_json::json!({
+                "description": problem.description(), "advice": problem.advice(),
+            })
+        });
+        println!(
+            "IRLUME_FIXTURE_RESULT={}",
+            serde_json::json!({
+                "checks": report.into_checks(), "problem": problem,
+            })
+        );
+    }
+
+    #[test]
+    fn collection_path_requires_an_object_path_reply() {
+        assert_eq!(super::parse_collection_path("o \"/\"\n"), Some("/".into()));
+        assert_eq!(
+            super::parse_collection_path("o \"/org/freedesktop/secrets/collection/login\""),
+            Some("/org/freedesktop/secrets/collection/login".into())
+        );
+        for malformed in [
+            "",
+            "s \"/\"",
+            "o \"relative\"",
+            "o \"/bad-path\"",
+            "o \"/bad//path\"",
+            "o \"/bad/\"",
+            "o \"/\" trailing",
+        ] {
+            assert_eq!(super::parse_collection_path(malformed), None, "{malformed}");
+        }
+    }
 
     #[test]
     fn parse_locked_reads_the_busctl_boolean_reply() {

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -796,8 +796,8 @@ struct Probes {
     tpm_present: bool,
     /// A distro PAM regeneration dropped the wiring (self-heal pending).
     reconcile_needed: bool,
-    /// The login keyring is locked right now (`None` = could not tell).
-    keyring_locked: Option<bool>,
+    /// A confirmed locked/missing default keyring (`None` = no confirmed problem).
+    keyring_problem: Option<crate::secrets::LoginKeyringProblem>,
     /// Secure Boot: (firmware supports it, currently enabled, setup mode).
     secureboot: (bool, bool, bool),
     /// Firmware boot mode label (UEFI/legacy), from efivars.
@@ -858,7 +858,7 @@ impl Probes {
             fp_keyring_wired: crate::pamwire::fp_keyring_wired(),
             tpm_present: crate::tpm_device().is_some(),
             reconcile_needed: crate::pamwire::reconcile_needed(),
-            keyring_locked: crate::secrets::login_keyring_locked(),
+            keyring_problem: crate::secrets::login_keyring_problem(),
             secureboot: (
                 secureboot::secure_boot_present(),
                 secureboot::is_secure_boot_enabled(),
@@ -2091,22 +2091,16 @@ impl App {
             }
         }
 
-        // Login keyring LOCKED: a Secret Service provider is up but its login
-        // collection is locked, so apps (Bitwarden, browsers) can't read their
-        // secrets even after a face login. Only flag it when the keyring is
-        // armed (else it's expected) and a provider actually answered. The TUI
-        // runs as the user, so unlike `sudo doctor` it can see the session bus.
+        // A running Secret Service can have a locked default wallet or none
+        // at all. Show the same reason/advice as doctor for an armed account.
+        // An unavailable bus/provider does not establish either problem.
         if self.keyring_armed == Some(true) {
-            if let Some(true) = self.probes.keyring_locked {
+            if let Some(problem) = self.probes.keyring_problem {
                 v.push(mk(
                     "Login keyring",
                     Sev::Warn,
-                    "the wallet is locked; apps (Bitwarden, browsers) can't read secrets yet"
-                        .into(),
-                    Fix::Manual(
-                        "unlock it by logging in with your face, or `sudo irlume keyring arm`"
-                            .into(),
-                    ),
+                    problem.description().into(),
+                    Fix::Manual(problem.advice().into()),
                 ));
             }
         }

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -2976,7 +2976,20 @@ impl App {
             ),
             Suspend::MoreAction(invocation) => {
                 let args = invocation.args(&self.user);
-                if invocation.action.root {
+                if invocation.action.args == ["auth", "test", "--events=jsonl"] {
+                    println!("Look at the camera for the authentication test.");
+                    match actions::auth_test_feedback(
+                        std::process::Command::new(Self::self_exe())
+                            .args(&args)
+                            .output(),
+                    ) {
+                        Ok(true) => self.log('✓', "Face authentication succeeded."),
+                        Ok(false) => self.set_error(
+                            "Face authentication did not succeed. You can retry the test.",
+                        ),
+                        Err(message) => self.set_error(message),
+                    }
+                } else if invocation.action.root {
                     let mut command = vec!["irlume"];
                     command.extend(args.iter().map(String::as_str));
                     self.sudo_step(invocation.action.label, &command);

--- a/crates/irlume-cli/src/tui/actions.rs
+++ b/crates/irlume-cli/src/tui/actions.rs
@@ -103,7 +103,7 @@ const TRANSACTION: Field = Field {
 };
 
 pub(super) static ACTIONS: &[Action] = &[
-    Action { label: "Test authentication for this account", description: "Engages the camera. Verifies this account without releasing a password; the JSON result's granted field is the verdict. This does not test a system approval dialog.", args: &["auth", "test", "--events=jsonl"], root: false, per_user: true, fields: &[] },
+    Action { label: "Test authentication for this account", description: "Engages the camera. Verifies this account without releasing a password; Shows whether this account was recognized. This does not test a system approval dialog.", args: &["auth", "test", "--events=jsonl"], root: false, per_user: true, fields: &[] },
     Action { label: "Enroll with a chosen scan count", description: "Captures a face profile. Approve the OS authorization prompt when asked.", args: &["enroll"], root: false, per_user: true, fields: &[NAME, SCANS] },
     Action { label: "Replace face enrollment", description: "Captures a replacement, then replaces existing profiles and camera binding only after success. Keeps the template key and recovery setup. Requires OS authorization.", args: &["enroll", "--reset"], root: false, per_user: true, fields: &[NAME, SCANS] },
     Action { label: "Add a chosen number of scans", description: "Captures additional scans for an existing profile. Requires OS authorization.", args: &["profiles", "add-scan"], root: false, per_user: true, fields: &[PROFILE, SCANS] },
@@ -153,4 +153,95 @@ pub(super) fn matching(query: &str) -> Vec<&'static Action> {
             words.iter().all(|w| text.contains(w))
         })
         .collect()
+}
+
+/// Summarize the current CLI's terminal event. Keep its session lock, request
+/// validation and single-capture semantics; never display arbitrary error prose.
+pub(super) fn auth_test_feedback(
+    output: std::io::Result<std::process::Output>,
+) -> Result<bool, &'static str> {
+    let output = output.map_err(|_| "Could not start the authentication test.")?;
+    let last = std::str::from_utf8(&output.stdout)
+        .ok()
+        .and_then(|text| text.lines().last());
+    let event: serde_json::Value = last
+        .and_then(|line| serde_json::from_str(line).ok())
+        .ok_or("Authentication test returned an unreadable result.")?;
+    if event["command"] != "auth.test" {
+        return Err("Authentication test returned an unexpected result.");
+    }
+    if output.status.success() && event["terminal"] == true && event["event"] == "result" {
+        return event["data"]["granted"]
+            .as_bool()
+            .ok_or("Authentication test returned an incomplete result.");
+    }
+    if !output.status.success() && (event["terminal"] == true || event["ok"] == false) {
+        return Err(match event["error"]["code"].as_str() {
+            Some("camera-busy") => crate::machine::CAMERA_BUSY_MESSAGE,
+            Some("session-busy") => {
+                "Another Irlume operation is running. Wait for it to finish, then retry."
+            }
+            Some("daemon-unavailable") => {
+                "Could not reach Irlume. Check the daemon status and retry."
+            }
+            _ => "Authentication test failed. Check Irlume diagnostics for details.",
+        });
+    }
+    Err("Authentication test ended without a final result.")
+}
+
+#[cfg(test)]
+mod auth_feedback_tests {
+    use super::auth_test_feedback;
+    use std::os::unix::process::ExitStatusExt;
+    fn output(code: i32, value: serde_json::Value) -> std::io::Result<std::process::Output> {
+        Ok(std::process::Output {
+            status: std::process::ExitStatus::from_raw(code << 8),
+            stdout: format!("{value}\n").into_bytes(),
+            stderr: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn camera_busy_feedback_is_actionable_without_rendering_daemon_prose() {
+        let event = |code| {
+            serde_json::json!({"command":"auth.test","terminal":true,"event":"error", "error":{
+                "code":code,"retryable":true,"message":"private fixture"
+            }})
+        };
+        let message = auth_test_feedback(output(1, event("camera-busy"))).unwrap_err();
+        assert!(message.contains("Close any app"));
+        assert!(message.contains("retry"));
+        let generic = auth_test_feedback(output(1, event("operation-failed"))).unwrap_err();
+        assert!(!generic.contains("private fixture"));
+        assert!(!generic.contains("Close any app"));
+        let session = serde_json::json!({"command":"auth.test","ok":false,"error":{"code":"session-busy","retryable":true}});
+        assert!(auth_test_feedback(output(2, session))
+            .unwrap_err()
+            .contains("Another Irlume operation"));
+        assert!(auth_test_feedback(output(1, event("daemon-unavailable")))
+            .unwrap_err()
+            .contains("daemon status"));
+    }
+
+    #[test]
+    fn auth_feedback_distinguishes_denial_and_grant_and_requires_completion() {
+        for granted in [true, false] {
+            let event = serde_json::json!({"command":"auth.test","terminal":true,"event":"result","data":{
+                "granted":granted,"live":true,"reason":"private fixture","refusal":null
+            }});
+            assert_eq!(auth_test_feedback(output(0, event.clone())), Ok(granted));
+            assert!(auth_test_feedback(output(1, event)).is_err());
+        }
+        assert!(auth_test_feedback(output(
+            0,
+            serde_json::json!({"command":"auth.test","event":"capturing","terminal":false})
+        ))
+        .is_err());
+        assert!(auth_test_feedback(output(
+            0,
+            serde_json::json!({"command":"auth.test","terminal":true,"event":"result","data":{}})
+        ))
+        .is_err());
+    }
 }

--- a/crates/irlume-cli/tests/machine_api.rs
+++ b/crates/irlume-cli/tests/machine_api.rs
@@ -940,3 +940,80 @@ fn an_unconfirmed_record_needs_the_acknowledgement() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// A busy camera is actionable, but arbitrary daemon prose must stay private.
+#[test]
+fn auth_camera_busy_is_typed_retryable_and_does_not_repeat_capture() {
+    use std::io::{BufRead, Write};
+    use std::os::unix::net::UnixListener;
+    for (index, reply, code, retryable) in [
+        (
+            0,
+            serde_json::json!({"OperationError":{"code":"camera-busy","retryable":true}}),
+            "camera-busy",
+            true,
+        ),
+        (
+            1,
+            serde_json::json!({"Error":"camera busy: private fixture detail"}),
+            "operation-failed",
+            false,
+        ),
+    ] {
+        let dir =
+            std::env::temp_dir().join(format!("irlume-auth-busy-{}-{index}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let socket = dir.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            let mut request = String::new();
+            std::io::BufReader::new(&stream)
+                .read_line(&mut request)
+                .unwrap();
+            writeln!(stream, "{reply}").unwrap();
+            request
+        });
+        let output = Command::new(env!("CARGO_BIN_EXE_irlume"))
+            .args(["auth", "test", "--events=jsonl", "--user", "root"])
+            .env("IRLUME_SOCKET", &socket)
+            .env("XDG_RUNTIME_DIR", &dir)
+            .output()
+            .unwrap();
+        let request: Value = serde_json::from_str(&server.join().unwrap()).unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        assert!(
+            output.stderr.is_empty(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let events: Vec<Value> = String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[2]["event"], "error");
+        assert_eq!(events[2]["terminal"], true);
+        assert_eq!(events[2]["error"]["code"], code);
+        assert_eq!(events[2]["error"]["retryable"], retryable);
+        if code == "camera-busy" {
+            assert!(events[2]["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("Close any app"));
+        } else {
+            assert!(events[2]["error"].get("message").is_none());
+        }
+        assert!(!serde_json::to_string(&events)
+            .unwrap()
+            .contains("private fixture"));
+        assert_eq!(request["Authenticate"]["structured_errors"], true);
+        assert_eq!(request["Authenticate"]["user"], "root");
+        assert!(request["Authenticate"]["service"].is_null());
+    }
+}

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -1102,6 +1102,14 @@ pub enum Response {
     /// `KdeWalletKey` envelope: the password already opens it, so nothing was
     /// unsealed and nothing needs releasing.
     KeyringUnlockNotNeeded,
+    /// `UnsealPassword` was refused before face authentication because credential
+    /// release is unavailable (peer privilege, device tier, or no armed secret).
+    /// An identity-only caller may request `Authenticate`, which independently
+    /// enforces authorization and policy. This is not a face grant, and must
+    /// never represent a failed capture, denial, throttle or secret delivery.
+    UnsealUnavailable {
+        reason: String,
+    },
     /// Face matched and the TPM released the secret (`UnsealPassword` /
     /// `UnsealKeyring`).
     PasswordUnsealed {

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -472,6 +472,10 @@ pub enum Request {
     /// (convenience) device only a screen-unlock service is honoured. `None`
     /// from older callers (treated as unrestricted on IR hardware).
     Authenticate {
+        /// Opt in to typed hardware errors. Omitted/false preserves legacy
+        /// Error replies; older daemons ignore this additional request field.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        structured_errors: bool,
         user: String,
         #[serde(default)]
         service: Option<String>,
@@ -780,6 +784,8 @@ pub enum OperationErrorCode {
     /// The request was well-formed but the engine could not carry it out, for
     /// example the enrollment store could not be read.
     OperationFailed,
+    /// The camera driver reports contention. Retry once the camera is free.
+    CameraBusy,
     /// A code this build does not know. Present so a client compiled against an
     /// older contract can still decode a response from a newer daemon rather
     /// than failing the whole message.
@@ -1062,7 +1068,7 @@ pub enum Response {
     EarMedian(Option<f32>),
     Error(String),
     /// A failure the caller can act on, sent ONLY to a request that opted in
-    /// (see `ListProfiles::structured_errors`).
+    /// (see `ListProfiles::structured_errors` and `Authenticate::structured_errors`).
     ///
     /// `Error(String)` carries prose meant for a human, so the machine API had
     /// to flatten every failure into one opaque code: a request refused for
@@ -1287,6 +1293,11 @@ pub enum Error {
     NotAuthorized(String),
     #[error("hardware: {0}")]
     Hardware(String),
+    /// EBUSY from camera I/O, excluding an identified self-only holder bug.
+    /// Display preserves the legacy hardware error while the type survives
+    /// through the engine to clients that request structured errors.
+    #[error("hardware: {0}")]
+    CameraBusy(String),
     #[error("tpm: {0}")]
     Tpm(String),
     #[error("policy: {0}")]
@@ -1324,6 +1335,61 @@ pub(crate) mod testenv {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn auth_structured_errors_preserves_legacy_wire_and_unknown_codes() {
+        use super::{OperationErrorCode, Request, Response};
+        let old = serde_json::json!({"Authenticate":{"user":"alice","service":null}});
+        let request: Request = serde_json::from_value(old.clone()).unwrap();
+        assert!(matches!(
+            &request,
+            Request::Authenticate {
+                structured_errors: false,
+                ..
+            }
+        ));
+        assert_eq!(serde_json::to_value(&request).unwrap(), old);
+        let opted_in: Request = serde_json::from_value(serde_json::json!({"Authenticate":{
+            "user":"alice","service":null,"structured_errors":true
+        }}))
+        .unwrap();
+        assert!(matches!(
+            opted_in,
+            Request::Authenticate {
+                structured_errors: true,
+                ..
+            }
+        ));
+        #[derive(serde::Deserialize)]
+        enum LegacyRequest {
+            Authenticate { user: String },
+        }
+        let LegacyRequest::Authenticate { user } =
+            serde_json::from_value(serde_json::to_value(opted_in).unwrap()).unwrap();
+        assert_eq!(user, "alice");
+        let busy: Response = serde_json::from_value(
+            serde_json::json!({"OperationError":{"code":"camera-busy","retryable":true}}),
+        )
+        .unwrap();
+        assert!(matches!(
+            busy,
+            Response::OperationError {
+                code: OperationErrorCode::CameraBusy,
+                retryable: true
+            }
+        ));
+        let future: Response = serde_json::from_value(
+            serde_json::json!({"OperationError":{"code":"future-code","retryable":false}}),
+        )
+        .unwrap();
+        assert!(matches!(
+            future,
+            Response::OperationError {
+                code: OperationErrorCode::Unknown,
+                ..
+            }
+        ));
+    }
+
     #[test]
     fn profile_ir_metadata_is_optional_in_both_wire_directions() {
         let old = r#"{"name":"P","scans":["s"]}"#;
@@ -2056,6 +2122,7 @@ mod tests {
         assert!(matches!(
             old,
             Request::Authenticate {
+                structured_errors: false,
                 user,
                 service: Some(service),
                 intent_confirmation: None,
@@ -2063,6 +2130,7 @@ mod tests {
         ));
 
         let without_attestation = Request::Authenticate {
+            structured_errors: false,
             user: "alice".into(),
             service: Some("kde".into()),
             intent_confirmation: None,
@@ -2075,6 +2143,7 @@ mod tests {
         );
 
         let new = Request::Authenticate {
+            structured_errors: false,
             user: "alice".into(),
             service: Some("sudo".into()),
             intent_confirmation: Some(IntentAttestation::PamConversation),
@@ -2084,6 +2153,7 @@ mod tests {
         assert!(matches!(
             round_trip,
             Request::Authenticate {
+                structured_errors: false,
                 user,
                 service: Some(service),
                 intent_confirmation: Some(IntentAttestation::PamConversation),

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -549,6 +549,7 @@ mod tests {
         use irlume_common::SecretBytes;
         assert_eq!(
             classify(&Request::Authenticate {
+                structured_errors: false,
                 user: "u".into(),
                 service: None,
                 intent_confirmation: None,

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3287,7 +3287,7 @@ fn enrollment_mutating_user(req: &Request) -> Option<&str> {
 /// The refusal for a peer that may not act on `user`, in the wording the
 /// request's own arm used before #344 moved the check here.
 fn not_authorized(req: &Request, verb: &str, user: &str) -> Response {
-    // `ListProfiles` is the one request that can ask for a typed error, and it
+    // `ListProfiles` can ask for a typed authorization error, and it
     // only ever gets one if it asked: an older client cannot deserialize a
     // response variant it does not know, so sending one unasked breaks it
     // across the upgrade window (#93).
@@ -3302,6 +3302,18 @@ fn not_authorized(req: &Request, verb: &str, user: &str) -> Response {
         };
     }
     Response::Error(format!("not authorized to {verb} '{user}'"))
+}
+
+/// Preserve legacy replies unless the caller can understand typed errors.
+fn authentication_error(error: irlume_common::Error, structured: bool) -> Response {
+    if structured && matches!(error, irlume_common::Error::CameraBusy(_)) {
+        Response::OperationError {
+            code: irlume_common::OperationErrorCode::CameraBusy,
+            retryable: true,
+        }
+    } else {
+        Response::Error(error.to_string())
+    }
 }
 
 /// Validate the PAM assertion before startup routing, worker queueing, or any
@@ -4323,7 +4335,12 @@ fn dispatch_scoped_session(
                 Err(e) => Response::Error(e.to_string()),
             }
         }
-        Request::Authenticate { user, service, .. } => {
+        Request::Authenticate {
+            user,
+            service,
+            structured_errors,
+            ..
+        } => {
             // Root (PAM stacks) or the account owner only, from the posture
             // table. Without that gate any local peer could probe
             // Authenticate{other_user} and read the raw similarity score, a
@@ -4462,7 +4479,7 @@ fn dispatch_scoped_session(
                         }
                     },
                 ),
-                Err(e) => Response::Error(e.to_string()),
+                Err(e) => authentication_error(e, structured_errors),
             }
         }
         Request::Identify => {
@@ -6866,9 +6883,35 @@ mod tests {
         };
     }
 
+    #[test]
+    fn camera_busy_auth_error_is_opt_in_and_never_classifies_prose() {
+        use irlume_common::{Error, OperationErrorCode};
+        assert!(matches!(
+            authentication_error(Error::CameraBusy("private holder detail".into()), true),
+            Response::OperationError {
+                code: OperationErrorCode::CameraBusy,
+                retryable: true
+            }
+        ));
+        match authentication_error(Error::CameraBusy("legacy detail".into()), false) {
+            Response::Error(message) => assert_eq!(message, "hardware: legacy detail"),
+            other => panic!("legacy client got {other:?}"),
+        }
+        for error in [
+            Error::Hardware("camera busy".into()),
+            Error::NotAuthorized("camera busy".into()),
+        ] {
+            assert!(matches!(
+                authentication_error(error, true),
+                Response::Error(_)
+            ));
+        }
+    }
+
     request_catalog! {
         u, secret;
         Authenticate => Request::Authenticate {
+            structured_errors: false,
             user: u(),
             service: Some("kde".into()),
             intent_confirmation: None,
@@ -7168,6 +7211,7 @@ mod tests {
         let root = peer(0);
         let nobody = peer(NOBODY);
         let auth = |service: Option<&str>, intent_confirmation| Request::Authenticate {
+            structured_errors: false,
             user: "root".into(),
             service: service.map(str::to_string),
             intent_confirmation,
@@ -7227,6 +7271,7 @@ mod tests {
         let _g = env_lock();
         let response = dispatch_before_engine(
             Request::Authenticate {
+                structured_errors: false,
                 user: "root".into(),
                 service: Some("sudo".into()),
                 intent_confirmation: None,
@@ -7756,6 +7801,7 @@ mod tests {
         for (request, request_peer) in [
             (
                 Request::Authenticate {
+                    structured_errors: false,
                     user: "root".into(),
                     service: Some("sudo".into()),
                     intent_confirmation: None,
@@ -7764,6 +7810,7 @@ mod tests {
             ),
             (
                 Request::Authenticate {
+                    structured_errors: false,
                     user: "root".into(),
                     service: Some("sudo".into()),
                     intent_confirmation: Some(IntentAttestation::PamConversation),
@@ -7856,6 +7903,7 @@ mod tests {
             })
         };
         let request = Request::Authenticate {
+            structured_errors: false,
             user: "root".into(),
             service: Some("sudo".into()),
             intent_confirmation: Some(IntentAttestation::PamConversation),
@@ -8618,6 +8666,7 @@ mod tests {
     #[test]
     fn trace_correlation_ignores_a_client_supplied_operation_id() {
         let mut wire = serde_json::to_value(Request::Authenticate {
+            structured_errors: false,
             user: "carol".into(),
             service: Some("sudo".into()),
             intent_confirmation: None,
@@ -9191,6 +9240,7 @@ mod tests {
     fn policy_waiver_is_honoured_only_when_the_daemon_reads_the_same_policy() {
         let _g = env_lock();
         let sudo_with = |attestation| Request::Authenticate {
+            structured_errors: false,
             user: "root".into(),
             service: Some("sudo".into()),
             intent_confirmation: attestation,
@@ -9451,6 +9501,7 @@ mod tests {
                 structured_errors: false,
             },
             Request::Authenticate {
+                structured_errors: false,
                 user: "a/b".into(),
                 service: None,
                 intent_confirmation: None,
@@ -9518,6 +9569,7 @@ mod tests {
         let _ = &sb;
         match dispatch(
             Request::Authenticate {
+                structured_errors: false,
                 user: "carol".into(),
                 service: None,
                 intent_confirmation: None,
@@ -9539,6 +9591,7 @@ mod tests {
         std::env::set_var("IRLUME_METHOD_CONF", sb.dir.join("method"));
         match dispatch(
             Request::Authenticate {
+                structured_errors: false,
                 user: "carol".into(),
                 service: Some("kde".into()),
                 intent_confirmation: None,
@@ -9581,6 +9634,7 @@ mod tests {
         for (service, class) in [("sshd", "Remote"), ("sudo", "Elevation")] {
             match dispatch(
                 Request::Authenticate {
+                    structured_errors: false,
                     user: "carol".into(),
                     service: Some(service.into()),
                     intent_confirmation: (service == "sudo")
@@ -9620,6 +9674,7 @@ mod tests {
         // capture (the devices don't exist, so reaching the camera would error).
         match dispatch(
             Request::Authenticate {
+                structured_errors: false,
                 user: user.clone(),
                 service: Some("kde".into()),
                 intent_confirmation: None,
@@ -9710,6 +9765,7 @@ mod tests {
                 } else {
                     dispatch(
                         Request::Authenticate {
+                            structured_errors: false,
                             user: user.clone(),
                             service: Some("kde".into()),
                             intent_confirmation: None,
@@ -9748,6 +9804,7 @@ mod tests {
             } else {
                 dispatch(
                     Request::Authenticate {
+                        structured_errors: false,
                         user: user.clone(),
                         service: Some("kde".into()),
                         intent_confirmation: None,
@@ -9772,6 +9829,7 @@ mod tests {
         write_enrollment(&sb.dir, &enrollment_with(&user, &["Face Scan 1"]));
         match dispatch(
             Request::Authenticate {
+                structured_errors: false,
                 user: user.clone(),
                 service: Some("kde".into()),
                 intent_confirmation: None,
@@ -11561,6 +11619,7 @@ mod tests {
         // whether or not the runner's loopback nodes register as an IR pair.
         let resp = dispatch(
             Request::Authenticate {
+                structured_errors: false,
                 user: user.clone(),
                 service: Some("kde".into()),
                 intent_confirmation: None,

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -3409,6 +3409,9 @@ fn pregate(req: &Request, peer: &Peer) -> Option<Response> {
             }
             if matches!(req, Request::UnsealPassword { .. }) {
                 note_unseal_password_refusal(peer.uid);
+                return Some(Response::UnsealUnavailable {
+                    reason: format!("{command} requires root (peer uid {})", peer.uid),
+                });
             }
             Some(Response::Error(format!(
                 "{command} requires root (peer uid {})",
@@ -4840,9 +4843,9 @@ fn dispatch_scoped_session(
             // sealed credential: no cold-login / keyring unlock by RGB-only face.
             if engine.tier() == irlume_core::biopolicy::Tier::Convenience {
                 eprintln!("irlumed: convenience(RGB-only) refuses credential release for '{user}' -> password");
-                return Response::Error(
-                    "RGB-only convenience: face cannot release the login credential".into(),
-                );
+                return Response::UnsealUnavailable {
+                    reason: "RGB-only convenience: face cannot release the login credential".into(),
+                };
             }
             // Refresh the external-camera prohibition on the credential-release
             // path too: live-read, applies to the next request.
@@ -5416,9 +5419,9 @@ fn do_unseal_password_scoped(
     eprintln!("irlumed: UnsealPassword: attempt for '{user}'");
     let t = std::time::Instant::now();
     if !irlume_core::keyring::has_sealed_password(user) {
-        return Response::Error(format!(
-            "no sealed password for '{user}': run `irlume keyring arm`"
-        ));
+        return Response::UnsealUnavailable {
+            reason: format!("no sealed password for '{user}': run `irlume keyring arm`"),
+        };
     }
     // Same failure throttle as the login/sudo path: after a run of failures,
     // skip the camera and let PAM fall to the password.
@@ -7134,6 +7137,14 @@ mod tests {
                     ),
                 },
                 Privilege::RootOnly { command } => match refused {
+                    Some(Response::UnsealUnavailable { reason })
+                        if matches!(req, Request::UnsealPassword { .. }) =>
+                    {
+                        assert_eq!(
+                            reason,
+                            format!("{command} requires root (peer uid {NOBODY})")
+                        );
+                    }
                     Some(Response::Error(msg)) => assert_eq!(
                         msg,
                         format!("{command} requires root (peer uid {NOBODY})"),
@@ -10830,7 +10841,7 @@ mod tests {
             &peer(NOBODY),
             &mut e,
         ) {
-            Response::Error(msg) => {
+            Response::UnsealUnavailable { reason: msg } => {
                 assert_eq!(
                     msg,
                     format!("unseal_password requires root (peer uid {NOBODY})")
@@ -10868,7 +10879,7 @@ mod tests {
             &peer(0),
             &mut e,
         ) {
-            Response::Error(msg) => assert_eq!(
+            Response::UnsealUnavailable { reason: msg } => assert_eq!(
                 msg,
                 "RGB-only convenience: face cannot release the login credential"
             ),
@@ -10906,7 +10917,7 @@ mod tests {
         let sb = sandbox("do-unseal");
         // Nothing armed: refused before any capture or TPM traffic.
         match do_unseal_password(&user, None, &mut e) {
-            Response::Error(msg) => {
+            Response::UnsealUnavailable { reason: msg } => {
                 assert_eq!(
                     msg,
                     format!("no sealed password for '{user}': run `irlume keyring arm`")

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -390,25 +390,26 @@ impl PamServiceModule for IrlumePam {
             // IGNOREs, so the password box still appears when the user did not shake).
             let deadline = Instant::now() + WAIT_BUDGET;
             loop {
-                let (mut attempt, mut delivered) = if unseal {
-                    try_unseal(&pamh, &user)
+                let (attempt, delivered) = if unseal {
+                    match try_unseal(&pamh, &user) {
+                        UnsealAttempt::Delivered(delivered) => (code_for(delivered), delivered),
+                        // Shared login/lock services may need identity only when
+                        // release was refused BEFORE any face attempt. A denial,
+                        // transport error or failed delivery must not buy a new
+                        // scan and deadline. Verify rechecks daemon policy.
+                        UnsealAttempt::Unavailable if facefirst || ondemand => {
+                            (try_verify(&pamh, &user, None), Released::Failed)
+                        }
+                        UnsealAttempt::Unavailable | UnsealAttempt::Failed => {
+                            (PamError::IGNORE, Released::Failed)
+                        }
+                    }
                 } else {
                     (
                         try_verify(&pamh, &user, intent_confirmation),
                         Released::Failed,
                     )
                 };
-                // GDM and cosmic-greeter each drive BOTH the cold greeter and the
-                // live lock screen through one service. Unsealing is refused on the
-                // convenience tier (and on an un-armed keyring); a warm screen unlock
-                // only needs identity, so fall back to a plain verify before giving up
-                // to the password. `try_verify` re-applies biopolicy in the daemon, so
-                // a cold login on a convenience tier still returns Deny here: the
-                // fallback only rescues the identity-only warm-unlock case.
-                if (facefirst || ondemand) && unseal && attempt != PamError::SUCCESS {
-                    attempt = try_verify(&pamh, &user, None);
-                    delivered = Released::Failed; // identity only, nothing released
-                }
                 // A polkit shake-decline is terminal: try_verify returned ABORT, so
                 // abort the whole PAM stack instead of cascading to the password. The
                 // attempt then fails with no password prompt, and the polkit agent
@@ -862,11 +863,18 @@ fn try_verify(pamh: &Pam, user: &str, intent_confirmation: Option<IntentAttestat
     }
 }
 
-/// One unseal attempt (login / cold-boot lock screen): release the sealed
-/// secret and deliver it by kind. `IGNORE` on decline/error so the password
-/// fallback runs. The second value reports HOW a success delivered, for the
-/// `kr` decision at the call site.
-fn try_unseal(pamh: &Pam, user: &str) -> (PamError, Released) {
+/// One unseal attempt: only an explicit pre-authentication refusal permits
+/// identity-only fallback.
+/// Unknown replies and legacy daemon errors fail closed to the password.
+enum UnsealAttempt {
+    Delivered(Released),
+    Unavailable,
+    Failed,
+}
+
+/// Release and deliver a secret by kind, preserving pre-auth refusal separately
+/// from failed authentication or delivery. Never log the secret.
+fn try_unseal(pamh: &Pam, user: &str) -> UnsealAttempt {
     // Pass the PAM service name so the daemon can apply opt-in biopolicy
     // operation-class gating (e.g. refuse credential release to a remote service).
     let service = pamh
@@ -879,10 +887,10 @@ fn try_unseal(pamh: &Pam, user: &str) -> (PamError, Released) {
         service,
     }) {
         Ok(Response::PasswordUnsealed { secret, kind }) => {
-            let delivered = release_secret(pamh, user, &secret, kind);
-            (code_for(delivered), delivered)
+            UnsealAttempt::Delivered(release_secret(pamh, user, &secret, kind))
         }
-        _ => (PamError::IGNORE, Released::Failed),
+        Ok(Response::UnsealUnavailable { .. }) => UnsealAttempt::Unavailable,
+        _ => UnsealAttempt::Failed,
     }
 }
 

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -827,6 +827,7 @@ fn try_verify(pamh: &Pam, user: &str, intent_confirmation: Option<IntentAttestat
         .and_then(irlume_common::pam_service::classify)
         .is_some_and(irlume_common::pam_service::ServiceKind::wants_consent_instruction);
     match request(&Request::Authenticate {
+        structured_errors: false,
         user: user.to_string(),
         service,
         intent_confirmation,

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -1039,30 +1039,12 @@ fn pamwrap_refused_challenge_falls_through_to_the_password_module() {
     let (ok, out) = h.run("irlume-crc-sufficient", &["authenticate"], "\n", None);
     assert!(ok, "sufficient layout must also fall through: {out}");
 
-    // The daemon really was asked, so the fall-through is a REFUSED release and
-    // not "face never ran". Each layout opens with UnsealPassword; `ondemand` then
-    // adds its documented warm-unlock retry (a refused release still lets a live
-    // lock screen unlock on identity alone), which releases no token and so does
-    // not weaken the gate.
+    // Both layouts attempted release exactly once and reached the password.
     let reqs = log.lock().unwrap();
-    assert!(
-        matches!(reqs.first(), Some(Request::UnsealPassword { .. })),
-        "the jump layout must attempt a release first: {reqs:?}"
-    );
-    assert_eq!(
-        reqs.iter()
-            .filter(|r| matches!(r, Request::UnsealPassword { .. }))
-            .count(),
-        2,
-        "one release attempt per layout: {reqs:?}"
-    );
-    assert!(
-        reqs.iter().all(|r| matches!(
-            r,
-            Request::UnsealPassword { .. } | Request::Authenticate { .. }
-        )),
-        "no other request kind belongs on this path: {reqs:?}"
-    );
+    assert_eq!(reqs.len(), 2, "one request per layout: {reqs:?}");
+    assert!(reqs
+        .iter()
+        .all(|r| matches!(r, Request::UnsealPassword { .. })));
 }
 
 /// The documented privacy property: typing a password NEVER starts a scan.
@@ -1193,30 +1175,75 @@ fn pamwrap_nul_poisoned_secret_is_ignore_fail_closed() {
 #[test]
 #[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
 fn pamwrap_ondemand_unseal_falls_back_to_verify() {
-    let Some(h) = Harness::try_new("ondemand") else {
-        return;
-    };
-    h.write_service(
-        "irlume-cosmic",
-        &[h.auth_line("required", "unseal ondemand")],
-    );
-    let log = serve(&h.socket, |req| match req {
-        Request::UnsealPassword { .. } => Response::Error("keyring not armed".into()),
-        Request::Authenticate { .. } => grant(),
-        _ => Response::Error("unexpected request".into()),
-    });
+    for (index, flags) in ["unseal ondemand", "unseal facefirst"].iter().enumerate() {
+        let Some(h) = Harness::try_new(&format!("preflight-{index}")) else {
+            return;
+        };
+        h.write_service("irlume-cosmic", &[h.auth_line("required", flags)]);
+        let log = serve(&h.socket, |req| match req {
+            Request::UnsealPassword { .. } => Response::UnsealUnavailable {
+                reason: "keyring not armed".into(),
+            },
+            Request::Authenticate { .. } => grant(),
+            _ => Response::Error("unexpected request".into()),
+        });
 
-    let (ok, out) = h.run("irlume-cosmic", &["authenticate"], "\n", None);
-    assert!(ok, "verify fallback must rescue the warm unlock: {out}");
+        let (ok, out) = h.run("irlume-cosmic", &["authenticate"], "\n", None);
+        assert!(ok, "verify fallback must rescue the warm unlock: {out}");
 
-    let reqs = log.lock().unwrap();
-    assert_eq!(
-        reqs.len(),
-        2,
-        "unseal attempt then verify fallback: {reqs:?}"
-    );
-    assert!(matches!(reqs[0], Request::UnsealPassword { .. }));
-    assert!(matches!(reqs[1], Request::Authenticate { .. }));
+        let reqs = log.lock().unwrap();
+        assert_eq!(
+            reqs.len(),
+            2,
+            "unseal attempt then verify fallback: {reqs:?}"
+        );
+        assert!(matches!(reqs[0], Request::UnsealPassword { .. }));
+        assert!(matches!(reqs[1], Request::Authenticate { .. }));
+    }
+}
+
+/// A completed release failure must not start another face request, even if
+/// a second verification would grant. Password fallback remains reachable.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_failed_unseal_never_starts_another_face_attempt() {
+    for (index, flags) in ["unseal ondemand", "unseal facefirst"].iter().enumerate() {
+        for (failure_index, failure) in [
+            Response::Error("face not granted: collecting RGB PAD evidence".into()),
+            Response::Error("camera failed".into()),
+            Response::Error("TPM unseal failed".into()),
+            Response::Pong, // Unexpected protocol reply is not permission to retry.
+            // Invalid secret delivery must not become identity-only admission.
+            unsealed("invalid\0password"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let Some(h) = Harness::try_new(&format!("no-repeat-{index}-{failure_index}")) else {
+                return;
+            };
+            h.write_service(
+                "plasmalogin",
+                &[
+                    h.auth_line("sufficient", flags),
+                    "auth required pam_deny.so".into(),
+                ],
+            );
+            let log = serve(&h.socket, move |req| match req {
+                Request::UnsealPassword { .. } => failure.clone(),
+                Request::Authenticate { .. } => grant(),
+                _ => Response::Error("unexpected request".into()),
+            });
+            let (ok, out) = h.run("plasmalogin", &["authenticate"], "\n", None);
+            assert!(
+                !ok,
+                "failed release must reach password fallback: {flags}: {out}"
+            );
+            let reqs = log.lock().unwrap();
+            assert_eq!(reqs.len(), 1, "no second capture request: {reqs:?}");
+            assert!(matches!(reqs[0], Request::UnsealPassword { .. }));
+        }
+    }
 }
 
 /// `keyring` mode (fingerprint path, post-auth landing): the module always

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -472,6 +472,7 @@ fn pamwrap_privileged_yes_prompts_once_and_attests_every_service() {
     for (request, expected_service) in reqs.iter().zip(services) {
         match request {
             Request::Authenticate {
+                structured_errors: false,
                 user,
                 service,
                 intent_confirmation,

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -193,3 +193,26 @@ at `/run/irlume.sock` is not.
 Include the output of `irlume doctor --json` and `irlume version --json`. Neither
 contains camera frames, embeddings, templates, passwords, TPM secrets, device
 paths, or usernames, so both are safe to attach to a public issue.
+
+## PAM credential-release retries
+
+Update the daemon and PAM module together. For `unseal ondemand` and
+`unseal facefirst`, an identity-only fallback is allowed only after the daemon
+returns `UnsealUnavailable`. This means credential release was refused before
+face authentication because the peer cannot unseal, the device is RGB-only,
+or no keyring secret is armed. The subsequent `Authenticate` request still
+enforces its own authorization and policy.
+
+A failed face attempt, incomplete PAD evidence, throttling, transport error,
+or failed secret delivery falls through to the password without starting a
+second verification. A new PAM module paired with an older daemon also falls
+back to the password on generic errors; it cannot safely infer permission to
+retry from old error text. An older module retains its old retry behavior
+until it is upgraded.
+
+Cold credential release can use grouped sequential evidence collection for a
+recognized local greeter or lock-screen service. It requires an exact measured
+camera contract, both PAD models, and the normal authentication budget. The
+five-sample evidence requirement, final identity and liveness checks, and
+deadline remain enforced. Unknown services and privileged application or
+elevation prompts do not gain access to this optimization for release.

--- a/docs/MACHINE-API.md
+++ b/docs/MACHINE-API.md
@@ -494,6 +494,7 @@ observation rather than absent records.
 | `daemon-unavailable` | The daemon could not be reached. | yes |
 | `not-authorized` | The caller may not act on the named account. | no |
 | `operation-failed` | The engine could not carry out a well-formed request. | no |
+| `camera-busy` | The camera driver reported contention. Close apps using the camera, then retry. Auth tests include a fixed human-readable `message`. | yes |
 | `protocol-error` | The daemon replied with something this command did not expect. | no |
 
 `not-authorized` and `operation-failed` are distinct so a consumer can tell "you
@@ -506,12 +507,23 @@ so a real account and an invented one produce the identical answer, and this
 command cannot be used to discover which accounts exist or which are enrolled.
 
 `retryable` means an identical request could plausibly succeed later without the
-caller changing anything. Only `daemon-unavailable` sets it today. It is not a
+caller changing the request. A camera conflict or another Irlume operation may
+clear, so `camera-busy` and `session-busy` can also be retryable. It is not a
 promise that a retry will succeed, and it carries no suggested delay.
 
 ### `irlume auth test --events=jsonl`
 
 Capability: `auth-test-events`.
+
+Camera-busy authentication errors are typed at the camera I/O boundary; text
+containing "camera busy" is never treated as a code. The diagnostic client opts
+in to structured daemon errors. An older daemon may still return
+`operation-failed`; no automatic second capture is attempted. Older clients
+retain legacy daemon replies. An identified Irlume-only holder fault remains a
+generic hardware failure rather than advice to close another application.
+The TUI's authentication test uses the same request and renders actionable
+camera-busy guidance rather than raw JSON. `retryable` does not trigger an
+automatic retry: the camera must become available first.
 
 Does the claimed account's live face match its own enrolment? This is
 verification against one account, never identification, and it releases nothing:

--- a/schemas/machine-api-v1.schema.json
+++ b/schemas/machine-api-v1.schema.json
@@ -240,12 +240,17 @@
             "daemon-unavailable",
             "not-authorized",
             "operation-failed",
-            "protocol-error"
+            "protocol-error",
+            "camera-busy"
           ]
         },
         "retryable": {
           "description": "Whether an identical request could plausibly succeed later with nothing changed by the caller. Not a promise, and it carries no suggested delay.",
           "type": "boolean"
+        },
+        "message": {
+          "type": "string",
+          "description": "Optional human guidance generated from a known error code, never daemon prose. Use code for decisions."
         }
       }
     },


### PR DESCRIPTION
## What & why

Cold-login credential release could trigger another full face scan after a failed authentication attempt. PAM now falls back to identity verification only when the daemon explicitly refuses unsealing before authentication starts. Authentication failures and delivery errors fall back to the password prompt. Qualified local greeter and screen-unlock credential release can use grouped capture while retaining the existing capture-contract, timing, PAD, vote and identity requirements.

Keyring diagnostics distinguish an absent provider, missing default collection, locked collection and unknown state without activating the provider. CLI JSON and TUI guidance reflect those states.

Camera contention now reaches opt-in authentication diagnostics as a typed, retryable `camera-busy` error with the guidance: "Camera busy. Close any app using the camera, then retry." The TUI preserves the existing CLI child and session lock while presenting readable feedback. Existing clients retain their default response behavior; raw daemon error text and camera-owner details are not exposed.

Upgrade PAM and daemon together for the new pre-authentication refusal response. Version mismatches fail safely to password authentication.

## Testing

- [x] `cargo test --workspace` passes (run with `--locked`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (run with `--locked`)
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean (run with `--locked`)
- [x] Docs/CHANGELOG updated if user-facing
- [x] Hardware-validated (if it touches PAM, the daemon, or capture)

Release CLI, daemon and PAM builds passed. Twenty-seven real PAM fixture integration tests passed separately. The committed source matches all 619 tracked-file hashes of the tested final candidate.

Hardware: local Fedora ASUS UX5406S with integrated RGB/IR cameras. The cold-login correction was validated through an actual reboot: one credential-release request, one successful face capture reported by the user, and no browser keyring prompt. A separate local KDE Secret Service activation preference was also present; the code change alone is not claimed to fix provider selection. On the combined installed build, Kamoso's running color preview produced the expected retryable camera-busy response in 0.337 seconds, with its camera holder unchanged and the daemon healthy. That is one functional observation, not a latency benchmark. TUI feedback is covered by automated tests; this live busy invocation used the CLI.

Known pre-existing validation mismatch: the full strict machine API conformance script reports 37 passed, 1 failed and 2 skipped on both the previous installed baseline and this candidate. Its blanket path prohibition rejects documented `camera-census` device-node fields. The checker also skips two unrecognized capability names. No validation gates were weakened, and this mismatch is not claimed to be resolved here.
